### PR TITLE
Set default file search path for lists visualization tool

### DIFF
--- a/ts/examples/viewList/package.json
+++ b/ts/examples/viewList/package.json
@@ -25,6 +25,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
+    "agent-dispatcher": "workspace:*",
     "chalk": "^5.3.0",
     "debug": "^4.3.4"
   },

--- a/ts/examples/viewList/src/route/route.ts
+++ b/ts/examples/viewList/src/route/route.ts
@@ -3,6 +3,27 @@
 
 import Server from "webpack-dev-server";
 import fs from "fs";
+import { getSessionsDirPath } from "agent-dispatcher/explorer";
+import path from "node:path";
+
+function getListFilePath() {
+    const sessionsDir = getSessionsDirPath();
+    const dirent = fs.readdirSync(sessionsDir, { withFileTypes: true });
+    const sessions = dirent.filter((d) => d.isDirectory()).map((d) => d.name);
+
+    // Sort the array in descending order
+    sessions.sort((a, b) => {
+        if (a < b) {
+            return 1;
+        } else if (a > b) {
+            return -1;
+        } else {
+            return 0;
+        }
+    });
+
+    return path.join(getSessionsDirPath(), sessions[0], "list", "lists.json");
+}
 
 export function setupMiddlewares(
     middlewares: Server.Middleware[],
@@ -12,11 +33,11 @@ export function setupMiddlewares(
     let clients: any[] = [];
 
     // Get the lists file path from command-line arguments
-    const listsFilePath = process.env.LISTS_FILE || process.env.NODE_ENV;
+    const listsFilePath = process.env.LISTS_FILE || getListFilePath();
 
-    if (!listsFilePath) {
+    if (!listsFilePath || !fs.existsSync(listsFilePath)) {
         console.error(
-            "Please provide the path to the lists file using the --node-env command-line argument.",
+            "There is no lists file in the current session. Make sure the Lists application agent is enabled.",
         );
         process.exit(1);
     }

--- a/ts/examples/viewList/src/site/tsconfig.json
+++ b/ts/examples/viewList/src/site/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "composite": false,
     "rootDir": ".",
-    "outDir": "../dist/site",
+    "outDir": "../../dist/site",
     "declaration": false,
     "declarationMap": false,
     "moduleResolution": "bundler",

--- a/ts/pnpm-lock.yaml
+++ b/ts/pnpm-lock.yaml
@@ -267,6 +267,9 @@ importers:
 
   examples/viewList:
     dependencies:
+      agent-dispatcher:
+        specifier: workspace:*
+        version: link:../../packages/dispatcher
       chalk:
         specifier: ^5.3.0
         version: 5.3.0


### PR DESCRIPTION
- Update the code to read the lists.json file from the latest session folder. Users can override this value by setting an environment variable when launching the viewList service.