### PR TITLE
Speed up HTML extraction in inline browser

### DIFF
--- a/ts/packages/agents/browser/src/electron/agentActivation.ts
+++ b/ts/packages/agents/browser/src/electron/agentActivation.ts
@@ -44,6 +44,7 @@ window.addEventListener("message", async (event) => {
                 "www.homedepot.com",
                 "www.target.com",
                 "www.walmart.com",
+                "www.instacart.com",
             ];
 
             if (commerceHosts.includes(host)) {

--- a/ts/packages/agents/browser/src/extension/serviceWorker.ts
+++ b/ts/packages/agents/browser/src/extension/serviceWorker.ts
@@ -767,6 +767,7 @@ async function toggleSiteTranslator(targetTab: chrome.tabs.Tab) {
             "www.homedepot.com",
             "www.target.com",
             "www.walmart.com",
+            "www.instacart.com",
         ];
 
         if (commerceHosts.includes(host)) {

--- a/ts/packages/shell/src/main/index.ts
+++ b/ts/packages/shell/src/main/index.ts
@@ -53,6 +53,8 @@ let inlineBrowserView: BrowserView | null = null;
 let chatView: BrowserView | null = null;
 
 const inlineBrowserSize = 1000;
+const userAgent =
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36 Edg/124.0.0.0";
 
 function setContentSize() {
     if (mainWindow && chatView) {
@@ -116,6 +118,8 @@ function createWindow(): void {
         height: ShellSettings.getinstance().height,
     });
 
+    mainWindow.webContents.setUserAgent(userAgent);
+
     chatView = new BrowserView({
         webPreferences: {
             preload: join(__dirname, "../preload/index.mjs"),
@@ -123,6 +127,8 @@ function createWindow(): void {
             zoomFactor: ShellSettings.getinstance().zoomLevel,
         },
     });
+
+    chatView.webContents.setUserAgent(userAgent);
 
     setContentSize();
 
@@ -246,6 +252,8 @@ function createWindow(): void {
                     sandbox: false,
                 },
             });
+
+            inlineBrowserView.webContents.setUserAgent(userAgent);
 
             mainWindow?.addBrowserView(inlineBrowserView);
 


### PR DESCRIPTION
- Skip iframes that are unlikely to contain user-visible html e.g. those with src="about:blank", those that are hidden or have 0 width and height etc.
- Enable exisging commerce schemas to work for instacart
- Add user agent string to inlineBrowser view