### PR TITLE
Fix app event and explained notification issues

### DIFF
--- a/ts/packages/dispatcher/src/action/actionHandlers.ts
+++ b/ts/packages/dispatcher/src/action/actionHandlers.ts
@@ -78,8 +78,8 @@ export function createSessionContext<T = unknown>(
         get profileStorage() {
             return profileStorage;
         },
-        notify(event: AppAgentEvent, data: any) {
-            context.requestIO.notify(event, data, name);
+        notify(event: AppAgentEvent, message: string) {
+            context.requestIO.notify(event, undefined, message, name);
         },
         async toggleTransientAgent(subAgentName: string, enable: boolean) {
             if (!subAgentName.startsWith(`${name}.`)) {

--- a/ts/packages/dispatcher/src/handlers/requestCommandHandler.ts
+++ b/ts/packages/dispatcher/src/handlers/requestCommandHandler.ts
@@ -629,10 +629,10 @@ async function requestExplain(
     fromCache: boolean,
     fromUser: boolean,
 ) {
-    // Make sure the current requestIO is captured
-    const requestIO = context.requestIO;
+    // Make sure the current requestId is captured
+    const requestId = context.requestId;
     const notifyExplained = () => {
-        requestIO.notify("explained", context.requestId, {
+        context.requestIO.notify("explained", requestId, {
             time: new Date().toLocaleTimeString(),
             fromCache,
             fromUser,

--- a/ts/packages/shell/src/renderer/src/main.ts
+++ b/ts/packages/shell/src/renderer/src/main.ts
@@ -201,7 +201,7 @@ function showNotifications(
 
     chatView.addAgentMessage(
         {
-            message: html,
+            message: { type: "html", content: html },
             source: "shell",
             requestId: requestId,
         },
@@ -239,7 +239,10 @@ function summarizeNotifications(
     summary += `</div><br/><span style="font-size: 10px">Run @notify show [all | unread] so see notifications.</span>`;
 
     chatView.addAgentMessage({
-        message: summary,
+        message: {
+            type: "html",
+            content: summary,
+        },
         requestId: requestId,
         source: agents.get("shell")!,
     });


### PR DESCRIPTION
- Need to capture the right requestId now that requestIO does not automatically use the captured requestIO when forwarding notifications.
- session context's notify need to pass in `undefined` for the requestId (the parameter was missing)
- Fix the content type for the notification displays.