### PR TITLE
Fix encoding of HTML when sent in SSE

### DIFF
--- a/ts/examples/viewMarkdown/src/route/route.ts
+++ b/ts/examples/viewMarkdown/src/route/route.ts
@@ -68,7 +68,7 @@ export function setupMiddlewares(
         const htmlContent = md.render(fileContent);
 
         clients.forEach((client) => {
-            client.write(`data: ${htmlContent}\n\n`);
+            client.write(`data: ${encodeURIComponent(htmlContent)}\n\n`);
         });
     });
 

--- a/ts/examples/viewMarkdown/src/site/index.ts
+++ b/ts/examples/viewMarkdown/src/site/index.ts
@@ -8,7 +8,7 @@ document.addEventListener("DOMContentLoaded", () => {
     eventSource.onmessage = function (event: MessageEvent) {
         const contentElement = document.getElementById("content");
         if (contentElement) {
-            contentElement.innerHTML = event.data;
+            contentElement.innerHTML = decodeURIComponent(event.data);
             mermaid.init(
                 undefined,
                 contentElement.querySelectorAll(".mermaid"),


### PR DESCRIPTION
- SSE treats newlines and colons as special characters. These characters are likely to appear in HTML, so we need to encode the HTML when sending it in a message.