### PR TITLE
[spelunker] Fix some bugs in what I merged last night 

### DIFF
--- a/ts/examples/spelunker/src/pythonImporter.ts
+++ b/ts/examples/spelunker/src/pythonImporter.ts
@@ -149,7 +149,7 @@ async function embedChunkedFile(
     // Limit concurrency to avoid 429 errors.
     await asyncArray.forEachAsync(
         chunks,
-        verbose ? 1 : 4,
+        1, // WAS: verbose ? 1 : 4, but concurrent writing to TextIndex isn't safe.
         async (chunk) => await embedChunk(chunk, chunkyIndex, verbose),
     );
 


### PR DESCRIPTION
You can't write concurrently to the same TextIndex; if you do, you may get multiple entries for the same keyword.

The change from KVPair to TextBlock had some repercussions that I didn't test properly. (Dammit, there are too many data structures with fields named 'value'. :-)
