### PR TITLE
Remove unused agent context API

### DIFF
--- a/ts/packages/agentSdk/src/agentInterface.ts
+++ b/ts/packages/agentSdk/src/agentInterface.ts
@@ -71,8 +71,6 @@ export interface DispatcherAgentContext<T = any> {
     readonly profileStorage: Storage; // storage that are preserved across sessions
     currentTranslatorName: string;
     issueCommand(command: string): Promise<void>;
-    getAlternativeAgentContext<T>(name: string): T;
-    getSessionDirPath(): string | undefined;
     getUpdateActionStatus():
         | ((message: string, group_id: string) => void)
         | undefined;

--- a/ts/packages/dispatcher/src/action/actionHandlers.ts
+++ b/ts/packages/dispatcher/src/action/actionHandlers.ts
@@ -86,12 +86,6 @@ function createDispatcherAgentContext(
         issueCommand(command: string) {
             return processCommandNoLock(command, context);
         },
-        getAlternativeAgentContext(name: string) {
-            return context.action[name];
-        },
-        getSessionDirPath() {
-            return context.session.getSessionDirPath();
-        },
         getUpdateActionStatus() {
             return context.clientIO?.updateActionStatus.bind(context.clientIO);
         },

--- a/ts/packages/dispatcher/src/agent/agentProcess.ts
+++ b/ts/packages/dispatcher/src/agent/agentProcess.ts
@@ -209,12 +209,6 @@ function createDispatcherAgentContextShim(
                 command,
             });
         },
-        getAlternativeAgentContext: (name: string): any => {
-            throw new Error("NYI");
-        },
-        getSessionDirPath: (): string | undefined => {
-            throw new Error("NYI");
-        },
         getUpdateActionStatus: ():
             | ((message: string, group_id: string) => void)
             | undefined => {


### PR DESCRIPTION
`getAlternativeAgentContext` and `getSessionDirPath` is not longer needed.