### PR TITLE
Shell confirm/replace flow: Allow search menu to be clicked and serval bug fixes

### DIFF
--- a/ts/packages/dispatcher/src/handlers/common/appAgentManager.ts
+++ b/ts/packages/dispatcher/src/handlers/common/appAgentManager.ts
@@ -165,8 +165,11 @@ export class AppAgentManager implements TranslatorConfigProvider {
         }
     }
 
+    public tryGetTranslatorConfig(mayBeTranslatorName: string) {
+        return this.translatorConfigs.get(mayBeTranslatorName);
+    }
     public getTranslatorConfig(translatorName: string) {
-        const config = this.translatorConfigs.get(translatorName);
+        const config = this.tryGetTranslatorConfig(translatorName);
         if (config === undefined) {
             throw new Error(`Unknown translator: ${translatorName}`);
         }

--- a/ts/packages/shell/src/renderer/assets/styles.less
+++ b/ts/packages/shell/src/renderer/assets/styles.less
@@ -685,16 +685,6 @@ input[type="file"] {
   height: 100%;
 }
 
-.action-text tr.missing {
-  display: none;
-}
-
-.action-text-editable tr.missing {
-  font-style: italic;
-  color: lightgray;
-  display: table-row;
-}
-
 .action-button {
   padding: 4px;
   border: lightgray;
@@ -722,4 +712,17 @@ input[type="file"] {
 .action-text tr.error input {
   color: red;
   font-weight: bold;
+}
+
+.action-text tr.missing {
+  display: none;
+}
+
+.action-text-editable tr.missing {
+  display: table-row;
+}
+
+.action-text-editable tr.missing td.name-cell {
+  font-style: italic;
+  color: lightgray;
 }

--- a/ts/packages/shell/src/renderer/src/search.ts
+++ b/ts/packages/shell/src/renderer/src/search.ts
@@ -172,6 +172,11 @@ export class SearchMenu {
                 resultSpan.innerText = suffix;
                 li.appendChild(resultSpan);
                 this.completions.appendChild(li);
+
+                li.onclick = () => {
+                    this.onCompletion(item);
+                };
+
                 if (i === this.items.length - 1) {
                     break;
                 }


### PR DESCRIPTION
- Search Menu can be selected by mouse.
- Search Menu select (mouse click or enter) will move to the next field.
- Schema refresh on field change will advance to the next field.
- Fix the bug of not able to get schema when the translator name is invalid.
- Fix the bug where schema doesn't refresh when changing action name when it was invalid before.
- Fix the UI bug where search menu should adopt the "missing" style when the optional field is empty
- Close the search menu when input lose focus.