### PR TITLE
Fix for 'Type quit OR exit to exit' which omits the @ prefix

### DIFF
--- a/ts/examples/playground/src/main.ts
+++ b/ts/examples/playground/src/main.ts
@@ -332,7 +332,7 @@ async function runPlayground(): Promise<void> {
         io.writer.writeLine("@help for a list of available commands.");
         io.writer.writeLine();
         io.writer.writeLine(
-            "To start, type something like 'hello and hit return.",
+            "To start, type something like 'hello' and hit Enter.",
         );
     }
 }

--- a/ts/packages/interactiveApp/src/interactiveApp.ts
+++ b/ts/packages/interactiveApp/src/interactiveApp.ts
@@ -279,7 +279,7 @@ class InteractiveApp {
     private writeWelcome() {
         if (this._settings.stopCommands) {
             this._stdio.stdout.write(
-                `Type ${this._settings.stopCommands.join(" OR ")} to exit\n`,
+                `Type ${this._settings.stopCommands.map((s) => this._settings.commandPrefix + s).join(" OR ")} to exit.\n`,
             );
         }
         if (this._settings.commandPrefix) {


### PR DESCRIPTION
At the start of a session, there's a message `Type quit OR exit to exit`.
However, if you type `quit`, it's an error.
The reason is that this is a command prefixed with `@` (though handled specially in the command parser).

My fix changes this to `Type @quit OR @exit to exit`,
taking the configured command prefix and list of stopcommands into account.

While I was here, I also fixed a missing quote in the final welcome message (`'hello`).