### PR TITLE
Improve Typing

### DIFF
--- a/ts/packages/agentSdk/src/agentInterface.ts
+++ b/ts/packages/agentSdk/src/agentInterface.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 import { ActionIO, DisplayType, DynamicDisplay } from "./display.js";
+import { ActionResult } from "./memory.js";
 import { Profiler } from "./profiler.js";
 
 //==============================================================================
@@ -50,15 +51,15 @@ export type CommandDescriptor = {
 
 export type CommandDescriptorTable = {
     description: string;
-    commands: Record<string, CommandDescriptor | CommandDescriptorTable>;
+    commands: Record<string, CommandDescriptors>;
     defaultSubCommand?: CommandDescriptor | undefined;
 };
 
+export type CommandDescriptors = CommandDescriptor | CommandDescriptorTable;
+
 export interface AppAgentCommandInterface {
     // Commands
-    getCommands(
-        context: SessionContext,
-    ): Promise<CommandDescriptor | CommandDescriptorTable>;
+    getCommands(context: SessionContext): Promise<CommandDescriptors>;
 
     executeCommand(
         commands: string[],
@@ -70,7 +71,7 @@ export interface AppAgentCommandInterface {
 
 export interface AppAgent extends Partial<AppAgentCommandInterface> {
     // Setup
-    initializeAgentContext?(): Promise<any>;
+    initializeAgentContext?(): Promise<unknown>;
     updateAgentContext?(
         enable: boolean,
         context: SessionContext,
@@ -89,7 +90,7 @@ export interface AppAgent extends Partial<AppAgentCommandInterface> {
     executeAction?(
         action: AppAction,
         context: ActionContext<unknown>,
-    ): Promise<any>; // TODO: define return type.
+    ): Promise<ActionResult | undefined>;
 
     // Cache extensions
     validateWildcardMatch?(

--- a/ts/packages/agentSdk/src/helpers/commandHelpers.ts
+++ b/ts/packages/agentSdk/src/helpers/commandHelpers.ts
@@ -5,6 +5,7 @@ import {
     ActionContext,
     AppAgentCommandInterface,
     CommandDescriptor,
+    CommandDescriptors,
     CommandDescriptorTable,
 } from "../agentInterface.js";
 
@@ -23,7 +24,7 @@ export interface CommandHandlerTable extends CommandDescriptorTable {
 }
 
 export function isCommandDescriptorTable(
-    entry: CommandDescriptor | CommandDescriptorTable,
+    entry: CommandDescriptors,
 ): entry is CommandDescriptorTable {
     return (entry as CommandDescriptorTable).commands !== undefined;
 }

--- a/ts/packages/agentSdk/src/index.ts
+++ b/ts/packages/agentSdk/src/index.ts
@@ -16,6 +16,7 @@ export {
     TokenCachePersistence,
     ActionContext,
     CommandDescriptor,
+    CommandDescriptors,
     CommandDescriptorTable,
 } from "./agentInterface.js";
 

--- a/ts/packages/agents/code/src/codeActionHandler.ts
+++ b/ts/packages/agents/code/src/codeActionHandler.ts
@@ -25,7 +25,7 @@ type CodeActionContext = {
     pendingCall: Map<
         number,
         {
-            resolve: () => void;
+            resolve: (value?: undefined) => void;
             context: ActionContext<CodeActionContext>;
         }
     >;
@@ -112,7 +112,7 @@ async function executeCodeAction(
     if (webSocketEndpoint) {
         try {
             const callId = agentContext.nextCallId++;
-            return new Promise<void>((resolve) => {
+            return new Promise<undefined>((resolve) => {
                 agentContext.pendingCall.set(callId, {
                     resolve,
                     context,
@@ -135,5 +135,4 @@ async function executeCodeAction(
     } else {
         throw new Error("No websocket connection.");
     }
-    return undefined;
 }

--- a/ts/packages/dispatcher/src/agent/agentProcess.ts
+++ b/ts/packages/dispatcher/src/agent/agentProcess.ts
@@ -39,7 +39,7 @@ if (typeof module.instantiate !== "function") {
 const agent: AppAgent = module.instantiate();
 
 const agentInvokeHandlers: AgentInvokeFunctions = {
-    async initializeAgentContext(): Promise<any> {
+    async initializeAgentContext(): Promise<unknown> {
         if (agent.initializeAgentContext === undefined) {
             throw new Error("Invalid invocation of initializeAgentContext");
         }
@@ -176,11 +176,11 @@ function getStorage(contextId: number, session: boolean): Storage {
                 session,
             });
         },
-        save: async (data: string): Promise<void> => {
+        save: async (token: string): Promise<void> => {
             return rpc.invoke("tokenCacheWrite", {
                 contextId,
                 session,
-                data,
+                token,
             });
         },
     };

--- a/ts/packages/dispatcher/src/agent/agentProcessShim.ts
+++ b/ts/packages/dispatcher/src/agent/agentProcessShim.ts
@@ -173,7 +173,7 @@ export async function createAgentProcessShim(
             contextId: number;
             session: boolean;
             storagePath: string;
-            options: StorageListOptions;
+            options?: StorageListOptions | undefined;
         }) => {
             const context = contextMap.get(param.contextId);
             return getStorage(param, context).list(
@@ -251,8 +251,8 @@ export async function createAgentProcessShim(
     >(process, agentContextInvokeHandlers, agentContextCallHandlers);
 
     const agent: AppAgent = {
-        initializeAgentContext(): Promise<ShimContext> {
-            return rpc.invoke("initializeAgentContext");
+        initializeAgentContext() {
+            return rpc.invoke("initializeAgentContext", undefined);
         },
         updateAgentContext(
             enable,
@@ -265,7 +265,7 @@ export async function createAgentProcessShim(
                 translatorName,
             });
         },
-        executeAction(action, context: ActionContext<ShimContext>) {
+        executeAction(action: any, context: ActionContext<ShimContext>) {
             return withActionContextAsync(context, (contextParams) =>
                 rpc.invoke("executeAction", {
                     ...contextParams,
@@ -273,7 +273,10 @@ export async function createAgentProcessShim(
                 }),
             );
         },
-        validateWildcardMatch(action, context: SessionContext<ShimContext>) {
+        validateWildcardMatch(
+            action: any,
+            context: SessionContext<ShimContext>,
+        ) {
             return rpc.invoke("validateWildcardMatch", {
                 ...getContextParam(context),
                 action,

--- a/ts/packages/dispatcher/src/agent/agentProcessShim.ts
+++ b/ts/packages/dispatcher/src/agent/agentProcessShim.ts
@@ -8,10 +8,9 @@ import {
     SessionContext,
     StorageListOptions,
     AppAgentEvent,
-    CommandDescriptor,
-    CommandDescriptorTable,
     DisplayContent,
     DisplayAppendMode,
+    CommandDescriptors,
 } from "@typeagent/agent-sdk";
 import {
     AgentCallFunctions,
@@ -314,7 +313,7 @@ export async function createAgentProcessShim(
 
         getCommands(
             context: SessionContext<ShimContext>,
-        ): Promise<CommandDescriptor | CommandDescriptorTable> {
+        ): Promise<CommandDescriptors> {
             return rpc.invoke("getCommands", getContextParam(context));
         },
         executeCommand(

--- a/ts/packages/dispatcher/src/agent/agentProcessTypes.ts
+++ b/ts/packages/dispatcher/src/agent/agentProcessTypes.ts
@@ -47,7 +47,7 @@ export type AgentContextInvokeFunctions = {
         contextId: number;
         session: boolean;
         storagePath: string;
-        options: StorageListOptions;
+        options?: StorageListOptions | undefined;
     }) => Promise<any>;
     storageExists: (param: {
         contextId: number;

--- a/ts/packages/dispatcher/src/agent/agentProcessTypes.ts
+++ b/ts/packages/dispatcher/src/agent/agentProcessTypes.ts
@@ -2,10 +2,13 @@
 // Licensed under the MIT License.
 
 import {
+    ActionResult,
     AppAgentEvent,
+    CommandDescriptors,
     DisplayAppendMode,
     DisplayContent,
     DisplayType,
+    DynamicDisplay,
     StorageListOptions,
 } from "@typeagent/agent-sdk";
 import { JSONAction } from "agent-cache";
@@ -84,27 +87,27 @@ export type AgentCallFunctions = {
 };
 
 export type AgentInvokeFunctions = {
-    initializeAgentContext: () => Promise<any>;
+    initializeAgentContext: () => Promise<unknown>;
     updateAgentContext: (
         param: Partial<ContextParams> & {
             enable: boolean;
             translatorName: string;
         },
-    ) => Promise<any>;
+    ) => Promise<void>;
     executeAction: (
         param: Partial<ActionContextParams> & { action: JSONAction },
-    ) => Promise<any>;
+    ) => Promise<ActionResult | undefined>;
     validateWildcardMatch: (
         param: Partial<ContextParams> & { action: JSONAction },
-    ) => Promise<any>;
+    ) => Promise<boolean>;
     getDynamicDisplay: (
         param: Partial<ContextParams> & {
             type: DisplayType;
             displayId: string;
         },
-    ) => Promise<any>;
-    closeAgentContext: (param: Partial<ContextParams>) => Promise<any>;
-    getCommands: (param: Partial<ContextParams>) => Promise<any>;
+    ) => Promise<DynamicDisplay>;
+    closeAgentContext: (param: Partial<ContextParams>) => Promise<void>;
+    getCommands: (param: Partial<ContextParams>) => Promise<CommandDescriptors>;
     executeCommand(
         param: Partial<ActionContextParams> & {
             commands: string[];


### PR DESCRIPTION
Improve some of the `any` typing.
Add type on the rpc `invoke` and `call` functions, to ensure the RPC calls are using the right param structures.