### PR TITLE
Remove impression interpreter

### DIFF
--- a/ts/packages/agentSdk/src/memory.ts
+++ b/ts/packages/agentSdk/src/memory.ts
@@ -6,9 +6,9 @@ export interface Entity {
     name: string;
     // the types of the entity such as "artist" or "animal"; an entity can have multiple types; entity types should be single words
     type: string[];
-    // a value associated with the entity such as { birthYear: 1685 } for "Bach" or { destination: "Paris" } for "flight"
-    value?: object;
-    interpreter?: ImpressionInterpreter | undefined;
+
+    additionalEntityText?: string;
+    uniqueId?: string;
 }
 
 export type AssociationType = string;
@@ -32,16 +32,6 @@ export interface Relationship {
     from: Entity;
     to: Entity;
     association: Association;
-}
-
-/**
- * Return the entity's id, if one exists
- * @param entity
- */
-export function getEntityId(entity: Entity): string | undefined {
-    return entity.interpreter?.getEntityId
-        ? entity.interpreter.getEntityId(entity)
-        : undefined;
 }
 
 export function entitiesToString(entities: Entity[], indent = ""): string {
@@ -68,15 +58,6 @@ export function turnImpressionToString(turnImpression: TurnImpression): string {
     }
 }
 
-export const defaultImpressionInterpreter: ImpressionInterpreter = {
-    entityToText: (entity) => `${entity.name} (${entity.type.join(", ")})`,
-};
-
-export interface ImpressionInterpreter {
-    entityToText: (entity: Entity) => string;
-    getEntityId?: (entity: Entity) => string | undefined;
-}
-
 export interface TurnImpression {
     literalText?: string | undefined;
     entities: Entity[];
@@ -85,9 +66,6 @@ export interface TurnImpression {
     dynamicDisplayId?: string | undefined;
     dynamicDisplayNextRefreshMs?: number | undefined;
     error?: string | undefined;
-
-    // REVIEW: this is not "remoteable", need to redesign to enable dispatcher agent isolation.
-    impressionInterpreter?: ImpressionInterpreter;
 }
 
 export function createTurnImpressionFromDisplay(

--- a/ts/packages/agents/calendar/src/calendarActionHandler.ts
+++ b/ts/packages/agents/calendar/src/calendarActionHandler.ts
@@ -23,9 +23,6 @@ import {
 } from "./calendarQueryHelper.js";
 import {
     SessionContext,
-    Entity,
-    ImpressionInterpreter,
-    defaultImpressionInterpreter,
     createTurnImpressionFromDisplay,
     createTurnImpressionFromError,
     AppAction,
@@ -50,7 +47,6 @@ type CalendarActionContext = {
     calendarClient: CalendarClient | undefined;
     graphEventIds: GraphEventRefIds[] | undefined;
     mapGraphEntity: Map<string, GraphEntity> | undefined;
-    interpreter: ImpressionInterpreter;
 };
 
 async function initializeCalendarContext() {
@@ -58,7 +54,6 @@ async function initializeCalendarContext() {
         calendarClient: undefined,
         graphEventIds: undefined,
         mapGraphEntity: undefined,
-        interpreter: createImpressionInterpreter(),
     };
 }
 
@@ -107,28 +102,6 @@ function getLocalEventId(
         }
     }
     return localEventId;
-}
-
-function createImpressionInterpreter(): ImpressionInterpreter {
-    return {
-        entityToText,
-        getEntityId,
-    };
-
-    function entityToText(entity: Entity): string {
-        const gentity = entity.value as GraphEntity;
-        return (
-            defaultImpressionInterpreter.entityToText(entity) +
-            "\n" +
-            JSON.stringify(gentity.localId, undefined, 2) +
-            "\n"
-        );
-    }
-
-    function getEntityId(entity: Entity): string | undefined {
-        const gentity = entity.value as GraphEntity;
-        return gentity ? gentity.localId : undefined;
-    }
 }
 
 async function updateCalendarContext(
@@ -407,14 +380,10 @@ export async function handleCalendarAction(
                                 {
                                     name: `${actionEvent.description}`,
                                     type: ["event"],
-                                    value: calendarContext.mapGraphEntity?.get(
-                                        localId,
-                                    ) as any,
-                                    interpreter: calendarContext.interpreter,
-                                } as Entity, // Add 'as Entity' to specify the type
+                                    additionalEntityText: localId,
+                                    uniqueId: localId,
+                                },
                             ];
-                            result.impressionInterpreter =
-                                calendarContext.interpreter;
 
                             return result;
                         }
