### PR TITLE
Explainer option to disable reference rejection

### DIFF
--- a/ts/packages/cache/src/cache/cache.ts
+++ b/ts/packages/cache/src/cache/cache.ts
@@ -143,12 +143,17 @@ export class AgentCache {
             const startTime = performance.now();
             const actions = requestAction.actions;
             const explainer = this.getExplainerForActions(actions);
-            const createConstructionInfo = {
+            const constructionCreationConfig = {
                 getSchemaConfig: this.getSchemaConfig,
+            };
+
+            const explainerConfig = {
+                rejectReferences: true,
+                constructionCreationConfig,
             };
             const explanation = await explainer.generate(
                 requestAction,
-                createConstructionInfo,
+                explainerConfig,
             );
             const elapsedMs = performance.now() - startTime;
 

--- a/ts/packages/cache/src/constructions/constructionPrint.ts
+++ b/ts/packages/cache/src/constructions/constructionPrint.ts
@@ -195,7 +195,10 @@ export function printConstructionCache(
             // Print the resulting JSON with symbolic values.
             const result = construction.getMatchedValues(
                 symbolicValues,
-                false,
+                {
+                    enableWildcard: false,
+                    rejectReferences: false,
+                },
                 printMatchedValueTranslator,
             );
 

--- a/ts/packages/cache/src/constructions/constructionValue.ts
+++ b/ts/packages/cache/src/constructions/constructionValue.ts
@@ -10,6 +10,7 @@ import {
 import { ConstructionPart } from "./constructions.js";
 import { TransformInfo, isMatchPart, toTransformInfoKey } from "./matchPart.js";
 import { ParsePart, isParsePart } from "./parsePart.js";
+import { MatchConfig } from "./constructionMatch.js";
 
 export type MatchedValueTranslator = {
     transform(
@@ -33,10 +34,8 @@ export type MatchedValues = {
 export function matchedValues(
     parts: ConstructionPart[],
     matched: string[],
-    enableWildcard: boolean,
+    config: MatchConfig,
     matchValueTranslator: MatchedValueTranslator,
-    history?: HistoryContext,
-    conflicts?: boolean,
 ): MatchedValues | undefined {
     const matchedParts = parts.filter((e) => e.capture);
     if (matchedParts.length !== matched.length) {
@@ -46,9 +45,8 @@ export function matchedValues(
     }
 
     const values: [string, ParamValueType][] = [];
-    const conflictValues: [string, ParamValueType[]][] | undefined = conflicts
-        ? []
-        : undefined;
+    const conflictValues: [string, ParamValueType[]][] | undefined =
+        config.conflicts ? [] : undefined;
     let matchedCount = 0;
     let wildcardCharCount = 0;
 
@@ -70,7 +68,7 @@ export function matchedValues(
                 } else {
                     entry = { transformInfo: info, text: [match] };
                     matchedTransformText.set(key, entry);
-                    if (enableWildcard && part.wildcard) {
+                    if (config.enableWildcard && part.wildcard) {
                         wildcardNames.add(key);
                     }
                 }
@@ -91,7 +89,7 @@ export function matchedValues(
         const value = matchValueTranslator.transform(
             matches.transformInfo,
             matches.text,
-            history,
+            config.history,
         );
         const { transformName, actionIndex } = matches.transformInfo;
         const propertyName = `${actionIndex !== undefined ? `${actionIndex}.` : ""}${transformName}`;

--- a/ts/packages/cache/src/constructions/constructions.ts
+++ b/ts/packages/cache/src/constructions/constructions.ts
@@ -7,7 +7,7 @@ import {
     Actions,
     HistoryContext,
 } from "../explanation/requestAction.js";
-import { MatchPartsCache, matchParts } from "./constructionMatch.js";
+import { MatchConfig, matchParts } from "./constructionMatch.js";
 import {
     ParsePart,
     ParsePartJSON,
@@ -102,21 +102,12 @@ export class Construction {
         return this.implicitParameters ? this.implicitParameters.length : 0;
     }
 
-    public match(
-        request: string,
-        enableWildcard: boolean = false,
-        history?: HistoryContext,
-        matchPartsCache?: MatchPartsCache,
-        conflicts?: boolean,
-    ): MatchResult[] {
+    public match(request: string, config: MatchConfig): MatchResult[] {
         const matchedValues = matchParts(
             request,
             this.parts,
-            enableWildcard,
+            config,
             getDefaultTranslator(this.transformNamespaces),
-            history,
-            matchPartsCache,
-            conflicts,
         );
 
         if (matchedValues === undefined) {
@@ -130,7 +121,7 @@ export class Construction {
                 match: new RequestAction(
                     request,
                     Actions.fromJSON(actionProps),
-                    history,
+                    config.history,
                 ),
                 conflictValues: matchedValues.conflictValues,
                 matchedCount: matchedValues.matchedCount,
@@ -142,16 +133,14 @@ export class Construction {
 
     public getMatchedValues(
         matched: string[],
-        enableWildcard: boolean,
+        config: MatchConfig,
         matchValueTranslator: MatchedValueTranslator,
-        history?: HistoryContext,
     ) {
         const result = matchedValues(
             this.parts,
             matched,
-            enableWildcard,
+            config,
             matchValueTranslator,
-            history,
         );
         if (result === undefined) {
             return undefined;

--- a/ts/packages/cache/src/constructions/importConstructions.ts
+++ b/ts/packages/cache/src/constructions/importConstructions.ts
@@ -69,7 +69,10 @@ function createConstructions(
                     "  ",
                 );
             }
-            const matched = construction.match(entry.request);
+            const matched = construction.match(entry.request, {
+                enableWildcard: false,
+                rejectReferences: false,
+            });
             if (explainer.validate !== undefined) {
                 const error = explainer.validate(requestAction, explanation);
                 if (error !== undefined) {

--- a/ts/packages/cache/src/explanation/genericExplainer.ts
+++ b/ts/packages/cache/src/explanation/genericExplainer.ts
@@ -32,14 +32,19 @@ export type ExplanationValidator<T> = (
     explanation: T,
 ) => string | undefined;
 
-export type CreateConstructionInfo = {
+export type ExplainerConfig = {
+    rejectReferences?: boolean | undefined;
+    constructionCreationConfig: ConstructionCreationConfig | undefined;
+};
+
+export type ConstructionCreationConfig = {
     getSchemaConfig?: SchemaConfigProvider | undefined;
 };
 
 export type ConstructionFactory<T> = (
     requestAction: RequestAction,
     explanation: T,
-    createConstructionInfo: CreateConstructionInfo,
+    constructionCreationConfig: ConstructionCreationConfig,
 ) => Construction;
 
 type ToPrettyString<T> = (explanation: T) => string;
@@ -47,7 +52,7 @@ type ToPrettyString<T> = (explanation: T) => string;
 export interface GenericExplainer<T extends object = object> {
     generate(
         requestAction: RequestAction,
-        createConstructionInfo?: CreateConstructionInfo,
+        config?: ExplainerConfig,
     ): Promise<GenericExplanationResult<T>>;
 
     correct?(
@@ -59,6 +64,7 @@ export interface GenericExplainer<T extends object = object> {
     validate(
         requestAction: RequestAction,
         explanation: T,
+        config?: ExplainerConfig,
     ): ValidationError | undefined;
     createConstruction?: ConstructionFactory<any> | undefined;
 

--- a/ts/packages/cache/src/explanation/v5/alternativesExplanationV5.ts
+++ b/ts/packages/cache/src/explanation/v5/alternativesExplanationV5.ts
@@ -15,6 +15,7 @@ import { getPackageFilePath } from "../../utils/getPackageFilePath.js";
 import { PromptSection } from "typechat";
 import { form } from "./explanationV5.js";
 import { hasPropertyNames } from "./subPhraseExplanationV5.js";
+import { ExplainerConfig } from "../genericExplainer.js";
 
 type AlternativeExplainerInput = [
     RequestAction,
@@ -72,7 +73,8 @@ function createInstructions([
 
 export type AlternativesExplainer = TypeChatAgent<
     AlternativeExplainerInput,
-    AlternativesExplanation
+    AlternativesExplanation,
+    ExplainerConfig
 >;
 
 export function createAlternativesExplainer(

--- a/ts/packages/cache/src/explanation/v5/explanationV5.ts
+++ b/ts/packages/cache/src/explanation/v5/explanationV5.ts
@@ -9,8 +9,9 @@
 
 import {
     CorrectionRecord,
-    CreateConstructionInfo,
+    ConstructionCreationConfig,
     GenericExplanationResult,
+    ExplainerConfig,
 } from "../genericExplainer.js";
 import { Explainer } from "../explainer.js";
 import {
@@ -91,18 +92,18 @@ class ExplanationV5TypeChatAgent {
         this.subPhrasesExplainer = createSubPhraseExplainer(model);
         this.alternativesExplainer = createAlternativesExplainer(model);
     }
-    public async run(input: RequestAction) {
+    public async run(input: RequestAction, config?: ExplainerConfig) {
         const propertyExplainer = input.history
             ? this.propertyExplainerWithContext
             : this.propertyExplainerWithoutContext;
-        const result1 = await propertyExplainer.run(input);
+        const result1 = await propertyExplainer.run(input, config);
         if (!result1.success) {
             return result1;
         }
-        const result2 = await this.subPhrasesExplainer.run([
-            input,
-            result1.data,
-        ]);
+        const result2 = await this.subPhrasesExplainer.run(
+            [input, result1.data],
+            config,
+        );
         if (result2.corrections) {
             // includes the data from agent1 in corrections
             result2.corrections.forEach((correction) => {
@@ -115,11 +116,10 @@ class ExplanationV5TypeChatAgent {
         if (!result2.success) {
             return result2;
         }
-        const result3 = await this.alternativesExplainer.run([
-            input,
-            result1.data,
-            result2.data,
-        ]);
+        const result3 = await this.alternativesExplainer.run(
+            [input, result1.data, result2.data],
+            config,
+        );
         if (result3.corrections) {
             // includes the data from agent1 in corrections
             result3.corrections.forEach((correction) => {
@@ -159,18 +159,21 @@ class ExplanationV5TypeChatAgent {
     public validate(
         input: RequestAction,
         result: Explanation,
+        config?: ExplainerConfig,
     ): ValidationError | undefined {
         const propertyExplainer = input.history
             ? this.propertyExplainerWithContext
             : this.propertyExplainerWithoutContext;
-        const result1 = propertyExplainer.validate?.(input, result);
+        const result1 = propertyExplainer.validate?.(input, result, config);
         const result2 = this.subPhrasesExplainer.validate?.(
             [input, result],
             result,
+            config,
         );
         const result3 = this.alternativesExplainer.validate?.(
             [input, result, result],
             result,
+            config,
         );
 
         const corrections: string[] = [];
@@ -285,11 +288,11 @@ function getPropertyTransformInfo(
 async function augmentExplanation(
     explanation: Explanation,
     requestAction: RequestAction,
-    createConstructionInfo: CreateConstructionInfo,
+    constructionCreationConfig: ConstructionCreationConfig,
 ) {
     // for each non-implicit parameter that matches a type in the schema config, generate all of the alternatives for that parameter
 
-    const getSchemaConfig = createConstructionInfo.getSchemaConfig;
+    const getSchemaConfig = constructionCreationConfig.getSchemaConfig;
     const actions = requestAction.actions;
 
     for (const param of explanation.propertyAlternatives) {
@@ -429,10 +432,10 @@ function getParserForPropertyValue(
 export function createConstructionV5(
     requestAction: RequestAction,
     explanation: Explanation,
-    createConstructionInfo: CreateConstructionInfo,
+    constructionCreationConfig: ConstructionCreationConfig,
 ) {
     const actions = requestAction.actions;
-    const getSchemaConfig = createConstructionInfo.getSchemaConfig;
+    const getSchemaConfig = constructionCreationConfig.getSchemaConfig;
     const entityParameters = explanation.properties.filter(
         (param) => isEntityParameter(param) && param.entityIndex !== undefined,
     ) as EntityProperty[];

--- a/ts/packages/cache/src/explanation/v5/propertyExplainationV5.ts
+++ b/ts/packages/cache/src/explanation/v5/propertyExplainationV5.ts
@@ -21,10 +21,12 @@ import {
 } from "../validateExplanation.js";
 import { form } from "./explanationV5.js";
 import { getLanguageTools } from "../../utils/language.js";
+import { ExplainerConfig } from "../genericExplainer.js";
 
 export type PropertyExplainer = TypeChatAgent<
     RequestAction,
-    PropertyExplanation
+    PropertyExplanation,
+    ExplainerConfig
 >;
 export function createPropertyExplainer(
     enableContext: boolean,
@@ -79,6 +81,7 @@ const langTool = getLanguageTools("en");
 function validatePropertyExplanation(
     requestAction: RequestAction,
     actionExplanation: PropertyExplanation,
+    config?: ExplainerConfig,
 ): string[] | undefined {
     const corrections: string[] = [];
     const propertyNameSet = new Set<string>();
@@ -140,6 +143,7 @@ function validatePropertyExplanation(
             }
 
             if (
+                config?.rejectReferences === true &&
                 typeof prop.value === "string" &&
                 langTool?.possibleReferentialPhrase(prop.value.toLowerCase())
             ) {

--- a/ts/packages/cache/src/explanation/v5/subPhraseExplanationV5.ts
+++ b/ts/packages/cache/src/explanation/v5/subPhraseExplanationV5.ts
@@ -25,6 +25,7 @@ import {
     isEntityParameter,
     isImplicitParameter,
 } from "./propertyExplainationV5.js";
+import { ExplainerConfig } from "../genericExplainer.js";
 
 // Subphrase explanation
 type SubPhraseExplainerInput = [RequestAction, PropertyExplanation];
@@ -51,7 +52,8 @@ function createInstructions([
 
 export type SubPhraseExplainer = TypeChatAgent<
     SubPhraseExplainerInput,
-    SubPhraseExplanation
+    SubPhraseExplanation,
+    ExplainerConfig
 >;
 export function createSubPhraseExplainer(model?: string) {
     return new TypeChatAgent(

--- a/ts/packages/cache/src/utils/language.ts
+++ b/ts/packages/cache/src/utils/language.ts
@@ -6,49 +6,46 @@ export interface LanguageTools {
 }
 
 const referenceWords = [
-    "he",
-    "she",
-    "it",
-    "they",
     "him",
-    "her",
+    // "her",
+    "it",
     "them",
-    "his",
+    // "his",  // doubled by referenceParts
     "hers",
     "theirs",
+    // "its", // doubled by referenceParts
+];
+
+const referenceOfSuffixes = referenceWords.map(
+    (w) => new RegExp(`\\bof\\s${w}$`),
+);
+
+const referenceSuffixes = ["here", "there"].map((w) => new RegExp(`\\b${w}$`));
+
+const referenceParts = [
+    "his",
+    "her",
     "its",
+    "their",
     "this",
     "that",
     "these",
     "those",
-    "here",
-    "there",
-];
-
-const referencePrefixes = [
-    "his ",
-    "her ",
-    "its",
-    "their ",
-    "this ",
-    "that ",
-    "these ",
-    "those ",
-];
+].map((w) => new RegExp(`\\b${w}\\b`));
 
 // REVIEW: Heuristics to allow time references from now.
 const relativeToNow =
-    /^this (week|month|year|quarter|season|day|hour|minute|second|morning|afternoon)$/;
+    /this (week|month|year|quarter|season|day|hour|minute|second|morning|afternoon)$/;
 
 const languageToolsEn: LanguageTools = {
     possibleReferentialPhrase(phrase: string) {
         // TODO: initiali implemention. Can be overbroad and incomplete.
         const lowerCase = phrase.toLowerCase();
         return (
-            (referenceWords.includes(lowerCase) ||
-                referencePrefixes.some((prefix) =>
-                    lowerCase.startsWith(prefix),
-                )) &&
+            (referenceWords.some((r) => r === lowerCase) ||
+                referenceSuffixes.some((r) => r.test(lowerCase)) ||
+                referenceOfSuffixes.some((r) => r.test(lowerCase)) ||
+                referenceParts.some((r) => r.test(lowerCase))) &&
             !relativeToNow.test(phrase)
         );
     },

--- a/ts/packages/cache/src/utils/language.ts
+++ b/ts/packages/cache/src/utils/language.ts
@@ -5,47 +5,82 @@ export interface LanguageTools {
     possibleReferentialPhrase(phrase: string): boolean;
 }
 
-const referenceWords = [
+const referenceWordList = [
+    // object pronouns
+    "me",
+    "you",
     "him",
-    // "her",
+    // "her",   // doubled by possessive pronouns in referenceParts
     "it",
+    "us",
+    // "you",  // doubled above/
     "them",
-    // "his",  // doubled by referenceParts
+
+    // possessive pronons
+    "mine",
+    "yours",
+    // "his", // doubled by possessive pronouns in referenceParts
     "hers",
+    // "its"  // doubled by possessive pronouns in referenceParts
+    "ours",
+    // "yours",  // doubled above
     "theirs",
-    // "its", // doubled by referenceParts
+
+    // reflexive pronouns
+    "myself",
+    "yourself",
+    "himself",
+    "herself",
+    "itself",
+    "ourselves",
+    "yourselves",
+    "themselves",
 ];
 
-const referenceOfSuffixes = referenceWords.map(
-    (w) => new RegExp(`\\bof\\s${w}$`),
+const referenceWords = new RegExp(`^(?:${referenceWordList.join("|")})$`, "i");
+const referenceOfSuffixes = new RegExp(
+    `\\bof\\s(?:${referenceWordList.join("|")})$`,
+    "i",
 );
 
-const referenceSuffixes = ["here", "there"].map((w) => new RegExp(`\\b${w}$`));
+const referenceSuffixes = new RegExp(
+    `\\b(?:${["here", "there"].join("|")})$`,
+    "i",
+);
 
-const referenceParts = [
-    "his",
-    "her",
-    "its",
-    "their",
-    "this",
-    "that",
-    "these",
-    "those",
-].map((w) => new RegExp(`\\b${w}\\b`));
+const referenceParts = new RegExp(
+    `\\b(?:${[
+        // possessive adjectives
+        "my",
+        "your",
+        "his",
+        "her",
+        "its",
+        "our",
+        "your",
+        "their",
+
+        // demostratives pronouns
+        "this",
+        "that",
+        "these",
+        "those",
+    ].join("|")})\\b`,
+    "i",
+);
 
 // REVIEW: Heuristics to allow time references from now.
 const relativeToNow =
-    /this (week|month|year|quarter|season|day|hour|minute|second|morning|afternoon)$/;
+    /this (week|month|year|quarter|season|day|hour|minute|second|morning|afternoon)$/i;
 
 const languageToolsEn: LanguageTools = {
     possibleReferentialPhrase(phrase: string) {
         // TODO: initiali implemention. Can be overbroad and incomplete.
-        const lowerCase = phrase.toLowerCase();
         return (
-            (referenceWords.some((r) => r === lowerCase) ||
-                referenceSuffixes.some((r) => r.test(lowerCase)) ||
-                referenceOfSuffixes.some((r) => r.test(lowerCase)) ||
-                referenceParts.some((r) => r.test(lowerCase))) &&
+            (referenceWords.test(phrase) ||
+                referenceSuffixes.test(phrase) ||
+                referenceOfSuffixes.test(phrase) ||
+                referenceParts.test(phrase)) &&
             !relativeToNow.test(phrase)
         );
     },

--- a/ts/packages/cache/test/reference.spec.ts
+++ b/ts/packages/cache/test/reference.spec.ts
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { getLanguageTools } from "../src/utils/language.js";
+
+const referenceTests = [
+    "him",
+    "all of his dishes",
+    "some of theirs",
+    "this song",
+    "that movie",
+    "some of these people",
+    "those places",
+    "that week",
+    "his album",
+    "her book",
+    "its cover",
+    "their car",
+    "all of him",
+    "location here",
+    "somewhere over there",
+];
+
+const nonReferenceTests = ["this week", "it's a good day", "Chemical Brothers"];
+
+const langTool = getLanguageTools("en")!;
+describe("LanguageTools", () => {
+    describe("possibleReferentialPhrase", () => {
+        it.each(referenceTests)("reference - %s", (phrase) => {
+            expect(langTool.possibleReferentialPhrase(phrase)).toBe(true);
+        });
+        it.each(nonReferenceTests)("not reference - %s", (phrase) => {
+            expect(langTool.possibleReferentialPhrase(phrase)).toBe(false);
+        });
+    });
+});

--- a/ts/packages/cache/test/reference.spec.ts
+++ b/ts/packages/cache/test/reference.spec.ts
@@ -21,7 +21,12 @@ const referenceTests = [
     "somewhere over there",
 ];
 
-const nonReferenceTests = ["this week", "it's a good day", "Chemical Brothers"];
+const nonReferenceTests = [
+    "this week",
+    "it's a good day",
+    "Chemical Brothers",
+    "here comes the sun",
+];
 
 const langTool = getLanguageTools("en")!;
 describe("LanguageTools", () => {

--- a/ts/packages/dispatcher/src/agent/agentConfig.ts
+++ b/ts/packages/dispatcher/src/agent/agentConfig.ts
@@ -12,13 +12,11 @@ import {
 } from "../utils/config.js";
 import { createRequire } from "module";
 import path from "node:path";
-import { promises as fs } from "node:fs";
 
 import { createAgentProcessShim } from "./agentProcessShim.js";
 import { AppAgentProvider } from "./agentProvider.js";
 import { CommandHandlerContext } from "../handlers/common/commandHandlerContext.js";
 import { loadInlineAgent } from "./inlineAgentHandlers.js";
-import { fileURLToPath } from "node:url";
 import { getUserProfileDir } from "../utils/userData.js";
 
 export type InlineAppAgentInfo = {

--- a/ts/packages/dispatcher/test/construction.spec.ts
+++ b/ts/packages/dispatcher/test/construction.spec.ts
@@ -26,6 +26,11 @@ const testInput = inputs.flatMap((f) =>
     ]),
 );
 
+const matchConfig = {
+    enableWildcard: false,
+    rejectReferences: false,
+};
+
 describe("construction", () => {
     describe("roundtrip", () => {
         it.each(testInput)(
@@ -49,9 +54,14 @@ describe("construction", () => {
                         getSchemaConfig: loadBuiltinTranslatorSchemaConfig,
                     },
                 );
-                const matched = construction.match(requestAction.request);
+
+                const matched = construction.match(
+                    requestAction.request,
+                    matchConfig,
+                );
                 const matchedLowercase = construction.match(
                     requestAction.request.toLowerCase(),
+                    matchConfig,
                 );
                 if (!tags.includes("failedRoundTripAction")) {
                     // Able to match roundtrip

--- a/ts/packages/dispatcher/test/constructionCacheTestCommon.ts
+++ b/ts/packages/dispatcher/test/constructionCacheTestCommon.ts
@@ -186,7 +186,10 @@ export function defineRoundtripTest(merge: boolean, testFileName: string) {
                     const cache = await cacheP;
                     const matched = cache.constructionStore.match(
                         requestAction.request,
-                        { conflicts: true },
+                        {
+                            rejectReferences: false,
+                            conflicts: true,
+                        },
                     );
                     const matchedActions = matched.flatMap((m) =>
                         expandActions(m.match.actions, m.conflictValues),

--- a/ts/packages/dispatcher/test/data/player/v5/full.json
+++ b/ts/packages/dispatcher/test/data/player/v5/full.json
@@ -234,11 +234,6 @@
       }
     },
     {
-      "tags": [
-        "failedRoundTripAction",
-        "failedImportRoundTripAction",
-        "failedImportMergeRoundTripAction"
-      ],
       "request": "Ayo, DJ, drop that 'Gin and Juice' like it's hot, ya dig?",
       "action": {
         "fullActionName": "player.playTrack",


### PR DESCRIPTION
- Add option to disable reference rejection so that we can continue to purely test explanation/construction round trips without interference.
- Expand reference detection for possessive that are can be just part of the phrase.