### PR TITLE
Add flags to control filtering for explainer.

### DIFF
--- a/ts/package.json
+++ b/ts/package.json
@@ -42,7 +42,7 @@
     "markdown-link-check": "^3.12.2",
     "prettier": "^3.2.5"
   },
-  "packageManager": "pnpm@9.12.1+sha512.e5a7e52a4183a02d5931057f7a0dbff9d5e9ce3161e33fa68ae392125b79282a8a8a470a51dfc8a0ed86221442eb2fb57019b0990ed24fab519bf0e1bc5ccfc4",
+  "packageManager": "pnpm@9.12.3+sha512.cce0f9de9c5a7c95bef944169cc5dfe8741abfb145078c0d508b868056848a87c81e626246cb60967cbd7fd29a6c062ef73ff840d96b3c86c40ac92cf4a813ee",
   "engines": {
     "node": ">=18",
     "pnpm": ">=9"

--- a/ts/packages/agentSdk/src/command.ts
+++ b/ts/packages/agentSdk/src/command.ts
@@ -39,7 +39,7 @@ export type CommandDescriptor = {
 export type CommandDescriptorTable = {
     description: string;
     commands: Record<string, CommandDescriptors>; // The 'command' table to resolve the next '<subcommand>' in the input
-    defaultSubCommand?: CommandDescriptor | undefined; // optional command to resolve to if this is the end of the command or the next '<subcommand>' doesn't match any in the 'commands' table
+    defaultSubCommand?: CommandDescriptor | string | undefined; // optional command to resolve to if this is the end of the command or the next '<subcommand>' doesn't match any in the 'commands' table
 };
 
 export type CommandDescriptors =

--- a/ts/packages/agents/calendar/src/calendarActionHandler.ts
+++ b/ts/packages/agents/calendar/src/calendarActionHandler.ts
@@ -53,7 +53,7 @@ export class CalendarClientLoginCommandHandler
 
 const handlers: CommandHandlerTable = {
     description: "Calendar login commmand",
-    defaultSubCommand: new CalendarClientLoginCommandHandler(),
+    defaultSubCommand: "login",
     commands: {
         login: new CalendarClientLoginCommandHandler(),
     },

--- a/ts/packages/agents/email/src/emailActionHandler.ts
+++ b/ts/packages/agents/email/src/emailActionHandler.ts
@@ -39,7 +39,7 @@ export class MailClientLoginCommandHandler implements CommandHandlerNoParams {
 
 const handlers: CommandHandlerTable = {
     description: "Email login commmand",
-    defaultSubCommand: new MailClientLoginCommandHandler(),
+    defaultSubCommand: "login",
     commands: {
         login: new MailClientLoginCommandHandler(),
     },

--- a/ts/packages/agents/player/src/agent/playerCommands.ts
+++ b/ts/packages/agents/player/src/agent/playerCommands.ts
@@ -49,7 +49,6 @@ const handlers: CommandHandlerTable = {
     commands: {
         spotify: {
             description: "Configure spotify integration",
-            defaultSubCommand: undefined,
             commands: {
                 load: loadHandler,
             },

--- a/ts/packages/cache/src/cache/cache.ts
+++ b/ts/packages/cache/src/cache/cache.ts
@@ -12,6 +12,7 @@ import {
 import { GenericExplanationResult } from "../index.js";
 import { ConstructionStore, ConstructionStoreImpl } from "./store.js";
 import { ExplainerFactory } from "./factory.js";
+import { getLanguageTools } from "../utils/language.js";
 
 export type ProcessExplanationResult = {
     explanation: GenericExplanationResult;
@@ -46,13 +47,59 @@ function getFailedResult(message: string): ProcessRequestActionResult {
     };
 }
 
-type ExplanationOptions = {
+export type ExplanationOptions = {
     concurrent?: boolean; // whether to limit to run one at a time, require cache to be false
-    rejectReferences?: boolean;
+    valueInRequest?: boolean;
+    noReferences?: boolean;
     checkExplainable?:
         | ((requestAction: RequestAction) => Promise<void>)
         | undefined; // throw exception if not explainable
 };
+
+const langTool = getLanguageTools("en");
+
+function checkExplainableValues(
+    requestAction: RequestAction,
+    valueInRequest: boolean,
+    noReferences: boolean,
+) {
+    // Do a cheap parameter check first.
+    const lowercase = requestAction.request.toLowerCase();
+    const pending: unknown[] = [];
+
+    for (const action of requestAction.actions) {
+        pending.push(action.parameters);
+    }
+
+    while (pending.length > 0) {
+        const value = pending.pop();
+        if (!value) {
+            continue;
+        }
+
+        // TODO: check number too.
+        if (typeof value === "string") {
+            if (noReferences && langTool?.possibleReferentialPhrase(value)) {
+                throw new Error(
+                    "Request contains a possible referential phrase used for property values.",
+                );
+            }
+            if (valueInRequest && !lowercase.includes(value.toLowerCase())) {
+                throw new Error(
+                    `Action parameter value '${value}' not found in the request`,
+                );
+            }
+            continue;
+        }
+        if (typeof value === "object") {
+            if (Array.isArray(value)) {
+                pending.push(...value);
+            } else {
+                pending.push(...Object.values(value));
+            }
+        }
+    }
+}
 
 export class AgentCache {
     private _constructionStore: ConstructionStoreImpl;
@@ -108,7 +155,8 @@ export class AgentCache {
         options?: ExplanationOptions,
     ): Promise<ProcessRequestActionResult> {
         const concurrent = options?.concurrent ?? false;
-        const rejectReferences = options?.rejectReferences ?? true;
+        const valueInRequest = options?.valueInRequest ?? true;
+        const noReferences = options?.noReferences ?? true;
         const checkExplainable = options?.checkExplainable;
         const actions = requestAction.actions;
         for (const action of actions) {
@@ -128,6 +176,8 @@ export class AgentCache {
             }
         }
 
+        checkExplainableValues(requestAction, valueInRequest, noReferences);
+
         const task = async () => {
             const store = this._constructionStore;
             const generateConstruction = cache && store.isEnabled();
@@ -139,7 +189,6 @@ export class AgentCache {
             };
 
             const explainerConfig = {
-                rejectReferences,
                 constructionCreationConfig,
             };
 
@@ -232,8 +281,7 @@ export class AgentCache {
                 actions: requestAction.actions,
                 history: requestAction.history,
                 cache,
-                concurrent: options?.concurrent,
-                rejectReferences: options?.rejectReferences,
+                options,
                 message: e.message,
                 stack: e.stack,
             });

--- a/ts/packages/cache/src/explanation/genericExplainer.ts
+++ b/ts/packages/cache/src/explanation/genericExplainer.ts
@@ -33,7 +33,6 @@ export type ExplanationValidator<T> = (
 ) => string | undefined;
 
 export type ExplainerConfig = {
-    rejectReferences?: boolean | undefined;
     constructionCreationConfig: ConstructionCreationConfig | undefined;
 };
 

--- a/ts/packages/cache/src/explanation/v5/propertyExplainationV5.ts
+++ b/ts/packages/cache/src/explanation/v5/propertyExplainationV5.ts
@@ -142,16 +142,6 @@ function validatePropertyExplanation(
                 }
             }
 
-            if (
-                config?.rejectReferences === true &&
-                typeof prop.value === "string" &&
-                langTool?.possibleReferentialPhrase(prop.value.toLowerCase())
-            ) {
-                throw new Error(
-                    "Request contains a possible referential phrase used for property values.",
-                );
-            }
-
             const lowerCaseRequest = requestAction.request.toLowerCase();
             for (const substring of prop.substrings) {
                 if (!lowerCaseRequest.includes(substring.toLowerCase())) {

--- a/ts/packages/cache/src/index.ts
+++ b/ts/packages/cache/src/index.ts
@@ -28,6 +28,7 @@ export type {
     AgentCache,
     CacheConfig,
     ProcessRequestActionResult,
+    ExplanationOptions,
 } from "./cache/cache.js";
 
 // Functionalities

--- a/ts/packages/cli/src/commands/interactive.ts
+++ b/ts/packages/cli/src/commands/interactive.ts
@@ -68,7 +68,7 @@ export default class Interactive extends Command {
         try {
             context = await initializeCommandHandlerContext("cli interactive", {
                 translators,
-                explainerName: flags.explainer,
+                explainer: { name: flags.explainer },
                 stdio,
                 persistSession: !flags.memory,
                 enableServiceHost: true,

--- a/ts/packages/cli/src/commands/run/explain.ts
+++ b/ts/packages/cli/src/commands/run/explain.ts
@@ -70,7 +70,7 @@ export default class ExplainCommand extends Command {
             {
                 translators,
                 actions: {}, // We don't need any actions
-                explainerName: flags.explainer,
+                explainer: { name: flags.explainer },
                 cache: false,
                 clientIO: flags.repeat > 1 ? null : undefined,
             },

--- a/ts/packages/cli/src/commands/run/request.ts
+++ b/ts/packages/cli/src/commands/run/request.ts
@@ -48,7 +48,7 @@ export default class RequestCommand extends Command {
             : undefined;
         const dispatcher = await createDispatcher("cli run request", {
             translators,
-            explainerName: flags.explainer,
+            explainer: { name: flags.explainer },
             cache: false,
         });
         await dispatcher.processCommand(

--- a/ts/packages/dispatcher/src/agent/inlineAgentHandlers.ts
+++ b/ts/packages/dispatcher/src/agent/inlineAgentHandlers.ts
@@ -34,6 +34,7 @@ import { getNotifyCommandHandlers } from "../handlers/notifyCommandHandler.js";
 import { processRequests } from "../utils/interactive.js";
 import { getConsoleRequestIO } from "../handlers/common/interactiveIO.js";
 import {
+    getDefaultSubCommandDescriptor,
     getParsedCommand,
     getPrompt,
     processCommandNoLock,
@@ -101,23 +102,36 @@ class HelpCommandHandler implements CommandHandler {
             );
 
             const command = getParsedCommand(result);
-            if (result.descriptor !== undefined) {
-                displayResult(getUsage(command, result.descriptor), context);
-            } else {
-                if (result.table === undefined) {
-                    throw new Error(`Unknown command '${params.args.command}'`);
-                }
-                if (result.suffix.length !== 0) {
-                    displayError(
-                        `ERROR: '${result.suffix}' is not a subcommand for '@${command}'`,
-                        context,
-                    );
-                }
-                displayResult(
-                    getHandlerTableUsage(result.table, command, systemContext),
+            if (result.suffix.length !== 0) {
+                displayError(
+                    `ERROR: '${result.suffix}' is not a subcommand for '@${command}'`,
                     context,
                 );
             }
+
+            if (result.descriptor !== undefined) {
+                const defaultSubCommand =
+                    result.table !== undefined
+                        ? getDefaultSubCommandDescriptor(result.table)
+                        : undefined;
+
+                if (defaultSubCommand !== result.descriptor) {
+                    displayResult(
+                        getUsage(command, result.descriptor),
+                        context,
+                    );
+                    return;
+                }
+            }
+
+            if (result.table === undefined) {
+                throw new Error(`Unknown command '${params.args.command}'`);
+            }
+
+            displayResult(
+                getHandlerTableUsage(result.table, command, systemContext),
+                context,
+            );
         }
     }
 }

--- a/ts/packages/dispatcher/src/dispatcher/commandHelp.ts
+++ b/ts/packages/dispatcher/src/dispatcher/commandHelp.ts
@@ -11,6 +11,7 @@ import {
     getFlagType,
     isCommandDescriptorTable,
 } from "@typeagent/agent-sdk/helpers/command";
+import { getDefaultSubCommandDescriptor } from "./command.js";
 
 export function getUsage(command: string, descriptor: CommandDescriptor) {
     if (descriptor.help) {
@@ -74,15 +75,25 @@ export function getHandlerTableUsage(
     systemContext: CommandHandlerContext,
 ) {
     const output: string[] = [];
-    output.push(`${chalk.bold(chalk.underline(table.description))}`);
-    output.push();
     if (command) {
+        const defaultSubCommand = getDefaultSubCommandDescriptor(table);
+        if (defaultSubCommand !== undefined) {
+            output.push(`${chalk.bold(chalk.underline("Command"))}`);
+            output.push(getUsage(command, defaultSubCommand));
+            output.push("");
+        }
+        output.push(
+            `${chalk.bold(chalk.underline(`Subcommands: ${table.description}`))}`,
+        );
+        output.push("");
         output.push(`${chalk.bold("Usage")}: @${command} <subcommand> ...`);
         output.push();
         output.push(`${chalk.bold("<subcommand>:")}`);
     } else {
+        output.push(`${chalk.bold(chalk.underline(table.description))}`);
+        output.push("");
         output.push(`${chalk.bold("Usage")}: @[<agentName>] <subcommand> ...`);
-        output.push();
+        output.push("");
         output.push(`${chalk.bold("<agentNames>:")} (default to 'system')`);
         const names = systemContext.agents.getAppAgentNames();
         const maxNameLength = Math.max(...names.map((name) => name.length));
@@ -93,7 +104,7 @@ export function getHandlerTableUsage(
                 );
             }
         }
-        output.push();
+        output.push("");
         output.push(`${chalk.bold("<subcommand>")} ('system')`);
     }
 

--- a/ts/packages/dispatcher/src/handlers/common/commandHandler.ts
+++ b/ts/packages/dispatcher/src/handlers/common/commandHandler.ts
@@ -40,7 +40,7 @@ export function getToggleHandlerTable(
 ): CommandHandlerTable {
     return {
         description: `Toggle ${name}`,
-        defaultSubCommand: undefined,
+        defaultSubCommand: "on",
         commands: getToggleCommandHandlers(name, toggle),
     };
 }

--- a/ts/packages/dispatcher/src/handlers/common/commandHandlerContext.ts
+++ b/ts/packages/dispatcher/src/handlers/common/commandHandlerContext.ts
@@ -421,7 +421,7 @@ export async function changeContextConfig(
     if (translatorChanged || actionsChanged || commandsChanged) {
         Object.assign(changed, await updateAppAgentStates(context, changed));
     }
-    if (changed.explainerName !== undefined) {
+    if (changed.explainer?.name !== undefined) {
         try {
             systemContext.agentCache = await getAgentCache(
                 systemContext.session,
@@ -430,10 +430,12 @@ export async function changeContextConfig(
             );
         } catch (e: any) {
             displayError(`Failed to change explainer: ${e.message}`, context);
-            delete changed.explainerName;
+            delete changed.explainer?.name;
             // Restore old explainer name
             systemContext.session.setConfig({
-                explainerName: systemContext.agentCache.explainerName,
+                explainer: {
+                    name: systemContext.agentCache.explainerName,
+                },
             });
         }
 

--- a/ts/packages/dispatcher/src/handlers/constructionCommandHandlers.ts
+++ b/ts/packages/dispatcher/src/handlers/constructionCommandHandlers.ts
@@ -418,7 +418,6 @@ class ConstructionDeleteCommandHandler implements CommandHandler {
 export function getConstructionCommandHandlers(): CommandHandlerTable {
     return {
         description: "Command to manage the construction store",
-        defaultSubCommand: undefined,
         commands: {
             new: new ConstructionNewCommandHandler(),
             load: new ConstructionLoadCommandHandler(),

--- a/ts/packages/dispatcher/src/handlers/historyCommandHandler.ts
+++ b/ts/packages/dispatcher/src/handlers/historyCommandHandler.ts
@@ -78,7 +78,7 @@ export class HistoryDeleteCommandHandler implements CommandHandler {
 export function getHistoryCommandHandlers(): CommandHandlerTable {
     return {
         description: "History commands",
-        defaultSubCommand: new HistoryListCommandHandler(),
+        defaultSubCommand: "list",
         commands: {
             list: new HistoryListCommandHandler(),
             clear: new HistoryClearCommandHandler(),

--- a/ts/packages/dispatcher/src/handlers/notifyCommandHandler.ts
+++ b/ts/packages/dispatcher/src/handlers/notifyCommandHandler.ts
@@ -73,13 +73,13 @@ class NotifyShowAllCommandHandler implements CommandHandlerNoParams {
 export function getNotifyCommandHandlers(): CommandHandlerTable {
     return {
         description: "Notify commands",
-        defaultSubCommand: new NotifyInfoCommandHandler(),
+        defaultSubCommand: "info",
         commands: {
             info: new NotifyInfoCommandHandler(),
             clear: new NotifyClearCommandHandler(),
             show: {
                 description: "Show notifications",
-                defaultSubCommand: new NotifyShowUnreadCommandHandler(),
+                defaultSubCommand: "unread",
                 commands: {
                     unread: new NotifyShowUnreadCommandHandler(),
                     all: new NotifyShowAllCommandHandler(),

--- a/ts/packages/dispatcher/src/handlers/randomCommandHandler.ts
+++ b/ts/packages/dispatcher/src/handlers/randomCommandHandler.ts
@@ -173,7 +173,7 @@ class RandomOnlineCommandHandler implements CommandHandlerNoParams {
 export function getRandomCommandHandlers(): CommandHandlerTable {
     return {
         description: "Random request commands",
-        defaultSubCommand: new RandomOfflineCommandHandler(),
+        defaultSubCommand: "offline",
         commands: {
             online: new RandomOnlineCommandHandler(),
             offline: new RandomOfflineCommandHandler(),

--- a/ts/packages/dispatcher/src/handlers/serviceHost/localWhisperCommandHandler.ts
+++ b/ts/packages/dispatcher/src/handlers/serviceHost/localWhisperCommandHandler.ts
@@ -77,7 +77,6 @@ export async function createLocalWhisperHost() {
 export function getLocalWhisperCommandHandlers(): CommandHandlerTable {
     return {
         description: "Configure Local Whisper",
-        defaultSubCommand: undefined,
         commands: {
             off: {
                 description: "Turn off Local Whisper integration",

--- a/ts/packages/dispatcher/src/handlers/serviceHost/serviceHostCommandHandler.ts
+++ b/ts/packages/dispatcher/src/handlers/serviceHost/serviceHostCommandHandler.ts
@@ -28,7 +28,6 @@ export async function createServiceHost() {
 export function getServiceHostCommandHandlers(): CommandHandlerTable {
     return {
         description: "Configure Service Hosting",
-        defaultSubCommand: undefined,
         commands: {
             off: {
                 description: "Turn off Service hosting integration",

--- a/ts/packages/dispatcher/src/handlers/sessionCommandHandlers.ts
+++ b/ts/packages/dispatcher/src/handlers/sessionCommandHandlers.ts
@@ -267,7 +267,6 @@ class SessionInfoCommandHandler implements CommandHandlerNoParams {
 export function getSessionCommandHandlers(): CommandHandlerTable {
     return {
         description: "Session commands",
-        defaultSubCommand: undefined,
         commands: {
             new: new SessionNewCommandHandler(),
             open: new SessionOpenCommandHandler(),

--- a/ts/packages/dispatcher/src/handlers/tokenCommandHandler.ts
+++ b/ts/packages/dispatcher/src/handlers/tokenCommandHandler.ts
@@ -55,7 +55,7 @@ class TokenDetailsCommandHandler implements CommandHandlerNoParams {
 export function getTokenCommandHandlers(): CommandHandlerTable {
     return {
         description: "Get LLM token usage statistics for this session.",
-        defaultSubCommand: new TokenSummaryCommandHandler(),
+        defaultSubCommand: "summary",
         commands: {
             summary: new TokenSummaryCommandHandler(),
             details: new TokenDetailsCommandHandler(),

--- a/ts/packages/dispatcher/src/session/session.ts
+++ b/ts/packages/dispatcher/src/session/session.ts
@@ -102,19 +102,25 @@ async function newSessionDir() {
 }
 
 type DispatcherConfig = {
-    explainerName: string;
     models: {
         translator: string;
         explainer: string;
     };
     bot: boolean;
     stream: boolean;
-    explanation: boolean;
-    explanationOptions: {
-        rejectReferences: boolean;
-        retranslateWithoutContext: boolean;
+    explainer: {
+        enabled: boolean;
+        name: string;
+        filter: {
+            multiple: boolean;
+            reference: {
+                value: boolean;
+                list: boolean;
+                translate: boolean;
+            };
+        };
     };
-    promptOptions: {
+    promptConfig: {
         additionalInstructions: boolean;
     };
     switch: {
@@ -141,19 +147,25 @@ const defaultSessionConfig: SessionConfig = {
     translators: undefined,
     actions: undefined,
     commands: undefined,
-    explainerName: getDefaultExplainerName(),
     models: {
         translator: "",
         explainer: "",
     },
     bot: true,
     stream: true,
-    explanation: true,
-    explanationOptions: {
-        rejectReferences: true,
-        retranslateWithoutContext: true,
+    explainer: {
+        enabled: true,
+        name: getDefaultExplainerName(),
+        filter: {
+            multiple: true,
+            reference: {
+                value: true,
+                list: true,
+                translate: true,
+            },
+        },
     },
-    promptOptions: {
+    promptConfig: {
         additionalInstructions: true,
     },
     switch: {
@@ -275,7 +287,7 @@ export class Session {
     }
 
     public get explainerName() {
-        return this.config.explainerName;
+        return this.config.explainer.name;
     }
 
     public get bot() {
@@ -283,7 +295,7 @@ export class Session {
     }
 
     public get explanation() {
-        return this.config.explanation;
+        return this.config.explainer.enabled;
     }
 
     public get cache() {

--- a/ts/packages/shell/src/main/agent.ts
+++ b/ts/packages/shell/src/main/agent.ts
@@ -191,7 +191,7 @@ const handlers: CommandHandlerTable = {
     commands: {
         show: {
             description: "Show shell settings",
-            defaultSubCommand: new ShellShowSettingsCommandHandler(),
+            defaultSubCommand: "settings",
             commands: {
                 settings: new ShellShowSettingsCommandHandler(),
                 help: new ShellShowHelpCommandHandler(),


### PR DESCRIPTION
- Add flags to control filtering for explainer  `@config explainer filter *`
  - `... multiple`: don't explain multiple actions (default: enabled)
  - `... reference list`: don't explain action with property value in the list of reference words (default: enabled)
  - `... reference value`: don't explain action whose property value isn't found in the request (default: enabled)
  - ``...reference translation`: don't explain action whose result changed after retranslation with the LLM without history context (default: enabled)
- To toggle all filters
   - `@config explainer filter`
   - `@config explainer filter on`
   - `@config explainer filter off`
- To toggle reference filters
   - `@config explainer filter reference`
   - `@config explainer filter reference on` 
   - `@config explainer filter reference off`


Additional changes:
- Show default subcommand information in `@help` 
- Add support of using sub command name for the `defaultSubCommand` instead of the duplicating the instance.
- Hoist the referential phrase detection in the value before any LLM explanation instead of during the `PropertyExplanation` to avoid the LLM cost.
- Fix command completion for sub command doesn't show up if the `defaultSubCommand` doesn't have parameters.
- Merge `@config explainer` and `@config explanation`
   - the original `@config explainer <name>` is now `@config explainer name <name>`
   - `@config explainer` will now enable the explainer along with toggles `@config explainer on` and `@config explainer off`.