### PR TITLE
Update zoom handling for inline browser

### DIFF
--- a/ts/packages/agents/browser/src/extension/contentScript.ts
+++ b/ts/packages/agents/browser/src/extension/contentScript.ts
@@ -570,17 +570,6 @@ async function handleScriptAction(
             break;
         }
 
-        case "zoom_in_page": {
-            sendResponse({});
-            break;
-        }
-        case "zoom_out_page": {
-            window.history.forward();
-
-            sendResponse({});
-            break;
-        }
-
         case "read_page_content": {
             const article = getReadablePageContent();
             sendResponse(article);

--- a/ts/packages/shell/src/main/index.ts
+++ b/ts/packages/shell/src/main/index.ts
@@ -687,7 +687,7 @@ app.whenReady().then(async () => {
             );
 
             mainWindow?.setTitle(
-                `${newSettingSummary} Zoom: ${ShellSettings.getinstance().zoomLevel * 100}%`,
+                `${newSettingSummary} Zoom: ${Math.round(chatView?.webContents.zoomFactor! * 100)}%`,
             );
         }
 
@@ -760,7 +760,7 @@ app.whenReady().then(async () => {
         );
 
         mainWindow?.setTitle(
-            `${settingSummary} Zoom: ${ShellSettings.getinstance().zoomLevel * 100}%`,
+            `${settingSummary} Zoom: ${Math.round(chatView?.webContents.zoomFactor! * 100)}%`,
         );
         mainWindow?.show();
 
@@ -835,6 +835,8 @@ function zoomIn(chatView: BrowserView) {
         "zoomLevel",
         chatView.webContents.zoomLevel,
     );
+
+    updateZoomInTitle(chatView);
 }
 
 function zoomOut(chatView: BrowserView) {
@@ -844,6 +846,25 @@ function zoomOut(chatView: BrowserView) {
         "zoomLevel",
         chatView.webContents.zoomLevel,
     );
+
+    updateZoomInTitle(chatView);
+}
+
+function resetZoom(chatView: BrowserView) {
+    chatView.webContents.zoomLevel = 0;
+    ShellSettings.getinstance().set("zoomLevel", 0);
+    updateZoomInTitle(chatView);
+}
+
+function updateZoomInTitle(chatView: BrowserView) {
+    const prevTitle = mainWindow?.getTitle();
+    if (prevTitle) {
+        let summary = prevTitle.substring(0, prevTitle.indexOf("Zoom: "));
+
+        mainWindow?.setTitle(
+            `${summary}Zoom: ${Math.round(chatView.webContents.zoomFactor * 100)}%`,
+        );
+    }
 }
 
 const isMac = process.platform === "darwin";
@@ -859,8 +880,7 @@ function setupZoomHandlers(chatView: BrowserView) {
             } else if (input.key === "-" || input.key === "NumpadMinus") {
                 zoomOut(chatView);
             } else if (input.key === "0") {
-                chatView.webContents.zoomLevel = 0;
-                ShellSettings.getinstance().set("zoomLevel", 0);
+                resetZoom(chatView);
             }
         }
     });

--- a/ts/packages/shell/src/preload/webView.ts
+++ b/ts/packages/shell/src/preload/webView.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 const { contextBridge } = require("electron/renderer");
+const { webFrame } = require("electron");
 
 import {
     WebSocketMessage,
@@ -332,9 +333,8 @@ async function runBrowserAction(action: any) {
                     action: action,
                 });
             } else {
-                sendScriptAction({
-                    type: "zoom_in_page",
-                });
+                const currZoom = webFrame.getZoomFactor();
+                webFrame.setZoomFactor(currZoom + 0.2);
             }
 
             break;
@@ -346,16 +346,13 @@ async function runBrowserAction(action: any) {
                     action: action,
                 });
             } else {
-                sendScriptAction({
-                    type: "zoom_out_page",
-                });
+                const currZoom = webFrame.getZoomFactor();
+                webFrame.setZoomFactor(currZoom - 0.2);
             }
             break;
         }
         case "zoomReset": {
-            sendScriptAction({
-                type: "zoom_reset",
-            });
+            webFrame.setZoomFactor(1.0);
             break;
         }
 


### PR DESCRIPTION
- Fix bug where zoom level was not getting updated in the window title
- use webFrame to enable the zoom browser action to work in the inline browser