### PR TITLE
[spelunker] Rationalize the index objects -- use TextIndex everywhere

### DIFF
--- a/ts/examples/spelunker/src/chunkyIndex.ts
+++ b/ts/examples/spelunker/src/chunkyIndex.ts
@@ -2,15 +2,10 @@
 // Licensed under the MIT License.
 
 import { openai, ChatModel, TextEmbeddingModel } from "aiclient";
-import { CodeDocumenter } from "code-processor";
 import * as knowLib from "knowledge-processor";
 import { createObjectFolder, ObjectFolder } from "typeagent";
 
-import {
-    createFakeCodeDocumenter,
-    createFileDocumenter,
-    FileDocumenter,
-} from "./fileDocumenter.js";
+import { createFileDocumenter, FileDocumenter } from "./fileDocumenter.js";
 import { Chunk, ChunkId } from "./pythonChunker.js";
 
 // A bundle of object stores and indices etc.
@@ -19,7 +14,6 @@ export class ChunkyIndex {
     chatModel: ChatModel;
     embeddingModel: TextEmbeddingModel;
     fileDocumenter: FileDocumenter;
-    fakeCodeDocumenter: CodeDocumenter;
     // The rest are asynchronously initialized by initialize().
     chunkFolder!: ObjectFolder<Chunk>;
     codeSummariesIndex!: knowLib.TextIndex<string, ChunkId>;
@@ -36,7 +30,6 @@ export class ChunkyIndex {
             1000,
         );
         this.fileDocumenter = createFileDocumenter(this.chatModel);
-        this.fakeCodeDocumenter = createFakeCodeDocumenter();
     }
 
     static async createInstance(rootDir: string): Promise<ChunkyIndex> {

--- a/ts/examples/spelunker/src/chunkyIndex.ts
+++ b/ts/examples/spelunker/src/chunkyIndex.ts
@@ -2,11 +2,7 @@
 // Licensed under the MIT License.
 
 import { openai, ChatModel, TextEmbeddingModel } from "aiclient";
-import {
-    CodeDocumenter,
-    createSemanticCodeIndex,
-    SemanticCodeIndex,
-} from "code-processor";
+import { CodeDocumenter } from "code-processor";
 import * as knowLib from "knowledge-processor";
 import { createObjectFolder, ObjectFolder } from "typeagent";
 
@@ -26,7 +22,7 @@ export class ChunkyIndex {
     fakeCodeDocumenter: CodeDocumenter;
     // The rest are asynchronously initialized by initialize().
     chunkFolder!: ObjectFolder<Chunk>;
-    codeIndex!: SemanticCodeIndex;
+    codeSummariesIndex!: knowLib.TextIndex<string, ChunkId>;
     keywordsIndex!: knowLib.TextIndex<string, ChunkId>;
     topicsIndex!: knowLib.TextIndex<string, ChunkId>;
     goalsIndex!: knowLib.TextIndex<string, ChunkId>;
@@ -49,12 +45,7 @@ export class ChunkyIndex {
             instance.rootDir + "/chunks",
             { serializer: (obj) => JSON.stringify(obj, null, 2) },
         );
-        instance.codeIndex = await createSemanticCodeIndex(
-            instance.rootDir + "/index",
-            instance.fakeCodeDocumenter,
-            instance.embeddingModel,
-            (obj) => JSON.stringify(obj, null, 2),
-        );
+        instance.codeSummariesIndex = await makeIndex("code-summaries");
         instance.keywordsIndex = await makeIndex("keywords");
         instance.topicsIndex = await makeIndex("topics");
         instance.goalsIndex = await makeIndex("goals");

--- a/ts/examples/spelunker/src/chunkyIndex.ts
+++ b/ts/examples/spelunker/src/chunkyIndex.ts
@@ -10,7 +10,6 @@ import {
 import * as knowLib from "knowledge-processor";
 import { createObjectFolder, ObjectFolder } from "typeagent";
 
-import { CodeDocumentation } from "./codeDocSchema.js";
 import {
     createFakeCodeDocumenter,
     createFileDocumenter,
@@ -28,7 +27,6 @@ export class ChunkyIndex {
     // The rest are asynchronously initialized by initialize().
     chunkFolder!: ObjectFolder<Chunk>;
     codeIndex!: SemanticCodeIndex;
-    summaryFolder!: ObjectFolder<CodeDocumentation>;
     keywordsIndex!: knowLib.TextIndex<string, ChunkId>;
     topicsIndex!: knowLib.TextIndex<string, ChunkId>;
     goalsIndex!: knowLib.TextIndex<string, ChunkId>;
@@ -56,10 +54,6 @@ export class ChunkyIndex {
             instance.fakeCodeDocumenter,
             instance.embeddingModel,
             (obj) => JSON.stringify(obj, null, 2),
-        );
-        instance.summaryFolder = await createObjectFolder<CodeDocumentation>(
-            instance.rootDir + "/summaries",
-            { serializer: (obj) => JSON.stringify(obj, null, 2) },
         );
         instance.keywordsIndex = await makeIndex("keywords");
         instance.topicsIndex = await makeIndex("topics");

--- a/ts/examples/spelunker/src/fileDocumenter.ts
+++ b/ts/examples/spelunker/src/fileDocumenter.ts
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 import { ChatModel } from "aiclient";
-import { CodeBlock, CodeDocumenter } from "code-processor";
 import { loadSchema } from "typeagent";
 import { createJsonTranslator, TypeChatJsonTranslator } from "typechat";
 import { createTypeScriptJsonValidator } from "typechat/ts";
@@ -14,10 +13,6 @@ import { Chunk } from "./pythonChunker.js";
 // but we want to produce their documentation in the context of the whole file.
 // FileDocumenter.document(chunks) produces documentation comments
 // and then assigns each comment to the appropriate chunk.
-// createFaleCodeDocumenter() returns a CodeDocumenter that retrieves
-// the pre-computed comments from the chunk's 'docs' field.
-
-// Fake code documenter to pass to createCodeIndex.
 
 // Document an entire file and assign comments to chunks.
 
@@ -84,6 +79,7 @@ export function createFileDocumenter(model: ChatModel): FileDocumenter {
 function createFileDocTranslator(
     model: ChatModel,
 ): TypeChatJsonTranslator<CodeDocumentation> {
+    // TODO: Rename the schema to avoid confusion with the *other* codeDocSchema.ts.
     const typeName = "CodeDocumentation";
     const schema = loadSchema(["codeDocSchema.ts"], import.meta.url);
     const validator = createTypeScriptJsonValidator<CodeDocumentation>(
@@ -95,23 +91,4 @@ function createFileDocTranslator(
         validator,
     );
     return translator;
-}
-
-export interface CodeBlockWithDocs extends CodeBlock {
-    docs: CodeDocumentation;
-}
-
-export function createFakeCodeDocumenter(): CodeDocumenter {
-    return {
-        document,
-    };
-
-    async function document(
-        code: CodeBlock | CodeBlockWithDocs,
-    ): Promise<CodeDocumentation> {
-        if ("docs" in code && code.docs) {
-            return code.docs;
-        }
-        return {};
-    }
 }

--- a/ts/examples/spelunker/src/pythonImporter.ts
+++ b/ts/examples/spelunker/src/pythonImporter.ts
@@ -185,7 +185,6 @@ async function embedChunk(
         chunk.id,
         chunk.filename,
     )) as CodeDocumentation;
-    await exponentialBackoff(chunkyIndex.summaryFolder.put, docs, chunk.id);
     for (const comment of docs.comments || []) {
         await writeToIndex(chunk.id, comment.topics, chunkyIndex.topicsIndex);
         await writeToIndex(

--- a/ts/examples/spelunker/src/pythonImporter.ts
+++ b/ts/examples/spelunker/src/pythonImporter.ts
@@ -172,7 +172,7 @@ async function embedChunk(
         0,
     );
     if (verbose) console.log(`  [Embedding ${chunk.id} (${lineCount} lines)]`);
-    await exponentialBackoff(chunkyIndex.chunkFolder!.put, chunk, chunk.id);
+    await exponentialBackoff(chunkyIndex.chunkFolder.put, chunk, chunk.id);
     const blobLines = extractBlobLines(chunk);
     const codeBlock: CodeBlockWithDocs = {
         code: blobLines,
@@ -180,7 +180,7 @@ async function embedChunk(
         docs: chunk.docs!,
     };
     const docs = (await exponentialBackoff(
-        chunkyIndex.codeIndex!.put,
+        chunkyIndex.codeIndex.put,
         codeBlock,
         chunk.id,
         chunk.filename,

--- a/ts/examples/spelunker/src/pythonImporter.ts
+++ b/ts/examples/spelunker/src/pythonImporter.ts
@@ -33,8 +33,7 @@ import * as knowLib from "knowledge-processor";
 import { asyncArray } from "typeagent";
 
 import { ChunkyIndex } from "./chunkyIndex.js";
-import { CodeDocumentation } from "./codeDocSchema.js";
-import { CodeBlockWithDocs } from "./fileDocumenter.js";
+import { LineDoc } from "./codeDocSchema.js";
 import {
     Chunk,
     ChunkedFile,
@@ -173,43 +172,44 @@ async function embedChunk(
     );
     if (verbose) console.log(`  [Embedding ${chunk.id} (${lineCount} lines)]`);
     await exponentialBackoff(chunkyIndex.chunkFolder.put, chunk, chunk.id);
-    const blobLines = extractBlobLines(chunk);
-    const codeBlock: CodeBlockWithDocs = {
-        code: blobLines,
-        language: "python",
-        docs: chunk.docs!,
-    };
-    const docs = (await exponentialBackoff(
-        chunkyIndex.codeIndex.put,
-        codeBlock,
-        chunk.id,
-        chunk.filename,
-    )) as CodeDocumentation;
-    for (const comment of docs.comments || []) {
-        await writeToIndex(chunk.id, comment.topics, chunkyIndex.topicsIndex);
+    const summaries: string[] = [];
+    const lineDocs: LineDoc[] = chunk.docs?.comments ?? [];
+    for (const lineDoc of lineDocs) {
+        summaries.push(lineDoc.comment);
+    }
+    const combinedSummaries = summaries.join("\n").trimEnd();
+    if (combinedSummaries) {
+        await exponentialBackoff(
+            chunkyIndex.codeSummariesIndex.put,
+            combinedSummaries,
+            [chunk.id],
+        );
+    }
+    for (const lineDoc of lineDocs) {
+        await writeToIndex(chunk.id, lineDoc.topics, chunkyIndex.topicsIndex);
         await writeToIndex(
             chunk.id,
-            comment.keywords,
+            lineDoc.keywords,
             chunkyIndex.keywordsIndex,
         );
-        await writeToIndex(chunk.id, comment.goals, chunkyIndex.goalsIndex);
+        await writeToIndex(chunk.id, lineDoc.goals, chunkyIndex.goalsIndex);
         await writeToIndex(
             chunk.id,
-            comment.dependencies,
+            lineDoc.dependencies,
             chunkyIndex.dependenciesIndex,
         );
     }
     if (verbose) {
-        for (const comment of docs.comments || []) {
-            console.log(wordWrap(`${comment.comment} (${comment.lineNumber})`));
-            if (comment.topics?.length)
-                console.log(`TOPICS: ${comment.topics.join(", ")}`);
-            if (comment.keywords?.length)
-                console.log(`KEYWORDS: ${comment.keywords.join(", ")}`);
-            if (comment.goals?.length)
-                console.log(`GOALS: ${comment.goals.join(", ")}`);
-            if (comment.dependencies?.length)
-                console.log(`DEPENDENCIES: ${comment.dependencies.join(", ")}`);
+        for (const lineDoc of lineDocs) {
+            console.log(wordWrap(`${lineDoc.comment} (${lineDoc.lineNumber})`));
+            if (lineDoc.topics?.length)
+                console.log(`TOPICS: ${lineDoc.topics.join(", ")}`);
+            if (lineDoc.keywords?.length)
+                console.log(`KEYWORDS: ${lineDoc.keywords.join(", ")}`);
+            if (lineDoc.goals?.length)
+                console.log(`GOALS: ${lineDoc.goals.join(", ")}`);
+            if (lineDoc.dependencies?.length)
+                console.log(`DEPENDENCIES: ${lineDoc.dependencies.join(", ")}`);
         }
     }
     const t1 = Date.now();
@@ -219,14 +219,6 @@ async function embedChunk(
                 `in ${((t1 - t0) * 0.001).toFixed(3)} seconds]`,
         );
     }
-}
-
-function extractBlobLines(chunk: Chunk): string[] {
-    const lines: string[] = [];
-    for (const blob of chunk.blobs) {
-        lines.push(...blob.lines);
-    }
-    return lines;
 }
 
 // Wrap words in anger. Written by Github Copilot.
@@ -259,7 +251,7 @@ async function writeToIndex(
 async function exponentialBackoff<T extends any[], R>(
     callable: (...args: T) => Promise<R>,
     ...args: T
-): Promise<any> {
+): Promise<R> {
     let timeout = 1;
     for (;;) {
         try {

--- a/ts/examples/spelunker/src/queryInterface.ts
+++ b/ts/examples/spelunker/src/queryInterface.ts
@@ -330,15 +330,15 @@ async function processQuery(
     // Next add hits from the code index. (Different API, same idea though.)
     try {
         if (options.verbose) io.writer.writeLine(`[Searching code index...]`);
-        const hits: ScoredItem<ChunkId>[] = await chunkyIndex.codeIndex!.find(
+        const hits: ScoredItem<ChunkId>[] = await chunkyIndex.codeIndex.find(
             input,
             options.maxHits * 5,
             options.minScore,
         );
         for (const hit of hits) {
             if (options.verbose) {
-                const comment = (await chunkyIndex.summaryFolder!.get(hit.item))
-                    ?.comments?.[0]?.comment;
+                const chunk = await chunkyIndex.chunkFolder.get(hit.item);
+                const comment = chunk?.docs?.comments?.[0]?.comment;
                 io.writer.writeLine(
                     `  ${hit.item} (${hit.score.toFixed(3)}) -- ${comment?.slice(0, 100) ?? "[no data]"}`,
                 );
@@ -364,7 +364,7 @@ async function processQuery(
 
     for (let i = 0; i < hits.length; i++) {
         const hit = hits[i];
-        const chunk: Chunk | undefined = await chunkyIndex.chunkFolder!.get(
+        const chunk: Chunk | undefined = await chunkyIndex.chunkFolder.get(
             hit.item,
         );
         if (!chunk) {
@@ -378,8 +378,7 @@ async function processQuery(
                 `file: ${path.relative(process.cwd(), chunk.filename!)}, ` +
                 `type: ${chunk.treeName}`,
         );
-        const summary: CodeDocumentation | undefined =
-            await chunkyIndex.summaryFolder!.get(hit.item);
+        const summary: CodeDocumentation | undefined = chunk.docs;
         if (summary?.comments?.length) {
             for (const comment of summary.comments)
                 io.writer.writeLine(


### PR DESCRIPTION
This lets us get rid of the whole "fake code documenter" concept and we are no longer dependent on code-processor at all.

(TODO: Refactor FileDocumenter now that it no longer needs to fit the CodeDocumenter interface.)