### PR TITLE
Improve help and command usage using the parameter definitions

### DIFF
--- a/ts/packages/agentSdk/src/agentInterface.ts
+++ b/ts/packages/agentSdk/src/agentInterface.ts
@@ -11,6 +11,7 @@ import { Profiler } from "./profiler.js";
 //==============================================================================
 export type AppAgentManifest = {
     emojiChar: string;
+    description: string;
     commandDefaultEnabled?: boolean;
 } & TranslatorDefinition;
 

--- a/ts/packages/agentSdk/test/flags.spec.ts
+++ b/ts/packages/agentSdk/test/flags.spec.ts
@@ -225,4 +225,12 @@ describe("Flag parsing", () => {
             expect(e.message).toStrictEqual("Invalid flag '-n'");
         }
     });
+
+    it("Duplicate flags", () => {
+        try {
+            parseParams("--num 10 --num 11", typeFlags);
+        } catch (e: any) {
+            expect(e.message).toStrictEqual("Duplicate flag '--num'");
+        }
+    });
 });

--- a/ts/packages/agents/browser/src/agent/manifest.json
+++ b/ts/packages/agents/browser/src/agent/manifest.json
@@ -1,6 +1,7 @@
 {
   "emojiChar": "👀",
   "defaultEnabled": false,
+  "description": "Agent that allows you control an existing browser window",
   "schema": {
     "description": "Browser agent that allows you control an existing browser window and perform actions such as opening a new tab, closing a tab, scrolling, zooming and navigating to a specific URL.",
     "schemaFile": "./actionsSchema.mts",

--- a/ts/packages/agents/calendar/src/calendarManifest.json
+++ b/ts/packages/agents/calendar/src/calendarManifest.json
@@ -1,5 +1,6 @@
 {
   "emojiChar": "📅",
+  "description": "Agent integration with MS Graph's calendar",
   "schema": {
     "description": "Calendar agent that keeps track of important dates and events. Use it to schedule appointments, set reminders, and organize activities.",
     "schemaFile": "./calendarActionsSchema.ts",

--- a/ts/packages/agents/chat/src/chatManifest.json
+++ b/ts/packages/agents/chat/src/chatManifest.json
@@ -1,5 +1,6 @@
 {
   "emojiChar": "💬",
+  "description": "Agent for conversation and information lookup",
   "schema": {
     "description": "Chat agent that helps you with general conversation and answering questions by looking up answers in past conversations or the internet.",
     "schemaFile": "./chatResponseActionSchema.ts",

--- a/ts/packages/agents/code/src/codeManifest.json
+++ b/ts/packages/agents/code/src/codeManifest.json
@@ -1,5 +1,6 @@
 {
   "emojiChar": "⚛️",
+  "description": "Agent for VSCode integration",
   "defaultEnabled": false,
   "schema": {
     "description": "Code agent helps you with productivity in using an editor and performing actions like creating files, editor customization, writing code, intelligent code suggestions, real-time error detection, debugging, and source control tasks etc.",

--- a/ts/packages/agents/desktop/src/manifest.json
+++ b/ts/packages/agents/desktop/src/manifest.json
@@ -1,5 +1,6 @@
 {
   "emojiChar": "🪟",
+  "description": "Agent to control the desktop",
   "defaultEnabled": false,
   "schema": {
     "description": "Desktop agent that allows you to manage the programs running on a computer, including performing actions such as opening a file, closing a window, tiling windows, launching a program, and maximizing windows.",

--- a/ts/packages/agents/email/src/emailManifest.json
+++ b/ts/packages/agents/email/src/emailManifest.json
@@ -1,5 +1,6 @@
 {
   "emojiChar": "📩",
+  "description": "Agent integration with MS Graph's email",
   "schema": {
     "description": "Email agent helps manage email messages. Use it to send, reply, forward, find messages etc.",
     "schemaFile": "./emailActionsSchema.ts",

--- a/ts/packages/agents/greeting/src/greetingManifest.json
+++ b/ts/packages/agents/greeting/src/greetingManifest.json
@@ -1,5 +1,6 @@
 {
   "emojiChar": "🖐",
+  "description": "Agent to generate greating messages",
   "schema": {
     "description": "Greeting agent that created personalized welcome messages.",
     "schemaFile": "./greetingActionSchema.ts",

--- a/ts/packages/agents/image/src/imageManifest.json
+++ b/ts/packages/agents/image/src/imageManifest.json
@@ -1,5 +1,6 @@
 {
   "emojiChar": "🖼️",
+  "description": "Agent to find images and create AI images",
   "schema": {
     "description": "Image agent that finds images online or creates them using AI image modes.",
     "schemaFile": "./imageActionSchema.ts",

--- a/ts/packages/agents/list/src/listManifest.json
+++ b/ts/packages/agents/list/src/listManifest.json
@@ -1,5 +1,6 @@
 {
   "emojiChar": "📝",
+  "description": "Agent to create and manage lists",
   "schema": {
     "description": "List agent with actions to create lists, show list items, add and remove list items",
     "schemaFile": "./listSchema.ts",

--- a/ts/packages/agents/photo/src/photoManifest.json
+++ b/ts/packages/agents/photo/src/photoManifest.json
@@ -1,5 +1,6 @@
 {
   "emojiChar": "📷",
+  "description": "Agent to take and upload photos",
   "schema": {
     "description": "Photo agent that helps the user provide images to the system either by taking pictures or uploading existing images.",
     "schemaFile": "./photoSchema.ts",

--- a/ts/packages/agents/player/src/agent/playerManifest.json
+++ b/ts/packages/agents/player/src/agent/playerManifest.json
@@ -1,5 +1,6 @@
 {
   "emojiChar": "🎧",
+  "description": "Agent to play music",
   "schema": {
     "description": "Music Player agent that lets you search for, play and control music.",
     "schemaFile": "./playerSchema.ts",

--- a/ts/packages/dispatcher/data/config.json
+++ b/ts/packages/dispatcher/data/config.json
@@ -38,10 +38,12 @@
       "execMode": "dispatcher"
     },
     "dispatcher": {
-      "emojiChar": "🤖"
+      "emojiChar": "🤖",
+      "description": "Built-in agent to dispatch request"
     },
     "system": {
       "emojiChar": "🔧",
+      "description": "Built-in agent to manage system configuration and sessions",
       "subTranslators": {
         "config": {
           "schema": {

--- a/ts/packages/dispatcher/src/command.ts
+++ b/ts/packages/dispatcher/src/command.ts
@@ -377,11 +377,12 @@ export async function getPartialCompletion(
         let flagsNeedsValue = false;
         if (result.suffix.length !== 0) {
             const lastArg = result.suffix[result.suffix.length - 1];
-            if (lastArg.startsWith("-")) {
-                const def = resolveFlag(flags, lastArg);
-                if (def !== undefined && getFlagType(def) !== "boolean") {
-                    flagsNeedsValue = true;
-                }
+            const resolvedFlag = resolveFlag(flags, lastArg);
+            if (
+                resolvedFlag !== undefined &&
+                getFlagType(resolvedFlag[1]) !== "boolean"
+            ) {
+                flagsNeedsValue = true;
             }
         }
         if (!flagsNeedsValue) {

--- a/ts/packages/dispatcher/src/handlers/common/appAgentManager.ts
+++ b/ts/packages/dispatcher/src/handlers/common/appAgentManager.ts
@@ -88,6 +88,15 @@ export class AppAgentManager implements TranslatorConfigProvider {
     >();
     private readonly emojis: Record<string, string> = {};
 
+    public getAppAgentNames(): string[] {
+        return Array.from(this.agents.keys());
+    }
+
+    public getAppAgentDescription(appAgentName: string) {
+        const record = this.getRecord(appAgentName);
+        return record.manifest.description;
+    }
+
     public isTranslatorEnabled(translatorName: string) {
         const appAgentName = getAppAgentName(translatorName);
         const record = this.getRecord(appAgentName);

--- a/ts/packages/shell/src/main/agent.ts
+++ b/ts/packages/shell/src/main/agent.ts
@@ -29,6 +29,7 @@ type ShellContext = {
 
 const config: AppAgentManifest = {
     emojiChar: "🐚",
+    description: "Shell",
 };
 
 class ShellShowSettingsCommandHandler implements CommandHandlerNoParams {


### PR DESCRIPTION
- Add app agent description and show it with "@help"
- Print usage and parameter description with "@help"

Also:
- Add agent name in partial completion at first level "@"
- Detect duplicate flags when it is not a multiple flag.
- Simplified `parseParams` by reusing `resolveFlags`, improve quote handling (support starting with both " or ' after a space)