### PR TITLE
Spelunker omnibus PR: tweak indexing, logging, use interactiveApp

### DIFF
--- a/ts/examples/spelunker/package.json
+++ b/ts/examples/spelunker/package.json
@@ -30,7 +30,7 @@
     "aiclient": "workspace:*",
     "code-processor": "workspace:*",
     "dotenv": "^16.3.1",
-    "readline-sync": "^1.4.10",
+    "interactive-app": "workspace:*",
     "typeagent": "workspace:*",
     "typechat": "^0.1.1",
     "typescript": "^5.4.2"

--- a/ts/examples/spelunker/src/chunker.py
+++ b/ts/examples/spelunker/src/chunker.py
@@ -186,6 +186,22 @@ def extract_blob(lines: list[str], node: ast.AST) -> Blob:
     return Blob(start, lines[start:end])  # type: ignore
 
 
+def summarize_chunk(chunk: Chunk, node: ast.AST) -> list[str]:
+    """Summarize a chunk into a summary to insert in the parent chunk."""
+    summary: list[str] = []
+    indent: str = node.col_offset * " "  # type: ignore
+    if isinstance(node, (ast.FunctionDef, ast.ClassDef)):
+        decorators: list[ast.AST] = node.decorator_list  # type: ignore
+        for d in decorators:
+            if isinstance(d, ast.Name) and d.id == "property":
+                summary.append(f"{indent}@property")
+    if isinstance(node, ast.FunctionDef):
+        summary.append(f"{indent}def {node.name}...")
+    elif isinstance(node, ast.ClassDef):
+        summary.append(f"{indent}class {node.name}...")
+    return summary
+
+
 def create_chunks_recursively(
     lines: list[str], tree: ast.AST, parent: Chunk
 ) -> list[Chunk]:
