### PR TITLE
Ignore diacritic difference (on top of case) when comparing LLM output

### DIFF
--- a/ts/packages/cache/src/cache/cache.ts
+++ b/ts/packages/cache/src/cache/cache.ts
@@ -5,7 +5,11 @@ import { QueueObject, queue } from "async";
 import { DeepPartialUndefined } from "common-utils";
 import { ChildLogger, Logger } from "telemetry";
 import { ExplanationData } from "../explanation/explanationData.js";
-import { Actions, RequestAction } from "../explanation/requestAction.js";
+import {
+    Actions,
+    normalizeParamString,
+    RequestAction,
+} from "../explanation/requestAction.js";
 import {
     SchemaConfigProvider,
     doCacheAction,
@@ -65,7 +69,7 @@ function checkExplainableValues(
     noReferences: boolean,
 ) {
     // Do a cheap parameter check first.
-    const lowercase = requestAction.request.toLowerCase();
+    const normalizedRequest = normalizeParamString(requestAction.request);
     const pending: unknown[] = [];
 
     for (const action of requestAction.actions) {
@@ -85,7 +89,10 @@ function checkExplainableValues(
                     "Request contains a possible referential phrase used for property values.",
                 );
             }
-            if (valueInRequest && !lowercase.includes(value.toLowerCase())) {
+            if (
+                valueInRequest &&
+                !normalizedRequest.includes(normalizeParamString(value))
+            ) {
                 throw new Error(
                     `Action parameter value '${value}' not found in the request`,
                 );

--- a/ts/packages/cache/src/constructions/constructionPrint.ts
+++ b/ts/packages/cache/src/constructions/constructionPrint.ts
@@ -11,6 +11,7 @@ import {
     MatchedValueTranslator,
     createActionProps,
 } from "./constructionValue.js";
+import { normalizeParamString } from "../explanation/requestAction.js";
 
 export function getMatchPartNames(parts: ConstructionPart[], verbose: boolean) {
     const counts = new Map<string, number>();
@@ -60,10 +61,12 @@ export type PrintOptions = {
 };
 
 function filterConstruction(construction: Construction, options: PrintOptions) {
-    const lowerMatches = options.match?.map((m) => m.toLowerCase());
-    if (lowerMatches && lowerMatches.length > 0) {
+    const normalizedMatches = options.match?.map((m) =>
+        normalizeParamString(m),
+    );
+    if (normalizedMatches && normalizedMatches.length > 0) {
         if (
-            !lowerMatches.every((m) =>
+            !normalizedMatches.every((m) =>
                 construction.parts.some((p) => {
                     if (isMatchPart(p)) {
                         for (const e of p.matchSet.matches.values()) {
@@ -106,7 +109,7 @@ export function printConstructionCache(
     options: PrintOptions,
 ) {
     const { all, verbose, match, id } = options;
-    const lowerMatches = match?.map((m) => m.toLowerCase());
+    const normalizedMatches = match?.map((m) => normalizeParamString(m));
     for (const name of cache.getConstructionNamespaces()) {
         const { constructions } = cache.getConstructionNamespace(name)!;
 
@@ -119,9 +122,9 @@ export function printConstructionCache(
             } ${filteredConstructions.length !== constructions.length ? "filtered " : ""}constructions)`,
         );
         for (const construction of filteredConstructions) {
-            if (lowerMatches && lowerMatches.length > 0) {
+            if (normalizedMatches && normalizedMatches.length > 0) {
                 if (
-                    !lowerMatches.every((m) =>
+                    !normalizedMatches.every((m) =>
                         construction.parts.some((p) => {
                             if (isMatchPart(p)) {
                                 for (const e of p.matchSet.matches.values()) {

--- a/ts/packages/cache/src/constructions/matchPart.ts
+++ b/ts/packages/cache/src/constructions/matchPart.ts
@@ -60,7 +60,8 @@ export class MatchSet {
         public readonly namespace: string | undefined,
         private readonly index: number = -1, // Assign an index as id for serialization and reference in construction
     ) {
-        // Case insensitive match, use lower case to avoid duplicates with only difference in case.
+        // Case insensitive match
+        // TODO: non-diacritic match
         this.matches = new Set(Array.from(matches).map((m) => m.toLowerCase()));
     }
 

--- a/ts/packages/cache/src/constructions/transforms.ts
+++ b/ts/packages/cache/src/constructions/transforms.ts
@@ -5,6 +5,7 @@ import {
     HistoryContext,
     ParamValueType,
     equalNormalizedParamValue,
+    normalizeParamString,
     normalizeParamValue,
 } from "../explanation/requestAction.js";
 
@@ -56,10 +57,10 @@ export class Transforms {
             map = new Map();
             this.transforms.set(paramName, map);
         }
-        // Case insensitive match, use lowercase for lookup
+        // Case insensitive/non-diacritic match
         // Use the count ot heuristic to prefer values original to user request
         // and not from a synonym or alternative suggested by GPT
-        this.addTransformRecord(map, text.toLowerCase(), {
+        this.addTransformRecord(map, normalizeParamString(text), {
             value,
             count: original ? 1 : 0,
         });
@@ -71,8 +72,10 @@ export class Transforms {
             map = new Map();
             this.transforms.set(paramName, map);
         }
-        // Case insensitive match, use lowercase for lookup
-        this.addTransformRecord(map, text.toLowerCase(), { entityTypes });
+        // Case insensitive/non-diacritic match
+        this.addTransformRecord(map, normalizeParamString(text), {
+            entityTypes,
+        });
     }
 
     private addTransformRecord(
@@ -204,8 +207,8 @@ export class Transforms {
                 `Internal error: no transform found for ${paramName}`,
             );
         }
-        // Case insensitive match, use lowercase for lookup
-        const record = textTransform.get(text.toLowerCase());
+        // Case insensitive/non-diacritic match
+        const record = textTransform.get(normalizeParamString(text));
         if (record === undefined) {
             return undefined;
         }
@@ -230,8 +233,8 @@ export class Transforms {
                 `Internal error: no transform found for ${paramName}`,
             );
         }
-        // Case insensitive match, use lowercase for lookup
-        const record = textTransform.get(text.toLowerCase());
+        // Case insensitive/non-diacritic match
+        const record = textTransform.get(normalizeParamString(text));
         if (
             record === undefined ||
             isTransformEntityRecord(record) ||

--- a/ts/packages/cache/src/explanation/requestAction.ts
+++ b/ts/packages/cache/src/explanation/requestAction.ts
@@ -9,8 +9,15 @@ export type HistoryContext = {
     additionalInstructions?: string[] | undefined;
 };
 
+export function normalizeParamString(str: string) {
+    return str
+        .normalize("NFD")
+        .replace(/\p{Diacritic}/gu, "")
+        .toLowerCase();
+}
+
 export function normalizeParamValue(value: ParamValueType) {
-    return typeof value === "string" ? value.toLowerCase() : value;
+    return typeof value === "string" ? normalizeParamString(value) : value;
 }
 
 export function equalNormalizedParamValue(
@@ -18,6 +25,16 @@ export function equalNormalizedParamValue(
     b: ParamValueType,
 ) {
     return a === b || normalizeParamValue(a) === normalizeParamValue(b);
+}
+
+export function equalNormalizedParamObject(
+    a: ParamObjectType = {},
+    b: ParamObjectType = {},
+) {
+    return (
+        normalizeParamString(JSON.stringify(a)) ===
+        normalizeParamString(JSON.stringify(b))
+    );
 }
 
 export type ParamValueType = string | number | boolean;

--- a/ts/packages/cache/src/explanation/v5/explanationV5.ts
+++ b/ts/packages/cache/src/explanation/v5/explanationV5.ts
@@ -28,7 +28,12 @@ import {
     EntityProperty,
     PropertyExplanation,
 } from "./propertyExplanationSchemaV5WithContext.js";
-import { Action, Actions, RequestAction } from "../requestAction.js";
+import {
+    Action,
+    Actions,
+    normalizeParamString,
+    RequestAction,
+} from "../requestAction.js";
 import { Construction } from "../../constructions/constructions.js";
 import { TypeChatAgentResult, ValidationError } from "../typeChatAgent.js";
 import {
@@ -568,8 +573,8 @@ export function createConstructionV5(
         phrase: SubPhrase,
         paramInfo: PropertyValue,
     ) => {
-        const ltext = phrase.text.toLowerCase();
-        const lval = paramInfo.propertyValue.toString().toLowerCase();
+        const ltext = normalizeParamString(phrase.text);
+        const lval = normalizeParamString(paramInfo.propertyValue.toString());
         return (
             getPropertySpec(
                 paramInfo.propertyName,

--- a/ts/packages/cache/src/explanation/v5/propertyExplainationV5.ts
+++ b/ts/packages/cache/src/explanation/v5/propertyExplainationV5.ts
@@ -10,7 +10,7 @@ import {
     EntityProperty,
 } from "./propertyExplanationSchemaV5WithContext.js";
 import { getPackageFilePath } from "../../utils/getPackageFilePath.js";
-import { RequestAction } from "../requestAction.js";
+import { normalizeParamString, RequestAction } from "../requestAction.js";
 import {
     getActionDescription,
     getExactStringRequirementMessage,
@@ -112,8 +112,8 @@ function validatePropertyExplanation(
             if (isEntityParameter(prop) && prop.entityIndex !== undefined) {
                 // TODO: fuzzy match
                 if (
-                    prop.substrings.join(" ").toLowerCase() ===
-                    prop.value.toString().toLowerCase()
+                    normalizeParamString(prop.substrings.join(" ")) ===
+                    normalizeParamString(prop.value.toString())
                 ) {
                     corrections.push(
                         `'${prop.name}' has value '${prop.value}' from a substring in the request. Should not have an entity index.`,
@@ -141,9 +141,13 @@ function validatePropertyExplanation(
                 }
             }
 
-            const lowerCaseRequest = requestAction.request.toLowerCase();
+            const normalizedRequest = normalizeParamString(
+                requestAction.request,
+            );
             for (const substring of prop.substrings) {
-                if (!lowerCaseRequest.includes(substring.toLowerCase())) {
+                if (
+                    !normalizedRequest.includes(normalizeParamString(substring))
+                ) {
                     corrections.push(
                         `Substring '${substring}' for property '${prop.name}' not found in the request string. ${getExactStringRequirementMessage(false)}`,
                     );

--- a/ts/packages/cache/src/explanation/v5/subPhraseExplanationV5.ts
+++ b/ts/packages/cache/src/explanation/v5/subPhraseExplanationV5.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import { PromptSection } from "typechat";
-import { RequestAction } from "../requestAction.js";
+import { normalizeParamString, RequestAction } from "../requestAction.js";
 import { PropertyExplanation } from "./propertyExplanationSchemaV5WithContext.js";
 import { form } from "./explanationV5.js";
 import {
@@ -135,12 +135,12 @@ function validateSubPhraseExplanationV5(
             }
 
             prop.substrings.forEach((substring) => {
-                const lowerCaseSubString = substring.toLowerCase();
+                const normalizedSubString = normalizeParamString(substring);
                 const found = subPhrases.some((phrase) => {
-                    const lowerCasePhrase = phrase.text.toLowerCase();
+                    const normalizedPhrase = normalizeParamString(phrase.text);
                     return (
-                        lowerCasePhrase.includes(lowerCaseSubString) ||
-                        lowerCaseSubString.includes(lowerCasePhrase)
+                        normalizedPhrase.includes(normalizedSubString) ||
+                        normalizedSubString.includes(normalizedPhrase)
                     );
                 });
                 if (!found) {

--- a/ts/packages/cache/src/index.ts
+++ b/ts/packages/cache/src/index.ts
@@ -36,7 +36,9 @@ export {
     Actions,
     RequestAction,
     normalizeParamValue,
+    normalizeParamString,
     equalNormalizedParamValue,
+    equalNormalizedParamObject,
 } from "./explanation/requestAction.js";
 export { AgentCacheFactory, getDefaultExplainerName } from "./cache/factory.js";
 export { MatchResult } from "./constructions/constructions.js";

--- a/ts/packages/dispatcher/src/handlers/requestCommandHandler.ts
+++ b/ts/packages/dispatcher/src/handlers/requestCommandHandler.ts
@@ -12,6 +12,7 @@ import {
     ProcessRequestActionResult,
     ExplanationOptions,
     ParamObjectType,
+    equalNormalizedParamObject,
 } from "agent-cache";
 import {
     CommandHandlerContext,
@@ -725,8 +726,10 @@ async function canTranslateWithoutContext(
             }
 
             if (
-                JSON.stringify(newAction.parameters ?? {}).toLowerCase() !==
-                JSON.stringify(oldAction.parameters ?? {}).toLowerCase()
+                !equalNormalizedParamObject(
+                    newAction.parameters,
+                    oldAction.parameters,
+                )
             ) {
                 throw new Error(`Action parameters mismatch without context`);
             }

--- a/ts/packages/dispatcher/test/construction.spec.ts
+++ b/ts/packages/dispatcher/test/construction.spec.ts
@@ -6,7 +6,7 @@ dotenv.config({ path: new URL("../../../../.env", import.meta.url) });
 
 import { getCacheFactory } from "../src/utils/cacheFactory.js";
 import { readTestData } from "../src/utils/test/testData.js";
-import { Actions, RequestAction } from "agent-cache";
+import { Actions, normalizeParamString, RequestAction } from "agent-cache";
 import { loadBuiltinTranslatorSchemaConfig } from "../src/translation/agentTranslators.js";
 import { glob } from "glob";
 
@@ -59,8 +59,8 @@ describe("construction", () => {
                     requestAction.request,
                     matchConfig,
                 );
-                const matchedLowercase = construction.match(
-                    requestAction.request.toLowerCase(),
+                const matchedNormalized = construction.match(
+                    normalizeParamString(requestAction.request),
                     matchConfig,
                 );
                 if (!tags.includes("failedRoundTripAction")) {
@@ -68,7 +68,7 @@ describe("construction", () => {
                     expect(matched.length).not.toEqual(0);
                     expect(matched[0].match).toEqual(requestAction);
 
-                    expect(matchedLowercase.length).not.toEqual(0);
+                    expect(matchedNormalized.length).not.toEqual(0);
                     // TODO: Validating the lower case action
                 } else {
                     // TODO: needs fix these

--- a/ts/packages/dispatcher/test/construction.spec.ts
+++ b/ts/packages/dispatcher/test/construction.spec.ts
@@ -6,7 +6,7 @@ dotenv.config({ path: new URL("../../../../.env", import.meta.url) });
 
 import { getCacheFactory } from "../src/utils/cacheFactory.js";
 import { readTestData } from "../src/utils/test/testData.js";
-import { Actions, normalizeParamString, RequestAction } from "agent-cache";
+import { Actions, RequestAction } from "agent-cache";
 import { loadBuiltinTranslatorSchemaConfig } from "../src/translation/agentTranslators.js";
 import { glob } from "glob";
 
@@ -59,8 +59,11 @@ describe("construction", () => {
                     requestAction.request,
                     matchConfig,
                 );
-                const matchedNormalized = construction.match(
-                    normalizeParamString(requestAction.request),
+
+                // TODO: once MatchPart allow matches ignoring diacritical marks,
+                // we can use normalizeParamString instead toLowerCase here.
+                const matchedLowerCase = construction.match(
+                    requestAction.request.toLowerCase(),
                     matchConfig,
                 );
                 if (!tags.includes("failedRoundTripAction")) {
@@ -68,7 +71,7 @@ describe("construction", () => {
                     expect(matched.length).not.toEqual(0);
                     expect(matched[0].match).toEqual(requestAction);
 
-                    expect(matchedNormalized.length).not.toEqual(0);
+                    expect(matchedLowerCase.length).not.toEqual(0);
                     // TODO: Validating the lower case action
                 } else {
                     // TODO: needs fix these

--- a/ts/packages/dispatcher/test/constructionCacheTestCommon.ts
+++ b/ts/packages/dispatcher/test/constructionCacheTestCommon.ts
@@ -17,6 +17,7 @@ import {
     getDefaultExplainerName,
     createActionProps,
     normalizeParamValue,
+    normalizeParamString,
 } from "agent-cache";
 import { loadBuiltinTranslatorSchemaConfig } from "../src/translation/agentTranslators.js";
 import { glob } from "glob";
@@ -124,7 +125,7 @@ function getTestInputPart(testFileName: string) {
 function normalizeParams(action: JSONAction) {
     if (action.parameters !== undefined) {
         action.parameters = JSON.parse(
-            JSON.stringify(action.parameters).toLowerCase(), // normalize the lower case
+            normalizeParamString(JSON.stringify(action.parameters)), // normalize the lower case
         );
     }
 }


### PR DESCRIPTION
LLM might fix the diacritic mark for entity it knows about from the request.  It should be ok to just ignore those when matching user requests or comparing LLM output