### PR TITLE
Cleanup and rename

### DIFF
--- a/ts/packages/agentSdk/README.md
+++ b/ts/packages/agentSdk/README.md
@@ -14,7 +14,7 @@ These are declared in the `package.json` as export paths:
 
 ### Manifest
 
-When loading dispatcher agent in a NPM package, the dispatcher first loads the manifest from the agent. It contains definition of the emoji representing the agent and the translator configuration for the agent. See the type `TopLevelTranslatorConfig` and `HierarchicalTranslatorConfig` for the detail.
+When loading dispatcher agent in a NPM package, the dispatcher first loads the manifest from the agent. It contains definition of the emoji representing the agent and the translator configuration for the agent. See the type `AppAgentManifest` and `TranslatorDefinition` for the detail.
 
 ### Instantiation Entry point
 

--- a/ts/packages/agentSdk/src/agentInterface.ts
+++ b/ts/packages/agentSdk/src/agentInterface.ts
@@ -1,31 +1,34 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-export type TopLevelTranslatorConfig = {
+//==============================================================================
+// Manifest
+//==============================================================================
+export type AppAgentManifest = {
     emojiChar: string;
-} & HierarchicalTranslatorConfig;
+} & TranslatorDefinition;
 
-export type HierarchicalTranslatorConfig = {
+export type SchemaDefinition = {
+    description: string;
+    schemaType: string;
+    schemaFile: string;
+    injected?: boolean; // whether the translator is injected into other domains, default is false
+    cached?: boolean; // whether the translator's action should be cached, default is true
+    streamingActions?: string[];
+};
+
+export type TranslatorDefinition = {
     translationDefaultEnabled?: boolean;
     actionDefaultEnabled?: boolean;
     transient?: boolean; // whether the translator is transient, default is false
-    schema?: {
-        description: string;
-        schemaFile: string;
-        schemaType: string;
-        constructions?: {
-            data: string[];
-            file: string;
-        };
-        translations?: string[];
-        dataFrameColumns?: { [key: string]: string };
-        injected?: boolean; // whether the translator is injected into other domains, default is false
-        cached?: boolean; // whether the translator's action should be cached, default is true
-        streamingActions?: string[];
-    };
-    subTranslators?: { [key: string]: HierarchicalTranslatorConfig };
+
+    schema?: SchemaDefinition;
+    subTranslators?: { [key: string]: TranslatorDefinition };
 };
 
+//==============================================================================
+// App Agent
+//==============================================================================
 export interface AppAction {
     actionName: string;
     translatorName?: string | undefined;
@@ -104,6 +107,9 @@ export interface AppAgent extends Partial<AppAgentCommandInterface> {
     ): Promise<DynamicDisplay>;
 }
 
+//==============================================================================
+// Context
+//==============================================================================
 export enum AppAgentEvent {
     Error = "error",
     Warning = "warning",

--- a/ts/packages/agentSdk/src/index.ts
+++ b/ts/packages/agentSdk/src/index.ts
@@ -2,8 +2,9 @@
 // Licensed under the MIT License.
 
 export {
-    TopLevelTranslatorConfig,
-    HierarchicalTranslatorConfig,
+    AppAgentManifest,
+    TranslatorDefinition,
+    SchemaDefinition,
     AppAgent,
     AppAgentEvent,
     AppAction,

--- a/ts/packages/dispatcher/src/agent/agentProvider.ts
+++ b/ts/packages/dispatcher/src/agent/agentProvider.ts
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { AppAgent, TopLevelTranslatorConfig } from "@typeagent/agent-sdk";
+import { AppAgent, AppAgentManifest } from "@typeagent/agent-sdk";
 
 export interface AppAgentProvider {
     getAppAgentNames(): string[];
-    getAppAgentConfig(appAgentName: string): Promise<TopLevelTranslatorConfig>;
+    getAppAgentManifest(appAgentName: string): Promise<AppAgentManifest>;
     loadAppAgent(appAgentName: string): Promise<AppAgent>;
 }

--- a/ts/packages/dispatcher/src/command.ts
+++ b/ts/packages/dispatcher/src/command.ts
@@ -44,7 +44,7 @@ export async function resolveCommand(
     const args = input.match(/"[^"]+"|\S+/g) ?? [];
     let appAgentName = "system";
     const arg0 = args[0];
-    if (arg0 !== undefined && context.agents.enableExecuteCommand(arg0)) {
+    if (arg0 !== undefined && context.agents.isCommandEnabled(arg0)) {
         appAgentName = args.shift()!;
     }
     const appAgent = context.agents.getAppAgent(appAgentName);

--- a/ts/packages/dispatcher/src/handlers/common/commandHandlerContext.ts
+++ b/ts/packages/dispatcher/src/handlers/common/commandHandlerContext.ts
@@ -449,8 +449,8 @@ export async function changeContextConfig(
 
 export function getActiveTranslatorList(context: CommandHandlerContext) {
     return context.agents
-        .getEnabledTranslators()
-        .filter((name) => context.transientAgents[name] !== false);
+        .getTranslatorNames()
+        .filter((name) => isTranslatorActive(name, context));
 }
 
 function getActiveTranslators(context: CommandHandlerContext) {
@@ -459,7 +459,7 @@ function getActiveTranslators(context: CommandHandlerContext) {
     );
 }
 
-export function isTranslatorEnabled(
+export function isTranslatorActive(
     translatorName: string,
     context: CommandHandlerContext,
 ) {
@@ -469,7 +469,7 @@ export function isTranslatorEnabled(
     );
 }
 
-export function isActionEnabled(
+export function isActionActive(
     translatorName: string,
     context: CommandHandlerContext,
 ) {

--- a/ts/packages/dispatcher/src/handlers/constructionCommandHandlers.ts
+++ b/ts/packages/dispatcher/src/handlers/constructionCommandHandlers.ts
@@ -230,7 +230,10 @@ async function getImportTranslationFiles(
     } else {
         const infos = config.agents;
         const enabledAgents = new Set(
-            context.agents.getEnabledTranslators().map(getAppAgentName),
+            context.agents
+                .getTranslatorNames()
+                .filter((name) => context.agents.isTranslatorEnabled(name))
+                .map(getAppAgentName),
         );
 
         files = Object.entries(infos).flatMap(([name, info]) =>

--- a/ts/packages/dispatcher/src/handlers/requestCommandHandler.ts
+++ b/ts/packages/dispatcher/src/handlers/requestCommandHandler.ts
@@ -15,9 +15,9 @@ import {
     CommandHandlerContext,
     getTranslator,
     getActiveTranslatorList,
-    isTranslatorEnabled,
+    isTranslatorActive,
     updateCorrectionContext,
-    isActionEnabled,
+    isActionActive,
 } from "./common/commandHandlerContext.js";
 
 import { getColorElapsedString, Profiler } from "common-utils";
@@ -374,7 +374,7 @@ async function finalizeAction(
         }
 
         const { request, nextTranslatorName, searched } = nextTranslation;
-        if (!isTranslatorEnabled(nextTranslatorName, context)) {
+        if (!isTranslatorActive(nextTranslatorName, context)) {
             // this is a bug. May be the translator cache didn't get updated when state change?
             throw new Error(
                 `Internal error: switch to disabled translator ${nextTranslatorName}`,
@@ -474,7 +474,7 @@ export async function translateRequest(
     }
     // Start with the last translator used
     let translatorName = context.lastActionTranslatorName;
-    if (!isTranslatorEnabled(translatorName, context)) {
+    if (!isTranslatorActive(translatorName, context)) {
         debugTranslate(
             `Translating request using default translator: ${translatorName} not active`,
         );
@@ -567,7 +567,7 @@ function canExecute(
         }
         if (
             action.translatorName &&
-            !isActionEnabled(action.translatorName, context)
+            !isActionActive(action.translatorName, context)
         ) {
             disabled.add(action.translatorName);
         }

--- a/ts/packages/dispatcher/src/translation/agentTranslators.ts
+++ b/ts/packages/dispatcher/src/translation/agentTranslators.ts
@@ -4,8 +4,9 @@
 import { createJsonTranslatorFromSchemaDef } from "common-utils";
 import {
     AppAction,
-    HierarchicalTranslatorConfig,
-    TopLevelTranslatorConfig,
+    TranslatorDefinition,
+    SchemaDefinition,
+    AppAgentManifest,
 } from "@typeagent/agent-sdk";
 import { TypeChatJsonTranslator } from "typechat";
 import { getPackageFilePath } from "../utils/getPackageFilePath.js";
@@ -18,24 +19,14 @@ import { loadTranslatorSchemaConfig } from "../utils/loadSchemaConfig.js";
 
 const debugConfig = registerDebug("typeagent:translator:config");
 
+// A flatten AppAgentManifest
 export type TranslatorConfig = {
     emojiChar: string;
-    description: string;
-    schemaFile: string;
-    schemaType: string;
-    constructions?: {
-        data: string[];
-        file: string;
-    };
-    dataFrameColumns?: { [key: string]: string };
-    injected?: boolean; // whether the translator is injected into other domains, default is false
-    cached?: boolean; // whether the translator's action should be cached, default is true
-    streamingActions?: string[];
 
     translationDefaultEnabled: boolean;
     actionDefaultEnabled: boolean;
     transient: boolean;
-};
+} & SchemaDefinition;
 
 export interface TranslatorConfigProvider {
     getTranslatorConfig(translatorName: string): TranslatorConfig;
@@ -45,7 +36,7 @@ export interface TranslatorConfigProvider {
 
 function collectTranslatorConfigs(
     translatorConfigs: { [key: string]: TranslatorConfig },
-    config: HierarchicalTranslatorConfig,
+    config: TranslatorDefinition,
     name: string,
     emojiChar: string,
     transient: boolean,
@@ -86,7 +77,7 @@ function collectTranslatorConfigs(
 
 export function convertToTranslatorConfigs(
     name: string,
-    config: TopLevelTranslatorConfig,
+    config: AppAgentManifest,
     translatorConfigs: Record<string, TranslatorConfig> = {},
 ): Record<string, TranslatorConfig> {
     const emojiChar = config.emojiChar;

--- a/ts/packages/shell/src/main/agent.ts
+++ b/ts/packages/shell/src/main/agent.ts
@@ -4,7 +4,7 @@
 import {
     ActionContext,
     AppAgent,
-    TopLevelTranslatorConfig,
+    AppAgentManifest,
 } from "@typeagent/agent-sdk";
 import {
     CommandHandler,
@@ -18,7 +18,7 @@ type ShellContext = {
     settings: ShellSettings;
 };
 
-const config: TopLevelTranslatorConfig = {
+const config: AppAgentManifest = {
     emojiChar: "🐚",
 };
 
@@ -92,7 +92,7 @@ export const shellAgentProvider: AppAgentProvider = {
     getAppAgentNames: () => {
         return ["shell"];
     },
-    getAppAgentConfig: async (appAgentName: string) => {
+    getAppAgentManifest: async (appAgentName: string) => {
         if (appAgentName !== "shell") {
             throw new Error(`Unknown app agent: ${appAgentName}`);
         }


### PR DESCRIPTION
- Renames
  - `TopLevelTranslatorConfig`  -> `AppAgentManifest`
  - `HierarchicalTranslatorConfig` -> `TranslatorDefinition`
  - Add type name `SchemaDefinition` to the schema field in `TranslatorDefinition`
-  Clean up unused fields in `SchemaDefinition`
- Make naming of `AppAgentManager` more consistent.