### PR TITLE
Fix chat view size in WSL/OSX, replace custom margin for windows and not resizing in WSL.

### DIFF
--- a/ts/packages/shell/src/main/index.ts
+++ b/ts/packages/shell/src/main/index.ts
@@ -154,11 +154,7 @@ function createWindow(): void {
         }
     });
 
-    if (isLinux) {
-        mainWindow.on("resize", setContentSize);
-    } else {
-        mainWindow.on("will-resize", setContentSize);
-    }
+    mainWindow.on("resize", setContentSize);
 
     // HMR for renderer base on electron-vite cli.
     // Load the remote URL for development or the local html file for production.
@@ -807,8 +803,6 @@ function zoomOut(chatView: BrowserView) {
 }
 
 const isMac = process.platform === "darwin";
-const isLinux = process.platform === "linux";
-
 function setupZoomHandlers(chatView: BrowserView) {
     chatView.webContents.on("before-input-event", (_event, input) => {
         if ((isMac ? input.meta : input.control) && input.type === "keyDown") {

--- a/ts/packages/shell/src/main/shellSettings.ts
+++ b/ts/packages/shell/src/main/shellSettings.ts
@@ -44,12 +44,12 @@ export class ShellSettings
     public onOpenInlineBrowser: ((targetUrl: URL) => void) | null;
     public onCloseInlineBrowser: EmptyFunction | null;
 
-    public get width(): number | undefined {
-        return this.size[0];
+    public get width(): number {
+        return this.size[0] ?? defaultSettings.size[0];
     }
 
-    public get height(): number | undefined {
-        return this.size[1];
+    public get height(): number {
+        return this.size[1] ?? defaultSettings.size[1];
     }
 
     public get x(): number | undefined {


### PR DESCRIPTION
- Use getContentBounds instead of getBounds for the view contents.
- Use "resize" event in linux instead of "will-resize"