### PR TITLE
Fix player wildcard validation with multiple queries

### DIFF
--- a/ts/packages/agents/player/src/agent/playerHandlers.ts
+++ b/ts/packages/agents/player/src/agent/playerHandlers.ts
@@ -100,16 +100,23 @@ async function validatePlayerWildcardMatch(
         const playAction = action as PlayAction;
         if (playAction.parameters.query) {
             for (const query of playAction.parameters.query) {
+                let result: boolean = false;
                 switch (query.constraint) {
                     case "track":
                     case undefined:
-                        return validateTrack(query.text, clientContext);
+                        result = await validateTrack(query.text, clientContext);
 
                     case "album":
-                        return validateAlbum(query.text, clientContext);
+                        result = await validateAlbum(query.text, clientContext);
 
                     case "artist":
-                        return validateArtist(query.text, clientContext);
+                        result = await validateArtist(
+                            query.text,
+                            clientContext,
+                        );
+                }
+                if (result === false) {
+                    return false;
                 }
             }
         }


### PR DESCRIPTION
The check should be "all query terms" are valid, instead of "any one of the query terms are valid"