### PR TITLE
Fix model completeStream API to handle error

### DIFF
--- a/ts/examples/playground/src/main.ts
+++ b/ts/examples/playground/src/main.ts
@@ -194,21 +194,26 @@ async function runPlayground(): Promise<void> {
         let responseText = "";
         stopWatch.start();
         let i = 0;
-        for await (const responseChunk of chatModel.completeStream(context)) {
-            if (i === 0) {
-                stopWatch.stop(io);
-                i++;
+        const result = await chatModel.completeStream(context);
+        if (result.success) {
+            for await (const responseChunk of result.data) {
+                if (i === 0) {
+                    stopWatch.stop(io);
+                    i++;
+                }
+                io.writer.write(responseChunk);
+                responseText += responseChunk;
             }
-            io.writer.write(responseChunk);
-            responseText += responseChunk;
-        }
-        io.writer.writeLine();
-        if (responseText) {
-            chatHistory.push(userMessage);
-            chatHistory.push({
-                role: MessageSourceRole.assistant,
-                content: responseText,
-            });
+            io.writer.writeLine();
+            if (responseText) {
+                chatHistory.push(userMessage);
+                chatHistory.push({
+                    role: MessageSourceRole.assistant,
+                    content: responseText,
+                });
+            }
+        } else {
+            io.writer.writeLine(result.message);
         }
         stopWatch.stop(io);
         io.writer.writeLine();

--- a/ts/packages/aiclient/src/models.ts
+++ b/ts/packages/aiclient/src/models.ts
@@ -26,7 +26,7 @@ export interface ChatModel extends TypeChatLanguageModel {
 export interface ChatModelWithStreaming extends ChatModel {
     completeStream(
         prompt: string | PromptSection[] | ChatMessage[],
-    ): AsyncIterableIterator<string>;
+    ): Promise<Result<AsyncIterableIterator<string>>>;
 }
 
 /**

--- a/ts/packages/cli/src/commands/prompt.ts
+++ b/ts/packages/cli/src/commands/prompt.ts
@@ -60,7 +60,11 @@ export default class Prompt extends Command {
                 let number_chunks = 0;
                 const start = performance.now();
                 let first = start;
-                for await (const chunk of model.completeStream(request)) {
+                const result = await model.completeStream(request);
+                if (!result.success) {
+                    throw new Error(result.message);
+                }
+                for await (const chunk of result.data) {
                     if (first === start) {
                         first = performance.now();
                     }

--- a/ts/packages/commonUtils/src/jsonTranslator.ts
+++ b/ts/packages/commonUtils/src/jsonTranslator.ts
@@ -90,7 +90,11 @@ export function enableJsonTranslatorStreaming<T extends object>(
             model.complete = async (prompt: string | PromptSection[]) => {
                 debug(prompt);
                 const chunks = [];
-                for await (const chunk of model.completeStream(prompt)) {
+                const result = await model.completeStream(prompt);
+                if (!result.success) {
+                    return result;
+                }
+                for await (const chunk of result.data) {
                     chunks.push(chunk);
                     parser.parse(chunk);
                 }


### PR DESCRIPTION
The `completeStream` API should consistently return a "Result" so that it can detect error, instead of an async iterator.