### PR TITLE
Disable entity constructions

### DIFF
--- a/ts/packages/cache/src/explanation/v5/propertyExplainationV5.ts
+++ b/ts/packages/cache/src/explanation/v5/propertyExplainationV5.ts
@@ -71,6 +71,9 @@ export function isEntityParameter(
     return parameter.hasOwnProperty("entityIndex");
 }
 
+// REVIEW: disable entity constructions.
+const enableEntityConstructions = false;
+
 function validatePropertyExplanation(
     requestAction: RequestAction,
     actionExplanation: PropertyExplanation,
@@ -103,6 +106,11 @@ function validatePropertyExplanation(
 
         if (!isImplicitParameter(prop)) {
             if (isEntityParameter(prop) && prop.entityIndex !== undefined) {
+                if (enableEntityConstructions === false) {
+                    throw new Error(
+                        "Request has references to entities in the context",
+                    );
+                }
                 const entities = requestAction.history?.entities;
                 if (
                     entities === undefined ||

--- a/ts/packages/cli/src/commands/run/explain.ts
+++ b/ts/packages/cli/src/commands/run/explain.ts
@@ -13,6 +13,7 @@ import {
     getCacheFactory,
     getBuiltinTranslatorNames,
     initializeCommandHandlerContext,
+    closeCommandHandlerContext,
 } from "agent-dispatcher/internal";
 
 // Default test case, that include multiple phrase action name (out of order) and implicit parameters (context)
@@ -150,5 +151,9 @@ export default class ExplainCommand extends Command {
 
             printProcessRequestActionResult(result);
         }
+        await closeCommandHandlerContext(context);
+
+        // Some background network (like monogo) might keep the process live, exit explicitly.
+        process.exit(0);
     }
 }

--- a/ts/packages/dispatcher/src/handlers/common/interactiveIO.ts
+++ b/ts/packages/dispatcher/src/handlers/common/interactiveIO.ts
@@ -31,6 +31,13 @@ export interface IAgentMessage {
     metrics?: RequestMetrics | undefined;
 }
 
+export type NotifyExplainedData = {
+    error?: string;
+    fromCache: boolean;
+    fromUser: boolean;
+    time: string;
+};
+
 // Client provided IO
 export interface ClientIO {
     clear(): void;
@@ -74,11 +81,7 @@ export interface ClientIO {
     notify(
         event: "explained",
         requestId: RequestId,
-        data: {
-            time: string;
-            fromCache: boolean;
-            fromUser: boolean;
-        },
+        data: NotifyExplainedData,
         source: string,
     ): void;
 
@@ -121,11 +124,7 @@ export interface RequestIO {
     notify(
         event: "explained",
         requestId: RequestId,
-        data: {
-            time: string;
-            fromCache: boolean;
-            fromUser: boolean;
-        },
+        data: NotifyExplainedData,
     ): void;
     notify(
         event: "randomCommandSelected",

--- a/ts/packages/dispatcher/src/handlers/requestCommandHandler.ts
+++ b/ts/packages/dispatcher/src/handlers/requestCommandHandler.ts
@@ -687,8 +687,14 @@ async function requestExplain(
     );
 
     if (context.explanationAsynchronousMode) {
-        // TODO: result/error handler in Asynchronous mode
-        processRequestActionP.then(notifyExplained).catch();
+        processRequestActionP.then(notifyExplained).catch((e) =>
+            context.requestIO.notify("explained", requestId, {
+                error: e.message,
+                fromCache,
+                fromUser,
+                time: new Date().toLocaleTimeString(),
+            }),
+        );
     } else {
         console.log(
             chalk.grey(`Generating explanation for '${requestAction}'`),

--- a/ts/packages/dispatcher/src/index.ts
+++ b/ts/packages/dispatcher/src/index.ts
@@ -11,6 +11,7 @@ export type {
     ClientIO,
     RequestId,
     IAgentMessage,
+    NotifyExplainedData,
 } from "./handlers/common/interactiveIO.js";
 export type { Timing, PhaseTiming, RequestMetrics } from "./utils/metrics.js";
 

--- a/ts/packages/shell/src/main/index.ts
+++ b/ts/packages/shell/src/main/index.ts
@@ -23,6 +23,7 @@ import {
     createDispatcher,
     RequestId,
     Dispatcher,
+    NotifyExplainedData,
 } from "agent-dispatcher";
 
 import { IAgentMessage, TemplateEditConfig } from "agent-dispatcher";
@@ -433,24 +434,13 @@ function updateDisplay(message: IAgentMessage, mode?: DisplayAppendMode) {
     chatView?.webContents.send("updateDisplay", message, mode);
 }
 
-function markRequestExplained(
-    requestId: RequestId,
-    timestamp: string,
-    fromCache?: boolean,
-    fromUser?: boolean,
-) {
+function notifyExplained(requestId: RequestId, data: NotifyExplainedData) {
     // Ignore message without requestId
     if (requestId === undefined) {
-        console.warn("markRequestExplained: requestId is undefined");
+        console.warn("notifyExplained: requestId is undefined");
         return;
     }
-    chatView?.webContents.send(
-        "mark-explained",
-        requestId,
-        timestamp,
-        fromCache,
-        fromUser,
-    );
+    chatView?.webContents.send("notifyExplained", requestId, data);
 }
 
 function updateRandomCommandSelected(requestId: RequestId, message: string) {
@@ -570,12 +560,7 @@ const clientIO: ClientIO = {
     notify(event: string, requestId: RequestId, data: any, source: string) {
         switch (event) {
             case "explained":
-                markRequestExplained(
-                    requestId,
-                    data.time,
-                    data.fromCache,
-                    data.fromUser,
-                );
+                notifyExplained(requestId, data);
                 break;
             case "randomCommandSelected":
                 updateRandomCommandSelected(requestId, data.message);

--- a/ts/packages/shell/src/preload/electronTypes.ts
+++ b/ts/packages/shell/src/preload/electronTypes.ts
@@ -13,6 +13,7 @@ import {
     TemplateEditConfig,
     IAgentMessage,
     CommandCompletionResult,
+    NotifyExplainedData,
 } from "agent-dispatcher";
 import { RequestMetrics } from "agent-dispatcher";
 
@@ -93,12 +94,11 @@ export interface ClientAPI {
             group_id: string,
         ) => void,
     ): void;
-    onMarkRequestExplained(
+    onNotifyExplained(
         callback: (
             e: Electron.IpcRendererEvent,
-            id: string,
-            timestamp: string,
-            fromCache?: boolean,
+            requestId: string,
+            data: NotifyExplainedData,
         ) => void,
     ): void;
     onRandomCommandSelected(

--- a/ts/packages/shell/src/preload/index.ts
+++ b/ts/packages/shell/src/preload/index.ts
@@ -105,8 +105,8 @@ const api: ClientAPI = {
     onSettingSummaryChanged(callback) {
         ipcRenderer.on("setting-summary-changed", callback);
     },
-    onMarkRequestExplained(callback) {
-        ipcRenderer.on("mark-explained", callback);
+    onNotifyExplained(callback) {
+        ipcRenderer.on("notifyExplained", callback);
     },
     onRandomCommandSelected(callback) {
         ipcRenderer.on("update-random-command", callback);

--- a/ts/packages/shell/src/renderer/src/chatView.ts
+++ b/ts/packages/shell/src/renderer/src/chatView.ts
@@ -10,7 +10,11 @@ import {
     DynamicDisplay,
 } from "@typeagent/agent-sdk";
 import { TTS } from "./tts/tts";
-import { IAgentMessage, TemplateEditConfig } from "agent-dispatcher";
+import {
+    IAgentMessage,
+    NotifyExplainedData,
+    TemplateEditConfig,
+} from "agent-dispatcher";
 
 import { PartialCompletion } from "./partial";
 import { InputChoice } from "./choicePanel";
@@ -404,10 +408,8 @@ export class ChatView {
         return retVal;
     }
 
-    markRequestExplained(id: string, timestamp: string, fromCache?: boolean) {
-        this.idToMessageGroup
-            .get(id)
-            ?.markRequestExplained(timestamp, fromCache);
+    notifyExplained(id: string, data: NotifyExplainedData) {
+        this.idToMessageGroup.get(id)?.notifyExplained(data);
     }
 
     randomCommandSelected(id: string, message: string) {

--- a/ts/packages/shell/src/renderer/src/main.ts
+++ b/ts/packages/shell/src/renderer/src/main.ts
@@ -99,8 +99,8 @@ function addEvents(
     api.onClear((_) => {
         chatView.clear();
     });
-    api.onMarkRequestExplained((_, id, timestamp, fromCache) => {
-        chatView.markRequestExplained(id, timestamp, fromCache);
+    api.onNotifyExplained((_, id, data) => {
+        chatView.notifyExplained(id, data);
     });
     api.onRandomCommandSelected((_, id, message) => {
         chatView.randomCommandSelected(id, message);

--- a/ts/packages/shell/src/renderer/src/messageContainer.ts
+++ b/ts/packages/shell/src/renderer/src/messageContainer.ts
@@ -3,7 +3,11 @@
 
 import { DisplayAppendMode, DisplayContent } from "@typeagent/agent-sdk";
 import { TTS, TTSMetrics } from "./tts/tts";
-import { TemplateEditConfig, PhaseTiming } from "agent-dispatcher";
+import {
+    TemplateEditConfig,
+    PhaseTiming,
+    NotifyExplainedData,
+} from "agent-dispatcher";
 
 import { ChoicePanel, InputChoice } from "./choicePanel";
 import { setContent } from "./setContent";
@@ -542,19 +546,25 @@ export class MessageContainer {
         updateMetricsVisibility(visible, this.messageBodyDiv);
     }
 
-    public markRequestExplained(timestamp: string, fromCache?: boolean) {
-        if (timestamp !== undefined) {
-            const cachePart = fromCache ? "by cache match" : "by model";
-            this.messageDiv.setAttribute(
-                "data-expl",
-                `Explained ${cachePart} at ${timestamp}`,
-            );
+    public notifyExplained(data: NotifyExplainedData) {
+        const fromCache = data.fromCache;
+        const timestamp = data.time;
+        const cachePart = fromCache
+            ? "Translated by cache match"
+            : "Translated by model";
+        let message: string;
+        let color: string;
+        if (data.error === undefined) {
+            message = `${cachePart}. Explained at ${timestamp}`;
+            color = fromCache ? "#00c000" : "#c0c000";
+        } else {
+            message = `${cachePart}. Not explained: ${data.error}`;
+            color = "#f08080";
         }
+        this.messageDiv.setAttribute("data-expl", message);
         this.messageDiv.classList.add("chat-message-explained");
         const icon = iconRoadrunner();
-        icon.getElementsByTagName("svg")[0].style.fill = fromCache
-            ? "#00c000"
-            : "#c0c000";
+        icon.getElementsByTagName("svg")[0].style.fill = color;
         icon.className = "chat-message-explained-icon";
         this.messageDiv.appendChild(icon);
     }

--- a/ts/packages/shell/src/renderer/src/messageGroup.ts
+++ b/ts/packages/shell/src/renderer/src/messageGroup.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import { DisplayContent } from "@typeagent/agent-sdk";
-import { IAgentMessage } from "agent-dispatcher";
+import { IAgentMessage, NotifyExplainedData } from "agent-dispatcher";
 import { RequestMetrics } from "agent-dispatcher";
 
 import { MessageContainer } from "./messageContainer";
@@ -188,8 +188,8 @@ export class MessageGroup {
         this.userMessage.setMessage(message, "");
     }
 
-    public markRequestExplained(timestamp: string, fromCache?: boolean) {
-        this.userMessage.markRequestExplained(timestamp, fromCache);
+    public notifyExplained(data: NotifyExplainedData) {
+        this.userMessage.notifyExplained(data);
     }
 
     public hideUserMessage() {

--- a/ts/packages/shell/src/renderer/src/webSocketAPI.ts
+++ b/ts/packages/shell/src/renderer/src/webSocketAPI.ts
@@ -118,8 +118,8 @@ export const webapi: ClientAPI = {
     onSettingSummaryChanged(callback) {
         fnMap.set("setting-summary-changed", callback);
     },
-    onMarkRequestExplained(callback) {
-        fnMap.set("mark-explained", callback);
+    onNotifyExplained(callback) {
+        fnMap.set("notifyExplained", callback);
     },
     onRandomCommandSelected(callback) {
         fnMap.set("update-random-command", callback);
@@ -376,9 +376,7 @@ export async function createWebSocket(
             switch (msg.data.event) {
                 case "explained":
                     if (msg.data.requestId === undefined) {
-                        console.warn(
-                            "markRequestExplained: requestId is undefined",
-                        );
+                        console.warn("notifyExplained: requestId is undefined");
                         return;
                     } else {
                         fnMap.get("mark-explained")(


### PR DESCRIPTION
- Disable entity constructions, those that reference context, and just let model handle them for now.
- Add notification when explanation error (like when there is a reference in the request)