### PR TITLE
Explanation: Filter caching with contextless translation

### DIFF
--- a/ts/packages/cache/src/cache/cache.ts
+++ b/ts/packages/cache/src/cache/cache.ts
@@ -50,7 +50,9 @@ function getFailedResult(message: string): ProcessRequestActionResult {
 type ExplanationOptions = {
     concurrent?: boolean; // whether to limit to run one at a time, require cache to be false
     rejectReferences?: boolean;
-    checkExplainable?: ((requestAction: RequestAction) => Promise<void>) | undefined; // throw exception if not explainable
+    checkExplainable?:
+        | ((requestAction: RequestAction) => Promise<void>)
+        | undefined; // throw exception if not explainable
 };
 
 export class AgentCache {

--- a/ts/packages/cache/src/cache/cache.ts
+++ b/ts/packages/cache/src/cache/cache.ts
@@ -47,6 +47,12 @@ function getFailedResult(message: string): ProcessRequestActionResult {
     };
 }
 
+type ExplanationOptions = {
+    concurrent?: boolean; // whether to limit to run one at a time, require cache to be false
+    rejectReferences?: boolean;
+    checkExplainable?: ((requestAction: RequestAction) => Promise<void>) | undefined; // throw exception if not explainable
+};
+
 export class AgentCache {
     private _constructionStore: ConstructionStoreImpl;
     private queue: QueueObject<{
@@ -96,7 +102,7 @@ export class AgentCache {
         const explanation = await explainMultipleActions(
             requestAction,
             async (subRequestAction) => {
-                return this.queueTask(subRequestAction, cache, false);
+                return this.queueTask(subRequestAction, cache);
             },
         );
         return {
@@ -117,9 +123,11 @@ export class AgentCache {
     private async queueTask(
         requestAction: RequestAction,
         cache: boolean,
-        concurrent: boolean = false, // whether to limit to run one at a time, require cache to be false
-        checkExplainable?: (requestAction: RequestAction) => void, // throw exception if not explainable
+        options?: ExplanationOptions,
     ): Promise<ProcessRequestActionResult> {
+        const concurrent = options?.concurrent ?? false;
+        const rejectReferences = options?.rejectReferences ?? true;
+        const checkExplainable = options?.checkExplainable;
         const actions = requestAction.actions;
         for (const action of actions) {
             const translatorName = action.translatorName;
@@ -149,7 +157,7 @@ export class AgentCache {
             };
 
             const explainerConfig = {
-                rejectReferences: true,
+                rejectReferences,
                 constructionCreationConfig,
             };
 
@@ -232,23 +240,18 @@ export class AgentCache {
     public async processRequestAction(
         requestAction: RequestAction,
         cache: boolean = true,
-        concurrent: boolean = false, // whether to limit to run one at a time, require cache to be false
-        checkExplainable?: (requestAction: RequestAction) => void,
+        options?: ExplanationOptions,
     ): Promise<ProcessRequestActionResult> {
         try {
-            return await this.queueTask(
-                requestAction,
-                cache,
-                concurrent,
-                checkExplainable,
-            );
+            return await this.queueTask(requestAction, cache, options);
         } catch (e: any) {
             this.logger?.logEvent("error", {
                 request: requestAction.request,
                 actions: requestAction.actions,
                 history: requestAction.history,
                 cache,
-                concurrent,
+                concurrent: options?.concurrent,
+                rejectReferences: options?.rejectReferences,
                 message: e.message,
                 stack: e.stack,
             });

--- a/ts/packages/cache/src/explanation/requestAction.ts
+++ b/ts/packages/cache/src/explanation/requestAction.ts
@@ -186,6 +186,12 @@ export class Actions {
             : this.actions.toIAction();
     }
 
+    public toIActions(): IAction[] {
+        return Array.isArray(this.actions)
+            ? this.actions.map((a) => a.toIAction())
+            : [this.actions.toIAction()];
+    }
+
     public toFullActions(): FullAction[] {
         return Array.isArray(this.actions)
             ? this.actions.map((a) => a.toFullAction())

--- a/ts/packages/cli/src/commands/run/explain.ts
+++ b/ts/packages/cli/src/commands/run/explain.ts
@@ -104,7 +104,7 @@ export default class ExplainCommand extends Command {
                             await context.agentCache.processRequestAction(
                                 requestAction,
                                 false,
-                                true,
+                                { concurrent: true },
                             );
                         console.log(
                             result.explanationResult.explanation.success

--- a/ts/packages/dispatcher/src/handlers/common/chatHistoryPrompt.ts
+++ b/ts/packages/dispatcher/src/handlers/common/chatHistoryPrompt.ts
@@ -4,7 +4,6 @@
 import { Entity } from "@typeagent/agent-sdk";
 import { HistoryContext } from "agent-cache";
 import { CachedImageWithDetails } from "common-utils";
-import { request } from "http";
 import { TypeChatJsonTranslator } from "typechat";
 
 function entityToText(entity: Entity) {

--- a/ts/packages/dispatcher/src/handlers/requestCommandHandler.ts
+++ b/ts/packages/dispatcher/src/handlers/requestCommandHandler.ts
@@ -450,11 +450,11 @@ async function finalizeAction(
     }
 
     if (isChangeAssistantAction(currentAction)) {
-        currentTranslatorName = DispatcherName;
-        currentAction = {
+        const unknownAction: UnknownAction = {
             actionName: "unknown",
-            parameters: { text: currentAction.parameters.request },
+            parameters: { request: currentAction.parameters.request },
         };
+        currentAction = unknownAction;
     }
 
     return new Action(
@@ -702,6 +702,8 @@ async function requestExplain(
     const processRequestActionP = context.agentCache.processRequestAction(
         requestAction,
         true,
+        false,
+        (requestAction: RequestAction) => {},
     );
 
     if (context.explanationAsynchronousMode) {

--- a/ts/packages/dispatcher/src/handlers/requestCommandHandler.ts
+++ b/ts/packages/dispatcher/src/handlers/requestCommandHandler.ts
@@ -18,7 +18,12 @@ import {
     updateCorrectionContext,
 } from "./common/commandHandlerContext.js";
 
-import { CachedImageWithDetails, getColorElapsedString } from "common-utils";
+import {
+    CachedImageWithDetails,
+    getColorElapsedString,
+    Logger,
+    TypeChatJsonTranslatorWithStreaming,
+} from "common-utils";
 import {
     executeActions,
     getTranslatorPrefix,
@@ -37,9 +42,12 @@ import { MatchResult } from "../../../cache/dist/constructions/constructions.js"
 import registerDebug from "debug";
 import { IncrementalJsonValueCallBack } from "../../../commonUtils/dist/incrementalJsonParser.js";
 import ExifReader from "exifreader";
-import { Result } from "typechat";
 import { ProfileNames } from "../utils/profileNames.js";
-import { ActionContext, ParsedCommandParams } from "@typeagent/agent-sdk";
+import {
+    ActionContext,
+    ParsedCommandParams,
+    Profiler,
+} from "@typeagent/agent-sdk";
 import { CommandHandler } from "@typeagent/agent-sdk/helpers/command";
 import {
     displayError,
@@ -54,6 +62,7 @@ import { isUnknownAction } from "../dispatcher/dispatcherAgent.js";
 import { UnknownAction } from "../dispatcher/dispatcherActionSchema.js";
 
 const debugTranslate = registerDebug("typeagent:translate");
+const debugExplain = registerDebug("typeagent:explain");
 const debugConstValidation = registerDebug("typeagent:const:validation");
 
 function validateReplaceActions(
@@ -236,82 +245,68 @@ async function translateRequestWithTranslator(
     const prefix = getTranslatorPrefix(translatorName, systemContext);
     displayStatus(`${prefix}Translating '${request}'`, context);
 
-    const translator = getTranslator(systemContext, translatorName);
-
-    const orp = translator.createRequestPrompt;
     if (history) {
         debugTranslate(
             `Using history for translation. Entities: ${JSON.stringify(history.entities)}`,
         );
     }
 
-    translator.createRequestPrompt = makeRequestPromptCreator(
-        translator,
-        history,
-        attachments,
-    );
-
     const profiler = systemContext.commandProfiler?.measure(
         ProfileNames.translate,
     );
 
-    let response: Result<object>;
-    try {
-        let firstToken = true;
-        let streamFunction: IncrementalJsonValueCallBack | undefined;
-        systemContext.streamingActionContext = undefined;
-        const onProperty: IncrementalJsonValueCallBack | undefined =
-            systemContext.session.getConfig().stream
-                ? (prop: string, value: any, delta: string | undefined) => {
-                      // TODO: streaming currently doesn't not support multiple actions
-                      if (prop === "actionName" && delta === undefined) {
-                          const actionTranslatorName =
-                              systemContext.agents.getInjectedTranslatorForActionName(
-                                  value,
-                              ) ?? translatorName;
+    let firstToken = true;
+    let streamFunction: IncrementalJsonValueCallBack | undefined;
+    systemContext.streamingActionContext = undefined;
+    const onProperty: IncrementalJsonValueCallBack | undefined =
+        systemContext.session.getConfig().stream
+            ? (prop: string, value: any, delta: string | undefined) => {
+                  // TODO: streaming currently doesn't not support multiple actions
+                  if (prop === "actionName" && delta === undefined) {
+                      const actionTranslatorName =
+                          systemContext.agents.getInjectedTranslatorForActionName(
+                              value,
+                          ) ?? translatorName;
 
-                          const prefix = getTranslatorPrefix(
+                      const prefix = getTranslatorPrefix(
+                          actionTranslatorName,
+                          systemContext,
+                      );
+                      displayStatus(
+                          `${prefix}Translating '${request}' into action '${value}'`,
+                          context,
+                      );
+                      const config =
+                          systemContext.agents.getTranslatorConfig(
                               actionTranslatorName,
+                          );
+                      if (config.streamingActions?.includes(value)) {
+                          streamFunction = startStreamPartialAction(
+                              actionTranslatorName,
+                              value,
                               systemContext,
                           );
-                          displayStatus(
-                              `${prefix}Translating '${request}' into action '${value}'`,
-                              context,
-                          );
-                          const config =
-                              systemContext.agents.getTranslatorConfig(
-                                  actionTranslatorName,
-                              );
-                          if (config.streamingActions?.includes(value)) {
-                              streamFunction = startStreamPartialAction(
-                                  actionTranslatorName,
-                                  value,
-                                  systemContext,
-                              );
-                          }
-                      }
-
-                      if (firstToken) {
-                          profiler?.mark(ProfileNames.firstToken);
-                          firstToken = false;
-                      }
-
-                      if (streamFunction) {
-                          streamFunction(prop, value, delta);
                       }
                   }
-                : undefined;
 
-        response = await translator.translate(
-            request,
-            history?.promptSections,
-            onProperty,
-            attachments,
-        );
-    } finally {
-        translator.createRequestPrompt = orp;
-        profiler?.stop();
-    }
+                  if (firstToken) {
+                      profiler?.mark(ProfileNames.firstToken);
+                      firstToken = false;
+                  }
+
+                  if (streamFunction) {
+                      streamFunction(prop, value, delta);
+                  }
+              }
+            : undefined;
+    const translator = getTranslator(systemContext, translatorName);
+    const response = await translateRequestToAction(
+        translator,
+        request,
+        history,
+        attachments,
+        onProperty,
+    );
 
     // TODO: figure out if we want to keep track of this
     //Profiler.getInstance().incrementLLMCallCount(context.requestId);
@@ -322,6 +317,33 @@ async function translateRequestWithTranslator(
     }
     // console.log(`response: ${JSON.stringify(response.data)}`);
     return response.data as IAction;
+}
+
+async function translateRequestToAction(
+    translator: TypeChatJsonTranslatorWithStreaming<object>,
+    request: string,
+    history?: HistoryContext,
+    attachments?: CachedImageWithDetails[],
+    onProperty?: IncrementalJsonValueCallBack,
+    profiler?: Profiler,
+) {
+    const orp = translator.createRequestPrompt;
+    translator.createRequestPrompt = makeRequestPromptCreator(
+        translator,
+        history,
+        attachments,
+    );
+    try {
+        return await translator.translate(
+            request,
+            history?.promptSections,
+            onProperty,
+            attachments,
+        );
+    } finally {
+        translator.createRequestPrompt = orp;
+        profiler?.stop();
+    }
 }
 
 type NextTranslation = {
@@ -652,6 +674,91 @@ async function requestExecute(
     await executeActions(requestAction.actions, context);
 }
 
+async function canTranslateWithoutContext(
+    requestAction: RequestAction,
+    usedTranslators: Map<string, TypeChatJsonTranslatorWithStreaming<object>>,
+    logger?: Logger,
+) {
+    if (requestAction.history === undefined) {
+        return;
+    }
+
+    const oldActions: IAction[] = requestAction.actions.toIActions();
+    const newActions: (IAction | undefined)[] = [];
+    const request = requestAction.request;
+    try {
+        const translations = new Map<string, IAction>();
+        for (const [translatorName, translator] of usedTranslators) {
+            const result = await translateRequestToAction(translator, request);
+            if (!result.success) {
+                throw new Error("Failed to translate without history context");
+            }
+            const newActions = result.data as IAction;
+            const count = isMultipleAction(newActions)
+                ? newActions.parameters.requests.length
+                : 1;
+
+            if (count !== oldActions.length) {
+                throw new Error("Action count mismatch without context");
+            }
+            translations.set(translatorName, result.data as IAction);
+        }
+
+        let index = 0;
+        for (const action of requestAction.actions) {
+            const translatorName = action.translatorName;
+            const newTranslatedActions = translations.get(translatorName)!;
+            const newAction = isMultipleAction(newTranslatedActions)
+                ? newTranslatedActions.parameters.requests[index].action
+                : newTranslatedActions;
+            newActions.push(newAction);
+        }
+
+        debugExplain(
+            `With context: ${JSON.stringify(oldActions)}\nWithout context: ${JSON.stringify(newActions)}`,
+        );
+
+        if (oldActions.length !== newActions.length) {
+            throw new Error("Action count mismatch without context");
+        }
+
+        index = 0;
+        for (const oldAction of oldActions) {
+            const newAction = newActions[index];
+            if (newAction === undefined) {
+                throw new Error(`Action missing without context`);
+            }
+
+            if (newAction.actionName !== oldAction.actionName) {
+                throw new Error(`Action Name mismatch without context`);
+            }
+
+            if (
+                JSON.stringify(newAction.parameters) !==
+                JSON.stringify(oldAction.parameters)
+            ) {
+                throw new Error(`Action parameters mismatch without context`);
+            }
+            index++;
+        }
+        logger?.logEvent("contextlessTranslation", {
+            request,
+            actions: oldActions,
+            history: requestAction.history,
+            newActions,
+        });
+    } catch (e: any) {
+        logger?.logEvent("contextlessTranslation", {
+            requestAction,
+            actions: oldActions,
+            history: requestAction.history,
+            newActions,
+            error: e.message,
+        });
+        throw e;
+    }
+}
+
 async function requestExplain(
     requestAction: RequestAction,
     context: CommandHandlerContext,
@@ -684,26 +791,39 @@ async function requestExplain(
         return;
     }
 
+    const usedTranslators = new Map<
+        string,
+        TypeChatJsonTranslatorWithStreaming<object>
+    >();
     const actions = requestAction.actions;
     for (const action of actions) {
         if (isUnknownAction(action)) {
             return;
         }
 
+        const translatorName = action.translatorName;
         if (
-            action.translatorName !== undefined &&
-            context.agents.getTranslatorConfig(action.translatorName).cached ===
-                false
+            context.agents.getTranslatorConfig(translatorName).cached === false
         ) {
             return;
         }
+
+        usedTranslators.set(
+            translatorName,
+            getTranslator(context, translatorName),
+        );
     }
+    const explanationOptions = context.session.getConfig().explanationOptions;
 
     const processRequestActionP = context.agentCache.processRequestAction(
         requestAction,
         true,
-        false,
-        (requestAction: RequestAction) => {},
+        {
+            checkExplainable: explanationOptions.retranslateWithoutContext
+                ? (requestAction: RequestAction) =>
+                      canTranslateWithoutContext(requestAction, usedTranslators)
+                : undefined,
+        },
     );
 
     if (context.explanationAsynchronousMode) {
@@ -764,8 +884,7 @@ export class RequestCommandHandler implements CommandHandler {
             }
 
             // store attachments for later reuse
-            let cachedAttachments: CachedImageWithDetails[] =
-                new Array<CachedImageWithDetails>();
+            const cachedAttachments: CachedImageWithDetails[] = [];
             if (attachments) {
                 for (let i = 0; i < attachments?.length; i++) {
                     const [attachmentName, tags]: [string, ExifReader.Tags] =
@@ -800,7 +919,11 @@ export class RequestCommandHandler implements CommandHandler {
             // Make sure we clear any left over streaming context
             systemContext.streamingActionContext = undefined;
 
-            const match = await matchRequest(request, context, history);
+            const canUseCacheMatch =
+                attachments === undefined || attachments.length === 0;
+            const match = canUseCacheMatch
+                ? await matchRequest(request, context, history)
+                : undefined;
             const translationResult =
                 match === undefined // undefined means not found
                     ? await translateRequest(
@@ -830,12 +953,14 @@ export class RequestCommandHandler implements CommandHandler {
                 );
             }
             await requestExecute(requestAction, context);
-            await requestExplain(
-                requestAction,
-                systemContext,
-                fromCache,
-                fromUser,
-            );
+            if (canUseCacheMatch) {
+                await requestExplain(
+                    requestAction,
+                    systemContext,
+                    fromCache,
+                    fromUser,
+                );
+            }
         } finally {
             profiler?.stop();
         }

--- a/ts/packages/dispatcher/src/handlers/requestCommandHandler.ts
+++ b/ts/packages/dispatcher/src/handlers/requestCommandHandler.ts
@@ -188,6 +188,7 @@ async function matchRequest(
         const useTranslators = systemContext.agents.getActiveTranslators();
         const matches = constructionStore.match(request, {
             wildcard: config.matchWildcard,
+            rejectReferences: config.explanationOptions.rejectReferences,
             useTranslators,
             history,
         });
@@ -813,13 +814,14 @@ async function requestExplain(
             getTranslator(context, translatorName),
         );
     }
-    const explanationOptions = context.session.getConfig().explanationOptions;
+    const { rejectReferences, retranslateWithoutContext } =
+        context.session.getConfig().explanationOptions;
 
     const processRequestActionP = context.agentCache.processRequestAction(
         requestAction,
         true,
         {
-            checkExplainable: explanationOptions.retranslateWithoutContext
+            checkExplainable: retranslateWithoutContext
                 ? (requestAction: RequestAction) =>
                       canTranslateWithoutContext(
                           requestAction,
@@ -827,6 +829,7 @@ async function requestExplain(
                           context.logger,
                       )
                 : undefined,
+            rejectReferences,
         },
     );
 

--- a/ts/packages/dispatcher/src/handlers/requestCommandHandler.ts
+++ b/ts/packages/dispatcher/src/handlers/requestCommandHandler.ts
@@ -821,7 +821,11 @@ async function requestExplain(
         {
             checkExplainable: explanationOptions.retranslateWithoutContext
                 ? (requestAction: RequestAction) =>
-                      canTranslateWithoutContext(requestAction, usedTranslators)
+                      canTranslateWithoutContext(
+                          requestAction,
+                          usedTranslators,
+                          context.logger,
+                      )
                 : undefined,
         },
     );

--- a/ts/packages/dispatcher/src/session/session.ts
+++ b/ts/packages/dispatcher/src/session/session.ts
@@ -111,7 +111,7 @@ type DispatcherConfig = {
     stream: boolean;
     explanation: boolean;
     explanationOptions: {
-        rejectReference: boolean;
+        rejectReferences: boolean;
         retranslateWithoutContext: boolean;
     };
     switch: {
@@ -147,7 +147,7 @@ const defaultSessionConfig: SessionConfig = {
     stream: true,
     explanation: true,
     explanationOptions: {
-        rejectReference: true,
+        rejectReferences: true,
         retranslateWithoutContext: true,
     },
     switch: {

--- a/ts/packages/dispatcher/src/session/session.ts
+++ b/ts/packages/dispatcher/src/session/session.ts
@@ -110,6 +110,10 @@ type DispatcherConfig = {
     bot: boolean;
     stream: boolean;
     explanation: boolean;
+    explanationOptions: {
+        rejectReference: boolean;
+        retranslateWithoutContext: boolean;
+    };
     switch: {
         inline: boolean;
         search: boolean;
@@ -142,6 +146,10 @@ const defaultSessionConfig: SessionConfig = {
     bot: true,
     stream: true,
     explanation: true,
+    explanationOptions: {
+        rejectReference: true,
+        retranslateWithoutContext: true,
+    },
     switch: {
         inline: true,
         search: true,


### PR DESCRIPTION
If we fail to translate to the same result without history context, Then it is likely that the translation is context sensitive, and we shouldn't cache it.