### PR TITLE
Dispatcher API

### DIFF
--- a/ts/.vscode/settings.json
+++ b/ts/.vscode/settings.json
@@ -1,8 +1,14 @@
 {
     "editor.defaultFormatter": "esbenp.prettier-vscode",
     "cSpell.words": [
+        "aiclient",
         "lightgray",
-        "openai"
+        "oclif",
+        "openai",
+        "regen",
+        "tsbuildinfo",
+        "typeagent",
+        "typechat"
     ],
     "[html]": {
         "editor.defaultFormatter": "vscode.html-language-features"

--- a/ts/packages/agentSdk/README.md
+++ b/ts/packages/agentSdk/README.md
@@ -24,7 +24,6 @@ the `instantiate` function will be call to get an instance of the `AppAgent`. Th
 - `initializeAgentContext` - Dispatcher will call after the agent is loaded. It is expected to create a context that will be passed back on all subsequent call to other APIs.
 - `updateAgentContext` - A signal indicating whether the action is enabled or disabled for the agent, allowing it to manage resources such as login. The dispatcher calls this function during initialization or when the user enables or disables actions for the dispatcher agent. Each sub-translator can be enabled or disabled independently and the dispatcher will call this API once for each sub-translator. The `translatorName` parameter can be used to distinguish the sub-translator.
 - `executeAction` - After the dispatcher translates a user request using the provided translator schema in the manifest, it will route to the agent and call this function to perform the action. All sub-translator actions route to the same API, and the agent will need to handle further routing to handlers.
-- `partialInput` - Function to help with auto completion.
 
 ## Trademarks
 

--- a/ts/packages/cli/src/commands/constructions.ts
+++ b/ts/packages/cli/src/commands/constructions.ts
@@ -6,7 +6,7 @@ import {
     readTestData,
     getCacheFactory,
     loadBuiltinTranslatorSchemaConfig,
-} from "agent-dispatcher";
+} from "agent-dispatcher/internal";
 import { printImportConstructionResult } from "agent-cache";
 import fs from "node:fs";
 import chalk from "chalk";

--- a/ts/packages/cli/src/commands/data/add.ts
+++ b/ts/packages/cli/src/commands/data/add.ts
@@ -10,9 +10,10 @@ import {
     generateTestDataFiles,
     printTestDataStats,
     getEmptyTestData,
-} from "agent-dispatcher";
+    getBuiltinTranslatorNames,
+    getCacheFactory,
+} from "agent-dispatcher/internal";
 import chalk from "chalk";
-import { getBuiltinTranslatorNames, getCacheFactory } from "agent-dispatcher";
 import { getDefaultExplainerName } from "agent-cache";
 import { getChatModelMaxConcurrency, getChatModelNames } from "common-utils";
 

--- a/ts/packages/cli/src/commands/data/diff.ts
+++ b/ts/packages/cli/src/commands/data/diff.ts
@@ -6,7 +6,7 @@ import path from "node:path";
 import os from "node:os";
 import child_process from "node:child_process";
 import { Args, Command } from "@oclif/core";
