### PR TITLE
Improve desktop agent usability.

### DIFF
--- a/ts/packages/agents/desktop/README.md
+++ b/ts/packages/agents/desktop/README.md
@@ -9,18 +9,19 @@ This project has two components
    - Launch Visual Studio
    - Open the repo directory [dotnet/autoShell](../../../../dotnet/autoShell/) folder. Build this project.
 
-2. The node process that integrates with TypeAgent. To build this:
-   - Go to the repo directory [ts/packages/agents/desktop](./) folder.
+2. App Agent for TypeAgent that sends actions to the .NET code:
+   - Go to the repo directory [ts/packages/agents/desktop](./) folder (current).
    - Run `pnpm run build`
 
 ## Running the automation
 
-1. In the repo directory [ts/packages/agents/desktop](./), run `pnpm run start`
-2. Launch the [TypeAgent Shell](../../shell) or the [TypeAgent CLI](../../cli). These are integrated with the automation agent and can send commands. You can issue commands from this interface such as:
-   - launch calculator
-   - maximize calculator
-   - tile calculator to the left and chrome to the right
-   - etc.
+Launch the [TypeAgent Shell](../../shell) or the [TypeAgent CLI](../../cli) and enable the app agent with command `@config agent desktop`.
+You can issue commands from these interfaces such as:
+
+- launch calculator
+- maximize calculator
+- tile calculator to the left and chrome to the right
+- etc.
 
 ## Trademarks
 

--- a/ts/packages/agents/desktop/package.json
+++ b/ts/packages/agents/desktop/package.json
@@ -16,15 +16,11 @@
     "./agent/manifest": "./src/agent/desktopManifest.json",
     "./agent/handlers": "./dist/agent/desktopActionHandler.js"
   },
