### PR TITLE
Music play: Expand movements

### DIFF
--- a/ts/packages/agents/player/src/agent/playerHandlers.ts
+++ b/ts/packages/agents/player/src/agent/playerHandlers.ts
@@ -160,18 +160,20 @@ async function validateTrack(
     };
     const queryString = toQueryString(query);
     const tracks = await searchTracks(queryString, context);
-    if (tracks && tracks.tracks && tracks.tracks.length > 0) {
+    if (tracks) {
         // For validation for wildcard match, only allow substring match.
         const lowerCaseTrackName = trackName.toLowerCase();
         const lowerCaseAlbumName = album?.toLowerCase();
-        return tracks.tracks.some(
-            (track) =>
-                track.name.toLowerCase().includes(lowerCaseTrackName) &&
-                (lowerCaseAlbumName === undefined ||
-                    track.album.name
-                        .toLowerCase()
-                        .includes(lowerCaseAlbumName)),
-        );
+        return tracks
+            .getTracks()
+            .some(
+                (track) =>
+                    track.name.toLowerCase().includes(lowerCaseTrackName) &&
+                    (lowerCaseAlbumName === undefined ||
+                        track.album.name
+                            .toLowerCase()
+                            .includes(lowerCaseAlbumName)),
+            );
     }
     return false;
 }

--- a/ts/packages/agents/player/src/endpoints.ts
+++ b/ts/packages/agents/player/src/endpoints.ts
@@ -531,6 +531,25 @@ export async function getPlaylists(service: SpotifyService) {
     return undefined;
 }
 
+export async function getAlbum(
+    service: SpotifyService,
+    id: string,
+): Promise<SpotifyApi.SingleAlbumResponse | undefined> {
+    const config = {
+        headers: {
+            Authorization: `Bearer ${await service.tokenProvider.getAccessToken()}`,
+        },
+    };
+
+    const artistsUrl = `https://api.spotify.com/v1/album/${encodeURIComponent(id)}`;
+    try {
+        const spotifyResult = await axios.get(artistsUrl, config);
+        return spotifyResult.data as SpotifyApi.SingleAlbumResponse;
+    } catch (e) {
+        translateAxiosError(e);
+    }
+}
+
 export async function getAlbums(
     service: SpotifyService,
     ids: string[],

--- a/ts/packages/agents/player/src/trackCollections.ts
+++ b/ts/packages/agents/player/src/trackCollections.ts
@@ -1,34 +1,31 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { SpotifyService } from "./service.js";
 import { toTrackObjectFull } from "./spotifyUtils.js";
 
 // for now, no paging of track lists; later add offset and count
 export interface ITrackCollection {
     getTrackCount(): number;
-    getTracks(service: SpotifyService): Promise<SpotifyApi.TrackObjectFull[]>;
+    getTracks(): SpotifyApi.TrackObjectFull[];
     getContext(): string | undefined;
     getPlaylist(): SpotifyApi.PlaylistObjectSimplified | undefined;
 }
 
 export class TrackCollection implements ITrackCollection {
-    contextUri: string | undefined = undefined;
-
     constructor(
-        public tracks: SpotifyApi.TrackObjectFull[],
-        public trackCount: number,
+        private readonly tracks: SpotifyApi.TrackObjectFull[],
+        private readonly contextUri?: string,
     ) {}
+
+    getTracks() {
+        return this.tracks;
+    }
     getContext() {
         return this.contextUri;
     }
 
-    async getTracks(service: SpotifyService) {
-        return this.tracks;
-    }
-
     getTrackCount(): number {
-        return this.trackCount;
+        return this.tracks.length;
     }
 
     getPlaylist(): SpotifyApi.PlaylistObjectSimplified | undefined {
@@ -41,9 +38,7 @@ export class PlaylistTrackCollection extends TrackCollection {
         public playlist: SpotifyApi.PlaylistObjectSimplified,
         tracks: SpotifyApi.TrackObjectFull[],
     ) {
-        super(tracks, 0);
-        this.contextUri = playlist.uri;
-        this.trackCount = tracks.length;
+        super(tracks, playlist.uri);
     }
 
     getPlaylist() {
@@ -52,15 +47,12 @@ export class PlaylistTrackCollection extends TrackCollection {
 }
 
 export class AlbumTrackCollection extends TrackCollection {
-    constructor(
-        public album: SpotifyApi.AlbumObjectSimplified,
-        tracks: SpotifyApi.TrackObjectSimplified[],
-    ) {
-        super([], 0);
-        this.contextUri = album.uri;
-        this.trackCount = tracks.length;
-        this.tracks = tracks.map((albumItem) =>
-            toTrackObjectFull(albumItem, album),
+    constructor(public album: SpotifyApi.AlbumObjectFull) {
+        super(
+            album.tracks.items.map((albumItem) =>
+                toTrackObjectFull(albumItem, album),
+            ),
+            album.uri,
         );
     }
 }


### PR DESCRIPTION
- When finding track and album, match the artist first and only match tracks of those artists.
- Apply expand movements heuristics to `playTrack` and `playGenre` Actions
- Clean up TrackCollection and play API.