### PR TITLE
Fix sub domain activation

### DIFF
--- a/ts/packages/dispatcher/src/handlers/common/appAgentManager.ts
+++ b/ts/packages/dispatcher/src/handlers/common/appAgentManager.ts
@@ -39,7 +39,7 @@ export class AppAgentManager implements TranslatorConfigProvider {
     >();
 
     public isTranslator(translatorName: string) {
-        return this.agents.has(translatorName);
+        return this.translatorConfigs.has(translatorName);
     }
 
     public async addProvider(provider: AppAgentProvider) {


### PR DESCRIPTION
When checking if a translatorName exists, it should look at the translator configs instead of the app agent map.