### PR TITLE
Streaming token count

### DIFF
--- a/ts/packages/aiclient/src/openai.ts
+++ b/ts/packages/aiclient/src/openai.ts
@@ -492,6 +492,7 @@ type ChatCompletionChoice = {
 type ChatCompletionChunk = {
     id: string;
     choices: ChatCompletionDelta[];
+    usage?: CompletionUsageStats;
 };
 
 type ChatCompletionDelta = {
@@ -650,6 +651,7 @@ export function createChatModel(
             ...defaultParams,
             messages: messages,
             stream: true,
+            stream_options: { include_usage: true },
             ...completionParams,
         };
         const result = await callApi(
@@ -676,6 +678,14 @@ export function createChatModel(
                             if (delta) {
                                 yield delta;
                             }
+                        }
+                        if (data.usage) {
+                            try {
+                                TokenCounter.getInstance().add(
+                                    data.usage,
+                                    tags,
+                                );
+                            } catch {}
                         }
                     }
                 }

--- a/ts/packages/dispatcher/src/handlers/tokenCommandHandler.ts
+++ b/ts/packages/dispatcher/src/handlers/tokenCommandHandler.ts
@@ -42,13 +42,11 @@ class TokenDetailsCommandHandler implements CommandHandlerNoParams {
 
     public async run(context: ActionContext<CommandHandlerContext>) {
         let retValue: string[] = [];
-        TokenCounter.getInstance().tags.map((t) => {
-            const tokens: CompletionUsageStats =
-                TokenCounter.getInstance().getTokenUsage(t)!;
+        for (const [t, tokens] of TokenCounter.getInstance().counters) {
             retValue.push(
-                `#${t}\n------------------\nPrompt: ${tokens.prompt_tokens}\nCompletion: ${tokens.completion_tokens}\nTotal: ${tokens.total_tokens}\n`,
+                `#${t}\n------------------\nPrompt: ${tokens.total.prompt_tokens}\nCompletion: ${tokens.total.completion_tokens}\nTotal: ${tokens.total.total_tokens}\n`,
             );
-        });
+        }
 
         displaySuccess(retValue, context);
     }

--- a/ts/packages/dispatcher/src/session/session.ts
+++ b/ts/packages/dispatcher/src/session/session.ts
@@ -20,7 +20,7 @@ import {
     AppAgentStateOptions,
 } from "../handlers/common/appAgentManager.js";
 import { cloneConfig, mergeConfig } from "./options.js";
-import { TokenCounter } from "aiclient";
+import { TokenCounter, TokenCounterData } from "aiclient";
 
 const debugSession = registerDebug("typeagent:session");
 
@@ -168,7 +168,7 @@ type SessionCacheData = {
 type SessionData = {
     config: SessionConfig;
     cacheData: SessionCacheData;
-    tokens?: TokenCounter;
+    tokens?: TokenCounterData;
 };
 
 // Fill in missing fields when loading sessions from disk


### PR DESCRIPTION
- Implement streaming token count.
- Track count and max for token count for tags.
- Add type name to the tags for translators.
- Fix counting for tags (it was always counting twice the latest value)
- debug trace now include the translator type name.
