### PR TITLE
Fix translator override

### DIFF
--- a/ts/packages/aiclient/src/models.ts
+++ b/ts/packages/aiclient/src/models.ts
@@ -19,14 +19,12 @@ export type CompletionSettings = {
 export interface ChatModel extends TypeChatLanguageModel {
     completionSettings: CompletionSettings;
     completionCallback?: ((request: any, response: any) => void) | undefined;
-    complete(
-        prompt: string | PromptSection[] | ChatMessage[],
-    ): Promise<Result<string>>;
+    complete(prompt: string | PromptSection[]): Promise<Result<string>>;
 }
 
 export interface ChatModelWithStreaming extends ChatModel {
     completeStream(
-        prompt: string | PromptSection[] | ChatMessage[],
+        prompt: string | PromptSection[],
     ): Promise<Result<AsyncIterableIterator<string>>>;
 }
 
@@ -69,31 +67,6 @@ export interface ImageModel {
         height: number,
     ): Promise<Result<ImageGeneration>>;
 }
-
-export type ChatMessage = {
-    role: "system" | "user" | "assistant";
-    content: ChatMessageContent[];
-};
-
-export type ChatMessageContent =
-    | string
-    | TextMessageContent
-    | ImageMessageContent;
-
-export type TextMessageContent = {
-    type: "text";
-    text: string;
-};
-
-export type ImageMessageContent = {
-    type: "image_url";
-    image_url: ImageUrl;
-};
-
-export type ImageUrl = {
-    url: string;
-    detail?: "auto" | "low" | "high";
-};
 
 export type ImageGeneration = {
     images: GeneratedImage[];

--- a/ts/packages/aiclient/src/openai.ts
+++ b/ts/packages/aiclient/src/openai.ts
@@ -5,7 +5,6 @@ import {
     TextEmbeddingModel,
     CompletionSettings,
     ChatModel,
-    ChatMessage,
     ChatModelWithStreaming,
     ImageModel,
     ImageGeneration,
@@ -578,7 +577,7 @@ export function createChatModel(
     return model;
 
     async function complete(
-        prompt: string | PromptSection[] | ChatMessage[],
+        prompt: string | PromptSection[],
     ): Promise<Result<string>> {
         verifyPromptLength(settings, prompt);
 
@@ -629,7 +628,7 @@ export function createChatModel(
     }
 
     async function completeStream(
-        prompt: string | PromptSection[] | ChatMessage[],
+        prompt: string | PromptSection[],
     ): Promise<Result<AsyncIterableIterator<string>>> {
         verifyPromptLength(settings, prompt);
 

--- a/ts/packages/commonUtils/src/incrementalJsonParser.ts
+++ b/ts/packages/commonUtils/src/incrementalJsonParser.ts
@@ -472,3 +472,7 @@ export function createIncrementalJsonParser(
         },
     };
 }
+
+export type IncrementalJsonParser = ReturnType<
+    typeof createIncrementalJsonParser
+>;

--- a/ts/packages/dispatcher/src/handlers/common/chatHistoryPrompt.ts
+++ b/ts/packages/dispatcher/src/handlers/common/chatHistoryPrompt.ts
@@ -4,22 +4,22 @@
 import { Entity } from "@typeagent/agent-sdk";
 import { HistoryContext } from "agent-cache";
 import { CachedImageWithDetails } from "common-utils";
-import { TypeChatJsonTranslator } from "typechat";
+import { PromptSection, TypeChatJsonTranslator } from "typechat";
 
 function entityToText(entity: Entity) {
     return `${entity.name} (${entity.type})${entity.additionalEntityText ? `: ${entity.additionalEntityText}` : ""}`;
 }
 
-export function makeRequestPromptCreator(
+export function createTypeAgentRequestPrompt(
     translator: TypeChatJsonTranslator<object>,
+    request: string,
     history: HistoryContext | undefined,
     attachments: CachedImageWithDetails[] | undefined,
 ) {
-    let promptSections: any[] = [];
-    let entities = [];
+    let promptSections: PromptSection[] = [];
+    let entities: Entity[] = [];
     let entityStr = "";
     let latestEntity = "";
-    let imageSuffix = "";
 
     if (history) {
         promptSections = history.promptSections;
@@ -41,34 +41,32 @@ export function makeRequestPromptCreator(
         }
     }
 
-    return (request: string) => {
-        if (attachments !== undefined && attachments?.length > 0) {
-            if (request.length == 0) {
-                request = `Caption the first image in no less than 150 words without making any assumptions, remain factual.`;
-            }
+    if (attachments !== undefined && attachments?.length > 0) {
+        if (request.length == 0) {
+            request = `Caption the first image in no less than 150 words without making any assumptions, remain factual.`;
         }
+    }
 
-        let prompt =
-            `You are a service that translates user requests into JSON objects of type "${translator.validator.getTypeName()}" according to the following TypeScript definitions:\n` +
-            `\`\`\`\n${translator.validator.getSchemaText()}\`\`\`\n`;
-        if (promptSections.length > 1) {
-            prompt +=
-                `The following is a summary of the chat history:\n###\n` +
-                entityStr +
-                "###\n" +
-                "The latest entity discussed:\n" +
-                latestEntity +
-                "\n" +
-                `The latest assistant response:\n` +
-                promptSections[promptSections.length - 1].content +
-                "\n";
-        }
+    let prompt =
+        `You are a service that translates user requests into JSON objects of type "${translator.validator.getTypeName()}" according to the following TypeScript definitions:\n` +
+        `\`\`\`\n${translator.validator.getSchemaText()}\`\`\`\n`;
+    if (promptSections.length > 1) {
         prompt +=
-            `Current Date is ${new Date().toLocaleDateString("en-US")}. The time is ${new Date().toLocaleTimeString()}.\n` +
-            `The following is the latest user request:\n` +
-            `"""\n${request}\n"""\n` +
-            `Based primarily on the request but considering all available information in our chat history, the following is the latest user request translated into a JSON object with 2 spaces of indentation and no properties with the value undefined:\n`;
-        //console.log(prompt);
-        return prompt;
-    };
+            `The following is a summary of the chat history:\n###\n` +
+            entityStr +
+            "###\n" +
+            "The latest entity discussed:\n" +
+            latestEntity +
+            "\n" +
+            `The latest assistant response:\n` +
+            promptSections[promptSections.length - 1].content +
+            "\n";
+    }
+    prompt +=
+        `Current Date is ${new Date().toLocaleDateString("en-US")}. The time is ${new Date().toLocaleTimeString()}.\n` +
+        `The following is the latest user request:\n` +
+        `"""\n${request}\n"""\n` +
+        `Based primarily on the request but considering all available information in our chat history, the following is the latest user request translated into a JSON object with 2 spaces of indentation and no properties with the value undefined:\n`;
+    //console.log(prompt);
+    return prompt;
 }

--- a/ts/packages/dispatcher/src/handlers/common/commandHandlerContext.ts
+++ b/ts/packages/dispatcher/src/handlers/common/commandHandlerContext.ts
@@ -8,11 +8,9 @@ import {
     Logger,
     LoggerSink,
     MultiSinkLogger,
-    TypeChatJsonTranslatorWithStreaming,
     createDebugLoggerSink,
     createLimiter,
     createMongoDBLoggerSink,
-    enableJsonTranslatorStreaming,
 } from "common-utils";
 import {
     AgentCache,
@@ -21,7 +19,6 @@ import {
 } from "agent-cache";
 import { randomUUID } from "crypto";
 import readline from "readline/promises";
-import type { TypeChatJsonTranslator } from "typechat";
 import {
     Session,
     SessionOptions,
@@ -31,6 +28,7 @@ import {
     getDefaultBuiltinTranslatorName,
     loadAgentJsonTranslator,
     TranslatorConfigProvider,
+    TypeAgentTranslator,
 } from "../../translation/agentTranslators.js";
 import { getCacheFactory } from "../../utils/cacheFactory.js";
 import { createServiceHost } from "../serviceHost/serviceHostCommandHandler.js";
@@ -95,7 +93,7 @@ export type CommandHandlerContext = {
     // Runtime context
     commandLock: Limiter; // Make sure we process one command at a time.
     lastActionTranslatorName: string;
-    translatorCache: Map<string, TypeChatJsonTranslatorWithStreaming<object>>;
+    translatorCache: Map<string, TypeAgentTranslator>;
     agentCache: AgentCache;
     currentScriptDir: string;
     logger?: Logger | undefined;
@@ -141,8 +139,7 @@ export function getTranslator(
         config.switch.inline ? getActiveTranslators(context) : undefined,
         config.multipleActions,
     );
-    const streamingTranslator = enableJsonTranslatorStreaming(newTranslator);
-    context.translatorCache.set(translatorName, streamingTranslator);
+    context.translatorCache.set(translatorName, newTranslator);
     return newTranslator;
 }
 
@@ -276,7 +273,7 @@ export async function initializeCommandHandlerContext(
         commandLock: createLimiter(1), // Make sure we process one command at a time.
         agentCache: await getAgentCache(session, agents, logger),
         lastActionTranslatorName: getDefaultBuiltinTranslatorName(), // REVIEW: just default to the first one on initialize?
-        translatorCache: new Map<string, TypeChatJsonTranslator<object>>(),
+        translatorCache: new Map<string, TypeAgentTranslator>(),
         currentScriptDir: process.cwd(),
         chatHistory: createChatHistory(),
         logger,

--- a/ts/packages/dispatcher/src/translation/agentTranslators.ts
+++ b/ts/packages/dispatcher/src/translation/agentTranslators.ts
@@ -1,14 +1,18 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { createJsonTranslatorFromSchemaDef } from "common-utils";
+import {
+    CachedImageWithDetails,
+    createJsonTranslatorFromSchemaDef,
+    enableJsonTranslatorStreaming,
+} from "common-utils";
 import {
     AppAction,
     TranslatorDefinition,
     SchemaDefinition,
     AppAgentManifest,
 } from "@typeagent/agent-sdk";
-import { TypeChatJsonTranslator } from "typechat";
+import { Result } from "typechat";
 import { getPackageFilePath } from "../utils/getPackageFilePath.js";
 import { getMultipleActionSchemaDef } from "./multipleActionSchema.js";
 import { TranslatorSchemaDef, composeTranslatorSchemas } from "common-utils";
@@ -16,6 +20,9 @@ import { TranslatorSchemaDef, composeTranslatorSchemas } from "common-utils";
 import registerDebug from "debug";
 import { getBuiltinAppAgentConfigs } from "../agent/agentConfig.js";
 import { loadTranslatorSchemaConfig } from "../utils/loadSchemaConfig.js";
+import { HistoryContext } from "agent-cache";
+import { createTypeAgentRequestPrompt } from "../handlers/common/chatHistoryPrompt.js";
+import { IncrementalJsonValueCallBack } from "../../../commonUtils/dist/incrementalJsonParser.js";
 
 const debugConfig = registerDebug("typeagent:translator:config");
 
@@ -141,11 +148,6 @@ export function loadBuiltinTranslatorSchemaConfig(translatorName: string) {
 export function getAppAgentName(translatorName: string) {
     return translatorName.split(".")[0];
 }
-
-// A list of translator factory methods, keyed by the config.SchemaType name
-const translatorFactories: {
-    [key: string]: (config: TranslatorConfig) => TypeChatJsonTranslator<Object>;
-} = {};
 
 const changeAssistantActionTypeName = "ChangeAssistantAction";
 const changeAssistantActionName = "changeAssistantAction";
@@ -293,6 +295,15 @@ function getTranslatorSchemaDefs(
     ];
 }
 
+export type TypeAgentTranslator<T = object> = {
+    translate: (
+        request: string,
+        history?: HistoryContext,
+        attachments?: CachedImageWithDetails[],
+        cb?: IncrementalJsonValueCallBack,
+    ) => Promise<Result<T>>;
+};
+
 /**
  *
  * @param translatorName name to get the translator for.
@@ -300,21 +311,17 @@ function getTranslatorSchemaDefs(
  * @param multipleActions Add the multiple action schema if true. Default to false.
  * @returns
  */
-export function loadAgentJsonTranslator(
+export function loadAgentJsonTranslator<T extends object = object>(
     translatorName: string,
     provider: TranslatorConfigProvider,
     model?: string,
     activeTranslators?: { [key: string]: boolean },
     multipleActions: boolean = false,
-) {
+): TypeAgentTranslator<T> {
     // See if we have a registered factory method for this translator
     const translatorConfig = provider.getTranslatorConfig(translatorName);
-    const factory = translatorFactories[translatorConfig.schemaType];
-    if (factory) {
-        return factory(translatorConfig);
-    }
 
-    return createJsonTranslatorFromSchemaDef(
+    const translator = createJsonTranslatorFromSchemaDef<T>(
         "AllActions",
         getTranslatorSchemaDefs(
             translatorConfig,
@@ -327,6 +334,40 @@ export function loadAgentJsonTranslator(
         undefined,
         model,
     );
+
+    const streamingTranslator = enableJsonTranslatorStreaming(translator);
+
+    // the request prompt is already expanded by the override replacement below
+    // So just return the request as is.
+    streamingTranslator.createRequestPrompt = (request: string) => {
+        return request;
+    };
+
+    const typeAgentTranslator = {
+        translate: async (
+            request: string,
+            history?: HistoryContext,
+            attachments?: CachedImageWithDetails[],
+            cb?: IncrementalJsonValueCallBack,
+        ) => {
+            // Expand the request prompt up front with the history and attachments
+            const requestPrompt = createTypeAgentRequestPrompt(
+                streamingTranslator,
+                request,
+                history,
+                attachments,
+            );
+
+            return streamingTranslator.translate(
+                requestPrompt,
+                history?.promptSections,
+                cb,
+                attachments,
+            );
+        },
+    };
+
+    return typeAgentTranslator;
 }
 
 // For CLI, replicate the behavior of loadAgentJsonTranslator to get the schema
@@ -337,9 +378,6 @@ export function getFullSchemaText(
     multipleActions: boolean,
 ) {
     const translatorConfig = provider.getTranslatorConfig(translatorName);
-    if (translatorFactories[translatorConfig.schemaType] !== undefined) {
-        throw new Error("Can't get schema for customfactory");
-    }
     const schemaDefs = getTranslatorSchemaDefs(
         translatorConfig,
         translatorName,


### PR DESCRIPTION
The current method of extending the TypeChat translator to include history context for request prompt creation, and streaming callback on each translation invocation, makes the translator unable to handle multiple call at the same time.   Now that we use the agent translators to detect context usage for the explainer with will cause overlapping calls and might cause the override to go across the call and cause random errors.

Change the method of extending by:
- For agent translation, expand request prompt with chat history upfront using a wrapped `TypeAgentTranslator` before passing it to the TypeChat translator.
- For the streaming, it needs to pass the incremental parser to the model, and the only way to do so thru TypeChat is hiding it in the prompt premble.

Additional changes:
- Remove `ChatMessage` types for image sections, where TypeChat `PromptSection` already have those now.
- Trace the translation result (and renamed the prompt trace name to be consistent `typeagent:translation:<typename>:prompt` and `typeagent:translation:<typename>:result`