-  "main": "dist/main.js",
   "scripts": {
     "build": "npm run tsc",
-    "postbuild": "copyfiles -u 1 \"src/**/*.txt\" \"src/**/*.html\" dist",
     "clean": "rimraf --glob dist *.tsbuildinfo *.done.build.log",
-    "dev": "tsx src/main.ts",
     "prettier": "prettier --check . --ignore-path ../../../.prettierignore",
     "prettier:fix": "prettier --write . --ignore-path ../../../.prettierignore",
-    "start": "node dist/main.js",
     "tsc": "tsc -p src"
   },
   "dependencies": {

--- a/ts/packages/agents/desktop/src/main.ts
+++ b/ts/packages/agents/desktop/src/main.ts
@@ -1,155 +1,120 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { ChildProcess, spawn } from "child_process";
+import child_process from "node:child_process";
 import { fileURLToPath } from "node:url";
-import {
-    ProgramNameIndex,
-    createProgramNameIndex,
-} from "./programNameIndex.js";
+import { ProgramNameIndex, loadProgramNameIndex } from "./programNameIndex.js";
+import { AppActionWithParameters, Storage } from "@typeagent/agent-sdk";
+import registerDebug from "debug";
 
-import {
-    WebSocketMessage,
-    createWebSocket,
-    keepWebSocketAlive,
-} from "common-utils";
+const debug = registerDebug("typeagent:desktop");
+const debugData = registerDebug("typeagent:desktop:data");
+const debugError = registerDebug("typeagent:desktop:error");
 
-import WebSocket from "ws";
-import dotenv from "dotenv";
-import findConfig from "find-config";
-import assert from "assert";
-import { processRequests } from "typechat/interactive";
+export type DesktopActionContext = {
+    desktopProcess: child_process.ChildProcess | undefined;
+    programNameIndex: ProgramNameIndex | undefined;
+    refreshPromise: Promise<void> | undefined;
+    abortRefresh: AbortController | undefined;
+};
 
-const envPath = findConfig(".env");
-assert(envPath, ".env file not found!");
-dotenv.config({ path: envPath });
+const autoShellPath = new URL(
+    "../../../../../dotnet/autoShell/bin/Debug/autoShell.exe",
+    import.meta.url,
+);
 
-let desktopProcess: ChildProcess | null;
-let webSocket: any = null;
-let programNameIndex: ProgramNameIndex;
-
-function spawnAutomationProcess() {
-    const autoShellPath = new URL(
-        "../../../../../dotnet/autoShell/bin/Debug/autoShell.exe",
-        import.meta.url,
-    );
-    const child = spawn(fileURLToPath(autoShellPath));
-
-    resetEventHandlers(child);
-
-    child.on("exit", (code) => {
-        console.log(`Child exited with code ${code}`);
-        desktopProcess = null;
+async function spawnAutomationProcess() {
+    return new Promise<child_process.ChildProcess>((resolve, reject) => {
+        const child = child_process.spawn(fileURLToPath(autoShellPath));
+        child.on("error", (err) => {
+            reject(err);
+        });
+        child.on("spawn", () => {
+            resolve(child);
+        });
     });
-
-    return child;
 }
 
-function resetEventHandlers(child: ChildProcess) {
+async function ensureAutomationProcess(agentContext: DesktopActionContext) {
+    if (agentContext.desktopProcess !== undefined) {
+        return agentContext.desktopProcess;
+    }
+
+    const child = await spawnAutomationProcess();
+    child.on("exit", (code) => {
+        debug(`Child exited with code ${code}`);
+        agentContext.desktopProcess = undefined;
+    });
+
+    // For tracing
     child.stdout?.on("data", (data) => {
-        console.log(data.toString());
+        debugData(`Process data: ${data.toString()}`);
     });
 
     child.stderr?.on("error", (data) => {
-        console.error(data.toString());
+        debugError(`Process error: ${data.toString()}`);
     });
+
+    agentContext.desktopProcess = child;
+    return child;
 }
 
-async function ensureWebsocketConnected() {
-    if (webSocket && webSocket.readyState === WebSocket.OPEN) {
-        return;
-    }
-
-    webSocket = await createWebSocket();
-    if (!webSocket) {
-        return;
-    }
-
-    webSocket.binaryType = "blob";
-    keepWebSocketAlive(webSocket, "desktop");
-
-    webSocket.onmessage = async (event: any) => {
-        const text = event.data.toString();
-        const data = JSON.parse(text) as WebSocketMessage;
-        if (data.target == "desktop") {
-            if (data.messageType == "desktopActionRequest") {
-                const message = await runDesktopActions(data.body.action);
-
-                webSocket.send(
-                    JSON.stringify({
-                        source: data.target,
-                        target: data.source,
-                        messageType: "desktopActionResponse",
-                        body: {
-                            actionContextId: data.body.callId,
-                            message,
-                        },
-                    }),
-                );
-            }
-
-            console.log(`Desktop websocket client received message: ${text}`);
-        }
-    };
-
-    webSocket.onclose = (event: any) => {
-        console.log("websocket connection closed");
-        webSocket = undefined;
-        reconnectWebSocket();
-    };
-}
-
-export function reconnectWebSocket() {
-    const connectionCheckIntervalId = setInterval(async () => {
-        if (webSocket && webSocket.readyState === WebSocket.OPEN) {
-            console.log("Clearing reconnect retry interval");
-            clearInterval(connectionCheckIntervalId);
-        } else {
-            console.log("Retrying connection");
-            await ensureWebsocketConnected();
-        }
-    }, 5 * 1000);
-}
-
-async function runDesktopActions(action: any) {
+export async function runDesktopActions(
+    action: AppActionWithParameters,
+    agentContext: DesktopActionContext,
+) {
     let confirmationMessage = "OK";
-    if (!desktopProcess) {
-        desktopProcess = spawnAutomationProcess();
-    }
-
     let actionData = "";
-    const actionName =
-        action.actionName ?? action.fullActionName.split(".").at(-1);
+    const actionName = action.actionName;
     switch (actionName) {
         case "launchProgram": {
-            actionData = await mapInputToAppName(action.parameters.name);
+            actionData = await mapInputToAppName(
+                action.parameters.name,
+                agentContext,
+            );
             confirmationMessage = "Launched " + action.parameters.name;
             break;
         }
         case "closeProgram": {
-            actionData = await mapInputToAppName(action.parameters.name);
+            actionData = await mapInputToAppName(
+                action.parameters.name,
+                agentContext,
+            );
             confirmationMessage = "Closed " + action.parameters.name;
             break;
         }
         case "maximize": {
-            actionData = await mapInputToAppName(action.parameters.name);
+            actionData = await mapInputToAppName(
+                action.parameters.name,
+                agentContext,
+            );
             confirmationMessage = "Maximized " + action.parameters.name;
             break;
         }
         case "minimize": {
-            actionData = await mapInputToAppName(action.parameters.name);
+            actionData = await mapInputToAppName(
+                action.parameters.name,
+                agentContext,
+            );
             confirmationMessage = "Minimized " + action.parameters.name;
             break;
         }
         case "switchTo": {
-            actionData = await mapInputToAppName(action.parameters.name);
+            actionData = await mapInputToAppName(
+                action.parameters.name,
+                agentContext,
+            );
             confirmationMessage = "Switched to " + action.parameters.name;
             break;
         }
         case "tile": {
-            const left = await mapInputToAppName(action.parameters.leftWindow);
+            const left = await mapInputToAppName(
+                action.parameters.leftWindow,
+                agentContext,
+            );
             const right = await mapInputToAppName(
                 action.parameters.rightWindow,
+                agentContext,
             );
             actionData = `${left},${right}`;
             confirmationMessage = `Tiled ${left} on the left and ${right} on the right`;
@@ -176,12 +141,14 @@ async function runDesktopActions(action: any) {
     // send message to child process
     let message: Record<string, string> = {};
     message[actionName] = actionData;
+
+    const desktopProcess = await ensureAutomationProcess(agentContext);
     desktopProcess.stdin?.write(JSON.stringify(message) + "\r\n");
 
     return confirmationMessage;
 }
 
-async function fetchInstalledApps() {
+async function fetchInstalledApps(desktopProcess: child_process.ChildProcess) {
     let timeoutHandle: NodeJS.Timeout;
 
     const timeoutPromise = new Promise<undefined>((_resolve, reject) => {
@@ -189,27 +156,28 @@ async function fetchInstalledApps() {
     });
 
     const appsPromise = new Promise<string[] | undefined>((resolve, reject) => {
-        if (!desktopProcess) {
-            resolve(undefined);
-            return;
-        }
-
         let message: Record<string, string> = {};
         message["listAppNames"] = "";
 
         let allOutput = "";
-        desktopProcess.stdout?.on("data", (data) => {
+        const dataCallBack = (data: any) => {
             allOutput += data.toString();
             try {
                 const programs = JSON.parse(allOutput);
+                desktopProcess.stdout?.off("data", dataCallBack);
+                desktopProcess.stderr?.off("error", errorCallback);
                 resolve(programs);
             } catch {}
-        });
+        };
 
-        desktopProcess.stderr?.on("error", (data) => {
-            console.error(data.toString());
-            resolve(undefined);
-        });
+        const errorCallback = (data: any) => {
+            desktopProcess.stdout?.off("data", dataCallBack);
+            desktopProcess.stderr?.off("error", errorCallback);
+            reject(data.toString());
+        };
+
+        desktopProcess.stdout?.on("data", dataCallBack);
+        desktopProcess.stderr?.on("error", errorCallback);
 
         desktopProcess.stdin?.write(JSON.stringify(message) + "\r\n");
     });
@@ -220,44 +188,128 @@ async function fetchInstalledApps() {
     });
 }
 
-async function mapInputToAppName(input: string): Promise<string> {
-    const matchedNames = await programNameIndex.search(input, 1);
+async function finishRefresh(agentContext: DesktopActionContext) {
+    if (agentContext.refreshPromise !== undefined) {
+        await agentContext.refreshPromise;
+        agentContext.refreshPromise = undefined;
+        return true;
+    }
+    return false;
+}
+
+async function mapInputToAppNameFromIndex(
+    input: string,
+    programNameIndex: ProgramNameIndex,
+): Promise<string | undefined> {
+    let matchedNames = await programNameIndex.search(input, 1);
     if (matchedNames && matchedNames.length > 0) {
         return matchedNames[0].item.value;
     }
+    return undefined;
+}
 
+async function mapInputToAppName(
+    input: string,
+    agentContext: DesktopActionContext,
+): Promise<string> {
+    const programNameIndex = agentContext.programNameIndex;
+    if (programNameIndex) {
+        let matchedNames = await mapInputToAppNameFromIndex(
+            input,
+            programNameIndex,
+        );
+        if (matchedNames === undefined && (await finishRefresh(agentContext))) {
+            matchedNames = await mapInputToAppNameFromIndex(
+                input,
+                programNameIndex,
+            );
+        }
+    }
     return input;
 }
 
-// Setup
-const initializeApp = async () => {
-    const vals = {};
-    dotenv.config({ path: envPath, processEnv: vals });
-    programNameIndex = createProgramNameIndex(vals);
-    desktopProcess = spawnAutomationProcess();
-    const programs = await fetchInstalledApps();
+const programNameIndexPath = "programNameIndex.json";
+
+async function readProgramNameIndex(storage?: Storage) {
+    if (storage !== undefined) {
+        try {
+            if (await storage.exists(programNameIndexPath)) {
+                const index = await storage.read(programNameIndexPath, "utf8");
+                return index ? JSON.parse(index) : undefined;
+            }
+        } catch (e: any) {
+            debugError(`Unable to read program name index ${e.message}`);
+        }
+    }
+    return undefined;
+}
+
+async function ensureProgramNameIndex(
+    agentContext: DesktopActionContext,
+    storage?: Storage,
+) {
+    if (agentContext.programNameIndex === undefined) {
+        const json = await readProgramNameIndex(storage);
+        const programNameIndex = loadProgramNameIndex(process.env, json);
+        agentContext.programNameIndex = programNameIndex;
+        agentContext.refreshPromise = refreshInstalledApps(
+            agentContext,
+            programNameIndex,
+            storage,
+        );
+    }
+}
+
+export async function setupDesktopActionContext(
+    agentContext: DesktopActionContext,
+    storage: Storage,
+) {
+    await ensureAutomationProcess(agentContext);
+    return ensureProgramNameIndex(agentContext, storage);
+}
+
+export async function disableDesktopActionContext(
+    agentContext: DesktopActionContext,
+) {
+    if (agentContext.desktopProcess) {
+        agentContext.desktopProcess.kill();
+    }
+    if (agentContext.abortRefresh) {
+        agentContext.abortRefresh?.abort();
+    }
+    if (agentContext.refreshPromise) {
+        await agentContext.refreshPromise;
+        agentContext.refreshPromise = undefined;
+    }
+}
+
+async function refreshInstalledApps(
+    agentContext: DesktopActionContext,
+    programNameIndex: ProgramNameIndex,
+    storage?: Storage,
+) {
+    if (agentContext.abortRefresh !== undefined) {
+        return;
+    }
+
+    const abortRefresh = new AbortController();
+    agentContext.abortRefresh = abortRefresh;
+    debug("Refreshing installed apps");
+
+    const desktopProcess = await ensureAutomationProcess(agentContext);
+    const programs = await fetchInstalledApps(desktopProcess);
     if (programs) {
         for (const element of programs) {
+            if (abortRefresh.signal.aborted) {
+                return;
+            }
             await programNameIndex.addOrUpdate(element);
         }
     }
-
-    resetEventHandlers(desktopProcess);
-
-    await ensureWebsocketConnected();
-    if (!webSocket) {
-        console.log("Websocket service not found. Will retry in 5 seconds");
-        reconnectWebSocket();
-    }
-};
-
-initializeApp();
-
-processRequests("🖥️> ", process.argv[2], async (request) => {
-    if (request.toLowerCase() === "websocket on") {
-        await ensureWebsocketConnected();
-        if (!webSocket) {
-            reconnectWebSocket();
-        }
-    }
-});
+    await storage?.write(
+        programNameIndexPath,
+        JSON.stringify(programNameIndex.toJSON()),
+    );
+    debug("Finish refreshing installed apps");
+    agentContext.abortRefresh = undefined;
+}

--- a/ts/packages/dispatcher/src/handlers/configCommandHandlers.ts
+++ b/ts/packages/dispatcher/src/handlers/configCommandHandlers.ts
@@ -120,12 +120,14 @@ class AgentToggleCommandHandler implements CommandHandler {
             context,
         );
 
-        const changedEntries = Object.entries(changed);
+        const changedEntries = Object.entries(changed).filter(
+            ([_, value]) => value !== undefined,
+        );
         if (changedEntries.length === 0) {
             context.requestIO.warn("No change");
         } else {
             const lines: string[] = [];
-            for (const [kind, options] of Object.entries(changed)) {
+            for (const [kind, options] of changedEntries) {
                 lines.push(`Changes (${kind}):`);
                 for (const [name, value] of Object.entries(options as any)) {
                     lines.push(`  ${name}: ${value ? "enabled" : "disabled"}`);

--- a/ts/packages/shell/src/main/index.ts
+++ b/ts/packages/shell/src/main/index.ts
@@ -165,7 +165,9 @@ function showResult(message: IAgentMessage) {
 function sendStatusMessage(message: IAgentMessage, temporary: boolean = false) {
     // Ignore message without requestId
     if (message.requestId === undefined) {
-        console.warn(`sendStatusMessage: requestId is undefined. ${message}`);
+        console.warn(
+            `sendStatusMessage: requestId is undefined. ${message.message}`,
+        );
         return;
     }
     mainWindow?.webContents.send("status-message", message, temporary);


### PR DESCRIPTION
Usability improvement for the desktop agent.
- desktop app agent automatically start the `autoShell` process without a extra step of `pnpm run start` in the desktop directory.
  - Currently, there is no reason that the desktop controller (`autoShell`) needs to be a singleton process.
  - Remove the websocket shim, and just implement the agent to directly manage it's only `autoShell` process.
- Automatically error and disable desktop agent if `autoShell` isn't built. 
- Save the program name index embedding to be reuse later in the typeagent profile storage. (i.e. shared across sessions), instead of recalculating it on every launch



