### PR TITLE
Switch Dispatcher command handler to use ActionContext

### DIFF
--- a/ts/packages/agentSdk/src/agentInterface.ts
+++ b/ts/packages/agentSdk/src/agentInterface.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+import { ActionIO, DisplayType, DynamicDisplay } from "./display.js";
 import { Profiler } from "./profiler.js";
 
 //==============================================================================
@@ -39,13 +40,6 @@ export interface AppAction {
 export interface AppActionWithParameters extends AppAction {
     parameters: { [key: string]: any };
 }
-
-export type DisplayType = "html" | "text";
-
-export type DynamicDisplay = {
-    content: DisplayContent;
-    nextRefreshMs: number; // in milliseconds, -1 means no more refresh.
-};
 
 export type CommandDescriptor = {
     description: string;
@@ -150,19 +144,6 @@ export interface Storage {
     delete(storagePath: string): Promise<void>;
 
     getTokenCachePersistence(): Promise<TokenCachePersistence>;
-}
-
-export type DisplayContent =
-    | string
-    | {
-          type: DisplayType;
-          content: string;
-      };
-
-export interface ActionIO {
-    readonly type: DisplayType;
-    setDisplay(content: DisplayContent): void;
-    appendDisplay(content: DisplayContent): void;
 }
 
 export interface ActionContext<T = void> {

--- a/ts/packages/agentSdk/src/display.ts
+++ b/ts/packages/agentSdk/src/display.ts
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+export type DisplayType = "html" | "text";
+
+export type DynamicDisplay = {
+    content: DisplayContent;
+    nextRefreshMs: number; // in milliseconds, -1 means no more refresh.
+};
+
+export type DisplayContent =
+    | string
+    | {
+          type: DisplayType;
+          content: string;
+      };
+
+export type DisplayAppendMode = "inline" | "block" | "temporary";
+
+export interface ActionIO {
+    readonly type: DisplayType;
+    setDisplay(content: DisplayContent): void;
+    appendDisplay(content: DisplayContent, mode?: DisplayAppendMode): void;
+}

--- a/ts/packages/agentSdk/src/index.ts
+++ b/ts/packages/agentSdk/src/index.ts
@@ -15,13 +15,17 @@ export {
     StorageEncoding,
     TokenCachePersistence,
     ActionContext,
+    CommandDescriptor,
+    CommandDescriptorTable,
+} from "./agentInterface.js";
+
+export {
     ActionIO,
     DisplayType,
     DynamicDisplay,
     DisplayContent,
-    CommandDescriptor,
-    CommandDescriptorTable,
-} from "./agentInterface.js";
+    DisplayAppendMode,
+} from "./display.js";
 export * from "./memory.js";
 
 export { Profiler } from "./profiler.js";

--- a/ts/packages/agentSdk/src/memory.ts
+++ b/ts/packages/agentSdk/src/memory.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { DisplayContent } from "./agentInterface.js";
+import { DisplayContent } from "./display.js";
 
 export interface Entity {
     // the name of the entity such as "Bach" or "frog"

--- a/ts/packages/cli/src/commands/run/request.ts
+++ b/ts/packages/cli/src/commands/run/request.ts
@@ -2,10 +2,9 @@
 // Licensed under the MIT License.
 
 import { Args, Command, Flags } from "@oclif/core";
+import { createDispatcher } from "agent-dispatcher";
 import {
     getCacheFactory,
-    initializeCommandHandlerContext,
-    RequestCommandHandler,
     getBuiltinTranslatorNames,
 } from "agent-dispatcher/internal";
 import chalk from "chalk";
@@ -47,14 +46,14 @@ export default class RequestCommand extends Command {
         const translators = flags.translator
             ? Object.fromEntries(flags.translator.map((name) => [name, true]))
             : undefined;
-        const handler = new RequestCommandHandler();
-        await handler.run(
-            args.request,
-            await initializeCommandHandlerContext("cli run request", {
-                translators,
-                explainerName: flags.explainer,
-                cache: false,
-            }),
+        const dispatcher = await createDispatcher("cli run request", {
+            translators,
+            explainerName: flags.explainer,
+            cache: false,
+        });
+        await dispatcher.processCommand(
+            `@request ${args.request}`,
+            undefined,
             this.loadAttachment(args.attachment),
         );
     }

--- a/ts/packages/cli/src/commands/run/translate.ts
+++ b/ts/packages/cli/src/commands/run/translate.ts
@@ -2,11 +2,8 @@
 // Licensed under the MIT License.
 
 import { Args, Command, Flags } from "@oclif/core";
-import {
-    initializeCommandHandlerContext,
-    TranslateCommandHandler,
-    getBuiltinTranslatorNames,
-} from "agent-dispatcher/internal";
+import { createDispatcher } from "agent-dispatcher";
+import { getBuiltinTranslatorNames } from "agent-dispatcher/internal";
 
 export default class TranslateCommand extends Command {
     static args = {
@@ -32,17 +29,15 @@ export default class TranslateCommand extends Command {
 
     async run(): Promise<void> {
         const { args, flags } = await this.parse(TranslateCommand);
-        const handler = new TranslateCommandHandler();
         const translators = flags.translator
             ? Object.fromEntries(flags.translator.map((name) => [name, true]))
             : undefined;
-        await handler.run(
-            args.request,
-            await initializeCommandHandlerContext("cli run translate", {
-                translators,
-                actions: {}, // We don't need any actions
-                cache: false,
-            }),
-        );
+
+        const dispatcher = await createDispatcher("cli run translate", {
+            translators,
+            actions: {}, // We don't need any actions
+            cache: false,
+        });
+        await dispatcher.processCommand(`@translate ${args.request}`);
     }
 }

--- a/ts/packages/dispatcher/src/action/actionHandlers.ts
+++ b/ts/packages/dispatcher/src/action/actionHandlers.ts
@@ -16,6 +16,7 @@ import {
     DisplayType,
     DisplayContent,
     ActionContext,
+    DisplayAppendMode,
 } from "@typeagent/agent-sdk";
 import { MatchResult } from "agent-cache";
 import { getStorage } from "./storageImpl.js";
@@ -40,8 +41,16 @@ function getActionContext(
         setDisplay(content: DisplayContent): void {
             context.requestIO.setDisplay(content, actionIndex, appAgentName);
         },
-        appendDisplay(content: DisplayContent): void {
-            context.requestIO.appendDisplay(content, actionIndex, appAgentName);
+        appendDisplay(
+            content: DisplayContent,
+            mode: DisplayAppendMode = "inline",
+        ): void {
+            context.requestIO.appendDisplay(
+                content,
+                actionIndex,
+                appAgentName,
+                mode,
+            );
         },
     };
     return {

--- a/ts/packages/dispatcher/src/agent/agentProcess.ts
+++ b/ts/packages/dispatcher/src/agent/agentProcess.ts
@@ -11,6 +11,8 @@ import {
     TokenCachePersistence,
     ActionIO,
     DisplayType,
+    DisplayContent,
+    DisplayAppendMode,
     AppAgentEvent,
 } from "@typeagent/agent-sdk";
 
@@ -316,16 +318,17 @@ function getActionContextShim(
         get type(): DisplayType {
             return "text";
         },
-        setDisplay(content: string): void {
+        setDisplay(content: DisplayContent): void {
             rpc.send("setDisplay", {
                 actionContextId,
                 content,
             });
         },
-        appendDisplay(content: string): void {
+        appendDisplay(content: DisplayContent, mode?: DisplayAppendMode): void {
             rpc.send("appendDisplay", {
                 actionContextId,
                 content,
+                mode,
             });
         },
     };

--- a/ts/packages/dispatcher/src/agent/agentProcessShim.ts
+++ b/ts/packages/dispatcher/src/agent/agentProcessShim.ts
@@ -11,6 +11,7 @@ import {
     CommandDescriptor,
     CommandDescriptorTable,
     DisplayContent,
+    DisplayAppendMode,
 } from "@typeagent/agent-sdk";
 import {
     AgentCallFunctions,
@@ -235,10 +236,11 @@ export async function createAgentProcessShim(
         appendDisplay: (param: {
             actionContextId: number;
             message: DisplayContent;
+            mode: DisplayAppendMode;
         }) => {
             actionContextMap
                 .get(param.actionContextId)
-                .actionIO.appendDisplay(param.message);
+                .actionIO.appendDisplay(param.message, param.mode);
         },
     };
 

--- a/ts/packages/dispatcher/src/agent/agentProcessTypes.ts
+++ b/ts/packages/dispatcher/src/agent/agentProcessTypes.ts
@@ -3,6 +3,7 @@
 
 import {
     AppAgentEvent,
+    DisplayAppendMode,
     DisplayContent,
     DisplayType,
     StorageListOptions,
@@ -22,6 +23,7 @@ export type AgentContextCallFunctions = {
     appendDisplay: (param: {
         actionContextId: number;
         message: DisplayContent;
+        mode: DisplayAppendMode;
     }) => void;
 };
 

--- a/ts/packages/dispatcher/src/handlers/common/appAgentManager.ts
+++ b/ts/packages/dispatcher/src/handlers/common/appAgentManager.ts
@@ -170,7 +170,7 @@ export class AppAgentManager implements TranslatorConfigProvider {
     public getAppAgent(appAgentName: string): AppAgent {
         const record = this.getRecord(appAgentName);
         if (record.appAgent === undefined) {
-            throw new Error("App agent is not initialized");
+            throw new Error(`App agent ${appAgentName} is not initialized`);
         }
         return record.appAgent;
     }
@@ -178,7 +178,9 @@ export class AppAgentManager implements TranslatorConfigProvider {
     public getSessionContext(appAgentName: string): SessionContext {
         const record = this.getRecord(appAgentName);
         if (record.sessionContext === undefined) {
-            throw new Error("Session context is not initialized");
+            throw new Error(
+                `Session context for ${appAgentName} is not initialized`,
+            );
         }
         return record.sessionContext;
     }

--- a/ts/packages/dispatcher/src/handlers/common/commandHandler.ts
+++ b/ts/packages/dispatcher/src/handlers/common/commandHandler.ts
@@ -1,25 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import {
-    CommandDescriptor,
-    CommandDescriptorTable,
-} from "@typeagent/agent-sdk";
+import { ActionContext } from "@typeagent/agent-sdk";
 import { CommandHandlerContext } from "./commandHandlerContext.js";
-
-export interface DispatcherCommandHandler extends CommandDescriptor {
-    run(
-        request: string,
-        context: CommandHandlerContext,
-        attachments?: string[],
-    ): Promise<void>;
-}
-
-export interface DispatcherHandlerTable extends CommandDescriptorTable {
-    description: string;
-    commands: Record<string, DispatcherCommandHandler | DispatcherHandlerTable>;
-    defaultSubCommand?: DispatcherCommandHandler | undefined;
-}
+import { CommandHandlerTable } from "@typeagent/agent-sdk/helpers/commands";
 
 export function getToggleCommandHandlers(
     name: string,
@@ -28,20 +12,26 @@ export function getToggleCommandHandlers(
     return {
         on: {
             description: `Turn on ${name}`,
-            run: async (request: string, context: CommandHandlerContext) => {
+            run: async (
+                request: string,
+                context: ActionContext<CommandHandlerContext>,
+            ) => {
                 if (request !== "") {
                     throw new Error(`Invalid extra arguments: ${request}`);
                 }
-                await toggle(context, true);
+                await toggle(context.sessionContext.agentContext, true);
             },
         },
         off: {
             description: `Turn off ${name}`,
-            run: async (request: string, context: CommandHandlerContext) => {
+            run: async (
+                request: string,
+                context: ActionContext<CommandHandlerContext>,
+            ) => {
                 if (request !== "") {
                     throw new Error(`Invalid extra arguments: ${request}`);
                 }
-                await toggle(context, false);
+                await toggle(context.sessionContext.agentContext, false);
             },
         },
     };
@@ -50,7 +40,7 @@ export function getToggleCommandHandlers(
 export function getToggleHandlerTable(
     name: string,
     toggle: (context: CommandHandlerContext, enable: boolean) => Promise<void>,
-): DispatcherHandlerTable {
+): CommandHandlerTable {
     return {
         description: `Toggle ${name}`,
         defaultSubCommand: undefined,

--- a/ts/packages/dispatcher/src/handlers/common/commandHandlerBase.ts
+++ b/ts/packages/dispatcher/src/handlers/common/commandHandlerBase.ts
@@ -4,15 +4,16 @@
 import { Result } from "typechat";
 import { CommandHandlerContext } from "./commandHandlerContext.js";
 import chalk from "chalk";
-import { DispatcherCommandHandler } from "./commandHandler.js";
 import { RequestIO } from "./interactiveIO.js";
 import { StopWatch } from "common-utils";
+import { CommandHandler } from "@typeagent/agent-sdk/helpers/commands";
+import { ActionContext } from "@typeagent/agent-sdk";
 
 /**
  * (Optional) Base class fro Command Handlers, with helper methods
  */
 
-export abstract class CommandHandlerBase implements DispatcherCommandHandler {
+export abstract class CommandHandlerBase implements CommandHandler {
     protected readonly _stopWatch: StopWatch;
 
     constructor(description: string, help?: string) {
@@ -26,7 +27,7 @@ export abstract class CommandHandlerBase implements DispatcherCommandHandler {
     public readonly description: string;
     public readonly help?: string;
 
-    run(request: string, context: CommandHandlerContext): Promise<void> {
+    run(request: string, context: ActionContext<unknown>): Promise<void> {
         throw new Error("Method not implemented.");
     }
 

--- a/ts/packages/dispatcher/src/handlers/common/commandHandlerContext.ts
+++ b/ts/packages/dispatcher/src/handlers/common/commandHandlerContext.ts
@@ -72,7 +72,7 @@ export type CommandHandlerContext = {
     agents: AppAgentManager;
     session: Session;
 
-    conversationManager?: Conversation.ConversationManager;
+    conversationManager?: Conversation.ConversationManager | undefined;
     // Per activation configs
     developerMode?: boolean;
     explanationAsynchronousMode: boolean;
@@ -227,12 +227,14 @@ export async function initializeCommandHandlerContext(
     if (options) {
         session.setConfig(options);
     }
-    const path = session.getSessionDirPath();
-    const conversationManager = await Conversation.createConversationManager(
-        "conversation",
-        path ? path : "/data/testChat",
-        false,
-    );
+    const sessionDirPath = session.getSessionDirPath();
+    const conversationManager = sessionDirPath
+        ? await Conversation.createConversationManager(
+              "conversation",
+              sessionDirPath,
+              false,
+          )
+        : undefined;
 
     const clientIO = options?.clientIO;
     const requestIO = clientIO

--- a/ts/packages/dispatcher/src/handlers/common/interactiveIO.ts
+++ b/ts/packages/dispatcher/src/handlers/common/interactiveIO.ts
@@ -199,7 +199,7 @@ export function getConsoleRequestIO(
         setDisplay: (content: DisplayContent) =>
             console.log(chalk.grey(displayContentToString(content))),
         appendDisplay: (content: DisplayContent) =>
-            // TODO: ignore newBlock
+            // TODO: ignore mode
             console.log(chalk.grey(displayContentToString(content))),
 
         isInputEnabled: () => stdio !== undefined,

--- a/ts/packages/dispatcher/src/handlers/correctCommandHandler.ts
+++ b/ts/packages/dispatcher/src/handlers/correctCommandHandler.ts
@@ -2,21 +2,26 @@
 // Licensed under the MIT License.
 
 import { printProcessExplanationResult } from "agent-cache";
-import { DispatcherCommandHandler } from "./common/commandHandler.js";
 import { CommandHandlerContext } from "./common/commandHandlerContext.js";
+import { CommandHandler } from "@typeagent/agent-sdk/helpers/commands";
+import { ActionContext } from "@typeagent/agent-sdk";
 
-export class CorrectCommandHandler implements DispatcherCommandHandler {
+export class CorrectCommandHandler implements CommandHandler {
     public readonly description = "Correct the last explanation";
-    public async run(input: string, context: CommandHandlerContext) {
-        if (context.lastRequestAction === undefined) {
+    public async run(
+        input: string,
+        context: ActionContext<CommandHandlerContext>,
+    ) {
+        const systemContext = context.sessionContext.agentContext;
+        if (systemContext.lastRequestAction === undefined) {
             throw new Error("No last request action to correct");
         }
-        if (context.lastExplanation === undefined) {
+        if (systemContext.lastExplanation === undefined) {
             throw new Error("No last explanation to correct");
         }
-        const result = await context.agentCache.correctExplanation(
-            context.lastRequestAction,
-            context.lastExplanation,
+        const result = await systemContext.agentCache.correctExplanation(
+            systemContext.lastRequestAction,
+            systemContext.lastExplanation,
             input,
         );
         printProcessExplanationResult(result);

--- a/ts/packages/dispatcher/src/handlers/debugCommandHandlers.ts
+++ b/ts/packages/dispatcher/src/handlers/debugCommandHandlers.ts
@@ -1,16 +1,21 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { DispatcherCommandHandler } from "./common/commandHandler.js";
+import { CommandHandler } from "@typeagent/agent-sdk/helpers/commands";
 import { CommandHandlerContext } from "./common/commandHandlerContext.js";
 import inspector from "node:inspector";
+import { ActionContext } from "@typeagent/agent-sdk";
+import { displayWarn } from "./common/interactiveIO.js";
 
-export class DebugCommandHandler implements DispatcherCommandHandler {
+export class DebugCommandHandler implements CommandHandler {
     public readonly description = "Start node inspector";
     private debugging = false;
-    public async run(input: string, context: CommandHandlerContext) {
+    public async run(
+        input: string,
+        context: ActionContext<CommandHandlerContext>,
+    ) {
         if (this.debugging) {
-            console.log("Node inspector already started");
+            displayWarn("Node inspector already started", context);
             return;
         }
         inspector.open(undefined, undefined, true);

--- a/ts/packages/dispatcher/src/handlers/explainCommandHandler.ts
+++ b/ts/packages/dispatcher/src/handlers/explainCommandHandler.ts
@@ -1,32 +1,34 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
-
-import { log } from "node:console";
-import { DispatcherCommandHandler } from "./common/commandHandler.js";
+import { CommandHandler } from "@typeagent/agent-sdk/helpers/commands";
 import {
     CommandHandlerContext,
     updateCorrectionContext,
 } from "./common/commandHandlerContext.js";
 import { RequestAction, printProcessRequestActionResult } from "agent-cache";
+import { ActionContext } from "@typeagent/agent-sdk";
+import { displayResult, displayStatus } from "./common/interactiveIO.js";
 
-export class ExplainCommandHandler implements DispatcherCommandHandler {
+export class ExplainCommandHandler implements CommandHandler {
     public readonly description = "Explain a translated request with action";
-    public async run(input: string, context: CommandHandlerContext) {
+    public async run(
+        input: string,
+        context: ActionContext<CommandHandlerContext>,
+    ) {
         const requestAction = RequestAction.fromString(input);
-        context.requestIO.status(
-            `Generating explanation for '${requestAction}'`,
-        );
-        const result = await context.agentCache.processRequestAction(
+        displayStatus(`Generating explanation for '${requestAction}'`, context);
+        const systemContext = context.sessionContext.agentContext;
+        const result = await systemContext.agentCache.processRequestAction(
             requestAction,
             false,
         );
         updateCorrectionContext(
-            context,
+            systemContext,
             requestAction,
             result.explanationResult.explanation,
         );
-        context.requestIO.result((log) => {
+        displayResult((log) => {
             printProcessRequestActionResult(result, log);
-        });
+        }, context);
     }
 }

--- a/ts/packages/dispatcher/src/handlers/historyCommandHandler.ts
+++ b/ts/packages/dispatcher/src/handlers/historyCommandHandler.ts
@@ -1,17 +1,22 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { StopWatch } from "common-utils";
 import {
-    DispatcherCommandHandler,
-    DispatcherHandlerTable,
-} from "./common/commandHandler.js";
+    CommandHandler,
+    CommandHandlerTable,
+} from "@typeagent/agent-sdk/helpers/commands";
 import { CommandHandlerContext } from "./common/commandHandlerContext.js";
+import { ActionContext } from "@typeagent/agent-sdk";
+import { displayResult } from "./common/interactiveIO.js";
 
-export class HistoryListCommandHandler implements DispatcherCommandHandler {
+export class HistoryListCommandHandler implements CommandHandler {
     public readonly description = "List history";
-    public async run(input: string, context: CommandHandlerContext) {
-        const history = context.chatHistory;
+    public async run(
+        input: string,
+        context: ActionContext<CommandHandlerContext>,
+    ) {
+        const systemContext = context.sessionContext.agentContext;
+        const history = systemContext.chatHistory;
 
         let index = 0;
         const output = [];
@@ -19,13 +24,12 @@ export class HistoryListCommandHandler implements DispatcherCommandHandler {
             output.push(`${index}: ${JSON.stringify(entry, undefined, 2)}`);
             index++;
         }
-        const h = output.join("\n");
 
-        context.requestIO.result(h);
+        displayResult(output, context);
     }
 }
 
-export function getHistoryCommandHandlers(): DispatcherHandlerTable {
+export function getHistoryCommandHandlers(): CommandHandlerTable {
     return {
         description: "History commands",
         defaultSubCommand: new HistoryListCommandHandler(),

--- a/ts/packages/dispatcher/src/handlers/notifyCommandHandler.ts
+++ b/ts/packages/dispatcher/src/handlers/notifyCommandHandler.ts
@@ -1,75 +1,79 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { log } from "node:console";
 import {
-    DispatcherCommandHandler,
-    DispatcherHandlerTable,
-} from "./common/commandHandler.js";
+    CommandHandler,
+    CommandHandlerTable,
+} from "@typeagent/agent-sdk/helpers/commands";
 import { CommandHandlerContext } from "./common/commandHandlerContext.js";
 import { NotifyCommands } from "./common/interactiveIO.js";
+import { ActionContext } from "@typeagent/agent-sdk";
 
-class NotifyInfoCommandHandler implements DispatcherCommandHandler {
+class NotifyInfoCommandHandler implements CommandHandler {
     description: string = "Shows the number of notifications available";
     help?: string;
     public async run(
         request: string,
-        context: CommandHandlerContext,
+        context: ActionContext<CommandHandlerContext>,
     ): Promise<void> {
-        context.requestIO.notify(
+        const systemContext = context.sessionContext.agentContext;
+        systemContext.requestIO.notify(
             "showNotifications",
-            context.requestId,
+            systemContext.requestId,
             NotifyCommands.ShowSummary,
         );
     }
 }
 
-class NotifyClearCommandHandler implements DispatcherCommandHandler {
+class NotifyClearCommandHandler implements CommandHandler {
     description: string = "Clears notifications";
     help?: string;
     public async run(
         request: string,
-        context: CommandHandlerContext,
+        context: ActionContext<CommandHandlerContext>,
     ): Promise<void> {
-        context.requestIO.notify(
+        const systemContext = context.sessionContext.agentContext;
+        systemContext.requestIO.notify(
             "showNotifications",
-            context.requestId,
+            systemContext.requestId,
             NotifyCommands.Clear,
         );
     }
 }
 
-class NotifyShowUnreadCommandHandler implements DispatcherCommandHandler {
+class NotifyShowUnreadCommandHandler implements CommandHandler {
     description: string = "Shows unread notifications";
     help?: string;
     public async run(
         request: string,
-        context: CommandHandlerContext,
+        context: ActionContext<CommandHandlerContext>,
     ): Promise<void> {
-        context.requestIO.notify(
+        const systemContext = context.sessionContext.agentContext;
+        systemContext.requestIO.notify(
             "showNotifications",
-            context.requestId,
+            systemContext.requestId,
             NotifyCommands.ShowUnread,
         );
     }
 }
 
-class NotifyShowAllCommandHandler implements DispatcherCommandHandler {
+class NotifyShowAllCommandHandler implements CommandHandler {
     description: string = "Shows all notifications";
     help?: string;
     public async run(
         request: string,
-        context: CommandHandlerContext,
+        context: ActionContext<CommandHandlerContext>,
     ): Promise<void> {
-        context.requestIO.notify(
+        const systemContext = context.sessionContext.agentContext;
+        systemContext.requestIO.notify(
             "showNotifications",
-            context.requestId,
+            systemContext.requestId,
             NotifyCommands.ShowAll,
         );
     }
 }
 
-export function getNotifyCommandHandlers(): DispatcherHandlerTable {
+export function getNotifyCommandHandlers(): CommandHandlerTable {
     return {
         description: "Notify commands",
         defaultSubCommand: new NotifyInfoCommandHandler(),

--- a/ts/packages/dispatcher/src/handlers/randomCommandHandler.ts
+++ b/ts/packages/dispatcher/src/handlers/randomCommandHandler.ts
@@ -1,11 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { log } from "node:console";
-import {
-    DispatcherCommandHandler,
-    DispatcherHandlerTable,
-} from "./common/commandHandler.js";
 import { CommandHandlerContext } from "./common/commandHandlerContext.js";
 import fs from "node:fs";
 import { randomInt } from "crypto";
@@ -13,7 +8,11 @@ import { processCommandNoLock } from "../command.js";
 import { ChatModelWithStreaming, CompletionSettings, openai } from "aiclient";
 import { createTypeChat, promptLib } from "typeagent";
 import { PromptSection, Result, TypeChatJsonTranslator } from "typechat";
-import { AppAgentEvent } from "@typeagent/agent-sdk";
+import { ActionContext, AppAgentEvent } from "@typeagent/agent-sdk";
+import {
+    CommandHandler,
+    CommandHandlerTable,
+} from "@typeagent/agent-sdk/helpers/commands";
 
 export type UserRequestList = {
     messages: UserRequest[];
@@ -33,14 +32,18 @@ export type UserRequest = {
     message: string;
 };`;
 
-class RandomOfflineCommandHandler implements DispatcherCommandHandler {
+class RandomOfflineCommandHandler implements CommandHandler {
     private list: string[] | undefined;
 
     public readonly description =
         "Issues a random request from a dataset of pre-generated requests.";
 
-    public async run(request: string, context: CommandHandlerContext) {
-        context.requestIO.status(`Selecting random request...`);
+    public async run(
+        request: string,
+        context: ActionContext<CommandHandlerContext>,
+    ) {
+        const systemContext = context.sessionContext.agentContext;
+        systemContext.requestIO.status(`Selecting random request...`);
 
         if (this.list == undefined) {
             this.list = await this.getRequests();
@@ -48,16 +51,20 @@ class RandomOfflineCommandHandler implements DispatcherCommandHandler {
 
         const randomRequest = this.list[randomInt(0, this.list.length)];
 
-        context.requestIO.notify("randomCommandSelected", context.requestId, {
-            message: randomRequest,
-        });
-        context.requestIO.notify(
+        systemContext.requestIO.notify(
+            "randomCommandSelected",
+            systemContext.requestId,
+            {
+                message: randomRequest,
+            },
+        );
+        systemContext.requestIO.notify(
             AppAgentEvent.Info,
-            context.requestId,
+            systemContext.requestId,
             randomRequest,
         );
 
-        await processCommandNoLock(randomRequest, context);
+        await processCommandNoLock(randomRequest, systemContext);
     }
 
     public async getRequests(): Promise<string[]> {
@@ -73,13 +80,19 @@ class RandomOfflineCommandHandler implements DispatcherCommandHandler {
     }
 }
 
-class RandomOnlineCommandHandler implements DispatcherCommandHandler {
+class RandomOnlineCommandHandler implements CommandHandler {
     private instructions = `You are an Siri/Alexa/Cortana prompt generator. You create user prompts that are both supported and unsupported.`;
 
     public readonly description = "Uses the LLM to generate random requests.";
 
-    public async run(request: string, context: CommandHandlerContext) {
-        context.requestIO.status(`Generating random request using LLM...`);
+    public async run(
+        request: string,
+        context: ActionContext<CommandHandlerContext>,
+    ) {
+        const systemContext = context.sessionContext.agentContext;
+        systemContext.requestIO.status(
+            `Generating random request using LLM...`,
+        );
 
         //
         // Create Model
@@ -114,17 +127,17 @@ class RandomOnlineCommandHandler implements DispatcherCommandHandler {
                     randomInt(0, response.data.messages.length)
                 ].message;
 
-            context.requestIO.notify(
+            systemContext.requestIO.notify(
                 "randomCommandSelected",
-                context.requestId,
+                systemContext.requestId,
                 {
                     message: message,
                 },
             );
 
-            await processCommandNoLock(message, context);
+            await processCommandNoLock(message, systemContext);
         } else {
-            context.requestIO.error(response.message);
+            throw new Error(response.message);
         }
     }
 
@@ -162,7 +175,7 @@ class RandomOnlineCommandHandler implements DispatcherCommandHandler {
     }
 }
 
-export function getRandomCommandHandlers(): DispatcherHandlerTable {
+export function getRandomCommandHandlers(): CommandHandlerTable {
     return {
         description: "Random request commands",
         defaultSubCommand: new RandomOfflineCommandHandler(),

--- a/ts/packages/dispatcher/src/handlers/serviceHost/localWhisperCommandHandler.ts
+++ b/ts/packages/dispatcher/src/handlers/serviceHost/localWhisperCommandHandler.ts
@@ -1,11 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { DispatcherHandlerTable } from "../common/commandHandler.js";
 import { CommandHandlerContext } from "../common/commandHandlerContext.js";
 import chalk from "chalk";
 import { ChildProcess, spawn } from "child_process";
 import { getPackageFilePath } from "../../utils/getPackageFilePath.js";
+import { CommandHandlerTable } from "@typeagent/agent-sdk/helpers/commands";
+import { displayResult, displayWarn } from "../common/interactiveIO.js";
+import { ActionContext } from "@typeagent/agent-sdk";
 
 export async function createLocalWhisperHost() {
     let timeoutHandle: NodeJS.Timeout;
@@ -69,7 +71,7 @@ export async function createLocalWhisperHost() {
     );
 }
 
-export function getLocalWhisperCommandHandlers(): DispatcherHandlerTable {
+export function getLocalWhisperCommandHandlers(): CommandHandlerTable {
     return {
         description: "Configure Local Whisper",
         defaultSubCommand: undefined,
@@ -78,14 +80,16 @@ export function getLocalWhisperCommandHandlers(): DispatcherHandlerTable {
                 description: "Turn off Local Whisper integration",
                 run: async (
                     request: string,
-                    context: CommandHandlerContext,
+                    context: ActionContext<CommandHandlerContext>,
                 ) => {
-                    if (context.localWhisper) {
-                        context.localWhisper?.kill();
-                        context.localWhisper = undefined;
+                    const systemContext = context.sessionContext.agentContext;
+                    if (systemContext.localWhisper) {
+                        systemContext.localWhisper?.kill();
+                        systemContext.localWhisper = undefined;
 
-                        context.requestIO.result(
+                        displayResult(
                             chalk.blue(`Local Whisper disabled.`),
+                            context,
                         );
                     }
                 },
@@ -94,23 +98,24 @@ export function getLocalWhisperCommandHandlers(): DispatcherHandlerTable {
                 description: "Turn on Local Whisper integration.",
                 run: async (
                     request: string,
-                    context: CommandHandlerContext,
+                    context: ActionContext<CommandHandlerContext>,
                 ) => {
-                    if (context.localWhisper) {
+                    const systemContext = context.sessionContext.agentContext;
+                    if (systemContext.localWhisper) {
                         return;
                     }
 
                     try {
-                        context.localWhisper = await createLocalWhisperHost();
-                        if (context.localWhisper) {
-                            context.requestIO.result(
+                        systemContext.localWhisper =
+                            await createLocalWhisperHost();
+                        if (systemContext.localWhisper) {
+                            displayResult(
                                 chalk.blue(`Local Whisper enabled.`),
+                                context,
                             );
                         }
                     } catch {
-                        context.requestIO.warn(
-                            `Local Whisper was not enabled.`,
-                        );
+                        displayWarn(`Local Whisper was not enabled.`, context);
                     }
                 },
             },

--- a/ts/packages/dispatcher/src/handlers/serviceHost/serviceHostCommandHandler.ts
+++ b/ts/packages/dispatcher/src/handlers/serviceHost/serviceHostCommandHandler.ts
@@ -1,11 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { DispatcherHandlerTable } from "../common/commandHandler.js";
 import { CommandHandlerContext } from "../common/commandHandlerContext.js";
 import chalk from "chalk";
 import { ChildProcess, fork } from "child_process";
 import { getPackageFilePath } from "../../utils/getPackageFilePath.js";
+import { ActionContext } from "@typeagent/agent-sdk";
+import { CommandHandlerTable } from "@typeagent/agent-sdk/helpers/commands";
 
 export async function createServiceHost() {
     return new Promise<ChildProcess | undefined>((resolve, reject) => {
@@ -24,7 +25,7 @@ export async function createServiceHost() {
     });
 }
 
-export function getServiceHostCommandHandlers(): DispatcherHandlerTable {
+export function getServiceHostCommandHandlers(): CommandHandlerTable {
     return {
         description: "Configure Service Hosting",
         defaultSubCommand: undefined,
@@ -33,11 +34,12 @@ export function getServiceHostCommandHandlers(): DispatcherHandlerTable {
                 description: "Turn off Service hosting integration",
                 run: async (
                     request: string,
-                    context: CommandHandlerContext,
+                    context: ActionContext<CommandHandlerContext>,
                 ) => {
-                    if (context.serviceHost) {
-                        context.serviceHost?.kill();
-                        context.serviceHost = undefined;
+                    const systemContext = context.sessionContext.agentContext;
+                    if (systemContext.serviceHost) {
+                        systemContext.serviceHost?.kill();
+                        systemContext.serviceHost = undefined;
                     }
                 },
             },
@@ -45,12 +47,13 @@ export function getServiceHostCommandHandlers(): DispatcherHandlerTable {
                 description: "Turn on Service hosting integration.",
                 run: async (
                     request: string,
-                    context: CommandHandlerContext,
+                    context: ActionContext<CommandHandlerContext>,
                 ) => {
-                    if (context.serviceHost) {
+                    const systemContext = context.sessionContext.agentContext;
+                    if (systemContext.serviceHost) {
                         return;
                     }
-                    context.serviceHost = await createServiceHost();
+                    systemContext.serviceHost = await createServiceHost();
                     console.log(chalk.blue(`Service hosting enabled.`));
                 },
             },

--- a/ts/packages/dispatcher/src/handlers/traceCommandHandler.ts
+++ b/ts/packages/dispatcher/src/handlers/traceCommandHandler.ts
@@ -1,9 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { DispatcherCommandHandler } from "./common/commandHandler.js";
+import { CommandHandler } from "@typeagent/agent-sdk/helpers/commands";
 import { CommandHandlerContext } from "./common/commandHandlerContext.js";
 import registerDebug from "debug";
+import { ActionContext } from "@typeagent/agent-sdk";
+import { displaySuccess } from "./common/interactiveIO.js";
 
 function toNamespace(regexp: RegExp) {
     return regexp
@@ -21,9 +23,12 @@ function getCurrentTraceSettings() {
     ];
 }
 
-export class TraceCommandHandler implements DispatcherCommandHandler {
+export class TraceCommandHandler implements CommandHandler {
     public readonly description = "Enable or disable trace namespaces";
-    public async run(input: string, context: CommandHandlerContext) {
+    public async run(
+        input: string,
+        context: ActionContext<CommandHandlerContext>,
+    ) {
         if (input !== "") {
             if (input === "-" || input === "-*") {
                 registerDebug.disable();
@@ -34,8 +39,9 @@ export class TraceCommandHandler implements DispatcherCommandHandler {
             }
         }
 
-        context.requestIO.success(
+        displaySuccess(
             `Current trace settings: ${getCurrentTraceSettings().join(",")}`,
+            context,
         );
     }
 }

--- a/ts/packages/dispatcher/src/handlers/translateCommandHandler.ts
+++ b/ts/packages/dispatcher/src/handlers/translateCommandHandler.ts
@@ -1,14 +1,22 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { DispatcherCommandHandler } from "./common/commandHandler.js";
+import { CommandHandler } from "@typeagent/agent-sdk/helpers/commands";
 import { CommandHandlerContext } from "./common/commandHandlerContext.js";
 import { translateRequest } from "./requestCommandHandler.js";
+import { ActionContext } from "@typeagent/agent-sdk";
+import { displaySuccess } from "./common/interactiveIO.js";
 
-export class TranslateCommandHandler implements DispatcherCommandHandler {
+export class TranslateCommandHandler implements CommandHandler {
     public readonly description = "Translate a request";
-    public async run(request: string, context: CommandHandlerContext) {
-        const requestAction = await translateRequest(request, context);
-        context.requestIO.success(`${requestAction}`);
+    public async run(
+        request: string,
+        context: ActionContext<CommandHandlerContext>,
+    ) {
+        const requestAction = await translateRequest(
+            request,
+            context.sessionContext.agentContext,
+        );
+        displaySuccess(`${requestAction}`, context);
     }
 }

--- a/ts/packages/dispatcher/src/internal.ts
+++ b/ts/packages/dispatcher/src/internal.ts
@@ -31,9 +31,6 @@ export {
 
 export { getBuiltinConstructionConfig } from "./utils/config.js";
 export { getBuiltinTranslatorNames } from "./translation/agentTranslators.js";
-export { RequestCommandHandler } from "./handlers/requestCommandHandler.js";
-export { TranslateCommandHandler } from "./handlers/translateCommandHandler.js";
-export { ExplainCommandHandler } from "./handlers/explainCommandHandler.js";
 export { getAssistantSelectionSchemas } from "./translation/unknownSwitcher.js";
 export { getTestDataFiles } from "./utils/config.js";
 export {

--- a/ts/packages/shell/src/main/index.ts
+++ b/ts/packages/shell/src/main/index.ts
@@ -37,7 +37,7 @@ import {
 import { ShellSettings } from "./shellSettings.js";
 import { unlinkSync } from "fs";
 import { existsSync } from "node:fs";
-import { AppAgentEvent } from "@typeagent/agent-sdk";
+import { AppAgentEvent, DisplayAppendMode } from "@typeagent/agent-sdk";
 import { shellAgentProvider } from "./agent.js";
 
 const debugShell = registerDebug("typeagent:shell");
@@ -266,13 +266,13 @@ async function triggerRecognitionOnce(dispatcher: Dispatcher) {
     );
 }
 
-function showResult(message: IAgentMessage, append: boolean = false) {
+function showResult(message: IAgentMessage, mode?: DisplayAppendMode) {
     // Ignore message without requestId
     if (message.requestId === undefined) {
         console.warn("showResult: requestId is undefined");
         return;
     }
-    mainWindow?.webContents.send("response", message, append);
+    mainWindow?.webContents.send("response", message, mode);
 }
 
 function sendStatusMessage(message: IAgentMessage, temporary: boolean = false) {
@@ -425,13 +425,11 @@ const clientIO: ClientIO = {
         mainWindow?.webContents.send("clear");
     },
     info: sendRequestMetrics,
-    success: sendStatusMessage,
     status: (message) => sendStatusMessage(message, true),
     warn: sendStatusMessage,
     error: sendStatusMessage,
-    result: showResult,
     setDisplay: showResult,
-    appendDisplay: (message) => showResult(message, true),
+    appendDisplay: (message, mode) => showResult(message, mode ?? "inline"),
     setDynamicDisplay,
     searchMenuCommand,
     actionCommand,

--- a/ts/packages/shell/src/preload/electronTypes.ts
+++ b/ts/packages/shell/src/preload/electronTypes.ts
@@ -2,7 +2,11 @@
 // Licensed under the MIT License.
 
 import { ElectronAPI } from "@electron-toolkit/preload";
-import { AppAgentEvent, DynamicDisplay } from "@typeagent/agent-sdk";
+import {
+    AppAgentEvent,
+    DisplayAppendMode,
+    DynamicDisplay,
+} from "@typeagent/agent-sdk";
 import { ShellSettings } from "../main/shellSettings.js";
 import { IAgentMessage } from "agent-dispatcher";
 import { RequestMetrics } from "agent-dispatcher";
@@ -113,7 +117,7 @@ export interface ClientAPI {
         callback: (
             e: Electron.IpcRendererEvent,
             message: IAgentMessage,
-            append: boolean,
+            mode?: DisplayAppendMode,
         ) => void,
     ): void;
     onSetDynamicActionDisplay(

--- a/ts/packages/shell/src/renderer/src/main.ts
+++ b/ts/packages/shell/src/renderer/src/main.ts
@@ -58,8 +58,8 @@ function addEvents(
             }
         }
     });
-    api.onResponse((_, agentMessage, append) => {
-        chatView.addAgentMessage(agentMessage, { append });
+    api.onResponse((_, agentMessage, appendMode) => {
+        chatView.addAgentMessage(agentMessage, { appendMode });
     });
     api.onRequestMetrics((_, requestId, requestMetrics) => {
         chatView.updateMetrics(requestId, requestMetrics);


### PR DESCRIPTION
- Command handlers get an ActionContext (instead of just the CommandHandlerContext)
- Remove special `executDispatcherCommand` and use the standard helper from the SDK.
- Switch most dispatcher command handlers to use `ActionIO`.   Remove `RequestIO` API that is no longer used.
- Add `block` append mode for `appendDisplay`