### PR TITLE
Fix `cli run translate`.

### DIFF
--- a/ts/packages/cli/src/commands/run/request.ts
+++ b/ts/packages/cli/src/commands/run/request.ts
@@ -33,6 +33,7 @@ export default class RequestCommand extends Command {
             description:
                 "Explainer name (defaults to the explainer associated with the translator)",
             options: getCacheFactory().getExplainerNames(),
+            required: false,
         }),
     };
 
@@ -50,7 +51,9 @@ export default class RequestCommand extends Command {
             translators,
             actions: translators,
             commands: { dispatcher: true },
-            explainer: { name: flags.explainer },
+            explainer: flags.explainer
+                ? { enabled: true, name: flags.explainer }
+                : { enabled: false },
             cache: { enabled: false },
         });
         await dispatcher.processCommand(
@@ -59,6 +62,9 @@ export default class RequestCommand extends Command {
             this.loadAttachment(args.attachment),
         );
         await dispatcher.close();
+
+        // Some background network (like monogo) might keep the process live, exit explicitly.
+        process.exit(0);
     }
 
     loadAttachment(fileName: string | undefined): string[] | undefined {

--- a/ts/packages/cli/src/commands/run/translate.ts
+++ b/ts/packages/cli/src/commands/run/translate.ts
@@ -35,10 +35,15 @@ export default class TranslateCommand extends Command {
 
         const dispatcher = await createDispatcher("cli run translate", {
             translators,
-            actions: {}, // We don't need any actions
+            actions: null,
+            commands: { dispatcher: true },
             cache: { enabled: false },
         });
-        await dispatcher.processCommand(`@translate ${args.request}`);
+        await dispatcher.processCommand(
+            `@dispatcher translate ${args.request}`,
+        );
         await dispatcher.close();
+        // Some background network (like monogo) might keep the process live, exit explicitly.
+        process.exit(0);
     }
 }


### PR DESCRIPTION
Also
- explicit exit the process after `cli run request` and `cli run translate`
- `cli run request` don't explain by default.  Use `--explainer <name>` to enable it.