### PR TITLE
Initial implementation running agents in a separate NodeJS process

### DIFF
--- a/ts/packages/agents/browser/src/agent/browserActionHandler.mts
+++ b/ts/packages/agents/browser/src/agent/browserActionHandler.mts
@@ -31,7 +31,7 @@ export type BrowserActionContext = {
   browserConnector: BrowserConnector | undefined;
 };
 
-function initializeBrowserContext(): BrowserActionContext {
+async function initializeBrowserContext(): Promise<BrowserActionContext> {
   return {
     webSocket: undefined,
     crossWordState: undefined,

--- a/ts/packages/agents/calendar/src/calendarActionHandler.ts
+++ b/ts/packages/agents/calendar/src/calendarActionHandler.ts
@@ -52,7 +52,7 @@ type CalendarActionContext = {
     interpreter: ImpressionInterpreter;
 };
 
-function initializeCalendarContext() {
+async function initializeCalendarContext() {
     return {
         calendarClient: undefined,
         graphEventIds: undefined,

--- a/ts/packages/agents/code/src/codeActionHandler.ts
+++ b/ts/packages/agents/code/src/codeActionHandler.ts
@@ -21,7 +21,7 @@ type CodeActionContext = {
     webSocket: WebSocket | undefined;
 };
 
-function initializeCodeContext(): CodeActionContext {
+async function initializeCodeContext(): Promise<CodeActionContext> {
     return {
         webSocket: undefined,
     };

--- a/ts/packages/agents/email/src/emailActionHandler.ts
+++ b/ts/packages/agents/email/src/emailActionHandler.ts
@@ -29,7 +29,7 @@ type EmailActionContext = {
     mailClient: MailClient | undefined;
 };
 
-function initializeEmailContext() {
+async function initializeEmailContext() {
     return {
         mailClient: undefined,
     };

--- a/ts/packages/agents/list/src/listActionHandler.ts
+++ b/ts/packages/agents/list/src/listActionHandler.ts
@@ -115,7 +115,7 @@ async function listValidateWildcardMatch(
     return true;
 }
 
-function initializeListContext() {
+async function initializeListContext() {
     return { store: undefined };
 }
 
@@ -210,7 +210,7 @@ async function createListStoreForSession(
 ) {
     let lists: List[] = [];
     // check whether file exists
-    if (storage.exists(listStoreName)) {
+    if (await storage.exists(listStoreName)) {
         const data = await storage.read(listStoreName, "utf8");
         lists = JSON.parse(data);
     } else {
@@ -250,7 +250,7 @@ async function handleListAction(
                     addAction.parameters.listName,
                     addAction.parameters.items,
                 );
-                listContext.store.save();
+                await listContext.store.save();
                 displayText = `Added items: ${addAction.parameters.items} to list ${addAction.parameters.listName}`;
                 result = createTurnImpressionFromDisplay(displayText);
                 result.literalText = `Added item: ${addAction.parameters.items} to list ${addAction.parameters.listName}`;
@@ -279,7 +279,7 @@ async function handleListAction(
                     removeAction.parameters.listName,
                     removeAction.parameters.items,
                 );
-                listContext.store.save();
+                await listContext.store.save();
                 displayText = `Removed items: ${removeAction.parameters.items} from list ${removeAction.parameters.listName}`;
                 result = createTurnImpressionFromDisplay(displayText);
                 result.literalText = `Removed items: ${removeAction.parameters.items} from list ${removeAction.parameters.listName}`;
@@ -310,7 +310,7 @@ async function handleListAction(
                         `Created list: ${createListAction.parameters.listName}`,
                     );
                     displayText = `Created list: ${createListAction.parameters.listName}`;
-                    listContext.store.save();
+                    await listContext.store.save();
                 } else {
                     console.log(
                         `List already exists: ${createListAction.parameters.listName}`,
@@ -350,6 +350,8 @@ async function handleListAction(
             }
             break;
         }
+        default:
+            throw new Error(`Unknown action: ${action.actionName}`);
     }
     return result;
 }

--- a/ts/packages/agents/player/src/agent/playerHandlers.ts
+++ b/ts/packages/agents/player/src/agent/playerHandlers.ts
@@ -34,7 +34,7 @@ type PlayerActionContext = {
     searchContext?: SearchMenuContext;
 };
 
-function initializePlayerContext() {
+async function initializePlayerContext() {
     return {
         spotify: undefined,
     };

--- a/ts/packages/agents/player/src/userData.ts
+++ b/ts/packages/agents/player/src/userData.ts
@@ -45,7 +45,7 @@ function getUserDataFilePath() {
 
 async function loadUserData(profileStorage: Storage): Promise<SpotifyUserData> {
     const userDataPath = getUserDataFilePath();
-    if (profileStorage.exists(userDataPath)) {
+    if (await profileStorage.exists(userDataPath)) {
         const content = await profileStorage.read(userDataPath, "utf8");
         const json: SpotifyUserDataJSON = JSON.parse(content);
         return {

--- a/ts/packages/dispatcher/data/config.json
+++ b/ts/packages/dispatcher/data/config.json
@@ -18,7 +18,8 @@
     },
     "list": {
       "type": "module",
-      "name": "list-agent"
+      "name": "list-agent",
+      "execMode": "separate"
     },
     "browser": {
       "type": "module",

--- a/ts/packages/dispatcher/src/action/storageImpl.ts
+++ b/ts/packages/dispatcher/src/action/storageImpl.ts
@@ -27,7 +27,7 @@ export function getStorage(name: string, baseDir: string): Storage {
                 )
                 .map((item) => item.name);
         },
-        exists: (storagePath: string) => {
+        exists: async (storagePath: string) => {
             const fullPath = getFullPath(storagePath);
             return fs.existsSync(fullPath);
         },

--- a/ts/packages/dispatcher/src/agent/agentConfig.ts
+++ b/ts/packages/dispatcher/src/agent/agentConfig.ts
@@ -11,13 +11,21 @@ import { loadInlineAgent } from "./inlineAgentHandlers.js";
 import { createRequire } from "module";
 import path from "node:path";
 
+import { createAgentProcessShim } from "./agentProcessShim.js";
+
 export type InlineDispatcherAgentInfo = {
     type?: undefined;
 } & TopLevelTranslatorConfig;
 
+const enum ExecutionMode {
+    SeparateProcess = "separate",
+    DispatcherProcess = "dispatcher",
+}
+
 export type ModuleDispatcherAgentInfo = {
     type: "module";
     name: string;
+    execMode?: ExecutionMode;
 };
 
 export type AgentInfo = (
@@ -68,13 +76,24 @@ export async function getDispatcherAgentConfigs() {
     return dispatcherAgentConfigs;
 }
 
+function enableExecutionMode() {
+    // TODO: change default
+    return process.env.TYPEAGENT_EXECMODE === "1";
+}
+
 async function loadModuleAgent(
-    config: ModuleDispatcherAgentInfo,
+    info: ModuleDispatcherAgentInfo,
 ): Promise<DispatcherAgent> {
-    const module = await import(`${config.name}/agent/handlers`);
+    // TODO: change default
+    const execMode = info.execMode ?? ExecutionMode.DispatcherProcess;
+    if (enableExecutionMode() && execMode === ExecutionMode.SeparateProcess) {
+        return createAgentProcessShim(`${info.name}/agent/handlers`);
+    }
+
+    const module = await import(`${info.name}/agent/handlers`);
     if (typeof module.instantiate !== "function") {
         throw new Error(
-            `Failed to load module agent ${config.name}: missing 'instantiate' function.`,
+            `Failed to load module agent ${info.name}: missing 'instantiate' function.`,
         );
     }
     return module.instantiate();

--- a/ts/packages/dispatcher/src/agent/agentProcess.ts
+++ b/ts/packages/dispatcher/src/agent/agentProcess.ts
@@ -1,0 +1,294 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import {
+    DispatcherAgent,
+    DispatcherAgentContext,
+    DispatcherAgentIO,
+    Storage,
+    StorageEncoding,
+    StorageListOptions,
+    TokenCachePersistence,
+} from "dispatcher-agent";
+
+import { setupInvoke } from "./agentProcessUtil.js";
+import {
+    AgentContextCallAPI,
+    AgentContextInvokeAPI,
+    AgentInvokeAPI,
+    ContextParams,
+} from "./agentProcessTypes.js";
+import { Action } from "agent-cache";
+
+const modulePath = process.argv[2];
+const module = await import(modulePath);
+if (typeof module.instantiate !== "function") {
+    throw new Error(
+        `Failed to load module agent ${modulePath}: missing 'instantiate' function.`,
+    );
+}
+
+const agent: DispatcherAgent = module.instantiate();
+
+async function agentInvokeHandler(name: string, param: any): Promise<any> {
+    switch (name) {
+        case AgentInvokeAPI.InitializeAgentContext:
+            if (agent.initializeAgentContext === undefined) {
+                throw new Error("Invalid invocation of initializeAgentContext");
+            }
+            const agentContext = await agent.initializeAgentContext?.();
+            return {
+                contextId: registerAgentContext(agentContext),
+            };
+        case AgentInvokeAPI.UpdateAgentContext:
+            if (agent.updateAgentContext === undefined) {
+                throw new Error(
+                    `Invalid invocation of ${AgentInvokeAPI.UpdateAgentContext}`,
+                );
+            }
+            return agent.updateAgentContext(
+                param.enable,
+                getDispatcherAgentContextShim(param),
+                param.translatorName,
+            );
+        case AgentInvokeAPI.ExecuteAction:
+            if (agent.executeAction === undefined) {
+                throw new Error("Invalid invocation of executeAction");
+            }
+            return agent.executeAction(
+                Action.fromJSONObject(param.action),
+                getDispatcherAgentContextShim(param),
+                param.actionIndex,
+            );
+
+        case AgentInvokeAPI.PartialInput:
+            if (agent.partialInput === undefined) {
+                throw new Error("Invalid invocation of partialInput");
+            }
+            return agent.partialInput(
+                param.text,
+                getDispatcherAgentContextShim(param),
+            );
+        case AgentInvokeAPI.ValidateWildcardMatch:
+            if (agent.validateWildcardMatch === undefined) {
+                throw new Error("Invalid invocation of validateWildcardMatch");
+            }
+            return agent.validateWildcardMatch(
+                param.action,
+                getDispatcherAgentContextShim(param),
+            );
+        case AgentInvokeAPI.CloseAgentContext:
+            const result = await agent.closeAgentContext?.(
+                getDispatcherAgentContextShim(param),
+            );
+            unregisterAgentContext(param.agentContextId);
+            return result;
+        default:
+            throw new Error(`Unknown invocation: ${name}`);
+    }
+}
+
+const rpc = setupInvoke<AgentContextInvokeAPI, AgentContextCallAPI>(
+    process,
+    agentInvokeHandler,
+);
+
+function getStorage(contextId: number, session: boolean): Storage {
+    return {
+        read: (
+            storagePath: string,
+            options: StorageEncoding,
+        ): Promise<string> => {
+            return rpc.invoke(AgentContextInvokeAPI.StorageRead, {
+                contextId,
+                session,
+                storagePath,
+                options,
+            });
+        },
+        write: (storagePath: string, data: string): Promise<void> => {
+            return rpc.invoke(AgentContextInvokeAPI.StorageWrite, {
+                contextId,
+                session,
+                storagePath,
+                data,
+            });
+        },
+        list: (
+            storagePath: string,
+            options?: StorageListOptions,
+        ): Promise<string[]> => {
+            return rpc.invoke(AgentContextInvokeAPI.StorageList, {
+                contextId,
+                session,
+                storagePath,
+                options,
+            });
+        },
+        exists: (storagePath: string): Promise<boolean> => {
+            return rpc.invoke(AgentContextInvokeAPI.StorageExists, {
+                contextId,
+                session,
+                storagePath,
+            });
+        },
+        delete: (storagePath: string): Promise<void> => {
+            return rpc.invoke(AgentContextInvokeAPI.StorageDelete, {
+                contextId,
+                session,
+                storagePath,
+            });
+        },
+
+        getTokenCachePersistence: (): Promise<TokenCachePersistence> => {
+            throw new Error("NYI");
+        },
+    };
+}
+
+function createDispatcherAgentContextShim(
+    contextId: number,
+    hasSessionStorage: boolean,
+    context: any,
+): DispatcherAgentContext<any> {
+    const requestIO: DispatcherAgentIO = {
+        type: "text",
+        clear: (): void => {
+            rpc.send(AgentContextCallAPI.AgentIOClear, { contextId });
+        },
+        info: (message: string): void => {
+            rpc.send(AgentContextCallAPI.AgentIOInfo, { contextId, message });
+        },
+        status: (message: string): void => {
+            rpc.send(AgentContextCallAPI.AgentIOStatus, { contextId, message });
+        },
+        success: (message: string): void => {
+            rpc.send(AgentContextCallAPI.AgentIOSuccess, {
+                contextId,
+                message,
+            });
+        },
+        warn: (message: string): void => {
+            rpc.send(AgentContextCallAPI.AgentIOWarn, { contextId, message });
+        },
+        error: (message: string): void => {
+            rpc.send(AgentContextCallAPI.AgentIOError, { contextId, message });
+        },
+        result: (message: string): void => {
+            rpc.send(AgentContextCallAPI.AgentIOResult, { contextId, message });
+        },
+        setActionStatus: (
+            message: string,
+            actionIndex: number,
+            groupId?: string,
+        ): void => {
+            rpc.send(AgentContextCallAPI.SetActionStatus, {
+                contextId,
+                message,
+                actionIndex,
+                groupId,
+            });
+        },
+    };
+    return {
+        context,
+        get currentTranslatorName(): string {
+            throw new Error("NYI");
+        },
+        requestIO,
+        get requestId(): string {
+            throw new Error("NYI");
+        },
+        sessionStorage: hasSessionStorage
+            ? getStorage(contextId, true)
+            : undefined,
+        profileStorage: getStorage(contextId, false),
+        issueCommand: async (command: string): Promise<void> => {
+            return rpc.invoke(AgentContextInvokeAPI.IssueCommand, {
+                contextId,
+                command,
+            });
+        },
+        getAlternativeAgentContext: (name: string): any => {
+            throw new Error("NYI");
+        },
+        getSessionDirPath: (): string | undefined => {
+            throw new Error("NYI");
+        },
+        getUpdateActionStatus: ():
+            | ((message: string, group_id: string) => void)
+            | undefined => {
+            throw new Error("NYI");
+        },
+
+        searchMenuCommand: (
+            menuId: string,
+            command: any, // TODO: Fix the type
+            prefix?: string,
+            choices?: any[], // TODO: Fix the type
+            visible?: boolean,
+        ): void => {
+            throw new Error("NYI");
+        },
+        toggleAgent: async (name: string, enable: boolean): Promise<void> => {
+            return rpc.invoke(AgentContextInvokeAPI.ToggleAgent, {
+                contextId,
+                name,
+                enable,
+            });
+        },
+    };
+}
+
+let nextAgentContextId = 0;
+const agentContexts = new Map<number, any>();
+function registerAgentContext(agentContext: any): number {
+    const agentContextId = nextAgentContextId++;
+    agentContexts.set(agentContextId, agentContext);
+    return agentContextId;
+}
+
+function unregisterAgentContext(agentContextId: number) {
+    agentContexts.delete(agentContextId);
+}
+
+function getAgentContext(agentContextId: number) {
+    const agentContext = agentContexts.get(agentContextId);
+    if (agentContext === undefined) {
+        throw new Error(`Invalid agent context ID: ${agentContextId}`);
+    }
+    return agentContext;
+}
+
+function getDispatcherAgentContextShim(
+    param: Partial<ContextParams>,
+): DispatcherAgentContext {
+    const { contextId, hasSessionStorage, agentContextId } = param;
+    if (contextId === undefined) {
+        throw new Error("Invalid context param: missing contextId");
+    }
+    if (hasSessionStorage === undefined) {
+        throw new Error("Invalid context param: missing hasSessionStorage");
+    }
+
+    const agentContext =
+        agentContextId !== undefined
+            ? getAgentContext(agentContextId)
+            : undefined;
+
+    return createDispatcherAgentContextShim(
+        contextId,
+        hasSessionStorage,
+        agentContext,
+    );
+}
+
+process.send!({
+    type: "initialized",
+    agentInterface: Object.values(AgentInvokeAPI).filter(
+        (a) =>
+            agent[a] !== undefined ||
+            (a === AgentInvokeAPI.CloseAgentContext &&
+                agent.initializeAgentContext !== undefined),
+    ),
+});

--- a/ts/packages/dispatcher/src/agent/agentProcessShim.ts
+++ b/ts/packages/dispatcher/src/agent/agentProcessShim.ts
@@ -1,0 +1,213 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import chlid_process from "child_process";
+import { DispatcherAgent, DispatcherAgentContext } from "dispatcher-agent";
+import {
+    AgentContextCallAPI,
+    AgentContextInvokeAPI,
+    AgentInvokeAPI,
+    ContextParams,
+    ShimContext,
+} from "./agentProcessTypes.js";
+import { setupInvoke } from "./agentProcessUtil.js";
+import { fileURLToPath } from "url";
+
+export async function createAgentProcessShim(
+    modulePath: string,
+): Promise<DispatcherAgent> {
+    const process = chlid_process.fork(
+        fileURLToPath(new URL(`./agentProcess.js`, import.meta.url)),
+        [modulePath],
+    );
+    const agentInterface = await new Promise<AgentInvokeAPI[]>(
+        (resolve, reject) => {
+            process.once("message", (message: any) => {
+                if (message.type === "initialized") {
+                    resolve(message.agentInterface);
+                } else {
+                    reject(new Error(`Unexpected message: ${message.type}`));
+                }
+            });
+        },
+    );
+    let nextContextId = 0;
+    const contextIdMap = new Map<DispatcherAgentContext<ShimContext>, number>();
+    const contextMap = new Map<number, DispatcherAgentContext<ShimContext>>();
+    async function withContext(
+        context: DispatcherAgentContext<ShimContext>,
+        fn: (contextParams: ContextParams) => Promise<any>,
+    ) {
+        let contextId = contextIdMap.get(context);
+        if (contextId === undefined) {
+            contextId = nextContextId++;
+            contextIdMap.set(context, contextId);
+            contextMap.set(contextId, context);
+        }
+
+        return fn({
+            contextId,
+            hasSessionStorage: context.sessionStorage !== undefined,
+            agentContextId: context.context?.contextId,
+        });
+    }
+
+    function getContext(contextId: number) {
+        const context = contextMap.get(contextId);
+        if (context === undefined) {
+            throw new Error(
+                `Internal error: Invalid contextId ${contextId}${contextId < nextContextId ? " used after action" : ""}`,
+            );
+        }
+        return context;
+    }
+    function getStorage(param: any, context: DispatcherAgentContext) {
+        const storage = param.session
+            ? context.sessionStorage
+            : context.profileStorage;
+        if (storage === undefined) {
+            throw new Error("Storage not available");
+        }
+        return storage;
+    }
+
+    async function agentContextInvokeHandler(
+        name: string,
+        param: any,
+    ): Promise<any> {
+        const context = getContext(param.contextId);
+        switch (name) {
+            case AgentContextInvokeAPI.IssueCommand:
+                return context.issueCommand(param.command);
+            case AgentContextInvokeAPI.ToggleAgent:
+                return context.toggleAgent(param.name, param.enable);
+            case AgentContextInvokeAPI.StorageRead:
+                return getStorage(param, context).read(
+                    param.storagePath,
+                    param.options,
+                );
+            case AgentContextInvokeAPI.StorageWrite:
+                return getStorage(param, context).write(
+                    param.storagePath,
+                    param.data,
+                );
+            case AgentContextInvokeAPI.StorageList:
+                return getStorage(param, context).list(
+                    param.storagePath,
+                    param.options,
+                );
+            case AgentContextInvokeAPI.StorageExists:
+                return getStorage(param, context).exists(param.storagePath);
+            case AgentContextInvokeAPI.StorageDelete:
+                return getStorage(param, context).delete(param.storagePath);
+            default:
+                throw new Error(`Unknown invocation: ${name}`);
+        }
+    }
+
+    function agentContextCallHandler(name: string, param: any) {
+        const context = getContext(param.contextId);
+        switch (name) {
+            case AgentContextCallAPI.AgentIOClear:
+                context.requestIO.clear();
+                break;
+            case AgentContextCallAPI.AgentIOInfo:
+                context.requestIO.info(param.message);
+                return;
+            case AgentContextCallAPI.AgentIOStatus:
+                context.requestIO.status(param.message);
+                return;
+            case AgentContextCallAPI.AgentIOSuccess:
+                context.requestIO.success(param.message);
+                return;
+            case AgentContextCallAPI.AgentIOWarn:
+                context.requestIO.warn(param.message);
+                return;
+            case AgentContextCallAPI.AgentIOError:
+                context.requestIO.error(param.message);
+                return;
+            case AgentContextCallAPI.AgentIOResult:
+                context.requestIO.result(param.message);
+                return;
+            default:
+                throw new Error(`Unknown invocation: ${name}`);
+        }
+    }
+
+    const rpc = setupInvoke<AgentInvokeAPI>(
+        process,
+        agentContextInvokeHandler,
+        agentContextCallHandler,
+    );
+
+    const agent: DispatcherAgent = {
+        initializeAgentContext(): Promise<ShimContext> {
+            return rpc.invoke(AgentInvokeAPI.InitializeAgentContext);
+        },
+        updateAgentContext(
+            enable,
+            context: DispatcherAgentContext<ShimContext>,
+            translatorName,
+        ) {
+            return withContext(context, (contextParams) =>
+                rpc.invoke(AgentInvokeAPI.UpdateAgentContext, {
+                    ...contextParams,
+                    enable,
+                    translatorName,
+                }),
+            );
+        },
+        executeAction(
+            action,
+            context: DispatcherAgentContext<ShimContext>,
+            actionIndex,
+        ) {
+            return withContext(context, (contextParams) =>
+                rpc.invoke(AgentInvokeAPI.ExecuteAction, {
+                    ...contextParams,
+                    action,
+                    actionIndex,
+                }),
+            );
+        },
+        partialInput(text, context: DispatcherAgentContext) {
+            return withContext(context, (contextParams) =>
+                rpc.invoke(AgentInvokeAPI.PartialInput, {
+                    ...contextParams,
+                    text,
+                }),
+            );
+        },
+        validateWildcardMatch(action, context: DispatcherAgentContext) {
+            return withContext(context, (contextParams) =>
+                rpc.invoke(AgentInvokeAPI.ValidateWildcardMatch, {
+                    ...contextParams,
+                    action,
+                }),
+            );
+        },
+        closeAgentContext(context: DispatcherAgentContext) {
+            return withContext(context, (contextParams) =>
+                rpc.invoke(AgentInvokeAPI.CloseAgentContext, {
+                    ...contextParams,
+                }),
+            );
+        },
+    };
+
+    const result: DispatcherAgent = Object.fromEntries(
+        agentInterface.map((name) => [name, agent[name]]),
+    );
+
+    const invokeCloseAgentContext = result.closeAgentContext;
+    result.closeAgentContext = async (context) => {
+        const result = await invokeCloseAgentContext?.(context);
+        const contextId = contextIdMap.get(context);
+        if (contextId !== undefined) {
+            contextIdMap.delete(context);
+            contextMap.delete(contextId);
+        }
+        return result;
+    };
+    return result;
+}

--- a/ts/packages/dispatcher/src/agent/agentProcessTypes.ts
+++ b/ts/packages/dispatcher/src/agent/agentProcessTypes.ts
@@ -1,0 +1,53 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+export type ShimContext =
+    | {
+          contextId: number;
+      }
+    | undefined;
+
+export enum AgentInvokeAPI {
+    InitializeAgentContext = "initializeAgentContext",
+    UpdateAgentContext = "updateAgentContext",
+    ExecuteAction = "executeAction",
+    PartialInput = "partialInput",
+    ValidateWildcardMatch = "validateWildcardMatch",
+    CloseAgentContext = "closeAgentContext",
+}
+
+export const enum AgentContextCallAPI {
+    // DispatcherAgentContext
+    AgentIOClear = "agentIOClear",
+    AgentIOInfo = "agentIOInfo",
+    AgentIOStatus = "agentIOStatus",
+    AgentIOSuccess = "agentIOSuccess",
+    AgentIOWarn = "agentIOWarn",
+    AgentIOError = "agentIOError",
+    AgentIOResult = "agentIOResult",
+    SetActionStatus = "agentIOSetActionStatus",
+}
+
+export const enum AgentContextInvokeAPI {
+    // Storage
+    StorageRead = "storageRead",
+    StorageWrite = "storageWrite",
+    StorageList = "storageList",
+    StorageExists = "storageExists",
+    StorageDelete = "storageDelete",
+
+    // Context
+    IssueCommand = "issueCommand",
+    ToggleAgent = "toggleAgent",
+}
+
+export type InitializeMessage = {
+    type: "initialized";
+    agentInterface: AgentInvokeAPI[];
+};
+
+export type ContextParams = {
+    contextId: number;
+    hasSessionStorage: boolean;
+    agentContextId: number | undefined;
+};

--- a/ts/packages/dispatcher/src/agent/agentProcessUtil.ts
+++ b/ts/packages/dispatcher/src/agent/agentProcessUtil.ts
@@ -1,0 +1,149 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { ChildProcess } from "child_process";
+import registerDebug from "debug";
+
+const debug = registerDebug("typeagent:process");
+const debugError = registerDebug("typeagent:process:error");
+
+export function setupInvoke<InvokeNames = string, CallNames = string>(
+    process: ChildProcess | NodeJS.Process,
+    invokeHandler?: (name: string, param?: any) => Promise<any>,
+    callHandler?: (name: string, param?: any) => void,
+) {
+    const pending = new Map<
+        number,
+        {
+            resolve: (result: any) => void;
+            reject: (error: any) => void;
+        }
+    >();
+
+    const cb = (message: any) => {
+        debug("message", message);
+        if (isCallMessage(message)) {
+            if (callHandler === undefined) {
+                debugError("No call handler", message);
+            } else {
+                callHandler(message.name, message.param);
+            }
+            return;
+        }
+        if (isInvokeMessage(message)) {
+            if (invokeHandler === undefined) {
+                process.send!({
+                    type: "invokeError",
+                    callId: message.callId,
+                    error: "No invoke handler",
+                });
+            } else {
+                invokeHandler(message.name, message.param).then(
+                    (result) => {
+                        process.send!({
+                            type: "invokeResult",
+                            callId: message.callId,
+                            result,
+                        });
+                    },
+                    (error) => {
+                        process.send!({
+                            type: "invokeError",
+                            callId: message.callId,
+                            error: error.message,
+                        });
+                    },
+                );
+            }
+            return;
+        }
+        if (!isInvokeResult(message) && !isInvokeError(message)) {
+            return;
+        }
+        const r = pending.get(message.callId);
+        if (r === undefined) {
+            debugError("Invalid callId", message);
+            return;
+        }
+        pending.delete(message.callId);
+        if (isInvokeResult(message)) {
+            r.resolve(message.result);
+        } else {
+            r.reject(new Error(message.error));
+        }
+    };
+    process.on("message", cb);
+    process.once("disconnect", () => {
+        process.off("message", cb);
+    });
+
+    let nextCallId = 0;
+    return {
+        invoke: async function <T = void>(
+            name: InvokeNames,
+            param?: any,
+        ): Promise<T> {
+            const message = {
+                type: "invoke",
+                callId: nextCallId++,
+                name,
+                param,
+            };
+            return new Promise<T>((resolve, reject) => {
+                pending.set(message.callId, { resolve, reject });
+                process.send!(message);
+            });
+        },
+        send: (name: CallNames, param?: any) => {
+            const message = {
+                type: "call",
+                callId: nextCallId++,
+                name,
+                param,
+            };
+            process.send!(message);
+        },
+    };
+}
+
+function isCallMessage(message: any): message is CallMessage {
+    return message.type === "call";
+}
+
+function isInvokeMessage(message: any): message is InvokeMessage {
+    return message.type === "invoke";
+}
+
+function isInvokeResult(message: any): message is InvokeResult {
+    return message.type === "invokeResult";
+}
+
+function isInvokeError(message: any): message is InvokeError {
+    return message.type === "invokeError";
+}
+
+export type CallMessage = {
+    type: "call";
+    callId: number;
+    name: string;
+    param: any;
+};
+
+export type InvokeMessage = {
+    type: "invoke";
+    callId: number;
+    name: string;
+    param: any;
+};
+
+export type InvokeResult<T = void> = {
+    type: "invokeResult";
+    callId: number;
+    result: T;
+};
+
+export type InvokeError = {
+    type: "invokeError";
+    callId: number;
+    error: string;
+};

--- a/ts/packages/dispatcher/src/handlers/common/interactiveIO.ts
+++ b/ts/packages/dispatcher/src/handlers/common/interactiveIO.ts
@@ -88,7 +88,6 @@ function getMessage(input: string | LogFn) {
 
 export interface RequestIO {
     type: "html" | "text";
-    getRequestId(): RequestId;
     clear(): void;
     info(message: string | LogFn): void;
     status(message: string | LogFn): void;
@@ -130,7 +129,6 @@ export function getConsoleRequestIO(
 ): RequestIO {
     return {
         type: "text",
-        getRequestId: () => undefined,
         clear: () => console.clear(),
         info: (input: string | LogFn) => console.info(getMessage(input)),
         status: (input: string | LogFn) =>
@@ -165,7 +163,6 @@ export function getRequestIO(
 ): RequestIO {
     return {
         type: "html",
-        getRequestId: () => requestId,
         clear: () => clientIO.clear(),
         info: (input: string | LogFn) =>
             clientIO.info(getMessage(input), requestId, source),
@@ -208,7 +205,6 @@ export function getRequestIO(
 export function getNullRequestIO(): RequestIO {
     return {
         type: "text",
-        getRequestId: () => undefined,
         clear: () => {},
         info: () => {},
         status: () => {},

--- a/ts/packages/dispatcher/src/handlers/requestCommandHandler.ts
+++ b/ts/packages/dispatcher/src/handlers/requestCommandHandler.ts
@@ -648,13 +648,12 @@ export class RequestCommandHandler implements CommandHandler {
             ? getChatHistoryForTranslation(context)
             : undefined;
         if (history) {
-            let entities = [];
             // prefetch entities here
             context.chatHistory.addEntry(
                 request,
                 [],
                 "user",
-                context.requestIO.getRequestId(),
+                context.requestId,
             );
         }
         const match = await matchRequest(request, context, history);

--- a/ts/packages/dispatcherAgent/src/agentInterface.ts
+++ b/ts/packages/dispatcherAgent/src/agentInterface.ts
@@ -42,7 +42,7 @@ export interface DispatcherActionWithParameters extends DispatcherAction {
 }
 
 export interface DispatcherAgent {
-    initializeAgentContext?(): any;
+    initializeAgentContext?(): Promise<any>;
     updateAgentContext?(
         enable: boolean,
         context: DispatcherAgentContext,
@@ -58,6 +58,7 @@ export interface DispatcherAgent {
         action: DispatcherAction,
         context: DispatcherAgentContext,
     ): Promise<boolean>;
+    closeAgentContext?(context: DispatcherAgentContext): Promise<void>;
 }
 
 export interface DispatcherAgentContext<T = any> {
@@ -102,7 +103,7 @@ export interface Storage {
     read(storagePath: string, options: StorageEncoding): Promise<string>;
     write(storagePath: string, data: string): Promise<void>;
     list(storagePath: string, options?: StorageListOptions): Promise<string[]>;
-    exists(storagePath: string): boolean;
+    exists(storagePath: string): Promise<boolean>;
     delete(storagePath: string): Promise<void>;
 
     getTokenCachePersistence(): Promise<TokenCachePersistence>;
@@ -110,17 +111,16 @@ export interface Storage {
 
 // TODO: review if these should be exposed. Duplicated from dispatcher's interactiveIO.ts
 export type RequestId = string | undefined;
-type LogFn = (log: (message?: string) => void) => void;
+
 export interface DispatcherAgentIO {
     type: "html" | "text";
-    getRequestId(): RequestId;
     clear(): void;
-    info(message: string | LogFn): void;
-    status(message: string | LogFn): void;
-    success(message: string | LogFn): void;
-    warn(message: string | LogFn): void;
-    error(message: string | LogFn): void;
-    result(message: string | LogFn): void;
+    info(message: string): void;
+    status(message: string): void;
+    success(message: string): void;
+    warn(message: string): void;
+    error(message: string): void;
+    result(message: string): void;
 
     // Action status
     setActionStatus(


### PR DESCRIPTION
Enable enough agent interface to be remotely callable via NodeJS RPC to allow `list` agent to run in a separate NodeJS process.

Disabled by default, but can be enabled via `TYPEAGENT_EXECMODE=1` in the env variable for dev purpose.
Not all API is in the right shape or implemented yet.