### PR TITLE
Explainer: add instruction to ignore explaining empty parameters

### DIFF
--- a/ts/packages/cache/src/explanation/v5/propertyExplainationV5.ts
+++ b/ts/packages/cache/src/explanation/v5/propertyExplainationV5.ts
@@ -51,7 +51,7 @@ export function createPropertyExplainer(
                 (enableContext
                     ? `For each property, explain which substring of the request or entities in the conversation history is used to compute the value. ${substringRequirement}\n`
                     : `For each property, explain which substring of the request is used to compute the value. ${substringRequirement}\n`) +
-                getActionDescription(requestAction, false)
+                getActionDescription(requestAction)
             );
         },
         (requestAction) => requestAction.toPromptString(true),

--- a/ts/packages/cache/src/explanation/v5/subPhraseExplanationV5.ts
+++ b/ts/packages/cache/src/explanation/v5/subPhraseExplanationV5.ts
@@ -38,7 +38,6 @@ function createInstructions([
             role: "system",
             content: `${form}\n${getSubphraseExplanationInstruction()}\n${getActionDescription(
                 requestAction,
-                false,
             )}`,
         },
         {

--- a/ts/packages/cache/src/index.ts
+++ b/ts/packages/cache/src/index.ts
@@ -51,10 +51,3 @@ export {
     printProcessRequestActionResult,
     printImportConstructionResult,
 } from "./utils/print.js";
-
-// REVIEW: For experimentation with specialized explainers.  Need to examine whether we want to support this long term.
-export {
-    buildExplanationInstructions,
-    createExplainer,
-    Explainer,
-} from "./explanation/explainer.js";

--- a/ts/packages/cli/src/commands/data/regenerate.ts
+++ b/ts/packages/cli/src/commands/data/regenerate.ts
@@ -89,6 +89,11 @@ export default class ExplanationDataRegenerateCommmand extends Command {
             description: "Resume incremental regeneration",
             default: false,
         }),
+        request: Flags.string({
+            description:
+                "Regenerate data with request matching pattern. Use * as wildcard",
+            multiple: true,
+        }),
         actionName: Flags.string({
             description:
                 "Regenerate data with action name matching pattern. Use * as wildcard",
@@ -294,6 +299,10 @@ export default class ExplanationDataRegenerateCommmand extends Command {
         const actionNameRegex = flags.actionName?.map(
             (e) => new RegExp(e.replaceAll("*", ".*")),
         );
+
+        const requestRegex = flags.request?.map(
+            (e) => new RegExp(e.replaceAll("*", ".*")),
+        );
         const dataInput: GenerateDataInput[] = [];
         for (const { file, data } of pending) {
             const inputs: (string | RequestAction)[] = [];
@@ -301,6 +310,13 @@ export default class ExplanationDataRegenerateCommmand extends Command {
                 const filter = (e: TestDataEntry | FailedTestDataEntry) => {
                     if (flags.resume) {
                         if ((e as any).message !== "Not processed") {
+                            return undefined;
+                        }
+                    }
+
+                    if (requestRegex) {
+                        const request = e.request;
+                        if (!requestRegex.some((f) => f.test(request))) {
                             return undefined;
                         }
                     }

--- a/ts/packages/dispatcher/test/data/calendar/v5/complex.json
+++ b/ts/packages/dispatcher/test/data/calendar/v5/complex.json
@@ -77,9 +77,9 @@
           {
             "text": "meeting with team",
             "synonyms": [
-              "conference with team",
-              "discussion with team",
-              "session with team"
+              "appointment with team",
+              "session with team",
+              "gathering with team"
             ],
             "category": "description",
             "propertyNames": [
@@ -102,8 +102,8 @@
           {
             "text": "at 2",
             "synonyms": [
+              "2:00 pm",
               "2 PM",
-              "2:00 PM",
               "14:00"
             ],
             "category": "time",
@@ -175,15 +175,15 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "colleagues",
-                "propertySubPhrases": [
-                  "meeting with colleagues"
-                ]
-              },
-              {
                 "propertyValue": "staff",
                 "propertySubPhrases": [
                   "meeting with staff"
+                ]
+              },
+              {
+                "propertyValue": "colleagues",
+                "propertySubPhrases": [
+                  "meeting with colleagues"
                 ]
               },
               {
@@ -309,9 +309,9 @@
               {
                 "text": "meeting with team",
                 "synonyms": [
-                  "conference with team",
-                  "discussion with team",
-                  "session with team"
+                  "appointment with team",
+                  "session with team",
+                  "gathering with team"
                 ],
                 "category": "description",
                 "propertyNames": [
@@ -333,8 +333,8 @@
               {
                 "text": "at 2",
                 "synonyms": [
+                  "2:00 pm",
                   "2 PM",
-                  "2:00 PM",
                   "14:00"
                 ],
                 "category": "time",
@@ -368,9 +368,7 @@
           {
             "name": "fullActionName",
             "value": "calendar.findEvents",
-            "substrings": [
-              "Do I have any plan with Rosy this month?"
-            ],
+            "substrings": [],
             "implied": true
           },
           {
@@ -392,63 +390,23 @@
         ],
         "subPhrases": [
           {
-            "text": "Do",
+            "text": "Do I have any plan",
             "synonyms": [
-              "Does",
-              "Will",
-              "Can"
+              "Do I have any plans",
+              "Do I have a plan",
+              "Do I have plans"
             ],
-            "category": "confirmation",
-            "isOptional": true
-          },
-          {
-            "text": "I",
-            "synonyms": [
-              "we",
-              "you",
-              "they"
-            ],
-            "category": "pronoun",
+            "category": "query",
             "isOptional": false
           },
           {
-            "text": "have",
+            "text": "with Rosy",
             "synonyms": [
-              "got",
-              "hold",
-              "possess"
+              "with Rosy",
+              "with Rosy",
+              "with Rosy"
             ],
-            "category": "verb",
-            "isOptional": false
-          },
-          {
-            "text": "any plan",
-            "synonyms": [
-              "a plan",
-              "plans",
-              "an event"
-            ],
-            "category": "noun phrase",
-            "isOptional": false
-          },
-          {
-            "text": "with",
-            "synonyms": [
-              "alongside",
-              "together with",
-              "accompanied by"
-            ],
-            "category": "preposition",
-            "isOptional": false
-          },
-          {
-            "text": "Rosy",
-            "synonyms": [
-              "Rose",
-              "Rosa",
-              "Rosie"
-            ],
-            "category": "name",
+            "category": "participant",
             "propertyNames": [
               "parameters.eventReference.participants.0"
             ]
@@ -456,24 +414,14 @@
           {
             "text": "this month",
             "synonyms": [
+              "this month",
               "in this month",
-              "during this month",
-              "within this month"
+              "during this month"
             ],
-            "category": "time period",
+            "category": "time",
             "propertyNames": [
               "parameters.eventReference.dayRange"
             ]
-          },
-          {
-            "text": "?",
-            "synonyms": [
-              "",
-              ".",
-              "!"
-            ],
-            "category": "punctuation",
-            "isOptional": true
           }
         ],
         "propertyAlternatives": [
@@ -481,25 +429,25 @@
             "propertyName": "parameters.eventReference.participants.0",
             "propertyValue": "Rosy",
             "propertySubPhrases": [
-              "Rosy"
+              "with Rosy"
             ],
             "alternatives": [
               {
                 "propertyValue": "John",
                 "propertySubPhrases": [
-                  "John"
+                  "with John"
                 ]
               },
               {
                 "propertyValue": "Alice",
                 "propertySubPhrases": [
-                  "Alice"
+                  "with Alice"
                 ]
               },
               {
                 "propertyValue": "Michael",
                 "propertySubPhrases": [
-                  "Michael"
+                  "with Michael"
                 ]
               }
             ]
@@ -650,9 +598,9 @@
                 ]
               },
               {
-                "propertyValue": "project discussion",
+                "propertyValue": "meeting with HR",
                 "propertySubPhrases": [
-                  "add a project discussion"
+                  "add a meeting with HR"
                 ]
               }
             ]
@@ -778,7 +726,7 @@
               "I must",
               "I want to"
             ],
-            "category": "politeness",
+            "category": "confirmation",
             "isOptional": true
           },
           {
@@ -822,7 +770,7 @@
             "synonyms": [
               "Friday March 15, 2024",
               "March 15, 2024",
-              "the 15th of March, 2024"
+              "on March 15, 2024"
             ],
             "category": "date",
             "propertyNames": [
@@ -851,9 +799,9 @@
                 ]
               },
               {
-                "propertyValue": "check my tire pressure",
+                "propertyValue": "check my tires",
                 "propertySubPhrases": [
-                  "check my tire pressure"
+                  "check my tires"
                 ]
               }
             ]
@@ -866,9 +814,9 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "10:00 am",
+                "propertyValue": "11:00 am",
                 "propertySubPhrases": [
-                  "from 10:00"
+                  "from 11:00"
                 ]
               },
               {
@@ -878,9 +826,9 @@
                 ]
               },
               {
-                "propertyValue": "3:00 pm",
+                "propertyValue": "10:00 am",
                 "propertySubPhrases": [
-                  "from 3:00"
+                  "from 10:00"
                 ]
               }
             ]
@@ -893,15 +841,15 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "1:00 pm",
-                "propertySubPhrases": [
-                  "to 1:00 pm"
-                ]
-              },
-              {
                 "propertyValue": "3:00 pm",
                 "propertySubPhrases": [
                   "to 3:00 pm"
+                ]
+              },
+              {
+                "propertyValue": "1:00 pm",
+                "propertySubPhrases": [
+                  "to 1:00 pm"
                 ]
               },
               {
@@ -920,15 +868,15 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "March 14, 2024",
-                "propertySubPhrases": [
-                  "on Thursday March 14, 2024"
-                ]
-              },
-              {
                 "propertyValue": "March 16, 2024",
                 "propertySubPhrases": [
                   "on Saturday March 16, 2024"
+                ]
+              },
+              {
+                "propertyValue": "March 14, 2024",
+                "propertySubPhrases": [
+                  "on Thursday March 14, 2024"
                 ]
               },
               {
@@ -968,9 +916,7 @@
           {
             "name": "parameters.event.day",
             "value": "today",
-            "substrings": [
-              "this afternoon"
-            ],
+            "substrings": [],
             "implied": true
           },
           {
@@ -1016,7 +962,7 @@
               "drop by the dry cleaner",
               "head to the dry cleaner"
             ],
-            "category": "task",
+            "category": "action",
             "propertyNames": [
               "parameters.event.description"
             ]
@@ -1029,9 +975,7 @@
               "this evening"
             ],
             "category": "time",
-            "propertyNames": [
-              "parameters.event.day"
-            ]
+            "isOptional": true
           },
           {
             "text": "Leave an hour",
@@ -1062,7 +1006,7 @@
               "commencing at 3:30",
               "from 3:30"
             ],
-            "category": "start time",
+            "category": "time",
             "propertyNames": [
               "parameters.event.timeRange.startTime"
             ]
@@ -1092,33 +1036,6 @@
                 "propertyValue": "attend a meeting",
                 "propertySubPhrases": [
                   "attend a meeting"
-                ]
-              }
-            ]
-          },
-          {
-            "propertyName": "parameters.event.day",
-            "propertyValue": "today",
-            "propertySubPhrases": [
-              "this afternoon"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "tomorrow",
-                "propertySubPhrases": [
-                  "tomorrow afternoon"
-                ]
-              },
-              {
-                "propertyValue": "next Monday",
-                "propertySubPhrases": [
-                  "next Monday afternoon"
-                ]
-              },
-              {
-                "propertyValue": "this Friday",
-                "propertySubPhrases": [
-                  "this Friday afternoon"
                 ]
               }
             ]
@@ -1265,9 +1182,9 @@
           {
             "text": "at 2pm",
             "synonyms": [
-              "at 2:00 pm",
-              "at 14:00",
-              "at two in the afternoon"
+              "2:00 pm",
+              "2 in the afternoon",
+              "14:00"
             ],
             "category": "time",
             "propertyNames": [
@@ -1442,7 +1359,7 @@
             "synonyms": [
               "ensure to",
               "be certain to",
-              "don't forget to"
+              "confirm to"
             ],
             "category": "politeness",
             "isOptional": true
@@ -1600,9 +1517,9 @@
                 ]
               },
               {
-                "propertyValue": "Liam",
+                "propertyValue": "Paul",
                 "propertySubPhrases": [
-                  "with Sally, May, and Liam"
+                  "with Sally, May, and Paul"
                 ]
               }
             ]
@@ -1669,16 +1586,16 @@
       "action": {
         "fullActionName": "calendar.addParticipants",
         "parameters": {
+          "participants": [
+            "Jesse",
+            "Abby"
+          ],
           "eventReference": {
             "participants": [
               "Sally"
             ],
             "lookup": true
-          },
-          "participants": [
-            "Jesse",
-            "Abby"
-          ]
+          }
         }
       },
       "explanation": {
@@ -1690,20 +1607,6 @@
               "add"
             ],
             "implied": true
-          },
-          {
-            "name": "parameters.eventReference.participants.0",
-            "value": "Sally",
-            "substrings": [
-              "Sally"
-            ],
-            "implied": false
-          },
-          {
-            "name": "parameters.eventReference.lookup",
-            "value": true,
-            "substrings": [],
-            "isImplicit": true
           },
           {
             "name": "parameters.participants.0",
@@ -1720,15 +1623,28 @@
               "Abby"
             ],
             "implied": false
+          },
+          {
+            "name": "parameters.eventReference.participants.0",
+            "value": "Sally",
+            "substrings": [
+              "Sally"
+            ],
+            "implied": false
+          },
+          {
+            "name": "parameters.eventReference.lookup",
+            "value": true,
+            "isImplicit": true
           }
         ],
         "subPhrases": [
           {
             "text": "Now",
             "synonyms": [
-              "Currently",
+              "Right now",
               "At this moment",
-              "Right now"
+              "Immediately"
             ],
             "category": "filler",
             "isOptional": true
@@ -1827,15 +1743,15 @@
                 ]
               },
               {
-                "propertyValue": "calendar.updateEvent",
-                "propertySubPhrases": [
-                  "update"
-                ]
-              },
-              {
                 "propertyValue": "calendar.createEvent",
                 "propertySubPhrases": [
                   "create"
+                ]
+              },
+              {
+                "propertyValue": "calendar.updateEvent",
+                "propertySubPhrases": [
+                  "update"
                 ]
               }
             ]
@@ -1854,15 +1770,15 @@
                 ]
               },
               {
-                "propertyValue": "James",
+                "propertyValue": "Jane",
                 "propertySubPhrases": [
-                  "James"
+                  "Jane"
                 ]
               },
               {
-                "propertyValue": "Jordan",
+                "propertyValue": "Jim",
                 "propertySubPhrases": [
-                  "Jordan"
+                  "Jim"
                 ]
               }
             ]
@@ -1887,9 +1803,9 @@
                 ]
               },
               {
-                "propertyValue": "Ava",
+                "propertyValue": "Aaron",
                 "propertySubPhrases": [
-                  "Ava"
+                  "Aaron"
                 ]
               }
             ]
@@ -1902,21 +1818,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "Sarah",
+                "propertyValue": "Sam",
                 "propertySubPhrases": [
-                  "Sarah"
+                  "Sam"
                 ]
               },
               {
-                "propertyValue": "Samantha",
+                "propertyValue": "Sara",
                 "propertySubPhrases": [
-                  "Samantha"
+                  "Sara"
                 ]
               },
               {
-                "propertyValue": "Sophie",
+                "propertyValue": "Steve",
                 "propertySubPhrases": [
-                  "Sophie"
+                  "Steve"
                 ]
               }
             ]
@@ -1973,23 +1889,37 @@
         ],
         "subPhrases": [
           {
-            "text": "Set up an event for",
+            "text": "Set up",
             "synonyms": [
-              "Schedule an event for",
-              "Create an event for",
-              "Arrange an event for"
+              "Schedule",
+              "Arrange",
+              "Organize"
             ],
             "category": "action",
-            "propertyNames": []
+            "propertyNames": [
+              "fullActionName"
+            ]
           },
           {
-            "text": "friday",
+            "text": "an event",
             "synonyms": [
-              "Friday",
-              "this Friday",
-              "on Friday"
+              "a meeting",
+              "an appointment",
+              "a gathering"
             ],
-            "category": "day",
+            "category": "event",
+            "propertyNames": [
+              "fullActionName"
+            ]
+          },
+          {
+            "text": "for friday",
+            "synonyms": [
+              "on Friday",
+              "this Friday",
+              "coming Friday"
+            ],
+            "category": "date",
             "propertyNames": [
               "parameters.event.day"
             ]
@@ -2011,7 +1941,7 @@
             "synonyms": [
               "6:00 pm",
               "6 in the evening",
-              "6 o'clock pm"
+              "18:00"
             ],
             "category": "time",
             "propertyNames": [
@@ -2021,28 +1951,59 @@
         ],
         "propertyAlternatives": [
           {
+            "propertyName": "fullActionName",
+            "propertyValue": "calendar.addEvent",
+            "propertySubPhrases": [
+              "Set up",
+              "an event"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "calendar.scheduleEvent",
+                "propertySubPhrases": [
+                  "Schedule",
+                  "an event"
+                ]
+              },
+              {
+                "propertyValue": "calendar.createEvent",
+                "propertySubPhrases": [
+                  "Create",
+                  "an event"
+                ]
+              },
+              {
+                "propertyValue": "calendar.planEvent",
+                "propertySubPhrases": [
+                  "Plan",
+                  "an event"
+                ]
+              }
+            ]
+          },
+          {
             "propertyName": "parameters.event.day",
             "propertyValue": "Friday",
             "propertySubPhrases": [
-              "friday"
+              "for friday"
             ],
             "alternatives": [
               {
                 "propertyValue": "Monday",
                 "propertySubPhrases": [
-                  "monday"
+                  "for monday"
                 ]
               },
               {
                 "propertyValue": "Wednesday",
                 "propertySubPhrases": [
-                  "wednesday"
+                  "for wednesday"
                 ]
               },
               {
                 "propertyValue": "Sunday",
                 "propertySubPhrases": [
-                  "sunday"
+                  "for sunday"
                 ]
               }
             ]
@@ -2055,21 +2016,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "Team meeting",
+                "propertyValue": "Jeffs birthday bash",
                 "propertySubPhrases": [
-                  "named Team meeting"
+                  "named Jeffs birthday bash"
                 ]
               },
               {
-                "propertyValue": "Birthday celebration",
+                "propertyValue": "Office meeting",
                 "propertySubPhrases": [
-                  "named Birthday celebration"
+                  "named Office meeting"
                 ]
               },
               {
-                "propertyValue": "Project kickoff",
+                "propertyValue": "Family gathering",
                 "propertySubPhrases": [
-                  "named Project kickoff"
+                  "named Family gathering"
                 ]
               }
             ]
@@ -2088,15 +2049,15 @@
                 ]
               },
               {
-                "propertyValue": "8:00 pm",
-                "propertySubPhrases": [
-                  "at 8pm"
-                ]
-              },
-              {
                 "propertyValue": "5:00 pm",
                 "propertySubPhrases": [
                   "at 5pm"
+                ]
+              },
+              {
+                "propertyValue": "8:00 pm",
+                "propertySubPhrases": [
+                  "at 8pm"
                 ]
               }
             ]
@@ -2181,8 +2142,8 @@
             "text": "Will you please",
             "synonyms": [
               "Can you please",
-              "Could you please",
-              "Would you please"
+              "Would you kindly",
+              "Could you please"
             ],
             "category": "politeness",
             "isOptional": true
@@ -2215,8 +2176,8 @@
             "text": "at 9 am",
             "synonyms": [
               "for 9 am",
-              "by 9 am",
-              "around 9 am"
+              "starting at 9 am",
+              "beginning at 9 am"
             ],
             "category": "time",
             "propertyNames": [
@@ -2226,9 +2187,9 @@
           {
             "text": "I need it to last 2 hours",
             "synonyms": [
-              "It should last 2 hours",
-              "Make it last 2 hours",
-              "It needs to last 2 hours"
+              "it should last 2 hours",
+              "make it last 2 hours",
+              "it needs to last 2 hours"
             ],
             "category": "duration",
             "propertyNames": [
@@ -2251,15 +2212,15 @@
                 ]
               },
               {
-                "propertyValue": "consultation",
+                "propertyValue": "call",
                 "propertySubPhrases": [
-                  "add a consultation"
+                  "schedule a call"
                 ]
               },
               {
-                "propertyValue": "discussion",
+                "propertyValue": "consultation",
                 "propertySubPhrases": [
-                  "add a discussion"
+                  "set up a consultation"
                 ]
               }
             ]
@@ -2284,9 +2245,9 @@
                 ]
               },
               {
-                "propertyValue": "Jordan Lee",
+                "propertyValue": "Morgan Lee",
                 "propertySubPhrases": [
-                  "with Jordan Lee"
+                  "with Morgan Lee"
                 ]
               }
             ]

--- a/ts/packages/dispatcher/test/data/calendar/v5/simple.json
+++ b/ts/packages/dispatcher/test/data/calendar/v5/simple.json
@@ -75,8 +75,8 @@
           {
             "text": "dentist appointment",
             "synonyms": [
-              "dental visit",
-              "dentist meeting",
+              "dental appointment",
+              "dentist visit",
               "dentist checkup"
             ],
             "category": "description",
@@ -152,15 +152,15 @@
                 ]
               },
               {
-                "propertyValue": "meeting with dentist",
+                "propertyValue": "meeting with client",
                 "propertySubPhrases": [
-                  "meeting with dentist"
+                  "meeting with client"
                 ]
               },
               {
-                "propertyValue": "dental checkup",
+                "propertyValue": "lunch with friend",
                 "propertySubPhrases": [
-                  "dental checkup"
+                  "lunch with friend"
                 ]
               }
             ]
@@ -335,7 +335,7 @@
             "synonyms": [
               "dental appointment",
               "dentist visit",
-              "dental checkup"
+              "dentist checkup"
             ],
             "category": "description",
             "propertyNames": [
@@ -367,8 +367,8 @@
           {
             "text": "next Thursday",
             "synonyms": [
-              "coming Thursday",
-              "this Thursday",
+              "this coming Thursday",
+              "the following Thursday",
               "Thursday next week"
             ],
             "category": "day",
@@ -591,8 +591,8 @@
             "text": "Isobel",
             "synonyms": [
               "Isabel",
-              "Isabella",
-              "Izzy"
+              "Izzy",
+              "Isabella"
             ],
             "category": "participant",
             "propertyNames": [
@@ -655,9 +655,9 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "calendar.createEvent",
+                "propertyValue": "calendar.scheduleEvent",
                 "propertySubPhrases": [
-                  "create"
+                  "schedule"
                 ]
               },
               {
@@ -709,9 +709,9 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "Monday",
+                "propertyValue": "Thursday",
                 "propertySubPhrases": [
-                  "Monday"
+                  "Thursday"
                 ]
               },
               {
@@ -721,9 +721,9 @@
                 ]
               },
               {
-                "propertyValue": "Sunday",
+                "propertyValue": "Saturday",
                 "propertySubPhrases": [
-                  "Sunday"
+                  "Saturday"
                 ]
               }
             ]
@@ -742,15 +742,15 @@
                 ]
               },
               {
-                "propertyValue": "basketball game",
+                "propertyValue": "soccer game",
                 "propertySubPhrases": [
-                  "basketball game"
+                  "soccer game"
                 ]
               },
               {
-                "propertyValue": "chess tournament",
+                "propertyValue": "basketball game",
                 "propertySubPhrases": [
-                  "chess tournament"
+                  "basketball game"
                 ]
               }
             ]
@@ -846,7 +846,7 @@
             "synonyms": [
               "include",
               "insert",
-              "append"
+              "invite"
             ],
             "category": "action",
             "propertyNames": [
@@ -857,8 +857,8 @@
             "text": "piali",
             "synonyms": [
               "Piali",
-              "piali",
-              "Piali"
+              "piali.",
+              "Piali."
             ],
             "category": "participant",
             "propertyNames": [
@@ -869,8 +869,8 @@
             "text": "to the",
             "synonyms": [
               "into the",
-              "for the",
-              "towards the"
+              "towards the",
+              "for the"
             ],
             "category": "preposition",
             "isOptional": true
@@ -878,9 +878,9 @@
           {
             "text": "AI Systems meeting",
             "synonyms": [
-              "AI Systems session",
-              "AI Systems conference",
-              "AI Systems gathering"
+              "AI systems meeting",
+              "AI Systems Meeting",
+              "AI systems Meeting"
             ],
             "category": "eventDescription",
             "propertyNames": [
@@ -891,10 +891,10 @@
             "text": "this week",
             "synonyms": [
               "this upcoming week",
-              "the current week",
-              "this week"
+              "this current week",
+              "this week's"
             ],
-            "category": "timeFrame",
+            "category": "dayRange",
             "propertyNames": [
               "parameters.eventReference.dayRange"
             ]
@@ -1109,8 +1109,8 @@
           {
             "text": "on Friday",
             "synonyms": [
-              "Friday",
               "this Friday",
+              "Friday",
               "coming Friday"
             ],
             "category": "day",
@@ -1540,8 +1540,8 @@
             "text": "bridge game",
             "synonyms": [
               "card game",
-              "game of bridge",
-              "bridge match"
+              "bridge session",
+              "game of bridge"
             ],
             "category": "description",
             "propertyNames": [
@@ -1561,19 +1561,39 @@
             ]
           },
           {
-            "text": "at 10",
+            "text": "at",
             "synonyms": [
-              "10:00 am",
-              "10 in the morning",
+              "on",
+              "during",
+              "around"
+            ],
+            "category": "preposition",
+            "isOptional": true
+          },
+          {
+            "text": "10",
+            "synonyms": [
+              "10:00",
+              "10 am",
               "10 o'clock"
             ],
-            "category": "time",
+            "category": "startTime",
             "propertyNames": [
               "parameters.event.timeRange.startTime"
             ]
           },
           {
-            "text": "for one hour",
+            "text": "for",
+            "synonyms": [
+              "lasting",
+              "during",
+              "over"
+            ],
+            "category": "preposition",
+            "isOptional": true
+          },
+          {
+            "text": "one hour",
             "synonyms": [
               "1 hour",
               "an hour",
@@ -1671,25 +1691,25 @@
             "propertyName": "parameters.event.timeRange.startTime",
             "propertyValue": "10:00 am",
             "propertySubPhrases": [
-              "at 10"
+              "10"
             ],
             "alternatives": [
               {
-                "propertyValue": "11:00 am",
-                "propertySubPhrases": [
-                  "at 11"
-                ]
-              },
-              {
                 "propertyValue": "9:00 am",
                 "propertySubPhrases": [
-                  "at 9"
+                  "9"
                 ]
               },
               {
-                "propertyValue": "2:00 pm",
+                "propertyValue": "11:00 am",
                 "propertySubPhrases": [
-                  "at 2"
+                  "11"
+                ]
+              },
+              {
+                "propertyValue": "12:00 pm",
+                "propertySubPhrases": [
+                  "12"
                 ]
               }
             ]
@@ -1698,25 +1718,25 @@
             "propertyName": "parameters.event.timeRange.duration",
             "propertyValue": "1 hour",
             "propertySubPhrases": [
-              "for one hour"
+              "one hour"
             ],
             "alternatives": [
               {
                 "propertyValue": "2 hours",
                 "propertySubPhrases": [
-                  "for two hours"
+                  "two hours"
                 ]
               },
               {
                 "propertyValue": "30 minutes",
                 "propertySubPhrases": [
-                  "for thirty minutes"
+                  "thirty minutes"
                 ]
               },
               {
-                "propertyValue": "3 hours",
+                "propertyValue": "1.5 hours",
                 "propertySubPhrases": [
-                  "for three hours"
+                  "one and a half hours"
                 ]
               }
             ]
@@ -1767,7 +1787,10 @@
           {
             "name": "parameters.eventReference.lookup",
             "value": true,
-            "isImplicit": true
+            "substrings": [
+              "Search for any meetings"
+            ],
+            "implied": true
           }
         ],
         "subPhrases": [
@@ -1776,11 +1799,12 @@
             "synonyms": [
               "Look for any meetings",
               "Find any meetings",
-              "Locate any meetings"
+              "Check for any meetings"
             ],
             "category": "action",
             "propertyNames": [
-              "fullActionName"
+              "fullActionName",
+              "parameters.eventReference.lookup"
             ]
           },
           {
@@ -1800,7 +1824,7 @@
             "synonyms": [
               "in the next seven days",
               "over the next week",
-              "within this week"
+              "during this week"
             ],
             "category": "time",
             "propertyNames": [
@@ -1817,21 +1841,48 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "calendar.listEvents",
+                "propertyValue": "calendar.searchEvents",
                 "propertySubPhrases": [
-                  "List any meetings"
+                  "Look for any meetings"
                 ]
               },
               {
-                "propertyValue": "calendar.getEvents",
+                "propertyValue": "calendar.queryEvents",
                 "propertySubPhrases": [
-                  "Get any meetings"
+                  "Find any meetings"
                 ]
               },
               {
-                "propertyValue": "calendar.lookupEvents",
+                "propertyValue": "calendar.locateEvents",
                 "propertySubPhrases": [
-                  "Look up any meetings"
+                  "Locate any meetings"
+                ]
+              }
+            ]
+          },
+          {
+            "propertyName": "parameters.eventReference.lookup",
+            "propertyValue": true,
+            "propertySubPhrases": [
+              "Search for any meetings"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": false,
+                "propertySubPhrases": [
+                  "Do not search for any meetings"
+                ]
+              },
+              {
+                "propertyValue": true,
+                "propertySubPhrases": [
+                  "Find any meetings"
+                ]
+              },
+              {
+                "propertyValue": true,
+                "propertySubPhrases": [
+                  "Look for any meetings"
                 ]
               }
             ]
@@ -1891,7 +1942,42 @@
             ]
           }
         ]
-      }
+      },
+      "corrections": [
+        {
+          "data": {
+            "properties": [
+              {
+                "name": "fullActionName",
+                "value": "calendar.findEvents",
+                "substrings": [
+                  "Search for any meetings"
+                ],
+                "implied": true
+              },
+              {
+                "name": "parameters.eventReference.dayRange",
+                "value": "this week",
+                "substrings": [
+                  "this week"
+                ],
+                "implied": false
+              },
+              {
+                "name": "parameters.eventReference.participants.0",
+                "value": "Gavin",
+                "substrings": [
+                  "Gavin"
+                ],
+                "implied": false
+              }
+            ]
+          },
+          "correction": [
+            "Missing parameter: parameter 'parameters.eventReference.lookup' in the action is missing from explanation"
+          ]
+        }
+      ]
     }
   ]
 }

--- a/ts/packages/dispatcher/test/data/player/v5/changeVolume.json
+++ b/ts/packages/dispatcher/test/data/player/v5/changeVolume.json
@@ -23,7 +23,7 @@
             "name": "parameters.volumeChangePercentage",
             "value": -20,
             "substrings": [
-              "20% reduction",
+              "20%",
               "reduction"
             ],
             "implied": false
@@ -37,17 +37,29 @@
               "An",
               "Any"
             ],
-            "category": "filler",
+            "category": "article",
             "isOptional": true
           },
           {
-            "text": "20% reduction",
+            "text": "20%",
             "synonyms": [
-              "20 percent decrease",
-              "20% decrease",
-              "20 percent reduction"
+              "twenty percent",
+              "20 percent",
+              "20%"
             ],
-            "category": "volume change",
+            "category": "percentage",
+            "propertyNames": [
+              "parameters.volumeChangePercentage"
+            ]
+          },
+          {
+            "text": "reduction",
+            "synonyms": [
+              "decrease",
+              "drop",
+              "cut"
+            ],
+            "category": "action",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
@@ -65,9 +77,9 @@
           {
             "text": "would be perfect",
             "synonyms": [
-              "would be great",
-              "would be ideal",
-              "would be excellent"
+              "is ideal",
+              "is perfect",
+              "would be ideal"
             ],
             "category": "confirmation",
             "isOptional": true
@@ -78,25 +90,29 @@
             "propertyName": "parameters.volumeChangePercentage",
             "propertyValue": -20,
             "propertySubPhrases": [
-              "20% reduction"
+              "20%",
+              "reduction"
             ],
             "alternatives": [
               {
                 "propertyValue": -10,
                 "propertySubPhrases": [
-                  "10% reduction"
+                  "10%",
+                  "reduction"
                 ]
               },
               {
                 "propertyValue": -30,
                 "propertySubPhrases": [
-                  "30% reduction"
+                  "30%",
+                  "reduction"
                 ]
               },
               {
                 "propertyValue": -50,
                 "propertySubPhrases": [
-                  "50% reduction"
+                  "50%",
+                  "reduction"
                 ]
               }
             ]
@@ -143,7 +159,7 @@
             "name": "fullActionName",
             "value": "player.changeVolume",
             "substrings": [
-              "Adjust the volume up"
+              "Adjust the volume up by 30%."
             ],
             "implied": true
           },
@@ -158,13 +174,25 @@
         ],
         "subPhrases": [
           {
-            "text": "Adjust the volume up",
+            "text": "Adjust",
             "synonyms": [
-              "Increase the volume",
-              "Raise the volume",
-              "Turn up the volume"
+              "Change",
+              "Modify",
+              "Alter"
             ],
-            "category": "command",
+            "category": "action",
+            "propertyNames": [
+              "fullActionName"
+            ]
+          },
+          {
+            "text": "the volume up",
+            "synonyms": [
+              "the sound level",
+              "the audio",
+              "the loudness"
+            ],
+            "category": "object",
             "propertyNames": [
               "fullActionName"
             ]
@@ -173,8 +201,8 @@
             "text": "by 30%",
             "synonyms": [
               "to 30%",
-              "up 30%",
-              "increase by 30%"
+              "at 30%",
+              "with 30%"
             ],
             "category": "parameter",
             "propertyNames": [
@@ -187,25 +215,29 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.changeVolume",
             "propertySubPhrases": [
-              "Adjust the volume up"
+              "Adjust",
+              "the volume up"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.increaseVolume",
                 "propertySubPhrases": [
-                  "Increase the volume"
+                  "Increase",
+                  "the volume"
                 ]
               },
               {
                 "propertyValue": "player.raiseVolume",
                 "propertySubPhrases": [
-                  "Raise the volume"
+                  "Raise",
+                  "the volume"
                 ]
               },
               {
                 "propertyValue": "player.turnUpVolume",
                 "propertySubPhrases": [
-                  "Turn up the volume"
+                  "Turn up",
+                  "the volume"
                 ]
               }
             ]
@@ -256,7 +288,7 @@
             "substrings": [
               "Alter the sound level"
             ],
-            "implied": false
+            "implied": true
           },
           {
             "name": "parameters.volumeChangePercentage",
@@ -287,7 +319,7 @@
               "raise it by 10%",
               "boost it by 10%"
             ],
-            "category": "parameter",
+            "category": "command",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
@@ -395,8 +427,8 @@
             "text": "by 30%",
             "synonyms": [
               "to 30%",
-              "up by 30%",
-              "increase by 30%"
+              "up to 30%",
+              "by thirty percent"
             ],
             "category": "parameter",
             "propertyNames": [
@@ -475,47 +507,51 @@
           {
             "name": "fullActionName",
             "value": "player.changeVolume",
-            "substrings": [],
+            "substrings": [
+              "Boost the volume"
+            ],
             "implied": true
           },
           {
             "name": "parameters.volumeChangePercentage",
             "value": 30,
             "substrings": [
-              "Boost the volume by a cool 30%."
+              "30%"
             ],
             "implied": false
           }
         ],
         "subPhrases": [
           {
-            "text": "Boost",
+            "text": "Boost the volume",
             "synonyms": [
-              "Increase",
-              "Raise",
-              "Amplify"
+              "Increase the volume",
+              "Raise the volume",
+              "Turn up the volume"
             ],
-            "category": "action",
-            "propertyNames": []
+            "category": "command",
+            "propertyNames": [
+              "fullActionName"
+            ]
           },
           {
-            "text": "the volume",
+            "text": "by a cool",
             "synonyms": [
-              "sound level",
-              "audio level",
-              "loudness"
+              "by exactly",
+              "by precisely",
+              "by an exact"
             ],
-            "category": "object",
-            "propertyNames": []
+            "category": "filler",
+            "isOptional": true
           },
           {
-            "text": "by a cool 30%",
+            "text": "30%",
             "synonyms": [
-              "by 30%",
-              "by an impressive 30%",
-              "by a significant 30%"
+              "thirty percent",
+              "30 percent",
+              "30%"
             ],
-            "category": "measurement",
+            "category": "quantity",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
@@ -523,34 +559,55 @@
         ],
         "propertyAlternatives": [
           {
-            "propertyName": "parameters.volumeChangePercentage",
-            "propertyValue": 30,
+            "propertyName": "fullActionName",
+            "propertyValue": "player.changeVolume",
             "propertySubPhrases": [
-              "by a cool 30%"
+              "Boost the volume"
             ],
             "alternatives": [
               {
-                "propertyValue": 10,
+                "propertyValue": "player.increaseVolume",
                 "propertySubPhrases": [
-                  "by a cool 10%"
+                  "Increase the volume"
                 ]
               },
+              {
+                "propertyValue": "player.raiseVolume",
+                "propertySubPhrases": [
+                  "Raise the volume"
+                ]
+              },
+              {
+                "propertyValue": "player.amplifyVolume",
+                "propertySubPhrases": [
+                  "Amplify the volume"
+                ]
+              }
+            ]
+          },
+          {
+            "propertyName": "parameters.volumeChangePercentage",
+            "propertyValue": 30,
+            "propertySubPhrases": [
+              "30%"
+            ],
+            "alternatives": [
               {
                 "propertyValue": 20,
                 "propertySubPhrases": [
-                  "by a cool 20%"
-                ]
-              },
-              {
-                "propertyValue": 40,
-                "propertySubPhrases": [
-                  "by a cool 40%"
+                  "20%"
                 ]
               },
               {
                 "propertyValue": 50,
                 "propertySubPhrases": [
-                  "by a cool 50%"
+                  "50%"
+                ]
+              },
+              {
+                "propertyValue": 10,
+                "propertySubPhrases": [
+                  "10%"
                 ]
               }
             ]
@@ -589,7 +646,7 @@
             "synonyms": [
               "Could we have",
               "May we get",
-              "Is it possible to get"
+              "Shall we get"
             ],
             "category": "politeness",
             "isOptional": true
@@ -601,15 +658,15 @@
               "the audio level",
               "the sound"
             ],
-            "category": "context",
+            "category": "preposition",
             "isOptional": false
           },
           {
             "text": "up by a decent 10%",
             "synonyms": [
-              "increased by a decent 10%",
-              "raised by a decent 10%",
-              "up by a good 10%"
+              "increase by a good 10%",
+              "raise by a solid 10%",
+              "boost by a nice 10%"
             ],
             "category": "volume change",
             "propertyNames": [
@@ -661,9 +718,7 @@
           {
             "name": "fullActionName",
             "value": "player.changeVolume",
-            "substrings": [
-              "Can we have the audio 20% down?"
-            ],
+            "substrings": [],
             "implied": true
           },
           {
@@ -694,15 +749,15 @@
               "the volume",
               "the audio level"
             ],
-            "category": "subject",
-            "propertyNames": []
+            "category": "preposition",
+            "isOptional": false
           },
           {
             "text": "20%",
             "synonyms": [
               "twenty percent",
               "20 percent",
-              "a 20%"
+              "20%"
             ],
             "category": "quantity",
             "propertyNames": [
@@ -763,9 +818,7 @@
               {
                 "name": "fullActionName",
                 "value": "player.changeVolume",
-                "substrings": [
-                  "Can we have the audio 20% down?"
-                ],
+                "substrings": [],
                 "implied": true
               },
               {
@@ -834,13 +887,23 @@
             ]
           },
           {
-            "text": "by a tiny 5%",
+            "text": "by a tiny",
             "synonyms": [
-              "by a small 5%",
-              "by a little 5%",
-              "by a slight 5%"
+              "by a small",
+              "by a little",
+              "by a slight"
             ],
-            "category": "magnitude",
+            "category": "modifier",
+            "isOptional": true
+          },
+          {
+            "text": "5%",
+            "synonyms": [
+              "five percent",
+              "5 percent",
+              "5 pct"
+            ],
+            "category": "amount",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
@@ -852,35 +915,28 @@
             "propertyValue": -5,
             "propertySubPhrases": [
               "trim down the volume",
-              "by a tiny 5%"
+              "5%"
             ],
             "alternatives": [
               {
                 "propertyValue": -10,
                 "propertySubPhrases": [
                   "trim down the volume",
-                  "by a tiny 10%"
+                  "10%"
                 ]
               },
               {
-                "propertyValue": -3,
+                "propertyValue": -15,
                 "propertySubPhrases": [
                   "trim down the volume",
-                  "by a tiny 3%"
+                  "15%"
                 ]
               },
               {
-                "propertyValue": -1,
+                "propertyValue": -20,
                 "propertySubPhrases": [
                   "trim down the volume",
-                  "by a tiny 1%"
-                ]
-              },
-              {
-                "propertyValue": -7,
-                "propertySubPhrases": [
-                  "trim down the volume",
-                  "by a tiny 7%"
+                  "20%"
                 ]
               }
             ]
@@ -990,7 +1046,7 @@
             "name": "parameters.volumeChangePercentage",
             "value": 5,
             "substrings": [
-              "5%"
+              "by 5%"
             ],
             "implied": false
           }
@@ -1021,11 +1077,11 @@
           {
             "text": "by 5%",
             "synonyms": [
-              "to 5%",
-              "up to 5%",
-              "increase by 5%"
+              "by five percent",
+              "by 5 percent",
+              "by 5% more"
             ],
-            "category": "measurement",
+            "category": "quantity",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
@@ -1102,18 +1158,15 @@
           {
             "name": "fullActionName",
             "value": "player.changeVolume",
-            "substrings": [
-              "shave off",
-              "volume"
-            ],
+            "substrings": [],
             "implied": true
           },
           {
             "name": "parameters.volumeChangePercentage",
             "value": -5,
             "substrings": [
-              "shave off 5%",
-              "from"
+              "shave off",
+              "5%"
             ],
             "implied": false
           }
@@ -1138,7 +1191,7 @@
             ],
             "category": "action",
             "propertyNames": [
-              "fullActionName"
+              "parameters.volumeChangePercentage"
             ]
           },
           {
@@ -1154,90 +1207,44 @@
             ]
           },
           {
-            "text": "from",
+            "text": "from the volume",
             "synonyms": [
-              "of",
-              "off",
-              "on"
+              "of the volume",
+              "on the volume",
+              "in the volume"
             ],
             "category": "preposition",
-            "isOptional": true,
-            "propertyNames": [
-              "parameters.volumeChangePercentage"
-            ]
-          },
-          {
-            "text": "the volume",
-            "synonyms": [
-              "volume",
-              "sound level",
-              "audio level"
-            ],
-            "category": "object",
-            "propertyNames": [
-              "fullActionName"
-            ]
+            "isOptional": true
           }
         ],
         "propertyAlternatives": [
           {
-            "propertyName": "fullActionName",
-            "propertyValue": "player.changeVolume",
-            "propertySubPhrases": [
-              "shave off",
-              "the volume"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "player.decreaseVolume",
-                "propertySubPhrases": [
-                  "decrease",
-                  "the volume"
-                ]
-              },
-              {
-                "propertyValue": "player.lowerVolume",
-                "propertySubPhrases": [
-                  "lower",
-                  "the volume"
-                ]
-              },
-              {
-                "propertyValue": "player.reduceVolume",
-                "propertySubPhrases": [
-                  "reduce",
-                  "the volume"
-                ]
-              }
-            ]
-          },
-          {
             "propertyName": "parameters.volumeChangePercentage",
             "propertyValue": -5,
             "propertySubPhrases": [
-              "5%",
-              "from"
+              "shave off",
+              "5%"
             ],
             "alternatives": [
               {
                 "propertyValue": -10,
                 "propertySubPhrases": [
-                  "10%",
-                  "from"
+                  "shave off",
+                  "10%"
                 ]
               },
               {
                 "propertyValue": -15,
                 "propertySubPhrases": [
-                  "15%",
-                  "from"
+                  "shave off",
+                  "15%"
                 ]
               },
               {
                 "propertyValue": -20,
                 "propertySubPhrases": [
-                  "20%",
-                  "from"
+                  "shave off",
+                  "20%"
                 ]
               }
             ]
@@ -1251,10 +1258,7 @@
               {
                 "name": "fullActionName",
                 "value": "player.changeVolume",
-                "substrings": [
-                  "shave off",
-                  "volume"
-                ],
+                "substrings": [],
                 "implied": true
               },
               {
@@ -1269,144 +1273,6 @@
           },
           "correction": [
             "Value -5 for property 'parameters.volumeChangePercentage' doesn't match the number 5 in the substring 'shave off 5%'. Missing other substring to explain the value."
-          ]
-        },
-        {
-          "data": {
-            "properties": [
-              {
-                "name": "fullActionName",
-                "value": "player.changeVolume",
-                "substrings": [
-                  "shave off",
-                  "volume"
-                ],
-                "implied": true
-              },
-              {
-                "name": "parameters.volumeChangePercentage",
-                "value": -5,
-                "substrings": [
-                  "shave off 5%",
-                  "-"
-                ],
-                "implied": false
-              }
-            ]
-          },
-          "correction": [
-            "Substring '-' for property 'parameters.volumeChangePercentage' not found in the request string. Substring must be exact copy of part of the original request and is not changed by correcting misspelling or grammar."
-          ]
-        },
-        {
-          "data": {
-            "properties": [
-              {
-                "name": "fullActionName",
-                "value": "player.changeVolume",
-                "substrings": [
-                  "shave off",
-                  "volume"
-                ],
-                "implied": true
-              },
-              {
-                "name": "parameters.volumeChangePercentage",
-                "value": -5,
-                "substrings": [
-                  "shave off 5%"
-                ],
-                "implied": false
-              }
-            ]
-          },
-          "correction": [
-            "Value -5 for property 'parameters.volumeChangePercentage' doesn't match the number 5 in the substring 'shave off 5%'. Missing other substring to explain the value."
-          ]
-        },
-        {
-          "data": {
-            "properties": [
-              {
-                "name": "fullActionName",
-                "value": "player.changeVolume",
-                "substrings": [
-                  "shave off",
-                  "volume"
-                ],
-                "implied": true
-              },
-              {
-                "name": "parameters.volumeChangePercentage",
-                "value": -5,
-                "substrings": [
-                  "shave off 5%",
-                  "from"
-                ],
-                "implied": false
-              }
-            ],
-            "subPhrases": [
-              {
-                "text": "Can you",
-                "synonyms": [
-                  "Could you",
-                  "Would you",
-                  "Will you"
-                ],
-                "category": "politeness",
-                "isOptional": true
-              },
-              {
-                "text": "shave off",
-                "synonyms": [
-                  "reduce",
-                  "decrease",
-                  "lower"
-                ],
-                "category": "action",
-                "propertyNames": [
-                  "fullActionName"
-                ]
-              },
-              {
-                "text": "5%",
-                "synonyms": [
-                  "five percent",
-                  "5 percent",
-                  "5 pct"
-                ],
-                "category": "quantity",
-                "propertyNames": [
-                  "parameters.volumeChangePercentage"
-                ]
-              },
-              {
-                "text": "from",
-                "synonyms": [
-                  "of",
-                  "off",
-                  "on"
-                ],
-                "category": "preposition",
-                "isOptional": true
-              },
-              {
-                "text": "the volume",
-                "synonyms": [
-                  "volume",
-                  "sound level",
-                  "audio level"
-                ],
-                "category": "object",
-                "propertyNames": [
-                  "fullActionName"
-                ]
-              }
-            ]
-          },
-          "correction": [
-            "Explicit property 'parameters.volumeChangePercentage' must be included as property names for all subphrases that contain the substring 'from'"
           ]
         }
       ]
@@ -1427,7 +1293,7 @@
             "substrings": [
               "Change the sound level"
             ],
-            "implied": false
+            "implied": true
           },
           {
             "name": "parameters.volumeChangePercentage",
@@ -1458,7 +1324,7 @@
               "raise it by 10%",
               "boost it by 10%"
             ],
-            "category": "parameter",
+            "category": "command",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
@@ -1473,21 +1339,21 @@
             ],
             "alternatives": [
               {
+                "propertyValue": "player.increaseVolume",
+                "propertySubPhrases": [
+                  "Increase the volume"
+                ]
+              },
+              {
                 "propertyValue": "player.adjustVolume",
                 "propertySubPhrases": [
-                  "Adjust the volume"
+                  "Adjust the sound level"
                 ]
               },
               {
-                "propertyValue": "player.setVolume",
+                "propertyValue": "player.raiseVolume",
                 "propertySubPhrases": [
-                  "Set the volume"
-                ]
-              },
-              {
-                "propertyValue": "player.modifyVolume",
-                "propertySubPhrases": [
-                  "Modify the sound level"
+                  "Raise the volume"
                 ]
               }
             ]
@@ -1553,7 +1419,7 @@
             "synonyms": [
               "Can you please",
               "Would you kindly",
-              "Please could you"
+              "Could you"
             ],
             "category": "politeness",
             "isOptional": true
@@ -1565,7 +1431,7 @@
               "raise the volume by 25%",
               "boost the volume by 25%"
             ],
-            "category": "volume adjustment",
+            "category": "volume change",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
@@ -1746,9 +1612,7 @@
           {
             "name": "fullActionName",
             "value": "player.changeVolume",
-            "substrings": [
-              "snip the volume"
-            ],
+            "substrings": [],
             "implied": true
           },
           {
@@ -1773,26 +1637,25 @@
             "isOptional": true
           },
           {
-            "text": "snip the volume",
+            "text": "snip",
             "synonyms": [
-              "reduce the volume",
-              "lower the volume",
-              "decrease the volume"
+              "reduce",
+              "decrease",
+              "lower"
             ],
             "category": "action",
             "propertyNames": [
-              "fullActionName",
               "parameters.volumeChangePercentage"
             ]
           },
           {
-            "text": "by just",
+            "text": "the volume by just",
             "synonyms": [
-              "by only",
-              "by exactly",
-              "by"
+              "the volume by only",
+              "the volume by exactly",
+              "the volume by"
             ],
-            "category": "preposition",
+            "category": "filler",
             "isOptional": true
           },
           {
@@ -1802,7 +1665,7 @@
               "5 percent",
               "5 pct"
             ],
-            "category": "quantity",
+            "category": "value",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
@@ -1810,58 +1673,31 @@
         ],
         "propertyAlternatives": [
           {
-            "propertyName": "fullActionName",
-            "propertyValue": "player.changeVolume",
-            "propertySubPhrases": [
-              "snip the volume"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "player.increaseVolume",
-                "propertySubPhrases": [
-                  "increase the volume"
-                ]
-              },
-              {
-                "propertyValue": "player.decreaseVolume",
-                "propertySubPhrases": [
-                  "decrease the volume"
-                ]
-              },
-              {
-                "propertyValue": "player.muteVolume",
-                "propertySubPhrases": [
-                  "mute the volume"
-                ]
-              }
-            ]
-          },
-          {
             "propertyName": "parameters.volumeChangePercentage",
             "propertyValue": -5,
             "propertySubPhrases": [
-              "snip the volume",
+              "snip",
               "5%"
             ],
             "alternatives": [
               {
                 "propertyValue": -10,
                 "propertySubPhrases": [
-                  "snip the volume",
+                  "snip",
                   "10%"
                 ]
               },
               {
                 "propertyValue": -15,
                 "propertySubPhrases": [
-                  "snip the volume",
+                  "snip",
                   "15%"
                 ]
               },
               {
                 "propertyValue": -20,
                 "propertySubPhrases": [
-                  "snip the volume",
+                  "snip",
                   "20%"
                 ]
               }
@@ -1876,95 +1712,21 @@
               {
                 "name": "fullActionName",
                 "value": "player.changeVolume",
-                "substrings": [
-                  "snip the volume"
-                ],
+                "substrings": [],
                 "implied": true
               },
               {
                 "name": "parameters.volumeChangePercentage",
                 "value": -5,
                 "substrings": [
-                  "5%"
+                  "snip the volume by just 5%"
                 ],
                 "implied": false
               }
             ]
           },
           "correction": [
-            "Value -5 for property 'parameters.volumeChangePercentage' doesn't match the number 5 in the substring '5%'. Missing other substring to explain the value."
-          ]
-        },
-        {
-          "data": {
-            "properties": [
-              {
-                "name": "fullActionName",
-                "value": "player.changeVolume",
-                "substrings": [
-                  "snip the volume"
-                ],
-                "implied": true
-              },
-              {
-                "name": "parameters.volumeChangePercentage",
-                "value": -5,
-                "substrings": [
-                  "snip",
-                  "5%"
-                ],
-                "implied": false
-              }
-            ],
-            "subPhrases": [
-              {
-                "text": "Could you",
-                "synonyms": [
-                  "Can you",
-                  "Would you",
-                  "Will you"
-                ],
-                "category": "politeness",
-                "isOptional": true
-              },
-              {
-                "text": "snip the volume",
-                "synonyms": [
-                  "reduce the volume",
-                  "lower the volume",
-                  "decrease the volume"
-                ],
-                "category": "action",
-                "propertyNames": [
-                  "fullActionName"
-                ]
-              },
-              {
-                "text": "by just",
-                "synonyms": [
-                  "by only",
-                  "by exactly",
-                  "by"
-                ],
-                "category": "preposition",
-                "isOptional": true
-              },
-              {
-                "text": "5%",
-                "synonyms": [
-                  "five percent",
-                  "5 percent",
-                  "5 pct"
-                ],
-                "category": "quantity",
-                "propertyNames": [
-                  "parameters.volumeChangePercentage"
-                ]
-              }
-            ]
-          },
-          "correction": [
-            "Explicit property 'parameters.volumeChangePercentage' must be included as property names for all subphrases that contain the substring 'snip'"
+            "Value -5 for property 'parameters.volumeChangePercentage' doesn't match the number 5 in the substring 'snip the volume by just 5%'. Missing other substring to explain the value."
           ]
         }
       ]
@@ -1982,16 +1744,14 @@
           {
             "name": "fullActionName",
             "value": "player.changeVolume",
-            "substrings": [
-              "tweak the volume"
-            ],
+            "substrings": [],
             "implied": true
           },
           {
             "name": "parameters.volumeChangePercentage",
             "value": -5,
             "substrings": [
-              "down",
+              "tweak the volume down",
               "5%"
             ],
             "implied": false
@@ -2009,25 +1769,13 @@
             "isOptional": true
           },
           {
-            "text": "tweak the volume",
+            "text": "tweak the volume down",
             "synonyms": [
-              "adjust the volume",
-              "change the volume",
-              "modify the volume"
+              "lower the volume",
+              "decrease the volume",
+              "turn the volume down"
             ],
             "category": "action",
-            "propertyNames": [
-              "fullActionName"
-            ]
-          },
-          {
-            "text": "down",
-            "synonyms": [
-              "lower",
-              "decrease",
-              "reduce"
-            ],
-            "category": "direction",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
@@ -2037,9 +1785,9 @@
             "synonyms": [
               "5 percent",
               "five percent",
-              "5%"
+              "by five percent"
             ],
-            "category": "amount",
+            "category": "quantity",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
@@ -2047,58 +1795,31 @@
         ],
         "propertyAlternatives": [
           {
-            "propertyName": "fullActionName",
-            "propertyValue": "player.changeVolume",
-            "propertySubPhrases": [
-              "tweak the volume"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "player.adjustVolume",
-                "propertySubPhrases": [
-                  "adjust the volume"
-                ]
-              },
-              {
-                "propertyValue": "player.setVolume",
-                "propertySubPhrases": [
-                  "set the volume"
-                ]
-              },
-              {
-                "propertyValue": "player.modifyVolume",
-                "propertySubPhrases": [
-                  "modify the volume"
-                ]
-              }
-            ]
-          },
-          {
             "propertyName": "parameters.volumeChangePercentage",
             "propertyValue": -5,
             "propertySubPhrases": [
-              "down",
+              "tweak the volume down",
               "by 5%"
             ],
             "alternatives": [
               {
                 "propertyValue": -10,
                 "propertySubPhrases": [
-                  "down",
+                  "tweak the volume down",
                   "by 10%"
                 ]
               },
               {
                 "propertyValue": -15,
                 "propertySubPhrases": [
-                  "down",
+                  "tweak the volume down",
                   "by 15%"
                 ]
               },
               {
                 "propertyValue": -20,
                 "propertySubPhrases": [
-                  "down",
+                  "tweak the volume down",
                   "by 20%"
                 ]
               }
@@ -2113,23 +1834,21 @@
               {
                 "name": "fullActionName",
                 "value": "player.changeVolume",
-                "substrings": [
-                  "tweak the volume"
-                ],
+                "substrings": [],
                 "implied": true
               },
               {
                 "name": "parameters.volumeChangePercentage",
                 "value": -5,
                 "substrings": [
-                  "down by 5%"
+                  "tweak the volume down by 5%"
                 ],
                 "implied": false
               }
             ]
           },
           "correction": [
-            "Value -5 for property 'parameters.volumeChangePercentage' doesn't match the number 5 in the substring 'down by 5%'. Missing other substring to explain the value."
+            "Value -5 for property 'parameters.volumeChangePercentage' doesn't match the number 5 in the substring 'tweak the volume down by 5%'. Missing other substring to explain the value."
           ]
         }
       ]
@@ -2147,16 +1866,14 @@
           {
             "name": "fullActionName",
             "value": "player.changeVolume",
-            "substrings": [
-              "up the volume"
-            ],
+            "substrings": [],
             "implied": true
           },
           {
             "name": "parameters.volumeChangePercentage",
             "value": 10,
             "substrings": [
-              "10%"
+              "up the volume by 10%"
             ],
             "implied": false
           }
@@ -2173,25 +1890,13 @@
             "isOptional": true
           },
           {
-            "text": "up the volume",
+            "text": "up the volume by 10%",
             "synonyms": [
-              "increase the volume",
-              "raise the volume",
-              "turn up the volume"
+              "increase the volume by 10%",
+              "raise the volume by 10%",
+              "turn up the volume by 10%"
             ],
             "category": "action",
-            "propertyNames": [
-              "fullActionName"
-            ]
-          },
-          {
-            "text": "by 10%",
-            "synonyms": [
-              "to 10%",
-              "at 10%",
-              "with 10%"
-            ],
-            "category": "measurement",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
@@ -2199,55 +1904,28 @@
         ],
         "propertyAlternatives": [
           {
-            "propertyName": "fullActionName",
-            "propertyValue": "player.changeVolume",
-            "propertySubPhrases": [
-              "up the volume"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "player.increaseVolume",
-                "propertySubPhrases": [
-                  "increase the volume"
-                ]
-              },
-              {
-                "propertyValue": "player.raiseVolume",
-                "propertySubPhrases": [
-                  "raise the volume"
-                ]
-              },
-              {
-                "propertyValue": "player.turnUpVolume",
-                "propertySubPhrases": [
-                  "turn up the volume"
-                ]
-              }
-            ]
-          },
-          {
             "propertyName": "parameters.volumeChangePercentage",
             "propertyValue": 10,
             "propertySubPhrases": [
-              "by 10%"
+              "up the volume by 10%"
             ],
             "alternatives": [
               {
                 "propertyValue": 5,
                 "propertySubPhrases": [
-                  "by 5%"
+                  "up the volume by 5%"
                 ]
               },
               {
                 "propertyValue": 15,
                 "propertySubPhrases": [
-                  "by 15%"
+                  "up the volume by 15%"
                 ]
               },
               {
                 "propertyValue": 20,
                 "propertySubPhrases": [
-                  "by 20%"
+                  "up the volume by 20%"
                 ]
               }
             ]
@@ -2268,24 +1946,22 @@
           {
             "name": "fullActionName",
             "value": "player.changeVolume",
-            "substrings": [
-              "Cut back on the volume"
-            ],
+            "substrings": [],
             "implied": true
           },
           {
             "name": "parameters.volumeChangePercentage",
             "value": -10,
             "substrings": [
-              "Cut back",
-              "by 10%"
+              "Cut back on",
+              "10%"
             ],
             "implied": false
           }
         ],
         "subPhrases": [
           {
-            "text": "Cut back",
+            "text": "Cut back on",
             "synonyms": [
               "Reduce",
               "Lower",
@@ -2293,30 +1969,27 @@
             ],
             "category": "action",
             "propertyNames": [
-              "fullActionName",
               "parameters.volumeChangePercentage"
             ]
           },
           {
-            "text": "on the volume",
+            "text": "the volume by",
             "synonyms": [
-              "the volume",
-              "volume level",
-              "sound level"
+              "the sound level by",
+              "the audio by",
+              "the loudness by"
             ],
-            "category": "object",
-            "propertyNames": [
-              "fullActionName"
-            ]
+            "category": "filler",
+            "isOptional": true
           },
           {
-            "text": "by 10%",
+            "text": "10%",
             "synonyms": [
-              "by ten percent",
-              "by 10 percent",
-              "by 10%"
+              "ten percent",
+              "10 percent",
+              "10%"
             ],
-            "category": "magnitude",
+            "category": "value",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
@@ -2324,63 +1997,32 @@
         ],
         "propertyAlternatives": [
           {
-            "propertyName": "fullActionName",
-            "propertyValue": "player.changeVolume",
-            "propertySubPhrases": [
-              "Cut back",
-              "on the volume"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "player.increaseVolume",
-                "propertySubPhrases": [
-                  "Increase",
-                  "the volume"
-                ]
-              },
-              {
-                "propertyValue": "player.muteVolume",
-                "propertySubPhrases": [
-                  "Mute",
-                  "the volume"
-                ]
-              },
-              {
-                "propertyValue": "player.unmuteVolume",
-                "propertySubPhrases": [
-                  "Unmute",
-                  "the volume"
-                ]
-              }
-            ]
-          },
-          {
             "propertyName": "parameters.volumeChangePercentage",
             "propertyValue": -10,
             "propertySubPhrases": [
-              "Cut back",
-              "by 10%"
+              "Cut back on",
+              "10%"
             ],
             "alternatives": [
               {
-                "propertyValue": -20,
-                "propertySubPhrases": [
-                  "Cut back",
-                  "by 20%"
-                ]
-              },
-              {
                 "propertyValue": -5,
                 "propertySubPhrases": [
-                  "Cut back",
-                  "by 5%"
+                  "Cut back on",
+                  "5%"
                 ]
               },
               {
                 "propertyValue": -15,
                 "propertySubPhrases": [
-                  "Cut back",
-                  "by 15%"
+                  "Cut back on",
+                  "15%"
+                ]
+              },
+              {
+                "propertyValue": -20,
+                "propertySubPhrases": [
+                  "Cut back on",
+                  "20%"
                 ]
               }
             ]
@@ -2394,23 +2036,21 @@
               {
                 "name": "fullActionName",
                 "value": "player.changeVolume",
-                "substrings": [
-                  "Cut back on the volume"
-                ],
+                "substrings": [],
                 "implied": true
               },
               {
                 "name": "parameters.volumeChangePercentage",
                 "value": -10,
                 "substrings": [
-                  "by 10%"
+                  "Cut back on the volume by 10%."
                 ],
                 "implied": false
               }
             ]
           },
           "correction": [
-            "Value -10 for property 'parameters.volumeChangePercentage' doesn't match the number 10 in the substring 'by 10%'. Missing other substring to explain the value."
+            "Value -10 for property 'parameters.volumeChangePercentage' doesn't match the number 10 in the substring 'Cut back on the volume by 10%.'. Missing other substring to explain the value."
           ]
         }
       ]
@@ -2458,11 +2098,23 @@
             ]
           },
           {
-            "text": "the volume by",
+            "text": "the volume",
             "synonyms": [
-              "the sound by",
-              "the audio by",
-              "the noise by"
+              "volume",
+              "sound level",
+              "audio level"
+            ],
+            "category": "object",
+            "propertyNames": [
+              "fullActionName"
+            ]
+          },
+          {
+            "text": "by",
+            "synonyms": [
+              "to",
+              "down to",
+              "at"
             ],
             "category": "preposition",
             "isOptional": true
@@ -2478,6 +2130,16 @@
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
+          },
+          {
+            "text": ".",
+            "synonyms": [
+              "",
+              " ",
+              " "
+            ],
+            "category": "punctuation",
+            "isOptional": true
           }
         ],
         "propertyAlternatives": [
@@ -2485,25 +2147,29 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.changeVolume",
             "propertySubPhrases": [
-              "Decrease"
+              "Decrease",
+              "the volume"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.increaseVolume",
                 "propertySubPhrases": [
-                  "Increase"
+                  "Increase",
+                  "the volume"
                 ]
               },
               {
                 "propertyValue": "player.muteVolume",
                 "propertySubPhrases": [
-                  "Mute"
+                  "Mute",
+                  "the volume"
                 ]
               },
               {
-                "propertyValue": "player.setVolume",
+                "propertyValue": "player.unmuteVolume",
                 "propertySubPhrases": [
-                  "Set"
+                  "Unmute",
+                  "the volume"
                 ]
               }
             ]
@@ -2602,11 +2268,21 @@
                 ]
               },
               {
-                "text": "the volume by",
+                "text": "the volume",
                 "synonyms": [
-                  "the sound by",
-                  "the audio by",
-                  "the noise by"
+                  "volume",
+                  "sound level",
+                  "audio level"
+                ],
+                "category": "object",
+                "propertyNames": []
+              },
+              {
+                "text": "by",
+                "synonyms": [
+                  "to",
+                  "down to",
+                  "at"
                 ],
                 "category": "preposition",
                 "isOptional": true
@@ -2622,6 +2298,16 @@
                 "propertyNames": [
                   "parameters.volumeChangePercentage"
                 ]
+              },
+              {
+                "text": ".",
+                "synonyms": [
+                  "",
+                  " ",
+                  " "
+                ],
+                "category": "punctuation",
+                "isOptional": true
               }
             ]
           },
@@ -2653,228 +2339,31 @@
             "name": "parameters.volumeChangePercentage",
             "value": -10,
             "substrings": [
-              "by 10%",
-              "Dial down"
+              "Dial down",
+              "by 10%"
             ],
             "implied": false
           }
         ],
         "subPhrases": [
           {
-            "text": "Dial down the volume",
+            "text": "Dial down",
             "synonyms": [
-              "Lower the volume",
-              "Decrease the volume",
-              "Turn down the volume"
+              "Lower",
+              "Decrease",
+              "Reduce"
             ],
             "category": "command",
             "propertyNames": [
-              "fullActionName",
-              "parameters.volumeChangePercentage"
-            ]
-          },
-          {
-            "text": "by 10%",
-            "synonyms": [
-              "by ten percent",
-              "by 10 percent",
-              "by 10%"
-            ],
-            "category": "modifier",
-            "propertyNames": [
-              "parameters.volumeChangePercentage"
-            ]
-          }
-        ],
-        "propertyAlternatives": [
-          {
-            "propertyName": "fullActionName",
-            "propertyValue": "player.changeVolume",
-            "propertySubPhrases": [
-              "Dial down the volume"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "player.decreaseVolume",
-                "propertySubPhrases": [
-                  "Decrease the volume"
-                ]
-              },
-              {
-                "propertyValue": "player.lowerVolume",
-                "propertySubPhrases": [
-                  "Lower the volume"
-                ]
-              },
-              {
-                "propertyValue": "player.reduceVolume",
-                "propertySubPhrases": [
-                  "Reduce the volume"
-                ]
-              }
-            ]
-          },
-          {
-            "propertyName": "parameters.volumeChangePercentage",
-            "propertyValue": -10,
-            "propertySubPhrases": [
-              "Dial down the volume",
-              "by 10%"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": -5,
-                "propertySubPhrases": [
-                  "Dial down the volume",
-                  "by 5%"
-                ]
-              },
-              {
-                "propertyValue": -15,
-                "propertySubPhrases": [
-                  "Dial down the volume",
-                  "by 15%"
-                ]
-              },
-              {
-                "propertyValue": -20,
-                "propertySubPhrases": [
-                  "Dial down the volume",
-                  "by 20%"
-                ]
-              }
-            ]
-          }
-        ]
-      },
-      "corrections": [
-        {
-          "data": {
-            "properties": [
-              {
-                "name": "fullActionName",
-                "value": "player.changeVolume",
-                "substrings": [
-                  "Dial down the volume"
-                ],
-                "implied": true
-              },
-              {
-                "name": "parameters.volumeChangePercentage",
-                "value": -10,
-                "substrings": [
-                  "by 10%"
-                ],
-                "implied": false
-              }
-            ]
-          },
-          "correction": [
-            "Value -10 for property 'parameters.volumeChangePercentage' doesn't match the number 10 in the substring 'by 10%'. Missing other substring to explain the value."
-          ]
-        },
-        {
-          "data": {
-            "properties": [
-              {
-                "name": "fullActionName",
-                "value": "player.changeVolume",
-                "substrings": [
-                  "Dial down the volume"
-                ],
-                "implied": true
-              },
-              {
-                "name": "parameters.volumeChangePercentage",
-                "value": -10,
-                "substrings": [
-                  "by 10%",
-                  "Dial down"
-                ],
-                "implied": false
-              }
-            ],
-            "subPhrases": [
-              {
-                "text": "Dial down the volume",
-                "synonyms": [
-                  "Lower the volume",
-                  "Decrease the volume",
-                  "Turn down the volume"
-                ],
-                "category": "command",
-                "propertyNames": [
-                  "fullActionName"
-                ]
-              },
-              {
-                "text": "by 10%",
-                "synonyms": [
-                  "by ten percent",
-                  "by 10 percent",
-                  "by 10%"
-                ],
-                "category": "modifier",
-                "propertyNames": [
-                  "parameters.volumeChangePercentage"
-                ]
-              }
-            ]
-          },
-          "correction": [
-            "Explicit property 'parameters.volumeChangePercentage' must be included as property names for all subphrases that contain the substring 'Dial down'"
-          ]
-        }
-      ]
-    },
-    {
-      "request": "Diminish the volume by 10%.",
-      "action": {
-        "fullActionName": "player.changeVolume",
-        "parameters": {
-          "volumeChangePercentage": -10
-        }
-      },
-      "explanation": {
-        "properties": [
-          {
-            "name": "fullActionName",
-            "value": "player.changeVolume",
-            "substrings": [
-              "Diminish the volume"
-            ],
-            "implied": true
-          },
-          {
-            "name": "parameters.volumeChangePercentage",
-            "value": -10,
-            "substrings": [
-              "by 10%",
-              "Diminish"
-            ],
-            "implied": false
-          }
-        ],
-        "subPhrases": [
-          {
-            "text": "Diminish",
-            "synonyms": [
-              "Reduce",
-              "Lower",
-              "Decrease"
-            ],
-            "category": "action",
-            "propertyNames": [
-              "fullActionName",
               "parameters.volumeChangePercentage"
             ]
           },
           {
             "text": "the volume",
             "synonyms": [
-              "the sound level",
+              "the sound",
               "the audio",
-              "the loudness"
+              "the noise"
             ],
             "category": "object",
             "propertyNames": [
@@ -2896,63 +2385,59 @@
         ],
         "propertyAlternatives": [
           {
-            "propertyName": "fullActionName",
-            "propertyValue": "player.changeVolume",
-            "propertySubPhrases": [
-              "Diminish",
-              "the volume"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "player.lowerVolume",
-                "propertySubPhrases": [
-                  "Lower",
-                  "the volume"
-                ]
-              },
-              {
-                "propertyValue": "player.decreaseVolume",
-                "propertySubPhrases": [
-                  "Decrease",
-                  "the volume"
-                ]
-              },
-              {
-                "propertyValue": "player.reduceVolume",
-                "propertySubPhrases": [
-                  "Reduce",
-                  "the volume"
-                ]
-              }
-            ]
-          },
-          {
             "propertyName": "parameters.volumeChangePercentage",
             "propertyValue": -10,
             "propertySubPhrases": [
-              "Diminish",
+              "Dial down",
               "by 10%"
             ],
             "alternatives": [
               {
                 "propertyValue": -5,
                 "propertySubPhrases": [
-                  "Diminish",
+                  "Dial down",
                   "by 5%"
-                ]
-              },
-              {
-                "propertyValue": -15,
-                "propertySubPhrases": [
-                  "Diminish",
-                  "by 15%"
                 ]
               },
               {
                 "propertyValue": -20,
                 "propertySubPhrases": [
-                  "Diminish",
+                  "Dial down",
                   "by 20%"
+                ]
+              },
+              {
+                "propertyValue": -15,
+                "propertySubPhrases": [
+                  "Dial down",
+                  "by 15%"
+                ]
+              }
+            ]
+          },
+          {
+            "propertyName": "fullActionName",
+            "propertyValue": "player.changeVolume",
+            "propertySubPhrases": [
+              "the volume"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "player.mute",
+                "propertySubPhrases": [
+                  "mute the volume"
+                ]
+              },
+              {
+                "propertyValue": "player.increaseVolume",
+                "propertySubPhrases": [
+                  "increase the volume"
+                ]
+              },
+              {
+                "propertyValue": "player.decreaseVolume",
+                "propertySubPhrases": [
+                  "decrease the volume"
                 ]
               }
             ]
@@ -2967,7 +2452,7 @@
                 "name": "fullActionName",
                 "value": "player.changeVolume",
                 "substrings": [
-                  "Diminish the volume"
+                  "Dial down the volume"
                 ],
                 "implied": true
               },
@@ -2983,6 +2468,128 @@
           },
           "correction": [
             "Value -10 for property 'parameters.volumeChangePercentage' doesn't match the number 10 in the substring 'by 10%'. Missing other substring to explain the value."
+          ]
+        }
+      ]
+    },
+    {
+      "request": "Diminish the volume by 10%.",
+      "action": {
+        "fullActionName": "player.changeVolume",
+        "parameters": {
+          "volumeChangePercentage": -10
+        }
+      },
+      "explanation": {
+        "properties": [
+          {
+            "name": "fullActionName",
+            "value": "player.changeVolume",
+            "substrings": [],
+            "implied": true
+          },
+          {
+            "name": "parameters.volumeChangePercentage",
+            "value": -10,
+            "substrings": [
+              "Diminish",
+              "10%"
+            ],
+            "implied": false
+          }
+        ],
+        "subPhrases": [
+          {
+            "text": "Diminish",
+            "synonyms": [
+              "Reduce",
+              "Lower",
+              "Decrease"
+            ],
+            "category": "command",
+            "propertyNames": [
+              "parameters.volumeChangePercentage"
+            ]
+          },
+          {
+            "text": "the volume by",
+            "synonyms": [
+              "the sound by",
+              "the audio by",
+              "the level by"
+            ],
+            "category": "preposition",
+            "isOptional": true
+          },
+          {
+            "text": "10%",
+            "synonyms": [
+              "ten percent",
+              "10 percent",
+              "10 pct"
+            ],
+            "category": "value",
+            "propertyNames": [
+              "parameters.volumeChangePercentage"
+            ]
+          }
+        ],
+        "propertyAlternatives": [
+          {
+            "propertyName": "parameters.volumeChangePercentage",
+            "propertyValue": -10,
+            "propertySubPhrases": [
+              "Diminish",
+              "10%"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": -5,
+                "propertySubPhrases": [
+                  "Diminish",
+                  "5%"
+                ]
+              },
+              {
+                "propertyValue": -15,
+                "propertySubPhrases": [
+                  "Diminish",
+                  "15%"
+                ]
+              },
+              {
+                "propertyValue": -20,
+                "propertySubPhrases": [
+                  "Diminish",
+                  "20%"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "corrections": [
+        {
+          "data": {
+            "properties": [
+              {
+                "name": "fullActionName",
+                "value": "player.changeVolume",
+                "substrings": [],
+                "implied": true
+              },
+              {
+                "name": "parameters.volumeChangePercentage",
+                "value": -10,
+                "substrings": [
+                  "Diminish the volume by 10%"
+                ],
+                "implied": false
+              }
+            ]
+          },
+          "correction": [
+            "Value -10 for property 'parameters.volumeChangePercentage' doesn't match the number 10 in the substring 'Diminish the volume by 10%'. Missing other substring to explain the value."
           ]
         }
       ]
@@ -3044,9 +2651,9 @@
           {
             "text": "by a small",
             "synonyms": [
-              "by a little",
               "by a slight",
-              "by a minor"
+              "by a minor",
+              "by a little"
             ],
             "category": "modifier",
             "isOptional": true
@@ -3058,7 +2665,7 @@
               "10 percent",
               "10 per cent"
             ],
-            "category": "quantity",
+            "category": "value",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
@@ -3211,7 +2818,7 @@
             "synonyms": [
               "ten percent",
               "10 percent",
-              "10 pct"
+              "10%"
             ],
             "category": "percentage",
             "propertyNames": [
@@ -3312,9 +2919,9 @@
             "synonyms": [
               "Increase the sound level,",
               "Raise the volume,",
-              "Boost the audio level,"
+              "Boost the audio,"
             ],
-            "category": "action",
+            "category": "fullActionName",
             "propertyNames": [
               "fullActionName"
             ]
@@ -3326,7 +2933,7 @@
               "raise it by 10%",
               "boost it by 10%"
             ],
-            "category": "action",
+            "category": "parameters.volumeChangePercentage",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
@@ -3343,19 +2950,19 @@
               {
                 "propertyValue": "player.increaseVolume",
                 "propertySubPhrases": [
-                  "Increase the volume,"
+                  "Increase the volume level,"
                 ]
               },
               {
                 "propertyValue": "player.raiseVolume",
                 "propertySubPhrases": [
-                  "Raise the volume,"
+                  "Raise the sound level,"
                 ]
               },
               {
                 "propertyValue": "player.adjustVolume",
                 "propertySubPhrases": [
-                  "Adjust the volume,"
+                  "Adjust the audio level,"
                 ]
               }
             ]
@@ -3370,19 +2977,19 @@
               {
                 "propertyValue": 5,
                 "propertySubPhrases": [
-                  "push it up by 5%"
+                  "increase it by 5%"
                 ]
               },
               {
                 "propertyValue": 15,
                 "propertySubPhrases": [
-                  "push it up by 15%"
+                  "raise it by 15%"
                 ]
               },
               {
                 "propertyValue": 20,
                 "propertySubPhrases": [
-                  "push it up by 20%"
+                  "boost it by 20%"
                 ]
               }
             ]
@@ -3425,8 +3032,10 @@
               "Boost the volume",
               "Raise the audio level"
             ],
-            "category": "command",
-            "propertyNames": []
+            "category": "fullActionName",
+            "propertyNames": [
+              "fullActionName"
+            ]
           },
           {
             "text": "jack it up by 10%",
@@ -3435,13 +3044,40 @@
               "raise it by 10%",
               "boost it by 10%"
             ],
-            "category": "command",
+            "category": "parameters.volumeChangePercentage",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
           }
         ],
         "propertyAlternatives": [
+          {
+            "propertyName": "fullActionName",
+            "propertyValue": "player.changeVolume",
+            "propertySubPhrases": [
+              "Enhance the audio level"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "player.increaseVolume",
+                "propertySubPhrases": [
+                  "Increase the audio level"
+                ]
+              },
+              {
+                "propertyValue": "player.raiseVolume",
+                "propertySubPhrases": [
+                  "Raise the audio level"
+                ]
+              },
+              {
+                "propertyValue": "player.boostVolume",
+                "propertySubPhrases": [
+                  "Boost the audio level"
+                ]
+              }
+            ]
+          },
           {
             "propertyName": "parameters.volumeChangePercentage",
             "propertyValue": 10,
@@ -3485,14 +3121,15 @@
           {
             "name": "fullActionName",
             "value": "player.changeVolume",
-            "substrings": [],
+            "substrings": [
+              "cranking up the volume"
+            ],
             "implied": true
           },
           {
             "name": "parameters.volumeChangePercentage",
             "value": 10,
             "substrings": [
-              "cranking up the volume",
               "10%"
             ],
             "implied": false
@@ -3518,7 +3155,7 @@
             ],
             "category": "action",
             "propertyNames": [
-              "parameters.volumeChangePercentage"
+              "fullActionName"
             ]
           },
           {
@@ -3536,7 +3173,7 @@
             "synonyms": [
               "ten percent",
               "10 percent",
-              "10%"
+              "a 10% increase"
             ],
             "category": "quantity",
             "propertyNames": [
@@ -3546,31 +3183,54 @@
         ],
         "propertyAlternatives": [
           {
+            "propertyName": "fullActionName",
+            "propertyValue": "player.changeVolume",
+            "propertySubPhrases": [
+              "cranking up the volume"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "player.increaseVolume",
+                "propertySubPhrases": [
+                  "turning up the volume"
+                ]
+              },
+              {
+                "propertyValue": "player.raiseVolume",
+                "propertySubPhrases": [
+                  "raising the volume"
+                ]
+              },
+              {
+                "propertyValue": "player.boostVolume",
+                "propertySubPhrases": [
+                  "boosting the volume"
+                ]
+              }
+            ]
+          },
+          {
             "propertyName": "parameters.volumeChangePercentage",
             "propertyValue": 10,
             "propertySubPhrases": [
-              "cranking up the volume",
               "10%"
             ],
             "alternatives": [
               {
                 "propertyValue": 5,
                 "propertySubPhrases": [
-                  "increasing the volume",
                   "5%"
                 ]
               },
               {
                 "propertyValue": 15,
                 "propertySubPhrases": [
-                  "boosting the volume",
                   "15%"
                 ]
               },
               {
                 "propertyValue": 20,
                 "propertySubPhrases": [
-                  "turning up the volume",
                   "20%"
                 ]
               }
@@ -3592,9 +3252,7 @@
           {
             "name": "fullActionName",
             "value": "player.changeVolume",
-            "substrings": [
-              "turning up the volume"
-            ],
+            "substrings": [],
             "implied": true
           },
           {
@@ -3610,9 +3268,9 @@
           {
             "text": "Fancy",
             "synonyms": [
-              "Would you like",
+              "Would you like to",
               "How about",
-              "Do you want"
+              "Do you want to"
             ],
             "category": "politeness",
             "isOptional": true
@@ -3622,7 +3280,7 @@
             "synonyms": [
               "increase the volume",
               "raise the volume",
-              "turn the volume up"
+              "make the volume louder"
             ],
             "category": "action",
             "propertyNames": [
@@ -3646,7 +3304,7 @@
               "10 percent",
               "10%"
             ],
-            "category": "quantity",
+            "category": "value",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
@@ -3663,13 +3321,13 @@
               {
                 "propertyValue": "player.increaseVolume",
                 "propertySubPhrases": [
-                  "increase the volume"
+                  "increasing the volume"
                 ]
               },
               {
                 "propertyValue": "player.raiseVolume",
                 "propertySubPhrases": [
-                  "raise the volume"
+                  "raising the volume"
                 ]
               },
               {
@@ -3744,7 +3402,7 @@
               "Carefully",
               "Gradually"
             ],
-            "category": "adverb",
+            "category": "politeness",
             "isOptional": true
           },
           {
@@ -3772,9 +3430,9 @@
           {
             "text": "by 20%",
             "synonyms": [
-              "20 percent",
-              "twenty percent",
-              "by twenty percent"
+              "by twenty percent",
+              "by 20 percent",
+              "by 20%"
             ],
             "category": "measurement",
             "propertyNames": [
@@ -3855,9 +3513,7 @@
           {
             "name": "fullActionName",
             "value": "player.changeVolume",
-            "substrings": [
-              "slash the volume"
-            ],
+            "substrings": [],
             "implied": true
           },
           {
@@ -3865,7 +3521,7 @@
             "value": -5,
             "substrings": [
               "slash",
-              "5%"
+              "the volume by 5%"
             ],
             "implied": false
           }
@@ -3882,24 +3538,23 @@
             "isOptional": true
           },
           {
-            "text": "slash the volume",
+            "text": "slash",
             "synonyms": [
-              "reduce the volume",
-              "decrease the volume",
-              "lower the volume"
+              "reduce",
+              "decrease",
+              "lower"
             ],
             "category": "action",
             "propertyNames": [
-              "fullActionName",
               "parameters.volumeChangePercentage"
             ]
           },
           {
-            "text": "by 5%",
+            "text": "the volume by 5%",
             "synonyms": [
-              "by five percent",
-              "by 5 percent",
-              "by 5%"
+              "the sound by 5%",
+              "the audio by 5%",
+              "the noise by 5%"
             ],
             "category": "measurement",
             "propertyNames": [
@@ -3909,59 +3564,32 @@
         ],
         "propertyAlternatives": [
           {
-            "propertyName": "fullActionName",
-            "propertyValue": "player.changeVolume",
-            "propertySubPhrases": [
-              "slash the volume"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "player.increaseVolume",
-                "propertySubPhrases": [
-                  "increase the volume"
-                ]
-              },
-              {
-                "propertyValue": "player.decreaseVolume",
-                "propertySubPhrases": [
-                  "decrease the volume"
-                ]
-              },
-              {
-                "propertyValue": "player.muteVolume",
-                "propertySubPhrases": [
-                  "mute the volume"
-                ]
-              }
-            ]
-          },
-          {
             "propertyName": "parameters.volumeChangePercentage",
             "propertyValue": -5,
             "propertySubPhrases": [
-              "slash the volume",
-              "by 5%"
+              "slash",
+              "the volume by 5%"
             ],
             "alternatives": [
               {
                 "propertyValue": -10,
                 "propertySubPhrases": [
-                  "slash the volume",
-                  "by 10%"
+                  "slash",
+                  "the volume by 10%"
                 ]
               },
               {
                 "propertyValue": -15,
                 "propertySubPhrases": [
-                  "slash the volume",
-                  "by 15%"
+                  "slash",
+                  "the volume by 15%"
                 ]
               },
               {
                 "propertyValue": -20,
                 "propertySubPhrases": [
-                  "slash the volume",
-                  "by 20%"
+                  "slash",
+                  "the volume by 20%"
                 ]
               }
             ]
@@ -3975,85 +3603,21 @@
               {
                 "name": "fullActionName",
                 "value": "player.changeVolume",
-                "substrings": [
-                  "slash the volume"
-                ],
+                "substrings": [],
                 "implied": true
               },
               {
                 "name": "parameters.volumeChangePercentage",
                 "value": -5,
                 "substrings": [
-                  "5%"
+                  "slash the volume by 5%"
                 ],
                 "implied": false
               }
             ]
           },
           "correction": [
-            "Value -5 for property 'parameters.volumeChangePercentage' doesn't match the number 5 in the substring '5%'. Missing other substring to explain the value."
-          ]
-        },
-        {
-          "data": {
-            "properties": [
-              {
-                "name": "fullActionName",
-                "value": "player.changeVolume",
-                "substrings": [
-                  "slash the volume"
-                ],
-                "implied": true
-              },
-              {
-                "name": "parameters.volumeChangePercentage",
-                "value": -5,
-                "substrings": [
-                  "slash",
-                  "5%"
-                ],
-                "implied": false
-              }
-            ],
-            "subPhrases": [
-              {
-                "text": "Hey",
-                "synonyms": [
-                  "Hi",
-                  "Hello",
-                  "Greetings"
-                ],
-                "category": "greeting",
-                "isOptional": true
-              },
-              {
-                "text": "slash the volume",
-                "synonyms": [
-                  "reduce the volume",
-                  "decrease the volume",
-                  "lower the volume"
-                ],
-                "category": "action",
-                "propertyNames": [
-                  "fullActionName"
-                ]
-              },
-              {
-                "text": "by 5%",
-                "synonyms": [
-                  "by five percent",
-                  "by 5 percent",
-                  "by 5%"
-                ],
-                "category": "measurement",
-                "propertyNames": [
-                  "parameters.volumeChangePercentage"
-                ]
-              }
-            ]
-          },
-          "correction": [
-            "Explicit property 'parameters.volumeChangePercentage' must be included as property names for all subphrases that contain the substring 'slash'"
+            "Value -5 for property 'parameters.volumeChangePercentage' doesn't match the number 5 in the substring 'slash the volume by 5%'. Missing other substring to explain the value."
           ]
         }
       ]
@@ -4151,16 +3715,14 @@
           {
             "name": "fullActionName",
             "value": "player.changeVolume",
-            "substrings": [
-              "crank up the volume"
-            ],
+            "substrings": [],
             "implied": true
           },
           {
             "name": "parameters.volumeChangePercentage",
             "value": 10,
             "substrings": [
-              "by 10%"
+              "crank up the volume by 10%"
             ],
             "implied": false
           }
@@ -4177,25 +3739,13 @@
             "isOptional": true
           },
           {
-            "text": "crank up the volume",
+            "text": "crank up the volume by 10%",
             "synonyms": [
-              "increase the volume",
-              "turn up the volume",
-              "raise the volume"
+              "increase the volume by 10%",
+              "raise the volume by 10%",
+              "turn up the volume by 10%"
             ],
             "category": "action",
-            "propertyNames": [
-              "fullActionName"
-            ]
-          },
-          {
-            "text": "by 10%",
-            "synonyms": [
-              "by ten percent",
-              "by 10 percent",
-              "by a tenth"
-            ],
-            "category": "parameter",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
@@ -4203,55 +3753,28 @@
         ],
         "propertyAlternatives": [
           {
-            "propertyName": "fullActionName",
-            "propertyValue": "player.changeVolume",
-            "propertySubPhrases": [
-              "crank up the volume"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "player.increaseVolume",
-                "propertySubPhrases": [
-                  "increase the volume"
-                ]
-              },
-              {
-                "propertyValue": "player.raiseVolume",
-                "propertySubPhrases": [
-                  "raise the volume"
-                ]
-              },
-              {
-                "propertyValue": "player.turnUpVolume",
-                "propertySubPhrases": [
-                  "turn up the volume"
-                ]
-              }
-            ]
-          },
-          {
             "propertyName": "parameters.volumeChangePercentage",
             "propertyValue": 10,
             "propertySubPhrases": [
-              "by 10%"
+              "crank up the volume by 10%"
             ],
             "alternatives": [
               {
                 "propertyValue": 5,
                 "propertySubPhrases": [
-                  "by 5%"
+                  "crank up the volume by 5%"
                 ]
               },
               {
                 "propertyValue": 15,
                 "propertySubPhrases": [
-                  "by 15%"
+                  "crank up the volume by 15%"
                 ]
               },
               {
                 "propertyValue": 20,
                 "propertySubPhrases": [
-                  "by 20%"
+                  "crank up the volume by 20%"
                 ]
               }
             ]
@@ -4293,13 +3816,13 @@
               "I believe",
               "I suppose"
             ],
-            "category": "acknowledgement",
+            "category": "filler",
             "isOptional": true
           },
           {
             "text": "a 20% decrease",
             "synonyms": [
-              "a 20 percent reduction",
+              "a 20% reduction",
               "a 20% drop",
               "a 20% cut"
             ],
@@ -4325,7 +3848,7 @@
               "would be great",
               "would be best"
             ],
-            "category": "preference",
+            "category": "filler",
             "isOptional": true
           }
         ],
@@ -4414,9 +3937,9 @@
           {
             "text": "I'd appreciate it if you could",
             "synonyms": [
-              "I would be grateful if you could",
-              "It would be great if you could",
-              "I would appreciate it if you could"
+              "Could you please",
+              "Would you mind",
+              "I would be grateful if you"
             ],
             "category": "politeness",
             "isOptional": true
@@ -4487,7 +4010,7 @@
             "name": "parameters.volumeChangePercentage",
             "value": 25,
             "substrings": [
-              "by 25%"
+              "25%"
             ],
             "implied": false
           }
@@ -4496,9 +4019,9 @@
           {
             "text": "I'd be grateful if you could",
             "synonyms": [
-              "I would appreciate it if you could",
-              "It would be great if you could",
-              "Could you please"
+              "Please",
+              "Kindly",
+              "Would you mind"
             ],
             "category": "politeness",
             "isOptional": true
@@ -4519,8 +4042,8 @@
             "text": "by 25%",
             "synonyms": [
               "to 25%",
-              "up by 25%",
-              "increase by 25%"
+              "up to 25%",
+              "at 25%"
             ],
             "category": "parameter",
             "propertyNames": [
@@ -4599,9 +4122,7 @@
           {
             "name": "fullActionName",
             "value": "player.changeVolume",
-            "substrings": [
-              "sweeten the volume"
-            ],
+            "substrings": [],
             "implied": true
           },
           {
@@ -4625,26 +4146,14 @@
             "isOptional": true
           },
           {
-            "text": "sweeten the volume",
+            "text": "sweeten the volume by a considerable",
             "synonyms": [
-              "increase the volume",
-              "raise the volume",
-              "turn up the volume"
+              "increase the volume by a significant",
+              "raise the volume by a notable",
+              "boost the volume by a substantial"
             ],
             "category": "action",
-            "propertyNames": [
-              "fullActionName"
-            ]
-          },
-          {
-            "text": "by a considerable",
-            "synonyms": [
-              "by a significant",
-              "by a notable",
-              "by a substantial"
-            ],
-            "category": "filler",
-            "isOptional": true
+            "propertyNames": []
           },
           {
             "text": "25%",
@@ -4653,40 +4162,13 @@
               "25 percent",
               "25%"
             ],
-            "category": "value",
+            "category": "quantity",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
           }
         ],
         "propertyAlternatives": [
-          {
-            "propertyName": "fullActionName",
-            "propertyValue": "player.changeVolume",
-            "propertySubPhrases": [
-              "sweeten the volume"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "player.increaseVolume",
-                "propertySubPhrases": [
-                  "increase the volume"
-                ]
-              },
-              {
-                "propertyValue": "player.raiseVolume",
-                "propertySubPhrases": [
-                  "raise the volume"
-                ]
-              },
-              {
-                "propertyValue": "player.boostVolume",
-                "propertySubPhrases": [
-                  "boost the volume"
-                ]
-              }
-            ]
-          },
           {
             "propertyName": "parameters.volumeChangePercentage",
             "propertyValue": 25,
@@ -4769,9 +4251,9 @@
             "synonyms": [
               "twenty percent",
               "20 percent",
-              "20% less"
+              "by 20%"
             ],
-            "category": "quantity",
+            "category": "percentage",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
@@ -4781,9 +4263,9 @@
             "synonyms": [
               "quieter",
               "lower",
-              "reduced"
+              "less loud"
             ],
-            "category": "quality",
+            "category": "volume change",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
@@ -4793,7 +4275,7 @@
             "synonyms": [
               "if you can",
               "if it's okay",
-              "if it's possible"
+              "if that's alright"
             ],
             "category": "politeness",
             "isOptional": true
@@ -4872,16 +4354,14 @@
           {
             "name": "fullActionName",
             "value": "player.changeVolume",
-            "substrings": [
-              "boost the audio level"
-            ],
+            "substrings": [],
             "implied": true
           },
           {
             "name": "parameters.volumeChangePercentage",
             "value": 20,
             "substrings": [
-              "20%"
+              "boost the audio level by 20%"
             ],
             "implied": false
           }
@@ -4898,25 +4378,13 @@
             "isOptional": true
           },
           {
-            "text": "boost the audio level",
+            "text": "boost the audio level by 20%",
             "synonyms": [
-              "increase the volume",
-              "raise the sound level",
-              "amplify the audio"
+              "increase the volume by 20%",
+              "raise the sound level by 20%",
+              "turn up the audio by 20%"
             ],
             "category": "action",
-            "propertyNames": [
-              "fullActionName"
-            ]
-          },
-          {
-            "text": "by 20%",
-            "synonyms": [
-              "to 20%",
-              "up by 20%",
-              "increase by 20%"
-            ],
-            "category": "parameter",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
@@ -4926,7 +4394,7 @@
             "synonyms": [
               "kindly",
               "if you don't mind",
-              "if possible"
+              "if you could"
             ],
             "category": "politeness",
             "isOptional": true
@@ -4934,55 +4402,34 @@
         ],
         "propertyAlternatives": [
           {
-            "propertyName": "fullActionName",
-            "propertyValue": "player.changeVolume",
-            "propertySubPhrases": [
-              "boost the audio level"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "player.increaseVolume",
-                "propertySubPhrases": [
-                  "increase the audio level"
-                ]
-              },
-              {
-                "propertyValue": "player.raiseVolume",
-                "propertySubPhrases": [
-                  "raise the audio level"
-                ]
-              },
-              {
-                "propertyValue": "player.amplifyVolume",
-                "propertySubPhrases": [
-                  "amplify the audio level"
-                ]
-              }
-            ]
-          },
-          {
             "propertyName": "parameters.volumeChangePercentage",
             "propertyValue": 20,
             "propertySubPhrases": [
-              "by 20%"
+              "boost the audio level by 20%"
             ],
             "alternatives": [
               {
                 "propertyValue": 10,
                 "propertySubPhrases": [
-                  "by 10%"
+                  "boost the audio level by 10%"
                 ]
               },
               {
                 "propertyValue": 30,
                 "propertySubPhrases": [
-                  "by 30%"
+                  "boost the audio level by 30%"
                 ]
               },
               {
                 "propertyValue": 50,
                 "propertySubPhrases": [
-                  "by 50%"
+                  "boost the audio level by 50%"
+                ]
+              },
+              {
+                "propertyValue": 5,
+                "propertySubPhrases": [
+                  "boost the audio level by 5%"
                 ]
               }
             ]
@@ -5083,9 +4530,7 @@
           {
             "name": "fullActionName",
             "value": "player.changeVolume",
-            "substrings": [
-              "I'd prefer if the audio was 20% lower."
-            ],
+            "substrings": [],
             "implied": true
           },
           {
@@ -5103,31 +4548,21 @@
             "text": "I'd prefer if",
             "synonyms": [
               "I would like it if",
-              "I wish",
-              "I want"
+              "I want",
+              "I would prefer"
             ],
             "category": "politeness",
             "isOptional": true
           },
           {
-            "text": "the audio",
+            "text": "the audio was",
             "synonyms": [
-              "the sound",
-              "the volume",
-              "the audio level"
+              "the sound was",
+              "the volume was",
+              "the audio level was"
             ],
-            "category": "subject",
-            "propertyNames": []
-          },
-          {
-            "text": "was",
-            "synonyms": [
-              "is",
-              "could be",
-              "would be"
-            ],
-            "category": "verb",
-            "propertyNames": []
+            "category": "preposition",
+            "isOptional": false
           },
           {
             "text": "20%",
@@ -5146,7 +4581,7 @@
             "synonyms": [
               "decreased",
               "reduced",
-              "less"
+              "turned down"
             ],
             "category": "direction",
             "propertyNames": [
@@ -5195,9 +4630,7 @@
               {
                 "name": "fullActionName",
                 "value": "player.changeVolume",
-                "substrings": [
-                  "I'd prefer if the audio was 20% lower."
-                ],
+                "substrings": [],
                 "implied": true
               },
               {
@@ -5236,7 +4669,7 @@
             "name": "parameters.volumeChangePercentage",
             "value": -20,
             "substrings": [
-              "20% cut",
+              "20%",
               "cut"
             ],
             "implied": false
@@ -5256,8 +4689,8 @@
           {
             "text": "a 20% cut",
             "synonyms": [
-              "a 20% decrease",
               "a 20% reduction",
+              "a 20% decrease",
               "a 20% drop"
             ],
             "category": "volume change",
@@ -5399,7 +4832,7 @@
             "synonyms": [
               "to",
               "up to",
-              "with"
+              "at"
             ],
             "category": "preposition",
             "isOptional": true
@@ -5492,16 +4925,14 @@
           {
             "name": "fullActionName",
             "value": "player.changeVolume",
-            "substrings": [
-              "Increment the volume by 30%."
-            ],
+            "substrings": [],
             "implied": true
           },
           {
             "name": "parameters.volumeChangePercentage",
             "value": 30,
             "substrings": [
-              "30%"
+              "Increment the volume by 30%."
             ],
             "implied": false
           }
@@ -5515,21 +4946,17 @@
               "Boost"
             ],
             "category": "action",
-            "propertyNames": [
-              "fullActionName"
-            ]
+            "propertyNames": []
           },
           {
             "text": "the volume",
             "synonyms": [
-              "volume",
+              "audio level",
               "sound level",
-              "audio level"
+              "loudness"
             ],
             "category": "object",
-            "propertyNames": [
-              "fullActionName"
-            ]
+            "propertyNames": []
           },
           {
             "text": "by 30%",
@@ -5538,44 +4965,13 @@
               "up to 30%",
               "at 30%"
             ],
-            "category": "parameter",
+            "category": "value",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
           }
         ],
         "propertyAlternatives": [
-          {
-            "propertyName": "fullActionName",
-            "propertyValue": "player.changeVolume",
-            "propertySubPhrases": [
-              "Increment",
-              "the volume"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "player.increaseVolume",
-                "propertySubPhrases": [
-                  "Increase",
-                  "the volume"
-                ]
-              },
-              {
-                "propertyValue": "player.raiseVolume",
-                "propertySubPhrases": [
-                  "Raise",
-                  "the volume"
-                ]
-              },
-              {
-                "propertyValue": "player.boostVolume",
-                "propertySubPhrases": [
-                  "Boost",
-                  "the volume"
-                ]
-              }
-            ]
-          },
           {
             "propertyName": "parameters.volumeChangePercentage",
             "propertyValue": 30,
@@ -5584,21 +4980,27 @@
             ],
             "alternatives": [
               {
+                "propertyValue": 10,
+                "propertySubPhrases": [
+                  "by 10%"
+                ]
+              },
+              {
                 "propertyValue": 20,
                 "propertySubPhrases": [
                   "by 20%"
                 ]
               },
               {
-                "propertyValue": 50,
+                "propertyValue": 40,
                 "propertySubPhrases": [
-                  "by 50%"
+                  "by 40%"
                 ]
               },
               {
-                "propertyValue": 10,
+                "propertyValue": 50,
                 "propertySubPhrases": [
-                  "by 10%"
+                  "by 50%"
                 ]
               }
             ]
@@ -5627,7 +5029,7 @@
             "value": -20,
             "substrings": [
               "reduce",
-              "the audio level by 20%"
+              "20%"
             ],
             "implied": false
           }
@@ -5656,13 +5058,23 @@
             ]
           },
           {
-            "text": "the audio level by 20%",
+            "text": "the audio level by",
             "synonyms": [
-              "the volume by 20%",
-              "the sound level by 20%",
-              "the audio by 20%"
+              "the volume by",
+              "the sound level by",
+              "the audio by"
             ],
-            "category": "specification",
+            "category": "context",
+            "isOptional": true
+          },
+          {
+            "text": "20%",
+            "synonyms": [
+              "twenty percent",
+              "20 percent",
+              "20%"
+            ],
+            "category": "value",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
@@ -5674,28 +5086,28 @@
             "propertyValue": -20,
             "propertySubPhrases": [
               "reduce",
-              "the audio level by 20%"
+              "20%"
             ],
             "alternatives": [
               {
                 "propertyValue": -10,
                 "propertySubPhrases": [
                   "reduce",
-                  "the audio level by 10%"
+                  "10%"
                 ]
               },
               {
                 "propertyValue": -30,
                 "propertySubPhrases": [
                   "reduce",
-                  "the audio level by 30%"
+                  "30%"
                 ]
               },
               {
                 "propertyValue": -50,
                 "propertySubPhrases": [
                   "reduce",
-                  "the audio level by 50%"
+                  "50%"
                 ]
               }
             ]
@@ -5741,9 +5153,7 @@
           {
             "name": "fullActionName",
             "value": "player.changeVolume",
-            "substrings": [
-              "volume"
-            ],
+            "substrings": [],
             "implied": true
           },
           {
@@ -5767,11 +5177,11 @@
             "isOptional": true
           },
           {
-            "text": "sweeten the volume",
+            "text": "sweeten the volume by",
             "synonyms": [
-              "increase the volume",
-              "raise the volume",
-              "turn up the volume"
+              "increase the volume by",
+              "raise the volume by",
+              "turn up the volume by"
             ],
             "category": "action",
             "propertyNames": [
@@ -5779,13 +5189,13 @@
             ]
           },
           {
-            "text": "by 25%",
+            "text": "25%",
             "synonyms": [
-              "to 25%",
-              "up to 25%",
-              "increase by 25%"
+              "twenty-five percent",
+              "25 percent",
+              "25"
             ],
-            "category": "measurement",
+            "category": "value",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
@@ -5796,25 +5206,25 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.changeVolume",
             "propertySubPhrases": [
-              "sweeten the volume"
+              "sweeten the volume by"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.increaseVolume",
                 "propertySubPhrases": [
-                  "increase the volume"
+                  "increase the volume by"
                 ]
               },
               {
-                "propertyValue": "player.raiseVolume",
+                "propertyValue": "player.decreaseVolume",
                 "propertySubPhrases": [
-                  "raise the volume"
+                  "decrease the volume by"
                 ]
               },
               {
-                "propertyValue": "player.amplifyVolume",
+                "propertyValue": "player.adjustVolume",
                 "propertySubPhrases": [
-                  "amplify the volume"
+                  "adjust the volume by"
                 ]
               }
             ]
@@ -5823,25 +5233,25 @@
             "propertyName": "parameters.volumeChangePercentage",
             "propertyValue": 25,
             "propertySubPhrases": [
-              "by 25%"
+              "25%"
             ],
             "alternatives": [
               {
                 "propertyValue": 10,
                 "propertySubPhrases": [
-                  "by 10%"
+                  "10%"
                 ]
               },
               {
                 "propertyValue": 50,
                 "propertySubPhrases": [
-                  "by 50%"
+                  "50%"
                 ]
               },
               {
                 "propertyValue": 75,
                 "propertySubPhrases": [
-                  "by 75%"
+                  "75%"
                 ]
               }
             ]
@@ -5862,16 +5272,14 @@
           {
             "name": "fullActionName",
             "value": "player.changeVolume",
-            "substrings": [
-              "amplify the sound"
-            ],
+            "substrings": [],
             "implied": true
           },
           {
             "name": "parameters.volumeChangePercentage",
             "value": 30,
             "substrings": [
-              "30%"
+              "amplify the sound by a massive 30%"
             ],
             "implied": false
           }
@@ -5888,35 +5296,13 @@
             "isOptional": true
           },
           {
-            "text": "amplify the sound",
+            "text": "amplify the sound by a massive 30%",
             "synonyms": [
-              "increase the volume",
-              "turn up the sound",
-              "boost the audio"
+              "increase the volume by 30%",
+              "boost the sound by 30%",
+              "raise the volume by 30%"
             ],
-            "category": "action",
-            "propertyNames": [
-              "fullActionName"
-            ]
-          },
-          {
-            "text": "by a massive",
-            "synonyms": [
-              "by a huge",
-              "by a significant",
-              "by a large"
-            ],
-            "category": "intensifier",
-            "isOptional": true
-          },
-          {
-            "text": "30%",
-            "synonyms": [
-              "thirty percent",
-              "30 percent",
-              "30% increase"
-            ],
-            "category": "quantity",
+            "category": "volume change",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
@@ -5924,55 +5310,34 @@
         ],
         "propertyAlternatives": [
           {
-            "propertyName": "fullActionName",
-            "propertyValue": "player.changeVolume",
-            "propertySubPhrases": [
-              "amplify the sound"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "player.increaseVolume",
-                "propertySubPhrases": [
-                  "increase the volume"
-                ]
-              },
-              {
-                "propertyValue": "player.raiseVolume",
-                "propertySubPhrases": [
-                  "raise the volume"
-                ]
-              },
-              {
-                "propertyValue": "player.boostVolume",
-                "propertySubPhrases": [
-                  "boost the volume"
-                ]
-              }
-            ]
-          },
-          {
             "propertyName": "parameters.volumeChangePercentage",
             "propertyValue": 30,
             "propertySubPhrases": [
-              "30%"
+              "amplify the sound by a massive 30%"
             ],
             "alternatives": [
               {
+                "propertyValue": 10,
+                "propertySubPhrases": [
+                  "amplify the sound by a slight 10%"
+                ]
+              },
+              {
                 "propertyValue": 20,
                 "propertySubPhrases": [
-                  "20%"
+                  "amplify the sound by a moderate 20%"
                 ]
               },
               {
                 "propertyValue": 50,
                 "propertySubPhrases": [
-                  "50%"
+                  "amplify the sound by a huge 50%"
                 ]
               },
               {
-                "propertyValue": 10,
+                "propertyValue": 70,
                 "propertySubPhrases": [
-                  "10%"
+                  "amplify the sound by an enormous 70%"
                 ]
               }
             ]
@@ -6000,7 +5365,7 @@
             "name": "parameters.volumeChangePercentage",
             "value": -15,
             "substrings": [
-              "dial back",
+              "dial back the sound",
               "15%"
             ],
             "implied": false
@@ -6014,15 +5379,15 @@
               "We should",
               "How about we"
             ],
-            "category": "suggestion",
+            "category": "politeness",
             "isOptional": true
           },
           {
-            "text": "dial back",
+            "text": "dial back the sound",
             "synonyms": [
-              "reduce",
-              "lower",
-              "decrease"
+              "lower the volume",
+              "reduce the sound",
+              "turn down the volume"
             ],
             "category": "action",
             "propertyNames": [
@@ -6030,23 +5395,13 @@
             ]
           },
           {
-            "text": "the sound",
-            "synonyms": [
-              "the volume",
-              "the audio",
-              "the noise"
-            ],
-            "category": "object",
-            "isOptional": true
-          },
-          {
             "text": "by a subtle",
             "synonyms": [
               "by a slight",
               "by a small",
-              "by a modest"
+              "by a gentle"
             ],
-            "category": "degree",
+            "category": "modifier",
             "isOptional": true
           },
           {
@@ -6054,7 +5409,7 @@
             "synonyms": [
               "fifteen percent",
               "15 percent",
-              "15% reduction"
+              "15%"
             ],
             "category": "amount",
             "propertyNames": [
@@ -6067,29 +5422,36 @@
             "propertyName": "parameters.volumeChangePercentage",
             "propertyValue": -15,
             "propertySubPhrases": [
-              "dial back",
+              "dial back the sound",
               "15%"
             ],
             "alternatives": [
               {
                 "propertyValue": -10,
                 "propertySubPhrases": [
-                  "dial back",
+                  "dial back the sound",
                   "10%"
                 ]
               },
               {
                 "propertyValue": -20,
                 "propertySubPhrases": [
-                  "dial back",
+                  "dial back the sound",
                   "20%"
                 ]
               },
               {
                 "propertyValue": -5,
                 "propertySubPhrases": [
-                  "dial back",
+                  "dial back the sound",
                   "5%"
+                ]
+              },
+              {
+                "propertyValue": -25,
+                "propertySubPhrases": [
+                  "dial back the sound",
+                  "25%"
                 ]
               }
             ]
@@ -6137,9 +5499,9 @@
           {
             "text": "have the sound",
             "synonyms": [
-              "set the volume",
+              "make the sound",
               "adjust the sound",
-              "change the volume"
+              "set the sound"
             ],
             "category": "action",
             "propertyNames": []
@@ -6151,7 +5513,7 @@
               "15 percent",
               "15%"
             ],
-            "category": "percentage",
+            "category": "volume change",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
@@ -6161,9 +5523,9 @@
             "synonyms": [
               "decrease",
               "reduce",
-              "drop"
+              "turn down"
             ],
-            "category": "direction",
+            "category": "volume change",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
@@ -6252,16 +5614,14 @@
           {
             "name": "fullActionName",
             "value": "player.changeVolume",
-            "substrings": [
-              "increase the volume"
-            ],
+            "substrings": [],
             "implied": true
           },
           {
             "name": "parameters.volumeChangePercentage",
             "value": 30,
             "substrings": [
-              "30%"
+              "increase the volume by a hefty 30%"
             ],
             "implied": false
           }
@@ -6278,35 +5638,13 @@
             "isOptional": true
           },
           {
-            "text": "increase the volume",
+            "text": "increase the volume by a hefty 30%",
             "synonyms": [
-              "raise the volume",
-              "turn up the volume",
-              "boost the volume"
+              "raise the volume by a significant 30%",
+              "boost the volume by a substantial 30%",
+              "turn up the volume by a considerable 30%"
             ],
-            "category": "action",
-            "propertyNames": [
-              "fullActionName"
-            ]
-          },
-          {
-            "text": "by a hefty",
-            "synonyms": [
-              "by a significant",
-              "by a large",
-              "by a considerable"
-            ],
-            "category": "intensifier",
-            "isOptional": true
-          },
-          {
-            "text": "30%",
-            "synonyms": [
-              "thirty percent",
-              "30 percent",
-              "30 pct"
-            ],
-            "category": "quantity",
+            "category": "volume adjustment",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
@@ -6314,55 +5652,34 @@
         ],
         "propertyAlternatives": [
           {
-            "propertyName": "fullActionName",
-            "propertyValue": "player.changeVolume",
-            "propertySubPhrases": [
-              "increase the volume"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "player.raiseVolume",
-                "propertySubPhrases": [
-                  "raise the volume"
-                ]
-              },
-              {
-                "propertyValue": "player.turnUpVolume",
-                "propertySubPhrases": [
-                  "turn up the volume"
-                ]
-              },
-              {
-                "propertyValue": "player.boostVolume",
-                "propertySubPhrases": [
-                  "boost the volume"
-                ]
-              }
-            ]
-          },
-          {
             "propertyName": "parameters.volumeChangePercentage",
             "propertyValue": 30,
             "propertySubPhrases": [
-              "30%"
+              "increase the volume by a hefty 30%"
             ],
             "alternatives": [
               {
+                "propertyValue": 10,
+                "propertySubPhrases": [
+                  "increase the volume by a slight 10%"
+                ]
+              },
+              {
                 "propertyValue": 20,
                 "propertySubPhrases": [
-                  "20%"
+                  "increase the volume by a moderate 20%"
                 ]
               },
               {
                 "propertyValue": 50,
                 "propertySubPhrases": [
-                  "50%"
+                  "increase the volume by a significant 50%"
                 ]
               },
               {
-                "propertyValue": 10,
+                "propertyValue": 70,
                 "propertySubPhrases": [
-                  "10%"
+                  "increase the volume by a substantial 70%"
                 ]
               }
             ]
@@ -6415,6 +5732,7 @@
               "modify the audio"
             ],
             "category": "action",
+            "isOptional": false,
             "propertyNames": []
           },
           {
@@ -6436,7 +5754,7 @@
               "softer",
               "less loud"
             ],
-            "category": "volume adjustment",
+            "category": "description",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
@@ -6515,17 +5833,15 @@
           {
             "name": "fullActionName",
             "value": "player.changeVolume",
-            "substrings": [
-              "trim the volume"
-            ],
+            "substrings": [],
             "implied": true
           },
           {
             "name": "parameters.volumeChangePercentage",
             "value": -5,
             "substrings": [
-              "by 5%",
-              "trim"
+              "trim the volume by 5%",
+              "by 5%"
             ],
             "implied": false
           }
@@ -6538,19 +5854,18 @@
               "We should",
               "How about we"
             ],
-            "category": "filler",
+            "category": "politeness",
             "isOptional": true
           },
           {
             "text": "trim the volume",
             "synonyms": [
-              "adjust the volume",
-              "change the volume",
-              "modify the volume"
+              "reduce the volume",
+              "lower the volume",
+              "decrease the volume"
             ],
             "category": "action",
             "propertyNames": [
-              "fullActionName",
               "parameters.volumeChangePercentage"
             ]
           },
@@ -6561,40 +5876,13 @@
               "by 5 percent",
               "by 5 pct"
             ],
-            "category": "parameter",
+            "category": "quantity",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
           }
         ],
         "propertyAlternatives": [
-          {
-            "propertyName": "fullActionName",
-            "propertyValue": "player.changeVolume",
-            "propertySubPhrases": [
-              "trim the volume"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "player.increaseVolume",
-                "propertySubPhrases": [
-                  "increase the volume"
-                ]
-              },
-              {
-                "propertyValue": "player.decreaseVolume",
-                "propertySubPhrases": [
-                  "decrease the volume"
-                ]
-              },
-              {
-                "propertyValue": "player.adjustVolume",
-                "propertySubPhrases": [
-                  "adjust the volume"
-                ]
-              }
-            ]
-          },
           {
             "propertyName": "parameters.volumeChangePercentage",
             "propertyValue": -5,
@@ -6635,85 +5923,21 @@
               {
                 "name": "fullActionName",
                 "value": "player.changeVolume",
-                "substrings": [
-                  "trim the volume"
-                ],
+                "substrings": [],
                 "implied": true
               },
               {
                 "name": "parameters.volumeChangePercentage",
                 "value": -5,
                 "substrings": [
-                  "by 5%"
+                  "trim the volume by 5%"
                 ],
                 "implied": false
               }
             ]
           },
           "correction": [
-            "Value -5 for property 'parameters.volumeChangePercentage' doesn't match the number 5 in the substring 'by 5%'. Missing other substring to explain the value."
-          ]
-        },
-        {
-          "data": {
-            "properties": [
-              {
-                "name": "fullActionName",
-                "value": "player.changeVolume",
-                "substrings": [
-                  "trim the volume"
-                ],
-                "implied": true
-              },
-              {
-                "name": "parameters.volumeChangePercentage",
-                "value": -5,
-                "substrings": [
-                  "by 5%",
-                  "trim"
-                ],
-                "implied": false
-              }
-            ],
-            "subPhrases": [
-              {
-                "text": "Let's",
-                "synonyms": [
-                  "Let us",
-                  "We should",
-                  "How about we"
-                ],
-                "category": "filler",
-                "isOptional": true
-              },
-              {
-                "text": "trim the volume",
-                "synonyms": [
-                  "adjust the volume",
-                  "change the volume",
-                  "modify the volume"
-                ],
-                "category": "action",
-                "propertyNames": [
-                  "fullActionName"
-                ]
-              },
-              {
-                "text": "by 5%",
-                "synonyms": [
-                  "by five percent",
-                  "by 5 percent",
-                  "by 5 pct"
-                ],
-                "category": "parameter",
-                "propertyNames": [
-                  "parameters.volumeChangePercentage"
-                ]
-              }
-            ]
-          },
-          "correction": [
-            "Explicit property 'parameters.volumeChangePercentage' must be included as property names for all subphrases that contain the substring 'trim'"
+            "Value -5 for property 'parameters.volumeChangePercentage' doesn't match the number 5 in the substring 'trim the volume by 5%'. Missing other substring to explain the value."
           ]
         }
       ]
@@ -6751,7 +5975,7 @@
               "We should",
               "How about we"
             ],
-            "category": "suggestion",
+            "category": "politeness",
             "isOptional": true
           },
           {
@@ -6761,7 +5985,7 @@
               "raise the volume by 30%",
               "turn up the volume by 30%"
             ],
-            "category": "action",
+            "category": "volume change",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
@@ -6817,16 +6041,14 @@
           {
             "name": "fullActionName",
             "value": "player.changeVolume",
-            "substrings": [
-              "Lower the sound"
-            ],
+            "substrings": [],
             "implied": true
           },
           {
             "name": "parameters.volumeChangePercentage",
             "value": -15,
             "substrings": [
-              "Lower",
+              "Lower the sound by",
               "15%"
             ],
             "implied": false
@@ -6834,38 +6056,25 @@
         ],
         "subPhrases": [
           {
-            "text": "Lower",
+            "text": "Lower the sound by",
             "synonyms": [
-              "Decrease",
-              "Reduce",
-              "Turn down"
+              "Decrease the volume by",
+              "Reduce the sound by",
+              "Turn down the volume by"
             ],
-            "category": "action",
+            "category": "command",
             "propertyNames": [
-              "fullActionName",
               "parameters.volumeChangePercentage"
             ]
           },
           {
-            "text": "the sound",
+            "text": "15%",
             "synonyms": [
-              "the volume",
-              "the audio",
-              "the noise"
+              "fifteen percent",
+              "15 percent",
+              "15%"
             ],
-            "category": "object",
-            "propertyNames": [
-              "fullActionName"
-            ]
-          },
-          {
-            "text": "by 15%",
-            "synonyms": [
-              "by fifteen percent",
-              "by 15 percent",
-              "by 15%"
-            ],
-            "category": "magnitude",
+            "category": "value",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
@@ -6873,63 +6082,32 @@
         ],
         "propertyAlternatives": [
           {
-            "propertyName": "fullActionName",
-            "propertyValue": "player.changeVolume",
-            "propertySubPhrases": [
-              "Lower",
-              "the sound"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "player.decreaseVolume",
-                "propertySubPhrases": [
-                  "Decrease",
-                  "the volume"
-                ]
-              },
-              {
-                "propertyValue": "player.reduceVolume",
-                "propertySubPhrases": [
-                  "Reduce",
-                  "the sound"
-                ]
-              },
-              {
-                "propertyValue": "player.turnDownVolume",
-                "propertySubPhrases": [
-                  "Turn down",
-                  "the volume"
-                ]
-              }
-            ]
-          },
-          {
             "propertyName": "parameters.volumeChangePercentage",
             "propertyValue": -15,
             "propertySubPhrases": [
-              "Lower",
-              "by 15%"
+              "Lower the sound by",
+              "15%"
             ],
             "alternatives": [
               {
                 "propertyValue": -10,
                 "propertySubPhrases": [
-                  "Lower",
-                  "by 10%"
+                  "Lower the sound by",
+                  "10%"
                 ]
               },
               {
                 "propertyValue": -20,
                 "propertySubPhrases": [
-                  "Lower",
-                  "by 20%"
+                  "Lower the sound by",
+                  "20%"
                 ]
               },
               {
                 "propertyValue": -25,
                 "propertySubPhrases": [
-                  "Lower",
-                  "by 25%"
+                  "Lower the sound by",
+                  "25%"
                 ]
               }
             ]
@@ -6943,23 +6121,21 @@
               {
                 "name": "fullActionName",
                 "value": "player.changeVolume",
-                "substrings": [
-                  "Lower the sound"
-                ],
+                "substrings": [],
                 "implied": true
               },
               {
                 "name": "parameters.volumeChangePercentage",
                 "value": -15,
                 "substrings": [
-                  "15%"
+                  "Lower the sound by 15%."
                 ],
                 "implied": false
               }
             ]
           },
           "correction": [
-            "Value -15 for property 'parameters.volumeChangePercentage' doesn't match the number 15 in the substring '15%'. Missing other substring to explain the value."
+            "Value -15 for property 'parameters.volumeChangePercentage' doesn't match the number 15 in the substring 'Lower the sound by 15%.'. Missing other substring to explain the value."
           ]
         }
       ]
@@ -6996,8 +6172,8 @@
             "text": "Magnify the sound",
             "synonyms": [
               "Increase the volume",
-              "Turn up the sound",
-              "Raise the volume"
+              "Raise the sound level",
+              "Amplify the audio"
             ],
             "category": "action",
             "propertyNames": [
@@ -7009,7 +6185,7 @@
             "synonyms": [
               "to 30%",
               "up to 30%",
-              "increase by 30%"
+              "at 30%"
             ],
             "category": "parameter",
             "propertyNames": [
@@ -7098,7 +6274,7 @@
             "value": -15,
             "substrings": [
               "15%",
-              "less loud"
+              "less"
             ],
             "implied": false
           }
@@ -7112,9 +6288,7 @@
               "Change"
             ],
             "category": "command",
-            "propertyNames": [
-              "fullActionName"
-            ]
+            "propertyNames": []
           },
           {
             "text": "the sound",
@@ -7124,9 +6298,7 @@
               "the noise"
             ],
             "category": "object",
-            "propertyNames": [
-              "fullActionName"
-            ]
+            "propertyNames": []
           },
           {
             "text": "15%",
@@ -7135,83 +6307,62 @@
               "15 percent",
               "15%"
             ],
-            "category": "percentage",
+            "category": "quantity",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
           },
           {
-            "text": "less loud",
+            "text": "less",
             "synonyms": [
-              "quieter",
-              "softer",
-              "lower"
+              "lower",
+              "decrease",
+              "reduce"
             ],
-            "category": "volume change",
+            "category": "modifier",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
+          },
+          {
+            "text": "loud",
+            "synonyms": [
+              "noisy",
+              "audible",
+              "sonorous"
+            ],
+            "category": "adjective",
+            "propertyNames": []
           }
         ],
         "propertyAlternatives": [
-          {
-            "propertyName": "fullActionName",
-            "propertyValue": "player.changeVolume",
-            "propertySubPhrases": [
-              "Make",
-              "the sound"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "player.increaseVolume",
-                "propertySubPhrases": [
-                  "Increase",
-                  "the sound"
-                ]
-              },
-              {
-                "propertyValue": "player.decreaseVolume",
-                "propertySubPhrases": [
-                  "Decrease",
-                  "the sound"
-                ]
-              },
-              {
-                "propertyValue": "player.mute",
-                "propertySubPhrases": [
-                  "Mute",
-                  "the sound"
-                ]
-              }
-            ]
-          },
           {
             "propertyName": "parameters.volumeChangePercentage",
             "propertyValue": -15,
             "propertySubPhrases": [
               "15%",
-              "less loud"
+              "less"
             ],
             "alternatives": [
               {
                 "propertyValue": -10,
                 "propertySubPhrases": [
                   "10%",
-                  "less loud"
+                  "less"
                 ]
               },
               {
                 "propertyValue": -20,
                 "propertySubPhrases": [
                   "20%",
-                  "less loud"
+                  "less"
                 ]
               },
               {
                 "propertyValue": -25,
                 "propertySubPhrases": [
                   "25%",
-                  "less loud"
+                  "less"
                 ]
               }
             ]
@@ -7234,14 +6385,14 @@
                 "name": "parameters.volumeChangePercentage",
                 "value": -15,
                 "substrings": [
-                  "15% less loud"
+                  "15% less"
                 ],
                 "implied": false
               }
             ]
           },
           "correction": [
-            "Value -15 for property 'parameters.volumeChangePercentage' doesn't match the number 15 in the substring '15% less loud'. Missing other substring to explain the value."
+            "Value -15 for property 'parameters.volumeChangePercentage' doesn't match the number 15 in the substring '15% less'. Missing other substring to explain the value."
           ]
         }
       ]
@@ -7283,17 +6434,17 @@
               "Change"
             ],
             "category": "command",
-            "propertyNames": []
+            "isOptional": false
           },
           {
             "text": "the volume",
             "synonyms": [
-              "volume level",
+              "volume",
               "sound level",
-              "audio volume"
+              "audio level"
             ],
             "category": "object",
-            "propertyNames": []
+            "isOptional": false
           },
           {
             "text": "softer",
@@ -7302,7 +6453,7 @@
               "lower",
               "decrease"
             ],
-            "category": "modifier",
+            "category": "property",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
@@ -7312,9 +6463,9 @@
             "synonyms": [
               "10 percent",
               "ten percent",
-              "10% less"
+              "10%"
             ],
-            "category": "quantity",
+            "category": "property",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
@@ -7370,14 +6521,14 @@
                 "name": "parameters.volumeChangePercentage",
                 "value": -10,
                 "substrings": [
-                  "10%"
+                  "softer by 10%"
                 ],
                 "implied": false
               }
             ]
           },
           "correction": [
-            "Value -10 for property 'parameters.volumeChangePercentage' doesn't match the number 10 in the substring '10%'. Missing other substring to explain the value."
+            "Value -10 for property 'parameters.volumeChangePercentage' doesn't match the number 10 in the substring 'softer by 10%'. Missing other substring to explain the value."
           ]
         }
       ]
@@ -7412,7 +6563,7 @@
           {
             "text": "Mind",
             "synonyms": [
-              "Would you mind",
+              "Would you",
               "Can you",
               "Could you"
             ],
@@ -7432,11 +6583,21 @@
             ]
           },
           {
-            "text": "by a sturdy 10%",
+            "text": "by a sturdy",
             "synonyms": [
-              "by a solid 10%",
-              "by a full 10%",
-              "by exactly 10%"
+              "by a solid",
+              "by a strong",
+              "by a good"
+            ],
+            "category": "filler",
+            "isOptional": true
+          },
+          {
+            "text": "10%",
+            "synonyms": [
+              "ten percent",
+              "10 percent",
+              "10%"
             ],
             "category": "quantity",
             "propertyNames": [
@@ -7450,28 +6611,28 @@
             "propertyValue": 10,
             "propertySubPhrases": [
               "bumping up the volume",
-              "by a sturdy 10%"
+              "10%"
             ],
             "alternatives": [
               {
                 "propertyValue": 5,
                 "propertySubPhrases": [
-                  "increasing the volume",
-                  "by a modest 5%"
+                  "bumping up the volume",
+                  "5%"
                 ]
               },
               {
                 "propertyValue": 15,
                 "propertySubPhrases": [
-                  "raising the volume",
-                  "by a solid 15%"
+                  "bumping up the volume",
+                  "15%"
                 ]
               },
               {
                 "propertyValue": 20,
                 "propertySubPhrases": [
-                  "turning up the volume",
-                  "by a hefty 20%"
+                  "bumping up the volume",
+                  "20%"
                 ]
               }
             ]
@@ -7501,7 +6662,7 @@
             "name": "parameters.volumeChangePercentage",
             "value": 10,
             "substrings": [
-              "10%"
+              "by 10%"
             ],
             "implied": false
           }
@@ -7510,9 +6671,9 @@
           {
             "text": "Mind",
             "synonyms": [
-              "Would you",
-              "Can you",
-              "Could you"
+              "Would you mind",
+              "Could you",
+              "Can you"
             ],
             "category": "politeness",
             "isOptional": true
@@ -7532,11 +6693,11 @@
           {
             "text": "by 10%",
             "synonyms": [
-              "to 10%",
-              "up 10%",
-              "10 percent"
+              "by ten percent",
+              "by 10 percent",
+              "by 10% more"
             ],
-            "category": "measurement",
+            "category": "parameter",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
@@ -7553,7 +6714,7 @@
               {
                 "propertyValue": "player.increaseVolume",
                 "propertySubPhrases": [
-                  "turning up the volume"
+                  "increasing the volume"
                 ]
               },
               {
@@ -7563,9 +6724,9 @@
                 ]
               },
               {
-                "propertyValue": "player.boostVolume",
+                "propertyValue": "player.turnUpVolume",
                 "propertySubPhrases": [
-                  "boosting the volume"
+                  "turning up the volume"
                 ]
               }
             ]
@@ -7613,9 +6774,7 @@
           {
             "name": "fullActionName",
             "value": "player.changeVolume",
-            "substrings": [
-              "Modify the sound level"
-            ],
+            "substrings": [],
             "implied": true
           },
           {
@@ -7636,9 +6795,7 @@
               "Alter the volume"
             ],
             "category": "command",
-            "propertyNames": [
-              "fullActionName"
-            ]
+            "isOptional": false
           },
           {
             "text": "increase it by 10%",
@@ -7647,40 +6804,13 @@
               "boost it by 10%",
               "turn it up by 10%"
             ],
-            "category": "command",
+            "category": "volume adjustment",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
           }
         ],
         "propertyAlternatives": [
-          {
-            "propertyName": "fullActionName",
-            "propertyValue": "player.changeVolume",
-            "propertySubPhrases": [
-              "Modify the sound level"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "player.adjustVolume",
-                "propertySubPhrases": [
-                  "Adjust the sound level"
-                ]
-              },
-              {
-                "propertyValue": "player.setVolume",
-                "propertySubPhrases": [
-                  "Set the sound level"
-                ]
-              },
-              {
-                "propertyValue": "player.volumeControl",
-                "propertySubPhrases": [
-                  "Control the sound level"
-                ]
-              }
-            ]
-          },
           {
             "propertyName": "parameters.volumeChangePercentage",
             "propertyValue": 10,
@@ -7689,21 +6819,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": 20,
-                "propertySubPhrases": [
-                  "increase it by 20%"
-                ]
-              },
-              {
                 "propertyValue": 5,
                 "propertySubPhrases": [
                   "increase it by 5%"
                 ]
               },
               {
-                "propertyValue": -10,
+                "propertyValue": 15,
                 "propertySubPhrases": [
-                  "decrease it by 10%"
+                  "increase it by 15%"
+                ]
+              },
+              {
+                "propertyValue": 20,
+                "propertySubPhrases": [
+                  "increase it by 20%"
                 ]
               }
             ]
@@ -7733,8 +6863,8 @@
             "name": "parameters.volumeChangePercentage",
             "value": -15,
             "substrings": [
-              "Muffle",
-              "15%"
+              "by 15%",
+              "Muffle"
             ],
             "implied": false
           }
@@ -7761,9 +6891,7 @@
               "the noise"
             ],
             "category": "object",
-            "propertyNames": [
-              "fullActionName"
-            ]
+            "propertyNames": []
           },
           {
             "text": "by 15%",
@@ -7783,29 +6911,25 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.changeVolume",
             "propertySubPhrases": [
-              "Muffle",
-              "the sound"
+              "Muffle"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.lowerVolume",
                 "propertySubPhrases": [
-                  "Lower",
-                  "the sound"
+                  "Lower"
                 ]
               },
               {
                 "propertyValue": "player.reduceVolume",
                 "propertySubPhrases": [
-                  "Reduce",
-                  "the sound"
+                  "Reduce"
                 ]
               },
               {
                 "propertyValue": "player.decreaseVolume",
                 "propertySubPhrases": [
-                  "Decrease",
-                  "the sound"
+                  "Decrease"
                 ]
               }
             ]
@@ -7859,14 +6983,14 @@
                 "name": "parameters.volumeChangePercentage",
                 "value": -15,
                 "substrings": [
-                  "15%"
+                  "by 15%"
                 ],
                 "implied": false
               }
             ]
           },
           "correction": [
-            "Value -15 for property 'parameters.volumeChangePercentage' doesn't match the number 15 in the substring '15%'. Missing other substring to explain the value."
+            "Value -15 for property 'parameters.volumeChangePercentage' doesn't match the number 15 in the substring 'by 15%'. Missing other substring to explain the value."
           ]
         }
       ]
@@ -7884,16 +7008,14 @@
           {
             "name": "fullActionName",
             "value": "player.changeVolume",
-            "substrings": [
-              "Nudge the volume up by 30%."
-            ],
-            "implied": false
+            "substrings": [],
+            "implied": true
           },
           {
             "name": "parameters.volumeChangePercentage",
             "value": 30,
             "substrings": [
-              "30%"
+              "Nudge the volume up by 30%."
             ],
             "implied": false
           }
@@ -7907,30 +7029,26 @@
               "Raise"
             ],
             "category": "action",
-            "propertyNames": [
-              "fullActionName"
-            ]
+            "propertyNames": []
           },
           {
-            "text": "the volume up",
+            "text": "the volume up by",
             "synonyms": [
-              "the sound level",
-              "the audio",
-              "the loudness"
+              "the sound level by",
+              "the audio level by",
+              "the volume level by"
             ],
-            "category": "object",
-            "propertyNames": [
-              "fullActionName"
-            ]
+            "category": "context",
+            "propertyNames": []
           },
           {
-            "text": "by 30%",
+            "text": "30%",
             "synonyms": [
-              "by thirty percent",
-              "by 30 percent",
-              "by 30%"
+              "thirty percent",
+              "30 percent",
+              "30%"
             ],
-            "category": "parameter",
+            "category": "value",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
@@ -7938,59 +7056,34 @@
         ],
         "propertyAlternatives": [
           {
-            "propertyName": "fullActionName",
-            "propertyValue": "player.changeVolume",
-            "propertySubPhrases": [
-              "Nudge",
-              "the volume up"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "player.increaseVolume",
-                "propertySubPhrases": [
-                  "Increase",
-                  "the volume"
-                ]
-              },
-              {
-                "propertyValue": "player.raiseVolume",
-                "propertySubPhrases": [
-                  "Raise",
-                  "the volume"
-                ]
-              },
-              {
-                "propertyValue": "player.adjustVolume",
-                "propertySubPhrases": [
-                  "Adjust",
-                  "the volume"
-                ]
-              }
-            ]
-          },
-          {
             "propertyName": "parameters.volumeChangePercentage",
             "propertyValue": 30,
             "propertySubPhrases": [
-              "by 30%"
+              "30%"
             ],
             "alternatives": [
               {
                 "propertyValue": 10,
                 "propertySubPhrases": [
-                  "by 10%"
+                  "10%"
                 ]
               },
               {
                 "propertyValue": 20,
                 "propertySubPhrases": [
-                  "by 20%"
+                  "20%"
+                ]
+              },
+              {
+                "propertyValue": 40,
+                "propertySubPhrases": [
+                  "40%"
                 ]
               },
               {
                 "propertyValue": 50,
                 "propertySubPhrases": [
-                  "by 50%"
+                  "50%"
                 ]
               }
             ]
@@ -8012,7 +7105,7 @@
             "name": "fullActionName",
             "value": "player.changeVolume",
             "substrings": [
-              "elevate the volume"
+              "Please elevate the volume by 25%."
             ],
             "implied": true
           },
@@ -8055,7 +7148,7 @@
               "up to 25%",
               "at 25%"
             ],
-            "category": "measurement",
+            "category": "specification",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
@@ -8082,9 +7175,9 @@
                 ]
               },
               {
-                "propertyValue": "player.amplifyVolume",
+                "propertyValue": "player.turnUpVolume",
                 "propertySubPhrases": [
-                  "amplify the volume"
+                  "turn up the volume"
                 ]
               }
             ]
@@ -8139,7 +7232,8 @@
             "name": "parameters.volumeChangePercentage",
             "value": 25,
             "substrings": [
-              "enhance the volume by a generous 25%"
+              "enhance the volume",
+              "25%"
             ],
             "implied": false
           }
@@ -8156,13 +7250,35 @@
             "isOptional": true
           },
           {
-            "text": "enhance the volume by a generous 25%",
+            "text": "enhance the volume",
             "synonyms": [
-              "increase the volume by a generous 25%",
-              "raise the volume by a generous 25%",
-              "boost the volume by a generous 25%"
+              "increase the volume",
+              "raise the volume",
+              "turn up the volume"
             ],
-            "category": "volume adjustment",
+            "category": "action",
+            "propertyNames": [
+              "parameters.volumeChangePercentage"
+            ]
+          },
+          {
+            "text": "by a generous",
+            "synonyms": [
+              "by a substantial",
+              "by a considerable",
+              "by a significant"
+            ],
+            "category": "filler",
+            "isOptional": true
+          },
+          {
+            "text": "25%",
+            "synonyms": [
+              "twenty-five percent",
+              "25 percent",
+              "25 per cent"
+            ],
+            "category": "value",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
@@ -8173,25 +7289,29 @@
             "propertyName": "parameters.volumeChangePercentage",
             "propertyValue": 25,
             "propertySubPhrases": [
-              "enhance the volume by a generous 25%"
+              "enhance the volume",
+              "25%"
             ],
             "alternatives": [
               {
                 "propertyValue": 10,
                 "propertySubPhrases": [
-                  "enhance the volume by a modest 10%"
+                  "enhance the volume",
+                  "10%"
                 ]
               },
               {
                 "propertyValue": 50,
                 "propertySubPhrases": [
-                  "enhance the volume by a substantial 50%"
+                  "enhance the volume",
+                  "50%"
                 ]
               },
               {
                 "propertyValue": 75,
                 "propertySubPhrases": [
-                  "enhance the volume by a significant 75%"
+                  "enhance the volume",
+                  "75%"
                 ]
               }
             ]
@@ -8212,9 +7332,7 @@
           {
             "name": "fullActionName",
             "value": "player.changeVolume",
-            "substrings": [
-              "sweeten the volume"
-            ],
+            "substrings": [],
             "implied": true
           },
           {
@@ -8238,11 +7356,11 @@
             "isOptional": true
           },
           {
-            "text": "sweeten the volume",
+            "text": "sweeten the volume by",
             "synonyms": [
-              "increase the volume",
-              "raise the volume",
-              "turn up the volume"
+              "increase the volume by",
+              "raise the volume by",
+              "turn up the volume by"
             ],
             "category": "action",
             "propertyNames": [
@@ -8250,13 +7368,13 @@
             ]
           },
           {
-            "text": "by 25%",
+            "text": "25%",
             "synonyms": [
-              "to 25%",
-              "up to 25%",
-              "at 25%"
+              "twenty-five percent",
+              "25 percent",
+              "25%"
             ],
-            "category": "measurement",
+            "category": "value",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
@@ -8267,25 +7385,25 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.changeVolume",
             "propertySubPhrases": [
-              "sweeten the volume"
+              "sweeten the volume by"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.increaseVolume",
                 "propertySubPhrases": [
-                  "increase the volume"
+                  "increase the volume by"
                 ]
               },
               {
                 "propertyValue": "player.raiseVolume",
                 "propertySubPhrases": [
-                  "raise the volume"
+                  "raise the volume by"
                 ]
               },
               {
                 "propertyValue": "player.amplifyVolume",
                 "propertySubPhrases": [
-                  "amplify the volume"
+                  "amplify the volume by"
                 ]
               }
             ]
@@ -8294,25 +7412,25 @@
             "propertyName": "parameters.volumeChangePercentage",
             "propertyValue": 25,
             "propertySubPhrases": [
-              "by 25%"
+              "25%"
             ],
             "alternatives": [
               {
                 "propertyValue": 10,
                 "propertySubPhrases": [
-                  "by 10%"
+                  "10%"
                 ]
               },
               {
                 "propertyValue": 50,
                 "propertySubPhrases": [
-                  "by 50%"
+                  "50%"
                 ]
               },
               {
                 "propertyValue": 75,
                 "propertySubPhrases": [
-                  "by 75%"
+                  "75%"
                 ]
               }
             ]
@@ -8374,9 +7492,9 @@
           {
             "text": "20% softer",
             "synonyms": [
-              "20% quieter",
-              "20% lower",
-              "20% reduced"
+              "quieter by 20%",
+              "reduced by 20%",
+              "lowered by 20%"
             ],
             "category": "volume change",
             "propertyNames": [
@@ -8466,40 +7584,6 @@
           "correction": [
             "Value -20 for property 'parameters.volumeChangePercentage' doesn't match the number 20 in the substring '20% softer'. Missing other substring to explain the value."
           ]
-        },
-        {
-          "data": {
-            "properties": [
-              {
-                "name": "fullActionName",
-                "value": "player.changeVolume",
-                "substrings": [
-                  "request the audio to be"
-                ],
-                "implied": true
-              },
-              {
-                "name": "parameters.volumeChangePercentage",
-                "value": -20,
-                "substrings": [
-                  "20% softer"
-                ],
-                "implied": false
-              },
-              {
-                "name": "parameters.volumeChangePercentage",
-                "value": -20,
-                "substrings": [
-                  "softer"
-                ],
-                "implied": false
-              }
-            ]
-          },
-          "correction": [
-            "Value -20 for property 'parameters.volumeChangePercentage' doesn't match the number 20 in the substring '20% softer'. Missing other substring to explain the value.",
-            "Multiple properties with property name 'parameters.volumeChangePercentage' found"
-          ]
         }
       ]
     },
@@ -8516,9 +7600,7 @@
           {
             "name": "fullActionName",
             "value": "player.changeVolume",
-            "substrings": [
-              "Ramp up the sound level"
-            ],
+            "substrings": [],
             "implied": true
           },
           {
@@ -8532,22 +7614,30 @@
         ],
         "subPhrases": [
           {
-            "text": "Ramp up the sound level",
+            "text": "Ramp up",
             "synonyms": [
-              "Increase the volume",
-              "Turn up the sound",
-              "Raise the audio level"
+              "Increase",
+              "Raise",
+              "Boost"
             ],
             "category": "action",
-            "propertyNames": [
-              "fullActionName"
-            ]
+            "propertyNames": []
+          },
+          {
+            "text": "the sound level",
+            "synonyms": [
+              "the volume",
+              "the audio level",
+              "the sound"
+            ],
+            "category": "object",
+            "propertyNames": []
           },
           {
             "text": "by a nifty",
             "synonyms": [
-              "by an impressive",
               "by a cool",
+              "by an impressive",
               "by a neat"
             ],
             "category": "filler",
@@ -8558,7 +7648,7 @@
             "synonyms": [
               "ten percent",
               "10 percent",
-              "10 pct"
+              "10%"
             ],
             "category": "value",
             "propertyNames": [
@@ -8567,33 +7657,6 @@
           }
         ],
         "propertyAlternatives": [
-          {
-            "propertyName": "fullActionName",
-            "propertyValue": "player.changeVolume",
-            "propertySubPhrases": [
-              "Ramp up the sound level"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "player.increaseVolume",
-                "propertySubPhrases": [
-                  "Increase the volume"
-                ]
-              },
-              {
-                "propertyValue": "player.raiseVolume",
-                "propertySubPhrases": [
-                  "Raise the volume"
-                ]
-              },
-              {
-                "propertyValue": "player.boostVolume",
-                "propertySubPhrases": [
-                  "Boost the volume"
-                ]
-              }
-            ]
-          },
           {
             "propertyName": "parameters.volumeChangePercentage",
             "propertyValue": 10,
@@ -8638,7 +7701,7 @@
             "name": "fullActionName",
             "value": "player.changeVolume",
             "substrings": [
-              "Scale down the volume"
+              "Scale down the volume by 10%."
             ],
             "implied": true
           },
@@ -8647,7 +7710,7 @@
             "value": -10,
             "substrings": [
               "Scale down",
-              "by 10%"
+              "10%"
             ],
             "implied": false
           }
@@ -8656,13 +7719,12 @@
           {
             "text": "Scale down",
             "synonyms": [
+              "Reduce",
               "Lower",
-              "Decrease",
-              "Reduce"
+              "Decrease"
             ],
             "category": "action",
             "propertyNames": [
-              "fullActionName",
               "parameters.volumeChangePercentage"
             ]
           },
@@ -8674,18 +7736,26 @@
               "volume level"
             ],
             "category": "object",
-            "propertyNames": [
-              "fullActionName"
-            ]
+            "isOptional": true
           },
           {
-            "text": "by 10%",
+            "text": "by",
             "synonyms": [
-              "by ten percent",
-              "by 10 percent",
-              "by 10%"
+              "to",
+              "at",
+              "with"
             ],
-            "category": "magnitude",
+            "category": "preposition",
+            "isOptional": true
+          },
+          {
+            "text": "10%",
+            "synonyms": [
+              "ten percent",
+              "10 percent",
+              "10%"
+            ],
+            "category": "value",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
@@ -8693,63 +7763,32 @@
         ],
         "propertyAlternatives": [
           {
-            "propertyName": "fullActionName",
-            "propertyValue": "player.changeVolume",
-            "propertySubPhrases": [
-              "Scale down",
-              "the volume"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "player.decreaseVolume",
-                "propertySubPhrases": [
-                  "Decrease",
-                  "the volume"
-                ]
-              },
-              {
-                "propertyValue": "player.lowerVolume",
-                "propertySubPhrases": [
-                  "Lower",
-                  "the volume"
-                ]
-              },
-              {
-                "propertyValue": "player.reduceVolume",
-                "propertySubPhrases": [
-                  "Reduce",
-                  "the volume"
-                ]
-              }
-            ]
-          },
-          {
             "propertyName": "parameters.volumeChangePercentage",
             "propertyValue": -10,
             "propertySubPhrases": [
               "Scale down",
-              "by 10%"
+              "10%"
             ],
             "alternatives": [
               {
                 "propertyValue": -5,
                 "propertySubPhrases": [
                   "Scale down",
-                  "by 5%"
+                  "5%"
                 ]
               },
               {
                 "propertyValue": -15,
                 "propertySubPhrases": [
                   "Scale down",
-                  "by 15%"
+                  "15%"
                 ]
               },
               {
                 "propertyValue": -20,
                 "propertySubPhrases": [
                   "Scale down",
-                  "by 20%"
+                  "20%"
                 ]
               }
             ]
@@ -8764,7 +7803,7 @@
                 "name": "fullActionName",
                 "value": "player.changeVolume",
                 "substrings": [
-                  "Scale down the volume"
+                  "Scale down the volume by 10%."
                 ],
                 "implied": true
               },
@@ -8772,14 +7811,14 @@
                 "name": "parameters.volumeChangePercentage",
                 "value": -10,
                 "substrings": [
-                  "by 10%"
+                  "10%"
                 ],
                 "implied": false
               }
             ]
           },
           "correction": [
-            "Value -10 for property 'parameters.volumeChangePercentage' doesn't match the number 10 in the substring 'by 10%'. Missing other substring to explain the value."
+            "Value -10 for property 'parameters.volumeChangePercentage' doesn't match the number 10 in the substring '10%'. Missing other substring to explain the value."
           ]
         }
       ]
@@ -8797,9 +7836,7 @@
           {
             "name": "fullActionName",
             "value": "player.changeVolume",
-            "substrings": [
-              "Set the sound to be 15% quieter."
-            ],
+            "substrings": [],
             "implied": true
           },
           {
@@ -8821,34 +7858,24 @@
               "Modify"
             ],
             "category": "command",
-            "propertyNames": []
+            "isOptional": true
           },
           {
-            "text": "the sound",
+            "text": "the sound to be",
             "synonyms": [
-              "the volume",
-              "the audio",
-              "the noise"
+              "the volume to be",
+              "the audio to be",
+              "the noise level to be"
             ],
-            "category": "object",
-            "propertyNames": []
-          },
-          {
-            "text": "to be",
-            "synonyms": [
-              "to become",
-              "to get",
-              "to turn"
-            ],
-            "category": "preposition",
-            "propertyNames": []
+            "category": "description",
+            "isOptional": true
           },
           {
             "text": "15%",
             "synonyms": [
               "fifteen percent",
               "15 percent",
-              "15 pct"
+              "15%"
             ],
             "category": "percentage",
             "propertyNames": [
@@ -8859,8 +7886,8 @@
             "text": "quieter",
             "synonyms": [
               "lower",
-              "softer",
-              "less loud"
+              "reduced",
+              "decreased"
             ],
             "category": "volumeChange",
             "propertyNames": [
@@ -8909,9 +7936,7 @@
               {
                 "name": "fullActionName",
                 "value": "player.changeVolume",
-                "substrings": [
-                  "Set the sound to be 15% quieter."
-                ],
+                "substrings": [],
                 "implied": true
               },
               {
@@ -8943,55 +7968,50 @@
           {
             "name": "fullActionName",
             "value": "player.changeVolume",
-            "substrings": [
-              "Shave the volume"
-            ],
+            "substrings": [],
             "implied": true
           },
           {
             "name": "parameters.volumeChangePercentage",
             "value": -10,
             "substrings": [
-              "a slight 10%",
-              "Shave"
+              "Shave the volume",
+              "10%"
             ],
             "implied": false
           }
         ],
         "subPhrases": [
           {
-            "text": "Shave",
+            "text": "Shave the volume",
             "synonyms": [
-              "Reduce",
-              "Lower",
-              "Decrease"
+              "Reduce the volume",
+              "Lower the volume",
+              "Decrease the volume"
             ],
-            "category": "action",
+            "category": "command",
             "propertyNames": [
-              "fullActionName",
               "parameters.volumeChangePercentage"
             ]
           },
           {
-            "text": "the volume",
+            "text": "by a slight",
             "synonyms": [
-              "the sound level",
-              "the audio",
-              "the loudness"
+              "by a small",
+              "by a little",
+              "by a minor"
             ],
-            "category": "object",
-            "propertyNames": [
-              "fullActionName"
-            ]
+            "category": "modifier",
+            "isOptional": true
           },
           {
-            "text": "by a slight 10%",
+            "text": "10%",
             "synonyms": [
-              "by a small 10%",
-              "by a minor 10%",
-              "by a modest 10%"
+              "ten percent",
+              "10 percent",
+              "10%"
             ],
-            "category": "magnitude",
+            "category": "quantity",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
@@ -8999,63 +8019,32 @@
         ],
         "propertyAlternatives": [
           {
-            "propertyName": "fullActionName",
-            "propertyValue": "player.changeVolume",
-            "propertySubPhrases": [
-              "Shave",
-              "the volume"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "player.lowerVolume",
-                "propertySubPhrases": [
-                  "Lower",
-                  "the volume"
-                ]
-              },
-              {
-                "propertyValue": "player.reduceVolume",
-                "propertySubPhrases": [
-                  "Reduce",
-                  "the volume"
-                ]
-              },
-              {
-                "propertyValue": "player.decreaseVolume",
-                "propertySubPhrases": [
-                  "Decrease",
-                  "the volume"
-                ]
-              }
-            ]
-          },
-          {
             "propertyName": "parameters.volumeChangePercentage",
             "propertyValue": -10,
             "propertySubPhrases": [
-              "Shave",
-              "by a slight 10%"
+              "Shave the volume",
+              "10%"
             ],
             "alternatives": [
               {
                 "propertyValue": -5,
                 "propertySubPhrases": [
-                  "Shave",
-                  "by a slight 5%"
+                  "Shave the volume",
+                  "5%"
                 ]
               },
               {
                 "propertyValue": -15,
                 "propertySubPhrases": [
-                  "Shave",
-                  "by a slight 15%"
+                  "Shave the volume",
+                  "15%"
                 ]
               },
               {
                 "propertyValue": -20,
                 "propertySubPhrases": [
-                  "Shave",
-                  "by a slight 20%"
+                  "Shave the volume",
+                  "20%"
                 ]
               }
             ]
@@ -9069,23 +8058,21 @@
               {
                 "name": "fullActionName",
                 "value": "player.changeVolume",
-                "substrings": [
-                  "Shave the volume"
-                ],
+                "substrings": [],
                 "implied": true
               },
               {
                 "name": "parameters.volumeChangePercentage",
                 "value": -10,
                 "substrings": [
-                  "a slight 10%"
+                  "Shave the volume by a slight 10%."
                 ],
                 "implied": false
               }
             ]
           },
           "correction": [
-            "Value -10 for property 'parameters.volumeChangePercentage' doesn't match the number 10 in the substring 'a slight 10%'. Missing other substring to explain the value."
+            "Value -10 for property 'parameters.volumeChangePercentage' doesn't match the number 10 in the substring 'Shave the volume by a slight 10%.'. Missing other substring to explain the value."
           ]
         }
       ]
@@ -9103,45 +8090,30 @@
           {
             "name": "fullActionName",
             "value": "player.changeVolume",
-            "substrings": [
-              "Subdue the sound"
-            ],
+            "substrings": [],
             "implied": true
           },
           {
             "name": "parameters.volumeChangePercentage",
             "value": -15,
             "substrings": [
-              "by 15%",
-              "Subdue"
+              "Subdue the sound",
+              "by 15%"
             ],
             "implied": false
           }
         ],
         "subPhrases": [
           {
-            "text": "Subdue",
+            "text": "Subdue the sound",
             "synonyms": [
-              "Lower",
-              "Reduce",
-              "Decrease"
+              "Lower the volume",
+              "Reduce the sound",
+              "Decrease the volume"
             ],
-            "category": "action",
+            "category": "command",
             "propertyNames": [
-              "fullActionName",
               "parameters.volumeChangePercentage"
-            ]
-          },
-          {
-            "text": "the sound",
-            "synonyms": [
-              "the volume",
-              "the audio",
-              "the noise"
-            ],
-            "category": "object",
-            "propertyNames": [
-              "fullActionName"
             ]
           },
           {
@@ -9151,7 +8123,7 @@
               "by 15 percent",
               "by 15%"
             ],
-            "category": "modifier",
+            "category": "magnitude",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
@@ -9159,63 +8131,32 @@
         ],
         "propertyAlternatives": [
           {
-            "propertyName": "fullActionName",
-            "propertyValue": "player.changeVolume",
-            "propertySubPhrases": [
-              "Subdue",
-              "the sound"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "player.lowerVolume",
-                "propertySubPhrases": [
-                  "Lower",
-                  "the sound"
-                ]
-              },
-              {
-                "propertyValue": "player.reduceVolume",
-                "propertySubPhrases": [
-                  "Reduce",
-                  "the sound"
-                ]
-              },
-              {
-                "propertyValue": "player.decreaseVolume",
-                "propertySubPhrases": [
-                  "Decrease",
-                  "the sound"
-                ]
-              }
-            ]
-          },
-          {
             "propertyName": "parameters.volumeChangePercentage",
             "propertyValue": -15,
             "propertySubPhrases": [
-              "Subdue",
+              "Subdue the sound",
               "by 15%"
             ],
             "alternatives": [
               {
                 "propertyValue": -10,
                 "propertySubPhrases": [
-                  "Subdue",
+                  "Lower the volume",
                   "by 10%"
                 ]
               },
               {
                 "propertyValue": -20,
                 "propertySubPhrases": [
-                  "Subdue",
+                  "Reduce the sound",
                   "by 20%"
                 ]
               },
               {
-                "propertyValue": -25,
+                "propertyValue": -5,
                 "propertySubPhrases": [
-                  "Subdue",
-                  "by 25%"
+                  "Decrease the volume",
+                  "by 5%"
                 ]
               }
             ]
@@ -9229,23 +8170,21 @@
               {
                 "name": "fullActionName",
                 "value": "player.changeVolume",
-                "substrings": [
-                  "Subdue the sound"
-                ],
+                "substrings": [],
                 "implied": true
               },
               {
                 "name": "parameters.volumeChangePercentage",
                 "value": -15,
                 "substrings": [
-                  "by 15%"
+                  "Subdue the sound by 15%."
                 ],
                 "implied": false
               }
             ]
           },
           "correction": [
-            "Value -15 for property 'parameters.volumeChangePercentage' doesn't match the number 15 in the substring 'by 15%'. Missing other substring to explain the value."
+            "Value -15 for property 'parameters.volumeChangePercentage' doesn't match the number 15 in the substring 'Subdue the sound by 15%.'. Missing other substring to explain the value."
           ]
         }
       ]
@@ -9263,45 +8202,30 @@
           {
             "name": "fullActionName",
             "value": "player.changeVolume",
-            "substrings": [
-              "Subdue the sound"
-            ],
+            "substrings": [],
             "implied": true
           },
           {
             "name": "parameters.volumeChangePercentage",
             "value": -15,
             "substrings": [
-              "15%",
-              "Subdue"
+              "Subdue the sound",
+              "15%"
             ],
             "implied": false
           }
         ],
         "subPhrases": [
           {
-            "text": "Subdue",
+            "text": "Subdue the sound",
             "synonyms": [
-              "Lower",
-              "Reduce",
-              "Decrease"
+              "Lower the volume",
+              "Reduce the sound",
+              "Decrease the volume"
             ],
-            "category": "action",
+            "category": "volume adjustment",
             "propertyNames": [
-              "fullActionName",
               "parameters.volumeChangePercentage"
-            ]
-          },
-          {
-            "text": "the sound",
-            "synonyms": [
-              "the volume",
-              "the audio",
-              "the noise"
-            ],
-            "category": "object",
-            "propertyNames": [
-              "fullActionName"
             ]
           },
           {
@@ -9311,7 +8235,7 @@
               "by a suitable",
               "by a fair"
             ],
-            "category": "modifier",
+            "category": "filler",
             "isOptional": true
           },
           {
@@ -9319,9 +8243,9 @@
             "synonyms": [
               "fifteen percent",
               "15 percent",
-              "15% reduction"
+              "15%"
             ],
-            "category": "quantity",
+            "category": "percentage",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
@@ -9329,63 +8253,32 @@
         ],
         "propertyAlternatives": [
           {
-            "propertyName": "fullActionName",
-            "propertyValue": "player.changeVolume",
-            "propertySubPhrases": [
-              "Subdue",
-              "the sound"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "player.lowerVolume",
-                "propertySubPhrases": [
-                  "Lower",
-                  "the sound"
-                ]
-              },
-              {
-                "propertyValue": "player.reduceVolume",
-                "propertySubPhrases": [
-                  "Reduce",
-                  "the sound"
-                ]
-              },
-              {
-                "propertyValue": "player.decreaseVolume",
-                "propertySubPhrases": [
-                  "Decrease",
-                  "the sound"
-                ]
-              }
-            ]
-          },
-          {
             "propertyName": "parameters.volumeChangePercentage",
             "propertyValue": -15,
             "propertySubPhrases": [
-              "Subdue",
+              "Subdue the sound",
               "15%"
             ],
             "alternatives": [
               {
                 "propertyValue": -10,
                 "propertySubPhrases": [
-                  "Subdue",
+                  "Lower the volume",
                   "10%"
                 ]
               },
               {
                 "propertyValue": -20,
                 "propertySubPhrases": [
-                  "Subdue",
+                  "Reduce the sound",
                   "20%"
                 ]
               },
               {
-                "propertyValue": -25,
+                "propertyValue": -5,
                 "propertySubPhrases": [
-                  "Subdue",
-                  "25%"
+                  "Decrease the volume",
+                  "5%"
                 ]
               }
             ]
@@ -9399,23 +8292,21 @@
               {
                 "name": "fullActionName",
                 "value": "player.changeVolume",
-                "substrings": [
-                  "Subdue the sound"
-                ],
+                "substrings": [],
                 "implied": true
               },
               {
                 "name": "parameters.volumeChangePercentage",
                 "value": -15,
                 "substrings": [
-                  "15%"
+                  "Subdue the sound by a reasonable 15%."
                 ],
                 "implied": false
               }
             ]
           },
           "correction": [
-            "Value -15 for property 'parameters.volumeChangePercentage' doesn't match the number 15 in the substring '15%'. Missing other substring to explain the value."
+            "Value -15 for property 'parameters.volumeChangePercentage' doesn't match the number 15 in the substring 'Subdue the sound by a reasonable 15%.'. Missing other substring to explain the value."
           ]
         }
       ]
@@ -9433,28 +8324,26 @@
           {
             "name": "fullActionName",
             "value": "player.changeVolume",
-            "substrings": [
-              "Take down the volume"
-            ],
-            "implied": false
+            "substrings": [],
+            "implied": true
           },
           {
             "name": "parameters.volumeChangePercentage",
             "value": -10,
             "substrings": [
-              "Take down",
-              "a modest 10%"
+              "Take down the volume",
+              "10%"
             ],
             "implied": false
           }
         ],
         "subPhrases": [
           {
-            "text": "Take down",
+            "text": "Take down the volume",
             "synonyms": [
-              "Lower",
-              "Reduce",
-              "Decrease"
+              "Lower the volume",
+              "Reduce the volume",
+              "Decrease the volume"
             ],
             "category": "command",
             "propertyNames": [
@@ -9462,25 +8351,23 @@
             ]
           },
           {
-            "text": "the volume",
+            "text": "by a modest",
             "synonyms": [
-              "the sound",
-              "the audio",
-              "the noise"
+              "by a small",
+              "by a slight",
+              "by a minor"
             ],
-            "category": "object",
-            "propertyNames": [
-              "fullActionName"
-            ]
+            "category": "modifier",
+            "isOptional": true
           },
           {
-            "text": "by a modest 10%",
+            "text": "10%",
             "synonyms": [
-              "by 10%",
-              "by a small 10%",
-              "by a slight 10%"
+              "ten percent",
+              "10 percent",
+              "10 per cent"
             ],
-            "category": "magnitude",
+            "category": "quantity",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
@@ -9491,89 +8378,35 @@
             "propertyName": "parameters.volumeChangePercentage",
             "propertyValue": -10,
             "propertySubPhrases": [
-              "Take down",
-              "by a modest 10%"
+              "Take down the volume",
+              "10%"
             ],
             "alternatives": [
               {
                 "propertyValue": -5,
                 "propertySubPhrases": [
-                  "Take down",
-                  "by a modest 5%"
+                  "Take down the volume",
+                  "5%"
                 ]
               },
               {
                 "propertyValue": -15,
                 "propertySubPhrases": [
-                  "Take down",
-                  "by a modest 15%"
+                  "Take down the volume",
+                  "15%"
                 ]
               },
               {
                 "propertyValue": -20,
                 "propertySubPhrases": [
-                  "Take down",
-                  "by a modest 20%"
-                ]
-              }
-            ]
-          },
-          {
-            "propertyName": "fullActionName",
-            "propertyValue": "player.changeVolume",
-            "propertySubPhrases": [
-              "the volume"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "player.mute",
-                "propertySubPhrases": [
-                  "mute the volume"
-                ]
-              },
-              {
-                "propertyValue": "player.increaseVolume",
-                "propertySubPhrases": [
-                  "increase the volume"
-                ]
-              },
-              {
-                "propertyValue": "player.setVolume",
-                "propertySubPhrases": [
-                  "set the volume"
+                  "Take down the volume",
+                  "20%"
                 ]
               }
             ]
           }
         ]
-      },
-      "corrections": [
-        {
-          "data": {
-            "properties": [
-              {
-                "name": "fullActionName",
-                "value": "player.changeVolume",
-                "substrings": [
-                  "Take down the volume"
-                ],
-                "implied": false
-              },
-              {
-                "name": "parameters.volumeChangePercentage",
-                "value": -10,
-                "substrings": [
-                  "a modest 10%"
-                ],
-                "implied": false
-              }
-            ]
-          },
-          "correction": [
-            "Value -10 for property 'parameters.volumeChangePercentage' doesn't match the number 10 in the substring 'a modest 10%'. Missing other substring to explain the value."
-          ]
-        }
-      ]
+      }
     },
     {
       "request": "Tone down the sound by 15%.",
@@ -9588,9 +8421,7 @@
           {
             "name": "fullActionName",
             "value": "player.changeVolume",
-            "substrings": [
-              "Tone down the sound"
-            ],
+            "substrings": [],
             "implied": true
           },
           {
@@ -9598,7 +8429,7 @@
             "value": -15,
             "substrings": [
               "Tone down",
-              "by 15%"
+              "15%"
             ],
             "implied": false
           }
@@ -9617,23 +8448,23 @@
             ]
           },
           {
-            "text": "the sound",
+            "text": "the sound by",
             "synonyms": [
-              "the volume",
-              "the audio",
-              "the noise"
+              "the volume by",
+              "the audio by",
+              "the noise by"
             ],
-            "category": "object",
-            "propertyNames": []
+            "category": "context",
+            "isOptional": true
           },
           {
-            "text": "by 15%",
+            "text": "15%",
             "synonyms": [
-              "by fifteen percent",
-              "by 15 percent",
-              "by 15%"
+              "fifteen percent",
+              "15 percent",
+              "15 pct"
             ],
-            "category": "modifier",
+            "category": "value",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
@@ -9645,28 +8476,28 @@
             "propertyValue": -15,
             "propertySubPhrases": [
               "Tone down",
-              "by 15%"
+              "15%"
             ],
             "alternatives": [
               {
                 "propertyValue": -10,
                 "propertySubPhrases": [
-                  "Lower",
-                  "by 10%"
+                  "Tone down",
+                  "10%"
                 ]
               },
               {
                 "propertyValue": -20,
                 "propertySubPhrases": [
-                  "Decrease",
-                  "by 20%"
+                  "Tone down",
+                  "20%"
                 ]
               },
               {
                 "propertyValue": -5,
                 "propertySubPhrases": [
-                  "Reduce",
-                  "by 5%"
+                  "Tone down",
+                  "5%"
                 ]
               }
             ]
@@ -9680,23 +8511,21 @@
               {
                 "name": "fullActionName",
                 "value": "player.changeVolume",
-                "substrings": [
-                  "Tone down the sound"
-                ],
+                "substrings": [],
                 "implied": true
               },
               {
                 "name": "parameters.volumeChangePercentage",
                 "value": -15,
                 "substrings": [
-                  "by 15%"
+                  "Tone down the sound by 15%."
                 ],
                 "implied": false
               }
             ]
           },
           "correction": [
-            "Value -15 for property 'parameters.volumeChangePercentage' doesn't match the number 15 in the substring 'by 15%'. Missing other substring to explain the value."
+            "Value -15 for property 'parameters.volumeChangePercentage' doesn't match the number 15 in the substring 'Tone down the sound by 15%.'. Missing other substring to explain the value."
           ]
         }
       ]
@@ -9715,7 +8544,7 @@
             "name": "fullActionName",
             "value": "player.changeVolume",
             "substrings": [
-              "Turn up the sound"
+              "Turn up the sound by 15%."
             ],
             "implied": true
           },
@@ -9730,11 +8559,11 @@
         ],
         "subPhrases": [
           {
-            "text": "Turn up the sound",
+            "text": "Turn up",
             "synonyms": [
-              "Increase the volume",
-              "Raise the sound",
-              "Amplify the audio"
+              "Increase",
+              "Raise",
+              "Amplify"
             ],
             "category": "command",
             "propertyNames": [
@@ -9742,13 +8571,25 @@
             ]
           },
           {
+            "text": "the sound",
+            "synonyms": [
+              "the volume",
+              "the audio",
+              "the noise"
+            ],
+            "category": "object",
+            "propertyNames": [
+              "fullActionName"
+            ]
+          },
+          {
             "text": "by 15%",
             "synonyms": [
-              "to 15%",
-              "at 15%",
-              "with 15%"
+              "by fifteen percent",
+              "by 15 percent",
+              "by 15%"
             ],
-            "category": "modifier",
+            "category": "measurement",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
@@ -9759,25 +8600,29 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.changeVolume",
             "propertySubPhrases": [
-              "Turn up the sound"
+              "Turn up",
+              "the sound"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.increaseVolume",
                 "propertySubPhrases": [
-                  "Increase the volume"
+                  "Increase",
+                  "the volume"
                 ]
               },
               {
                 "propertyValue": "player.raiseVolume",
                 "propertySubPhrases": [
-                  "Raise the volume"
+                  "Raise",
+                  "the sound level"
                 ]
               },
               {
-                "propertyValue": "player.volumeUp",
+                "propertyValue": "player.amplifyVolume",
                 "propertySubPhrases": [
-                  "Volume up"
+                  "Amplify",
+                  "the audio"
                 ]
               }
             ]
@@ -9825,19 +8670,17 @@
           {
             "name": "fullActionName",
             "value": "player.changeVolume",
-            "substrings": [
-              "slice the volume"
-            ],
+            "substrings": [],
             "implied": true
           },
           {
             "name": "parameters.volumeChangePercentage",
             "value": -5,
             "substrings": [
-              "5%",
-              "slice"
+              "slice the volume",
+              "5%"
             ],
-            "implied": true
+            "implied": false
           }
         ],
         "subPhrases": [
@@ -9845,8 +8688,8 @@
             "text": "Wanna",
             "synonyms": [
               "Want to",
-              "Do you want to",
-              "Would you like to"
+              "Would like to",
+              "Do you want to"
             ],
             "category": "politeness",
             "isOptional": true
@@ -9860,7 +8703,6 @@
             ],
             "category": "action",
             "propertyNames": [
-              "fullActionName",
               "parameters.volumeChangePercentage"
             ]
           },
@@ -9881,40 +8723,13 @@
               "5 percent",
               "5 pct"
             ],
-            "category": "percentage",
+            "category": "value",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
           }
         ],
         "propertyAlternatives": [
-          {
-            "propertyName": "fullActionName",
-            "propertyValue": "player.changeVolume",
-            "propertySubPhrases": [
-              "slice the volume"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "player.increaseVolume",
-                "propertySubPhrases": [
-                  "boost the volume"
-                ]
-              },
-              {
-                "propertyValue": "player.muteVolume",
-                "propertySubPhrases": [
-                  "mute the volume"
-                ]
-              },
-              {
-                "propertyValue": "player.setVolume",
-                "propertySubPhrases": [
-                  "set the volume"
-                ]
-              }
-            ]
-          },
           {
             "propertyName": "parameters.volumeChangePercentage",
             "propertyValue": -5,
@@ -9947,106 +8762,7 @@
             ]
           }
         ]
-      },
-      "corrections": [
-        {
-          "data": {
-            "properties": [
-              {
-                "name": "fullActionName",
-                "value": "player.changeVolume",
-                "substrings": [
-                  "slice the volume"
-                ],
-                "implied": true
-              },
-              {
-                "name": "parameters.volumeChangePercentage",
-                "value": -5,
-                "substrings": [
-                  "5%"
-                ],
-                "implied": true
-              }
-            ]
-          },
-          "correction": [
-            "Value -5 for property 'parameters.volumeChangePercentage' doesn't match the number 5 in the substring '5%'. Missing other substring to explain the value."
-          ]
-        },
-        {
-          "data": {
-            "properties": [
-              {
-                "name": "fullActionName",
-                "value": "player.changeVolume",
-                "substrings": [
-                  "slice the volume"
-                ],
-                "implied": true
-              },
-              {
-                "name": "parameters.volumeChangePercentage",
-                "value": -5,
-                "substrings": [
-                  "5%",
-                  "slice"
-                ],
-                "implied": true
-              }
-            ],
-            "subPhrases": [
-              {
-                "text": "Wanna",
-                "synonyms": [
-                  "Want to",
-                  "Do you want to",
-                  "Would you like to"
-                ],
-                "category": "politeness",
-                "isOptional": true
-              },
-              {
-                "text": "slice the volume",
-                "synonyms": [
-                  "reduce the volume",
-                  "decrease the volume",
-                  "lower the volume"
-                ],
-                "category": "action",
-                "propertyNames": [
-                  "fullActionName"
-                ]
-              },
-              {
-                "text": "by a neat",
-                "synonyms": [
-                  "by exactly",
-                  "by precisely",
-                  "by an exact"
-                ],
-                "category": "filler",
-                "isOptional": true
-              },
-              {
-                "text": "5%",
-                "synonyms": [
-                  "five percent",
-                  "5 percent",
-                  "5 pct"
-                ],
-                "category": "percentage",
-                "propertyNames": [
-                  "parameters.volumeChangePercentage"
-                ]
-              }
-            ]
-          },
-          "correction": [
-            "Explicit property 'parameters.volumeChangePercentage' must be included as property names for all subphrases that contain the substring 'slice'"
-          ]
-        }
-      ]
+      }
     },
     {
       "request": "Would it be possible to augment the volume by 10%?",
@@ -10061,16 +8777,14 @@
           {
             "name": "fullActionName",
             "value": "player.changeVolume",
-            "substrings": [
-              "augment the volume"
-            ],
+            "substrings": [],
             "implied": true
           },
           {
             "name": "parameters.volumeChangePercentage",
             "value": 10,
             "substrings": [
-              "by 10%"
+              "augment the volume by 10%"
             ],
             "implied": false
           }
@@ -10087,25 +8801,13 @@
             "isOptional": true
           },
           {
-            "text": "augment the volume",
+            "text": "augment the volume by 10%",
             "synonyms": [
-              "increase the volume",
-              "raise the volume",
-              "turn up the volume"
+              "increase the volume by 10%",
+              "raise the volume by 10%",
+              "turn up the volume by 10%"
             ],
             "category": "action",
-            "propertyNames": [
-              "fullActionName"
-            ]
-          },
-          {
-            "text": "by 10%",
-            "synonyms": [
-              "by ten percent",
-              "by 10 percent",
-              "by a tenth"
-            ],
-            "category": "parameter",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
@@ -10113,55 +8815,28 @@
         ],
         "propertyAlternatives": [
           {
-            "propertyName": "fullActionName",
-            "propertyValue": "player.changeVolume",
-            "propertySubPhrases": [
-              "augment the volume"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "player.increaseVolume",
-                "propertySubPhrases": [
-                  "increase the volume"
-                ]
-              },
-              {
-                "propertyValue": "player.raiseVolume",
-                "propertySubPhrases": [
-                  "raise the volume"
-                ]
-              },
-              {
-                "propertyValue": "player.boostVolume",
-                "propertySubPhrases": [
-                  "boost the volume"
-                ]
-              }
-            ]
-          },
-          {
             "propertyName": "parameters.volumeChangePercentage",
             "propertyValue": 10,
             "propertySubPhrases": [
-              "by 10%"
+              "augment the volume by 10%"
             ],
             "alternatives": [
               {
                 "propertyValue": 5,
                 "propertySubPhrases": [
-                  "by 5%"
+                  "augment the volume by 5%"
                 ]
               },
               {
                 "propertyValue": 15,
                 "propertySubPhrases": [
-                  "by 15%"
+                  "augment the volume by 15%"
                 ]
               },
               {
                 "propertyValue": 20,
                 "propertySubPhrases": [
-                  "by 20%"
+                  "augment the volume by 20%"
                 ]
               }
             ]
@@ -10222,8 +8897,8 @@
           {
             "text": "by 10%",
             "synonyms": [
-              "to 10%",
-              "up 10%",
+              "to 10% more",
+              "up by 10%",
               "increase by 10%"
             ],
             "category": "quantity",
@@ -10315,16 +8990,16 @@
               "trim",
               "by 5%"
             ],
-            "implied": false
+            "implied": true
           }
         ],
         "subPhrases": [
           {
-            "text": "Yo,",
+            "text": "Yo",
             "synonyms": [
-              "Hey,",
-              "Hi,",
-              "Hello,"
+              "Hey",
+              "Hi",
+              "Hello"
             ],
             "category": "greeting",
             "isOptional": true
@@ -10340,11 +9015,11 @@
             "isOptional": true
           },
           {
-            "text": "trim",
+            "text": "trim the volume",
             "synonyms": [
-              "lower",
-              "reduce",
-              "decrease"
+              "lower the volume",
+              "reduce the volume",
+              "decrease the volume"
             ],
             "category": "action",
             "propertyNames": [
@@ -10353,23 +9028,11 @@
             ]
           },
           {
-            "text": "the volume",
-            "synonyms": [
-              "the sound",
-              "the audio",
-              "the noise"
-            ],
-            "category": "object",
-            "propertyNames": [
-              "fullActionName"
-            ]
-          },
-          {
             "text": "by 5%",
             "synonyms": [
               "by five percent",
               "by 5 percent",
-              "by 5%"
+              "by 5 pct"
             ],
             "category": "amount",
             "propertyNames": [
@@ -10382,29 +9045,25 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.changeVolume",
             "propertySubPhrases": [
-              "trim",
-              "the volume"
+              "trim the volume"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.increaseVolume",
                 "propertySubPhrases": [
-                  "increase",
-                  "the volume"
+                  "increase the volume"
                 ]
               },
               {
                 "propertyValue": "player.decreaseVolume",
                 "propertySubPhrases": [
-                  "decrease",
-                  "the volume"
+                  "decrease the volume"
                 ]
               },
               {
-                "propertyValue": "player.muteVolume",
+                "propertyValue": "player.setVolume",
                 "propertySubPhrases": [
-                  "mute",
-                  "the volume"
+                  "set the volume"
                 ]
               }
             ]
@@ -10413,29 +9072,29 @@
             "propertyName": "parameters.volumeChangePercentage",
             "propertyValue": -5,
             "propertySubPhrases": [
-              "trim",
+              "trim the volume",
               "by 5%"
             ],
             "alternatives": [
               {
                 "propertyValue": -10,
                 "propertySubPhrases": [
-                  "trim",
+                  "trim the volume",
                   "by 10%"
                 ]
               },
               {
-                "propertyValue": -15,
+                "propertyValue": 5,
                 "propertySubPhrases": [
-                  "trim",
-                  "by 15%"
+                  "increase the volume",
+                  "by 5%"
                 ]
               },
               {
-                "propertyValue": -20,
+                "propertyValue": 10,
                 "propertySubPhrases": [
-                  "trim",
-                  "by 20%"
+                  "increase the volume",
+                  "by 10%"
                 ]
               }
             ]
@@ -10460,7 +9119,7 @@
                 "substrings": [
                   "by 5%"
                 ],
-                "implied": false
+                "implied": true
               }
             ]
           },
@@ -10486,16 +9145,16 @@
                   "trim",
                   "by 5%"
                 ],
-                "implied": false
+                "implied": true
               }
             ],
             "subPhrases": [
               {
-                "text": "Yo,",
+                "text": "Yo",
                 "synonyms": [
-                  "Hey,",
-                  "Hi,",
-                  "Hello,"
+                  "Hey",
+                  "Hi",
+                  "Hello"
                 ],
                 "category": "greeting",
                 "isOptional": true
@@ -10527,7 +9186,7 @@
                 "synonyms": [
                   "by five percent",
                   "by 5 percent",
-                  "by 5%"
+                  "by 5 pct"
                 ],
                 "category": "amount",
                 "propertyNames": [
@@ -10555,17 +9214,15 @@
           {
             "name": "fullActionName",
             "value": "player.changeVolume",
-            "substrings": [
-              "drop the volume"
-            ],
+            "substrings": [],
             "implied": true
           },
           {
             "name": "parameters.volumeChangePercentage",
             "value": -5,
             "substrings": [
-              "drop the volume",
-              "by 5%"
+              "drop the volume by",
+              "5%"
             ],
             "implied": false
           }
@@ -10582,26 +9239,25 @@
             "isOptional": true
           },
           {
-            "text": "drop the volume",
+            "text": "drop the volume by",
             "synonyms": [
-              "lower the volume",
-              "decrease the volume",
-              "reduce the volume"
+              "lower the volume by",
+              "decrease the volume by",
+              "reduce the volume by"
             ],
-            "category": "action",
+            "category": "command",
             "propertyNames": [
-              "fullActionName",
               "parameters.volumeChangePercentage"
             ]
           },
           {
-            "text": "by 5%",
+            "text": "5%",
             "synonyms": [
-              "by five percent",
-              "by 5 percent",
-              "by 5 pct"
+              "five percent",
+              "5 percent",
+              "5 pct"
             ],
-            "category": "modifier",
+            "category": "value",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
@@ -10609,59 +9265,32 @@
         ],
         "propertyAlternatives": [
           {
-            "propertyName": "fullActionName",
-            "propertyValue": "player.changeVolume",
-            "propertySubPhrases": [
-              "drop the volume"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "player.increaseVolume",
-                "propertySubPhrases": [
-                  "raise the volume"
-                ]
-              },
-              {
-                "propertyValue": "player.muteVolume",
-                "propertySubPhrases": [
-                  "mute the volume"
-                ]
-              },
-              {
-                "propertyValue": "player.setVolume",
-                "propertySubPhrases": [
-                  "set the volume"
-                ]
-              }
-            ]
-          },
-          {
             "propertyName": "parameters.volumeChangePercentage",
             "propertyValue": -5,
             "propertySubPhrases": [
-              "drop the volume",
-              "by 5%"
+              "drop the volume by",
+              "5%"
             ],
             "alternatives": [
               {
                 "propertyValue": -10,
                 "propertySubPhrases": [
-                  "drop the volume",
-                  "by 10%"
+                  "drop the volume by",
+                  "10%"
                 ]
               },
               {
                 "propertyValue": -15,
                 "propertySubPhrases": [
-                  "drop the volume",
-                  "by 15%"
+                  "drop the volume by",
+                  "15%"
                 ]
               },
               {
                 "propertyValue": -20,
                 "propertySubPhrases": [
-                  "drop the volume",
-                  "by 20%"
+                  "drop the volume by",
+                  "20%"
                 ]
               }
             ]
@@ -10675,9 +9304,7 @@
               {
                 "name": "fullActionName",
                 "value": "player.changeVolume",
-                "substrings": [
-                  "drop the volume"
-                ],
+                "substrings": [],
                 "implied": true
               },
               {
@@ -10709,19 +9336,17 @@
           {
             "name": "fullActionName",
             "value": "player.changeVolume",
-            "substrings": [
-              "shave the volume"
-            ],
+            "substrings": [],
             "implied": true
           },
           {
             "name": "parameters.volumeChangePercentage",
             "value": -5,
             "substrings": [
-              "shave",
+              "shave the volume",
               "5%"
             ],
-            "implied": true
+            "implied": false
           }
         ],
         "subPhrases": [
@@ -10746,38 +9371,25 @@
             "isOptional": true
           },
           {
-            "text": "shave",
+            "text": "shave the volume",
             "synonyms": [
-              "reduce",
-              "decrease",
-              "lower"
+              "reduce the volume",
+              "lower the volume",
+              "decrease the volume"
             ],
             "category": "action",
             "propertyNames": [
-              "fullActionName",
               "parameters.volumeChangePercentage"
-            ]
-          },
-          {
-            "text": "the volume",
-            "synonyms": [
-              "volume",
-              "sound level",
-              "audio level"
-            ],
-            "category": "object",
-            "propertyNames": [
-              "fullActionName"
             ]
           },
           {
             "text": "by a cool",
             "synonyms": [
-              "by",
               "by exactly",
-              "by precisely"
+              "by precisely",
+              "by"
             ],
-            "category": "preposition",
+            "category": "filler",
             "isOptional": true
           },
           {
@@ -10787,7 +9399,7 @@
               "5 percent",
               "5 pct"
             ],
-            "category": "quantity",
+            "category": "value",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
@@ -10795,62 +9407,31 @@
         ],
         "propertyAlternatives": [
           {
-            "propertyName": "fullActionName",
-            "propertyValue": "player.changeVolume",
-            "propertySubPhrases": [
-              "shave",
-              "the volume"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "player.increaseVolume",
-                "propertySubPhrases": [
-                  "boost",
-                  "the volume"
-                ]
-              },
-              {
-                "propertyValue": "player.muteVolume",
-                "propertySubPhrases": [
-                  "mute",
-                  "the volume"
-                ]
-              },
-              {
-                "propertyValue": "player.setVolume",
-                "propertySubPhrases": [
-                  "set",
-                  "the volume"
-                ]
-              }
-            ]
-          },
-          {
             "propertyName": "parameters.volumeChangePercentage",
             "propertyValue": -5,
             "propertySubPhrases": [
-              "shave",
+              "shave the volume",
               "5%"
             ],
             "alternatives": [
               {
                 "propertyValue": -10,
                 "propertySubPhrases": [
-                  "shave",
+                  "shave the volume",
                   "10%"
                 ]
               },
               {
                 "propertyValue": -15,
                 "propertySubPhrases": [
-                  "shave",
+                  "shave the volume",
                   "15%"
                 ]
               },
               {
                 "propertyValue": -20,
                 "propertySubPhrases": [
-                  "shave",
+                  "shave the volume",
                   "20%"
                 ]
               }
@@ -10865,23 +9446,21 @@
               {
                 "name": "fullActionName",
                 "value": "player.changeVolume",
-                "substrings": [
-                  "shave the volume"
-                ],
+                "substrings": [],
                 "implied": true
               },
               {
                 "name": "parameters.volumeChangePercentage",
                 "value": -5,
                 "substrings": [
-                  "5%"
+                  "shave the volume by a cool 5%"
                 ],
-                "implied": true
+                "implied": false
               }
             ]
           },
           "correction": [
-            "Value -5 for property 'parameters.volumeChangePercentage' doesn't match the number 5 in the substring '5%'. Missing other substring to explain the value."
+            "Value -5 for property 'parameters.volumeChangePercentage' doesn't match the number 5 in the substring 'shave the volume by a cool 5%'. Missing other substring to explain the value."
           ]
         }
       ]

--- a/ts/packages/dispatcher/test/data/player/v5/full.json
+++ b/ts/packages/dispatcher/test/data/player/v5/full.json
@@ -16,7 +16,9 @@
           {
             "name": "fullActionName",
             "value": "player.playTrack",
-            "substrings": [],
+            "substrings": [
+              "get down to"
+            ],
             "implied": true
           },
           {
@@ -34,29 +36,41 @@
             "synonyms": [
               "Alright",
               "Okay",
-              "Hey"
+              "Sure"
             ],
             "category": "acknowledgement",
             "isOptional": true
           },
           {
-            "text": "it's time to get down to some",
+            "text": "it's time to",
             "synonyms": [
-              "let's play",
-              "start playing",
-              "put on"
+              "let's",
+              "we should",
+              "time to"
             ],
-            "category": "command",
-            "isOptional": false
+            "category": "filler",
+            "isOptional": true
           },
           {
-            "text": "'Sensual Seduction'",
+            "text": "get down to",
+            "synonyms": [
+              "play",
+              "start",
+              "begin"
+            ],
+            "category": "action",
+            "propertyNames": [
+              "fullActionName"
+            ]
+          },
+          {
+            "text": "some 'Sensual Seduction'",
             "synonyms": [
               "'Sensual Seduction'",
-              "'Sensual Seduction'",
-              "'Sensual Seduction'"
+              "the track 'Sensual Seduction'",
+              "the song 'Sensual Seduction'"
             ],
-            "category": "trackName",
+            "category": "track",
             "propertyNames": [
               "parameters.trackName"
             ]
@@ -65,8 +79,8 @@
             "text": "ya feel me?",
             "synonyms": [
               "you know?",
-              "you get it?",
-              "understand?"
+              "understand?",
+              "got it?"
             ],
             "category": "confirmation",
             "isOptional": true
@@ -74,28 +88,55 @@
         ],
         "propertyAlternatives": [
           {
-            "propertyName": "parameters.trackName",
-            "propertyValue": "Sensual Seduction",
+            "propertyName": "fullActionName",
+            "propertyValue": "player.playTrack",
             "propertySubPhrases": [
-              "'Sensual Seduction'"
+              "get down to"
             ],
             "alternatives": [
               {
-                "propertyValue": "Drop It Like It's Hot",
+                "propertyValue": "player.startTrack",
                 "propertySubPhrases": [
-                  "'Drop It Like It's Hot'"
+                  "start playing"
                 ]
               },
               {
+                "propertyValue": "player.queueTrack",
+                "propertySubPhrases": [
+                  "queue up"
+                ]
+              },
+              {
+                "propertyValue": "player.addTrack",
+                "propertySubPhrases": [
+                  "add to playlist"
+                ]
+              }
+            ]
+          },
+          {
+            "propertyName": "parameters.trackName",
+            "propertyValue": "Sensual Seduction",
+            "propertySubPhrases": [
+              "some 'Sensual Seduction'"
+            ],
+            "alternatives": [
+              {
                 "propertyValue": "Gin and Juice",
                 "propertySubPhrases": [
-                  "'Gin and Juice'"
+                  "some 'Gin and Juice'"
+                ]
+              },
+              {
+                "propertyValue": "Drop It Like It's Hot",
+                "propertySubPhrases": [
+                  "some 'Drop It Like It's Hot'"
                 ]
               },
               {
                 "propertyValue": "Beautiful",
                 "propertySubPhrases": [
-                  "'Beautiful'"
+                  "some 'Beautiful'"
                 ]
               }
             ]
@@ -115,8 +156,7 @@
             "name": "fullActionName",
             "value": "player.playRandom",
             "substrings": [
-              "pump up the volume",
-              "fresh beats"
+              "pump up the volume with some fresh beats!"
             ],
             "implied": true
           }
@@ -127,7 +167,7 @@
             "synonyms": [
               "Alright",
               "Okay",
-              "Sure"
+              "Hey"
             ],
             "category": "acknowledgement",
             "isOptional": true
@@ -143,25 +183,13 @@
             "isOptional": true
           },
           {
-            "text": "pump up the volume",
+            "text": "pump up the volume with some fresh beats!",
             "synonyms": [
-              "increase the volume",
-              "turn up the volume",
-              "raise the volume"
+              "play some music",
+              "start the music",
+              "turn on some tunes"
             ],
-            "category": "action",
-            "propertyNames": [
-              "fullActionName"
-            ]
-          },
-          {
-            "text": "with some fresh beats",
-            "synonyms": [
-              "with new music",
-              "with fresh tracks",
-              "with some new beats"
-            ],
-            "category": "action",
+            "category": "command",
             "propertyNames": [
               "fullActionName"
             ]
@@ -172,29 +200,25 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.playRandom",
             "propertySubPhrases": [
-              "pump up the volume",
-              "with some fresh beats"
+              "pump up the volume with some fresh beats!"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.playTopHits",
                 "propertySubPhrases": [
-                  "turn up the hits",
-                  "with some chart-toppers"
+                  "play the top hits!"
                 ]
               },
               {
                 "propertyValue": "player.playChill",
                 "propertySubPhrases": [
-                  "relax",
-                  "with some chill vibes"
+                  "play some chill tunes!"
                 ]
               },
               {
                 "propertyValue": "player.playClassics",
                 "propertySubPhrases": [
-                  "enjoy",
-                  "with some timeless classics"
+                  "play some classic tracks!"
                 ]
               }
             ]
@@ -243,11 +267,11 @@
           {
             "text": "DJ",
             "synonyms": [
-              "Deejay",
               "Disc Jockey",
+              "Deejay",
               "Music Mixer"
             ],
-            "category": "address",
+            "category": "acknowledgement",
             "isOptional": true
           },
           {
@@ -257,7 +281,7 @@
               "spin",
               "put on"
             ],
-            "category": "action",
+            "category": "command",
             "propertyNames": [
               "fullActionName"
             ]
@@ -269,7 +293,7 @@
               "the song 'Gin and Juice'",
               "'Gin and Juice'"
             ],
-            "category": "track",
+            "category": "trackName",
             "propertyNames": [
               "parameters.trackName"
             ]
@@ -281,15 +305,15 @@
               "immediately",
               "ASAP"
             ],
-            "category": "urgency",
+            "category": "filler",
             "isOptional": true
           },
           {
             "text": "ya dig?",
             "synonyms": [
               "you understand?",
-              "you get it?",
-              "got it?"
+              "got it?",
+              "capisce?"
             ],
             "category": "confirmation",
             "isOptional": true
@@ -304,12 +328,6 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.queueTrack",
-                "propertySubPhrases": [
-                  "queue"
-                ]
-              },
-              {
                 "propertyValue": "player.pauseTrack",
                 "propertySubPhrases": [
                   "pause"
@@ -319,6 +337,12 @@
                 "propertyValue": "player.stopTrack",
                 "propertySubPhrases": [
                   "stop"
+                ]
+              },
+              {
+                "propertyValue": "player.skipTrack",
+                "propertySubPhrases": [
+                  "skip"
                 ]
               }
             ]
@@ -337,15 +361,15 @@
                 ]
               },
               {
-                "propertyValue": "Still D.R.E.",
+                "propertyValue": "Drop It Like It's Hot",
                 "propertySubPhrases": [
-                  "that 'Still D.R.E.'"
+                  "that 'Drop It Like It's Hot'"
                 ]
               },
               {
-                "propertyValue": "The Next Episode",
+                "propertyValue": "Still D.R.E.",
                 "propertySubPhrases": [
-                  "that 'The Next Episode'"
+                  "that 'Still D.R.E.'"
                 ]
               }
             ]
@@ -367,7 +391,7 @@
             "name": "fullActionName",
             "value": "player.playArtist",
             "substrings": [
-              "drop that"
+              "drop that Snoop Dogg beat!"
             ],
             "implied": true
           },
@@ -396,7 +420,7 @@
             "synonyms": [
               "play",
               "start",
-              "put on"
+              "begin"
             ],
             "category": "command",
             "propertyNames": [
@@ -407,8 +431,8 @@
             "text": "Snoop Dogg",
             "synonyms": [
               "Snoop",
-              "Snoop Doggy Dogg",
-              "Calvin Broadus"
+              "Dogg",
+              "Snoop Doggy Dogg"
             ],
             "category": "artist",
             "propertyNames": [
@@ -416,13 +440,13 @@
             ]
           },
           {
-            "text": "beat",
+            "text": "beat!",
             "synonyms": [
               "track",
               "song",
               "music"
             ],
-            "category": "filler",
+            "category": "music",
             "isOptional": true
           }
         ],
@@ -498,7 +522,7 @@
             "name": "fullActionName",
             "value": "player.playGenre",
             "substrings": [
-              "let's bump some dope beats"
+              "Ayo, let's bump some dope beats up in here!"
             ],
             "implied": true
           },
@@ -529,7 +553,7 @@
               "let's listen to",
               "let's enjoy"
             ],
-            "category": "command",
+            "category": "action",
             "propertyNames": [
               "fullActionName"
             ]
@@ -538,8 +562,8 @@
             "text": "some dope beats",
             "synonyms": [
               "some hip hop",
-              "some rap music",
-              "some cool tracks"
+              "some rap",
+              "some tracks"
             ],
             "category": "genre",
             "propertyNames": [
@@ -549,11 +573,11 @@
           {
             "text": "up in here",
             "synonyms": [
+              "right now",
               "in this place",
-              "right here",
-              "around here"
+              "here"
             ],
-            "category": "location",
+            "category": "filler",
             "isOptional": true
           }
         ],
@@ -629,10 +653,7 @@
             "name": "fullActionName",
             "value": "player.playArtist",
             "substrings": [
-              "bump",
-              "some",
-              "classic",
-              "Snoop Dogg"
+              "Ayo, let's bump some of that classic Snoop Dogg, ya dig?"
             ],
             "implied": true
           },
@@ -657,29 +678,16 @@
             "isOptional": true
           },
           {
-            "text": "let's bump",
+            "text": "let's bump some of that classic",
             "synonyms": [
-              "let's play",
-              "let's listen to",
-              "let's hear"
+              "let's play some of that classic",
+              "let's listen to some of that classic",
+              "let's enjoy some of that classic"
             ],
             "category": "command",
             "propertyNames": [
               "fullActionName"
             ]
-          },
-          {
-            "text": "some of that classic",
-            "synonyms": [
-              "some classic",
-              "a bit of classic",
-              "some old school"
-            ],
-            "category": "description",
-            "propertyNames": [
-              "fullActionName"
-            ],
-            "isOptional": true
           },
           {
             "text": "Snoop Dogg",
@@ -690,8 +698,7 @@
             ],
             "category": "artist",
             "propertyNames": [
-              "parameters.artist",
-              "fullActionName"
+              "parameters.artist"
             ]
           },
           {
@@ -699,7 +706,7 @@
             "synonyms": [
               "you know?",
               "right?",
-              "got it?"
+              "okay?"
             ],
             "category": "filler",
             "isOptional": true
@@ -710,33 +717,25 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.playArtist",
             "propertySubPhrases": [
-              "let's bump",
-              "some of that classic",
-              "Snoop Dogg"
+              "let's bump some of that classic"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.playAlbum",
                 "propertySubPhrases": [
-                  "let's bump",
-                  "some of that classic",
-                  "Doggystyle"
-                ]
-              },
-              {
-                "propertyValue": "player.playSong",
-                "propertySubPhrases": [
-                  "let's bump",
-                  "some of that classic",
-                  "Gin and Juice"
+                  "let's bump some of that classic album"
                 ]
               },
               {
                 "propertyValue": "player.playPlaylist",
                 "propertySubPhrases": [
-                  "let's bump",
-                  "some of that classic",
-                  "Snoop Dogg Essentials"
+                  "let's bump some of that classic playlist"
+                ]
+              },
+              {
+                "propertyValue": "player.playSong",
+                "propertySubPhrases": [
+                  "let's bump some of that classic track"
                 ]
               }
             ]
@@ -778,83 +777,23 @@
                 "name": "fullActionName",
                 "value": "player.playArtist",
                 "substrings": [
-                  "bump",
-                  "some",
-                  "classic",
-                  "Snoop Dogg"
+                  "Ayo, let's bump some of that classic Snoop Dogg, ya dig?"
                 ],
                 "implied": true
               },
               {
-                "name": "parameters.artist",
+                "name": "artist",
                 "value": "Snoop Dogg",
                 "substrings": [
                   "Snoop Dogg"
                 ],
                 "implied": false
               }
-            ],
-            "subPhrases": [
-              {
-                "text": "Ayo",
-                "synonyms": [
-                  "Hey",
-                  "Yo",
-                  "Hi"
-                ],
-                "category": "greeting",
-                "isOptional": true
-              },
-              {
-                "text": "let's bump",
-                "synonyms": [
-                  "let's play",
-                  "let's listen to",
-                  "let's hear"
-                ],
-                "category": "command",
-                "propertyNames": [
-                  "fullActionName"
-                ]
-              },
-              {
-                "text": "some of that classic",
-                "synonyms": [
-                  "some classic",
-                  "a bit of classic",
-                  "some old school"
-                ],
-                "category": "description",
-                "isOptional": true
-              },
-              {
-                "text": "Snoop Dogg",
-                "synonyms": [
-                  "Snoop",
-                  "Snoop Doggy Dogg",
-                  "Calvin Broadus"
-                ],
-                "category": "artist",
-                "propertyNames": [
-                  "parameters.artist"
-                ]
-              },
-              {
-                "text": "ya dig?",
-                "synonyms": [
-                  "you know?",
-                  "right?",
-                  "got it?"
-                ],
-                "category": "filler",
-                "isOptional": true
-              }
             ]
           },
           "correction": [
-            "Explicit property 'fullActionName' must be included as property names for all subphrases that contain the substring 'some'",
-            "Explicit property 'fullActionName' must be included as property names for all subphrases that contain the substring 'classic'",
-            "Explicit property 'fullActionName' must be included as property names for all subphrases that contain the substring 'Snoop Dogg'"
+            "Extraneous parameter: 'artist' is not a parameter in the action",
+            "Missing parameter: parameter 'parameters.artist' in the action is missing from explanation"
           ]
         }
       ]
@@ -871,7 +810,8 @@
             "name": "fullActionName",
             "value": "player.playRandom",
             "substrings": [
-              "turn up the heat with some fire tracks"
+              "turn up the heat",
+              "fire tracks"
             ],
             "implied": true
           }
@@ -898,13 +838,25 @@
             "isOptional": true
           },
           {
-            "text": "turn up the heat with some fire tracks",
+            "text": "turn up the heat",
             "synonyms": [
-              "play some hot songs",
-              "start some fire music",
-              "put on some lit tracks"
+              "increase the intensity",
+              "make it hotter",
+              "raise the temperature"
             ],
-            "category": "action",
+            "category": "command",
+            "propertyNames": [
+              "fullActionName"
+            ]
+          },
+          {
+            "text": "with some fire tracks",
+            "synonyms": [
+              "with some hot songs",
+              "with some great music",
+              "with some awesome tunes"
+            ],
+            "category": "command",
             "propertyNames": [
               "fullActionName"
             ]
@@ -914,9 +866,9 @@
             "synonyms": [
               "here",
               "in this place",
-              "around here"
+              "in this spot"
             ],
-            "category": "location",
+            "category": "filler",
             "isOptional": true
           }
         ],
@@ -925,25 +877,36 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.playRandom",
             "propertySubPhrases": [
-              "turn up the heat with some fire tracks"
+              "turn up the heat",
+              "with some fire tracks"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.playTopHits",
                 "propertySubPhrases": [
-                  "play the top hits"
+                  "turn up the heat",
+                  "with the top hits"
                 ]
               },
               {
-                "propertyValue": "player.playChill",
+                "propertyValue": "player.playFavorites",
                 "propertySubPhrases": [
-                  "play some chill tunes"
+                  "turn up the heat",
+                  "with my favorites"
                 ]
               },
               {
-                "propertyValue": "player.playClassics",
+                "propertyValue": "player.playNewReleases",
                 "propertySubPhrases": [
-                  "play some classic tracks"
+                  "turn up the heat",
+                  "with the new releases"
+                ]
+              },
+              {
+                "propertyValue": "player.playGenre",
+                "propertySubPhrases": [
+                  "turn up the heat",
+                  "with some jazz tracks"
                 ]
               }
             ]
@@ -965,7 +928,7 @@
             "name": "fullActionName",
             "value": "player.playTrack",
             "substrings": [
-              "let's get this party poppin' with some"
+              "let's get this party poppin' with some 'Lay Low'!"
             ],
             "implied": true
           },
@@ -980,43 +943,51 @@
         ],
         "subPhrases": [
           {
-            "text": "Ayo",
+            "text": "Ayo,",
             "synonyms": [
-              "Hey",
-              "Yo",
-              "Hi"
+              "Hey,",
+              "Yo,",
+              "Hi,"
             ],
             "category": "greeting",
             "isOptional": true
           },
           {
-            "text": "nephew",
+            "text": "nephew,",
             "synonyms": [
-              "buddy",
-              "pal",
-              "friend"
+              "buddy,",
+              "friend,",
+              "pal,"
             ],
             "category": "acknowledgement",
             "isOptional": true
           },
           {
-            "text": "let's get this party poppin' with some",
+            "text": "let's get this party poppin'",
             "synonyms": [
-              "let's start the music with",
-              "let's play",
-              "let's begin the party with"
+              "let's start the party",
+              "let's get the party started",
+              "let's begin the party"
             ],
-            "category": "command",
-            "propertyNames": [
-              "fullActionName"
-            ]
+            "category": "filler",
+            "isOptional": true
+          },
+          {
+            "text": "with some",
+            "synonyms": [
+              "with a bit of",
+              "featuring",
+              "including"
+            ],
+            "category": "preposition",
+            "isOptional": true
           },
           {
             "text": "'Lay Low'",
             "synonyms": [
               "'Lay Low'",
-              "'Lay Low' by Snoop Dogg",
-              "'Lay Low' track"
+              "'Lay Low'",
+              "'Lay Low'"
             ],
             "category": "trackName",
             "propertyNames": [
@@ -1025,33 +996,6 @@
           }
         ],
         "propertyAlternatives": [
-          {
-            "propertyName": "fullActionName",
-            "propertyValue": "player.playTrack",
-            "propertySubPhrases": [
-              "let's get this party poppin' with some"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "player.queueTrack",
-                "propertySubPhrases": [
-                  "let's add some"
-                ]
-              },
-              {
-                "propertyValue": "player.pauseTrack",
-                "propertySubPhrases": [
-                  "let's take a break from"
-                ]
-              },
-              {
-                "propertyValue": "player.stopTrack",
-                "propertySubPhrases": [
-                  "let's stop"
-                ]
-              }
-            ]
-          },
           {
             "propertyName": "parameters.trackName",
             "propertyValue": "Lay Low",
@@ -1105,7 +1049,7 @@
             "name": "parameters.trackName",
             "value": "Beautiful",
             "substrings": [
-              "'Beautiful'"
+              "Beautiful"
             ],
             "implied": false
           },
@@ -1113,7 +1057,7 @@
             "name": "parameters.artists.0",
             "value": "Pharrell",
             "substrings": [
-              "featuring Pharrell"
+              "Pharrell"
             ],
             "implied": false
           }
@@ -1142,9 +1086,9 @@
           {
             "text": "'Beautiful'",
             "synonyms": [
-              "'Beautiful' by Snoop Dogg",
-              "'Beautiful' track",
-              "'Beautiful' song"
+              "\"Beautiful\"",
+              "the track 'Beautiful'",
+              "the song 'Beautiful'"
             ],
             "category": "trackName",
             "propertyNames": [
@@ -1155,8 +1099,8 @@
             "text": "featuring Pharrell",
             "synonyms": [
               "with Pharrell",
-              "featuring Pharrell Williams",
-              "including Pharrell"
+              "by Pharrell",
+              "featuring artist Pharrell"
             ],
             "category": "artist",
             "propertyNames": [
@@ -1287,7 +1231,7 @@
             "synonyms": [
               "a few",
               "several",
-              "a number of"
+              "a bit of"
             ],
             "category": "filler",
             "isOptional": true
@@ -1332,13 +1276,13 @@
               {
                 "propertyValue": "player.playAlbum",
                 "propertySubPhrases": [
-                  "play album"
+                  "put on"
                 ]
               },
               {
                 "propertyValue": "player.playPlaylist",
                 "propertySubPhrases": [
-                  "play playlist"
+                  "queue up"
                 ]
               }
             ]
@@ -1387,7 +1331,7 @@
             "name": "fullActionName",
             "value": "player.playGenre",
             "substrings": [
-              "Can we listen to"
+              "listen to"
             ],
             "implied": true
           },
@@ -1395,21 +1339,33 @@
             "name": "parameters.genre",
             "value": "chill electronic",
             "substrings": [
-              "chill electronic music"
+              "chill electronic"
             ],
             "implied": false
           }
         ],
         "subPhrases": [
           {
-            "text": "Can we listen to",
+            "text": "Can we",
             "synonyms": [
-              "Could we play",
-              "Shall we listen to",
-              "Would you play"
+              "Could we",
+              "Shall we",
+              "May we"
             ],
             "category": "politeness",
             "isOptional": true
+          },
+          {
+            "text": "listen to",
+            "synonyms": [
+              "play",
+              "put on",
+              "start"
+            ],
+            "category": "action",
+            "propertyNames": [
+              "fullActionName"
+            ]
           },
           {
             "text": "some",
@@ -1422,48 +1378,79 @@
             "isOptional": true
           },
           {
-            "text": "chill electronic music",
+            "text": "chill electronic",
             "synonyms": [
-              "chill electronic tunes",
-              "chill electronic tracks",
-              "chill electronic songs"
+              "ambient electronic",
+              "downtempo electronic",
+              "relaxed electronic"
             ],
             "category": "genre",
             "propertyNames": [
               "parameters.genre"
             ]
+          },
+          {
+            "text": "music",
+            "synonyms": [
+              "tunes",
+              "tracks",
+              "songs"
+            ],
+            "category": "filler",
+            "isOptional": true
           }
         ],
         "propertyAlternatives": [
           {
-            "propertyName": "parameters.genre",
-            "propertyValue": "chill electronic",
+            "propertyName": "fullActionName",
+            "propertyValue": "player.playGenre",
             "propertySubPhrases": [
-              "chill electronic music"
+              "listen to"
             ],
             "alternatives": [
               {
-                "propertyValue": "lofi hip hop",
+                "propertyValue": "player.pause",
                 "propertySubPhrases": [
-                  "lofi hip hop music"
+                  "pause"
                 ]
               },
               {
-                "propertyValue": "ambient",
+                "propertyValue": "player.stop",
                 "propertySubPhrases": [
-                  "ambient music"
+                  "stop"
                 ]
               },
               {
-                "propertyValue": "downtempo",
+                "propertyValue": "player.skip",
                 "propertySubPhrases": [
-                  "downtempo music"
+                  "skip"
+                ]
+              }
+            ]
+          },
+          {
+            "propertyName": "parameters.genre",
+            "propertyValue": "chill electronic",
+            "propertySubPhrases": [
+              "chill electronic"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "jazz",
+                "propertySubPhrases": [
+                  "jazz"
                 ]
               },
               {
-                "propertyValue": "synthwave",
+                "propertyValue": "classical",
                 "propertySubPhrases": [
-                  "synthwave music"
+                  "classical"
+                ]
+              },
+              {
+                "propertyValue": "rock",
+                "propertySubPhrases": [
+                  "rock"
                 ]
               }
             ]
@@ -1493,7 +1480,7 @@
             "name": "parameters.genre",
             "value": "mellow acoustic guitar",
             "substrings": [
-              "mellow acoustic guitar music"
+              "mellow acoustic guitar"
             ],
             "implied": false
           }
@@ -1503,8 +1490,8 @@
             "text": "Can we listen to",
             "synonyms": [
               "Could we hear",
-              "Shall we play",
-              "Would you play"
+              "May we play",
+              "Shall we listen to"
             ],
             "category": "politeness",
             "isOptional": true
@@ -1520,16 +1507,26 @@
             "isOptional": true
           },
           {
-            "text": "mellow acoustic guitar music",
+            "text": "mellow acoustic guitar",
             "synonyms": [
-              "soft acoustic guitar tunes",
-              "calm acoustic guitar songs",
-              "relaxing acoustic guitar tracks"
+              "soft acoustic guitar",
+              "gentle acoustic guitar",
+              "calm acoustic guitar"
             ],
             "category": "genre",
             "propertyNames": [
               "parameters.genre"
             ]
+          },
+          {
+            "text": "music",
+            "synonyms": [
+              "tunes",
+              "melodies",
+              "songs"
+            ],
+            "category": "filler",
+            "isOptional": true
           }
         ],
         "propertyAlternatives": [
@@ -1537,31 +1534,31 @@
             "propertyName": "parameters.genre",
             "propertyValue": "mellow acoustic guitar",
             "propertySubPhrases": [
-              "mellow acoustic guitar music"
+              "mellow acoustic guitar"
             ],
             "alternatives": [
               {
                 "propertyValue": "classical piano",
                 "propertySubPhrases": [
-                  "classical piano music"
+                  "classical piano"
                 ]
               },
               {
                 "propertyValue": "jazz saxophone",
                 "propertySubPhrases": [
-                  "jazz saxophone music"
+                  "jazz saxophone"
                 ]
               },
               {
-                "propertyValue": "upbeat pop",
+                "propertyValue": "soft rock",
                 "propertySubPhrases": [
-                  "upbeat pop music"
+                  "soft rock"
                 ]
               },
               {
-                "propertyValue": "relaxing ambient",
+                "propertyValue": "ambient electronic",
                 "propertySubPhrases": [
-                  "relaxing ambient music"
+                  "ambient electronic"
                 ]
               }
             ]
@@ -1583,7 +1580,7 @@
             "name": "fullActionName",
             "value": "player.playArtist",
             "substrings": [
-              "entertain me with some"
+              "Can you entertain me with some Bach melodies, please?"
             ],
             "implied": true
           },
@@ -1608,11 +1605,11 @@
             "isOptional": true
           },
           {
-            "text": "entertain me with some",
+            "text": "entertain me with",
             "synonyms": [
-              "play me some",
-              "give me some",
-              "provide me with some"
+              "play for me",
+              "provide me with",
+              "give me"
             ],
             "category": "action",
             "propertyNames": [
@@ -1620,26 +1617,16 @@
             ]
           },
           {
-            "text": "Bach",
+            "text": "some Bach melodies",
             "synonyms": [
-              "Beethoven",
-              "Mozart",
-              "Chopin"
+              "Bach music",
+              "Bach tunes",
+              "Bach songs"
             ],
-            "category": "artist",
+            "category": "content",
             "propertyNames": [
               "parameters.artist"
             ]
-          },
-          {
-            "text": "melodies",
-            "synonyms": [
-              "tunes",
-              "songs",
-              "pieces"
-            ],
-            "category": "music",
-            "isOptional": true
           },
           {
             "text": "please",
@@ -1657,25 +1644,25 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.playArtist",
             "propertySubPhrases": [
-              "entertain me with some"
+              "entertain me with"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.playSong",
                 "propertySubPhrases": [
-                  "play a song by"
+                  "play me"
                 ]
               },
               {
                 "propertyValue": "player.playAlbum",
                 "propertySubPhrases": [
-                  "play an album by"
+                  "put on"
                 ]
               },
               {
                 "propertyValue": "player.playPlaylist",
                 "propertySubPhrases": [
-                  "play a playlist by"
+                  "start a playlist with"
                 ]
               }
             ]
@@ -1684,25 +1671,25 @@
             "propertyName": "parameters.artist",
             "propertyValue": "Bach",
             "propertySubPhrases": [
-              "Bach"
+              "some Bach melodies"
             ],
             "alternatives": [
               {
                 "propertyValue": "Mozart",
                 "propertySubPhrases": [
-                  "Mozart"
+                  "some Mozart tunes"
                 ]
               },
               {
                 "propertyValue": "Beethoven",
                 "propertySubPhrases": [
-                  "Beethoven"
+                  "some Beethoven pieces"
                 ]
               },
               {
                 "propertyValue": "Chopin",
                 "propertySubPhrases": [
-                  "Chopin"
+                  "some Chopin compositions"
                 ]
               }
             ]
@@ -1724,7 +1711,7 @@
             "name": "fullActionName",
             "value": "player.playArtist",
             "substrings": [
-              "entertain me with some"
+              "Can you entertain me with some Bach music?"
             ],
             "implied": true
           },
@@ -1749,11 +1736,11 @@
             "isOptional": true
           },
           {
-            "text": "entertain me with some",
+            "text": "entertain me with",
             "synonyms": [
-              "play some",
-              "put on some",
-              "give me some"
+              "play for me",
+              "provide me with",
+              "give me"
             ],
             "category": "action",
             "propertyNames": [
@@ -1761,26 +1748,16 @@
             ]
           },
           {
-            "text": "Bach",
+            "text": "some Bach music",
             "synonyms": [
-              "Beethoven",
-              "Mozart",
-              "Chopin"
+              "Bach tunes",
+              "Bach songs",
+              "Bach pieces"
             ],
-            "category": "artist",
+            "category": "content",
             "propertyNames": [
               "parameters.artist"
             ]
-          },
-          {
-            "text": "music",
-            "synonyms": [
-              "tunes",
-              "songs",
-              "melodies"
-            ],
-            "category": "filler",
-            "isOptional": true
           }
         ],
         "propertyAlternatives": [
@@ -1788,7 +1765,7 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.playArtist",
             "propertySubPhrases": [
-              "entertain me with some"
+              "entertain me with"
             ],
             "alternatives": [
               {
@@ -1815,25 +1792,25 @@
             "propertyName": "parameters.artist",
             "propertyValue": "Bach",
             "propertySubPhrases": [
-              "Bach"
+              "some Bach music"
             ],
             "alternatives": [
               {
                 "propertyValue": "Mozart",
                 "propertySubPhrases": [
-                  "Mozart"
+                  "some Mozart music"
                 ]
               },
               {
                 "propertyValue": "Beethoven",
                 "propertySubPhrases": [
-                  "Beethoven"
+                  "some Beethoven music"
                 ]
               },
               {
                 "propertyValue": "Chopin",
                 "propertySubPhrases": [
-                  "Chopin"
+                  "some Chopin music"
                 ]
               }
             ]
@@ -1884,7 +1861,7 @@
             "synonyms": [
               "start",
               "put on",
-              "stream"
+              "turn on"
             ],
             "category": "action",
             "propertyNames": [
@@ -1894,9 +1871,9 @@
           {
             "text": "some fun",
             "synonyms": [
-              "a few fun",
-              "some enjoyable",
-              "a couple of fun"
+              "a few",
+              "some cool",
+              "some great"
             ],
             "category": "filler",
             "isOptional": true
@@ -1916,9 +1893,9 @@
           {
             "text": "for us to enjoy",
             "synonyms": [
-              "for our enjoyment",
+              "for us",
               "so we can enjoy",
-              "for us"
+              "for our enjoyment"
             ],
             "category": "filler",
             "isOptional": true
@@ -1966,9 +1943,9 @@
                 ]
               },
               {
-                "propertyValue": "classic rock",
+                "propertyValue": "rock music",
                 "propertySubPhrases": [
-                  "classic rock"
+                  "rock music"
                 ]
               },
               {
@@ -1996,7 +1973,7 @@
             "name": "fullActionName",
             "value": "player.playArtist",
             "substrings": [
-              "Can you play some music"
+              "Can you play some music by"
             ],
             "implied": true
           },
@@ -2021,11 +1998,11 @@
             "isOptional": true
           },
           {
-            "text": "play some music",
+            "text": "play some music by",
             "synonyms": [
-              "play a song",
-              "play tunes",
-              "play tracks"
+              "play music by",
+              "play songs by",
+              "play tracks by"
             ],
             "category": "action",
             "propertyNames": [
@@ -2033,11 +2010,11 @@
             ]
           },
           {
-            "text": "by Bach",
+            "text": "Bach",
             "synonyms": [
-              "from Bach",
-              "of Bach",
-              "Bach's music"
+              "Johann Sebastian Bach",
+              "J.S. Bach",
+              "Sebastian Bach"
             ],
             "category": "artist",
             "propertyNames": [
@@ -2050,7 +2027,166 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.playArtist",
             "propertySubPhrases": [
-              "play some music"
+              "play some music by"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "player.playSong",
+                "propertySubPhrases": [
+                  "play a song by"
+                ]
+              },
+              {
+                "propertyValue": "player.playAlbum",
+                "propertySubPhrases": [
+                  "play an album by"
+                ]
+              },
+              {
+                "propertyValue": "player.playPlaylist",
+                "propertySubPhrases": [
+                  "play a playlist by"
+                ]
+              }
+            ]
+          },
+          {
+            "propertyName": "parameters.artist",
+            "propertyValue": "Bach",
+            "propertySubPhrases": [
+              "Bach"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "Mozart",
+                "propertySubPhrases": [
+                  "Mozart"
+                ]
+              },
+              {
+                "propertyValue": "Beethoven",
+                "propertySubPhrases": [
+                  "Beethoven"
+                ]
+              },
+              {
+                "propertyValue": "Chopin",
+                "propertySubPhrases": [
+                  "Chopin"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "corrections": [
+        {
+          "data": {
+            "properties": [
+              {
+                "name": "fullActionName",
+                "value": "player.playArtist",
+                "substrings": [
+                  "Can you play some music by"
+                ],
+                "implied": true
+              },
+              {
+                "name": "artist",
+                "value": "Bach",
+                "substrings": [
+                  "Bach"
+                ],
+                "implied": false
+              }
+            ]
+          },
+          "correction": [
+            "Extraneous parameter: 'artist' is not a parameter in the action",
+            "Missing parameter: parameter 'parameters.artist' in the action is missing from explanation"
+          ]
+        }
+      ]
+    },
+    {
+      "request": "Can you play some of Bach's works for us?",
+      "action": {
+        "fullActionName": "player.playArtist",
+        "parameters": {
+          "artist": "Bach"
+        }
+      },
+      "explanation": {
+        "properties": [
+          {
+            "name": "fullActionName",
+            "value": "player.playArtist",
+            "substrings": [
+              "play"
+            ],
+            "implied": false
+          },
+          {
+            "name": "parameters.artist",
+            "value": "Bach",
+            "substrings": [
+              "Bach"
+            ],
+            "implied": false
+          }
+        ],
+        "subPhrases": [
+          {
+            "text": "Can you",
+            "synonyms": [
+              "Could you",
+              "Would you",
+              "Will you"
+            ],
+            "category": "politeness",
+            "isOptional": true
+          },
+          {
+            "text": "play",
+            "synonyms": [
+              "perform",
+              "put on",
+              "start"
+            ],
+            "category": "action",
+            "propertyNames": [
+              "fullActionName"
+            ]
+          },
+          {
+            "text": "some of Bach's works",
+            "synonyms": [
+              "Bach's music",
+              "Bach's compositions",
+              "Bach's pieces"
+            ],
+            "category": "artist",
+            "propertyNames": [
+              "parameters.artist"
+            ]
+          },
+          {
+            "text": "for us",
+            "synonyms": [
+              "for me",
+              "for them",
+              "for everyone"
+            ],
+            "category": "filler",
+            "isOptional": true
+          }
+        ],
+        "propertyAlternatives": [
+          {
+            "propertyName": "fullActionName",
+            "propertyValue": "player.playArtist",
+            "propertySubPhrases": [
+              "play"
             ],
             "alternatives": [
               {
@@ -2077,156 +2213,25 @@
             "propertyName": "parameters.artist",
             "propertyValue": "Bach",
             "propertySubPhrases": [
-              "by Bach"
+              "some of Bach's works"
             ],
             "alternatives": [
               {
                 "propertyValue": "Mozart",
                 "propertySubPhrases": [
-                  "by Mozart"
+                  "some of Mozart's works"
                 ]
               },
               {
                 "propertyValue": "Beethoven",
                 "propertySubPhrases": [
-                  "by Beethoven"
+                  "some of Beethoven's works"
                 ]
               },
               {
                 "propertyValue": "Chopin",
                 "propertySubPhrases": [
-                  "by Chopin"
-                ]
-              }
-            ]
-          }
-        ]
-      }
-    },
-    {
-      "request": "Can you play some of Bach's works for us?",
-      "action": {
-        "fullActionName": "player.playArtist",
-        "parameters": {
-          "artist": "Bach"
-        }
-      },
-      "explanation": {
-        "properties": [
-          {
-            "name": "fullActionName",
-            "value": "player.playArtist",
-            "substrings": [
-              "Can you play"
-            ],
-            "implied": true
-          },
-          {
-            "name": "parameters.artist",
-            "value": "Bach",
-            "substrings": [
-              "Bach"
-            ],
-            "implied": false
-          }
-        ],
-        "subPhrases": [
-          {
-            "text": "Can you play",
-            "synonyms": [
-              "Could you play",
-              "Would you play",
-              "Please play"
-            ],
-            "category": "request",
-            "propertyNames": [
-              "fullActionName"
-            ]
-          },
-          {
-            "text": "some of",
-            "synonyms": [
-              "a few of",
-              "any of",
-              "a selection of"
-            ],
-            "category": "filler",
-            "isOptional": true
-          },
-          {
-            "text": "Bach's works",
-            "synonyms": [
-              "Bach's music",
-              "Bach's compositions",
-              "Bach's pieces"
-            ],
-            "category": "artist",
-            "propertyNames": [
-              "parameters.artist"
-            ]
-          },
-          {
-            "text": "for us",
-            "synonyms": [
-              "for me",
-              "for everyone",
-              "for the group"
-            ],
-            "category": "filler",
-            "isOptional": true
-          }
-        ],
-        "propertyAlternatives": [
-          {
-            "propertyName": "fullActionName",
-            "propertyValue": "player.playArtist",
-            "propertySubPhrases": [
-              "Can you play"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "player.playSong",
-                "propertySubPhrases": [
-                  "Can you play a song by"
-                ]
-              },
-              {
-                "propertyValue": "player.playAlbum",
-                "propertySubPhrases": [
-                  "Can you play an album by"
-                ]
-              },
-              {
-                "propertyValue": "player.playPlaylist",
-                "propertySubPhrases": [
-                  "Can you play a playlist by"
-                ]
-              }
-            ]
-          },
-          {
-            "propertyName": "parameters.artist",
-            "propertyValue": "Bach",
-            "propertySubPhrases": [
-              "Bach's works"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "Mozart",
-                "propertySubPhrases": [
-                  "Mozart's works"
-                ]
-              },
-              {
-                "propertyValue": "Beethoven",
-                "propertySubPhrases": [
-                  "Beethoven's works"
-                ]
-              },
-              {
-                "propertyValue": "Chopin",
-                "propertySubPhrases": [
-                  "Chopin's works"
+                  "some of Chopin's works"
                 ]
               }
             ]
@@ -2263,26 +2268,14 @@
         ],
         "subPhrases": [
           {
-            "text": "Can you",
+            "text": "Can you play",
             "synonyms": [
-              "Could you",
-              "Would you",
-              "Will you"
+              "Could you play",
+              "Would you play",
+              "Please play"
             ],
             "category": "politeness",
             "isOptional": true
-          },
-          {
-            "text": "play",
-            "synonyms": [
-              "perform",
-              "put on",
-              "start"
-            ],
-            "category": "action",
-            "propertyNames": [
-              "fullActionName"
-            ]
           },
           {
             "text": "some pieces by",
@@ -2299,7 +2292,7 @@
             "synonyms": [
               "Johann Sebastian Bach",
               "J.S. Bach",
-              "Bach's compositions"
+              "Bach's music"
             ],
             "category": "artist",
             "propertyNames": [
@@ -2308,33 +2301,6 @@
           }
         ],
         "propertyAlternatives": [
-          {
-            "propertyName": "fullActionName",
-            "propertyValue": "player.playArtist",
-            "propertySubPhrases": [
-              "play"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "player.playSong",
-                "propertySubPhrases": [
-                  "play a song"
-                ]
-              },
-              {
-                "propertyValue": "player.playAlbum",
-                "propertySubPhrases": [
-                  "play an album"
-                ]
-              },
-              {
-                "propertyValue": "player.playPlaylist",
-                "propertySubPhrases": [
-                  "play a playlist"
-                ]
-              }
-            ]
-          },
           {
             "propertyName": "parameters.artist",
             "propertyValue": "Bach",
@@ -2363,7 +2329,35 @@
             ]
           }
         ]
-      }
+      },
+      "corrections": [
+        {
+          "data": {
+            "properties": [
+              {
+                "name": "fullActionName",
+                "value": "player.playArtist",
+                "substrings": [
+                  "Can you play"
+                ],
+                "implied": true
+              },
+              {
+                "name": "artist",
+                "value": "Bach",
+                "substrings": [
+                  "Bach"
+                ],
+                "implied": false
+              }
+            ]
+          },
+          "correction": [
+            "Extraneous parameter: 'artist' is not a parameter in the action",
+            "Missing parameter: parameter 'parameters.artist' in the action is missing from explanation"
+          ]
+        }
+      ]
     },
     {
       "request": "Can you play some relaxing jazz music for us?",
@@ -2379,7 +2373,7 @@
             "name": "fullActionName",
             "value": "player.playGenre",
             "substrings": [
-              "play"
+              "Can you play some relaxing jazz music for us?"
             ],
             "implied": true
           },
@@ -2406,9 +2400,9 @@
           {
             "text": "play",
             "synonyms": [
+              "put on",
               "start",
-              "begin",
-              "put on"
+              "begin"
             ],
             "category": "action",
             "propertyNames": [
@@ -2418,9 +2412,9 @@
           {
             "text": "some relaxing",
             "synonyms": [
-              "a bit of relaxing",
-              "some soothing",
-              "a little relaxing"
+              "a bit of",
+              "a little",
+              "some soothing"
             ],
             "category": "description",
             "isOptional": true
@@ -2428,9 +2422,9 @@
           {
             "text": "jazz",
             "synonyms": [
-              "jazz music",
-              "smooth jazz",
-              "jazz tunes"
+              "blues",
+              "swing",
+              "bebop"
             ],
             "category": "genre",
             "propertyNames": [
@@ -2444,7 +2438,7 @@
               "melodies",
               "songs"
             ],
-            "category": "filler",
+            "category": "object",
             "isOptional": true
           },
           {
@@ -2454,7 +2448,7 @@
               "for everyone",
               "for the group"
             ],
-            "category": "filler",
+            "category": "preposition",
             "isOptional": true
           }
         ],
@@ -2467,21 +2461,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.pause",
+                "propertyValue": "player.startGenre",
                 "propertySubPhrases": [
-                  "pause"
+                  "start"
                 ]
               },
               {
-                "propertyValue": "player.stop",
+                "propertyValue": "player.beginGenre",
                 "propertySubPhrases": [
-                  "stop"
+                  "begin"
                 ]
               },
               {
-                "propertyValue": "player.resume",
+                "propertyValue": "player.initiateGenre",
                 "propertySubPhrases": [
-                  "resume"
+                  "initiate"
                 ]
               }
             ]
@@ -2556,26 +2550,14 @@
         ],
         "subPhrases": [
           {
-            "text": "Can you",
+            "text": "Can you play",
             "synonyms": [
-              "Could you",
-              "Would you",
-              "Will you"
+              "Could you play",
+              "Would you play",
+              "Please play"
             ],
             "category": "politeness",
             "isOptional": true
-          },
-          {
-            "text": "play",
-            "synonyms": [
-              "put on",
-              "start",
-              "playback"
-            ],
-            "category": "action",
-            "propertyNames": [
-              "fullActionName"
-            ]
           },
           {
             "text": "some",
@@ -2602,9 +2584,9 @@
           {
             "text": "'Gin and Juice'",
             "synonyms": [
-              "\"Gin and Juice\"",
               "the track 'Gin and Juice'",
-              "the song 'Gin and Juice'"
+              "the song 'Gin and Juice'",
+              "'Gin and Juice' by Snoop Dogg"
             ],
             "category": "track",
             "propertyNames": [
@@ -2613,33 +2595,6 @@
           }
         ],
         "propertyAlternatives": [
-          {
-            "propertyName": "fullActionName",
-            "propertyValue": "player.playTrack",
-            "propertySubPhrases": [
-              "play"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "player.queueTrack",
-                "propertySubPhrases": [
-                  "queue"
-                ]
-              },
-              {
-                "propertyValue": "player.addTrackToPlaylist",
-                "propertySubPhrases": [
-                  "add"
-                ]
-              },
-              {
-                "propertyValue": "player.shufflePlay",
-                "propertySubPhrases": [
-                  "shuffle"
-                ]
-              }
-            ]
-          },
           {
             "propertyName": "parameters.artists.0",
             "propertyValue": "Snoop Dogg",
@@ -2681,15 +2636,15 @@
                 ]
               },
               {
-                "propertyValue": "Still D.R.E.",
-                "propertySubPhrases": [
-                  "'Still D.R.E.'"
-                ]
-              },
-              {
                 "propertyValue": "Drop It Like It's Hot",
                 "propertySubPhrases": [
                   "'Drop It Like It's Hot'"
+                ]
+              },
+              {
+                "propertyValue": "Still D.R.E.",
+                "propertySubPhrases": [
+                  "'Still D.R.E.'"
                 ]
               }
             ]
@@ -2711,7 +2666,7 @@
             "name": "fullActionName",
             "value": "player.playArtist",
             "substrings": [
-              "Can you put on"
+              "Can you put on some Bach tunes?"
             ],
             "implied": true
           },
@@ -2748,16 +2703,36 @@
             ]
           },
           {
-            "text": "some Bach tunes",
+            "text": "some",
             "synonyms": [
-              "Bach music",
-              "Bach songs",
-              "Bach pieces"
+              "a few",
+              "any",
+              "several"
+            ],
+            "category": "filler",
+            "isOptional": true
+          },
+          {
+            "text": "Bach",
+            "synonyms": [
+              "Beethoven",
+              "Mozart",
+              "Chopin"
             ],
             "category": "artist",
             "propertyNames": [
               "parameters.artist"
             ]
+          },
+          {
+            "text": "tunes",
+            "synonyms": [
+              "songs",
+              "tracks",
+              "music"
+            ],
+            "category": "music",
+            "isOptional": true
           }
         ],
         "propertyAlternatives": [
@@ -2771,19 +2746,19 @@
               {
                 "propertyValue": "player.startArtist",
                 "propertySubPhrases": [
-                  "start playing"
+                  "play"
                 ]
               },
               {
                 "propertyValue": "player.queueArtist",
                 "propertySubPhrases": [
-                  "queue up"
+                  "add"
                 ]
               },
               {
-                "propertyValue": "player.beginArtist",
+                "propertyValue": "player.streamArtist",
                 "propertySubPhrases": [
-                  "begin playing"
+                  "stream"
                 ]
               }
             ]
@@ -2792,31 +2767,59 @@
             "propertyName": "parameters.artist",
             "propertyValue": "Bach",
             "propertySubPhrases": [
-              "some Bach tunes"
+              "Bach"
             ],
             "alternatives": [
               {
                 "propertyValue": "Mozart",
                 "propertySubPhrases": [
-                  "some Mozart tunes"
+                  "Mozart"
                 ]
               },
               {
                 "propertyValue": "Beethoven",
                 "propertySubPhrases": [
-                  "some Beethoven tunes"
+                  "Beethoven"
                 ]
               },
               {
                 "propertyValue": "Chopin",
                 "propertySubPhrases": [
-                  "some Chopin tunes"
+                  "Chopin"
                 ]
               }
             ]
           }
         ]
-      }
+      },
+      "corrections": [
+        {
+          "data": {
+            "properties": [
+              {
+                "name": "fullActionName",
+                "value": "player.playArtist",
+                "substrings": [
+                  "Can you put on some Bach tunes?"
+                ],
+                "implied": true
+              },
+              {
+                "name": "artist",
+                "value": "Bach",
+                "substrings": [
+                  "Bach"
+                ],
+                "implied": false
+              }
+            ]
+          },
+          "correction": [
+            "Extraneous parameter: 'artist' is not a parameter in the action",
+            "Missing parameter: parameter 'parameters.artist' in the action is missing from explanation"
+          ]
+        }
+      ]
     },
     {
       "request": "Can you put on some music?",
@@ -2868,9 +2871,15 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.playSpecific",
+                "propertyValue": "player.playSong",
                 "propertySubPhrases": [
-                  "play a specific song"
+                  "play a song"
+                ]
+              },
+              {
+                "propertyValue": "player.playAlbum",
+                "propertySubPhrases": [
+                  "play an album"
                 ]
               },
               {
@@ -2880,9 +2889,9 @@
                 ]
               },
               {
-                "propertyValue": "player.playGenre",
+                "propertyValue": "player.playArtist",
                 "propertySubPhrases": [
-                  "play some jazz"
+                  "play some artist"
                 ]
               }
             ]
@@ -2922,8 +2931,8 @@
             "text": "put on some tunes",
             "synonyms": [
               "play some music",
-              "start the music",
-              "turn on some tunes"
+              "start some songs",
+              "turn on some tracks"
             ],
             "category": "action",
             "propertyNames": [
@@ -2995,7 +3004,7 @@
             "name": "parameters.artists.0",
             "value": "Fleetwood Mac",
             "substrings": [
-              "Fleetwood Mac"
+              "by Fleetwood Mac"
             ],
             "implied": false
           }
@@ -3027,8 +3036,8 @@
             "text": "'Rumours'",
             "synonyms": [
               "'Rumors'",
-              "'Rumours' album",
-              "'Rumours' record"
+              "'RUMOURS'",
+              "'rumours'"
             ],
             "category": "albumName",
             "propertyNames": [
@@ -3040,7 +3049,7 @@
             "synonyms": [
               "from Fleetwood Mac",
               "Fleetwood Mac's",
-              "Fleetwood Mac album"
+              "by the band Fleetwood Mac"
             ],
             "category": "artist",
             "propertyNames": [
@@ -3111,15 +3120,15 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "The Beatles",
-                "propertySubPhrases": [
-                  "by The Beatles"
-                ]
-              },
-              {
                 "propertyValue": "Pink Floyd",
                 "propertySubPhrases": [
                   "by Pink Floyd"
+                ]
+              },
+              {
+                "propertyValue": "The Beatles",
+                "propertySubPhrases": [
+                  "by The Beatles"
                 ]
               },
               {
@@ -3149,16 +3158,14 @@
           {
             "name": "fullActionName",
             "value": "player.playAlbum",
-            "substrings": [
-              "put on the album"
-            ],
+            "substrings": [],
             "implied": true
           },
           {
             "name": "parameters.albumName",
             "value": "Thriller",
             "substrings": [
-              "'Thriller'"
+              "the album 'Thriller'"
             ],
             "implied": false
           },
@@ -3166,7 +3173,7 @@
             "name": "parameters.artists.0",
             "value": "Michael Jackson",
             "substrings": [
-              "Michael Jackson"
+              "by Michael Jackson"
             ],
             "implied": false
           }
@@ -3183,11 +3190,11 @@
             "isOptional": true
           },
           {
-            "text": "put on the album",
+            "text": "put on",
             "synonyms": [
-              "play the album",
-              "start the album",
-              "begin the album"
+              "play",
+              "start",
+              "turn on"
             ],
             "category": "action",
             "propertyNames": [
@@ -3195,13 +3202,13 @@
             ]
           },
           {
-            "text": "'Thriller'",
+            "text": "the album 'Thriller'",
             "synonyms": [
-              "'Bad'",
-              "'Dangerous'",
-              "'Off the Wall'"
+              "the record 'Thriller'",
+              "the music album 'Thriller'",
+              "the LP 'Thriller'"
             ],
-            "category": "albumName",
+            "category": "object",
             "propertyNames": [
               "parameters.albumName"
             ]
@@ -3210,8 +3217,8 @@
             "text": "by Michael Jackson",
             "synonyms": [
               "by MJ",
-              "by the King of Pop",
-              "by Michael"
+              "by the artist Michael Jackson",
+              "by the singer Michael Jackson"
             ],
             "category": "artist",
             "propertyNames": [
@@ -3224,25 +3231,25 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.playAlbum",
             "propertySubPhrases": [
-              "put on the album"
+              "put on"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.startAlbum",
                 "propertySubPhrases": [
-                  "start the album"
+                  "start"
                 ]
               },
               {
                 "propertyValue": "player.queueAlbum",
                 "propertySubPhrases": [
-                  "queue the album"
+                  "queue"
                 ]
               },
               {
-                "propertyValue": "player.playRecord",
+                "propertyValue": "player.playMusic",
                 "propertySubPhrases": [
-                  "play the record"
+                  "play"
                 ]
               }
             ]
@@ -3251,25 +3258,25 @@
             "propertyName": "parameters.albumName",
             "propertyValue": "Thriller",
             "propertySubPhrases": [
-              "'Thriller'"
+              "the album 'Thriller'"
             ],
             "alternatives": [
               {
                 "propertyValue": "Bad",
                 "propertySubPhrases": [
-                  "'Bad'"
+                  "the album 'Bad'"
                 ]
               },
               {
                 "propertyValue": "Dangerous",
                 "propertySubPhrases": [
-                  "'Dangerous'"
+                  "the album 'Dangerous'"
                 ]
               },
               {
                 "propertyValue": "Off the Wall",
                 "propertySubPhrases": [
-                  "'Off the Wall'"
+                  "the album 'Off the Wall'"
                 ]
               }
             ]
@@ -3318,7 +3325,7 @@
             "name": "fullActionName",
             "value": "player.playArtist",
             "substrings": [
-              "serenade me with some beautiful Bach compositions"
+              "Can you serenade me with some beautiful Bach compositions?"
             ],
             "implied": true
           },
@@ -3343,16 +3350,24 @@
             "isOptional": true
           },
           {
-            "text": "serenade me with some beautiful",
+            "text": "serenade me with",
             "synonyms": [
-              "play me some beautiful",
-              "give me some beautiful",
-              "provide me with some beautiful"
+              "play for me",
+              "perform for me",
+              "give me"
             ],
-            "category": "action",
-            "propertyNames": [
-              "fullActionName"
-            ]
+            "category": "request",
+            "isOptional": false
+          },
+          {
+            "text": "some beautiful",
+            "synonyms": [
+              "a few lovely",
+              "several wonderful",
+              "a number of delightful"
+            ],
+            "category": "description",
+            "isOptional": true
           },
           {
             "text": "Bach",
@@ -3379,33 +3394,6 @@
         ],
         "propertyAlternatives": [
           {
-            "propertyName": "fullActionName",
-            "propertyValue": "player.playArtist",
-            "propertySubPhrases": [
-              "serenade me with some beautiful"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "player.playSong",
-                "propertySubPhrases": [
-                  "play a beautiful"
-                ]
-              },
-              {
-                "propertyValue": "player.playAlbum",
-                "propertySubPhrases": [
-                  "play an amazing"
-                ]
-              },
-              {
-                "propertyValue": "player.playPlaylist",
-                "propertySubPhrases": [
-                  "play a wonderful"
-                ]
-              }
-            ]
-          },
-          {
             "propertyName": "parameters.artist",
             "propertyValue": "Bach",
             "propertySubPhrases": [
@@ -3413,15 +3401,15 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "Mozart",
-                "propertySubPhrases": [
-                  "Mozart"
-                ]
-              },
-              {
                 "propertyValue": "Beethoven",
                 "propertySubPhrases": [
                   "Beethoven"
+                ]
+              },
+              {
+                "propertyValue": "Mozart",
+                "propertySubPhrases": [
+                  "Mozart"
                 ]
               },
               {
@@ -3468,7 +3456,7 @@
             "synonyms": [
               "Would you kindly",
               "Please",
-              "Can you"
+              "Would you be so kind as to"
             ],
             "category": "politeness",
             "isOptional": true
@@ -3554,7 +3542,35 @@
             ]
           }
         ]
-      }
+      },
+      "corrections": [
+        {
+          "data": {
+            "properties": [
+              {
+                "name": "fullActionName",
+                "value": "player.playArtist",
+                "substrings": [
+                  "entertain us with a touch of"
+                ],
+                "implied": true
+              },
+              {
+                "name": "artist",
+                "value": "Handel",
+                "substrings": [
+                  "Handel"
+                ],
+                "implied": false
+              }
+            ]
+          },
+          "correction": [
+            "Extraneous parameter: 'artist' is not a parameter in the action",
+            "Missing parameter: parameter 'parameters.artist' in the action is missing from explanation"
+          ]
+        }
+      ]
     },
     {
       "request": "Could you be so gracious as to treat us to some of Wagner's most enthralling works?",
@@ -3570,7 +3586,7 @@
             "name": "fullActionName",
             "value": "player.playArtist",
             "substrings": [
-              "treat us to some of"
+              "treat us to"
             ],
             "implied": true
           },
@@ -3595,10 +3611,10 @@
             "isOptional": true
           },
           {
-            "text": "treat us to some of",
+            "text": "treat us to",
             "synonyms": [
-              "play",
-              "put on",
+              "play for us",
+              "let us hear",
               "give us"
             ],
             "category": "action",
@@ -3607,26 +3623,16 @@
             ]
           },
           {
-            "text": "Wagner's",
+            "text": "some of Wagner's most enthralling works",
             "synonyms": [
-              "Wagner",
-              "the works of Wagner",
-              "music by Wagner"
+              "Wagner's best pieces",
+              "Wagner's top compositions",
+              "Wagner's finest music"
             ],
             "category": "artist",
             "propertyNames": [
               "parameters.artist"
             ]
-          },
-          {
-            "text": "most enthralling works",
-            "synonyms": [
-              "best pieces",
-              "most captivating compositions",
-              "top tracks"
-            ],
-            "category": "description",
-            "isOptional": true
           }
         ],
         "propertyAlternatives": [
@@ -3634,25 +3640,25 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.playArtist",
             "propertySubPhrases": [
-              "treat us to some of"
+              "treat us to"
             ],
             "alternatives": [
               {
-                "propertyValue": "player.playAlbum",
+                "propertyValue": "player.playSong",
                 "propertySubPhrases": [
-                  "play an album by"
+                  "play a song for us"
                 ]
               },
               {
-                "propertyValue": "player.playSong",
+                "propertyValue": "player.playAlbum",
                 "propertySubPhrases": [
-                  "play a song by"
+                  "play an album for us"
                 ]
               },
               {
                 "propertyValue": "player.playPlaylist",
                 "propertySubPhrases": [
-                  "play a playlist by"
+                  "play a playlist for us"
                 ]
               }
             ]
@@ -3661,31 +3667,59 @@
             "propertyName": "parameters.artist",
             "propertyValue": "Wagner",
             "propertySubPhrases": [
-              "Wagner's"
+              "some of Wagner's most enthralling works"
             ],
             "alternatives": [
               {
                 "propertyValue": "Beethoven",
                 "propertySubPhrases": [
-                  "Beethoven's"
+                  "some of Beethoven's most enthralling works"
                 ]
               },
               {
                 "propertyValue": "Mozart",
                 "propertySubPhrases": [
-                  "Mozart's"
+                  "some of Mozart's most enthralling works"
                 ]
               },
               {
                 "propertyValue": "Bach",
                 "propertySubPhrases": [
-                  "Bach's"
+                  "some of Bach's most enthralling works"
                 ]
               }
             ]
           }
         ]
-      }
+      },
+      "corrections": [
+        {
+          "data": {
+            "properties": [
+              {
+                "name": "fullActionName",
+                "value": "player.playArtist",
+                "substrings": [
+                  "treat us to"
+                ],
+                "implied": true
+              },
+              {
+                "name": "artist",
+                "value": "Wagner",
+                "substrings": [
+                  "Wagner"
+                ],
+                "implied": false
+              }
+            ]
+          },
+          "correction": [
+            "Extraneous parameter: 'artist' is not a parameter in the action",
+            "Missing parameter: parameter 'parameters.artist' in the action is missing from explanation"
+          ]
+        }
+      ]
     },
     {
       "request": "Could you kindly play some Bach compositions, bot?",
@@ -3754,7 +3788,7 @@
             "synonyms": [
               "assistant",
               "AI",
-              "helper"
+              "system"
             ],
             "category": "acknowledgement",
             "isOptional": true
@@ -3832,9 +3866,9 @@
             "name": "fullActionName",
             "value": "player.playArtist",
             "substrings": [
-              "play"
+              "Could you play some compositions by Bach?"
             ],
-            "implied": true
+            "implied": false
           },
           {
             "name": "parameters.artist",
@@ -3857,26 +3891,16 @@
             "isOptional": true
           },
           {
-            "text": "play",
+            "text": "play some compositions by",
             "synonyms": [
-              "start",
-              "begin",
-              "put on"
+              "play music by",
+              "play pieces by",
+              "play works by"
             ],
             "category": "action",
             "propertyNames": [
               "fullActionName"
             ]
-          },
-          {
-            "text": "some compositions by",
-            "synonyms": [
-              "music by",
-              "pieces by",
-              "works by"
-            ],
-            "category": "preposition",
-            "isOptional": true
           },
           {
             "text": "Bach",
@@ -3896,25 +3920,25 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.playArtist",
             "propertySubPhrases": [
-              "play"
+              "play some compositions by"
             ],
             "alternatives": [
               {
-                "propertyValue": "player.pauseArtist",
+                "propertyValue": "player.playAlbum",
                 "propertySubPhrases": [
-                  "pause"
+                  "play the album by"
                 ]
               },
               {
-                "propertyValue": "player.stopArtist",
+                "propertyValue": "player.playSong",
                 "propertySubPhrases": [
-                  "stop"
+                  "play the song by"
                 ]
               },
               {
-                "propertyValue": "player.skipArtist",
+                "propertyValue": "player.playPlaylist",
                 "propertySubPhrases": [
-                  "skip"
+                  "play the playlist by"
                 ]
               }
             ]
@@ -3963,7 +3987,7 @@
             "name": "fullActionName",
             "value": "player.playAlbum",
             "substrings": [
-              "Could you play"
+              "play"
             ],
             "implied": true
           },
@@ -3978,29 +4002,68 @@
         ],
         "subPhrases": [
           {
-            "text": "Could you play",
+            "text": "Could you",
             "synonyms": [
-              "Can you play",
-              "Would you play",
-              "Please play"
+              "Can you",
+              "Would you",
+              "Will you"
             ],
             "category": "politeness",
             "isOptional": true
+          },
+          {
+            "text": "play",
+            "synonyms": [
+              "start",
+              "begin",
+              "put on"
+            ],
+            "category": "action",
+            "propertyNames": [
+              "fullActionName"
+            ]
           },
           {
             "text": "the 'Hamilton' Original Broadway Cast Recording",
             "synonyms": [
               "'Hamilton' Original Broadway Cast Recording",
               "Hamilton Original Broadway Cast Recording",
-              "the Hamilton Original Broadway Cast Recording"
+              "the Hamilton soundtrack"
             ],
-            "category": "albumName",
+            "category": "album",
             "propertyNames": [
               "parameters.albumName"
             ]
           }
         ],
         "propertyAlternatives": [
+          {
+            "propertyName": "fullActionName",
+            "propertyValue": "player.playAlbum",
+            "propertySubPhrases": [
+              "play"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "player.pauseAlbum",
+                "propertySubPhrases": [
+                  "pause"
+                ]
+              },
+              {
+                "propertyValue": "player.stopAlbum",
+                "propertySubPhrases": [
+                  "stop"
+                ]
+              },
+              {
+                "propertyValue": "player.resumeAlbum",
+                "propertySubPhrases": [
+                  "resume"
+                ]
+              }
+            ]
+          },
           {
             "propertyName": "parameters.albumName",
             "propertyValue": "Hamilton Original Broadway Cast Recording",
@@ -4009,21 +4072,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "Dear Evan Hansen Original Broadway Cast Recording",
-                "propertySubPhrases": [
-                  "the 'Dear Evan Hansen' Original Broadway Cast Recording"
-                ]
-              },
-              {
                 "propertyValue": "The Phantom of the Opera Original London Cast Recording",
                 "propertySubPhrases": [
-                  "the 'The Phantom of the Opera' Original London Cast Recording"
+                  "the 'Phantom of the Opera' Original London Cast Recording"
                 ]
               },
               {
                 "propertyValue": "Les Misérables Original Broadway Cast Recording",
                 "propertySubPhrases": [
                   "the 'Les Misérables' Original Broadway Cast Recording"
+                ]
+              },
+              {
+                "propertyValue": "Wicked Original Broadway Cast Recording",
+                "propertySubPhrases": [
+                  "the 'Wicked' Original Broadway Cast Recording"
                 ]
               }
             ]
@@ -4045,7 +4108,7 @@
             "name": "fullActionName",
             "value": "player.playArtist",
             "substrings": [
-              "play"
+              "Could you please play some Bach music?"
             ],
             "implied": true
           },
@@ -4073,8 +4136,8 @@
             "text": "please",
             "synonyms": [
               "kindly",
-              "if you could",
-              "if you would"
+              "if you don't mind",
+              "if you could"
             ],
             "category": "politeness",
             "isOptional": true
@@ -4082,8 +4145,8 @@
           {
             "text": "play",
             "synonyms": [
-              "start",
               "put on",
+              "start",
               "turn on"
             ],
             "category": "action",
@@ -4094,11 +4157,11 @@
           {
             "text": "some Bach music",
             "synonyms": [
-              "Bach",
               "Bach's music",
-              "music by Bach"
+              "music by Bach",
+              "Bach tunes"
             ],
-            "category": "artist",
+            "category": "content",
             "propertyNames": [
               "parameters.artist"
             ]
@@ -4194,7 +4257,7 @@
             "text": "Could you please",
             "synonyms": [
               "Can you please",
-              "Would you please",
+              "Would you mind",
               "Could you kindly"
             ],
             "category": "politeness",
@@ -4216,8 +4279,8 @@
             "text": "some",
             "synonyms": [
               "a few",
-              "any",
-              "several"
+              "a bit of",
+              "any"
             ],
             "category": "filler",
             "isOptional": true
@@ -4332,11 +4395,21 @@
         ],
         "subPhrases": [
           {
-            "text": "Could you please",
+            "text": "Could you",
             "synonyms": [
-              "Can you please",
-              "Would you kindly",
-              "Please"
+              "Can you",
+              "Would you",
+              "Will you"
+            ],
+            "category": "politeness",
+            "isOptional": true
+          },
+          {
+            "text": "please",
+            "synonyms": [
+              "kindly",
+              "if you don't mind",
+              "if you could"
             ],
             "category": "politeness",
             "isOptional": true
@@ -4357,8 +4430,8 @@
             "text": "some Bach music",
             "synonyms": [
               "Bach",
-              "music by Bach",
-              "Bach's music"
+              "Bach's music",
+              "music by Bach"
             ],
             "category": "artist",
             "propertyNames": [
@@ -4381,15 +4454,15 @@
                 ]
               },
               {
-                "propertyValue": "player.queueArtist",
-                "propertySubPhrases": [
-                  "queue up"
-                ]
-              },
-              {
                 "propertyValue": "player.playComposer",
                 "propertySubPhrases": [
                   "play"
+                ]
+              },
+              {
+                "propertyValue": "player.queueArtist",
+                "propertySubPhrases": [
+                  "queue"
                 ]
               }
             ]
@@ -4453,11 +4526,21 @@
         ],
         "subPhrases": [
           {
-            "text": "Could you please",
+            "text": "Could you",
             "synonyms": [
-              "Can you please",
-              "Would you mind",
-              "Please"
+              "Can you",
+              "Would you",
+              "Will you"
+            ],
+            "category": "politeness",
+            "isOptional": true
+          },
+          {
+            "text": "please",
+            "synonyms": [
+              "kindly",
+              "if you don't mind",
+              "if you could"
             ],
             "category": "politeness",
             "isOptional": true
@@ -4579,8 +4662,7 @@
             "name": "fullActionName",
             "value": "player.playGenre",
             "substrings": [
-              "put on",
-              "music"
+              "put on"
             ],
             "implied": true
           },
@@ -4617,31 +4699,21 @@
             ]
           },
           {
-            "text": "some",
+            "text": "some soothing",
             "synonyms": [
               "a bit of",
-              "a little",
-              "any"
+              "some relaxing",
+              "a little"
             ],
             "category": "filler",
             "isOptional": true
           },
           {
-            "text": "soothing",
-            "synonyms": [
-              "calming",
-              "relaxing",
-              "peaceful"
-            ],
-            "category": "descriptor",
-            "isOptional": true
-          },
-          {
             "text": "classical",
             "synonyms": [
+              "baroque",
               "symphonic",
-              "orchestral",
-              "baroque"
+              "orchestral"
             ],
             "category": "genre",
             "propertyNames": [
@@ -4655,10 +4727,8 @@
               "melodies",
               "songs"
             ],
-            "category": "object",
-            "propertyNames": [
-              "fullActionName"
-            ]
+            "category": "filler",
+            "isOptional": true
           }
         ],
         "propertyAlternatives": [
@@ -4666,29 +4736,25 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.playGenre",
             "propertySubPhrases": [
-              "put on",
-              "music"
+              "put on"
             ],
             "alternatives": [
               {
-                "propertyValue": "player.playSong",
+                "propertyValue": "player.startGenre",
                 "propertySubPhrases": [
-                  "play",
-                  "song"
+                  "start"
                 ]
               },
               {
-                "propertyValue": "player.playAlbum",
+                "propertyValue": "player.playCategory",
                 "propertySubPhrases": [
-                  "play",
-                  "album"
+                  "play"
                 ]
               },
               {
-                "propertyValue": "player.playPlaylist",
+                "propertyValue": "player.beginGenre",
                 "propertySubPhrases": [
-                  "play",
-                  "playlist"
+                  "begin"
                 ]
               }
             ]
@@ -4756,7 +4822,7 @@
             "synonyms": [
               "play some music",
               "start the music",
-              "put on some music"
+              "begin the music"
             ],
             "category": "action",
             "propertyNames": [
@@ -4783,21 +4849,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.playSpecific",
+                "propertyValue": "player.play",
                 "propertySubPhrases": [
-                  "play a specific song"
+                  "play the music"
                 ]
               },
               {
-                "propertyValue": "player.pause",
+                "propertyValue": "player.resume",
                 "propertySubPhrases": [
-                  "pause the music"
+                  "resume the music"
                 ]
               },
               {
-                "propertyValue": "player.stop",
+                "propertyValue": "player.start",
                 "propertySubPhrases": [
-                  "stop the music"
+                  "start the music"
                 ]
               }
             ]
@@ -4887,7 +4953,7 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.startMusic",
+                "propertyValue": "player.startArtist",
                 "propertySubPhrases": [
                   "Start playing"
                 ]
@@ -4899,9 +4965,9 @@
                 ]
               },
               {
-                "propertyValue": "player.playMusic",
+                "propertyValue": "player.beginArtist",
                 "propertySubPhrases": [
-                  "Play"
+                  "Begin playing"
                 ]
               }
             ]
@@ -4922,7 +4988,7 @@
               {
                 "propertyValue": "Eminem",
                 "propertySubPhrases": [
-                  "Slim Shady"
+                  "Eminem"
                 ]
               },
               {
@@ -4977,9 +5043,9 @@
           {
             "text": "Bach",
             "synonyms": [
-              "Beethoven",
-              "Mozart",
-              "Chopin"
+              "Johann Sebastian Bach",
+              "J.S. Bach",
+              "Bach's"
             ],
             "category": "artist",
             "propertyNames": [
@@ -4991,7 +5057,7 @@
             "synonyms": [
               "songs we can hear",
               "tracks we could play",
-              "music we can enjoy"
+              "music we can listen to"
             ],
             "category": "request",
             "isOptional": true
@@ -4999,9 +5065,9 @@
           {
             "text": "?",
             "synonyms": [
-              "",
               ".",
-              "!"
+              "!",
+              ""
             ],
             "category": "punctuation",
             "isOptional": true
@@ -5081,9 +5147,9 @@
             "synonyms": [
               "let's play",
               "let's listen to",
-              "how about we play"
+              "let's put on"
             ],
-            "category": "politeness",
+            "category": "command",
             "isOptional": true
           },
           {
@@ -5093,7 +5159,7 @@
               "Doggystyle music",
               "Doggystyle tracks"
             ],
-            "category": "albumName",
+            "category": "album",
             "propertyNames": [
               "parameters.albumName"
             ]
@@ -5105,10 +5171,8 @@
               "playing now",
               "playing in this place"
             ],
-            "category": "fullActionName",
-            "propertyNames": [
-              "fullActionName"
-            ]
+            "category": "command",
+            "isOptional": true
           }
         ],
         "propertyAlternatives": [
@@ -5138,33 +5202,6 @@
                 ]
               }
             ]
-          },
-          {
-            "propertyName": "fullActionName",
-            "propertyValue": "player.playAlbum",
-            "propertySubPhrases": [
-              "playin' up in here"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "player.queueAlbum",
-                "propertySubPhrases": [
-                  "queue it up"
-                ]
-              },
-              {
-                "propertyValue": "player.shuffleAlbum",
-                "propertySubPhrases": [
-                  "shuffle it up"
-                ]
-              },
-              {
-                "propertyValue": "player.repeatAlbum",
-                "propertySubPhrases": [
-                  "repeat it up"
-                ]
-              }
-            ]
           }
         ]
       }
@@ -5183,7 +5220,7 @@
             "name": "fullActionName",
             "value": "player.playTrack",
             "substrings": [
-              "let's get this party bumpin'"
+              "let's get this party bumpin' with some"
             ],
             "implied": true
           },
@@ -5204,15 +5241,15 @@
               "Absolutely,",
               "Definitely,"
             ],
-            "category": "filler",
+            "category": "acknowledgement",
             "isOptional": true
           },
           {
-            "text": "let's get this party bumpin'",
+            "text": "let's get this party bumpin' with some",
             "synonyms": [
-              "let's start the music",
-              "let's get the music going",
-              "let's play some tunes"
+              "let's start the music with",
+              "let's play",
+              "let's begin with"
             ],
             "category": "action",
             "propertyNames": [
@@ -5220,21 +5257,11 @@
             ]
           },
           {
-            "text": "with some",
-            "synonyms": [
-              "featuring",
-              "including",
-              "playing"
-            ],
-            "category": "preposition",
-            "isOptional": true
-          },
-          {
             "text": "'Drop It Like It's Hot'",
             "synonyms": [
-              "'Drop It Like It's Hot' by Snoop Dogg",
-              "'Drop It Like It's Hot' track",
-              "'Drop It Like It's Hot' song"
+              "'Drop It Like It's Hot'",
+              "'Drop It Like It's Hot'",
+              "'Drop It Like It's Hot'"
             ],
             "category": "trackName",
             "propertyNames": [
@@ -5244,9 +5271,9 @@
           {
             "text": "!",
             "synonyms": [
+              "!",
               ".",
-              "",
-              "?"
+              ""
             ],
             "category": "punctuation",
             "isOptional": true
@@ -5257,25 +5284,25 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.playTrack",
             "propertySubPhrases": [
-              "let's get this party bumpin'"
+              "let's get this party bumpin' with some"
             ],
             "alternatives": [
               {
-                "propertyValue": "player.pauseTrack",
+                "propertyValue": "player.queueTrack",
                 "propertySubPhrases": [
-                  "let's take a break"
+                  "let's queue up some"
                 ]
               },
               {
-                "propertyValue": "player.stopTrack",
+                "propertyValue": "player.addTrackToPlaylist",
                 "propertySubPhrases": [
-                  "let's stop the music"
+                  "add to the playlist"
                 ]
               },
               {
-                "propertyValue": "player.nextTrack",
+                "propertyValue": "player.shufflePlay",
                 "propertySubPhrases": [
-                  "let's skip to the next song"
+                  "shuffle play some"
                 ]
               }
             ]
@@ -5294,9 +5321,9 @@
                 ]
               },
               {
-                "propertyValue": "Nuthin' but a 'G' Thang",
+                "propertyValue": "Nuthin' But a 'G' Thang",
                 "propertySubPhrases": [
-                  "'Nuthin' but a 'G' Thang'"
+                  "'Nuthin' But a 'G' Thang'"
                 ]
               },
               {
@@ -5324,9 +5351,9 @@
             "name": "fullActionName",
             "value": "player.playArtist",
             "substrings": [
-              "play some music"
+              "play some music by Bach"
             ],
-            "implied": true
+            "implied": false
           },
           {
             "name": "parameters.artist",
@@ -5353,17 +5380,17 @@
             "synonyms": [
               "could you please",
               "would you mind",
-              "can you kindly"
+              "please"
             ],
             "category": "politeness",
             "isOptional": true
           },
           {
-            "text": "play some music",
+            "text": "play some music by",
             "synonyms": [
-              "play music",
-              "start playing music",
-              "put on some music"
+              "play music by",
+              "play songs by",
+              "play tracks by"
             ],
             "category": "action",
             "propertyNames": [
@@ -5371,11 +5398,11 @@
             ]
           },
           {
-            "text": "by Bach",
+            "text": "Bach",
             "synonyms": [
-              "from Bach",
-              "of Bach",
-              "composed by Bach"
+              "Johann Sebastian Bach",
+              "J.S. Bach",
+              "Bach the composer"
             ],
             "category": "artist",
             "propertyNames": [
@@ -5386,8 +5413,8 @@
             "text": "for me",
             "synonyms": [
               "for myself",
-              "for my sake",
-              "for my benefit"
+              "for my listening",
+              "for my enjoyment"
             ],
             "category": "filler",
             "isOptional": true
@@ -5398,25 +5425,25 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.playArtist",
             "propertySubPhrases": [
-              "play some music"
+              "play some music by"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.playSong",
                 "propertySubPhrases": [
-                  "play a song"
+                  "play a song by"
                 ]
               },
               {
                 "propertyValue": "player.playAlbum",
                 "propertySubPhrases": [
-                  "play an album"
+                  "play an album by"
                 ]
               },
               {
                 "propertyValue": "player.playPlaylist",
                 "propertySubPhrases": [
-                  "play a playlist"
+                  "play a playlist by"
                 ]
               }
             ]
@@ -5425,25 +5452,25 @@
             "propertyName": "parameters.artist",
             "propertyValue": "Bach",
             "propertySubPhrases": [
-              "by Bach"
+              "Bach"
             ],
             "alternatives": [
               {
                 "propertyValue": "Mozart",
                 "propertySubPhrases": [
-                  "by Mozart"
+                  "Mozart"
                 ]
               },
               {
                 "propertyValue": "Beethoven",
                 "propertySubPhrases": [
-                  "by Beethoven"
+                  "Beethoven"
                 ]
               },
               {
                 "propertyValue": "Chopin",
                 "propertySubPhrases": [
-                  "by Chopin"
+                  "Chopin"
                 ]
               }
             ]
@@ -5465,7 +5492,8 @@
             "name": "fullActionName",
             "value": "player.playGenre",
             "substrings": [
-              "put on"
+              "put on",
+              "for me"
             ],
             "implied": true
           },
@@ -5484,7 +5512,7 @@
             "synonyms": [
               "Hello nephew",
               "Hi nephew",
-              "Hey there"
+              "Hey there nephew"
             ],
             "category": "greeting",
             "isOptional": true
@@ -5516,7 +5544,7 @@
             "synonyms": [
               "some smooth",
               "a bit of smooth",
-              "some nice"
+              "that smooth"
             ],
             "category": "filler",
             "isOptional": true
@@ -5526,7 +5554,7 @@
             "synonyms": [
               "G-funk music",
               "G-funk genre",
-              "G-funk style"
+              "G-funk tunes"
             ],
             "category": "genre",
             "propertyNames": [
@@ -5536,12 +5564,15 @@
           {
             "text": "for me",
             "synonyms": [
-              "please",
-              "if you could",
-              "thanks"
+              "for myself",
+              "for my sake",
+              "for yours truly"
             ],
             "category": "politeness",
-            "isOptional": true
+            "isOptional": true,
+            "propertyNames": [
+              "fullActionName"
+            ]
           }
         ],
         "propertyAlternatives": [
@@ -5549,25 +5580,29 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.playGenre",
             "propertySubPhrases": [
-              "put on"
+              "put on",
+              "for me"
             ],
             "alternatives": [
               {
-                "propertyValue": "player.startGenre",
+                "propertyValue": "player.playSong",
                 "propertySubPhrases": [
-                  "start"
+                  "play",
+                  "for me"
                 ]
               },
               {
-                "propertyValue": "player.queueGenre",
+                "propertyValue": "player.playAlbum",
                 "propertySubPhrases": [
-                  "queue up"
+                  "put on the album",
+                  "for me"
                 ]
               },
               {
-                "propertyValue": "player.playMusic",
+                "propertyValue": "player.playPlaylist",
                 "propertySubPhrases": [
-                  "play"
+                  "put on the playlist",
+                  "for me"
                 ]
               }
             ]
@@ -5600,7 +5635,101 @@
             ]
           }
         ]
-      }
+      },
+      "corrections": [
+        {
+          "data": {
+            "properties": [
+              {
+                "name": "fullActionName",
+                "value": "player.playGenre",
+                "substrings": [
+                  "put on",
+                  "for me"
+                ],
+                "implied": true
+              },
+              {
+                "name": "parameters.genre",
+                "value": "G-funk",
+                "substrings": [
+                  "G-funk"
+                ],
+                "implied": false
+              }
+            ],
+            "subPhrases": [
+              {
+                "text": "Hey nephew",
+                "synonyms": [
+                  "Hello nephew",
+                  "Hi nephew",
+                  "Hey there nephew"
+                ],
+                "category": "greeting",
+                "isOptional": true
+              },
+              {
+                "text": "can you",
+                "synonyms": [
+                  "could you",
+                  "would you",
+                  "will you"
+                ],
+                "category": "politeness",
+                "isOptional": true
+              },
+              {
+                "text": "put on",
+                "synonyms": [
+                  "play",
+                  "start",
+                  "turn on"
+                ],
+                "category": "action",
+                "propertyNames": [
+                  "fullActionName"
+                ]
+              },
+              {
+                "text": "some of that smooth",
+                "synonyms": [
+                  "some smooth",
+                  "a bit of smooth",
+                  "that smooth"
+                ],
+                "category": "filler",
+                "isOptional": true
+              },
+              {
+                "text": "G-funk",
+                "synonyms": [
+                  "G-funk music",
+                  "G-funk genre",
+                  "G-funk tunes"
+                ],
+                "category": "genre",
+                "propertyNames": [
+                  "parameters.genre"
+                ]
+              },
+              {
+                "text": "for me",
+                "synonyms": [
+                  "for myself",
+                  "for my sake",
+                  "for yours truly"
+                ],
+                "category": "politeness",
+                "isOptional": true
+              }
+            ]
+          },
+          "correction": [
+            "Explicit property 'fullActionName' must be included as property names for all subphrases that contain the substring 'for me'"
+          ]
+        }
+      ]
     },
     {
       "request": "Hey nephew, spin that 'Who Am I (What's My Name)?' and let's get this place groovin'!",
@@ -5633,9 +5762,9 @@
           {
             "text": "Hey nephew",
             "synonyms": [
-              "Hey buddy",
-              "Hello there",
-              "Hi friend"
+              "Hello nephew",
+              "Hi nephew",
+              "Hey there nephew"
             ],
             "category": "greeting",
             "isOptional": true
@@ -5655,9 +5784,9 @@
           {
             "text": "'Who Am I (What's My Name)?'",
             "synonyms": [
-              "'Who Am I'",
-              "'What's My Name?'",
-              "'Who Am I (What's My Name)?' by Snoop Dogg"
+              "the song 'Who Am I (What's My Name)?'",
+              "'Who Am I (What's My Name)?' by Snoop Dogg",
+              "the track 'Who Am I (What's My Name)?'"
             ],
             "category": "trackName",
             "propertyNames": [
@@ -5668,8 +5797,8 @@
             "text": "and let's get this place groovin'!",
             "synonyms": [
               "and let's get the party started!",
-              "and let's dance!",
-              "and let's have some fun!"
+              "and let's make this place lively!",
+              "and let's get everyone dancing!"
             ],
             "category": "filler",
             "isOptional": true
@@ -5717,9 +5846,9 @@
                 ]
               },
               {
-                "propertyValue": "Nuthin' But a 'G' Thang",
+                "propertyValue": "Nuthin' but a 'G' Thang",
                 "propertySubPhrases": [
-                  "'Nuthin' But a 'G' Thang'"
+                  "'Nuthin' but a 'G' Thang'"
                 ]
               },
               {
@@ -5777,7 +5906,7 @@
               "shall we",
               "let's"
             ],
-            "category": "politeness",
+            "category": "confirmation",
             "isOptional": true
           },
           {
@@ -5856,7 +5985,7 @@
               {
                 "propertyValue": "jazz",
                 "propertySubPhrases": [
-                  "smooth tunes",
+                  "some smooth tunes",
                   "and mellow vibes"
                 ]
               },
@@ -5870,8 +5999,8 @@
               {
                 "propertyValue": "electronic",
                 "propertySubPhrases": [
-                  "some sick drops",
-                  "and electronic beats"
+                  "some electronic beats",
+                  "and synth sounds"
                 ]
               }
             ]
@@ -5933,7 +6062,7 @@
               "shall we",
               "let's"
             ],
-            "category": "politeness",
+            "category": "confirmation",
             "isOptional": true
           },
           {
@@ -5941,7 +6070,7 @@
             "synonyms": [
               "listen to",
               "play",
-              "put on"
+              "hear"
             ],
             "category": "action",
             "propertyNames": [
@@ -5951,7 +6080,7 @@
           {
             "text": "'Beautiful'",
             "synonyms": [
-              "'Beautiful' by Snoop Dogg",
+              "'Beautiful' by",
               "'Beautiful' track",
               "'Beautiful' song"
             ],
@@ -5963,9 +6092,9 @@
           {
             "text": "featuring Pharrell",
             "synonyms": [
-              "with Pharrell",
               "by Pharrell",
-              "Pharrell"
+              "with Pharrell",
+              "Pharrell's"
             ],
             "category": "artist",
             "propertyNames": [
@@ -5994,19 +6123,19 @@
               {
                 "propertyValue": "player.queueTrack",
                 "propertySubPhrases": [
-                  "queue up"
+                  "add to the queue"
                 ]
               },
               {
-                "propertyValue": "player.addTrackToPlaylist",
+                "propertyValue": "player.pauseTrack",
                 "propertySubPhrases": [
-                  "add to my playlist"
+                  "pause the music"
                 ]
               },
               {
-                "propertyValue": "player.shufflePlay",
+                "propertyValue": "player.stopTrack",
                 "propertySubPhrases": [
-                  "shuffle play"
+                  "stop the music"
                 ]
               }
             ]
@@ -6080,9 +6209,7 @@
             "name": "fullActionName",
             "value": "player.playRandom",
             "substrings": [
-              "crank up",
-              "some fly jams",
-              "right now"
+              "crank up some fly jams right now"
             ],
             "implied": true
           }
@@ -6093,53 +6220,29 @@
             "synonyms": [
               "Hi",
               "Hello",
-              "Hey there"
+              "Yo"
             ],
             "category": "greeting",
             "isOptional": true
           },
           {
-            "text": "how about we",
+            "text": "how about",
             "synonyms": [
-              "let's",
-              "shall we",
-              "why don't we"
+              "what about",
+              "why not",
+              "let's"
             ],
             "category": "filler",
             "isOptional": true
           },
           {
-            "text": "crank up",
+            "text": "we crank up some fly jams right now",
             "synonyms": [
-              "play",
-              "turn on",
-              "start"
+              "play some cool music now",
+              "start some awesome tunes immediately",
+              "put on some great songs right away"
             ],
             "category": "action",
-            "propertyNames": [
-              "fullActionName"
-            ]
-          },
-          {
-            "text": "some fly jams",
-            "synonyms": [
-              "some cool music",
-              "some great tunes",
-              "some awesome tracks"
-            ],
-            "category": "content",
-            "propertyNames": [
-              "fullActionName"
-            ]
-          },
-          {
-            "text": "right now",
-            "synonyms": [
-              "immediately",
-              "at once",
-              "straight away"
-            ],
-            "category": "time",
             "propertyNames": [
               "fullActionName"
             ]
@@ -6150,33 +6253,25 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.playRandom",
             "propertySubPhrases": [
-              "crank up",
-              "some fly jams",
-              "right now"
+              "we crank up some fly jams right now"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.play",
                 "propertySubPhrases": [
-                  "play",
-                  "some music",
-                  "right now"
+                  "we play some music right now"
                 ]
               },
               {
                 "propertyValue": "player.shuffle",
                 "propertySubPhrases": [
-                  "shuffle",
-                  "some tracks",
-                  "right now"
+                  "we shuffle some tunes right now"
                 ]
               },
               {
                 "propertyValue": "player.startRadio",
                 "propertySubPhrases": [
-                  "start",
-                  "a radio station",
-                  "right now"
+                  "we start a radio station right now"
                 ]
               }
             ]
@@ -6225,7 +6320,7 @@
             "synonyms": [
               "let us have",
               "let's play",
-              "how about some"
+              "let's put on"
             ],
             "category": "filler",
             "isOptional": true
@@ -6233,9 +6328,9 @@
           {
             "text": "Snoop Dogg",
             "synonyms": [
-              "Snoop Lion",
-              "Calvin Broadus",
-              "Tha Doggfather"
+              "Snoop",
+              "Snoop Doggy Dogg",
+              "Calvin Broadus"
             ],
             "category": "artist",
             "propertyNames": [
@@ -6247,7 +6342,7 @@
             "synonyms": [
               "music here",
               "tunes playing",
-              "songs in the room"
+              "songs going"
             ],
             "category": "filler",
             "isOptional": true
@@ -6274,9 +6369,9 @@
                 ]
               },
               {
-                "propertyValue": "Ice Cube",
+                "propertyValue": "Kendrick Lamar",
                 "propertySubPhrases": [
-                  "Ice Cube"
+                  "Kendrick Lamar"
                 ]
               }
             ]
@@ -6315,7 +6410,7 @@
             "synonyms": [
               "Hi",
               "Hello",
-              "Greetings"
+              "Yo"
             ],
             "category": "greeting",
             "isOptional": true
@@ -6341,13 +6436,23 @@
             "isOptional": true
           },
           {
-            "text": "with some classic",
+            "text": "with some",
             "synonyms": [
-              "with some timeless",
-              "with some vintage",
-              "with some old-school"
+              "featuring",
+              "including",
+              "with"
             ],
-            "category": "property",
+            "category": "preposition",
+            "isOptional": true
+          },
+          {
+            "text": "classic",
+            "synonyms": [
+              "vintage",
+              "timeless",
+              "old-school"
+            ],
+            "category": "genre",
             "propertyNames": [
               "parameters.genre"
             ]
@@ -6357,7 +6462,7 @@
             "synonyms": [
               "tunes",
               "songs",
-              "music"
+              "tracks"
             ],
             "category": "filler",
             "isOptional": true
@@ -6369,15 +6474,15 @@
               "on the speakers",
               "on the hi-fi"
             ],
-            "category": "filler",
+            "category": "preposition",
             "isOptional": true
           },
           {
             "text": "!",
             "synonyms": [
-              "",
               ".",
-              "!!"
+              "!!",
+              "!!!"
             ],
             "category": "punctuation",
             "isOptional": true
@@ -6388,31 +6493,25 @@
             "propertyName": "parameters.genre",
             "propertyValue": "classic",
             "propertySubPhrases": [
-              "with some classic"
+              "classic"
             ],
             "alternatives": [
               {
                 "propertyValue": "rock",
                 "propertySubPhrases": [
-                  "with some rock"
+                  "rock"
                 ]
               },
               {
                 "propertyValue": "jazz",
                 "propertySubPhrases": [
-                  "with some jazz"
+                  "jazz"
                 ]
               },
               {
                 "propertyValue": "pop",
                 "propertySubPhrases": [
-                  "with some pop"
-                ]
-              },
-              {
-                "propertyValue": "hip-hop",
-                "propertySubPhrases": [
-                  "with some hip-hop"
+                  "pop"
                 ]
               }
             ]
@@ -6434,7 +6533,7 @@
             "name": "fullActionName",
             "value": "player.playArtist",
             "substrings": [
-              "spin some"
+              "spin some Snoop Dogg tracks"
             ],
             "implied": true
           },
@@ -6465,7 +6564,7 @@
               "put on some",
               "start some"
             ],
-            "category": "action",
+            "category": "fullActionName",
             "propertyNames": [
               "fullActionName"
             ]
@@ -6477,19 +6576,41 @@
               "Snoop Doggy Dogg",
               "Calvin Broadus"
             ],
-            "category": "artist",
+            "category": "parameters.artist",
             "propertyNames": [
               "parameters.artist"
             ]
           },
           {
-            "text": "tracks for us",
+            "text": "tracks",
             "synonyms": [
-              "songs for us",
-              "music for us",
-              "tunes for us"
+              "songs",
+              "music",
+              "tunes"
             ],
-            "category": "filler",
+            "category": "fullActionName",
+            "propertyNames": [
+              "fullActionName"
+            ]
+          },
+          {
+            "text": "for us",
+            "synonyms": [
+              "for me",
+              "for everyone",
+              "for the group"
+            ],
+            "category": "politeness",
+            "isOptional": true
+          },
+          {
+            "text": "!",
+            "synonyms": [
+              ".",
+              "!!",
+              ""
+            ],
+            "category": "punctuation",
             "isOptional": true
           }
         ],
@@ -6498,25 +6619,29 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.playArtist",
             "propertySubPhrases": [
-              "spin some"
+              "spin some",
+              "tracks"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.playSong",
                 "propertySubPhrases": [
-                  "play a song by"
+                  "play a",
+                  "song"
                 ]
               },
               {
                 "propertyValue": "player.playAlbum",
                 "propertySubPhrases": [
-                  "play an album by"
+                  "spin an",
+                  "album"
                 ]
               },
               {
                 "propertyValue": "player.playPlaylist",
                 "propertySubPhrases": [
-                  "play a playlist by"
+                  "play a",
+                  "playlist"
                 ]
               }
             ]
@@ -6565,7 +6690,7 @@
             "name": "fullActionName",
             "value": "player.playAlbum",
             "substrings": [
-              "chill to some of that"
+              "How about we chill to some of that"
             ],
             "implied": true
           },
@@ -6573,7 +6698,7 @@
             "name": "parameters.albumName",
             "value": "Murder Was the Case",
             "substrings": [
-              "'Murder Was the Case'"
+              "'Murder Was the Case' soundtrack"
             ],
             "implied": false
           }
@@ -6586,7 +6711,7 @@
               "Shall we",
               "Let's"
             ],
-            "category": "suggestion",
+            "category": "politeness",
             "isOptional": true
           },
           {
@@ -6596,32 +6721,22 @@
               "we play",
               "we enjoy"
             ],
-            "category": "action",
+            "category": "fullActionName",
             "propertyNames": [
               "fullActionName"
             ]
           },
           {
-            "text": "'Murder Was the Case'",
+            "text": "'Murder Was the Case' soundtrack",
             "synonyms": [
               "'Murder Was the Case' album",
-              "'Murder Was the Case' soundtrack",
-              "'Murder Was the Case' record"
+              "'Murder Was the Case' record",
+              "'Murder Was the Case' music"
             ],
-            "category": "album",
+            "category": "parameters.albumName",
             "propertyNames": [
               "parameters.albumName"
             ]
-          },
-          {
-            "text": "soundtrack",
-            "synonyms": [
-              "album",
-              "record",
-              "music"
-            ],
-            "category": "clarification",
-            "isOptional": true
           }
         ],
         "propertyAlternatives": [
@@ -6645,9 +6760,9 @@
                 ]
               },
               {
-                "propertyValue": "player.playRadio",
+                "propertyValue": "player.playArtist",
                 "propertySubPhrases": [
-                  "we tune into the station"
+                  "we enjoy some tunes by"
                 ]
               }
             ]
@@ -6656,25 +6771,25 @@
             "propertyName": "parameters.albumName",
             "propertyValue": "Murder Was the Case",
             "propertySubPhrases": [
-              "'Murder Was the Case'"
+              "'Murder Was the Case' soundtrack"
             ],
             "alternatives": [
               {
                 "propertyValue": "The Chronic",
                 "propertySubPhrases": [
-                  "'The Chronic'"
+                  "'The Chronic' album"
                 ]
               },
               {
                 "propertyValue": "Doggystyle",
                 "propertySubPhrases": [
-                  "'Doggystyle'"
+                  "'Doggystyle' record"
                 ]
               },
               {
                 "propertyValue": "All Eyez on Me",
                 "propertySubPhrases": [
-                  "'All Eyez on Me'"
+                  "'All Eyez on Me' soundtrack"
                 ]
               }
             ]
@@ -6696,9 +6811,9 @@
             "name": "fullActionName",
             "value": "player.playArtist",
             "substrings": [
-              "enjoy some tunes by"
+              "How about we enjoy some tunes by Bach?"
             ],
-            "implied": true
+            "implied": false
           },
           {
             "name": "parameters.artist",
@@ -6711,21 +6826,21 @@
         ],
         "subPhrases": [
           {
-            "text": "How about we",
+            "text": "How about",
             "synonyms": [
-              "What if we",
+              "What about",
               "Shall we",
-              "Let's"
+              "Let's consider"
             ],
             "category": "politeness",
             "isOptional": true
           },
           {
-            "text": "enjoy some tunes by",
+            "text": "we enjoy some tunes",
             "synonyms": [
-              "listen to some music by",
-              "play some songs by",
-              "hear some tracks by"
+              "we listen to some music",
+              "we play some songs",
+              "we hear some tracks"
             ],
             "category": "action",
             "propertyNames": [
@@ -6733,11 +6848,11 @@
             ]
           },
           {
-            "text": "Bach",
+            "text": "by Bach",
             "synonyms": [
-              "Johann Sebastian Bach",
-              "J.S. Bach",
-              "the composer Bach"
+              "from Bach",
+              "composed by Bach",
+              "by Johann Sebastian Bach"
             ],
             "category": "artist",
             "propertyNames": [
@@ -6750,25 +6865,25 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.playArtist",
             "propertySubPhrases": [
-              "enjoy some tunes by"
+              "we enjoy some tunes"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.playSong",
                 "propertySubPhrases": [
-                  "listen to a song by"
+                  "we listen to a song"
                 ]
               },
               {
                 "propertyValue": "player.playAlbum",
                 "propertySubPhrases": [
-                  "listen to an album by"
+                  "we enjoy an album"
                 ]
               },
               {
                 "propertyValue": "player.playPlaylist",
                 "propertySubPhrases": [
-                  "enjoy a playlist by"
+                  "we enjoy a playlist"
                 ]
               }
             ]
@@ -6777,25 +6892,25 @@
             "propertyName": "parameters.artist",
             "propertyValue": "Bach",
             "propertySubPhrases": [
-              "Bach"
+              "by Bach"
             ],
             "alternatives": [
               {
                 "propertyValue": "Mozart",
                 "propertySubPhrases": [
-                  "Mozart"
+                  "by Mozart"
                 ]
               },
               {
                 "propertyValue": "Beethoven",
                 "propertySubPhrases": [
-                  "Beethoven"
+                  "by Beethoven"
                 ]
               },
               {
                 "propertyValue": "Chopin",
                 "propertySubPhrases": [
-                  "Chopin"
+                  "by Chopin"
                 ]
               }
             ]
@@ -6822,21 +6937,11 @@
         ],
         "subPhrases": [
           {
-            "text": "How about",
+            "text": "How about we",
             "synonyms": [
-              "What if",
+              "What if we",
               "Shall we",
               "Let's"
-            ],
-            "category": "filler",
-            "isOptional": true
-          },
-          {
-            "text": "we",
-            "synonyms": [
-              "us",
-              "you and I",
-              "everyone"
             ],
             "category": "filler",
             "isOptional": true
@@ -6845,8 +6950,8 @@
             "text": "listen to some music",
             "synonyms": [
               "play some tunes",
-              "hear some songs",
-              "enjoy some music"
+              "put on some music",
+              "start some music"
             ],
             "category": "action",
             "propertyNames": [
@@ -6898,35 +7003,37 @@
           {
             "name": "fullActionName",
             "value": "player.playArtist",
-            "substrings": [],
+            "substrings": [
+              "could you please indulge me?"
+            ],
             "implied": true
           },
           {
             "name": "parameters.artist",
             "value": "Beethoven",
             "substrings": [
-              "Beethoven"
+              "a bit of Beethoven"
             ],
             "implied": false
           }
         ],
         "subPhrases": [
           {
-            "text": "I do fancy a bit of",
+            "text": "I do fancy",
             "synonyms": [
-              "I would like to hear",
-              "I want to listen to",
-              "I am in the mood for"
+              "I would like",
+              "I want",
+              "I desire"
             ],
             "category": "request",
-            "isOptional": true
+            "propertyNames": []
           },
           {
-            "text": "Beethoven",
+            "text": "a bit of Beethoven",
             "synonyms": [
-              "Ludwig van Beethoven",
+              "some Beethoven",
               "Beethoven's music",
-              "some Beethoven"
+              "Beethoven's pieces"
             ],
             "category": "artist",
             "propertyNames": [
@@ -6936,12 +7043,13 @@
           {
             "text": "could you please indulge me?",
             "synonyms": [
-              "can you play it for me?",
+              "could you please play it?",
               "would you mind playing it?",
-              "please play it for me"
+              "can you play it for me?"
             ],
             "category": "politeness",
-            "isOptional": true
+            "isOptional": true,
+            "propertyNames": []
           }
         ],
         "propertyAlternatives": [
@@ -6949,31 +7057,59 @@
             "propertyName": "parameters.artist",
             "propertyValue": "Beethoven",
             "propertySubPhrases": [
-              "Beethoven"
+              "a bit of Beethoven"
             ],
             "alternatives": [
               {
                 "propertyValue": "Mozart",
                 "propertySubPhrases": [
-                  "Mozart"
+                  "a bit of Mozart"
                 ]
               },
               {
                 "propertyValue": "Bach",
                 "propertySubPhrases": [
-                  "Bach"
+                  "a bit of Bach"
                 ]
               },
               {
                 "propertyValue": "Chopin",
                 "propertySubPhrases": [
-                  "Chopin"
+                  "a bit of Chopin"
                 ]
               }
             ]
           }
         ]
-      }
+      },
+      "corrections": [
+        {
+          "data": {
+            "properties": [
+              {
+                "name": "fullActionName",
+                "value": "player.playArtist",
+                "substrings": [
+                  "could you please indulge me?"
+                ],
+                "implied": true
+              },
+              {
+                "name": "artist",
+                "value": "Beethoven",
+                "substrings": [
+                  "a bit of Beethoven"
+                ],
+                "implied": false
+              }
+            ]
+          },
+          "correction": [
+            "Extraneous parameter: 'artist' is not a parameter in the action",
+            "Missing parameter: parameter 'parameters.artist' in the action is missing from explanation"
+          ]
+        }
+      ]
     },
     {
       "request": "I should be most delighted if you could present us with some enchanting Debussy.",
@@ -7006,7 +7142,7 @@
           {
             "text": "I should be most delighted if you could",
             "synonyms": [
-              "I would be very happy if you could",
+              "I would be very happy if you can",
               "It would be wonderful if you could",
               "I would appreciate it if you could"
             ],
@@ -7059,19 +7195,19 @@
               {
                 "propertyValue": "player.playSong",
                 "propertySubPhrases": [
-                  "play the song"
+                  "play a song by"
                 ]
               },
               {
                 "propertyValue": "player.playAlbum",
                 "propertySubPhrases": [
-                  "play the album"
+                  "play an album by"
                 ]
               },
               {
                 "propertyValue": "player.playPlaylist",
                 "propertySubPhrases": [
-                  "play the playlist"
+                  "play a playlist by"
                 ]
               }
             ]
@@ -7120,7 +7256,7 @@
             "name": "fullActionName",
             "value": "player.playArtist",
             "substrings": [
-              "regale us with"
+              "regale us with some splendid Vivaldi"
             ],
             "implied": true
           },
@@ -7145,35 +7281,25 @@
             "isOptional": true
           },
           {
-            "text": "regale us with",
+            "text": "regale us with some splendid",
             "synonyms": [
-              "play for us",
-              "entertain us with",
-              "provide us with"
+              "play us some wonderful",
+              "provide us with some excellent",
+              "give us some amazing"
             ],
-            "category": "action",
+            "category": "fullActionName",
             "propertyNames": [
               "fullActionName"
             ]
           },
           {
-            "text": "some splendid",
-            "synonyms": [
-              "some wonderful",
-              "some amazing",
-              "some excellent"
-            ],
-            "category": "filler",
-            "isOptional": true
-          },
-          {
             "text": "Vivaldi",
             "synonyms": [
-              "Antonio Vivaldi",
-              "music by Vivaldi",
-              "Vivaldi's compositions"
+              "Bach",
+              "Mozart",
+              "Beethoven"
             ],
-            "category": "artist",
+            "category": "parameters.artist",
             "propertyNames": [
               "parameters.artist"
             ]
@@ -7184,25 +7310,25 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.playArtist",
             "propertySubPhrases": [
-              "regale us with"
+              "regale us with some splendid"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.playSong",
                 "propertySubPhrases": [
-                  "play us"
+                  "play a wonderful"
                 ]
               },
               {
                 "propertyValue": "player.playAlbum",
                 "propertySubPhrases": [
-                  "entertain us with"
+                  "play the amazing album"
                 ]
               },
               {
                 "propertyValue": "player.playPlaylist",
                 "propertySubPhrases": [
-                  "delight us with"
+                  "play the fantastic playlist"
                 ]
               }
             ]
@@ -7215,9 +7341,9 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "Bach",
+                "propertyValue": "Beethoven",
                 "propertySubPhrases": [
-                  "Bach"
+                  "Beethoven"
                 ]
               },
               {
@@ -7227,9 +7353,9 @@
                 ]
               },
               {
-                "propertyValue": "Beethoven",
+                "propertyValue": "Bach",
                 "propertySubPhrases": [
-                  "Beethoven"
+                  "Bach"
                 ]
               }
             ]
@@ -7303,6 +7429,12 @@
                 "propertySubPhrases": [
                   "hear an album"
                 ]
+              },
+              {
+                "propertyValue": "player.playGenre",
+                "propertySubPhrases": [
+                  "hear some jazz"
+                ]
               }
             ]
           }
@@ -7373,7 +7505,7 @@
             "text": "Chopin",
             "synonyms": [
               "Frédéric Chopin",
-              "the composer Chopin",
+              "the works of Chopin",
               "Chopin's music"
             ],
             "category": "artist",
@@ -7399,13 +7531,13 @@
               {
                 "propertyValue": "player.playAlbum",
                 "propertySubPhrases": [
-                  "play album"
+                  "play an album by"
                 ]
               },
               {
                 "propertyValue": "player.playPlaylist",
                 "propertySubPhrases": [
-                  "play playlist"
+                  "play a playlist by"
                 ]
               }
             ]
@@ -7454,7 +7586,7 @@
             "name": "fullActionName",
             "value": "player.playArtist",
             "substrings": [
-              "play some Bach music"
+              "play"
             ],
             "implied": true
           },
@@ -7479,11 +7611,11 @@
             "isOptional": true
           },
           {
-            "text": "play some",
+            "text": "play",
             "synonyms": [
-              "play",
+              "start",
               "put on",
-              "start playing"
+              "play some"
             ],
             "category": "action",
             "propertyNames": [
@@ -7491,11 +7623,11 @@
             ]
           },
           {
-            "text": "Bach",
+            "text": "some Bach music",
             "synonyms": [
-              "Johann Sebastian Bach",
-              "J.S. Bach",
-              "Bach's"
+              "Bach",
+              "music by Bach",
+              "Bach's compositions"
             ],
             "category": "artist",
             "propertyNames": [
@@ -7503,13 +7635,13 @@
             ]
           },
           {
-            "text": "music for me",
+            "text": "for me",
             "synonyms": [
-              "some tunes for me",
-              "a few songs for me",
-              "some tracks for me"
+              "please",
+              "if you can",
+              "if possible"
             ],
-            "category": "filler",
+            "category": "politeness",
             "isOptional": true
           }
         ],
@@ -7518,25 +7650,25 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.playArtist",
             "propertySubPhrases": [
-              "play some"
+              "play"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.playSong",
                 "propertySubPhrases": [
-                  "play a song by"
+                  "play a song"
                 ]
               },
               {
                 "propertyValue": "player.playAlbum",
                 "propertySubPhrases": [
-                  "play an album by"
+                  "play an album"
                 ]
               },
               {
                 "propertyValue": "player.playPlaylist",
                 "propertySubPhrases": [
-                  "play a playlist of"
+                  "play a playlist"
                 ]
               }
             ]
@@ -7545,25 +7677,25 @@
             "propertyName": "parameters.artist",
             "propertyValue": "Bach",
             "propertySubPhrases": [
-              "Bach"
+              "some Bach music"
             ],
             "alternatives": [
               {
                 "propertyValue": "Mozart",
                 "propertySubPhrases": [
-                  "Mozart"
+                  "some Mozart music"
                 ]
               },
               {
                 "propertyValue": "Beethoven",
                 "propertySubPhrases": [
-                  "Beethoven"
+                  "some Beethoven music"
                 ]
               },
               {
                 "propertyValue": "Chopin",
                 "propertySubPhrases": [
-                  "Chopin"
+                  "some Chopin music"
                 ]
               }
             ]
@@ -7587,7 +7719,7 @@
             "substrings": [
               "play"
             ],
-            "implied": false
+            "implied": true
           },
           {
             "name": "parameters.artist",
@@ -7604,7 +7736,7 @@
             "synonyms": [
               "Could you please",
               "Would you mind",
-              "Can you"
+              "I would be grateful if you"
             ],
             "category": "politeness",
             "isOptional": true
@@ -7624,9 +7756,9 @@
           {
             "text": "some",
             "synonyms": [
+              "any",
               "a bit of",
-              "a little",
-              "any"
+              "a little"
             ],
             "category": "filler",
             "isOptional": true
@@ -7735,7 +7867,7 @@
               "I would like to play",
               "Can you play"
             ],
-            "category": "politeness",
+            "category": "request",
             "isOptional": true
           },
           {
@@ -7754,10 +7886,10 @@
             "text": "perhaps Beethoven's Symphony No. 9.",
             "synonyms": [
               "maybe Beethoven's Symphony No. 9.",
-              "possibly Beethoven's Symphony No. 9.",
-              "Beethoven's Symphony No. 9 might be nice."
+              "such as Beethoven's Symphony No. 9.",
+              "for example, Beethoven's Symphony No. 9."
             ],
-            "category": "suggestion",
+            "category": "example",
             "isOptional": true
           }
         ],
@@ -7786,6 +7918,12 @@
                 "propertySubPhrases": [
                   "pop music"
                 ]
+              },
+              {
+                "propertyValue": "hip-hop",
+                "propertySubPhrases": [
+                  "hip-hop music"
+                ]
               }
             ]
           }
@@ -7808,7 +7946,9 @@
           {
             "name": "fullActionName",
             "value": "player.playTrack",
-            "substrings": [],
+            "substrings": [
+              "I'd like to listen to"
+            ],
             "implied": true
           },
           {
@@ -7833,11 +7973,13 @@
             "text": "I'd like to listen to",
             "synonyms": [
               "I want to hear",
-              "Play for me",
+              "Play",
               "Can you play"
             ],
             "category": "request",
-            "isOptional": true
+            "propertyNames": [
+              "fullActionName"
+            ]
           },
           {
             "text": "'Hotel California'",
@@ -7865,6 +8007,33 @@
           }
         ],
         "propertyAlternatives": [
+          {
+            "propertyName": "fullActionName",
+            "propertyValue": "player.playTrack",
+            "propertySubPhrases": [
+              "I'd like to listen to"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "player.queueTrack",
+                "propertySubPhrases": [
+                  "I'd like to add to the queue"
+                ]
+              },
+              {
+                "propertyValue": "player.playAlbum",
+                "propertySubPhrases": [
+                  "I'd like to listen to the album"
+                ]
+              },
+              {
+                "propertyValue": "player.playPlaylist",
+                "propertySubPhrases": [
+                  "I'd like to listen to the playlist"
+                ]
+              }
+            ]
+          },
           {
             "propertyName": "parameters.trackName",
             "propertyValue": "Hotel California",
@@ -7953,7 +8122,7 @@
           {
             "text": "listen to music",
             "synonyms": [
-              "play music",
+              "play some music",
               "start music",
               "begin music"
             ],
@@ -8018,7 +8187,7 @@
             "name": "fullActionName",
             "value": "player.playArtist",
             "substrings": [
-              "can you play his music?"
+              "play his music"
             ],
             "implied": true
           },
@@ -8049,15 +8218,15 @@
               "play some",
               "enjoy some"
             ],
-            "category": "request",
+            "category": "filler",
             "isOptional": true
           },
           {
             "text": "Bach",
             "synonyms": [
-              "Johann Sebastian Bach",
-              "J.S. Bach",
-              "Bach's music"
+              "Beethoven",
+              "Mozart",
+              "Chopin"
             ],
             "category": "artist",
             "propertyNames": [
@@ -8065,13 +8234,23 @@
             ]
           },
           {
-            "text": "can you play his music?",
+            "text": "can you",
             "synonyms": [
-              "could you play his music?",
-              "would you play his music?",
-              "can you put on his music?"
+              "could you",
+              "would you",
+              "will you"
             ],
-            "category": "request",
+            "category": "politeness",
+            "isOptional": true
+          },
+          {
+            "text": "play his music",
+            "synonyms": [
+              "play his songs",
+              "play his tracks",
+              "play his pieces"
+            ],
+            "category": "action",
             "propertyNames": [
               "fullActionName"
             ]
@@ -8109,25 +8288,25 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.playArtist",
             "propertySubPhrases": [
-              "can you play his music?"
+              "play his music"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.playAlbum",
                 "propertySubPhrases": [
-                  "can you play his album?"
+                  "play his album"
                 ]
               },
               {
                 "propertyValue": "player.playSong",
                 "propertySubPhrases": [
-                  "can you play his song?"
+                  "play his song"
                 ]
               },
               {
                 "propertyValue": "player.playPlaylist",
                 "propertySubPhrases": [
-                  "can you play his playlist?"
+                  "play his playlist"
                 ]
               }
             ]
@@ -8149,7 +8328,7 @@
             "name": "fullActionName",
             "value": "player.playArtist",
             "substrings": [
-              "can you play it?"
+              "play it"
             ],
             "implied": true
           },
@@ -8157,97 +8336,7 @@
             "name": "parameters.artist",
             "value": "Bach",
             "substrings": [
-              "some Bach"
-            ],
-            "implied": false
-          }
-        ],
-        "subPhrases": [
-          {
-            "text": "I'd like to listen to",
-            "synonyms": [
-              "I want to hear",
-              "I would like to listen to",
-              "I want to listen to"
-            ],
-            "category": "politeness",
-            "isOptional": true
-          },
-          {
-            "text": "some Bach",
-            "synonyms": [
-              "Bach music",
-              "music by Bach",
-              "a piece by Bach"
-            ],
-            "category": "artist",
-            "propertyNames": [
-              "parameters.artist"
-            ]
-          },
-          {
-            "text": "can you play it?",
-            "synonyms": [
-              "could you play it?",
-              "would you play it?",
-              "can you start it?"
-            ],
-            "category": "confirmation",
-            "isOptional": true
-          }
-        ],
-        "propertyAlternatives": [
-          {
-            "propertyName": "parameters.artist",
-            "propertyValue": "Bach",
-            "propertySubPhrases": [
-              "some Bach"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "Mozart",
-                "propertySubPhrases": [
-                  "some Mozart"
-                ]
-              },
-              {
-                "propertyValue": "Beethoven",
-                "propertySubPhrases": [
-                  "some Beethoven"
-                ]
-              },
-              {
-                "propertyValue": "Chopin",
-                "propertySubPhrases": [
-                  "some Chopin"
-                ]
-              }
-            ]
-          }
-        ]
-      }
-    },
-    {
-      "request": "I'd like to listen to some jazz music, maybe something by Miles Davis.",
-      "action": {
-        "fullActionName": "player.playGenre",
-        "parameters": {
-          "genre": "jazz"
-        }
-      },
-      "explanation": {
-        "properties": [
-          {
-            "name": "fullActionName",
-            "value": "player.playGenre",
-            "substrings": [],
-            "implied": true
-          },
-          {
-            "name": "parameters.genre",
-            "value": "jazz",
-            "substrings": [
-              "jazz"
+              "Bach"
             ],
             "implied": false
           }
@@ -8270,15 +8359,186 @@
               "play some",
               "enjoy some"
             ],
-            "category": "action",
+            "category": "filler",
             "isOptional": true
+          },
+          {
+            "text": "Bach",
+            "synonyms": [
+              "Johann Sebastian Bach",
+              "J.S. Bach",
+              "Bach's music"
+            ],
+            "category": "artist",
+            "propertyNames": [
+              "parameters.artist"
+            ]
+          },
+          {
+            "text": "can you",
+            "synonyms": [
+              "could you",
+              "would you",
+              "will you"
+            ],
+            "category": "politeness",
+            "isOptional": true
+          },
+          {
+            "text": "play it",
+            "synonyms": [
+              "play this",
+              "play that",
+              "start it"
+            ],
+            "category": "action",
+            "propertyNames": [
+              "fullActionName"
+            ]
+          }
+        ],
+        "propertyAlternatives": [
+          {
+            "propertyName": "parameters.artist",
+            "propertyValue": "Bach",
+            "propertySubPhrases": [
+              "Bach"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "Mozart",
+                "propertySubPhrases": [
+                  "Mozart"
+                ]
+              },
+              {
+                "propertyValue": "Beethoven",
+                "propertySubPhrases": [
+                  "Beethoven"
+                ]
+              },
+              {
+                "propertyValue": "Chopin",
+                "propertySubPhrases": [
+                  "Chopin"
+                ]
+              }
+            ]
+          },
+          {
+            "propertyName": "fullActionName",
+            "propertyValue": "player.playArtist",
+            "propertySubPhrases": [
+              "play it"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "player.shuffleArtist",
+                "propertySubPhrases": [
+                  "shuffle it"
+                ]
+              },
+              {
+                "propertyValue": "player.queueArtist",
+                "propertySubPhrases": [
+                  "queue it"
+                ]
+              },
+              {
+                "propertyValue": "player.repeatArtist",
+                "propertySubPhrases": [
+                  "repeat it"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "corrections": [
+        {
+          "data": {
+            "properties": [
+              {
+                "name": "fullActionName",
+                "value": "player.playArtist",
+                "substrings": [
+                  "play it"
+                ],
+                "implied": true
+              },
+              {
+                "name": "artist",
+                "value": "Bach",
+                "substrings": [
+                  "Bach"
+                ],
+                "implied": false
+              }
+            ]
+          },
+          "correction": [
+            "Extraneous parameter: 'artist' is not a parameter in the action",
+            "Missing parameter: parameter 'parameters.artist' in the action is missing from explanation"
+          ]
+        }
+      ]
+    },
+    {
+      "request": "I'd like to listen to some jazz music, maybe something by Miles Davis.",
+      "action": {
+        "fullActionName": "player.playGenre",
+        "parameters": {
+          "genre": "jazz"
+        }
+      },
+      "explanation": {
+        "properties": [
+          {
+            "name": "fullActionName",
+            "value": "player.playGenre",
+            "substrings": [
+              "I'd like to listen to some jazz music, maybe something by Miles Davis."
+            ],
+            "implied": true
+          },
+          {
+            "name": "parameters.genre",
+            "value": "jazz",
+            "substrings": [
+              "jazz"
+            ],
+            "implied": false
+          }
+        ],
+        "subPhrases": [
+          {
+            "text": "I'd like to",
+            "synonyms": [
+              "I want to",
+              "I would like to",
+              "I wish to"
+            ],
+            "category": "politeness",
+            "isOptional": true
+          },
+          {
+            "text": "listen to some",
+            "synonyms": [
+              "hear some",
+              "play some",
+              "enjoy some"
+            ],
+            "category": "action",
+            "propertyNames": [
+              "fullActionName"
+            ]
           },
           {
             "text": "jazz",
             "synonyms": [
-              "jazz music",
-              "jazz tunes",
-              "jazz songs"
+              "blues",
+              "swing",
+              "bebop"
             ],
             "category": "genre",
             "propertyNames": [
@@ -8286,17 +8546,54 @@
             ]
           },
           {
-            "text": "music, maybe something by Miles Davis.",
+            "text": "music",
             "synonyms": [
-              "music, perhaps something by Miles Davis.",
-              "music, possibly something by Miles Davis.",
-              "music, like something by Miles Davis."
+              "tunes",
+              "melodies",
+              "songs"
             ],
-            "category": "additional context",
+            "category": "object",
+            "isOptional": true
+          },
+          {
+            "text": "maybe something by Miles Davis.",
+            "synonyms": [
+              "perhaps something by Miles Davis.",
+              "possibly something by Miles Davis.",
+              "how about something by Miles Davis."
+            ],
+            "category": "suggestion",
             "isOptional": true
           }
         ],
         "propertyAlternatives": [
+          {
+            "propertyName": "fullActionName",
+            "propertyValue": "player.playGenre",
+            "propertySubPhrases": [
+              "listen to some"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "player.playSong",
+                "propertySubPhrases": [
+                  "play a song"
+                ]
+              },
+              {
+                "propertyValue": "player.playAlbum",
+                "propertySubPhrases": [
+                  "play an album"
+                ]
+              },
+              {
+                "propertyValue": "player.playArtist",
+                "propertySubPhrases": [
+                  "play some music by"
+                ]
+              }
+            ]
+          },
           {
             "propertyName": "parameters.genre",
             "propertyValue": "jazz",
@@ -8304,12 +8601,6 @@
               "jazz"
             ],
             "alternatives": [
-              {
-                "propertyValue": "blues",
-                "propertySubPhrases": [
-                  "blues"
-                ]
-              },
               {
                 "propertyValue": "rock",
                 "propertySubPhrases": [
@@ -8320,6 +8611,12 @@
                 "propertyValue": "classical",
                 "propertySubPhrases": [
                   "classical"
+                ]
+              },
+              {
+                "propertyValue": "pop",
+                "propertySubPhrases": [
+                  "pop"
                 ]
               }
             ]
@@ -8360,17 +8657,17 @@
             "synonyms": [
               "I would like to listen to",
               "I want to hear",
-              "I would enjoy hearing"
+              "I would enjoy listening to"
             ],
-            "category": "request",
-            "propertyNames": []
+            "category": "politeness",
+            "isOptional": true
           },
           {
             "text": "Bach",
             "synonyms": [
-              "Johann Sebastian Bach",
-              "J.S. Bach",
-              "Bach's music"
+              "Beethoven",
+              "Mozart",
+              "Chopin"
             ],
             "category": "artist",
             "propertyNames": [
@@ -8381,11 +8678,11 @@
             "text": "tunes",
             "synonyms": [
               "songs",
-              "pieces",
-              "tracks"
+              "music",
+              "melodies"
             ],
-            "category": "music",
-            "propertyNames": []
+            "category": "filler",
+            "isOptional": true
           },
           {
             "text": "can you play some?",
@@ -8442,15 +8739,15 @@
                 ]
               },
               {
-                "propertyValue": "player.playSong",
-                "propertySubPhrases": [
-                  "can you play a song?"
-                ]
-              },
-              {
                 "propertyValue": "player.playPlaylist",
                 "propertySubPhrases": [
                   "can you play a playlist?"
+                ]
+              },
+              {
+                "propertyValue": "player.playSong",
+                "propertySubPhrases": [
+                  "can you play a song?"
                 ]
               }
             ]
@@ -8499,9 +8796,9 @@
           {
             "text": "Bach",
             "synonyms": [
-              "Johann Sebastian Bach",
-              "J.S. Bach",
-              "Bach's music"
+              "Beethoven",
+              "Mozart",
+              "Chopin"
             ],
             "category": "artist",
             "propertyNames": [
@@ -8548,7 +8845,35 @@
             ]
           }
         ]
-      }
+      },
+      "corrections": [
+        {
+          "data": {
+            "properties": [
+              {
+                "name": "fullActionName",
+                "value": "player.playArtist",
+                "substrings": [
+                  "can you play it?"
+                ],
+                "implied": true
+              },
+              {
+                "name": "artist",
+                "value": "Bach",
+                "substrings": [
+                  "Bach"
+                ],
+                "implied": false
+              }
+            ]
+          },
+          "correction": [
+            "Extraneous parameter: 'artist' is not a parameter in the action",
+            "Missing parameter: parameter 'parameters.artist' in the action is missing from explanation"
+          ]
+        }
+      ]
     },
     {
       "request": "I'd love to hear some Bach, can you play some?",
@@ -8585,15 +8910,15 @@
               "I want to hear",
               "I would enjoy listening to"
             ],
-            "category": "request",
-            "propertyNames": []
+            "category": "politeness",
+            "isOptional": true
           },
           {
             "text": "Bach",
             "synonyms": [
-              "Johann Sebastian Bach",
-              "J.S. Bach",
-              "the composer Bach"
+              "Beethoven",
+              "Mozart",
+              "Chopin"
             ],
             "category": "artist",
             "propertyNames": [
@@ -8608,9 +8933,7 @@
               "can you put on some?"
             ],
             "category": "request",
-            "propertyNames": [
-              "fullActionName"
-            ]
+            "isOptional": true
           }
         ],
         "propertyAlternatives": [
@@ -8640,33 +8963,6 @@
                 ]
               }
             ]
-          },
-          {
-            "propertyName": "fullActionName",
-            "propertyValue": "player.playArtist",
-            "propertySubPhrases": [
-              "can you play some?"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "player.playAlbum",
-                "propertySubPhrases": [
-                  "can you play an album?"
-                ]
-              },
-              {
-                "propertyValue": "player.playSong",
-                "propertySubPhrases": [
-                  "can you play a song?"
-                ]
-              },
-              {
-                "propertyValue": "player.playPlaylist",
-                "propertySubPhrases": [
-                  "can you play a playlist?"
-                ]
-              }
-            ]
           }
         ]
       }
@@ -8683,7 +8979,7 @@
             "name": "fullActionName",
             "value": "player.playRandom",
             "substrings": [
-              "hear some music"
+              "I'd love to hear some music"
             ],
             "implied": true
           }
@@ -8737,12 +9033,6 @@
                 "propertySubPhrases": [
                   "play some jazz"
                 ]
-              },
-              {
-                "propertyValue": "player.playArtist",
-                "propertySubPhrases": [
-                  "play some Beatles"
-                ]
               }
             ]
           }
@@ -8782,10 +9072,10 @@
             "synonyms": [
               "I feel like listening to",
               "I want to hear",
-              "I'm craving"
+              "I would like to play"
             ],
             "category": "request",
-            "propertyNames": []
+            "isOptional": true
           },
           {
             "text": "'Sensual Seduction'",
@@ -8804,12 +9094,10 @@
             "synonyms": [
               "could you play that for me?",
               "would you play that for me?",
-              "can you put that on for me?"
+              "please play that for me?"
             ],
             "category": "request",
-            "propertyNames": [
-              "fullActionName"
-            ]
+            "isOptional": true
           }
         ],
         "propertyAlternatives": [
@@ -8833,36 +9121,9 @@
                 ]
               },
               {
-                "propertyValue": "Blinding Lights",
+                "propertyValue": "Hotel California",
                 "propertySubPhrases": [
-                  "'Blinding Lights'"
-                ]
-              }
-            ]
-          },
-          {
-            "propertyName": "fullActionName",
-            "propertyValue": "player.playTrack",
-            "propertySubPhrases": [
-              "can you play that for me?"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "player.pauseTrack",
-                "propertySubPhrases": [
-                  "can you pause that for me?"
-                ]
-              },
-              {
-                "propertyValue": "player.stopTrack",
-                "propertySubPhrases": [
-                  "can you stop that for me?"
-                ]
-              },
-              {
-                "propertyValue": "player.nextTrack",
-                "propertySubPhrases": [
-                  "can you skip to the next track?"
+                  "'Hotel California'"
                 ]
               }
             ]
@@ -8927,8 +9188,10 @@
               "would you play some?",
               "please play some?"
             ],
-            "category": "politeness",
-            "isOptional": true
+            "category": "request",
+            "propertyNames": [
+              "fullActionName"
+            ]
           }
         ],
         "propertyAlternatives": [
@@ -8940,21 +9203,48 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "Beethoven",
-                "propertySubPhrases": [
-                  "Beethoven"
-                ]
-              },
-              {
                 "propertyValue": "Mozart",
                 "propertySubPhrases": [
                   "Mozart"
                 ]
               },
               {
+                "propertyValue": "Beethoven",
+                "propertySubPhrases": [
+                  "Beethoven"
+                ]
+              },
+              {
                 "propertyValue": "Chopin",
                 "propertySubPhrases": [
                   "Chopin"
+                ]
+              }
+            ]
+          },
+          {
+            "propertyName": "fullActionName",
+            "propertyValue": "player.playArtist",
+            "propertySubPhrases": [
+              "can you play some?"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "player.playAlbum",
+                "propertySubPhrases": [
+                  "can you play an album?"
+                ]
+              },
+              {
+                "propertyValue": "player.playSong",
+                "propertySubPhrases": [
+                  "can you play a song?"
+                ]
+              },
+              {
+                "propertyValue": "player.playPlaylist",
+                "propertySubPhrases": [
+                  "can you play a playlist?"
                 ]
               }
             ]
@@ -9044,9 +9334,9 @@
                 ]
               },
               {
-                "propertyValue": "Chopin",
+                "propertyValue": "Vivaldi",
                 "propertySubPhrases": [
-                  "some Chopin"
+                  "some Vivaldi"
                 ]
               }
             ]
@@ -9085,7 +9375,7 @@
             "synonyms": [
               "It's not a party without",
               "No party is complete without",
-              "Can't have a party without"
+              "A party isn't the same without"
             ],
             "category": "filler",
             "isOptional": true
@@ -9094,8 +9384,8 @@
             "text": "'Doggy Dogg World'",
             "synonyms": [
               "'Doggy Dogg World'",
-              "'Doggy Dogg World'",
-              "'Doggy Dogg World'"
+              "Doggy Dogg World",
+              "the track 'Doggy Dogg World'"
             ],
             "category": "trackName",
             "propertyNames": [
@@ -9107,7 +9397,7 @@
             "synonyms": [
               "so let's begin!",
               "so let's start!",
-              "so let's kick it off!"
+              "so let's play it!"
             ],
             "category": "filler",
             "isOptional": true
@@ -9142,66 +9432,7 @@
             ]
           }
         ]
-      },
-      "corrections": [
-        {
-          "data": {
-            "properties": [
-              {
-                "name": "fullActionName",
-                "value": "player.playTrack",
-                "substrings": [],
-                "implied": true
-              },
-              {
-                "name": "parameters.trackName",
-                "value": "Doggy Dogg World",
-                "substrings": [
-                  "Doggy Dogg World"
-                ],
-                "implied": false
-              }
-            ],
-            "subPhrases": [
-              {
-                "text": "It ain't a party without some",
-                "synonyms": [
-                  "It's not a party without",
-                  "No party is complete without",
-                  "Can't have a party without"
-                ],
-                "category": "filler",
-                "isOptional": true
-              },
-              {
-                "text": "Doggy Dogg World",
-                "synonyms": [
-                  "Doggy Dogg World",
-                  "Doggy Dogg World",
-                  "Doggy Dogg World"
-                ],
-                "category": "trackName",
-                "propertyNames": [
-                  "parameters.trackName"
-                ]
-              },
-              {
-                "text": "so let's get it started!",
-                "synonyms": [
-                  "so let's begin!",
-                  "so let's start!",
-                  "so let's kick it off!"
-                ],
-                "category": "filler",
-                "isOptional": true
-              }
-            ]
-          },
-          "correction": [
-            "Missing sub-phrase: explanation missing for '''"
-          ]
-        }
-      ]
+      }
     },
     {
       "request": "Let's get this party started with some 'Drop It Like It's Hot', ya feel me?",
@@ -9234,31 +9465,23 @@
           {
             "text": "Let's get this party started",
             "synonyms": [
-              "Let's begin the festivities",
-              "Let's start the celebration",
+              "Let's begin the celebration",
+              "Let's start the event",
               "Let's kick off the party"
             ],
-            "category": "filler",
-            "isOptional": true
+            "category": "command",
+            "propertyNames": [
+              "fullActionName"
+            ]
           },
           {
-            "text": "with some",
+            "text": "with some 'Drop It Like It's Hot'",
             "synonyms": [
-              "featuring",
-              "including",
-              "playing"
+              "by playing 'Drop It Like It's Hot'",
+              "with the track 'Drop It Like It's Hot'",
+              "featuring 'Drop It Like It's Hot'"
             ],
-            "category": "preposition",
-            "isOptional": true
-          },
-          {
-            "text": "'Drop It Like It's Hot'",
-            "synonyms": [
-              "'Drop It Like It's Hot'",
-              "'Drop It Like It's Hot'",
-              "'Drop It Like It's Hot'"
-            ],
-            "category": "trackName",
+            "category": "track",
             "propertyNames": [
               "parameters.trackName"
             ]
@@ -9268,36 +9491,63 @@
             "synonyms": [
               "you know?",
               "do you understand?",
-              "get it?"
+              "right?"
             ],
-            "category": "confirmation",
+            "category": "filler",
             "isOptional": true
           }
         ],
         "propertyAlternatives": [
           {
+            "propertyName": "fullActionName",
+            "propertyValue": "player.playTrack",
+            "propertySubPhrases": [
+              "Let's get this party started"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "player.startMusic",
+                "propertySubPhrases": [
+                  "Let's start the music"
+                ]
+              },
+              {
+                "propertyValue": "player.beginPlayback",
+                "propertySubPhrases": [
+                  "Let's begin the playback"
+                ]
+              },
+              {
+                "propertyValue": "player.initiateTunes",
+                "propertySubPhrases": [
+                  "Let's initiate the tunes"
+                ]
+              }
+            ]
+          },
+          {
             "propertyName": "parameters.trackName",
             "propertyValue": "Drop It Like It's Hot",
             "propertySubPhrases": [
-              "'Drop It Like It's Hot'"
+              "with some 'Drop It Like It's Hot'"
             ],
             "alternatives": [
               {
                 "propertyValue": "Uptown Funk",
                 "propertySubPhrases": [
-                  "'Uptown Funk'"
-                ]
-              },
-              {
-                "propertyValue": "Happy",
-                "propertySubPhrases": [
-                  "'Happy'"
+                  "with some 'Uptown Funk'"
                 ]
               },
               {
                 "propertyValue": "Shape of You",
                 "propertySubPhrases": [
-                  "'Shape of You'"
+                  "with some 'Shape of You'"
+                ]
+              },
+              {
+                "propertyValue": "Blinding Lights",
+                "propertySubPhrases": [
+                  "with some 'Blinding Lights'"
                 ]
               }
             ]
@@ -9346,7 +9596,7 @@
           {
             "text": "get this place smokin'",
             "synonyms": [
-              "liven up this place",
+              "liven things up",
               "make this place lively",
               "get the party started"
             ],
@@ -9380,7 +9630,7 @@
             "synonyms": [
               "you know?",
               "right?",
-              "got it?"
+              "understand?"
             ],
             "category": "confirmation",
             "isOptional": true
@@ -9513,7 +9763,7 @@
               {
                 "propertyValue": "player.playPlaylist",
                 "propertySubPhrases": [
-                  "queue up a playlist"
+                  "play the playlist"
                 ]
               }
             ]
@@ -9599,8 +9849,8 @@
             "text": "Snoop Dogg's",
             "synonyms": [
               "by Snoop Dogg",
-              "Snoop Dogg",
-              "from Snoop Dogg"
+              "from Snoop Dogg",
+              "Snoop Dogg"
             ],
             "category": "artist",
             "propertyNames": [
@@ -9610,9 +9860,9 @@
           {
             "text": "'Drop It Like It's Hot'",
             "synonyms": [
-              "Drop It Like It's Hot",
-              "the song Drop It Like It's Hot",
-              "Drop It Like It's Hot track"
+              "the song 'Drop It Like It's Hot'",
+              "'Drop It Like It's Hot' track",
+              "'Drop It Like It's Hot' by Snoop Dogg"
             ],
             "category": "track",
             "propertyNames": [
@@ -9721,7 +9971,7 @@
             "synonyms": [
               "play some",
               "hear some",
-              "put on some"
+              "enjoy some"
             ],
             "category": "action",
             "propertyNames": [
@@ -9745,7 +9995,7 @@
             "synonyms": [
               "okay?",
               "alright?",
-              "if you please?"
+              "right?"
             ],
             "category": "confirmation",
             "isOptional": true
@@ -9916,7 +10166,7 @@
               "We should",
               "How about we"
             ],
-            "category": "filler",
+            "category": "politeness",
             "isOptional": true
           },
           {
@@ -10032,7 +10282,7 @@
             "synonyms": [
               "featuring",
               "including",
-              "by playing"
+              "such as"
             ],
             "category": "preposition",
             "isOptional": true
@@ -10041,8 +10291,8 @@
             "text": "'Murder Was the Case'",
             "synonyms": [
               "'Murder Was the Case'",
-              "'Murder Was the Case'",
-              "'Murder Was the Case'"
+              "'Murder Was the Case' by Snoop Dogg",
+              "'Murder Was the Case' track"
             ],
             "category": "trackName",
             "propertyNames": [
@@ -10104,7 +10354,9 @@
           {
             "name": "fullActionName",
             "value": "player.playTrack",
-            "substrings": [],
+            "substrings": [
+              "Let's take it back to the old school with some 'Who Am I (What's My Name)?'"
+            ],
             "implied": true
           },
           {
@@ -10124,14 +10376,14 @@
               "We should",
               "How about we"
             ],
-            "category": "suggestion",
+            "category": "politeness",
             "isOptional": true
           },
           {
             "text": "take it back to the old school",
             "synonyms": [
-              "reminisce about the old school",
-              "go back to the old school",
+              "revisit the classics",
+              "go back to the old days",
               "return to the old school"
             ],
             "category": "action",
@@ -10142,7 +10394,7 @@
             "synonyms": [
               "featuring",
               "including",
-              "along with"
+              "playing"
             ],
             "category": "preposition",
             "isOptional": true
@@ -10205,7 +10457,7 @@
             "name": "fullActionName",
             "value": "player.playArtist",
             "substrings": [
-              "Might I request the pleasure of listening to some exquisite Bach?"
+              "request the pleasure of listening to"
             ],
             "implied": true
           },
@@ -10220,21 +10472,33 @@
         ],
         "subPhrases": [
           {
-            "text": "Might I request",
+            "text": "Might I",
             "synonyms": [
-              "Can I request",
-              "May I request",
-              "Could I request"
+              "Could I",
+              "May I",
+              "Would I"
             ],
             "category": "politeness",
             "isOptional": true
           },
           {
-            "text": "the pleasure of listening to some exquisite",
+            "text": "request the pleasure of listening to",
             "synonyms": [
-              "the joy of hearing some wonderful",
-              "the delight of enjoying some beautiful",
-              "the privilege of experiencing some amazing"
+              "ask to hear",
+              "wish to listen to",
+              "desire to play"
+            ],
+            "category": "action",
+            "propertyNames": [
+              "fullActionName"
+            ]
+          },
+          {
+            "text": "some exquisite",
+            "synonyms": [
+              "a bit of",
+              "some wonderful",
+              "some beautiful"
             ],
             "category": "filler",
             "isOptional": true
@@ -10244,7 +10508,7 @@
             "synonyms": [
               "Johann Sebastian Bach",
               "J.S. Bach",
-              "Bach's music"
+              "the music of Bach"
             ],
             "category": "artist",
             "propertyNames": [
@@ -10253,6 +10517,33 @@
           }
         ],
         "propertyAlternatives": [
+          {
+            "propertyName": "fullActionName",
+            "propertyValue": "player.playArtist",
+            "propertySubPhrases": [
+              "request the pleasure of listening to"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "player.playSong",
+                "propertySubPhrases": [
+                  "request the pleasure of listening to a song by"
+                ]
+              },
+              {
+                "propertyValue": "player.playAlbum",
+                "propertySubPhrases": [
+                  "request the pleasure of listening to an album by"
+                ]
+              },
+              {
+                "propertyValue": "player.playPlaylist",
+                "propertySubPhrases": [
+                  "request the pleasure of listening to a playlist by"
+                ]
+              }
+            ]
+          },
           {
             "propertyName": "parameters.artist",
             "propertyValue": "Bach",
@@ -10273,9 +10564,9 @@
                 ]
               },
               {
-                "propertyValue": "Vivaldi",
+                "propertyValue": "Chopin",
                 "propertySubPhrases": [
-                  "Vivaldi"
+                  "Chopin"
                 ]
               }
             ]
@@ -10297,7 +10588,7 @@
             "name": "fullActionName",
             "value": "player.playGenre",
             "substrings": [
-              "Play"
+              "Play some relaxing jazz music"
             ],
             "implied": true
           },
@@ -10336,9 +10627,9 @@
           {
             "text": "relaxing jazz",
             "synonyms": [
-              "chill jazz",
               "smooth jazz",
-              "easy jazz"
+              "chill jazz",
+              "soft jazz"
             ],
             "category": "genre",
             "propertyNames": [
@@ -10350,7 +10641,7 @@
             "synonyms": [
               "tunes",
               "melodies",
-              "songs"
+              "tracks"
             ],
             "category": "filler",
             "isOptional": true
@@ -10428,7 +10719,7 @@
             "name": "fullActionName",
             "value": "player.playArtist",
             "substrings": [
-              "Play some songs by"
+              "Play some songs by The Beatles, please."
             ],
             "implied": true
           },
@@ -10445,11 +10736,11 @@
           {
             "text": "Play some songs by",
             "synonyms": [
-              "Play music by",
               "Play tracks by",
+              "Play music by",
               "Play tunes by"
             ],
-            "category": "action",
+            "category": "command",
             "propertyNames": [
               "fullActionName"
             ]
@@ -10471,7 +10762,7 @@
             "synonyms": [
               "kindly",
               "if you don't mind",
-              "if you please"
+              "would you"
             ],
             "category": "politeness",
             "isOptional": true
@@ -10557,7 +10848,7 @@
             "name": "parameters.genre",
             "value": "acoustic guitar",
             "substrings": [
-              "soothing acoustic guitar songs"
+              "acoustic guitar"
             ],
             "implied": false
           }
@@ -10586,16 +10877,36 @@
             "isOptional": true
           },
           {
-            "text": "soothing acoustic guitar songs",
+            "text": "soothing",
             "synonyms": [
-              "relaxing acoustic guitar tracks",
-              "calming acoustic guitar music",
-              "peaceful acoustic guitar tunes"
+              "calming",
+              "relaxing",
+              "peaceful"
+            ],
+            "category": "descriptor",
+            "isOptional": true
+          },
+          {
+            "text": "acoustic guitar",
+            "synonyms": [
+              "acoustic",
+              "guitar",
+              "acoustic music"
             ],
             "category": "genre",
             "propertyNames": [
               "parameters.genre"
             ]
+          },
+          {
+            "text": "songs",
+            "synonyms": [
+              "tracks",
+              "tunes",
+              "melodies"
+            ],
+            "category": "filler",
+            "isOptional": true
           }
         ],
         "propertyAlternatives": [
@@ -10630,25 +10941,25 @@
             "propertyName": "parameters.genre",
             "propertyValue": "acoustic guitar",
             "propertySubPhrases": [
-              "soothing acoustic guitar songs"
+              "acoustic guitar"
             ],
             "alternatives": [
               {
                 "propertyValue": "classical",
                 "propertySubPhrases": [
-                  "classical music"
+                  "classical"
                 ]
               },
               {
                 "propertyValue": "jazz",
                 "propertySubPhrases": [
-                  "smooth jazz"
+                  "jazz"
                 ]
               },
               {
-                "propertyValue": "pop",
+                "propertyValue": "rock",
                 "propertySubPhrases": [
-                  "pop hits"
+                  "rock"
                 ]
               }
             ]
@@ -10669,9 +10980,7 @@
           {
             "name": "fullActionName",
             "value": "player.playGenre",
-            "substrings": [
-              "Play"
-            ],
+            "substrings": [],
             "implied": true
           },
           {
@@ -10689,12 +10998,10 @@
             "synonyms": [
               "Start",
               "Begin",
-              "Launch"
+              "Initiate"
             ],
             "category": "command",
-            "propertyNames": [
-              "fullActionName"
-            ]
+            "propertyNames": []
           },
           {
             "text": "the best of",
@@ -10704,7 +11011,8 @@
               "finest"
             ],
             "category": "filler",
-            "isOptional": true
+            "isOptional": true,
+            "propertyNames": []
           },
           {
             "text": "90s alternative rock",
@@ -10721,33 +11029,6 @@
         ],
         "propertyAlternatives": [
           {
-            "propertyName": "fullActionName",
-            "propertyValue": "player.playGenre",
-            "propertySubPhrases": [
-              "Play"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "player.playSong",
-                "propertySubPhrases": [
-                  "Play a song"
-                ]
-              },
-              {
-                "propertyValue": "player.playAlbum",
-                "propertySubPhrases": [
-                  "Play an album"
-                ]
-              },
-              {
-                "propertyValue": "player.playPlaylist",
-                "propertySubPhrases": [
-                  "Play a playlist"
-                ]
-              }
-            ]
-          },
-          {
             "propertyName": "parameters.genre",
             "propertyValue": "90s alternative rock",
             "propertySubPhrases": [
@@ -10761,15 +11042,15 @@
                 ]
               },
               {
-                "propertyValue": "classic rock",
+                "propertyValue": "2000s hip hop",
                 "propertySubPhrases": [
-                  "classic rock"
+                  "2000s hip hop"
                 ]
               },
               {
-                "propertyValue": "modern indie",
+                "propertyValue": "classic rock",
                 "propertySubPhrases": [
-                  "modern indie"
+                  "classic rock"
                 ]
               }
             ]
@@ -10819,9 +11100,9 @@
           {
             "text": "Play the song",
             "synonyms": [
-              "Play the track",
-              "Start the song",
-              "Play the music"
+              "Start the track",
+              "Play the music",
+              "Play the tune"
             ],
             "category": "command",
             "propertyNames": [
@@ -10832,8 +11113,8 @@
             "text": "'Bohemian Rhapsody'",
             "synonyms": [
               "'Bohemian Rhapsody'",
-              "the song 'Bohemian Rhapsody'",
-              "track 'Bohemian Rhapsody'"
+              "'Bohemian Rhapsody' by Queen",
+              "'Bohemian Rhapsody' track"
             ],
             "category": "trackName",
             "propertyNames": [
@@ -10843,9 +11124,9 @@
           {
             "text": "by Queen",
             "synonyms": [
+              "by the band Queen",
               "by Queen",
-              "performed by Queen",
-              "sung by Queen"
+              "by the artist Queen"
             ],
             "category": "artist",
             "propertyNames": [
@@ -10874,9 +11155,9 @@
                 ]
               },
               {
-                "propertyValue": "player.playNextTrack",
+                "propertyValue": "player.playAlbum",
                 "propertySubPhrases": [
-                  "Play the next song"
+                  "Play the album"
                 ]
               }
             ]
@@ -10980,7 +11261,7 @@
             "synonyms": [
               "Start",
               "Begin",
-              "Commence"
+              "Execute"
             ],
             "category": "command",
             "propertyNames": [
@@ -10992,7 +11273,7 @@
             "synonyms": [
               "these",
               "those",
-              "some"
+              "them"
             ],
             "category": "filler",
             "isOptional": true
@@ -11150,7 +11431,7 @@
             "name": "parameters.artists.0",
             "value": "John Lennon",
             "substrings": [
-              "by John Lennon"
+              "John Lennon"
             ],
             "implied": false
           }
@@ -11160,7 +11441,7 @@
             "text": "Please",
             "synonyms": [
               "Kindly",
-              "Would you",
+              "Would you mind",
               "Could you"
             ],
             "category": "politeness",
@@ -11182,8 +11463,8 @@
             "text": "'Imagine'",
             "synonyms": [
               "the song 'Imagine'",
-              "the track 'Imagine'",
-              "the music 'Imagine'"
+              "'Imagine' by itself",
+              "the track 'Imagine'"
             ],
             "category": "trackName",
             "propertyNames": [
@@ -11191,11 +11472,21 @@
             ]
           },
           {
-            "text": "by John Lennon",
+            "text": "by",
             "synonyms": [
-              "performed by John Lennon",
-              "sung by John Lennon",
-              "from John Lennon"
+              "from",
+              "performed by",
+              "sung by"
+            ],
+            "category": "preposition",
+            "isOptional": true
+          },
+          {
+            "text": "John Lennon",
+            "synonyms": [
+              "the artist John Lennon",
+              "John Lennon himself",
+              "Lennon"
             ],
             "category": "artist",
             "propertyNames": [
@@ -11220,13 +11511,13 @@
               {
                 "propertyValue": "player.addTrackToPlaylist",
                 "propertySubPhrases": [
-                  "add"
+                  "add to playlist"
                 ]
               },
               {
                 "propertyValue": "player.shufflePlay",
                 "propertySubPhrases": [
-                  "shuffle"
+                  "shuffle play"
                 ]
               }
             ]
@@ -11262,25 +11553,25 @@
             "propertyName": "parameters.artists.0",
             "propertyValue": "John Lennon",
             "propertySubPhrases": [
-              "by John Lennon"
+              "John Lennon"
             ],
             "alternatives": [
               {
                 "propertyValue": "The Beatles",
                 "propertySubPhrases": [
-                  "by The Beatles"
+                  "The Beatles"
                 ]
               },
               {
                 "propertyValue": "Queen",
                 "propertySubPhrases": [
-                  "by Queen"
+                  "Queen"
                 ]
               },
               {
                 "propertyValue": "Eagles",
                 "propertySubPhrases": [
-                  "by Eagles"
+                  "Eagles"
                 ]
               }
             ]
@@ -11320,7 +11611,7 @@
             "text": "Please",
             "synonyms": [
               "Kindly",
-              "Would you",
+              "Would you mind",
               "Could you"
             ],
             "category": "politeness",
@@ -11343,7 +11634,7 @@
             "synonyms": [
               "some",
               "several",
-              "a handful of"
+              "a couple of"
             ],
             "category": "quantity",
             "propertyNames": [
@@ -11372,7 +11663,7 @@
               {
                 "propertyValue": "player.play",
                 "propertySubPhrases": [
-                  "play"
+                  "play some"
                 ]
               },
               {
@@ -11411,7 +11702,7 @@
               {
                 "propertyValue": 10,
                 "propertySubPhrases": [
-                  "a bunch"
+                  "a bunch of"
                 ]
               }
             ]
@@ -11462,7 +11753,7 @@
             "synonyms": [
               "play a few",
               "play several",
-              "play"
+              "play a number of"
             ],
             "category": "action",
             "propertyNames": [
@@ -11472,9 +11763,9 @@
           {
             "text": "Bach",
             "synonyms": [
-              "Johann Sebastian Bach",
-              "J.S. Bach",
-              "Bach's"
+              "Beethoven",
+              "Mozart",
+              "Chopin"
             ],
             "category": "artist",
             "propertyNames": [
@@ -11488,17 +11779,19 @@
               "compositions",
               "pieces"
             ],
-            "category": "description",
-            "isOptional": true
+            "category": "music",
+            "propertyNames": [
+              "fullActionName"
+            ]
           },
           {
             "text": "for me",
             "synonyms": [
               "for myself",
-              "for my enjoyment",
-              "for my listening"
+              "for my benefit",
+              "for my enjoyment"
             ],
-            "category": "preposition",
+            "category": "recipient",
             "isOptional": true
           },
           {
@@ -11506,7 +11799,7 @@
             "synonyms": [
               "assistant",
               "AI",
-              "helper"
+              "system"
             ],
             "category": "address",
             "isOptional": true
@@ -11517,25 +11810,29 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.playArtist",
             "propertySubPhrases": [
-              "play some"
+              "play some",
+              "masterpieces"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.playSong",
                 "propertySubPhrases": [
-                  "play a song"
+                  "play some",
+                  "songs"
                 ]
               },
               {
                 "propertyValue": "player.playAlbum",
                 "propertySubPhrases": [
-                  "play an album"
+                  "play some",
+                  "albums"
                 ]
               },
               {
                 "propertyValue": "player.playPlaylist",
                 "propertySubPhrases": [
-                  "play a playlist"
+                  "play some",
+                  "playlists"
                 ]
               }
             ]
@@ -11568,7 +11865,35 @@
             ]
           }
         ]
-      }
+      },
+      "corrections": [
+        {
+          "data": {
+            "properties": [
+              {
+                "name": "fullActionName",
+                "value": "player.playArtist",
+                "substrings": [
+                  "Please play some Bach masterpieces for me, bot."
+                ],
+                "implied": true
+              },
+              {
+                "name": "artist",
+                "value": "Bach",
+                "substrings": [
+                  "Bach"
+                ],
+                "implied": false
+              }
+            ]
+          },
+          "correction": [
+            "Extraneous parameter: 'artist' is not a parameter in the action",
+            "Missing parameter: parameter 'parameters.artist' in the action is missing from explanation"
+          ]
+        }
+      ]
     },
     {
       "request": "Please play some music composed by Bach.",
@@ -11642,15 +11967,15 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.playSong",
-                "propertySubPhrases": [
-                  "play a song by"
-                ]
-              },
-              {
                 "propertyValue": "player.playAlbum",
                 "propertySubPhrases": [
                   "play an album by"
+                ]
+              },
+              {
+                "propertyValue": "player.playSong",
+                "propertySubPhrases": [
+                  "play a song by"
                 ]
               },
               {
@@ -11734,7 +12059,7 @@
             "synonyms": [
               "play music",
               "start playing songs",
-              "put on some music"
+              "put on some tunes"
             ],
             "category": "action",
             "propertyNames": [
@@ -11742,13 +12067,23 @@
             ]
           },
           {
-            "text": "from the 'Guardians of the Galaxy' soundtrack",
+            "text": "from the",
             "synonyms": [
-              "from the 'Guardians of the Galaxy' album",
-              "from the soundtrack of 'Guardians of the Galaxy'",
-              "from the 'Guardians of the Galaxy' music collection"
+              "off the",
+              "out of the",
+              "taken from the"
             ],
-            "category": "album",
+            "category": "preposition",
+            "isOptional": true
+          },
+          {
+            "text": "'Guardians of the Galaxy' soundtrack",
+            "synonyms": [
+              "'Guardians of the Galaxy' album",
+              "'Guardians of the Galaxy' music",
+              "'Guardians of the Galaxy' OST"
+            ],
+            "category": "object",
             "propertyNames": [
               "parameters.albumName"
             ]
@@ -11775,9 +12110,9 @@
                 ]
               },
               {
-                "propertyValue": "player.playRadio",
+                "propertyValue": "player.playArtist",
                 "propertySubPhrases": [
-                  "play the radio"
+                  "play some music by"
                 ]
               }
             ]
@@ -11786,25 +12121,25 @@
             "propertyName": "parameters.albumName",
             "propertyValue": "Guardians of the Galaxy",
             "propertySubPhrases": [
-              "from the 'Guardians of the Galaxy' soundtrack"
+              "'Guardians of the Galaxy' soundtrack"
             ],
             "alternatives": [
               {
-                "propertyValue": "Awesome Mix Vol. 1",
+                "propertyValue": "The Beatles",
                 "propertySubPhrases": [
-                  "from the 'Awesome Mix Vol. 1' soundtrack"
+                  "'The Beatles' album"
                 ]
               },
               {
-                "propertyValue": "Awesome Mix Vol. 2",
+                "propertyValue": "Thriller",
                 "propertySubPhrases": [
-                  "from the 'Awesome Mix Vol. 2' soundtrack"
+                  "'Thriller' album"
                 ]
               },
               {
-                "propertyValue": "Guardians of the Galaxy Vol. 2",
+                "propertyValue": "Abbey Road",
                 "propertySubPhrases": [
-                  "from the 'Guardians of the Galaxy Vol. 2' soundtrack"
+                  "'Abbey Road' album"
                 ]
               }
             ]
@@ -11856,18 +12191,18 @@
             "text": "some energetic",
             "synonyms": [
               "a few lively",
-              "some vibrant",
-              "a bit of energetic"
+              "some upbeat",
+              "a couple of energetic"
             ],
-            "category": "descriptor",
+            "category": "filler",
             "isOptional": true
           },
           {
             "text": "rock",
             "synonyms": [
+              "rock and roll",
               "rock music",
-              "rock songs",
-              "rock tracks"
+              "rock genre"
             ],
             "category": "genre",
             "propertyNames": [
@@ -11879,9 +12214,9 @@
             "synonyms": [
               "songs",
               "tracks",
-              "melodies"
+              "music"
             ],
-            "category": "music",
+            "category": "filler",
             "isOptional": true
           }
         ],
@@ -11894,21 +12229,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.startGenre",
+                "propertyValue": "player.pause",
                 "propertySubPhrases": [
-                  "Start"
+                  "Pause"
                 ]
               },
               {
-                "propertyValue": "player.queueGenre",
+                "propertyValue": "player.stop",
                 "propertySubPhrases": [
-                  "Queue up"
+                  "Stop"
                 ]
               },
               {
-                "propertyValue": "player.beginGenre",
+                "propertyValue": "player.skip",
                 "propertySubPhrases": [
-                  "Begin"
+                  "Skip"
                 ]
               }
             ]
@@ -11972,31 +12307,21 @@
         ],
         "subPhrases": [
           {
-            "text": "Put on",
+            "text": "Put on some",
             "synonyms": [
               "Play",
-              "Start",
-              "Begin"
+              "Start playing",
+              "Begin playing"
             ],
             "category": "command",
-            "isOptional": false
-          },
-          {
-            "text": "some",
-            "synonyms": [
-              "a bit of",
-              "a little",
-              "some of"
-            ],
-            "category": "filler",
-            "isOptional": true
+            "propertyNames": []
           },
           {
             "text": "Snoop Dogg",
             "synonyms": [
               "Snoop",
               "Snoop Doggy Dogg",
-              "Calvin Broadus"
+              "Snoop Lion"
             ],
             "category": "artist",
             "propertyNames": [
@@ -12035,9 +12360,9 @@
                 ]
               },
               {
-                "propertyValue": "Kendrick Lamar",
+                "propertyValue": "Ice Cube",
                 "propertySubPhrases": [
-                  "Kendrick Lamar"
+                  "Ice Cube"
                 ]
               }
             ]
@@ -12093,15 +12418,14 @@
               "a"
             ],
             "category": "article",
-            "isOptional": true,
-            "propertyNames": []
+            "isOptional": true
           },
           {
             "text": "80s dance party mix",
             "synonyms": [
               "80s dance playlist",
-              "80s dance mix",
-              "80s party mix"
+              "80s party mix",
+              "80s dance collection"
             ],
             "category": "playlistName",
             "propertyNames": [
@@ -12118,21 +12442,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.playPlaylist",
+                "propertyValue": "player.play",
                 "propertySubPhrases": [
                   "Play"
                 ]
               },
               {
-                "propertyValue": "player.queuePlaylist",
+                "propertyValue": "player.resume",
                 "propertySubPhrases": [
-                  "Queue"
+                  "Resume"
                 ]
               },
               {
-                "propertyValue": "player.shufflePlaylist",
+                "propertyValue": "player.begin",
                 "propertySubPhrases": [
-                  "Shuffle"
+                  "Begin"
                 ]
               }
             ]
@@ -12145,90 +12469,27 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "90s rock hits",
+                "propertyValue": "90s dance party mix",
                 "propertySubPhrases": [
-                  "90s rock hits"
+                  "90s dance party mix"
                 ]
               },
               {
-                "propertyValue": "classic jazz collection",
+                "propertyValue": "70s disco mix",
                 "propertySubPhrases": [
-                  "classic jazz collection"
+                  "70s disco mix"
                 ]
               },
               {
-                "propertyValue": "top pop songs",
+                "propertyValue": "classic rock mix",
                 "propertySubPhrases": [
-                  "top pop songs"
+                  "classic rock mix"
                 ]
               }
             ]
           }
         ]
-      },
-      "corrections": [
-        {
-          "data": {
-            "properties": [
-              {
-                "name": "fullActionName",
-                "value": "player.getPlaylist",
-                "substrings": [
-                  "Start the 80s dance party mix"
-                ],
-                "implied": true
-              },
-              {
-                "name": "parameters.name",
-                "value": "80s dance party mix",
-                "substrings": [
-                  "80s dance party mix"
-                ],
-                "implied": false
-              }
-            ],
-            "subPhrases": [
-              {
-                "text": "Start",
-                "synonyms": [
-                  "Begin",
-                  "Initiate",
-                  "Launch"
-                ],
-                "category": "command",
-                "propertyNames": []
-              },
-              {
-                "text": "the",
-                "synonyms": [
-                  "this",
-                  "that",
-                  "a"
-                ],
-                "category": "article",
-                "isOptional": true,
-                "propertyNames": []
-              },
-              {
-                "text": "80s dance party mix",
-                "synonyms": [
-                  "80s dance playlist",
-                  "80s dance mix",
-                  "80s party mix"
-                ],
-                "category": "playlistName",
-                "propertyNames": [
-                  "name"
-                ]
-              }
-            ]
-          },
-          "correction": [
-            "Extraneous parameter: 'name' is not a parameter in the action",
-            "Property 'parameters.name' is expected to be explicit and should be included as a property name for a sub-phrase"
-          ]
-        }
-      ]
+      }
     },
     {
       "request": "Start the classical symphony playlist",
@@ -12263,12 +12524,10 @@
             "synonyms": [
               "Begin",
               "Initiate",
-              "Launch"
+              "Commence"
             ],
             "category": "command",
-            "propertyNames": [
-              "fullActionName"
-            ]
+            "propertyNames": []
           },
           {
             "text": "the",
@@ -12295,48 +12554,15 @@
           {
             "text": "playlist",
             "synonyms": [
-              "tracklist",
               "music list",
+              "track list",
               "song collection"
             ],
             "category": "object",
-            "propertyNames": [
-              "fullActionName"
-            ]
+            "propertyNames": []
           }
         ],
         "propertyAlternatives": [
-          {
-            "propertyName": "fullActionName",
-            "propertyValue": "player.getPlaylist",
-            "propertySubPhrases": [
-              "Start",
-              "playlist"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "player.playPlaylist",
-                "propertySubPhrases": [
-                  "Play",
-                  "playlist"
-                ]
-              },
-              {
-                "propertyValue": "player.resumePlaylist",
-                "propertySubPhrases": [
-                  "Resume",
-                  "playlist"
-                ]
-              },
-              {
-                "propertyValue": "player.queuePlaylist",
-                "propertySubPhrases": [
-                  "Queue",
-                  "playlist"
-                ]
-              }
-            ]
-          },
           {
             "propertyName": "parameters.name",
             "propertyValue": "classical symphony",
@@ -12345,21 +12571,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "jazz classics",
+                "propertyValue": "baroque classics",
                 "propertySubPhrases": [
-                  "jazz classics"
+                  "baroque classics"
                 ]
               },
               {
-                "propertyValue": "rock anthems",
+                "propertyValue": "romantic era",
                 "propertySubPhrases": [
-                  "rock anthems"
+                  "romantic era"
                 ]
               },
               {
-                "propertyValue": "pop hits",
+                "propertyValue": "modern symphony",
                 "propertySubPhrases": [
-                  "pop hits"
+                  "modern symphony"
                 ]
               }
             ]
@@ -12420,8 +12646,8 @@
           {
             "text": "smooth R&B",
             "synonyms": [
-              "smooth rhythm and blues",
               "smooth RnB",
+              "smooth rhythm and blues",
               "smooth R and B"
             ],
             "category": "playlistName",
@@ -12488,9 +12714,9 @@
                 ]
               },
               {
-                "propertyValue": "evening jazz",
+                "propertyValue": "easy listening",
                 "propertySubPhrases": [
-                  "evening jazz"
+                  "easy listening"
                 ]
               }
             ]
@@ -12511,9 +12737,7 @@
           {
             "name": "fullActionName",
             "value": "player.playArtist",
-            "substrings": [
-              "Time to bump some Snoop Dogg, homie!"
-            ],
+            "substrings": [],
             "implied": true
           },
           {
@@ -12533,15 +12757,15 @@
               "How about some",
               "Play some"
             ],
-            "category": "command",
-            "isOptional": false
+            "category": "filler",
+            "isOptional": true
           },
           {
             "text": "Snoop Dogg",
             "synonyms": [
               "Snoop Doggy Dogg",
-              "Snoop",
-              "Snoop D-O-double-G"
+              "Snoop Lion",
+              "Calvin Broadus"
             ],
             "category": "artist",
             "propertyNames": [
@@ -12604,7 +12828,7 @@
             "name": "fullActionName",
             "value": "player.playGenre",
             "substrings": [
-              "Turn on"
+              "Turn on the latest pop hits"
             ],
             "implied": true
           },
@@ -12626,9 +12850,7 @@
               "Activate"
             ],
             "category": "command",
-            "propertyNames": [
-              "fullActionName"
-            ]
+            "propertyNames": []
           },
           {
             "text": "the latest",
@@ -12638,7 +12860,7 @@
               "current"
             ],
             "category": "descriptor",
-            "isOptional": true
+            "propertyNames": []
           },
           {
             "text": "pop",
@@ -12660,37 +12882,10 @@
               "tunes"
             ],
             "category": "descriptor",
-            "isOptional": true
+            "propertyNames": []
           }
         ],
         "propertyAlternatives": [
-          {
-            "propertyName": "fullActionName",
-            "propertyValue": "player.playGenre",
-            "propertySubPhrases": [
-              "Turn on"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "player.startGenre",
-                "propertySubPhrases": [
-                  "Start"
-                ]
-              },
-              {
-                "propertyValue": "player.activateGenre",
-                "propertySubPhrases": [
-                  "Activate"
-                ]
-              },
-              {
-                "propertyValue": "player.initiateGenre",
-                "propertySubPhrases": [
-                  "Initiate"
-                ]
-              }
-            ]
-          },
           {
             "propertyName": "parameters.genre",
             "propertyValue": "pop",
@@ -12708,6 +12903,12 @@
                 "propertyValue": "jazz",
                 "propertySubPhrases": [
                   "jazz"
+                ]
+              },
+              {
+                "propertyValue": "hip-hop",
+                "propertySubPhrases": [
+                  "hip-hop"
                 ]
               },
               {
@@ -12763,8 +12964,8 @@
             "text": "play",
             "synonyms": [
               "start",
-              "put on",
-              "begin"
+              "begin",
+              "put on"
             ],
             "category": "action",
             "propertyNames": [
@@ -12772,16 +12973,36 @@
             ]
           },
           {
-            "text": "some energetic dance tracks",
+            "text": "some energetic",
             "synonyms": [
-              "some lively dance music",
-              "some upbeat dance songs",
-              "some high-energy dance tunes"
+              "a few lively",
+              "some upbeat",
+              "a couple of energetic"
+            ],
+            "category": "description",
+            "isOptional": true
+          },
+          {
+            "text": "dance",
+            "synonyms": [
+              "electronic dance",
+              "EDM",
+              "club"
             ],
             "category": "genre",
             "propertyNames": [
               "parameters.genre"
             ]
+          },
+          {
+            "text": "tracks",
+            "synonyms": [
+              "songs",
+              "tunes",
+              "music"
+            ],
+            "category": "object",
+            "isOptional": true
           }
         ],
         "propertyAlternatives": [
@@ -12816,25 +13037,25 @@
             "propertyName": "parameters.genre",
             "propertyValue": "dance",
             "propertySubPhrases": [
-              "some energetic dance tracks"
+              "dance"
             ],
             "alternatives": [
               {
                 "propertyValue": "rock",
                 "propertySubPhrases": [
-                  "some energetic rock tracks"
+                  "rock"
+                ]
+              },
+              {
+                "propertyValue": "jazz",
+                "propertySubPhrases": [
+                  "jazz"
                 ]
               },
               {
                 "propertyValue": "pop",
                 "propertySubPhrases": [
-                  "some energetic pop tracks"
-                ]
-              },
-              {
-                "propertyValue": "hip-hop",
-                "propertySubPhrases": [
-                  "some energetic hip-hop tracks"
+                  "pop"
                 ]
               }
             ]
@@ -12907,7 +13128,7 @@
             "synonyms": [
               "Johann Sebastian Bach",
               "J.S. Bach",
-              "Bach's music"
+              "the music of Bach"
             ],
             "category": "artist",
             "propertyNames": [
@@ -12971,7 +13192,35 @@
             ]
           }
         ]
-      }
+      },
+      "corrections": [
+        {
+          "data": {
+            "properties": [
+              {
+                "name": "fullActionName",
+                "value": "player.playArtist",
+                "substrings": [
+                  "play"
+                ],
+                "implied": true
+              },
+              {
+                "name": "artist",
+                "value": "Bach",
+                "substrings": [
+                  "Bach"
+                ],
+                "implied": false
+              }
+            ]
+          },
+          "correction": [
+            "Extraneous parameter: 'artist' is not a parameter in the action",
+            "Missing parameter: parameter 'parameters.artist' in the action is missing from explanation"
+          ]
+        }
+      ]
     },
     {
       "request": "Would you be so kind as to play some delightful Mozart for us?",
@@ -12989,7 +13238,7 @@
             "substrings": [
               "play"
             ],
-            "implied": true
+            "implied": false
           },
           {
             "name": "parameters.artist",
@@ -13026,9 +13275,9 @@
           {
             "text": "some delightful",
             "synonyms": [
-              "a bit of",
               "some wonderful",
-              "a little"
+              "some lovely",
+              "some beautiful"
             ],
             "category": "filler",
             "isOptional": true
@@ -13225,25 +13474,53 @@
               {
                 "propertyValue": "Beethoven",
                 "propertySubPhrases": [
-                  "Beethoven's finest"
+                  "Beethoven's best"
                 ]
               },
               {
                 "propertyValue": "Mozart",
                 "propertySubPhrases": [
-                  "Mozart's finest"
+                  "Mozart's masterpieces"
                 ]
               },
               {
                 "propertyValue": "Bach",
                 "propertySubPhrases": [
-                  "Bach's finest"
+                  "Bach's greatest"
                 ]
               }
             ]
           }
         ]
-      }
+      },
+      "corrections": [
+        {
+          "data": {
+            "properties": [
+              {
+                "name": "fullActionName",
+                "value": "player.playArtist",
+                "substrings": [
+                  "playing"
+                ],
+                "implied": true
+              },
+              {
+                "name": "artist",
+                "value": "Tchaikovsky",
+                "substrings": [
+                  "Tchaikovsky"
+                ],
+                "implied": false
+              }
+            ]
+          },
+          "correction": [
+            "Extraneous parameter: 'artist' is not a parameter in the action",
+            "Missing parameter: parameter 'parameters.artist' in the action is missing from explanation"
+          ]
+        }
+      ]
     },
     {
       "request": "Would you mind playing some Bach music?",
@@ -13278,7 +13555,7 @@
             "synonyms": [
               "Could you",
               "Can you",
-              "Would it be possible to"
+              "Would it be possible for you to"
             ],
             "category": "politeness",
             "isOptional": true
@@ -13380,7 +13657,7 @@
             "name": "fullActionName",
             "value": "player.playArtist",
             "substrings": [
-              "playing some music"
+              "playing some music by"
             ],
             "implied": true
           },
@@ -13405,11 +13682,11 @@
             "isOptional": true
           },
           {
-            "text": "playing some music",
+            "text": "playing some music by",
             "synonyms": [
-              "play some tunes",
-              "start some music",
-              "put on some music"
+              "play some songs by",
+              "play music from",
+              "play tracks by"
             ],
             "category": "action",
             "propertyNames": [
@@ -13417,11 +13694,11 @@
             ]
           },
           {
-            "text": "by Bach",
+            "text": "Bach",
             "synonyms": [
-              "from Bach",
-              "of Bach",
-              "Bach's music"
+              "Johann Sebastian Bach",
+              "J.S. Bach",
+              "Bach's compositions"
             ],
             "category": "artist",
             "propertyNames": [
@@ -13434,25 +13711,25 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.playArtist",
             "propertySubPhrases": [
-              "playing some music"
+              "playing some music by"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.playSong",
                 "propertySubPhrases": [
-                  "playing a song"
+                  "playing a song by"
                 ]
               },
               {
                 "propertyValue": "player.playAlbum",
                 "propertySubPhrases": [
-                  "playing an album"
+                  "playing an album by"
                 ]
               },
               {
                 "propertyValue": "player.playPlaylist",
                 "propertySubPhrases": [
-                  "playing a playlist"
+                  "playing a playlist by"
                 ]
               }
             ]
@@ -13461,25 +13738,25 @@
             "propertyName": "parameters.artist",
             "propertyValue": "Bach",
             "propertySubPhrases": [
-              "by Bach"
+              "Bach"
             ],
             "alternatives": [
               {
                 "propertyValue": "Mozart",
                 "propertySubPhrases": [
-                  "by Mozart"
+                  "Mozart"
                 ]
               },
               {
                 "propertyValue": "Beethoven",
                 "propertySubPhrases": [
-                  "by Beethoven"
+                  "Beethoven"
                 ]
               },
               {
                 "propertyValue": "Chopin",
                 "propertySubPhrases": [
-                  "by Chopin"
+                  "Chopin"
                 ]
               }
             ]
@@ -13488,6 +13765,9 @@
       }
     },
     {
+      "tags": [
+        "failedImportMergeRoundTripAction"
+      ],
       "request": "Would you mind playing some music by Johann Sebastian Bach?",
       "action": {
         "fullActionName": "player.playArtist",
@@ -13520,7 +13800,7 @@
             "synonyms": [
               "Could you",
               "Can you",
-              "Would it be possible to"
+              "Would you please"
             ],
             "category": "politeness",
             "isOptional": true
@@ -13542,7 +13822,7 @@
             "synonyms": [
               "from Johann Sebastian Bach",
               "of Johann Sebastian Bach",
-              "composed by Johann Sebastian Bach"
+              "featuring Johann Sebastian Bach"
             ],
             "category": "artist",
             "propertyNames": [
@@ -13613,7 +13893,7 @@
       "action": {
         "fullActionName": "player.playGenre",
         "parameters": {
-          "genre": "R&B"
+          "genre": "smooth R&B"
         }
       },
       "explanation": {
@@ -13628,9 +13908,9 @@
           },
           {
             "name": "parameters.genre",
-            "value": "R&B",
+            "value": "smooth R&B",
             "substrings": [
-              "R&B"
+              "smooth R&B"
             ],
             "implied": false
           }
@@ -13650,8 +13930,8 @@
             "text": "playing",
             "synonyms": [
               "play",
-              "put on",
-              "start"
+              "start playing",
+              "put on"
             ],
             "category": "action",
             "propertyNames": [
@@ -13659,21 +13939,21 @@
             ]
           },
           {
-            "text": "some smooth",
+            "text": "some",
             "synonyms": [
               "a few",
-              "some",
-              "a couple of"
+              "a couple of",
+              "several"
             ],
             "category": "filler",
             "isOptional": true
           },
           {
-            "text": "R&B",
+            "text": "smooth R&B",
             "synonyms": [
-              "rhythm and blues",
-              "R and B",
-              "R n B"
+              "R&B",
+              "smooth rhythm and blues",
+              "R&B music"
             ],
             "category": "genre",
             "propertyNames": [
@@ -13700,30 +13980,30 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.pause",
+                "propertyValue": "player.startGenre",
                 "propertySubPhrases": [
-                  "pausing"
+                  "start playing"
                 ]
               },
               {
-                "propertyValue": "player.stop",
+                "propertyValue": "player.queueGenre",
                 "propertySubPhrases": [
-                  "stopping"
+                  "queue"
                 ]
               },
               {
-                "propertyValue": "player.skip",
+                "propertyValue": "player.streamGenre",
                 "propertySubPhrases": [
-                  "skipping"
+                  "stream"
                 ]
               }
             ]
           },
           {
             "propertyName": "parameters.genre",
-            "propertyValue": "R&B",
+            "propertyValue": "smooth R&B",
             "propertySubPhrases": [
-              "R&B"
+              "smooth R&B"
             ],
             "alternatives": [
               {
@@ -13733,15 +14013,15 @@
                 ]
               },
               {
-                "propertyValue": "pop",
+                "propertyValue": "hip hop",
                 "propertySubPhrases": [
-                  "pop"
+                  "hip hop"
                 ]
               },
               {
-                "propertyValue": "rock",
+                "propertyValue": "soul",
                 "propertySubPhrases": [
-                  "rock"
+                  "soul"
                 ]
               }
             ]
@@ -13782,7 +14062,7 @@
             "synonyms": [
               "Could you",
               "Can you",
-              "Would it be possible"
+              "Would you please"
             ],
             "category": "politeness",
             "isOptional": true
@@ -13791,8 +14071,8 @@
             "text": "putting on",
             "synonyms": [
               "playing",
-              "turning on",
-              "starting"
+              "start",
+              "turn on"
             ],
             "category": "action",
             "propertyNames": [
@@ -13802,11 +14082,11 @@
           {
             "text": "some upbeat",
             "synonyms": [
+              "a few",
               "some lively",
-              "some energetic",
-              "some peppy"
+              "some energetic"
             ],
-            "category": "description",
+            "category": "filler",
             "isOptional": true
           },
           {
@@ -13826,7 +14106,7 @@
             "synonyms": [
               "songs",
               "tracks",
-              "melodies"
+              "music"
             ],
             "category": "filler",
             "isOptional": true
@@ -13933,7 +14213,7 @@
             "synonyms": [
               "start",
               "put on",
-              "play"
+              "turn on"
             ],
             "category": "action",
             "propertyNames": [
@@ -14045,7 +14325,7 @@
             "name": "fullActionName",
             "value": "player.playTrack",
             "substrings": [
-              "Yo, DJ, let's get this place jumpin' with some"
+              "Yo, DJ, let's get this place jumpin' with some 'Young, Wild & Free'!"
             ],
             "implied": true
           },
@@ -14080,23 +14360,31 @@
             "isOptional": true
           },
           {
-            "text": "let's get this place jumpin' with some",
+            "text": "let's get this place jumpin'",
             "synonyms": [
-              "play",
-              "start playing",
-              "put on"
+              "let's start the party",
+              "let's get the music going",
+              "let's make some noise"
             ],
-            "category": "command",
-            "propertyNames": [
-              "fullActionName"
-            ]
+            "category": "filler",
+            "isOptional": true
+          },
+          {
+            "text": "with some",
+            "synonyms": [
+              "playing",
+              "featuring",
+              "including"
+            ],
+            "category": "preposition",
+            "isOptional": true
           },
           {
             "text": "'Young, Wild & Free'",
             "synonyms": [
               "'Young, Wild & Free'",
-              "'Young Wild and Free'",
-              "'Young, Wild, and Free'"
+              "'Young, Wild and Free'",
+              "'Young, Wild & Free'"
             ],
             "category": "trackName",
             "propertyNames": [
@@ -14105,33 +14393,6 @@
           }
         ],
         "propertyAlternatives": [
-          {
-            "propertyName": "fullActionName",
-            "propertyValue": "player.playTrack",
-            "propertySubPhrases": [
-              "let's get this place jumpin' with some"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "player.queueTrack",
-                "propertySubPhrases": [
-                  "add some tunes like"
-                ]
-              },
-              {
-                "propertyValue": "player.shufflePlay",
-                "propertySubPhrases": [
-                  "shuffle things up with"
-                ]
-              },
-              {
-                "propertyValue": "player.playAlbum",
-                "propertySubPhrases": [
-                  "spin the whole album of"
-                ]
-              }
-            ]
-          },
           {
             "propertyName": "parameters.trackName",
             "propertyValue": "Young, Wild & Free",
@@ -14176,7 +14437,8 @@
             "name": "fullActionName",
             "value": "player.playTrack",
             "substrings": [
-              "groove to"
+              "groove to",
+              "right now?"
             ],
             "implied": true
           },
@@ -14191,11 +14453,11 @@
         ],
         "subPhrases": [
           {
-            "text": "Yo",
+            "text": "Yo,",
             "synonyms": [
-              "Hey",
-              "Hi",
-              "Hello"
+              "Hey,",
+              "Hi,",
+              "Hello,"
             ],
             "category": "greeting",
             "isOptional": true
@@ -14207,7 +14469,7 @@
               "shall we",
               "why don't we"
             ],
-            "category": "suggestion",
+            "category": "filler",
             "isOptional": true
           },
           {
@@ -14225,8 +14487,8 @@
           {
             "text": "some of that",
             "synonyms": [
-              "a bit of",
               "some",
+              "a bit of",
               "a little of"
             ],
             "category": "filler",
@@ -14237,7 +14499,7 @@
             "synonyms": [
               "'Gin & Juice'",
               "'Gin n Juice'",
-              "'Gin n' Juice'"
+              "'Gin 'n' Juice'"
             ],
             "category": "trackName",
             "propertyNames": [
@@ -14245,14 +14507,16 @@
             ]
           },
           {
-            "text": "right now",
+            "text": "right now?",
             "synonyms": [
-              "immediately",
-              "at once",
-              "this instant"
+              "immediately?",
+              "at this moment?",
+              "right away?"
             ],
             "category": "time",
-            "isOptional": true
+            "propertyNames": [
+              "fullActionName"
+            ]
           }
         ],
         "propertyAlternatives": [
@@ -14260,25 +14524,29 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.playTrack",
             "propertySubPhrases": [
-              "groove to"
+              "groove to",
+              "right now?"
             ],
             "alternatives": [
               {
-                "propertyValue": "player.startSong",
+                "propertyValue": "player.pauseTrack",
                 "propertySubPhrases": [
-                  "jam to"
+                  "pause",
+                  "right now?"
                 ]
               },
               {
-                "propertyValue": "player.playMusic",
+                "propertyValue": "player.stopTrack",
                 "propertySubPhrases": [
-                  "listen to"
+                  "stop",
+                  "right now?"
                 ]
               },
               {
-                "propertyValue": "player.queueTrack",
+                "propertyValue": "player.skipTrack",
                 "propertySubPhrases": [
-                  "queue up"
+                  "skip",
+                  "right now?"
                 ]
               }
             ]
@@ -14291,21 +14559,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "California Love",
-                "propertySubPhrases": [
-                  "'California Love'"
-                ]
-              },
-              {
                 "propertyValue": "Nuthin' but a 'G' Thang",
                 "propertySubPhrases": [
                   "'Nuthin' but a 'G' Thang'"
                 ]
               },
               {
-                "propertyValue": "Regulate",
+                "propertyValue": "Still D.R.E.",
                 "propertySubPhrases": [
-                  "'Regulate'"
+                  "'Still D.R.E.'"
+                ]
+              },
+              {
+                "propertyValue": "The Next Episode",
+                "propertySubPhrases": [
+                  "'The Next Episode'"
                 ]
               }
             ]
@@ -14365,7 +14633,7 @@
             "synonyms": [
               "let's play",
               "let's listen to",
-              "how about we play"
+              "how about"
             ],
             "category": "confirmation",
             "isOptional": true
@@ -14375,7 +14643,7 @@
             "synonyms": [
               "'Young, Wild and Free'",
               "'Young Wild & Free'",
-              "'Young Wild and Free'"
+              "'Young, Wild & Free' by Snoop Dogg"
             ],
             "category": "trackName",
             "propertyNames": [
@@ -14510,7 +14778,7 @@
             "synonyms": [
               "through the speakers",
               "via the speakers",
-              "on the sound system"
+              "using the speakers"
             ],
             "category": "location",
             "propertyNames": [
@@ -14529,26 +14797,26 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.play",
+                "propertyValue": "player.playPlaylist",
                 "propertySubPhrases": [
-                  "let's play",
-                  "some music",
+                  "let's vibe",
+                  "with a cool playlist",
                   "on the speakers"
                 ]
               },
               {
-                "propertyValue": "player.shuffle",
+                "propertyValue": "player.playAlbum",
                 "propertySubPhrases": [
-                  "shuffle",
-                  "the playlist",
+                  "let's chill",
+                  "with a dope album",
                   "on the speakers"
                 ]
               },
               {
-                "propertyValue": "player.playNext",
+                "propertyValue": "player.playSong",
                 "propertySubPhrases": [
-                  "play next",
-                  "track",
+                  "let's jam",
+                  "with a sick track",
                   "on the speakers"
                 ]
               }
@@ -14600,9 +14868,9 @@
           {
             "text": "with some phat tracks!",
             "synonyms": [
-              "with some cool tracks",
-              "with some awesome tracks",
-              "with some great tracks"
+              "with some cool music",
+              "with some great tunes",
+              "with some awesome songs"
             ],
             "category": "command",
             "propertyNames": [
@@ -14623,21 +14891,21 @@
                 "propertyValue": "player.playPlaylist",
                 "propertySubPhrases": [
                   "let's get this party started",
-                  "with a killer playlist!"
+                  "with a cool playlist!"
                 ]
               },
               {
                 "propertyValue": "player.playAlbum",
                 "propertySubPhrases": [
                   "let's get this party started",
-                  "with a dope album!"
+                  "with a great album!"
                 ]
               },
               {
-                "propertyValue": "player.playSong",
+                "propertyValue": "player.playFavorites",
                 "propertySubPhrases": [
                   "let's get this party started",
-                  "with a sick track!"
+                  "with my favorite songs!"
                 ]
               }
             ]
@@ -14658,7 +14926,9 @@
           {
             "name": "fullActionName",
             "value": "player.playGenre",
-            "substrings": [],
+            "substrings": [
+              "Yo, let's get this place jumpin' with some sick hip-hop beats!"
+            ],
             "implied": true
           },
           {
@@ -14684,9 +14954,9 @@
           {
             "text": "let's get this place jumpin'",
             "synonyms": [
-              "let's get this party started",
-              "let's make some noise",
-              "let's get the energy up"
+              "let's make this place lively",
+              "let's energize this place",
+              "let's get the party started"
             ],
             "category": "filler",
             "isOptional": true
@@ -14771,7 +15041,7 @@
             "substrings": [
               "play"
             ],
-            "implied": true
+            "implied": false
           },
           {
             "name": "parameters.artist",
@@ -14810,7 +15080,7 @@
             "synonyms": [
               "some",
               "a bit of",
-              "a little of"
+              "a little"
             ],
             "category": "filler",
             "isOptional": true
@@ -14837,21 +15107,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.playSong",
+                "propertyValue": "player.pause",
                 "propertySubPhrases": [
-                  "play a song by"
+                  "pause"
                 ]
               },
               {
-                "propertyValue": "player.playAlbum",
+                "propertyValue": "player.stop",
                 "propertySubPhrases": [
-                  "play an album by"
+                  "stop"
                 ]
               },
               {
-                "propertyValue": "player.playPlaylist",
+                "propertyValue": "player.skip",
                 "propertySubPhrases": [
-                  "play a playlist by"
+                  "skip"
                 ]
               }
             ]

--- a/ts/packages/dispatcher/test/data/player/v5/nextAction.json
+++ b/ts/packages/dispatcher/test/data/player/v5/nextAction.json
@@ -17,7 +17,7 @@
             "substrings": [
               "Advance to the next item."
             ],
-            "implied": true
+            "implied": false
           }
         ],
         "subPhrases": [
@@ -40,20 +40,10 @@
               "the subsequent item",
               "the next one"
             ],
-            "category": "object",
+            "category": "target",
             "propertyNames": [
               "fullActionName"
             ]
-          },
-          {
-            "text": ".",
-            "synonyms": [
-              "",
-              "",
-              ""
-            ],
-            "category": "punctuation",
-            "isOptional": true
           }
         ],
         "propertyAlternatives": [
@@ -205,11 +195,21 @@
         ],
         "subPhrases": [
           {
-            "text": "Can we",
+            "text": "Can",
             "synonyms": [
-              "Could we",
-              "Shall we",
-              "May we"
+              "Could",
+              "Would",
+              "Will"
+            ],
+            "category": "politeness",
+            "isOptional": true
+          },
+          {
+            "text": "we",
+            "synonyms": [
+              "you",
+              "I",
+              "they"
             ],
             "category": "politeness",
             "isOptional": true
@@ -217,9 +217,9 @@
           {
             "text": "get to the next track",
             "synonyms": [
+              "skip to the next song",
               "move to the next track",
-              "skip to the next track",
-              "advance to the next track"
+              "play the next track"
             ],
             "category": "action",
             "propertyNames": [
@@ -297,7 +297,7 @@
             "synonyms": [
               "skip to the next track",
               "move to the next track",
-              "jump to the next track"
+              "go to the next track"
             ],
             "category": "action",
             "propertyNames": [
@@ -452,8 +452,8 @@
             "text": "go to the next track",
             "synonyms": [
               "skip to the next song",
-              "play the next track",
-              "move to the next track"
+              "move to the next track",
+              "play the next track"
             ],
             "category": "action",
             "propertyNames": [
@@ -512,7 +512,7 @@
             "substrings": [
               "hit the next button"
             ],
-            "implied": true
+            "implied": false
           }
         ],
         "subPhrases": [
@@ -601,8 +601,8 @@
           {
             "text": "advance to the next track",
             "synonyms": [
+              "skip to the next song",
               "move to the next track",
-              "skip to the next track",
               "go to the next track"
             ],
             "category": "action",
@@ -714,6 +714,12 @@
                 "propertySubPhrases": [
                   "play the track"
                 ]
+              },
+              {
+                "propertyValue": "player.stop",
+                "propertySubPhrases": [
+                  "stop the track"
+                ]
               }
             ]
           }
@@ -734,7 +740,7 @@
             "substrings": [
               "Flick to the next tune."
             ],
-            "implied": true
+            "implied": false
           }
         ],
         "subPhrases": [
@@ -822,7 +828,7 @@
             "substrings": [
               "Flip to the next song."
             ],
-            "implied": true
+            "implied": false
           }
         ],
         "subPhrases": [
@@ -842,7 +848,7 @@
             "text": "to the next song",
             "synonyms": [
               "to the following track",
-              "to the subsequent tune",
+              "to the subsequent song",
               "to the next track"
             ],
             "category": "target",
@@ -995,7 +1001,7 @@
             "substrings": [
               "listen to the next song"
             ],
-            "implied": true
+            "implied": false
           }
         ],
         "subPhrases": [
@@ -1014,7 +1020,7 @@
             "synonyms": [
               "play the next song",
               "skip to the next song",
-              "move to the next track"
+              "go to the next song"
             ],
             "category": "action",
             "propertyNames": [
@@ -1090,9 +1096,9 @@
           {
             "text": "the next song",
             "synonyms": [
-              "the following song",
-              "the upcoming song",
-              "the subsequent song"
+              "next track",
+              "next tune",
+              "the following song"
             ],
             "category": "action",
             "propertyNames": [
@@ -1207,12 +1213,6 @@
                 "propertySubPhrases": [
                   "play the track"
                 ]
-              },
-              {
-                "propertyValue": "player.stop",
-                "propertySubPhrases": [
-                  "stop the track"
-                ]
               }
             ]
           }
@@ -1240,8 +1240,8 @@
           {
             "text": "I'd like to",
             "synonyms": [
-              "I want to",
               "I would like to",
+              "I want to",
               "I wish to"
             ],
             "category": "politeness",
@@ -1323,8 +1323,8 @@
             "text": "the next track",
             "synonyms": [
               "the following song",
-              "the upcoming track",
-              "the next song"
+              "the next song",
+              "the upcoming track"
             ],
             "category": "action",
             "propertyNames": [
@@ -1377,7 +1377,7 @@
             "substrings": [
               "next song"
             ],
-            "implied": true
+            "implied": false
           }
         ],
         "subPhrases": [
@@ -1386,17 +1386,17 @@
             "synonyms": [
               "I am prepared for",
               "I am ready for",
-              "I'm prepared for"
+              "I'm set for"
             ],
-            "category": "acknowledgement",
+            "category": "filler",
             "isOptional": true
           },
           {
             "text": "the next song",
             "synonyms": [
-              "the following track",
-              "the next track",
-              "the upcoming song"
+              "the following song",
+              "the upcoming song",
+              "the subsequent song"
             ],
             "category": "action",
             "propertyNames": [
@@ -1449,7 +1449,7 @@
             "substrings": [
               "Jump to the next track."
             ],
-            "implied": true
+            "implied": false
           }
         ],
         "subPhrases": [
@@ -1458,7 +1458,7 @@
             "synonyms": [
               "Go to",
               "Move to",
-              "Skip to"
+              "Advance to"
             ],
             "category": "command",
             "propertyNames": [
@@ -1472,7 +1472,7 @@
               "the subsequent track",
               "the upcoming track"
             ],
-            "category": "target",
+            "category": "object",
             "propertyNames": [
               "fullActionName"
             ]
@@ -1481,8 +1481,8 @@
             "text": ".",
             "synonyms": [
               "",
-              " ",
-              "!"
+              "!",
+              ""
             ],
             "category": "punctuation",
             "isOptional": true
@@ -1535,7 +1535,7 @@
             "name": "fullActionName",
             "value": "player.next",
             "substrings": [
-              "take us to the next track"
+              "next track"
             ],
             "implied": true
           }
@@ -1545,18 +1545,28 @@
             "text": "Kindly",
             "synonyms": [
               "Please",
-              "Would you mind",
+              "Would you",
               "Could you"
             ],
             "category": "politeness",
             "isOptional": true
           },
           {
-            "text": "take us to the next track",
+            "text": "take us to the",
             "synonyms": [
-              "skip to the next song",
-              "move to the next track",
-              "play the next track"
+              "move us to",
+              "skip to",
+              "go to"
+            ],
+            "category": "command",
+            "propertyNames": []
+          },
+          {
+            "text": "next track",
+            "synonyms": [
+              "following track",
+              "subsequent track",
+              "next song"
             ],
             "category": "action",
             "propertyNames": [
@@ -1569,25 +1579,25 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.next",
             "propertySubPhrases": [
-              "take us to the next track"
+              "next track"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.previous",
                 "propertySubPhrases": [
-                  "take us to the previous track"
+                  "previous track"
                 ]
               },
               {
                 "propertyValue": "player.pause",
                 "propertySubPhrases": [
-                  "pause the track"
+                  "pause track"
                 ]
               },
               {
                 "propertyValue": "player.play",
                 "propertySubPhrases": [
-                  "play the track"
+                  "play track"
                 ]
               }
             ]
@@ -1659,13 +1669,7 @@
               {
                 "propertyValue": "player.play",
                 "propertySubPhrases": [
-                  "play the player"
-                ]
-              },
-              {
-                "propertyValue": "player.stop",
-                "propertySubPhrases": [
-                  "stop the player"
+                  "start the player"
                 ]
               }
             ]
@@ -1687,7 +1691,7 @@
             "substrings": [
               "Let's hear the next one."
             ],
-            "implied": true
+            "implied": false
           }
         ],
         "subPhrases": [
@@ -1718,7 +1722,7 @@
             "synonyms": [
               "the following one",
               "the subsequent one",
-              "the upcoming one"
+              "the next track"
             ],
             "category": "object",
             "propertyNames": [
@@ -1746,14 +1750,14 @@
                 "propertyValue": "player.pause",
                 "propertySubPhrases": [
                   "pause",
-                  "the playback"
+                  "the music"
                 ]
               },
               {
-                "propertyValue": "player.stop",
+                "propertyValue": "player.play",
                 "propertySubPhrases": [
-                  "stop",
-                  "the playback"
+                  "play",
+                  "the music"
                 ]
               }
             ]
@@ -1775,7 +1779,7 @@
             "substrings": [
               "jump to the next tune"
             ],
-            "implied": true
+            "implied": false
           }
         ],
         "subPhrases": [
@@ -1825,7 +1829,7 @@
               {
                 "propertyValue": "player.play",
                 "propertySubPhrases": [
-                  "play the music"
+                  "start playing the music"
                 ]
               },
               {
@@ -1853,7 +1857,7 @@
             "substrings": [
               "proceed to the next song"
             ],
-            "implied": true
+            "implied": false
           }
         ],
         "subPhrases": [
@@ -1925,7 +1929,7 @@
             "substrings": [
               "roll to the next song"
             ],
-            "implied": true
+            "implied": false
           }
         ],
         "subPhrases": [
@@ -1936,13 +1940,13 @@
               "We should",
               "How about we"
             ],
-            "category": "politeness",
+            "category": "filler",
             "isOptional": true
           },
           {
             "text": "roll to the next song",
             "synonyms": [
-              "skip to the next song",
+              "skip to the next track",
               "move to the next song",
               "play the next song"
             ],
@@ -1997,7 +2001,7 @@
             "substrings": [
               "skip this track"
             ],
-            "implied": true
+            "implied": false
           }
         ],
         "subPhrases": [
@@ -2008,15 +2012,15 @@
               "We should",
               "How about we"
             ],
-            "category": "suggestion",
+            "category": "filler",
             "isOptional": true
           },
           {
             "text": "skip this track",
             "synonyms": [
-              "move to the next song",
-              "go to the next track",
-              "play the next song"
+              "next song",
+              "move to the next track",
+              "skip the current song"
             ],
             "category": "action",
             "propertyNames": [
@@ -2049,12 +2053,6 @@
                 "propertySubPhrases": [
                   "stop the music"
                 ]
-              },
-              {
-                "propertyValue": "player.play",
-                "propertySubPhrases": [
-                  "play the music"
-                ]
               }
             ]
           }
@@ -2075,7 +2073,7 @@
             "substrings": [
               "Move on to the next song."
             ],
-            "implied": true
+            "implied": false
           }
         ],
         "subPhrases": [
@@ -2107,8 +2105,8 @@
             "text": ".",
             "synonyms": [
               "",
-              "",
-              ""
+              " ",
+              "  "
             ],
             "category": "punctuation",
             "isOptional": true
@@ -2243,6 +2241,78 @@
             "name": "fullActionName",
             "value": "player.next",
             "substrings": [
+              "Next melody"
+            ],
+            "implied": true
+          }
+        ],
+        "subPhrases": [
+          {
+            "text": "Next melody",
+            "synonyms": [
+              "Next song",
+              "Next track",
+              "Next tune"
+            ],
+            "category": "command",
+            "propertyNames": [
+              "fullActionName"
+            ]
+          },
+          {
+            "text": "please",
+            "synonyms": [
+              "kindly",
+              "if you could",
+              "would you mind"
+            ],
+            "category": "politeness",
+            "isOptional": true
+          }
+        ],
+        "propertyAlternatives": [
+          {
+            "propertyName": "fullActionName",
+            "propertyValue": "player.next",
+            "propertySubPhrases": [
+              "Next melody"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "player.previous",
+                "propertySubPhrases": [
+                  "Previous melody"
+                ]
+              },
+              {
+                "propertyValue": "player.pause",
+                "propertySubPhrases": [
+                  "Pause melody"
+                ]
+              },
+              {
+                "propertyValue": "player.play",
+                "propertySubPhrases": [
+                  "Play melody"
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "request": "Next number, please.",
+      "action": {
+        "fullActionName": "player.next",
+        "parameters": {}
+      },
+      "explanation": {
+        "properties": [
+          {
+            "name": "fullActionName",
+            "value": "player.next",
+            "substrings": [
               "Next"
             ],
             "implied": true
@@ -2254,7 +2324,7 @@
             "synonyms": [
               "Following",
               "Subsequent",
-              "Upcoming"
+              "Coming"
             ],
             "category": "command",
             "propertyNames": [
@@ -2262,11 +2332,11 @@
             ]
           },
           {
-            "text": "melody",
+            "text": "number",
             "synonyms": [
-              "song",
-              "tune",
-              "track"
+              "digit",
+              "numeral",
+              "figure"
             ],
             "category": "object",
             "propertyNames": []
@@ -2314,78 +2384,6 @@
       }
     },
     {
-      "request": "Next number, please.",
-      "action": {
-        "fullActionName": "player.next",
-        "parameters": {}
-      },
-      "explanation": {
-        "properties": [
-          {
-            "name": "fullActionName",
-            "value": "player.next",
-            "substrings": [
-              "Next number"
-            ],
-            "implied": true
-          }
-        ],
-        "subPhrases": [
-          {
-            "text": "Next number",
-            "synonyms": [
-              "Next digit",
-              "Following number",
-              "Subsequent number"
-            ],
-            "category": "command",
-            "propertyNames": [
-              "fullActionName"
-            ]
-          },
-          {
-            "text": "please",
-            "synonyms": [
-              "kindly",
-              "if you would",
-              "if you please"
-            ],
-            "category": "politeness",
-            "isOptional": true
-          }
-        ],
-        "propertyAlternatives": [
-          {
-            "propertyName": "fullActionName",
-            "propertyValue": "player.next",
-            "propertySubPhrases": [
-              "Next number"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "player.previous",
-                "propertySubPhrases": [
-                  "Previous number"
-                ]
-              },
-              {
-                "propertyValue": "player.pause",
-                "propertySubPhrases": [
-                  "Pause"
-                ]
-              },
-              {
-                "propertyValue": "player.play",
-                "propertySubPhrases": [
-                  "Play"
-                ]
-              }
-            ]
-          }
-        ]
-      }
-    },
-    {
       "request": "Next on the queue.",
       "action": {
         "fullActionName": "player.next",
@@ -2399,7 +2397,7 @@
             "substrings": [
               "Next on the queue."
             ],
-            "implied": true
+            "implied": false
           }
         ],
         "subPhrases": [
@@ -2410,7 +2408,7 @@
               "Subsequent",
               "Upcoming"
             ],
-            "category": "action",
+            "category": "command",
             "propertyNames": [
               "fullActionName"
             ]
@@ -2420,12 +2418,10 @@
             "synonyms": [
               "in the queue.",
               "in line.",
-              "on the list."
+              "in the list."
             ],
             "category": "context",
-            "propertyNames": [
-              "fullActionName"
-            ]
+            "propertyNames": []
           }
         ],
         "propertyAlternatives": [
@@ -2433,29 +2429,25 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.next",
             "propertySubPhrases": [
-              "Next",
-              "on the queue."
+              "Next"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.previous",
                 "propertySubPhrases": [
-                  "Previous",
-                  "on the queue."
+                  "Previous"
                 ]
               },
               {
                 "propertyValue": "player.pause",
                 "propertySubPhrases": [
-                  "Pause",
-                  "the queue."
+                  "Pause"
                 ]
               },
               {
                 "propertyValue": "player.play",
                 "propertySubPhrases": [
-                  "Play",
-                  "the queue."
+                  "Play"
                 ]
               }
             ]
@@ -2477,7 +2469,7 @@
             "substrings": [
               "Next song"
             ],
-            "implied": true
+            "implied": false
           }
         ],
         "subPhrases": [
@@ -2497,8 +2489,8 @@
             "text": "if you don't mind",
             "synonyms": [
               "if that's okay",
-              "if it's not a problem",
-              "if you could"
+              "if you could",
+              "if possible"
             ],
             "category": "politeness",
             "isOptional": true
@@ -2558,7 +2550,7 @@
             "synonyms": [
               "Next song",
               "Skip track",
-              "Play next"
+              "Skip song"
             ],
             "category": "command",
             "propertyNames": [
@@ -2569,8 +2561,8 @@
             "text": "please",
             "synonyms": [
               "kindly",
-              "if you could",
-              "would you mind"
+              "if you would",
+              "if you could"
             ],
             "category": "politeness",
             "isOptional": true
@@ -2619,9 +2611,9 @@
             "name": "fullActionName",
             "value": "player.next",
             "substrings": [
-              "Next tune"
+              "Next"
             ],
-            "implied": true
+            "implied": false
           }
         ],
         "subPhrases": [
@@ -2630,7 +2622,7 @@
             "synonyms": [
               "Next song",
               "Next track",
-              "Skip to next"
+              "Next piece"
             ],
             "category": "command",
             "propertyNames": [
@@ -2717,7 +2709,7 @@
               "within the playlist"
             ],
             "category": "context",
-            "isOptional": true
+            "propertyNames": []
           }
         ],
         "propertyAlternatives": [
@@ -2774,7 +2766,7 @@
             "synonyms": [
               "Following",
               "Subsequent",
-              "After"
+              "Upcoming"
             ],
             "category": "command",
             "propertyNames": [
@@ -2844,9 +2836,9 @@
           {
             "text": "On to the next one.",
             "synonyms": [
-              "Next track",
-              "Skip to the next",
-              "Play the next song"
+              "Next track.",
+              "Skip to the next.",
+              "Play the next one."
             ],
             "category": "command",
             "propertyNames": [
@@ -2865,7 +2857,7 @@
               {
                 "propertyValue": "player.previous",
                 "propertySubPhrases": [
-                  "Go back to the previous one."
+                  "Go back to the last one."
                 ]
               },
               {
@@ -2877,7 +2869,7 @@
               {
                 "propertyValue": "player.play",
                 "propertySubPhrases": [
-                  "Play the music."
+                  "Start playing the music."
                 ]
               }
             ]
@@ -2899,7 +2891,7 @@
             "substrings": [
               "cue the next track"
             ],
-            "implied": true
+            "implied": false
           }
         ],
         "subPhrases": [
@@ -2918,7 +2910,7 @@
             "synonyms": [
               "play the next song",
               "skip to the next track",
-              "move to the next track"
+              "move to the next song"
             ],
             "category": "action",
             "propertyNames": [
@@ -2996,7 +2988,7 @@
             "synonyms": [
               "skip to the next song",
               "move to the next track",
-              "go to the next track"
+              "go to the next song"
             ],
             "category": "action",
             "propertyNames": [
@@ -3029,6 +3021,12 @@
                 "propertySubPhrases": [
                   "play the track"
                 ]
+              },
+              {
+                "propertyValue": "player.stop",
+                "propertySubPhrases": [
+                  "stop the track"
+                ]
               }
             ]
           }
@@ -3047,9 +3045,9 @@
             "name": "fullActionName",
             "value": "player.next",
             "substrings": [
-              "play the next"
+              "play the next one"
             ],
-            "implied": true
+            "implied": false
           }
         ],
         "subPhrases": [
@@ -3064,26 +3062,16 @@
             "isOptional": true
           },
           {
-            "text": "play the next",
+            "text": "play the next one",
             "synonyms": [
-              "skip to the next",
-              "go to the next",
-              "move to the next"
+              "play the following one",
+              "play the subsequent one",
+              "play the next track"
             ],
             "category": "action",
             "propertyNames": [
               "fullActionName"
             ]
-          },
-          {
-            "text": "one",
-            "synonyms": [
-              "track",
-              "song",
-              "item"
-            ],
-            "category": "object",
-            "isOptional": true
           }
         ],
         "propertyAlternatives": [
@@ -3091,25 +3079,25 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.next",
             "propertySubPhrases": [
-              "play the next"
+              "play the next one"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.previous",
                 "propertySubPhrases": [
-                  "play the previous"
+                  "play the previous one"
                 ]
               },
               {
                 "propertyValue": "player.pause",
                 "propertySubPhrases": [
-                  "pause the"
+                  "pause the playback"
                 ]
               },
               {
                 "propertyValue": "player.stop",
                 "propertySubPhrases": [
-                  "stop the"
+                  "stop the playback"
                 ]
               }
             ]
@@ -3148,9 +3136,9 @@
           {
             "text": "skip",
             "synonyms": [
-              "next",
               "move to the next",
-              "advance"
+              "advance",
+              "go to the next"
             ],
             "category": "action",
             "propertyNames": [
@@ -3213,7 +3201,7 @@
             "substrings": [
               "Proceed to the next song."
             ],
-            "implied": true
+            "implied": false
           }
         ],
         "subPhrases": [
@@ -3224,7 +3212,7 @@
               "Move to",
               "Advance to"
             ],
-            "category": "action",
+            "category": "command",
             "propertyNames": [
               "fullActionName"
             ]
@@ -3246,7 +3234,7 @@
             "synonyms": [
               "",
               " ",
-              " "
+              "!"
             ],
             "category": "punctuation",
             "isOptional": true
@@ -3281,13 +3269,6 @@
                   "Play",
                   "the current song"
                 ]
-              },
-              {
-                "propertyValue": "player.shuffle",
-                "propertySubPhrases": [
-                  "Shuffle",
-                  "the playlist"
-                ]
               }
             ]
           }
@@ -3316,7 +3297,7 @@
             "text": "Push",
             "synonyms": [
               "Press",
-              "Hit",
+              "Click",
               "Tap"
             ],
             "category": "command",
@@ -3327,11 +3308,11 @@
           {
             "text": "next",
             "synonyms": [
-              "following",
-              "subsequent",
-              "upcoming"
+              "forward",
+              "advance",
+              "skip"
             ],
-            "category": "action",
+            "category": "command",
             "propertyNames": [
               "fullActionName"
             ]
@@ -3386,7 +3367,7 @@
             "substrings": [
               "Queue up the next song."
             ],
-            "implied": true
+            "implied": false
           }
         ],
         "subPhrases": [
@@ -3418,8 +3399,8 @@
             "text": ".",
             "synonyms": [
               "",
-              "",
-              ""
+              " ",
+              " "
             ],
             "category": "punctuation",
             "isOptional": true
@@ -3474,30 +3455,30 @@
             "substrings": [
               "Shift to the next track."
             ],
-            "implied": true
+            "implied": false
           }
         ],
         "subPhrases": [
           {
-            "text": "Shift",
+            "text": "Shift to",
             "synonyms": [
-              "Move",
-              "Change",
-              "Switch"
+              "Move to",
+              "Go to",
+              "Switch to"
             ],
-            "category": "action",
+            "category": "command",
             "propertyNames": [
               "fullActionName"
             ]
           },
           {
-            "text": "to the next track",
+            "text": "the next track",
             "synonyms": [
-              "to the following track",
-              "to the subsequent track",
-              "to the upcoming track"
+              "the following track",
+              "the subsequent track",
+              "the upcoming track"
             ],
-            "category": "target",
+            "category": "object",
             "propertyNames": [
               "fullActionName"
             ]
@@ -3506,8 +3487,8 @@
             "text": ".",
             "synonyms": [
               "",
-              " ",
-              "  "
+              "!",
+              ""
             ],
             "category": "punctuation",
             "isOptional": true
@@ -3518,15 +3499,15 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.next",
             "propertySubPhrases": [
-              "Shift",
-              "to the next track"
+              "Shift to",
+              "the next track"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.previous",
                 "propertySubPhrases": [
-                  "Shift",
-                  "to the previous track"
+                  "Shift to",
+                  "the previous track"
                 ]
               },
               {
@@ -3540,6 +3521,13 @@
                 "propertyValue": "player.play",
                 "propertySubPhrases": [
                   "Play",
+                  "the track"
+                ]
+              },
+              {
+                "propertyValue": "player.stop",
+                "propertySubPhrases": [
+                  "Stop",
                   "the track"
                 ]
               }
@@ -3595,7 +3583,7 @@
             "synonyms": [
               "",
               " ",
-              "  "
+              "!"
             ],
             "category": "punctuation",
             "isOptional": true
@@ -3628,7 +3616,7 @@
                 "propertyValue": "player.play",
                 "propertySubPhrases": [
                   "Play",
-                  "the music"
+                  "the current song"
                 ]
               }
             ]
@@ -3673,7 +3661,7 @@
               "the upcoming song",
               "the subsequent song"
             ],
-            "category": "target",
+            "category": "object",
             "propertyNames": [
               "fullActionName"
             ]
@@ -3699,21 +3687,14 @@
                 "propertyValue": "player.pause",
                 "propertySubPhrases": [
                   "Pause",
-                  "the song"
+                  "the music"
                 ]
               },
               {
                 "propertyValue": "player.play",
                 "propertySubPhrases": [
                   "Play",
-                  "the song"
-                ]
-              },
-              {
-                "propertyValue": "player.shuffle",
-                "propertySubPhrases": [
-                  "Shuffle",
-                  "the playlist"
+                  "the music"
                 ]
               }
             ]
@@ -3735,7 +3716,7 @@
             "substrings": [
               "Swipe to the next track."
             ],
-            "implied": true
+            "implied": false
           }
         ],
         "subPhrases": [
@@ -3758,7 +3739,7 @@
               "to the subsequent track",
               "to the next song"
             ],
-            "category": "target",
+            "category": "action detail",
             "propertyNames": [
               "fullActionName"
             ]
@@ -3767,8 +3748,8 @@
             "text": ".",
             "synonyms": [
               "",
-              "",
-              ""
+              " ",
+              "!"
             ],
             "category": "punctuation",
             "isOptional": true
@@ -3794,14 +3775,14 @@
                 "propertyValue": "player.pause",
                 "propertySubPhrases": [
                   "Swipe",
-                  "to pause"
+                  "to pause the track"
                 ]
               },
               {
                 "propertyValue": "player.play",
                 "propertySubPhrases": [
                   "Swipe",
-                  "to play"
+                  "to play the track"
                 ]
               }
             ]
@@ -3823,7 +3804,7 @@
             "substrings": [
               "the next track"
             ],
-            "implied": true
+            "implied": false
           }
         ],
         "subPhrases": [
@@ -3840,9 +3821,9 @@
           {
             "text": "the next track",
             "synonyms": [
-              "the following song",
-              "the upcoming track",
-              "the next song"
+              "next song",
+              "next tune",
+              "skip track"
             ],
             "category": "action",
             "propertyNames": [
@@ -3946,12 +3927,6 @@
                 "propertyValue": "player.play",
                 "propertySubPhrases": [
                   "play track"
-                ]
-              },
-              {
-                "propertyValue": "player.stop",
-                "propertySubPhrases": [
-                  "stop track"
                 ]
               }
             ]

--- a/ts/packages/dispatcher/test/data/player/v5/param.json
+++ b/ts/packages/dispatcher/test/data/player/v5/param.json
@@ -34,7 +34,7 @@
           {
             "text": "start the music",
             "synonyms": [
-              "play some music",
+              "play the music",
               "begin the music",
               "turn on the music"
             ],
@@ -48,7 +48,7 @@
             "synonyms": [
               "kindly",
               "if you don't mind",
-              "if you could"
+              "if you please"
             ],
             "category": "politeness",
             "isOptional": true
@@ -77,7 +77,7 @@
               {
                 "propertyValue": "player.next",
                 "propertySubPhrases": [
-                  "skip to the next song"
+                  "skip the song"
                 ]
               },
               {
@@ -114,23 +114,13 @@
             "synonyms": [
               "What if",
               "Why don't",
-              "How's about"
+              "Would you"
             ],
-            "category": "filler",
+            "category": "politeness",
             "isOptional": true
           },
           {
-            "text": "you",
-            "synonyms": [
-              "you could",
-              "you might",
-              "you should"
-            ],
-            "category": "filler",
-            "isOptional": true
-          },
-          {
-            "text": "choose a song to play",
+            "text": "you choose a song to play",
             "synonyms": [
               "select a song to play",
               "pick a song to play",
@@ -147,25 +137,25 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.playRandom",
             "propertySubPhrases": [
-              "choose a song to play"
+              "you choose a song to play"
             ],
             "alternatives": [
+              {
+                "propertyValue": "player.play",
+                "propertySubPhrases": [
+                  "play a song"
+                ]
+              },
+              {
+                "propertyValue": "player.shufflePlay",
+                "propertySubPhrases": [
+                  "shuffle and play songs"
+                ]
+              },
               {
                 "propertyValue": "player.playNext",
                 "propertySubPhrases": [
                   "play the next song"
-                ]
-              },
-              {
-                "propertyValue": "player.playPrevious",
-                "propertySubPhrases": [
-                  "play the previous song"
-                ]
-              },
-              {
-                "propertyValue": "player.playSpecific",
-                "propertySubPhrases": [
-                  "play a specific song"
                 ]
               }
             ]
@@ -222,7 +212,7 @@
               "for my benefit",
               "on my behalf"
             ],
-            "category": "preposition",
+            "category": "recipient",
             "isOptional": true
           }
         ],
@@ -243,17 +233,17 @@
                 ]
               },
               {
-                "propertyValue": "player.playPlaylist",
-                "propertySubPhrases": [
-                  "Play",
-                  "a playlist"
-                ]
-              },
-              {
                 "propertyValue": "player.playAlbum",
                 "propertySubPhrases": [
                   "Play",
                   "an album"
+                ]
+              },
+              {
+                "propertyValue": "player.playPlaylist",
+                "propertySubPhrases": [
+                  "Play",
+                  "a playlist"
                 ]
               }
             ]
@@ -294,9 +284,9 @@
           {
             "text": "some tunes",
             "synonyms": [
-              "some music",
-              "a few songs",
-              "a playlist"
+              "music",
+              "songs",
+              "tracks"
             ],
             "category": "content",
             "propertyNames": [
@@ -307,13 +297,11 @@
             "text": "for me",
             "synonyms": [
               "for myself",
-              "for my enjoyment",
-              "for my listening"
+              "for my benefit",
+              "on my behalf"
             ],
-            "category": "recipient",
-            "propertyNames": [
-              "fullActionName"
-            ]
+            "category": "politeness",
+            "isOptional": true
           }
         ],
         "propertyAlternatives": [
@@ -322,40 +310,28 @@
             "propertyValue": "player.playRandom",
             "propertySubPhrases": [
               "Play",
-              "some tunes",
-              "for me"
+              "some tunes"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.playSpecific",
                 "propertySubPhrases": [
                   "Play",
-                  "a specific song",
-                  "for me"
+                  "a specific song"
                 ]
               },
               {
                 "propertyValue": "player.playPlaylist",
                 "propertySubPhrases": [
                   "Play",
-                  "a playlist",
-                  "for me"
+                  "a playlist"
                 ]
               },
               {
                 "propertyValue": "player.playAlbum",
                 "propertySubPhrases": [
                   "Play",
-                  "an album",
-                  "for me"
-                ]
-              },
-              {
-                "propertyValue": "player.playGenre",
-                "propertySubPhrases": [
-                  "Play",
-                  "some jazz",
-                  "for me"
+                  "an album"
                 ]
               }
             ]
@@ -406,8 +382,8 @@
           {
             "text": "together",
             "synonyms": [
-              "as a group",
               "with each other",
+              "as a group",
               "in unison"
             ],
             "category": "preposition",
@@ -431,7 +407,7 @@
               {
                 "propertyValue": "player.playPlaylist",
                 "propertySubPhrases": [
-                  "play a playlist"
+                  "listen to a playlist"
                 ]
               },
               {
@@ -533,6 +509,14 @@
                   "playing",
                   "my favorite songs"
                 ]
+              },
+              {
+                "propertyValue": "player.stop",
+                "propertySubPhrases": [
+                  "Stop",
+                  "playing",
+                  "music"
+                ]
               }
             ]
           }
@@ -560,9 +544,9 @@
           {
             "text": "Start the music",
             "synonyms": [
-              "Play the music",
+              "Play some music",
               "Begin the music",
-              "Initiate the music"
+              "Turn on the music"
             ],
             "category": "command",
             "propertyNames": [
@@ -573,8 +557,8 @@
             "text": "please",
             "synonyms": [
               "kindly",
-              "if you would",
-              "if you please"
+              "if you could",
+              "would you mind"
             ],
             "category": "politeness",
             "isOptional": true
@@ -627,7 +611,7 @@
             "substrings": [
               "Turn up the volume"
             ],
-            "implied": false
+            "implied": true
           },
           {
             "name": "parameters.volumeChangePercentage",
@@ -644,7 +628,7 @@
             "synonyms": [
               "Increase the volume",
               "Raise the volume",
-              "Make the volume louder"
+              "Amplify the volume"
             ],
             "category": "command",
             "propertyNames": [
@@ -660,7 +644,7 @@
               "with the electronic dance music"
             ],
             "category": "context",
-            "isOptional": true
+            "propertyNames": []
           }
         ],
         "propertyAlternatives": [
@@ -701,19 +685,19 @@
               {
                 "propertyValue": 20,
                 "propertySubPhrases": [
-                  "Turn up the volume a lot"
-                ]
-              },
-              {
-                "propertyValue": 5,
-                "propertySubPhrases": [
-                  "Turn up the volume a bit"
+                  "Turn up the volume by 20%"
                 ]
               },
               {
                 "propertyValue": 15,
                 "propertySubPhrases": [
-                  "Turn up the volume more"
+                  "Increase the volume by 15%"
+                ]
+              },
+              {
+                "propertyValue": 5,
+                "propertySubPhrases": [
+                  "Raise the volume by 5%"
                 ]
               }
             ]
@@ -744,7 +728,7 @@
             "synonyms": [
               "Could you",
               "Can you",
-              "Would it be possible for you to"
+              "Would you please"
             ],
             "category": "politeness",
             "isOptional": true
@@ -752,7 +736,7 @@
           {
             "text": "playing some music",
             "synonyms": [
-              "play some tunes",
+              "play some music",
               "start some music",
               "put on some music"
             ],
@@ -786,6 +770,12 @@
                 "propertyValue": "player.playGenre",
                 "propertySubPhrases": [
                   "playing some jazz"
+                ]
+              },
+              {
+                "propertyValue": "player.playArtist",
+                "propertySubPhrases": [
+                  "playing some music by The Beatles"
                 ]
               }
             ]
@@ -826,33 +816,19 @@
             "synonyms": [
               "could we have",
               "may we get",
-              "can we have"
+              "is it possible to get"
+            ],
+            "category": "politeness",
+            "isOptional": true
+          },
+          {
+            "text": "some sick tunes blastin' on these streets",
+            "synonyms": [
+              "some cool music playing here",
+              "some awesome songs blasting around",
+              "some great tracks playing in this area"
             ],
             "category": "request",
-            "propertyNames": [
-              "fullActionName"
-            ]
-          },
-          {
-            "text": "some sick tunes",
-            "synonyms": [
-              "some cool music",
-              "some awesome tracks",
-              "some great songs"
-            ],
-            "category": "content",
-            "propertyNames": [
-              "fullActionName"
-            ]
-          },
-          {
-            "text": "blastin' on these streets",
-            "synonyms": [
-              "playing loudly here",
-              "blaring around",
-              "booming in this area"
-            ],
-            "category": "location",
             "propertyNames": [
               "fullActionName"
             ]
@@ -863,33 +839,25 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.playRandom",
             "propertySubPhrases": [
-              "can we get",
-              "some sick tunes",
-              "blastin' on these streets"
+              "some sick tunes blastin' on these streets"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.playSpecific",
                 "propertySubPhrases": [
-                  "can we get",
-                  "a specific track",
-                  "blastin' on these streets"
-                ]
-              },
-              {
-                "propertyValue": "player.playPlaylist",
-                "propertySubPhrases": [
-                  "can we get",
-                  "a playlist",
-                  "blastin' on these streets"
+                  "some specific tunes blastin' on these streets"
                 ]
               },
               {
                 "propertyValue": "player.playGenre",
                 "propertySubPhrases": [
-                  "can we get",
-                  "some genre music",
-                  "blastin' on these streets"
+                  "some rock tunes blastin' on these streets"
+                ]
+              },
+              {
+                "propertyValue": "player.playPlaylist",
+                "propertySubPhrases": [
+                  "some playlist tunes blastin' on these streets"
                 ]
               }
             ]

--- a/ts/packages/dispatcher/test/data/player/v5/pauseAction.json
+++ b/ts/packages/dispatcher/test/data/player/v5/pauseAction.json
@@ -36,7 +36,7 @@
             "synonyms": [
               "Stop the music.",
               "Halt the music.",
-              "Silence the music."
+              "Suspend the music."
             ],
             "category": "command",
             "propertyNames": [
@@ -111,9 +111,7 @@
               "end the sound"
             ],
             "category": "action",
-            "propertyNames": [
-              "fullActionName"
-            ]
+            "propertyNames": []
           },
           {
             "text": "Pause it.",
@@ -133,29 +131,25 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.pause",
             "propertySubPhrases": [
-              "stop the sound",
               "Pause it."
             ],
             "alternatives": [
               {
                 "propertyValue": "player.stop",
                 "propertySubPhrases": [
-                  "halt the audio",
-                  "Stop it."
+                  "stop the sound"
                 ]
               },
               {
                 "propertyValue": "player.mute",
                 "propertySubPhrases": [
-                  "mute the sound",
-                  "Silence it."
+                  "mute the sound"
                 ]
               },
               {
                 "propertyValue": "player.resume",
                 "propertySubPhrases": [
-                  "continue the sound",
-                  "Resume it."
+                  "resume the sound"
                 ]
               }
             ]
@@ -182,23 +176,13 @@
         ],
         "subPhrases": [
           {
-            "text": "Can we",
+            "text": "Can we take a brief intermission?",
             "synonyms": [
-              "Could we",
-              "Shall we",
-              "May we"
+              "Shall we take a short break?",
+              "How about a quick pause?",
+              "Let's have a brief pause."
             ],
             "category": "politeness",
-            "isOptional": true
-          },
-          {
-            "text": "take a brief intermission",
-            "synonyms": [
-              "have a short break",
-              "take a quick pause",
-              "have a brief pause"
-            ],
-            "category": "request",
             "isOptional": true
           },
           {
@@ -280,7 +264,7 @@
               "halt the play button?",
               "pause the play button?"
             ],
-            "category": "command",
+            "category": "request",
             "propertyNames": []
           },
           {
@@ -288,7 +272,7 @@
             "synonyms": [
               "Stop it.",
               "Halt it.",
-              "Cease it."
+              "Pause the playback."
             ],
             "category": "command",
             "propertyNames": [
@@ -339,7 +323,7 @@
             "name": "fullActionName",
             "value": "player.pause",
             "substrings": [
-              "pause"
+              "pause the playback"
             ],
             "implied": false
           }
@@ -356,11 +340,11 @@
             "isOptional": true
           },
           {
-            "text": "pause",
+            "text": "pause the playback",
             "synonyms": [
-              "stop",
-              "halt",
-              "freeze"
+              "stop the playback",
+              "halt the playback",
+              "pause the video"
             ],
             "category": "action",
             "propertyNames": [
@@ -368,23 +352,13 @@
             ]
           },
           {
-            "text": "the playback",
-            "synonyms": [
-              "the video",
-              "the audio",
-              "the media"
-            ],
-            "category": "object",
-            "isOptional": true
-          },
-          {
             "text": "there",
             "synonyms": [
               "at that point",
               "right there",
-              "at this moment"
+              "at that moment"
             ],
-            "category": "location",
+            "category": "filler",
             "isOptional": true
           }
         ],
@@ -393,25 +367,31 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.pause",
             "propertySubPhrases": [
-              "pause"
+              "pause the playback"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.play",
                 "propertySubPhrases": [
-                  "play"
+                  "start the playback"
                 ]
               },
               {
                 "propertyValue": "player.stop",
                 "propertySubPhrases": [
-                  "stop"
+                  "stop the playback"
                 ]
               },
               {
                 "propertyValue": "player.rewind",
                 "propertySubPhrases": [
-                  "rewind"
+                  "rewind the playback"
+                ]
+              },
+              {
+                "propertyValue": "player.fastForward",
+                "propertySubPhrases": [
+                  "fast forward the playback"
                 ]
               }
             ]
@@ -462,9 +442,9 @@
           {
             "text": "the track",
             "synonyms": [
-              "this track",
               "the song",
-              "the music"
+              "the music",
+              "the audio"
             ],
             "category": "object",
             "isOptional": true
@@ -571,17 +551,17 @@
                 ]
               },
               {
+                "propertyValue": "player.play",
+                "propertySubPhrases": [
+                  "start the music",
+                  "Play it."
+                ]
+              },
+              {
                 "propertyValue": "player.resume",
                 "propertySubPhrases": [
                   "resume the music",
                   "Resume it."
-                ]
-              },
-              {
-                "propertyValue": "player.next",
-                "propertySubPhrases": [
-                  "skip to the next song",
-                  "Next song."
                 ]
               }
             ]
@@ -601,7 +581,7 @@
             "name": "fullActionName",
             "value": "player.pause",
             "substrings": [
-              "pause"
+              "please pause"
             ],
             "implied": false
           }
@@ -615,9 +595,7 @@
               "End the sound"
             ],
             "category": "command",
-            "propertyNames": [
-              "fullActionName"
-            ]
+            "propertyNames": []
           },
           {
             "text": "please",
@@ -647,29 +625,25 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.pause",
             "propertySubPhrases": [
-              "Cease the sound",
               "pause"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.stop",
                 "propertySubPhrases": [
-                  "Stop the sound",
-                  "halt"
+                  "Cease the sound"
                 ]
               },
               {
                 "propertyValue": "player.mute",
                 "propertySubPhrases": [
-                  "Mute the sound",
-                  "silence"
+                  "please"
                 ]
               },
               {
-                "propertyValue": "player.resume",
+                "propertyValue": "player.silence",
                 "propertySubPhrases": [
-                  "Resume the sound",
-                  "continue"
+                  "Cease the sound"
                 ]
               }
             ]
@@ -743,28 +717,21 @@
                 "propertyValue": "player.stop",
                 "propertySubPhrases": [
                   "stop the song",
-                  "Halt it."
+                  "Stop it."
                 ]
               },
               {
                 "propertyValue": "player.resume",
                 "propertySubPhrases": [
-                  "continue the song",
+                  "resume the song",
                   "Resume it."
                 ]
               },
               {
-                "propertyValue": "player.rewind",
+                "propertyValue": "player.skip",
                 "propertySubPhrases": [
-                  "rewind the song",
-                  "Rewind it."
-                ]
-              },
-              {
-                "propertyValue": "player.fastForward",
-                "propertySubPhrases": [
-                  "fast forward the song",
-                  "Skip ahead."
+                  "skip the song",
+                  "Skip it."
                 ]
               }
             ]
@@ -883,7 +850,7 @@
               "stop the music",
               "hit pause"
             ],
-            "implied": true
+            "implied": false
           }
         ],
         "subPhrases": [
@@ -912,9 +879,9 @@
           {
             "text": "Just hit pause",
             "synonyms": [
-              "Simply hit pause",
+              "Simply press pause",
               "Just press pause",
-              "Just click pause"
+              "Just pause it"
             ],
             "category": "command",
             "propertyNames": [
@@ -985,8 +952,8 @@
           {
             "text": "Freeze the beats",
             "synonyms": [
-              "Stop the beats",
-              "Halt the beats",
+              "Stop the rhythm",
+              "Halt the tunes",
               "Cease the beats"
             ],
             "category": "command",
@@ -1104,9 +1071,9 @@
                 ]
               },
               {
-                "propertyValue": "player.mute",
+                "propertyValue": "player.play",
                 "propertySubPhrases": [
-                  "mute it"
+                  "play it"
                 ]
               }
             ]
@@ -1126,30 +1093,40 @@
             "name": "fullActionName",
             "value": "player.pause",
             "substrings": [
-              "Hit the pause button"
+              "pause"
             ],
-            "implied": false
+            "implied": true
           }
         ],
         "subPhrases": [
           {
-            "text": "Hit the pause button",
+            "text": "Hit the",
             "synonyms": [
-              "Press the pause button",
-              "Pause the player",
-              "Stop the playback"
+              "Press the",
+              "Tap the",
+              "Click the"
             ],
             "category": "command",
+            "propertyNames": []
+          },
+          {
+            "text": "pause button",
+            "synonyms": [
+              "pause",
+              "stop",
+              "halt"
+            ],
+            "category": "action",
             "propertyNames": [
               "fullActionName"
             ]
           },
           {
-            "text": "will you",
+            "text": "will you?",
             "synonyms": [
               "please",
-              "if you can",
-              "if you don't mind"
+              "if you don't mind",
+              "could you"
             ],
             "category": "politeness",
             "isOptional": true
@@ -1160,25 +1137,25 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.pause",
             "propertySubPhrases": [
-              "Hit the pause button"
+              "pause button"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.play",
                 "propertySubPhrases": [
-                  "Hit the play button"
+                  "play button"
                 ]
               },
               {
                 "propertyValue": "player.stop",
                 "propertySubPhrases": [
-                  "Hit the stop button"
+                  "stop button"
                 ]
               },
               {
                 "propertyValue": "player.rewind",
                 "propertySubPhrases": [
-                  "Hit the rewind button"
+                  "rewind button"
                 ]
               }
             ]
@@ -1198,7 +1175,7 @@
             "name": "fullActionName",
             "value": "player.pause",
             "substrings": [
-              "pause"
+              "pause the tunes"
             ],
             "implied": false
           }
@@ -1208,8 +1185,8 @@
             "text": "Hold on",
             "synonyms": [
               "Wait a moment",
-              "Just a second",
-              "Hang on"
+              "Hang on",
+              "Just a second"
             ],
             "category": "filler",
             "isOptional": true
@@ -1219,32 +1196,22 @@
             "synonyms": [
               "let us",
               "we should",
-              "we will"
+              "how about we"
             ],
             "category": "filler",
             "isOptional": true
           },
           {
-            "text": "pause",
+            "text": "pause the tunes",
             "synonyms": [
-              "stop",
-              "halt",
-              "interrupt"
+              "stop the music",
+              "halt the songs",
+              "pause the music"
             ],
             "category": "action",
             "propertyNames": [
               "fullActionName"
             ]
-          },
-          {
-            "text": "the tunes",
-            "synonyms": [
-              "the music",
-              "the songs",
-              "the audio"
-            ],
-            "category": "object",
-            "isOptional": true
           }
         ],
         "propertyAlternatives": [
@@ -1252,25 +1219,25 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.pause",
             "propertySubPhrases": [
-              "pause"
+              "pause the tunes"
             ],
             "alternatives": [
               {
-                "propertyValue": "player.play",
+                "propertyValue": "player.stop",
                 "propertySubPhrases": [
-                  "play"
+                  "stop the music"
                 ]
               },
               {
-                "propertyValue": "player.stop",
+                "propertyValue": "player.mute",
                 "propertySubPhrases": [
-                  "stop"
+                  "mute the sound"
                 ]
               },
               {
                 "propertyValue": "player.resume",
                 "propertySubPhrases": [
-                  "resume"
+                  "resume the playback"
                 ]
               }
             ]
@@ -1368,7 +1335,7 @@
             "name": "fullActionName",
             "value": "player.pause",
             "substrings": [
-              "pause"
+              "pause that"
             ],
             "implied": false
           }
@@ -1378,33 +1345,23 @@
             "text": "Hold up",
             "synonyms": [
               "Wait",
-              "Stop",
-              "Hang on"
+              "Hang on",
+              "Just a moment"
             ],
             "category": "filler",
             "isOptional": true
           },
           {
-            "text": "pause",
+            "text": "pause that",
             "synonyms": [
-              "halt",
-              "stop",
-              "freeze"
+              "stop that",
+              "halt that",
+              "freeze that"
             ],
-            "category": "action",
+            "category": "command",
             "propertyNames": [
               "fullActionName"
             ]
-          },
-          {
-            "text": "that",
-            "synonyms": [
-              "it",
-              "this",
-              "the playback"
-            ],
-            "category": "object",
-            "isOptional": true
           }
         ],
         "propertyAlternatives": [
@@ -1412,25 +1369,25 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.pause",
             "propertySubPhrases": [
-              "pause"
+              "pause that"
             ],
             "alternatives": [
               {
-                "propertyValue": "player.play",
+                "propertyValue": "player.stop",
                 "propertySubPhrases": [
-                  "play"
+                  "stop that"
                 ]
               },
               {
-                "propertyValue": "player.stop",
+                "propertyValue": "player.resume",
                 "propertySubPhrases": [
-                  "stop"
+                  "resume that"
                 ]
               },
               {
                 "propertyValue": "player.rewind",
                 "propertySubPhrases": [
-                  "rewind"
+                  "rewind that"
                 ]
               }
             ]
@@ -1481,7 +1438,7 @@
             "synonyms": [
               "stop the music",
               "halt the music",
-              "pause the audio"
+              "put the music on hold"
             ],
             "category": "command",
             "propertyNames": [
@@ -1534,16 +1491,16 @@
             "substrings": [
               "paused the song"
             ],
-            "implied": true
+            "implied": false
           }
         ],
         "subPhrases": [
           {
             "text": "I'd appreciate it if you",
             "synonyms": [
-              "Could you please",
+              "Could you",
               "Would you mind",
-              "I would be grateful if you"
+              "Please"
             ],
             "category": "politeness",
             "isOptional": true
@@ -1553,7 +1510,7 @@
             "synonyms": [
               "stop the music",
               "halt the track",
-              "pause the audio"
+              "pause the music"
             ],
             "category": "action",
             "propertyNames": [
@@ -1648,15 +1605,15 @@
                 ]
               },
               {
-                "propertyValue": "player.resume",
+                "propertyValue": "player.play",
                 "propertySubPhrases": [
-                  "resume the track"
+                  "play the track"
                 ]
               },
               {
-                "propertyValue": "player.rewind",
+                "propertyValue": "player.resume",
                 "propertySubPhrases": [
-                  "rewind the track"
+                  "resume the track"
                 ]
               }
             ]
@@ -1689,7 +1646,7 @@
               "We should",
               "How about we"
             ],
-            "category": "politeness",
+            "category": "filler",
             "isOptional": true
           },
           {
@@ -1699,8 +1656,8 @@
               "halt the playlist",
               "pause the playlist"
             ],
-            "category": "action",
-            "propertyNames": []
+            "category": "filler",
+            "isOptional": true
           },
           {
             "text": "pause the song",
@@ -1736,9 +1693,9 @@
                 ]
               },
               {
-                "propertyValue": "player.skip",
+                "propertyValue": "player.rewind",
                 "propertySubPhrases": [
-                  "skip the song"
+                  "rewind the song"
                 ]
               }
             ]
@@ -1758,7 +1715,7 @@
             "name": "fullActionName",
             "value": "player.pause",
             "substrings": [
-              "pause in the music"
+              "Let's have a pause in the music."
             ],
             "implied": false
           }
@@ -1771,27 +1728,29 @@
               "We should",
               "How about"
             ],
-            "category": "suggestion",
+            "category": "politeness",
             "isOptional": true
           },
           {
-            "text": "have a",
+            "text": "have a pause",
             "synonyms": [
-              "take a",
-              "do a",
-              "make a"
+              "take a break",
+              "pause",
+              "stop for a moment"
             ],
             "category": "action",
-            "isOptional": true
+            "propertyNames": [
+              "fullActionName"
+            ]
           },
           {
-            "text": "pause in the music",
+            "text": "in the music",
             "synonyms": [
-              "stop the music",
-              "halt the music",
-              "pause the music"
+              "with the music",
+              "of the music",
+              "regarding the music"
             ],
-            "category": "action",
+            "category": "context",
             "propertyNames": [
               "fullActionName"
             ]
@@ -1802,25 +1761,29 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.pause",
             "propertySubPhrases": [
-              "pause in the music"
+              "have a pause",
+              "in the music"
             ],
             "alternatives": [
               {
-                "propertyValue": "player.play",
-                "propertySubPhrases": [
-                  "play the music"
-                ]
-              },
-              {
                 "propertyValue": "player.stop",
                 "propertySubPhrases": [
-                  "stop the music"
+                  "stop",
+                  "the music"
                 ]
               },
               {
                 "propertyValue": "player.resume",
                 "propertySubPhrases": [
-                  "resume the music"
+                  "resume",
+                  "the music"
+                ]
+              },
+              {
+                "propertyValue": "player.mute",
+                "propertySubPhrases": [
+                  "mute",
+                  "the music"
                 ]
               }
             ]
@@ -1849,19 +1812,19 @@
           {
             "text": "Let's hold off on the music",
             "synonyms": [
-              "Stop the music",
-              "Pause the music",
-              "Hold the music"
+              "Let's stop the music",
+              "Let's pause the music",
+              "Let's take a break from the music"
             ],
-            "category": "command",
-            "propertyNames": []
+            "category": "politeness",
+            "isOptional": true
           },
           {
             "text": "pause it",
             "synonyms": [
               "pause",
-              "stop it",
-              "halt it"
+              "halt it",
+              "stop it"
             ],
             "category": "command",
             "propertyNames": [
@@ -1931,9 +1894,9 @@
           {
             "text": "interrupt the flow",
             "synonyms": [
-              "stop the flow",
-              "halt the flow",
-              "disrupt the flow"
+              "stop the music",
+              "halt the playback",
+              "break the sequence"
             ],
             "category": "filler",
             "isOptional": true
@@ -1941,9 +1904,9 @@
           {
             "text": "pause the track",
             "synonyms": [
-              "stop the track",
-              "halt the track",
-              "pause the song"
+              "pause the song",
+              "pause the music",
+              "pause the audio"
             ],
             "category": "action",
             "propertyNames": [
@@ -1960,6 +1923,12 @@
             ],
             "alternatives": [
               {
+                "propertyValue": "player.play",
+                "propertySubPhrases": [
+                  "play the track"
+                ]
+              },
+              {
                 "propertyValue": "player.stop",
                 "propertySubPhrases": [
                   "stop the track"
@@ -1969,12 +1938,6 @@
                 "propertyValue": "player.resume",
                 "propertySubPhrases": [
                   "resume the track"
-                ]
-              },
-              {
-                "propertyValue": "player.skip",
-                "propertySubPhrases": [
-                  "skip the track"
                 ]
               }
             ]
@@ -2004,8 +1967,8 @@
             "text": "Let's put a pin in it",
             "synonyms": [
               "Let's hold off",
-              "Let's delay",
-              "Let's postpone"
+              "Let's wait",
+              "Let's delay"
             ],
             "category": "filler",
             "isOptional": true
@@ -2087,7 +2050,7 @@
             "synonyms": [
               "mute the audio for a moment",
               "turn off the sound briefly",
-              "stop the sound for a second"
+              "stop the sound for a bit"
             ],
             "category": "action",
             "propertyNames": []
@@ -2095,9 +2058,9 @@
           {
             "text": "hit pause",
             "synonyms": [
-              "pause",
-              "stop",
-              "halt"
+              "pause it",
+              "stop it",
+              "pause the playback"
             ],
             "category": "action",
             "propertyNames": [
@@ -2116,7 +2079,7 @@
               {
                 "propertyValue": "player.stop",
                 "propertySubPhrases": [
-                  "stop the playback"
+                  "stop the player"
                 ]
               },
               {
@@ -2171,7 +2134,7 @@
               "halt the track",
               "pause the music"
             ],
-            "category": "action",
+            "category": "command",
             "propertyNames": [
               "fullActionName"
             ]
@@ -2186,15 +2149,15 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.stop",
-                "propertySubPhrases": [
-                  "stop the song"
-                ]
-              },
-              {
                 "propertyValue": "player.play",
                 "propertySubPhrases": [
                   "play the song"
+                ]
+              },
+              {
+                "propertyValue": "player.stop",
+                "propertySubPhrases": [
+                  "stop the song"
                 ]
               },
               {
@@ -2230,8 +2193,8 @@
             "text": "Let's take a music break",
             "synonyms": [
               "Let's have a music break",
-              "Let's enjoy a music break",
-              "Let's take a break with music"
+              "Let's take a break from music",
+              "Let's pause the music"
             ],
             "category": "filler",
             "isOptional": true
@@ -2240,7 +2203,7 @@
             "text": "hit pause",
             "synonyms": [
               "press pause",
-              "pause the music",
+              "pause it",
               "stop the music"
             ],
             "category": "command",
@@ -2274,12 +2237,6 @@
                 "propertySubPhrases": [
                   "hit next"
                 ]
-              },
-              {
-                "propertyValue": "player.previous",
-                "propertySubPhrases": [
-                  "hit previous"
-                ]
               }
             ]
           }
@@ -2311,14 +2268,14 @@
               "We should",
               "How about we"
             ],
-            "category": "suggestion",
+            "category": "filler",
             "isOptional": true
           },
           {
             "text": "take a pause",
             "synonyms": [
               "pause",
-              "stop for a moment",
+              "stop",
               "halt"
             ],
             "category": "action",
@@ -2330,7 +2287,7 @@
             "text": "from the music",
             "synonyms": [
               "from playing music",
-              "from the songs",
+              "from the song",
               "from the audio"
             ],
             "category": "context",
@@ -2389,7 +2346,7 @@
           {
             "text": "Mind",
             "synonyms": [
-              "Would you",
+              "Would you mind",
               "Could you",
               "Can you"
             ],
@@ -2397,11 +2354,11 @@
             "isOptional": true
           },
           {
-            "text": "suspending the tunes",
+            "text": "suspending the tunes?",
             "synonyms": [
-              "pausing the music",
-              "stopping the songs",
-              "halting the tracks"
+              "pausing the music?",
+              "stopping the songs?",
+              "halting the tracks?"
             ],
             "category": "action",
             "propertyNames": [
@@ -2426,28 +2383,28 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.pause",
             "propertySubPhrases": [
-              "suspending the tunes",
+              "suspending the tunes?",
               "Hit pause."
             ],
             "alternatives": [
               {
                 "propertyValue": "player.stop",
                 "propertySubPhrases": [
-                  "stopping the music",
+                  "stopping the music?",
                   "Hit stop."
                 ]
               },
               {
                 "propertyValue": "player.play",
                 "propertySubPhrases": [
-                  "starting the music",
+                  "starting the music?",
                   "Hit play."
                 ]
               },
               {
                 "propertyValue": "player.resume",
                 "propertySubPhrases": [
-                  "resuming the tunes",
+                  "resuming the tunes?",
                   "Hit resume."
                 ]
               }
@@ -2479,7 +2436,7 @@
             "synonyms": [
               "Stop the audio",
               "Halt the audio",
-              "Pause playback"
+              "Suspend the audio"
             ],
             "category": "command",
             "propertyNames": [
@@ -2490,7 +2447,7 @@
             "text": "thanks",
             "synonyms": [
               "thank you",
-              "thanks a lot",
+              "cheers",
               "much appreciated"
             ],
             "category": "politeness",
@@ -2542,18 +2499,30 @@
             "substrings": [
               "Pause the beats"
             ],
-            "implied": true
+            "implied": false
           }
         ],
         "subPhrases": [
           {
-            "text": "Pause the beats",
+            "text": "Pause",
             "synonyms": [
-              "Stop the music",
-              "Halt the tunes",
-              "Pause the track"
+              "Stop",
+              "Halt",
+              "Suspend"
             ],
             "category": "command",
+            "propertyNames": [
+              "fullActionName"
+            ]
+          },
+          {
+            "text": "the beats",
+            "synonyms": [
+              "the music",
+              "the track",
+              "the song"
+            ],
+            "category": "object",
             "propertyNames": [
               "fullActionName"
             ]
@@ -2562,8 +2531,8 @@
             "text": "for me",
             "synonyms": [
               "for myself",
-              "for my sake",
-              "on my behalf"
+              "on my behalf",
+              "for my sake"
             ],
             "category": "politeness",
             "isOptional": true
@@ -2584,25 +2553,29 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.pause",
             "propertySubPhrases": [
-              "Pause the beats"
+              "Pause",
+              "the beats"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.stop",
                 "propertySubPhrases": [
-                  "Stop the beats"
+                  "Stop",
+                  "the beats"
                 ]
               },
               {
-                "propertyValue": "player.play",
+                "propertyValue": "player.halt",
                 "propertySubPhrases": [
-                  "Play the beats"
+                  "Halt",
+                  "the beats"
                 ]
               },
               {
-                "propertyValue": "player.resume",
+                "propertyValue": "player.suspend",
                 "propertySubPhrases": [
-                  "Resume the beats"
+                  "Suspend",
+                  "the beats"
                 ]
               }
             ]
@@ -2645,7 +2618,7 @@
             "synonyms": [
               "for a moment",
               "for a while",
-              "briefly"
+              "temporarily"
             ],
             "category": "duration",
             "isOptional": true
@@ -2682,9 +2655,9 @@
                 ]
               },
               {
-                "propertyValue": "player.suspend",
+                "propertyValue": "player.hold",
                 "propertySubPhrases": [
-                  "Suspend the melody"
+                  "Hold the melody"
                 ]
               }
             ]
@@ -2729,7 +2702,7 @@
               "for a second",
               "for a bit"
             ],
-            "category": "duration",
+            "category": "filler",
             "isOptional": true
           },
           {
@@ -2805,13 +2778,13 @@
             ]
           },
           {
-            "text": ", I have an announcement.",
+            "text": "I have an announcement",
             "synonyms": [
-              ", I need to say something.",
-              ", I have something to announce.",
-              ", I need to make an announcement."
+              "I need to say something",
+              "I have something to announce",
+              "I need to make an announcement"
             ],
-            "category": "additional information",
+            "category": "statement",
             "isOptional": true
           }
         ],
@@ -2824,15 +2797,15 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.stop",
+                "propertyValue": "player.play",
                 "propertySubPhrases": [
-                  "Stop the music"
+                  "Play the music"
                 ]
               },
               {
-                "propertyValue": "player.mute",
+                "propertyValue": "player.stop",
                 "propertySubPhrases": [
-                  "Mute the music"
+                  "Stop the music"
                 ]
               },
               {
@@ -2869,7 +2842,7 @@
             "synonyms": [
               "Stop the music",
               "Halt the music",
-              "Cease the music"
+              "Pause playback"
             ],
             "category": "command",
             "propertyNames": [
@@ -2877,13 +2850,13 @@
             ]
           },
           {
-            "text": ", it's too loud.",
+            "text": "it's too loud",
             "synonyms": [
-              ", the volume is too high.",
-              ", it's very noisy.",
-              ", it's too deafening."
+              "the volume is too high",
+              "it's very loud",
+              "the sound is too loud"
             ],
-            "category": "explanation",
+            "category": "reason",
             "isOptional": true
           }
         ],
@@ -2937,11 +2910,11 @@
         ],
         "subPhrases": [
           {
-            "text": "Pause the playback",
+            "text": "Pause",
             "synonyms": [
-              "Stop the playback",
-              "Halt the playback",
-              "Pause the audio"
+              "Stop",
+              "Halt",
+              "Suspend"
             ],
             "category": "command",
             "propertyNames": [
@@ -2949,11 +2922,23 @@
             ]
           },
           {
+            "text": "the playback",
+            "synonyms": [
+              "the audio",
+              "the video",
+              "the media"
+            ],
+            "category": "object",
+            "propertyNames": [
+              "fullActionName"
+            ]
+          },
+          {
             "text": "for a moment",
             "synonyms": [
-              "for a bit",
-              "for a short while",
-              "briefly"
+              "briefly",
+              "temporarily",
+              "for a short time"
             ],
             "category": "duration",
             "isOptional": true
@@ -2964,25 +2949,29 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.pause",
             "propertySubPhrases": [
-              "Pause the playback"
+              "Pause",
+              "the playback"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.stop",
                 "propertySubPhrases": [
-                  "Stop the playback"
+                  "Stop",
+                  "the playback"
                 ]
               },
               {
                 "propertyValue": "player.resume",
                 "propertySubPhrases": [
-                  "Resume the playback"
+                  "Resume",
+                  "the playback"
                 ]
               },
               {
-                "propertyValue": "player.mute",
+                "propertyValue": "player.rewind",
                 "propertySubPhrases": [
-                  "Mute the playback"
+                  "Rewind",
+                  "the playback"
                 ]
               }
             ]
@@ -3011,9 +3000,9 @@
           {
             "text": "Pause the record",
             "synonyms": [
-              "Stop the recording",
+              "Stop the record",
               "Halt the record",
-              "Pause the recording"
+              "Cease the record"
             ],
             "category": "command",
             "propertyNames": [
@@ -3023,9 +3012,9 @@
           {
             "text": "if you don't mind",
             "synonyms": [
-              "if it's okay with you",
+              "if it's okay",
               "if you could",
-              "if you would"
+              "if possible"
             ],
             "category": "politeness",
             "isOptional": true
@@ -3046,15 +3035,15 @@
                 ]
               },
               {
-                "propertyValue": "player.play",
-                "propertySubPhrases": [
-                  "Play the record"
-                ]
-              },
-              {
                 "propertyValue": "player.resume",
                 "propertySubPhrases": [
                   "Resume the record"
+                ]
+              },
+              {
+                "propertyValue": "player.rewind",
+                "propertySubPhrases": [
+                  "Rewind the record"
                 ]
               }
             ]
@@ -3085,7 +3074,7 @@
             "synonyms": [
               "Stop the music",
               "Halt the track",
-              "Pause the music"
+              "Cease the audio"
             ],
             "category": "command",
             "propertyNames": [
@@ -3124,9 +3113,9 @@
                 ]
               },
               {
-                "propertyValue": "player.resume",
+                "propertyValue": "player.skip",
                 "propertySubPhrases": [
-                  "Resume the song"
+                  "Skip the song"
                 ]
               }
             ]
@@ -3157,7 +3146,7 @@
             "synonyms": [
               "Stop the audio",
               "Halt the music",
-              "Mute the sound"
+              "Pause the audio"
             ],
             "category": "command",
             "propertyNames": [
@@ -3169,7 +3158,7 @@
             "synonyms": [
               "I have to speak",
               "I need to say something",
-              "I must talk"
+              "I need to chat"
             ],
             "category": "reason",
             "isOptional": true
@@ -3218,33 +3207,23 @@
             "name": "fullActionName",
             "value": "player.pause",
             "substrings": [
-              "Pause"
+              "Pause the tune"
             ],
             "implied": false
           }
         ],
         "subPhrases": [
           {
-            "text": "Pause",
+            "text": "Pause the tune",
             "synonyms": [
-              "Stop",
-              "Halt",
-              "Interrupt"
+              "Stop the music",
+              "Halt the song",
+              "Pause the track"
             ],
             "category": "command",
             "propertyNames": [
               "fullActionName"
             ]
-          },
-          {
-            "text": "the tune",
-            "synonyms": [
-              "the music",
-              "the song",
-              "the track"
-            ],
-            "category": "object",
-            "propertyNames": []
           },
           {
             "text": "please",
@@ -3262,25 +3241,25 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.pause",
             "propertySubPhrases": [
-              "Pause"
+              "Pause the tune"
             ],
             "alternatives": [
               {
-                "propertyValue": "player.play",
+                "propertyValue": "player.stop",
                 "propertySubPhrases": [
-                  "Play"
+                  "Stop the tune"
                 ]
               },
               {
-                "propertyValue": "player.stop",
+                "propertyValue": "player.play",
                 "propertySubPhrases": [
-                  "Stop"
+                  "Play the tune"
                 ]
               },
               {
                 "propertyValue": "player.resume",
                 "propertySubPhrases": [
-                  "Resume"
+                  "Resume the tune"
                 ]
               }
             ]
@@ -3300,7 +3279,7 @@
             "name": "fullActionName",
             "value": "player.pause",
             "substrings": [
-              "Pause"
+              "Pause the tunes for a moment."
             ],
             "implied": false
           }
@@ -3311,7 +3290,7 @@
             "synonyms": [
               "Stop",
               "Halt",
-              "Suspend"
+              "Cease"
             ],
             "category": "command",
             "propertyNames": [
@@ -3326,7 +3305,9 @@
               "the audio"
             ],
             "category": "object",
-            "propertyNames": []
+            "propertyNames": [
+              "fullActionName"
+            ]
           },
           {
             "text": "for a moment",
@@ -3336,7 +3317,9 @@
               "temporarily"
             ],
             "category": "duration",
-            "propertyNames": []
+            "propertyNames": [
+              "fullActionName"
+            ]
           }
         ],
         "propertyAlternatives": [
@@ -3344,25 +3327,33 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.pause",
             "propertySubPhrases": [
-              "Pause"
+              "Pause",
+              "the tunes",
+              "for a moment"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.stop",
                 "propertySubPhrases": [
-                  "Stop"
-                ]
-              },
-              {
-                "propertyValue": "player.resume",
-                "propertySubPhrases": [
-                  "Resume"
+                  "Stop",
+                  "the music",
+                  "for now"
                 ]
               },
               {
                 "propertyValue": "player.mute",
                 "propertySubPhrases": [
-                  "Mute"
+                  "Mute",
+                  "the sound",
+                  "for a bit"
+                ]
+              },
+              {
+                "propertyValue": "player.hold",
+                "propertySubPhrases": [
+                  "Hold",
+                  "the audio",
+                  "for a second"
                 ]
               }
             ]
@@ -3384,7 +3375,7 @@
             "substrings": [
               "Pause"
             ],
-            "implied": true
+            "implied": false
           }
         ],
         "subPhrases": [
@@ -3559,7 +3550,7 @@
             "synonyms": [
               "on this",
               "on it",
-              "on the thing"
+              "on the current"
             ],
             "category": "preposition",
             "isOptional": true
@@ -3569,7 +3560,7 @@
             "synonyms": [
               "please?",
               "could you?",
-              "if you don't mind?"
+              "can you?"
             ],
             "category": "politeness",
             "isOptional": true
@@ -3618,32 +3609,42 @@
             "name": "fullActionName",
             "value": "player.pause",
             "substrings": [
-              "Take a quick pause on the music"
+              "pause on the music"
             ],
             "implied": false
           }
         ],
         "subPhrases": [
           {
-            "text": "Take a quick pause on the music",
+            "text": "Take a quick",
             "synonyms": [
-              "Pause the music",
-              "Stop the music for a moment",
-              "Hold the music"
+              "Give a brief",
+              "Make a short",
+              "Do a quick"
             ],
-            "category": "command",
+            "category": "filler",
+            "isOptional": true
+          },
+          {
+            "text": "pause on the music",
+            "synonyms": [
+              "stop the music",
+              "halt the music",
+              "pause the song"
+            ],
+            "category": "action",
             "propertyNames": [
               "fullActionName"
             ]
           },
           {
-            "text": "okay?",
+            "text": "okay",
             "synonyms": [
-              "alright?",
-              "is that fine?",
-              "is that okay?"
+              "alright",
+              "ok",
+              "fine"
             ],
-            "category": "confirmation",
+            "category": "acknowledgement",
             "isOptional": true
           }
         ],
@@ -3652,25 +3653,25 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.pause",
             "propertySubPhrases": [
-              "Take a quick pause on the music"
+              "pause on the music"
             ],
             "alternatives": [
               {
-                "propertyValue": "player.stop",
+                "propertyValue": "player.play",
                 "propertySubPhrases": [
-                  "Stop the music"
+                  "play the music"
                 ]
               },
               {
-                "propertyValue": "player.play",
+                "propertyValue": "player.stop",
                 "propertySubPhrases": [
-                  "Start the music"
+                  "stop the music"
                 ]
               },
               {
                 "propertyValue": "player.resume",
                 "propertySubPhrases": [
-                  "Resume the music"
+                  "resume the music"
                 ]
               }
             ]
@@ -3704,21 +3705,29 @@
               "Cease the tunes"
             ],
             "category": "command",
+            "propertyNames": []
+          },
+          {
+            "text": "pause",
+            "synonyms": [
+              "halt",
+              "stop",
+              "freeze"
+            ],
+            "category": "action",
             "propertyNames": [
               "fullActionName"
             ]
           },
           {
-            "text": "pause them",
+            "text": "them",
             "synonyms": [
-              "pause it",
-              "pause the music",
-              "pause the songs"
+              "the music",
+              "the songs",
+              "the tunes"
             ],
-            "category": "command",
-            "propertyNames": [
-              "fullActionName"
-            ]
+            "category": "object",
+            "propertyNames": []
           }
         ],
         "propertyAlternatives": [
@@ -3726,29 +3735,25 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.pause",
             "propertySubPhrases": [
-              "Time out on the tunes",
-              "pause them"
+              "pause"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.stop",
                 "propertySubPhrases": [
-                  "Stop the music",
-                  "halt them"
+                  "stop"
+                ]
+              },
+              {
+                "propertyValue": "player.play",
+                "propertySubPhrases": [
+                  "play"
                 ]
               },
               {
                 "propertyValue": "player.resume",
                 "propertySubPhrases": [
-                  "Resume the tunes",
-                  "continue them"
-                ]
-              },
-              {
-                "propertyValue": "player.skip",
-                "propertySubPhrases": [
-                  "Skip the track",
-                  "move to the next"
+                  "resume"
                 ]
               }
             ]
@@ -3779,7 +3784,7 @@
             "synonyms": [
               "Could you",
               "Can you",
-              "Do you mind"
+              "Would you please"
             ],
             "category": "politeness",
             "isOptional": true
@@ -3806,21 +3811,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.play",
-                "propertySubPhrases": [
-                  "playing the music"
-                ]
-              },
-              {
                 "propertyValue": "player.stop",
                 "propertySubPhrases": [
                   "stopping the music"
                 ]
               },
               {
-                "propertyValue": "player.next",
+                "propertyValue": "player.play",
                 "propertySubPhrases": [
-                  "skipping to the next track"
+                  "playing the music"
+                ]
+              },
+              {
+                "propertyValue": "player.mute",
+                "propertySubPhrases": [
+                  "muting the music"
                 ]
               }
             ]

--- a/ts/packages/dispatcher/test/data/player/v5/previousAction.json
+++ b/ts/packages/dispatcher/test/data/player/v5/previousAction.json
@@ -17,26 +17,16 @@
             "substrings": [
               "go back one song"
             ],
-            "implied": true
+            "implied": false
           }
         ],
         "subPhrases": [
           {
-            "text": "Can",
+            "text": "Can we",
             "synonyms": [
-              "Could",
-              "Would",
-              "Will"
-            ],
-            "category": "politeness",
-            "isOptional": true
-          },
-          {
-            "text": "we",
-            "synonyms": [
-              "you",
-              "I",
-              "they"
+              "Could we",
+              "Shall we",
+              "May we"
             ],
             "category": "politeness",
             "isOptional": true
@@ -44,9 +34,9 @@
           {
             "text": "go back one song",
             "synonyms": [
-              "return to the previous track",
-              "play the last song again",
-              "skip back one song"
+              "play the previous song",
+              "skip back one track",
+              "rewind to the last song"
             ],
             "category": "action",
             "propertyNames": [
@@ -103,7 +93,7 @@
             "name": "fullActionName",
             "value": "player.previous",
             "substrings": [
-              "the song before this one again"
+              "before this one again"
             ],
             "implied": true
           }
@@ -120,11 +110,11 @@
             "isOptional": true
           },
           {
-            "text": "hear",
+            "text": "hear the song",
             "synonyms": [
-              "listen to",
-              "play",
-              "put on"
+              "play the song",
+              "listen to the song",
+              "put on the song"
             ],
             "category": "action",
             "propertyNames": [
@@ -132,13 +122,13 @@
             ]
           },
           {
-            "text": "the song before this one again",
+            "text": "before this one again",
             "synonyms": [
-              "the previous song",
+              "previous song",
               "the last song",
               "the prior song"
             ],
-            "category": "object",
+            "category": "time",
             "propertyNames": [
               "fullActionName"
             ]
@@ -149,29 +139,29 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.previous",
             "propertySubPhrases": [
-              "hear",
-              "the song before this one again"
+              "hear the song",
+              "before this one again"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.next",
                 "propertySubPhrases": [
-                  "hear",
-                  "the next song"
+                  "hear the song",
+                  "after this one"
                 ]
               },
               {
-                "propertyValue": "player.pause",
+                "propertyValue": "player.repeat",
                 "propertySubPhrases": [
-                  "pause",
-                  "the song"
+                  "hear the song",
+                  "again"
                 ]
               },
               {
-                "propertyValue": "player.play",
+                "propertyValue": "player.shuffle",
                 "propertySubPhrases": [
-                  "play",
-                  "the song"
+                  "shuffle the songs",
+                  "again"
                 ]
               }
             ]
@@ -212,7 +202,7 @@
             "synonyms": [
               "play the previous song",
               "go back to the last song",
-              "replay the last song"
+              "return to the previous song"
             ],
             "category": "action",
             "propertyNames": [
@@ -241,9 +231,9 @@
                 ]
               },
               {
-                "propertyValue": "player.stop",
+                "propertyValue": "player.play",
                 "propertySubPhrases": [
-                  "stop the music"
+                  "play the song"
                 ]
               }
             ]
@@ -298,7 +288,7 @@
               "from the playlist",
               "within the playlist"
             ],
-            "category": "context",
+            "category": "preposition",
             "isOptional": true
           }
         ],
@@ -365,7 +355,7 @@
             "text": "play the last track over",
             "synonyms": [
               "replay the last track",
-              "play the previous track",
+              "play the previous track again",
               "repeat the last track"
             ],
             "category": "action",
@@ -455,13 +445,7 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.rewind",
-                "propertySubPhrases": [
-                  "rewind the song"
-                ]
-              },
-              {
-                "propertyValue": "player.skip",
+                "propertyValue": "player.next",
                 "propertySubPhrases": [
                   "skip to the next song"
                 ]
@@ -470,6 +454,12 @@
                 "propertyValue": "player.pause",
                 "propertySubPhrases": [
                   "pause the song"
+                ]
+              },
+              {
+                "propertyValue": "player.play",
+                "propertySubPhrases": [
+                  "play the song"
                 ]
               }
             ]
@@ -509,18 +499,18 @@
             "text": "take it to the",
             "synonyms": [
               "go to the",
-              "move to the",
-              "switch to the"
+              "switch to the",
+              "move to the"
             ],
-            "category": "action",
-            "propertyNames": []
+            "category": "preposition",
+            "isOptional": false
           },
           {
             "text": "previous song",
             "synonyms": [
               "last song",
               "prior song",
-              "preceding song"
+              "earlier song"
             ],
             "category": "action",
             "propertyNames": [
@@ -553,6 +543,12 @@
                 "propertySubPhrases": [
                   "play the song"
                 ]
+              },
+              {
+                "propertyValue": "player.stop",
+                "propertySubPhrases": [
+                  "stop the song"
+                ]
               }
             ]
           }
@@ -582,7 +578,7 @@
             "synonyms": [
               "Can",
               "Would",
-              "May"
+              "Will"
             ],
             "category": "politeness",
             "isOptional": true
@@ -614,7 +610,7 @@
             "synonyms": [
               "the last song",
               "the prior track",
-              "the earlier song"
+              "the previous song"
             ],
             "category": "object",
             "propertyNames": [
@@ -688,7 +684,7 @@
             "substrings": [
               "go back to the last song"
             ],
-            "implied": false
+            "implied": true
           }
         ],
         "subPhrases": [
@@ -717,7 +713,7 @@
             "synonyms": [
               "return to the previous song",
               "play the previous track",
-              "replay the last song"
+              "go to the previous song"
             ],
             "category": "action",
             "propertyNames": [
@@ -791,7 +787,7 @@
               "start the previous track",
               "go to the previous track"
             ],
-            "category": "action",
+            "category": "command",
             "propertyNames": [
               "fullActionName"
             ]
@@ -821,6 +817,12 @@
                 "propertyValue": "player.play",
                 "propertySubPhrases": [
                   "play the track"
+                ]
+              },
+              {
+                "propertyValue": "player.stop",
+                "propertySubPhrases": [
+                  "stop the track"
                 ]
               }
             ]
@@ -860,8 +862,8 @@
             "text": "skip back to the song before",
             "synonyms": [
               "go back to the previous song",
-              "rewind to the last song",
-              "return to the earlier song"
+              "return to the last song",
+              "play the song before this one"
             ],
             "category": "action",
             "propertyNames": [
@@ -914,7 +916,7 @@
             "substrings": [
               "take us back a track"
             ],
-            "implied": true
+            "implied": false
           }
         ],
         "subPhrases": [
@@ -933,7 +935,7 @@
             "synonyms": [
               "go back one track",
               "play the previous track",
-              "skip back a track"
+              "rewind one track"
             ],
             "category": "action",
             "propertyNames": [
@@ -964,7 +966,7 @@
               {
                 "propertyValue": "player.play",
                 "propertySubPhrases": [
-                  "play the music"
+                  "start playing the music"
                 ]
               }
             ]
@@ -1019,7 +1021,7 @@
             "synonyms": [
               "",
               " ",
-              " "
+              "!"
             ],
             "category": "punctuation",
             "isOptional": true
@@ -1052,7 +1054,7 @@
                 "propertyValue": "player.play",
                 "propertySubPhrases": [
                   "Play",
-                  "the current track"
+                  "the music"
                 ]
               }
             ]
@@ -1085,7 +1087,7 @@
               "Tap",
               "Click"
             ],
-            "category": "action",
+            "category": "command",
             "propertyNames": [
               "fullActionName"
             ]
@@ -1109,7 +1111,7 @@
               "on the audio player",
               "on the video player"
             ],
-            "category": "location",
+            "category": "context",
             "propertyNames": [
               "fullActionName"
             ]
@@ -1366,19 +1368,19 @@
               {
                 "propertyValue": "player.next",
                 "propertySubPhrases": [
-                  "skip to the next track"
+                  "listen to the next track"
                 ]
               },
               {
                 "propertyValue": "player.pause",
                 "propertySubPhrases": [
-                  "pause the music"
+                  "pause the track"
                 ]
               },
               {
                 "propertyValue": "player.play",
                 "propertySubPhrases": [
-                  "play the music"
+                  "play the track"
                 ]
               }
             ]
@@ -1400,7 +1402,7 @@
             "substrings": [
               "replay the last song"
             ],
-            "implied": true
+            "implied": false
           }
         ],
         "subPhrases": [
@@ -1470,9 +1472,9 @@
             "name": "fullActionName",
             "value": "player.previous",
             "substrings": [
-              "listen to the previous track"
+              "listen to the previous track again"
             ],
-            "implied": true
+            "implied": false
           }
         ],
         "subPhrases": [
@@ -1487,26 +1489,16 @@
             "isOptional": true
           },
           {
-            "text": "listen to the previous track",
+            "text": "listen to the previous track again",
             "synonyms": [
-              "play the previous song",
-              "go back to the last track",
-              "replay the previous track"
+              "play the previous track again",
+              "replay the previous track",
+              "go back to the previous track"
             ],
             "category": "action",
             "propertyNames": [
               "fullActionName"
             ]
-          },
-          {
-            "text": "again",
-            "synonyms": [
-              "once more",
-              "one more time",
-              "another time"
-            ],
-            "category": "confirmation",
-            "isOptional": true
           }
         ],
         "propertyAlternatives": [
@@ -1514,7 +1506,7 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.previous",
             "propertySubPhrases": [
-              "listen to the previous track"
+              "listen to the previous track again"
             ],
             "alternatives": [
               {
@@ -1554,7 +1546,7 @@
             "substrings": [
               "go back to the last track"
             ],
-            "implied": true
+            "implied": false
           }
         ],
         "subPhrases": [
@@ -1572,7 +1564,7 @@
             "text": "go back to the last track",
             "synonyms": [
               "return to the previous track",
-              "replay the last track",
+              "rewind to the last track",
               "play the previous track"
             ],
             "category": "action",
@@ -1585,7 +1577,7 @@
             "synonyms": [
               "kindly",
               "if you don't mind",
-              "if you please"
+              "if you could"
             ],
             "category": "politeness",
             "isOptional": true
@@ -1616,6 +1608,12 @@
                 "propertySubPhrases": [
                   "play the music"
                 ]
+              },
+              {
+                "propertyValue": "player.stop",
+                "propertySubPhrases": [
+                  "stop the music"
+                ]
               }
             ]
           }
@@ -1634,7 +1632,7 @@
             "name": "fullActionName",
             "value": "player.previous",
             "substrings": [
-              "hear the previous song"
+              "previous"
             ],
             "implied": false
           }
@@ -1651,13 +1649,23 @@
             "isOptional": true
           },
           {
-            "text": "hear the previous song",
+            "text": "hear",
             "synonyms": [
-              "play the previous song",
-              "listen to the previous song",
-              "replay the previous song"
+              "listen to",
+              "play",
+              "enjoy"
             ],
             "category": "action",
+            "propertyNames": []
+          },
+          {
+            "text": "the previous song",
+            "synonyms": [
+              "the last song",
+              "the prior song",
+              "the earlier song"
+            ],
+            "category": "object",
             "propertyNames": [
               "fullActionName"
             ]
@@ -1667,9 +1675,9 @@
             "synonyms": [
               "again",
               "one more time",
-              "another time"
+              "replay"
             ],
-            "category": "confirmation",
+            "category": "repetition",
             "isOptional": true
           }
         ],
@@ -1678,13 +1686,13 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.previous",
             "propertySubPhrases": [
-              "hear the previous song"
+              "the previous song"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.next",
                 "propertySubPhrases": [
-                  "hear the next song"
+                  "the next song"
                 ]
               },
               {
@@ -1737,7 +1745,7 @@
             "synonyms": [
               "play the previous song",
               "replay the last song",
-              "repeat the previous track"
+              "repeat the last song"
             ],
             "category": "action",
             "propertyNames": [
@@ -1788,9 +1796,9 @@
             "name": "fullActionName",
             "value": "player.previous",
             "substrings": [
-              "backtrack to the previous song"
+              "previous song"
             ],
-            "implied": true
+            "implied": false
           }
         ],
         "subPhrases": [
@@ -1805,11 +1813,21 @@
             "isOptional": true
           },
           {
-            "text": "backtrack to the previous song",
+            "text": "backtrack to the",
             "synonyms": [
-              "go back to the last song",
-              "return to the previous track",
-              "rewind to the last song"
+              "go back to",
+              "return to",
+              "rewind to"
+            ],
+            "category": "preposition",
+            "propertyNames": []
+          },
+          {
+            "text": "previous song",
+            "synonyms": [
+              "last song",
+              "prior song",
+              "preceding song"
             ],
             "category": "action",
             "propertyNames": [
@@ -1822,25 +1840,25 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.previous",
             "propertySubPhrases": [
-              "backtrack to the previous song"
+              "previous song"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.next",
                 "propertySubPhrases": [
-                  "skip to the next song"
+                  "next song"
                 ]
               },
               {
                 "propertyValue": "player.pause",
                 "propertySubPhrases": [
-                  "pause the music"
+                  "pause the song"
                 ]
               },
               {
                 "propertyValue": "player.play",
                 "propertySubPhrases": [
-                  "play the music"
+                  "play the song"
                 ]
               }
             ]
@@ -1879,9 +1897,9 @@
           {
             "text": "do a quick backtrack",
             "synonyms": [
-              "go back quickly",
-              "quickly rewind",
-              "immediately return"
+              "perform a quick rewind",
+              "make a quick return",
+              "execute a quick reverse"
             ],
             "category": "action",
             "propertyNames": [
@@ -1889,11 +1907,11 @@
             ]
           },
           {
-            "text": "to the last song",
+            "text": "to the last song.",
             "synonyms": [
-              "to the previous track",
-              "to the prior song",
-              "to the earlier song"
+              "to the previous track.",
+              "to the prior song.",
+              "to the former track."
             ],
             "category": "target",
             "propertyNames": [
@@ -1907,28 +1925,28 @@
             "propertyValue": "player.previous",
             "propertySubPhrases": [
               "do a quick backtrack",
-              "to the last song"
+              "to the last song."
             ],
             "alternatives": [
               {
                 "propertyValue": "player.rewind",
                 "propertySubPhrases": [
                   "rewind",
-                  "to the last song"
+                  "to the last song."
                 ]
               },
               {
                 "propertyValue": "player.skipBack",
                 "propertySubPhrases": [
                   "skip back",
-                  "to the last song"
+                  "to the last song."
                 ]
               },
               {
                 "propertyValue": "player.goBack",
                 "propertySubPhrases": [
                   "go back",
-                  "to the last song"
+                  "to the last song."
                 ]
               }
             ]
@@ -1950,7 +1968,7 @@
             "substrings": [
               "Let's go back to the song that played before."
             ],
-            "implied": true
+            "implied": false
           }
         ],
         "subPhrases": [
@@ -1969,7 +1987,7 @@
             "synonyms": [
               "return to",
               "revisit",
-              "go to"
+              "head back to"
             ],
             "category": "action",
             "propertyNames": [
@@ -1981,7 +1999,7 @@
             "synonyms": [
               "the previous song",
               "the last song",
-              "the song that was played earlier"
+              "the earlier song"
             ],
             "category": "object",
             "propertyNames": [
@@ -1999,10 +2017,10 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.rewind",
+                "propertyValue": "player.replay",
                 "propertySubPhrases": [
-                  "rewind to",
-                  "the previous track."
+                  "replay",
+                  "the song that just ended."
                 ]
               },
               {
@@ -2013,10 +2031,10 @@
                 ]
               },
               {
-                "propertyValue": "player.replay",
+                "propertyValue": "player.rewind",
                 "propertySubPhrases": [
-                  "replay",
-                  "the last song."
+                  "rewind",
+                  "the track."
                 ]
               }
             ]
@@ -2036,42 +2054,30 @@
             "name": "fullActionName",
             "value": "player.previous",
             "substrings": [
-              "Let's go one song back."
+              "one song back"
             ],
-            "implied": false
+            "implied": true
           }
         ],
         "subPhrases": [
           {
-            "text": "Let's",
+            "text": "Let's go",
             "synonyms": [
-              "Let us",
-              "We should",
-              "How about we"
+              "Let us go",
+              "We should go",
+              "Let's move"
             ],
-            "category": "politeness",
+            "category": "filler",
             "isOptional": true
-          },
-          {
-            "text": "go",
-            "synonyms": [
-              "move",
-              "proceed",
-              "head"
-            ],
-            "category": "action",
-            "propertyNames": [
-              "fullActionName"
-            ]
           },
           {
             "text": "one song back",
             "synonyms": [
-              "one track back",
               "previous song",
-              "last track"
+              "go back one song",
+              "rewind one song"
             ],
-            "category": "direction",
+            "category": "action",
             "propertyNames": [
               "fullActionName"
             ]
@@ -2082,28 +2088,24 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.previous",
             "propertySubPhrases": [
-              "go",
               "one song back"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.next",
                 "propertySubPhrases": [
-                  "go",
                   "one song forward"
                 ]
               },
               {
                 "propertyValue": "player.pause",
                 "propertySubPhrases": [
-                  "go",
                   "pause the song"
                 ]
               },
               {
                 "propertyValue": "player.play",
                 "propertySubPhrases": [
-                  "go",
                   "play the song"
                 ]
               }
@@ -2124,7 +2126,7 @@
             "name": "fullActionName",
             "value": "player.previous",
             "substrings": [
-              "preceding song"
+              "preceding"
             ],
             "implied": true
           }
@@ -2137,7 +2139,7 @@
               "We should",
               "How about we"
             ],
-            "category": "suggestion",
+            "category": "politeness",
             "isOptional": true
           },
           {
@@ -2145,12 +2147,10 @@
             "synonyms": [
               "listen to",
               "play",
-              "put on"
+              "enjoy"
             ],
             "category": "action",
-            "propertyNames": [
-              "fullActionName"
-            ]
+            "propertyNames": []
           },
           {
             "text": "the preceding song",
@@ -2180,29 +2180,25 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.previous",
             "propertySubPhrases": [
-              "hear",
               "the preceding song"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.next",
                 "propertySubPhrases": [
-                  "hear",
                   "the next song"
                 ]
               },
               {
                 "propertyValue": "player.pause",
                 "propertySubPhrases": [
-                  "pause",
-                  "the song"
+                  "pause the song"
                 ]
               },
               {
                 "propertyValue": "player.play",
                 "propertySubPhrases": [
-                  "play",
-                  "the song"
+                  "play the song"
                 ]
               }
             ]
@@ -2224,7 +2220,7 @@
             "substrings": [
               "jump back one track"
             ],
-            "implied": true
+            "implied": false
           }
         ],
         "subPhrases": [
@@ -2235,7 +2231,7 @@
               "We should",
               "How about we"
             ],
-            "category": "politeness",
+            "category": "suggestion",
             "isOptional": true
           },
           {
@@ -2296,7 +2292,7 @@
             "substrings": [
               "replay the song that was on before this one"
             ],
-            "implied": false
+            "implied": true
           }
         ],
         "subPhrases": [
@@ -2307,7 +2303,7 @@
               "We should",
               "How about we"
             ],
-            "category": "filler",
+            "category": "politeness",
             "isOptional": true
           },
           {
@@ -2329,7 +2325,7 @@
               "that was playing before",
               "that came before this"
             ],
-            "category": "description",
+            "category": "context",
             "propertyNames": [
               "fullActionName"
             ]
@@ -2348,21 +2344,21 @@
                 "propertyValue": "player.replay",
                 "propertySubPhrases": [
                   "replay the song",
-                  "that was on before this one"
+                  "again"
                 ]
               },
               {
                 "propertyValue": "player.restart",
                 "propertySubPhrases": [
                   "restart the song",
-                  "that was on before this one"
+                  "from the beginning"
                 ]
               },
               {
                 "propertyValue": "player.repeat",
                 "propertySubPhrases": [
                   "repeat the song",
-                  "that was on before this one"
+                  "once more"
                 ]
               }
             ]
@@ -2384,7 +2380,7 @@
             "substrings": [
               "return to the last track"
             ],
-            "implied": true
+            "implied": false
           }
         ],
         "subPhrases": [
@@ -2395,15 +2391,15 @@
               "We should",
               "How about we"
             ],
-            "category": "politeness",
+            "category": "filler",
             "isOptional": true
           },
           {
             "text": "return to the last track",
             "synonyms": [
               "go back to the previous song",
-              "play the previous track",
-              "replay the last song"
+              "replay the previous track",
+              "play the last song again"
             ],
             "category": "action",
             "propertyNames": [
@@ -2465,7 +2461,7 @@
             "synonyms": [
               "Let us",
               "We should",
-              "We could"
+              "How about we"
             ],
             "category": "politeness",
             "isOptional": true
@@ -2473,9 +2469,9 @@
           {
             "text": "reverse to the previous track",
             "synonyms": [
-              "go back to the previous track",
-              "move to the previous track",
-              "return to the previous track"
+              "go back to the last song",
+              "play the prior track",
+              "move to the earlier track"
             ],
             "category": "action",
             "propertyNames": [
@@ -2578,13 +2574,13 @@
               {
                 "propertyValue": "player.pause",
                 "propertySubPhrases": [
-                  "pause the track"
+                  "pause the current track"
                 ]
               },
               {
                 "propertyValue": "player.play",
                 "propertySubPhrases": [
-                  "play the track"
+                  "play the current track"
                 ]
               }
             ]
@@ -2606,7 +2602,7 @@
             "substrings": [
               "rewind to the song we just heard"
             ],
-            "implied": true
+            "implied": false
           }
         ],
         "subPhrases": [
@@ -2617,29 +2613,17 @@
               "We should",
               "How about we"
             ],
-            "category": "suggestion",
+            "category": "filler",
             "isOptional": true
           },
           {
-            "text": "rewind to the song",
+            "text": "rewind to the song we just heard",
             "synonyms": [
-              "go back to the song",
-              "return to the song",
-              "play the previous song"
+              "go back to the previous song",
+              "play the last song again",
+              "return to the song we just played"
             ],
             "category": "action",
-            "propertyNames": [
-              "fullActionName"
-            ]
-          },
-          {
-            "text": "we just heard",
-            "synonyms": [
-              "we recently listened to",
-              "we just played",
-              "we heard a moment ago"
-            ],
-            "category": "context",
             "propertyNames": [
               "fullActionName"
             ]
@@ -2650,29 +2634,25 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.previous",
             "propertySubPhrases": [
-              "rewind to the song",
-              "we just heard"
+              "rewind to the song we just heard"
             ],
             "alternatives": [
               {
-                "propertyValue": "player.replay",
+                "propertyValue": "player.rewind",
                 "propertySubPhrases": [
-                  "replay the song",
-                  "we just heard"
+                  "rewind the song"
                 ]
               },
               {
                 "propertyValue": "player.restart",
                 "propertySubPhrases": [
-                  "restart the song",
-                  "we just heard"
+                  "restart the song"
                 ]
               },
               {
-                "propertyValue": "player.repeat",
+                "propertyValue": "player.replay",
                 "propertySubPhrases": [
-                  "repeat the song",
-                  "we just heard"
+                  "replay the song"
                 ]
               }
             ]
@@ -2692,9 +2672,9 @@
             "name": "fullActionName",
             "value": "player.previous",
             "substrings": [
-              "previous song"
+              "previous"
             ],
-            "implied": true
+            "implied": false
           }
         ],
         "subPhrases": [
@@ -2702,8 +2682,8 @@
             "text": "Mind",
             "synonyms": [
               "Would you",
-              "Could you",
-              "Do you mind"
+              "Can you",
+              "Could you"
             ],
             "category": "politeness",
             "isOptional": true
@@ -2725,7 +2705,7 @@
               "the prior song",
               "the previous track"
             ],
-            "category": "object",
+            "category": "action",
             "propertyNames": [
               "fullActionName"
             ]
@@ -2793,9 +2773,9 @@
           {
             "text": "reversing to the previous song",
             "synonyms": [
-              "go back to the last song",
-              "play the previous track",
-              "return to the previous song"
+              "go back to the last track",
+              "play the prior song",
+              "return to the previous track"
             ],
             "category": "action",
             "propertyNames": [
@@ -2971,7 +2951,7 @@
             "synonyms": [
               "the previous track",
               "the last track",
-              "the earlier track"
+              "the prior track"
             ],
             "category": "object",
             "propertyNames": [
@@ -3036,21 +3016,23 @@
             "name": "fullActionName",
             "value": "player.previous",
             "substrings": [
-              "Press the prev button"
+              "Press the prev button on the music player."
             ],
-            "implied": true
+            "implied": false
           }
         ],
         "subPhrases": [
           {
             "text": "Press",
             "synonyms": [
-              "Click",
+              "Hit",
               "Tap",
-              "Hit"
+              "Click"
             ],
-            "category": "action",
-            "propertyNames": []
+            "category": "command",
+            "propertyNames": [
+              "fullActionName"
+            ]
           },
           {
             "text": "the prev button",
@@ -3071,8 +3053,10 @@
               "on the media player",
               "on the sound system"
             ],
-            "category": "context",
-            "propertyNames": []
+            "category": "location",
+            "propertyNames": [
+              "fullActionName"
+            ]
           }
         ],
         "propertyAlternatives": [
@@ -3080,25 +3064,33 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.previous",
             "propertySubPhrases": [
-              "the prev button"
+              "Press",
+              "the prev button",
+              "on the music player"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.next",
                 "propertySubPhrases": [
-                  "the next button"
-                ]
-              },
-              {
-                "propertyValue": "player.play",
-                "propertySubPhrases": [
-                  "the play button"
+                  "Press",
+                  "the next button",
+                  "on the music player"
                 ]
               },
               {
                 "propertyValue": "player.pause",
                 "propertySubPhrases": [
-                  "the pause button"
+                  "Press",
+                  "the pause button",
+                  "on the music player"
+                ]
+              },
+              {
+                "propertyValue": "player.play",
+                "propertySubPhrases": [
+                  "Press",
+                  "the play button",
+                  "on the music player"
                 ]
               }
             ]
@@ -3127,9 +3119,9 @@
           {
             "text": "Previous song",
             "synonyms": [
-              "Play the previous track",
+              "Last track",
               "Go back one song",
-              "Play the last song"
+              "Play the previous song"
             ],
             "category": "command",
             "propertyNames": [
@@ -3139,8 +3131,8 @@
           {
             "text": "if you don't mind",
             "synonyms": [
-              "if that's okay",
-              "if it's not a problem",
+              "if it's okay",
+              "if that's alright",
               "if you could"
             ],
             "category": "politeness",
@@ -3199,9 +3191,9 @@
           {
             "text": "Previous song",
             "synonyms": [
-              "Play the previous song",
+              "Last track",
               "Go back one song",
-              "Play the last song"
+              "Play the previous song"
             ],
             "category": "command",
             "propertyNames": [
@@ -3212,8 +3204,8 @@
             "text": "please",
             "synonyms": [
               "kindly",
-              "if you don't mind",
-              "would you mind"
+              "if you would",
+              "if you don't mind"
             ],
             "category": "politeness",
             "isOptional": true
@@ -3344,8 +3336,8 @@
             "text": "Previous track",
             "synonyms": [
               "Last song",
-              "Go back one track",
-              "Play the previous song"
+              "Go back one",
+              "Rewind one track"
             ],
             "category": "command",
             "propertyNames": [
@@ -3356,8 +3348,8 @@
             "text": "please",
             "synonyms": [
               "kindly",
-              "if you would",
-              "if you don't mind"
+              "if you could",
+              "would you mind"
             ],
             "category": "politeness",
             "isOptional": true
@@ -3408,7 +3400,7 @@
             "substrings": [
               "previous track"
             ],
-            "implied": true
+            "implied": false
           }
         ],
         "subPhrases": [
@@ -3442,7 +3434,7 @@
               "replay"
             ],
             "category": "repetition",
-            "propertyNames": []
+            "isOptional": true
           }
         ],
         "propertyAlternatives": [
@@ -3460,15 +3452,15 @@
                 ]
               },
               {
-                "propertyValue": "player.play",
-                "propertySubPhrases": [
-                  "play the track"
-                ]
-              },
-              {
                 "propertyValue": "player.pause",
                 "propertySubPhrases": [
                   "pause the track"
+                ]
+              },
+              {
+                "propertyValue": "player.play",
+                "propertySubPhrases": [
+                  "play the track"
                 ]
               }
             ]
@@ -3501,7 +3493,7 @@
               "Return",
               "Move back"
             ],
-            "category": "action",
+            "category": "command",
             "propertyNames": [
               "fullActionName"
             ]
@@ -3511,7 +3503,7 @@
             "synonyms": [
               "to the previous track",
               "to the prior track",
-              "to the preceding track"
+              "to the earlier track"
             ],
             "category": "target",
             "propertyNames": [
@@ -3549,14 +3541,14 @@
                 "propertyValue": "player.pause",
                 "propertySubPhrases": [
                   "Pause",
-                  "the track"
+                  "the current track"
                 ]
               },
               {
                 "propertyValue": "player.play",
                 "propertySubPhrases": [
                   "Play",
-                  "the track"
+                  "the current track"
                 ]
               }
             ]
@@ -3583,13 +3575,25 @@
         ],
         "subPhrases": [
           {
-            "text": "Skip back to the former track",
+            "text": "Skip back to",
             "synonyms": [
-              "Go back to the previous song",
-              "Rewind to the last track",
-              "Return to the previous track"
+              "Go back to",
+              "Rewind to",
+              "Return to"
             ],
-            "category": "action",
+            "category": "command",
+            "propertyNames": [
+              "fullActionName"
+            ]
+          },
+          {
+            "text": "the former track",
+            "synonyms": [
+              "the previous track",
+              "the last track",
+              "the earlier track"
+            ],
+            "category": "object",
             "propertyNames": [
               "fullActionName"
             ]
@@ -3610,25 +3614,29 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.previous",
             "propertySubPhrases": [
-              "Skip back to the former track"
+              "Skip back to",
+              "the former track"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.next",
                 "propertySubPhrases": [
-                  "Skip to the next track"
+                  "Skip forward to",
+                  "the next track"
                 ]
               },
               {
                 "propertyValue": "player.pause",
                 "propertySubPhrases": [
-                  "Pause the track"
+                  "Pause",
+                  "the current track"
                 ]
               },
               {
                 "propertyValue": "player.play",
                 "propertySubPhrases": [
-                  "Play the track"
+                  "Play",
+                  "the current track"
                 ]
               }
             ]
@@ -3679,13 +3687,13 @@
             ]
           },
           {
-            "text": "that just played.",
+            "text": "that just played",
             "synonyms": [
               "that just finished",
               "that just ended",
               "that was just on"
             ],
-            "category": "time reference",
+            "category": "time",
             "propertyNames": [
               "fullActionName"
             ]
@@ -3698,7 +3706,7 @@
             "propertySubPhrases": [
               "Take it back",
               "to the song",
-              "that just played."
+              "that just played"
             ],
             "alternatives": [
               {
@@ -3706,7 +3714,7 @@
                 "propertySubPhrases": [
                   "Rewind",
                   "to the song",
-                  "that just played."
+                  "that just played"
                 ]
               },
               {
@@ -3714,7 +3722,7 @@
                 "propertySubPhrases": [
                   "Restart",
                   "the song",
-                  "that just played."
+                  "that just played"
                 ]
               },
               {
@@ -3722,7 +3730,7 @@
                 "propertySubPhrases": [
                   "Replay",
                   "the song",
-                  "that just played."
+                  "that just played"
                 ]
               }
             ]
@@ -3744,7 +3752,7 @@
             "substrings": [
               "previous song"
             ],
-            "implied": true
+            "implied": false
           }
         ],
         "subPhrases": [
@@ -3753,7 +3761,7 @@
             "synonyms": [
               "Bring us to the",
               "Move us to the",
-              "Navigate us to the"
+              "Guide us to the"
             ],
             "category": "command",
             "propertyNames": []
@@ -3843,9 +3851,9 @@
           {
             "text": "playing the last track again",
             "synonyms": [
-              "replay the last track",
+              "replay the last song",
               "play the previous track",
-              "play the last song again"
+              "repeat the last track"
             ],
             "category": "action",
             "propertyNames": [
@@ -3934,21 +3942,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.next",
+                "propertyValue": "player.replay",
                 "propertySubPhrases": [
-                  "play the next one"
+                  "replay that last one"
                 ]
               },
               {
-                "propertyValue": "player.pause",
+                "propertyValue": "player.restart",
                 "propertySubPhrases": [
-                  "pause the music"
+                  "restart that last one"
                 ]
               },
               {
-                "propertyValue": "player.stop",
+                "propertyValue": "player.rewind",
                 "propertySubPhrases": [
-                  "stop the track"
+                  "rewind that last one"
                 ]
               }
             ]

--- a/ts/packages/dispatcher/test/data/player/v5/resumeAction.json
+++ b/ts/packages/dispatcher/test/data/player/v5/resumeAction.json
@@ -38,7 +38,7 @@
             "synonyms": [
               "audio",
               "music",
-              "noise"
+              "playback"
             ],
             "category": "object",
             "propertyNames": [
@@ -49,8 +49,8 @@
             "text": "once more",
             "synonyms": [
               "again",
-              "one more time",
-              "another time"
+              "resume",
+              "restart"
             ],
             "category": "frequency",
             "propertyNames": [
@@ -81,7 +81,7 @@
                 "propertySubPhrases": [
                   "Unpause",
                   "the audio",
-                  "now"
+                  "again"
                 ]
               },
               {
@@ -89,7 +89,7 @@
                 "propertySubPhrases": [
                   "Continue",
                   "the music",
-                  "from here"
+                  "once more"
                 ]
               }
             ]
@@ -122,7 +122,7 @@
               "Continue",
               "Restart"
             ],
-            "category": "action",
+            "category": "command",
             "propertyNames": [
               "fullActionName"
             ]
@@ -131,8 +131,8 @@
             "text": "the beats",
             "synonyms": [
               "the music",
-              "the tunes",
-              "the songs"
+              "the track",
+              "the song"
             ],
             "category": "object",
             "propertyNames": [
@@ -207,32 +207,20 @@
             "text": "we",
             "synonyms": [
               "us",
-              "me and you",
-              "everyone"
+              "I",
+              "you"
             ],
-            "category": "politeness",
+            "category": "pronoun",
             "isOptional": true
           },
           {
-            "text": "continue with",
+            "text": "continue with the songs",
             "synonyms": [
-              "resume",
-              "carry on with",
-              "proceed with"
+              "resume the songs",
+              "play the songs again",
+              "start the songs again"
             ],
             "category": "action",
-            "propertyNames": [
-              "fullActionName"
-            ]
-          },
-          {
-            "text": "the songs",
-            "synonyms": [
-              "the music",
-              "the tracks",
-              "the playlist"
-            ],
-            "category": "object",
             "propertyNames": [
               "fullActionName"
             ]
@@ -253,29 +241,31 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.resume",
             "propertySubPhrases": [
-              "continue with",
-              "the songs"
+              "continue with the songs"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.play",
                 "propertySubPhrases": [
-                  "start",
-                  "the songs"
+                  "start the songs"
                 ]
               },
               {
                 "propertyValue": "player.pause",
                 "propertySubPhrases": [
-                  "pause",
-                  "the songs"
+                  "pause the songs"
                 ]
               },
               {
                 "propertyValue": "player.stop",
                 "propertySubPhrases": [
-                  "stop",
-                  "the songs"
+                  "stop the songs"
+                ]
+              },
+              {
+                "propertyValue": "player.next",
+                "propertySubPhrases": [
+                  "skip to the next song"
                 ]
               }
             ]
@@ -295,7 +285,7 @@
             "name": "fullActionName",
             "value": "player.resume",
             "substrings": [
-              "get the sound back"
+              "Can we get the sound back?"
             ],
             "implied": true
           }
@@ -314,9 +304,9 @@
           {
             "text": "we",
             "synonyms": [
-              "you",
+              "us",
               "I",
-              "they"
+              "you"
             ],
             "category": "politeness",
             "isOptional": true
@@ -324,9 +314,9 @@
           {
             "text": "get the sound back",
             "synonyms": [
-              "resume the audio",
+              "resume the sound",
               "turn the sound back on",
-              "unmute the sound"
+              "restore the sound"
             ],
             "category": "action",
             "propertyNames": [
@@ -575,12 +565,6 @@
                 "propertySubPhrases": [
                   "pause the music"
                 ]
-              },
-              {
-                "propertyValue": "player.skip",
-                "propertySubPhrases": [
-                  "skip the music"
-                ]
               }
             ]
           }
@@ -601,7 +585,7 @@
             "substrings": [
               "start the music back up"
             ],
-            "implied": true
+            "implied": false
           }
         ],
         "subPhrases": [
@@ -673,7 +657,7 @@
             "substrings": [
               "Continue playing"
             ],
-            "implied": false
+            "implied": true
           }
         ],
         "subPhrases": [
@@ -682,7 +666,7 @@
             "synonyms": [
               "Resume playing",
               "Keep playing",
-              "Carry on playing"
+              "Start playing again"
             ],
             "category": "action",
             "propertyNames": [
@@ -709,7 +693,7 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.play",
+                "propertyValue": "player.start",
                 "propertySubPhrases": [
                   "Start playing"
                 ]
@@ -717,7 +701,7 @@
               {
                 "propertyValue": "player.pause",
                 "propertySubPhrases": [
-                  "Pause"
+                  "Pause playing"
                 ]
               },
               {
@@ -765,8 +749,8 @@
             "text": "please",
             "synonyms": [
               "kindly",
-              "if you would",
-              "if you don't mind"
+              "if you don't mind",
+              "would you mind"
             ],
             "category": "politeness",
             "isOptional": true
@@ -783,19 +767,19 @@
               {
                 "propertyValue": "player.play",
                 "propertySubPhrases": [
+                  "Play the melody"
+                ]
+              },
+              {
+                "propertyValue": "player.start",
+                "propertySubPhrases": [
                   "Start the melody"
                 ]
               },
               {
-                "propertyValue": "player.pause",
+                "propertyValue": "player.unpause",
                 "propertySubPhrases": [
-                  "Pause the melody"
-                ]
-              },
-              {
-                "propertyValue": "player.stop",
-                "propertySubPhrases": [
-                  "Stop the melody"
+                  "Unpause the melody"
                 ]
               }
             ]
@@ -817,7 +801,7 @@
             "substrings": [
               "continue the tunes"
             ],
-            "implied": true
+            "implied": false
           }
         ],
         "subPhrases": [
@@ -836,7 +820,7 @@
             "synonyms": [
               "resume the music",
               "play the songs again",
-              "start the tunes again"
+              "start the tunes"
             ],
             "category": "action",
             "propertyNames": [
@@ -861,13 +845,13 @@
               {
                 "propertyValue": "player.start",
                 "propertySubPhrases": [
-                  "start the songs"
+                  "start the tunes"
                 ]
               },
               {
                 "propertyValue": "player.unpause",
                 "propertySubPhrases": [
-                  "unpause the audio"
+                  "unpause the music"
                 ]
               }
             ]
@@ -889,7 +873,7 @@
             "substrings": [
               "get the music started again"
             ],
-            "implied": true
+            "implied": false
           }
         ],
         "subPhrases": [
@@ -997,27 +981,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.pause",
-                "propertySubPhrases": [
-                  "pause the track"
-                ]
-              },
-              {
-                "propertyValue": "player.stop",
-                "propertySubPhrases": [
-                  "stop the track"
-                ]
-              },
-              {
                 "propertyValue": "player.play",
                 "propertySubPhrases": [
                   "play the track"
                 ]
               },
               {
-                "propertyValue": "player.next",
+                "propertyValue": "player.start",
                 "propertySubPhrases": [
-                  "skip to the next track"
+                  "start the track"
+                ]
+              },
+              {
+                "propertyValue": "player.continue",
+                "propertySubPhrases": [
+                  "continue the track"
                 ]
               }
             ]
@@ -1141,8 +1119,8 @@
             "text": "Get",
             "synonyms": [
               "Start",
-              "Resume",
-              "Begin"
+              "Begin",
+              "Resume"
             ],
             "category": "command",
             "propertyNames": [
@@ -1193,19 +1171,19 @@
                 ]
               },
               {
+                "propertyValue": "player.restart",
+                "propertySubPhrases": [
+                  "Restart",
+                  "the tracks",
+                  "from the beginning"
+                ]
+              },
+              {
                 "propertyValue": "player.unpause",
                 "propertySubPhrases": [
                   "Unpause",
                   "the tracks",
                   "now"
-                ]
-              },
-              {
-                "propertyValue": "player.continue",
-                "propertySubPhrases": [
-                  "Continue",
-                  "the tracks",
-                  "from where they left off"
                 ]
               }
             ]
@@ -1238,14 +1216,14 @@
               "Continue",
               "Carry on"
             ],
-            "category": "confirmation",
+            "category": "filler",
             "isOptional": true
           },
           {
             "text": "and",
             "synonyms": [
               "plus",
-              "along with",
+              "also",
               "as well as"
             ],
             "category": "conjunction",
@@ -1254,8 +1232,8 @@
           {
             "text": "resume",
             "synonyms": [
-              "restart",
               "continue",
+              "restart",
               "pick up"
             ],
             "category": "action",
@@ -1266,9 +1244,9 @@
           {
             "text": "the playlist",
             "synonyms": [
-              "the song list",
-              "the music queue",
-              "the track collection"
+              "the music list",
+              "the song collection",
+              "the track list"
             ],
             "category": "object",
             "propertyNames": []
@@ -1303,7 +1281,60 @@
             ]
           }
         ]
-      }
+      },
+      "corrections": [
+        {
+          "data": {
+            "properties": [
+              {
+                "name": "fullActionName",
+                "value": "player.resume",
+                "substrings": [
+                  "resume"
+                ],
+                "implied": false
+              }
+            ],
+            "subPhrases": [
+              {
+                "text": "Go ahead",
+                "synonyms": [
+                  "Proceed",
+                  "Continue",
+                  "Carry on"
+                ],
+                "category": "filler",
+                "isOptional": true
+              },
+              {
+                "text": "resume",
+                "synonyms": [
+                  "continue",
+                  "restart",
+                  "pick up"
+                ],
+                "category": "action",
+                "propertyNames": [
+                  "fullActionName"
+                ]
+              },
+              {
+                "text": "the playlist",
+                "synonyms": [
+                  "the music list",
+                  "the song collection",
+                  "the track list"
+                ],
+                "category": "object",
+                "propertyNames": []
+              }
+            ]
+          },
+          "correction": [
+            "Missing sub-phrase: explanation missing for 'and'"
+          ]
+        }
+      ]
     },
     {
       "request": "Hey, could you hit play?",
@@ -1346,9 +1377,9 @@
           {
             "text": "hit play",
             "synonyms": [
+              "press play",
               "start playing",
-              "resume",
-              "play"
+              "resume"
             ],
             "category": "action",
             "propertyNames": [
@@ -1373,7 +1404,7 @@
               {
                 "propertyValue": "player.stop",
                 "propertySubPhrases": [
-                  "stop playing"
+                  "hit stop"
                 ]
               },
               {
@@ -1407,7 +1438,7 @@
             "substrings": [
               "Hit play again."
             ],
-            "implied": true
+            "implied": false
           }
         ],
         "subPhrases": [
@@ -1426,7 +1457,7 @@
             "synonyms": [
               "start",
               "resume",
-              "begin"
+              "continue"
             ],
             "category": "action",
             "propertyNames": [
@@ -1440,7 +1471,7 @@
               "another time",
               "replay"
             ],
-            "category": "frequency",
+            "category": "repetition",
             "propertyNames": [
               "fullActionName"
             ]
@@ -1516,7 +1547,7 @@
             "synonyms": [
               "the play icon",
               "the play control",
-              "the play symbol"
+              "the play key"
             ],
             "category": "object",
             "propertyNames": [
@@ -1527,7 +1558,7 @@
             "text": "again",
             "synonyms": [
               "once more",
-              "one more time",
+              "another time",
               "repeatedly"
             ],
             "category": "frequency",
@@ -1558,7 +1589,7 @@
                 "propertyValue": "player.start",
                 "propertySubPhrases": [
                   "Start",
-                  "the playback",
+                  "the play button",
                   "immediately"
                 ]
               },
@@ -1566,8 +1597,8 @@
                 "propertyValue": "player.continue",
                 "propertySubPhrases": [
                   "Continue",
-                  "the playback",
-                  "from where it left off"
+                  "the play button",
+                  "once more"
                 ]
               }
             ]
@@ -1598,7 +1629,7 @@
             "synonyms": [
               "I would be grateful if you could",
               "It would be great if you could",
-              "I would like you to"
+              "I would appreciate it if you"
             ],
             "category": "politeness",
             "isOptional": true
@@ -1608,7 +1639,7 @@
             "synonyms": [
               "resume the music",
               "start the music again",
-              "play the music once more"
+              "continue the music"
             ],
             "category": "action",
             "propertyNames": [
@@ -1631,9 +1662,9 @@
                 ]
               },
               {
-                "propertyValue": "player.restart",
+                "propertyValue": "player.start",
                 "propertySubPhrases": [
-                  "restart the music"
+                  "start the music"
                 ]
               },
               {
@@ -1733,7 +1764,7 @@
             "substrings": [
               "continue the music"
             ],
-            "implied": false
+            "implied": true
           }
         ],
         "subPhrases": [
@@ -1824,9 +1855,9 @@
           {
             "text": "the music",
             "synonyms": [
-              "the song",
-              "the audio",
-              "the track"
+              "the songs",
+              "the tunes",
+              "the audio"
             ],
             "category": "object",
             "propertyNames": [
@@ -1838,7 +1869,7 @@
             "synonyms": [
               "playing",
               "going",
-              "on"
+              "running"
             ],
             "category": "action",
             "propertyNames": [
@@ -1904,11 +1935,11 @@
         ],
         "subPhrases": [
           {
-            "text": "Keep the party going",
+            "text": "Keep",
             "synonyms": [
-              "Continue the celebration",
-              "Maintain the fun",
-              "Keep the event lively"
+              "Maintain",
+              "Continue",
+              "Sustain"
             ],
             "category": "command",
             "propertyNames": [
@@ -1916,11 +1947,23 @@
             ]
           },
           {
-            "text": "with the music",
+            "text": "the party going",
             "synonyms": [
-              "using the tunes",
-              "with the songs",
-              "with the playlist"
+              "the celebration active",
+              "the event lively",
+              "the gathering energetic"
+            ],
+            "category": "context",
+            "propertyNames": [
+              "fullActionName"
+            ]
+          },
+          {
+            "text": "with the music.",
+            "synonyms": [
+              "with tunes",
+              "with songs",
+              "with melodies"
             ],
             "category": "context",
             "propertyNames": [
@@ -1933,29 +1976,33 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.playRandom",
             "propertySubPhrases": [
-              "Keep the party going",
-              "with the music"
+              "Keep",
+              "the party going",
+              "with the music."
             ],
             "alternatives": [
               {
                 "propertyValue": "player.playNext",
                 "propertySubPhrases": [
-                  "Play the next song",
-                  "to keep the party going"
+                  "Continue",
+                  "the party",
+                  "with the next song."
                 ]
               },
               {
-                "propertyValue": "player.shuffle",
+                "propertyValue": "player.playFavorite",
                 "propertySubPhrases": [
-                  "Shuffle the playlist",
-                  "for the party"
+                  "Keep",
+                  "the vibe",
+                  "with your favorite tracks."
                 ]
               },
               {
-                "propertyValue": "player.playFavorites",
+                "propertyValue": "player.playPlaylist",
                 "propertySubPhrases": [
-                  "Play my favorite tracks",
-                  "for the party"
+                  "Maintain",
+                  "the energy",
+                  "with the playlist."
                 ]
               }
             ]
@@ -2069,7 +2116,7 @@
             "name": "fullActionName",
             "value": "player.resume",
             "substrings": [
-              "Kindly continue with the playlist."
+              "continue with the playlist"
             ],
             "implied": true
           }
@@ -2215,7 +2262,7 @@
                 "propertySubPhrases": [
                   "Continue",
                   "the music",
-                  "playing"
+                  "from where it left off"
                 ]
               }
             ]
@@ -2293,17 +2340,17 @@
                 ]
               },
               {
-                "propertyValue": "player.continue",
+                "propertyValue": "player.restart",
                 "propertySubPhrases": [
-                  "continue",
-                  "the tunes."
+                  "restart",
+                  "the track."
                 ]
               },
               {
-                "propertyValue": "player.replay",
+                "propertyValue": "player.continue",
                 "propertySubPhrases": [
-                  "replay",
-                  "the tracks."
+                  "continue",
+                  "the playlist."
                 ]
               }
             ]
@@ -2344,9 +2391,9 @@
             "synonyms": [
               "resume the music",
               "play the music again",
-              "turn the music back on"
+              "start the music"
             ],
-            "category": "action",
+            "category": "command",
             "propertyNames": [
               "fullActionName"
             ]
@@ -2367,15 +2414,15 @@
                 ]
               },
               {
-                "propertyValue": "player.restart",
-                "propertySubPhrases": [
-                  "restart the music"
-                ]
-              },
-              {
                 "propertyValue": "player.unpause",
                 "propertySubPhrases": [
                   "unpause the music"
+                ]
+              },
+              {
+                "propertyValue": "player.continue",
+                "propertySubPhrases": [
+                  "continue the music"
                 ]
               }
             ]
@@ -2405,8 +2452,8 @@
             "text": "Let's",
             "synonyms": [
               "Let us",
-              "Allow us",
-              "We should"
+              "We should",
+              "How about we"
             ],
             "category": "politeness",
             "isOptional": true
@@ -2449,6 +2496,12 @@
                 "propertySubPhrases": [
                   "play my favorite song"
                 ]
+              },
+              {
+                "propertyValue": "player.playPlaylist",
+                "propertySubPhrases": [
+                  "play my playlist"
+                ]
               }
             ]
           }
@@ -2488,7 +2541,7 @@
             "synonyms": [
               "resume",
               "continue from where we stopped",
-              "start again from the last point"
+              "start again from where we paused"
             ],
             "category": "action",
             "propertyNames": [
@@ -2537,6 +2590,13 @@
                   "stop",
                   "the music"
                 ]
+              },
+              {
+                "propertyValue": "player.rewind",
+                "propertySubPhrases": [
+                  "rewind",
+                  "the music"
+                ]
               }
             ]
           }
@@ -2566,9 +2626,9 @@
             "synonyms": [
               "Let us",
               "We should",
-              "How about we"
+              "Let's go ahead and"
             ],
-            "category": "politeness",
+            "category": "filler",
             "isOptional": true
           },
           {
@@ -2601,7 +2661,7 @@
               {
                 "propertyValue": "player.start",
                 "propertySubPhrases": [
-                  "start the audio"
+                  "start the audio playback"
                 ]
               },
               {
@@ -2629,7 +2689,7 @@
             "substrings": [
               "Play on"
             ],
-            "implied": true
+            "implied": false
           }
         ],
         "subPhrases": [
@@ -2637,8 +2697,8 @@
             "text": "Play on",
             "synonyms": [
               "Resume",
-              "Continue",
-              "Start playing"
+              "Continue playing",
+              "Start again"
             ],
             "category": "command",
             "propertyNames": [
@@ -2665,21 +2725,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.pause",
+                "propertyValue": "player.start",
                 "propertySubPhrases": [
-                  "Pause"
+                  "Start playing"
                 ]
               },
               {
-                "propertyValue": "player.stop",
+                "propertyValue": "player.continue",
                 "propertySubPhrases": [
-                  "Stop"
+                  "Continue playing"
                 ]
               },
               {
-                "propertyValue": "player.next",
+                "propertyValue": "player.play",
                 "propertySubPhrases": [
-                  "Next"
+                  "Play"
                 ]
               }
             ]
@@ -2709,8 +2769,8 @@
             "text": "Play",
             "synonyms": [
               "Start",
-              "Resume",
-              "Begin"
+              "Begin",
+              "Resume"
             ],
             "category": "command",
             "propertyNames": [
@@ -2736,7 +2796,7 @@
               "one more time",
               "another time"
             ],
-            "category": "repetition",
+            "category": "frequency",
             "propertyNames": [
               "fullActionName"
             ]
@@ -2813,8 +2873,8 @@
             "text": "continue the music",
             "synonyms": [
               "resume the music",
-              "keep playing the music",
-              "start the music again"
+              "play the music again",
+              "start the music"
             ],
             "category": "action",
             "propertyNames": [
@@ -2915,9 +2975,9 @@
                 ]
               },
               {
-                "propertyValue": "player.shufflePlay",
+                "propertyValue": "player.shuffle",
                 "propertySubPhrases": [
-                  "shuffle play the music"
+                  "shuffle the music"
                 ]
               }
             ]
@@ -2975,21 +3035,21 @@
             ],
             "alternatives": [
               {
+                "propertyValue": "player.pause",
+                "propertySubPhrases": [
+                  "pause the music"
+                ]
+              },
+              {
+                "propertyValue": "player.stop",
+                "propertySubPhrases": [
+                  "stop the music"
+                ]
+              },
+              {
                 "propertyValue": "player.play",
                 "propertySubPhrases": [
                   "play the music"
-                ]
-              },
-              {
-                "propertyValue": "player.start",
-                "propertySubPhrases": [
-                  "start the music"
-                ]
-              },
-              {
-                "propertyValue": "player.continue",
-                "propertySubPhrases": [
-                  "continue the music"
                 ]
               }
             ]
@@ -3016,11 +3076,11 @@
         ],
         "subPhrases": [
           {
-            "text": "Proceed",
+            "text": "Proceed with",
             "synonyms": [
-              "Continue",
-              "Resume",
-              "Go ahead"
+              "Continue with",
+              "Go ahead with",
+              "Resume"
             ],
             "category": "command",
             "propertyNames": [
@@ -3028,26 +3088,16 @@
             ]
           },
           {
-            "text": "with the audio playback",
+            "text": "the audio playback.",
             "synonyms": [
-              "with the music",
-              "with the sound",
-              "with the audio"
+              "the sound playback.",
+              "the music playback.",
+              "the audio stream."
             ],
             "category": "object",
             "propertyNames": [
               "fullActionName"
             ]
-          },
-          {
-            "text": ".",
-            "synonyms": [
-              "",
-              " ",
-              " "
-            ],
-            "category": "punctuation",
-            "isOptional": true
           }
         ],
         "propertyAlternatives": [
@@ -3055,29 +3105,29 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.resume",
             "propertySubPhrases": [
-              "Proceed",
-              "with the audio playback"
+              "Proceed with",
+              "the audio playback."
             ],
             "alternatives": [
               {
                 "propertyValue": "player.play",
                 "propertySubPhrases": [
                   "Start",
-                  "the audio playback"
+                  "the audio playback."
                 ]
               },
               {
                 "propertyValue": "player.pause",
                 "propertySubPhrases": [
                   "Pause",
-                  "the audio playback"
+                  "the audio playback."
                 ]
               },
               {
                 "propertyValue": "player.stop",
                 "propertySubPhrases": [
                   "Stop",
-                  "the audio playback"
+                  "the audio playback."
                 ]
               }
             ]
@@ -3099,7 +3149,7 @@
             "substrings": [
               "Restart the jam"
             ],
-            "implied": true
+            "implied": false
           }
         ],
         "subPhrases": [
@@ -3107,8 +3157,8 @@
             "text": "Restart the jam",
             "synonyms": [
               "Resume the music",
-              "Play the song again",
-              "Start the track over"
+              "Continue the track",
+              "Play the song again"
             ],
             "category": "command",
             "propertyNames": [
@@ -3119,7 +3169,7 @@
             "text": "please",
             "synonyms": [
               "kindly",
-              "if you could",
+              "if you don't mind",
               "would you mind"
             ],
             "category": "politeness",
@@ -3135,9 +3185,9 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.start",
+                "propertyValue": "player.play",
                 "propertySubPhrases": [
-                  "Start the jam"
+                  "Play the jam"
                 ]
               },
               {
@@ -3147,9 +3197,9 @@
                 ]
               },
               {
-                "propertyValue": "player.restart",
+                "propertyValue": "player.startOver",
                 "propertySubPhrases": [
-                  "Restart the track"
+                  "Start over the jam"
                 ]
               }
             ]
@@ -3191,8 +3241,8 @@
             "text": "please",
             "synonyms": [
               "kindly",
-              "if you would",
-              "if you please"
+              "if you could",
+              "would you mind"
             ],
             "category": "politeness",
             "isOptional": true
@@ -3252,7 +3302,7 @@
             "synonyms": [
               "Play the song again",
               "Continue the song",
-              "Start the song from where it left off"
+              "Unpause the song"
             ],
             "category": "command",
             "propertyNames": [
@@ -3263,8 +3313,8 @@
             "text": "if you don't mind",
             "synonyms": [
               "if it's okay with you",
-              "if that's alright",
-              "if you could"
+              "if you could",
+              "if you would"
             ],
             "category": "politeness",
             "isOptional": true
@@ -3285,15 +3335,15 @@
                 ]
               },
               {
-                "propertyValue": "player.pause",
+                "propertyValue": "player.start",
                 "propertySubPhrases": [
-                  "Pause the song"
+                  "Start the song"
                 ]
               },
               {
-                "propertyValue": "player.stop",
+                "propertyValue": "player.continue",
                 "propertySubPhrases": [
-                  "Stop the song"
+                  "Continue the song"
                 ]
               }
             ]
@@ -3322,9 +3372,9 @@
           {
             "text": "Resume the sound",
             "synonyms": [
-              "Play the audio",
-              "Continue the music",
-              "Start the sound"
+              "Continue the audio",
+              "Play the sound",
+              "Unpause the audio"
             ],
             "category": "command",
             "propertyNames": [
@@ -3335,8 +3385,8 @@
             "text": "if you will",
             "synonyms": [
               "please",
-              "kindly",
-              "if possible"
+              "if you don't mind",
+              "if you could"
             ],
             "category": "politeness",
             "isOptional": true
@@ -3417,8 +3467,8 @@
             "text": "please",
             "synonyms": [
               "kindly",
-              "if you would",
-              "if you please"
+              "if you could",
+              "would you mind"
             ],
             "category": "politeness",
             "isOptional": true
@@ -3469,7 +3519,7 @@
             "substrings": [
               "Start the music up again."
             ],
-            "implied": true
+            "implied": false
           }
         ],
         "subPhrases": [
@@ -3477,8 +3527,8 @@
             "text": "Start",
             "synonyms": [
               "Begin",
-              "Initiate",
-              "Commence"
+              "Commence",
+              "Initiate"
             ],
             "category": "command",
             "propertyNames": [
@@ -3529,11 +3579,11 @@
                 ]
               },
               {
-                "propertyValue": "player.restart",
+                "propertyValue": "player.start",
                 "propertySubPhrases": [
-                  "Restart",
+                  "Begin",
                   "the music",
-                  "from the beginning"
+                  "again"
                 ]
               },
               {
@@ -3571,8 +3621,8 @@
             "text": "Unpause the tunes",
             "synonyms": [
               "Resume the music",
-              "Continue playing",
-              "Start the songs"
+              "Continue playing the songs",
+              "Start the tunes again"
             ],
             "category": "command",
             "propertyNames": [
@@ -3584,7 +3634,7 @@
             "synonyms": [
               "please",
               "if you can",
-              "if you don't mind"
+              "if possible"
             ],
             "category": "politeness",
             "isOptional": true
@@ -3644,7 +3694,7 @@
             "synonyms": [
               "Could you",
               "Can you",
-              "Would it be possible to"
+              "Would you please"
             ],
             "category": "politeness",
             "isOptional": true
@@ -3652,9 +3702,9 @@
           {
             "text": "resuming the song",
             "synonyms": [
-              "resume the song",
+              "continue the song",
               "play the song again",
-              "continue the song"
+              "restart the song"
             ],
             "category": "action",
             "propertyNames": [
@@ -3724,9 +3774,9 @@
           {
             "text": "resume the audio",
             "synonyms": [
-              "play the audio again",
               "continue the audio",
-              "restart the audio"
+              "restart the audio",
+              "play the audio again"
             ],
             "category": "action",
             "propertyNames": [
@@ -3758,12 +3808,6 @@
                 "propertyValue": "player.stop",
                 "propertySubPhrases": [
                   "stop the audio"
-                ]
-              },
-              {
-                "propertyValue": "player.rewind",
-                "propertySubPhrases": [
-                  "rewind the audio"
                 ]
               }
             ]
@@ -3804,7 +3848,7 @@
             "synonyms": [
               "continue the music",
               "resume the tracks",
-              "play the songs"
+              "keep playing the songs"
             ],
             "category": "command",
             "propertyNames": [
@@ -3829,13 +3873,13 @@
               {
                 "propertyValue": "player.continue",
                 "propertySubPhrases": [
-                  "continue the tracks"
+                  "continue the playlist"
                 ]
               },
               {
                 "propertyValue": "player.unpause",
                 "propertySubPhrases": [
-                  "unpause the tunes"
+                  "unpause the track"
                 ]
               }
             ]
@@ -3858,7 +3902,7 @@
               "press play",
               "again"
             ],
-            "implied": false
+            "implied": true
           }
         ],
         "subPhrases": [
@@ -3876,8 +3920,8 @@
             "text": "press play",
             "synonyms": [
               "start",
-              "begin",
-              "resume"
+              "resume",
+              "continue"
             ],
             "category": "command",
             "propertyNames": [
@@ -3889,7 +3933,7 @@
             "synonyms": [
               "on it",
               "on this",
-              "on the thing"
+              "on the player"
             ],
             "category": "preposition",
             "isOptional": true
@@ -3898,10 +3942,10 @@
             "text": "again",
             "synonyms": [
               "once more",
-              "another time",
-              "one more time"
+              "one more time",
+              "replay"
             ],
-            "category": "repetition",
+            "category": "command",
             "propertyNames": [
               "fullActionName"
             ]
@@ -3917,24 +3961,24 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.start",
+                "propertyValue": "player.play",
                 "propertySubPhrases": [
-                  "start playing",
-                  "again"
+                  "press play",
+                  "on that"
                 ]
               },
               {
-                "propertyValue": "player.replay",
+                "propertyValue": "player.pause",
                 "propertySubPhrases": [
-                  "replay",
-                  "again"
+                  "pause",
+                  "on that"
                 ]
               },
               {
-                "propertyValue": "player.continue",
+                "propertyValue": "player.stop",
                 "propertySubPhrases": [
-                  "continue",
-                  "again"
+                  "stop",
+                  "on that"
                 ]
               }
             ]

--- a/ts/packages/dispatcher/test/data/player/v5/searchTracks.json
+++ b/ts/packages/dispatcher/test/data/player/v5/searchTracks.json
@@ -16,9 +16,7 @@
           {
             "name": "fullActionName",
             "value": "player.searchTracks",
-            "substrings": [
-              "Find"
-            ],
+            "substrings": [],
             "implied": true
           },
           {
@@ -35,13 +33,11 @@
             "text": "Find",
             "synonyms": [
               "Search for",
-              "Look up",
+              "Look for",
               "Locate"
             ],
             "category": "action",
-            "propertyNames": [
-              "fullActionName"
-            ]
+            "propertyNames": []
           },
           {
             "text": "acoustic versions of popular songs",
@@ -58,33 +54,6 @@
         ],
         "propertyAlternatives": [
           {
-            "propertyName": "fullActionName",
-            "propertyValue": "player.searchTracks",
-            "propertySubPhrases": [
-              "Find"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "player.findTracks",
-                "propertySubPhrases": [
-                  "Find"
-                ]
-              },
-              {
-                "propertyValue": "player.lookupTracks",
-                "propertySubPhrases": [
-                  "Find"
-                ]
-              },
-              {
-                "propertyValue": "player.locateTracks",
-                "propertySubPhrases": [
-                  "Find"
-                ]
-              }
-            ]
-          },
-          {
             "propertyName": "parameters.query",
             "propertyValue": "acoustic versions of popular songs",
             "propertySubPhrases": [
@@ -92,27 +61,60 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "acoustic covers of popular songs",
+                "propertyValue": "live versions of popular songs",
                 "propertySubPhrases": [
-                  "acoustic covers of popular songs"
+                  "live versions of popular songs"
                 ]
               },
               {
-                "propertyValue": "unplugged versions of popular songs",
+                "propertyValue": "instrumental versions of popular songs",
                 "propertySubPhrases": [
-                  "unplugged versions of popular songs"
+                  "instrumental versions of popular songs"
                 ]
               },
               {
-                "propertyValue": "acoustic renditions of popular songs",
+                "propertyValue": "cover versions of popular songs",
                 "propertySubPhrases": [
-                  "acoustic renditions of popular songs"
+                  "cover versions of popular songs"
+                ]
+              },
+              {
+                "propertyValue": "remixes of popular songs",
+                "propertySubPhrases": [
+                  "remixes of popular songs"
                 ]
               }
             ]
           }
         ]
-      }
+      },
+      "corrections": [
+        {
+          "data": {
+            "properties": [
+              {
+                "name": "fullActionName",
+                "value": "player.searchTracks",
+                "substrings": [
+                  "player.searchTracks"
+                ],
+                "implied": false
+              },
+              {
+                "name": "parameters.query",
+                "value": "acoustic versions of popular songs",
+                "substrings": [
+                  "acoustic versions of popular songs"
+                ],
+                "implied": false
+              }
+            ]
+          },
+          "correction": [
+            "Substring 'player.searchTracks' for property 'fullActionName' not found in the request string. Substring must be exact copy of part of the original request and is not changed by correcting misspelling or grammar."
+          ]
+        }
+      ]
     },
     {
       "request": "Find chillout music for relaxation",
@@ -147,7 +149,7 @@
             "synonyms": [
               "Search for",
               "Look for",
-              "Get"
+              "Locate"
             ],
             "category": "command",
             "propertyNames": []
@@ -169,7 +171,7 @@
             "synonyms": [
               "relaxing music",
               "music to relax",
-              "calm music"
+              "soothing music"
             ],
             "category": "description",
             "propertyNames": []
@@ -200,6 +202,12 @@
                 "propertySubPhrases": [
                   "downtempo"
                 ]
+              },
+              {
+                "propertyValue": "new age",
+                "propertySubPhrases": [
+                  "new age"
+                ]
               }
             ]
           }
@@ -220,7 +228,7 @@
             "name": "fullActionName",
             "value": "player.searchTracks",
             "substrings": [
-              "Find"
+              "Find chillwave tracks for a laid-back evening"
             ],
             "implied": true
           },
@@ -241,7 +249,7 @@
               "Look for",
               "Locate"
             ],
-            "category": "command",
+            "category": "action",
             "propertyNames": [
               "fullActionName"
             ]
@@ -274,13 +282,13 @@
                 ]
               },
               {
-                "propertyValue": "music.searchTracks",
+                "propertyValue": "player.lookupMusic",
                 "propertySubPhrases": [
                   "Find"
                 ]
               },
               {
-                "propertyValue": "audio.searchTracks",
+                "propertyValue": "player.searchMusic",
                 "propertySubPhrases": [
                   "Find"
                 ]
@@ -295,21 +303,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "chillwave music for a relaxed night",
+                "propertyValue": "chillwave songs for a relaxing night",
                 "propertySubPhrases": [
-                  "chillwave music for a relaxed night"
+                  "chillwave songs for a relaxing night"
                 ]
               },
               {
-                "propertyValue": "chillwave songs for a calm evening",
+                "propertyValue": "chillwave music for a calm evening",
                 "propertySubPhrases": [
-                  "chillwave songs for a calm evening"
+                  "chillwave music for a calm evening"
                 ]
               },
               {
-                "propertyValue": "chillwave tunes for a peaceful night",
+                "propertyValue": "chillwave tunes for a peaceful evening",
                 "propertySubPhrases": [
-                  "chillwave tunes for a peaceful night"
+                  "chillwave tunes for a peaceful evening"
                 ]
               }
             ]
@@ -330,9 +338,7 @@
           {
             "name": "fullActionName",
             "value": "player.searchTracks",
-            "substrings": [
-              "Find duets by Elton John and Kiki Dee"
-            ],
+            "substrings": [],
             "implied": true
           },
           {
@@ -352,10 +358,8 @@
               "Look for",
               "Locate"
             ],
-            "category": "action",
-            "propertyNames": [
-              "fullActionName"
-            ]
+            "category": "command",
+            "propertyNames": []
           },
           {
             "text": "duets by Elton John and Kiki Dee",
@@ -363,6 +367,123 @@
               "songs by Elton John and Kiki Dee",
               "tracks by Elton John and Kiki Dee",
               "music by Elton John and Kiki Dee"
+            ],
+            "category": "query",
+            "propertyNames": [
+              "parameters.query"
+            ]
+          }
+        ],
+        "propertyAlternatives": [
+          {
+            "propertyName": "parameters.query",
+            "propertyValue": "duets by Elton John and Kiki Dee",
+            "propertySubPhrases": [
+              "duets by Elton John and Kiki Dee"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "duets by Elton John",
+                "propertySubPhrases": [
+                  "duets by Elton John"
+                ]
+              },
+              {
+                "propertyValue": "duets by Kiki Dee",
+                "propertySubPhrases": [
+                  "duets by Kiki Dee"
+                ]
+              },
+              {
+                "propertyValue": "songs by Elton John and Kiki Dee",
+                "propertySubPhrases": [
+                  "songs by Elton John and Kiki Dee"
+                ]
+              },
+              {
+                "propertyValue": "collaborations by Elton John and Kiki Dee",
+                "propertySubPhrases": [
+                  "collaborations by Elton John and Kiki Dee"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "corrections": [
+        {
+          "data": {
+            "properties": [
+              {
+                "name": "fullActionName",
+                "value": "player.searchTracks",
+                "substrings": [
+                  "player.searchTracks"
+                ],
+                "implied": false
+              },
+              {
+                "name": "parameters.query",
+                "value": "duets by Elton John and Kiki Dee",
+                "substrings": [
+                  "duets by Elton John and Kiki Dee"
+                ],
+                "implied": false
+              }
+            ]
+          },
+          "correction": [
+            "Substring 'player.searchTracks' for property 'fullActionName' not found in the request string. Substring must be exact copy of part of the original request and is not changed by correcting misspelling or grammar."
+          ]
+        }
+      ]
+    },
+    {
+      "request": "Find electronic dance music hits",
+      "action": {
+        "fullActionName": "player.searchTracks",
+        "parameters": {
+          "query": "electronic dance music hits"
+        }
+      },
+      "explanation": {
+        "properties": [
+          {
+            "name": "fullActionName",
+            "value": "player.searchTracks",
+            "substrings": [
+              "Find electronic dance music hits"
+            ],
+            "implied": true
+          },
+          {
+            "name": "parameters.query",
+            "value": "electronic dance music hits",
+            "substrings": [
+              "electronic dance music hits"
+            ],
+            "implied": false
+          }
+        ],
+        "subPhrases": [
+          {
+            "text": "Find",
+            "synonyms": [
+              "Search for",
+              "Look for",
+              "Locate"
+            ],
+            "category": "command",
+            "propertyNames": [
+              "fullActionName"
+            ]
+          },
+          {
+            "text": "electronic dance music hits",
+            "synonyms": [
+              "EDM hits",
+              "electronic dance tracks",
+              "dance music hits"
             ],
             "category": "query",
             "propertyNames": [
@@ -400,103 +521,11 @@
           },
           {
             "propertyName": "parameters.query",
-            "propertyValue": "duets by Elton John and Kiki Dee",
-            "propertySubPhrases": [
-              "duets by Elton John and Kiki Dee"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "songs by Elton John and Kiki Dee",
-                "propertySubPhrases": [
-                  "songs by Elton John and Kiki Dee"
-                ]
-              },
-              {
-                "propertyValue": "tracks by Elton John and Kiki Dee",
-                "propertySubPhrases": [
-                  "tracks by Elton John and Kiki Dee"
-                ]
-              },
-              {
-                "propertyValue": "music by Elton John and Kiki Dee",
-                "propertySubPhrases": [
-                  "music by Elton John and Kiki Dee"
-                ]
-              }
-            ]
-          }
-        ]
-      }
-    },
-    {
-      "request": "Find electronic dance music hits",
-      "action": {
-        "fullActionName": "player.searchTracks",
-        "parameters": {
-          "query": "electronic dance music hits"
-        }
-      },
-      "explanation": {
-        "properties": [
-          {
-            "name": "fullActionName",
-            "value": "player.searchTracks",
-            "substrings": [],
-            "implied": true
-          },
-          {
-            "name": "parameters.query",
-            "value": "electronic dance music hits",
-            "substrings": [
-              "electronic dance music hits"
-            ],
-            "implied": false
-          }
-        ],
-        "subPhrases": [
-          {
-            "text": "Find",
-            "synonyms": [
-              "Search for",
-              "Look up",
-              "Locate"
-            ],
-            "category": "command",
-            "isOptional": false
-          },
-          {
-            "text": "electronic dance music hits",
-            "synonyms": [
-              "EDM hits",
-              "electronic dance hits",
-              "dance music hits"
-            ],
-            "category": "music genre",
-            "propertyNames": [
-              "parameters.query"
-            ]
-          }
-        ],
-        "propertyAlternatives": [
-          {
-            "propertyName": "parameters.query",
             "propertyValue": "electronic dance music hits",
             "propertySubPhrases": [
               "electronic dance music hits"
             ],
             "alternatives": [
-              {
-                "propertyValue": "electronic dance music",
-                "propertySubPhrases": [
-                  "electronic dance music"
-                ]
-              },
-              {
-                "propertyValue": "dance music hits",
-                "propertySubPhrases": [
-                  "dance music hits"
-                ]
-              },
               {
                 "propertyValue": "EDM hits",
                 "propertySubPhrases": [
@@ -504,9 +533,15 @@
                 ]
               },
               {
-                "propertyValue": "electronic hits",
+                "propertyValue": "electronic music top tracks",
                 "propertySubPhrases": [
-                  "electronic hits"
+                  "electronic music top tracks"
+                ]
+              },
+              {
+                "propertyValue": "best electronic dance songs",
+                "propertySubPhrases": [
+                  "best electronic dance songs"
                 ]
               }
             ]
@@ -559,9 +594,7 @@
               "Locate"
             ],
             "category": "command",
-            "propertyNames": [
-              "fullActionName"
-            ]
+            "isOptional": false
           },
           {
             "text": "Hotel California",
@@ -590,33 +623,6 @@
         ],
         "propertyAlternatives": [
           {
-            "propertyName": "fullActionName",
-            "propertyValue": "player.playTrack",
-            "propertySubPhrases": [
-              "Find"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "player.searchTrack",
-                "propertySubPhrases": [
-                  "Search"
-                ]
-              },
-              {
-                "propertyValue": "player.locateTrack",
-                "propertySubPhrases": [
-                  "Locate"
-                ]
-              },
-              {
-                "propertyValue": "player.findTrack",
-                "propertySubPhrases": [
-                  "Look for"
-                ]
-              }
-            ]
-          },
-          {
             "propertyName": "parameters.trackName",
             "propertyValue": "Hotel California",
             "propertySubPhrases": [
@@ -624,15 +630,15 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "Stairway to Heaven",
-                "propertySubPhrases": [
-                  "Stairway to Heaven"
-                ]
-              },
-              {
                 "propertyValue": "Bohemian Rhapsody",
                 "propertySubPhrases": [
                   "Bohemian Rhapsody"
+                ]
+              },
+              {
+                "propertyValue": "Stairway to Heaven",
+                "propertySubPhrases": [
+                  "Stairway to Heaven"
                 ]
               },
               {
@@ -651,15 +657,15 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "Led Zeppelin",
-                "propertySubPhrases": [
-                  "by Led Zeppelin"
-                ]
-              },
-              {
                 "propertyValue": "Queen",
                 "propertySubPhrases": [
                   "by Queen"
+                ]
+              },
+              {
+                "propertyValue": "Led Zeppelin",
+                "propertySubPhrases": [
+                  "by Led Zeppelin"
                 ]
               },
               {
@@ -687,7 +693,7 @@
             "name": "fullActionName",
             "value": "player.searchTracks",
             "substrings": [
-              "Find"
+              "Find K-pop hits like Dynamite by BTS"
             ],
             "implied": true
           },
@@ -816,7 +822,7 @@
             "text": "Find",
             "synonyms": [
               "Search for",
-              "Look for",
+              "Look up",
               "Locate"
             ],
             "category": "action",
@@ -908,9 +914,7 @@
           {
             "name": "fullActionName",
             "value": "player.searchTracks",
-            "substrings": [
-              "Find me some jazz tunes from the 60s"
-            ],
+            "substrings": [],
             "implied": true
           },
           {
@@ -934,23 +938,13 @@
             "propertyNames": []
           },
           {
-            "text": "some",
+            "text": "some jazz tunes from the 60s",
             "synonyms": [
-              "a few",
-              "several",
-              "a number of"
+              "jazz music from the 60s",
+              "jazz songs from the 60s",
+              "60s jazz tracks"
             ],
-            "category": "quantifier",
-            "propertyNames": []
-          },
-          {
-            "text": "jazz tunes from the 60s",
-            "synonyms": [
-              "60s jazz music",
-              "jazz songs from the 1960s",
-              "1960s jazz tracks"
-            ],
-            "category": "music query",
+            "category": "query",
             "propertyNames": [
               "parameters.query"
             ]
@@ -961,37 +955,64 @@
             "propertyName": "parameters.query",
             "propertyValue": "jazz tunes from the 60s",
             "propertySubPhrases": [
-              "jazz tunes from the 60s"
+              "some jazz tunes from the 60s"
             ],
             "alternatives": [
               {
+                "propertyValue": "jazz tunes from the 70s",
+                "propertySubPhrases": [
+                  "some jazz tunes from the 70s"
+                ]
+              },
+              {
                 "propertyValue": "blues tunes from the 60s",
                 "propertySubPhrases": [
-                  "blues tunes from the 60s"
+                  "some blues tunes from the 60s"
                 ]
               },
               {
                 "propertyValue": "rock tunes from the 60s",
                 "propertySubPhrases": [
-                  "rock tunes from the 60s"
+                  "some rock tunes from the 60s"
                 ]
               },
               {
-                "propertyValue": "jazz tunes from the 70s",
+                "propertyValue": "jazz albums from the 60s",
                 "propertySubPhrases": [
-                  "jazz tunes from the 70s"
-                ]
-              },
-              {
-                "propertyValue": "jazz tunes from the 50s",
-                "propertySubPhrases": [
-                  "jazz tunes from the 50s"
+                  "some jazz albums from the 60s"
                 ]
               }
             ]
           }
         ]
-      }
+      },
+      "corrections": [
+        {
+          "data": {
+            "properties": [
+              {
+                "name": "fullActionName",
+                "value": "player.searchTracks",
+                "substrings": [
+                  "player.searchTracks"
+                ],
+                "implied": false
+              },
+              {
+                "name": "parameters.query",
+                "value": "jazz tunes from the 60s",
+                "substrings": [
+                  "jazz tunes from the 60s"
+                ],
+                "implied": false
+              }
+            ]
+          },
+          "correction": [
+            "Substring 'player.searchTracks' for property 'fullActionName' not found in the request string. Substring must be exact copy of part of the original request and is not changed by correcting misspelling or grammar."
+          ]
+        }
+      ]
     },
     {
       "request": "Find music by legendary guitarist Jimi Hendrix",
@@ -1007,7 +1028,7 @@
             "name": "fullActionName",
             "value": "player.playArtist",
             "substrings": [
-              "Find music"
+              "Find music by"
             ],
             "implied": true
           },
@@ -1022,11 +1043,11 @@
         ],
         "subPhrases": [
           {
-            "text": "Find music",
+            "text": "Find music by",
             "synonyms": [
-              "Play music",
-              "Search for music",
-              "Get music"
+              "Search for songs by",
+              "Look for music by",
+              "Play music by"
             ],
             "category": "command",
             "propertyNames": [
@@ -1034,21 +1055,11 @@
             ]
           },
           {
-            "text": "by",
-            "synonyms": [
-              "from",
-              "of",
-              "featuring"
-            ],
-            "category": "preposition",
-            "isOptional": true
-          },
-          {
             "text": "legendary guitarist",
             "synonyms": [
               "famous guitarist",
-              "iconic guitarist",
-              "renowned guitarist"
+              "renowned guitarist",
+              "iconic guitarist"
             ],
             "category": "descriptor",
             "isOptional": true
@@ -1056,8 +1067,8 @@
           {
             "text": "Jimi Hendrix",
             "synonyms": [
+              "Jimi Hendrix",
               "Hendrix",
-              "Jimi",
               "James Marshall Hendrix"
             ],
             "category": "artist",
@@ -1071,25 +1082,25 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.playArtist",
             "propertySubPhrases": [
-              "Find music"
+              "Find music by"
             ],
             "alternatives": [
               {
-                "propertyValue": "player.playSong",
+                "propertyValue": "player.searchArtist",
                 "propertySubPhrases": [
-                  "Play song"
+                  "Search for music by"
                 ]
               },
               {
-                "propertyValue": "player.playAlbum",
+                "propertyValue": "player.queueArtist",
                 "propertySubPhrases": [
-                  "Play album"
+                  "Queue music by"
                 ]
               },
               {
-                "propertyValue": "player.playPlaylist",
+                "propertyValue": "player.browseArtist",
                 "propertySubPhrases": [
-                  "Play playlist"
+                  "Browse music by"
                 ]
               }
             ]
@@ -1137,9 +1148,7 @@
           {
             "name": "fullActionName",
             "value": "player.searchTracks",
-            "substrings": [
-              "Find music"
-            ],
+            "substrings": [],
             "implied": true
           },
           {
@@ -1147,125 +1156,6 @@
             "value": "upcoming artists",
             "substrings": [
               "upcoming artists"
-            ],
-            "implied": false
-          }
-        ],
-        "subPhrases": [
-          {
-            "text": "Find music",
-            "synonyms": [
-              "Search for music",
-              "Look for music",
-              "Discover music"
-            ],
-            "category": "action",
-            "propertyNames": [
-              "fullActionName"
-            ]
-          },
-          {
-            "text": "by",
-            "synonyms": [
-              "from",
-              "featuring",
-              "with"
-            ],
-            "category": "preposition",
-            "isOptional": true
-          },
-          {
-            "text": "upcoming artists",
-            "synonyms": [
-              "new artists",
-              "emerging artists",
-              "rising artists"
-            ],
-            "category": "query",
-            "propertyNames": [
-              "parameters.query"
-            ]
-          }
-        ],
-        "propertyAlternatives": [
-          {
-            "propertyName": "fullActionName",
-            "propertyValue": "player.searchTracks",
-            "propertySubPhrases": [
-              "Find music"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "player.playTracks",
-                "propertySubPhrases": [
-                  "Play music"
-                ]
-              },
-              {
-                "propertyValue": "player.browseTracks",
-                "propertySubPhrases": [
-                  "Browse music"
-                ]
-              },
-              {
-                "propertyValue": "player.recommendTracks",
-                "propertySubPhrases": [
-                  "Recommend music"
-                ]
-              }
-            ]
-          },
-          {
-            "propertyName": "parameters.query",
-            "propertyValue": "upcoming artists",
-            "propertySubPhrases": [
-              "upcoming artists"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "popular artists",
-                "propertySubPhrases": [
-                  "popular artists"
-                ]
-              },
-              {
-                "propertyValue": "new releases",
-                "propertySubPhrases": [
-                  "new releases"
-                ]
-              },
-              {
-                "propertyValue": "top charts",
-                "propertySubPhrases": [
-                  "top charts"
-                ]
-              }
-            ]
-          }
-        ]
-      }
-    },
-    {
-      "request": "Find music for a beach party",
-      "action": {
-        "fullActionName": "player.searchTracks",
-        "parameters": {
-          "query": "beach party"
-        }
-      },
-      "explanation": {
-        "properties": [
-          {
-            "name": "fullActionName",
-            "value": "player.searchTracks",
-            "substrings": [],
-            "implied": true
-          },
-          {
-            "name": "parameters.query",
-            "value": "beach party",
-            "substrings": [
-              "beach party"
             ],
             "implied": false
           }
@@ -1282,21 +1172,21 @@
             "propertyNames": []
           },
           {
-            "text": "music for a",
+            "text": "music by",
             "synonyms": [
-              "songs for a",
-              "tracks for a",
-              "tunes for a"
+              "songs by",
+              "tracks by",
+              "tunes by"
             ],
-            "category": "context",
+            "category": "preposition",
             "propertyNames": []
           },
           {
-            "text": "beach party",
+            "text": "upcoming artists",
             "synonyms": [
-              "beach gathering",
-              "seaside party",
-              "beach bash"
+              "new artists",
+              "emerging artists",
+              "rising artists"
             ],
             "category": "query",
             "propertyNames": [
@@ -1307,25 +1197,179 @@
         "propertyAlternatives": [
           {
             "propertyName": "parameters.query",
-            "propertyValue": "beach party",
+            "propertyValue": "upcoming artists",
+            "propertySubPhrases": [
+              "upcoming artists"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "new artists",
+                "propertySubPhrases": [
+                  "new artists"
+                ]
+              },
+              {
+                "propertyValue": "emerging artists",
+                "propertySubPhrases": [
+                  "emerging artists"
+                ]
+              },
+              {
+                "propertyValue": "rising stars",
+                "propertySubPhrases": [
+                  "rising stars"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "corrections": [
+        {
+          "data": {
+            "properties": [
+              {
+                "name": "fullActionName",
+                "value": "player.searchTracks",
+                "substrings": [
+                  "player.searchTracks"
+                ],
+                "implied": false
+              },
+              {
+                "name": "parameters.query",
+                "value": "upcoming artists",
+                "substrings": [
+                  "upcoming artists"
+                ],
+                "implied": false
+              }
+            ]
+          },
+          "correction": [
+            "Substring 'player.searchTracks' for property 'fullActionName' not found in the request string. Substring must be exact copy of part of the original request and is not changed by correcting misspelling or grammar."
+          ]
+        }
+      ]
+    },
+    {
+      "request": "Find music for a beach party",
+      "action": {
+        "fullActionName": "player.searchTracks",
+        "parameters": {
+          "query": "beach party music"
+        }
+      },
+      "explanation": {
+        "properties": [
+          {
+            "name": "fullActionName",
+            "value": "player.searchTracks",
+            "substrings": [
+              "Find music for a beach party"
+            ],
+            "implied": true
+          },
+          {
+            "name": "parameters.query",
+            "value": "beach party music",
+            "substrings": [
+              "beach party"
+            ],
+            "implied": true
+          }
+        ],
+        "subPhrases": [
+          {
+            "text": "Find",
+            "synonyms": [
+              "Search for",
+              "Look for",
+              "Get"
+            ],
+            "category": "action",
+            "propertyNames": [
+              "fullActionName"
+            ]
+          },
+          {
+            "text": "music for a",
+            "synonyms": [
+              "songs for a",
+              "tunes for a",
+              "tracks for a"
+            ],
+            "category": "context",
+            "propertyNames": [
+              "fullActionName"
+            ]
+          },
+          {
+            "text": "beach party",
+            "synonyms": [
+              "beach gathering",
+              "seaside party",
+              "coastal party"
+            ],
+            "category": "query",
+            "propertyNames": [
+              "parameters.query"
+            ]
+          }
+        ],
+        "propertyAlternatives": [
+          {
+            "propertyName": "fullActionName",
+            "propertyValue": "player.searchTracks",
+            "propertySubPhrases": [
+              "Find",
+              "music for a"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "player.playTracks",
+                "propertySubPhrases": [
+                  "Play",
+                  "music for a"
+                ]
+              },
+              {
+                "propertyValue": "player.queueTracks",
+                "propertySubPhrases": [
+                  "Queue",
+                  "music for a"
+                ]
+              },
+              {
+                "propertyValue": "player.recommendTracks",
+                "propertySubPhrases": [
+                  "Recommend",
+                  "music for a"
+                ]
+              }
+            ]
+          },
+          {
+            "propertyName": "parameters.query",
+            "propertyValue": "beach party music",
             "propertySubPhrases": [
               "beach party"
             ],
             "alternatives": [
               {
-                "propertyValue": "pool party",
-                "propertySubPhrases": [
-                  "pool party"
-                ]
-              },
-              {
-                "propertyValue": "summer party",
+                "propertyValue": "summer party music",
                 "propertySubPhrases": [
                   "summer party"
                 ]
               },
               {
-                "propertyValue": "tropical party",
+                "propertyValue": "pool party music",
+                "propertySubPhrases": [
+                  "pool party"
+                ]
+              },
+              {
+                "propertyValue": "tropical party music",
                 "propertySubPhrases": [
                   "tropical party"
                 ]
@@ -1349,7 +1393,7 @@
             "name": "fullActionName",
             "value": "player.searchTracks",
             "substrings": [
-              "Find music"
+              "Find music from the Baroque period"
             ],
             "implied": true
           },
@@ -1364,13 +1408,25 @@
         ],
         "subPhrases": [
           {
-            "text": "Find music",
+            "text": "Find",
             "synonyms": [
-              "Search for music",
-              "Look for music",
-              "Locate music"
+              "Search for",
+              "Look for",
+              "Locate"
             ],
-            "category": "command",
+            "category": "action",
+            "propertyNames": [
+              "fullActionName"
+            ]
+          },
+          {
+            "text": "music",
+            "synonyms": [
+              "songs",
+              "tracks",
+              "tunes"
+            ],
+            "category": "object",
             "propertyNames": [
               "fullActionName"
             ]
@@ -1379,8 +1435,8 @@
             "text": "from the",
             "synonyms": [
               "of the",
-              "in the",
-              "during the"
+              "belonging to the",
+              "originating from the"
             ],
             "category": "preposition",
             "isOptional": true
@@ -1389,8 +1445,8 @@
             "text": "Baroque period",
             "synonyms": [
               "Baroque era",
-              "Baroque time",
-              "Baroque age"
+              "Baroque age",
+              "Baroque time"
             ],
             "category": "time period",
             "propertyNames": [
@@ -1403,25 +1459,29 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.searchTracks",
             "propertySubPhrases": [
-              "Find music"
+              "Find",
+              "music"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.playTracks",
                 "propertySubPhrases": [
-                  "Play music"
+                  "Play",
+                  "music"
                 ]
               },
               {
-                "propertyValue": "player.queueTracks",
+                "propertyValue": "player.pauseTracks",
                 "propertySubPhrases": [
-                  "Queue music"
+                  "Pause",
+                  "music"
                 ]
               },
               {
-                "propertyValue": "player.browseTracks",
+                "propertyValue": "player.stopTracks",
                 "propertySubPhrases": [
-                  "Browse music"
+                  "Stop",
+                  "music"
                 ]
               }
             ]
@@ -1469,16 +1529,18 @@
           {
             "name": "fullActionName",
             "value": "player.searchTracks",
-            "substrings": [],
+            "substrings": [
+              "Find music to play at a wedding reception"
+            ],
             "implied": true
           },
           {
             "name": "parameters.query",
             "value": "wedding reception music",
             "substrings": [
-              "Find music to play at a wedding reception"
+              "wedding reception"
             ],
-            "implied": false
+            "implied": true
           }
         ],
         "subPhrases": [
@@ -1490,14 +1552,28 @@
               "Locate"
             ],
             "category": "action",
-            "propertyNames": []
+            "propertyNames": [
+              "fullActionName"
+            ]
           },
           {
-            "text": "music to play at a wedding reception",
+            "text": "music to play",
             "synonyms": [
-              "songs for a wedding reception",
-              "tracks for a wedding reception",
-              "wedding reception tunes"
+              "songs to play",
+              "tracks to play",
+              "tunes to play"
+            ],
+            "category": "query",
+            "propertyNames": [
+              "parameters.query"
+            ]
+          },
+          {
+            "text": "at a wedding reception",
+            "synonyms": [
+              "for a wedding reception",
+              "during a wedding reception",
+              "for a wedding party"
             ],
             "category": "query",
             "propertyNames": [
@@ -1507,34 +1583,59 @@
         ],
         "propertyAlternatives": [
           {
-            "propertyName": "parameters.query",
-            "propertyValue": "wedding reception music",
+            "propertyName": "fullActionName",
+            "propertyValue": "player.searchTracks",
             "propertySubPhrases": [
-              "music to play at a wedding reception"
+              "Find"
             ],
             "alternatives": [
               {
-                "propertyValue": "wedding party music",
+                "propertyValue": "player.findSongs",
                 "propertySubPhrases": [
-                  "music to play at a wedding party"
+                  "Find"
                 ]
               },
               {
-                "propertyValue": "wedding dance music",
+                "propertyValue": "player.lookupMusic",
                 "propertySubPhrases": [
-                  "music to play for a wedding dance"
+                  "Find"
                 ]
               },
               {
-                "propertyValue": "wedding celebration music",
+                "propertyValue": "player.browseTracks",
                 "propertySubPhrases": [
-                  "music to play for a wedding celebration"
+                  "Find"
+                ]
+              }
+            ]
+          },
+          {
+            "propertyName": "parameters.query",
+            "propertyValue": "wedding reception music",
+            "propertySubPhrases": [
+              "music to play",
+              "at a wedding reception"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "wedding party songs",
+                "propertySubPhrases": [
+                  "music to play",
+                  "at a wedding reception"
                 ]
               },
               {
-                "propertyValue": "reception party music",
+                "propertyValue": "reception playlist",
                 "propertySubPhrases": [
-                  "music to play at a reception party"
+                  "music to play",
+                  "at a wedding reception"
+                ]
+              },
+              {
+                "propertyValue": "wedding dance tracks",
+                "propertySubPhrases": [
+                  "music to play",
+                  "at a wedding reception"
                 ]
               }
             ]
@@ -1555,8 +1656,10 @@
           {
             "name": "fullActionName",
             "value": "player.searchTracks",
-            "substrings": [],
-            "implied": true
+            "substrings": [
+              "Find punk rock songs by The Ramones"
+            ],
+            "implied": false
           },
           {
             "name": "parameters.query",
@@ -1577,7 +1680,9 @@
               "Locate"
             ],
             "category": "command",
-            "isOptional": true
+            "propertyNames": [
+              "fullActionName"
+            ]
           },
           {
             "text": "punk rock",
@@ -1592,13 +1697,25 @@
             ]
           },
           {
-            "text": "songs by",
+            "text": "songs",
             "synonyms": [
-              "tracks by",
-              "music by",
-              "songs from"
+              "tracks",
+              "tunes",
+              "music"
             ],
-            "category": "music reference",
+            "category": "music type",
+            "propertyNames": [
+              "fullActionName"
+            ]
+          },
+          {
+            "text": "by",
+            "synonyms": [
+              "from",
+              "performed by",
+              "created by"
+            ],
+            "category": "preposition",
             "isOptional": true
           },
           {
@@ -1616,6 +1733,37 @@
         ],
         "propertyAlternatives": [
           {
+            "propertyName": "fullActionName",
+            "propertyValue": "player.searchTracks",
+            "propertySubPhrases": [
+              "Find",
+              "songs"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "player.searchAlbums",
+                "propertySubPhrases": [
+                  "Find",
+                  "albums"
+                ]
+              },
+              {
+                "propertyValue": "player.searchArtists",
+                "propertySubPhrases": [
+                  "Find",
+                  "artists"
+                ]
+              },
+              {
+                "propertyValue": "player.searchPlaylists",
+                "propertySubPhrases": [
+                  "Find",
+                  "playlists"
+                ]
+              }
+            ]
+          },
+          {
             "propertyName": "parameters.query",
             "propertyValue": "punk rock The Ramones",
             "propertySubPhrases": [
@@ -1624,17 +1772,10 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "punk rock The Clash",
+                "propertyValue": "classic rock The Ramones",
                 "propertySubPhrases": [
-                  "punk rock",
-                  "The Clash"
-                ]
-              },
-              {
-                "propertyValue": "punk rock Sex Pistols",
-                "propertySubPhrases": [
-                  "punk rock",
-                  "Sex Pistols"
+                  "classic rock",
+                  "The Ramones"
                 ]
               },
               {
@@ -1642,6 +1783,13 @@
                 "propertySubPhrases": [
                   "punk rock",
                   "Green Day"
+                ]
+              },
+              {
+                "propertyValue": "alternative rock The Ramones",
+                "propertySubPhrases": [
+                  "alternative rock",
+                  "The Ramones"
                 ]
               }
             ]
@@ -1678,11 +1826,11 @@
           {
             "text": "Find",
             "synonyms": [
-              "Search",
+              "Search for",
               "Look for",
               "Locate"
             ],
-            "category": "command",
+            "category": "action",
             "propertyNames": []
           },
           {
@@ -1698,8 +1846,8 @@
           {
             "text": "road trip",
             "synonyms": [
-              "travel",
               "journey",
+              "travel",
               "drive"
             ],
             "category": "query",
@@ -1710,9 +1858,9 @@
           {
             "text": "playlist",
             "synonyms": [
-              "collection",
-              "list",
-              "set"
+              "music list",
+              "song list",
+              "track list"
             ],
             "category": "context",
             "propertyNames": []
@@ -1739,9 +1887,9 @@
                 ]
               },
               {
-                "propertyValue": "relaxing evening",
+                "propertyValue": "relaxing",
                 "propertySubPhrases": [
-                  "relaxing evening"
+                  "relaxing"
                 ]
               }
             ]
@@ -1780,8 +1928,8 @@
           {
             "text": "Find songs",
             "synonyms": [
-              "Search for music",
-              "Look for tracks",
+              "Search for songs",
+              "Look for songs",
               "Get songs"
             ],
             "category": "action",
@@ -1793,8 +1941,8 @@
             "text": "for a",
             "synonyms": [
               "for an",
-              "for the purpose of",
-              "intended for"
+              "for the",
+              "for"
             ],
             "category": "preposition",
             "isOptional": true
@@ -1833,9 +1981,9 @@
                 ]
               },
               {
-                "propertyValue": "player.recommendTracks",
+                "propertyValue": "player.browseTracks",
                 "propertySubPhrases": [
-                  "Recommend songs"
+                  "Browse songs"
                 ]
               }
             ]
@@ -1905,7 +2053,7 @@
               "Look for songs",
               "Get songs"
             ],
-            "category": "action",
+            "category": "command",
             "propertyNames": [
               "fullActionName"
             ]
@@ -1915,7 +2063,7 @@
             "synonyms": [
               "of the",
               "in the",
-              "belonging to the"
+              "on the"
             ],
             "category": "preposition",
             "isOptional": true
@@ -2004,9 +2152,7 @@
           {
             "name": "fullActionName",
             "value": "player.searchTracks",
-            "substrings": [
-              "Find songs that feature a saxophone"
-            ],
+            "substrings": [],
             "implied": true
           },
           {
@@ -2026,10 +2172,8 @@
               "Look for",
               "Locate"
             ],
-            "category": "action",
-            "propertyNames": [
-              "fullActionName"
-            ]
+            "category": "command",
+            "propertyNames": []
           },
           {
             "text": "songs that feature a saxophone",
@@ -2045,33 +2189,6 @@
           }
         ],
         "propertyAlternatives": [
-          {
-            "propertyName": "fullActionName",
-            "propertyValue": "player.searchTracks",
-            "propertySubPhrases": [
-              "Find"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "player.findSongs",
-                "propertySubPhrases": [
-                  "Find"
-                ]
-              },
-              {
-                "propertyValue": "music.searchTracks",
-                "propertySubPhrases": [
-                  "Find"
-                ]
-              },
-              {
-                "propertyValue": "audio.searchTracks",
-                "propertySubPhrases": [
-                  "Find"
-                ]
-              }
-            ]
-          },
           {
             "propertyName": "parameters.query",
             "propertyValue": "songs that feature a saxophone",
@@ -2096,11 +2213,44 @@
                 "propertySubPhrases": [
                   "music with saxophone"
                 ]
+              },
+              {
+                "propertyValue": "songs that include saxophone",
+                "propertySubPhrases": [
+                  "songs that include saxophone"
+                ]
               }
             ]
           }
         ]
-      }
+      },
+      "corrections": [
+        {
+          "data": {
+            "properties": [
+              {
+                "name": "fullActionName",
+                "value": "player.searchTracks",
+                "substrings": [
+                  "player.searchTracks"
+                ],
+                "implied": false
+              },
+              {
+                "name": "parameters.query",
+                "value": "songs that feature a saxophone",
+                "substrings": [
+                  "songs that feature a saxophone"
+                ],
+                "implied": false
+              }
+            ]
+          },
+          "correction": [
+            "Substring 'player.searchTracks' for property 'fullActionName' not found in the request string. Substring must be exact copy of part of the original request and is not changed by correcting misspelling or grammar."
+          ]
+        }
+      ]
     },
     {
       "request": "Find songs to belt out in the car",
@@ -2115,9 +2265,7 @@
           {
             "name": "fullActionName",
             "value": "player.searchTracks",
-            "substrings": [
-              "Find songs to belt out in the car"
-            ],
+            "substrings": [],
             "implied": true
           },
           {
@@ -2135,19 +2283,17 @@
             "synonyms": [
               "Search for",
               "Look for",
-              "Locate"
+              "Get"
             ],
-            "category": "action",
-            "propertyNames": [
-              "fullActionName"
-            ]
+            "category": "command",
+            "isOptional": true
           },
           {
             "text": "songs to belt out in the car",
             "synonyms": [
-              "tracks to sing loudly in the car",
-              "music to sing along to in the car",
-              "tunes to enjoy in the car"
+              "songs to sing loudly in the car",
+              "songs to enjoy in the car",
+              "songs to play in the car"
             ],
             "category": "query",
             "propertyNames": [
@@ -2157,33 +2303,6 @@
         ],
         "propertyAlternatives": [
           {
-            "propertyName": "fullActionName",
-            "propertyValue": "player.searchTracks",
-            "propertySubPhrases": [
-              "Find"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "player.playTracks",
-                "propertySubPhrases": [
-                  "Play"
-                ]
-              },
-              {
-                "propertyValue": "player.queueTracks",
-                "propertySubPhrases": [
-                  "Queue"
-                ]
-              },
-              {
-                "propertyValue": "player.addTracks",
-                "propertySubPhrases": [
-                  "Add"
-                ]
-              }
-            ]
-          },
-          {
             "propertyName": "parameters.query",
             "propertyValue": "songs to belt out in the car",
             "propertySubPhrases": [
@@ -2191,27 +2310,54 @@
             ],
             "alternatives": [
               {
+                "propertyValue": "songs to sing along to in the car",
+                "propertySubPhrases": [
+                  "songs to sing along to in the car"
+                ]
+              },
+              {
                 "propertyValue": "road trip anthems",
                 "propertySubPhrases": [
                   "road trip anthems"
                 ]
               },
               {
-                "propertyValue": "sing-along hits",
+                "propertyValue": "car karaoke hits",
                 "propertySubPhrases": [
-                  "sing-along hits"
-                ]
-              },
-              {
-                "propertyValue": "car karaoke",
-                "propertySubPhrases": [
-                  "car karaoke"
+                  "car karaoke hits"
                 ]
               }
             ]
           }
         ]
-      }
+      },
+      "corrections": [
+        {
+          "data": {
+            "properties": [
+              {
+                "name": "fullActionName",
+                "value": "player.searchTracks",
+                "substrings": [
+                  "player.searchTracks"
+                ],
+                "implied": false
+              },
+              {
+                "name": "parameters.query",
+                "value": "songs to belt out in the car",
+                "substrings": [
+                  "songs to belt out in the car"
+                ],
+                "implied": false
+              }
+            ]
+          },
+          "correction": [
+            "Substring 'player.searchTracks' for property 'fullActionName' not found in the request string. Substring must be exact copy of part of the original request and is not changed by correcting misspelling or grammar."
+          ]
+        }
+      ]
     },
     {
       "request": "Find songs to boost your mood",
@@ -2226,9 +2372,7 @@
           {
             "name": "fullActionName",
             "value": "player.searchTracks",
-            "substrings": [
-              "Find songs to boost your mood"
-            ],
+            "substrings": [],
             "implied": true
           },
           {
@@ -2248,10 +2392,8 @@
               "Look for",
               "Locate"
             ],
-            "category": "action",
-            "propertyNames": [
-              "fullActionName"
-            ]
+            "category": "command",
+            "isOptional": true
           },
           {
             "text": "songs to boost your mood",
@@ -2259,6 +2401,374 @@
               "music to lift your spirits",
               "tracks to make you happy",
               "tunes to improve your mood"
+            ],
+            "category": "query",
+            "propertyNames": [
+              "parameters.query"
+            ]
+          }
+        ],
+        "propertyAlternatives": [
+          {
+            "propertyName": "parameters.query",
+            "propertyValue": "songs to boost your mood",
+            "propertySubPhrases": [
+              "songs to boost your mood"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "happy songs",
+                "propertySubPhrases": [
+                  "happy songs"
+                ]
+              },
+              {
+                "propertyValue": "uplifting music",
+                "propertySubPhrases": [
+                  "uplifting music"
+                ]
+              },
+              {
+                "propertyValue": "feel-good tracks",
+                "propertySubPhrases": [
+                  "feel-good tracks"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "corrections": [
+        {
+          "data": {
+            "properties": [
+              {
+                "name": "fullActionName",
+                "value": "player.searchTracks",
+                "substrings": [
+                  "player.searchTracks"
+                ],
+                "implied": false
+              },
+              {
+                "name": "parameters.query",
+                "value": "songs to boost your mood",
+                "substrings": [
+                  "songs to boost your mood"
+                ],
+                "implied": false
+              }
+            ]
+          },
+          "correction": [
+            "Substring 'player.searchTracks' for property 'fullActionName' not found in the request string. Substring must be exact copy of part of the original request and is not changed by correcting misspelling or grammar."
+          ]
+        }
+      ]
+    },
+    {
+      "request": "Find songs to sing in the shower",
+      "action": {
+        "fullActionName": "player.searchTracks",
+        "parameters": {
+          "query": "songs to sing in the shower"
+        }
+      },
+      "explanation": {
+        "properties": [
+          {
+            "name": "fullActionName",
+            "value": "player.searchTracks",
+            "substrings": [],
+            "implied": true
+          },
+          {
+            "name": "parameters.query",
+            "value": "songs to sing in the shower",
+            "substrings": [
+              "songs to sing in the shower"
+            ],
+            "implied": false
+          }
+        ],
+        "subPhrases": [
+          {
+            "text": "Find",
+            "synonyms": [
+              "Search for",
+              "Look for",
+              "Locate"
+            ],
+            "category": "command",
+            "isOptional": true
+          },
+          {
+            "text": "songs to sing in the shower",
+            "synonyms": [
+              "music to sing in the shower",
+              "tracks to sing in the shower",
+              "tunes to sing in the shower"
+            ],
+            "category": "query",
+            "propertyNames": [
+              "parameters.query"
+            ]
+          }
+        ],
+        "propertyAlternatives": [
+          {
+            "propertyName": "parameters.query",
+            "propertyValue": "songs to sing in the shower",
+            "propertySubPhrases": [
+              "songs to sing in the shower"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "songs to sing while cooking",
+                "propertySubPhrases": [
+                  "songs to sing while cooking"
+                ]
+              },
+              {
+                "propertyValue": "songs to sing on a road trip",
+                "propertySubPhrases": [
+                  "songs to sing on a road trip"
+                ]
+              },
+              {
+                "propertyValue": "songs to sing at a party",
+                "propertySubPhrases": [
+                  "songs to sing at a party"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "corrections": [
+        {
+          "data": {
+            "properties": [
+              {
+                "name": "fullActionName",
+                "value": "player.searchTracks",
+                "substrings": [
+                  "player.searchTracks"
+                ],
+                "implied": false
+              },
+              {
+                "name": "parameters.query",
+                "value": "songs to sing in the shower",
+                "substrings": [
+                  "songs to sing in the shower"
+                ],
+                "implied": false
+              }
+            ]
+          },
+          "correction": [
+            "Substring 'player.searchTracks' for property 'fullActionName' not found in the request string. Substring must be exact copy of part of the original request and is not changed by correcting misspelling or grammar."
+          ]
+        }
+      ]
+    },
+    {
+      "request": "Find songs with the word love in the title",
+      "action": {
+        "fullActionName": "player.filterTracks",
+        "parameters": {
+          "filterType": "name",
+          "filterValue": "love"
+        }
+      },
+      "explanation": {
+        "properties": [
+          {
+            "name": "fullActionName",
+            "value": "player.filterTracks",
+            "substrings": [
+              "Find songs with the word love in the title"
+            ],
+            "implied": true
+          },
+          {
+            "name": "parameters.filterType",
+            "value": "name",
+            "substrings": [
+              "title"
+            ],
+            "implied": true
+          },
+          {
+            "name": "parameters.filterValue",
+            "value": "love",
+            "substrings": [
+              "love"
+            ],
+            "implied": false
+          }
+        ],
+        "subPhrases": [
+          {
+            "text": "Find",
+            "synonyms": [
+              "Search for",
+              "Look for",
+              "Locate"
+            ],
+            "category": "command",
+            "isOptional": false
+          },
+          {
+            "text": "songs",
+            "synonyms": [
+              "tracks",
+              "music",
+              "tunes"
+            ],
+            "category": "object",
+            "isOptional": false
+          },
+          {
+            "text": "with the word",
+            "synonyms": [
+              "containing the word",
+              "that have the word",
+              "including the word"
+            ],
+            "category": "preposition",
+            "isOptional": true
+          },
+          {
+            "text": "love",
+            "synonyms": [
+              "affection",
+              "romance",
+              "adoration"
+            ],
+            "category": "filterValue",
+            "propertyNames": [
+              "parameters.filterValue"
+            ]
+          },
+          {
+            "text": "in the title",
+            "synonyms": [
+              "in the name",
+              "in the heading",
+              "in the caption"
+            ],
+            "category": "filterType",
+            "propertyNames": [
+              "parameters.filterType"
+            ]
+          }
+        ],
+        "propertyAlternatives": [
+          {
+            "propertyName": "parameters.filterValue",
+            "propertyValue": "love",
+            "propertySubPhrases": [
+              "love"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "heart",
+                "propertySubPhrases": [
+                  "heart"
+                ]
+              },
+              {
+                "propertyValue": "life",
+                "propertySubPhrases": [
+                  "life"
+                ]
+              },
+              {
+                "propertyValue": "dream",
+                "propertySubPhrases": [
+                  "dream"
+                ]
+              }
+            ]
+          },
+          {
+            "propertyName": "parameters.filterType",
+            "propertyValue": "name",
+            "propertySubPhrases": [
+              "in the title"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "lyrics",
+                "propertySubPhrases": [
+                  "in the lyrics"
+                ]
+              },
+              {
+                "propertyValue": "artist",
+                "propertySubPhrases": [
+                  "by the artist"
+                ]
+              },
+              {
+                "propertyValue": "album",
+                "propertySubPhrases": [
+                  "in the album"
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "request": "Find the best of 90s R&B",
+      "action": {
+        "fullActionName": "player.searchTracks",
+        "parameters": {
+          "query": "best of 90s R&B"
+        }
+      },
+      "explanation": {
+        "properties": [
+          {
+            "name": "fullActionName",
+            "value": "player.searchTracks",
+            "substrings": [
+              "Find the best of 90s R&B"
+            ],
+            "implied": true
+          },
+          {
+            "name": "parameters.query",
+            "value": "best of 90s R&B",
+            "substrings": [
+              "best of 90s R&B"
+            ],
+            "implied": false
+          }
+        ],
+        "subPhrases": [
+          {
+            "text": "Find",
+            "synonyms": [
+              "Search for",
+              "Look for",
+              "Locate"
+            ],
+            "category": "command",
+            "propertyNames": [
+              "fullActionName"
+            ]
+          },
+          {
+            "text": "the best of 90s R&B",
+            "synonyms": [
+              "top 90s R&B",
+              "greatest 90s R&B",
+              "90s R&B hits"
             ],
             "category": "query",
             "propertyNames": [
@@ -2296,27 +2806,27 @@
           },
           {
             "propertyName": "parameters.query",
-            "propertyValue": "songs to boost your mood",
+            "propertyValue": "best of 90s R&B",
             "propertySubPhrases": [
-              "songs to boost your mood"
+              "the best of 90s R&B"
             ],
             "alternatives": [
               {
-                "propertyValue": "happy songs",
+                "propertyValue": "top 90s R&B hits",
                 "propertySubPhrases": [
-                  "happy songs"
+                  "the best of 90s R&B"
                 ]
               },
               {
-                "propertyValue": "uplifting music",
+                "propertyValue": "90s R&B classics",
                 "propertySubPhrases": [
-                  "uplifting music"
+                  "the best of 90s R&B"
                 ]
               },
               {
-                "propertyValue": "feel-good tracks",
+                "propertyValue": "greatest 90s R&B songs",
                 "propertySubPhrases": [
-                  "feel-good tracks"
+                  "the best of 90s R&B"
                 ]
               }
             ]
@@ -2325,11 +2835,11 @@
       }
     },
     {
-      "request": "Find songs to sing in the shower",
+      "request": "Find the best of country rock",
       "action": {
         "fullActionName": "player.searchTracks",
         "parameters": {
-          "query": "songs to sing in the shower"
+          "query": "best of country rock"
         }
       },
       "explanation": {
@@ -2337,14 +2847,16 @@
           {
             "name": "fullActionName",
             "value": "player.searchTracks",
-            "substrings": [],
+            "substrings": [
+              "Find the best of country rock"
+            ],
             "implied": true
           },
           {
             "name": "parameters.query",
-            "value": "songs to sing in the shower",
+            "value": "best of country rock",
             "substrings": [
-              "songs to sing in the shower"
+              "best of country rock"
             ],
             "implied": false
           }
@@ -2355,260 +2867,19 @@
             "synonyms": [
               "Search for",
               "Look for",
-              "Get"
-            ],
-            "category": "command",
-            "propertyNames": []
-          },
-          {
-            "text": "songs to sing in the shower",
-            "synonyms": [
-              "music for showering",
-              "tunes for the shower",
-              "shower songs"
-            ],
-            "category": "query",
-            "propertyNames": [
-              "parameters.query"
-            ]
-          }
-        ],
-        "propertyAlternatives": [
-          {
-            "propertyName": "parameters.query",
-            "propertyValue": "songs to sing in the shower",
-            "propertySubPhrases": [
-              "songs to sing in the shower"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "songs to sing while cooking",
-                "propertySubPhrases": [
-                  "songs to sing while cooking"
-                ]
-              },
-              {
-                "propertyValue": "songs to sing on a road trip",
-                "propertySubPhrases": [
-                  "songs to sing on a road trip"
-                ]
-              },
-              {
-                "propertyValue": "songs to sing at a party",
-                "propertySubPhrases": [
-                  "songs to sing at a party"
-                ]
-              }
-            ]
-          }
-        ]
-      }
-    },
-    {
-      "request": "Find songs with the word love in the title",
-      "action": {
-        "fullActionName": "player.filterTracks",
-        "parameters": {
-          "filterType": "name",
-          "filterValue": "love"
-        }
-      },
-      "explanation": {
-        "properties": [
-          {
-            "name": "fullActionName",
-            "value": "player.filterTracks",
-            "substrings": [
-              "Find songs"
-            ],
-            "implied": true
-          },
-          {
-            "name": "parameters.filterType",
-            "value": "name",
-            "substrings": [
-              "in the title"
-            ],
-            "implied": true
-          },
-          {
-            "name": "parameters.filterValue",
-            "value": "love",
-            "substrings": [
-              "the word love"
-            ],
-            "implied": false
-          }
-        ],
-        "subPhrases": [
-          {
-            "text": "Find songs",
-            "synonyms": [
-              "Search for songs",
-              "Look for tracks",
-              "Get songs"
-            ],
-            "category": "action",
-            "propertyNames": [
-              "fullActionName"
-            ]
-          },
-          {
-            "text": "with the word love",
-            "synonyms": [
-              "containing the word love",
-              "that have the word love",
-              "which include the word love"
-            ],
-            "category": "filter",
-            "propertyNames": [
-              "parameters.filterValue"
-            ]
-          },
-          {
-            "text": "in the title",
-            "synonyms": [
-              "in their titles",
-              "within the title",
-              "in the song title"
-            ],
-            "category": "filter",
-            "propertyNames": [
-              "parameters.filterType"
-            ]
-          }
-        ],
-        "propertyAlternatives": [
-          {
-            "propertyName": "fullActionName",
-            "propertyValue": "player.filterTracks",
-            "propertySubPhrases": [
-              "Find songs"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "player.searchTracks",
-                "propertySubPhrases": [
-                  "Search for songs"
-                ]
-              },
-              {
-                "propertyValue": "player.browseTracks",
-                "propertySubPhrases": [
-                  "Browse songs"
-                ]
-              },
-              {
-                "propertyValue": "player.listTracks",
-                "propertySubPhrases": [
-                  "List songs"
-                ]
-              }
-            ]
-          },
-          {
-            "propertyName": "parameters.filterValue",
-            "propertyValue": "love",
-            "propertySubPhrases": [
-              "with the word love"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "happy",
-                "propertySubPhrases": [
-                  "with the word happy"
-                ]
-              },
-              {
-                "propertyValue": "sad",
-                "propertySubPhrases": [
-                  "with the word sad"
-                ]
-              },
-              {
-                "propertyValue": "dance",
-                "propertySubPhrases": [
-                  "with the word dance"
-                ]
-              }
-            ]
-          },
-          {
-            "propertyName": "parameters.filterType",
-            "propertyValue": "name",
-            "propertySubPhrases": [
-              "in the title"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "artist",
-                "propertySubPhrases": [
-                  "by the artist"
-                ]
-              },
-              {
-                "propertyValue": "album",
-                "propertySubPhrases": [
-                  "in the album"
-                ]
-              },
-              {
-                "propertyValue": "genre",
-                "propertySubPhrases": [
-                  "in the genre"
-                ]
-              }
-            ]
-          }
-        ]
-      }
-    },
-    {
-      "request": "Find the best of 90s R&B",
-      "action": {
-        "fullActionName": "player.searchTracks",
-        "parameters": {
-          "query": "best of 90s R&B"
-        }
-      },
-      "explanation": {
-        "properties": [
-          {
-            "name": "fullActionName",
-            "value": "player.searchTracks",
-            "substrings": [
-              "Find"
-            ],
-            "implied": true
-          },
-          {
-            "name": "parameters.query",
-            "value": "best of 90s R&B",
-            "substrings": [
-              "best of 90s R&B"
-            ],
-            "implied": false
-          }
-        ],
-        "subPhrases": [
-          {
-            "text": "Find",
-            "synonyms": [
-              "Search for",
-              "Look up",
               "Locate"
             ],
-            "category": "action",
+            "category": "command",
             "propertyNames": [
               "fullActionName"
             ]
           },
           {
-            "text": "the best of 90s R&B",
+            "text": "the best of country rock",
             "synonyms": [
-              "top 90s R&B",
-              "greatest 90s R&B hits",
-              "90s R&B classics"
+              "top country rock",
+              "greatest country rock",
+              "finest country rock"
             ],
             "category": "query",
             "propertyNames": [
@@ -2646,118 +2917,27 @@
           },
           {
             "propertyName": "parameters.query",
-            "propertyValue": "best of 90s R&B",
-            "propertySubPhrases": [
-              "the best of 90s R&B"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "90s R&B hits",
-                "propertySubPhrases": [
-                  "90s R&B hits"
-                ]
-              },
-              {
-                "propertyValue": "top 90s R&B",
-                "propertySubPhrases": [
-                  "top 90s R&B"
-                ]
-              },
-              {
-                "propertyValue": "classic 90s R&B",
-                "propertySubPhrases": [
-                  "classic 90s R&B"
-                ]
-              }
-            ]
-          }
-        ]
-      }
-    },
-    {
-      "request": "Find the best of country rock",
-      "action": {
-        "fullActionName": "player.searchTracks",
-        "parameters": {
-          "query": "best of country rock"
-        }
-      },
-      "explanation": {
-        "properties": [
-          {
-            "name": "fullActionName",
-            "value": "player.searchTracks",
-            "substrings": [],
-            "implied": true
-          },
-          {
-            "name": "parameters.query",
-            "value": "best of country rock",
-            "substrings": [
-              "best of country rock"
-            ],
-            "implied": false
-          }
-        ],
-        "subPhrases": [
-          {
-            "text": "Find",
-            "synonyms": [
-              "Search for",
-              "Look for",
-              "Locate"
-            ],
-            "category": "command",
-            "propertyNames": []
-          },
-          {
-            "text": "the",
-            "synonyms": [
-              "a",
-              "an",
-              "some"
-            ],
-            "category": "article",
-            "isOptional": true,
-            "propertyNames": []
-          },
-          {
-            "text": "best of country rock",
-            "synonyms": [
-              "top country rock",
-              "greatest country rock",
-              "finest country rock"
-            ],
-            "category": "music genre",
-            "propertyNames": [
-              "parameters.query"
-            ]
-          }
-        ],
-        "propertyAlternatives": [
-          {
-            "propertyName": "parameters.query",
             "propertyValue": "best of country rock",
             "propertySubPhrases": [
-              "best of country rock"
+              "the best of country rock"
             ],
             "alternatives": [
               {
                 "propertyValue": "top country rock hits",
                 "propertySubPhrases": [
-                  "top country rock hits"
+                  "the top country rock hits"
                 ]
               },
               {
                 "propertyValue": "greatest country rock songs",
                 "propertySubPhrases": [
-                  "greatest country rock songs"
+                  "the greatest country rock songs"
                 ]
               },
               {
                 "propertyValue": "country rock classics",
                 "propertySubPhrases": [
-                  "country rock classics"
+                  "the country rock classics"
                 ]
               }
             ]
@@ -2778,7 +2958,9 @@
           {
             "name": "fullActionName",
             "value": "player.searchTracks",
-            "substrings": [],
+            "substrings": [
+              "Find the best of electronic trance music"
+            ],
             "implied": true
           },
           {
@@ -2798,8 +2980,10 @@
               "Look for",
               "Locate"
             ],
-            "category": "command",
-            "propertyNames": []
+            "category": "action",
+            "propertyNames": [
+              "fullActionName"
+            ]
           },
           {
             "text": "the best of electronic trance music",
@@ -2816,6 +3000,33 @@
         ],
         "propertyAlternatives": [
           {
+            "propertyName": "fullActionName",
+            "propertyValue": "player.searchTracks",
+            "propertySubPhrases": [
+              "Find"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "player.findSongs",
+                "propertySubPhrases": [
+                  "Find"
+                ]
+              },
+              {
+                "propertyValue": "player.lookupTracks",
+                "propertySubPhrases": [
+                  "Find"
+                ]
+              },
+              {
+                "propertyValue": "player.locateMusic",
+                "propertySubPhrases": [
+                  "Find"
+                ]
+              }
+            ]
+          },
+          {
             "propertyName": "parameters.query",
             "propertyValue": "best of electronic trance music",
             "propertySubPhrases": [
@@ -2823,21 +3034,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "top electronic trance tracks",
+                "propertyValue": "top electronic trance music",
                 "propertySubPhrases": [
-                  "the top electronic trance tracks"
+                  "the best of electronic trance music"
                 ]
               },
               {
-                "propertyValue": "greatest electronic trance hits",
+                "propertyValue": "greatest electronic trance music",
                 "propertySubPhrases": [
-                  "the greatest electronic trance hits"
+                  "the best of electronic trance music"
                 ]
               },
               {
-                "propertyValue": "popular electronic trance songs",
+                "propertyValue": "finest electronic trance music",
                 "propertySubPhrases": [
-                  "the popular electronic trance songs"
+                  "the best of electronic trance music"
                 ]
               }
             ]
@@ -2875,21 +3086,21 @@
             "text": "Find",
             "synonyms": [
               "Search for",
-              "Look for",
+              "Look up",
               "Locate"
             ],
             "category": "command",
-            "isOptional": true
+            "propertyNames": []
           },
           {
             "text": "the",
             "synonyms": [
               "a",
-              "some",
-              "any"
+              "an",
+              "some"
             ],
             "category": "article",
-            "isOptional": true
+            "propertyNames": []
           },
           {
             "text": "best of reggaeton",
@@ -2898,7 +3109,7 @@
               "greatest reggaeton hits",
               "popular reggaeton"
             ],
-            "category": "music genre",
+            "category": "query",
             "propertyNames": [
               "parameters.query"
             ]
@@ -2948,7 +3159,9 @@
           {
             "name": "fullActionName",
             "value": "player.searchTracks",
-            "substrings": [],
+            "substrings": [
+              "Find the best of synth-pop"
+            ],
             "implied": true
           },
           {
@@ -2968,25 +3181,17 @@
               "Look for",
               "Locate"
             ],
-            "category": "action",
-            "propertyNames": []
+            "category": "command",
+            "propertyNames": [
+              "fullActionName"
+            ]
           },
           {
-            "text": "the",
+            "text": "the best of synth-pop",
             "synonyms": [
-              "a",
-              "some",
-              "any"
-            ],
-            "category": "article",
-            "propertyNames": []
-          },
-          {
-            "text": "best of synth-pop",
-            "synonyms": [
-              "top synth-pop",
-              "greatest synth-pop",
-              "finest synth-pop"
+              "top synth-pop tracks",
+              "greatest synth-pop hits",
+              "best synth-pop songs"
             ],
             "category": "query",
             "propertyNames": [
@@ -2996,28 +3201,55 @@
         ],
         "propertyAlternatives": [
           {
+            "propertyName": "fullActionName",
+            "propertyValue": "player.searchTracks",
+            "propertySubPhrases": [
+              "Find"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "player.findSongs",
+                "propertySubPhrases": [
+                  "Find"
+                ]
+              },
+              {
+                "propertyValue": "player.lookupTracks",
+                "propertySubPhrases": [
+                  "Find"
+                ]
+              },
+              {
+                "propertyValue": "player.searchMusic",
+                "propertySubPhrases": [
+                  "Find"
+                ]
+              }
+            ]
+          },
+          {
             "propertyName": "parameters.query",
             "propertyValue": "best of synth-pop",
             "propertySubPhrases": [
-              "best of synth-pop"
+              "the best of synth-pop"
             ],
             "alternatives": [
               {
                 "propertyValue": "top synth-pop hits",
                 "propertySubPhrases": [
-                  "top synth-pop hits"
+                  "the best of synth-pop"
                 ]
               },
               {
                 "propertyValue": "greatest synth-pop songs",
                 "propertySubPhrases": [
-                  "greatest synth-pop songs"
+                  "the best of synth-pop"
                 ]
               },
               {
                 "propertyValue": "synth-pop classics",
                 "propertySubPhrases": [
-                  "synth-pop classics"
+                  "the best of synth-pop"
                 ]
               }
             ]
@@ -3068,9 +3300,9 @@
           {
             "text": "the greatest hits of the 80s",
             "synonyms": [
-              "80s greatest hits",
-              "top hits of the 80s",
-              "best songs of the 80s"
+              "the best songs of the 80s",
+              "top tracks from the 80s",
+              "hit songs from the 1980s"
             ],
             "category": "query",
             "propertyNames": [
@@ -3149,9 +3381,7 @@
           {
             "name": "fullActionName",
             "value": "player.searchTracks",
-            "substrings": [
-              "Find the most iconic guitar solos"
-            ],
+            "substrings": [],
             "implied": true
           },
           {
@@ -3172,16 +3402,24 @@
               "Locate"
             ],
             "category": "command",
-            "propertyNames": [
-              "fullActionName"
-            ]
+            "isOptional": true
           },
           {
-            "text": "the most iconic guitar solos",
+            "text": "the",
             "synonyms": [
-              "the greatest guitar solos",
-              "the best guitar solos",
-              "the top guitar solos"
+              "a",
+              "some",
+              "any"
+            ],
+            "category": "article",
+            "isOptional": true
+          },
+          {
+            "text": "most iconic guitar solos",
+            "synonyms": [
+              "top guitar solos",
+              "famous guitar solos",
+              "legendary guitar solos"
             ],
             "category": "query",
             "propertyNames": [
@@ -3191,61 +3429,61 @@
         ],
         "propertyAlternatives": [
           {
-            "propertyName": "fullActionName",
-            "propertyValue": "player.searchTracks",
-            "propertySubPhrases": [
-              "Find"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "player.searchAlbums",
-                "propertySubPhrases": [
-                  "Find albums"
-                ]
-              },
-              {
-                "propertyValue": "player.searchArtists",
-                "propertySubPhrases": [
-                  "Find artists"
-                ]
-              },
-              {
-                "propertyValue": "player.searchPlaylists",
-                "propertySubPhrases": [
-                  "Find playlists"
-                ]
-              }
-            ]
-          },
-          {
             "propertyName": "parameters.query",
             "propertyValue": "most iconic guitar solos",
             "propertySubPhrases": [
-              "the most iconic guitar solos"
+              "most iconic guitar solos"
             ],
             "alternatives": [
               {
-                "propertyValue": "greatest rock guitar solos",
+                "propertyValue": "best guitar solos of all time",
                 "propertySubPhrases": [
-                  "the greatest rock guitar solos"
+                  "best guitar solos of all time"
                 ]
               },
               {
-                "propertyValue": "legendary guitar solos",
+                "propertyValue": "greatest guitar solos ever",
                 "propertySubPhrases": [
-                  "the legendary guitar solos"
+                  "greatest guitar solos ever"
                 ]
               },
               {
-                "propertyValue": "top guitar solos of all time",
+                "propertyValue": "top legendary guitar solos",
                 "propertySubPhrases": [
-                  "the top guitar solos of all time"
+                  "top legendary guitar solos"
                 ]
               }
             ]
           }
         ]
-      }
+      },
+      "corrections": [
+        {
+          "data": {
+            "properties": [
+              {
+                "name": "fullActionName",
+                "value": "player.searchTracks",
+                "substrings": [
+                  "player.searchTracks"
+                ],
+                "implied": false
+              },
+              {
+                "name": "parameters.query",
+                "value": "most iconic guitar solos",
+                "substrings": [
+                  "most iconic guitar solos"
+                ],
+                "implied": false
+              }
+            ]
+          },
+          "correction": [
+            "Substring 'player.searchTracks' for property 'fullActionName' not found in the request string. Substring must be exact copy of part of the original request and is not changed by correcting misspelling or grammar."
+          ]
+        }
+      ]
     },
     {
       "request": "Find the most relaxing songs ever",
@@ -3356,7 +3594,34 @@
             ]
           }
         ]
-      }
+      },
+      "corrections": [
+        {
+          "data": {
+            "properties": [
+              {
+                "name": "fullActionName",
+                "value": "player.searchTracks",
+                "substrings": [
+                  "player.searchTracks"
+                ],
+                "implied": false
+              },
+              {
+                "name": "parameters.query",
+                "value": "most relaxing songs ever",
+                "substrings": [
+                  "most relaxing songs ever"
+                ],
+                "implied": false
+              }
+            ]
+          },
+          "correction": [
+            "Substring 'player.searchTracks' for property 'fullActionName' not found in the request string. Substring must be exact copy of part of the original request and is not changed by correcting misspelling or grammar."
+          ]
+        }
+      ]
     },
     {
       "request": "Find the top 10 viral songs on TikTok",
@@ -3371,16 +3636,14 @@
           {
             "name": "fullActionName",
             "value": "player.searchTracks",
-            "substrings": [
-              "Find the top 10 viral songs on TikTok"
-            ],
-            "implied": false
+            "substrings": [],
+            "implied": true
           },
           {
             "name": "parameters.query",
             "value": "top 10 viral songs on TikTok",
             "substrings": [
-              "top 10 viral songs on TikTok"
+              "Find the top 10 viral songs on TikTok"
             ],
             "implied": false
           }
@@ -3390,13 +3653,11 @@
             "text": "Find",
             "synonyms": [
               "Search for",
-              "Look for",
-              "Locate"
+              "Look up",
+              "Get"
             ],
             "category": "action",
-            "propertyNames": [
-              "fullActionName"
-            ]
+            "propertyNames": []
           },
           {
             "text": "the top 10 viral songs on TikTok",
@@ -3412,33 +3673,6 @@
           }
         ],
         "propertyAlternatives": [
-          {
-            "propertyName": "fullActionName",
-            "propertyValue": "player.searchTracks",
-            "propertySubPhrases": [
-              "Find"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "player.findTracks",
-                "propertySubPhrases": [
-                  "Locate"
-                ]
-              },
-              {
-                "propertyValue": "player.lookupTracks",
-                "propertySubPhrases": [
-                  "Search"
-                ]
-              },
-              {
-                "propertyValue": "player.getTracks",
-                "propertySubPhrases": [
-                  "Get"
-                ]
-              }
-            ]
-          },
           {
             "propertyName": "parameters.query",
             "propertyValue": "top 10 viral songs on TikTok",
@@ -3463,11 +3697,44 @@
                 "propertySubPhrases": [
                   "the top 10 hit songs on TikTok"
                 ]
+              },
+              {
+                "propertyValue": "top 10 songs on TikTok",
+                "propertySubPhrases": [
+                  "the top 10 songs on TikTok"
+                ]
               }
             ]
           }
         ]
-      }
+      },
+      "corrections": [
+        {
+          "data": {
+            "properties": [
+              {
+                "name": "fullActionName",
+                "value": "player.searchTracks",
+                "substrings": [
+                  "player.searchTracks"
+                ],
+                "implied": false
+              },
+              {
+                "name": "parameters.query",
+                "value": "top 10 viral songs on TikTok",
+                "substrings": [
+                  "top 10 viral songs on TikTok"
+                ],
+                "implied": false
+              }
+            ]
+          },
+          "correction": [
+            "Substring 'player.searchTracks' for property 'fullActionName' not found in the request string. Substring must be exact copy of part of the original request and is not changed by correcting misspelling or grammar."
+          ]
+        }
+      ]
     },
     {
       "request": "Find top hits from the 2000s",
@@ -3485,7 +3752,7 @@
             "substrings": [
               "Find top hits from the 2000s"
             ],
-            "implied": true
+            "implied": false
           },
           {
             "name": "parameters.query",
@@ -3504,7 +3771,7 @@
               "Look for",
               "Locate"
             ],
-            "category": "action",
+            "category": "command",
             "propertyNames": [
               "fullActionName"
             ]
@@ -3531,21 +3798,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.playTracks",
+                "propertyValue": "player.findSongs",
                 "propertySubPhrases": [
-                  "Play"
+                  "Find"
                 ]
               },
               {
-                "propertyValue": "player.queueTracks",
+                "propertyValue": "music.searchTracks",
                 "propertySubPhrases": [
-                  "Queue"
+                  "Find"
                 ]
               },
               {
-                "propertyValue": "player.browseTracks",
+                "propertyValue": "audio.searchTracks",
                 "propertySubPhrases": [
-                  "Browse"
+                  "Find"
                 ]
               }
             ]
@@ -3558,21 +3825,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "top hits from the 90s",
+                "propertyValue": "best songs of the 2000s",
                 "propertySubPhrases": [
-                  "top hits from the 90s"
+                  "best songs of the 2000s"
                 ]
               },
               {
-                "propertyValue": "top hits from the 2010s",
+                "propertyValue": "popular tracks from the 2000s",
                 "propertySubPhrases": [
-                  "top hits from the 2010s"
+                  "popular tracks from the 2000s"
                 ]
               },
               {
-                "propertyValue": "top rock hits from the 2000s",
+                "propertyValue": "greatest hits of the 2000s",
                 "propertySubPhrases": [
-                  "top rock hits from the 2000s"
+                  "greatest hits of the 2000s"
                 ]
               }
             ]
@@ -3594,7 +3861,7 @@
             "name": "fullActionName",
             "value": "player.searchTracks",
             "substrings": [
-              "Find tracks featuring"
+              "Find tracks featuring Ariana Grande"
             ],
             "implied": false
           },
@@ -3609,16 +3876,26 @@
         ],
         "subPhrases": [
           {
-            "text": "Find tracks featuring",
+            "text": "Find tracks",
             "synonyms": [
-              "Search for songs with",
-              "Look for tracks that include",
-              "Find music featuring"
+              "Search for songs",
+              "Look for tracks",
+              "Find music"
             ],
             "category": "action",
             "propertyNames": [
               "fullActionName"
             ]
+          },
+          {
+            "text": "featuring",
+            "synonyms": [
+              "with",
+              "including",
+              "starring"
+            ],
+            "category": "preposition",
+            "isOptional": true
           },
           {
             "text": "Ariana Grande",
@@ -3627,7 +3904,7 @@
               "A. Grande",
               "Ariana"
             ],
-            "category": "query",
+            "category": "artist",
             "propertyNames": [
               "parameters.query"
             ]
@@ -3638,25 +3915,25 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.searchTracks",
             "propertySubPhrases": [
-              "Find tracks featuring"
+              "Find tracks"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.findSongs",
                 "propertySubPhrases": [
-                  "Search for songs by"
+                  "Find songs"
                 ]
               },
               {
-                "propertyValue": "music.lookupTracks",
+                "propertyValue": "player.lookupTracks",
                 "propertySubPhrases": [
-                  "Look up tracks with"
+                  "Look up tracks"
                 ]
               },
               {
-                "propertyValue": "audio.findTracks",
+                "propertyValue": "player.searchMusic",
                 "propertySubPhrases": [
-                  "Locate tracks featuring"
+                  "Search music"
                 ]
               }
             ]
@@ -3707,9 +3984,7 @@
           {
             "name": "fullActionName",
             "value": "player.playAlbum",
-            "substrings": [
-              "Find tracks from the album"
-            ],
+            "substrings": [],
             "implied": true
           },
           {
@@ -3734,13 +4009,11 @@
             "text": "Find tracks from the album",
             "synonyms": [
               "Play songs from the album",
-              "Get tracks from the album",
-              "Stream songs from the album"
+              "Stream tracks from the album",
+              "Get songs from the album"
             ],
             "category": "action",
-            "propertyNames": [
-              "fullActionName"
-            ]
+            "propertyNames": []
           },
           {
             "text": "Rumours",
@@ -3769,33 +4042,6 @@
         ],
         "propertyAlternatives": [
           {
-            "propertyName": "fullActionName",
-            "propertyValue": "player.playAlbum",
-            "propertySubPhrases": [
-              "Find tracks from the album"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "player.queueAlbum",
-                "propertySubPhrases": [
-                  "Queue tracks from the album"
-                ]
-              },
-              {
-                "propertyValue": "player.addAlbumToPlaylist",
-                "propertySubPhrases": [
-                  "Add tracks from the album"
-                ]
-              },
-              {
-                "propertyValue": "player.shuffleAlbum",
-                "propertySubPhrases": [
-                  "Shuffle tracks from the album"
-                ]
-              }
-            ]
-          },
-          {
             "propertyName": "parameters.albumName",
             "propertyValue": "Rumours",
             "propertySubPhrases": [
@@ -3803,21 +4049,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "The Dark Side of the Moon",
+                "propertyValue": "Tusk",
                 "propertySubPhrases": [
-                  "The Dark Side of the Moon"
+                  "Tusk"
                 ]
               },
               {
-                "propertyValue": "Abbey Road",
+                "propertyValue": "Mirage",
                 "propertySubPhrases": [
-                  "Abbey Road"
+                  "Mirage"
                 ]
               },
               {
-                "propertyValue": "Hotel California",
+                "propertyValue": "Tango in the Night",
                 "propertySubPhrases": [
-                  "Hotel California"
+                  "Tango in the Night"
                 ]
               }
             ]
@@ -3830,21 +4076,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "Pink Floyd",
-                "propertySubPhrases": [
-                  "by Pink Floyd"
-                ]
-              },
-              {
                 "propertyValue": "The Beatles",
                 "propertySubPhrases": [
                   "by The Beatles"
                 ]
               },
               {
-                "propertyValue": "Eagles",
+                "propertyValue": "Led Zeppelin",
                 "propertySubPhrases": [
-                  "by Eagles"
+                  "by Led Zeppelin"
+                ]
+              },
+              {
+                "propertyValue": "Pink Floyd",
+                "propertySubPhrases": [
+                  "by Pink Floyd"
                 ]
               }
             ]
@@ -3883,17 +4129,17 @@
             "synonyms": [
               "Search for",
               "Find",
-              "Seek out"
+              "Locate"
             ],
             "category": "command",
-            "propertyNames": []
+            "isOptional": true
           },
           {
             "text": "90s grunge bands like Nirvana",
             "synonyms": [
+              "90s grunge music similar to Nirvana",
               "90s grunge artists such as Nirvana",
-              "90s grunge groups like Nirvana",
-              "90s grunge musicians like Nirvana"
+              "90s grunge groups like Nirvana"
             ],
             "category": "query",
             "propertyNames": [
@@ -3930,7 +4176,34 @@
             ]
           }
         ]
-      }
+      },
+      "corrections": [
+        {
+          "data": {
+            "properties": [
+              {
+                "name": "fullActionName",
+                "value": "player.searchTracks",
+                "substrings": [
+                  "player.searchTracks"
+                ],
+                "implied": false
+              },
+              {
+                "name": "parameters.query",
+                "value": "90s grunge bands like Nirvana",
+                "substrings": [
+                  "90s grunge bands like Nirvana"
+                ],
+                "implied": false
+              }
+            ]
+          },
+          "correction": [
+            "Substring 'player.searchTracks' for property 'fullActionName' not found in the request string. Substring must be exact copy of part of the original request and is not changed by correcting misspelling or grammar."
+          ]
+        }
+      ]
     },
     {
       "request": "Look for Africa by Toto",
@@ -3945,9 +4218,7 @@
           {
             "name": "fullActionName",
             "value": "player.searchTracks",
-            "substrings": [
-              "Look for"
-            ],
+            "substrings": [],
             "implied": true
           },
           {
@@ -3968,16 +4239,14 @@
               "Locate"
             ],
             "category": "command",
-            "propertyNames": [
-              "fullActionName"
-            ]
+            "propertyNames": []
           },
           {
             "text": "Africa by Toto",
             "synonyms": [
               "Africa by Toto",
               "Toto's Africa",
-              "Song Africa by Toto"
+              "the song Africa by Toto"
             ],
             "category": "query",
             "propertyNames": [
@@ -3986,33 +4255,6 @@
           }
         ],
         "propertyAlternatives": [
-          {
-            "propertyName": "fullActionName",
-            "propertyValue": "player.searchTracks",
-            "propertySubPhrases": [
-              "Look for"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "player.findSongs",
-                "propertySubPhrases": [
-                  "Find"
-                ]
-              },
-              {
-                "propertyValue": "player.lookupTracks",
-                "propertySubPhrases": [
-                  "Lookup"
-                ]
-              },
-              {
-                "propertyValue": "player.searchMusic",
-                "propertySubPhrases": [
-                  "Search for"
-                ]
-              }
-            ]
-          },
           {
             "propertyName": "parameters.query",
             "propertyValue": "Africa by Toto",
@@ -4087,8 +4329,8 @@
             "text": "All I Want for Christmas Is You by Mariah Carey",
             "synonyms": [
               "All I Want for Christmas Is You by Mariah Carey",
-              "Mariah Carey's All I Want for Christmas Is You",
-              "The song All I Want for Christmas Is You by Mariah Carey"
+              "All I Want for Christmas Is You by Mariah Carey",
+              "All I Want for Christmas Is You by Mariah Carey"
             ],
             "category": "query",
             "propertyNames": [
@@ -4167,7 +4409,9 @@
           {
             "name": "fullActionName",
             "value": "player.searchTracks",
-            "substrings": [],
+            "substrings": [
+              "Look for"
+            ],
             "implied": true
           },
           {
@@ -4188,14 +4432,16 @@
               "Locate"
             ],
             "category": "command",
-            "isOptional": true
+            "propertyNames": [
+              "fullActionName"
+            ]
           },
           {
             "text": "Billie Jean by Michael Jackson",
             "synonyms": [
               "Billie Jean by MJ",
               "Billie Jean by the King of Pop",
-              "Billie Jean by M. Jackson"
+              "Billie Jean by Michael J."
             ],
             "category": "query",
             "propertyNames": [
@@ -4204,6 +4450,33 @@
           }
         ],
         "propertyAlternatives": [
+          {
+            "propertyName": "fullActionName",
+            "propertyValue": "player.searchTracks",
+            "propertySubPhrases": [
+              "Look for"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "player.findSongs",
+                "propertySubPhrases": [
+                  "Search for"
+                ]
+              },
+              {
+                "propertyValue": "player.lookupTracks",
+                "propertySubPhrases": [
+                  "Find"
+                ]
+              },
+              {
+                "propertyValue": "player.queryMusic",
+                "propertySubPhrases": [
+                  "Query"
+                ]
+              }
+            ]
+          },
           {
             "propertyName": "parameters.query",
             "propertyValue": "Billie Jean by Michael Jackson",
@@ -4218,15 +4491,15 @@
                 ]
               },
               {
-                "propertyValue": "Smooth Criminal by Michael Jackson",
-                "propertySubPhrases": [
-                  "Smooth Criminal by Michael Jackson"
-                ]
-              },
-              {
                 "propertyValue": "Beat It by Michael Jackson",
                 "propertySubPhrases": [
                   "Beat It by Michael Jackson"
+                ]
+              },
+              {
+                "propertyValue": "Smooth Criminal by Michael Jackson",
+                "propertySubPhrases": [
+                  "Smooth Criminal by Michael Jackson"
                 ]
               }
             ]
@@ -4278,8 +4551,8 @@
             "text": "Bohemian Rhapsody performed by Queen",
             "synonyms": [
               "Bohemian Rhapsody by Queen",
-              "Bohemian Rhapsody sung by Queen",
-              "Bohemian Rhapsody from Queen"
+              "Bohemian Rhapsody from Queen",
+              "Queen's Bohemian Rhapsody"
             ],
             "category": "query",
             "propertyNames": [
@@ -4446,9 +4719,9 @@
                 ]
               },
               {
-                "propertyValue": "Hound Dog by Elvis Presley",
+                "propertyValue": "Love Me Tender by Elvis Presley",
                 "propertySubPhrases": [
-                  "Hound Dog by Elvis Presley"
+                  "Love Me Tender by Elvis Presley"
                 ]
               }
             ]
@@ -4469,9 +4742,7 @@
           {
             "name": "fullActionName",
             "value": "player.searchTracks",
-            "substrings": [
-              "Look for"
-            ],
+            "substrings": [],
             "implied": true
           },
           {
@@ -4492,9 +4763,7 @@
               "Locate"
             ],
             "category": "command",
-            "propertyNames": [
-              "fullActionName"
-            ]
+            "propertyNames": []
           },
           {
             "text": "country hits by Johnny Cash",
@@ -4502,6 +4771,90 @@
               "country songs by Johnny Cash",
               "Johnny Cash country hits",
               "Johnny Cash country songs"
+            ],
+            "category": "query",
+            "propertyNames": [
+              "parameters.query"
+            ]
+          }
+        ],
+        "propertyAlternatives": [
+          {
+            "propertyName": "parameters.query",
+            "propertyValue": "country hits by Johnny Cash",
+            "propertySubPhrases": [
+              "country hits by Johnny Cash"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "rock hits by Johnny Cash",
+                "propertySubPhrases": [
+                  "rock hits by Johnny Cash"
+                ]
+              },
+              {
+                "propertyValue": "country hits by Willie Nelson",
+                "propertySubPhrases": [
+                  "country hits by Willie Nelson"
+                ]
+              },
+              {
+                "propertyValue": "country hits by Dolly Parton",
+                "propertySubPhrases": [
+                  "country hits by Dolly Parton"
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "request": "Look for energetic workout playlists",
+      "action": {
+        "fullActionName": "player.searchTracks",
+        "parameters": {
+          "query": "energetic workout playlists"
+        }
+      },
+      "explanation": {
+        "properties": [
+          {
+            "name": "fullActionName",
+            "value": "player.searchTracks",
+            "substrings": [
+              "Look for energetic workout playlists"
+            ],
+            "implied": true
+          },
+          {
+            "name": "parameters.query",
+            "value": "energetic workout playlists",
+            "substrings": [
+              "energetic workout playlists"
+            ],
+            "implied": false
+          }
+        ],
+        "subPhrases": [
+          {
+            "text": "Look for",
+            "synonyms": [
+              "Search for",
+              "Find",
+              "Seek out"
+            ],
+            "category": "command",
+            "propertyNames": [
+              "fullActionName"
+            ]
+          },
+          {
+            "text": "energetic workout playlists",
+            "synonyms": [
+              "high-energy workout playlists",
+              "upbeat workout playlists",
+              "intense workout playlists"
             ],
             "category": "query",
             "propertyNames": [
@@ -4539,27 +4892,27 @@
           },
           {
             "propertyName": "parameters.query",
-            "propertyValue": "country hits by Johnny Cash",
+            "propertyValue": "energetic workout playlists",
             "propertySubPhrases": [
-              "country hits by Johnny Cash"
+              "energetic workout playlists"
             ],
             "alternatives": [
               {
-                "propertyValue": "rock hits by Johnny Cash",
+                "propertyValue": "high-energy gym playlists",
                 "propertySubPhrases": [
-                  "rock hits by Johnny Cash"
+                  "high-energy gym playlists"
                 ]
               },
               {
-                "propertyValue": "country songs by Johnny Cash",
+                "propertyValue": "upbeat exercise playlists",
                 "propertySubPhrases": [
-                  "country songs by Johnny Cash"
+                  "upbeat exercise playlists"
                 ]
               },
               {
-                "propertyValue": "top tracks by Johnny Cash",
+                "propertyValue": "motivational fitness playlists",
                 "propertySubPhrases": [
-                  "top tracks by Johnny Cash"
+                  "motivational fitness playlists"
                 ]
               }
             ]
@@ -4568,11 +4921,11 @@
       }
     },
     {
-      "request": "Look for energetic workout playlists",
+      "request": "Look for Eurovision Song Contest winners",
       "action": {
         "fullActionName": "player.searchTracks",
         "parameters": {
-          "query": "energetic workout playlists"
+          "query": "Eurovision Song Contest winners"
         }
       },
       "explanation": {
@@ -4581,15 +4934,15 @@
             "name": "fullActionName",
             "value": "player.searchTracks",
             "substrings": [
-              "Look for"
+              "Look for Eurovision Song Contest winners"
             ],
             "implied": true
           },
           {
             "name": "parameters.query",
-            "value": "energetic workout playlists",
+            "value": "Eurovision Song Contest winners",
             "substrings": [
-              "energetic workout playlists"
+              "Eurovision Song Contest winners"
             ],
             "implied": false
           }
@@ -4600,7 +4953,7 @@
             "synonyms": [
               "Search for",
               "Find",
-              "Locate"
+              "Seek"
             ],
             "category": "command",
             "propertyNames": [
@@ -4608,11 +4961,11 @@
             ]
           },
           {
-            "text": "energetic workout playlists",
+            "text": "Eurovision Song Contest winners",
             "synonyms": [
-              "high-energy exercise playlists",
-              "upbeat fitness playlists",
-              "lively gym playlists"
+              "Eurovision champions",
+              "Eurovision victors",
+              "Eurovision winners"
             ],
             "category": "query",
             "propertyNames": [
@@ -4635,7 +4988,7 @@
                 ]
               },
               {
-                "propertyValue": "player.lookupMusic",
+                "propertyValue": "player.lookupTracks",
                 "propertySubPhrases": [
                   "Search for"
                 ]
@@ -4650,107 +5003,27 @@
           },
           {
             "propertyName": "parameters.query",
-            "propertyValue": "energetic workout playlists",
-            "propertySubPhrases": [
-              "energetic workout playlists"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "high-energy exercise playlists",
-                "propertySubPhrases": [
-                  "high-energy exercise playlists"
-                ]
-              },
-              {
-                "propertyValue": "upbeat fitness playlists",
-                "propertySubPhrases": [
-                  "upbeat fitness playlists"
-                ]
-              },
-              {
-                "propertyValue": "motivational gym playlists",
-                "propertySubPhrases": [
-                  "motivational gym playlists"
-                ]
-              }
-            ]
-          }
-        ]
-      }
-    },
-    {
-      "request": "Look for Eurovision Song Contest winners",
-      "action": {
-        "fullActionName": "player.searchTracks",
-        "parameters": {
-          "query": "Eurovision Song Contest winners"
-        }
-      },
-      "explanation": {
-        "properties": [
-          {
-            "name": "fullActionName",
-            "value": "player.searchTracks",
-            "substrings": [],
-            "implied": true
-          },
-          {
-            "name": "parameters.query",
-            "value": "Eurovision Song Contest winners",
-            "substrings": [
-              "Eurovision Song Contest winners"
-            ],
-            "implied": false
-          }
-        ],
-        "subPhrases": [
-          {
-            "text": "Look for",
-            "synonyms": [
-              "Search for",
-              "Find",
-              "Seek"
-            ],
-            "category": "command",
-            "isOptional": true
-          },
-          {
-            "text": "Eurovision Song Contest winners",
-            "synonyms": [
-              "Eurovision champions",
-              "Eurovision victors",
-              "Eurovision winners"
-            ],
-            "category": "query",
-            "propertyNames": [
-              "parameters.query"
-            ]
-          }
-        ],
-        "propertyAlternatives": [
-          {
-            "propertyName": "parameters.query",
             "propertyValue": "Eurovision Song Contest winners",
             "propertySubPhrases": [
               "Eurovision Song Contest winners"
             ],
             "alternatives": [
               {
-                "propertyValue": "Eurovision Song Contest 2022 winners",
+                "propertyValue": "Grammy Award winners",
                 "propertySubPhrases": [
-                  "Eurovision Song Contest 2022 winners"
+                  "Grammy Award winners"
                 ]
               },
               {
-                "propertyValue": "Eurovision Song Contest 2021 winners",
+                "propertyValue": "Billboard Hot 100",
                 "propertySubPhrases": [
-                  "Eurovision Song Contest 2021 winners"
+                  "Billboard Hot 100"
                 ]
               },
               {
-                "propertyValue": "Eurovision Song Contest 2020 winners",
+                "propertyValue": "Top 40 hits",
                 "propertySubPhrases": [
-                  "Eurovision Song Contest 2020 winners"
+                  "Top 40 hits"
                 ]
               }
             ]
@@ -4771,7 +5044,9 @@
           {
             "name": "fullActionName",
             "value": "player.searchTracks",
-            "substrings": [],
+            "substrings": [
+              "Look for"
+            ],
             "implied": true
           },
           {
@@ -4792,7 +5067,9 @@
               "Seek"
             ],
             "category": "command",
-            "isOptional": false
+            "propertyNames": [
+              "fullActionName"
+            ]
           },
           {
             "text": "French chansons",
@@ -4808,6 +5085,33 @@
           }
         ],
         "propertyAlternatives": [
+          {
+            "propertyName": "fullActionName",
+            "propertyValue": "player.searchTracks",
+            "propertySubPhrases": [
+              "Look for"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "player.findSongs",
+                "propertySubPhrases": [
+                  "Search for"
+                ]
+              },
+              {
+                "propertyValue": "player.lookupMusic",
+                "propertySubPhrases": [
+                  "Find"
+                ]
+              },
+              {
+                "propertyValue": "player.browseTracks",
+                "propertySubPhrases": [
+                  "Browse"
+                ]
+              }
+            ]
+          },
           {
             "propertyName": "parameters.query",
             "propertyValue": "French chansons",
@@ -4828,9 +5132,9 @@
                 ]
               },
               {
-                "propertyValue": "French ballads",
+                "propertyValue": "French melodies",
                 "propertySubPhrases": [
-                  "French ballads"
+                  "French melodies"
                 ]
               }
             ]
@@ -4869,7 +5173,7 @@
             "synonyms": [
               "Search for",
               "Find",
-              "Seek"
+              "Seek out"
             ],
             "category": "command",
             "propertyNames": []
@@ -4877,9 +5181,9 @@
           {
             "text": "Grammy award-winning songs",
             "synonyms": [
-              "Grammy-winning songs",
+              "Grammy-winning tracks",
               "Award-winning songs",
-              "Songs that won Grammy"
+              "Grammy songs"
             ],
             "category": "query",
             "propertyNames": [
@@ -5019,9 +5323,9 @@
                 ]
               },
               {
-                "propertyValue": "Uptown Funk by Mark Ronson ft. Bruno Mars",
+                "propertyValue": "Rolling in the Deep by Adele",
                 "propertySubPhrases": [
-                  "Uptown Funk by Mark Ronson ft. Bruno Mars"
+                  "Rolling in the Deep by Adele"
                 ]
               }
             ]
@@ -5042,18 +5346,15 @@
           {
             "name": "fullActionName",
             "value": "player.searchTracks",
-            "substrings": [
-              "Look for"
-            ],
-            "implied": true
+            "isImplicit": true
           },
           {
             "name": "parameters.query",
             "value": "heavy metal bands like Metallica",
             "substrings": [
-              "heavy metal bands like Metallica"
+              "Look for heavy metal bands like Metallica"
             ],
-            "implied": false
+            "implied": true
           }
         ],
         "subPhrases": [
@@ -5065,16 +5366,237 @@
               "Seek out"
             ],
             "category": "command",
+            "propertyNames": []
+          },
+          {
+            "text": "heavy metal bands like Metallica",
+            "synonyms": [
+              "heavy metal groups such as Metallica",
+              "metal bands similar to Metallica",
+              "heavy metal artists like Metallica"
+            ],
+            "category": "query",
+            "propertyNames": [
+              "parameters.query"
+            ]
+          }
+        ],
+        "propertyAlternatives": [
+          {
+            "propertyName": "parameters.query",
+            "propertyValue": "heavy metal bands like Metallica",
+            "propertySubPhrases": [
+              "heavy metal bands like Metallica"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "heavy metal bands like Iron Maiden",
+                "propertySubPhrases": [
+                  "heavy metal bands like Iron Maiden"
+                ]
+              },
+              {
+                "propertyValue": "heavy metal bands like Black Sabbath",
+                "propertySubPhrases": [
+                  "heavy metal bands like Black Sabbath"
+                ]
+              },
+              {
+                "propertyValue": "heavy metal bands like Slayer",
+                "propertySubPhrases": [
+                  "heavy metal bands like Slayer"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "corrections": [
+        {
+          "data": {
+            "properties": [
+              {
+                "name": "fullActionName",
+                "value": "player.searchTracks",
+                "substrings": [
+                  "player.searchTracks"
+                ],
+                "implied": false
+              },
+              {
+                "name": "parameters.query",
+                "value": "heavy metal bands like Metallica",
+                "substrings": [
+                  "heavy metal bands like Metallica"
+                ],
+                "implied": false
+              }
+            ]
+          },
+          "correction": [
+            "Substring 'player.searchTracks' for property 'fullActionName' not found in the request string. Substring must be exact copy of part of the original request and is not changed by correcting misspelling or grammar."
+          ]
+        }
+      ]
+    },
+    {
+      "request": "Look for iconic 70s disco tracks",
+      "action": {
+        "fullActionName": "player.searchTracks",
+        "parameters": {
+          "query": "iconic 70s disco tracks"
+        }
+      },
+      "explanation": {
+        "properties": [
+          {
+            "name": "fullActionName",
+            "value": "player.searchTracks",
+            "isImplicit": true
+          },
+          {
+            "name": "parameters.query",
+            "value": "iconic 70s disco tracks",
+            "substrings": [
+              "Look for iconic 70s disco tracks"
+            ],
+            "implied": true
+          }
+        ],
+        "subPhrases": [
+          {
+            "text": "Look for",
+            "synonyms": [
+              "Search for",
+              "Find",
+              "Seek out"
+            ],
+            "category": "command",
+            "propertyNames": []
+          },
+          {
+            "text": "iconic 70s disco tracks",
+            "synonyms": [
+              "classic 70s disco songs",
+              "famous 70s disco hits",
+              "legendary 70s disco tunes"
+            ],
+            "category": "query",
+            "propertyNames": [
+              "parameters.query"
+            ]
+          }
+        ],
+        "propertyAlternatives": [
+          {
+            "propertyName": "parameters.query",
+            "propertyValue": "iconic 70s disco tracks",
+            "propertySubPhrases": [
+              "iconic 70s disco tracks"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "classic 70s disco hits",
+                "propertySubPhrases": [
+                  "classic 70s disco hits"
+                ]
+              },
+              {
+                "propertyValue": "famous 70s disco songs",
+                "propertySubPhrases": [
+                  "famous 70s disco songs"
+                ]
+              },
+              {
+                "propertyValue": "popular 70s disco anthems",
+                "propertySubPhrases": [
+                  "popular 70s disco anthems"
+                ]
+              },
+              {
+                "propertyValue": "best 70s disco tracks",
+                "propertySubPhrases": [
+                  "best 70s disco tracks"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "corrections": [
+        {
+          "data": {
+            "properties": [
+              {
+                "name": "fullActionName",
+                "value": "player.searchTracks",
+                "substrings": [
+                  "player.searchTracks"
+                ],
+                "implied": false
+              },
+              {
+                "name": "parameters.query",
+                "value": "iconic 70s disco tracks",
+                "substrings": [
+                  "iconic 70s disco tracks"
+                ],
+                "implied": false
+              }
+            ]
+          },
+          "correction": [
+            "Substring 'player.searchTracks' for property 'fullActionName' not found in the request string. Substring must be exact copy of part of the original request and is not changed by correcting misspelling or grammar."
+          ]
+        }
+      ]
+    },
+    {
+      "request": "Look for instrumental jazz music",
+      "action": {
+        "fullActionName": "player.searchTracks",
+        "parameters": {
+          "query": "instrumental jazz music"
+        }
+      },
+      "explanation": {
+        "properties": [
+          {
+            "name": "fullActionName",
+            "value": "player.searchTracks",
+            "substrings": [
+              "Look for"
+            ],
+            "implied": true
+          },
+          {
+            "name": "parameters.query",
+            "value": "instrumental jazz music",
+            "substrings": [
+              "instrumental jazz music"
+            ],
+            "implied": false
+          }
+        ],
+        "subPhrases": [
+          {
+            "text": "Look for",
+            "synonyms": [
+              "Search for",
+              "Find",
+              "Locate"
+            ],
+            "category": "command",
             "propertyNames": [
               "fullActionName"
             ]
           },
           {
-            "text": "heavy metal bands like Metallica",
+            "text": "instrumental jazz music",
             "synonyms": [
-              "metal groups such as Metallica",
-              "heavy rock bands like Metallica",
-              "metal bands similar to Metallica"
+              "jazz instrumentals",
+              "instrumental jazz tracks",
+              "jazz music without vocals"
             ],
             "category": "query",
             "propertyNames": [
@@ -5103,204 +5625,13 @@
                 ]
               },
               {
-                "propertyValue": "player.browseTracks",
+                "propertyValue": "player.browseMusic",
                 "propertySubPhrases": [
                   "Browse"
                 ]
               }
             ]
           },
-          {
-            "propertyName": "parameters.query",
-            "propertyValue": "heavy metal bands like Metallica",
-            "propertySubPhrases": [
-              "heavy metal bands like Metallica"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "rock bands like Led Zeppelin",
-                "propertySubPhrases": [
-                  "rock bands like Led Zeppelin"
-                ]
-              },
-              {
-                "propertyValue": "punk bands like The Ramones",
-                "propertySubPhrases": [
-                  "punk bands like The Ramones"
-                ]
-              },
-              {
-                "propertyValue": "grunge bands like Nirvana",
-                "propertySubPhrases": [
-                  "grunge bands like Nirvana"
-                ]
-              }
-            ]
-          }
-        ]
-      }
-    },
-    {
-      "request": "Look for iconic 70s disco tracks",
-      "action": {
-        "fullActionName": "player.searchTracks",
-        "parameters": {
-          "query": "iconic 70s disco tracks"
-        }
-      },
-      "explanation": {
-        "properties": [
-          {
-            "name": "fullActionName",
-            "value": "player.searchTracks",
-            "substrings": [
-              "Look for"
-            ],
-            "implied": true
-          },
-          {
-            "name": "parameters.query",
-            "value": "iconic 70s disco tracks",
-            "substrings": [
-              "iconic 70s disco tracks"
-            ],
-            "implied": false
-          }
-        ],
-        "subPhrases": [
-          {
-            "text": "Look for",
-            "synonyms": [
-              "Search for",
-              "Find",
-              "Locate"
-            ],
-            "category": "command",
-            "propertyNames": [
-              "fullActionName"
-            ]
-          },
-          {
-            "text": "iconic 70s disco tracks",
-            "synonyms": [
-              "classic 70s disco songs",
-              "famous 70s disco hits",
-              "legendary 70s disco tunes"
-            ],
-            "category": "query",
-            "propertyNames": [
-              "parameters.query"
-            ]
-          }
-        ],
-        "propertyAlternatives": [
-          {
-            "propertyName": "fullActionName",
-            "propertyValue": "player.searchTracks",
-            "propertySubPhrases": [
-              "Look for"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "player.findSongs",
-                "propertySubPhrases": [
-                  "Find"
-                ]
-              },
-              {
-                "propertyValue": "player.lookupMusic",
-                "propertySubPhrases": [
-                  "Search for"
-                ]
-              },
-              {
-                "propertyValue": "player.browseTracks",
-                "propertySubPhrases": [
-                  "Browse"
-                ]
-              }
-            ]
-          },
-          {
-            "propertyName": "parameters.query",
-            "propertyValue": "iconic 70s disco tracks",
-            "propertySubPhrases": [
-              "iconic 70s disco tracks"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "classic 80s pop songs",
-                "propertySubPhrases": [
-                  "classic 80s pop songs"
-                ]
-              },
-              {
-                "propertyValue": "famous 90s rock anthems",
-                "propertySubPhrases": [
-                  "famous 90s rock anthems"
-                ]
-              },
-              {
-                "propertyValue": "legendary 60s soul hits",
-                "propertySubPhrases": [
-                  "legendary 60s soul hits"
-                ]
-              }
-            ]
-          }
-        ]
-      }
-    },
-    {
-      "request": "Look for instrumental jazz music",
-      "action": {
-        "fullActionName": "player.searchTracks",
-        "parameters": {
-          "query": "instrumental jazz music"
-        }
-      },
-      "explanation": {
-        "properties": [
-          {
-            "name": "fullActionName",
-            "value": "player.searchTracks",
-            "substrings": [],
-            "implied": true
-          },
-          {
-            "name": "parameters.query",
-            "value": "instrumental jazz music",
-            "substrings": [
-              "instrumental jazz music"
-            ],
-            "implied": false
-          }
-        ],
-        "subPhrases": [
-          {
-            "text": "Look for",
-            "synonyms": [
-              "Search for",
-              "Find",
-              "Seek"
-            ],
-            "category": "command",
-            "propertyNames": []
-          },
-          {
-            "text": "instrumental jazz music",
-            "synonyms": [
-              "instrumental jazz songs",
-              "instrumental jazz tracks",
-              "instrumental jazz tunes"
-            ],
-            "category": "query",
-            "propertyNames": [
-              "parameters.query"
-            ]
-          }
-        ],
-        "propertyAlternatives": [
           {
             "propertyName": "parameters.query",
             "propertyValue": "instrumental jazz music",
@@ -5309,21 +5640,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "smooth jazz music",
+                "propertyValue": "smooth jazz",
                 "propertySubPhrases": [
-                  "smooth jazz music"
+                  "smooth jazz"
                 ]
               },
               {
-                "propertyValue": "classic jazz music",
+                "propertyValue": "classic jazz",
                 "propertySubPhrases": [
-                  "classic jazz music"
+                  "classic jazz"
                 ]
               },
               {
-                "propertyValue": "modern jazz music",
+                "propertyValue": "modern jazz",
                 "propertySubPhrases": [
-                  "modern jazz music"
+                  "modern jazz"
                 ]
               }
             ]
@@ -5362,7 +5693,7 @@
             "synonyms": [
               "Search for",
               "Find",
-              "Seek"
+              "Seek out"
             ],
             "category": "command",
             "propertyNames": []
@@ -5485,9 +5816,9 @@
                 ]
               },
               {
-                "propertyValue": "player.searchMusic",
+                "propertyValue": "player.browseTracks",
                 "propertySubPhrases": [
-                  "Search for"
+                  "Browse"
                 ]
               }
             ]
@@ -5565,9 +5896,9 @@
           {
             "text": "My Heart Will Go On by Celine Dion",
             "synonyms": [
-              "My Heart Will Go On by Celine Dion",
-              "The song My Heart Will Go On by Celine Dion",
-              "Celine Dion's My Heart Will Go On"
+              "My Heart Will Go On by Céline Dion",
+              "My Heart Will Go On by C. Dion",
+              "My Heart Will Go On by Celine D."
             ],
             "category": "query",
             "propertyNames": [
@@ -5646,16 +5977,14 @@
           {
             "name": "fullActionName",
             "value": "player.searchTracks",
-            "substrings": [
-              "Look for party anthems for a night out"
-            ],
+            "substrings": [],
             "implied": true
           },
           {
             "name": "parameters.query",
             "value": "party anthems for a night out",
             "substrings": [
-              "party anthems for a night out"
+              "Look for party anthems for a night out"
             ],
             "implied": false
           }
@@ -5666,19 +5995,17 @@
             "synonyms": [
               "Search for",
               "Find",
-              "Seek out"
+              "Seek"
             ],
-            "category": "action",
-            "propertyNames": [
-              "fullActionName"
-            ]
+            "category": "command",
+            "propertyNames": []
           },
           {
             "text": "party anthems for a night out",
             "synonyms": [
-              "songs for a night out",
+              "songs for a party night",
               "music for a night out",
-              "tracks for a night out"
+              "party tracks for a night out"
             ],
             "category": "query",
             "propertyNames": [
@@ -5687,33 +6014,6 @@
           }
         ],
         "propertyAlternatives": [
-          {
-            "propertyName": "fullActionName",
-            "propertyValue": "player.searchTracks",
-            "propertySubPhrases": [
-              "Look for"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "player.findSongs",
-                "propertySubPhrases": [
-                  "Find"
-                ]
-              },
-              {
-                "propertyValue": "player.lookupMusic",
-                "propertySubPhrases": [
-                  "Search for"
-                ]
-              },
-              {
-                "propertyValue": "player.browseTracks",
-                "propertySubPhrases": [
-                  "Browse"
-                ]
-              }
-            ]
-          },
           {
             "propertyName": "parameters.query",
             "propertyValue": "party anthems for a night out",
@@ -5734,15 +6034,42 @@
                 ]
               },
               {
-                "propertyValue": "night out party songs",
+                "propertyValue": "night out music",
                 "propertySubPhrases": [
-                  "night out party songs"
+                  "night out music"
                 ]
               }
             ]
           }
         ]
-      }
+      },
+      "corrections": [
+        {
+          "data": {
+            "properties": [
+              {
+                "name": "fullActionName",
+                "value": "player.searchTracks",
+                "substrings": [
+                  "player.searchTracks"
+                ],
+                "implied": false
+              },
+              {
+                "name": "parameters.query",
+                "value": "party anthems for a night out",
+                "substrings": [
+                  "party anthems for a night out"
+                ],
+                "implied": false
+              }
+            ]
+          },
+          "correction": [
+            "Substring 'player.searchTracks' for property 'fullActionName' not found in the request string. Substring must be exact copy of part of the original request and is not changed by correcting misspelling or grammar."
+          ]
+        }
+      ]
     },
     {
       "request": "Look for reggae music by Bob Marley",
@@ -5789,7 +6116,7 @@
             "synonyms": [
               "Bob Marley reggae songs",
               "Bob Marley reggae tracks",
-              "Bob Marley reggae tunes"
+              "songs by Bob Marley in reggae genre"
             ],
             "category": "query",
             "propertyNames": [
@@ -5818,7 +6145,7 @@
                 ]
               },
               {
-                "propertyValue": "player.browseMusic",
+                "propertyValue": "player.browseTracks",
                 "propertySubPhrases": [
                   "Browse"
                 ]
@@ -5980,7 +6307,7 @@
             "name": "fullActionName",
             "value": "player.searchTracks",
             "substrings": [
-              "Look for"
+              "Look for rock anthems from the 90s"
             ],
             "implied": true
           },
@@ -5999,7 +6326,7 @@
             "synonyms": [
               "Search for",
               "Find",
-              "Locate"
+              "Seek out"
             ],
             "category": "command",
             "propertyNames": [
@@ -6036,7 +6363,7 @@
               {
                 "propertyValue": "player.lookupTracks",
                 "propertySubPhrases": [
-                  "Search for"
+                  "Lookup"
                 ]
               },
               {
@@ -6090,7 +6417,9 @@
           {
             "name": "fullActionName",
             "value": "player.searchTracks",
-            "substrings": [],
+            "substrings": [
+              "Look for Rolling in the Deep by Adele"
+            ],
             "implied": true
           },
           {
@@ -6117,8 +6446,8 @@
             "text": "Rolling in the Deep by Adele",
             "synonyms": [
               "Rolling in the Deep by Adele",
-              "Adele's Rolling in the Deep",
-              "the song Rolling in the Deep by Adele"
+              "Rolling in the Deep by Adele",
+              "Rolling in the Deep by Adele"
             ],
             "category": "query",
             "propertyNames": [
@@ -6141,15 +6470,15 @@
                 ]
               },
               {
-                "propertyValue": "Set Fire to the Rain by Adele",
-                "propertySubPhrases": [
-                  "Set Fire to the Rain by Adele"
-                ]
-              },
-              {
                 "propertyValue": "Hello by Adele",
                 "propertySubPhrases": [
                   "Hello by Adele"
+                ]
+              },
+              {
+                "propertyValue": "Set Fire to the Rain by Adele",
+                "propertySubPhrases": [
+                  "Set Fire to the Rain by Adele"
                 ]
               }
             ]
@@ -6170,7 +6499,9 @@
           {
             "name": "fullActionName",
             "value": "player.searchTracks",
-            "substrings": [],
+            "substrings": [
+              "Look for salsa music to dance to"
+            ],
             "implied": true
           },
           {
@@ -6186,19 +6517,21 @@
           {
             "text": "Look for",
             "synonyms": [
-              "Find",
               "Search for",
+              "Find",
               "Seek out"
             ],
             "category": "command",
-            "propertyNames": []
+            "propertyNames": [
+              "fullActionName"
+            ]
           },
           {
             "text": "salsa music to dance to",
             "synonyms": [
-              "salsa dance music",
               "salsa songs for dancing",
-              "salsa tracks to dance to"
+              "salsa tracks to dance to",
+              "salsa tunes for dancing"
             ],
             "category": "query",
             "propertyNames": [
@@ -6207,6 +6540,33 @@
           }
         ],
         "propertyAlternatives": [
+          {
+            "propertyName": "fullActionName",
+            "propertyValue": "player.searchTracks",
+            "propertySubPhrases": [
+              "Look for"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "player.findSongs",
+                "propertySubPhrases": [
+                  "Find"
+                ]
+              },
+              {
+                "propertyValue": "player.lookupTracks",
+                "propertySubPhrases": [
+                  "Search for"
+                ]
+              },
+              {
+                "propertyValue": "player.browseMusic",
+                "propertySubPhrases": [
+                  "Browse"
+                ]
+              }
+            ]
+          },
           {
             "propertyName": "parameters.query",
             "propertyValue": "salsa music to dance to",
@@ -6227,9 +6587,9 @@
                 ]
               },
               {
-                "propertyValue": "reggaeton music to dance to",
+                "propertyValue": "tango music to dance to",
                 "propertySubPhrases": [
-                  "reggaeton music to dance to"
+                  "tango music to dance to"
                 ]
               }
             ]
@@ -6281,8 +6641,8 @@
             "text": "Smells Like Teen Spirit by Nirvana",
             "synonyms": [
               "Smells Like Teen Spirit by Nirvana",
-              "Smells Like Teen Spirit by the band Nirvana",
-              "Smells Like Teen Spirit by Nirvana band"
+              "Smells Like Teen Spirit from Nirvana",
+              "Nirvana's Smells Like Teen Spirit"
             ],
             "category": "query",
             "propertyNames": [
@@ -6391,9 +6751,9 @@
           {
             "text": "Stairway to Heaven by Led Zeppelin",
             "synonyms": [
-              "Stairway to Heaven performed by Led Zeppelin",
-              "Stairway to Heaven from Led Zeppelin",
-              "Stairway to Heaven sung by Led Zeppelin"
+              "Stairway to Heaven by Led Zeppelin",
+              "Stairway to Heaven by Led Zeppelin",
+              "Stairway to Heaven by Led Zeppelin"
             ],
             "category": "query",
             "propertyNames": [
@@ -6418,13 +6778,13 @@
               {
                 "propertyValue": "player.lookupTracks",
                 "propertySubPhrases": [
-                  "Search for"
+                  "Lookup"
                 ]
               },
               {
-                "propertyValue": "player.browseTracks",
+                "propertyValue": "player.searchMusic",
                 "propertySubPhrases": [
-                  "Browse"
+                  "Search for"
                 ]
               }
             ]
@@ -6472,7 +6832,9 @@
           {
             "name": "fullActionName",
             "value": "player.searchTracks",
-            "substrings": [],
+            "substrings": [
+              "Look for"
+            ],
             "implied": true
           },
           {
@@ -6493,14 +6855,16 @@
               "Locate"
             ],
             "category": "command",
-            "propertyNames": []
+            "propertyNames": [
+              "fullActionName"
+            ]
           },
           {
             "text": "Sweet Caroline by Neil Diamond",
             "synonyms": [
               "Sweet Caroline by Neil Diamond",
               "Sweet Caroline from Neil Diamond",
-              "Sweet Caroline sung by Neil Diamond"
+              "Sweet Caroline - Neil Diamond"
             ],
             "category": "query",
             "propertyNames": [
@@ -6509,6 +6873,33 @@
           }
         ],
         "propertyAlternatives": [
+          {
+            "propertyName": "fullActionName",
+            "propertyValue": "player.searchTracks",
+            "propertySubPhrases": [
+              "Look for"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "player.findSongs",
+                "propertySubPhrases": [
+                  "Find"
+                ]
+              },
+              {
+                "propertyValue": "player.lookupTracks",
+                "propertySubPhrases": [
+                  "Search for"
+                ]
+              },
+              {
+                "propertyValue": "player.seekTracks",
+                "propertySubPhrases": [
+                  "Seek"
+                ]
+              }
+            ]
+          },
           {
             "propertyName": "parameters.query",
             "propertyValue": "Sweet Caroline by Neil Diamond",
@@ -6572,7 +6963,7 @@
             "synonyms": [
               "Search for",
               "Find",
-              "Seek"
+              "Locate"
             ],
             "category": "command",
             "propertyNames": [
@@ -6601,21 +6992,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.findSongs",
+                "propertyValue": "player.playTrack",
                 "propertySubPhrases": [
-                  "Find"
+                  "Play"
                 ]
               },
               {
-                "propertyValue": "player.lookupTracks",
+                "propertyValue": "player.addToQueue",
                 "propertySubPhrases": [
-                  "Search for"
+                  "Add to queue"
                 ]
               },
               {
-                "propertyValue": "player.browseTracks",
+                "propertyValue": "player.likeTrack",
                 "propertySubPhrases": [
-                  "Browse"
+                  "Like"
                 ]
               }
             ]
@@ -6693,9 +7084,9 @@
           {
             "text": "Tennessee Whiskey by Chris Stapleton",
             "synonyms": [
-              "Tennessee Whiskey performed by Chris Stapleton",
-              "Tennessee Whiskey sung by Chris Stapleton",
-              "Tennessee Whiskey from Chris Stapleton"
+              "Tennessee Whiskey by Chris S.",
+              "Tennessee Whiskey by Stapleton",
+              "Tennessee Whiskey by C. Stapleton"
             ],
             "category": "query",
             "propertyNames": [
@@ -6712,21 +7103,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.playTrack",
+                "propertyValue": "player.findSongs",
                 "propertySubPhrases": [
-                  "Play"
+                  "Find"
                 ]
               },
               {
-                "propertyValue": "player.addToQueue",
+                "propertyValue": "player.lookupTracks",
                 "propertySubPhrases": [
-                  "Add to queue"
+                  "Search for"
                 ]
               },
               {
-                "propertyValue": "player.likeTrack",
+                "propertyValue": "player.browseTracks",
                 "propertySubPhrases": [
-                  "Like"
+                  "Browse"
                 ]
               }
             ]
@@ -6792,19 +7183,19 @@
             "synonyms": [
               "Search for",
               "Find",
-              "Seek out"
+              "Seek"
             ],
             "category": "command",
-            "isOptional": true
+            "propertyNames": []
           },
           {
             "text": "the latest hip-hop releases",
             "synonyms": [
               "newest hip-hop tracks",
               "recent hip-hop songs",
-              "current hip-hop releases"
+              "latest rap releases"
             ],
-            "category": "music query",
+            "category": "query",
             "propertyNames": [
               "parameters.query"
             ]
@@ -6965,9 +7356,7 @@
           {
             "name": "fullActionName",
             "value": "player.searchTracks",
-            "substrings": [
-              "Look for the song"
-            ],
+            "substrings": [],
             "implied": true
           },
           {
@@ -6981,24 +7370,28 @@
         ],
         "subPhrases": [
           {
-            "text": "Look for the song",
+            "text": "Look for",
             "synonyms": [
-              "Search for the song",
-              "Find the song",
-              "Locate the song"
+              "Search for",
+              "Find",
+              "Locate"
             ],
             "category": "command",
-            "propertyNames": [
-              "fullActionName"
-            ]
+            "propertyNames": []
+          },
+          {
+            "text": "the song",
+            "synonyms": [
+              "the track",
+              "the music",
+              "the tune"
+            ],
+            "category": "object",
+            "propertyNames": []
           },
           {
             "text": "Bohemian Rhapsody",
-            "synonyms": [
-              "Bohemian Rhapsody",
-              "Queen's Bohemian Rhapsody",
-              "The song Bohemian Rhapsody"
-            ],
+            "synonyms": [],
             "category": "query",
             "propertyNames": [
               "parameters.query"
@@ -7006,33 +7399,6 @@
           }
         ],
         "propertyAlternatives": [
-          {
-            "propertyName": "fullActionName",
-            "propertyValue": "player.searchTracks",
-            "propertySubPhrases": [
-              "Look for the song"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "player.findSongs",
-                "propertySubPhrases": [
-                  "Find the song"
-                ]
-              },
-              {
-                "propertyValue": "player.lookupTracks",
-                "propertySubPhrases": [
-                  "Search for the song"
-                ]
-              },
-              {
-                "propertyValue": "player.seekTracks",
-                "propertySubPhrases": [
-                  "Seek the song"
-                ]
-              }
-            ]
-          },
           {
             "propertyName": "parameters.query",
             "propertyValue": "Bohemian Rhapsody",
@@ -7237,7 +7603,7 @@
             "name": "fullActionName",
             "value": "player.searchTracks",
             "substrings": [
-              "Search for"
+              "Search for ambient tracks for meditation"
             ],
             "implied": true
           },
@@ -7258,7 +7624,7 @@
               "Look for",
               "Seek"
             ],
-            "category": "command",
+            "category": "action",
             "propertyNames": [
               "fullActionName"
             ]
@@ -7266,9 +7632,9 @@
           {
             "text": "ambient tracks for meditation",
             "synonyms": [
-              "meditation ambient tracks",
-              "tracks for meditation",
-              "ambient music for meditation"
+              "meditation music",
+              "relaxing ambient tracks",
+              "calming music for meditation"
             ],
             "category": "query",
             "propertyNames": [
@@ -7350,7 +7716,7 @@
             "substrings": [
               "Search for"
             ],
-            "implied": true
+            "implied": false
           },
           {
             "name": "parameters.query",
@@ -7365,11 +7731,11 @@
           {
             "text": "Search for",
             "synonyms": [
-              "Find",
               "Look for",
+              "Find",
               "Seek"
             ],
-            "category": "command",
+            "category": "action",
             "propertyNames": [
               "fullActionName"
             ]
@@ -7379,7 +7745,7 @@
             "synonyms": [
               "B.B. King blues albums",
               "albums by B.B. King in blues",
-              "B.B. King albums in blues genre"
+              "B.B. King blues records"
             ],
             "category": "query",
             "propertyNames": [
@@ -7398,19 +7764,19 @@
               {
                 "propertyValue": "player.searchAlbums",
                 "propertySubPhrases": [
-                  "Find albums"
+                  "Find albums by"
                 ]
               },
               {
                 "propertyValue": "player.searchArtists",
                 "propertySubPhrases": [
-                  "Look up artists"
+                  "Look up artists like"
                 ]
               },
               {
                 "propertyValue": "player.searchPlaylists",
                 "propertySubPhrases": [
-                  "Search for playlists"
+                  "Search for playlists featuring"
                 ]
               }
             ]
@@ -7429,9 +7795,9 @@
                 ]
               },
               {
-                "propertyValue": "rock albums from The Beatles",
+                "propertyValue": "rock albums from Led Zeppelin",
                 "propertySubPhrases": [
-                  "rock albums from The Beatles"
+                  "rock albums from Led Zeppelin"
                 ]
               },
               {
@@ -7478,7 +7844,7 @@
             "synonyms": [
               "Look for",
               "Find",
-              "Seek out"
+              "Seek"
             ],
             "category": "command",
             "propertyNames": [
@@ -7507,21 +7873,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.findSongs",
+                "propertyValue": "player.playTracks",
                 "propertySubPhrases": [
-                  "Look for"
+                  "Play"
                 ]
               },
               {
-                "propertyValue": "player.lookupTracks",
+                "propertyValue": "player.addTracks",
                 "propertySubPhrases": [
-                  "Find"
+                  "Add"
                 ]
               },
               {
-                "propertyValue": "player.queryMusic",
+                "propertyValue": "player.queueTracks",
                 "propertySubPhrases": [
-                  "Query"
+                  "Queue"
                 ]
               }
             ]
@@ -7534,21 +7900,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "Broadway show tunes",
+                "propertyValue": "classical music",
                 "propertySubPhrases": [
-                  "Broadway show tunes"
+                  "classical music"
                 ]
               },
               {
-                "propertyValue": "musical theater songs",
+                "propertyValue": "pop hits",
                 "propertySubPhrases": [
-                  "musical theater songs"
+                  "pop hits"
                 ]
               },
               {
-                "propertyValue": "Broadway hits",
+                "propertyValue": "jazz standards",
                 "propertySubPhrases": [
-                  "Broadway hits"
+                  "jazz standards"
                 ]
               }
             ]
@@ -7570,7 +7936,7 @@
             "name": "fullActionName",
             "value": "player.searchTracks",
             "substrings": [
-              "Search for"
+              "Search for classical music by Beethoven"
             ],
             "implied": true
           },
@@ -7587,9 +7953,9 @@
           {
             "text": "Search for",
             "synonyms": [
-              "Find",
               "Look for",
-              "Seek"
+              "Find",
+              "Seek out"
             ],
             "category": "command",
             "propertyNames": [
@@ -7600,8 +7966,8 @@
             "text": "classical music by Beethoven",
             "synonyms": [
               "Beethoven's classical music",
-              "Beethoven's compositions",
-              "Beethoven's works"
+              "Beethoven classical tracks",
+              "Beethoven's music"
             ],
             "category": "query",
             "propertyNames": [
@@ -7645,21 +8011,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "symphonies by Beethoven",
+                "propertyValue": "symphonies by Mozart",
                 "propertySubPhrases": [
-                  "symphonies by Beethoven"
+                  "symphonies by Mozart"
                 ]
               },
               {
-                "propertyValue": "Beethoven's piano sonatas",
+                "propertyValue": "piano sonatas by Chopin",
                 "propertySubPhrases": [
-                  "Beethoven's piano sonatas"
+                  "piano sonatas by Chopin"
                 ]
               },
               {
-                "propertyValue": "Beethoven's orchestral works",
+                "propertyValue": "operas by Verdi",
                 "propertySubPhrases": [
-                  "Beethoven's orchestral works"
+                  "operas by Verdi"
                 ]
               }
             ]
@@ -7681,7 +8047,7 @@
             "name": "fullActionName",
             "value": "player.searchTracks",
             "substrings": [
-              "Search for"
+              "Search for cover songs by famous YouTubers"
             ],
             "implied": true
           },
@@ -7698,9 +8064,9 @@
           {
             "text": "Search for",
             "synonyms": [
-              "Find",
               "Look for",
-              "Seek"
+              "Find",
+              "Seek out"
             ],
             "category": "action",
             "propertyNames": [
@@ -7711,7 +8077,7 @@
             "text": "cover songs by famous YouTubers",
             "synonyms": [
               "covers by popular YouTubers",
-              "YouTuber cover songs",
+              "YouTube cover songs",
               "famous YouTuber covers"
             ],
             "category": "query",
@@ -7762,15 +8128,15 @@
                 ]
               },
               {
-                "propertyValue": "piano covers by trending YouTubers",
+                "propertyValue": "piano covers by well-known YouTubers",
                 "propertySubPhrases": [
-                  "piano covers by trending YouTubers"
+                  "piano covers by well-known YouTubers"
                 ]
               },
               {
-                "propertyValue": "guitar covers by well-known YouTubers",
+                "propertyValue": "guitar covers by top YouTubers",
                 "propertySubPhrases": [
-                  "guitar covers by well-known YouTubers"
+                  "guitar covers by top YouTubers"
                 ]
               }
             ]
@@ -7792,7 +8158,7 @@
             "name": "fullActionName",
             "value": "player.searchTracks",
             "substrings": [
-              "Search for"
+              "Search for Disney movie soundtracks"
             ],
             "implied": true
           },
@@ -7809,14 +8175,12 @@
           {
             "text": "Search for",
             "synonyms": [
-              "Find",
               "Look for",
+              "Find",
               "Seek"
             ],
-            "category": "action",
-            "propertyNames": [
-              "fullActionName"
-            ]
+            "category": "command",
+            "propertyNames": []
           },
           {
             "text": "Disney movie soundtracks",
@@ -7832,33 +8196,6 @@
           }
         ],
         "propertyAlternatives": [
-          {
-            "propertyName": "fullActionName",
-            "propertyValue": "player.searchTracks",
-            "propertySubPhrases": [
-              "Search for"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "player.findSongs",
-                "propertySubPhrases": [
-                  "Find"
-                ]
-              },
-              {
-                "propertyValue": "player.lookupTracks",
-                "propertySubPhrases": [
-                  "Look up"
-                ]
-              },
-              {
-                "propertyValue": "player.browseTracks",
-                "propertySubPhrases": [
-                  "Browse"
-                ]
-              }
-            ]
-          },
           {
             "propertyName": "parameters.query",
             "propertyValue": "Disney movie soundtracks",
@@ -7879,9 +8216,9 @@
                 ]
               },
               {
-                "propertyValue": "Disney animated movie soundtracks",
+                "propertyValue": "DreamWorks movie soundtracks",
                 "propertySubPhrases": [
-                  "Disney animated movie soundtracks"
+                  "DreamWorks movie soundtracks"
                 ]
               }
             ]
@@ -7903,9 +8240,9 @@
             "name": "fullActionName",
             "value": "player.searchTracks",
             "substrings": [
-              "Search for"
+              "Search for Dont Stop Believin by Journey"
             ],
-            "implied": true
+            "implied": false
           },
           {
             "name": "parameters.query",
@@ -7933,8 +8270,8 @@
             "text": "Dont Stop Believin by Journey",
             "synonyms": [
               "Don't Stop Believin by Journey",
-              "Don't Stop Believin' by Journey",
-              "Dont Stop Believin' by Journey"
+              "Dont Stop Believing by Journey",
+              "Don't Stop Believing by Journey"
             ],
             "category": "query",
             "propertyNames": [
@@ -7963,9 +8300,9 @@
                 ]
               },
               {
-                "propertyValue": "player.browseTracks",
+                "propertyValue": "player.querySongs",
                 "propertySubPhrases": [
-                  "Browse"
+                  "Query"
                 ]
               }
             ]
@@ -8014,7 +8351,7 @@
             "name": "fullActionName",
             "value": "player.searchTracks",
             "substrings": [
-              "Search for"
+              "Search for Eye of the Tiger by Survivor"
             ],
             "implied": true
           },
@@ -8031,9 +8368,9 @@
           {
             "text": "Search for",
             "synonyms": [
-              "Find",
               "Look for",
-              "Seek"
+              "Find",
+              "Seek out"
             ],
             "category": "command",
             "propertyNames": [
@@ -8043,9 +8380,9 @@
           {
             "text": "Eye of the Tiger by Survivor",
             "synonyms": [
-              "Eye of the Tiger by Survivor",
-              "Eye of the Tiger from Survivor",
-              "Eye of the Tiger - Survivor"
+              "Eye of the Tiger by the band Survivor",
+              "Eye of the Tiger by the group Survivor",
+              "Eye of the Tiger by Survivor band"
             ],
             "category": "query",
             "propertyNames": [
@@ -8125,7 +8462,7 @@
             "name": "fullActionName",
             "value": "player.searchTracks",
             "substrings": [
-              "Search for"
+              "Search for famous opera arias"
             ],
             "implied": true
           },
@@ -8144,9 +8481,9 @@
             "synonyms": [
               "Look for",
               "Find",
-              "Seek"
+              "Locate"
             ],
-            "category": "action",
+            "category": "command",
             "propertyNames": [
               "fullActionName"
             ]
@@ -8175,17 +8512,17 @@
               {
                 "propertyValue": "player.findSongs",
                 "propertySubPhrases": [
+                  "Look for"
+                ]
+              },
+              {
+                "propertyValue": "player.lookupTracks",
+                "propertySubPhrases": [
                   "Find"
                 ]
               },
               {
-                "propertyValue": "player.lookupMusic",
-                "propertySubPhrases": [
-                  "Look up"
-                ]
-              },
-              {
-                "propertyValue": "player.browseTracks",
+                "propertyValue": "player.browseMusic",
                 "propertySubPhrases": [
                   "Browse"
                 ]
@@ -8200,21 +8537,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "popular opera arias",
+                "propertyValue": "popular opera songs",
                 "propertySubPhrases": [
-                  "popular opera arias"
+                  "popular opera songs"
                 ]
               },
               {
-                "propertyValue": "classic opera arias",
+                "propertyValue": "well-known opera pieces",
                 "propertySubPhrases": [
-                  "classic opera arias"
+                  "well-known opera pieces"
                 ]
               },
               {
-                "propertyValue": "well-known opera arias",
+                "propertyValue": "renowned opera arias",
                 "propertySubPhrases": [
-                  "well-known opera arias"
+                  "renowned opera arias"
                 ]
               }
             ]
@@ -8253,8 +8590,8 @@
           {
             "text": "Search for",
             "synonyms": [
-              "Look for",
               "Find",
+              "Look for",
               "Seek"
             ],
             "category": "command",
@@ -8290,7 +8627,7 @@
                 ]
               },
               {
-                "propertyValue": "player.lookupTracks",
+                "propertyValue": "player.lookupMusic",
                 "propertySubPhrases": [
                   "Look up"
                 ]
@@ -8311,21 +8648,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "traditional music from different countries",
+                "propertyValue": "traditional music globally",
                 "propertySubPhrases": [
-                  "traditional music from different countries"
+                  "traditional music globally"
                 ]
               },
               {
-                "propertyValue": "world folk songs",
+                "propertyValue": "worldwide folk songs",
                 "propertySubPhrases": [
-                  "world folk songs"
+                  "worldwide folk songs"
                 ]
               },
               {
-                "propertyValue": "global folk music",
+                "propertyValue": "international folk tunes",
                 "propertySubPhrases": [
-                  "global folk music"
+                  "international folk tunes"
                 ]
               }
             ]
@@ -8368,7 +8705,7 @@
               "Look for",
               "Seek"
             ],
-            "category": "command",
+            "category": "action",
             "propertyNames": [
               "fullActionName"
             ]
@@ -8376,9 +8713,9 @@
           {
             "text": "Girls Just Want to Have Fun by Cyndi Lauper",
             "synonyms": [
-              "Girls Just Wanna Have Fun by Cyndi Lauper",
+              "Girls Just Want to Have Fun by C. Lauper",
               "Girls Just Want to Have Fun by Lauper",
-              "Girls Just Want to Have Fun by C. Lauper"
+              "Girls Just Want to Have Fun by Cyndi L."
             ],
             "category": "query",
             "propertyNames": [
@@ -8407,9 +8744,9 @@
                 ]
               },
               {
-                "propertyValue": "player.querySongs",
+                "propertyValue": "player.browseTracks",
                 "propertySubPhrases": [
-                  "Query"
+                  "Browse"
                 ]
               }
             ]
@@ -8475,8 +8812,8 @@
           {
             "text": "Search for",
             "synonyms": [
-              "Look for",
               "Find",
+              "Look for",
               "Seek"
             ],
             "category": "command",
@@ -8488,8 +8825,8 @@
             "text": "Halo by Beyoncé",
             "synonyms": [
               "Halo by Beyonce",
-              "Halo by Queen B",
-              "Halo by the artist Beyoncé"
+              "Halo by Beyoncè",
+              "Halo by Bey"
             ],
             "category": "query",
             "propertyNames": [
@@ -8545,9 +8882,9 @@
                 ]
               },
               {
-                "propertyValue": "Irreplaceable by Beyoncé",
+                "propertyValue": "Formation by Beyoncé",
                 "propertySubPhrases": [
-                  "Irreplaceable by Beyoncé"
+                  "Formation by Beyoncé"
                 ]
               }
             ]
@@ -8569,7 +8906,7 @@
             "name": "fullActionName",
             "value": "player.searchTracks",
             "substrings": [
-              "Search for"
+              "Search for Hotline Bling by Drake"
             ],
             "implied": true
           },
@@ -8586,9 +8923,9 @@
           {
             "text": "Search for",
             "synonyms": [
-              "Find",
               "Look for",
-              "Seek"
+              "Find",
+              "Locate"
             ],
             "category": "command",
             "propertyNames": [
@@ -8598,9 +8935,9 @@
           {
             "text": "Hotline Bling by Drake",
             "synonyms": [
-              "Hotline Bling from Drake",
+              "Hotline Bling by Drake",
               "Drake's Hotline Bling",
-              "Hotline Bling performed by Drake"
+              "the song Hotline Bling by Drake"
             ],
             "category": "query",
             "propertyNames": [
@@ -8617,21 +8954,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.findSongs",
+                "propertyValue": "player.playTrack",
                 "propertySubPhrases": [
-                  "Find"
+                  "Play"
                 ]
               },
               {
-                "propertyValue": "player.lookupTracks",
+                "propertyValue": "player.addTrackToQueue",
                 "propertySubPhrases": [
-                  "Look up"
+                  "Add to queue"
                 ]
               },
               {
-                "propertyValue": "player.browseTracks",
+                "propertyValue": "player.likeTrack",
                 "propertySubPhrases": [
-                  "Browse"
+                  "Like"
                 ]
               }
             ]
@@ -8644,21 +8981,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "God's Plan by Drake",
+                "propertyValue": "Shape of You by Ed Sheeran",
                 "propertySubPhrases": [
-                  "God's Plan by Drake"
+                  "Shape of You by Ed Sheeran"
                 ]
               },
               {
-                "propertyValue": "In My Feelings by Drake",
+                "propertyValue": "Blinding Lights by The Weeknd",
                 "propertySubPhrases": [
-                  "In My Feelings by Drake"
+                  "Blinding Lights by The Weeknd"
                 ]
               },
               {
-                "propertyValue": "One Dance by Drake",
+                "propertyValue": "Rolling in the Deep by Adele",
                 "propertySubPhrases": [
-                  "One Dance by Drake"
+                  "Rolling in the Deep by Adele"
                 ]
               }
             ]
@@ -8680,9 +9017,9 @@
             "name": "fullActionName",
             "value": "player.searchTracks",
             "substrings": [
-              "Search for"
+              "Search for I Will Always Love You by Whitney Houston"
             ],
-            "implied": true
+            "implied": false
           },
           {
             "name": "parameters.query",
@@ -8709,9 +9046,9 @@
           {
             "text": "I Will Always Love You by Whitney Houston",
             "synonyms": [
-              "I Will Always Love You by Whitney",
-              "I Will Always Love You by Houston",
-              "I Will Always Love You by Whitney H."
+              "I Will Always Love You by Whitney Houston",
+              "I Will Always Love You by Whitney Houston",
+              "I Will Always Love You by Whitney Houston"
             ],
             "category": "query",
             "propertyNames": [
@@ -8767,9 +9104,9 @@
                 ]
               },
               {
-                "propertyValue": "Rolling in the Deep by Adele",
+                "propertyValue": "Billie Jean by Michael Jackson",
                 "propertySubPhrases": [
-                  "Rolling in the Deep by Adele"
+                  "Billie Jean by Michael Jackson"
                 ]
               }
             ]
@@ -8791,7 +9128,7 @@
             "name": "fullActionName",
             "value": "player.searchTracks",
             "substrings": [
-              "Search for"
+              "Search for Imagine by John Lennon"
             ],
             "implied": true
           },
@@ -8810,9 +9147,9 @@
             "synonyms": [
               "Look for",
               "Find",
-              "Seek"
+              "Seek out"
             ],
-            "category": "command",
+            "category": "action",
             "propertyNames": [
               "fullActionName"
             ]
@@ -8841,19 +9178,19 @@
               {
                 "propertyValue": "player.findSongs",
                 "propertySubPhrases": [
-                  "Find"
+                  "Find songs"
                 ]
               },
               {
                 "propertyValue": "player.lookupTracks",
                 "propertySubPhrases": [
-                  "Look up"
+                  "Look up tracks"
                 ]
               },
               {
-                "propertyValue": "player.seekTracks",
+                "propertyValue": "player.locateMusic",
                 "propertySubPhrases": [
-                  "Seek"
+                  "Locate music"
                 ]
               }
             ]
@@ -8904,7 +9241,7 @@
             "substrings": [
               "Search for"
             ],
-            "implied": true
+            "implied": false
           },
           {
             "name": "parameters.query",
@@ -8932,8 +9269,8 @@
             "text": "indie bands like Arctic Monkeys",
             "synonyms": [
               "alternative bands like Arctic Monkeys",
-              "indie groups such as Arctic Monkeys",
-              "bands similar to Arctic Monkeys"
+              "indie groups similar to Arctic Monkeys",
+              "indie artists such as Arctic Monkeys"
             ],
             "category": "query",
             "propertyNames": [
@@ -8950,21 +9287,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.searchAlbums",
+                "propertyValue": "player.findSongs",
                 "propertySubPhrases": [
-                  "Search for albums by"
+                  "Find songs"
                 ]
               },
               {
-                "propertyValue": "player.searchArtists",
+                "propertyValue": "player.lookupTracks",
                 "propertySubPhrases": [
-                  "Search for artists like"
+                  "Look up tracks"
                 ]
               },
               {
-                "propertyValue": "player.searchPlaylists",
+                "propertyValue": "player.browseMusic",
                 "propertySubPhrases": [
-                  "Search for playlists featuring"
+                  "Browse music"
                 ]
               }
             ]
@@ -8977,21 +9314,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "indie bands like The Strokes",
+                "propertyValue": "indie rock bands similar to Arctic Monkeys",
                 "propertySubPhrases": [
-                  "indie bands like The Strokes"
+                  "indie rock bands similar to Arctic Monkeys"
                 ]
               },
               {
-                "propertyValue": "indie bands like Tame Impala",
+                "propertyValue": "bands in the style of Arctic Monkeys",
                 "propertySubPhrases": [
-                  "indie bands like Tame Impala"
+                  "bands in the style of Arctic Monkeys"
                 ]
               },
               {
-                "propertyValue": "indie bands like Vampire Weekend",
+                "propertyValue": "artists like Arctic Monkeys",
                 "propertySubPhrases": [
-                  "indie bands like Vampire Weekend"
+                  "artists like Arctic Monkeys"
                 ]
               }
             ]
@@ -9030,8 +9367,8 @@
           {
             "text": "Search for",
             "synonyms": [
-              "Look for",
               "Find",
+              "Look for",
               "Seek"
             ],
             "category": "command",
@@ -9042,8 +9379,8 @@
           {
             "text": "Italian opera classics",
             "synonyms": [
-              "Italian opera masterpieces",
               "Italian opera hits",
+              "Italian opera masterpieces",
               "Italian opera favorites"
             ],
             "category": "query",
@@ -9063,19 +9400,19 @@
               {
                 "propertyValue": "player.findSongs",
                 "propertySubPhrases": [
-                  "Find songs"
+                  "Look for"
                 ]
               },
               {
                 "propertyValue": "player.lookupMusic",
                 "propertySubPhrases": [
-                  "Look up music"
+                  "Find"
                 ]
               },
               {
                 "propertyValue": "player.browseTracks",
                 "propertySubPhrases": [
-                  "Browse tracks"
+                  "Browse for"
                 ]
               }
             ]
@@ -9088,6 +9425,12 @@
             ],
             "alternatives": [
               {
+                "propertyValue": "Italian classical music",
+                "propertySubPhrases": [
+                  "Italian classical music"
+                ]
+              },
+              {
                 "propertyValue": "Italian opera hits",
                 "propertySubPhrases": [
                   "Italian opera hits"
@@ -9097,12 +9440,6 @@
                 "propertyValue": "Italian opera masterpieces",
                 "propertySubPhrases": [
                   "Italian opera masterpieces"
-                ]
-              },
-              {
-                "propertyValue": "Italian opera favorites",
-                "propertySubPhrases": [
-                  "Italian opera favorites"
                 ]
               }
             ]
@@ -9126,7 +9463,7 @@
             "substrings": [
               "Search for"
             ],
-            "implied": true
+            "implied": false
           },
           {
             "name": "parameters.query",
@@ -9142,18 +9479,20 @@
             "text": "Search for",
             "synonyms": [
               "Find",
-              "Look up",
-              "Locate"
+              "Look for",
+              "Seek"
             ],
-            "category": "command",
-            "propertyNames": []
+            "category": "action",
+            "propertyNames": [
+              "fullActionName"
+            ]
           },
           {
             "text": "Let It Be by The Beatles",
             "synonyms": [
               "Let It Be by The Fab Four",
-              "Let It Be by Beatles",
-              "Let It Be by the band The Beatles"
+              "Let It Be by The Band",
+              "Let It Be by The Group"
             ],
             "category": "query",
             "propertyNames": [
@@ -9162,6 +9501,33 @@
           }
         ],
         "propertyAlternatives": [
+          {
+            "propertyName": "fullActionName",
+            "propertyValue": "player.searchTracks",
+            "propertySubPhrases": [
+              "Search for"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "player.findSongs",
+                "propertySubPhrases": [
+                  "Find"
+                ]
+              },
+              {
+                "propertyValue": "player.lookupTracks",
+                "propertySubPhrases": [
+                  "Look up"
+                ]
+              },
+              {
+                "propertyValue": "player.browseTracks",
+                "propertySubPhrases": [
+                  "Browse"
+                ]
+              }
+            ]
+          },
           {
             "propertyName": "parameters.query",
             "propertyValue": "Let It Be by The Beatles",
@@ -9206,7 +9572,7 @@
             "name": "fullActionName",
             "value": "player.searchTracks",
             "substrings": [
-              "Search for"
+              "Search for love ballads by Adele"
             ],
             "implied": true
           },
@@ -9228,9 +9594,7 @@
               "Seek"
             ],
             "category": "command",
-            "propertyNames": [
-              "fullActionName"
-            ]
+            "propertyNames": []
           },
           {
             "text": "love ballads by Adele",
@@ -9246,33 +9610,6 @@
           }
         ],
         "propertyAlternatives": [
-          {
-            "propertyName": "fullActionName",
-            "propertyValue": "player.searchTracks",
-            "propertySubPhrases": [
-              "Search for"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "player.findSongs",
-                "propertySubPhrases": [
-                  "Find"
-                ]
-              },
-              {
-                "propertyValue": "player.lookupTracks",
-                "propertySubPhrases": [
-                  "Look up"
-                ]
-              },
-              {
-                "propertyValue": "player.browseTracks",
-                "propertySubPhrases": [
-                  "Browse"
-                ]
-              }
-            ]
-          },
           {
             "propertyName": "parameters.query",
             "propertyValue": "love ballads by Adele",
@@ -9317,7 +9654,7 @@
             "name": "fullActionName",
             "value": "player.searchTracks",
             "substrings": [
-              "Search for"
+              "Search for No Scrubs by TLC"
             ],
             "implied": true
           },
@@ -9334,11 +9671,11 @@
           {
             "text": "Search for",
             "synonyms": [
-              "Find",
               "Look for",
-              "Seek"
+              "Find",
+              "Seek out"
             ],
-            "category": "command",
+            "category": "action",
             "propertyNames": [
               "fullActionName"
             ]
@@ -9346,9 +9683,9 @@
           {
             "text": "No Scrubs by TLC",
             "synonyms": [
-              "No Scrubs from TLC",
-              "No Scrubs performed by TLC",
-              "No Scrubs sung by TLC"
+              "No Scrubs by the band TLC",
+              "No Scrubs by the group TLC",
+              "No Scrubs by the artist TLC"
             ],
             "category": "query",
             "propertyNames": [
@@ -9377,9 +9714,9 @@
                 ]
               },
               {
-                "propertyValue": "player.discoverTracks",
+                "propertyValue": "player.querySongs",
                 "propertySubPhrases": [
-                  "Discover"
+                  "Query"
                 ]
               }
             ]
@@ -9430,7 +9767,7 @@
             "substrings": [
               "Search for"
             ],
-            "implied": true
+            "implied": false
           },
           {
             "name": "parameters.query",
@@ -9449,7 +9786,7 @@
               "Look for",
               "Seek"
             ],
-            "category": "action",
+            "category": "command",
             "propertyNames": [
               "fullActionName"
             ]
@@ -9488,9 +9825,9 @@
                 ]
               },
               {
-                "propertyValue": "player.querySongs",
+                "propertyValue": "player.browseTracks",
                 "propertySubPhrases": [
-                  "Query"
+                  "Browse"
                 ]
               }
             ]
@@ -9539,7 +9876,7 @@
             "name": "fullActionName",
             "value": "player.searchTracks",
             "substrings": [
-              "Search for"
+              "Search for R&B love songs"
             ],
             "implied": true
           },
@@ -9560,7 +9897,7 @@
               "Look for",
               "Seek"
             ],
-            "category": "command",
+            "category": "action",
             "propertyNames": [
               "fullActionName"
             ]
@@ -9569,8 +9906,8 @@
             "text": "R&B love songs",
             "synonyms": [
               "R&B romantic songs",
-              "R&B ballads",
-              "R&B love tracks"
+              "R&B love tracks",
+              "R&B love music"
             ],
             "category": "query",
             "propertyNames": [
@@ -9589,17 +9926,17 @@
               {
                 "propertyValue": "player.findSongs",
                 "propertySubPhrases": [
-                  "Look for"
+                  "Find"
                 ]
               },
               {
                 "propertyValue": "player.lookupTracks",
                 "propertySubPhrases": [
-                  "Find"
+                  "Look up"
                 ]
               },
               {
-                "propertyValue": "player.browseMusic",
+                "propertyValue": "player.browseTracks",
                 "propertySubPhrases": [
                   "Browse"
                 ]
@@ -9669,9 +10006,9 @@
             "synonyms": [
               "Find",
               "Look for",
-              "Seek"
+              "Locate"
             ],
-            "category": "action",
+            "category": "command",
             "propertyNames": [
               "fullActionName"
             ]
@@ -9710,9 +10047,9 @@
                 ]
               },
               {
-                "propertyValue": "player.browseTracks",
+                "propertyValue": "player.searchMusic",
                 "propertySubPhrases": [
-                  "Browse"
+                  "Search music for"
                 ]
               }
             ]
@@ -9778,11 +10115,11 @@
           {
             "text": "Search for",
             "synonyms": [
-              "Find",
               "Look for",
+              "Find",
               "Seek"
             ],
-            "category": "action",
+            "category": "command",
             "propertyNames": [
               "fullActionName"
             ]
@@ -9791,8 +10128,8 @@
             "text": "Shape of You by Ed Sheeran",
             "synonyms": [
               "Shape of You by Ed Sheeran",
-              "Shape of You by Ed Sheeran",
-              "Shape of You by Ed Sheeran"
+              "Shape of You from Ed Sheeran",
+              "Ed Sheeran's Shape of You"
             ],
             "category": "query",
             "propertyNames": [
@@ -9836,21 +10173,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "Blinding Lights by The Weeknd",
+                "propertyValue": "Perfect by Ed Sheeran",
                 "propertySubPhrases": [
-                  "Blinding Lights by The Weeknd"
+                  "Perfect by Ed Sheeran"
                 ]
               },
               {
-                "propertyValue": "Rolling in the Deep by Adele",
+                "propertyValue": "Thinking Out Loud by Ed Sheeran",
                 "propertySubPhrases": [
-                  "Rolling in the Deep by Adele"
+                  "Thinking Out Loud by Ed Sheeran"
                 ]
               },
               {
-                "propertyValue": "Uptown Funk by Mark Ronson ft. Bruno Mars",
+                "propertyValue": "Castle on the Hill by Ed Sheeran",
                 "propertySubPhrases": [
-                  "Uptown Funk by Mark Ronson ft. Bruno Mars"
+                  "Castle on the Hill by Ed Sheeran"
                 ]
               }
             ]
@@ -9891,7 +10228,7 @@
             "synonyms": [
               "Find tracks",
               "Look for music",
-              "Seek songs"
+              "Search for tunes"
             ],
             "category": "action",
             "propertyNames": [
@@ -9930,21 +10267,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.searchAlbums",
+                "propertyValue": "player.findSongs",
                 "propertySubPhrases": [
-                  "Search for albums"
+                  "Find songs"
                 ]
               },
               {
-                "propertyValue": "player.searchArtists",
+                "propertyValue": "player.lookupTracks",
                 "propertySubPhrases": [
-                  "Search for artists"
+                  "Look up songs"
                 ]
               },
               {
-                "propertyValue": "player.searchPlaylists",
+                "propertyValue": "player.discoverMusic",
                 "propertySubPhrases": [
-                  "Search for playlists"
+                  "Discover music"
                 ]
               }
             ]
@@ -9992,7 +10329,9 @@
           {
             "name": "fullActionName",
             "value": "player.searchTracks",
-            "substrings": [],
+            "substrings": [
+              "Search for soulful tunes by Aretha Franklin"
+            ],
             "implied": true
           },
           {
@@ -10008,19 +10347,21 @@
           {
             "text": "Search for",
             "synonyms": [
-              "Find",
               "Look for",
-              "Seek"
+              "Find",
+              "Seek out"
             ],
             "category": "command",
-            "propertyNames": []
+            "propertyNames": [
+              "fullActionName"
+            ]
           },
           {
             "text": "soulful tunes by Aretha Franklin",
             "synonyms": [
-              "soulful songs by Aretha Franklin",
-              "soulful music by Aretha Franklin",
-              "soulful tracks by Aretha Franklin"
+              "soul music by Aretha Franklin",
+              "songs by Aretha Franklin",
+              "Aretha Franklin's tracks"
             ],
             "category": "query",
             "propertyNames": [
@@ -10030,6 +10371,33 @@
         ],
         "propertyAlternatives": [
           {
+            "propertyName": "fullActionName",
+            "propertyValue": "player.searchTracks",
+            "propertySubPhrases": [
+              "Search for"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "player.findSongs",
+                "propertySubPhrases": [
+                  "Find"
+                ]
+              },
+              {
+                "propertyValue": "player.lookupMusic",
+                "propertySubPhrases": [
+                  "Look up"
+                ]
+              },
+              {
+                "propertyValue": "player.browseTracks",
+                "propertySubPhrases": [
+                  "Browse"
+                ]
+              }
+            ]
+          },
+          {
             "propertyName": "parameters.query",
             "propertyValue": "soulful tunes by Aretha Franklin",
             "propertySubPhrases": [
@@ -10037,21 +10405,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "soulful songs by Aretha Franklin",
+                "propertyValue": "Aretha Franklin hits",
                 "propertySubPhrases": [
-                  "soulful songs by Aretha Franklin"
+                  "Aretha Franklin hits"
                 ]
               },
               {
-                "propertyValue": "soulful music by Aretha Franklin",
+                "propertyValue": "Aretha Franklin songs",
                 "propertySubPhrases": [
-                  "soulful music by Aretha Franklin"
+                  "Aretha Franklin songs"
                 ]
               },
               {
-                "propertyValue": "soulful tracks by Aretha Franklin",
+                "propertyValue": "Aretha Franklin music",
                 "propertySubPhrases": [
-                  "soulful tracks by Aretha Franklin"
+                  "Aretha Franklin music"
                 ]
               }
             ]
@@ -10090,8 +10458,8 @@
           {
             "text": "Search for",
             "synonyms": [
-              "Find",
               "Look for",
+              "Find",
               "Seek"
             ],
             "category": "command",
@@ -10184,7 +10552,7 @@
             "name": "fullActionName",
             "value": "player.searchTracks",
             "substrings": [
-              "Search for"
+              "Search for Sweet Child o Mine by Guns N Roses"
             ],
             "implied": true
           },
@@ -10203,7 +10571,7 @@
             "synonyms": [
               "Look for",
               "Find",
-              "Seek"
+              "Locate"
             ],
             "category": "command",
             "propertyNames": [
@@ -10244,7 +10612,7 @@
                 ]
               },
               {
-                "propertyValue": "player.queryTracks",
+                "propertyValue": "player.querySongs",
                 "propertySubPhrases": [
                   "Query"
                 ]
@@ -10295,9 +10663,9 @@
             "name": "fullActionName",
             "value": "player.searchTracks",
             "substrings": [
-              "Search for the album"
+              "Search for the album Thriller by Michael Jackson"
             ],
-            "implied": true
+            "implied": false
           },
           {
             "name": "parameters.query",
@@ -10310,13 +10678,25 @@
         ],
         "subPhrases": [
           {
-            "text": "Search for the album",
+            "text": "Search for",
             "synonyms": [
-              "Find the album",
-              "Look for the album",
-              "Locate the album"
+              "Look for",
+              "Find",
+              "Seek out"
             ],
-            "category": "action",
+            "category": "command",
+            "propertyNames": [
+              "fullActionName"
+            ]
+          },
+          {
+            "text": "the album",
+            "synonyms": [
+              "the record",
+              "the music album",
+              "the LP"
+            ],
+            "category": "object",
             "propertyNames": [
               "fullActionName"
             ]
@@ -10324,9 +10704,9 @@
           {
             "text": "Thriller by Michael Jackson",
             "synonyms": [
-              "Thriller from Michael Jackson",
-              "Michael Jackson's Thriller",
-              "The album Thriller by Michael Jackson"
+              "Thriller by MJ",
+              "Thriller by Michael J.",
+              "Thriller by Jackson"
             ],
             "category": "query",
             "propertyNames": [
@@ -10339,25 +10719,29 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.searchTracks",
             "propertySubPhrases": [
-              "Search for the album"
+              "Search for",
+              "the album"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.searchAlbums",
                 "propertySubPhrases": [
-                  "Find the album"
-                ]
-              },
-              {
-                "propertyValue": "player.searchSongs",
-                "propertySubPhrases": [
-                  "Search for the song"
+                  "Search for",
+                  "the album"
                 ]
               },
               {
                 "propertyValue": "player.searchArtists",
                 "propertySubPhrases": [
-                  "Search for the artist"
+                  "Search for",
+                  "the artist"
+                ]
+              },
+              {
+                "propertyValue": "player.searchPlaylists",
+                "propertySubPhrases": [
+                  "Search for",
+                  "the playlist"
                 ]
               }
             ]
@@ -10406,7 +10790,7 @@
             "name": "fullActionName",
             "value": "player.searchTracks",
             "substrings": [
-              "Search for"
+              "Search"
             ],
             "implied": true
           },
@@ -10421,16 +10805,26 @@
         ],
         "subPhrases": [
           {
-            "text": "Search for",
+            "text": "Search",
             "synonyms": [
               "Find",
               "Look for",
               "Seek"
             ],
-            "category": "command",
+            "category": "action",
             "propertyNames": [
               "fullActionName"
             ]
+          },
+          {
+            "text": "for",
+            "synonyms": [
+              "to find",
+              "in search of",
+              "seeking"
+            ],
+            "category": "preposition",
+            "isOptional": true
           },
           {
             "text": "the best of British rock",
@@ -10450,7 +10844,7 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.searchTracks",
             "propertySubPhrases": [
-              "Search for"
+              "Search"
             ],
             "alternatives": [
               {
@@ -10517,7 +10911,7 @@
             "name": "fullActionName",
             "value": "player.searchTracks",
             "substrings": [
-              "Search for"
+              "Search for top charting pop songs"
             ],
             "implied": true
           },
@@ -10538,7 +10932,7 @@
               "Look for",
               "Seek"
             ],
-            "category": "action",
+            "category": "command",
             "propertyNames": [
               "fullActionName"
             ]
@@ -10547,8 +10941,8 @@
             "text": "top charting pop songs",
             "synonyms": [
               "popular pop songs",
-              "top pop hits",
-              "chart-topping pop songs"
+              "hit pop songs",
+              "top pop tracks"
             ],
             "category": "query",
             "propertyNames": [
@@ -10760,7 +11154,7 @@
               "Find",
               "Seek out"
             ],
-            "category": "action",
+            "category": "command",
             "propertyNames": [
               "fullActionName"
             ]
@@ -10880,8 +11274,8 @@
             "text": "Wannabe by Spice Girls",
             "synonyms": [
               "Wannabe from Spice Girls",
-              "Wannabe performed by Spice Girls",
-              "Wannabe sung by Spice Girls"
+              "Wannabe by the Spice Girls",
+              "Wannabe by Spice Girls band"
             ],
             "category": "query",
             "propertyNames": [
@@ -10937,9 +11331,9 @@
                 ]
               },
               {
-                "propertyValue": "Rolling in the Deep by Adele",
+                "propertyValue": "Billie Jean by Michael Jackson",
                 "propertySubPhrases": [
-                  "Rolling in the Deep by Adele"
+                  "Billie Jean by Michael Jackson"
                 ]
               }
             ]
@@ -10991,8 +11385,8 @@
             "text": "Wonderwall by Oasis",
             "synonyms": [
               "Wonderwall from Oasis",
-              "Oasis's Wonderwall",
-              "the song Wonderwall by Oasis"
+              "Wonderwall - Oasis",
+              "Oasis' Wonderwall"
             ],
             "category": "query",
             "propertyNames": [
@@ -11021,7 +11415,7 @@
                 ]
               },
               {
-                "propertyValue": "player.queryTracks",
+                "propertyValue": "player.querySongs",
                 "propertySubPhrases": [
                   "Query"
                 ]

--- a/ts/packages/dispatcher/test/data/player/v5/simple.json
+++ b/ts/packages/dispatcher/test/data/player/v5/simple.json
@@ -16,7 +16,9 @@
           {
             "name": "fullActionName",
             "value": "player.playArtist",
-            "substrings": [],
+            "substrings": [
+              "play"
+            ],
             "implied": true
           },
           {
@@ -64,7 +66,7 @@
             "synonyms": [
               "start",
               "put on",
-              "playback"
+              "spin"
             ],
             "category": "action",
             "propertyNames": [
@@ -123,15 +125,15 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.playSong",
-                "propertySubPhrases": [
-                  "play a song by"
-                ]
-              },
-              {
                 "propertyValue": "player.playAlbum",
                 "propertySubPhrases": [
                   "play an album by"
+                ]
+              },
+              {
+                "propertyValue": "player.playSong",
+                "propertySubPhrases": [
+                  "play a song by"
                 ]
               },
               {
@@ -162,9 +164,9 @@
                 ]
               },
               {
-                "propertyValue": "Stevie Wonder",
+                "propertyValue": "Joni Mitchell",
                 "propertySubPhrases": [
-                  "Stevie Wonder"
+                  "Joni Mitchell"
                 ]
               }
             ]
@@ -210,24 +212,34 @@
         ],
         "subPhrases": [
           {
-            "text": "all right buddy",
+            "text": "all right",
             "synonyms": [
-              "okay buddy",
-              "sure buddy",
-              "alright buddy"
+              "okay",
+              "alright",
+              "sure"
             ],
             "category": "acknowledgement",
             "isOptional": true
           },
           {
+            "text": "buddy",
+            "synonyms": [
+              "pal",
+              "friend",
+              "mate"
+            ],
+            "category": "greeting",
+            "isOptional": true
+          },
+          {
             "text": "lets hear some",
             "synonyms": [
-              "let's play some",
-              "let's listen to",
-              "how about"
+              "play",
+              "put on",
+              "let's listen to"
             ],
-            "category": "confirmation",
-            "isOptional": true
+            "category": "command",
+            "isOptional": false
           },
           {
             "text": "ahh",
@@ -242,19 +254,19 @@
           {
             "text": "I guess",
             "synonyms": [
-              "I think",
               "maybe",
-              "perhaps"
+              "perhaps",
+              "I think"
             ],
-            "category": "confirmation",
+            "category": "uncertainty",
             "isOptional": true
           },
           {
             "text": "Debussy",
             "synonyms": [
               "Claude Debussy",
-              "Debussy's",
-              "by Debussy"
+              "composer Debussy",
+              "Debussy's"
             ],
             "category": "artist",
             "propertyNames": [
@@ -435,21 +447,21 @@
             ],
             "alternatives": [
               {
+                "propertyValue": "player.playSong",
+                "propertySubPhrases": [
+                  "can I listen to"
+                ]
+              },
+              {
                 "propertyValue": "player.playAlbum",
                 "propertySubPhrases": [
-                  "can I listen to an album by"
+                  "can I play"
                 ]
               },
               {
                 "propertyValue": "player.playPlaylist",
                 "propertySubPhrases": [
-                  "can I hear a playlist from"
-                ]
-              },
-              {
-                "propertyValue": "player.playSong",
-                "propertySubPhrases": [
-                  "can I hear a song by"
+                  "can I queue up"
                 ]
               }
             ]
@@ -497,13 +509,13 @@
               {
                 "propertyValue": 3,
                 "propertySubPhrases": [
-                  "three songs"
+                  "a few songs"
                 ]
               },
               {
                 "propertyValue": 5,
                 "propertySubPhrases": [
-                  "five songs"
+                  "several songs"
                 ]
               }
             ]
@@ -565,8 +577,8 @@
             "text": "katie perry",
             "synonyms": [
               "katy perry",
-              "Katy Perry",
-              "Katy P."
+              "K. Perry",
+              "Katy Hudson"
             ],
             "category": "artist",
             "propertyNames": [
@@ -667,7 +679,7 @@
               "start",
               "begin"
             ],
-            "category": "command",
+            "category": "action",
             "propertyNames": [
               "fullActionName"
             ]
@@ -716,9 +728,9 @@
                 ]
               },
               {
-                "propertyValue": "player.playMusicBy",
+                "propertyValue": "player.playArtist",
                 "propertySubPhrases": [
-                  "play music by"
+                  "play"
                 ]
               }
             ]
@@ -767,7 +779,7 @@
             "name": "fullActionName",
             "value": "player.playArtist",
             "substrings": [
-              "crank up"
+              "crank up the Bach vibes"
             ],
             "implied": true
           },
@@ -792,7 +804,7 @@
             "isOptional": true
           },
           {
-            "text": "crank up",
+            "text": "crank up the",
             "synonyms": [
               "play",
               "turn on",
@@ -804,16 +816,26 @@
             ]
           },
           {
-            "text": "the Bach vibes",
+            "text": "Bach",
             "synonyms": [
-              "some Bach",
-              "Bach music",
-              "Bach tunes"
+              "Johann Sebastian Bach",
+              "J.S. Bach",
+              "the composer Bach"
             ],
             "category": "artist",
             "propertyNames": [
               "parameters.artist"
             ]
+          },
+          {
+            "text": "vibes",
+            "synonyms": [
+              "music",
+              "tunes",
+              "melodies"
+            ],
+            "category": "context",
+            "isOptional": true
           }
         ],
         "propertyAlternatives": [
@@ -821,25 +843,25 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.playArtist",
             "propertySubPhrases": [
-              "crank up"
+              "crank up the"
             ],
             "alternatives": [
               {
-                "propertyValue": "player.startMusic",
+                "propertyValue": "player.playSong",
                 "propertySubPhrases": [
-                  "start the music"
+                  "play the song"
                 ]
               },
               {
-                "propertyValue": "player.beginPlayback",
+                "propertyValue": "player.playAlbum",
                 "propertySubPhrases": [
-                  "begin playback"
+                  "play the album"
                 ]
               },
               {
-                "propertyValue": "player.initiateTunes",
+                "propertyValue": "player.playPlaylist",
                 "propertySubPhrases": [
-                  "initiate the tunes"
+                  "play the playlist"
                 ]
               }
             ]
@@ -848,25 +870,25 @@
             "propertyName": "parameters.artist",
             "propertyValue": "Bach",
             "propertySubPhrases": [
-              "the Bach vibes"
+              "Bach"
             ],
             "alternatives": [
               {
                 "propertyValue": "Mozart",
                 "propertySubPhrases": [
-                  "the Mozart vibes"
+                  "Mozart"
                 ]
               },
               {
                 "propertyValue": "Beethoven",
                 "propertySubPhrases": [
-                  "the Beethoven vibes"
+                  "Beethoven"
                 ]
               },
               {
                 "propertyValue": "Chopin",
                 "propertySubPhrases": [
-                  "the Chopin vibes"
+                  "Chopin"
                 ]
               }
             ]
@@ -890,7 +912,9 @@
           {
             "name": "fullActionName",
             "value": "player.playAlbum",
-            "substrings": [],
+            "substrings": [
+              "i want to listen to the album"
+            ],
             "implied": true
           },
           {
@@ -912,31 +936,23 @@
         ],
         "subPhrases": [
           {
-            "text": "i want to listen to",
+            "text": "i want to listen to the album",
             "synonyms": [
-              "I would like to hear",
-              "I want to play",
-              "I wish to listen to"
+              "I would like to hear the album",
+              "Play the album",
+              "Can you play the album"
             ],
-            "category": "request",
-            "propertyNames": []
-          },
-          {
-            "text": "the album",
-            "synonyms": [
-              "the record",
-              "the music album",
-              "the LP"
-            ],
-            "category": "object",
-            "propertyNames": []
+            "category": "action",
+            "propertyNames": [
+              "fullActionName"
+            ]
           },
           {
             "text": "Pretzel Logic",
             "synonyms": [
-              "Pretzel Logic",
-              "Pretzel Logic album",
-              "album Pretzel Logic"
+              "Aja",
+              "Gaucho",
+              "Countdown to Ecstasy"
             ],
             "category": "albumName",
             "propertyNames": [
@@ -944,21 +960,11 @@
             ]
           },
           {
-            "text": "by",
+            "text": "by Steely Dan",
             "synonyms": [
-              "from",
-              "of",
-              "by the band"
-            ],
-            "category": "preposition",
-            "propertyNames": []
-          },
-          {
-            "text": "Steely Dan",
-            "synonyms": [
-              "Steely Dan",
-              "the band Steely Dan",
-              "Steely Dan group"
+              "from Steely Dan",
+              "performed by Steely Dan",
+              "by the band Steely Dan"
             ],
             "category": "artist",
             "propertyNames": [
@@ -967,6 +973,33 @@
           }
         ],
         "propertyAlternatives": [
+          {
+            "propertyName": "fullActionName",
+            "propertyValue": "player.playAlbum",
+            "propertySubPhrases": [
+              "i want to listen to the album"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "player.queueAlbum",
+                "propertySubPhrases": [
+                  "i want to queue the album"
+                ]
+              },
+              {
+                "propertyValue": "player.addAlbumToPlaylist",
+                "propertySubPhrases": [
+                  "i want to add the album to my playlist"
+                ]
+              },
+              {
+                "propertyValue": "player.shuffleAlbum",
+                "propertySubPhrases": [
+                  "i want to shuffle the album"
+                ]
+              }
+            ]
+          },
           {
             "propertyName": "parameters.albumName",
             "propertyValue": "Pretzel Logic",
@@ -987,9 +1020,9 @@
                 ]
               },
               {
-                "propertyValue": "Countdown to Ecstasy",
+                "propertyValue": "The Royal Scam",
                 "propertySubPhrases": [
-                  "Countdown to Ecstasy"
+                  "The Royal Scam"
                 ]
               }
             ]
@@ -998,25 +1031,25 @@
             "propertyName": "parameters.artists.0",
             "propertyValue": "Steely Dan",
             "propertySubPhrases": [
-              "Steely Dan"
+              "by Steely Dan"
             ],
             "alternatives": [
               {
                 "propertyValue": "The Beatles",
                 "propertySubPhrases": [
-                  "The Beatles"
+                  "by The Beatles"
                 ]
               },
               {
                 "propertyValue": "Pink Floyd",
                 "propertySubPhrases": [
-                  "Pink Floyd"
+                  "by Pink Floyd"
                 ]
               },
               {
                 "propertyValue": "Led Zeppelin",
                 "propertySubPhrases": [
-                  "Led Zeppelin"
+                  "by Led Zeppelin"
                 ]
               }
             ]
@@ -1062,26 +1095,14 @@
         ],
         "subPhrases": [
           {
-            "text": "lets",
+            "text": "lets listen to",
             "synonyms": [
-              "let us",
-              "let's",
-              "allow us to"
-            ],
-            "category": "filler",
-            "isOptional": true
-          },
-          {
-            "text": "listen to",
-            "synonyms": [
+              "let's play",
               "play",
-              "hear",
-              "put on"
+              "start playing"
             ],
-            "category": "action",
-            "propertyNames": [
-              "fullActionName"
-            ]
+            "category": "command",
+            "isOptional": true
           },
           {
             "text": "Pretzel Logic",
@@ -1090,27 +1111,17 @@
               "Pretzel Logic album",
               "Pretzel Logic by Steely Dan"
             ],
-            "category": "album",
+            "category": "albumName",
             "propertyNames": [
               "parameters.albumName"
             ]
           },
           {
-            "text": "by",
+            "text": "by Steely Dan",
             "synonyms": [
-              "from",
-              "performed by",
-              "created by"
-            ],
-            "category": "preposition",
-            "isOptional": true
-          },
-          {
-            "text": "Steely Dan",
-            "synonyms": [
-              "the band Steely Dan",
-              "Steely Dan group",
-              "Steely Dan music"
+              "from Steely Dan",
+              "Steely Dan's",
+              "performed by Steely Dan"
             ],
             "category": "artist",
             "propertyNames": [
@@ -1119,33 +1130,6 @@
           }
         ],
         "propertyAlternatives": [
-          {
-            "propertyName": "fullActionName",
-            "propertyValue": "player.playAlbum",
-            "propertySubPhrases": [
-              "listen to"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "player.playSong",
-                "propertySubPhrases": [
-                  "play"
-                ]
-              },
-              {
-                "propertyValue": "player.queueAlbum",
-                "propertySubPhrases": [
-                  "queue"
-                ]
-              },
-              {
-                "propertyValue": "player.shuffleAlbum",
-                "propertySubPhrases": [
-                  "shuffle"
-                ]
-              }
-            ]
-          },
           {
             "propertyName": "parameters.albumName",
             "propertyValue": "Pretzel Logic",
@@ -1177,25 +1161,25 @@
             "propertyName": "parameters.artists.0",
             "propertyValue": "Steely Dan",
             "propertySubPhrases": [
-              "Steely Dan"
+              "by Steely Dan"
             ],
             "alternatives": [
               {
                 "propertyValue": "The Beatles",
                 "propertySubPhrases": [
-                  "The Beatles"
+                  "by The Beatles"
                 ]
               },
               {
                 "propertyValue": "Pink Floyd",
                 "propertySubPhrases": [
-                  "Pink Floyd"
+                  "by Pink Floyd"
                 ]
               },
               {
                 "propertyValue": "Led Zeppelin",
                 "propertySubPhrases": [
-                  "Led Zeppelin"
+                  "by Led Zeppelin"
                 ]
               }
             ]
@@ -1254,11 +1238,11 @@
           {
             "text": "play some pieces by",
             "synonyms": [
-              "play music by",
-              "play songs by",
-              "play tracks by"
+              "play some music by",
+              "play works by",
+              "play compositions by"
             ],
-            "category": "action",
+            "category": "command",
             "propertyNames": [
               "fullActionName"
             ]
@@ -1383,8 +1367,8 @@
           {
             "text": "Ok",
             "synonyms": [
-              "Alright",
               "Okay",
+              "Alright",
               "Sure"
             ],
             "category": "acknowledgement",
@@ -1407,7 +1391,7 @@
               "I'd like to hear",
               "I would like to listen to"
             ],
-            "category": "request",
+            "category": "confirmation",
             "isOptional": false
           },
           {
@@ -1415,7 +1399,7 @@
             "synonyms": [
               "ah",
               "uh",
-              "hmm"
+              "er"
             ],
             "category": "filler",
             "isOptional": true
@@ -1425,7 +1409,7 @@
             "synonyms": [
               "uh",
               "er",
-              "hmm"
+              "ah"
             ],
             "category": "filler",
             "isOptional": true
@@ -1444,8 +1428,8 @@
             "text": "some Def Leppard",
             "synonyms": [
               "a bit of Def Leppard",
-              "any Def Leppard",
-              "Def Leppard music"
+              "Def Leppard music",
+              "Def Leppard songs"
             ],
             "category": "artist",
             "propertyNames": [
@@ -1455,9 +1439,9 @@
           {
             "text": "Armageddon It",
             "synonyms": [
-              "Play Armageddon It",
-              "The song Armageddon It",
-              "Track Armageddon It"
+              "Armageddon It track",
+              "Armageddon It song",
+              "Armageddon It by Def Leppard"
             ],
             "category": "track",
             "propertyNames": [
@@ -1625,9 +1609,9 @@
           {
             "text": "Alice in Chains",
             "synonyms": [
-              "Alice in Chains",
-              "AIC",
-              "the band Alice in Chains"
+              "the band Alice in Chains",
+              "Alice in Chains group",
+              "Alice in Chains music"
             ],
             "category": "artist",
             "propertyNames": [
@@ -1644,21 +1628,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.shuffleArtist",
-                "propertySubPhrases": [
-                  "shuffle"
-                ]
-              },
-              {
-                "propertyValue": "player.queueArtist",
-                "propertySubPhrases": [
-                  "queue"
-                ]
-              },
-              {
                 "propertyValue": "player.playAlbum",
                 "propertySubPhrases": [
                   "play an album by"
+                ]
+              },
+              {
+                "propertyValue": "player.playPlaylist",
+                "propertySubPhrases": [
+                  "play a playlist by"
+                ]
+              },
+              {
+                "propertyValue": "player.playSong",
+                "propertySubPhrases": [
+                  "play a song by"
                 ]
               }
             ]
@@ -1673,7 +1657,7 @@
               {
                 "propertyValue": 1,
                 "propertySubPhrases": [
-                  "a song by"
+                  "one"
                 ]
               },
               {
@@ -1735,9 +1719,9 @@
             "name": "fullActionName",
             "value": "player.playArtist",
             "substrings": [
-              "please play"
+              "please play a couple of fugues by Bach"
             ],
-            "implied": true
+            "implied": false
           },
           {
             "name": "parameters.artist",
@@ -1761,7 +1745,7 @@
             "text": "please",
             "synonyms": [
               "kindly",
-              "would you",
+              "would you mind",
               "could you"
             ],
             "category": "politeness",
@@ -1770,9 +1754,9 @@
           {
             "text": "play",
             "synonyms": [
-              "start",
-              "begin",
-              "perform"
+              "perform",
+              "put on",
+              "start"
             ],
             "category": "action",
             "propertyNames": [
@@ -1784,7 +1768,7 @@
             "synonyms": [
               "two",
               "a few",
-              "several"
+              "a pair of"
             ],
             "category": "quantity",
             "propertyNames": [
@@ -1792,11 +1776,21 @@
             ]
           },
           {
-            "text": "fugues by",
+            "text": "fugues",
             "synonyms": [
-              "pieces by",
-              "works by",
-              "compositions by"
+              "pieces",
+              "compositions",
+              "works"
+            ],
+            "category": "musicType",
+            "propertyNames": []
+          },
+          {
+            "text": "by",
+            "synonyms": [
+              "from",
+              "composed by",
+              "written by"
             ],
             "category": "preposition",
             "isOptional": true
@@ -1806,7 +1800,7 @@
             "synonyms": [
               "Johann Sebastian Bach",
               "J.S. Bach",
-              "Bach the composer"
+              "the composer Bach"
             ],
             "category": "artist",
             "propertyNames": [
@@ -1835,9 +1829,9 @@
                 ]
               },
               {
-                "propertyValue": "player.skipArtist",
+                "propertyValue": "player.shuffleArtist",
                 "propertySubPhrases": [
-                  "skip"
+                  "shuffle"
                 ]
               }
             ]
@@ -1952,9 +1946,9 @@
           {
             "text": "Paul Simon",
             "synonyms": [
-              "the artist Paul Simon",
-              "music by Paul Simon",
-              "songs by Paul Simon"
+              "Simon & Garfunkel",
+              "Paul",
+              "Simon"
             ],
             "category": "artist",
             "propertyNames": [
@@ -1968,7 +1962,7 @@
               "music",
               "tunes"
             ],
-            "category": "content",
+            "category": "object",
             "isOptional": true
           }
         ],
@@ -2055,7 +2049,7 @@
             "name": "parameters.albumName",
             "value": "Graceland",
             "substrings": [
-              "album Graceland"
+              "Graceland"
             ],
             "implied": false
           },
@@ -2073,7 +2067,7 @@
             "text": "please",
             "synonyms": [
               "kindly",
-              "would you",
+              "would you mind",
               "could you"
             ],
             "category": "politeness",
@@ -2083,10 +2077,10 @@
             "text": "play the",
             "synonyms": [
               "start the",
-              "begin the",
-              "put on the"
+              "put on the",
+              "begin the"
             ],
-            "category": "command",
+            "category": "action",
             "propertyNames": [
               "fullActionName"
             ]
@@ -2094,9 +2088,9 @@
           {
             "text": "Paul Simon",
             "synonyms": [
-              "Simon",
-              "Paul",
-              "the artist Paul Simon"
+              "the artist Paul Simon",
+              "Paul Simon's",
+              "by Paul Simon"
             ],
             "category": "artist",
             "propertyNames": [
@@ -2104,10 +2098,20 @@
             ]
           },
           {
-            "text": "album Graceland",
+            "text": "album",
             "synonyms": [
-              "record Graceland",
-              "Graceland album",
+              "record",
+              "music album",
+              "collection"
+            ],
+            "category": "media type",
+            "isOptional": true
+          },
+          {
+            "text": "Graceland",
+            "synonyms": [
+              "the album Graceland",
+              "Graceland by Paul Simon",
               "Graceland record"
             ],
             "category": "album",
@@ -2175,25 +2179,25 @@
             "propertyName": "parameters.albumName",
             "propertyValue": "Graceland",
             "propertySubPhrases": [
-              "album Graceland"
+              "Graceland"
             ],
             "alternatives": [
               {
                 "propertyValue": "Bridge Over Troubled Water",
                 "propertySubPhrases": [
-                  "album Bridge Over Troubled Water"
+                  "Bridge Over Troubled Water"
                 ]
               },
               {
                 "propertyValue": "Blood on the Tracks",
                 "propertySubPhrases": [
-                  "album Blood on the Tracks"
+                  "Blood on the Tracks"
                 ]
               },
               {
                 "propertyValue": "Born to Run",
                 "propertySubPhrases": [
-                  "album Born to Run"
+                  "Born to Run"
                 ]
               }
             ]
@@ -2214,9 +2218,7 @@
           {
             "name": "fullActionName",
             "value": "player.playArtist",
-            "substrings": [
-              "que up some Taylor Swift"
-            ],
+            "substrings": [],
             "implied": true
           },
           {
@@ -2230,26 +2232,14 @@
         ],
         "subPhrases": [
           {
-            "text": "que up",
+            "text": "que up some",
             "synonyms": [
               "play",
-              "start",
-              "begin"
+              "start playing",
+              "put on"
             ],
-            "category": "action",
-            "propertyNames": [
-              "fullActionName"
-            ]
-          },
-          {
-            "text": "some",
-            "synonyms": [
-              "a bit of",
-              "a little",
-              "a few"
-            ],
-            "category": "filler",
-            "isOptional": true
+            "category": "command",
+            "propertyNames": []
           },
           {
             "text": "Taylor Swift",
@@ -2265,33 +2255,6 @@
           }
         ],
         "propertyAlternatives": [
-          {
-            "propertyName": "fullActionName",
-            "propertyValue": "player.playArtist",
-            "propertySubPhrases": [
-              "que up"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "player.queueArtist",
-                "propertySubPhrases": [
-                  "queue up"
-                ]
-              },
-              {
-                "propertyValue": "player.addArtistToQueue",
-                "propertySubPhrases": [
-                  "add to queue"
-                ]
-              },
-              {
-                "propertyValue": "player.enqueueArtist",
-                "propertySubPhrases": [
-                  "enqueue"
-                ]
-              }
-            ]
-          },
           {
             "propertyName": "parameters.artist",
             "propertyValue": "Taylor Swift",
@@ -2357,7 +2320,7 @@
               "start",
               "begin"
             ],
-            "category": "action",
+            "category": "command",
             "propertyNames": [
               "fullActionName"
             ]
@@ -2433,9 +2396,9 @@
                 ]
               },
               {
-                "propertyValue": "Kendrick Lamar",
+                "propertyValue": "Ice Cube",
                 "propertySubPhrases": [
-                  "Kendrick Lamar"
+                  "Ice Cube"
                 ]
               }
             ]
@@ -2505,6 +2468,12 @@
             ],
             "alternatives": [
               {
+                "propertyValue": "player.resumeTrack",
+                "propertySubPhrases": [
+                  "resume playing"
+                ]
+              },
+              {
                 "propertyValue": "player.startTrack",
                 "propertySubPhrases": [
                   "begin playing"
@@ -2513,13 +2482,7 @@
               {
                 "propertyValue": "player.playSong",
                 "propertySubPhrases": [
-                  "play"
-                ]
-              },
-              {
-                "propertyValue": "player.startMusic",
-                "propertySubPhrases": [
-                  "start music"
+                  "play song"
                 ]
               }
             ]
@@ -2568,7 +2531,7 @@
             "name": "fullActionName",
             "value": "player.playArtist",
             "substrings": [
-              "start some music"
+              "start some music by"
             ],
             "implied": true
           },
@@ -2583,33 +2546,23 @@
         ],
         "subPhrases": [
           {
-            "text": "start some music",
+            "text": "start some music by",
             "synonyms": [
-              "play some tunes",
-              "begin playing music",
-              "start the music"
+              "play some tunes by",
+              "put on some music by",
+              "start playing music by"
             ],
-            "category": "action",
+            "category": "command",
             "propertyNames": [
               "fullActionName"
             ]
           },
           {
-            "text": "by",
-            "synonyms": [
-              "from",
-              "featuring",
-              "performed by"
-            ],
-            "category": "preposition",
-            "isOptional": true
-          },
-          {
             "text": "CPE bach",
             "synonyms": [
-              "Carl Philipp Emanuel Bach",
               "C.P.E. Bach",
-              "CPE B."
+              "Carl Philipp Emanuel Bach",
+              "CPE Bach"
             ],
             "category": "artist",
             "propertyNames": [
@@ -2622,25 +2575,25 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.playArtist",
             "propertySubPhrases": [
-              "start some music"
+              "start some music by"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.playSong",
                 "propertySubPhrases": [
-                  "play a song"
+                  "play a song by"
                 ]
               },
               {
                 "propertyValue": "player.playAlbum",
                 "propertySubPhrases": [
-                  "play an album"
+                  "play an album by"
                 ]
               },
               {
                 "propertyValue": "player.playPlaylist",
                 "propertySubPhrases": [
-                  "play a playlist"
+                  "play a playlist by"
                 ]
               }
             ]
@@ -2765,13 +2718,13 @@
               {
                 "propertyValue": "player.startRadio",
                 "propertySubPhrases": [
-                  "start a radio station with"
+                  "start a radio station for"
                 ]
               },
               {
-                "propertyValue": "player.playNext",
+                "propertyValue": "player.shufflePlay",
                 "propertySubPhrases": [
-                  "play next"
+                  "shuffle play"
                 ]
               }
             ]
@@ -2804,7 +2757,35 @@
             ]
           }
         ]
-      }
+      },
+      "corrections": [
+        {
+          "data": {
+            "properties": [
+              {
+                "name": "fullActionName",
+                "value": "player.playArtist",
+                "substrings": [
+                  "queue up some Chemical Brothers"
+                ],
+                "implied": true
+              },
+              {
+                "name": "artist",
+                "value": "Chemical Brothers",
+                "substrings": [
+                  "Chemical Brothers"
+                ],
+                "implied": false
+              }
+            ]
+          },
+          "correction": [
+            "Extraneous parameter: 'artist' is not a parameter in the action",
+            "Missing parameter: parameter 'parameters.artist' in the action is missing from explanation"
+          ]
+        }
+      ]
     },
     {
       "request": "would you please play a couple of Duran Duran songs",
@@ -2823,7 +2804,7 @@
             "substrings": [
               "play"
             ],
-            "implied": true
+            "implied": false
           },
           {
             "name": "parameters.artist",
@@ -2844,11 +2825,21 @@
         ],
         "subPhrases": [
           {
-            "text": "would you please",
+            "text": "would you",
             "synonyms": [
-              "could you please",
-              "can you please",
-              "would you mind"
+              "could you",
+              "can you",
+              "will you"
+            ],
+            "category": "politeness",
+            "isOptional": true
+          },
+          {
+            "text": "please",
+            "synonyms": [
+              "kindly",
+              "if you would",
+              "if you could"
             ],
             "category": "politeness",
             "isOptional": true
@@ -2858,7 +2849,7 @@
             "synonyms": [
               "start",
               "put on",
-              "playback"
+              "turn on"
             ],
             "category": "action",
             "propertyNames": [
@@ -2868,8 +2859,8 @@
           {
             "text": "a couple of",
             "synonyms": [
-              "a few",
               "two",
+              "a few",
               "a pair of"
             ],
             "category": "quantity",
@@ -2921,9 +2912,9 @@
                 ]
               },
               {
-                "propertyValue": "player.addArtist",
+                "propertyValue": "player.addArtistToPlaylist",
                 "propertySubPhrases": [
-                  "add"
+                  "add to playlist"
                 ]
               }
             ]
@@ -3025,11 +3016,21 @@
         ],
         "subPhrases": [
           {
-            "text": "would you please",
+            "text": "would you",
             "synonyms": [
-              "could you please",
-              "can you please",
-              "would you mind"
+              "could you",
+              "can you",
+              "will you"
+            ],
+            "category": "politeness",
+            "isOptional": true
+          },
+          {
+            "text": "please",
+            "synonyms": [
+              "kindly",
+              "if you don't mind",
+              "if you could"
             ],
             "category": "politeness",
             "isOptional": true
@@ -3038,8 +3039,8 @@
             "text": "play",
             "synonyms": [
               "start",
-              "begin",
-              "put on"
+              "put on",
+              "turn on"
             ],
             "category": "action",
             "propertyNames": [
@@ -3053,7 +3054,7 @@
               "Aja album",
               "Aja by Steely Dan"
             ],
-            "category": "album",
+            "category": "albumName",
             "propertyNames": [
               "parameters.albumName"
             ]
@@ -3062,8 +3063,8 @@
             "text": "by Steely Dan",
             "synonyms": [
               "from Steely Dan",
-              "performed by Steely Dan",
-              "Steely Dan's"
+              "Steely Dan's",
+              "performed by Steely Dan"
             ],
             "category": "artist",
             "propertyNames": [
@@ -3082,19 +3083,19 @@
               {
                 "propertyValue": "player.playSong",
                 "propertySubPhrases": [
-                  "play a song"
+                  "play the song"
                 ]
               },
               {
                 "propertyValue": "player.playPlaylist",
                 "propertySubPhrases": [
-                  "play a playlist"
+                  "play the playlist"
                 ]
               },
               {
                 "propertyValue": "player.playPodcast",
                 "propertySubPhrases": [
-                  "play a podcast"
+                  "play the podcast"
                 ]
               }
             ]
@@ -3119,9 +3120,9 @@
                 ]
               },
               {
-                "propertyValue": "The Royal Scam",
+                "propertyValue": "Countdown to Ecstasy",
                 "propertySubPhrases": [
-                  "The Royal Scam"
+                  "Countdown to Ecstasy"
                 ]
               }
             ]
@@ -3222,9 +3223,9 @@
             "synonyms": [
               "the album Graceland",
               "Graceland album",
-              "Graceland record"
+              "Graceland by Paul Simon"
             ],
-            "category": "albumName",
+            "category": "album",
             "propertyNames": [
               "parameters.albumName"
             ]
@@ -3341,7 +3342,7 @@
             "name": "fullActionName",
             "value": "player.playArtist",
             "substrings": [
-              "play"
+              "would you please play"
             ],
             "implied": true
           },
@@ -3356,11 +3357,21 @@
         ],
         "subPhrases": [
           {
-            "text": "would you please",
+            "text": "would you",
             "synonyms": [
-              "could you please",
-              "can you please",
-              "would you mind"
+              "can you",
+              "could you",
+              "will you"
+            ],
+            "category": "politeness",
+            "isOptional": true
+          },
+          {
+            "text": "please",
+            "synonyms": [
+              "kindly",
+              "if you would",
+              "if you please"
             ],
             "category": "politeness",
             "isOptional": true
@@ -3368,8 +3379,8 @@
           {
             "text": "play",
             "synonyms": [
-              "start",
               "put on",
+              "start",
               "begin"
             ],
             "category": "action",
@@ -3391,7 +3402,7 @@
             "text": "Duran Duran",
             "synonyms": [
               "the band Duran Duran",
-              "Duran Duran's music",
+              "Duran Duran music",
               "songs by Duran Duran"
             ],
             "category": "artist",
@@ -3456,7 +3467,35 @@
             ]
           }
         ]
-      }
+      },
+      "corrections": [
+        {
+          "data": {
+            "properties": [
+              {
+                "name": "fullActionName",
+                "value": "player.playArtist",
+                "substrings": [
+                  "would you please play"
+                ],
+                "implied": true
+              },
+              {
+                "name": "artist",
+                "value": "Duran Duran",
+                "substrings": [
+                  "Duran Duran"
+                ],
+                "implied": false
+              }
+            ]
+          },
+          "correction": [
+            "Extraneous parameter: 'artist' is not a parameter in the action",
+            "Missing parameter: parameter 'parameters.artist' in the action is missing from explanation"
+          ]
+        }
+      ]
     },
     {
       "request": "yo, play some Metallica And Justice for All",
@@ -3506,26 +3545,14 @@
             "isOptional": true
           },
           {
-            "text": "play",
+            "text": "play some",
             "synonyms": [
-              "start",
-              "begin",
-              "put on"
+              "play",
+              "put on",
+              "start"
             ],
             "category": "command",
-            "propertyNames": [
-              "fullActionName"
-            ]
-          },
-          {
-            "text": "some",
-            "synonyms": [
-              "a bit of",
-              "a little",
-              "some of"
-            ],
-            "category": "filler",
-            "isOptional": true
+            "isOptional": false
           },
           {
             "text": "Metallica",
@@ -3554,33 +3581,6 @@
         ],
         "propertyAlternatives": [
           {
-            "propertyName": "fullActionName",
-            "propertyValue": "player.playAlbum",
-            "propertySubPhrases": [
-              "play"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "player.playSong",
-                "propertySubPhrases": [
-                  "play a song"
-                ]
-              },
-              {
-                "propertyValue": "player.playPlaylist",
-                "propertySubPhrases": [
-                  "play a playlist"
-                ]
-              },
-              {
-                "propertyValue": "player.playArtist",
-                "propertySubPhrases": [
-                  "play artist"
-                ]
-              }
-            ]
-          },
-          {
             "propertyName": "parameters.artists.0",
             "propertyValue": "Metallica",
             "propertySubPhrases": [
@@ -3588,21 +3588,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "Nirvana",
+                "propertyValue": "Iron Maiden",
                 "propertySubPhrases": [
-                  "Nirvana"
+                  "Iron Maiden"
                 ]
               },
               {
-                "propertyValue": "AC/DC",
+                "propertyValue": "Megadeth",
                 "propertySubPhrases": [
-                  "AC/DC"
+                  "Megadeth"
                 ]
               },
               {
-                "propertyValue": "Led Zeppelin",
+                "propertyValue": "Slayer",
                 "propertySubPhrases": [
-                  "Led Zeppelin"
+                  "Slayer"
                 ]
               }
             ]
@@ -3653,7 +3653,9 @@
           {
             "name": "fullActionName",
             "value": "player.playAlbum",
-            "substrings": [],
+            "substrings": [
+              "yo, yo play the third one on Nevermind"
+            ],
             "implied": true
           },
           {
@@ -3709,11 +3711,21 @@
             ]
           },
           {
-            "text": "on Nevermind",
+            "text": "on",
             "synonyms": [
-              "from Nevermind",
-              "in Nevermind",
-              "off Nevermind"
+              "from",
+              "in",
+              "off"
+            ],
+            "category": "preposition",
+            "isOptional": true
+          },
+          {
+            "text": "Nevermind",
+            "synonyms": [
+              "the album Nevermind",
+              "Nevermind album",
+              "Nirvana's Nevermind"
             ],
             "category": "albumName",
             "propertyNames": [
@@ -3780,25 +3792,25 @@
             "propertyName": "parameters.albumName",
             "propertyValue": "Nevermind",
             "propertySubPhrases": [
-              "on Nevermind"
+              "Nevermind"
             ],
             "alternatives": [
               {
                 "propertyValue": "In Utero",
                 "propertySubPhrases": [
-                  "on In Utero"
+                  "In Utero"
                 ]
               },
               {
                 "propertyValue": "Bleach",
                 "propertySubPhrases": [
-                  "on Bleach"
+                  "Bleach"
                 ]
               },
               {
                 "propertyValue": "MTV Unplugged in New York",
                 "propertySubPhrases": [
-                  "on MTV Unplugged in New York"
+                  "MTV Unplugged in New York"
                 ]
               }
             ]
@@ -3820,9 +3832,9 @@
             "name": "fullActionName",
             "value": "player.playArtist",
             "substrings": [
-              "spin me some"
+              "spin me some Snoop Dogg"
             ],
-            "implied": true
+            "implied": false
           },
           {
             "name": "parameters.artist",
@@ -3847,11 +3859,11 @@
           {
             "text": "spin me some",
             "synonyms": [
-              "play me some",
-              "put on some",
-              "give me some"
+              "play",
+              "put on",
+              "start"
             ],
-            "category": "command",
+            "category": "fullActionName",
             "propertyNames": [
               "fullActionName"
             ]
@@ -3863,7 +3875,7 @@
               "Snoop Doggy Dogg",
               "Calvin Broadus"
             ],
-            "category": "artist",
+            "category": "parameters.artist",
             "propertyNames": [
               "parameters.artist"
             ]
@@ -3872,8 +3884,8 @@
             "text": "you know what I am sayin?",
             "synonyms": [
               "you get me?",
-              "you understand?",
-              "you feel me?"
+              "you feel me?",
+              "you understand?"
             ],
             "category": "filler",
             "isOptional": true
@@ -3890,19 +3902,19 @@
               {
                 "propertyValue": "player.playSong",
                 "propertySubPhrases": [
-                  "play me a track"
+                  "play me a song by"
                 ]
               },
               {
                 "propertyValue": "player.playAlbum",
                 "propertySubPhrases": [
-                  "spin me an album"
+                  "spin me an album by"
                 ]
               },
               {
                 "propertyValue": "player.playPlaylist",
                 "propertySubPhrases": [
-                  "play me a playlist"
+                  "play me a playlist by"
                 ]
               }
             ]


### PR DESCRIPTION
GPT4o has the propensity to explain empty parameters, even thought that is not a property listed.
Add instruction to explicitly ignore explaining empty properties.

Also:
- Add flag `--request` to command `cli data regenerate` to filter to specified request pattern
-  clean up unused code path.