### PR TITLE
Constructions: detect additional pronouns and conjunction for explanation/merging 

### DIFF
--- a/ts/packages/cache/src/utils/language.ts
+++ b/ts/packages/cache/src/utils/language.ts
@@ -19,6 +19,7 @@ const subjectPronouns = [
     "y'all",
     "thou",
     "ye",
+    "youse",
 ];
 
 const objectPronouns = [
@@ -33,6 +34,8 @@ const objectPronouns = [
     "you-all",
     "y'all",
     "thee",
+    "ye",
+    "youse",
 ];
 
 const possessivePronouns = [
@@ -44,7 +47,12 @@ const possessivePronouns = [
     "ours",
     "yours",
     "theirs",
+    "one's",
     "thine",
+    "yeers",
+    "y'all's",
+    "each other's",
+    "one another's",
 ];
 
 const reflexivePronouns = [
@@ -58,6 +66,7 @@ const reflexivePronouns = [
     "themselves",
     "oneself",
     "thyself",
+    "whoself",
 ];
 const demostrativePronouns = ["this", "that", "these", "those"];
 const indefinitePronouns = [
@@ -91,8 +100,10 @@ const indefinitePronouns = [
     "one",
     "other",
     "others",
+    "own",
     "plenty",
     "several",
+    "same",
     "some",
     "somebody",
     "someone",
@@ -100,6 +111,7 @@ const indefinitePronouns = [
     "somewhat",
     "such and such",
     "such",
+    "suchlike",
 ];
 
 const interrogativePronouns = [
@@ -122,7 +134,6 @@ const interrogativePronouns = [
 
 const relativePronuns = ["as", "that", ...interrogativePronouns];
 const reciprocalPronouns = ["each other", "one another"];
-const otherPronouns = ["same", "own", "suchlike"];
 const possessiveAdjectives = [
     "my",
     "your",
@@ -132,6 +143,11 @@ const possessiveAdjectives = [
     "our",
     "your",
     "their",
+    "one's",
+    "yeer",
+    "y'all's",
+    "each other's",
+    "one another's",
 ];
 
 const demostrativeAdverbs = ["here", "there"];
@@ -318,7 +334,7 @@ function combineSets(words: string[][]): string[] {
 }
 
 function exactMatch(words: string[][]): RegExp {
-    return new RegExp(`\\b(?:${combineSets(words).join("|")})\\b`, "i");
+    return new RegExp(`^(?:${combineSets(words).join("|")})$`, "i");
 }
 
 function suffixMatch(words: string[][], prefix?: string): RegExp {

--- a/ts/packages/cache/src/utils/language.ts
+++ b/ts/packages/cache/src/utils/language.ts
@@ -6,28 +6,48 @@ export interface LanguageTools {
     hasClosedClass(phrase: string): boolean;
 }
 
-const referenceWordList = [
-    // object pronouns
+const subjectPronouns = [
+    "i",
+    "you",
+    "he",
+    "she",
+    "it",
+    "we",
+    // "you",  // doubled above
+    "they",
+    "you-all",
+    "y'all",
+    "thou",
+    "ye",
+];
+
+const objectPronouns = [
     "me",
     "you",
     "him",
-    // "her",   // doubled by possessive pronouns in referenceParts
+    "her",
     "it",
     "us",
-    // "you",  // doubled above/
+    // "you",  // doubled above
     "them",
+    "you-all",
+    "y'all",
+    "thee",
+];
 
-    // possessive pronons
+const possessivePronouns = [
     "mine",
     "yours",
-    // "his", // doubled by possessive pronouns in referenceParts
+    "his",
     "hers",
-    // "its"  // doubled by possessive pronouns in referenceParts
+    "its",
     "ours",
-    // "yours",  // doubled above
+    "yours",
     "theirs",
+    "thine",
+];
 
-    // reflexive pronouns
+const reflexivePronouns = [
     "myself",
     "yourself",
     "himself",
@@ -36,120 +56,318 @@ const referenceWordList = [
     "ourselves",
     "yourselves",
     "themselves",
+    "oneself",
+    "thyself",
+];
+const demostrativePronouns = ["this", "that", "these", "those"];
+const indefinitePronouns = [
+    "all",
+    "another",
+    "any",
+    "anybody",
+    "anyone",
+    "anything",
+    "aught",
+    "both",
+    "certain",
+    "each",
+    "either",
+    "enough",
+    "everybody",
+    "everyone",
+    "everything",
+    "few",
+    "fewer",
+    "fewest",
+    "little",
+    "many",
+    "more",
+    "most",
+    "neither",
+    "no one",
+    "nobody",
+    "none",
+    "nothing",
+    "one",
+    "other",
+    "others",
+    "plenty",
+    "several",
+    "some",
+    "somebody",
+    "someone",
+    "something",
+    "somewhat",
+    "such and such",
+    "such",
 ];
 
-const referenceWords = new RegExp(`^(?:${referenceWordList.join("|")})$`, "i");
-const referenceOfSuffixes = new RegExp(
-    `\\bof\\s(?:${referenceWordList.join("|")})$`,
-    "i",
+const interrogativePronouns = [
+    "what",
+    "whate'er",
+    "whatever",
+    "whatsoever",
+    "which",
+    "whichever",
+    "whichsoever",
+    "who",
+    "whoever",
+    "whoso",
+    "whosoever",
+    "whom",
+    "whomever",
+    "whomsoever",
+    "whose",
+];
+
+const relativePronuns = ["as", "that", ...interrogativePronouns];
+const reciprocalPronouns = ["each other", "one another"];
+const otherPronouns = ["same", "own", "suchlike"];
+const possessiveAdjectives = [
+    "my",
+    "your",
+    "his",
+    "her",
+    "its",
+    "our",
+    "your",
+    "their",
+];
+
+const demostrativeAdverbs = ["here", "there"];
+
+const conjunctions = [
+    "according as",
+    "and",
+    "after",
+    "albeit",
+    "although",
+    "as if",
+    "as long as",
+    "as though",
+    "as",
+    "because",
+    "before",
+    "both and",
+    "but that",
+    "but then again",
+    "but then",
+    "but",
+    "considering",
+    "cos",
+    "directly",
+    "either or",
+    "ere",
+    "except",
+    "for",
+    "forasmuchas",
+    "how",
+    "however",
+    "if",
+    "immediately",
+    "in as far as",
+    "inasmuch as",
+    "insofar as",
+    "insomuch that",
+    "insomuchas",
+    "lest",
+    "like",
+    "neither nor",
+    "neither",
+    "nor",
+    "notwithstanding",
+    "now that",
+    "now",
+    "once",
+    "only",
+    "or",
+    "provided that",
+    "provided",
+    "providing that",
+    "providing",
+    "seeing as how",
+    "seeing as",
+    "seeing that",
+    "seeing",
+    "since",
+    "so",
+    "suppose",
+    "supposing",
+    "than",
+    "that",
+    "though",
+    "till",
+    "unless",
+    "until",
+    "when",
+    "whenever",
+    "where",
+    "whereas",
+    "whereat",
+    "whereby",
+    "wherever",
+    "whereof",
+    "wherein",
+    "whereon",
+    "wheresoever",
+    "whereto",
+    "whereupon",
+    "whereunto",
+    "whether",
+    "while",
+    "whilst",
+    "why",
+    "without",
+    "yet",
+];
+
+const prepositions = [
+    "aboard",
+    "about",
+    "above",
+    "across",
+    "after",
+    "against",
+    "along",
+    "amid",
+    "amidst",
+    "among",
+    "amongst",
+    "around",
+    "as",
+    "at",
+    "before",
+    "behind",
+    "below",
+    "beneath",
+    "beside",
+    "besides",
+    "between",
+    "beyond",
+    "but",
+    "by",
+    "circa",
+    "concerning",
+    "considering",
+    "despite",
+    "down",
+    "during",
+    "ere",
+    "except",
+    "following",
+    "for",
+    "from",
+    "in",
+    "inside",
+    "into",
+    "less",
+    "like",
+    "mid", // amid
+    "midst",
+    "minus",
+    "near",
+    "next",
+    "nigh",
+    "of",
+    "off",
+    "on",
+    "onto",
+    "opposite",
+    "out",
+    "outside",
+    "over",
+    "o'vr", // over
+    "pace",
+    "past",
+    "per",
+    "plus",
+    "re",
+    "regarding",
+    "round",
+    "sans",
+    "save",
+    "since",
+    "than",
+    "through",
+    "throughout",
+    "thru",
+    "till",
+    "to",
+    "toward",
+    "towards",
+    "under",
+    "underneath",
+    "unlike",
+    "until",
+    "up",
+    "upon",
+    "versus",
+    "via",
+    "vice",
+    "vs",
+    "while",
+    "with",
+    "within",
+    "without",
+    "worth",
+];
+
+function combineSets(words: string[][]): string[] {
+    const set = new Set<string>(words.flat());
+    return Array.from(set.values()).sort();
+}
+
+function exactMatch(words: string[][]): RegExp {
+    return new RegExp(`\\b(?:${combineSets(words).join("|")})\\b`, "i");
+}
+
+function suffixMatch(words: string[][], prefix?: string): RegExp {
+    return new RegExp(
+        `\\b${prefix ? `${prefix}\\s` : ""}(?:${combineSets(words).join("|")})$`,
+        "i",
+    );
+}
+
+function partOfMatch(words: string[][]): RegExp {
+    return new RegExp(`\\b(?:${combineSets(words).join("|")})\\b`, "i");
+}
+
+const referenceWords = exactMatch([
+    objectPronouns,
+    possessivePronouns,
+    reflexivePronouns,
+]);
+const referenceOfSuffixes = suffixMatch(
+    [objectPronouns, possessivePronouns, reflexivePronouns],
+    "of",
 );
 
-const referenceSuffixes = new RegExp(
-    `\\b(?:${["here", "there"].join("|")})$`,
-    "i",
-);
+const referenceParts = partOfMatch([
+    demostrativePronouns,
+    indefinitePronouns,
+    interrogativePronouns,
+    relativePronuns,
+    reciprocalPronouns,
+    possessiveAdjectives,
+]);
 
-const referenceParts = new RegExp(
-    `\\b(?:${[
-        // possessive adjectives
-        "my",
-        "your",
-        "his",
-        "her",
-        "its",
-        "our",
-        "your",
-        "their",
+const referenceSuffixes = suffixMatch([demostrativeAdverbs]);
 
-        // demostratives pronouns
-        "this",
-        "that",
-        "these",
-        "those",
-    ].join("|")})\\b`,
-    "i",
-);
-
-const prepositions = new RegExp(
-    `\\b(?:${[
-        "aboard",
-        "about",
-        "above",
-        "across",
-        "after",
-        "against",
-        "along",
-        "amid",
-        "amidst",
-        "among",
-        "amongst",
-        "around",
-        "as",
-        "at",
-        "before",
-        "behind",
-        "below",
-        "beneath",
-        "beside",
-        "besides",
-        "between",
-        "beyond",
-        "but",
-        "by",
-        "concerning",
-        "considering",
-        "despite",
-        "down",
-        "during",
-        "except",
-        "following",
-        "for",
-        "from",
-        "in",
-        "inside",
-        "into",
-        "like",
-        "minus",
-        "near",
-        "next",
-        "of",
-        "off",
-        "on",
-        "onto",
-        "opposite",
-        "out",
-        "outside",
-        "over",
-        "past",
-        "per",
-        "plus",
-        "regarding",
-        "round",
-        "save",
-        "since",
-        "than",
-        "through",
-        "throughout",
-        "till",
-        "to",
-        "toward",
-        "towards",
-        "under",
-        "underneath",
-        "unlike",
-        "until",
-        "up",
-        "upon",
-        "versus",
-        "via",
-        "vs",
-        "while",
-        "with",
-        "within",
-        "without",
-    ].join("|")})\\b`,
-    "i",
-);
+const closedClass = partOfMatch([
+    subjectPronouns,
+    objectPronouns,
+    possessivePronouns,
+    reflexivePronouns,
+    demostrativePronouns,
+    indefinitePronouns,
+    interrogativePronouns,
+    relativePronuns,
+    reciprocalPronouns,
+    possessiveAdjectives,
+    demostrativeAdverbs,
+    prepositions,
+    conjunctions,
+]);
 
 // REVIEW: Heuristics to allow time references from now.
 const relativeToNow =
@@ -167,7 +385,7 @@ const languageToolsEn: LanguageTools = {
         );
     },
     hasClosedClass(phrase: string) {
-        return prepositions.test(phrase);
+        return closedClass.test(phrase);
     },
 };
 


### PR DESCRIPTION
- Conjunctions and pronouns are also force to not merge and not use synonyms.
- Add more pronouns for reference detections.