### PR TITLE
Updated dompurify to not strip "target" attributes.

### DIFF
--- a/ts/packages/shell/src/renderer/src/chatView.ts
+++ b/ts/packages/shell/src/renderer/src/chatView.ts
@@ -550,7 +550,7 @@ export function setContent(
     // Process content according to type
     const contentHtml =
         type === "html"
-            ? DOMPurify.sanitize(text)
+            ? DOMPurify.sanitize(text, { ADD_ATTR: ["target"] })
             : enableText2Html
               ? textToHtml(text)
               : stripAnsi(text);


### PR DESCRIPTION
DOMPurify was stripping target attributes so any links in the shell were opening within the shell browser window. 