### PR TITLE
Split the clarify action into a separate translator

### DIFF
--- a/ts/packages/dispatcher/data/config.json
+++ b/ts/packages/dispatcher/data/config.json
@@ -44,9 +44,20 @@
       "description": "Built-in agent to dispatch request",
       "schema": {
         "schemaType": "DispatcherActions",
-        "schemaFile": "./src/dispatcher/dispatcherActionSchema.ts",
+        "schemaFile": "./src/dispatcher/schema/dispatcherActionSchema.ts",
         "injected": true,
         "cached": false
+      },
+      "subTranslators": {
+        "clarify": {
+          "description": "Action that helps you clarify your request.",
+          "schema": {
+            "schemaFile": "./src/dispatcher/schema/clarifyActionSchema.ts",
+            "schemaType": "ClarifyRequestAction",
+            "injected": true,
+            "cached": false
+          }
+        }
       }
     },
     "system": {

--- a/ts/packages/dispatcher/src/dispatcher/dispatcherAgent.ts
+++ b/ts/packages/dispatcher/src/dispatcher/dispatcherAgent.ts
@@ -13,10 +13,10 @@ import { ActionContext, AppAction, AppAgent } from "@typeagent/agent-sdk";
 import { CommandHandlerContext } from "../internal.js";
 import { createActionResultNoDisplay } from "@typeagent/agent-sdk/helpers/action";
 import {
-    ClarifyRequestAction,
     DispatcherActions,
     UnknownAction,
-} from "./dispatcherActionSchema.js";
+} from "./schema/dispatcherActionSchema.js";
+import { ClarifyRequestAction } from "./schema/clarifyActionSchema.js";
 
 export function isUnknownAction(action: AppAction): action is UnknownAction {
     return action.actionName === "unknown";
@@ -33,7 +33,7 @@ const dispatcherHandlers: CommandHandlerTable = {
 };
 
 async function executeDispatcherAction(
-    action: DispatcherActions,
+    action: DispatcherActions | ClarifyRequestAction,
     context: ActionContext<CommandHandlerContext>,
 ) {
     if (action.actionName === "clarifyRequest") {

--- a/ts/packages/dispatcher/src/dispatcher/schema/clarifyActionSchema.ts
+++ b/ts/packages/dispatcher/src/dispatcher/schema/clarifyActionSchema.ts
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-export type DispatcherActions = ClarifyRequestAction | UnknownAction;
-
 // The request has ambiguities, including multiple possible actions, multiple interpretations, unresolved references, missing parameters, etc.
 export interface ClarifyRequestAction {
     actionName: "clarifyRequest";
@@ -14,14 +12,5 @@ export interface ClarifyRequestAction {
         possibleActionName: string[];
         ambiguity: string[]; // multiple possible actions, multiple interpretations, unresolved pronoun or references, missing parameters, non-typical parameters, etc.
         clarifyingQuestion: string;
-    };
-}
-
-// the user request isn't any of the action available
-export interface UnknownAction {
-    actionName: "unknown";
-    parameters: {
-        // user request that couldn't be matched to any action
-        request: string;
     };
 }

--- a/ts/packages/dispatcher/src/dispatcher/schema/dispatcherActionSchema.ts
+++ b/ts/packages/dispatcher/src/dispatcher/schema/dispatcherActionSchema.ts
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+export type DispatcherActions = UnknownAction;
+
+// the user request isn't any of the action available
+export interface UnknownAction {
+    actionName: "unknown";
+    parameters: {
+        // user request that couldn't be matched to any action
+        request: string;
+    };
+}

--- a/ts/packages/dispatcher/src/handlers/requestCommandHandler.ts
+++ b/ts/packages/dispatcher/src/handlers/requestCommandHandler.ts
@@ -45,11 +45,7 @@ import registerDebug from "debug";
 import { IncrementalJsonValueCallBack } from "../../../commonUtils/dist/incrementalJsonParser.js";
 import ExifReader from "exifreader";
 import { ProfileNames } from "../utils/profileNames.js";
-import {
-    ActionContext,
-    ParsedCommandParams,
-    Profiler,
-} from "@typeagent/agent-sdk";
+import { ActionContext, ParsedCommandParams } from "@typeagent/agent-sdk";
 import { CommandHandler } from "@typeagent/agent-sdk/helpers/command";
 import {
     displayError,
@@ -61,8 +57,7 @@ import { DispatcherName } from "./common/interactiveIO.js";
 import { getActionTemplateEditConfig } from "../translation/actionTemplate.js";
 import { getActionInfo, validateAction } from "../translation/actionInfo.js";
 import { isUnknownAction } from "../dispatcher/dispatcherAgent.js";
-import { UnknownAction } from "../dispatcher/dispatcherActionSchema.js";
-import { RequestMetricsManager } from "../utils/metrics.js";
+import { UnknownAction } from "../dispatcher/schema/dispatcherActionSchema.js";
 
 const debugTranslate = registerDebug("typeagent:translate");
 const debugExplain = registerDebug("typeagent:explain");


### PR DESCRIPTION
So that it can be disabled independently.