### PR TITLE
Use declarative parameters for config model sets.

### DIFF
--- a/ts/packages/agentSdk/src/helpers/commandHelpers.ts
+++ b/ts/packages/agentSdk/src/helpers/commandHelpers.ts
@@ -12,7 +12,6 @@ import {
 import { parseParams, ParsedCommandParams } from "./parameterHelpers.js";
 
 export {
-    splitParams,
     ParsedCommandParams,
     resolveFlag,
     getFlagMultiple,
@@ -28,15 +27,6 @@ export type CommandHandlerNoParams = CommandDescriptor & {
     ): Promise<void>;
 };
 
-export type CommandHandlerNoParse = CommandDescriptor & {
-    parameters: true;
-    run(
-        context: ActionContext<unknown>,
-        params: string,
-        attachments?: string[],
-    ): Promise<void>;
-};
-
 export type CommandHandler = CommandDescriptor & {
     parameters: ParameterDefinitions;
     run(
@@ -46,21 +36,12 @@ export type CommandHandler = CommandDescriptor & {
     ): Promise<void>;
 };
 
-type CommandHandlerTypes =
-    | CommandHandlerNoParams
-    | CommandHandlerNoParse
-    | CommandHandler;
+type CommandHandlerTypes = CommandHandlerNoParams | CommandHandler;
 
 function isCommandHandlerNoParams(
     handler: CommandHandlerTypes,
 ): handler is CommandHandlerNoParams {
     return handler.parameters === undefined || handler.parameters === false;
-}
-
-function isCommandHandlerNoParse(
-    handler: CommandHandlerTypes,
-): handler is CommandHandlerNoParse {
-    return handler.parameters === true;
 }
 
 type CommandDefinitions = CommandHandlerTypes | CommandHandlerTable;
@@ -125,8 +106,6 @@ export function getCommandInterface(
                     );
                 }
                 await curr.run(context, undefined, attachments);
-            } else if (isCommandHandlerNoParse(curr)) {
-                await curr.run(context, args, attachments);
             } else {
                 await curr.run(
                     context,

--- a/ts/packages/agentSdk/src/helpers/parameterHelpers.ts
+++ b/ts/packages/agentSdk/src/helpers/parameterHelpers.ts
@@ -138,11 +138,6 @@ function parseIntParameter(
     return value;
 }
 
-export function splitParams(params: string) {
-    const split = params.match(/"[^"]+"|\S+/g) ?? [];
-    return split.map((s) => s.replace(/^"|"$/g, ""));
-}
-
 function stripQuoteFromTerm(term: string) {
     if (term.length !== 0 && (term[0] === "'" || term[0] === '"')) {
         const lastChar = term[term.length - 1];

--- a/ts/packages/dispatcher/src/handlers/common/appAgentManager.ts
+++ b/ts/packages/dispatcher/src/handlers/common/appAgentManager.ts
@@ -112,7 +112,7 @@ export class AppAgentManager implements TranslatorConfigProvider {
     public isCommandEnabled(appAgentName: string) {
         const record = this.agents.get(appAgentName);
         return record !== undefined
-            ? record.appAgent?.executeCommand !== undefined
+            ? record.commands && record.appAgent?.executeCommand !== undefined
             : false;
     }
 

--- a/ts/packages/dispatcher/src/handlers/configCommandHandlers.ts
+++ b/ts/packages/dispatcher/src/handlers/configCommandHandlers.ts
@@ -9,11 +9,7 @@ import {
     CommandHandlerContext,
     changeContextConfig,
 } from "./common/commandHandlerContext.js";
-import {
-    getAppAgentName,
-    TranslatorConfigProvider,
-} from "../translation/agentTranslators.js";
-import { getCacheFactory } from "../utils/cacheFactory.js";
+import { getAppAgentName } from "../translation/agentTranslators.js";
 import { getServiceHostCommandHandlers } from "./serviceHost/serviceHostCommandHandler.js";
 import { getLocalWhisperCommandHandlers } from "./serviceHost/localWhisperCommandHandler.js";
 
@@ -24,10 +20,8 @@ import chalk from "chalk";
 import { ActionContext } from "@typeagent/agent-sdk";
 import {
     CommandHandler,
-    CommandHandlerNoParse,
     CommandHandlerTable,
     ParsedCommandParams,
-    splitParams,
 } from "@typeagent/agent-sdk/helpers/command";
 import {
     displayResult,
@@ -288,17 +282,27 @@ class ConfigModelShowCommandHandler implements CommandHandler {
     }
 }
 
-class ConfigModelSetCommandHandler implements CommandHandlerNoParse {
+class ConfigModelSetCommandHandler implements CommandHandler {
     public readonly description = "Set model";
-    public readonly parameters = true;
+    public readonly parameters = {
+        args: {
+            kindOrModel: {
+                description: "Model kind or name",
+                optional: true,
+            },
+            model: {
+                description: "Model name",
+                optional: true,
+            },
+        },
+    } as const;
     public async run(
         context: ActionContext<CommandHandlerContext>,
-        request: string,
+        params: ParsedCommandParams<typeof this.parameters>,
     ) {
         const systemContext = context.sessionContext.agentContext;
-        const args = splitParams(request);
         const models = systemContext.session.getConfig().models;
-        if (args.length === 0) {
+        if (params.args.kindOrModel === undefined) {
             const newConfig = {
                 models: Object.fromEntries(
                     Object.keys(models).map((kind) => [kind, ""]),
@@ -311,15 +315,15 @@ class ConfigModelSetCommandHandler implements CommandHandlerNoParse {
 
         let kind = "translator";
         let model = "";
-        if (args.length === 1) {
-            if (models.hasOwnProperty(args[0])) {
-                kind = args[0];
+        if (params.args.model === undefined) {
+            if (models.hasOwnProperty(params.args.kindOrModel)) {
+                kind = params.args.kindOrModel;
             } else {
-                model = args[0];
+                model = params.args.kindOrModel;
             }
         } else {
-            kind = args[0];
-            model = args[1];
+            kind = params.args.kindOrModel;
+            model = params.args.model;
         }
 
         if (!models.hasOwnProperty(kind)) {

--- a/ts/packages/dispatcher/src/handlers/configCommandHandlers.ts
+++ b/ts/packages/dispatcher/src/handlers/configCommandHandlers.ts
@@ -338,6 +338,8 @@ class ConfigModelSetCommandHandler implements CommandHandler {
             throw new Error(
                 `Invalid model name: ${model}\nValid model names: ${modelNames.join(", ")}`,
             );
+        } else {
+            displayResult(`Model for ${kind} is set to ${model}`, context);
         }
         await changeContextConfig(
             {

--- a/ts/packages/dispatcher/src/handlers/constructionCommandHandlers.ts
+++ b/ts/packages/dispatcher/src/handlers/constructionCommandHandlers.ts
@@ -26,7 +26,6 @@ import {
 import {
     CommandHandler,
     CommandHandlerNoParams,
-    CommandHandlerNoParse,
     CommandHandlerTable,
     ParsedCommandParams,
 } from "@typeagent/agent-sdk/helpers/command";

--- a/ts/packages/dispatcher/src/handlers/sessionCommandHandlers.ts
+++ b/ts/packages/dispatcher/src/handlers/sessionCommandHandlers.ts
@@ -19,7 +19,6 @@ import chalk from "chalk";
 import {
     CommandHandler,
     CommandHandlerNoParams,
-    CommandHandlerNoParse,
     CommandHandlerTable,
     ParsedCommandParams,
 } from "@typeagent/agent-sdk/helpers/command";


### PR DESCRIPTION
This is the last of the "NoParse" commands, so removing the option.

Also fix the `isCommandEnabled` state for partial completion.