### PR TITLE
Batching and retry support for Semantic map + list

### DIFF
--- a/ts/.vscode/launch.json
+++ b/ts/.vscode/launch.json
@@ -137,7 +137,7 @@
             "cwd": "${workspaceFolder}/examples/chat/src/codeChat",
             //"args": ["codeMemory"]
             //"args": ["code"]
-            //"args": ["tests"]
+            "args": ["tests"]
         },
         {
             "name": "Launch YOUR Example",

--- a/ts/examples/chat/src/tests/test.ts
+++ b/ts/examples/chat/src/tests/test.ts
@@ -16,6 +16,7 @@ import {
     collections,
     readAllText,
     dotProductSimple,
+    createSemanticMap,
 } from "typeagent";
 import * as path from "path";
 import { getData } from "typechat";
@@ -107,6 +108,41 @@ export async function testEmbeddingModel() {
             console.log("Success");
         }
     }
+}
+
+export async function testEmbeddingBasic() {
+    const model = openai.createEmbeddingModel();
+
+    const strings = ["object", "instrument", "person", "food", "pizza"];
+    for (const str of strings) {
+        const e = await model.generateEmbedding(str);
+        if (e.success) {
+            console.log("Success");
+        }
+    }
+}
+
+export async function testSemanticMap() {
+    const strings = [
+        "lunch meeting",
+        "pick up groceries",
+        "The quick brown fox",
+        "Who is a good dog?",
+        "I am so very hungry for pizza",
+    ];
+    const model = openai.createEmbeddingModel();
+    const sm = await createSemanticMap<number>(model);
+    for (let i = 0; i < strings.length; ++i) {
+        await sm.set(strings[i], i);
+    }
+    let match = await sm.getNearest("Toto is a good dog");
+    console.log(match);
+
+    match = await sm.getNearest("pepperoni and margarhita");
+    console.log(match);
+
+    match = await sm.getNearest("we should meet up for lunch");
+    console.log(match);
 }
 
 export function generateMessageLines(count: number): string[] {
@@ -265,6 +301,7 @@ export async function testPerf() {
     testDotPerf2(1536);
 }
 export async function runTests(): Promise<void> {
+    await testSemanticMap();
     //await testEmbeddingModel();
     //await runTestCases();
     // await runKnowledgeTests();

--- a/ts/packages/typeagent/src/async.ts
+++ b/ts/packages/typeagent/src/async.ts
@@ -2,16 +2,16 @@
 // Licensed under the MIT License.
 
 /**
- * Call an async function with retry
+ * Call an async function with automatic retry in the case of exceptions
  * @param asyncFn Use closures to pass parameters
- * @param retryMaxAttempts maximum retry attempts. Default is 1
- * @param retryPauseMs Pause between attempts. Default is 1000 ms
+ * @param retryMaxAttempts maximum retry attempts. Default is 2
+ * @param retryPauseMs Pause between attempts. Default is 1000 ms. Uses exponential backoff
  * @param shouldAbort (Optional) Inspect the error and abort
  * @returns Result<T>
  */
 export async function callWithRetry<T = any>(
     asyncFn: () => Promise<T>,
-    retryMaxAttempts: number = 1,
+    retryMaxAttempts: number = 2,
     retryPauseMs: number = 1000,
     shouldAbort?: (error: any) => boolean | undefined,
 ): Promise<T> {
@@ -29,6 +29,7 @@ export async function callWithRetry<T = any>(
         }
         await pause(retryPauseMs);
         retryCount++;
+        retryPauseMs *= 2; // Use exponential backoff for retries
     }
 }
 

--- a/ts/packages/typeagent/src/index.ts
+++ b/ts/packages/typeagent/src/index.ts
@@ -14,6 +14,8 @@ export * from "./vector/embeddings";
 export * from "./vector/vector";
 export * from "./vector/vectorIndex";
 export * from "./vector/semanticIndex";
+export * from "./vector/semanticList";
+export * from "./vector/semanticMap";
 
 export * from "./storage/objectFolder";
 export * from "./storage/embeddingFS";

--- a/ts/packages/typeagent/src/vector/semanticList.ts
+++ b/ts/packages/typeagent/src/vector/semanticList.ts
@@ -1,0 +1,178 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { TextEmbeddingModel } from "aiclient";
+import { ScoredItem } from "../memory";
+import {
+    NormalizedEmbedding,
+    similarity,
+    SimilarityType,
+    TopNCollection,
+} from "./embeddings";
+import { EmbeddedValue, generateEmbedding, VectorIndex } from "./vectorIndex";
+import { asyncArray } from "..";
+import assert from "assert";
+
+/**
+ * An in-memory list of T, {stringValue of T} items that also maintains embeddings of stringValue
+ * You can semantic search this list using query stringValues
+ *
+ * {stringValue could be a Description of T, or any other string forms}
+ */
+export interface SemanticList<T> extends VectorIndex<T> {
+    values: EmbeddedValue<T>[];
+
+    indexOf(value: string | NormalizedEmbedding): Promise<ScoredItem>;
+    indexesOf(
+        value: string | NormalizedEmbedding,
+        maxMatches: number,
+        minScore?: number,
+    ): Promise<ScoredItem[]>;
+    nearestNeighbor(
+        value: string | NormalizedEmbedding,
+    ): Promise<ScoredItem<T>>;
+    nearestNeighbors(
+        value: string | NormalizedEmbedding,
+        maxMatches: number,
+        minScore?: number,
+    ): Promise<ScoredItem<T>[]>;
+
+    push(value: T, stringValue?: string): Promise<void>;
+    pushMultiple(values: T[], concurrency?: number): Promise<void>;
+    pushValue(value: EmbeddedValue<T>): void;
+}
+
+export function createSemanticList<T>(
+    model: TextEmbeddingModel,
+    existingValues?: EmbeddedValue<T>[],
+    stringify?: (value: T) => string,
+): SemanticList<T> {
+    let values = existingValues ?? [];
+    return {
+        values,
+        push,
+        pushMultiple,
+        pushValue,
+        indexOf,
+        indexesOf,
+        nearestNeighbor,
+        nearestNeighbors,
+    };
+
+    async function push(value: T, stringValue?: string): Promise<void> {
+        const embedding = await generateEmbedding<string>(
+            model,
+            toString(value, stringValue),
+        );
+        pushValue({ value, embedding });
+    }
+
+    async function pushMultiple(
+        values: T[],
+        concurrency?: number,
+    ): Promise<void> {
+        concurrency ??= 2;
+        // Generate embeddings in parallel
+        const embeddings = await asyncArray.mapAsync(values, concurrency, (v) =>
+            generateEmbedding(model, toString(v)),
+        );
+        assert(values.length === embeddings.length);
+        for (let i = 0; i < values.length; ++i) {
+            pushValue({ value: values[i], embedding: embeddings[i] });
+        }
+    }
+
+    function pushValue(value: EmbeddedValue<T>): void {
+        values.push(value);
+    }
+
+    async function nearestNeighbor(
+        value: string | NormalizedEmbedding,
+    ): Promise<ScoredItem<T>> {
+        const match = await indexOf(value);
+        return { score: match.score, item: values[match.item].value };
+    }
+
+    async function nearestNeighbors(
+        value: string | NormalizedEmbedding,
+        maxMatches: number,
+        minScore?: number,
+    ): Promise<ScoredItem<T>[]> {
+        const matches = await indexesOf(value, maxMatches, minScore);
+        return matches.map((m) => {
+            return {
+                score: m.score,
+                item: values[m.item].value,
+            };
+        });
+    }
+
+    async function indexOf(
+        value: string | NormalizedEmbedding,
+    ): Promise<ScoredItem> {
+        const embedding = await generateEmbedding(model, value);
+        return indexOfNearest(values, embedding, SimilarityType.Dot);
+    }
+
+    async function indexesOf(
+        value: string | NormalizedEmbedding,
+        maxMatches: number,
+        minScore?: number,
+    ): Promise<ScoredItem[]> {
+        minScore ??= 0;
+        const embedding = await generateEmbedding(model, value);
+        return indexesOfNearest(
+            values,
+            embedding,
+            maxMatches,
+            SimilarityType.Dot,
+            minScore,
+        );
+    }
+
+    function toString(value: T, stringValue?: string): string {
+        if (!stringValue) {
+            if (stringify) {
+                stringValue = stringify(value);
+            } else if (typeof value === "string") {
+                stringValue = value;
+            } else {
+                stringValue = JSON.stringify(value);
+            }
+        }
+        return stringValue;
+    }
+
+    function indexOfNearest<T>(
+        list: EmbeddedValue<T>[],
+        other: NormalizedEmbedding,
+        type: SimilarityType,
+    ): ScoredItem {
+        let best: ScoredItem = { score: Number.MIN_VALUE, item: -1 };
+        for (let i = 0; i < list.length; ++i) {
+            const score: number = similarity(list[i].embedding, other, type);
+            if (score > best.score) {
+                best.score = score;
+                best.item = i;
+            }
+        }
+        return best;
+    }
+
+    function indexesOfNearest<T>(
+        list: EmbeddedValue<T>[],
+        other: NormalizedEmbedding,
+        maxMatches: number,
+        type: SimilarityType,
+        minScore: number = 0,
+    ): ScoredItem[] {
+        const matches = new TopNCollection(maxMatches, -1);
+        for (let i = 0; i < list.length; ++i) {
+            const score: number = similarity(list[i].embedding, other, type);
+            if (score >= minScore) {
+                matches.push(i, score);
+            }
+        }
+        return matches.byRank();
+    }
+}

--- a/ts/packages/typeagent/src/vector/semanticList.ts
+++ b/ts/packages/typeagent/src/vector/semanticList.ts
@@ -63,7 +63,7 @@ export interface SemanticList<T> extends VectorIndex<T> {
     pushValue(value: EmbeddedValue<T>): void;
 }
 
-export function createSemanticList<T>(
+export function createSemanticList<T = any>(
     model: TextEmbeddingModel,
     existingValues?: EmbeddedValue<T>[],
     stringify?: (value: T) => string,
@@ -105,7 +105,6 @@ export function createSemanticList<T>(
         retryPauseMs?: number,
         concurrency?: number,
     ): Promise<void> {
-        concurrency ??= 2;
         // Generate embeddings in parallel
         const valueStrings = values.map((v) => toString(v));
         await callWithRetry(

--- a/ts/packages/typeagent/src/vector/semanticMap.ts
+++ b/ts/packages/typeagent/src/vector/semanticMap.ts
@@ -1,0 +1,146 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { TextEmbeddingModel, openai } from "aiclient";
+import { EmbeddedValue } from "./vectorIndex";
+import { NormalizedEmbedding } from "./embeddings";
+import { ScoredItem } from "../memory";
+import { createSemanticList } from "./semanticList";
+
+export interface SemanticMap<T> {
+    readonly size: number;
+    readonly model: TextEmbeddingModel;
+
+    keys(): IterableIterator<EmbeddedValue<string>>;
+    values(): IterableIterator<T>;
+    entries(): IterableIterator<[EmbeddedValue<string>, T]>;
+    has(text: string): boolean;
+    get(text: string): T | undefined;
+    getNearest(text: string | NormalizedEmbedding): Promise<ScoredItem<T>>;
+    set(text: string, value: T): Promise<void>;
+    setMultiple(items: [string, T][], concurrency?: number): Promise<void>;
+    nearestNeighbors(
+        value: string | NormalizedEmbedding,
+        maxMatches: number,
+        minScore?: number,
+    ): Promise<ScoredItem<T>[]>;
+}
+
+export async function createSemanticMap<T>(
+    model?: TextEmbeddingModel,
+    existingValues?: [EmbeddedValue<string>, T][],
+): Promise<SemanticMap<T>> {
+    model ??= openai.createEmbeddingModel();
+    const map = new Map<string, T>();
+    const semanticIndex = createSemanticList<string>(model);
+    if (existingValues) {
+        init(existingValues);
+    }
+    return {
+        model,
+        get size() {
+            return map.size;
+        },
+        entries,
+        keys,
+        values: () => map.values(),
+        has: (text: string) => map.has(text),
+        get,
+        set,
+        setMultiple,
+        getNearest,
+        nearestNeighbors,
+    };
+
+    function* keys(): IterableIterator<EmbeddedValue<string>> {
+        for (const key of semanticIndex.values) {
+            yield key;
+        }
+    }
+
+    function* entries(): IterableIterator<[EmbeddedValue<string>, T]> {
+        for (const key of semanticIndex.values) {
+            yield [key, map.get(key.value)!];
+        }
+    }
+
+    function get(text: string): T | undefined {
+        return map.get(text);
+    }
+
+    async function set(text: string, value: T): Promise<void> {
+        // If new item, have to embed.
+        if (!map.has(text)) {
+            // New item. Must embed
+            await semanticIndex.push(text, text);
+        }
+        map.set(text, value);
+    }
+
+    async function setMultiple(
+        items: [string, T][],
+        concurrency?: number,
+    ): Promise<void> {
+        let newItems: string[] | undefined;
+        for (const item of items) {
+            let [text, value] = item;
+            if (!map.has(text)) {
+                newItems ??= [];
+                newItems.push(text);
+            }
+            map.set(text, value);
+        }
+        if (newItems) {
+            await semanticIndex.pushMultiple(newItems, concurrency);
+        }
+    }
+
+    async function getNearest(
+        text: string | NormalizedEmbedding,
+    ): Promise<ScoredItem<T>> {
+        // First try an exact match
+        if (typeof text === "string") {
+            const exactMatch = map.get(text);
+            if (exactMatch) {
+                return {
+                    score: 1,
+                    item: exactMatch,
+                };
+            }
+        }
+        const key = await semanticIndex.nearestNeighbor(text);
+        return valueFromScoredKey(key);
+    }
+
+    async function nearestNeighbors(
+        value: string | NormalizedEmbedding,
+        maxMatches: number,
+        minScore?: number,
+    ): Promise<ScoredItem<T>[]> {
+        const keys = await semanticIndex.nearestNeighbors(
+            value,
+            maxMatches,
+            minScore,
+        );
+        return keys.map((k) => valueFromScoredKey(k));
+    }
+
+    function valueFromScoredKey(match: ScoredItem<string>): ScoredItem<T> {
+        return {
+            score: match.score,
+            item: map.get(match.item)!,
+        };
+    }
+
+    function init(entries: [EmbeddedValue<string>, T][]): void {
+        for (const [key, value] of entries) {
+            map.set(key.value, value);
+            semanticIndex.pushValue(key);
+        }
+    }
+}
+
+export type SemanticMapEntry<T> = {
+    key: EmbeddedValue<string>;
+    value: T;
+};

--- a/ts/packages/typeagent/src/vector/semanticMap.ts
+++ b/ts/packages/typeagent/src/vector/semanticMap.ts
@@ -36,7 +36,7 @@ export interface SemanticMap<T> {
     ): Promise<ScoredItem<T>[]>;
 }
 
-export async function createSemanticMap<T>(
+export async function createSemanticMap<T = any>(
     model?: TextEmbeddingModel,
     existingValues?: [EmbeddedValue<string>, T][],
 ): Promise<SemanticMap<T>> {

--- a/ts/packages/typeagent/src/vector/vectorIndex.ts
+++ b/ts/packages/typeagent/src/vector/vectorIndex.ts
@@ -76,7 +76,7 @@ export async function generateTextEmbeddings(
             `Values contains string with length > ${maxCharsPerChunk}`,
         );
     }
-    concurrency ??= 2;
+    concurrency ??= 1;
     if (model.maxBatchSize > 1 && model.generateEmbeddingBatch) {
         const chunks = [
             ...collections.getStringChunks(

--- a/ts/packages/typeagent/test/async.spec.ts
+++ b/ts/packages/typeagent/test/async.spec.ts
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { callWithRetry } from "../src/async";
+
+describe("async", () => {
+    const timeoutMs = 1000 * 5 * 60;
+    test(
+        "callWithRetry",
+        async () => {
+            let expectedResult = "Yay";
+
+            let callNumber = 0;
+            let callsToFail = 2;
+            const result = await callWithRetry(async () => api(), 2, 1000);
+            expect(result).toBe(expectedResult);
+
+            callNumber = 0;
+            callsToFail = 3; // Fail all retries. Make sure exception falls through
+            let lastError: any | undefined;
+            try {
+                await callWithRetry(async () => api(), 2, 1000);
+            } catch (e) {
+                lastError = e;
+            }
+            expect(lastError).toBeDefined();
+
+            async function api(): Promise<string> {
+                ++callNumber;
+                if (callNumber <= callsToFail) {
+                    throw new Error("Too many requests");
+                }
+                return expectedResult;
+            }
+        },
+        timeoutMs,
+    );
+});

--- a/ts/packages/typeagent/test/vector.vectorIndex.spec.ts
+++ b/ts/packages/typeagent/test/vector.vectorIndex.spec.ts
@@ -90,6 +90,9 @@ describe("vector.vectorIndex", () => {
                     expect(match.item).toBe(item.value);
                 }
             }
+            // add one more
+            await semanticList.push("The last string");
+            expect(semanticList.values).toHaveLength(smallStrings.length + 1);
         },
         timeoutMs,
     );
@@ -111,6 +114,10 @@ describe("vector.vectorIndex", () => {
             if (match) {
                 expect(match.item).toBe(smallStrings[0]);
             }
+
+            // add one more
+            await semanticMap.set("The last string", "abc");
+            expect(semanticMap.size).toBe(smallStrings.length + 1);
         },
         timeoutMs,
     );

--- a/ts/packages/typeagent/test/vector.vectorIndex.spec.ts
+++ b/ts/packages/typeagent/test/vector.vectorIndex.spec.ts
@@ -18,6 +18,7 @@ import {
     dotProductSimple,
     euclideanLength,
 } from "../src/vector/vector";
+import { createSemanticList } from "../src";
 
 describe("vector.vectorIndex", () => {
     const timeoutMs = 5 * 1000 * 60;
@@ -53,4 +54,22 @@ describe("vector.vectorIndex", () => {
         },
         timeoutMs,
     );
+    testIf(hasEmbeddingModel, "semanticList", async () => {
+        const strings = [
+            "object",
+            "person",
+            "composer",
+            "instrument",
+            "book",
+            "movie",
+            "dog",
+            "cat",
+            "computer",
+            "phone",
+        ];
+        const model = openai.createEmbeddingModel();
+        const semanticList = createSemanticList(model);
+        await semanticList.pushMultiple(strings);
+        expect(semanticList.values).toHaveLength(strings.length);
+    });
 });


### PR DESCRIPTION
Semantic map & list:
* setMultiple and putMultiple now use Batching embedding Api
* Built in retry that goes beyond default retry at model level
* Generic "callWithRetry" function that retries any async function with exponential backoff.
* Unit tests