@@ -212,6 +228,9 @@ def create_chunks_recursively(
             last_end = last_blob.start + len(last_blob.lines)
             if parent_start <= last_end and last_end <= parent_end:
                 parent.blobs.append(Blob(parent_start, lines[parent_start:first_start]))
+                summary = summarize_chunk(chunk, node)
+                if summary:
+                    parent.blobs.append(Blob(first_start, summary))
                 parent.blobs.append(Blob(last_end, lines[last_end:parent_end]))
 
     return chunks

--- a/ts/examples/spelunker/src/chunker.py
+++ b/ts/examples/spelunker/src/chunker.py
@@ -27,7 +27,7 @@ from dataclasses import dataclass
 import datetime
 import json
 import sys
-from typing import Iterator
+from typing import Any, Iterator
 
 
 @dataclass
@@ -36,12 +36,16 @@ class Blob:
 
     start: int  # 0-based!
     lines: list[str]
+    breadcrumb: bool = False # True for blobs that should be ignored in the reconstruction
 
     def to_dict(self) -> dict[str, object]:
-        return {
+        result: dict[str, Any] = {
             "start": self.start,
             "lines": self.lines,
         }
+        if self.breadcrumb:
+            result["breadcrumb"] = True
+        return result
 
 
 IdType = str
@@ -230,7 +234,7 @@ def create_chunks_recursively(
                 parent.blobs.append(Blob(parent_start, lines[parent_start:first_start]))
                 summary = summarize_chunk(chunk, node)
                 if summary:
-                    parent.blobs.append(Blob(first_start, summary))
+                    parent.blobs.append(Blob(first_start, summary, breadcrumb=True))
                 parent.blobs.append(Blob(last_end, lines[last_end:parent_end]))
 
     return chunks

--- a/ts/examples/spelunker/src/dumper.py
+++ b/ts/examples/spelunker/src/dumper.py
@@ -1,0 +1,16 @@
+import json
+import sys
+
+def main():
+    data = json.load(sys.stdin)
+    for chunked_file in data:
+        print(f"{chunked_file['filename']}")
+        print()
+        for chunk in chunked_file["chunks"]:
+            print(f"{chunk['id']}")
+            for blob in chunk["blobs"]:
+                for lineno, line in enumerate(blob["lines"], 1):
+                    print(f"{blob['start'] + lineno:2d}. {line.rstrip()}")
+                print()
+
+main()

--- a/ts/examples/spelunker/src/dumper.py
+++ b/ts/examples/spelunker/src/dumper.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 import json
 import sys
 

--- a/ts/examples/spelunker/src/main.ts
+++ b/ts/examples/spelunker/src/main.ts
@@ -104,34 +104,6 @@ async function main(): Promise<void> {
     }
 
     await runQueryInterface(chunkFolder, codeIndex, summaryFolder, verbose);
-
-    // // Loop processing searches. (TODO: Use interactiveApp.)
-    // const help = "[Type 'q', 'quit' or 'exit' to end query session.]";
-    // console.log(help);
-    // while (true) {
-    //     const input = readlineSync
-    //         .question("~> ", {
-    //             history: true, // Enable history (TODO: Doesn't seem to work)
-    //             keepWhitespace: true, // Keep leading/trailing whitespace in history
-    //         })
-    //         .trimEnd();
-    //     // TODO: Distinguish between EOF (e.g. ^D) and blank line.
-    //     if (!input) {
-    //         console.log(help);
-    //         continue;
-    //     }
-    //     if (input === "q" || input == "quit" || input === "exit") {
-    //         console.log("[Bye!]");
-    //         return;
-    //     }
-    //     await processQuery(
-    //         input,
-    //         chunkFolder,
-    //         codeIndex,
-    //         summaryFolder,
-    //         verbose,
-    //     );
-    // }
 }
 
 function processArgs(): string[] {

--- a/ts/examples/spelunker/src/main.ts
+++ b/ts/examples/spelunker/src/main.ts
@@ -260,19 +260,23 @@ async function createFileDocumenter(model: ChatModel): Promise<FileDocumenter> {
         if (result.success) {
             const codeDocs: CodeDocumentation = result.data;
             // Assign each comment to its chunk.
-            for (const comment of codeDocs.comments ?? []) {
-                for (const chunk of chunks) {
+            for (const chunk of chunks) {
+                chunk.docs = {
+                    comments: [
+                        {
+                            lineNumber: chunk.blobs[0].start + 1,
+                            comment: `${chunk.treeName}`,
+                        },
+                    ],
+                };
+                for (const comment of codeDocs.comments ?? []) {
                     for (const blob of chunk.blobs) {
                         if (
                             !blob.breadcrumb &&
                             blob.start < comment.lineNumber &&
                             comment.lineNumber <= blob.start + blob.lines.length
                         ) {
-                            if (chunk.docs === undefined) {
-                                chunk.docs = { comments: [comment] };
-                            } else {
-                                chunk.docs.comments!.push(comment);
-                            }
+                            chunk.docs.comments!.push(comment);
                         }
                     }
                 }

--- a/ts/examples/spelunker/src/main.ts
+++ b/ts/examples/spelunker/src/main.ts
@@ -99,12 +99,19 @@ async function main(): Promise<void> {
     }
 
     // Loop processing searches. (TODO: Use interactiveApp.)
+    const help = "[Type 'q', 'quit' or 'exit' to end query session.]";
+    console.log(help);
     while (true) {
         const input = readlineSync.question("~> ", {
             history: true, // Enable history
             keepWhitespace: true, // Keep leading/trailing whitespace in history
-        });
-        if (!input.trim()) {
+        }).trimEnd();
+        // TODO: Distinguish between EOF (e.g. ^D) and blank line.
+        if (!input) {
+            console.log(help);
+            continue;
+        }
+        if (input === "q" || input == "quit" || input === "exit") {
             console.log("[Bye!]");
             return;
         }

--- a/ts/examples/spelunker/src/main.ts
+++ b/ts/examples/spelunker/src/main.ts
@@ -246,6 +246,7 @@ async function createFileDocumenter(model: ChatModel): Promise<FileDocumenter> {
                 for (const chunk of chunks) {
                     for (const blob of chunk.blobs) {
                         if (
+                            !blob.breadcrumb &&
                             blob.start < comment.lineNumber &&
                             comment.lineNumber <= blob.start + blob.lines.length
                         ) {

--- a/ts/examples/spelunker/src/pythonChunker.ts
+++ b/ts/examples/spelunker/src/pythonChunker.ts
@@ -20,6 +20,7 @@ export type IdType = string;
 export interface Blob {
     start: number; // int; 0-based!
     lines: string[];
+    breadcrumb?: boolean;
 }
 
 export interface Chunk {

--- a/ts/examples/spelunker/src/pythonImporter.ts
+++ b/ts/examples/spelunker/src/pythonImporter.ts
@@ -155,7 +155,7 @@ async function processChunkedFile(
     // Limit concurrency to avoid 429 errors.
     await asyncArray.forEachAsync(
         chunks,
-        4,
+        verbose ? 1 : 4,
         async (chunk) =>
             await processChunk(
                 chunk,

--- a/ts/examples/spelunker/src/pythonImporter.ts
+++ b/ts/examples/spelunker/src/pythonImporter.ts
@@ -95,9 +95,14 @@ export async function importPythonFiles(
             `[Documenting ${chunks.length} chunks from ${chunkedFile.filename}]`,
         );
         const t0 = Date.now();
-        const docs = await fileDocumenter.document(chunks);
+        try {
+            const docs = await fileDocumenter.document(chunks);
+            console.log(docs);
+        } catch (error) {
+            console.log(`[Error documenting ${chunkedFile.filename}: ${error}]`);
+            continue;
+        }
         const t1 = Date.now();
-        console.log(docs);
         console.log(
             `[Documented ${chunks.length} chunks in ${((t1 - t0) * 0.001).toFixed(3)} seconds]`,
         );

--- a/ts/examples/spelunker/src/pythonImporter.ts
+++ b/ts/examples/spelunker/src/pythonImporter.ts
@@ -57,12 +57,14 @@ export async function importPythonFiles(
     // Compute some stats for log message.
     let lines = 0;
     let blobs = 0;
+    let chunks = 0;
     let errors = 0;
     for (const result of results) {
         if ("error" in result) {
             errors++;
         } else {
             const chunkedFile = result;
+            chunks += chunkedFile.chunks.length;
             for (const chunk of chunkedFile.chunks) {
                 blobs += chunk.blobs.length;
                 for (const blob of chunk.blobs) {
@@ -73,7 +75,7 @@ export async function importPythonFiles(
     }
     console.log(
         `[Chunked ${filenames.length} files ` +
-            `(${lines} lines, ${blobs} blobs, ${errors} errors) ` +
+            `(${lines} lines, ${blobs} blobs, ${chunks} chunks, ${errors} errors) ` +
             `in ${((t1 - t0) * 0.001).toFixed(3)} seconds]`,
     );
 

--- a/ts/examples/spelunker/src/pythonImporter.ts
+++ b/ts/examples/spelunker/src/pythonImporter.ts
@@ -97,9 +97,11 @@ export async function importPythonFiles(
         const t0 = Date.now();
         try {
             const docs = await fileDocumenter.document(chunks);
-            console.log(docs);
+            if (verbose) console.log(docs);
         } catch (error) {
-            console.log(`[Error documenting ${chunkedFile.filename}: ${error}]`);
+            console.log(
+                `[Error documenting ${chunkedFile.filename}: ${error}]`,
+            );
             continue;
         }
         const t1 = Date.now();
@@ -181,7 +183,7 @@ async function processChunk(
         (acc, blob) => acc + blob.lines.length,
         0,
     );
-    // console.log(`  [Embedding ${chunk.id} (${lineCount} lines)]`);
+    if (verbose) console.log(`  [Embedding ${chunk.id} (${lineCount} lines)]`);
     const putPromise = chunkFolder.put(chunk, chunk.id);
     const blobLines = extractBlobLines(chunk);
     const codeBlock: CodeBlockWithDocs = {
@@ -192,9 +194,13 @@ async function processChunk(
     const docs = await codeIndex.put(codeBlock, chunk.id, chunk.filename);
     await summaryFolder.put(docs, chunk.id);
     await putPromise;
-    // for (const comment of docs.comments || []) {
-    //     console.log(wordWrap(`    ${comment.lineNumber}. ${comment.comment}`));
-    // }
+    if (verbose) {
+        for (const comment of docs.comments || []) {
+            console.log(
+                wordWrap(`    ${comment.lineNumber}. ${comment.comment}`),
+            );
+        }
+    }
     const t1 = Date.now();
     if (verbose) {
         console.log(

--- a/ts/examples/spelunker/src/queryInterface.ts
+++ b/ts/examples/spelunker/src/queryInterface.ts
@@ -1,0 +1,91 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// User interface for querying the index.
+
+import { CodeDocumentation, SemanticCodeIndex } from "code-processor";
+import * as iapp from "interactive-app";
+import { ObjectFolder } from "typeagent";
+import { Chunk } from "./pythonChunker.js";
+import { wordWrap } from "./pythonImporter.js";
+import path from "path";
+
+export async function runQueryInterface(
+    chunkFolder: ObjectFolder<Chunk>,
+    codeIndex: SemanticCodeIndex,
+    summaryFolder: ObjectFolder<CodeDocumentation>,
+    verbose = false,
+): Promise<void> {
+    const handlers: Record<string, iapp.CommandHandler> = {
+        search,
+    };
+    iapp.addStandardHandlers(handlers);
+
+    handlers.search.metadata = "Search command (TODO)";
+    async function search(args: string[] | iapp.NamedArgs, io: iapp.InteractiveIo): Promise<void> {
+        await processQuery("why is the sky blue", chunkFolder, codeIndex, summaryFolder, verbose);
+    }
+
+    async function onStart(io: iapp.InteractiveIo): Promise<void> {
+        io.writer.writeLine("Welcome to the query interface!");
+    }
+    async function inputHandler(input: string, io: iapp.InteractiveIo): Promise<void> {
+        io.writer.writeLine("Use @ command prefix; see @help.");
+    }
+
+    await iapp.runConsole({
+        onStart,
+        inputHandler,
+        handlers,
+    });
+}
+
+async function processQuery(
+    input: string,
+    chunkFolder: ObjectFolder<Chunk>,
+    codeIndex: SemanticCodeIndex,
+    summaryFolder: ObjectFolder<CodeDocumentation>,
+    verbose = false,
+): Promise<void> {
+    let hits;
+    try {
+        hits = await codeIndex.find(input, 2);
+    } catch (error) {
+        console.log(`[${error}]`);
+        return;
+    }
+    console.log(
+        `Got ${hits.length} hit${hits.length == 0 ? "s." : hits.length === 1 ? ":" : "s:"}`,
+    );
+    for (let i = 0; i < hits.length; i++) {
+        const hit = hits[i];
+        const chunk: Chunk | undefined = await chunkFolder.get(hit.item);
+        if (!chunk) {
+            console.log(hit, "--> [No data]");
+        } else {
+            console.log(
+                `Hit ${i + 1}: score: ${hit.score.toFixed(3)}, ` +
+                    `id: ${chunk.id}, ` +
+                    `file: ${path.relative(process.cwd(), chunk.filename!)}, ` +
+                    `type: ${chunk.treeName}`,
+            );
+            const summary: CodeDocumentation | undefined =
+                await summaryFolder.get(hit.item);
+            if (summary?.comments?.length) {
+                for (const comment of summary.comments)
+                    console.log(
+                        wordWrap(`${comment.comment} (${comment.lineNumber})`),
+                    );
+            }
+            for (const blob of chunk.blobs) {
+                for (let index = 0; index < blob.lines.length; index++) {
+                    console.log(
+                        `${(1 + blob.start + index).toString().padStart(3)}: ${blob.lines[index].trimEnd()}`,
+                    );
+                }
+                console.log("");
+                if (!verbose) break;
+            }
+        }
+    }
+}

--- a/ts/examples/spelunker/src/sample.py.txt
+++ b/ts/examples/spelunker/src/sample.py.txt
@@ -10,8 +10,10 @@ def chunker(text: str) -> Chunk:  # Returns a toplevel chunk for the whole file
     def debug():
         print(ast.dump(tree, indent=4))
 
-    def undebug():
-        pass
+    class C:
+        @property
+        def undebug():
+            pass
 
     return create_chunks(text, tree)
 

--- a/ts/packages/codeProcessor/src/codeIndex.ts
+++ b/ts/packages/codeProcessor/src/codeIndex.ts
@@ -15,7 +15,11 @@ import path from "path";
 import { CodeDocumentation } from "./codeDocSchema.js";
 
 export interface SemanticCodeIndex {
-    find(question: string, maxMatches: number, minScore?: number): Promise<ScoredItem<string>[]>;
+    find(
+        question: string,
+        maxMatches: number,
+        minScore?: number,
+    ): Promise<ScoredItem<string>[]>;
     get(name: string): Promise<StoredCodeBlock | undefined>;
     put(
         code: CodeBlock,

--- a/ts/packages/codeProcessor/src/codeIndex.ts
+++ b/ts/packages/codeProcessor/src/codeIndex.ts
@@ -15,7 +15,7 @@ import path from "path";
 import { CodeDocumentation } from "./codeDocSchema.js";
 
 export interface SemanticCodeIndex {
-    find(question: string, maxMatches: number): Promise<ScoredItem<string>[]>;
+    find(question: string, maxMatches: number, minScore?: number): Promise<ScoredItem<string>[]>;
     get(name: string): Promise<StoredCodeBlock | undefined>;
     put(
         code: CodeBlock,
@@ -58,8 +58,9 @@ export async function createSemanticCodeIndex(
     async function find(
         question: string,
         maxMatches: number,
+        minScore?: number,
     ): Promise<ScoredItem<string>[]> {
-        return codeIndex.nearestNeighbors(question, maxMatches);
+        return codeIndex.nearestNeighbors(question, maxMatches, minScore);
     }
 
     async function put(

--- a/ts/pnpm-lock.yaml
+++ b/ts/pnpm-lock.yaml
@@ -245,9 +245,9 @@ importers:
       dotenv:
         specifier: ^16.3.1
         version: 16.3.1
-      readline-sync:
-        specifier: ^1.4.10
-        version: 1.4.10
+      interactive-app:
+        specifier: workspace:*
+        version: link:../../packages/interactiveApp
       typeagent:
         specifier: workspace:*
         version: link:../../packages/typeagent


### PR DESCRIPTION
- Add -v/--verbose flag to command line
- Many logging improvements (but still no color)
- Catch errors when documenting a file (e.g. file too large)
- Introduce one-line "breadcrumb blobs" in chunks for sub-chunks, e.g. `def foo...`
- Switch to @-prefixed commands, e.g. @search --query "why is the sky blue" --maxHits 10 --minScore 0.7 --verbose false
