### PR TITLE
Config translator and explainer model

### DIFF
--- a/ts/packages/aiclient/src/restClient.ts
+++ b/ts/packages/aiclient/src/restClient.ts
@@ -4,6 +4,7 @@
 import { success, error, Result } from "typechat";
 import registerDebug from "debug";
 
+const debugUrl = registerDebug("typeagent:rest:url");
 const debugHeader = registerDebug("typeagent:rest:header");
 
 /**
@@ -255,6 +256,7 @@ async function fetchWithTimeout(
     options?: RequestInit,
     timeoutMs?: number,
 ): Promise<Response> {
+    debugUrl(url);
     if (!timeoutMs || timeoutMs <= 0) {
         return fetch(url, options);
     }

--- a/ts/packages/cache/src/cache/cache.ts
+++ b/ts/packages/cache/src/cache/cache.ts
@@ -56,6 +56,7 @@ export class AgentCache {
     }>;
 
     private readonly logger: Logger | undefined;
+    public model?: string;
     constructor(
         public readonly explainerName: string,
         private readonly getExplainerForTranslator: ExplainerFactory,
@@ -107,7 +108,10 @@ export class AgentCache {
     }
 
     private getExplainerForActions(actions: Actions) {
-        return this.getExplainerForTranslator(actions.action?.translatorName);
+        return this.getExplainerForTranslator(
+            actions.action?.translatorName,
+            this.model,
+        );
     }
 
     private async queueTask(
@@ -238,7 +242,7 @@ export class AgentCache {
         }
     }
 
-    public async correctExplaination(
+    public async correctExplanation(
         requestAction: RequestAction,
         explanation: object,
         correction: string,

--- a/ts/packages/cache/src/cache/factory.ts
+++ b/ts/packages/cache/src/cache/factory.ts
@@ -70,7 +70,7 @@ export class AgentCacheFactory {
         const customFactory = this.getCustomExplainerFactory?.(explainerName);
         const cache = new Map<string | undefined, GenericExplainer>();
         const factory = (translator: string | undefined, model?: string) => {
-            const existing = cache.get(translator);
+            const existing = cache.get(`${translator ?? ""}|${model ?? ""}`);
             if (existing) {
                 return existing;
             }

--- a/ts/packages/commonUtils/src/jsonTranslator.ts
+++ b/ts/packages/commonUtils/src/jsonTranslator.ts
@@ -137,7 +137,6 @@ export function createJsonTranslatorFromSchemaDef<T extends object>(
     constraintsValidator?: TypeChatConstraintsValidator<T>, // Optional
     instructions?: PromptSection[],
     model?: string | TypeChatLanguageModel, // optional
-    enableStreaming?: boolean,
 ) {
     if (typeof model !== "object") {
         model = ai.createChatModel(model, {

--- a/ts/packages/dispatcher/src/command.ts
+++ b/ts/packages/dispatcher/src/command.ts
@@ -287,9 +287,25 @@ export function getSettingSummary(context: CommandHandlerContext) {
         ).values(),
     );
     prompt.push("  [", translators.join(""));
-    if (context.agentCache.explainerName !== getDefaultExplainerName()) {
-        prompt.push(` (explainer: ${context.agentCache.explainerName})`);
+    if (context.session.getConfig().models.translator !== "") {
+        prompt.push(
+            ` (model: ${context.session.getConfig().models.translator})`,
+        );
     }
+    if (context.agentCache.explainerName !== getDefaultExplainerName()) {
+        prompt.push(` (explainer: ${context.agentCache.explainerName}`);
+        if (context.session.getConfig().models.explainer !== "") {
+            prompt.push(
+                ` model: ${context.session.getConfig().models.translator}`,
+            );
+        }
+        prompt.push(")");
+    } else if (context.session.getConfig().models.explainer !== "") {
+        prompt.push(
+            ` (explainer model: ${context.session.getConfig().models.explainer})`,
+        );
+    }
+
     prompt.push("]");
 
     return prompt.join("");

--- a/ts/packages/dispatcher/src/handlers/configCommandHandlers.ts
+++ b/ts/packages/dispatcher/src/handlers/configCommandHandlers.ts
@@ -21,7 +21,10 @@ import { getServiceHostCommandHandlers } from "./serviceHost/serviceHostCommandH
 import { getLocalWhisperCommandHandlers } from "./serviceHost/localWhisperCommandHandler.js";
 
 import { parseRequestArgs } from "../utils/args.js";
-import { simpleStarRegex } from "common-utils";
+import { getChatModelNames, simpleStarRegex } from "common-utils";
+import { openai as ai } from "aiclient";
+import { SessionConfig } from "../session/session.js";
+import chalk from "chalk";
 
 function parseToggleTranslatorName(args: string[], action: boolean) {
     const options: any = {};
@@ -69,68 +72,66 @@ function parseToggleTranslatorName(args: string[], action: boolean) {
     return options;
 }
 
-class TranslatorCommandHandler implements CommandHandler {
-    public description = "Toggle translators";
-    public async run(request: string, context: CommandHandlerContext) {
-        const { args } = parseRequestArgs(request);
-        if (args.length < 1) {
-            context.requestIO.warn((log) => {
-                log("Usage: @config translator [-]<translator>]");
-                const translators = getTranslatorNames().join(", ");
-                log(`   <translator>: ${translators}`);
-            });
-            return;
-        }
+const enum AgentToggle {
+    Translator,
+    Action,
+    Agent,
+}
 
-        const options = parseToggleTranslatorName(args, false);
-        const changed = await changeContextConfig(
-            { translators: options },
-            context,
-        );
+const AgentToggleDescription = [
+    "agent translators",
+    "agent actions",
+    "agents",
+] as const;
 
-        const translators = changed.translators;
-        if (translators) {
-            context.requestIO.result((log) => {
-                log("Changes:");
-                for (const [name, value] of Object.entries(translators)) {
-                    log(`  ${name}: ${value ? "enabled" : "disabled"}`);
-                }
-            });
-        } else {
-            context.requestIO.warn("No change");
-        }
+const AgentToggleCommand = ["translator", "action", "agent"] as const;
+
+function getAgentToggleOptions(toggle: AgentToggle, options: any) {
+    switch (toggle) {
+        case AgentToggle.Translator:
+            return { translators: options };
+        case AgentToggle.Action:
+            return { actions: options };
+        case AgentToggle.Agent:
+            return { translators: options, actions: options };
     }
 }
 
-class ActionCommandHandler implements CommandHandler {
-    public description = "Toggle translator actions";
+class AgentToggleCommandHandler implements CommandHandler {
+    public description = `Toggle ${AgentToggleDescription[this.toggle]}`;
+    constructor(private toggle: AgentToggle) {}
+
     public async run(request: string, context: CommandHandlerContext) {
         const { args } = parseRequestArgs(request);
         if (args.length < 1) {
             context.requestIO.warn((log) => {
-                log("Usage: @config action [-]<translator>]");
+                log(
+                    `Usage: @config ${AgentToggleCommand[this.toggle]} [-]<agent>]`,
+                );
                 const translators = getTranslatorNames().join(", ");
-                log(`   <translator>: ${translators}`);
+                log(`   <agent>: ${translators}`);
             });
             return;
         }
 
         const options = parseToggleTranslatorName(args, false);
         const changed = await changeContextConfig(
-            { actions: options },
+            getAgentToggleOptions(this.toggle, options),
             context,
         );
 
-        const actions = changed.actions;
-        if (actions) {
-            context.requestIO.result((log) => {
-                log("Changes:");
-                for (const [name, value] of Object.entries(actions)) {
-                    log(`  ${name}: ${value ? "enabled" : "disabled"}`);
-                }
-            });
-        } else {
+        const changedEntries = Object.entries(changed);
+        if (changedEntries.length === 0) {
             context.requestIO.warn("No change");
+        } else {
+            const lines: string[] = [];
+            for (const [kind, options] of Object.entries(changed)) {
+                lines.push(`Changes (${kind}):`);
+                for (const [name, value] of Object.entries(options as any)) {
+                    lines.push(`  ${name}: ${value ? "enabled" : "disabled"}`);
+                }
+            }
+            context.requestIO.result(lines.join("\n"));
         }
     }
 }
@@ -157,13 +158,106 @@ class ExplainerCommandHandler implements CommandHandler {
     }
 }
 
+function getConfigModel(models: SessionConfig["models"], kind: string) {
+    if (!models.hasOwnProperty(kind)) {
+        throw new Error(
+            `Invalid model kind: ${kind}\nValid model kinds: ${Object.keys(models).join(", ")}`,
+        );
+    }
+    const model = models[kind as keyof typeof models];
+    const settings = ai.getChatModelSettings(model);
+    return `Current ${chalk.cyan(kind)} model: ${model ? model : "(default)"}\nURL:${settings.endpoint}`;
+}
+
+class ConfigModelShowCommandHandler implements CommandHandler {
+    public readonly description = "Show current model";
+    public async run(request: string, context: CommandHandlerContext) {
+        const models = context.session.getConfig().models;
+        const { args } = parseRequestArgs(request);
+        if (args.length > 1) {
+            throw new Error("Too many arguments.");
+        }
+        if (args.length === 1) {
+            context.requestIO.result(getConfigModel(models, args[0]));
+        } else {
+            context.requestIO.result(
+                Object.keys(models)
+                    .map((kind) => getConfigModel(models, kind))
+                    .join("\n"),
+            );
+        }
+    }
+}
+
+class ConfigModelSetCommandHandler implements CommandHandler {
+    public readonly description = "Set model";
+    public async run(request: string, context: CommandHandlerContext) {
+        const { args } = parseRequestArgs(request);
+        const models = context.session.getConfig().models;
+        if (args.length === 0) {
+            const newConfig = {
+                models: Object.fromEntries(
+                    Object.keys(models).map((kind) => [kind, ""]),
+                ),
+            };
+            await changeContextConfig(newConfig, context);
+            context.requestIO.result(`Reset to default model for all`);
+            return;
+        }
+
+        let kind = "translation";
+        let model = "";
+        if (args.length === 1) {
+            if (models.hasOwnProperty(args[0])) {
+                kind = args[0];
+            } else {
+                model = args[0];
+            }
+        } else {
+            kind = args[0];
+            model = args[1];
+        }
+
+        if (!models.hasOwnProperty(kind)) {
+            throw new Error(
+                `Invalid model kind: ${kind}\nValid model kinds: ${Object.keys(models).join(", ")}`,
+            );
+        }
+        const modelNames = getChatModelNames();
+        if (model === "") {
+            context.requestIO.result(`Reset to default model for ${kind}`);
+        } else if (!modelNames.includes(model)) {
+            context.requestIO.error(
+                `Invalid model name: ${model}\nValid model names: ${modelNames.join(", ")}`,
+            );
+            return;
+        }
+        await changeContextConfig(
+            {
+                models: {
+                    [kind]: model,
+                },
+            },
+            context,
+        );
+    }
+}
+
 export function getConfigCommandHandlers(): HandlerTable {
     return {
         description: "Configuration commands",
-        defaultSubCommand: undefined,
         commands: {
-            translator: new TranslatorCommandHandler(),
-            action: new ActionCommandHandler(),
+            translator: new AgentToggleCommandHandler(AgentToggle.Translator),
+            action: new AgentToggleCommandHandler(AgentToggle.Action),
+            agent: new AgentToggleCommandHandler(AgentToggle.Agent),
+            model: {
+                description: "Configure model",
+                defaultSubCommand: new ConfigModelShowCommandHandler(),
+                commands: {
+                    show: new ConfigModelShowCommandHandler(),
+                    set: new ConfigModelSetCommandHandler(),
+                },
+            },
             multi: getToggleHandlerTable(
                 "multiple action translation",
                 async (context, enable: boolean) => {
@@ -175,7 +269,6 @@ export function getConfigCommandHandlers(): HandlerTable {
             ),
             switch: {
                 description: "auto switch translator",
-                defaultSubCommand: undefined,
                 commands: {
                     ...getToggleCommandHandlers(
                         "switch translator",

--- a/ts/packages/dispatcher/src/handlers/correctCommandHandler.ts
+++ b/ts/packages/dispatcher/src/handlers/correctCommandHandler.ts
@@ -14,7 +14,7 @@ export class CorrectCommandHandler implements CommandHandler {
         if (context.lastExplanation === undefined) {
             throw new Error("No last explanation to correct");
         }
-        const result = await context.agentCache.correctExplaination(
+        const result = await context.agentCache.correctExplanation(
             context.lastRequestAction,
             context.lastExplanation,
             input,

--- a/ts/packages/dispatcher/src/handlers/requestCommandHandler.ts
+++ b/ts/packages/dispatcher/src/handlers/requestCommandHandler.ts
@@ -226,7 +226,7 @@ async function translateRequestWithTranslator(
         ? (prop: string, value: any, partial: boolean) => {
               // TODO: implemented for chat's generate response.
               // Need to design the interface for agents to use streaming
-              if (prop === "actionName") {
+              if (prop === "actionName" && !partial) {
                   context.requestIO.status(
                       `[${translatorName}] Translating '${request}' into action '${value}'`,
                   );

--- a/ts/packages/dispatcher/src/session/session.ts
+++ b/ts/packages/dispatcher/src/session/session.ts
@@ -140,6 +140,10 @@ type DispatcherConfig = {
     translators: ConfigObject;
     actions: ConfigObject;
     explainerName: string;
+    models: {
+        translator: string;
+        explainer: string;
+    };
     bot: boolean;
     stream: boolean;
     explanation: boolean;
@@ -173,6 +177,10 @@ export const defaultSessionConfig: SessionConfig = {
         ]),
     ),
     explainerName: getDefaultExplainerName(),
+    models: {
+        translator: "",
+        explainer: "",
+    },
     bot: true,
     stream: true,
     explanation: true,
@@ -405,6 +413,7 @@ export async function configAgentCache(
     session: Session,
     agentCache: AgentCache,
 ) {
+    agentCache.model = session.getConfig().models.explainer;
     agentCache.constructionStore.clear();
     if (session.cache) {
         const cacheData = session.getCacheDataFilePath();


### PR DESCRIPTION
Enable `shell` and `cli` to config model that is used for translation and explanation.
Use command `@config model set <kind> <model>` to set the model for kind = translation or explanation
Use command `@config model show [<kind>]` to show the current set model (and the URL for the model)

Also add command to enable/disable an agent (i.e. both translation and action for an agent) using `@config agent <agentname>`