-import { readTestData } from "agent-dispatcher";
+import { readTestData } from "agent-dispatcher/internal";
 
 export default class ExplanationDataDiffCommand extends Command {
     static args = {

--- a/ts/packages/cli/src/commands/data/list.ts
+++ b/ts/packages/cli/src/commands/data/list.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import { Args, Command } from "@oclif/core";
-import { readTestData } from "agent-dispatcher";
+import { readTestData } from "agent-dispatcher/internal";
 
 export default class ExplanationDataListCommand extends Command {
     static args = {

--- a/ts/packages/cli/src/commands/data/regenerate.ts
+++ b/ts/packages/cli/src/commands/data/regenerate.ts
@@ -16,7 +16,7 @@ import {
     getEmptyTestData,
     getTestDataFiles,
     loadBuiltinTranslatorSchemaConfig,
-} from "agent-dispatcher";
+} from "agent-dispatcher/internal";
 import {
     Actions,
     getDefaultExplainerName,

--- a/ts/packages/cli/src/commands/data/split.ts
+++ b/ts/packages/cli/src/commands/data/split.ts
@@ -3,7 +3,11 @@
 
 import { Args, Command, Flags } from "@oclif/core";
 import chalk from "chalk";
-import { TestData, getEmptyTestData, readTestData } from "agent-dispatcher";
+import {
+    TestData,
+    getEmptyTestData,
+    readTestData,
+} from "agent-dispatcher/internal";
 import fs from "node:fs";
 import path from "node:path";
 export default class ExplanationDataSplitCommmand extends Command {

--- a/ts/packages/cli/src/commands/data/stat.ts
+++ b/ts/packages/cli/src/commands/data/stat.ts
@@ -8,7 +8,7 @@ import {
     getCacheFactory,
     getBuiltinTranslatorNames,
     readTestData,
-} from "agent-dispatcher";
+} from "agent-dispatcher/internal";
 import { getTestDataFiles } from "../../../../dispatcher/dist/utils/config.js";
 import path from "node:path";
 

--- a/ts/packages/cli/src/commands/interactive.ts
+++ b/ts/packages/cli/src/commands/interactive.ts
@@ -9,10 +9,10 @@ import {
     processCommand,
     processRequests,
     getPrompt,
-    CommandHandlerContext,
     initializeCommandHandlerContext,
+    CommandHandlerContext,
     closeCommandHandlerContext,
-} from "agent-dispatcher";
+} from "agent-dispatcher/internal";
 import inspector from "node:inspector";
 
 export default class Interactive extends Command {
@@ -66,13 +66,17 @@ export default class Interactive extends Command {
             ? Object.fromEntries(flags.translator.map((name) => [name, true]))
             : undefined;
         try {
-            context = await initializeCommandHandlerContext("cli interactive", {
-                translators,
-                explainerName: flags.explainer,
-                stdio,
-                persistSession: !flags.memory,
-                enableServiceHost: true,
-            });
+            context = await initializeCommandHandlerContext(
+                "cli interactive",
+                undefined,
+                {
+                    translators,
+                    explainerName: flags.explainer,
+                    stdio,
+                    persistSession: !flags.memory,
+                    enableServiceHost: true,
+                },
+            );
 
             if (args.input) {
                 await processCommand(`@run ${args.input}`, context);

--- a/ts/packages/cli/src/commands/run/explain.ts
+++ b/ts/packages/cli/src/commands/run/explain.ts
@@ -9,9 +9,11 @@ import {
     Actions,
     printProcessRequestActionResult,
 } from "agent-cache";
-import { initializeCommandHandlerContext } from "agent-dispatcher";
-import { getCacheFactory } from "agent-dispatcher";
-import { getBuiltinTranslatorNames } from "agent-dispatcher";
+import {
+    getCacheFactory,
+    getBuiltinTranslatorNames,
+    initializeCommandHandlerContext,
+} from "agent-dispatcher/internal";
 
 // Default test case, that include multiple phrase action name (out of order) and implicit parameters (context)
 const testRequest = new RequestAction(
@@ -43,7 +45,7 @@ export default class ExplainCommand extends Command {
             options: getCacheFactory().getExplainerNames(),
         }),
         repeat: Flags.integer({
-            description: "Number of times to repeat the explaination",
+            description: "Number of times to repeat the explanation",
             default: 1,
         }),
         concurrency: Flags.integer({
@@ -64,6 +66,7 @@ export default class ExplainCommand extends Command {
             : undefined;
         const context = await initializeCommandHandlerContext(
             "cli run explain",
+            undefined,
             {
                 translators,
                 actions: {}, // We don't need any actions

--- a/ts/packages/cli/src/commands/run/request.ts
+++ b/ts/packages/cli/src/commands/run/request.ts
@@ -2,10 +2,12 @@
 // Licensed under the MIT License.
 
 import { Args, Command, Flags } from "@oclif/core";
-import { RequestCommandHandler } from "agent-dispatcher";
-import { initializeCommandHandlerContext } from "agent-dispatcher";
-import { getCacheFactory } from "agent-dispatcher";
-import { getBuiltinTranslatorNames } from "agent-dispatcher";
+import {
+    getCacheFactory,
+    initializeCommandHandlerContext,
+    RequestCommandHandler,
+    getBuiltinTranslatorNames,
+} from "agent-dispatcher/internal";
 import chalk from "chalk";
 import { readFileSync, existsSync } from "fs";
 
@@ -48,11 +50,15 @@ export default class RequestCommand extends Command {
         const handler = new RequestCommandHandler();
         await handler.run(
             args.request,
-            await initializeCommandHandlerContext("cli run request", {
-                translators,
-                explainerName: flags.explainer,
-                cache: false,
-            }),
+            await initializeCommandHandlerContext(
+                "cli run request",
+                undefined,
+                {
+                    translators,
+                    explainerName: flags.explainer,
+                    cache: false,
+                },
+            ),
             this.loadAttachment(args.attachment),
         );
     }

--- a/ts/packages/cli/src/commands/run/translate.ts
+++ b/ts/packages/cli/src/commands/run/translate.ts
@@ -2,9 +2,11 @@
 // Licensed under the MIT License.
 
 import { Args, Command, Flags } from "@oclif/core";
-import { TranslateCommandHandler } from "agent-dispatcher";
-import { initializeCommandHandlerContext } from "agent-dispatcher";
-import { getBuiltinTranslatorNames } from "agent-dispatcher";
+import {
+    initializeCommandHandlerContext,
+    TranslateCommandHandler,
+    getBuiltinTranslatorNames,
+} from "agent-dispatcher/internal";
 
 export default class TranslateCommand extends Command {
     static args = {
@@ -36,11 +38,15 @@ export default class TranslateCommand extends Command {
             : undefined;
         await handler.run(
             args.request,
-            await initializeCommandHandlerContext("cli run translate", {
-                translators,
-                actions: {}, // We don't need any actions
-                cache: false,
-            }),
+            await initializeCommandHandlerContext(
+                "cli run translate",
+                undefined,
+                {
+                    translators,
+                    actions: {}, // We don't need any actions
+                    cache: false,
+                },
+            ),
         );
     }
 }

--- a/ts/packages/cli/src/commands/schema.ts
+++ b/ts/packages/cli/src/commands/schema.ts
@@ -8,7 +8,7 @@ import {
     getFullSchemaText,
     getBuiltinTranslatorNames,
     getBuiltinTranslatorConfigProvider,
-} from "agent-dispatcher";
+} from "agent-dispatcher/internal";
 
 export default class Schema extends Command {
     static description = "Show schema used by translators";

--- a/ts/packages/dispatcher/package.json
+++ b/ts/packages/dispatcher/package.json
@@ -13,6 +13,7 @@
   "type": "module",
   "exports": {
     ".": "./dist/index.js",
+    "./internal": "./dist/internal.js",
     "./explorer": "./dist/explorer.js"
   },
   "scripts": {

--- a/ts/packages/dispatcher/src/action/actionHandlers.ts
+++ b/ts/packages/dispatcher/src/action/actionHandlers.ts
@@ -128,19 +128,11 @@ export function createSessionContext<T = unknown>(
     return sessionContext;
 }
 
-export async function partialInput(
-    text: string,
-    context: CommandHandlerContext,
-) {
-    // For auto completion
-    throw new Error("NYI");
-}
-
 export async function getDynamicDisplay(
+    context: CommandHandlerContext,
     appAgentName: string,
     type: DisplayType,
     displayId: string,
-    context: CommandHandlerContext,
 ): Promise<DynamicDisplay> {
     const appAgent = context.agents.getAppAgent(appAgentName);
     if (appAgent.getDynamicDisplay === undefined) {

--- a/ts/packages/dispatcher/src/dispatcher/dispatcher.ts
+++ b/ts/packages/dispatcher/src/dispatcher/dispatcher.ts
@@ -1,0 +1,76 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { DisplayType, DynamicDisplay } from "@typeagent/agent-sdk";
+import {
+    getPrompt,
+    getSettingSummary,
+    getTranslatorNameToEmojiMap,
+    processCommand,
+} from "../command.js";
+import {
+    closeCommandHandlerContext,
+    CommandHandlerContext,
+    initializeCommandHandlerContext,
+    InitializeCommandHandlerContextOptions,
+} from "../handlers/common/commandHandlerContext.js";
+import { getDynamicDisplay } from "../action/actionHandlers.js";
+import { RequestId } from "../handlers/common/interactiveIO.js";
+
+export interface Dispatcher {
+    processCommand(
+        command: string,
+        requestId?: RequestId,
+        attachments?: string[],
+    ): Promise<void>;
+    getDynamicDisplay(
+        appAgentName: string,
+        type: DisplayType,
+        id: string,
+    ): Promise<DynamicDisplay>;
+    close(): Promise<void>;
+
+    // TODO: Review these APIs
+    getPrompt(): string;
+    getSettingSummary(): string;
+    getTranslatorNameToEmojiMap(): Map<string, string>;
+
+    // TODO: Remove access to context
+    getContext(): CommandHandlerContext;
+}
+
+export type DispatcherOptions = InitializeCommandHandlerContextOptions;
+export async function createDispatcher(
+    hostName: string,
+    hostSettings: any,
+    options: DispatcherOptions,
+): Promise<Dispatcher> {
+    const context = await initializeCommandHandlerContext(
+        hostName,
+        hostSettings,
+        options,
+    );
+    return {
+        processCommand(command, requestId, attachments) {
+            return processCommand(command, context, requestId, attachments);
+        },
+        getDynamicDisplay(appAgentName, type, id) {
+            return getDynamicDisplay(context, appAgentName, type, id);
+        },
+        async close() {
+            await closeCommandHandlerContext(context);
+        },
+        getPrompt() {
+            return getPrompt(context);
+        },
+        getSettingSummary() {
+            return getSettingSummary(context);
+        },
+        getTranslatorNameToEmojiMap() {
+            return getTranslatorNameToEmojiMap(context);
+        },
+        getContext() {
+            return context;
+        },
+    };
+}

--- a/ts/packages/dispatcher/src/handlers/common/commandHandlerContext.ts
+++ b/ts/packages/dispatcher/src/handlers/common/commandHandlerContext.ts
@@ -51,6 +51,7 @@ import { conversation as Conversation } from "knowledge-processor";
 import { AppAgentManager } from "./appAgentManager.js";
 import { getBuiltinAppAgentProvider } from "../../agent/agentConfig.js";
 import { loadTranslatorSchemaConfig } from "../../utils/loadSchemaConfig.js";
+import { AppAgentProvider } from "../../agent/agentProvider.js";
 
 export interface CommandResult {
     error?: boolean;

--- a/ts/packages/dispatcher/src/index.ts
+++ b/ts/packages/dispatcher/src/index.ts
@@ -1,45 +1,5 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-export {
-    processCommand,
-    getSettingSummary,
-    getPrompt,
-    getTranslatorNameToEmojiMap,
-} from "./command.js";
-export { partialInput, getDynamicDisplay } from "./action/actionHandlers.js";
-export { processRequests } from "./utils/interactive.js";
+export { createDispatcher, Dispatcher } from "./dispatcher/dispatcher.js";
 export { ClientIO, RequestId } from "./handlers/common/interactiveIO.js";
-export {
-    initializeCommandHandlerContext,
-    closeCommandHandlerContext,
-    CommandHandlerContext,
-} from "./handlers/common/commandHandlerContext.js";
-export { getBuiltinTranslatorNames } from "./translation/agentTranslators.js";
-export { getCacheFactory } from "./utils/cacheFactory.js";
-export { loadTranslatorSchemaConfig } from "./utils/loadSchemaConfig.js";
-export {
-    GenerateTestDataResult,
-    GenerateDataInput,
-    generateTestDataFiles,
-    TestData,
-    readLineData,
-    getEmptyTestData,
-    readTestData,
-    printTestDataStats,
-    TestDataEntry,
-    FailedTestDataEntry,
-} from "./utils/test/testData.js";
-export { getBuiltinConstructionConfig } from "./utils/config.js";
-
-// for CLI/ testing
-export { RequestCommandHandler } from "./handlers/requestCommandHandler.js";
-export { TranslateCommandHandler } from "./handlers/translateCommandHandler.js";
-export { ExplainCommandHandler } from "./handlers/explainCommandHandler.js";
-export { getAssistantSelectionSchemas } from "./translation/unknownSwitcher.js";
-export { getTestDataFiles } from "./utils/config.js";
-export {
-    loadBuiltinTranslatorSchemaConfig,
-    getBuiltinTranslatorConfigProvider,
-    getFullSchemaText,
-} from "./translation/agentTranslators.js";

--- a/ts/packages/dispatcher/src/internal.ts
+++ b/ts/packages/dispatcher/src/internal.ts
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// Internal exports for CLI/testing/debugging purposes
+
+export {
+    initializeCommandHandlerContext,
+    closeCommandHandlerContext,
+    CommandHandlerContext,
+} from "./handlers/common/commandHandlerContext.js";
+export {
+    processCommand,
+    getSettingSummary,
+    getPrompt,
+    getTranslatorNameToEmojiMap,
+} from "./command.js";
+export { processRequests } from "./utils/interactive.js";
+export { getCacheFactory } from "./utils/cacheFactory.js";
+export {
+    GenerateTestDataResult,
+    GenerateDataInput,
+    generateTestDataFiles,
+    TestData,
+    readLineData,
+    getEmptyTestData,
+    readTestData,
+    printTestDataStats,
+    TestDataEntry,
+    FailedTestDataEntry,
+} from "./utils/test/testData.js";
+
+export { getBuiltinConstructionConfig } from "./utils/config.js";
+export { getBuiltinTranslatorNames } from "./translation/agentTranslators.js";
+export { RequestCommandHandler } from "./handlers/requestCommandHandler.js";
+export { TranslateCommandHandler } from "./handlers/translateCommandHandler.js";
+export { ExplainCommandHandler } from "./handlers/explainCommandHandler.js";
+export { getAssistantSelectionSchemas } from "./translation/unknownSwitcher.js";
+export { getTestDataFiles } from "./utils/config.js";
+export {
+    loadBuiltinTranslatorSchemaConfig,
+    getBuiltinTranslatorConfigProvider,
+    getFullSchemaText,
+} from "./translation/agentTranslators.js";

--- a/ts/packages/shell/src/preload/electronTypes.ts
+++ b/ts/packages/shell/src/preload/electronTypes.ts
@@ -113,7 +113,6 @@ export interface ClientAPI {
         id: string,
         images: string[],
     ) => Promise<void>;
-    sendPartialInput: (text: string) => void;
     getDynamicDisplay: (source: string, id: string) => Promise<DynamicDisplay>;
     onResponse(
         callback: (

--- a/ts/packages/shell/src/preload/index.ts
+++ b/ts/packages/shell/src/preload/index.ts
@@ -54,9 +54,6 @@ const api: ClientAPI = {
     ) => ipcRenderer.on("listen-event", callback),
 
     processShellRequest: getProcessShellRequest(),
-    sendPartialInput: (text: string) => {
-        ipcRenderer.send("partial-input", text);
-    },
     getDynamicDisplay(source: string, id: string) {
         return ipcRenderer.invoke("get-dynamic-display", source, id);
     },

--- a/ts/packages/shell/src/renderer/src/chatView.ts
+++ b/ts/packages/shell/src/renderer/src/chatView.ts
@@ -659,7 +659,7 @@ export class ChatView {
             (eta: ExpandableTextarea) => {
                 if (this.partialInputEnabled) {
                     this.placeSearchMenu();
-                    getClientAPI().sendPartialInput(eta.getEditedText());
+                    // TODO: NYI
                 } else if (this.searchMenu) {
                     this.placeSearchMenu();
                     this.searchMenu.completePrefix(eta.getEditedText());


### PR DESCRIPTION
- Clean up main dispatcher API, hide internal behind an interface
- Expose internals via `agent-dispatcher/internal` exports.
- Fix `initialCommandHandlerContext` call from the CLI, missing the new `hostSettings` parameter.
- Clean up more of the NYI `partialInput` code in preparation to re-implementing them.