### PR TITLE
Remove requestId access in agents

### DIFF
--- a/ts/examples/siteSchemas/src/common/connector.ts
+++ b/ts/examples/siteSchemas/src/common/connector.ts
@@ -130,14 +130,14 @@ export class BrowserConnector {
                 try {
                     messageType = messageType ?? this.siteTranslatedActionName;
 
-                    const requestId = new Date().getTime().toString();
+                    const callId = new Date().getTime().toString();
 
                     this.webSocket.send(
                         JSON.stringify({
                             source: this.siteClientName,
                             target: "browser",
                             messageType: messageType,
-                            id: requestId,
+                            id: callId,
                             body: action,
                         }),
                     );
@@ -149,7 +149,7 @@ export class BrowserConnector {
                             data.target == this.siteClientName &&
                             data.source == "browser" &&
                             data.messageType == "browserActionResponse" &&
-                            data.id == requestId &&
+                            data.id == callId &&
                             data.body
                         ) {
                             this.webSocket.removeEventListener(

--- a/ts/packages/agentSdk/src/agentInterface.ts
+++ b/ts/packages/agentSdk/src/agentInterface.ts
@@ -78,7 +78,6 @@ export interface SessionContext<T = any> {
 
     // TODO: review if these should be exposed.
     readonly agentIO: AppAgentIO;
-    readonly requestId: RequestId;
     readonly sessionStorage: Storage | undefined;
     readonly profileStorage: Storage; // storage that are preserved across sessions
 
@@ -109,8 +108,6 @@ export interface Storage {
     getTokenCachePersistence(): Promise<TokenCachePersistence>;
 }
 
-// TODO: review if these should be exposed. Duplicated from dispatcher's interactiveIO.ts
-export type RequestId = string | undefined;
 export interface AppAgentIO {
     readonly type: DisplayType;
     status(message: string): void;
@@ -128,4 +125,5 @@ export interface ActionIO {
 export interface ActionContext<T = void> {
     readonly actionIO: ActionIO;
     readonly sessionContext: SessionContext<T>;
+    performanceMark(markName: string): void;
 }

--- a/ts/packages/agents/browser/src/agent/actionHandler.mts
+++ b/ts/packages/agents/browser/src/agent/actionHandler.mts
@@ -132,9 +132,8 @@ async function executeBrowserAction(
   const webSocketEndpoint = context.sessionContext.agentContext.webSocket;
   if (webSocketEndpoint) {
     try {
-      const agentIO = context.sessionContext.agentIO;
-      const requestId = context.sessionContext.requestId;
-      agentIO.status("Running remote action.");
+      const callId = new Date().getTime().toString();
+      context.actionIO.setActionDisplay("Running remote action.");
 
       let messageType = "browserActionRequest";
       let target = "browser";
@@ -153,7 +152,7 @@ async function executeBrowserAction(
           source: "dispatcher",
           target: target,
           messageType,
-          id: requestId,
+          id: callId,
           body: action,
         }),
       );
@@ -174,7 +173,7 @@ function sendSiteTranslatorStatus(
   context: SessionContext<BrowserActionContext>,
 ) {
   const webSocketEndpoint = context.agentContext.webSocket;
-  const requestId = context.requestId;
+  const callId = new Date().getTime().toString();
 
   if (webSocketEndpoint) {
     webSocketEndpoint.send(
@@ -182,7 +181,7 @@ function sendSiteTranslatorStatus(
         source: "dispatcher",
         target: "browser",
         messageType: "siteTranslatorStatus",
-        id: requestId,
+        id: callId,
         body: {
           translator: translatorName,
           status: status,

--- a/ts/packages/agents/browser/src/agent/browserConnector.mts
+++ b/ts/packages/agents/browser/src/agent/browserConnector.mts
@@ -6,11 +6,9 @@ import { AppActionWithParameters, SessionContext } from "@typeagent/agent-sdk";
 import { BrowserActionContext } from "./actionHandler.mjs";
 
 export class BrowserConnector {
-  private context: SessionContext<BrowserActionContext>;
   private webSocket: any;
 
   constructor(context: SessionContext<BrowserActionContext>) {
-    this.context = context;
     this.webSocket = context.agentContext.webSocket;
   }
 
@@ -21,13 +19,7 @@ export class BrowserConnector {
     return new Promise<any | undefined>((resolve, reject) => {
       if (this.webSocket) {
         try {
-          const agentIO = this.context.agentIO;
-          let requestId = this.context.requestId;
-          if (requestId) {
-            agentIO.status("Running remote action.");
-          } else {
-            requestId = new Date().getTime().toString();
-          }
+          const callId = new Date().getTime().toString();
           if (!messageType) {
             messageType = "browserActionRequest";
           }
@@ -37,7 +29,7 @@ export class BrowserConnector {
               source: "dispatcher",
               target: "browser",
               messageType: messageType,
-              id: requestId,
+              id: callId,
               body: action,
             }),
           );
@@ -49,7 +41,7 @@ export class BrowserConnector {
               data.target == "dispatcher" &&
               data.source == "browser" &&
               data.messageType == "browserActionResponse" &&
-              data.id == requestId &&
+              data.id == callId &&
               data.body
             ) {
               this.webSocket.removeEventListener("message", handler);

--- a/ts/packages/agents/browser/src/extension/serviceWorker.ts
+++ b/ts/packages/agents/browser/src/extension/serviceWorker.ts
@@ -796,7 +796,7 @@ async function sendActionToTabIndex(action: any) {
     return new Promise<string | undefined>((resolve, reject) => {
         if (webSocket) {
             try {
-                const requestId = new Date().getTime().toString();
+                const callId = new Date().getTime().toString();
                 const messageType = "tabIndexRequest";
 
                 webSocket.send(
@@ -804,7 +804,7 @@ async function sendActionToTabIndex(action: any) {
                         source: "browser",
                         target: "dispatcher",
                         messageType: messageType,
-                        id: requestId,
+                        id: callId,
                         body: action,
                     }),
                 );
@@ -815,7 +815,7 @@ async function sendActionToTabIndex(action: any) {
                     if (
                         data.target == "browser" &&
                         data.source == "dispatcher" &&
-                        data.id == requestId &&
+                        data.id == callId &&
                         data.body
                     ) {
                         switch (data.messageType) {

--- a/ts/packages/agents/chat/src/chatResponseHandler.ts
+++ b/ts/packages/agents/chat/src/chatResponseHandler.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import fs from "node:fs";
-import { Profiler, StopWatch } from "common-utils";
+import { StopWatch } from "common-utils";
 import {
     ChatResponseAction,
     LookupAndGenerateResponseAction,
@@ -409,11 +409,7 @@ async function runLookup(
         getLookupInstructions(),
         (url, answerSoFar) => {
             if (firstToken) {
-                Profiler.getInstance().mark(
-                    actionContext.sessionContext.requestId,
-                    "First Token",
-                );
-
+                actionContext.performanceMark("First Token");
                 firstToken = false;
             }
 

--- a/ts/packages/dispatcher/src/agent/agentProcess.ts
+++ b/ts/packages/dispatcher/src/agent/agentProcess.ts
@@ -236,9 +236,6 @@ function createSessionContextShim(
     return {
         agentContext: context,
         agentIO,
-        get requestId(): string {
-            throw new Error("NYI");
-        },
         sessionStorage: hasSessionStorage
             ? getStorage(contextId, true)
             : undefined,
@@ -326,6 +323,12 @@ function getActionContextShim(
         },
         get actionIO() {
             return actionIO;
+        },
+        performanceMark: (name: string): void => {
+            rpc.send("performanceMark", {
+                actionContextId,
+                name,
+            });
         },
     };
 }

--- a/ts/packages/dispatcher/src/agent/agentProcessShim.ts
+++ b/ts/packages/dispatcher/src/agent/agentProcessShim.ts
@@ -15,7 +15,7 @@ import {
     AgentInvokeFunctions,
     ContextParams,
 } from "./agentProcessTypes.js";
-import { createRpc } from "common-utils";
+import { createRpc, Profiler } from "common-utils";
 import { fileURLToPath } from "url";
 
 type ShimContext =
@@ -232,6 +232,11 @@ export async function createAgentProcessShim(
             actionContextMap
                 .get(param.actionContextId)
                 .actionIO.setActionDisplay(param.message);
+        },
+        performanceMark: (param: { actionContextId: number; name: string }) => {
+            actionContextMap
+                .get(param.actionContextId)
+                .performanceMark(param.name);
         },
     };
 

--- a/ts/packages/dispatcher/src/agent/agentProcessTypes.ts
+++ b/ts/packages/dispatcher/src/agent/agentProcessTypes.ts
@@ -16,6 +16,7 @@ export type AgentContextCallFunctions = {
         actionContextId: number;
         message: string;
     }) => void;
+    performanceMark: (param: { actionContextId: number; name: string }) => void;
 };
 
 export type AgentContextInvokeFunctions = {


### PR DESCRIPTION
- Browser should use their own id to track calls
- Add `performanceMark` to `ActionContext`.