### PR TITLE
Shell: fix auto scroll on streaming

### DIFF
--- a/ts/packages/shell/src/renderer/src/main.ts
+++ b/ts/packages/shell/src/renderer/src/main.ts
@@ -198,6 +198,7 @@ function showNotifications(
             source: "shell",
             requestId: requestId,
         },
+        false,
         true,
     );
 }


### PR DESCRIPTION
When streaming chat generate text, it doesn't auto scroll to content.

Change how we enable "auto scroll":
- Auto scroll to the bottom by default.
- Stop auto scrolling if user scroll away.
- Resume auto scroll on a new request.
