### PR TITLE
Fix marshalling issue that caused the cli/shell to crash when running the vscode agent

### DIFF
--- a/ts/packages/agents/code/README.md
+++ b/ts/packages/agents/code/README.md
@@ -4,25 +4,18 @@ The code agent is sample code to demonstrate how to automate vscode.
 
 The code dispatcher agent is not enabled by default. It is integrated to work with the vscode extension [coda](../../coda/README.md). Please deploy the vscode extension to see the code agent in action.
 
-You can enable the code agent by typing these commands in the typeagent cli or shell:
-
-```
-@config translator code.code-debug
-@config action code.code-debug
-```
-
-Please look at the agent [manifest](./src/codeManifest.json) file to look at other sub-agents that are part of the code agent. The code agent shows how to extend an agent to handle a hierarchical set of actions. For instance if you want to run different commands related to debugging an application on vscode, you will want to run these commands:
-
-```
-@config translator code.debug
-@config action code.debug
-```
-
 You can enable all the sub-agents as part of the code agent by running the following commands on the typeagent cli or shell:
 
 ```
 @config action code*
 @config translator code*
+```
+
+Please look at the agent [manifest](./src/codeManifest.json) file to look at other sub-agents that are part of the code agent. The code agent shows how to extend an agent to handle a hierarchical set of actions. For instance if you want to run different commands related to debugging an application on vscode, you will want to run these commands:
+
+```
+@config translator code.code-debug
+@config action code.code-debug
 ```
 
 ## Trademarks

--- a/ts/packages/coda/README.md
+++ b/ts/packages/coda/README.md
@@ -2,11 +2,11 @@
 
 ## Build
 
-To build the browser extension, run `pnpm run build` in this folder.
+To build the vs code extension, run `pnpm run build` in this folder.
 
 ## Deploy
 
-To deploy the extension locally in your vscode environment, run `pnpm run deploy:local` in this folder.
+To deploy the extension locally in your vscode environment, run `pnpm run deploy:local` in this folder. You should see the extension in the list of installed extensions in vscode using the command `code --list-extensions`. To uninstall the extension, run `code --uninstall-extension aisystems.copilot-coda`.
 
 ## Features
 
@@ -26,7 +26,7 @@ To deploy the extension locally in your vscode environment, run `pnpm run deploy
 
 ## Requirements
 
-This extension works is integrated to work with the code app agent in the dispatcher. You can manually turn the code app agent on using the typeagent cli or shell.
+This extension is integrated to work with the code app agent in the dispatcher. You can manually turn the code app agent on using the typeagent cli or shell.
 
 ## Trademarks
 

--- a/ts/packages/coda/src/handleCodeEditorActions.ts
+++ b/ts/packages/coda/src/handleCodeEditorActions.ts
@@ -307,7 +307,7 @@ export async function handleGeneralKBActions(
             actionResult.handled = false;
         }
     }
-    return action;
+    return actionResult;
 }
 
 export async function handleBaseEditorActions(

--- a/ts/packages/dispatcher/src/agent/agentProcessShim.ts
+++ b/ts/packages/dispatcher/src/agent/agentProcessShim.ts
@@ -227,20 +227,20 @@ export async function createAgentProcessShim(
         },
         setDisplay: (param: {
             actionContextId: number;
-            message: DisplayContent;
+            content: DisplayContent;
         }) => {
             actionContextMap
                 .get(param.actionContextId)
-                .actionIO.setDisplay(param.message);
+                .actionIO.setDisplay(param.content);
         },
         appendDisplay: (param: {
             actionContextId: number;
-            message: DisplayContent;
+            content: DisplayContent;
             mode: DisplayAppendMode;
         }) => {
             actionContextMap
                 .get(param.actionContextId)
-                .actionIO.appendDisplay(param.message, param.mode);
+                .actionIO.appendDisplay(param.content, param.mode);
         },
     };
 

--- a/ts/packages/dispatcher/src/agent/agentProcessTypes.ts
+++ b/ts/packages/dispatcher/src/agent/agentProcessTypes.ts
@@ -18,11 +18,11 @@ export type AgentContextCallFunctions = {
     }): void;
     setDisplay: (param: {
         actionContextId: number;
-        message: DisplayContent;
+        content: DisplayContent;
     }) => void;
     appendDisplay: (param: {
         actionContextId: number;
-        message: DisplayContent;
+        content: DisplayContent;
         mode: DisplayAppendMode;
     }) => void;
 };


### PR DESCRIPTION
- Fix `AgentContextCallFunctions` function signatures for setDisplay and appendDisplay to use content instead of message
- Fix typo in code agent handler
- Minor readme update.
