### PR TITLE
Changed embedding tactics for chunks (again!)

### DIFF
--- a/ts/examples/spelunker/src/codeDocSchema.ts
+++ b/ts/examples/spelunker/src/codeDocSchema.ts
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// Line of code for which this is a comment
+export type LineDoc = {
+    lineNumber: number;
+    comment: string; // Can be multiline
+};
+
+export type CodeDocumentation = {
+    comments?: LineDoc[];
+};

--- a/ts/examples/spelunker/src/main.ts
+++ b/ts/examples/spelunker/src/main.ts
@@ -21,8 +21,9 @@ import {
     CodeDocumentation,
     CodeDocumenter,
     createSemanticCodeIndex,
+    SemanticCodeIndex,
 } from "code-processor";
-import { createObjectFolder, loadSchema } from "typeagent";
+import { createObjectFolder, loadSchema, ObjectFolder } from "typeagent";
 
 // Local imports
 import { ChunkDocumentation } from "./chunkDocSchema.js";
@@ -37,32 +38,18 @@ const __dirname = path.dirname(__filename);
 const envPath = new URL("../../../.env", import.meta.url);
 dotenv.config({ path: envPath });
 
+const verbose = true; // true for more, false for less chatty output.
+
+await main();
+
 // Usage: node main.js [file1.py] [file2.py] ...
 // OR:    node main.js --files filelist.txt
 // OR:    node main.js -  # Load sample file (sample.py.txt)
 // OR:    node main.js    # Query previously loaded files
 async function main(): Promise<void> {
-    console.log("Hi!");
-    const verbose = false;
-    let files: string[];
-    // TODO: Use a proper command-line parser.
-    if (process.argv.length > 2) {
-        files = process.argv.slice(2);
-        if (files.length === 1 && files[0] === "-") {
-            const sampleFile = path.join(__dirname, "sample.py.txt");
-            files = [sampleFile];
-        } else if (files.length === 2 && files[0] === "--files") {
-            // Read list of files from a file.
-            const fileList = files[1];
-            files = fs
-                .readFileSync(fileList, "utf-8")
-                .split("\n")
-                .map((line) => line.trim())
-                .filter((line) => line.length > 0 && line[0] !== "#");
-        }
-    } else {
-        files = [];
-    }
+    console.log("[Hi!]");
+
+    const files = processArgs();
 
     let homeDir = process.platform === "darwin" ? process.env.HOME || "" : "";
     const dataRoot = homeDir + "/data";
@@ -88,6 +75,7 @@ async function main(): Promise<void> {
     // Import all files. (TODO: Break up very long lists.)
     if (files.length > 0) {
         console.log(`[Importing ${files.length} files]`);
+        const t0 = new Date().getTime();
         await importPythonFiles(
             files,
             chunkFolder,
@@ -95,6 +83,10 @@ async function main(): Promise<void> {
             summaryFolder,
             true,
             verbose,
+        );
+        const t1 = new Date().getTime();
+        console.log(
+            `[Imported ${files.length} files in ${((t1 - t0) * 0.001).toFixed(3)} seconds]`,
         );
     }
 
@@ -105,61 +97,85 @@ async function main(): Promise<void> {
             keepWhitespace: true, // Keep leading/trailing whitespace in history
         });
         if (!input) {
-            console.log("Bye!");
+            console.log("[Bye!]");
             return;
         }
-        const searchKey = input.replace(/\W+/g, " ").trim();
-        let hits;
-        try {
-            hits = await codeIndex.find(searchKey, 2);
-        } catch (error) {
-            console.log(`[${error}]`);
-            continue;
+        await processQuery(input, chunkFolder, codeIndex, summaryFolder);
+    }
+}
+
+function processArgs() {
+    let files: string[];
+    // TODO: Use a proper command-line parser.
+    if (process.argv.length > 2) {
+        files = process.argv.slice(2);
+        if (files.length === 1 && files[0] === "-") {
+            const sampleFile = path.join(__dirname, "sample.py.txt");
+            files = [sampleFile];
+        } else if (files.length === 2 && files[0] === "--files") {
+            // Read list of files from a file.
+            const fileList = files[1];
+            files = fs
+                .readFileSync(fileList, "utf-8")
+                .split("\n")
+                .map((line) => line.trim())
+                .filter((line) => line.length > 0 && line[0] !== "#");
         }
-        console.log(
-            `Got ${hits.length} hit${hits.length == 0 ? "s." : hits.length === 1 ? ":" : "s:"}`,
-        );
-        for (const hit of hits) {
-            const chunk: Chunk | undefined = await chunkFolder.get(hit.item);
-            if (!chunk) {
-                console.log(hit, "--> [No data]");
-            } else {
-                console.log(
-                    `score: ${hit.score.toFixed(3)}, ` +
-                        `id: ${chunk.id}, ` +
-                        `file: ${path.relative(process.cwd(), chunk.filename!)}, ` +
-                        `type: ${chunk.treeName}`,
-                );
-                const summary: CodeDocumentation | undefined =
-                    await summaryFolder.get(hit.item);
-                if (
-                    summary &&
-                    summary.comments &&
-                    summary.comments.length > 0
-                ) {
-                    for (const comment of summary.comments)
-                        console.log(
-                            wordWrap(
-                                `${comment.lineNumber}. ${comment.comment}`,
-                            ),
-                        );
+    } else {
+        files = [];
+    }
+    return files;
+}
+
+async function processQuery(
+    input: string,
+    chunkFolder: ObjectFolder<Chunk>,
+    codeIndex: SemanticCodeIndex,
+    summaryFolder: ObjectFolder<CodeDocumentation>,
+): Promise<void> {
+    const searchKey = input.replace(/\W+/g, " ").trim();
+    let hits;
+    try {
+        hits = await codeIndex.find(searchKey, 2);
+    } catch (error) {
+        console.log(`[${error}]`);
+        return;
+    }
+    console.log(
+        `Got ${hits.length} hit${hits.length == 0 ? "s." : hits.length === 1 ? ":" : "s:"}`,
+    );
+    for (const hit of hits) {
+        const chunk: Chunk | undefined = await chunkFolder.get(hit.item);
+        if (!chunk) {
+            console.log(hit, "--> [No data]");
+        } else {
+            console.log(
+                `score: ${hit.score.toFixed(3)}, ` +
+                    `id: ${chunk.id}, ` +
+                    `file: ${path.relative(process.cwd(), chunk.filename!)}, ` +
+                    `type: ${chunk.treeName}`,
+            );
+            const summary: CodeDocumentation | undefined =
+                await summaryFolder.get(hit.item);
+            if (summary && summary.comments && summary.comments.length > 0) {
+                for (const comment of summary.comments)
+                    console.log(
+                        wordWrap(`${comment.lineNumber}. ${comment.comment}`),
+                    );
+            }
+            for (const blob of chunk.blobs) {
+                let lineno = 1 + blob.start;
+                for (const index in blob.lines) {
+                    console.log(
+                        `${String(lineno).padStart(3)}: ${blob.lines[index].trimEnd()}`,
+                    );
+                    lineno += 1;
                 }
-                for (const blob of chunk.blobs) {
-                    let lineno = 1 + blob.start;
-                    for (const index in blob.lines) {
-                        console.log(
-                            `${String(lineno).padStart(3)}: ${blob.lines[index].trimEnd()}`,
-                        );
-                        lineno += 1;
-                    }
-                    console.log("");
-                }
+                console.log("");
             }
         }
     }
 }
-
-await main();
 
 // We have our own code documenter to pass to createSemanticCodeIndex.
 

--- a/ts/examples/spelunker/src/main.ts
+++ b/ts/examples/spelunker/src/main.ts
@@ -225,9 +225,10 @@ async function createFileDocumenter(model: ChatModel): Promise<FileDocumenter> {
         }
         const request =
             "Document the given Python code, its purpose, and any relevant details.\n" +
-            "The code has (non-contiguous) line numbers, e.g.: '[1]: def foo():'\n" +
-            "There are also marker lines, e.g.: '***: Document the following FuncDef'\n" +
-            "Provide a comment for ALL markers. DON'T document any lines without markers!\n";
+            "The code has (non-contiguous) line numbers, e.g.: `[1]: def foo():`\n" +
+            "There are also marker lines, e.g.: `***: Document the following FuncDef`\n" +
+            "Write a concise paragraph for EACH marker. Also write a paragraph about the whole file." +
+            "DON'T document any lines without markers!\n";
         const result = await fileDocTranslator.translate(request, text);
 
         // Now assign each comment to its chunk.

--- a/ts/examples/spelunker/src/pythonChunker.ts
+++ b/ts/examples/spelunker/src/pythonChunker.ts
@@ -8,6 +8,7 @@ import { exec } from "child_process";
 import path from "path";
 import { promisify } from "util";
 import { fileURLToPath } from "url";
+import { CodeDocumentation } from "code-processor";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -28,7 +29,8 @@ export interface Chunk {
     blobs: Blob[];
     parentId: IdType;
     children: IdType[];
-    filename?: string;
+    filename?: string; // Set on receiving end to reduce JSON size.
+    docs?: CodeDocumentation; // Computed on receiving end from file docs.
 }
 
 export interface ChunkedFile {

--- a/ts/examples/spelunker/src/pythonImporter.ts
+++ b/ts/examples/spelunker/src/pythonImporter.ts
@@ -91,6 +91,9 @@ export async function importPythonFiles(
         for (const chunk of chunks) {
             chunk.filename = chunkedFile.filename;
         }
+        console.log(
+            `[Documenting ${chunks.length} chunks from ${chunkedFile.filename}]`,
+        );
         const t0 = Date.now();
         const docs = await fileDocumenter.document(chunks);
         const t1 = Date.now();
@@ -124,7 +127,7 @@ async function processChunkedFile(
         return firstFile;
     }
     console.log(
-        `[Processing ${chunks.length} chunks from ${chunkedFile.filename}]`,
+        `[Embedding ${chunks.length} chunks from ${chunkedFile.filename}]`,
     );
     const t0 = Date.now();
 
@@ -156,7 +159,7 @@ async function processChunkedFile(
 
     const t1 = Date.now();
     console.log(
-        `[Processed ${+firstFile + chunks.length} chunks in ${((t1 - t0) * 0.001).toFixed(3)} seconds]`,
+        `[Embedded ${+firstFile + chunks.length} chunks in ${((t1 - t0) * 0.001).toFixed(3)} seconds]`,
     );
     return false;
 }
@@ -173,7 +176,7 @@ async function processChunk(
         (acc, blob) => acc + blob.lines.length,
         0,
     );
-    // console.log(`[Embedding ${chunk.id} (${lineCount} lines)]`);
+    // console.log(`  [Embedding ${chunk.id} (${lineCount} lines)]`);
     const putPromise = chunkFolder.put(chunk, chunk.id);
     const blobLines = extractBlobLines(chunk);
     const codeBlock: CodeBlockWithDocs = {
@@ -185,12 +188,12 @@ async function processChunk(
     await summaryFolder.put(docs, chunk.id);
     await putPromise;
     // for (const comment of docs.comments || []) {
-    //     console.log(wordWrap(`${comment.lineNumber}. ${comment.comment}`));
+    //     console.log(wordWrap(`    ${comment.lineNumber}. ${comment.comment}`));
     // }
     const t1 = Date.now();
     if (verbose) {
         console.log(
-            `[Embedded ${chunk.id} (${lineCount} lines @ ${chunk.blobs[0].start}) ` +
+            `  [Embedded ${chunk.id} (${lineCount} lines @ ${chunk.blobs[0].start}) ` +
                 `in ${((t1 - t0) * 0.001).toFixed(3)} seconds]`,
         );
     }


### PR DESCRIPTION
New indexing approach:

Instead of asking a documenter to produce a comment for each chunk separately (and without other chunks as context),
ask a different documenter to produce comments for the whole file, but only at points where a chunk starts.
Then extract those comments and add them to the chunk to which they apply.
Use some hackery to pass the relevant comments (with correct line numbers, even!) to the code index
(so it no longer needs an LLM roundtrip to summarize the chunk).

I struggled a bit to get the chunk comments brief, but not too brief --
if you ask for "a paragraph" it explains the `@dataclass` decorator each time it is used. :-)

Also improve the search UX and logging a bit (maybe logging is a bit too verbose, we'll take it down later).

I believe that this improves the quality of the indexing.
However, I don't think it has made much of a difference for the *speed*.
It takes about 13 seconds to document the chunker.py program (nearly 300 lines, 17 chunks).
The embeddings are then super-fast, between 80 and 250 msec per chunk
 I guess this is a *bit* faster -- IIRC the previous approach took about a second per chunk,
but about 4 seconds for the first chunk (for account setup etc.).