@@ -639,14 +608,10 @@ export async function handleCalendarAction(
                             {
                                 name: `${actionEvent.description}`,
                                 type: ["event"],
-                                value: calendarContext.mapGraphEntity?.get(
-                                    localId,
-                                ) as any,
-                                interpreter: calendarContext.interpreter,
-                            } as Entity,
+                                additionalEntityText: localId,
+                                uniqueId: localId,
+                            },
                         ];
-                        result.impressionInterpreter =
-                            calendarContext.interpreter;
                         return result;
                     }
                 } else {
@@ -732,15 +697,11 @@ export async function handleCalendarAction(
                                         {
                                             name: `${meeting.subject}`,
                                             type: ["event"],
-                                            value: calendarContext.mapGraphEntity?.get(
+                                            additionalEntityText:
                                                 lastLocalEventId,
-                                            ) as any,
-                                            interpreter:
-                                                calendarContext.interpreter,
-                                        } as Entity,
+                                            uniqueId: lastLocalEventId,
+                                        },
                                     ];
-                                    result.impressionInterpreter =
-                                        calendarContext.interpreter;
                                     return result;
                                 } else {
                                     // Could happen because the calendar event was deleted

--- a/ts/packages/dispatcher/src/action/actionHandlers.ts
+++ b/ts/packages/dispatcher/src/action/actionHandlers.ts
@@ -220,7 +220,6 @@ async function executeAction(
             result.entities,
             "assistant",
             context.requestId,
-            result.impressionInterpreter,
         );
     }
     return result;

--- a/ts/packages/dispatcher/src/handlers/common/chatHistoryPrompt.ts
+++ b/ts/packages/dispatcher/src/handlers/common/chatHistoryPrompt.ts
@@ -1,9 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { defaultImpressionInterpreter } from "@typeagent/agent-sdk";
+import { Entity } from "@typeagent/agent-sdk";
 import { HistoryContext } from "agent-cache";
 import { TypeChatJsonTranslator } from "typechat";
+
+function entityToText(entity: Entity) {
+    return `${entity.name} (${entity.type})${entity.additionalEntityText ? `: ${entity.additionalEntityText}` : ""}`;
+}
 
 export function makeRequestPromptCreator(
     translator: TypeChatJsonTranslator<object>,
@@ -24,9 +28,8 @@ export function makeRequestPromptCreator(
         latestEntity = "";
         for (let i = 0; i < entities.length; ++i) {
             const entity = entities[i];
-            let interpreter =
-                entity.interpreter || defaultImpressionInterpreter;
-            let curEntityStr = interpreter.entityToText(entity) + "\n";
+
+            let curEntityStr = entityToText(entity) + "\n";
             if (i > 0) {
                 entityStr += curEntityStr;
             } else {

--- a/ts/packages/dispatcher/src/handlers/requestCommandHandler.ts
+++ b/ts/packages/dispatcher/src/handlers/requestCommandHandler.ts
@@ -703,7 +703,6 @@ export class RequestCommandHandler implements CommandHandler {
                 [],
                 "user",
                 context.requestId,
-                undefined,
                 attachments,
             );
         }


### PR DESCRIPTION
Remove ImpressionInterpreter because it doesn't work across process boundary when agent is running out of proc.
Since it has minimal use right now, just change it to precompute the value that is needed for the dispatcher (instead of delay calling to interpret). We can design something different if there are additional need.