### PR TITLE
Look up ActionInfo

### DIFF
--- a/ts/packages/dispatcher/src/handlers/common/appAgentManager.ts
+++ b/ts/packages/dispatcher/src/handlers/common/appAgentManager.ts
@@ -143,7 +143,7 @@ export class AppAgentManager implements TranslatorConfigProvider {
                 if (config.injected) {
                     for (const info of getTranslatorActionInfo(config, name)) {
                         this.injectedTranslatorForActionName.set(
-                            info.name,
+                            info.actionName,
                             name,
                         );
                     }

--- a/ts/packages/dispatcher/src/handlers/common/appAgentManager.ts
+++ b/ts/packages/dispatcher/src/handlers/common/appAgentManager.ts
@@ -16,7 +16,7 @@ import {
 import { createSessionContext } from "../../action/actionHandlers.js";
 import { AppAgentProvider } from "../../agent/agentProvider.js";
 import registerDebug from "debug";
-import { getTranslatorActionInfo } from "../../translation/actionInfo.js";
+import { getTranslatorActionInfos } from "../../translation/actionInfo.js";
 import { DeepPartialUndefinedAndNull } from "common-utils";
 
 const debug = registerDebug("typeagent:agents");
@@ -141,7 +141,8 @@ export class AppAgentManager implements TranslatorConfigProvider {
                 this.emojis[name] = config.emojiChar;
 
                 if (config.injected) {
-                    for (const info of getTranslatorActionInfo(config, name)) {
+                    const actionInfos = getTranslatorActionInfos(config, name);
+                    for (const info of actionInfos.values()) {
                         this.injectedTranslatorForActionName.set(
                             info.actionName,
                             name,

--- a/ts/packages/dispatcher/src/handlers/requestCommandHandler.ts
+++ b/ts/packages/dispatcher/src/handlers/requestCommandHandler.ts
@@ -37,7 +37,6 @@ import {
 import { makeRequestPromptCreator } from "./common/chatHistoryPrompt.js";
 import { MatchResult } from "../../../cache/dist/constructions/constructions.js";
 import registerDebug from "debug";
-import { getAllActionInfo } from "../translation/actionInfo.js";
 import { IncrementalJsonValueCallBack } from "../../../commonUtils/dist/incrementalJsonParser.js";
 import ExifReader from "exifreader";
 import { Result } from "typechat";
@@ -88,19 +87,12 @@ async function confirmTranslation(
     const preface =
         "Use the buttons to run or cancel the following action(s). You can also press [Enter] to run it, [Del] to edit it, or [Escape] to cancel it.";
     const editPreface = `Edit the following action(s) to match your requests.  Click on the values to start editing. Use the ➕/✕ buttons to add/delete optional fields.`;
-    const translatorNames = getActiveTranslatorList(systemContext).filter(
-        (name) => !name.startsWith("system."),
-    );
 
-    const allActionInfo = getAllActionInfo(
-        translatorNames,
-        systemContext.agents,
-    );
     const templateSequence = toTemplateSequence(
+        systemContext.agents,
         actions,
         preface,
         editPreface,
-        allActionInfo,
     );
 
     // TODO: Need to validate

--- a/ts/packages/dispatcher/src/index.ts
+++ b/ts/packages/dispatcher/src/index.ts
@@ -15,9 +15,9 @@ export type {
 export type { Timing, PhaseTiming, RequestMetrics } from "./utils/metrics.js";
 
 export type {
-    TemplateParamArray,
-    TemplateParamField,
-    TemplateParamFieldOpt,
-    TemplateParamScalar,
+    ActionParamArray,
+    ActionParamField,
+    ActionParamFieldOpt,
+    ActionParamScalar,
 } from "./translation/actionInfo.js";
 export type { ActionTemplateSequence } from "./translation/actionTemplate.js";

--- a/ts/packages/dispatcher/src/translation/actionTemplate.ts
+++ b/ts/packages/dispatcher/src/translation/actionTemplate.ts
@@ -2,7 +2,13 @@
 // Licensed under the MIT License.
 
 import { Actions } from "agent-cache";
-import { ActionInfo, ActionTemplate } from "./actionInfo.js";
+import { ActionInfo, TemplateParamObject } from "./actionInfo.js";
+
+export type ActionTemplate = {
+    agent: string;
+    name: string;
+    parameterStructure?: TemplateParamObject | undefined;
+};
 
 export type ActionTemplateSequence = {
     templates: ActionTemplate[];
@@ -27,7 +33,7 @@ export function toTemplateSequence(
             );
         }
         templates.push({
-            parameterStructure: actionInfo.template!.parameterStructure,
+            parameterStructure: actionInfo.parameters,
             name: action.actionName,
             agent: action.translatorNameString,
         });

--- a/ts/packages/dispatcher/src/translation/actionTemplate.ts
+++ b/ts/packages/dispatcher/src/translation/actionTemplate.ts
@@ -2,12 +2,12 @@
 // Licensed under the MIT License.
 
 import { Actions } from "agent-cache";
-import { ActionInfo, TemplateParamObject } from "./actionInfo.js";
+import { ActionInfo, ActionParamObject } from "./actionInfo.js";
 
 export type ActionTemplate = {
     agent: string;
     name: string;
-    parameterStructure?: TemplateParamObject | undefined;
+    parameterStructure?: ActionParamObject | undefined;
 };
 
 export type ActionTemplateSequence = {

--- a/ts/packages/dispatcher/src/translation/actionTemplate.ts
+++ b/ts/packages/dispatcher/src/translation/actionTemplate.ts
@@ -2,7 +2,8 @@
 // Licensed under the MIT License.
 
 import { Actions } from "agent-cache";
-import { ActionInfo, ActionParamObject } from "./actionInfo.js";
+import { ActionParamObject, getTranslatorActionInfos } from "./actionInfo.js";
+import { TranslatorConfigProvider } from "./agentTranslators.js";
 
 export type ActionTemplate = {
     agent: string;
@@ -18,18 +19,23 @@ export type ActionTemplateSequence = {
 };
 
 export function toTemplateSequence(
+    provider: TranslatorConfigProvider,
     actions: Actions,
     preface: string,
     editPreface: string,
-    parameterStructures: Map<string, ActionInfo>,
 ): ActionTemplateSequence {
     const templates: ActionTemplate[] = [];
 
     for (const action of actions) {
-        const actionInfo = parameterStructures.get(action.fullActionName);
+        const config = provider.getTranslatorConfig(action.translatorName);
+        const actionInfos = getTranslatorActionInfos(
+            config,
+            action.translatorName,
+        );
+        const actionInfo = actionInfos.get(action.actionName);
         if (actionInfo === undefined) {
             throw new Error(
-                `Action ${action.fullActionName} not found in parameterStructures`,
+                `ActionInfo for '${action.fullActionName}' not found`,
             );
         }
         templates.push({

--- a/ts/packages/dispatcher/src/translation/unknownSwitcher.ts
+++ b/ts/packages/dispatcher/src/translation/unknownSwitcher.ts
@@ -32,9 +32,9 @@ function createSelectionSchema(
     const actionComments: string[] = [];
     for (const info of actionInfos) {
         if (info !== undefined) {
-            actionNames.push(`"${info.name}"`);
+            actionNames.push(`"${info.actionName}"`);
             actionComments.push(
-                `"${info.name}"${info.comments ? ` - ${info.comments}` : ""}`,
+                `"${info.actionName}"${info.comments ? ` - ${info.comments}` : ""}`,
             );
         }
     }

--- a/ts/packages/dispatcher/src/translation/unknownSwitcher.ts
+++ b/ts/packages/dispatcher/src/translation/unknownSwitcher.ts
@@ -5,7 +5,7 @@ import {
     InlineTranslatorSchemaDef,
     createJsonTranslatorFromSchemaDef,
 } from "common-utils";
-import { getTranslatorActionInfo } from "./actionInfo.js";
+import { getTranslatorActionInfos } from "./actionInfo.js";
 import { Result, success } from "typechat";
 import registerDebug from "debug";
 import { TranslatorConfigProvider } from "./agentTranslators.js";
@@ -23,20 +23,18 @@ function createSelectionSchema(
         selectSchemaCache.set(translatorName, undefined);
         return undefined;
     }
-    const actionInfos = getTranslatorActionInfo(
+    const actionInfos = getTranslatorActionInfos(
         translatorConfig,
         translatorName,
     );
 
     const actionNames: string[] = [];
     const actionComments: string[] = [];
-    for (const info of actionInfos) {
-        if (info !== undefined) {
-            actionNames.push(`"${info.actionName}"`);
-            actionComments.push(
-                `"${info.actionName}"${info.comments ? ` - ${info.comments}` : ""}`,
-            );
-        }
+    for (const info of actionInfos.values()) {
+        actionNames.push(`"${info.actionName}"`);
+        actionComments.push(
+            `"${info.actionName}"${info.comments ? ` - ${info.comments}` : ""}`,
+        );
     }
 
     if (actionNames.length === 0) {

--- a/ts/packages/shell/src/renderer/src/fieldEditor.ts
+++ b/ts/packages/shell/src/renderer/src/fieldEditor.ts
@@ -2,19 +2,19 @@
 // Licensed under the MIT License.
 
 import {
-    TemplateParamArray,
-    TemplateParamField,
+    ActionParamArray,
+    ActionParamField,
     ActionTemplateSequence,
-    TemplateParamFieldOpt,
-    TemplateParamScalar,
+    ActionParamFieldOpt,
+    ActionParamScalar,
 } from "agent-dispatcher";
 
-function isValidValue(paramField: TemplateParamScalar, value: any) {
+function isValidValue(paramField: ActionParamScalar, value: any) {
     return paramField.type === "string-union"
         ? paramField.typeEnum.includes(value)
         : typeof value === paramField.type;
 }
-function toValueType(paramField: TemplateParamScalar, value: string) {
+function toValueType(paramField: ActionParamScalar, value: string) {
     switch (paramField.type) {
         case "string":
             return value;
@@ -274,7 +274,7 @@ abstract class FieldGroup extends FieldBase {
     protected createChildField(
         fieldName: string | number,
         label: string,
-        fieldType: TemplateParamField,
+        fieldType: ActionParamField,
         optional: boolean,
     ) {
         const field = createUIForField(
@@ -316,7 +316,7 @@ class FieldScalar extends FieldBase {
         data: FieldData,
         fullPropertyName: string,
         label: string,
-        private readonly fieldType: TemplateParamScalar = defaultTemplatParamScalar,
+        private readonly fieldType: ActionParamScalar = defaultTemplatParamScalar,
         optional: boolean = false,
         level: number = 0,
         parent?: FieldGroup,
@@ -447,7 +447,7 @@ class FieldObject extends FieldGroup {
         data: FieldData,
         fullPropertyName: string,
         paramName: string,
-        private readonly fieldTypes: Record<string, TemplateParamFieldOpt>,
+        private readonly fieldTypes: Record<string, ActionParamFieldOpt>,
         optional: boolean = false,
         level = 0,
         parent?: FieldGroup,
@@ -547,7 +547,7 @@ class FieldArray extends FieldGroup {
         data: FieldData,
         fullPropertyName: string,
         paramName: string,
-        private readonly paramValue: TemplateParamArray,
+        private readonly paramValue: ActionParamArray,
         optional: boolean,
         level: number,
         parent: FieldGroup | undefined,
@@ -631,7 +631,7 @@ function createUIForField(
     data: FieldData,
     fullPropertyName: string,
     paramName: string,
-    paramField: TemplateParamField,
+    paramField: ActionParamField,
     optional: boolean,
     level: number,
     parent: FieldGroup | undefined,

--- a/ts/packages/shell/src/renderer/src/fieldEditor.ts
+++ b/ts/packages/shell/src/renderer/src/fieldEditor.ts
@@ -715,12 +715,15 @@ class FieldContainer {
 
             new FieldScalar(this.data, `${i}.translatorName`, "Agent");
             new FieldScalar(this.data, `${i}.actionName`, "Action");
-            new FieldObject(
-                this.data,
-                `${i}.parameters`,
-                "Parameters",
-                actionTemplate.parameterStructure.fields,
-            );
+
+            if (actionTemplate.parameterStructure) {
+                new FieldObject(
+                    this.data,
+                    `${i}.parameters`,
+                    "Parameters",
+                    actionTemplate.parameterStructure.fields,
+                );
+            }
         }
     }
 }


### PR DESCRIPTION
- Instead of getting all action info to generate the template sequence, do a look up instead.
- Change the underlying data structure and API to enable the look up.
- Also rename the ActionInfo's parameter type names