### PR TITLE
Instructions to handle lag when starting the shell

### DIFF
--- a/ts/packages/shell/README.md
+++ b/ts/packages/shell/README.md
@@ -20,7 +20,7 @@ npm run shell
 
 On Windows, if you notice a lag when starting up the shell, you can add the source code folder to the exclusions list for Windows Defender scans following the [instruction](https://support.microsoft.com/en-us/windows/add-an-exclusion-to-windows-security-811816c0-4dfd-af4a-47e4-c301afe13b26).
 
-Additionally, if you are running MS Graph based sample agents like Calendar and Email, there is a auth tokens persisted in the idenitity cache that can occassionally get corrupted. This could also slow down the start up time of the shell, you can delete that by running:
+Additionally, if you are running MS Graph based sample agents like Calendar and Email, there is an auth token persisted in the idenitity cache that can occassionally get corrupted. This could also slow down the start up time of the shell, you can delete that by running:
 
 ```console
 >del %LOCALAPPDATA%\.IdentityService\typeagent-tokencache


### PR DESCRIPTION
- [x] Add exclusion from windows defender scan
- [x] Delete the identity token cache file