### PR TITLE
Shell: switch processShellRequest from invoke to just message response/reply

### DIFF
--- a/ts/packages/dispatcher/src/handlers/requestCommandHandler.ts
+++ b/ts/packages/dispatcher/src/handlers/requestCommandHandler.ts
@@ -52,23 +52,24 @@ async function confirmTranslation(
     requestAction: RequestAction | undefined | null;
     replacedAction?: Actions;
 }> {
-    const messages = [];
-    const requestIO = context.requestIO;
-    if (requestIO.type === "text") {
-        // Provide a one line information for text output
-        messages.push(
-            `${source}: ${chalk.blueBright(
-                ` ${requestAction.toString()}`,
-            )} ${getColorElapsedString(elapsedMs)}`,
-        );
-        messages.push();
-    }
-
     const actions = requestAction.actions;
-    const prettyStr = JSON.stringify(actions, undefined, 2);
-    messages.push(`${chalk.italic(chalk.cyanBright(prettyStr))}`);
+    const requestIO = context.requestIO;
 
     if (!context.developerMode) {
+        const messages = [];
+
+        if (requestIO.type === "text") {
+            // Provide a one line information for text output
+            messages.push(
+                `${source}: ${chalk.blueBright(
+                    ` ${requestAction.toString()}`,
+                )} ${getColorElapsedString(elapsedMs)}`,
+            );
+            messages.push();
+        }
+
+        const prettyStr = JSON.stringify(actions, undefined, 2);
+        messages.push(`${chalk.italic(chalk.cyanBright(prettyStr))}`);
         requestIO.info(messages.join("\n"));
         return { requestAction };
     }

--- a/ts/packages/shell/src/preload/index.ts
+++ b/ts/packages/shell/src/preload/index.ts
@@ -5,6 +5,44 @@ import { contextBridge, ipcRenderer } from "electron";
 import { electronAPI } from "@electron-toolkit/preload";
 import { ClientAPI, SpeechToken } from "./electronTypes.js"; // Custom APIs for renderer
 
+function getProcessShellRequest() {
+    const pendingRequests = new Map<
+        string,
+        { resolve: () => void; reject: (reason?: any) => void }
+    >();
+
+    ipcRenderer.on("process-shell-request-done", (_, id: string) => {
+        const pendingRequest = pendingRequests.get(id);
+        if (pendingRequest !== undefined) {
+            pendingRequest.resolve();
+            pendingRequests.delete(id);
+        } else {
+            console.warn(`Pending request ${id} not found`);
+        }
+    });
+    ipcRenderer.on(
+        "process-shell-request-error",
+        (_, id: string, message: string) => {
+            const pendingRequest = pendingRequests.get(id);
+            if (pendingRequest !== undefined) {
+                pendingRequest.reject(new Error(message));
+                pendingRequests.delete(id);
+            } else {
+                console.warn(
+                    `Pending request ${id} not found for error: ${message}`,
+                );
+            }
+        },
+    );
+
+    return (request: string, id: string, images: string[]) => {
+        return new Promise<void>((resolve, reject) => {
+            pendingRequests.set(id, { resolve, reject });
+            ipcRenderer.send("process-shell-request", request, id, images);
+        });
+    };
+}
+
 const api: ClientAPI = {
     onListenEvent: (
         callback: (
@@ -14,9 +52,8 @@ const api: ClientAPI = {
             useLocalWhisper?: boolean,
         ) => void,
     ) => ipcRenderer.on("listen-event", callback),
-    processShellRequest: (request: string, id: string, images: string[]) => {
-        return ipcRenderer.invoke("request", request, id, images);
-    },
+
+    processShellRequest: getProcessShellRequest(),
     sendPartialInput: (text: string) => {
         ipcRenderer.send("partial-input", text);
     },

--- a/ts/packages/shell/src/renderer/src/settingsView.ts
+++ b/ts/packages/shell/src/renderer/src/settingsView.ts
@@ -204,7 +204,12 @@ export class SettingsView {
 
         this.updateFromSettings = async () => {
             updateTabsView();
+            updateChatView();
             await updateTTSSelections();
+        };
+
+        speechSynthesis.onvoiceschanged = () => {
+            updateTTSSelections();
         };
     }
 


### PR DESCRIPTION
In the render process the order of message processing send from the main process and invoke completion can be out of order.
That make some of the display message for action comes after the `processShellRequest` is finished.
In the tts case, that means the content is not spoken.

Change from using `invoke` to just message, so that (in theory and manual testing) that the completion of `processShellRequest` will be in the same order as other message.

Also
- fix the case where the browser voices get loaded after the setting view is construction.
- chat view get the tts when the settings are loaded.
