### PR TITLE
[spelunker] Add nearestNeighborsPairs to TextTable and createTextIndex

### DIFF
--- a/ts/examples/memoryProviders/src/sqlite/textTable.ts
+++ b/ts/examples/memoryProviders/src/sqlite/textTable.ts
@@ -554,8 +554,8 @@ export async function createTextIndex<
             return {
                 score: m.score,
                 item: {
-                        key: isIdInt ? m.item : serializer.serialize(m.item),
-                        value: postingsTable.getSync(m.item) ?? [],
+                    key: isIdInt ? m.item : serializer.serialize(m.item),
+                    value: postingsTable.getSync(m.item) ?? [],
                 },
             };
         });

--- a/ts/examples/memoryProviders/src/sqlite/textTable.ts
+++ b/ts/examples/memoryProviders/src/sqlite/textTable.ts
@@ -252,6 +252,7 @@ export async function createTextIndex<
         addSources,
         nearestNeighbors,
         nearestNeighborsText,
+        nearestNeighborsPairs,
         remove,
     };
 
@@ -537,6 +538,28 @@ export async function createTextIndex<
             matches.splice(0, 0, { score: 1.0, item: textId });
         }
         return matches;
+    }
+
+    async function nearestNeighborsPairs(
+        value: string,
+        maxMatches: number,
+        minScore?: number,
+    ): Promise<ScoredItem<knowLib.KVPair<TTextId, TSourceId[]>>[]> {
+        const matches = await nearestNeighborsTextIds(
+            value,
+            maxMatches,
+            minScore,
+        );
+        const results = matches.map((m) => {
+            return {
+                score: m.score,
+                item: {
+                        key: isIdInt ? m.item : serializer.serialize(m.item),
+                        value: postingsTable.getSync(m.item) ?? [],
+                },
+            };
+        });
+        return results;
     }
 
     // TODO: Optimize

--- a/ts/examples/memoryProviders/src/sqlite/textTable.ts
+++ b/ts/examples/memoryProviders/src/sqlite/textTable.ts
@@ -544,7 +544,7 @@ export async function createTextIndex<
         value: string,
         maxMatches: number,
         minScore?: number,
-    ): Promise<ScoredItem<knowLib.KVPair<TTextId, TSourceId[]>>[]> {
+    ): Promise<ScoredItem<TextBlock<TSourceId>>[]> {
         const matches = await nearestNeighborsTextIds(
             value,
             maxMatches,
@@ -554,8 +554,9 @@ export async function createTextIndex<
             return {
                 score: m.score,
                 item: {
-                    key: isIdInt ? m.item : serializer.serialize(m.item),
-                    value: postingsTable.getSync(m.item) ?? [],
+                    type: TextBlockType.Sentence,
+                    value: isIdInt ? m.item : serializer.serialize(m.item),
+                    sourceIds: postingsTable.getSync(m.item) ?? [],
                 },
             };
         });

--- a/ts/examples/spelunker/src/pythonImporter.ts
+++ b/ts/examples/spelunker/src/pythonImporter.ts
@@ -42,8 +42,6 @@ import {
     chunkifyPythonFiles,
 } from "./pythonChunker.js";
 
