### PR TITLE
Ollama support

### DIFF
--- a/ts/examples/playground/src/main.ts
+++ b/ts/examples/playground/src/main.ts
@@ -264,10 +264,8 @@ async function runPlayground(): Promise<void> {
         let completionSettings: CompletionSettings = {
             temperature: 0.8,
             max_tokens: 1000, // Max response tokens
+            response_format: { type: "json_object" }, // createChatModel will remove it if the model doesn't support it
         };
-        if (apiSettings.supportsResponseFormat) {
-            completionSettings.response_format = { type: "json_object" };
-        }
         const chatModel = openai.createChatModel(
             apiSettings,
             completionSettings,

--- a/ts/packages/agents/greeting/src/greetingActionHandler.ts
+++ b/ts/packages/agents/greeting/src/greetingActionHandler.ts
@@ -113,10 +113,8 @@ export class GreetingCommandHandler implements CommandHandlerNoParams {
         let completionSettings: CompletionSettings = {
             temperature: 1.0,
             max_tokens: 1000, // Max response tokens
+            response_format: { type: "json_object" }, // createChatModel will remove it if the model doesn't support it
         };
-        if (apiSettings?.supportsResponseFormat) {
-            completionSettings.response_format = { type: "json_object" };
-        }
         const chatModel = openai.createChatModel(
             apiSettings,
             completionSettings,

--- a/ts/packages/aiclient/src/azureSettings.ts
+++ b/ts/packages/aiclient/src/azureSettings.ts
@@ -1,0 +1,138 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import {
+    AuthTokenProvider,
+    AzureTokenScopes,
+    createAzureTokenProvider,
+} from "./auth";
+import { getEnvSetting, getIntFromEnv } from "./common";
+import { CommonApiSettings, EnvVars, ModelType } from "./openai";
+
+export type AzureApiSettings = CommonApiSettings & {
+    provider: "azure";
+
+    apiKey: string;
+    modelName?: string;
+    supportsResponseFormat?: boolean; // only apply to chat models
+    tokenProvider?: AuthTokenProvider;
+    maxPromptChars?: number | undefined; // Maximum # of allowed prompt chars to send
+};
+
+const IdentityApiKey = "identity";
+const azureTokenProvider = createAzureTokenProvider(
+    AzureTokenScopes.CogServices,
+);
+/**
+ * Load settings for the Azure OpenAI services from env
+ * @param modelType
+ * @param env
+ * @returns
+ */
+export function azureApiSettingsFromEnv(
+    modelType: ModelType,
+    env?: Record<string, string | undefined>,
+    endpointName?: string,
+): AzureApiSettings {
+    env ??= process.env;
+    const settings =
+        modelType == ModelType.Chat
+            ? azureChatApiSettingsFromEnv(env, endpointName)
+            : modelType == ModelType.Image
+              ? azureImageApiSettingsFromEnv(env, endpointName)
+              : azureEmbeddingApiSettingsFromEnv(env, endpointName);
+
+    if (settings.apiKey.toLowerCase() === IdentityApiKey) {
+        settings.tokenProvider = azureTokenProvider;
+    }
+
+    return settings;
+}
+
+/**
+ * Load settings for the Azure OpenAI Chat Api from env
+ * @param env
+ * @returns
+ */
+function azureChatApiSettingsFromEnv(
+    env: Record<string, string | undefined>,
+    endpointName?: string,
+): AzureApiSettings {
+    return {
+        provider: "azure",
+        modelType: ModelType.Chat,
+        apiKey: getEnvSetting(env, EnvVars.AZURE_OPENAI_API_KEY, endpointName),
+        endpoint: getEnvSetting(
+            env,
+            EnvVars.AZURE_OPENAI_ENDPOINT,
+            endpointName,
+        ),
+        supportsResponseFormat:
+            getEnvSetting(
+                env,
+                EnvVars.AZURE_OPENAI_RESPONSE_FORMAT,
+                endpointName,
+                "0",
+            ) === "1",
+        maxConcurrency: getIntFromEnv(
+            env,
+            EnvVars.AZURE_OPENAI_MAX_CONCURRENCY,
+            endpointName,
+        ),
+        maxPromptChars: getIntFromEnv(
+            env,
+            EnvVars.AZURE_OPENAI_MAX_CHARS,
+            endpointName,
+        ),
+    };
+}
+
+/**
+ * Load settings for the Azure OpenAI Embedding service from env
+ * @param env
+ * @returns
+ */
+function azureEmbeddingApiSettingsFromEnv(
+    env: Record<string, string | undefined>,
+    endpointName?: string,
+): AzureApiSettings {
+    return {
+        provider: "azure",
+        modelType: ModelType.Embedding,
+        apiKey: getEnvSetting(
+            env,
+            EnvVars.AZURE_OPENAI_API_KEY_EMBEDDING,
+            endpointName,
+        ),
+        endpoint: getEnvSetting(
+            env,
+            EnvVars.AZURE_OPENAI_ENDPOINT_EMBEDDING,
+            endpointName,
+        ),
+    };
+}
+
+/**
+ * Load settings for the Azure OpenAI Image service from env
+ * @param env
+ * @returns
+ */
+function azureImageApiSettingsFromEnv(
+    env: Record<string, string | undefined>,
+    endpointName?: string,
+): AzureApiSettings {
+    return {
+        provider: "azure",
+        modelType: ModelType.Image,
+        apiKey: getEnvSetting(
+            env,
+            EnvVars.AZURE_OPENAI_API_KEY_DALLE,
+            endpointName,
+        ),
+        endpoint: getEnvSetting(
+            env,
+            EnvVars.AZURE_OPENAI_ENDPOINT_DALLE,
+            endpointName,
+        ),
+    };
+}

--- a/ts/packages/aiclient/src/common.ts
+++ b/ts/packages/aiclient/src/common.ts
@@ -47,3 +47,17 @@ export function hasEnvSettings(
     } catch {}
     return false;
 }
+
+export function getIntFromEnv(
+    env: Record<string, string | undefined>,
+    envName: string,
+    endpointName?: string,
+): number | undefined {
+    const numString = getEnvSetting(env, envName, endpointName, "");
+    const num = numString ? parseInt(numString) : undefined;
+
+    if (num !== undefined && (num.toString() !== numString || num <= 0)) {
+        throw new Error(`Invalid value for ${envName}: ${numString}`);
+    }
+    return num;
+}

--- a/ts/packages/aiclient/src/index.ts
+++ b/ts/packages/aiclient/src/index.ts
@@ -8,3 +8,4 @@ export * as bing from "./bing";
 export * from "./restClient";
 export * from "./auth";
 export * from "./tokenCounter";
+export { getChatModelNames, getChatModelMaxConcurrency } from "./modelResource";

--- a/ts/packages/aiclient/src/modelResource.ts
+++ b/ts/packages/aiclient/src/modelResource.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 import { openai as ai } from "aiclient";
+import { getOllamaModelNames } from "./ollamaModels";
 
 export function getChatModelMaxConcurrency(
     userMaxConcurrency?: number,
@@ -20,7 +21,7 @@ export function getChatModelMaxConcurrency(
         : userMaxConcurrency;
 }
 
-export function getChatModelNames() {
+export async function getChatModelNames() {
     const envKeys = Object.keys(process.env);
     const knownEnvKeys = Object.keys(ai.EnvVars);
 
@@ -41,7 +42,8 @@ export function getChatModelNames() {
     const openaiNames = getPrefixedNames(ai.EnvVars.OPENAI_API_KEY).map(
         (key) => `openai:${key}`,
     );
-    return [...azureNames, ...openaiNames];
+
+    return [...azureNames, ...openaiNames, ...(await getOllamaModelNames())];
 }
 
 export function isMultiModalContentSupported(modelName: string | undefined) {

--- a/ts/packages/aiclient/src/ollamaModels.ts
+++ b/ts/packages/aiclient/src/ollamaModels.ts
@@ -1,0 +1,268 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import {
+    ImagePromptContent,
+    MultimodalPromptContent,
+    PromptSection,
+    Result,
+    success,
+} from "typechat";
+import { getEnvSetting } from "./common";
+import { ChatModelWithStreaming, CompletionSettings } from "./models";
+import {
+    CommonApiSettings,
+    CompletionUsageStats,
+    EnvVars,
+    ModelType,
+} from "./openai";
+import {
+    callApi,
+    callJsonApi,
+    getJson,
+    readResponseStream,
+} from "./restClient";
+import { TokenCounter } from "./tokenCounter";
+
+export type OllamaApiSettings = CommonApiSettings & {
+    provider: "ollama";
+    modelType: ModelType;
+    endpoint: string;
+    modelName: string;
+};
+
+function getOllamaEndpointUrl(env: Record<string, string | undefined>) {
+    return getEnvSetting(
+        env,
+        EnvVars.OLLAMA_ENDPOINT,
+        undefined,
+        "http://localhost:11434",
+    );
+}
+
+type OllamaTagResult = {
+    models: {
+        name: string;
+        modified_at: string;
+        size: number;
+        digest: string;
+        details: {
+            format: string;
+            family: string;
+            families: string[];
+            parameter_size: string;
+            quantization_level: string;
+        };
+    }[];
+};
+
+let modelNames: string[] | undefined;
+export async function getOllamaModelNames(
+    env: Record<string, string | undefined> = process.env,
+): Promise<string[]> {
+    if (modelNames === undefined) {
+        const url = getOllamaEndpointUrl(env);
+        const result = await getJson({}, `${url}/api/tags`, undefined);
+        if (result.success) {
+            const tags = result.data as OllamaTagResult;
+            modelNames = tags.models.map(
+                (m) =>
+                    `ollama:${
+                        m.name.endsWith(":latest")
+                            ? m.name.substring(0, m.name.length - 7)
+                            : m.name
+                    }`,
+            );
+        } else {
+            modelNames = [];
+        }
+    }
+    return modelNames;
+}
+
+export function ollamaApiSettingsFromEnv(
+    modelType: ModelType,
+    env?: Record<string, string | undefined>,
+    endpointName?: string,
+): OllamaApiSettings {
+    if (modelType === ModelType.Image) {
+        throw new Error("Image model not supported");
+    }
+    env ??= process.env;
+    const url = getOllamaEndpointUrl(env);
+    return {
+        provider: "ollama",
+        modelType,
+        endpoint:
+            modelType === ModelType.Chat
+                ? `${url}/api/chat`
+                : `${url}/api/embed`,
+        modelName: endpointName ?? "phi3",
+    };
+}
+
+type OllamaChatCompletionUsage = {
+    total_duration: number;
+    load_duration: number;
+    prompt_eval_count: number;
+    prompt_eval_duration: number;
+    eval_count: number;
+    eval_duration: number;
+};
+
+type OllamaChatCompletion = {
+    model: string;
+    created_at: string;
+    message: {
+        role: "assistant";
+        content: string;
+    };
+    done: true;
+} & OllamaChatCompletionUsage;
+
+type OllamaChatCompletionChunk =
+    | {
+          model: string;
+          created_at: string;
+          done: false;
+          message: {
+              role: "assistant";
+              content: string;
+          };
+      }
+    | ({
+          model: string;
+          created_at: string;
+          done: true;
+      } & OllamaChatCompletionUsage);
+
+export function createOllamaChatModel(
+    settings: OllamaApiSettings,
+    completionSettings?: CompletionSettings,
+    completionCallback?: (request: any, response: any) => void,
+    tags?: string[],
+) {
+    completionSettings ??= {};
+    completionSettings.n ??= 1;
+    completionSettings.temperature ??= 0;
+
+    const defaultParams = {
+        model: settings.modelName,
+    };
+    const model: ChatModelWithStreaming = {
+        completionSettings: completionSettings,
+        completionCallback,
+        complete,
+        completeStream,
+    };
+    return model;
+
+    function reportUsage(data: OllamaChatCompletionUsage) {
+        try {
+            // track token usage
+            const usage: CompletionUsageStats = {
+                completion_tokens: data.eval_count,
+                prompt_tokens: data.prompt_eval_count,
+                total_tokens: data.prompt_eval_count + data.eval_count,
+            };
+
+            TokenCounter.getInstance().add(usage, tags);
+        } catch {}
+    }
+
+    async function complete(
+        prompt: string | PromptSection[],
+    ): Promise<Result<string>> {
+        const messages =
+            typeof prompt === "string"
+                ? [{ role: "user", content: prompt }]
+                : prompt;
+        const isImageProptContent = (c: MultimodalPromptContent) =>
+            (c as ImagePromptContent).type == "image_url";
+        messages.map((ps) => {
+            if (Array.isArray(ps.content)) {
+                if (ps.content.some(isImageProptContent)) {
+                    throw new Error("Image content not supported");
+                }
+            }
+        });
+        const params = {
+            ...defaultParams,
+            messages: messages,
+            stream: false,
+            ...completionSettings,
+        };
+
+        const result = await callJsonApi(
+            {},
+            settings.endpoint,
+            params,
+            settings.maxRetryAttempts,
+            settings.retryPauseMs,
+            undefined,
+            settings.throttler,
+        );
+        if (!result.success) {
+            return result;
+        }
+
+        const data = result.data as OllamaChatCompletion;
+        if (model.completionCallback) {
+            model.completionCallback(params, data);
+        }
+
+        reportUsage(data);
+
+        return success(data.message.content as string);
+    }
+
+    async function completeStream(
+        prompt: string | PromptSection[],
+    ): Promise<Result<AsyncIterableIterator<string>>> {
+        const messages: PromptSection[] =
+            typeof prompt === "string"
+                ? [{ role: "user", content: prompt }]
+                : prompt;
+
+        const isImageProptContent = (c: MultimodalPromptContent) =>
+            (c as ImagePromptContent).type == "image_url";
+        messages.map((ps) => {
+            if (Array.isArray(ps.content)) {
+                if (ps.content.some(isImageProptContent)) {
+                    throw new Error("Image content not supported");
+                }
+            }
+        });
+
+        const params = {
+            ...defaultParams,
+            messages: messages,
+            stream: true,
+            ...completionSettings,
+        };
+        const result = await callApi(
+            {},
+            settings.endpoint,
+            params,
+            settings.maxRetryAttempts,
+            settings.retryPauseMs,
+        );
+        if (!result.success) {
+            return result;
+        }
+        return {
+            success: true,
+            data: (async function* () {
+                const messageStream = readResponseStream(result.data);
+                for await (const message of messageStream) {
+                    const data: OllamaChatCompletionChunk = JSON.parse(message);
+                    if (data.done) {
+                        reportUsage(data);
+                        break;
+                    }
+                    yield data.message.content;
+                }
+            })(),
+        };
+    }
+}

--- a/ts/packages/aiclient/src/openaiSettings.ts
+++ b/ts/packages/aiclient/src/openaiSettings.ts
@@ -1,0 +1,71 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { CommonApiSettings, EnvVars } from "./openai";
+import { getEnvSetting, getIntFromEnv } from "./common";
+import { ModelType } from "./openai";
+
+export type OpenAIApiSettings = CommonApiSettings & {
+    provider: "openai";
+
+    apiKey: string;
+    modelName?: string;
+    organization?: string;
+    supportsResponseFormat?: boolean; // only apply to chat models
+};
+
+/**
+ * Load settings for the OpenAI services from env
+ * @param modelType Chat or Embedding
+ * @param env Environment variables
+ * @param endpointName Name of endpoint, e.g. GPT_35_TURBO or PHI3. This is appended as a suffix to base environment key
+ * @param requireEndpoint If false (default), falls back to using non-endpoint specific settings
+ * @returns
+ */
+
+export function openAIApiSettingsFromEnv(
+    modelType: ModelType,
+    env?: Record<string, string | undefined>,
+    endpointName?: string,
+    requireEndpoint: boolean = false,
+): OpenAIApiSettings {
+    env ??= process.env;
+    return {
+        provider: "openai",
+        modelType: modelType,
+        apiKey: getEnvSetting(env, EnvVars.OPENAI_API_KEY, endpointName),
+        endpoint: getEnvSetting(
+            env,
+            modelType === ModelType.Chat
+                ? EnvVars.OPENAI_ENDPOINT
+                : EnvVars.OPENAI_ENDPOINT_EMBEDDING,
+            endpointName,
+            undefined,
+            requireEndpoint,
+        ),
+        modelName: getEnvSetting(
+            env,
+            modelType === ModelType.Chat
+                ? EnvVars.OPENAI_MODEL
+                : EnvVars.OPENAI_MODEL_EMBEDDING,
+            endpointName,
+        ),
+        organization: getEnvSetting(
+            env,
+            EnvVars.OPENAI_ORGANIZATION,
+            endpointName,
+        ),
+        supportsResponseFormat:
+            getEnvSetting(
+                env,
+                EnvVars.OPENAI_RESPONSE_FORMAT,
+                endpointName,
+                "0",
+            ) === "1",
+        maxConcurrency: getIntFromEnv(
+            env,
+            EnvVars.OPENAI_MAX_CONCURRENCY,
+            endpointName,
+        ),
+    };
+}

--- a/ts/packages/cli/src/commands/data/add.ts
+++ b/ts/packages/cli/src/commands/data/add.ts
@@ -15,10 +15,10 @@ import {
 } from "agent-dispatcher/internal";
 import chalk from "chalk";
 import { getDefaultExplainerName } from "agent-cache";
-import { getChatModelMaxConcurrency, getChatModelNames } from "common-utils";
+import { getChatModelMaxConcurrency, getChatModelNames } from "aiclient";
 
 const cacheFactory = getCacheFactory();
-
+const modelNames = await getChatModelNames();
 export default class ExplanationDataAddCommand extends Command {
     static args = {
         request: Args.string({
@@ -63,7 +63,7 @@ export default class ExplanationDataAddCommand extends Command {
         }),
         model: Flags.string({
             description: "Model to use",
-            options: getChatModelNames(),
+            options: modelNames,
         }),
     };
 

--- a/ts/packages/cli/src/commands/data/regenerate.ts
+++ b/ts/packages/cli/src/commands/data/regenerate.ts
@@ -24,12 +24,8 @@ import {
     printImportConstructionResult,
     RequestAction,
 } from "agent-cache";
-import {
-    createLimiter,
-    getElapsedString,
-    getChatModelMaxConcurrency,
-    getChatModelNames,
-} from "common-utils";
+import { createLimiter, getElapsedString } from "common-utils";
+import { getChatModelMaxConcurrency, getChatModelNames } from "aiclient";
 import { Entity } from "@typeagent/agent-sdk";
 
 function toEntities(actions: Actions): Entity[] {
@@ -50,6 +46,7 @@ function toEntities(actions: Actions): Entity[] {
     return entities;
 }
 
+const modelNames = await getChatModelNames();
 export default class ExplanationDataRegenerateCommmand extends Command {
     static strict = false;
     static args = {
@@ -91,7 +88,7 @@ export default class ExplanationDataRegenerateCommmand extends Command {
         }),
         model: Flags.string({
             description: "Model to use",
-            options: getChatModelNames(),
+            options: modelNames,
         }),
         explanation: Flags.boolean({
             description: "Regenerate explanation only",

--- a/ts/packages/cli/src/commands/interactive.ts
+++ b/ts/packages/cli/src/commands/interactive.ts
@@ -14,6 +14,9 @@ import {
     closeCommandHandlerContext,
 } from "agent-dispatcher/internal";
 import inspector from "node:inspector";
+import { getChatModelNames } from "aiclient";
+
+const modelNames = await getChatModelNames();
 
 export default class Interactive extends Command {
     static description = "Interactive mode";
@@ -27,6 +30,10 @@ export default class Interactive extends Command {
             description:
                 "Explainer name (defaults to the explainer associated with the translator)",
             options: getCacheFactory().getExplainerNames(),
+        }),
+        model: Flags.string({
+            description: "Translation model to use",
+            options: modelNames,
         }),
         debug: Flags.boolean({
             description: "Enable debug mode",
@@ -68,6 +75,7 @@ export default class Interactive extends Command {
         try {
             context = await initializeCommandHandlerContext("cli interactive", {
                 translators,
+                translation: { model: flags.model },
                 explainer: { name: flags.explainer },
                 stdio,
                 persistSession: !flags.memory,

--- a/ts/packages/cli/src/commands/prompt.ts
+++ b/ts/packages/cli/src/commands/prompt.ts
@@ -2,11 +2,11 @@
 // Licensed under the MIT License.
 
 import { Args, Command, Flags } from "@oclif/core";
-import { getChatModelNames } from "common-utils";
-import { openai } from "aiclient";
+import { openai, getChatModelNames } from "aiclient";
 import fs from "node:fs";
 import chalk from "chalk";
 
+const modelNames = await getChatModelNames();
 export default class Prompt extends Command {
     static description = "Send a prompt to GPT";
     static args = {
@@ -18,7 +18,7 @@ export default class Prompt extends Command {
     static flags = {
         model: Flags.string({
             description: "Model to use",
-            options: getChatModelNames(),
+            options: modelNames,
         }),
         stream: Flags.boolean({
             description: "Whether to stream the result",

--- a/ts/packages/cli/src/commands/run/request.ts
+++ b/ts/packages/cli/src/commands/run/request.ts
@@ -8,8 +8,10 @@ import {
     getBuiltinTranslatorNames,
 } from "agent-dispatcher/internal";
 import chalk from "chalk";
+import { getChatModelNames } from "aiclient";
 import { readFileSync, existsSync } from "fs";
 
+const modelNames = await getChatModelNames();
 export default class RequestCommand extends Command {
     static args = {
         request: Args.string({
@@ -35,6 +37,10 @@ export default class RequestCommand extends Command {
             options: getCacheFactory().getExplainerNames(),
             required: false,
         }),
+        model: Flags.string({
+            description: "Translation model to use",
+            options: modelNames,
+        }),
     };
 
     static description = "Translate a request into action and explain it";
@@ -51,6 +57,7 @@ export default class RequestCommand extends Command {
             translators,
             actions: translators,
             commands: { dispatcher: true },
+            translation: { model: flags.model },
             explainer: flags.explainer
                 ? { enabled: true, name: flags.explainer }
                 : { enabled: false },

--- a/ts/packages/cli/src/commands/run/translate.ts
+++ b/ts/packages/cli/src/commands/run/translate.ts
@@ -4,7 +4,9 @@
 import { Args, Command, Flags } from "@oclif/core";
 import { createDispatcher } from "agent-dispatcher";
 import { getBuiltinTranslatorNames } from "agent-dispatcher/internal";
+import { getChatModelNames } from "aiclient";
 
+const modelNames = await getChatModelNames();
 export default class TranslateCommand extends Command {
     static args = {
         request: Args.string({
@@ -19,6 +21,10 @@ export default class TranslateCommand extends Command {
             description: "Translator name",
             options: getBuiltinTranslatorNames(),
             multiple: true,
+        }),
+        model: Flags.string({
+            description: "Translation model to use",
+            options: modelNames,
         }),
     };
 
@@ -37,6 +43,7 @@ export default class TranslateCommand extends Command {
             translators,
             actions: null,
             commands: { dispatcher: true },
+            translation: { model: flags.model },
             cache: { enabled: false },
         });
         await dispatcher.processCommand(

--- a/ts/packages/commonUtils/src/indexNode.ts
+++ b/ts/packages/commonUtils/src/indexNode.ts
@@ -14,10 +14,6 @@ export {
 export { Limiter, createLimiter } from "./limiter.js";
 export * from "./print.js";
 
-export {
-    getChatModelNames,
-    getChatModelMaxConcurrency,
-} from "./modelResource.js";
 export * from "./command.js";
 
 export * from "./constraints.js";

--- a/ts/packages/dispatcher/src/dispatcher/command.ts
+++ b/ts/packages/dispatcher/src/dispatcher/command.ts
@@ -320,23 +320,20 @@ export function getSettingSummary(context: CommandHandlerContext) {
         ).values(),
     );
     prompt.push("  [", translators.join(""));
-    if (context.session.getConfig().models.translator !== "") {
-        prompt.push(
-            ` (model: ${context.session.getConfig().models.translator})`,
-        );
+    const translationModel = context.session.getConfig().translation.model;
+    if (translationModel !== "") {
+        prompt.push(` (model: ${translationModel})`);
     }
+    const explainerModel = context.session.getConfig().explainer.model;
     if (context.agentCache.explainerName !== getDefaultExplainerName()) {
         prompt.push(` (explainer: ${context.agentCache.explainerName}`);
-        if (context.session.getConfig().models.explainer !== "") {
-            prompt.push(
-                ` model: ${context.session.getConfig().models.translator}`,
-            );
+
+        if (explainerModel !== "") {
+            prompt.push(` model: ${explainerModel}`);
         }
         prompt.push(")");
-    } else if (context.session.getConfig().models.explainer !== "") {
-        prompt.push(
-            ` (explainer model: ${context.session.getConfig().models.explainer})`,
-        );
+    } else if (explainerModel !== "") {
+        prompt.push(` (explainer model: ${explainerModel})`);
     }
 
     prompt.push("]");

--- a/ts/packages/dispatcher/src/handlers/common/commandHandlerContext.ts
+++ b/ts/packages/dispatcher/src/handlers/common/commandHandlerContext.ts
@@ -132,11 +132,11 @@ export function getTranslator(
     if (translator !== undefined) {
         return translator;
     }
-    const config = context.session.getConfig();
+    const config = context.session.getConfig().translation;
     const newTranslator = loadAgentJsonTranslator(
         translatorName,
         context.agents,
-        config.models.translator,
+        config.model,
         config.switch.inline ? getActiveTranslators(context) : undefined,
         config.multipleActions,
     );
@@ -415,9 +415,9 @@ export async function changeContextConfig(
 
     if (
         translatorChanged ||
-        changed.models?.translator !== undefined ||
-        changed.switch?.inline ||
-        changed.multipleActions
+        changed.translation?.model !== undefined ||
+        changed.translation?.switch?.inline ||
+        changed.translation?.multipleActions
     ) {
         // The dynamic schema for change assistant is changed.
         // Clear the cache to regenerate them.
@@ -474,8 +474,8 @@ export async function changeContextConfig(
             }
             await agentCache.constructionStore.setAutoSave(autoSave);
         }
-        if (changed.models?.explainer !== undefined) {
-            agentCache.model = changed.models.explainer;
+        if (changed.explainer?.model !== undefined) {
+            agentCache.model = changed.explainer?.model;
         }
         const builtInCache = changed.cache?.builtInCache;
         if (builtInCache !== undefined) {

--- a/ts/packages/dispatcher/src/handlers/configCommandHandlers.ts
+++ b/ts/packages/dispatcher/src/handlers/configCommandHandlers.ts
@@ -13,12 +13,13 @@ import { getAppAgentName } from "../translation/agentTranslators.js";
 import { getServiceHostCommandHandlers } from "./serviceHost/serviceHostCommandHandler.js";
 import { getLocalWhisperCommandHandlers } from "./serviceHost/localWhisperCommandHandler.js";
 
-import { getChatModelNames, simpleStarRegex } from "common-utils";
-import { openai as ai } from "aiclient";
-import { SessionConfig } from "../session/session.js";
+import { simpleStarRegex } from "common-utils";
+import { openai as ai, getChatModelNames } from "aiclient";
+import { SessionConfig, SessionOptions } from "../session/session.js";
 import chalk from "chalk";
 import {
     ActionContext,
+    ParameterDefinitions,
     ParsedCommandParams,
     PartialParsedCommandParams,
     SessionContext,
@@ -282,114 +283,76 @@ class ExplainerCommandHandler implements CommandHandler {
     }
 }
 
-function getConfigModel(models: SessionConfig["models"], kind: string) {
-    if (!models.hasOwnProperty(kind)) {
-        throw new Error(
-            `Invalid model kind: ${kind}\nValid model kinds: ${Object.keys(models).join(", ")}`,
-        );
-    }
-    const model = models[kind as keyof typeof models];
+function getConfigModel(kind: string, model: string) {
     const settings = ai.getChatModelSettings(model);
     return `Current ${chalk.cyan(kind)} model: ${model ? model : "(default)"}\nURL:${settings.endpoint}`;
-}
-
-class ConfigModelShowCommandHandler implements CommandHandler {
-    public readonly description = "Show current model";
-    public readonly parameters = {
-        args: {
-            kind: {
-                description: "Model kind to show",
-                optional: true,
-            },
-        },
-    } as const;
-    public async run(
-        context: ActionContext<CommandHandlerContext>,
-        params: ParsedCommandParams<typeof this.parameters>,
-    ) {
-        const systemContext = context.sessionContext.agentContext;
-        const models = systemContext.session.getConfig().models;
-
-        if (params.args.kind !== undefined) {
-            displayResult(getConfigModel(models, params.args.kind), context);
-        } else {
-            displayResult(
-                Object.keys(models)
-                    .map((kind) => getConfigModel(models, kind))
-                    .join("\n"),
-                context,
-            );
-        }
-    }
 }
 
 class ConfigModelSetCommandHandler implements CommandHandler {
     public readonly description = "Set model";
     public readonly parameters = {
-        args: {
-            kindOrModel: {
-                description: "Model kind or name",
-                optional: true,
+        flags: {
+            reset: {
+                description: "Reset to default model",
+                char: "r",
+                type: "boolean",
+                default: false,
             },
+        },
+        args: {
             model: {
                 description: "Model name",
                 optional: true,
             },
         },
     } as const;
+    public constructor(private readonly kind: "translation" | "explainer") {}
     public async run(
         context: ActionContext<CommandHandlerContext>,
         params: ParsedCommandParams<typeof this.parameters>,
     ) {
-        const systemContext = context.sessionContext.agentContext;
-        const models = systemContext.session.getConfig().models;
-        if (params.args.kindOrModel === undefined) {
-            const newConfig = {
-                models: Object.fromEntries(
-                    Object.keys(models).map((kind) => [kind, ""]),
-                ),
-            };
-            await changeContextConfig(newConfig, context);
-            displayResult(`Reset to default model for all`, context);
+        const reset = params.flags.reset;
+        const model = params.args.model;
+        if (reset || model === "") {
+            if (model !== "") {
+                throw new Error("Model name is not allowed with reset option");
+            }
+            const config: SessionOptions = {};
+            config[this.kind] = { model: "" };
+            await changeContextConfig(config, context);
+            displayResult(`Reset to default model for ${this.kind}`, context);
             return;
         }
-
-        let kind = "translator";
-        let model = "";
-        if (params.args.model === undefined) {
-            if (models.hasOwnProperty(params.args.kindOrModel)) {
-                kind = params.args.kindOrModel;
-            } else {
-                model = params.args.kindOrModel;
-            }
-        } else {
-            kind = params.args.kindOrModel;
-            model = params.args.model;
-        }
-
-        if (!models.hasOwnProperty(kind)) {
-            throw new Error(
-                `Invalid model kind: ${kind}\nValid model kinds: ${Object.keys(models).join(", ")}`,
+        if (model === undefined) {
+            const config =
+                context.sessionContext.agentContext.session.getConfig();
+            displayResult(
+                getConfigModel(this.kind, config[this.kind].model),
+                context,
             );
+            return;
         }
-        const modelNames = getChatModelNames();
-        if (model === "") {
-            displayResult(`Reset to default model for ${kind}`, context);
-        } else if (!modelNames.includes(model)) {
+        const modelNames = await getChatModelNames();
+        if (!modelNames.includes(model)) {
             throw new Error(
                 `Invalid model name: ${model}\nValid model names: ${modelNames.join(", ")}`,
             );
         } else {
-            displayResult(`Model for ${kind} is set to ${model}`, context);
+            displayResult(`Model for ${this.kind} is set to ${model}`, context);
         }
-        await changeContextConfig(
-            {
-                models: {
-                    [kind]: model,
-                },
-            },
-            context,
-        );
+        const config: SessionOptions = {};
+        config[this.kind] = { model };
+        await changeContextConfig(config, context);
+    }
+    public async getCompletion(
+        context: SessionContext<CommandHandlerContext>,
+        params: PartialParsedCommandParams<ParameterDefinitions>,
+        names: string[],
+    ): Promise<string[]> {
+        if (params.args?.model === undefined) {
+            return getChatModelNames();
+        }
+        return [];
     }
 }
 
@@ -401,86 +364,100 @@ export function getConfigCommandHandlers(): CommandHandlerTable {
             action: new AgentToggleCommandHandler(AgentToggle.Action),
             command: new AgentToggleCommandHandler(AgentToggle.Command),
             agent: new AgentToggleCommandHandler(AgentToggle.Agent),
-            model: {
-                description: "Configure model",
-                defaultSubCommand: "show",
-                commands: {
-                    show: new ConfigModelShowCommandHandler(),
-                    set: new ConfigModelSetCommandHandler(),
-                },
-            },
-            multi: getToggleHandlerTable(
-                "multiple action translation",
-                async (context, enable: boolean) => {
-                    await changeContextConfig(
-                        { multipleActions: enable },
-                        context,
-                    );
-                },
-            ),
-            switch: {
-                description: "auto switch translator",
+            translation: {
+                description: "Translation configuration",
+                defaultSubCommand: "on",
                 commands: {
                     ...getToggleCommandHandlers(
-                        "switch translator",
-                        async (context, enable: boolean) => {
+                        "translation",
+                        async (context, enable) => {
                             await changeContextConfig(
-                                {
-                                    switch: {
-                                        inline: enable,
-                                        search: enable,
-                                    },
-                                },
+                                { translation: { enabled: enable } },
                                 context,
                             );
                         },
                     ),
-                    inline: getToggleHandlerTable(
-                        "inject inline switch",
+                    model: new ConfigModelSetCommandHandler("translation"),
+                    multi: getToggleHandlerTable(
+                        "multiple action translation",
                         async (context, enable: boolean) => {
                             await changeContextConfig(
-                                {
-                                    switch: {
-                                        inline: enable,
-                                    },
-                                },
+                                { translation: { multipleActions: enable } },
                                 context,
                             );
                         },
                     ),
-                    search: getToggleHandlerTable(
-                        "inject inline switch",
+                    switch: {
+                        description: "auto switch translator",
+                        commands: {
+                            ...getToggleCommandHandlers(
+                                "switch translator",
+                                async (context, enable: boolean) => {
+                                    await changeContextConfig(
+                                        {
+                                            translation: {
+                                                switch: {
+                                                    inline: enable,
+                                                    search: enable,
+                                                },
+                                            },
+                                        },
+                                        context,
+                                    );
+                                },
+                            ),
+                            inline: getToggleHandlerTable(
+                                "inject inline switch",
+                                async (context, enable: boolean) => {
+                                    await changeContextConfig(
+                                        {
+                                            translation: {
+                                                switch: {
+                                                    inline: enable,
+                                                },
+                                            },
+                                        },
+                                        context,
+                                    );
+                                },
+                            ),
+                            search: getToggleHandlerTable(
+                                "inject inline switch",
+                                async (context, enable: boolean) => {
+                                    await changeContextConfig(
+                                        {
+                                            translation: {
+                                                switch: {
+                                                    search: enable,
+                                                },
+                                            },
+                                        },
+                                        context,
+                                    );
+                                },
+                            ),
+                        },
+                    },
+                    history: getToggleHandlerTable(
+                        "history",
                         async (context, enable: boolean) => {
                             await changeContextConfig(
-                                {
-                                    switch: {
-                                        search: enable,
-                                    },
-                                },
+                                { translation: { history: enable } },
+                                context,
+                            );
+                        },
+                    ),
+                    stream: getToggleHandlerTable(
+                        "streaming translation",
+                        async (context, enable: boolean) => {
+                            await changeContextConfig(
+                                { translation: { stream: enable } },
                                 context,
                             );
                         },
                     ),
                 },
             },
-            history: getToggleHandlerTable(
-                "history",
-                async (context, enable: boolean) => {
-                    await changeContextConfig({ history: enable }, context);
-                },
-            ),
-            bot: getToggleHandlerTable(
-                "translation LLM usage",
-                async (context, enable: boolean) => {
-                    await changeContextConfig({ bot: enable }, context);
-                },
-            ),
-            stream: getToggleHandlerTable(
-                "streaming translation",
-                async (context, enable: boolean) => {
-                    await changeContextConfig({ stream: enable }, context);
-                },
-            ),
             explainer: {
                 description: "Explainer configuration",
                 defaultSubCommand: "on",
@@ -502,6 +479,7 @@ export function getConfigCommandHandlers(): CommandHandlerTable {
                         },
                     ),
                     name: new ExplainerCommandHandler(),
+                    model: new ConfigModelSetCommandHandler("explainer"),
                     filter: {
                         description: "Toggle explanation filter",
                         defaultSubCommand: "on",

--- a/ts/packages/dispatcher/src/handlers/randomCommandHandler.ts
+++ b/ts/packages/dispatcher/src/handlers/randomCommandHandler.ts
@@ -155,10 +155,8 @@ class RandomOnlineCommandHandler implements CommandHandlerNoParams {
         let completionSettings: CompletionSettings = {
             temperature: 1.0,
             max_tokens: 1000, // Max response tokens
+            response_format: { type: "json_object" }, // createChatModel will remove it if the model doesn't support it
         };
-        if (apiSettings.supportsResponseFormat) {
-            completionSettings.response_format = { type: "json_object" };
-        }
         const chatModel = openai.createChatModel(
             apiSettings,
             completionSettings,

--- a/ts/packages/dispatcher/src/handlers/requestCommandHandler.ts
+++ b/ts/packages/dispatcher/src/handlers/requestCommandHandler.ts
@@ -264,7 +264,7 @@ async function translateRequestWithTranslator(
     let streamFunction: IncrementalJsonValueCallBack | undefined;
     systemContext.streamingActionContext = undefined;
     const onProperty: IncrementalJsonValueCallBack | undefined =
-        systemContext.session.getConfig().stream
+        systemContext.session.getConfig().translation.stream
             ? (prop: string, value: any, delta: string | undefined) => {
                   // TODO: streaming currently doesn't not support multiple actions
                   if (prop === "actionName" && delta === undefined) {
@@ -388,7 +388,8 @@ async function getNextTranslation(
         return undefined;
     }
 
-    return context.sessionContext.agentContext.session.getConfig().switch.search
+    const config = context.sessionContext.agentContext.session.getConfig();
+    return config.translation.switch.search
         ? findAssistantForRequest(request, translatorName, context)
         : undefined;
 }
@@ -502,8 +503,8 @@ function getChatHistoryForTranslation(
         role: "system",
     });
     const entities = context.chatHistory.getTopKEntities(20);
-    const additionalInstructions = context.session.getConfig().promptConfig
-        .additionalInstructions
+    const additionalInstructions = context.session.getConfig().translation
+        .promptConfig.additionalInstructions
         ? context.chatHistory.getCurrentInstructions()
         : undefined;
     return { promptSections, entities, additionalInstructions };
@@ -929,7 +930,8 @@ export class RequestCommandHandler implements CommandHandler {
                 }
             }
 
-            const history = systemContext.session.getConfig().history
+            const history = systemContext.session.getConfig().translation
+                .history
                 ? getChatHistoryForTranslation(systemContext)
                 : undefined;
             if (history) {

--- a/ts/packages/dispatcher/src/handlers/sessionCommandHandlers.ts
+++ b/ts/packages/dispatcher/src/handlers/sessionCommandHandlers.ts
@@ -275,18 +275,6 @@ export function getSessionCommandHandlers(): CommandHandlerTable {
             list: new SessionListCommandHandler(),
             delete: new SessionDeleteCommandHandler(),
             info: new SessionInfoCommandHandler(),
-            history: getToggleHandlerTable(
-                "history",
-                async (
-                    context: ActionContext<CommandHandlerContext>,
-                    enable: boolean,
-                ) => {
-                    const systemContext = context.sessionContext.agentContext;
-                    systemContext.session.setConfig({
-                        history: enable,
-                    });
-                },
-            ),
         },
     };
 }

--- a/ts/packages/dispatcher/src/session/session.ts
+++ b/ts/packages/dispatcher/src/session/session.ts
@@ -102,14 +102,23 @@ async function newSessionDir() {
 }
 
 type DispatcherConfig = {
-    models: {
-        translator: string;
-        explainer: string;
+    translation: {
+        enabled: boolean;
+        model: string;
+        stream: boolean;
+        promptConfig: {
+            additionalInstructions: boolean;
+        };
+        switch: {
+            inline: boolean;
+            search: boolean;
+        };
+        multipleActions: boolean;
+        history: boolean;
     };
-    bot: boolean;
-    stream: boolean;
     explainer: {
         enabled: boolean;
+        model: string;
         name: string;
         filter: {
             multiple: boolean;
@@ -120,15 +129,6 @@ type DispatcherConfig = {
             };
         };
     };
-    promptConfig: {
-        additionalInstructions: boolean;
-    };
-    switch: {
-        inline: boolean;
-        search: boolean;
-    };
-    multipleActions: boolean;
-    history: boolean;
 
     // Cache behaviors
     cache: CacheConfig & {
@@ -148,23 +148,24 @@ const defaultSessionConfig: SessionConfig = {
     translators: undefined,
     actions: undefined,
     commands: undefined,
-    models: {
-        translator: "",
-        explainer: "",
+
+    translation: {
+        enabled: true,
+        model: "",
+        stream: true,
+        promptConfig: {
+            additionalInstructions: true,
+        },
+        switch: {
+            inline: true,
+            search: true,
+        },
+        multipleActions: true,
+        history: true,
     },
-    bot: true,
-    stream: true,
-    promptConfig: {
-        additionalInstructions: true,
-    },
-    switch: {
-        inline: true,
-        search: true,
-    },
-    multipleActions: true,
-    history: true,
     explainer: {
         enabled: true,
+        model: "",
         name: getDefaultExplainerName(),
         filter: {
             multiple: true,
@@ -294,7 +295,7 @@ export class Session {
     }
 
     public get bot() {
-        return this.config.bot;
+        return this.config.translation.enabled;
     }
 
     public get explanation() {
@@ -448,7 +449,7 @@ export async function setupAgentCache(
     agentCache: AgentCache,
 ) {
     const config = session.getConfig();
-    agentCache.model = config.models.explainer;
+    agentCache.model = config.explainer.model;
     agentCache.constructionStore.clear();
     if (config.cache.enabled) {
         const cacheData = session.getCacheDataFilePath();


### PR DESCRIPTION
Add ollama model support.  Their API and response are different then OAI.  Soadd a new provide and model implementation.
Add flags to control translation model for `cli run request` and `cli run translation` in addition to `cli interactive`

Change the commands `@config translation model <name>` to set translation model.  `@config explainer model <name>` to set the explainer model.

Also group other translation options and command under "translation" .

