### PR TITLE
Restrict `@action` translator completion to active ones

### DIFF
--- a/ts/packages/dispatcher/src/agent/inlineAgentHandlers.ts
+++ b/ts/packages/dispatcher/src/agent/inlineAgentHandlers.ts
@@ -228,7 +228,7 @@ class ActionCommandHandler implements CommandHandler {
         const completions: string[] = [];
         for (const name of names) {
             if (name === "translatorName") {
-                const translators = systemContext.agents.getTranslatorNames();
+                const translators = systemContext.agents.getActiveTranslators();
                 completions.push(...translators);
                 continue;
             }

--- a/ts/packages/dispatcher/src/dispatcher/command.ts
+++ b/ts/packages/dispatcher/src/dispatcher/command.ts
@@ -9,10 +9,7 @@ import {
     DispatcherName,
 } from "../handlers/common/interactiveIO.js";
 import { getDefaultExplainerName } from "agent-cache";
-import {
-    CommandHandlerContext,
-    getActiveTranslatorList,
-} from "../handlers/common/commandHandlerContext.js";
+import { CommandHandlerContext } from "../handlers/common/commandHandlerContext.js";
 
 import { unicodeChar } from "../utils/interactive.js";
 import {
@@ -291,7 +288,7 @@ export function getSettingSummary(context: CommandHandlerContext) {
         }
     }
 
-    const names = getActiveTranslatorList(context);
+    const names = context.agents.getActiveTranslators();
     const ordered = names.filter(
         (name) => name !== context.lastActionTranslatorName,
     );

--- a/ts/packages/dispatcher/src/translation/actionTemplate.ts
+++ b/ts/packages/dispatcher/src/translation/actionTemplate.ts
@@ -4,7 +4,6 @@
 import { Action, Actions } from "agent-cache";
 import { getActionInfo, getTranslatorActionInfos } from "./actionInfo.js";
 import { CommandHandlerContext } from "../internal.js";
-import { getActiveTranslatorList } from "../handlers/common/commandHandlerContext.js";
 import {
     TemplateFieldStringUnion,
     TemplateSchema,
@@ -94,7 +93,7 @@ export function getActionTemplateEditConfig(
 ): TemplateEditConfig {
     const templateData: TemplateData[] = [];
 
-    const translators = getActiveTranslatorList(context);
+    const translators = context.agents.getActiveTranslators();
     for (const action of actions) {
         templateData.push({
             schema: toTemplate(context, translators, action),
@@ -134,7 +133,7 @@ export async function getSystemTemplateSchema(
         data.actionName = "";
     }
 
-    const translators = getActiveTranslatorList(systemContext);
+    const translators = systemContext.agents.getActiveTranslators();
     return toTemplate(systemContext, translators, data);
 }
 

--- a/ts/packages/dispatcher/src/translation/agentTranslators.ts
+++ b/ts/packages/dispatcher/src/translation/agentTranslators.ts
@@ -30,7 +30,6 @@ export type TranslatorConfig = {
 
 export interface TranslatorConfigProvider {
     getTranslatorConfig(translatorName: string): TranslatorConfig;
-    getTranslatorNames(): string[];
     getTranslatorConfigs(): [string, TranslatorConfig][];
 }
 
@@ -125,9 +124,6 @@ export function getBuiltinTranslatorConfigProvider(): TranslatorConfigProvider {
                 throw new Error(`Unknown translator: ${translatorName}`);
             }
             return config;
-        },
-        getTranslatorNames() {
-            return Object.keys(translatorConfigs);
         },
         getTranslatorConfigs() {
             return Object.entries(translatorConfigs);


### PR DESCRIPTION
Also move the tracking of transient state into the `AppAgentManger`.