### PR TITLE
Dynamic schema creation API

### DIFF
--- a/ts/packages/actionSchema/src/creator.ts
+++ b/ts/packages/actionSchema/src/creator.ts
@@ -1,0 +1,94 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import {
+    ActionAliasTypeDefinition,
+    ActionInterfaceTypeDefinition,
+    ActionParamArray,
+    ActionParamField,
+    ActionParamObject,
+    ActionParamPrimitive,
+    ActionParamStringUnion,
+    ActionParamType,
+    ActionParamTypeReference,
+    ActionTypeDefinition,
+} from "./type.js";
+
+export function string(
+    union?: string | string[],
+): ActionParamPrimitive | ActionParamStringUnion {
+    return union
+        ? {
+              type: "string-union",
+              typeEnum: Array.isArray(union) ? union : [union],
+          }
+        : { type: "string" };
+}
+
+export function number(): ActionParamPrimitive {
+    return { type: "number" };
+}
+
+export function boolean(): ActionParamPrimitive {
+    return { type: "boolean" };
+}
+
+export function array(elementType: ActionParamType): ActionParamArray {
+    return { type: "array", elementType };
+}
+
+type FieldSpec = Record<string, ActionParamField | ActionParamType>;
+type CommentSpec = string | string[];
+function toComments(comments?: CommentSpec) {
+    return Array.isArray(comments)
+        ? comments
+        : comments
+          ? [comments]
+          : undefined;
+}
+
+export function type(
+    name: string,
+    type: ActionParamType,
+    comments?: CommentSpec,
+): ActionAliasTypeDefinition {
+    return { alias: true, name, type, comments: toComments(comments) };
+}
+
+export function inf(
+    name: string,
+    type: ActionParamObject,
+    comments?: CommentSpec,
+): ActionInterfaceTypeDefinition {
+    return { alias: false, name, type, comments: toComments(comments) };
+}
+
+export function field(
+    type: ActionParamType,
+    comments?: CommentSpec,
+): ActionParamField {
+    return { type, comments: toComments(comments) };
+}
+
+export function optional(
+    type: ActionParamType,
+    comments?: CommentSpec,
+): ActionParamField {
+    return { optional: true, type, comments: toComments(comments) };
+}
+
+export function obj(f: FieldSpec): ActionParamObject {
+    const fields: Record<string, ActionParamField> = {};
+    for (const [key, value] of Object.entries(f)) {
+        const fl = typeof value.type === "string" ? field(value) : value;
+        fields[key] = fl;
+    }
+    return { type: "object", fields };
+}
+
+export function ref(
+    name: string,
+    definition: ActionTypeDefinition,
+): ActionParamTypeReference {
+    return { type: "type-reference", name, definition };
+}

