### PR TITLE
App Agent provider infrastructure

### DIFF
--- a/ts/packages/cli/src/commands/constructions.ts
+++ b/ts/packages/cli/src/commands/constructions.ts
@@ -5,7 +5,7 @@ import { Args, Command, Flags } from "@oclif/core";
 import {
     readTestData,
     getCacheFactory,
-    loadTranslatorSchemaConfig,
+    loadBuiltinTranslatorSchemaConfig,
 } from "agent-dispatcher";
 import { printImportConstructionResult } from "agent-cache";
 import fs from "node:fs";
@@ -36,7 +36,7 @@ export default class ConstructionsCommand extends Command {
 
         const agentCache = getCacheFactory().create(
             testDataFile.explainerName,
-            loadTranslatorSchemaConfig,
+            loadBuiltinTranslatorSchemaConfig,
         );
         if (!flags.overwrite && args.output && fs.existsSync(args.output)) {
             await agentCache.constructionStore.load(args.output);

--- a/ts/packages/cli/src/commands/data/add.ts
+++ b/ts/packages/cli/src/commands/data/add.ts
@@ -12,7 +12,7 @@ import {
     getEmptyTestData,
 } from "agent-dispatcher";
 import chalk from "chalk";
-import { getTranslatorNames, getCacheFactory } from "agent-dispatcher";
+import { getBuiltinTranslatorNames, getCacheFactory } from "agent-dispatcher";
 import { getDefaultExplainerName } from "agent-cache";
 import { getChatModelMaxConcurrency, getChatModelNames } from "common-utils";
 
@@ -44,7 +44,7 @@ export default class ExplanationDataAddCommand extends Command {
         }),
         translator: Flags.string({
             description: "Translator name",
-            options: getTranslatorNames(),
+            options: getBuiltinTranslatorNames(),
         }),
         explainer: Flags.string({
             description:

--- a/ts/packages/cli/src/commands/data/regenerate.ts
+++ b/ts/packages/cli/src/commands/data/regenerate.ts
@@ -11,11 +11,11 @@ import {
     TestDataEntry,
     FailedTestDataEntry,
     getCacheFactory,
-    loadTranslatorSchemaConfig,
     getBuiltinConstructionConfig,
     GenerateDataInput,
     getEmptyTestData,
     getTestDataFiles,
+    loadBuiltinTranslatorSchemaConfig,
 } from "agent-dispatcher";
 import {
     Actions,
@@ -430,7 +430,7 @@ export default class ExplanationDataRegenerateCommmand extends Command {
         if (builtinConstructionConfig !== undefined) {
             const agentCache = getCacheFactory().create(
                 flags.builtin!,
-                loadTranslatorSchemaConfig,
+                loadBuiltinTranslatorSchemaConfig,
             );
             await agentCache.constructionStore.newCache(
                 flags.none ? undefined : builtinConstructionConfig.file,

--- a/ts/packages/cli/src/commands/data/stat.ts
+++ b/ts/packages/cli/src/commands/data/stat.ts
@@ -6,7 +6,7 @@ import chalk from "chalk";
 import { CorrectionRecord } from "agent-cache";
 import {
     getCacheFactory,
-    getTranslatorNames,
+    getBuiltinTranslatorNames,
     readTestData,
 } from "agent-dispatcher";
 import { getTestDataFiles } from "../../../../dispatcher/dist/utils/config.js";
@@ -148,7 +148,7 @@ export default class ExplanationDataStatCommmand extends Command {
     static flags = {
         translator: Flags.string({
             description: "Filter by translator",
-            options: getTranslatorNames(),
+            options: getBuiltinTranslatorNames(),
             multiple: true,
         }),
         explainer: Flags.string({

--- a/ts/packages/cli/src/commands/interactive.ts
+++ b/ts/packages/cli/src/commands/interactive.ts
@@ -4,7 +4,7 @@
 import { Args, Command, Flags } from "@oclif/core";
 import readline from "readline/promises";
 import {
-    getTranslatorNames,
+    getBuiltinTranslatorNames,
     getCacheFactory,
     processCommand,
     processRequests,
@@ -20,7 +20,7 @@ export default class Interactive extends Command {
     static flags = {
         translator: Flags.string({
             description: "Translator names",
-            options: getTranslatorNames(),
+            options: getBuiltinTranslatorNames(),
             multiple: true,
         }),
         explainer: Flags.string({

--- a/ts/packages/cli/src/commands/run/explain.ts
+++ b/ts/packages/cli/src/commands/run/explain.ts
@@ -11,7 +11,7 @@ import {
 } from "agent-cache";
 import { initializeCommandHandlerContext } from "agent-dispatcher";
 import { getCacheFactory } from "agent-dispatcher";
-import { getTranslatorNames } from "agent-dispatcher";
+import { getBuiltinTranslatorNames } from "agent-dispatcher";
 
 // Default test case, that include multiple phrase action name (out of order) and implicit parameters (context)
 const testRequest = new RequestAction(
@@ -34,7 +34,7 @@ export default class ExplainCommand extends Command {
     static flags = {
         translator: Flags.string({
             description: "Translator names",
-            options: getTranslatorNames(),
+            options: getBuiltinTranslatorNames(),
             multiple: true,
         }),
         explainer: Flags.string({

--- a/ts/packages/cli/src/commands/run/request.ts
+++ b/ts/packages/cli/src/commands/run/request.ts
@@ -5,7 +5,7 @@ import { Args, Command, Flags } from "@oclif/core";
 import { RequestCommandHandler } from "agent-dispatcher";
 import { initializeCommandHandlerContext } from "agent-dispatcher";
 import { getCacheFactory } from "agent-dispatcher";
-import { getTranslatorNames } from "agent-dispatcher";
+import { getBuiltinTranslatorNames } from "agent-dispatcher";
 import chalk from "chalk";
 import { readFileSync, existsSync } from "fs";
 
@@ -25,7 +25,7 @@ export default class RequestCommand extends Command {
     static flags = {
         translator: Flags.string({
             description: "Translator name",
-            options: getTranslatorNames(),
+            options: getBuiltinTranslatorNames(),
             multiple: true,
         }),
         explainer: Flags.string({

--- a/ts/packages/cli/src/commands/run/translate.ts
+++ b/ts/packages/cli/src/commands/run/translate.ts
@@ -4,7 +4,7 @@
 import { Args, Command, Flags } from "@oclif/core";
 import { TranslateCommandHandler } from "agent-dispatcher";
 import { initializeCommandHandlerContext } from "agent-dispatcher";
-import { getTranslatorNames } from "agent-dispatcher";
+import { getBuiltinTranslatorNames } from "agent-dispatcher";
 
 export default class TranslateCommand extends Command {
     static args = {
@@ -18,7 +18,7 @@ export default class TranslateCommand extends Command {
     static flags = {
         translator: Flags.string({
             description: "Translator name",
-            options: getTranslatorNames(),
+            options: getBuiltinTranslatorNames(),
             multiple: true,
         }),
     };

--- a/ts/packages/cli/src/commands/schema.ts
+++ b/ts/packages/cli/src/commands/schema.ts
@@ -6,7 +6,8 @@ import { composeTranslatorSchemas } from "common-utils";
 import {
     getAssistantSelectionSchemas,
     getFullSchemaText,
-    getTranslatorNames,
+    getBuiltinTranslatorNames,
+    getBuiltinTranslatorConfigProvider,
 } from "agent-dispatcher";
 
 export default class Schema extends Command {
@@ -30,23 +31,26 @@ export default class Schema extends Command {
         translator: Args.string({
             description: "Translator name",
             required: true,
-            options: getTranslatorNames(),
+            options: getBuiltinTranslatorNames(),
         }),
     };
 
     async run(): Promise<void> {
         const { args, flags } = await this.parse(Schema);
+        const provider = getBuiltinTranslatorConfigProvider();
         if (!flags.assistant) {
             console.log(
                 getFullSchemaText(
                     args.translator,
+                    provider,
                     flags.change,
                     flags.multiple,
                 ),
             );
         } else {
             const schemas = getAssistantSelectionSchemas(
-                getTranslatorNames(),
+                getBuiltinTranslatorNames(),
+                provider,
             ).map((entry) => entry.schema);
             console.log(
                 composeTranslatorSchemas("AllAssistantSelection", schemas),

--- a/ts/packages/dispatcher/src/agent/agentProvider.ts
+++ b/ts/packages/dispatcher/src/agent/agentProvider.ts
@@ -1,0 +1,10 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { AppAgent, TopLevelTranslatorConfig } from "@typeagent/agent-sdk";
+
+export interface AppAgentProvider {
+    getAppAgentNames(): string[];
+    getAppAgentConfig(appAgentName: string): Promise<TopLevelTranslatorConfig>;
+    loadAppAgent(appAgentName: string): Promise<AppAgent>;
+}

--- a/ts/packages/dispatcher/src/command.ts
+++ b/ts/packages/dispatcher/src/command.ts
@@ -327,7 +327,7 @@ export function getSettingSummary(context: CommandHandlerContext) {
 
 export function getTranslatorNameToEmojiMap(context: CommandHandlerContext) {
     const emojis = context.agents
-        .getAppAgentConfigs()
+        .getTranslatorConfigs()
         .map(([name, config]) => [name, config.emojiChar] as const);
 
     const tMap = new Map<string, string>(emojis);

--- a/ts/packages/dispatcher/src/command.ts
+++ b/ts/packages/dispatcher/src/command.ts
@@ -33,10 +33,6 @@ import { getSessionCommandHandlers } from "./handlers/sessionCommandHandlers.js"
 import { getHistoryCommandHandlers } from "./handlers/historyCommandHandler.js";
 import { TraceCommandHandler } from "./handlers/traceCommandHandler.js";
 import { TranslateCommandHandler } from "./handlers/translateCommandHandler.js";
-import {
-    getTranslatorConfig,
-    getTranslatorConfigs,
-} from "./translation/agentTranslators.js";
 import { processRequests, unicodeChar } from "./utils/interactive.js";
 /* ==Experimental== */
 import { getRandomCommandHandlers } from "./handlers/randomCommandHandler.js";
@@ -299,7 +295,9 @@ export function getSettingSummary(context: CommandHandlerContext) {
 
     const translators = Array.from(
         new Set(
-            ordered.map((name) => getTranslatorConfig(name).emojiChar),
+            ordered.map(
+                (name) => context.agents.getTranslatorConfig(name).emojiChar,
+            ),
         ).values(),
     );
     prompt.push("  [", translators.join(""));
@@ -328,9 +326,9 @@ export function getSettingSummary(context: CommandHandlerContext) {
 }
 
 export function getTranslatorNameToEmojiMap(context: CommandHandlerContext) {
-    const emojis = getTranslatorConfigs().map(
-        ([name, config]) => [name, config.emojiChar] as const,
-    );
+    const emojis = context.agents
+        .getAppAgentConfigs()
+        .map(([name, config]) => [name, config.emojiChar] as const);
 
     const tMap = new Map<string, string>(emojis);
     tMap.set(DispatcherName, "🤖");

--- a/ts/packages/dispatcher/src/handlers/configCommandHandlers.ts
+++ b/ts/packages/dispatcher/src/handlers/configCommandHandlers.ts
@@ -12,8 +12,9 @@ import {
     changeContextConfig,
 } from "./common/commandHandlerContext.js";
 import {
-    getTranslatorConfigs,
-    getTranslatorNames,
+    getBuiltinTranslatorNames,
+    TranslatorConfig,
+    TranslatorConfigProvider,
 } from "../translation/agentTranslators.js";
 import { getSpotifyConfigCommandHandlers } from "./configSpotifyCommandHandlers.js";
 import { getCacheFactory } from "../utils/cacheFactory.js";
@@ -26,12 +27,16 @@ import { openai as ai } from "aiclient";
 import { SessionConfig } from "../session/session.js";
 import chalk from "chalk";
 
-function parseToggleTranslatorName(args: string[], action: boolean) {
+function parseToggleTranslatorName(
+    args: string[],
+    action: boolean,
+    provider: TranslatorConfigProvider,
+) {
     const options: any = {};
-    const translatorNames = getTranslatorNames();
+    const translatorNames = getBuiltinTranslatorNames();
     for (const arg of args) {
         if (arg === "@") {
-            for (const [name, config] of getTranslatorConfigs()) {
+            for (const [name, config] of provider.getTranslatorConfigs()) {
                 options[name] = action
                     ? config.actionDefaultEnabled
                     : config.defaultEnabled;
@@ -108,13 +113,13 @@ class AgentToggleCommandHandler implements CommandHandler {
                 log(
                     `Usage: @config ${AgentToggleCommand[this.toggle]} [-]<agent>]`,
                 );
-                const translators = getTranslatorNames().join(", ");
+                const translators = getBuiltinTranslatorNames().join(", ");
                 log(`   <agent>: ${translators}`);
             });
             return;
         }
 
-        const options = parseToggleTranslatorName(args, false);
+        const options = parseToggleTranslatorName(args, false, context.agents);
         const changed = await changeContextConfig(
             getAgentToggleOptions(this.toggle, options),
             context,

--- a/ts/packages/dispatcher/src/handlers/sessionCommandHandlers.ts
+++ b/ts/packages/dispatcher/src/handlers/sessionCommandHandlers.ts
@@ -13,7 +13,7 @@ import {
     deleteAllSessions,
     deleteSession,
     getSessionNames,
-    defaultSessionConfig,
+    getDefaultSessionConfig,
     getSessionCaches,
 } from "../session/session.js";
 import chalk from "chalk";
@@ -34,7 +34,9 @@ class SessionNewCommandHandler implements CommandHandler {
         await setSessionOnCommandHandlerContext(
             context,
             await Session.create(
-                flags.keep ? context.session.getConfig() : defaultSessionConfig,
+                flags.keep
+                    ? context.session.getConfig()
+                    : getDefaultSessionConfig(context.agents),
                 flags.persist,
             ),
         );
@@ -58,7 +60,10 @@ class SessionOpenCommandHandler implements CommandHandler {
 class SessionResetCommandHandler implements CommandHandler {
     public readonly description = "Reset config on session and keep the data";
     public async run(request: string, context: CommandHandlerContext) {
-        await changeContextConfig(defaultSessionConfig, context);
+        await changeContextConfig(
+            getDefaultSessionConfig(context.agents),
+            context,
+        );
         context.requestIO.success(`Session settings revert to default.`);
     }
 }

--- a/ts/packages/dispatcher/src/index.ts
+++ b/ts/packages/dispatcher/src/index.ts
@@ -15,10 +15,7 @@ export {
     closeCommandHandlerContext,
     CommandHandlerContext,
 } from "./handlers/common/commandHandlerContext.js";
-export {
-    getDefaultTranslatorName,
-    getTranslatorNames,
-} from "./translation/agentTranslators.js";
+export { getBuiltinTranslatorNames } from "./translation/agentTranslators.js";
 export { getCacheFactory } from "./utils/cacheFactory.js";
 export { loadTranslatorSchemaConfig } from "./utils/loadSchemaConfig.js";
 export {
@@ -35,10 +32,14 @@ export {
 } from "./utils/test/testData.js";
 export { getBuiltinConstructionConfig } from "./utils/config.js";
 
-// for CLI
+// for CLI/ testing
 export { RequestCommandHandler } from "./handlers/requestCommandHandler.js";
 export { TranslateCommandHandler } from "./handlers/translateCommandHandler.js";
 export { ExplainCommandHandler } from "./handlers/explainCommandHandler.js";
-export { getFullSchemaText } from "./translation/agentTranslators.js";
 export { getAssistantSelectionSchemas } from "./translation/unknownSwitcher.js";
 export { getTestDataFiles } from "./utils/config.js";
+export {
+    loadBuiltinTranslatorSchemaConfig,
+    getBuiltinTranslatorConfigProvider,
+    getFullSchemaText,
+} from "./translation/agentTranslators.js";

--- a/ts/packages/dispatcher/src/translation/actionInfo.ts
+++ b/ts/packages/dispatcher/src/translation/actionInfo.ts
@@ -2,7 +2,10 @@
 // Licensed under the MIT License.
 
 import { ISymbol, SchemaParser, NodeType } from "schema-parser";
-import { getTranslatorConfig, TranslatorConfig } from "./agentTranslators.js";
+import {
+    TranslatorConfig,
+    TranslatorConfigProvider,
+} from "./agentTranslators.js";
 import { getPackageFilePath } from "../utils/getPackageFilePath.js";
 import {
     ActionTemplate,
@@ -95,10 +98,13 @@ export function getTranslatorActionInfo(
     }
 }
 
-export function getAllActionInfo(translatorNames: string[]) {
+export function getAllActionInfo(
+    translatorNames: string[],
+    provider: TranslatorConfigProvider,
+) {
     let allActionInfo = new Map<string, ActionInfo>();
     for (const name of translatorNames) {
-        const translatorConfig = getTranslatorConfig(name);
+        const translatorConfig = provider.getTranslatorConfig(name);
         if (translatorConfig.injected) {
             continue;
         }

--- a/ts/packages/dispatcher/src/translation/agentTranslators.ts
+++ b/ts/packages/dispatcher/src/translation/agentTranslators.ts
@@ -235,10 +235,9 @@ function getInjectedTranslatorConfigs(
         .getTranslatorConfigs()
         .filter(
             ([name, config]) =>
-                (config.injected &&
-                    name !== translatorName && // don't include itself
-                    activeTranslators[name]) ??
-                config.defaultEnabled,
+                config.injected &&
+                name !== translatorName && // don't include itself
+                (activeTranslators[name] ?? config.defaultEnabled),
         )
         .map(([_, config]) => config);
 }

--- a/ts/packages/dispatcher/src/translation/agentTranslators.ts
+++ b/ts/packages/dispatcher/src/translation/agentTranslators.ts
@@ -2,15 +2,19 @@
 // Licensed under the MIT License.
 
 import { createJsonTranslatorFromSchemaDef } from "common-utils";
-import { AppAction, HierarchicalTranslatorConfig } from "@typeagent/agent-sdk";
+import {
+    AppAction,
+    HierarchicalTranslatorConfig,
+    TopLevelTranslatorConfig,
+} from "@typeagent/agent-sdk";
 import { TypeChatJsonTranslator } from "typechat";
 import { getPackageFilePath } from "../utils/getPackageFilePath.js";
 import { getMultipleActionSchemaDef } from "./systemActionsInlineSchema.js";
 import { TranslatorSchemaDef, composeTranslatorSchemas } from "common-utils";
-import { getTranslatorActionInfo } from "./actionInfo.js";
 
 import registerDebug from "debug";
-import { getAppAgentConfigs } from "../agent/agentConfig.js";
+import { getBuiltinAppAgentConfigs } from "../agent/agentConfig.js";
+import { loadTranslatorSchemaConfig } from "../utils/loadSchemaConfig.js";
 
 const debugConfig = registerDebug("typeagent:translator:config");
 
@@ -32,6 +36,11 @@ export type TranslatorConfig = {
     actionDefaultEnabled: boolean;
     transient: boolean;
 };
+
+export interface TranslatorConfigProvider {
+    getTranslatorConfig(translatorName: string): TranslatorConfig;
+    getTranslatorConfigs(): [string, TranslatorConfig][];
+}
 
 function collectTranslatorConfigs(
     translatorConfigs: { [key: string]: TranslatorConfig },
@@ -73,10 +82,28 @@ function collectTranslatorConfigs(
     }
 }
 
+export function convertToTranslatorConfigs(
+    name: string,
+    config: TopLevelTranslatorConfig,
+): Record<string, TranslatorConfig> {
+    const translatorConfigs: Record<string, TranslatorConfig> = {};
+    const emojiChar = config.emojiChar;
+    collectTranslatorConfigs(
+        translatorConfigs,
+        config,
+        name,
+        emojiChar,
+        true, // default to true if not specified
+        true, // default to true if not specified
+        false, // default to false if not specified
+    );
+    return translatorConfigs;
+}
+
 const translatorConfigs: { [key: string]: TranslatorConfig } =
     await (async () => {
         const translatorConfigs = {};
-        const configs = await getAppAgentConfigs();
+        const configs = await getBuiltinAppAgentConfigs();
         for (const [name, config] of configs.entries()) {
             const emojiChar = config.emojiChar;
             collectTranslatorConfigs(
@@ -92,30 +119,39 @@ const translatorConfigs: { [key: string]: TranslatorConfig } =
         return translatorConfigs;
     })();
 
-export function getTranslatorNames() {
+export function getBuiltinTranslatorNames() {
     return Object.keys(translatorConfigs);
 }
 
-export function getDefaultTranslatorName() {
+export function getDefaultBuiltinTranslatorName() {
     // Default to the first translator for now.
-    return getTranslatorNames()[0];
+    return getBuiltinTranslatorNames()[0];
 }
 
-export function getTranslatorConfigs() {
-    return Object.entries(translatorConfigs);
+export function getBuiltinTranslatorConfigProvider(): TranslatorConfigProvider {
+    return {
+        getTranslatorConfig(translatorName: string) {
+            const config = translatorConfigs[translatorName];
+            if (!config) {
+                throw new Error(`Unknown translator: ${translatorName}`);
+            }
+            return config;
+        },
+        getTranslatorConfigs() {
+            return Object.entries(translatorConfigs);
+        },
+    };
+}
+
+export function loadBuiltinTranslatorSchemaConfig(translatorName: string) {
+    return loadTranslatorSchemaConfig(
+        translatorName,
+        getBuiltinTranslatorConfigProvider(),
+    );
 }
 
 export function getAppAgentName(translatorName: string) {
     return translatorName.split(".")[0];
-}
-
-export function getTranslatorConfig(translatorName: string): TranslatorConfig {
-    const config = translatorConfigs[translatorName];
-
-    if (config === undefined) {
-        throw new Error(`Translator '${translatorName}' not found in config`);
-    }
-    return config;
 }
 
 // A list of translator factory methods, keyed by the config.SchemaType name
@@ -129,7 +165,7 @@ export type ChangeAssistantAction = {
     actionName: "changeAssistantAction";
     parameters: {
         assistant: string;
-        request: string; // this is constrainted to active translators in the LLM schema
+        request: string; // this is constrained to active translators in the LLM schema
     };
 };
 
@@ -141,10 +177,11 @@ export function isChangeAssistantAction(
 
 function getChangeAssistantSchemaDef(
     translatorName: string,
+    provider: TranslatorConfigProvider,
     activeTranslators: { [key: string]: boolean },
 ): TranslatorSchemaDef | undefined {
     // Default to no switching if active translator isn't passed in.
-    const translators = getTranslatorConfigs().filter(
+    const translators = provider.getTranslatorConfigs().filter(
         ([name, translatorConfig]) =>
             name !== translatorName && // don't include itself
             !translatorConfig.injected && // don't include injected translators
@@ -186,55 +223,37 @@ function getTranslatorSchemaDef(
     };
 }
 
-let injectedTranslatorConfig: [string, TranslatorConfig][] | undefined;
-const injectedTranslatorForActionName = new Map<string, string>();
-function ensureInjectedTranslatorConfig() {
-    if (injectedTranslatorConfig === undefined) {
-        // Cache some info.
-        injectedTranslatorConfig = getTranslatorConfigs().filter(
-            ([_, config]) => config.injected,
-        );
-
-        for (const [name, config] of injectedTranslatorConfig) {
-            for (const info of getTranslatorActionInfo(config, name)) {
-                injectedTranslatorForActionName.set(info.name, name);
-            }
-        }
-    }
-    return injectedTranslatorConfig;
-}
-
 function getInjectedTranslatorConfigs(
     translatorName: string,
+    provider: TranslatorConfigProvider,
     activeTranslators: { [key: string]: boolean } | undefined,
 ) {
     if (activeTranslators === undefined) {
         return [];
     }
-    return ensureInjectedTranslatorConfig()
+    return provider
+        .getTranslatorConfigs()
         .filter(
             ([name, config]) =>
-                (name !== translatorName && // don't include itself
+                (config.injected &&
+                    name !== translatorName && // don't include itself
                     activeTranslators[name]) ??
                 config.defaultEnabled,
         )
         .map(([_, config]) => config);
 }
 
-export function getInjectedTranslatorForActionName(actionName: string) {
-    ensureInjectedTranslatorConfig();
-    return injectedTranslatorForActionName.get(actionName);
-}
-
 function getInjectedSchemaDefs(
     type: string,
     translatorName: string,
+    provider: TranslatorConfigProvider,
     activeTranslators: { [key: string]: boolean } | undefined,
     multipleActions: boolean = false,
 ): TranslatorSchemaDef[] {
     // Add all injected schemas
     const injectSchemaConfigs = getInjectedTranslatorConfigs(
         translatorName,
+        provider,
         activeTranslators,
     );
     const injectedSchemaDefs = injectSchemaConfigs.map(getTranslatorSchemaDef);
@@ -244,7 +263,11 @@ function getInjectedSchemaDefs(
 
     // Add change assistant schema if needed
     const changeAssistantSchemaDef = activeTranslators
-        ? getChangeAssistantSchemaDef(translatorName, activeTranslators)
+        ? getChangeAssistantSchemaDef(
+              translatorName,
+              provider,
+              activeTranslators,
+          )
         : undefined;
 
     if (changeAssistantSchemaDef) {
@@ -266,6 +289,7 @@ function getInjectedSchemaDefs(
 function getTranslatorSchemaDefs(
     translatorConfig: TranslatorConfig,
     translatorName: string,
+    provider: TranslatorConfigProvider,
     activeTranslators: { [key: string]: boolean } | undefined,
     multipleActions: boolean = false,
 ): TranslatorSchemaDef[] {
@@ -274,6 +298,7 @@ function getTranslatorSchemaDefs(
         ...getInjectedSchemaDefs(
             translatorConfig.schemaType,
             translatorName,
+            provider,
             activeTranslators,
             multipleActions,
         ),
@@ -289,12 +314,13 @@ function getTranslatorSchemaDefs(
  */
 export function loadAgentJsonTranslator(
     translatorName: string,
+    provider: TranslatorConfigProvider,
     model?: string,
     activeTranslators?: { [key: string]: boolean },
     multipleActions: boolean = false,
 ) {
-    const translatorConfig = getTranslatorConfig(translatorName);
     // See if we have a registered factory method for this translator
+    const translatorConfig = provider.getTranslatorConfig(translatorName);
     const factory = translatorFactories[translatorConfig.schemaType];
     if (factory) {
         return factory(translatorConfig);
@@ -305,6 +331,7 @@ export function loadAgentJsonTranslator(
         getTranslatorSchemaDefs(
             translatorConfig,
             translatorName,
+            provider,
             activeTranslators,
             multipleActions,
         ),
@@ -317,16 +344,18 @@ export function loadAgentJsonTranslator(
 // For CLI, replicate the behavior of loadAgentJsonTranslator to get the schema
 export function getFullSchemaText(
     translatorName: string,
+    provider: TranslatorConfigProvider,
     changeAssistant: boolean,
     multipleActions: boolean,
 ) {
-    const translatorConfig = getTranslatorConfig(translatorName);
+    const translatorConfig = provider.getTranslatorConfig(translatorName);
     if (translatorFactories[translatorConfig.schemaType] !== undefined) {
         throw new Error("Can't get schema for customfactory");
     }
     const schemaDefs = getTranslatorSchemaDefs(
         translatorConfig,
         translatorName,
+        provider,
         changeAssistant ? {} : undefined,
         multipleActions,
     );

--- a/ts/packages/dispatcher/src/utils/loadSchemaConfig.ts
+++ b/ts/packages/dispatcher/src/utils/loadSchemaConfig.ts
@@ -4,8 +4,8 @@
 import { SchemaConfig } from "agent-cache";
 import fs from "node:fs";
 import path from "node:path";
-import { getTranslatorConfig } from "../translation/agentTranslators.js";
 import { getPackageFilePath } from "../utils/getPackageFilePath.js";
+import { TranslatorConfigProvider } from "../translation/agentTranslators.js";
 
 function loadSchemaConfig(schemaFile: string): SchemaConfig | undefined {
     const parseSchemaFile = path.parse(getPackageFilePath(schemaFile));
@@ -20,12 +20,15 @@ function loadSchemaConfig(schemaFile: string): SchemaConfig | undefined {
 
 const schemaConfigCache = new Map<string, SchemaConfig | undefined>();
 
-export function loadTranslatorSchemaConfig(translatorName: string) {
+export function loadTranslatorSchemaConfig(
+    translatorName: string,
+    provider: TranslatorConfigProvider,
+) {
     if (schemaConfigCache.has(translatorName)) {
         return schemaConfigCache.get(translatorName);
     }
     const schemaConfig = loadSchemaConfig(
-        getTranslatorConfig(translatorName).schemaFile,
+        provider.getTranslatorConfig(translatorName).schemaFile,
     );
     schemaConfigCache.set(translatorName, schemaConfig);
     return schemaConfig;

--- a/ts/packages/dispatcher/src/utils/test/testData.ts
+++ b/ts/packages/dispatcher/src/utils/test/testData.ts
@@ -4,7 +4,10 @@
 import fs from "node:fs";
 import path from "node:path";
 import chalk from "chalk";
-import { loadAgentJsonTranslator } from "../../translation/agentTranslators.js";
+import {
+    getBuiltinTranslatorConfigProvider,
+    loadAgentJsonTranslator,
+} from "../../translation/agentTranslators.js";
 import {
     IAction,
     JSONAction,
@@ -254,8 +257,13 @@ function toExceptionMessage(e: any) {
         : undefined;
     return `Exception: ${e.message}${suffix ? `: ${suffix}` : ""}`;
 }
+
 function getSafeTranslateFn(translatorName: string, model?: string) {
-    const translator = loadAgentJsonTranslator(translatorName, model);
+    const translator = loadAgentJsonTranslator(
+        translatorName,
+        getBuiltinTranslatorConfigProvider(),
+        model,
+    );
     return async (request: string): Promise<Result<Object>> => {
         try {
             return await translator.translate(request);

--- a/ts/packages/dispatcher/test/construction.spec.ts
+++ b/ts/packages/dispatcher/test/construction.spec.ts
@@ -7,7 +7,7 @@ dotenv.config({ path: new URL("../../../../.env", import.meta.url) });
 import { getCacheFactory } from "../src/utils/cacheFactory.js";
 import { readTestData } from "../src/utils/test/testData.js";
 import { Actions, RequestAction } from "agent-cache";
-import { loadTranslatorSchemaConfig } from "../src/utils/loadSchemaConfig.js";
+import { loadBuiltinTranslatorSchemaConfig } from "../src/translation/agentTranslators.js";
 import { glob } from "glob";
 
 const dataFiles = ["test/data/**/v5/*.json"];
@@ -46,7 +46,7 @@ describe("construction", () => {
                     requestAction,
                     explanation,
                     {
-                        getSchemaConfig: loadTranslatorSchemaConfig,
+                        getSchemaConfig: loadBuiltinTranslatorSchemaConfig,
                     },
                 );
                 const matched = construction.match(requestAction.request);

--- a/ts/packages/dispatcher/test/constructionCacheTestCommon.ts
+++ b/ts/packages/dispatcher/test/constructionCacheTestCommon.ts
@@ -18,7 +18,7 @@ import {
     createActionProps,
     normalizeParamValue,
 } from "agent-cache";
-import { loadTranslatorSchemaConfig } from "../src/utils/loadSchemaConfig.js";
+import { loadBuiltinTranslatorSchemaConfig } from "../src/translation/agentTranslators.js";
 import { glob } from "glob";
 import { fileURLToPath } from "node:url";
 
@@ -28,7 +28,7 @@ export async function getImportedCache(
 ) {
     const cache = getCacheFactory().create(
         explainerName,
-        loadTranslatorSchemaConfig,
+        loadBuiltinTranslatorSchemaConfig,
         {
             mergeMatchSets: merge,
             cacheConflicts: true,

--- a/ts/packages/dispatcher/test/translate.test.ts
+++ b/ts/packages/dispatcher/test/translate.test.ts
@@ -6,7 +6,10 @@ dotenv.config({ path: new URL("../../../../.env", import.meta.url) });
 
 import { getPackageFilePath } from "../src/utils/getPackageFilePath.js";
 import { readTestData } from "../src/utils/test/testData.js";
-import { loadAgentJsonTranslator } from "../src/translation/agentTranslators.js";
+import {
+    getBuiltinTranslatorConfigProvider,
+    loadAgentJsonTranslator,
+} from "../src/translation/agentTranslators.js";
 import { JSONAction } from "agent-cache";
 
 const dataFiles = [
@@ -31,7 +34,10 @@ describe("translation", () => {
     it.each(testInput)(
         "translate [%s] '%s'",
         async (translatorName, request, action) => {
-            const translator = loadAgentJsonTranslator(translatorName);
+            const translator = loadAgentJsonTranslator(
+                translatorName,
+                getBuiltinTranslatorConfigProvider(),
+            );
             const result = await translator.translate(request);
             expect(result.success).toBe(true);
             if (result.success) {


### PR DESCRIPTION
Move away from globals, and move to wrapping AppAgent loading in a provider. 
This will prepare for host to inject their own app agent, and also alternative implementation that provide different loading mechanism.