### PR TITLE
Constructions: Allow optional phrases to merge and use synonyms with closed class words

### DIFF
--- a/ts/packages/cache/src/explanation/v5/explanationV5.ts
+++ b/ts/packages/cache/src/explanation/v5/explanationV5.ts
@@ -440,11 +440,11 @@ function getParserForPropertyValue(
 
 const langTool = getLanguageTools("en");
 function canBeMergedNonPropertySubPhrase(phrase: NonPropertySubPhrase) {
-    return langTool?.hasClosedClass(phrase.text) !== true;
+    return langTool?.hasClosedClass(phrase.text, phrase.isOptional) !== true;
 }
 
-function useSynonymsForNonPropertySubPhrase(phrase: SubPhrase) {
-    return langTool?.hasClosedClass(phrase.text) !== true;
+function useSynonymsForNonPropertySubPhrase(phrase: NonPropertySubPhrase) {
+    return langTool?.hasClosedClass(phrase.text, phrase.isOptional) !== true;
 }
 
 export function createConstructionV5(

--- a/ts/packages/cache/src/utils/language.ts
+++ b/ts/packages/cache/src/utils/language.ts
@@ -3,7 +3,7 @@
 
 export interface LanguageTools {
     possibleReferentialPhrase(phrase: string): boolean;
-    hasClosedClass(phrase: string): boolean;
+    hasClosedClass(phase: string, exact?: boolean /* = false */): boolean;
 }
 
 const subjectPronouns = [
@@ -369,7 +369,7 @@ const referenceParts = partOfMatch([
 
 const referenceSuffixes = suffixMatch([demostrativeAdverbs]);
 
-const closedClass = partOfMatch([
+const closeClass = [
     subjectPronouns,
     objectPronouns,
     possessivePronouns,
@@ -383,7 +383,9 @@ const closedClass = partOfMatch([
     demostrativeAdverbs,
     prepositions,
     conjunctions,
-]);
+];
+const partClosedClass = partOfMatch(closeClass);
+const exactClosedClass = exactMatch(closeClass);
 
 // REVIEW: Heuristics to allow time references from now.
 const relativeToNow =
@@ -400,8 +402,8 @@ const languageToolsEn: LanguageTools = {
             !relativeToNow.test(phrase)
         );
     },
-    hasClosedClass(phrase: string) {
-        return closedClass.test(phrase);
+    hasClosedClass(phrase: string, exact: boolean = false) {
+        return (exact ? exactClosedClass : partClosedClass).test(phrase);
     },
 };
 


### PR DESCRIPTION
Optional phrases don't impact translation, so it is ok if it has closed class words, but only disallow it if it exactly matches the closed class words