### PR TITLE
Fixing gaps in crossword and commerce automation in inline browser

### DIFF
--- a/ts/packages/agents/browser/src/agent/actionsSchema.mts
+++ b/ts/packages/agents/browser/src/agent/actionsSchema.mts
@@ -6,6 +6,7 @@ export type BrowserActions =
   | CloseTabAction
   | SwitchToTabAction
   | SwitchToTabByPositionAction
+  | CloseWindowAction
   | GoBackAction
   | GoForwardAction
   | ScrollDownAction
@@ -22,6 +23,7 @@ export type BrowserActions =
   | ZoomOut
   | ZoomReset
   | CaptureScreenshot
+  | ReloadPage
   | UnknownAction;
 
 export type UnknownAction = {
@@ -46,6 +48,13 @@ export type OpenTabAction = {
 // IMPORTANT: This does NOT close browser programs.
 export type CloseTabAction = {
   actionName: "closeTab";
+  parameters: {
+    title?: string;
+  };
+};
+
+export type CloseWindowAction = {
+  actionName: "closeWindow";
   parameters: {
     title?: string;
   };
@@ -176,6 +185,11 @@ export type StopReadPageContent = {
 
 export type CaptureScreenshot = {
   actionName: "captureScreenshot";
+  parameters: {};
+};
+
+export type ReloadPage = {
+  actionName: "reloadPage";
   parameters: {};
 };
 

--- a/ts/packages/agents/browser/src/agent/commerce/schema/userActions.mts
+++ b/ts/packages/agents/browser/src/agent/commerce/schema/userActions.mts
@@ -23,6 +23,7 @@ export type LookupAtStoreAction = {
   };
 };
 
+// IMPORTANT: Use this action when the user query involves search for products on an e-commerce store, such as "aaa batteries"
 export type SearchForProductAction = {
   actionName: "searchForProductAction";
   parameters: {

--- a/ts/packages/agents/browser/src/electron/agentActivation.ts
+++ b/ts/packages/agents/browser/src/electron/agentActivation.ts
@@ -9,7 +9,7 @@ declare global {
     }
 }
 
-let siteAgent:string = "";
+let siteAgent: string = "";
 window.addEventListener("message", async (event) => {
     if (event.data === "setupSiteAgent") {
         if (window.browserConnect) {
@@ -54,7 +54,11 @@ window.addEventListener("message", async (event) => {
             console.log("browserconnect not found by UI events script");
         }
     }
-    if ((event.data === "disableSiteAgent") && siteAgent && (window.browserConnect)) {
+    if (
+        event.data === "disableSiteAgent" &&
+        siteAgent &&
+        window.browserConnect
+    ) {
         window.browserConnect.disableSiteAgent(siteAgent);
     }
 });

--- a/ts/packages/agents/browser/src/electron/agentActivation.ts
+++ b/ts/packages/agents/browser/src/electron/agentActivation.ts
@@ -9,6 +9,7 @@ declare global {
     }
 }
 
+let siteAgent:string = "";
 window.addEventListener("message", async (event) => {
     if (event.data === "setupSiteAgent") {
         if (window.browserConnect) {
@@ -16,6 +17,7 @@ window.addEventListener("message", async (event) => {
             const host = new URL(pageUrl).host;
 
             if (host === "paleobiodb.org" || host === "www.paleobiodb.org") {
+                siteAgent = "browser.paleoBioDb";
                 window.browserConnect.enableSiteAgent("browser.paleoBioDb");
             }
 
@@ -34,6 +36,7 @@ window.addEventListener("message", async (event) => {
                     "https://www.bestcrosswords.com/bestcrosswords/guestconstructor",
                 )
             ) {
+                siteAgent = "browser.crossword";
                 window.browserConnect.enableSiteAgent("browser.crossword");
             }
 
@@ -44,10 +47,14 @@ window.addEventListener("message", async (event) => {
             ];
 
             if (commerceHosts.includes(host)) {
+                siteAgent = "browser.commerce";
                 window.browserConnect.enableSiteAgent("browser.commerce");
             }
         } else {
             console.log("browserconnect not found by UI events script");
         }
+    }
+    if ((event.data === "disableSiteAgent") && siteAgent && (window.browserConnect)) {
+        window.browserConnect.disableSiteAgent(siteAgent);
     }
 });

--- a/ts/packages/agents/browser/src/extension/contentScript.ts
+++ b/ts/packages/agents/browser/src/extension/contentScript.ts
@@ -651,16 +651,16 @@ async function handleScriptAction(
         }
         case "get_page_schema": {
             const value = localStorage.getItem("pageSchema");
-            if(value){
-                sendResponse(JSON.parse(value));    
-            }else{
+            if (value) {
+                sendResponse(JSON.parse(value));
+            } else {
                 sendResponse(null);
             }
             break;
         }
         case "set_page_schema": {
             let updatedSchema = message.action.parameters.schema;
-            localStorage.setItem("pageSchema",  JSON.stringify(updatedSchema));
+            localStorage.setItem("pageSchema", JSON.stringify(updatedSchema));
             sendResponse({});
             break;
         }

--- a/ts/packages/agents/browser/src/extension/contentScript.ts
+++ b/ts/packages/agents/browser/src/extension/contentScript.ts
@@ -651,12 +651,16 @@ async function handleScriptAction(
         }
         case "get_page_schema": {
             const value = localStorage.getItem("pageSchema");
-            sendResponse(value);
+            if(value){
+                sendResponse(JSON.parse(value));    
+            }else{
+                sendResponse(null);
+            }
             break;
         }
         case "set_page_schema": {
             let updatedSchema = message.action.parameters.schema;
-            localStorage.setItem("pageSchema", updatedSchema);
+            localStorage.setItem("pageSchema",  JSON.stringify(updatedSchema));
             sendResponse({});
             break;
         }

--- a/ts/packages/shell/src/preload/webView.ts
+++ b/ts/packages/shell/src/preload/webView.ts
@@ -343,6 +343,20 @@ async function runBrowserAction(action: any) {
             });
             break;
         }
+        case "reloadPage": {
+            sendScriptAction({
+                type: "clear_page_schema",
+            });
+            location.reload();
+            break;
+        }
+        case "closeWindow": {
+            window.close();
+            // todo: call method on IPC process to close the window/view
+
+            break;
+        }
+        
 
         case "unknown": {
             confirmationMessage = `Did not understand the request "${action.parameters.text}"`;
@@ -440,14 +454,8 @@ contextBridge.exposeInMainWorld("browserConnect", {
 
 await ensureWebsocketConnected();
 
-window.addEventListener(
-    "message",
-    async (event) => {
-        if (event.data === "page-to-bridge") {
-            console.log("Message from page to bridge");
-        }
-    },
-    false,
-);
+window.onbeforeunload = () => {
+    window.postMessage("disableSiteAgent");
+};
 
 window.postMessage("setupSiteAgent");

--- a/ts/packages/shell/src/preload/webView.ts
+++ b/ts/packages/shell/src/preload/webView.ts
@@ -142,7 +142,7 @@ export async function getTabHTML(fullSize: boolean) {
         type: "get_reduced_html",
         fullSize: fullSize,
         frameId: 0,
-    });
+    }, 1000);
 
     return outerHTML;
 }
@@ -163,7 +163,7 @@ export async function getTabHTMLFragments(fullSize: boolean) {
         type: "get_page_text",
         inputHtml: frameHTML,
         frameId: 0,
-    });
+    },1000);
 
     htmlFragments.push({
         frameId: 0,

--- a/ts/packages/shell/src/preload/webView.ts
+++ b/ts/packages/shell/src/preload/webView.ts
@@ -138,11 +138,14 @@ export async function awaitPageLoad() {
 }
 
 export async function getTabHTML(fullSize: boolean) {
-    let outerHTML = await sendScriptAction({
-        type: "get_reduced_html",
-        fullSize: fullSize,
-        frameId: 0,
-    }, 1000);
+    let outerHTML = await sendScriptAction(
+        {
+            type: "get_reduced_html",
+            fullSize: fullSize,
+            frameId: 0,
+        },
+        1000,
+    );
 
     return outerHTML;
 }
@@ -159,11 +162,14 @@ export async function getTabHTMLFragments(fullSize: boolean) {
         5000,
     );
 
-    const frameText = await sendScriptAction({
-        type: "get_page_text",
-        inputHtml: frameHTML,
-        frameId: 0,
-    },1000);
+    const frameText = await sendScriptAction(
+        {
+            type: "get_page_text",
+            inputHtml: frameHTML,
+            frameId: 0,
+        },
+        1000,
+    );
 
     htmlFragments.push({
         frameId: 0,
@@ -356,7 +362,6 @@ async function runBrowserAction(action: any) {
 
             break;
         }
-        
 
         case "unknown": {
             confirmationMessage = `Did not understand the request "${action.parameters.text}"`;


### PR DESCRIPTION
- Added actions to reload page and close window for inline browser scenarios
- Updated crossword schema caching in local storage
- Add logic to disable transient agent when inline browser window is closed