### PR TITLE
Clean up the command transformer

### DIFF
--- a/ts/examples/chat/src/codeChat/codeChat.ts
+++ b/ts/examples/chat/src/codeChat/codeChat.ts
@@ -443,7 +443,7 @@ export async function runCodeChat(): Promise<void> {
         // Pass it to TypeChat to transform and dispatch as an @ command
         const error = await commandTransformer.transformAndDispatch(line, io);
         if (error) {
-            io.writer.writeLine("[Error:] " + error);
+            io.writer.writeLine("[Error:] " + error + "; try @help");
             return;
         }
     }

--- a/ts/examples/chat/src/codeChat/codeChat.ts
+++ b/ts/examples/chat/src/codeChat/codeChat.ts
@@ -8,7 +8,6 @@ import {
     CommandMetadata,
     InteractiveIo,
     NamedArgs,
-    CommandHandler2,
     addStandardHandlers,
     parseNamedArguments,
     runConsole,
@@ -33,15 +32,11 @@ import {
     loadTypescriptCode,
     sampleFiles,
 } from "./common.js";
-import {
-    createCommandTransformer,
-    completeCommandTransformer,
-} from "./commandTransformer.js";
+import { createCommandTransformer } from "./commandTransformer.js";
 
 export async function runCodeChat(): Promise<void> {
     const model = openai.createChatModel();
     const codeReviewer = createCodeReviewer(model);
-    const commandTransformer = createCommandTransformer(model);
     // For answer/code indexing examples
     const folderPath = "/data/code";
     const vectorModel = openai.createEmbeddingModel();
@@ -61,49 +56,6 @@ export async function runCodeChat(): Promise<void> {
         regex,
         cwd,
     };
-
-    // Handles input not starting with @,
-    // Transforming it into a regular @ command (which it then calls)
-    // or printing an error message.
-    async function inputHandler(
-        line: string,
-        io: InteractiveIo,
-    ): Promise<void> {
-        // Try to pass it to an LLM for transformation in a regular @ command
-        const transformed = (await commandTransformer.transform(line, io)) as
-            | NamedArgs
-            | undefined;
-        // io.writer.writeLine("[Transformed]: " + JSON.stringify(transformed));
-        if (!transformed) {
-            io.writer.writeLine(
-                "Sorry, I didn't get that (or the server is down); try @help",
-            );
-        } else if (transformed.name === "Unknown") {
-            io.writer.writeLine("Sorry, I didn't get that; try @help");
-        } else {
-            const name = transformed.name as string;
-            if (name in handlers) {
-                if (!handlers[name].metadata) {
-                    // Missing metadata: handler ignores arguments
-                    const handler = handlers[name];
-                    await handler([], io);
-                } else if (typeof handlers[name].metadata === "string") {
-                    // Metadata is a string: handler only takes a list of strings
-                    const handler = handlers[name];
-                    await handler(transformed.args, io);
-                } else {
-                    // Otherwise: handler takes a NamedArgs as well (best case)
-                    const handler = handlers[name] as CommandHandler2;
-                    await handler(transformed, io);
-                }
-            } else {
-                // Should never get this if the schema is correct
-                io.writer.writeLine(
-                    `Sorry, I don't know how to handle ${name}; try @help`,
-                );
-            }
-        }
-    }
 
     function onStart(io: InteractiveIo): void {
         printer = new CodePrinter(io);
@@ -479,7 +431,22 @@ export async function runCodeChat(): Promise<void> {
     }
 
     addStandardHandlers(handlers);
-    completeCommandTransformer(handlers, commandTransformer);
+    const commandTransformer = createCommandTransformer(model, handlers);
+
+    // Handles input not starting with @,
+    // Transforming it into a regular @ command (which it then calls)
+    // or printing an error message.
+    async function inputHandler(
+        line: string,
+        io: InteractiveIo,
+    ): Promise<void> {
+        // Pass it to TypeChat to transform and dispatch as an @ command
+        const error = await commandTransformer.transformAndDispatch(line, io);
+        if (error) {
+            io.writer.writeLine("[Error:] " + error);
+            return;
+        }
+    }
 
     await runConsole({
         onStart,

--- a/ts/examples/chat/src/codeChat/commandTransformer.ts
+++ b/ts/examples/chat/src/codeChat/commandTransformer.ts
@@ -22,7 +22,7 @@ export interface CommandTransformer {
     model: TypeChatLanguageModel;
     metadata?: Record<string, string | CommandMetadata>;
     schemaText?: string;
-    translator?: TypeChatJsonTranslator<any>;
+    translator?: TypeChatJsonTranslator<NamedArgs>;
     transform(command: string): Promise<NamedArgs | undefined>;
     dispatch(namedArgs: NamedArgs, io: InteractiveIo): Promise<string | void>; // String gives an error message
     transformAndDispatch(
@@ -46,7 +46,7 @@ export function createCommandTransformer(
 
     async function transform(command: string): Promise<NamedArgs | undefined> {
         const promptPreamble =
-            "If no value is given for a parameter, use the default from the comment, if any.";
+            "If no value is given for a parameter, use the default from the comment, if present.";
         const result = await transformer.translator!.translate(
             command,
             promptPreamble,
@@ -143,11 +143,11 @@ export function completeCommandTransformer(
     // console.log(schemaText);
 
     // Now construct the translator and add it
-    const validator = createTypeScriptJsonValidator<any>(
+    const validator = createTypeScriptJsonValidator<NamedArgs>(
         commandTransformer.schemaText,
         "Command",
     );
-    const translator = createJsonTranslator<any>(
+    const translator = createJsonTranslator<NamedArgs>(
         commandTransformer.model,
         validator,
     );

--- a/ts/examples/chat/src/codeChat/commandTransformer.ts
+++ b/ts/examples/chat/src/codeChat/commandTransformer.ts
@@ -66,7 +66,7 @@ export function createCommandTransformer(
         namedArgs: NamedArgs,
         io: InteractiveIo,
     ): Promise<string | undefined> {
-        // io.writer.writeLine("[Transformed]: " + JSON.stringify(transformed));
+        // io.writer.writeLine("[Transformed:] " + JSON.stringify(transformed));
         if (!namedArgs) {
             return "Sorry, I didn't get that (or the server is down)";
         } else if (namedArgs.name === "Unknown") {

--- a/ts/examples/chat/src/codeChat/commandTransformer.ts
+++ b/ts/examples/chat/src/codeChat/commandTransformer.ts
@@ -6,8 +6,10 @@
 
 import {
     CommandHandler,
+    CommandHandler2,
     CommandMetadata,
     InteractiveIo,
+    NamedArgs,
 } from "interactive-app";
 import {
     TypeChatLanguageModel,
@@ -21,18 +23,28 @@ export interface CommandTransformer {
     metadata?: Record<string, string | CommandMetadata>;
     schemaText?: string;
     translator?: TypeChatJsonTranslator<any>;
-    transform(command: string, io: InteractiveIo): Promise<object | undefined>;
+    transform(command: string): Promise<NamedArgs | undefined>;
+    dispatch(namedArgs: NamedArgs, io: InteractiveIo): Promise<string | void>; // String gives an error message
+    transformAndDispatch(
+        command: string,
+        io: InteractiveIo,
+    ): Promise<string | undefined>; // String gives an error message
 }
 
 export function createCommandTransformer(
     model: TypeChatLanguageModel,
+    handlers: Record<string, CommandHandler>,
 ): CommandTransformer {
     const transformer: CommandTransformer = {
         model,
         transform,
+        dispatch,
+        transformAndDispatch,
     };
 
-    async function transform(command: string): Promise<object | undefined> {
+    completeCommandTransformer(handlers, transformer);
+
+    async function transform(command: string): Promise<NamedArgs | undefined> {
         const promptPreamble =
             "If no value is given for a parameter, use the default from the comment, if any.";
         const result = await transformer.translator!.translate(
@@ -40,11 +52,56 @@ export function createCommandTransformer(
             promptPreamble,
         );
         if (result.success === false) {
-            console.log("[Error]:", result.message);
+            console.log("[Error:]", result.message);
             return undefined;
         } else {
-            // console.log("[Success]:", JSON.stringify(result, null, 2));
+            // console.log("[Success:]", JSON.stringify(result, null, 2));
+            // TODO: Validate that result.data is a valid NamedArgs?
             return result.data;
+        }
+    }
+
+    // Returns a string if an error occurred
+    async function dispatch(
+        namedArgs: NamedArgs,
+        io: InteractiveIo,
+    ): Promise<string | undefined> {
+        // io.writer.writeLine("[Transformed]: " + JSON.stringify(transformed));
+        if (!namedArgs) {
+            return "Sorry, I didn't get that (or the server is down)";
+        } else if (namedArgs.name === "Unknown") {
+            return "Sorry, I didn't get that";
+        } else {
+            const name = namedArgs.name as string;
+            if (name in handlers) {
+                if (!handlers[name].metadata) {
+                    // Missing metadata: handler ignores arguments
+                    const handler = handlers[name];
+                    await handler([], io);
+                } else if (typeof handlers[name].metadata === "string") {
+                    // Metadata is a string: handler only takes a list of strings
+                    const handler = handlers[name];
+                    await handler(namedArgs.args, io);
+                } else {
+                    // Otherwise: handler takes a NamedArgs as well (best case)
+                    const handler = handlers[name] as CommandHandler2;
+                    await handler(namedArgs, io);
+                }
+            } else {
+                // Should never get this if the schema is correct
+                return `Sorry, I don't know how to handle ${name}`;
+            }
+        }
+    }
+
+    // Returns a string if an error occurred
+    async function transformAndDispatch(
+        command: string,
+        io: InteractiveIo,
+    ): Promise<string | undefined> {
+        const namedArgs = await transform(command);
+        if (namedArgs) {
+            return await dispatch(namedArgs, io);
         }
     }
 

--- a/ts/examples/chat/src/memory/chatMemory.ts
+++ b/ts/examples/chat/src/memory/chatMemory.ts
@@ -310,7 +310,7 @@ export async function runChatMemory(): Promise<void> {
 
     handlers.history.metadata = "Display search history.";
     async function history(
-        args: string[] | NamedArgs,
+        args: string[],
         io: InteractiveIo,
     ): Promise<void> {
         if (context.searchMemory) {
@@ -518,7 +518,7 @@ export async function runChatMemory(): Promise<void> {
     }
 
     handlers.replay.metadata = "Replay the chat";
-    async function replay(args: string[] | NamedArgs, io: InteractiveIo) {
+    async function replay(args: string[], io: InteractiveIo) {
         await writeHistory(context.conversation);
     }
 


### PR DESCRIPTION
Add `dispatch` and `transformAndDispatch` methods to `CommandTransformer`.

- `dispatch()` takes the output from `transform()` and dispatches (this used to be in `inputHandler()`).
- `transformAndDispatch()` calls `transform()` and then `dispatch()`.

These two return an error message if something went wrong, else `undefined`.

Also:

- Make the non-failure return type of `transform()` into `NamedArgs`, which is assumed everywhere else anyway.
- Combined the construction and completion of `CommandTransformer`.
- Move its construction and the slimmed-down `inputHandler()` towards the end of `runCodeChat`.
- Remove some overenthusiastic `| NamedArgs` from various signatures.
- Strictly type the TypeChatJsonTransformer to use `<NamedArgs>`