### PR TITLE
Formalize display format and html and streaming delta

### DIFF
--- a/ts/packages/agentSdk/src/agentInterface.ts
+++ b/ts/packages/agentSdk/src/agentInterface.ts
@@ -41,7 +41,7 @@ export interface AppActionWithParameters extends AppAction {
 export type DisplayType = "html" | "text";
 
 export type DynamicDisplay = {
-    content: string;
+    content: DisplayContent;
     nextRefreshMs: number; // in milliseconds, -1 means no more refresh.
 };
 
@@ -85,7 +85,7 @@ export interface AppAgent extends Partial<AppAgentCommandInterface> {
         actionName: string,
         name: string,
         value: string,
-        partial: boolean,
+        delta: string | undefined,
         context: ActionContext<unknown>,
     ): void;
     executeAction?(
@@ -150,12 +150,21 @@ export interface Storage {
     getTokenCachePersistence(): Promise<TokenCachePersistence>;
 }
 
+export type DisplayContent =
+    | string
+    | {
+          type: DisplayType;
+          content: string;
+      };
+
 export interface ActionIO {
     readonly type: DisplayType;
-    setActionDisplay(content: string): void;
+    setDisplay(content: DisplayContent): void;
+    appendDisplay(content: DisplayContent): void;
 }
 
 export interface ActionContext<T = void> {
+    streamingContext: unknown;
     readonly actionIO: ActionIO;
     readonly sessionContext: SessionContext<T>;
     performanceMark(markName: string): void;

--- a/ts/packages/agentSdk/src/index.ts
+++ b/ts/packages/agentSdk/src/index.ts
@@ -18,6 +18,7 @@ export {
     ActionIO,
     DisplayType,
     DynamicDisplay,
+    DisplayContent,
     CommandDescriptor,
     CommandDescriptorTable,
 } from "./agentInterface.js";

--- a/ts/packages/agentSdk/src/memory.ts
+++ b/ts/packages/agentSdk/src/memory.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+import { DisplayContent } from "./agentInterface.js";
+
 export interface Entity {
     // the name of the entity such as "Bach" or "frog"
     name: string;
@@ -47,10 +49,10 @@ export function turnImpressionToString(turnImpression: TurnImpression): string {
     } else {
         // add to result all non-empty fields of the turn impression, using entitiesToString for the entities
         const fields = Object.entries(turnImpression)
-            .filter(([key, value]) => value && value.length > 0)
+            .filter(([key, value]) => Array.isArray(value) && value.length > 0)
             .map(([key, value]) => {
                 if (key === "entities") {
-                    return `${key}:\n${entitiesToString(value, "  ")}`;
+                    return `${key}:\n${entitiesToString(value as Entity[], "  ")}`;
                 }
                 return `${key}: ${value}`;
             });
@@ -58,41 +60,83 @@ export function turnImpressionToString(turnImpression: TurnImpression): string {
     }
 }
 
-export interface TurnImpression {
+export type TurnImpressionError = {
+    error: string;
+};
+
+export type TurnImpressionSuccessNoDisplay = {
     literalText?: string | undefined;
+    displayContent?: undefined;
     entities: Entity[];
     relationships?: Relationship[] | undefined;
-    displayText: string;
     dynamicDisplayId?: string | undefined;
     dynamicDisplayNextRefreshMs?: number | undefined;
-    error?: string | undefined;
+    error?: undefined;
+};
+
+export type TurnImpressionSuccess = {
+    literalText?: string | undefined;
+    displayContent: DisplayContent;
+    entities: Entity[];
+    relationships?: Relationship[] | undefined;
+    dynamicDisplayId?: string | undefined;
+    dynamicDisplayNextRefreshMs?: number | undefined;
+    error?: undefined;
+};
+
+export type TurnImpression =
+    | TurnImpressionSuccessNoDisplay
+    | TurnImpressionSuccess
+    | TurnImpressionError;
+
+export function createTurnImpressionNoDisplay(
+    literalText: string,
+): TurnImpressionSuccessNoDisplay {
+    return {
+        literalText,
+        entities: [],
+    };
 }
 
-export function createTurnImpressionFromDisplay(
+export function createTurnImpression(
+    literalText: string,
+): TurnImpressionSuccess {
+    return {
+        literalText,
+        entities: [],
+        displayContent: literalText,
+    };
+}
+
+export function createTurnImpressionFromTextDisplay(
     displayText: string,
     literalText?: string,
-): TurnImpression {
+): TurnImpressionSuccess {
     return {
         literalText,
         entities: [],
-        displayText,
+        displayContent: displayText,
     };
 }
 
-export function createTurnImpressionFromError(error: string): TurnImpression {
+export function createTurnImpressionFromHtmlDisplay(
+    displayText: string,
+    literalText?: string,
+): TurnImpressionSuccess {
     return {
+        literalText,
         entities: [],
-        displayText: "",
+        displayContent: {
+            type: "html",
+            content: displayText,
+        },
+    };
+}
+
+export function createTurnImpressionFromError(
+    error: string,
+): TurnImpressionError {
+    return {
         error,
-    };
-}
-
-export function createTurnImpressionFromLiteral(
-    literalText: string,
-): TurnImpression {
-    return {
-        literalText,
-        entities: [],
-        displayText: literalText,
     };
 }

--- a/ts/packages/agents/browser/src/agent/actionHandler.mts
+++ b/ts/packages/agents/browser/src/agent/actionHandler.mts
@@ -8,7 +8,7 @@ import {
   AppActionWithParameters,
   AppAgent,
   SessionContext,
-  createTurnImpressionFromLiteral,
+  createTurnImpression,
 } from "@typeagent/agent-sdk";
 import { Crossword } from "./crossword/schema/pageSchema.mjs";
 import {
@@ -133,7 +133,7 @@ async function executeBrowserAction(
   if (webSocketEndpoint) {
     try {
       const callId = new Date().getTime().toString();
-      context.actionIO.setActionDisplay("Running remote action.");
+      context.actionIO.setDisplay("Running remote action.");
 
       let messageType = "browserActionRequest";
       let target = "browser";
@@ -141,10 +141,10 @@ async function executeBrowserAction(
         messageType = "browserActionRequest.paleoBioDb";
       } else if (action.translatorName === "browser.crossword") {
         const crosswordResult = await handleCrosswordAction(action, context);
-        return createTurnImpressionFromLiteral(crosswordResult);
+        return createTurnImpression(crosswordResult);
       } else if (action.translatorName === "browser.commerce") {
         const commerceResult = await handleCommerceAction(action, context);
-        return createTurnImpressionFromLiteral(commerceResult);
+        return createTurnImpression(commerceResult);
       }
 
       webSocketEndpoint.send(

--- a/ts/packages/agents/calendar/src/calendarActionHandler.ts
+++ b/ts/packages/agents/calendar/src/calendarActionHandler.ts
@@ -23,7 +23,8 @@ import {
 } from "./calendarQueryHelper.js";
 import {
     SessionContext,
-    createTurnImpressionFromDisplay,
+    createTurnImpressionFromTextDisplay,
+    createTurnImpressionFromHtmlDisplay,
     createTurnImpressionFromError,
     AppAction,
     AppAgent,
@@ -266,7 +267,7 @@ export async function handleCalendarAction(
         !calendarContext.calendarClient ||
         !calendarContext.calendarClient?.isGraphClientInitialized()
     ) {
-        return createTurnImpressionFromDisplay(
+        return createTurnImpressionFromTextDisplay(
             "Not handling calendar actions ...",
         );
     }
@@ -373,7 +374,7 @@ export async function handleCalendarAction(
                         console.log(displayText);
 
                         let result =
-                            createTurnImpressionFromDisplay(displayText);
+                            createTurnImpressionFromHtmlDisplay(displayText);
 
                         if (result && localId) {
                             result.entities = [
@@ -602,7 +603,8 @@ export async function handleCalendarAction(
                     );
                     console.log(displayText);
 
-                    let result = createTurnImpressionFromDisplay(displayText);
+                    let result =
+                        createTurnImpressionFromHtmlDisplay(displayText);
                     if (result && localId) {
                         result.entities = [
                             {
@@ -689,7 +691,7 @@ export async function handleCalendarAction(
                                     console.log(displayText);
 
                                     let result =
-                                        createTurnImpressionFromDisplay(
+                                        createTurnImpressionFromHtmlDisplay(
                                             displayText,
                                         );
 
@@ -744,16 +746,16 @@ async function populateMeetingDetailsFromEvent(
     if (events instanceof Array) {
         if (events && events.length > 0) {
             const displayText = findEventsDisplayHtml(events);
-            let result = createTurnImpressionFromDisplay(displayText);
+            let result = createTurnImpressionFromHtmlDisplay(displayText);
             return result;
         } else {
             const displayText = `You have a meeting free day 😊`;
-            let result = createTurnImpressionFromDisplay(displayText);
+            let result = createTurnImpressionFromTextDisplay(displayText);
             return result;
         }
     } else {
         const displayText = findEventsDisplayHtml(events);
-        let result = createTurnImpressionFromDisplay(displayText);
+        let result = createTurnImpressionFromHtmlDisplay(displayText);
         return result;
     }
 }

--- a/ts/packages/agents/chat/src/chatResponseHandler.ts
+++ b/ts/packages/agents/chat/src/chatResponseHandler.ts
@@ -17,12 +17,17 @@ import {
     Entity,
 } from "typeagent";
 import { ChatModel, bing, openai } from "aiclient";
-import { ActionContext, AppAgent } from "@typeagent/agent-sdk";
+import {
+    ActionContext,
+    AppAgent,
+    createTurnImpressionNoDisplay,
+    TurnImpressionSuccess,
+} from "@typeagent/agent-sdk";
 import { PromptSection } from "typechat";
 import {
     AppAction,
     TurnImpression,
-    createTurnImpressionFromLiteral,
+    createTurnImpression,
 } from "@typeagent/agent-sdk";
 import { fileURLToPath } from "node:url";
 import { conversation as Conversation } from "knowledge-processor";
@@ -59,32 +64,21 @@ async function handleChatResponse(
     switch (chatAction.actionName) {
         case "generateResponse": {
             const generateResponseAction = chatAction as GenerateResponseAction;
-            if (generateResponseAction.parameters.generatedText !== undefined) {
-                logEntities(
-                    "UR Entities:",
-                    generateResponseAction.parameters.userRequestEntities,
-                );
-                logEntities(
-                    "GT Entities:",
-                    generateResponseAction.parameters.generatedTextEntities,
-                );
+            const parameters = generateResponseAction.parameters;
+            const generatedText = parameters.generatedText;
+            if (generatedText !== undefined) {
+                logEntities("UR Entities:", parameters.userRequestEntities);
+                logEntities("GT Entities:", parameters.generatedTextEntities);
                 console.log("Got generated text");
 
-                const result = createTurnImpressionFromLiteral(
-                    generateResponseAction.parameters.generatedText,
-                );
+                const needDisplay = context.streamingContext !== generatedText;
+                const result = needDisplay
+                    ? createTurnImpression(generatedText)
+                    : createTurnImpressionNoDisplay(generatedText);
 
-                let entities =
-                    generateResponseAction.parameters.generatedTextEntities ||
-                    [];
-                if (
-                    generateResponseAction.parameters.userRequestEntities !==
-                    undefined
-                ) {
-                    entities =
-                        generateResponseAction.parameters.userRequestEntities.concat(
-                            entities,
-                        );
+                let entities = parameters.generatedTextEntities || [];
+                if (parameters.userRequestEntities !== undefined) {
+                    entities = parameters.userRequestEntities.concat(entities);
                 }
                 result.entities = entities;
                 return result;
@@ -129,7 +123,7 @@ async function handleChatResponse(
                             matches.response &&
                             matches.response.answer
                         ) {
-                            return createTurnImpressionFromLiteral(
+                            return createTurnImpression(
                                 matches.response.answer.answer!,
                             );
                         } else {
@@ -140,7 +134,7 @@ async function handleChatResponse(
             }
         }
     }
-    return createTurnImpressionFromLiteral("No information found");
+    return createTurnImpression("No information found");
 }
 
 function logEntities(label: string, entities?: Entity[]): void {
@@ -182,7 +176,7 @@ function answerToHtml(answer: ChunkChatResponse, lookup?: string) {
     return html;
 }
 
-function answersToHtml(context: LookupContext) {
+function answersToHtml(context: LookupContext): string {
     let html = "";
     for (const [lookup, chatResponse] of context.answers) {
         html += answerToHtml(chatResponse, lookup);
@@ -274,9 +268,7 @@ async function handleLookup(
     context: ActionContext,
     settings: LookupSettings,
 ): Promise<TurnImpression> {
-    let literalResponse = createTurnImpressionFromLiteral(
-        "No information found",
-    );
+    let literalResponse = createTurnImpression("No information found");
 
     let lookups = chatAction.parameters.internetLookups;
     if (!lookups || lookups.length === 0) {
@@ -294,7 +286,10 @@ async function handleLookup(
     if (lookups.length === 1 && lookUpConfig?.documentConcurrency) {
         documentConcurrency = lookUpConfig.documentConcurrency;
     }
-    context.actionIO.setActionDisplay(lookupToHtml(lookups));
+    context.actionIO.setDisplay({
+        type: "html",
+        content: lookupToHtml(lookups),
+    });
     const lookupContext: LookupContext = {
         lookups,
         answers: new Map<string, ChunkChatResponse>(),
@@ -308,7 +303,7 @@ async function handleLookup(
     );
     // Capture answers in the turn impression to return
     literalResponse = updateTurnImpression(lookupContext, literalResponse);
-    context.actionIO.setActionDisplay(literalResponse.displayText);
+    context.actionIO.setDisplay(literalResponse.displayContent);
     // Generate entities if needed
     if (settings.entityGenModel) {
         const entities = await runEntityExtraction(lookupContext, settings);
@@ -367,11 +362,14 @@ function getLookupInstructions(): PromptSection[] {
 
 function updateTurnImpression(
     context: LookupContext,
-    literalResponse: TurnImpression,
-): TurnImpression {
+    literalResponse: TurnImpressionSuccess,
+): TurnImpressionSuccess {
     if (context.answers.size > 0) {
         literalResponse.literalText = "";
-        literalResponse.displayText = answersToHtml(context);
+        literalResponse.displayContent = {
+            type: "html",
+            content: answersToHtml(context),
+        };
         for (const [_lookup, chatResponse] of context.answers) {
             literalResponse.literalText += chatResponse.generatedText! + "\n";
             if (chatResponse.entities && chatResponse.entities.length > 0) {
@@ -431,9 +429,10 @@ async function runLookup(
     return answer;
 
     function updateStatus() {
-        actionContext.actionIO.setActionDisplay(
-            lookupProgressAsHtml(lookupContext),
-        );
+        actionContext.actionIO.setDisplay({
+            type: "html",
+            content: lookupProgressAsHtml(lookupContext),
+        });
     }
 }
 
@@ -513,14 +512,18 @@ function streamPartialChatResponseAction(
     actionName: string,
     name: string,
     value: string,
-    partial: boolean,
+    delta: string | undefined,
     context: ActionContext,
 ) {
     if (actionName !== "generateResponse") {
         return;
     }
 
-    if (name === "parameters.generatedText") {
-        context.actionIO.setActionDisplay(`${value}${partial ? "..." : ""}`);
+    if (name === "parameters.generatedText" && delta !== undefined) {
+        if (context.streamingContext === undefined) {
+            context.streamingContext = "";
+        }
+        context.streamingContext += delta;
+        context.actionIO.appendDisplay(delta);
     }
 }

--- a/ts/packages/agents/code/src/codeActionHandler.ts
+++ b/ts/packages/agents/code/src/codeActionHandler.ts
@@ -79,9 +79,7 @@ async function updateCodeContext(
                                     data.body.callId,
                                 );
                                 const { resolve, context } = pendingCall;
-                                context.actionIO.setActionDisplay(
-                                    data.body.message,
-                                );
+                                context.actionIO.setDisplay(data.body.message);
                                 resolve();
                             }
 

--- a/ts/packages/agents/desktop/src/actionHandler.ts
+++ b/ts/packages/agents/desktop/src/actionHandler.ts
@@ -4,7 +4,7 @@
 import {
     ActionContext,
     AppActionWithParameters,
-    createTurnImpressionFromLiteral,
+    createTurnImpression,
     SessionContext,
 } from "@typeagent/agent-sdk";
 import {
@@ -50,5 +50,5 @@ async function executeDesktopAction(
         action,
         context.sessionContext.agentContext,
     );
-    return createTurnImpressionFromLiteral(message);
+    return createTurnImpression(message);
 }

--- a/ts/packages/agents/email/src/emailActionHandler.ts
+++ b/ts/packages/agents/email/src/emailActionHandler.ts
@@ -15,7 +15,7 @@ import {
     AppAction,
     AppAgent,
     SessionContext,
-    createTurnImpressionFromDisplay,
+    createTurnImpressionFromHtmlDisplay,
 } from "@typeagent/agent-sdk";
 
 export function instantiate(): AppAgent {
@@ -53,7 +53,7 @@ async function executeEmailAction(
 ) {
     let result = await handleEmailAction(action as EmailAction, context);
     if (result) {
-        return createTurnImpressionFromDisplay(result);
+        return createTurnImpressionFromHtmlDisplay(result);
     }
 }
 

--- a/ts/packages/agents/list/src/listActionHandler.ts
+++ b/ts/packages/agents/list/src/listActionHandler.ts
@@ -8,7 +8,8 @@ import {
     SessionContext,
     Storage,
     TurnImpression,
-    createTurnImpressionFromDisplay,
+    createTurnImpressionFromTextDisplay,
+    createTurnImpressionFromHtmlDisplay,
 } from "@typeagent/agent-sdk";
 import {
     ListAction,
@@ -257,8 +258,10 @@ async function handleListAction(
                 );
                 await listContext.store.save();
                 displayText = `Added items: ${addAction.parameters.items} to list ${addAction.parameters.listName}`;
-                result = createTurnImpressionFromDisplay(displayText);
-                result.literalText = `Added item: ${addAction.parameters.items} to list ${addAction.parameters.listName}`;
+                result = createTurnImpressionFromTextDisplay(
+                    displayText,
+                    displayText,
+                );
                 result.entities = [
                     {
                         name: addAction.parameters.listName,
@@ -286,8 +289,10 @@ async function handleListAction(
                 );
                 await listContext.store.save();
                 displayText = `Removed items: ${removeAction.parameters.items} from list ${removeAction.parameters.listName}`;
-                result = createTurnImpressionFromDisplay(displayText);
-                result.literalText = `Removed items: ${removeAction.parameters.items} from list ${removeAction.parameters.listName}`;
+                result = createTurnImpressionFromTextDisplay(
+                    displayText,
+                    displayText,
+                );
                 result.entities = [
                     {
                         name: removeAction.parameters.listName,
@@ -322,8 +327,10 @@ async function handleListAction(
                     );
                     displayText = `List already exists: ${createListAction.parameters.listName}`;
                 }
-                result = createTurnImpressionFromDisplay(displayText);
-                result.literalText = `Created list: ${createListAction.parameters.listName}`;
+                result = createTurnImpressionFromTextDisplay(
+                    displayText,
+                    displayText,
+                );
                 result.entities = [
                     {
                         name: createListAction.parameters.listName,
@@ -344,8 +351,10 @@ async function handleListAction(
                 displayText = `<ul>${plainList
                     .map((item) => `<li>${item}</li>`)
                     .join("")}</ul>`;
-                result = createTurnImpressionFromDisplay(displayText);
-                result.literalText = `List ${getListAction.parameters.listName} has items: ${plainList.join(",")}`;
+                result = createTurnImpressionFromHtmlDisplay(
+                    displayText,
+                    `List ${getListAction.parameters.listName} has items: ${plainList.join(",")}`,
+                );
                 result.entities = [
                     {
                         name: getListAction.parameters.listName,
@@ -369,8 +378,10 @@ async function handleListAction(
                     list.itemsSet.clear();
                     await listContext.store.save();
                     displayText = `Cleared list: ${clearListAction.parameters.listName}`;
-                    result = createTurnImpressionFromDisplay(displayText);
-                    result.literalText = `Cleared list: ${clearListAction.parameters.listName}`;
+                    result = createTurnImpressionFromTextDisplay(
+                        displayText,
+                        displayText,
+                    );
                     result.entities = [
                         {
                             name: clearListAction.parameters.listName,

--- a/ts/packages/agents/photos/src/photoActionHandler.ts
+++ b/ts/packages/agents/photos/src/photoActionHandler.ts
@@ -6,10 +6,8 @@ import {
     AppAction,
     AppAgent,
     SessionContext,
-    Storage,
     TurnImpression,
-    createTurnImpressionFromDisplay,
-    createTurnImpressionFromLiteral,
+    createTurnImpression,
 } from "@typeagent/agent-sdk";
 import { AnswerImageQuestionAction, PhotoAction } from "./photoSchema.js";
 
@@ -71,7 +69,7 @@ async function handlePhotoAction(
         case "answerImageQuestion": {
             const answerAction = action as AnswerImageQuestionAction;
             const literalText = `Can't yet answer question: ${answerAction.parameters.questionText}`;
-            result = createTurnImpressionFromLiteral(literalText);
+            result = createTurnImpression(literalText);
             break;
         }
         default:

--- a/ts/packages/agents/player/src/agent/playerCommands.ts
+++ b/ts/packages/agents/player/src/agent/playerCommands.ts
@@ -33,7 +33,7 @@ const handlers: CommandHandlerTable = {
                                 "Spotify integration is not enabled.",
                             );
                         }
-                        context.actionIO.setActionDisplay(
+                        context.actionIO.setDisplay(
                             "Loading Spotify user data...",
                         );
 
@@ -43,7 +43,7 @@ const handlers: CommandHandlerTable = {
                             agentContext.spotify,
                         );
 
-                        context.actionIO.setActionDisplay(
+                        context.actionIO.setDisplay(
                             "Spotify user data loaded.",
                         );
                     },

--- a/ts/packages/agents/player/src/agent/playerHandlers.ts
+++ b/ts/packages/agents/player/src/agent/playerHandlers.ts
@@ -52,6 +52,7 @@ async function executePlayerAction(
         return handleCall(
             action as PlayerAction,
             context.sessionContext.agentContext.spotify,
+            context.actionIO,
         );
     }
 
@@ -160,7 +161,9 @@ async function getPlayerDynamicDisplay(
     if (displayId === "status") {
         const status = await htmlStatus(context.agentContext.spotify);
         return {
-            content: type === "html" ? status.displayText : status.literalText!,
+            content:
+                type === "html" ? status.displayContent : status.literalText!,
+
             nextRefreshMs: 1000,
         };
     }

--- a/ts/packages/dispatcher/src/agent/agentProcessShim.ts
+++ b/ts/packages/dispatcher/src/agent/agentProcessShim.ts
@@ -10,6 +10,7 @@ import {
     AppAgentEvent,
     CommandDescriptor,
     CommandDescriptorTable,
+    DisplayContent,
 } from "@typeagent/agent-sdk";
 import {
     AgentCallFunctions,
@@ -223,13 +224,21 @@ export async function createAgentProcessShim(
         }) => {
             contextMap.get(param.contextId).notify(param.event, param.message);
         },
-        setActionDisplay: (param: {
+        setDisplay: (param: {
             actionContextId: number;
-            message: string;
+            message: DisplayContent;
         }) => {
             actionContextMap
                 .get(param.actionContextId)
-                .actionIO.setActionDisplay(param.message);
+                .actionIO.setDisplay(param.message);
+        },
+        appendDisplay: (param: {
+            actionContextId: number;
+            message: DisplayContent;
+        }) => {
+            actionContextMap
+                .get(param.actionContextId)
+                .actionIO.appendDisplay(param.message);
         },
         performanceMark: (param: { actionContextId: number; name: string }) => {
             actionContextMap
@@ -278,7 +287,7 @@ export async function createAgentProcessShim(
             actionName: string,
             name: string,
             value: string,
-            partial: boolean,
+            delta: string | undefined,
             context: ActionContext<ShimContext>,
         ) {
             return withActionContext(context, (contextParams) =>
@@ -287,7 +296,7 @@ export async function createAgentProcessShim(
                     actionName,
                     name,
                     value,
-                    partial,
+                    delta,
                 }),
             );
         },

--- a/ts/packages/dispatcher/src/agent/agentProcessTypes.ts
+++ b/ts/packages/dispatcher/src/agent/agentProcessTypes.ts
@@ -3,6 +3,7 @@
 
 import {
     AppAgentEvent,
+    DisplayContent,
     DisplayType,
     StorageListOptions,
 } from "@typeagent/agent-sdk";
@@ -14,9 +15,13 @@ export type AgentContextCallFunctions = {
         event: AppAgentEvent;
         message: string;
     }): void;
-    setActionDisplay: (param: {
+    setDisplay: (param: {
         actionContextId: number;
-        message: string;
+        message: DisplayContent;
+    }) => void;
+    appendDisplay: (param: {
+        actionContextId: number;
+        message: DisplayContent;
     }) => void;
     performanceMark: (param: { actionContextId: number; name: string }) => void;
 };
@@ -67,7 +72,14 @@ export type AgentContextInvokeFunctions = {
 };
 
 export type AgentCallFunctions = {
-    streamPartialAction: (param: any) => void;
+    streamPartialAction: (
+        param: Partial<ContextParams> & {
+            actionName: string;
+            name: string;
+            value: string;
+            delta: string | undefined;
+        },
+    ) => void;
 };
 
 export type AgentInvokeFunctions = {
@@ -88,14 +100,6 @@ export type AgentInvokeFunctions = {
         param: Partial<ContextParams> & {
             type: DisplayType;
             displayId: string;
-        },
-    ) => Promise<any>;
-    streamPartialAction: (
-        param: Partial<ContextParams> & {
-            actionName: string;
-            type: string;
-            displayId: string;
-            partial: boolean;
         },
     ) => Promise<any>;
     closeAgentContext: (param: Partial<ContextParams>) => Promise<any>;

--- a/ts/packages/dispatcher/src/handlers/common/commandHandlerContext.ts
+++ b/ts/packages/dispatcher/src/handlers/common/commandHandlerContext.ts
@@ -47,7 +47,7 @@ import {
 } from "./interactiveIO.js";
 import { ChatHistory, createChatHistory } from "./chatHistory.js";
 import { getUserId } from "../../utils/userData.js";
-import { AppAgentEvent } from "@typeagent/agent-sdk";
+import { ActionContext, AppAgentEvent } from "@typeagent/agent-sdk";
 import { conversation as Conversation } from "knowledge-processor";
 import { AppAgentManager, AppAgentState } from "./appAgentManager.js";
 import { getBuiltinAppAgentProvider } from "../../agent/agentConfig.js";
@@ -90,6 +90,8 @@ export type CommandHandlerContext = {
     lastExplanation?: object;
 
     transientAgents: Record<string, boolean | undefined>;
+
+    streamingActionContext?: ActionContext<unknown> | undefined;
 };
 
 export function updateCorrectionContext(

--- a/ts/packages/dispatcher/src/handlers/requestCommandHandler.ts
+++ b/ts/packages/dispatcher/src/handlers/requestCommandHandler.ts
@@ -37,6 +37,7 @@ import { makeRequestPromptCreator } from "./common/chatHistoryPrompt.js";
 import { MatchResult } from "../../../cache/dist/constructions/constructions.js";
 import registerDebug from "debug";
 import { getAllActionInfo } from "../translation/actionInfo.js";
+import { IncrementalJsonValueCallBack } from "../../../commonUtils/dist/incrementalJsonParser.js";
 
 const debugTranslate = registerDebug("typeagent:translate");
 const debugConstValidation = registerDebug("typeagent:const:validation");
@@ -230,43 +231,47 @@ async function translateRequestWithTranslator(
     );
 
     let firstToken = true;
-    let streamFunction:
-        | ((name: string, value: any, partial: boolean) => void)
-        | undefined;
-
-    const onProperty = context.session.getConfig().stream
-        ? (prop: string, value: any, partial: boolean) => {
-              // TODO: streaming currently doesn't not support multiple actions
-              if (prop === "actionName" && !partial) {
-                  const actionTranslatorName =
-                      context.agents.getInjectedTranslatorForActionName(
-                          value,
-                      ) ?? translatorName;
-                  context.requestIO.status(
-                      `[${actionTranslatorName}] Translating '${request}' into action '${value}'`,
-                      actionTranslatorName,
-                  );
-                  const config =
-                      context.agents.getTranslatorConfig(actionTranslatorName);
-                  if (config.streamingActions?.includes(value)) {
-                      streamFunction = startStreamPartialAction(
+    let streamFunction: IncrementalJsonValueCallBack | undefined;
+    context.streamingActionContext = undefined;
+    const onProperty: IncrementalJsonValueCallBack | undefined =
+        context.session.getConfig().stream
+            ? (prop: string, value: any, delta: string | undefined) => {
+                  // TODO: streaming currently doesn't not support multiple actions
+                  if (prop === "actionName" && delta === undefined) {
+                      const actionTranslatorName =
+                          context.agents.getInjectedTranslatorForActionName(
+                              value,
+                          ) ?? translatorName;
+                      context.requestIO.status(
+                          `[${actionTranslatorName}] Translating '${request}' into action '${value}'`,
                           actionTranslatorName,
-                          value,
-                          context,
                       );
+                      const config =
+                          context.agents.getTranslatorConfig(
+                              actionTranslatorName,
+                          );
+                      if (config.streamingActions?.includes(value)) {
+                          streamFunction = startStreamPartialAction(
+                              actionTranslatorName,
+                              value,
+                              context,
+                          );
+                      }
+                  }
+
+                  if (firstToken) {
+                      Profiler.getInstance().mark(
+                          context.requestId,
+                          "First Token",
+                      );
+                      firstToken = false;
+                  }
+
+                  if (streamFunction) {
+                      streamFunction(prop, value, delta);
                   }
               }
-
-              if (firstToken) {
-                  Profiler.getInstance().mark(context.requestId, "First Token");
-                  firstToken = false;
-              }
-
-              if (streamFunction) {
-                  streamFunction(prop, value, partial);
-              }
-          }
-        : undefined;
+            : undefined;
 
     const response = await translator.translate(
         request,
@@ -707,6 +712,10 @@ export class RequestCommandHandler implements DispatcherCommandHandler {
                 attachments,
             );
         }
+
+        // Make sure we clear any left over streaming context
+        context.streamingActionContext = undefined;
+
         const match = await matchRequest(request, context, history);
         const translationResult =
             match === undefined // undefined means not found

--- a/ts/packages/dispatcher/src/index.ts
+++ b/ts/packages/dispatcher/src/index.ts
@@ -3,4 +3,8 @@
 
 export { createDispatcher, Dispatcher } from "./dispatcher/dispatcher.js";
 export { AppAgentProvider } from "./agent/agentProvider.js";
-export { ClientIO, RequestId } from "./handlers/common/interactiveIO.js";
+export {
+    ClientIO,
+    RequestId,
+    IAgentMessage,
+} from "./handlers/common/interactiveIO.js";

--- a/ts/packages/shell/package.json
+++ b/ts/packages/shell/package.json
@@ -36,6 +36,7 @@
     "aiclient": "workspace:*",
     "ansi_up": "^6.0.2",
     "debug": "4.3.4",
+    "dompurify": "^3.1.6",
     "dotenv": "^16.3.1",
     "electron-updater": "^6.3.2",
     "microsoft-cognitiveservices-speech-sdk": "^1.38.0",
@@ -45,6 +46,7 @@
   "devDependencies": {
     "@electron-toolkit/tsconfig": "^1.0.1",
     "@types/debug": "^4.1.10",
+    "@types/dompurify": "^3.0.5",
     "@types/node": "^18.17.5",
     "concurrently": "^8.2.2",
     "cross-env": "^7.0.3",

--- a/ts/packages/shell/src/main/agent.ts
+++ b/ts/packages/shell/src/main/agent.ts
@@ -40,7 +40,7 @@ class ShellShowSettingsCommandHandler implements CommandHandler {
             }
         };
         printConfig(agentContext.settings);
-        context.actionIO.setActionDisplay(message.join("\n"));
+        context.actionIO.setDisplay(message.join("\n"));
     }
 }
 
@@ -66,7 +66,7 @@ class ShellSetSettingCommandHandler implements CommandHandler {
                 `The supplied shell setting '${name}' could not be found.'`,
             );
         }
-        context.actionIO.setActionDisplay(`${name} was set to ${newValue}`);
+        context.actionIO.setDisplay(`${name} was set to ${newValue}`);
     }
 }
 

--- a/ts/packages/shell/src/main/index.ts
+++ b/ts/packages/shell/src/main/index.ts
@@ -26,10 +26,12 @@ import {
     Dispatcher,
 } from "agent-dispatcher";
 
-import { SearchMenuCommand } from "../../../dispatcher/dist/handlers/common/interactiveIO.js";
+import {
+    IAgentMessage,
+    SearchMenuCommand,
+} from "../../../dispatcher/dist/handlers/common/interactiveIO.js";
 import {
     ActionTemplateSequence,
-    IAgentMessage,
     SearchMenuItem,
 } from "../preload/electronTypes.js";
 import { ShellSettings } from "./shellSettings.js";
@@ -253,13 +255,13 @@ async function triggerRecognitionOnce(dispatcher: Dispatcher) {
     );
 }
 
-function showResult(message: IAgentMessage) {
+function showResult(message: IAgentMessage, append: boolean = false) {
     // Ignore message without requestId
     if (message.requestId === undefined) {
         console.warn("showResult: requestId is undefined");
         return;
     }
-    mainWindow?.webContents.send("response", message);
+    mainWindow?.webContents.send("response", message, append);
 }
 
 function sendStatusMessage(message: IAgentMessage, temporary: boolean = false) {
@@ -408,7 +410,8 @@ const clientIO: ClientIO = {
     warn: sendStatusMessage,
     error: sendStatusMessage,
     result: showResult,
-    setActionDisplay: showResult,
+    setDisplay: showResult,
+    appendDisplay: (message) => showResult(message, true),
     setDynamicDisplay,
     searchMenuCommand,
     actionCommand,

--- a/ts/packages/shell/src/preload/electronTypes.ts
+++ b/ts/packages/shell/src/preload/electronTypes.ts
@@ -4,6 +4,7 @@
 import { ElectronAPI } from "@electron-toolkit/preload";
 import { AppAgentEvent, DynamicDisplay } from "@typeagent/agent-sdk";
 import { ShellSettings } from "../main/shellSettings.js";
+import { IAgentMessage } from "agent-dispatcher";
 
 export type SpeechToken = {
     token: string;
@@ -77,14 +78,6 @@ export type ActionTemplateSequence = {
     prefaceMultiple?: string;
 };
 
-export interface IAgentMessage {
-    message: string;
-    requestId?: string | undefined;
-    source: string;
-    actionIndex?: number | undefined;
-    metrics?: IMessageMetrics;
-}
-
 export interface IMessageMetrics {
     duration: number | undefined;
     marks?: Map<string, number> | undefined;
@@ -118,6 +111,7 @@ export interface ClientAPI {
         callback: (
             e: Electron.IpcRendererEvent,
             message: IAgentMessage,
+            append: boolean,
         ) => void,
     ): void;
     onSetDynamicActionDisplay(

--- a/ts/packages/shell/src/renderer/assets/styles.less
+++ b/ts/packages/shell/src/renderer/assets/styles.less
@@ -238,6 +238,10 @@ body {
   word-wrap: break-word;
 }
 
+.chat-message-agent-text {
+  white-space: break-spaces;
+}
+
 .chat-message-metrics {
   background-color: #c2edff;
   margin-top: -5px;

--- a/ts/packages/shell/src/renderer/src/chatInput.ts
+++ b/ts/packages/shell/src/renderer/src/chatInput.ts
@@ -93,8 +93,9 @@ export function questionInput(
         "replacementDiv",
         "replacement-textarea",
         {
-            onSend: (text) => {
-                chatView.answer(questionId, text, id);
+            onSend: (html) => {
+                // REVIEW: text is from innerHTML, is that ok?
+                chatView.answer(questionId, html, id);
             },
         },
     );

--- a/ts/packages/shell/src/renderer/src/chatView.ts
+++ b/ts/packages/shell/src/renderer/src/chatView.ts
@@ -10,13 +10,18 @@ import {
     ActionInfo,
     ActionTemplateSequence,
     ActionUICommand,
-    IAgentMessage,
     IMessageMetrics,
     SearchMenuItem,
 } from "../../preload/electronTypes";
 import { ActionCascade } from "./ActionCascade";
-import { DynamicDisplay } from "@typeagent/agent-sdk";
+import {
+    DisplayContent,
+    DisplayType,
+    DynamicDisplay,
+} from "@typeagent/agent-sdk";
 import { TTS } from "./tts";
+import { IAgentMessage } from "agent-dispatcher";
+import DOMPurify from "dompurify";
 
 export interface InputChoice {
     element: HTMLElement;
@@ -273,7 +278,12 @@ class MessageContainer {
         }
         return message.innerText;
     }
-    public setMessage(text: string, source: string, sourceIcon?: string) {
+    public setMessage(
+        content: DisplayContent,
+        source: string,
+        sourceIcon?: string,
+        append: boolean = false,
+    ) {
         const message = this.div.lastChild?.previousSibling as HTMLDivElement;
         if (message === undefined) {
             return undefined;
@@ -285,7 +295,7 @@ class MessageContainer {
         const iconDiv: HTMLDivElement = this.div.children[1] as HTMLDivElement;
         iconDiv.innerText = sourceIcon ?? "❔"; // icon
 
-        setContent(message, text);
+        setContent(message, content, append);
     }
 
     public updateMetrics(metrics?: IMessageMetrics) {
@@ -307,14 +317,16 @@ class MessageGroup {
     public readonly userMessageContainer: HTMLDivElement;
     public readonly userMessage: HTMLDivElement;
     private statusMessage: MessageContainer | undefined;
-    private readonly statusMessages: { message: string; temporary: boolean }[] =
-        [];
+    private readonly statusMessages: {
+        message: DisplayContent;
+        temporary: boolean;
+    }[] = [];
     private readonly agentMessages: MessageContainer[] = [];
 
     private completed = false;
     constructor(
         private readonly chatView: ChatView,
-        request: string,
+        request: DisplayContent,
         container: HTMLDivElement,
         requestPromise: Promise<void>,
         timeStamp: Date,
@@ -420,11 +432,24 @@ class MessageGroup {
             .filter((m) => !m.temporary)
             .map((m) => m.message);
         messages.push(message);
-        statusMessage.setMessage(
-            messages.join("<br />"),
-            msg.source,
-            this.agents.get(msg.source),
-        );
+        let append = false;
+        for (const message of messages) {
+            if (append) {
+                statusMessage.setMessage(
+                    "\n",
+                    msg.source,
+                    this.agents.get(msg.source),
+                    append,
+                );
+            }
+            statusMessage.setMessage(
+                message,
+                msg.source,
+                this.agents.get(msg.source),
+                append,
+            );
+            append = true;
+        }
         this.statusMessages.push({ message, temporary });
         statusMessage.updateMetrics(msg.metrics);
         this.updateStatusMessageDivState();
@@ -465,23 +490,72 @@ ansi_up.use_classes = true;
 
 function textToHtml(text: string): string {
     const value = ansi_up.ansi_to_html(text);
-    const line = value.replace(/\n/gm, "<br>").replace(/  /g, " &nbsp;");
+    const line = value.replace(/\n/gm, "<br>");
     return line;
 }
 
 function stripAnsi(text: string): string {
-    return text.replace(/\x1b\[[0-9;]*m/g, "");
+    return text
+        .replace(/&/gm, "&amp;")
+        .replace(/</gm, "&lt;")
+        .replace(/>/gm, "&gt;")
+        .replace(/\x1b\[[0-9;]*m/g, "");
 }
 
 const enableText2Html = true;
-export function setContent(elm: HTMLElement, text: string) {
-    if (text.indexOf("<") > -1 && text.indexOf("Usage: @") == -1) {
-        elm.innerHTML = text;
-    } else if (enableText2Html) {
-        elm.innerHTML = textToHtml(text);
-    } else {
-        elm.innerText = stripAnsi(text);
+export function setContent(
+    elm: HTMLElement,
+    content: DisplayContent,
+    append: boolean = false,
+) {
+    // Remove existing content if we are not appending.
+    if (!append) {
+        while (elm.firstChild) {
+            elm.removeChild(elm.firstChild);
+        }
     }
+
+    let type: DisplayType;
+    let text: string;
+    if (typeof content === "string") {
+        type = "text";
+        text = content;
+    } else {
+        type = content.type;
+        text = content.content;
+    }
+
+    let contentDiv: HTMLDivElement | undefined;
+    if (elm.lastChild) {
+        const prevContentDiv = elm.lastChild as HTMLDivElement;
+        const isPrevText = prevContentDiv.classList.contains(
+            "chat-message-agent-text",
+        );
+
+        if ((type === "text") === isPrevText) {
+            // Reuse the previous div they are of the same type.
+            contentDiv = prevContentDiv;
+        }
+    }
+
+    if (contentDiv === undefined) {
+        contentDiv = document.createElement("div");
+        if (type === "text") {
+            // create a text diff so we can set "whitespace: break-spaces" css style of text content.
+            contentDiv.className = "chat-message-agent-text";
+        }
+        elm.appendChild(contentDiv);
+    }
+
+    // Process content according to type
+    const contentHtml =
+        type === "html"
+            ? DOMPurify.sanitize(text)
+            : enableText2Html
+              ? textToHtml(text)
+              : stripAnsi(text);
+
+    contentDiv.innerHTML += contentHtml;
 }
 
 export function createTimestampDiv(timestamp: Date, className: string) {
@@ -650,8 +724,12 @@ export class ChatView {
         this.chatInput = new ChatInput(
             "phraseDiv",
             "reco",
-            (message) => {
-                this.addUserMessage(message);
+            (messageHtml) => {
+                // message from chat input are from innerHTML
+                this.addUserMessage({
+                    type: "html",
+                    content: messageHtml,
+                });
                 if (this.searchMenu) {
                     this.cancelSearchMenu();
                 }
@@ -1022,7 +1100,7 @@ export class ChatView {
                         source: source,
                         actionIndex: actionIndex,
                     },
-                    true,
+                    { dynamicUpdate: true },
                 );
                 if (result.nextRefreshMs !== -1) {
                     this.dynamicDisplays.push({
@@ -1049,7 +1127,7 @@ export class ChatView {
                         source: source,
                         actionIndex: actionIndex,
                     },
-                    true,
+                    { dynamicUpdate: true },
                 );
             }
 
@@ -1080,19 +1158,28 @@ export class ChatView {
         this.commandBackStackIndex = -1;
     }
 
-    async addUserMessage(request: string, hidden: boolean = false) {
+    async addUserMessage(request: DisplayContent, hidden: boolean = false) {
         const id = this.idGenerator.genId();
 
-        let tempDiv: HTMLDivElement = document.createElement("div");
-        tempDiv.innerHTML = request;
+        let images: string[] = [];
+        let requestText: string;
+        if (typeof request === "string") {
+            requestText = request;
+        } else if (request.type === "html") {
+            let tempDiv: HTMLDivElement = document.createElement("div");
+            tempDiv.innerHTML = request.content;
 
-        let images = await this.extractMultiModalContent(tempDiv);
+            images = await this.extractMultiModalContent(tempDiv);
+            requestText = tempDiv.innerText;
+        } else {
+            requestText = request.content;
+        }
 
         const mg: MessageGroup = new MessageGroup(
             this,
             request,
             this.messageDiv,
-            getClientAPI().processShellRequest(tempDiv.innerText, id, images),
+            getClientAPI().processShellRequest(requestText, id, images),
             new Date(),
             this.agents,
         );
@@ -1160,17 +1247,29 @@ export class ChatView {
 
     addAgentMessage(
         msg: IAgentMessage,
-        dynamicUpdate = false,
-        notification = false,
+        options?: {
+            append?: boolean;
+            dynamicUpdate?: boolean;
+            notification?: boolean;
+        },
     ) {
-        const text: string = msg.message;
+        const append = options?.append ?? false;
+        const dynamicUpdate = options?.dynamicUpdate ?? false;
+        const notification = options?.notification ?? false;
+
+        const content: DisplayContent = msg.message;
         const source: string = msg.source;
 
         const agentMessage = this.ensureAgentMessage(msg, notification);
         if (agentMessage === undefined) {
             return;
         }
-        agentMessage.setMessage(text, source, this.agents.get(source));
+        agentMessage.setMessage(
+            content,
+            source,
+            this.agents.get(source),
+            append,
+        );
         this.updateScroll();
 
         if (!dynamicUpdate) {

--- a/ts/packages/shell/src/renderer/src/main.ts
+++ b/ts/packages/shell/src/renderer/src/main.ts
@@ -58,8 +58,8 @@ function addEvents(
             }
         }
     });
-    api.onResponse((_, agentMessage) => {
-        chatView.addAgentMessage(agentMessage);
+    api.onResponse((_, agentMessage, append) => {
+        chatView.addAgentMessage(agentMessage, { append });
     });
     api.onSetDynamicActionDisplay(
         (_, source, id, actionIndex, displayId, nextRefreshMs) =>
@@ -198,8 +198,7 @@ function showNotifications(
             source: "shell",
             requestId: requestId,
         },
-        false,
-        true,
+        { notification: true },
     );
 }
 

--- a/ts/pnpm-lock.yaml
+++ b/ts/pnpm-lock.yaml
@@ -1291,6 +1291,9 @@ importers:
       debug:
         specifier: 4.3.4
         version: 4.3.4(supports-color@8.1.1)
+      dompurify:
+        specifier: ^3.1.6
+        version: 3.1.6
       dotenv:
         specifier: ^16.3.1
         version: 16.3.1
@@ -1313,6 +1316,9 @@ importers:
       '@types/debug':
         specifier: ^4.1.10
         version: 4.1.10
+      '@types/dompurify':
+        specifier: ^3.0.5
+        version: 3.0.5
       '@types/node':
         specifier: ^18.17.5
         version: 18.18.7
@@ -2466,6 +2472,9 @@ packages:
   '@types/debug@4.1.10':
     resolution: {integrity: sha512-tOSCru6s732pofZ+sMv9o4o3Zc+Sa8l3bxd/tweTQudFn06vAzb13ZX46Zi6m6EJ+RUbRTHvgQJ1gBtSgkaUYA==}
 
+  '@types/dompurify@3.0.5':
+    resolution: {integrity: sha512-1Wg0g3BtQF7sSb27fJQAKck1HECM6zV1EB66j8JH9i3LCjYabJa0FSdiSgsD5K/RbrsR0SiraKacLB+T8ZVYAg==}
+
   '@types/eslint-scope@3.7.7':
     resolution: {integrity: sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==}
 
@@ -2612,6 +2621,9 @@ packages:
 
   '@types/stack-utils@2.0.2':
     resolution: {integrity: sha512-g7CK9nHdwjK2n0ymT2CW698FuWJRIx+RP6embAzZ2Qi8/ilIrA1Imt2LVSeHUzKvpoi7BhmmQcXz95eS0f2JXw==}
+
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
 
   '@types/verror@1.10.9':
     resolution: {integrity: sha512-MLx9Z+9lGzwEuW16ubGeNkpBDE84RpB/NyGgg6z2BTpWzKkGU451cAY3UkUzZEp72RHF585oJ3V8JVNqIplcAQ==}
@@ -3666,6 +3678,9 @@ packages:
   domhandler@5.0.3:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
+
+  dompurify@3.1.6:
+    resolution: {integrity: sha512-cTOAhc36AalkjtBpfG6O8JimdTMWNXjiePT2xQH/ppBGi/4uIpmj8eKyIkMJErXWARyINV/sB38yf8JCLF5pbQ==}
 
   domutils@2.8.0:
     resolution: {integrity: sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==}
@@ -8301,6 +8316,10 @@ snapshots:
     dependencies:
       '@types/ms': 0.7.33
 
+  '@types/dompurify@3.0.5':
+    dependencies:
+      '@types/trusted-types': 2.0.7
+
   '@types/eslint-scope@3.7.7':
     dependencies:
       '@types/eslint': 8.56.2
@@ -8466,6 +8485,8 @@ snapshots:
   '@types/spotify-api@0.0.22': {}
 
   '@types/stack-utils@2.0.2': {}
+
+  '@types/trusted-types@2.0.7': {}
 
   '@types/verror@1.10.9':
     optional: true
@@ -9804,6 +9825,8 @@ snapshots:
   domhandler@5.0.3:
     dependencies:
       domelementtype: 2.3.0
+
+  dompurify@3.1.6: {}
 
   domutils@2.8.0:
     dependencies:


### PR DESCRIPTION
Display format:
- for setDisplay, explicit declare the format is HTML to get correct processing.
- Fix the request message to process the content as HTML (since we switched to getting the content using innerHTML to get images). 
  -  Repros includes if the user request has multiple spaces (which would come out as "&nbsp; ", or any formatting in the input box.
  - Use explicitly format so it can avoid processing pure text as html

HTML output:
- Use dompurify to sanitize HTML given by agent to improve security and prevent XSS.

Streaming delta:
- Instead of replacing the full content of the action during streaming, just send the delta and append.  (In preparation to streaming TTS)
  - incremental JSON parser now sends delta along with the content so far.
  - add `appendDisplay` API.
  - Track streaming context so that we don't replace the output during the actual action execution.

Other improvements:
- player always return TurnImpression, include not found errors.