### PR TITLE
[spelunker] Implement LLM-guided answering of questions about a code base

### DIFF
--- a/ts/examples/spelunker/src/chunkyIndex.ts
+++ b/ts/examples/spelunker/src/chunkyIndex.ts
@@ -11,7 +11,7 @@ import { QuerySpecs } from "./makeQuerySchema.js";
 import { createJsonTranslator, TypeChatJsonTranslator } from "typechat";
 import { createTypeScriptJsonValidator } from "typechat/ts";
 
-// A bundle of object stores and indices etc.
+// A bundle of object stores and indexes etc.
 export class ChunkyIndex {
     rootDir: string;
     chatModel: ChatModel;

--- a/ts/examples/spelunker/src/chunkyIndex.ts
+++ b/ts/examples/spelunker/src/chunkyIndex.ts
@@ -65,6 +65,29 @@ export class ChunkyIndex {
             );
         }
     }
+
+    // TODO: Do this type-safe?
+    getIndexByName(name: string): knowLib.TextIndex<string, ChunkId> {
+        for (const pair of this.allIndexes()) {
+            if (pair.name === name) {
+                return pair.index;
+            }
+        }
+        throw new Error(`Unknown index: ${name}`);
+    }
+
+    allIndexes(): {
+        name: string;
+        index: knowLib.TextIndex<string, ChunkId>;
+    }[] {
+        return [
+            { name: "summaries", index: this.summariesIndex },
+            { name: "keywords", index: this.keywordsIndex },
+            { name: "topics", index: this.topicsIndex },
+            { name: "goals", index: this.goalsIndex },
+            { name: "dependencies", index: this.dependenciesIndex },
+        ];
+    }
 }
 
 function createQueryMaker(

--- a/ts/examples/spelunker/src/chunkyIndex.ts
+++ b/ts/examples/spelunker/src/chunkyIndex.ts
@@ -16,7 +16,7 @@ export class ChunkyIndex {
     fileDocumenter: FileDocumenter;
     // The rest are asynchronously initialized by initialize().
     chunkFolder!: ObjectFolder<Chunk>;
-    codeSummariesIndex!: knowLib.TextIndex<string, ChunkId>;
+    summariesIndex!: knowLib.TextIndex<string, ChunkId>;
     keywordsIndex!: knowLib.TextIndex<string, ChunkId>;
     topicsIndex!: knowLib.TextIndex<string, ChunkId>;
     goalsIndex!: knowLib.TextIndex<string, ChunkId>;
@@ -38,7 +38,7 @@ export class ChunkyIndex {
             instance.rootDir + "/chunks",
             { serializer: (obj) => JSON.stringify(obj, null, 2) },
         );
-        instance.codeSummariesIndex = await makeIndex("code-summaries");
+        instance.summariesIndex = await makeIndex("summaries");
         instance.keywordsIndex = await makeIndex("keywords");
         instance.topicsIndex = await makeIndex("topics");
         instance.goalsIndex = await makeIndex("goals");

--- a/ts/examples/spelunker/src/makeAnswerSchema.ts
+++ b/ts/examples/spelunker/src/makeAnswerSchema.ts
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// Identifier for a chunk of code.
+export type ChunkId = string;
+
+// Answer to the original question.
+export type AnswerSpecs = {
+    question: string; // Original question (e.g. "How can items be related")
+    answer: string; // A paragraph or more of answer text.
+    references: ChunkId[]; // Chunks that support this answer.
+    confidence: number; // A number between 0 and 1.
+    message?: string; // Optional message to the user (notably for low confidence). Might request more input.
+};

--- a/ts/examples/spelunker/src/makeQuerySchema.ts
+++ b/ts/examples/spelunker/src/makeQuerySchema.ts
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// Proposed query for one index.
+export type QuerySpec = {
+    query: string;
+    maxHits?: number;
+    minScore?: number;
+};
+
+// Proposed queries for all indices (or unknownText if none apply).
+export type QuerySpecs = {
+    summaries: QuerySpec;
+    keywords: QuerySpec;
+    topics: QuerySpec;
+    goals: QuerySpec;
+    dependencies: QuerySpec;
+
+    unknownText?: string; // Fallback if nothing applies
+};

--- a/ts/examples/spelunker/src/makeQuerySchema.ts
+++ b/ts/examples/spelunker/src/makeQuerySchema.ts
@@ -8,7 +8,7 @@ export type QuerySpec = {
     minScore?: number;
 };
 
-// Proposed queries for all indices (or unknownText if none apply).
+// Proposed queries for all indexes (or unknownText if none apply).
 export type QuerySpecs = {
     summaries: QuerySpec;
     keywords: QuerySpec;

--- a/ts/examples/spelunker/src/pythonImporter.ts
+++ b/ts/examples/spelunker/src/pythonImporter.ts
@@ -180,7 +180,7 @@ async function embedChunk(
     const combinedSummaries = summaries.join("\n").trimEnd();
     if (combinedSummaries) {
         await exponentialBackoff(
-            chunkyIndex.codeSummariesIndex.put,
+            chunkyIndex.summariesIndex.put,
             combinedSummaries,
             [chunk.id],
         );

--- a/ts/examples/spelunker/src/queryInterface.ts
+++ b/ts/examples/spelunker/src/queryInterface.ts
@@ -117,7 +117,7 @@ export async function runQueryInterface(
         args: string[] | iapp.NamedArgs,
         io: iapp.InteractiveIo,
     ): Promise<void> {
-        await reportIndex(args, io, "codeSummaries");
+        await reportIndex(args, io, "summaries");
     }
 
     function keywordsDef(): iapp.CommandMetadata {
@@ -308,7 +308,13 @@ async function processQuery(
     const hitTable = new Map<ChunkId, number>();
 
     // First gather hits from keywords, topics etc. indexes.
-    for (const indexType of ["keywords", "topics", "goals", "dependencies", "codeSummaries"]) {
+    for (const indexType of [
+        "keywords",
+        "topics",
+        "goals",
+        "dependencies",
+        "summaries",
+    ]) {
         // TODO: Find a more type-safe way (so a typo in the index name is caught by the compiler).
         const index: knowLib.TextIndex<string, ChunkId> = (chunkyIndex as any)[
             indexType + "Index"
@@ -351,7 +357,7 @@ async function processQuery(
     results.sort((a, b) => b.score - a.score);
     results.splice(options.maxHits);
     io.writer.writeLine(
-        `\nFound ${results.length} ${plural("hit", results.length)} for "${input}":`,
+        `Found ${results.length} ${plural("hit", results.length)} for "${input}":`,
     );
 
     for (let i = 0; i < results.length; i++) {

--- a/ts/examples/spelunker/src/queryInterface.ts
+++ b/ts/examples/spelunker/src/queryInterface.ts
@@ -24,6 +24,7 @@ export async function runQueryInterface(
 ): Promise<void> {
     const handlers: Record<string, iapp.CommandHandler> = {
         search,
+        summaries,
         keywords,
         topics,
         goals,
@@ -103,6 +104,20 @@ export async function runQueryInterface(
                 type: "boolean",
             },
         };
+    }
+
+    function summariesDef(): iapp.CommandMetadata {
+        return {
+            description: "Show all recorded summaries and their postings.",
+            options: commonOptions(),
+        };
+    }
+    handlers.summaries.metadata = summariesDef();
+    async function summaries(
+        args: string[] | iapp.NamedArgs,
+        io: iapp.InteractiveIo,
+    ): Promise<void> {
+        await reportIndex(args, io, "codeSummaries");
     }
 
     function keywordsDef(): iapp.CommandMetadata {
@@ -265,10 +280,6 @@ export async function runQueryInterface(
 
     // Define special handlers, then run the console loop.
 
-    async function onStart(io: iapp.InteractiveIo): Promise<void> {
-        io.writer.writeLine("Welcome to the query interface!");
-    }
-
     async function inputHandler(
         input: string,
         io: iapp.InteractiveIo,
@@ -282,9 +293,9 @@ export async function runQueryInterface(
     }
 
     await iapp.runConsole({
-        onStart,
         inputHandler,
         handlers,
+        prompt: "\n🤖> ",
     });
 }
 


### PR DESCRIPTION
The new default query approach is as follows:

- Ask an LLM for suggested queries to send to each index, based on the user's query input.
- Execute those queries (this uses embeddings and is fast, especially after all the indexes are loaded and embeddings cached).
- Send their results, together with the chunks referenced, to another LLM, which is requested to answer the original question.
- Print the answer.

Note that there is no conversational memory -- each question is answered solely based on the indexed information.

Example session:

```
🤖> what is a breadcrumb

Answer (confidence 0.9):
In the context of the provided code, a breadcrumb is a flag associated with a
Blob instance. It indicates whether the blob should be ignored during the
reconstruction process. This flag is used to mark certain blobs that are not
relevant for the final output or reconstruction of the code structure.
References: 2024_11_18-11_20_45.681056,2024_11_18-11_20_45.681057,2024_11_18-11_20_45.681069

🤖>
```