-// TODO: Turn (chunkFolder, codeIndex, summaryFolder) into a single object.
-
 export async function importPythonFiles(
     files: string[],
     chunkyIndex: ChunkyIndex,

--- a/ts/examples/spelunker/src/queryInterface.ts
+++ b/ts/examples/spelunker/src/queryInterface.ts
@@ -204,21 +204,15 @@ async function processQuery(
             options.maxHits,
             options.minScore,
         );
-        let exactMatch: ChunkId = "";
         for (const hit of hits) {
             for (const id of hit.item) {
-                if (id !== exactMatch) {
-                    if (options.verbose) {
-                        io.writer.writeLine(
-                            `  ${indexType} hit: ${id} (${hit.score.toFixed(3)})`,
-                        );
-                    }
-                    const oldScore = hitTable.get(id) || 0.0;
-                    hitTable.set(id, oldScore + hit.score);
+                if (options.verbose) {
+                    io.writer.writeLine(
+                        `  ${indexType} hit: ${id} (${hit.score.toFixed(3)})`,
+                    );
                 }
-            }
-            if (hit.score === 1.0) {
-                exactMatch = hit.item[0]; // TODO: Can there be more than one exact match?
+                const oldScore = hitTable.get(id) || 0.0;
+                hitTable.set(id, oldScore + hit.score);
             }
         }
     }

--- a/ts/examples/spelunker/src/queryInterface.ts
+++ b/ts/examples/spelunker/src/queryInterface.ts
@@ -203,7 +203,7 @@ async function processQuery(
             await index.nearestNeighborsPairs(
                 input,
                 options.maxHits * 5,
-                options.minScore * 0.8,
+                options.minScore,
             );
         for (const hit of hits) {
             if (options.verbose) {
@@ -224,7 +224,7 @@ async function processQuery(
         const hits: ScoredItem<ChunkId>[] = await chunkyIndex.codeIndex!.find(
             input,
             options.maxHits * 5,
-            options.minScore * 0.8,
+            options.minScore,
         );
         for (const hit of hits) {
             if (options.verbose) {

--- a/ts/examples/spelunker/src/queryInterface.ts
+++ b/ts/examples/spelunker/src/queryInterface.ts
@@ -186,9 +186,9 @@ export async function runQueryInterface(
         if (!namedArgs.filter) {
             hits = matches;
         } else {
-            for await (const hit of matches) {
+            for await (const match of matches) {
                 if (namedArgs.filter) {
-                    const valueWords: string[] = hit.item.value
+                    const valueWords: string[] = match.item.value
                         .split(/\s+/)
                         .filter(Boolean)
                         .map((w) => w.toLowerCase());
@@ -199,7 +199,10 @@ export async function runQueryInterface(
                     if (
                         filterWords.every((word) => valueWords.includes(word))
                     ) {
-                        hits.push(hit);
+                        if (match.score === 1.0) {
+                            match.score = filterWords.length / valueWords.length;
+                        }
+                        hits.push(match);
                     }
                 }
             }
@@ -209,9 +212,9 @@ export async function runQueryInterface(
         } else {
             io.writer.writeLine(`Found ${hits.length} ${indexName}.`);
             hits.sort((a, b) => a.item.value.localeCompare(b.item.value));
-            for (const v of hits) {
+            for (const hit of hits) {
                 io.writer.writeLine(
-                    `${v.item.value} (${v.score.toFixed(3)}) :: ${(v.item.sourceIds || []).join(", ")}`,
+                    `${hit.item.value} (${hit.score.toFixed(3)}) :: ${(hit.item.sourceIds || []).join(", ")}`,
                 );
             }
         }

--- a/ts/examples/spelunker/src/queryInterface.ts
+++ b/ts/examples/spelunker/src/queryInterface.ts
@@ -200,7 +200,8 @@ export async function runQueryInterface(
                         filterWords.every((word) => valueWords.includes(word))
                     ) {
                         if (match.score === 1.0) {
-                            match.score = filterWords.length / valueWords.length;
+                            match.score =
+                                filterWords.length / valueWords.length;
                         }
                         hits.push(match);
                     }

--- a/ts/examples/spelunker/src/queryInterface.ts
+++ b/ts/examples/spelunker/src/queryInterface.ts
@@ -199,7 +199,7 @@ async function processQuery(
         if (options.verbose)
             io.writer.writeLine(`[Searching ${indexType} index...]`);
         // TODO: try/catch like below? Embeddings can fail too...
-        const hits: ScoredItem<knowLib.KVPair<string, ChunkId[]>>[] =
+        const hits: ScoredItem<knowLib.TextBlock<ChunkId>>[] =
             await index.nearestNeighborsPairs(
                 input,
                 options.maxHits * 5,
@@ -208,7 +208,7 @@ async function processQuery(
         for (const hit of hits) {
             if (options.verbose) {
                 io.writer.writeLine(
-                    `  ${hit.item.key} (${hit.score.toFixed(3)}) -- ${hit.item.value}`,
+                    `  ${hit.item.value} (${hit.score.toFixed(3)}) -- ${hit.item.sourceIds}`,
                 );
             }
             for (const id of hit.item.value) {

--- a/ts/packages/knowledgeProcessor/src/knowledgeIndex.ts
+++ b/ts/packages/knowledgeProcessor/src/knowledgeIndex.ts
@@ -139,7 +139,7 @@ export interface TextIndex<TTextId = any, TSourceId = any> {
         maxMatches: number,
         minScore?: number,
     ): Promise<ScoredItem<TTextId>[]>;
-    nearestNeighborsPairs( // Pairs of plain text and array of source ID
+    nearestNeighborsPairs(
         value: string,
         maxMatches: number,
         minScore?: number,
@@ -438,7 +438,6 @@ export async function createTextIndex<TSourceId = any>(
         return Array.isArray(combined) ? combined : [...combined];
     }
 
-    // TODO: ename to getNearestTextIds
     async function getNearestText(
         value: string,
         maxMatches?: number,
@@ -479,7 +478,6 @@ export async function createTextIndex<TSourceId = any>(
         });
     }
 
-    // TODO: Rename to nearestNeighborsTextId
     async function nearestNeighborsText(
         value: string,
         maxMatches: number,

--- a/ts/packages/knowledgeProcessor/src/knowledgeIndex.ts
+++ b/ts/packages/knowledgeProcessor/src/knowledgeIndex.ts
@@ -143,7 +143,7 @@ export interface TextIndex<TTextId = any, TSourceId = any> {
         value: string,
         maxMatches: number,
         minScore?: number,
-    ): Promise<ScoredItem<KVPair<string, TSourceId[]>>[]>;
+    ): Promise<ScoredItem<KVPair<TTextId, TSourceId[]>>[]>;
     remove(textId: TTextId, postings: TSourceId | TSourceId[]): Promise<void>;
 }
 


### PR DESCRIPTION
This extends the TextTable interface and its two known implementations to support nearestNeighborsPairs, which returns scored pairs of (entry text, array of source ids) for the nearest matches.

I needed this for detailed logging what was going in. (I found that "ast" is somehow a universal attractor in embedding space!)

Also add some clarifying (for me!) comments to createTextIndex (in knowledgeIndex.js) and added some extra (redundant) types that made the meaning of various variables clearer to me (I was mightily confused by the two uses of strings, for entry values and for internal Ids created by the semantic index's put() method).

And some cleanup in spelunker (notably removing a special case to avoid double-scoring exact matches that was based on a misunderstanding) and of course use the new nearestNeighborsPairs for better logging of the index matching mechanism.

I refrained from more serious refactoring.