### PR TITLE
Shell confirm/replace flow: Improve template editor UI

### DIFF
--- a/ts/packages/shell/src/renderer/assets/styles.less
+++ b/ts/packages/shell/src/renderer/assets/styles.less
@@ -194,6 +194,11 @@ body {
   margin-left: 10px;
 }
 
+// Make sure that the popup search menu is on top of other messages
+.chat-message-container-agent:has(.autocomplete-container) {
+  z-index: 100;
+}
+
 .chat-message-container-user {
   .chat-message-container;
   margin-right: 10px;
@@ -253,7 +258,7 @@ body {
   border-radius: 0px 0px 8px 8px;
   font-size: 10px;
   font-style: normal;
-  z-index: 100;
+  z-index: 50;
   text-align: right;
 }
 
@@ -505,14 +510,6 @@ body {
   margin-right: 5px;
 }
 
-.overlay {
-  height: 100%;
-  width: 100%;
-  position: absolute;
-  background-color: rgba(0, 0, 0, 0.5);
-  z-index: 100;
-}
-
 span.ansi-black-fg {
   color: black;
 }
@@ -660,15 +657,13 @@ input[type="file"] {
   border-bottom: 1px solid lightgray;
 }
 .action-text td {
-  padding-left: 10px;
-  padding-right: 10px;
+  padding: 1px 10px 1px 10px;
   height: 22px;
 }
 
-.action-text div {
-  display: inline-block;
+.action-text .autocomplete-container {
+  bottom: 25px;
 }
-
 .action-text td.name-cell {
   width: 30%;
 }
@@ -723,7 +718,7 @@ input[type="file"] {
   display: none;
 }
 
-.action-text tr.error,
+.action-text tr.error td.name-cell,
 .action-text tr.error input {
   color: red;
   font-weight: bold;

--- a/ts/packages/shell/src/renderer/assets/styles.less
+++ b/ts/packages/shell/src/renderer/assets/styles.less
@@ -694,14 +694,9 @@ input[type="file"] {
   height: 100%;
 }
 
-.action-text .temp {
-  text-align: right;
+.action-text tr.missing {
   font-style: italic;
   color: lightgray;
-}
-
-.action-text tr.hidden {
-  display: none;
 }
 
 .action-edit-button,

--- a/ts/packages/shell/src/renderer/assets/styles.less
+++ b/ts/packages/shell/src/renderer/assets/styles.less
@@ -668,10 +668,6 @@ input[type="file"] {
 .action-text div {
   display: inline-block;
 }
-.left-button-div {
-  position: absolute;
-  left: -10px;
-}
 
 .action-text td.name-cell {
   width: 30%;
@@ -695,15 +691,16 @@ input[type="file"] {
 }
 
 .action-text tr.missing {
-  font-style: italic;
-  color: lightgray;
+  display: none;
 }
 
-.action-edit-button,
-.action-editing-button,
-.action-text-editable table.editing .action-edit-button,
-.action-text-editable table.editing tr:hover .action-edit-button,
-.action-text-editable tr.editing:hover .action-edit-button {
+.action-text-editable tr.missing {
+  font-style: italic;
+  color: lightgray;
+  display: table-row;
+}
+
+.action-button {
   padding: 4px;
   border: lightgray;
   background-color: transparent;
@@ -711,15 +708,19 @@ input[type="file"] {
   opacity: 0;
   width: 100%;
 }
-.action-text-editable .action-edit-button {
+.action-text-editable .action-button {
   display: block;
   opacity: 0.25;
 }
 
-.action-text-editable tr:hover .action-edit-button,
-.action-text-editable tr.editing .action-editing-button {
+.action-text-editable tr:hover .action-button,
+.action-text-editable tr.editing .action-button {
   display: block;
   opacity: 1;
+}
+
+.action-text-editable tr.missing .delete-button {
+  display: none;
 }
 
 .action-text tr.error,

--- a/ts/packages/shell/src/renderer/src/partial.ts
+++ b/ts/packages/shell/src/renderer/src/partial.ts
@@ -207,10 +207,6 @@ export class PartialCompletion {
         });
     }
 
-    private isSearchMenuActive() {
-        return this.searchMenu.getContainer().parentElement !== null;
-    }
-
     private showCompletionMenu() {
         const prefix = this.getCompletionPrefix(
             this.getCurrentInputForCompletion(),
@@ -220,7 +216,7 @@ export class PartialCompletion {
             debugError(`Partial completion prefix not found`);
             return;
         }
-        if (this.isSearchMenuActive() && prefix !== "") {
+        if (this.searchMenu.isActive() && prefix !== "") {
             return;
         }
         const r = document.createRange();
@@ -238,13 +234,13 @@ export class PartialCompletion {
         const x = rects[0].left;
         const leftBound = this.container.getBoundingClientRect().left;
         this.searchMenu.getContainer().style.left = `${x - leftBound}px`;
-        if (!this.isSearchMenuActive()) {
+        if (!this.searchMenu.isActive()) {
             this.container.appendChild(this.searchMenu.getContainer());
         }
     }
 
     private cancelCompletionMenu() {
-        if (this.isSearchMenuActive()) {
+        if (this.searchMenu.isActive()) {
             this.container.removeChild(this.searchMenu.getContainer());
         }
     }
@@ -265,7 +261,7 @@ export class PartialCompletion {
     }
 
     public handleSpecialKeys(event: KeyboardEvent) {
-        if (!this.isSearchMenuActive()) {
+        if (!this.searchMenu.isActive()) {
             return false;
         }
         if (event.key === "Escape") {

--- a/ts/packages/shell/src/renderer/src/search.ts
+++ b/ts/packages/shell/src/renderer/src/search.ts
@@ -47,6 +47,10 @@ export class SearchMenu {
         return this.searchContainer;
     }
 
+    public isActive() {
+        return this.searchContainer.parentElement !== null;
+    }
+
     public selectCompletion(index: number) {
         if (index >= 0 && index < this.items.length) {
             this.onCompletion(this.items[index]);


### PR DESCRIPTION
Reducing the amount of mouse click needed to edit the schema:

- Remove edit save/cancel button, just auto save when moved off the field
- "Enter" key will move to the next field to edit.
- Track editing field on array reordering, and default to next scalar field on array entry deletion.
- Always show optional fields that can be filled in fill in (instead of clicking the + side and choose the field to add)
- Use search menu for string-union fields. (in preparation for field auto-complete as well)
- Buttons are lightgray except on hover or the field it is editing.