### PR TITLE
Shell translation confirm/replace flow: add/delete array entries and optional properties

### DIFF
--- a/ts/packages/dispatcher/src/handlers/requestCommandHandler.ts
+++ b/ts/packages/dispatcher/src/handlers/requestCommandHandler.ts
@@ -106,7 +106,11 @@ async function confirmTranslation(
     const newActions = (await systemContext.requestIO.proposeAction(
         templateSequence,
         DispatcherName,
-    )) as FullAction[] | undefined;
+    )) as FullAction[] | undefined | null;
+
+    if (newActions === null) {
+        throw new Error("Request cancelled");
+    }
 
     return newActions
         ? {

--- a/ts/packages/shell/src/renderer/assets/styles.less
+++ b/ts/packages/shell/src/renderer/assets/styles.less
@@ -690,12 +690,15 @@ input[type="file"] {
 }
 
 .action-text td.button-cell {
-  width: 100%;
   padding: 0px;
 }
 
 .action-text input {
   width: 100%;
+}
+
+.action-text tr.hidden {
+  display: none;
 }
 
 .action-edit-button,
@@ -715,4 +718,5 @@ input[type="file"] {
 .action-text tr.error,
 .action-text tr.error input {
   color: red;
+  font-weight: bold;
 }

--- a/ts/packages/shell/src/renderer/assets/styles.less
+++ b/ts/packages/shell/src/renderer/assets/styles.less
@@ -693,8 +693,15 @@ input[type="file"] {
   padding: 0px;
 }
 
-.action-text input {
+.action-text input,
+.action-text select {
   width: 100%;
+}
+
+.action-text .temp {
+  text-align: right;
+  font-style: italic;
+  color: lightgray;
 }
 
 .action-text tr.hidden {

--- a/ts/packages/shell/src/renderer/assets/styles.less
+++ b/ts/packages/shell/src/renderer/assets/styles.less
@@ -694,6 +694,10 @@ input[type="file"] {
   padding: 0px;
 }
 
+.action-text input {
+  width: 100%;
+}
+
 .action-edit-button,
 .action-editing-button,
 .action-text-editable table.editing .action-edit-button,

--- a/ts/packages/shell/src/renderer/src/ActionCascade.ts
+++ b/ts/packages/shell/src/renderer/src/ActionCascade.ts
@@ -44,17 +44,19 @@ function removeFieldGroup(fieldGroup: FieldGroup) {
 }
 
 class FieldContainer {
-    public readonly table: HTMLTableElement;
+    private readonly table: HTMLTableElement;
     private current: any;
     private errorCount = 0;
 
     constructor(
+        appendTo: HTMLElement,
         private actionTemplates: ActionTemplateSequence,
         private enableEdit = true,
     ) {
         this.current = structuredClone(actionTemplates.actions);
         this.table = document.createElement("table");
-        this.createTable();
+        this.createFields();
+        appendTo.appendChild(this.table);
     }
 
     public get value() {
@@ -69,7 +71,7 @@ class FieldContainer {
         this.current = structuredClone(this.actionTemplates.actions);
         this.table.classList.remove("editing");
         this.errorCount = 0;
-        this.createTable();
+        this.createFields();
     }
 
     private createFieldGroup(
@@ -338,7 +340,7 @@ class FieldContainer {
         }
     }
 
-    private createTable() {
+    private createFields() {
         this.clearTable();
         for (let i = 0; i < this.actionTemplates.templates.length; i++) {
             const actionTemplate = this.actionTemplates.templates[i];
@@ -445,8 +447,12 @@ export class ActionCascade {
         this.container.className = "action-text";
         appendTo.appendChild(this.container);
 
-        this.fieldContainer = new FieldContainer(actionTemplates, enableEdit);
         this.createUI();
+        this.fieldContainer = new FieldContainer(
+            this.container,
+            actionTemplates,
+            enableEdit,
+        );
     }
 
     public get value() {
@@ -502,10 +508,6 @@ export class ActionCascade {
             preface.className = "preface-text";
             preface.innerText = this.actionTemplates.prefaceMultiple;
             div.appendChild(preface);
-        }
-
-        if (this.fieldContainer.table.children.length !== 0) {
-            this.container.appendChild(this.fieldContainer.table);
         }
     }
 }

--- a/ts/packages/shell/src/renderer/src/ActionCascade.ts
+++ b/ts/packages/shell/src/renderer/src/ActionCascade.ts
@@ -43,25 +43,18 @@ function removeFieldGroup(fieldGroup: FieldGroup) {
     fieldGroup.row.remove();
 }
 
-export class ActionCascade {
-    private readonly container: HTMLDivElement;
-    private readonly table: HTMLTableElement;
+class FieldContainer {
+    public readonly table: HTMLTableElement;
     private current: any;
-    private editMode = false;
-
     private errorCount = 0;
+
     constructor(
-        appendTo: HTMLElement,
         private actionTemplates: ActionTemplateSequence,
         private enableEdit = true,
     ) {
         this.current = structuredClone(actionTemplates.actions);
-        this.container = document.createElement("div");
-        this.container.className = "action-text";
-        appendTo.appendChild(this.container);
-
         this.table = document.createElement("table");
-        this.createUI();
+        this.createTable();
     }
 
     public get value() {
@@ -79,27 +72,6 @@ export class ActionCascade {
         this.createTable();
     }
 
-    public setEditMode(editMode: boolean) {
-        if (this.editMode === editMode) {
-            return;
-        }
-        if (!this.enableEdit && editMode === true) {
-            throw new Error(
-                "Cannot set edit mode to true on a non-editable action cascade",
-            );
-        }
-
-        this.editMode = editMode;
-        if (editMode) {
-            this.container.classList.add("action-text-editable");
-        } else {
-            this.container.classList.remove("action-text-editable");
-        }
-    }
-
-    public remove() {
-        this.container.remove();
-    }
     private createFieldGroup(
         paramName: string,
         valueDisplay: string | undefined,
@@ -383,40 +355,11 @@ export class ActionCascade {
                 actionTemplate.parameterStructure.fields,
             );
         }
-
-        if (this.table.children.length !== 0) {
-            this.container.appendChild(this.table);
-        }
     }
     private clearTable() {
         this.table.remove();
         this.table.replaceChildren();
     }
-
-    private createUI() {
-        // for now assume a single action
-        const div = this.container;
-        if (
-            this.actionTemplates.templates.length === 1 &&
-            this.actionTemplates.prefaceSingle
-        ) {
-            const preface = document.createElement("div");
-            preface.className = "preface-text";
-            preface.innerText = this.actionTemplates.prefaceSingle;
-            div.appendChild(preface);
-        } else if (
-            this.actionTemplates.templates.length > 1 &&
-            this.actionTemplates.prefaceMultiple
-        ) {
-            const preface = document.createElement("div");
-            preface.className = "preface-text";
-            preface.innerText = this.actionTemplates.prefaceMultiple;
-            div.appendChild(preface);
-        }
-
-        this.createTable();
-    }
-
     private getProperty(name: string) {
         const properties = name.split(".");
         let lastName: string | number = "current";
@@ -486,5 +429,83 @@ export class ActionCascade {
             }
         }
         curr[lastName] = value;
+    }
+}
+export class ActionCascade {
+    private readonly container: HTMLDivElement;
+    private readonly fieldContainer: FieldContainer;
+    private editMode = false;
+
+    constructor(
+        appendTo: HTMLElement,
+        private actionTemplates: ActionTemplateSequence,
+        private enableEdit = true,
+    ) {
+        this.container = document.createElement("div");
+        this.container.className = "action-text";
+        appendTo.appendChild(this.container);
+
+        this.fieldContainer = new FieldContainer(actionTemplates, enableEdit);
+        this.createUI();
+    }
+
+    public get value() {
+        return this.fieldContainer.value;
+    }
+
+    public get hasErrors() {
+        return this.fieldContainer.hasErrors;
+    }
+
+    public reset() {
+        this.fieldContainer.reset();
+    }
+
+    public setEditMode(editMode: boolean) {
+        if (this.editMode === editMode) {
+            return;
+        }
+        if (!this.enableEdit && editMode === true) {
+            throw new Error(
+                "Cannot set edit mode to true on a non-editable action cascade",
+            );
+        }
+
+        this.editMode = editMode;
+        if (editMode) {
+            this.container.classList.add("action-text-editable");
+        } else {
+            this.container.classList.remove("action-text-editable");
+        }
+    }
+
+    public remove() {
+        this.container.remove();
+    }
+
+    private createUI() {
+        // for now assume a single action
+        const div = this.container;
+        if (
+            this.actionTemplates.templates.length === 1 &&
+            this.actionTemplates.prefaceSingle
+        ) {
+            const preface = document.createElement("div");
+            preface.className = "preface-text";
+            preface.innerText = this.actionTemplates.prefaceSingle;
+            div.appendChild(preface);
+        } else if (
+            this.actionTemplates.templates.length > 1 &&
+            this.actionTemplates.prefaceMultiple
+        ) {
+            const preface = document.createElement("div");
+            preface.className = "preface-text";
+            preface.innerText = this.actionTemplates.prefaceMultiple;
+            div.appendChild(preface);
+        }
+
+        if (this.fieldContainer.table.children.length !== 0) {
+            this.container.appendChild(this.fieldContainer.table);
+        }
     }
 }

--- a/ts/packages/shell/src/renderer/src/messageContainer.ts
+++ b/ts/packages/shell/src/renderer/src/messageContainer.ts
@@ -243,29 +243,42 @@ export class MessageContainer {
             actionTemplates,
         );
 
+        const createTextSpan = (text: string) => {
+            const span = document.createElement("span");
+            span.innerText = text;
+            return span;
+        };
         const confirm = () => {
             const choices: InputChoice[] = [
                 {
                     text: "Accept",
-                    element: iconCheckMarkCircle(),
+                    element: createTextSpan("✓"),
                     selectKey: ["y", "Y", "Enter"],
                     value: true,
                 },
                 {
                     text: "Edit",
-                    element: iconX(),
+                    element: createTextSpan("✎"),
                     selectKey: ["n", "N", "Delete"],
+                    value: undefined,
+                },
+                {
+                    text: "Cancel",
+                    element: createTextSpan("✕"),
+                    selectKey: ["Escape"],
                     value: false,
                 },
             ];
             this.addChoicePanel(choices, (choice: InputChoice) => {
-                if (choice.value === true) {
-                    actionContainer.remove();
-                    getClientAPI().sendProposedAction(proposeActionId);
+                if (choice.value === undefined) {
+                    edit();
                     return;
                 }
-                edit();
+                actionContainer.remove();
+                const replacement = choice.value ? undefined : null;
+                getClientAPI().sendProposedAction(proposeActionId, replacement);
             });
+            this.scrollIntoView();
         };
         const edit = () => {
             actionCascade.setEditMode(true);
@@ -298,6 +311,7 @@ export class MessageContainer {
                 }
                 return true;
             });
+            this.scrollIntoView();
         };
 
         confirm();


### PR DESCRIPTION
Add capability to add and delete optional fields and array entries.

Additionally:
- Add option to cancel the action entirely.
- Use different input/drop-box for different field types.
- Refactor the `ActionCascade` and break it into different kind of rows 