### PR TITLE
Enable separate agent process by default

### DIFF
--- a/ts/packages/dispatcher/src/action/actionHandlers.ts
+++ b/ts/packages/dispatcher/src/action/actionHandlers.ts
@@ -2,16 +2,12 @@
 // Licensed under the MIT License.
 
 import { Action, Actions } from "agent-cache";
-import {
-    CommandHandlerContext,
-    getAppAgent,
-} from "../handlers/common/commandHandlerContext.js";
+import { CommandHandlerContext } from "../handlers/common/commandHandlerContext.js";
 import registerDebug from "debug";
 import { getAppAgentName } from "../translation/agentTranslators.js";
 import {
     ActionIO,
     createTurnImpressionFromLiteral,
-    AppAgent,
     AppAgentEvent,
     SessionContext,
     TurnImpression,
@@ -27,24 +23,13 @@ import { Profiler } from "common-utils";
 const debugAgent = registerDebug("typeagent:agent");
 const debugActions = registerDebug("typeagent:actions");
 
-export async function initializeActionContext(agents: Map<string, AppAgent>) {
-    return Object.fromEntries(
-        await Promise.all(
-            Array.from(agents.entries()).map(async ([name, agent]) => [
-                name,
-                await agent.initializeAgentContext?.(),
-            ]),
-        ),
-    );
-}
-
 function getActionContext(
     name: string,
     context: CommandHandlerContext,
     requestId: string,
     actionIndex: number,
 ) {
-    const sessionContext = getSessionContext(name, context);
+    const sessionContext = context.agents.getSessionContext(name);
     const actionIO: ActionIO = {
         get type() {
             return context.requestIO.type;
@@ -75,19 +60,11 @@ function getActionContext(
     };
 }
 
-function getSessionContext(
+export function createSessionContext<T = any>(
     name: string,
+    agentContext: T,
     context: CommandHandlerContext,
-): SessionContext {
-    return (
-        context.sessionContext.get(name) ?? createSessionContext(name, context)
-    );
-}
-
-function createSessionContext(
-    name: string,
-    context: CommandHandlerContext,
-): SessionContext {
+): SessionContext<T> {
     const sessionDirPath = context.session.getSessionDirPath();
     const storage = sessionDirPath
         ? getStorage(name, sessionDirPath)
@@ -95,7 +72,7 @@ function createSessionContext(
     const profileStorage = getStorage(name, getUserProfileDir());
     const sessionContext: SessionContext = {
         get agentContext() {
-            return context.action[name];
+            return agentContext;
         },
         get sessionStorage() {
             return storage;
@@ -139,59 +116,7 @@ function createSessionContext(
         },
     };
     (sessionContext as any).conversationManager = context.conversationManager;
-    context.sessionContext.set(name, sessionContext);
     return sessionContext;
-}
-
-export async function updateActionContext(
-    changed: { [key: string]: boolean },
-    context: CommandHandlerContext,
-) {
-    const newChanged = { ...changed };
-    const failed: any = {};
-    const entries = Object.entries(changed);
-    for (const [translatorName, enable] of entries) {
-        try {
-            await updateAgentContext(translatorName, enable, context);
-        } catch (e: any) {
-            context.requestIO.error(
-                `[${translatorName}]: Failed to ${enable ? "enable" : "disable"} action: ${e.message}`,
-                translatorName,
-            );
-            failed[translatorName] = !enable;
-            delete newChanged[translatorName];
-        }
-    }
-    const failedCount = Object.keys(failed).length;
-    if (failedCount !== 0) {
-        context.session.setConfig({ actions: failed });
-    }
-
-    return entries.length === failedCount ? undefined : newChanged;
-}
-
-async function updateAgentContext(
-    translatorName: string,
-    enable: boolean,
-    context: CommandHandlerContext,
-) {
-    const appAgentName = getAppAgentName(translatorName);
-    const appAgent = getAppAgent(appAgentName, context);
-    await appAgent.updateAgentContext?.(
-        enable,
-        getSessionContext(appAgentName, context),
-        translatorName,
-    );
-}
-
-export async function closeActionContext(context: CommandHandlerContext) {
-    for (const [name, enabled] of Object.entries(context.action)) {
-        if (enabled) {
-            try {
-                await updateAgentContext(name, false, context);
-            } catch {}
-        }
-    }
 }
 
 export async function partialInput(
@@ -208,11 +133,11 @@ export async function getDynamicDisplay(
     displayId: string,
     context: CommandHandlerContext,
 ): Promise<DynamicDisplay> {
-    const appAgent = getAppAgent(appAgentName, context);
+    const appAgent = context.agents.getAppAgent(appAgentName);
     if (appAgent.getDynamicDisplay === undefined) {
         throw new Error(`Dynamic display not supported by '${appAgentName}'`);
     }
-    const sessionContext = getSessionContext(appAgentName, context);
+    const sessionContext = context.agents.getSessionContext(appAgentName);
     return appAgent.getDynamicDisplay(type, displayId, sessionContext);
 }
 
@@ -227,7 +152,7 @@ async function executeAction(
         throw new Error(`Cannot execute action without translator name.`);
     }
     const appAgentName = getAppAgentName(translatorName);
-    const appAgent = getAppAgent(appAgentName, context);
+    const appAgent = context.agents.getAppAgent(appAgentName);
 
     // Update the last action translator.
     context.lastActionTranslatorName = translatorName;
@@ -324,8 +249,8 @@ export async function validateWildcardMatch(
             continue;
         }
         const appAgentName = getAppAgentName(translatorName);
-        const appAgent = getAppAgent(appAgentName, context);
-        const sessionContext = getSessionContext(appAgentName, context);
+        const appAgent = context.agents.getAppAgent(appAgentName);
+        const sessionContext = context.agents.getSessionContext(appAgentName);
         if (
             (await appAgent.validateWildcardMatch?.(action, sessionContext)) ===
             false
@@ -342,7 +267,7 @@ export function startStreamPartialAction(
     context: CommandHandlerContext,
 ) {
     const appAgentName = getAppAgentName(translatorName);
-    const appAgent = getAppAgent(appAgentName, context);
+    const appAgent = context.agents.getAppAgent(appAgentName);
     if (appAgent.streamPartialAction === undefined) {
         // The config declared that there are streaming action, but the agent didn't implement it.
         throw new Error(

--- a/ts/packages/dispatcher/src/agent/inlineAgentHandlers.ts
+++ b/ts/packages/dispatcher/src/agent/inlineAgentHandlers.ts
@@ -5,21 +5,8 @@ import { AppAgent, AppAction, ActionContext } from "@typeagent/agent-sdk";
 import { executeSessionAction } from "../action/system/sessionActionHandler.js";
 import { executeConfigAction } from "../action/system/configActionHandler.js";
 import { CommandHandlerContext } from "../handlers/common/commandHandlerContext.js";
-import { getDispatcherConfig } from "../utils/config.js";
 
-export function loadInlineAgents(context: CommandHandlerContext) {
-    const configs = getDispatcherConfig().agents;
-    const inlineAgents: [string, AppAgent][] = [];
-
-    for (const [name, config] of Object.entries(configs)) {
-        if (config.type !== "module") {
-            inlineAgents.push([name, loadInlineAgent(name, context)]);
-        }
-    }
-    return inlineAgents;
-}
-
-function loadInlineAgent(
+export function loadInlineAgent(
     name: string,
     context: CommandHandlerContext,
 ): AppAgent {

--- a/ts/packages/dispatcher/src/handlers/common/appAgentManager.ts
+++ b/ts/packages/dispatcher/src/handlers/common/appAgentManager.ts
@@ -1,0 +1,169 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import {
+    AppAgent,
+    SessionContext,
+    TopLevelTranslatorConfig,
+} from "@typeagent/agent-sdk";
+import { getDispatcherConfig } from "../../utils/config.js";
+import { CommandHandlerContext } from "./commandHandlerContext.js";
+import { getAppAgentName } from "../../translation/agentTranslators.js";
+import { getModuleAgent } from "../../agent/agentConfig.js";
+import { loadInlineAgent } from "../../agent/inlineAgentHandlers.js";
+import { createSessionContext } from "../../action/actionHandlers.js";
+import registerDebug from "debug";
+
+const debug = registerDebug("typeagent:agents");
+
+type AppAgentRecord = {
+    name: string;
+    type: "module" | "inline";
+    enabled: Set<string>;
+    config: TopLevelTranslatorConfig;
+    appAgent?: AppAgent | undefined;
+    sessionContext?: SessionContext | undefined;
+    sessionContextP?: Promise<SessionContext> | undefined;
+};
+
+export class AppAgentManager {
+    private readonly agents: Map<string, AppAgentRecord>;
+    constructor(configs: Map<string, TopLevelTranslatorConfig>) {
+        this.agents = new Map<string, AppAgentRecord>(
+            Array.from(configs.entries()).map(([name, config]) => [
+                name,
+                {
+                    name,
+                    type: getDispatcherConfig().agents[name].type ?? "inline",
+                    config,
+                    enabled: new Set(),
+                },
+            ]),
+        );
+    }
+
+    public getAppAgent(appAgentName: string): AppAgent {
+        const record = this.getRecord(appAgentName);
+        if (record.appAgent === undefined) {
+            throw new Error("App agent is not initialized");
+        }
+        return record.appAgent;
+    }
+
+    public getSessionContext(appAgentName: string): SessionContext {
+        const record = this.getRecord(appAgentName);
+        if (record.sessionContext === undefined) {
+            throw new Error("Session context is not initialized");
+        }
+        return record.sessionContext;
+    }
+
+    public async update(
+        translatorName: string,
+        enable: boolean,
+        context: CommandHandlerContext,
+    ) {
+        const appAgentName = getAppAgentName(translatorName);
+        const record = this.getRecord(appAgentName);
+        if (enable) {
+            if (record.enabled.has(translatorName)) {
+                return;
+            }
+
+            record.enabled.add(translatorName);
+            const sessionContext = await this.ensureSessionContext(
+                record,
+                context,
+            );
+            await record.appAgent!.updateAgentContext?.(
+                enable,
+                sessionContext,
+                translatorName,
+            );
+            debug(`Enabled ${translatorName}`);
+        } else {
+            if (!record.enabled.has(translatorName)) {
+                return;
+            }
+            record.enabled.delete(translatorName);
+            const sessionContext = await record.sessionContextP!;
+            await record.appAgent!.updateAgentContext?.(
+                enable,
+                sessionContext,
+                translatorName,
+            );
+            debug(`Disabled ${translatorName}`);
+            if (record.enabled.size === 0) {
+                await this.closeSessionContext(record);
+            }
+        }
+    }
+
+    public async close() {
+        for (const record of this.agents.values()) {
+            record.enabled.clear();
+            await this.closeSessionContext(record);
+        }
+    }
+
+    private async ensureSessionContext(
+        record: AppAgentRecord,
+        context: CommandHandlerContext,
+    ) {
+        if (record.sessionContextP === undefined) {
+            record.sessionContextP = this.initializeSessionContext(
+                record,
+                context,
+            );
+        }
+
+        return record.sessionContextP;
+    }
+    private async initializeSessionContext(
+        record: AppAgentRecord,
+        context: CommandHandlerContext,
+    ) {
+        const appAgent = await this.ensureAppAgent(record, context);
+        const agentContext = await appAgent.initializeAgentContext?.();
+        record.sessionContext = createSessionContext(
+            record.name,
+            agentContext,
+            context,
+        );
+
+        debug(`Session context created for ${record.name}`);
+        return record.sessionContext;
+    }
+
+    private async closeSessionContext(record: AppAgentRecord) {
+        if (record.sessionContextP !== undefined) {
+            const sessionContext = await record.sessionContextP;
+            await record.appAgent!.closeAgentContext?.(sessionContext);
+            record.sessionContext = undefined;
+            record.sessionContextP = undefined;
+            // TODO: close the unload agent as well?
+            debug(`Session context closed for ${record.name}`);
+        }
+    }
+
+    private async ensureAppAgent(
+        record: AppAgentRecord,
+        context: CommandHandlerContext,
+    ) {
+        if (record.appAgent === undefined) {
+            record.appAgent =
+                record.type === "module"
+                    ? await getModuleAgent(record.name)
+                    : loadInlineAgent(record.name, context);
+        }
+        return record.appAgent;
+    }
+
+    private getRecord(appAgentName: string) {
+        const record = this.agents.get(appAgentName);
+        if (record === undefined) {
+            throw new Error(`Unknown app agent: ${appAgentName}`);
+        }
+        return record;
+    }
+}

--- a/ts/packages/dispatcher/src/handlers/configSpotifyCommandHandlers.ts
+++ b/ts/packages/dispatcher/src/handlers/configSpotifyCommandHandlers.ts
@@ -46,16 +46,20 @@ export function getSpotifyConfigCommandHandlers(): HandlerTable {
                     request: string,
                     context: CommandHandlerContext,
                 ) => {
-                    if (context.action.player.spotify) {
-                        const historyPath = path.isAbsolute(request)
-                            ? request
-                            : path.join(getUserProfileDir(), request);
-                        await loadHistoryFile(
-                            getStorage("player", getUserProfileDir()),
-                            historyPath,
-                            context.action.player.spotify,
-                        );
-                    } else {
+                    try {
+                        const sessionContext =
+                            context.agents.getSessionContext("player");
+                        if (sessionContext.agentContext.spotify) {
+                            const historyPath = path.isAbsolute(request)
+                                ? request
+                                : path.join(getUserProfileDir(), request);
+                            return loadHistoryFile(
+                                getStorage("player", getUserProfileDir()),
+                                historyPath,
+                                sessionContext.agentContext.spotify,
+                            );
+                        }
+                    } catch (e) {
                         context.requestIO.error(
                             "Spotify integration is not enabled.",
                         );

--- a/ts/packages/dispatcher/src/handlers/requestCommandHandler.ts
+++ b/ts/packages/dispatcher/src/handlers/requestCommandHandler.ts
@@ -13,7 +13,6 @@ import {
 import { CommandHandler } from "./common/commandHandler.js";
 import {
     CommandHandlerContext,
-    getAppAgent,
     getTranslator,
     getActiveTranslatorList,
     isTranslatorEnabled,
@@ -29,7 +28,6 @@ import {
 } from "../action/actionHandlers.js";
 import { unicodeChar } from "../utils/interactive.js";
 import {
-    getAppAgentName,
     getInjectedTranslatorForActionName,
     getTranslatorConfig,
     isChangeAssistantAction,

--- a/ts/packages/dispatcher/src/handlers/sessionCommandHandlers.ts
+++ b/ts/packages/dispatcher/src/handlers/sessionCommandHandlers.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 import {
+    changeContextConfig,
     CommandHandlerContext,
     reloadSessionOnCommandHandlerContext,
 } from "./common/commandHandlerContext.js";
@@ -57,8 +58,8 @@ class SessionOpenCommandHandler implements CommandHandler {
 class SessionResetCommandHandler implements CommandHandler {
     public readonly description = "Reset config on session and keep the data";
     public async run(request: string, context: CommandHandlerContext) {
-        context.session.setConfig(defaultSessionConfig);
-        context.requestIO.success(`Session resetted.`);
+        await changeContextConfig(defaultSessionConfig, context);
+        context.requestIO.success(`Session settings revert to default.`);
     }
 }
 

--- a/ts/packages/shell/src/renderer/src/speech.ts
+++ b/ts/packages/shell/src/renderer/src/speech.ts
@@ -7,24 +7,20 @@ import { WhisperRecognizer } from "./localWhisperClient";
 import registerDebug from "debug";
 
 const debug = registerDebug("typeagent:shell:speech");
-const debugError = registerDebug("typeagent:shell:speech");
+const debugError = registerDebug("typeagent:shell:speech:error");
 
 export async function enumerateMicrophones() {
-    if (
-        !navigator ||
-        !navigator.mediaDevices ||
-        !navigator.mediaDevices.enumerateDevices
-    ) {
+    // Not all environments will be able to enumerate mic labels and ids. All environments will be able
+    // to select a default input, assuming appropriate permissions.
+    const deviceIds = new Set<string>();
+    const result: [string, string][] = [];
+    const devices = await navigator?.mediaDevices?.enumerateDevices?.();
+    if (devices === undefined) {
         debugError(
             `Unable to query for audio input devices. Default will be used.\r\n`,
         );
         return [];
     }
-    // Not all environments will be able to enumerate mic labels and ids. All environments will be able
-    // to select a default input, assuming appropriate permissions.
-    const deviceIds = new Set<string>();
-    const result: [string, string][] = [];
-    const devices = await navigator.mediaDevices.enumerateDevices();
     for (const device of devices) {
         debug(device);
         if (device.kind === "audioinput") {


### PR DESCRIPTION
- Clean up the code and move all agents enable/disable state management into `AppAgentManager`.
- Defer instantiating app agent until it is enabled.
- Update app agent enable/disable (and therefore instantiation) in parallel.   Allow process to be spawn and started in parallel in out of proc mode, reduce the impact to load time.