--- a/ts/packages/actionSchema/src/generator.ts
+++ b/ts/packages/actionSchema/src/generator.ts
@@ -82,14 +82,12 @@ function generateTypeDefinition(
 }
 
 export function generateSchema(
-    actionSchemas: ActionSchema[],
+    definitions: ActionTypeDefinition[],
     typeName: string = "AllAction",
-    exact: boolean = false, // for testing
-): string {
+    exact: boolean = false,
+) {
     const emitted = new Map<ActionTypeDefinition, string[]>();
-    const pending: ActionTypeDefinition[] = actionSchemas.map(
-        (actionInfo) => actionInfo.definition,
-    );
+    const pending: ActionTypeDefinition[] = [...definitions];
 
     while (pending.length > 0) {
         const definition = pending.pop()!;
@@ -110,10 +108,10 @@ export function generateSchema(
 
     const finalLines: string[] = [];
 
-    if (actionSchemas.length !== 1 || actionSchemas[0].typeName !== typeName) {
+    if (definitions.length !== 1 || definitions[0].name !== typeName) {
         // If there is only on action and it is the type name, don't need to emit the main type alias
         finalLines.push(
-            `export type ${typeName} = ${actionSchemas.map((actionInfo) => actionInfo.typeName).join("|")};`,
+            `export type ${typeName} = ${definitions.map((definition) => definition.name).join("|")};`,
         );
     }
 
@@ -121,4 +119,16 @@ export function generateSchema(
         finalLines.push(...emitted.get(key)!);
     }
     return finalLines.join("\n");
+}
+
+export function generateActionSchema(
+    actionSchemas: ActionSchema[],
+    typeName: string = "AllAction",
+    exact: boolean = false, // for testing
+): string {
+    return generateSchema(
+        actionSchemas.map((actionInfo) => actionInfo.definition),
+        typeName,
+        exact,
+    );
 }

--- a/ts/packages/actionSchema/src/index.ts
+++ b/ts/packages/actionSchema/src/index.ts
@@ -9,8 +9,10 @@ export {
 } from "./type.js";
 
 export { parseActionSchemaFile } from "./parser.js";
-export { generateSchema } from "./generator.js";
+export { generateActionSchema, generateSchema } from "./generator.js";
 export { validateAction } from "./validate.js";
 export { getParameterType, getParameterNames } from "./utils.js";
 
 export { NodeType, SchemaParser, ISymbol, SymbolNode } from "./schemaParser.js";
+
+export * as ActionSchemaCreator from "./creator.js";

--- a/ts/packages/actionSchema/src/type.ts
+++ b/ts/packages/actionSchema/src/type.ts
@@ -46,7 +46,7 @@ export type ActionInterfaceTypeDefinition = {
     name: string;
     type: ActionParamObject;
     comments?: string[] | undefined;
-    exported: boolean; // for exact regen
+    exported?: boolean; // for exact regen
     order?: number; // for exact regen
 };
 
@@ -55,7 +55,7 @@ export type ActionAliasTypeDefinition<T = ActionParamType> = {
     name: string;
     type: T;
     comments?: string[] | undefined;
-    exported: boolean; // for exact regen
+    exported?: boolean; // for exact regen
     order?: number; // for exact regen
 };
 
@@ -76,7 +76,6 @@ export type ActionParamType =
 
 export type ActionSchema = {
     translatorName: string;
-    typeName: string;
     actionName: string;
     definition: ActionSchemaTypeDefinition;
 };

--- a/ts/packages/actionSchema/test/regen.spec.ts
+++ b/ts/packages/actionSchema/test/regen.spec.ts
@@ -8,7 +8,7 @@ import os from "node:os";
 import { parseActionSchemaFile } from "../src/parser.js";
 
 import { fileURLToPath } from "node:url";
-import { generateSchema } from "../src/generator.js";
+import { generateActionSchema } from "../src/generator.js";
 
 const dispatcherPath = fileURLToPath(
     new URL("../../../dispatcher", import.meta.url),
@@ -118,11 +118,11 @@ describe("Action Schema Regeneration", () => {
                 tempTestDir,
                 `${name}.${process.pid}.ts`,
             );
-            const regenerated = await generateSchema(actionSchemas, type);
+            const regenerated = await generateActionSchema(actionSchemas, type);
             fs.writeFileSync(tempFile, regenerated);
 
             const roundtrip = parseActionSchemaFile(tempFile, name, type);
-            const schema2 = await generateSchema(roundtrip, type);
+            const schema2 = await generateActionSchema(roundtrip, type);
             expect(schema2).toEqual(regenerated);
 
             fs.unlinkSync(tempFile);

--- a/ts/packages/cache/src/explanation/v5/alternativesExplanationV5.ts
+++ b/ts/packages/cache/src/explanation/v5/alternativesExplanationV5.ts
@@ -88,9 +88,7 @@ export function createAlternativesExplainer(
                 getPackageFilePath(
                     "./src/explanation/v5/alternativesExplanationSchemaV5.ts",
                 ),
-                undefined,
-                undefined,
-                model,
+                { model },
             );
         },
         createInstructions,

--- a/ts/packages/cache/src/explanation/v5/politenessGeneralizationV5.ts
+++ b/ts/packages/cache/src/explanation/v5/politenessGeneralizationV5.ts
@@ -41,9 +41,7 @@ export function createPolitenessGeneralizer(
                 getPackageFilePath(
                     "./src/explanation/v5/politenessGeneralizationSchemaV5.ts",
                 ),
-                undefined,
-                undefined,
-                model,
+                { model },
             );
         },
         createInstructions,

--- a/ts/packages/cache/src/explanation/v5/propertyExplainationV5.ts
+++ b/ts/packages/cache/src/explanation/v5/propertyExplainationV5.ts
@@ -20,7 +20,6 @@ import {
     ensureProperties,
 } from "../validateExplanation.js";
 import { form } from "./explanationV5.js";
-import { getLanguageTools } from "../../utils/language.js";
 import { ExplainerConfig } from "../genericExplainer.js";
 
 export type PropertyExplainer = TypeChatAgent<
@@ -43,9 +42,7 @@ export function createPropertyExplainer(
                         ? "./src/explanation/v5/propertyExplanationSchemaV5WithContext.ts"
                         : "./src/explanation/v5/propertyExplanationSchemaV5.ts",
                 ),
-                undefined,
-                undefined,
-                model,
+                { model },
             );
         },
         (requestAction: RequestAction) => {

--- a/ts/packages/cache/src/explanation/v5/subPhraseExplanationV5.ts
+++ b/ts/packages/cache/src/explanation/v5/subPhraseExplanationV5.ts
@@ -64,9 +64,7 @@ export function createSubPhraseExplainer(model?: string) {
                 getPackageFilePath(
                     "./src/explanation/v5/subPhraseExplanationSchemaV5.ts",
                 ),
-                undefined,
-                undefined,
-                model,
+                { model },
             );
         },
         createInstructions,

--- a/ts/packages/cache/src/tsconfig.json
+++ b/ts/packages/cache/src/tsconfig.json
@@ -4,7 +4,6 @@
     "composite": true,
     "rootDir": ".",
     "outDir": "../dist",
-    "noUnusedLocals": false,
   },
   "include": ["./**/*"],
   "ts-node": {

--- a/ts/packages/cli/src/commands/schema.ts
+++ b/ts/packages/cli/src/commands/schema.ts
@@ -10,7 +10,7 @@ import {
     getBuiltinTranslatorConfigProvider,
     getActionSchema,
 } from "agent-dispatcher/internal";
-import { generateSchema } from "action-schema";
+import { generateActionSchema } from "action-schema";
 
 export default class Schema extends Command {
     static description = "Show schema used by translators";
@@ -54,7 +54,7 @@ export default class Schema extends Command {
                     provider,
                 );
                 if (actionSchema) {
-                    console.log(generateSchema([actionSchema]));
+                    console.log(generateActionSchema([actionSchema]));
                 } else {
                     console.error(
                         `Action ${args.actionName} not found in translator ${args.translator}`,

--- a/ts/packages/dispatcher/src/handlers/configCommandHandlers.ts
+++ b/ts/packages/dispatcher/src/handlers/configCommandHandlers.ts
@@ -15,7 +15,7 @@ import { getLocalWhisperCommandHandlers } from "./serviceHost/localWhisperComman
 
 import { simpleStarRegex } from "common-utils";
 import { openai as ai, getChatModelNames } from "aiclient";
-import { SessionConfig, SessionOptions } from "../session/session.js";
+import { SessionOptions } from "../session/session.js";
 import chalk from "chalk";
 import {
     ActionContext,

--- a/ts/packages/dispatcher/src/handlers/requestCommandHandler.ts
+++ b/ts/packages/dispatcher/src/handlers/requestCommandHandler.ts
@@ -497,11 +497,13 @@ function getChatHistoryForTranslation(
     context: CommandHandlerContext,
 ): HistoryContext {
     const promptSections = context.chatHistory.getPromptSections();
-    promptSections.unshift({
-        content:
-            "The following is a history of the conversation with the user that can be used to translate user requests",
-        role: "system",
-    });
+    if (promptSections.length !== 0) {
+        promptSections.unshift({
+            content:
+                "The following is a history of the conversation with the user that can be used to translate user requests",
+            role: "system",
+        });
+    }
     const entities = context.chatHistory.getTopKEntities(20);
     const additionalInstructions = context.session.getConfig().translation
         .promptConfig.additionalInstructions

--- a/ts/packages/dispatcher/src/translation/actionJsonValidator.ts
+++ b/ts/packages/dispatcher/src/translation/actionJsonValidator.ts
@@ -3,12 +3,16 @@
 
 import { error, Result, success, TypeChatJsonValidator } from "typechat";
 import { TranslatedAction } from "../handlers/requestCommandHandler.js";
-import { ActionSchema, generateSchema, validateAction } from "action-schema";
+import {
+    ActionSchema,
+    generateActionSchema,
+    validateAction,
+} from "action-schema";
 
 export function createTypeAgentJsonValidator(
     actionInfos: ActionSchema[],
 ): TypeChatJsonValidator<TranslatedAction> {
-    const schema = generateSchema(actionInfos);
+    const schema = generateActionSchema(actionInfos);
     return {
         getSchemaText: () => schema,
         getTypeName: () => "AllActions",
@@ -30,7 +34,6 @@ export function createTypeAgentJsonValidator(
             } catch (e: any) {
                 return error(e.message);
             }
-            return error("Validation failed");
         },
     };
 }

--- a/ts/packages/dispatcher/src/translation/agentTranslators.ts
+++ b/ts/packages/dispatcher/src/translation/agentTranslators.ts
@@ -336,9 +336,7 @@ export function loadAgentJsonTranslator<T extends object = object>(
             activeTranslators,
             multipleActions,
         ),
-        undefined,
-        undefined,
-        model,
+        { model },
     );
 
     const streamingTranslator = enableJsonTranslatorStreaming(translator);

--- a/ts/packages/dispatcher/src/translation/unknownSwitcher.ts
+++ b/ts/packages/dispatcher/src/translation/unknownSwitcher.ts
@@ -9,18 +9,18 @@ import { getTranslatorActionSchemas } from "./actionSchema.js";
 import { Result, success } from "typechat";
 import registerDebug from "debug";
 import { TranslatorConfigProvider } from "./agentTranslators.js";
+import { generateSchema, ActionSchemaCreator as sc } from "action-schema";
 
 const debugSwitchSearch = registerDebug("typeagent:switch:search");
 
-function createSelectionSchema(
+function createSelectionActionTypeDefinition(
     translatorName: string,
     provider: TranslatorConfigProvider,
-): InlineTranslatorSchemaDef | undefined {
+) {
     const translatorConfig = provider.getTranslatorConfig(translatorName);
     // Skip injected schemas except for chat; investigate whether we can get chat always on first pass
     if (translatorConfig.injected && translatorName !== "chat") {
         // No need to select for injected schemas
-        selectSchemaCache.set(translatorName, undefined);
         return undefined;
     }
     const actionSchemas = getTranslatorActionSchemas(
@@ -31,26 +31,48 @@ function createSelectionSchema(
     const actionNames: string[] = [];
     const actionComments: string[] = [];
     for (const info of actionSchemas.values()) {
-        actionNames.push(`"${info.actionName}"`);
+        actionNames.push(info.actionName);
         actionComments.push(
-            `"${info.actionName}"${info.definition.comments ? ` - ${info.definition.comments[0]}` : ""}`,
+            ` "${info.actionName}"${info.definition.comments ? ` - ${info.definition.comments[0].trim()}` : ""}`,
         );
     }
 
     if (actionNames.length === 0) {
-        selectSchemaCache.set(translatorName, undefined);
         return undefined;
     }
-    const typeName = `${translatorConfig.schemaType}Assistant`;
-    const schema = `
-export type ${typeName} = {
-    // ${translatorConfig.description}
-    assistant: "${translatorName}";
-    // ${actionComments.join("\n    // ")}
-    action: ${actionNames.join(" | ")};
-};`;
 
-    return { kind: "inline", typeName, schema };
+    const typeName = `${translatorConfig.schemaType}Assistant`;
+
+    const schema = sc.type(
+        typeName,
+        sc.obj({
+            assistant: sc.field(
+                sc.string(translatorName),
+                ` ${translatorConfig.description}`,
+            ),
+            action: sc.field(sc.string(actionNames), actionComments),
+        }),
+    );
+    return schema;
+}
+
+function createSelectionSchema(
+    translatorName: string,
+    provider: TranslatorConfigProvider,
+): InlineTranslatorSchemaDef | undefined {
+    const schema = createSelectionActionTypeDefinition(
+        translatorName,
+        provider,
+    );
+    if (schema === undefined) {
+        return undefined;
+    }
+    const typeName = schema.name;
+    return {
+        kind: "inline",
+        typeName,
+        schema: generateSchema([schema], typeName),
+    };
 }
 
 const selectSchemaCache = new Map<
@@ -138,13 +160,15 @@ export function loadAssistantSelectionJsonTranslator(
                 entries
                     .map((entry) => entry.schema)
                     .concat(unknownAssistantSelectionSchemaDef),
-                undefined,
-                [
-                    {
-                        role: "system",
-                        content: "Select the assistant to handle the request",
-                    },
-                ],
+                {
+                    instructions: [
+                        {
+                            role: "system",
+                            content:
+                                "Select the assistant to handle the request",
+                        },
+                    ],
+                },
             ),
         };
     });


### PR DESCRIPTION
Implement dynamic schema create API.  Switch large assistant switcher to use it.

Also:
- refactor `createJsonTranslatorFromSchemaDef` to allow for creating translator with an alternate validator, in preparation for using action schema based validator.
- Stop adding the history system prompt section when there is no history.
- Simply createJsonTranslator* parameters with option object.
- Allow generation of schema that are not `Action`.
