### PR TITLE
[spelunker] Many refactorings and improvements

### DIFF
--- a/ts/examples/spelunker/src/chunkyIndex.ts
+++ b/ts/examples/spelunker/src/chunkyIndex.ts
@@ -25,7 +25,6 @@ export type NamedIndex = {
 
 // A bundle of object stores and indexes etc.
 export class ChunkyIndex {
-    rootDir: string;
     chatModel: ChatModel;
     embeddingModel: TextEmbeddingModel;
     fileDocumenter: FileDocumenter;
@@ -33,6 +32,7 @@ export class ChunkyIndex {
     answerMaker: TypeChatJsonTranslator<AnswerSpecs>;
 
     // The rest are asynchronously initialized by initialize().
+    rootDir!: string;
     chunkFolder!: ObjectFolder<Chunk>;
     summariesIndex!: knowLib.TextIndex<string, ChunkId>;
     keywordsIndex!: knowLib.TextIndex<string, ChunkId>;
@@ -40,8 +40,7 @@ export class ChunkyIndex {
     goalsIndex!: knowLib.TextIndex<string, ChunkId>;
     dependenciesIndex!: knowLib.TextIndex<string, ChunkId>;
 
-    private constructor(rootDir: string) {
-        this.rootDir = rootDir;
+    private constructor() {
         this.chatModel = openai.createChatModelDefault("spelunkerChat");
         this.embeddingModel = knowLib.createEmbeddingCache(
             openai.createEmbeddingModel(),
@@ -53,7 +52,14 @@ export class ChunkyIndex {
     }
 
     static async createInstance(rootDir: string): Promise<ChunkyIndex> {
-        const instance = new ChunkyIndex(rootDir);
+        const instance = new ChunkyIndex();
+        await instance.reInitialize(rootDir);
+        return instance;
+    }
+
+    async reInitialize(rootDir: string): Promise<void> {
+        const instance = this; // So makeIndex can see it.
+        instance.rootDir = rootDir;
         instance.chunkFolder = await createObjectFolder<Chunk>(
             instance.rootDir + "/chunks",
             { serializer: (obj) => JSON.stringify(obj, null, 2) },
@@ -63,8 +69,6 @@ export class ChunkyIndex {
         instance.topicsIndex = await makeIndex("topics");
         instance.goalsIndex = await makeIndex("goals");
         instance.dependenciesIndex = await makeIndex("dependencies");
-
-        return instance;
 
         async function makeIndex(
             name: string,

--- a/ts/examples/spelunker/src/chunkyIndex.ts
+++ b/ts/examples/spelunker/src/chunkyIndex.ts
@@ -85,7 +85,6 @@ export class ChunkyIndex {
         }
     }
 
-    // TODO: Do this type-safe?
     getIndexByName(name: IndexType): knowLib.TextIndex<string, ChunkId> {
         for (const pair of this.allIndexes()) {
             if (pair.name === name) {

--- a/ts/examples/spelunker/src/main.ts
+++ b/ts/examples/spelunker/src/main.ts
@@ -11,7 +11,7 @@ import { fileURLToPath } from "url";
 
 // Local imports
 import { importPythonFiles } from "./pythonImporter.js";
-import { runQueryInterface } from "./queryInterface.js";
+import { interactiveQueryLoop } from "./queryInterface.js";
 import { ChunkyIndex } from "./chunkyIndex.js";
 
 // Set __dirname to emulate old JS behavior
@@ -23,68 +23,58 @@ const envPath = new URL("../../../.env", import.meta.url);
 dotenv.config({ path: envPath });
 
 // Sample file to load with `-` argument
-const sampleFile = path.join(__dirname, "sample.py.txt");
+const sampleFile = path.join(__dirname, "chunker.py");
+
+const usageMessage = `\
+Usage:
+Loading modules:
+    node dist/main.js file1.py [file2.py] ...  # Load files
+    node dist/main.js --files filelist.txt     # Load files listed in filelist.txt
+    node dist/main.js -  # Load sample file (${path.relative(process.cwd(), sampleFile)})
+Interactive query loop:
+    node dist/main.js    # Query previously loaded files (use @search --query 'your query')
+Verbose mode: add -v or --verbose before any of the above commands.
+You can also use 'pnpm start' instead of 'node dist/main.js'.
+Actual args: '${process.argv[0]}' '${process.argv[1]}'
+`;
 
 await main();
 
 async function main(): Promise<void> {
-    const t0 = Date.now();
+    // TODO: switch to whatever interactive-app uses to parse the command line?
 
-    // TODO: switch to whatever interactive-app does.
-    const help =
-        process.argv.includes("-h") ||
-        process.argv.includes("--help") ||
-        process.argv.includes("-?") ||
-        process.argv.includes("--?");
+    const helpFlags = ["-h", "--help", "-?", "--?"];
+    const help = helpFlags.some((arg) => process.argv.includes(arg));
     if (help) {
-        console.log(
-            "Usage:\n" +
-                "Loading modules:\n" +
-                "   node main.js file1.py [file2.py] ...  # Load files\n" +
-                "   node main.js --files filelist.txt  # Load files listed in filelist.txt\n" +
-                `   node main.js -  # Load sample file (${path.relative(process.cwd(), sampleFile)})\n` +
-                "Interactive query loop:\n" +
-                "   node main.js    # Query previously loaded files (use @search --query 'your query')\n",
-        );
+        console.log(usageMessage);
         return;
     }
 
-    const verbose =
-        process.argv.includes("-v") || process.argv.includes("--verbose");
+    const verboseFlags = ["-v", "--verbose"];
+    const verbose = verboseFlags.some((arg) => process.argv.includes(arg));
     if (verbose) {
         process.argv = process.argv.filter(
             (arg) => arg !== "-v" && arg !== "--verbose",
         );
     }
 
-    const files = processArgs();
+    const files = parseCommandLine();
 
-    let homeDir = process.platform === "darwin" ? process.env.HOME || "" : "";
-    const rootDir = path.join(homeDir, "/data/spelunker");
-    const chunkyIndex = await ChunkyIndex.createInstance(rootDir);
+    const homeDir = process.platform === "darwin" ? process.env.HOME || "" : "";
+    const databaseRootDir = path.join(homeDir, "/data/spelunker");
 
-    const t1 = Date.now();
-    console.log(`[Initialized in ${((t1 - t0) * 0.001).toFixed(3)} seconds]`);
+    const chunkyIndex = await ChunkyIndex.createInstance(databaseRootDir);
 
-    // Import all files. (TODO: Break up very long lists.)
     if (files.length > 0) {
-        console.log(`[Importing ${files.length} files]`);
-        const t0 = Date.now();
-
-        await importPythonFiles(files, chunkyIndex, verbose);
-
-        const t1 = Date.now();
-        console.log(
-            `[Imported ${files.length} files in ${((t1 - t0) * 0.001).toFixed(3)} seconds]`,
-        );
+        await importAllFiles(files, chunkyIndex, verbose);
     } else {
-        await runQueryInterface(chunkyIndex, verbose);
+        await interactiveQueryLoop(chunkyIndex, verbose);
     }
 }
 
-function processArgs(): string[] {
+function parseCommandLine(): string[] {
     let files: string[];
-    // TODO: Use a proper command-line parser.
+    // TODO: Use a proper command-line parser?
     if (process.argv.length > 2) {
         files = process.argv.slice(2);
         if (files.length === 1 && files[0] === "-") {
@@ -102,4 +92,20 @@ function processArgs(): string[] {
         files = [];
     }
     return files;
+}
+
+async function importAllFiles(
+    files: string[],
+    chunkyIndex: ChunkyIndex,
+    verbose: boolean,
+): Promise<void> {
+    console.log(`[Importing ${files.length} files]`);
+
+    const t0 = Date.now();
+    await importPythonFiles(files, chunkyIndex, verbose);
+    const t1 = Date.now();
+
+    console.log(
+        `[Imported ${files.length} files in ${((t1 - t0) * 0.001).toFixed(3)} seconds]`,
+    );
 }

--- a/ts/examples/spelunker/src/main.ts
+++ b/ts/examples/spelunker/src/main.ts
@@ -71,7 +71,7 @@ async function main(): Promise<void> {
         console.log(`[Importing ${files.length} files]`);
         const t0 = Date.now();
 
-        await importPythonFiles(files, chunkyIndex, true, verbose);
+        await importPythonFiles(files, chunkyIndex, verbose);
 
         const t1 = Date.now();
         console.log(

--- a/ts/examples/spelunker/src/main.ts
+++ b/ts/examples/spelunker/src/main.ts
@@ -10,7 +10,7 @@ import path from "path";
 import { fileURLToPath } from "url";
 
 // Local imports
-import { importPythonFiles } from "./pythonImporter.js";
+import { importAllFiles } from "./pythonImporter.js";
 import { interactiveQueryLoop } from "./queryInterface.js";
 import { ChunkyIndex } from "./chunkyIndex.js";
 
@@ -92,20 +92,4 @@ function parseCommandLine(): string[] {
         files = [];
     }
     return files;
-}
-
-async function importAllFiles(
-    files: string[],
-    chunkyIndex: ChunkyIndex,
-    verbose: boolean,
-): Promise<void> {
-    console.log(`[Importing ${files.length} files]`);
-
-    const t0 = Date.now();
-    await importPythonFiles(files, chunkyIndex, verbose);
-    const t1 = Date.now();
-
-    console.log(
-        `[Imported ${files.length} files in ${((t1 - t0) * 0.001).toFixed(3)} seconds]`,
-    );
 }

--- a/ts/examples/spelunker/src/pythonImporter.ts
+++ b/ts/examples/spelunker/src/pythonImporter.ts
@@ -203,22 +203,42 @@ async function embedChunk(
     }
 }
 
-// Wrap words in anger. Written by Github Copilot.
-// TODO: Wrap each line separately; Honor indents; honor '*' or '-' for bullets.
-export function wordWrap(text: string, width: number = 80): string {
-    const words = text.split(/\s+/);
-    let line = "";
-    let lines = [];
-    for (const word of words) {
-        if (line.length + word.length + 1 > width) {
-            lines.push(line);
-            line = word;
-        } else {
-            line += (line.length ? " " : "") + word;
+// Wrap long lines. Still written by Github Copilot.
+export function wordWrap(text: string, wrapLength: number = 100): string {
+    const wrappedLines: string[] = [];
+
+    text.split("\n").forEach((line) => {
+        let match = line.match(/^(\s*[-*]\s+|\s*)/); // Match leading indent or "- ", "* ", etc.
+        let indent = match ? match[0] : "";
+        let baseIndent = indent;
+
+        // Special handling for list items: add 2 spaces to the indent for overflow lines
+        if (match && /^(\s*[-*]\s+)/.test(indent)) {
+            // const listMarkerLength = indent.length - indent.trimStart().length;
+            indent = " ".repeat(indent.length + 2);
         }
-    }
-    lines.push(line);
-    return lines.join("\n");
+
+        let currentLine = "";
+        line.trimEnd()
+            .split(/\s+/)
+            .forEach((word) => {
+                if (
+                    currentLine.length + word.length + 1 > wrapLength &&
+                    currentLine.length > 0
+                ) {
+                    wrappedLines.push(baseIndent + currentLine.trimEnd());
+                    currentLine = indent + word + " ";
+                } else {
+                    currentLine += word + " ";
+                }
+            });
+
+        if (currentLine.trimEnd()) {
+            wrappedLines.push(baseIndent + currentLine.trimEnd());
+        }
+    });
+
+    return wrappedLines.join("\n");
 }
 
 async function writeToIndex(

--- a/ts/examples/spelunker/src/queryInterface.ts
+++ b/ts/examples/spelunker/src/queryInterface.ts
@@ -3,15 +3,18 @@
 
 // User interface for querying the index.
 
+import * as fs from "fs";
+import path from "path";
+
 import * as iapp from "interactive-app";
 import * as knowLib from "knowledge-processor";
-import path from "path";
 import { ScoredItem } from "typeagent";
+
 import { IndexType, ChunkyIndex } from "./chunkyIndex.js";
 import { FileDocumentation } from "./fileDocSchema.js";
+import { QuerySpec } from "./makeQuerySchema.js";
 import { Chunk, ChunkId } from "./pythonChunker.js";
 import { wordWrap } from "./pythonImporter.js";
-import { QuerySpec } from "./makeQuerySchema.js";
 
 type QueryOptions = {
     maxHits: number;
@@ -24,6 +27,8 @@ export async function interactiveQueryLoop(
     verbose = false,
 ): Promise<void> {
     const handlers: Record<string, iapp.CommandHandler> = {
+        import: importHandler,
+        clearMemory,
         search,
         summaries,
         keywords,
@@ -32,6 +37,33 @@ export async function interactiveQueryLoop(
         dependencies,
     };
     iapp.addStandardHandlers(handlers);
+
+    function importDef(): iapp.CommandMetadata {
+        return {
+            // TODO
+        };
+    }
+    handlers.import.metadata = importDef();
+    async function importHandler(
+        args: string[] | iapp.NamedArgs,
+        io: iapp.InteractiveIo,
+    ): Promise<void> {
+        // TODO
+    }
+
+    handlers.clearMemory.metadata = "Clear all memory (and all indexes)";
+    async function clearMemory(
+        args: string[],
+        io: iapp.InteractiveIo,
+    ): Promise<void> {
+        await fs.promises.rm(chunkyIndex.rootDir, {
+            recursive: true,
+            force: true,
+        });
+        await chunkyIndex.reInitialize(chunkyIndex.rootDir);
+        io.writer.writeLine("[All memory and all indexes cleared]");
+        // Actually the embeddings cache isn't. But we shouldn't have to care.
+    }
 
     function searchDef(): iapp.CommandMetadata {
         return {

--- a/ts/examples/spelunker/src/queryInterface.ts
+++ b/ts/examples/spelunker/src/queryInterface.ts
@@ -19,7 +19,7 @@ type QueryOptions = {
     verbose: boolean;
 };
 
-export async function runQueryInterface(
+export async function interactiveQueryLoop(
     chunkyIndex: ChunkyIndex,
     verbose = false,
 ): Promise<void> {

--- a/ts/examples/spelunker/src/queryInterface.ts
+++ b/ts/examples/spelunker/src/queryInterface.ts
@@ -581,7 +581,7 @@ async function processQuery(
     results.sort((a, b) => b.score - a.score);
     results.splice(options.maxHits);
     io.writer.writeLine(
-        `Found ${results.length} ${plural("hit", results.length)} for "${input}":`,
+        `Found ${results.length} hits for "${input}":`,
     );
 
     for (let i = 0; i < results.length; i++) {
@@ -626,11 +626,6 @@ function writeChunkLines(
             );
         }
     }
-}
-
-function plural(s: string, n: number): string {
-    // TOO: Use Intl.PluralRules.
-    return n === 1 ? s : s + "s";
 }
 
 // Wrap long lines. Still written by Github Copilot.


### PR DESCRIPTION
- Add @chunk command to display individual chunks.
- Make @search just a verbose version of the same querying that happens when a non-command is executed.
- Add @import command that takes --fileName or --files (a file containing a list of files).
- Add @clearMemory to erase the spelunker part of the database.
- Do the expensive part of import (asking the model to write a summary for each chunk in a file) concurrently.
- Various other small improvements, refactorings, code moves etc. 
