### PR TITLE
Cache: Reject reference phrases

### DIFF
--- a/ts/packages/cache/src/constructions/constructionMatch.ts
+++ b/ts/packages/cache/src/constructions/constructionMatch.ts
@@ -102,7 +102,8 @@ function captureMatch(
         state.capture.push(m.text);
 
         if (langTool?.possibleReferentialPhrase(m.text)) {
-            // The captured text can't be a referential phrase. Return false here
+            // The captured text can't be a referential phrase.
+            // Return false after adding the text to capture so that backtrack will
             // try longer wildcard before this part or shorter match for this part.
             return false;
         }
@@ -112,9 +113,9 @@ function captureMatch(
 
 function captureWildcardMatch(state: MatchState, wildcardText: string) {
     if (langTool?.possibleReferentialPhrase(wildcardText)) {
-        // The wildcard can't be a referential phrase. Return false here
-        // So that we will stop backtrack and try another state from the wildcard queue
-        // (that are not at this position).
+        // The wildcard can't be a referential phrase. Return false before adding
+        // the wildcard text to capture to stop backtrack and try another state
+        // from the wildcard queue (that is not at this position).
         return false;
     }
 

--- a/ts/packages/cache/src/explanation/v5/propertyExplainationV5.ts
+++ b/ts/packages/cache/src/explanation/v5/propertyExplainationV5.ts
@@ -20,6 +20,7 @@ import {
     ensureProperties,
 } from "../validateExplanation.js";
 import { form } from "./explanationV5.js";
+import { getLanguageTools } from "../../utils/language.js";
 
 export type PropertyExplainer = TypeChatAgent<
     RequestAction,
@@ -73,6 +74,7 @@ export function isEntityParameter(
 
 // REVIEW: disable entity constructions.
 const enableEntityConstructions = false;
+const langTool = getLanguageTools("en");
 
 function validatePropertyExplanation(
     requestAction: RequestAction,
@@ -136,6 +138,16 @@ function validatePropertyExplanation(
                     }
                 }
             }
+
+            if (
+                typeof prop.value === "string" &&
+                langTool?.possibleReferentialPhrase(prop.value.toLowerCase())
+            ) {
+                throw new Error(
+                    "Request contains a possible referential phrase used for property values.",
+                );
+            }
+
             const lowerCaseRequest = requestAction.request.toLowerCase();
             for (const substring of prop.substrings) {
                 if (!lowerCaseRequest.includes(substring.toLowerCase())) {

--- a/ts/packages/cache/src/explanation/v5/subPhraseExplanationV5.ts
+++ b/ts/packages/cache/src/explanation/v5/subPhraseExplanationV5.ts
@@ -25,7 +25,6 @@ import {
     isEntityParameter,
     isImplicitParameter,
 } from "./propertyExplainationV5.js";
-import { getLanguageTools } from "../../utils/language.js";
 
 // Subphrase explanation
 type SubPhraseExplainerInput = [RequestAction, PropertyExplanation];
@@ -84,7 +83,6 @@ export function hasPropertyNames(
     return isPropertySubPhrase(phrase) && phrase.propertyNames.length > 0;
 }
 
-const langTool = getLanguageTools("en");
 function validateSubPhraseExplanationV5(
     [requestAction, propertyExplanation]: SubPhraseExplainerInput,
     explanation: SubPhraseExplanation,
@@ -100,11 +98,6 @@ function validateSubPhraseExplanationV5(
         // check if the parameter name is valid
         // Ideally LLM wouldn't emit a sub-phrase with parameter names array empty, but it does, so be relax about it
         if (hasPropertyNames(phrase)) {
-            if (langTool?.possibleReferentialPhrase(phrase.text)) {
-                throw new Error(
-                    "Request contains a possible referential phrase used for property values.",
-                );
-            }
             phrase.propertyNames.forEach((propertyName) => {
                 // Call checkActionPropertyValue() to ensure the value exist for the parameter name in the sub-phrase
                 try {

--- a/ts/packages/cache/src/explanation/v5/subPhraseExplanationV5.ts
+++ b/ts/packages/cache/src/explanation/v5/subPhraseExplanationV5.ts
@@ -25,6 +25,7 @@ import {
     isEntityParameter,
     isImplicitParameter,
 } from "./propertyExplainationV5.js";
+import { getLanguageTools } from "../../utils/language.js";
 
 // Subphrase explanation
 type SubPhraseExplainerInput = [RequestAction, PropertyExplanation];
@@ -83,6 +84,7 @@ export function hasPropertyNames(
     return isPropertySubPhrase(phrase) && phrase.propertyNames.length > 0;
 }
 
+const langTool = getLanguageTools("en");
 function validateSubPhraseExplanationV5(
     [requestAction, propertyExplanation]: SubPhraseExplainerInput,
     explanation: SubPhraseExplanation,
@@ -98,6 +100,11 @@ function validateSubPhraseExplanationV5(
         // check if the parameter name is valid
         // Ideally LLM wouldn't emit a sub-phrase with parameter names array empty, but it does, so be relax about it
         if (hasPropertyNames(phrase)) {
+            if (langTool?.possibleReferentialPhrase(phrase.text)) {
+                throw new Error(
+                    "Request contains a possible referential phrase used for property values.",
+                );
+            }
             phrase.propertyNames.forEach((propertyName) => {
                 // Call checkActionPropertyValue() to ensure the value exist for the parameter name in the sub-phrase
                 try {

--- a/ts/packages/cache/src/utils/language.ts
+++ b/ts/packages/cache/src/utils/language.ts
@@ -1,0 +1,56 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+export interface LanguageTools {
+    possibleReferentialPhrase(phrase: string): boolean;
+}
+
+const referenceWords = [
+    "he",
+    "she",
+    "it",
+    "they",
+    "him",
+    "her",
+    "them",
+    "his",
+    "hers",
+    "theirs",
+    "its",
+    "this",
+    "that",
+    "these",
+    "those",
+    "here",
+    "there",
+];
+
+const referencePrefixes = [
+    "his ",
+    "her ",
+    "its",
+    "their ",
+    "this ",
+    "that ",
+    "these ",
+    "those ",
+];
+
+const languageToolsEn: LanguageTools = {
+    possibleReferentialPhrase(phrase: string) {
+        // TODO: initiali implemention. Can be overbroad and incomplete.
+        const lowerCase = phrase.toLowerCase();
+        return (
+            referenceWords.includes(lowerCase) ||
+            referencePrefixes.some((prefix) => lowerCase.startsWith(prefix))
+        );
+    },
+};
+
+export function getLanguageTools(language: string): LanguageTools | undefined {
+    if (language !== "en") {
+        return undefined;
+    }
+
+    return languageToolsEn;
+}

--- a/ts/packages/cache/src/utils/language.ts
+++ b/ts/packages/cache/src/utils/language.ts
@@ -36,13 +36,20 @@ const referencePrefixes = [
     "those ",
 ];
 
+// REVIEW: Heuristics to allow time references from now.
+const relativeToNow =
+    /^this (week|month|year|quarter|season|day|hour|minute|second|morning|afternoon)$/;
+
 const languageToolsEn: LanguageTools = {
     possibleReferentialPhrase(phrase: string) {
         // TODO: initiali implemention. Can be overbroad and incomplete.
         const lowerCase = phrase.toLowerCase();
         return (
-            referenceWords.includes(lowerCase) ||
-            referencePrefixes.some((prefix) => lowerCase.startsWith(prefix))
+            (referenceWords.includes(lowerCase) ||
+                referencePrefixes.some((prefix) =>
+                    lowerCase.startsWith(prefix),
+                )) &&
+            !relativeToNow.test(phrase)
         );
     },
 };

--- a/ts/packages/dispatcher/test/construction.spec.ts
+++ b/ts/packages/dispatcher/test/construction.spec.ts
@@ -50,25 +50,22 @@ describe("construction", () => {
                     },
                 );
                 const matched = construction.match(requestAction.request);
-
-                // Able to match roundtrip
-                expect(matched.length).not.toEqual(0);
-
-                if (!tags.includes("failedRoundTripAction")) {
-                    expect(matched[0].match).toEqual(requestAction);
-                } else {
-                    // TODO: needs fix these
-                    expect(matched[0].match).not.toEqual(requestAction);
-                }
-
                 const matchedLowercase = construction.match(
                     requestAction.request.toLowerCase(),
                 );
+                if (!tags.includes("failedRoundTripAction")) {
+                    // Able to match roundtrip
+                    expect(matched.length).not.toEqual(0);
+                    expect(matched[0].match).toEqual(requestAction);
 
-                // Able to match roundtrip
-                expect(matchedLowercase.length).not.toEqual(0);
-
-                // TODO: Validating the lower case action
+                    expect(matchedLowercase.length).not.toEqual(0);
+                    // TODO: Validating the lower case action
+                } else {
+                    // TODO: needs fix these
+                    if (matched.length !== 0) {
+                        expect(matched[0].match).not.toEqual(requestAction);
+                    }
+                }
             },
         );
     });

--- a/ts/packages/dispatcher/test/data/player/v5/full.json
+++ b/ts/packages/dispatcher/test/data/player/v5/full.json
@@ -234,6 +234,11 @@
       }
     },
     {
+      "tags": [
+        "failedRoundTripAction",
+        "failedImportRoundTripAction",
+        "failedImportMergeRoundTripAction"
+      ],
       "request": "Ayo, DJ, drop that 'Gin and Juice' like it's hot, ya dig?",
       "action": {
         "fullActionName": "player.playTrack",


### PR DESCRIPTION
- Both explainer and cache matching will reject phrases that looks like reference.
- Initial reference phrases is probably overboard/has gaps, and will improve it overtime.
