### PR TITLE
Introduce transient app agents

### DIFF
--- a/ts/packages/agentSdk/src/agentInterface.ts
+++ b/ts/packages/agentSdk/src/agentInterface.ts
@@ -8,6 +8,7 @@ export type TopLevelTranslatorConfig = {
 export type HierarchicalTranslatorConfig = {
     defaultEnabled?: boolean;
     actionDefaultEnabled?: boolean;
+    transient?: boolean; // whether the translator is transient, default is false
     schema?: {
         description: string;
         schemaFile: string;
@@ -80,9 +81,10 @@ export interface SessionContext<T = any> {
     readonly requestId: RequestId;
     readonly sessionStorage: Storage | undefined;
     readonly profileStorage: Storage; // storage that are preserved across sessions
-    currentTranslatorName: string;
+
+    // can only toggle the sub agent of the current agent
+    toggleTransientAgent(agentName: string, active: boolean): Promise<void>;
     issueCommand(command: string): Promise<void>;
-    toggleAgent(name: string, enable: boolean): Promise<void>;
 }
 
 // TODO: only utf8 is supported for now.

--- a/ts/packages/agents/browser/src/agent/browserActionHandler.mts
+++ b/ts/packages/agents/browser/src/agent/browserActionHandler.mts
@@ -81,20 +81,11 @@ async function updateBrowserContext(
                   await getBoardSchema(context);
                 sendSiteTranslatorStatus(data.body, "initialized", context);
               }
-
-              if (context.currentTranslatorName !== data.body) {
-                await context.toggleAgent(data.body, true);
-
-                context.currentTranslatorName = data.body;
-              }
+              await context.toggleTransientAgent(data.body, true);
               break;
             }
             case "disableSiteTranslator": {
-              if (context.currentTranslatorName == data.body) {
-                await context.toggleAgent(data.body, false);
-
-                context.currentTranslatorName = "browser";
-              }
+              await context.toggleTransientAgent(data.body, false);
               break;
             }
             case "confirmAction": {

--- a/ts/packages/agents/browser/src/agent/browserConnector.mts
+++ b/ts/packages/agents/browser/src/agent/browserConnector.mts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import { WebSocketMessage } from "common-utils";
-import { SessionContext } from "@typeagent/agent-sdk";
+import { AppAction, SessionContext } from "@typeagent/agent-sdk";
 import { BrowserActionContext } from "./browserActionHandler.mjs";
 
 export class BrowserConnector {
@@ -14,7 +14,7 @@ export class BrowserConnector {
     this.webSocket = context.agentContext.webSocket;
   }
 
-  async sendActionToBrowser(action: any, messageType?: string) {
+  async sendActionToBrowser(action: AppAction, messageType?: string) {
     return new Promise<string | undefined>((resolve, reject) => {
       if (this.webSocket) {
         try {
@@ -26,8 +26,8 @@ export class BrowserConnector {
             requestId = new Date().getTime().toString();
           }
           if (!messageType) {
-            if (this.context.currentTranslatorName.startsWith("browser.")) {
-              messageType = `siteTranslatedAction_${this.context.currentTranslatorName.substring(8)}`;
+            if (action.translatorName!.startsWith("browser.")) {
+              messageType = `siteTranslatedAction_${action.translatorName!.substring(8)}`;
             } else {
               messageType = "translatedAction";
             }

--- a/ts/packages/agents/browser/src/agent/browserManifest.json
+++ b/ts/packages/agents/browser/src/agent/browserManifest.json
@@ -11,6 +11,7 @@
     "paleoBioDb": {
       "defaultEnabled": false,
       "actionDefaultEnabled": false,
+      "transient": true,
       "schema": {
         "description": "This enables users to explore paleological data. Users can filter fossil data by location, by geological time and by taxon.",
         "schemaFile": "./paleoBioDb/paleoBioDbSchema.mts",
@@ -20,6 +21,7 @@
     "crossword": {
       "defaultEnabled": false,
       "actionDefaultEnabled": false,
+      "transient": true,
       "schema": {
         "description": "This allows users to interact with a crossword puzzle.",
         "schemaFile": "./crossword/schema/userActions.mts",
@@ -29,6 +31,7 @@
     "commerce": {
       "defaultEnabled": false,
       "actionDefaultEnabled": false,
+      "transient": true,
       "schema": {
         "description": "This allows users to interact with e-commerce websites to find, compare and purchase various products.",
         "schemaFile": "./commerce/schema/userActions.mts",

--- a/ts/packages/agents/browser/src/serviceWorker.ts
+++ b/ts/packages/agents/browser/src/serviceWorker.ts
@@ -73,15 +73,15 @@ async function ensureWebsocketConnected() {
         const data = JSON.parse(text) as WebSocketMessage;
         if (data.target == "browser") {
             if (data.messageType == "translatedAction") {
-                const respose = await runBrowserAction(data.body);
-                if (respose.data) {
+                const response = await runBrowserAction(data.body);
+                if (response.data) {
                     webSocket.send(
                         JSON.stringify({
                             source: data.target,
                             target: data.source,
                             messageType: "confirmActionWithData",
                             id: data.id,
-                            body: respose,
+                            body: response,
                         }),
                     );
                 } else {
@@ -91,7 +91,7 @@ async function ensureWebsocketConnected() {
                             target: data.source,
                             messageType: "confirmAction",
                             id: data.id,
-                            body: respose.message,
+                            body: response.message,
                         }),
                     );
                 }

--- a/ts/packages/cache/src/explanation/typeChatAgent.ts
+++ b/ts/packages/cache/src/explanation/typeChatAgent.ts
@@ -25,7 +25,7 @@ export type TypeChatAgentResult<T extends object = object> =
     | TypeChatAgentSuccess<T>
     | TypeChatAgentError;
 
-const debugAgent = registerDebug("typeagent:agent:correction");
+const debugAgent = registerDebug("typeagent:typechatagent:correction");
 
 export type ValidationError = string | string[];
 

--- a/ts/packages/cacheExplorer/src/site/index.ts
+++ b/ts/packages/cacheExplorer/src/site/index.ts
@@ -234,7 +234,7 @@ async function loadConstructionCache(session: string, cacheName: string) {
             `Failed to load construction cache: ${content.statusText}`,
         );
     }
-    const cacheData = (await content.json()) as any;
+    const cacheData = await content.json();
     return ConstructionCache.fromJSON(cacheData);
 }
 

--- a/ts/packages/dispatcher/src/agent/agentProcess.ts
+++ b/ts/packages/dispatcher/src/agent/agentProcess.ts
@@ -189,9 +189,6 @@ function createSessionContextShim(
     };
     return {
         agentContext: context,
-        get currentTranslatorName(): string {
-            throw new Error("NYI");
-        },
         agentIO,
         get requestId(): string {
             throw new Error("NYI");
@@ -206,8 +203,11 @@ function createSessionContextShim(
                 command,
             });
         },
-        toggleAgent: async (name: string, enable: boolean): Promise<void> => {
-            return rpc.invoke(AgentContextInvokeAPI.ToggleAgent, {
+        toggleTransientAgent: async (
+            name: string,
+            enable: boolean,
+        ): Promise<void> => {
+            return rpc.invoke(AgentContextInvokeAPI.ToggleTransientAgent, {
                 contextId,
                 name,
                 enable,

--- a/ts/packages/dispatcher/src/agent/agentProcessShim.ts
+++ b/ts/packages/dispatcher/src/agent/agentProcessShim.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import chlid_process from "child_process";
+import child_process from "child_process";
 import { AppAgent, ActionContext, SessionContext } from "@typeagent/agent-sdk";
 import {
     AgentCallAPI,
@@ -54,7 +54,7 @@ function createContextMap<T>() {
 export async function createAgentProcessShim(
     modulePath: string,
 ): Promise<AppAgent> {
-    const process = chlid_process.fork(
+    const process = child_process.fork(
         fileURLToPath(new URL(`./agentProcess.js`, import.meta.url)),
         [modulePath],
     );
@@ -118,8 +118,8 @@ export async function createAgentProcessShim(
         switch (name) {
             case AgentContextInvokeAPI.IssueCommand:
                 return context.issueCommand(param.command);
-            case AgentContextInvokeAPI.ToggleAgent:
-                return context.toggleAgent(param.name, param.enable);
+            case AgentContextInvokeAPI.ToggleTransientAgent:
+                return context.toggleTransientAgent(param.name, param.enable);
             case AgentContextInvokeAPI.StorageRead:
                 return getStorage(param, context).read(
                     param.storagePath,

--- a/ts/packages/dispatcher/src/agent/agentProcessTypes.ts
+++ b/ts/packages/dispatcher/src/agent/agentProcessTypes.ts
@@ -43,7 +43,7 @@ export const enum AgentContextInvokeAPI {
 
     // Context
     IssueCommand = "issueCommand",
-    ToggleAgent = "toggleAgent",
+    ToggleTransientAgent = "toggleTransientAgent",
 }
 
 export type InitializeMessage = {

--- a/ts/packages/dispatcher/src/handlers/common/interactiveIO.ts
+++ b/ts/packages/dispatcher/src/handlers/common/interactiveIO.ts
@@ -5,6 +5,7 @@ import { askYesNo } from "../../utils/interactive.js";
 import readline from "readline/promises";
 import { SearchMenuItem, ActionTemplateSequence, Profiler } from "common-utils";
 import chalk from "chalk";
+import { DispatcherName } from "../requestCommandHandler.js";
 import { CommandHandlerContext } from "./commandHandlerContext.js";
 
 export type RequestId = string | undefined;
@@ -107,12 +108,12 @@ export interface RequestIO {
     context: CommandHandlerContext | undefined;
     getRequestId(): RequestId;
     clear(): void;
-    info(message: string | LogFn): void;
-    status(message: string | LogFn): void;
-    success(message: string | LogFn): void;
-    warn(message: string | LogFn): void;
-    error(message: string | LogFn): void;
-    result(message: string | LogFn): void;
+    info(message: string | LogFn, source?: string): void;
+    status(message: string | LogFn, source?: string): void;
+    success(message: string | LogFn, source?: string): void;
+    warn(message: string | LogFn, source?: string): void;
+    error(message: string | LogFn, source?: string): void;
+    result(message: string | LogFn, source?: string): void;
 
     // Action status
     setActionStatus(message: string, actionIndex: number, source: string): void;
@@ -193,14 +194,13 @@ export function getRequestIO(
     context: CommandHandlerContext | undefined,
     clientIO: ClientIO,
     requestId: RequestId,
-    source: string,
 ): RequestIO {
     return {
         type: "html",
         context: context,
         getRequestId: () => requestId,
         clear: () => clientIO.clear(),
-        info: (input: string | LogFn) =>
+        info: (input: string | LogFn, source: string = DispatcherName) =>
             clientIO.info(
                 makeClientIOMessage(
                     context,
@@ -209,7 +209,7 @@ export function getRequestIO(
                     source,
                 ),
             ),
-        status: (input: string | LogFn) =>
+        status: (input: string | LogFn, source: string = DispatcherName) =>
             clientIO.status(
                 makeClientIOMessage(
                     context,
@@ -218,7 +218,7 @@ export function getRequestIO(
                     source,
                 ),
             ),
-        success: (input: string | LogFn) =>
+        success: (input: string | LogFn, source: string = DispatcherName) =>
             clientIO.success(
                 makeClientIOMessage(
                     context,
@@ -227,7 +227,7 @@ export function getRequestIO(
                     source,
                 ),
             ),
-        warn: (input: string | LogFn) =>
+        warn: (input: string | LogFn, source: string = DispatcherName) =>
             clientIO.warn(
                 makeClientIOMessage(
                     context,
@@ -236,7 +236,7 @@ export function getRequestIO(
                     source,
                 ),
             ),
-        error: (input: string | LogFn) =>
+        error: (input: string | LogFn, source: string = DispatcherName) =>
             clientIO.error(
                 makeClientIOMessage(
                     context,
@@ -245,7 +245,7 @@ export function getRequestIO(
                     source,
                 ),
             ),
-        result: (input: string | LogFn) =>
+        result: (input: string | LogFn, source: string = DispatcherName) =>
             clientIO.result(
                 makeClientIOMessage(
                     context,

--- a/ts/packages/dispatcher/src/session/session.ts
+++ b/ts/packages/dispatcher/src/session/session.ts
@@ -286,11 +286,6 @@ export class Session {
         this.cacheData = sessionData.cacheData;
     }
 
-    public get useTranslators() {
-        return Object.entries(this.config.translators)
-            .filter(([, value]) => value)
-            .map(([name]) => name);
-    }
     public get explainerName() {
         return this.config.explainerName;
     }

--- a/ts/packages/shell/src/main/index.ts
+++ b/ts/packages/shell/src/main/index.ts
@@ -405,7 +405,7 @@ app.whenReady().then(async () => {
     function translatorSetPartialInputHandler() {
         mainWindow?.webContents.send(
             "set-partial-input-handler",
-            context.currentTranslatorName === "player",
+            context.lastActionTranslatorName === "player",
         );
     }
 

--- a/ts/packages/shell/src/renderer/src/chatView.ts
+++ b/ts/packages/shell/src/renderer/src/chatView.ts
@@ -487,7 +487,7 @@ export function setSource(
 
 export function updateMetrics(div: HTMLDivElement, metrics?: IMessageMetrics) {
     if (metrics) {
-        // clear out previous perf datanpm
+        // clear out previous perf data
         div.innerHTML = "";
 
         let timeDiv = document.createElement("div");
@@ -1005,7 +1005,7 @@ export class ChatView {
                         source: source,
                         actionIndex: actionIndex,
                     },
-                    false,
+                    true,
                 );
                 if (result.nextRefreshMs !== -1) {
                     this.dynamicDisplays.push({
@@ -1032,7 +1032,7 @@ export class ChatView {
                         source: source,
                         actionIndex: actionIndex,
                     },
-                    false,
+                    true,
                 );
             }
 
@@ -1106,13 +1106,13 @@ export class ChatView {
         }
     }
 
-    addAgentMessage(msg: IAgentMessage, focus = true) {
+    addAgentMessage(msg: IAgentMessage, dynamicUpdate = false) {
         const text: string = msg.message;
         const source: string = msg.source;
 
         const messageContainer = this.ensureAgentMessage(
             msg,
-            focus,
+            !dynamicUpdate,
         ) as HTMLDivElement;
         const message = messageContainer.lastChild
             ?.previousSibling as HTMLDivElement;
@@ -1122,12 +1122,12 @@ export class ChatView {
 
         setSource(messageContainer, source, this.agents);
         setContent(message, text);
-        updateMetrics(
-            messageContainer.lastChild as HTMLDivElement,
-            msg.metrics,
-        );
 
-        if (focus) {
+        if (!dynamicUpdate) {
+            updateMetrics(
+                messageContainer.lastChild as HTMLDivElement,
+                msg.metrics,
+            );
             this.chatInputFocus();
         }
     }


### PR DESCRIPTION
- Sub agent like paliodb, crosswords, etc. only is active if the web page is opened.  Before, it just toggles the agent directory, overwriting the user setting.   Introduce a runtime state for transient agent to set whether it is active or not, separate from whether the user has enable/disable them.
  - remove the need to expose "currentTranslatorName" to the agent's session context. (One less "NYI" to run separate process)
  - Also add a lock to make sure we don't change the state while we are servicing a request int he toggle.
- Fix the `currentTranslatorName` getting overwritten on every request.  The state is meant to record what is the last translator use so we will try to resolve the next request first.
- Improve the "source" agent for status messages,  it shouldn't get bound to the current translator's name (or dispatcher).  Now it defaults to dispatcher, but get passed in during translation using the translator that is currently trying.
- Fix the bug where the metric disappear on dynamic displays.