### PR TITLE
Shell dev UI mode

### DIFF
--- a/ts/packages/shell/src/main/shellSettings.ts
+++ b/ts/packages/shell/src/main/shellSettings.ts
@@ -33,6 +33,7 @@ export class ShellSettings
     public ttsSettings: TTSSettings;
     public agentGreeting: boolean;
     public multiModalContent: boolean;
+    public devUI: boolean;
     public onSettingsChanged: EmptyFunction | null;
     public onShowSettingsDialog: ((dialogName: string) => void) | null;
     public onRunDemo: ((interactive: boolean) => void) | null;
@@ -73,6 +74,7 @@ export class ShellSettings
         this.ttsSettings = settings.ttsSettings;
         this.agentGreeting = settings.agentGreeting;
         this.multiModalContent = settings.multiModalContent;
+        this.devUI = settings.devUI;
 
         this.onSettingsChanged = null;
         this.onShowSettingsDialog = null;

--- a/ts/packages/shell/src/main/shellSettingsType.ts
+++ b/ts/packages/shell/src/main/shellSettingsType.ts
@@ -18,6 +18,7 @@ export type ShellSettingsType = {
     ttsSettings: TTSSettings;
     agentGreeting: boolean;
     multiModalContent: boolean;
+    devUI: boolean;
 };
 
 export const defaultSettings: ShellSettingsType = {
@@ -29,4 +30,5 @@ export const defaultSettings: ShellSettingsType = {
     ttsSettings: {},
     agentGreeting: false,
     multiModalContent: false,
+    devUI: false,
 };

--- a/ts/packages/shell/src/renderer/assets/styles.less
+++ b/ts/packages/shell/src/renderer/assets/styles.less
@@ -218,12 +218,13 @@ body {
 
 .chat-message-user {
   .chat-message-body;
+  position: relative;
   background-color: lavender;
 }
 
 .chat-message-agent {
-  .chat-message-body;
-  margin-left: 30px;
+  left: 30px;
+  position: relative;
   background-color: #d6f3ff;
 }
 
@@ -259,12 +260,10 @@ body {
 
 .chat-message-metrics {
   margin: 0px;
-  padding: 5px;
   border-radius: 0px 0px 8px 8px;
   font-size: 8px;
   font-style: normal;
   z-index: 100;
-  position: relative;
   text-align: right;
 }
 
@@ -278,13 +277,43 @@ body {
   background-color: rgb(150, 150, 202);
 }
 
+/* hidden metrics */
+.chat-message-body-hide-metrics {
+  .chat-message-body;
+}
+.chat-message-body-hide-metrics .chat-message-metrics {
+  display: none;
+}
+
+.chat-message-body-hide-metrics:hover {
+  border-radius: 8px 8px 0px 0px;
+}
+
+.chat-message-body-hide-metrics:hover .chat-message-metrics {
+  display: block;
+  position: absolute;
+  width: 100%;
+  transform-origin: 0 0;
+  transform: scaleY(0);
+  animation: metrics 0.15s ease-out 0s forwards;
+}
+
+@keyframes metrics {
+  0% {
+  }
+  100% {
+    transform: scaleY(1);
+    overflow: visible;
+  }
+}
+
 .metrics-tts {
   text-align: left;
 }
 
 .metrics-details {
   display: inline-flex;
-  width: 100%;
+  margin: 5px;
   justify-content: space-between;
 }
 

--- a/ts/packages/shell/src/renderer/src/settingsView.ts
+++ b/ts/packages/shell/src/renderer/src/settingsView.ts
@@ -160,6 +160,8 @@ export class SettingsView {
                       this.shellSettings.ttsSettings.voice,
                   )
                 : undefined;
+
+            chatView.setMetricsVisible(this.shellSettings.devUI);
         };
 
         const updateInputs = () => {

--- a/ts/pnpm-lock.yaml
+++ b/ts/pnpm-lock.yaml
@@ -179,55 +179,6 @@ importers:
         specifier: ^5.0.5
         version: 5.0.5
 
-  examples/siteSchemas:
-    dependencies:
-      aiclient:
-        specifier: workspace:*
-        version: link:../../packages/aiclient
-      common-utils:
-        specifier: workspace:*
-        version: link:../../packages/commonUtils
-      copyfiles:
-        specifier: ^2.4.1
-        version: 2.4.1
-      dotenv:
-        specifier: ^16.3.1
-        version: 16.3.1
-      find-config:
-        specifier: ^1.0.0
-        version: 1.0.0
-      jsonpath:
-        specifier: ^1.1.1
-        version: 1.1.1
-      typeagent:
-        specifier: workspace:*
-        version: link:../../packages/typeagent
-      typechat:
-        specifier: ^0.1.1
-        version: 0.1.1(typescript@5.4.3)
-      typescript:
-        specifier: ^5.4.2
-        version: 5.4.3
-      ws:
-        specifier: ^8.17.1
-        version: 8.17.1
-    devDependencies:
-      '@types/find-config':
-        specifier: 1.0.4
-        version: 1.0.4
-      '@types/jsonpath':
-        specifier: ^0.2.4
-        version: 0.2.4
-      '@types/node':
-        specifier: ^18.18.7
-        version: 18.18.7
-      '@types/ws':
-        specifier: ^8.5.10
-        version: 8.5.10
-      rimraf:
-        specifier: ^5.0.5
-        version: 5.0.5
-
   examples/whisperClient:
     dependencies:
       chalk:


### PR DESCRIPTION
Hide the perf metrics by default and show only on hover.
Add `devUI` shell settings to allow it always show the perf metrics  (any additional dev time UI can be added under that flag in the future).