### PR TITLE
add chat into schemas considered by switcher

### DIFF
--- a/ts/packages/dispatcher/src/translation/unknownSwitcher.ts
+++ b/ts/packages/dispatcher/src/translation/unknownSwitcher.ts
@@ -17,7 +17,8 @@ function createSelectionSchema(
     provider: TranslatorConfigProvider,
 ): InlineTranslatorSchemaDef | undefined {
     const translatorConfig = provider.getTranslatorConfig(translatorName);
-    if (translatorConfig.injected) {
+    // Skip injected schemas except for chat; investigate whether we can get chat always on first pass
+    if (translatorConfig.injected && translatorName !== "chat") {
         // No need to select for injected schemas
         selectSchemaCache.set(translatorName, undefined);
         return undefined;


### PR DESCRIPTION
we should try hard to get chat to be selected on the first pass, but there are some tough cases like "mares eat oats and does eat oats..." where the LLM decides it's not sure enough about chat