### PR TITLE
Mark commands as disabled as well when closing all session contexts

### DIFF
--- a/ts/packages/dispatcher/src/handlers/common/appAgentManager.ts
+++ b/ts/packages/dispatcher/src/handlers/common/appAgentManager.ts
@@ -336,6 +336,7 @@ export class AppAgentManager implements TranslatorConfigProvider {
     public async close() {
         for (const record of this.agents.values()) {
             record.actions.clear();
+            record.commands = false;
             await this.closeSessionContext(record);
         }
     }


### PR DESCRIPTION
Fix the problem where dispatcher session context didn't get reinitialized on `@session new`