### PR TITLE
Update inline browser to support sites with strict CSPs

### DIFF
--- a/ts/packages/agents/browser/src/electron/agentActivation.ts
+++ b/ts/packages/agents/browser/src/electron/agentActivation.ts
@@ -55,7 +55,7 @@ function setupSiteAgent() {
     }
 }
 
-window.addEventListener("message", async (event) => {
+window.addEventListener("message", (event) => {
     if (event.data === "setupSiteAgent") {
         setupSiteAgent();
     }
@@ -68,6 +68,3 @@ window.addEventListener("message", async (event) => {
     }
 });
 
-document.addEventListener("DOMContentLoaded", () => {
-    setupSiteAgent();
-});

--- a/ts/packages/agents/browser/src/electron/agentActivation.ts
+++ b/ts/packages/agents/browser/src/electron/agentActivation.ts
@@ -10,50 +10,54 @@ declare global {
 }
 
 let siteAgent: string = "";
+function setupSiteAgent() {
+    if (window.browserConnect) {
+        const pageUrl = window.location.href;
+        const host = new URL(pageUrl).host;
+
+        if (host === "paleobiodb.org" || host === "www.paleobiodb.org") {
+            siteAgent = "browser.paleoBioDb";
+            window.browserConnect.enableSiteAgent("browser.paleoBioDb");
+        }
+
+        if (
+            pageUrl.startsWith("https://embed.universaluclick.com/") ||
+            pageUrl.startsWith("https://data.puzzlexperts.com/puzzleapp") ||
+            pageUrl.startsWith("https://nytsyn.pzzl.com/cwd_seattle") ||
+            pageUrl.startsWith("https://www.wsj.com/puzzles/crossword") ||
+            pageUrl.startsWith(
+                "https://www.seattletimes.com/games-nytimes-crossword",
+            ) ||
+            pageUrl.startsWith(
+                "https://www.denverpost.com/games/daily-crossword",
+            ) ||
+            pageUrl.startsWith(
+                "https://www.bestcrosswords.com/bestcrosswords/guestconstructor",
+            )
+        ) {
+            siteAgent = "browser.crossword";
+            window.browserConnect.enableSiteAgent("browser.crossword");
+        }
+
+        const commerceHosts = [
+            "www.homedepot.com",
+            "www.target.com",
+            "www.walmart.com",
+            "www.instacart.com",
+        ];
+
+        if (commerceHosts.includes(host)) {
+            siteAgent = "browser.commerce";
+            window.browserConnect.enableSiteAgent("browser.commerce");
+        }
+    } else {
+        console.log("browserconnect not found by UI events script");
+    }
+}
+
 window.addEventListener("message", async (event) => {
     if (event.data === "setupSiteAgent") {
-        if (window.browserConnect) {
-            const pageUrl = window.location.href;
-            const host = new URL(pageUrl).host;
-
-            if (host === "paleobiodb.org" || host === "www.paleobiodb.org") {
-                siteAgent = "browser.paleoBioDb";
-                window.browserConnect.enableSiteAgent("browser.paleoBioDb");
-            }
-
-            if (
-                pageUrl.startsWith("https://embed.universaluclick.com/") ||
-                pageUrl.startsWith("https://data.puzzlexperts.com/puzzleapp") ||
-                pageUrl.startsWith("https://nytsyn.pzzl.com/cwd_seattle") ||
-                pageUrl.startsWith("https://www.wsj.com/puzzles/crossword") ||
-                pageUrl.startsWith(
-                    "https://www.seattletimes.com/games-nytimes-crossword",
-                ) ||
-                pageUrl.startsWith(
-                    "https://www.denverpost.com/games/daily-crossword",
-                ) ||
-                pageUrl.startsWith(
-                    "https://www.bestcrosswords.com/bestcrosswords/guestconstructor",
-                )
-            ) {
-                siteAgent = "browser.crossword";
-                window.browserConnect.enableSiteAgent("browser.crossword");
-            }
-
-            const commerceHosts = [
-                "www.homedepot.com",
-                "www.target.com",
-                "www.walmart.com",
-                "www.instacart.com",
-            ];
-
-            if (commerceHosts.includes(host)) {
-                siteAgent = "browser.commerce";
-                window.browserConnect.enableSiteAgent("browser.commerce");
-            }
-        } else {
-            console.log("browserconnect not found by UI events script");
-        }
+        setupSiteAgent();
     }
     if (
         event.data === "disableSiteAgent" &&
@@ -62,4 +66,8 @@ window.addEventListener("message", async (event) => {
     ) {
         window.browserConnect.disableSiteAgent(siteAgent);
     }
+});
+
+document.addEventListener("DOMContentLoaded", () => {
+    setupSiteAgent();
 });

--- a/ts/packages/agents/browser/src/electron/agentActivation.ts
+++ b/ts/packages/agents/browser/src/electron/agentActivation.ts
@@ -67,4 +67,3 @@ window.addEventListener("message", (event) => {
         window.browserConnect.disableSiteAgent(siteAgent);
     }
 });
-

--- a/ts/packages/agents/browser/src/electron/manifest.json
+++ b/ts/packages/agents/browser/src/electron/manifest.json
@@ -14,7 +14,8 @@
     {
       "matches": ["https://*/*"],
       "js": ["agentActivation.js"],
-      "world": "MAIN"
+      "world": "MAIN",
+      "runAt": "document_start"
     },
     {
       "matches": ["https://*/*"],

--- a/ts/packages/shell/package.json
+++ b/ts/packages/shell/package.json
@@ -19,7 +19,7 @@
     "build:mac": "npm run build && electron-builder --mac --config",
     "build:win": "npm run build && electron-builder --win --config",
     "clean": "rimraf --glob out *.tsbuildinfo *.done.build.log",
-    "dev": "electron-vite dev",
+    "dev": "electron-vite dev --inspect 9229",
     "postinstall": "cross-env \"npm_execpath=\" electron-builder install-app-deps",
     "prettier": "prettier --check . --ignore-path ../../.prettierignore",
     "prettier:fix": "prettier --write . --ignore-path ../../.prettierignore",

--- a/ts/packages/shell/src/main/browserIpc.ts
+++ b/ts/packages/shell/src/main/browserIpc.ts
@@ -85,6 +85,5 @@ export class BrowserAgentIpc {
     public async send(message: WebSocketMessage) {
         await this.ensureWebsocketConnected();
         this.webSocket.send(JSON.stringify(message));
-    
     }
 }

--- a/ts/packages/shell/src/main/browserIpc.ts
+++ b/ts/packages/shell/src/main/browserIpc.ts
@@ -1,0 +1,90 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import {
+    WebSocketMessage,
+    createWebSocket,
+    keepWebSocketAlive,
+} from "common-utils";
+
+import WebSocket from "ws";
+
+export class BrowserAgentIpc {
+    private static instance: BrowserAgentIpc;
+    public onMessageReceived: ((message: WebSocketMessage) => void) | null;
+    private webSocket: any;
+
+    private constructor() {
+        this.webSocket = null;
+        this.onMessageReceived = null;
+    }
+
+    public static getinstance = (): BrowserAgentIpc => {
+        if (!BrowserAgentIpc.instance) {
+            BrowserAgentIpc.instance = new BrowserAgentIpc();
+        }
+
+        return BrowserAgentIpc.instance;
+    };
+
+    public async ensureWebsocketConnected() {
+        return new Promise<WebSocket | undefined>(async (resolve) => {
+            if (this.webSocket) {
+                if (this.webSocket.readyState === WebSocket.OPEN) {
+                    resolve(this.webSocket);
+                    return;
+                }
+                try {
+                    this.webSocket.close();
+                    this.webSocket = undefined;
+                } catch {}
+            }
+
+            this.webSocket = await createWebSocket();
+            if (!this.webSocket) {
+                resolve(undefined);
+                return;
+            }
+
+            this.webSocket.binaryType = "blob";
+            keepWebSocketAlive(this.webSocket, "browser");
+
+            this.webSocket.onmessage = async (event: any) => {
+                const text = event.data.toString();
+                const data = JSON.parse(text) as WebSocketMessage;
+                if (data.target == "browser" && this.onMessageReceived) {
+                    this.onMessageReceived(data);
+                }
+            };
+
+            this.webSocket.onclose = () => {
+                console.log("websocket connection closed");
+                this.webSocket = undefined;
+                this.reconnectWebSocket();
+            };
+
+            resolve(this.webSocket);
+        });
+    }
+
+    private reconnectWebSocket() {
+        const connectionCheckIntervalId = setInterval(async () => {
+            if (
+                this.webSocket &&
+                this.webSocket.readyState === WebSocket.OPEN
+            ) {
+                console.log("Clearing reconnect retry interval");
+                clearInterval(connectionCheckIntervalId);
+            } else {
+                console.log("Retrying connection");
+                await this.ensureWebsocketConnected();
+            }
+        }, 5 * 1000);
+    }
+
+    public send(message: WebSocketMessage) {
+        if (this.webSocket && this.webSocket.readyState === WebSocket.OPEN) {
+            this.webSocket.send(JSON.stringify(message));
+        }
+    }
+}

--- a/ts/packages/shell/src/main/browserIpc.ts
+++ b/ts/packages/shell/src/main/browserIpc.ts
@@ -82,9 +82,9 @@ export class BrowserAgentIpc {
         }, 5 * 1000);
     }
 
-    public send(message: WebSocketMessage) {
-        if (this.webSocket && this.webSocket.readyState === WebSocket.OPEN) {
-            this.webSocket.send(JSON.stringify(message));
-        }
+    public async send(message: WebSocketMessage) {
+        await this.ensureWebsocketConnected();
+        this.webSocket.send(JSON.stringify(message));
+    
     }
 }

--- a/ts/packages/shell/src/main/index.ts
+++ b/ts/packages/shell/src/main/index.ts
@@ -159,7 +159,7 @@ function createWindow(dispatcher: Dispatcher): void {
                 mainWindow.webContents.zoomLevel;
             ShellSettings.getinstance().devTools =
                 mainWindow.webContents.isDevToolsOpened();
-            
+
             mainWindow.hide();
             ShellSettings.getinstance().closeInlineBrowser();
             ShellSettings.getinstance().size = mainWindow.getSize();
@@ -276,7 +276,7 @@ function createWindow(dispatcher: Dispatcher): void {
         inlineBrowserView?.webContents.loadURL(targetUrl.toString());
         inlineBrowserView?.webContents.on("did-finish-load", () => {
             inlineBrowserView?.webContents.send("init-site-agent");
-        });      
+        });
     };
 
     ShellSettings.getinstance().onCloseInlineBrowser = (): void => {
@@ -296,7 +296,7 @@ function createWindow(dispatcher: Dispatcher): void {
         }
     };
 
-    ipcMain.handle("init-browser-ipc",async () =>{
+    ipcMain.handle("init-browser-ipc", async () => {
         await BrowserAgentIpc.getinstance().ensureWebsocketConnected();
 
         BrowserAgentIpc.getinstance().onMessageReceived = (
@@ -307,7 +307,7 @@ function createWindow(dispatcher: Dispatcher): void {
                 message,
             );
         };
-    })
+    });
 }
 
 /**
@@ -813,9 +813,12 @@ app.whenReady().then(async () => {
         chatView?.webContents.send("send-demo-event", "Alt+Right");
     });
 
-    ipcMain.on("send-to-browser-ipc", async (_event, data: WebSocketMessage) => {
-        await BrowserAgentIpc.getinstance().send(data);
-    });
+    ipcMain.on(
+        "send-to-browser-ipc",
+        async (_event, data: WebSocketMessage) => {
+            await BrowserAgentIpc.getinstance().send(data);
+        },
+    );
 
     // Default open or close DevTools by F12 in development
     // and ignore CommandOrControl + R in production.

--- a/ts/packages/shell/src/main/shellSettings.ts
+++ b/ts/packages/shell/src/main/shellSettings.ts
@@ -41,7 +41,7 @@ export class ShellSettings
     public onShowSettingsDialog: ((dialogName: string) => void) | null;
     public onRunDemo: ((interactive: boolean) => void) | null;
     public onToggleTopMost: EmptyFunction | null;
-    public onOpenInlineBrowser: ((targetUrl: URL) => void) | null;
+    public onOpenInlineBrowser: ((targetUrl: URL) => Promise<void>) | null;
     public onCloseInlineBrowser: EmptyFunction | null;
 
     public get width(): number {
@@ -187,9 +187,9 @@ export class ShellSettings
         return false;
     }
 
-    public openInlineBrowser(targetUrl: URL) {
+    public async openInlineBrowser(targetUrl: URL) {
         if (ShellSettings.getinstance().onOpenInlineBrowser != null) {
-            ShellSettings.getinstance().onOpenInlineBrowser!(targetUrl);
+            await ShellSettings.getinstance().onOpenInlineBrowser!(targetUrl);
         }
     }
 

--- a/ts/packages/shell/src/main/shellSettings.ts
+++ b/ts/packages/shell/src/main/shellSettings.ts
@@ -41,7 +41,7 @@ export class ShellSettings
     public onShowSettingsDialog: ((dialogName: string) => void) | null;
     public onRunDemo: ((interactive: boolean) => void) | null;
     public onToggleTopMost: EmptyFunction | null;
-    public onOpenInlineBrowser: ((targetUrl: URL) => Promise<void>) | null;
+    public onOpenInlineBrowser: ((targetUrl: URL) => void) | null;
     public onCloseInlineBrowser: EmptyFunction | null;
 
     public get width(): number {
@@ -189,7 +189,7 @@ export class ShellSettings
 
     public async openInlineBrowser(targetUrl: URL) {
         if (ShellSettings.getinstance().onOpenInlineBrowser != null) {
-            await ShellSettings.getinstance().onOpenInlineBrowser!(targetUrl);
+            ShellSettings.getinstance().onOpenInlineBrowser!(targetUrl);
         }
     }
 

--- a/ts/packages/shell/src/preload/webView.ts
+++ b/ts/packages/shell/src/preload/webView.ts
@@ -42,6 +42,10 @@ ipcRenderer.on("received-from-browser-ipc", async (_, data) => {
     }
 });
 
+ipcRenderer.on("init-site-agent", () => {
+    window.postMessage("setupSiteAgent");
+})
+
 function sendToBrowserAgent(message: any) {
     ipcRenderer.send("send-to-browser-ipc", message);
 }
@@ -442,4 +446,3 @@ window.onbeforeunload = () => {
     window.postMessage("disableSiteAgent");
 };
 
-window.postMessage("setupSiteAgent");

--- a/ts/packages/shell/src/preload/webView.ts
+++ b/ts/packages/shell/src/preload/webView.ts
@@ -44,7 +44,7 @@ ipcRenderer.on("received-from-browser-ipc", async (_, data) => {
 
 ipcRenderer.on("init-site-agent", () => {
     window.postMessage("setupSiteAgent");
-})
+});
 
 function sendToBrowserAgent(message: any) {
     ipcRenderer.send("send-to-browser-ipc", message);
@@ -309,7 +309,7 @@ async function runBrowserAction(action: any) {
         }
 
         case "clickOnElement":
-        case "enterTextInElement": 
+        case "enterTextInElement":
         case "enterTextOnPage": {
             sendScriptActionToAllFrames({
                 type: "run_ui_event",
@@ -445,4 +445,3 @@ contextBridge.exposeInMainWorld("browserConnect", {
 window.onbeforeunload = () => {
     window.postMessage("disableSiteAgent");
 };
-


### PR DESCRIPTION
- Some sites have content security policies that limit connections to a set of known domains. This was blocking the websocket connection on localhost. To fix this, I moved the websocket logic from render process to the main process.
- Improve robustness of site agent initialization for inline browser.  Use the "did-finish-load" event to detect when all frames in the inline browser are loaded.