### PR TITLE
Enable field edits and action replacement.

### DIFF
--- a/ts/packages/cache/src/explanation/requestAction.ts
+++ b/ts/packages/cache/src/explanation/requestAction.ts
@@ -181,26 +181,6 @@ export class Action {
         return pstructCopy;
     }
 
-    public toHTML(prefaceText?: string) {
-        let html = "<div>";
-        if (prefaceText) {
-            html += `<div class="preface-text">${prefaceText}</div>`;
-        }
-        // make a nested html list starting with the action name and then the parameters
-        html += `<div>Action: ${this.fullActionName}</div>`;
-        const entries = Object.entries(this.action.parameters);
-        if (entries.length !== 0) {
-            html += "<div>Parameters: <ul>";
-            for (const [key, value] of entries.sort()) {
-                html += this.paramToHTML(key, value);
-            }
-            html += "</ul>";
-            html += "</div>";
-        }
-        html += "</div>";
-        return html;
-    }
-
     public toIAction(): IAction {
         return this.action;
     }
@@ -337,21 +317,6 @@ export class Actions {
             prefaceMultiple,
             templates: [],
         };
-    }
-
-    public toHTML(prefaceSingle: string, prefaceMultiple: string) {
-        if (Array.isArray(this.actions)) {
-            let html = "<div>";
-            if (prefaceMultiple) {
-                html += `<div class="preface-text">${prefaceMultiple}</div>`;
-            }
-            const actionDivs = this.actions.map((a) => a.toHTML());
-            html += actionDivs.join("\n");
-            html += "</div>";
-            return html;
-        } else {
-            return this.actions.toHTML(prefaceSingle);
-        }
     }
 
     public toIAction() {

--- a/ts/packages/cache/src/explanation/requestAction.ts
+++ b/ts/packages/cache/src/explanation/requestAction.ts
@@ -268,54 +268,47 @@ export class Actions {
         prefaceMultiple: string,
         parameterStructures: Map<string, ActionInfo>,
     ): ActionTemplateSequence {
+        const templates: ActionTemplate[] = [];
         if (Array.isArray(this.actions)) {
-            const templates: ActionTemplate[] = [];
             for (const action of this.actions) {
                 const actionInfo = parameterStructures.get(
                     action.fullActionName,
                 );
-                if (actionInfo) {
-                    templates.push({
-                        parameterStructure: action.addValues(
-                            actionInfo.template!.parameterStructure,
-                        ),
-                        name: action.actionName,
-                        agent: action.translatorNameString,
-                    });
-                } else {
-                    console.log(
+                if (actionInfo === undefined) {
+                    throw new Error(
                         `Action ${action.fullActionName} not found in parameterStructures`,
                     );
                 }
+                templates.push({
+                    parameterStructure: action.addValues(
+                        actionInfo.template!.parameterStructure,
+                    ),
+                    name: action.actionName,
+                    agent: action.translatorNameString,
+                });
             }
         } else {
             const actionInfo = parameterStructures.get(
                 this.actions.fullActionName,
             );
-            if (actionInfo) {
-                return {
-                    prefaceSingle,
-                    prefaceMultiple,
-                    templates: [
-                        {
-                            parameterStructure: this.actions.addValues(
-                                actionInfo.template!.parameterStructure,
-                            ),
-                            name: this.actions.actionName,
-                            agent: this.actions.translatorNameString,
-                        },
-                    ],
-                };
-            } else {
-                console.log(
+            if (actionInfo === undefined) {
+                throw new Error(
                     `Action ${this.actions.fullActionName} not found in parameterStructures`,
                 );
             }
+            templates.push({
+                parameterStructure: this.actions.addValues(
+                    actionInfo.template!.parameterStructure,
+                ),
+                name: this.actions.actionName,
+                agent: this.actions.translatorNameString,
+            });
         }
         return {
             prefaceSingle,
             prefaceMultiple,
-            templates: [],
+            actions: this.toJSON(),
+            templates,
         };
     }
 

--- a/ts/packages/commonUtils/src/command.ts
+++ b/ts/packages/commonUtils/src/command.ts
@@ -23,13 +23,11 @@ export type ActionInfo = {
 
 export type TemplateParamPrimitive = {
     type: "string" | "number" | "boolean";
-    value?: string | number | boolean;
 };
 
 export type TemplateParamStringUnion = {
     type: "string-union";
     typeEnum: string[];
-    value?: string;
 };
 
 export type TemplateParamScalar =
@@ -39,7 +37,6 @@ export type TemplateParamScalar =
 export type TemplateParamArray = {
     type: "array";
     elementType: TemplateParamField;
-    elements?: TemplateParamField[];
 };
 
 export type TemplateParamObject = {

--- a/ts/packages/commonUtils/src/command.ts
+++ b/ts/packages/commonUtils/src/command.ts
@@ -67,6 +67,7 @@ export type ActionTemplate = {
 
 export type ActionTemplateSequence = {
     templates: ActionTemplate[];
+    actions: unknown;
     prefaceSingle?: string;
     prefaceMultiple?: string;
 };

--- a/ts/packages/dispatcher/src/handlers/common/interactiveIO.ts
+++ b/ts/packages/dispatcher/src/handlers/common/interactiveIO.ts
@@ -57,7 +57,7 @@ export interface ClientIO {
         actionTemplates: ActionTemplateSequence,
         requestId: RequestId,
         source: string,
-    ): Promise<string | undefined>;
+    ): Promise<unknown>;
 
     question(
         message: string,
@@ -112,7 +112,7 @@ export interface RequestIO {
     proposeAction(
         actionTemplates: ActionTemplateSequence,
         source: string,
-    ): Promise<string | undefined>;
+    ): Promise<unknown>;
     // returns undefined if input is disabled
     question(
         message: string,

--- a/ts/packages/dispatcher/src/handlers/common/interactiveIO.ts
+++ b/ts/packages/dispatcher/src/handlers/common/interactiveIO.ts
@@ -16,17 +16,7 @@ import { RequestMetrics } from "../../utils/metrics.js";
 export const DispatcherName = "dispatcher";
 export type RequestId = string | undefined;
 
-export type SearchMenuCommand =
-    | "register"
-    | "legend"
-    | "complete"
-    | "cancel"
-    | "show"
-    | "remove";
-
 export type ActionUICommand = "register" | "replace" | "remove";
-
-export type SearchMenuState = "active" | "inactive";
 
 export enum NotifyCommands {
     ShowSummary = "summarize",
@@ -34,13 +24,6 @@ export enum NotifyCommands {
     ShowUnread = "unread",
     ShowAll = "all",
 }
-
-export type SearchMenuContext = {
-    state: SearchMenuState;
-    menuId: string;
-    lastPrefix: string;
-    choices?: string[];
-};
 
 export interface IAgentMessage {
     message: DisplayContent;
@@ -54,19 +37,6 @@ export interface IAgentMessage {
 export interface ClientIO {
     clear(): void;
     exit(): void;
-
-    actionCommand(
-        actionTemplates: ActionTemplateSequence,
-        command: ActionUICommand,
-        requestId: RequestId,
-    ): void;
-    searchMenuCommand(
-        menuId: string,
-        command: SearchMenuCommand,
-        prefix?: string,
-        choices?: SearchMenuItem[],
-        visible?: boolean,
-    ): void;
 
     // Display
     setDisplay(message: IAgentMessage): void;

--- a/ts/packages/dispatcher/src/handlers/common/interactiveIO.ts
+++ b/ts/packages/dispatcher/src/handlers/common/interactiveIO.ts
@@ -53,6 +53,8 @@ export interface IAgentMessage {
 // Client provided IO
 export interface ClientIO {
     clear(): void;
+    exit(): void;
+
     actionCommand(
         actionTemplates: ActionTemplateSequence,
         command: ActionUICommand,
@@ -65,17 +67,36 @@ export interface ClientIO {
         choices?: SearchMenuItem[],
         visible?: boolean,
     ): void;
+
+    // Display
     setDisplay(message: IAgentMessage): void;
     appendDisplay(message: IAgentMessage, mode: DisplayAppendMode): void;
+    setDynamicDisplay(
+        source: string,
+        requestId: RequestId,
+        actionIndex: number,
+        displayId: string,
+        nextRefreshMs: number,
+    ): void;
+
+    // Input
     askYesNo(
         message: string,
         requestId: RequestId,
         defaultValue?: boolean,
     ): Promise<boolean>;
+    proposeAction(
+        actionTemplates: ActionTemplateSequence,
+        requestId: RequestId,
+        source: string,
+    ): Promise<string | undefined>;
+
     question(
         message: string,
         requestId: RequestId,
     ): Promise<string | undefined>;
+
+    // Notification (TODO: turn these in to dispatcher events)
     notify(
         event: string,
         requestId: RequestId,
@@ -92,14 +113,8 @@ export interface ClientIO {
         },
         source: string,
     ): void;
-    setDynamicDisplay(
-        source: string,
-        requestId: RequestId,
-        actionIndex: number,
-        displayId: string,
-        nextRefreshMs: number,
-    ): void;
-    exit(): void;
+
+    // Host specific (TODO: Formalize the API)
     takeAction(action: string): void;
 }
 
@@ -126,7 +141,10 @@ export interface RequestIO {
     // Input
     isInputEnabled(): boolean;
     askYesNo(message: string, defaultValue?: boolean): Promise<boolean>;
-
+    proposeAction(
+        actionTemplates: ActionTemplateSequence,
+        source: string,
+    ): Promise<string | undefined>;
     // returns undefined if input is disabled
     question(
         message: string,
@@ -226,6 +244,13 @@ export function getConsoleRequestIO(
         askYesNo: async (message: string, defaultValue?: boolean) => {
             return await askYesNo(message, stdio, defaultValue);
         },
+        proposeAction: async (
+            actionTemplates: ActionTemplateSequence,
+            source: string,
+        ) => {
+            // TODO: Not implemented
+            return undefined;
+        },
         question: async (message: string) => {
             return await stdio?.question(`${message}: `);
         },
@@ -312,6 +337,10 @@ export function getRequestIO(
         isInputEnabled: () => true,
         askYesNo: async (message: string, defaultValue?: boolean) =>
             clientIO.askYesNo(message, requestId, defaultValue),
+        proposeAction: async (
+            actionTemplates: ActionTemplateSequence,
+            source: string,
+        ) => clientIO.proposeAction(actionTemplates, requestId, source),
         question: async (message: string) =>
             clientIO.question(message, requestId),
         notify(
@@ -337,6 +366,7 @@ export function getNullRequestIO(): RequestIO {
         appendDisplay: () => {},
         isInputEnabled: () => false,
         askYesNo: async () => false,
+        proposeAction: async () => undefined,
         question: async () => undefined,
         notify: () => {},
         takeAction: () => {},

--- a/ts/packages/dispatcher/src/handlers/common/interactiveIO.ts
+++ b/ts/packages/dispatcher/src/handlers/common/interactiveIO.ts
@@ -16,8 +16,6 @@ import { RequestMetrics } from "../../utils/metrics.js";
 export const DispatcherName = "dispatcher";
 export type RequestId = string | undefined;
 
-export type ActionUICommand = "register" | "replace" | "remove";
-
 export enum NotifyCommands {
     ShowSummary = "summarize",
     Clear = "clear",

--- a/ts/packages/dispatcher/src/handlers/requestCommandHandler.ts
+++ b/ts/packages/dispatcher/src/handlers/requestCommandHandler.ts
@@ -100,6 +100,7 @@ async function confirmTranslation(
         prefaceMultiple,
         allActionInfo,
     );
+
     const newActions = await systemContext.requestIO.proposeAction(
         templateSequence,
         DispatcherName,

--- a/ts/packages/dispatcher/src/handlers/requestCommandHandler.ts
+++ b/ts/packages/dispatcher/src/handlers/requestCommandHandler.ts
@@ -100,11 +100,6 @@ async function confirmTranslation(
         prefaceMultiple,
         allActionInfo,
     );
-    systemContext.clientIO?.actionCommand(
-        templateSequence,
-        "register",
-        systemContext.requestId!,
-    );
     const newActions = await systemContext.requestIO.proposeAction(
         templateSequence,
         DispatcherName,

--- a/ts/packages/dispatcher/src/handlers/requestCommandHandler.ts
+++ b/ts/packages/dispatcher/src/handlers/requestCommandHandler.ts
@@ -9,6 +9,7 @@ import {
     printProcessRequestActionResult,
     Actions,
     HistoryContext,
+    JSONAction,
 } from "agent-cache";
 import {
     CommandHandlerContext,
@@ -101,22 +102,20 @@ async function confirmTranslation(
         allActionInfo,
     );
 
-    const newActions = await systemContext.requestIO.proposeAction(
+    // TODO: Need to validate
+    const newActions = (await systemContext.requestIO.proposeAction(
         templateSequence,
         DispatcherName,
-    );
+    )) as JSONAction | JSONAction[];
 
-    if (newActions !== undefined) {
-        return { requestAction };
-    }
     return newActions
         ? {
               requestAction: new RequestAction(
                   requestAction.request,
-                  actions,
+                  Actions.fromJSON(newActions),
                   requestAction.history,
               ),
-              replacedAction: newActions,
+              replacedAction: actions,
           }
         : { requestAction };
 }

--- a/ts/packages/dispatcher/src/translation/actionInfo.ts
+++ b/ts/packages/dispatcher/src/translation/actionInfo.ts
@@ -173,7 +173,7 @@ function getTemplateParamFieldType(
         default:
             console.log(`Unhandled type ${param.type}`);
     }
-    return { type: "string", value: "unhandled" };
+    return { type: "string" };
 }
 
 // assumes parser is open to the correct parameter object

--- a/ts/packages/shell/src/main/index.ts
+++ b/ts/packages/shell/src/main/index.ts
@@ -24,12 +24,8 @@ import {
     Dispatcher,
 } from "agent-dispatcher";
 
-import {
-    IAgentMessage,
-} from "../../../dispatcher/dist/handlers/common/interactiveIO.js";
-import {
-    ActionTemplateSequence,
-} from "../preload/electronTypes.js";
+import { IAgentMessage } from "../../../dispatcher/dist/handlers/common/interactiveIO.js";
+import { ActionTemplateSequence } from "../preload/electronTypes.js";
 import { ShellSettings } from "./shellSettings.js";
 import { unlinkSync } from "fs";
 import { existsSync } from "node:fs";
@@ -342,17 +338,17 @@ async function proposeAction(
     source: string,
 ) {
     const currentProposeActionId = maxProposeActionId++;
-    return new Promise<string | undefined>((resolve) => {
+    return new Promise<unknown>((resolve) => {
         const callback = (
             _event: Electron.IpcMainEvent,
             proposeActionId: number,
-            response?: string,
+            replacement?: unknown,
         ) => {
             if (currentProposeActionId !== proposeActionId) {
                 return;
             }
             ipcMain.removeListener("proposeActionResponse", callback);
-            resolve(response);
+            resolve(replacement);
         };
         ipcMain.on("proposeActionResponse", callback);
         mainWindow?.webContents.send(

--- a/ts/packages/shell/src/main/index.ts
+++ b/ts/packages/shell/src/main/index.ts
@@ -26,11 +26,9 @@ import {
 
 import {
     IAgentMessage,
-    SearchMenuCommand,
 } from "../../../dispatcher/dist/handlers/common/interactiveIO.js";
 import {
     ActionTemplateSequence,
-    SearchMenuItem,
 } from "../preload/electronTypes.js";
 import { ShellSettings } from "./shellSettings.js";
 import { unlinkSync } from "fs";
@@ -397,36 +395,6 @@ async function question(message: string, requestId: RequestId) {
     });
 }
 
-function searchMenuCommand(
-    menuId: string,
-    command: SearchMenuCommand,
-    prefix?: string,
-    choices?: SearchMenuItem[],
-    visible?: boolean,
-) {
-    mainWindow?.webContents.send(
-        "search-menu-command",
-        menuId,
-        command,
-        prefix,
-        choices,
-        visible,
-    );
-}
-
-function actionCommand(
-    actionTemplates: ActionTemplateSequence,
-    command: string,
-    requestId: RequestId,
-) {
-    mainWindow?.webContents.send(
-        "action-command",
-        actionTemplates,
-        command,
-        requestId,
-    );
-}
-
 const clientIO: ClientIO = {
     clear: () => {
         mainWindow?.webContents.send("clear");
@@ -434,8 +402,6 @@ const clientIO: ClientIO = {
     setDisplay: updateDisplay,
     appendDisplay: (message, mode) => updateDisplay(message, mode ?? "inline"),
     setDynamicDisplay,
-    searchMenuCommand,
-    actionCommand,
     askYesNo,
     proposeAction,
     question,

--- a/ts/packages/shell/src/preload/electronTypes.ts
+++ b/ts/packages/shell/src/preload/electronTypes.ts
@@ -33,13 +33,11 @@ export type ActionInfo = {
 
 export type TemplateParamPrimitive = {
     type: "string" | "number" | "boolean";
-    value?: string | number | boolean;
 };
 
 export type TemplateParamStringUnion = {
     type: "string-union";
     typeEnum: string[];
-    value?: string;
 };
 
 export type TemplateParamScalar =
@@ -49,7 +47,6 @@ export type TemplateParamScalar =
 export type TemplateParamArray = {
     type: "array";
     elementType: TemplateParamField;
-    elements?: TemplateParamField[];
 };
 
 export type TemplateParamObject = {
@@ -180,7 +177,7 @@ export interface ClientAPI {
             source: string,
         ) => void,
     ): void;
-    sendProposedAction(proposeActionId: number, response?: string): void;
+    sendProposedAction(proposeActionId: number, replacement?: unknown): void;
     onQuestion(
         callback: (
             e: Electron.IpcRendererEvent,

--- a/ts/packages/shell/src/preload/electronTypes.ts
+++ b/ts/packages/shell/src/preload/electronTypes.ts
@@ -140,24 +140,6 @@ export interface ClientAPI {
             group_id: string,
         ) => void,
     ): void;
-    onActionCommand(
-        callback: (
-            e: Electron.IpcRendererEvent,
-            actionTemplates: ActionTemplateSequence,
-            command: ActionUICommand,
-            requestId: string,
-        ) => void,
-    ): void;
-    onSearchMenuCommand(
-        callback: (
-            e: Electron.IpcRendererEvent,
-            menuId: string,
-            command: string,
-            prefix?: string,
-            choices?: SearchMenuItem[],
-            visible?: boolean,
-        ) => void,
-    ): void;
     onMarkRequestExplained(
         callback: (
             e: Electron.IpcRendererEvent,

--- a/ts/packages/shell/src/preload/electronTypes.ts
+++ b/ts/packages/shell/src/preload/electronTypes.ts
@@ -26,8 +26,6 @@ export type SearchMenuItem = {
     emojiChar?: string;
     groupName?: string;
 };
-
-export type ActionUICommand = "register" | "replace" | "remove";
 export type ActionInfo = {
     actionTemplates: ActionTemplateSequence;
     requestId: string;

--- a/ts/packages/shell/src/preload/electronTypes.ts
+++ b/ts/packages/shell/src/preload/electronTypes.ts
@@ -77,6 +77,7 @@ export type ActionTemplate = {
 
 export type ActionTemplateSequence = {
     templates: ActionTemplate[];
+    actions: unknown;
     prefaceSingle?: string;
     prefaceMultiple?: string;
 };

--- a/ts/packages/shell/src/preload/electronTypes.ts
+++ b/ts/packages/shell/src/preload/electronTypes.ts
@@ -190,6 +190,16 @@ export interface ClientAPI {
         ) => void,
     ): void;
     sendYesNo: (askYesNoId: number, accept: boolean) => void;
+    onProposeAction(
+        callback: (
+            e: Electron.IpcRendererEvent,
+            proposeActionId: number,
+            actionTemplates: ActionTemplateSequence,
+            requestId: string,
+            source: string,
+        ) => void,
+    ): void;
+    sendProposedAction(proposeActionId: number, response?: string): void;
     onQuestion(
         callback: (
             e: Electron.IpcRendererEvent,

--- a/ts/packages/shell/src/preload/index.ts
+++ b/ts/packages/shell/src/preload/index.ts
@@ -67,12 +67,6 @@ const api: ClientAPI = {
     getDynamicDisplay(source: string, id: string) {
         return ipcRenderer.invoke("get-dynamic-display", source, id);
     },
-    onActionCommand: (callback) => {
-        ipcRenderer.on("action-command", callback);
-    },
-    onSearchMenuCommand: (callback) => {
-        ipcRenderer.on("search-menu-command", callback);
-    },
     onUpdateDisplay(callback) {
         ipcRenderer.on("updateDisplay", callback);
     },

--- a/ts/packages/shell/src/preload/index.ts
+++ b/ts/packages/shell/src/preload/index.ts
@@ -94,8 +94,8 @@ const api: ClientAPI = {
     onProposeAction(callback) {
         ipcRenderer.on("proposeAction", callback);
     },
-    sendProposedAction: (proposeActionId: number, action?: string) => {
-        ipcRenderer.send("proposeActionResponse", proposeActionId, action);
+    sendProposedAction: (proposeActionId: number, replacement?: unknown) => {
+        ipcRenderer.send("proposeActionResponse", proposeActionId, replacement);
     },
     onQuestion(callback) {
         ipcRenderer.on("question", callback);

--- a/ts/packages/shell/src/preload/index.ts
+++ b/ts/packages/shell/src/preload/index.ts
@@ -97,6 +97,12 @@ const api: ClientAPI = {
     sendYesNo: (askYesNoId: number, accept: boolean) => {
         ipcRenderer.send("askYesNoResponse", askYesNoId, accept);
     },
+    onProposeAction(callback) {
+        ipcRenderer.on("proposeAction", callback);
+    },
+    sendProposedAction: (proposeActionId: number, action?: string) => {
+        ipcRenderer.send("proposeActionResponse", proposeActionId, action);
+    },
     onQuestion(callback) {
         ipcRenderer.on("question", callback);
     },

--- a/ts/packages/shell/src/renderer/assets/styles.less
+++ b/ts/packages/shell/src/renderer/assets/styles.less
@@ -666,3 +666,18 @@ input[type="file"] {
 .notification-debug {
   color: pink;
 }
+
+.action-edit-button,
+.action-editing-button,
+.action-text-editable table.editing .action-edit-button,
+.action-text-editable tr.editing .action-edit-button {
+  visibility: hidden;
+}
+.action-text-editable .action-edit-button,
+.action-text-editable tr.editing .action-editing-button {
+  visibility: visible;
+}
+
+.action-text td.error {
+  color: red;
+}

--- a/ts/packages/shell/src/renderer/src/ActionCascade.ts
+++ b/ts/packages/shell/src/renderer/src/ActionCascade.ts
@@ -36,6 +36,7 @@ export class ActionCascade {
             const input = document.createElement("input");
             input.type = "text";
             input.name = paramName;
+            input.value = paramValue.value?.toString() || "";
             li.appendChild(input);
         } else {
             li.innerText = `${paramName}: ${paramValue.value}`;

--- a/ts/packages/shell/src/renderer/src/ActionCascade.ts
+++ b/ts/packages/shell/src/renderer/src/ActionCascade.ts
@@ -15,7 +15,7 @@ export class ActionCascade {
         public editMode = false,
     ) {}
 
-    public scalarToHTML(
+    private scalarToHTML(
         li: HTMLLIElement,
         paramName: string,
         paramValue: TemplateParamScalar,
@@ -42,7 +42,7 @@ export class ActionCascade {
         }
     }
 
-    public paramToHTML(
+    private paramToHTML(
         paramName: string,
         paramValue: TemplateParamFieldOpt,
         topLevel = false,

--- a/ts/packages/shell/src/renderer/src/chatView.ts
+++ b/ts/packages/shell/src/renderer/src/chatView.ts
@@ -375,23 +375,6 @@ export class ChatView {
         return actionInfo.actionTemplates;
     }
 
-    proposeAction(requestId: string) {
-        // use this div to show the proposed action
-        const actionContainer = document.createElement("div");
-        actionContainer.className = "action-container";
-
-        // build the action div from the reserved action templates
-        const actionTemplates = this.getActionTemplates(requestId);
-        if (actionTemplates !== undefined) {
-            this.actionCascade = new ActionCascade(actionTemplates);
-            const actionDiv = this.actionCascade.toHTML();
-            actionDiv.className = "action-text";
-            actionContainer.appendChild(actionDiv);
-        }
-
-        return actionContainer;
-    }
-
     registerSearchMenu(
         id: string,
         initialChoices: SearchMenuItem[],
@@ -819,15 +802,7 @@ export class ChatView {
         if (agentMessage === undefined) {
             return;
         }
-        if (message === "reserved") {
-            const container = this.proposeAction(requestId);
-            agentMessage.setMessage(
-                { type: "html", content: container.innerHTML },
-                source,
-            );
-        } else {
-            agentMessage.setMessage(message, source, "inline");
-        }
+        agentMessage.setMessage(message, source, "inline");
         const choices: InputChoice[] = [
             {
                 text: "Yes",
@@ -849,6 +824,22 @@ export class ChatView {
         this.updateScroll();
     }
 
+    public proposeAction(
+        proposeActionId: number,
+        actionTemplates: ActionTemplateSequence,
+        requestId: string,
+        source: string,
+    ) {
+        const agentMessage = this.ensureAgentMessage({
+            message: "",
+            requestId,
+            source,
+        });
+        if (agentMessage === undefined) {
+            return;
+        }
+        agentMessage.proposeAction(proposeActionId, actionTemplates);
+    }
     question(
         questionId: number,
         message: string,

--- a/ts/packages/shell/src/renderer/src/chatView.ts
+++ b/ts/packages/shell/src/renderer/src/chatView.ts
@@ -4,9 +4,7 @@
 import { IdGenerator, getClientAPI } from "./main";
 import { ChatInput, ExpandableTextarea, questionInput } from "./chatInput";
 import { iconCheckMarkCircle, iconX } from "./icon";
-import {
-    ActionTemplateSequence
-} from "../../preload/electronTypes";
+import { ActionTemplateSequence } from "../../preload/electronTypes";
 import {
     DisplayAppendMode,
     DisplayContent,

--- a/ts/packages/shell/src/renderer/src/main.ts
+++ b/ts/packages/shell/src/renderer/src/main.ts
@@ -71,12 +71,6 @@ function addEvents(
                 nextRefreshMs,
             ),
     );
-    api.onActionCommand((_, actionTemplates, command, requestId) => {
-        chatView.actionCommand(actionTemplates, command, requestId);
-    });
-    api.onSearchMenuCommand((_, menuId, command, prefix, choices, visible) => {
-        chatView.searchMenuCommand(menuId, command, prefix, choices, visible);
-    });
     api.onClear((_) => {
         chatView.clear();
     });

--- a/ts/packages/shell/src/renderer/src/main.ts
+++ b/ts/packages/shell/src/renderer/src/main.ts
@@ -89,6 +89,16 @@ function addEvents(
     api.onAskYesNo(async (_, askYesNoId, message, id, source) => {
         chatView.askYesNo(askYesNoId, message, id, source);
     });
+    api.onProposeAction(
+        async (_, proposeActionId, actionTemplates, id, source) => {
+            chatView.proposeAction(
+                proposeActionId,
+                actionTemplates,
+                id,
+                source,
+            );
+        },
+    );
     api.onQuestion(async (_, questionId, message, id, source) => {
         chatView.question(questionId, message, id, source);
     });

--- a/ts/packages/shell/src/renderer/src/messageContainer.ts
+++ b/ts/packages/shell/src/renderer/src/messageContainer.ts
@@ -264,7 +264,11 @@ export class MessageContainer {
             }
 
             actionContainer.innerHTML = "";
-            const actionCascade = new ActionCascade(actionTemplates, true);
+            const actionCascade = new ActionCascade(
+                actionTemplates,
+
+                true,
+            );
             const actionDiv = actionCascade.toHTML();
             actionDiv.className = "action-text";
             this.messageDiv.appendChild(actionDiv);

--- a/ts/packages/shell/src/renderer/src/messageContainer.ts
+++ b/ts/packages/shell/src/renderer/src/messageContainer.ts
@@ -235,44 +235,66 @@ export class MessageContainer {
         // use this div to show the proposed action
         const actionContainer = document.createElement("div");
         actionContainer.className = "action-container";
-
-        const actionCascade = new ActionCascade(actionTemplates);
-        const actionDiv = actionCascade.toHTML();
-        actionDiv.className = "action-text";
-        actionContainer.appendChild(actionDiv);
         this.messageDiv.appendChild(actionContainer);
 
-        const choices: InputChoice[] = [
-            {
-                text: "Yes",
-                element: iconCheckMarkCircle(),
-                selectKey: ["y", "Y", "Enter"],
-                value: true,
-            },
-            {
-                text: "No",
-                element: iconX(),
-                selectKey: ["n", "N", "Delete"],
-                value: false,
-            },
-        ];
-        this.addChoicePanel(choices, (choice: InputChoice) => {
-            if (choice.value === true) {
-                actionContainer.remove();
-                getClientAPI().sendProposedAction(proposeActionId);
-                return;
-            }
+        const actionCascade = new ActionCascade(
+            actionContainer,
+            actionTemplates,
+        );
 
-            actionContainer.innerHTML = "";
-            const actionCascade = new ActionCascade(
-                actionTemplates,
+        const confirm = () => {
+            const choices: InputChoice[] = [
+                {
+                    text: "Accept",
+                    element: iconCheckMarkCircle(),
+                    selectKey: ["y", "Y", "Enter"],
+                    value: true,
+                },
+                {
+                    text: "Edit",
+                    element: iconX(),
+                    selectKey: ["n", "N", "Delete"],
+                    value: false,
+                },
+            ];
+            this.addChoicePanel(choices, (choice: InputChoice) => {
+                if (choice.value === true) {
+                    actionContainer.remove();
+                    getClientAPI().sendProposedAction(proposeActionId);
+                    return;
+                }
+                edit();
+            });
+        };
+        const edit = () => {
+            actionCascade.setEditMode(true);
+            const choices: InputChoice[] = [
+                {
+                    text: "Replace",
+                    element: iconCheckMarkCircle(),
+                    value: true,
+                },
+                {
+                    text: "Cancel",
+                    element: iconX(),
+                    value: false,
+                },
+            ];
+            this.addChoicePanel(choices, (choice: InputChoice) => {
+                if (choice.value === true) {
+                    actionContainer.remove();
+                    getClientAPI().sendProposedAction(
+                        proposeActionId,
+                        actionCascade.value,
+                    );
+                }
+                actionCascade.reset();
+                actionCascade.setEditMode(false);
+                confirm();
+            });
+        };
 
-                true,
-            );
-            const actionDiv = actionCascade.toHTML();
-            actionDiv.className = "action-text";
-            this.messageDiv.appendChild(actionDiv);
-        });
+        confirm();
     }
 
     private speakText(tts: TTS, speakText: string) {


### PR DESCRIPTION
- Initial wiring of propose action using existing `ActionCascade`. 
- Finishing the field editing UI in ActionCascade. 
  - Add per field edit button.
  - Accept/Replace flow and send back for replacement.
  - TODO: adding and deleting of optional fields and array items, switching translator and action name.

Additional cleanup:
- Separate the data vs schema in the action template.
- Separate proposeAction and askYesNo.
- Remove the dispatcher driven SearchMenu and Action Command.  For additional action templates, will switch to having host request action templates when we need it.