### PR TITLE
Switch inline switcher and multiple action schema to use dynamic action schema creation API

### DIFF
--- a/ts/packages/actionSchema/src/creator.ts
+++ b/ts/packages/actionSchema/src/creator.ts
@@ -14,15 +14,17 @@ import {
     SchemaTypeNumber,
     SchemaTypeBoolean,
     SchemaTypeString,
+    SchemaTypeUnion,
 } from "./type.js";
 
 export function string(
-    ...union: string[]
+    ...union: (string | string[])[]
 ): SchemaTypeString | SchemaTypeStringUnion {
-    return union.length !== 0
+    const flat = union.flat();
+    return flat.length !== 0
         ? {
               type: "string-union",
-              typeEnum: union,
+              typeEnum: flat,
           }
         : { type: "string" };
 }
@@ -35,13 +37,15 @@ export function boolean(): SchemaTypeBoolean {
     return { type: "boolean" };
 }
 
-export function array(elementType: SchemaType): SchemaTypeArray {
+export function array<T extends SchemaType>(
+    elementType: T,
+): SchemaTypeArray<T> {
     return { type: "array", elementType };
 }
 
 export type FieldSpec = Record<string, SchemaObjectField | SchemaType>;
 type CommentSpec = string | string[];
-function toComments(comments?: CommentSpec) {
+function toComments(comments?: CommentSpec): string[] | undefined {
     return Array.isArray(comments)
         ? comments
         : comments
@@ -50,51 +54,92 @@ function toComments(comments?: CommentSpec) {
 }
 
 // alias definition
-export function type(
+export function type<T extends SchemaType = SchemaType>(
     name: string,
-    type: SchemaType,
+    type: T,
     comments?: CommentSpec,
-): SchemaTypeAliasDefinition {
-    return { alias: true, name, type, comments: toComments(comments) };
+    exported?: boolean,
+): SchemaTypeAliasDefinition<T> {
+    return {
+        alias: true,
+        name,
+        type,
+        comments: toComments(comments),
+        exported,
+    };
 }
 
 // interface definition
-export function intf(
+export function intf<T extends SchemaTypeObject = SchemaTypeObject>(
     name: string,
-    type: SchemaTypeObject,
+    type: T,
     comments?: CommentSpec,
-): SchemaTypeInterfaceDefinition {
-    return { alias: false, name, type, comments: toComments(comments) };
+    exported?: boolean,
+): SchemaTypeInterfaceDefinition<T> {
+    return {
+        alias: false,
+        name,
+        type,
+        comments: toComments(comments),
+        exported,
+    };
 }
 
-export function field(
-    type: SchemaType,
+export function field<T extends SchemaType = SchemaType>(
+    type: T,
     comments?: CommentSpec,
-): SchemaObjectField {
+): SchemaObjectField<T> {
     return { type, comments: toComments(comments) };
 }
 
-export function optional(
-    type: SchemaType,
+export function optional<T extends SchemaType = SchemaType>(
+    type: T,
     comments?: CommentSpec,
-): SchemaObjectField {
+): SchemaObjectField<T> {
     return { optional: true, type, comments: toComments(comments) };
 }
 
-export function obj(f: FieldSpec): SchemaTypeObject {
+type SchemaObjectFieldTypeFromFieldSpec<
+    T extends SchemaObjectField | SchemaType,
+> = T extends SchemaType ? SchemaObjectField<T> : T;
+
+type SchemaObjectFieldsFromSpec<T extends FieldSpec> = {
+    [K in keyof T]: SchemaObjectFieldTypeFromFieldSpec<T[K]>;
+};
+
+type SchemaTypeObjectFromSpec<T extends FieldSpec> = SchemaTypeObject<
+    SchemaObjectFieldsFromSpec<T>
+>;
+
+export function obj<T extends FieldSpec>(f: T): SchemaTypeObjectFromSpec<T> {
     const fields: Record<string, SchemaObjectField> = {};
     for (const [key, value] of Object.entries(f)) {
         const fl = typeof value.type === "string" ? field(value) : value;
         fields[key] = fl;
     }
-    return { type: "object", fields };
+    return {
+        type: "object",
+        fields: fields as SchemaObjectFieldsFromSpec<T>,
+    };
 }
 
-// Doesn't support cucular reference, so only accept existing definition only.
-export function ref(definition: SchemaTypeDefinition): SchemaTypeReference {
+export function ref<T extends SchemaTypeDefinition = SchemaTypeDefinition>(
+    definition: string | T,
+): SchemaTypeReference<T> {
+    if (typeof definition === "string") {
+        return { type: "type-reference", name: definition };
+    }
     return { type: "type-reference", name: definition.name, definition };
 }
 
-export function union(...types: SchemaType[]): SchemaType {
-    return { type: "type-union", types };
+export function union<T extends SchemaType>(
+    ...types: (T | T[])[]
+): SchemaTypeUnion<T>;
+export function union(
+    ...types: (SchemaType | SchemaType[])[]
+): SchemaTypeUnion<SchemaType>;
+export function union(
+    ...types: (SchemaType | SchemaType[])[]
+): SchemaTypeUnion<SchemaType> {
+    return { type: "type-union", types: types.flat() };
 }

--- a/ts/packages/actionSchema/src/generator.ts
+++ b/ts/packages/actionSchema/src/generator.ts
@@ -14,25 +14,36 @@ function generateSchemaType(
     type: SchemaType,
     pending: SchemaTypeDefinition[],
     indent: number,
+    strict: boolean,
     paren: boolean = false,
 ): string {
     switch (type.type) {
         case "object":
             const lines: string[] = [];
-            generateSchemaParamObject(lines, type.fields, pending, indent + 1);
+            generateSchemaObjectFields(
+                lines,
+                type.fields,
+                pending,
+                indent + 1,
+                strict,
+            );
             return `{\n${lines.join("\n")}\n${"    ".repeat(indent)}}`;
         case "array":
-            return `${generateSchemaType(type.elementType, pending, indent, true)}[]`;
+            return `${generateSchemaType(type.elementType, pending, indent, strict, true)}[]`;
         case "string-union":
             const stringUnion = type.typeEnum.map((v) => `"${v}"`).join(" | ");
             return paren ? `(${stringUnion})` : stringUnion;
         case "type-union":
             const typeUnion = type.types
-                .map((t) => generateSchemaType(t, pending, indent))
+                .map((t) => generateSchemaType(t, pending, indent, strict))
                 .join(" | ");
             return paren ? `(${typeUnion})` : typeUnion;
         case "type-reference":
-            pending.push(type.definition);
+            if (type.definition) {
+                pending.push(type.definition);
+            } else if (strict) {
+                throw new Error(`Unresolved type reference: ${type.name}`);
+            }
             return type.name;
 
         default:
@@ -52,18 +63,19 @@ function generateComments(
         lines.push(`${indentStr}//${comment}`);
     }
 }
-function generateSchemaParamObject(
+function generateSchemaObjectFields(
     lines: string[],
     fields: SchemaObjectFields,
     pending: SchemaTypeDefinition[],
     indent: number,
+    strict: boolean,
 ) {
     const indentStr = "    ".repeat(indent);
     for (const [key, field] of Object.entries(fields)) {
         generateComments(lines, field.comments, indentStr);
         const optional = field.optional ? "?" : "";
         lines.push(
-            `${indentStr}${key}${optional}: ${generateSchemaType(field.type, pending, indent)};${field.trailingComments ? ` //${field.trailingComments.join(" ")}` : ""}`,
+            `${indentStr}${key}${optional}: ${generateSchemaType(field.type, pending, indent, strict)};${field.trailingComments ? ` //${field.trailingComments.join(" ")}` : ""}`,
         );
     }
 }
@@ -72,63 +84,67 @@ function generateTypeDefinition(
     lines: string[],
     definition: SchemaTypeDefinition,
     pending: SchemaTypeDefinition[],
+    strict: boolean,
     exact: boolean,
 ) {
     generateComments(lines, definition.comments, "");
     const prefix = exact && definition.exported ? "export " : "";
-    const generatedDefinition = generateSchemaType(definition.type, pending, 0);
+    const generatedDefinition = generateSchemaType(
+        definition.type,
+        pending,
+        0,
+        strict,
+    );
     const line = definition.alias
         ? `${prefix}type ${definition.name} = ${generatedDefinition};`
         : `${prefix}interface ${definition.name} ${generatedDefinition}`;
     lines.push(line);
 }
 
-export function generateSchema(
-    definitions: SchemaTypeDefinition[],
-    typeName: string = "AllAction",
-    exact: boolean = false,
+type GenerateSchemaOptions = {
+    strict?: boolean; // default true
+    exact?: boolean; // default false
+};
+
+export function generateSchemaTypeDefinition(
+    definition: SchemaTypeDefinition,
+    options?: GenerateSchemaOptions,
 ) {
+    const strict = options?.strict ?? true;
+    const exact = options?.exact ?? false;
     const emitted = new Map<SchemaTypeDefinition, string[]>();
-    const pending = [...definitions];
+    const pending = [definition];
 
     while (pending.length > 0) {
-        const definition = pending.pop()!;
+        const definition = pending.shift()!;
         if (!emitted.has(definition)) {
             const lines: string[] = [];
             emitted.set(definition, lines);
-            generateTypeDefinition(lines, definition, pending, exact);
+            const dep: SchemaTypeDefinition[] = [];
+            generateTypeDefinition(lines, definition, dep, strict, exact);
+
+            // Generate the dependencies first to be close to the usage
+            pending.unshift(...dep);
         }
     }
 
-    const keys = exact
-        ? Array.from(emitted.keys()).sort((a, b) => {
-              const orderA = a.order ?? 0;
-              const orderB = b.order ?? 0;
+    const entries = Array.from(emitted.entries());
+    const emit = exact
+        ? entries.sort((a, b) => {
+              const orderA = a[0].order ?? 0;
+              const orderB = b[0].order ?? 0;
               return orderA - orderB;
           })
-        : Array.from(emitted.keys());
+        : entries;
 
-    const finalLines: string[] = [];
-
-    if (definitions.length !== 1 || definitions[0].name !== typeName) {
-        // If there is only on action and it is the type name, don't need to emit the main type alias
-        finalLines.push(
-            `export type ${typeName} = ${definitions.map((definition) => definition.name).join("|")};`,
-        );
-    }
-
-    for (const key of keys) {
-        finalLines.push(...emitted.get(key)!);
-    }
-    const result = finalLines.join("\n");
+    const result = emit.flatMap((e) => e[1]).join("\n");
     debug(result);
     return result;
 }
 
 export function generateActionSchema(
     actionSchemaFile: ActionSchemaFile,
-    typeName: string = "AllAction",
-    exact: boolean = false, // for testing
+    options?: GenerateSchemaOptions,
 ): string {
-    return generateSchema([actionSchemaFile.definition], typeName, exact);
+    return generateSchemaTypeDefinition(actionSchemaFile.definition, options);
 }

--- a/ts/packages/actionSchema/src/generator.ts
+++ b/ts/packages/actionSchema/src/generator.ts
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { ActionSchemaFile } from "./type.js";
 import {
     SchemaType,
     SchemaObjectFields,
     SchemaTypeDefinition,
+    ActionSchemaFile,
 } from "./type.js";
 import registerDebug from "debug";
 const debug = registerDebug("typeagent:schema:generate");

--- a/ts/packages/actionSchema/src/index.ts
+++ b/ts/packages/actionSchema/src/index.ts
@@ -6,11 +6,17 @@ export {
     SchemaTypeArray as ActionParamArray,
     SchemaTypeObject as ActionParamObject,
     ActionSchemaTypeDefinition,
+    ActionSchemaEntryTypeDefinition,
     ActionSchemaFile,
+    ActionSchemaObject,
+    ActionSchemaUnion,
 } from "./type.js";
 
 export { parseActionSchemaFile, parseActionSchemaSource } from "./parser.js";
-export { generateActionSchema, generateSchema } from "./generator.js";
+export {
+    generateActionSchema,
+    generateSchemaTypeDefinition,
+} from "./generator.js";
 export { validateAction } from "./validate.js";
 export { getParameterType, getParameterNames } from "./utils.js";
 

--- a/ts/packages/actionSchema/src/parser.ts
+++ b/ts/packages/actionSchema/src/parser.ts
@@ -13,6 +13,7 @@ import {
     SchemaTypeDefinition,
     ActionSchemaTypeDefinition,
     ActionSchemaFile,
+    ActionSchemaEntryTypeDefinition,
 } from "./type.js";
 
 function checkActionSchema(
@@ -89,6 +90,11 @@ function createActionSchemaFile(
                             "Schema Error: expected type reference in the entry type union",
                         );
                     }
+                    if (t.definition === undefined) {
+                        throw new Error(
+                            `Schema Error: unresolved type reference in the entry type union`,
+                        );
+                    }
                     pending.push(t.definition);
                 });
                 break;
@@ -97,6 +103,11 @@ function createActionSchemaFile(
                 if (strict && current.comments) {
                     throw new Error(
                         "Schema Error: entry type comments are not supported",
+                    );
+                }
+                if (current.type.definition === undefined) {
+                    throw new Error(
+                        `Schema Error: unresolved type reference in the entry type union`,
                     );
                 }
                 pending.push(current.type.definition);
@@ -113,7 +124,7 @@ function createActionSchemaFile(
     return {
         translatorName,
         actionSchemaMap: new Map(actionSchemas),
-        definition,
+        definition: definition as ActionSchemaEntryTypeDefinition,
     };
 }
 
@@ -314,7 +325,6 @@ class ActionParser {
         const result: SchemaTypeReference = {
             type: "type-reference",
             name: typeName,
-            definition: undefined!, // we will make sure this get resolved later.
         };
         this.pendingReferences.set(typeName, result);
         return result;

--- a/ts/packages/actionSchema/src/validate.ts
+++ b/ts/packages/actionSchema/src/validate.ts
@@ -30,7 +30,9 @@ export function validateSchema(
             throw new Error(`'${name}' does not match any union type`);
         }
         case "type-reference":
-            validateSchema(name, expected.definition.type, actual, coerce);
+            if (expected.definition !== undefined) {
+                validateSchema(name, expected.definition.type, actual, coerce);
+            }
             break;
         case "object":
             if (typeof actual !== "object" || Array.isArray(actual)) {

--- a/ts/packages/actionSchema/test/regen.spec.ts
+++ b/ts/packages/actionSchema/test/regen.spec.ts
@@ -98,11 +98,9 @@ describe("Action Schema Regeneration", () => {
                 type,
                 true,
             );
-            const regenerated = await generateActionSchema(
-                actionSchemaFile,
-                type,
-                true,
-            );
+            const regenerated = await generateActionSchema(actionSchemaFile, {
+                exact: true,
+            });
             await compare(original, regenerated);
         },
     );
@@ -111,13 +109,10 @@ describe("Action Schema Regeneration", () => {
         "should roundtrip regenerated - %s",
         async (name, file, type) => {
             const actionSchemaFile = parseActionSchemaFile(file, name, type);
-            const regenerated = await generateActionSchema(
-                actionSchemaFile,
-                type,
-            );
+            const regenerated = await generateActionSchema(actionSchemaFile);
 
             const roundtrip = parseActionSchemaSource(regenerated, name, type);
-            const schema2 = await generateActionSchema(roundtrip, type);
+            const schema2 = await generateActionSchema(roundtrip);
             expect(schema2).toEqual(regenerated);
         },
     );

--- a/ts/packages/agentSdk/README.md
+++ b/ts/packages/agentSdk/README.md
@@ -14,7 +14,7 @@ These are declared in the `package.json` as export paths:
 
 ### Manifest
 
-When loading dispatcher agent in a NPM package, the dispatcher first loads the manifest from the agent. It contains definition of the emoji representing the agent and the translator configuration for the agent. See the type `AppAgentManifest` and `TranslatorDefinition` for the detail.
+When loading dispatcher agent in a NPM package, the dispatcher first loads the manifest from the agent. It contains definition of the emoji representing the agent and the translator configuration for the agent. See the type `AppAgentManifest` and `ActionManifest` for the detail.
 
 ### Instantiation Entry point
 

--- a/ts/packages/agentSdk/src/agentInterface.ts
+++ b/ts/packages/agentSdk/src/agentInterface.ts
@@ -14,9 +14,9 @@ export type AppAgentManifest = {
     emojiChar: string;
     description: string;
     commandDefaultEnabled?: boolean;
-} & TranslatorDefinition;
+} & ActionManifest;
 
-export type SchemaDefinition = {
+export type SchemaManifest = {
     description: string;
     schemaType: string;
     schemaFile: string;
@@ -25,14 +25,14 @@ export type SchemaDefinition = {
     streamingActions?: string[];
 };
 
-export type TranslatorDefinition = {
+export type ActionManifest = {
     defaultEnabled?: boolean;
     translationDefaultEnabled?: boolean;
     actionDefaultEnabled?: boolean;
     transient?: boolean; // whether the translator is transient, default is false
 
-    schema?: SchemaDefinition;
-    subTranslators?: { [key: string]: TranslatorDefinition };
+    schema?: SchemaManifest;
+    subActionManifests?: { [key: string]: ActionManifest };
 };
 
 //==============================================================================

--- a/ts/packages/agentSdk/src/index.ts
+++ b/ts/packages/agentSdk/src/index.ts
@@ -3,8 +3,8 @@
 
 export {
     AppAgentManifest,
-    TranslatorDefinition,
-    SchemaDefinition,
+    ActionManifest,
+    SchemaManifest as SchemaDefinition,
     AppAgent,
     AppAgentEvent,
     SessionContext,

--- a/ts/packages/cli/src/commands/schema.ts
+++ b/ts/packages/cli/src/commands/schema.ts
@@ -10,15 +10,16 @@ import {
     getBuiltinTranslatorConfigProvider,
     getActionSchema,
 } from "agent-dispatcher/internal";
-import { generateSchema } from "action-schema";
+import { generateSchemaTypeDefinition } from "action-schema";
 
 export default class Schema extends Command {
     static description = "Show schema used by translators";
 
     static flags = {
-        change: Flags.boolean({
-            description: "Include change assistant schema",
-            default: false,
+        active: Flags.string({
+            description:
+                "Active scheam to include in the inlined change assistant schema",
+            multiple: true,
         }),
         multiple: Flags.boolean({
             description: "Include multiple action schema",
@@ -27,6 +28,10 @@ export default class Schema extends Command {
         assistant: Flags.boolean({
             description: "Show all assistant selection schema",
             default: false,
+        }),
+        generated: Flags.boolean({
+            description: "Generated schema",
+            default: true,
         }),
     };
     static args = {
@@ -54,7 +59,7 @@ export default class Schema extends Command {
                     provider,
                 );
                 if (actionSchema) {
-                    console.log(generateSchema([actionSchema]));
+                    console.log(generateSchemaTypeDefinition(actionSchema));
                 } else {
                     console.error(
                         `Action ${args.actionName} not found in translator ${args.translator}`,
@@ -67,8 +72,9 @@ export default class Schema extends Command {
                 getFullSchemaText(
                     args.translator,
                     provider,
-                    flags.change,
+                    flags.active,
                     flags.multiple,
+                    flags.generated,
                 ),
             );
         } else {

--- a/ts/packages/dispatcher/src/agent/agentConfig.ts
+++ b/ts/packages/dispatcher/src/agent/agentConfig.ts
@@ -3,7 +3,7 @@
 
 import {
     AppAgent,
-    TranslatorDefinition,
+    ActionManifest,
     AppAgentManifest,
 } from "@typeagent/agent-sdk";
 import {
@@ -39,13 +39,16 @@ export type AgentInfo = (InlineAppAgentInfo | ModuleAppAgentInfo) & {
     imports?: string[]; // for @const import
 };
 
-function patchPaths(config: TranslatorDefinition, dir: string) {
-    if (config.schema) {
-        config.schema.schemaFile = path.resolve(dir, config.schema.schemaFile);
+function patchPaths(manifest: ActionManifest, dir: string) {
+    if (manifest.schema) {
+        manifest.schema.schemaFile = path.resolve(
+            dir,
+            manifest.schema.schemaFile,
+        );
     }
-    if (config.subTranslators) {
-        for (const subTranslator of Object.values(config.subTranslators)) {
-            patchPaths(subTranslator, dir);
+    if (manifest.subActionManifests) {
+        for (const subManfiest of Object.values(manifest.subActionManifests)) {
+            patchPaths(subManfiest, dir);
         }
     }
 }

--- a/ts/packages/dispatcher/src/handlers/common/appAgentManager.ts
+++ b/ts/packages/dispatcher/src/handlers/common/appAgentManager.ts
@@ -10,8 +10,8 @@ import { CommandHandlerContext } from "./commandHandlerContext.js";
 import {
     convertToTranslatorConfigs,
     getAppAgentName,
-    TranslatorConfig,
-    TranslatorConfigProvider,
+    ActionConfig,
+    ActionConfigProvider,
 } from "../../translation/agentTranslators.js";
 import { createSessionContext } from "../../action/actionHandlers.js";
 import { AppAgentProvider } from "../../agent/agentProvider.js";
@@ -128,9 +128,9 @@ export const alwaysEnabledAgents = {
     commands: ["system"],
 };
 
-export class AppAgentManager implements TranslatorConfigProvider {
+export class AppAgentManager implements ActionConfigProvider {
     private readonly agents = new Map<string, AppAgentRecord>();
-    private readonly translatorConfigs = new Map<string, TranslatorConfig>();
+    private readonly translatorConfigs = new Map<string, ActionConfig>();
     private readonly injectedTranslatorForActionName = new Map<
         string,
         string

--- a/ts/packages/dispatcher/src/handlers/common/commandHandlerContext.ts
+++ b/ts/packages/dispatcher/src/handlers/common/commandHandlerContext.ts
@@ -27,7 +27,7 @@ import {
 import {
     getDefaultBuiltinTranslatorName,
     loadAgentJsonTranslator,
-    TranslatorConfigProvider,
+    ActionConfigProvider,
     TypeAgentTranslator,
 } from "../../translation/agentTranslators.js";
 import { getCacheFactory } from "../../utils/cacheFactory.js";
@@ -147,7 +147,7 @@ export function getTranslator(
 
 async function getAgentCache(
     session: Session,
-    provider: TranslatorConfigProvider,
+    provider: ActionConfigProvider,
     logger: Logger | undefined,
 ) {
     const cacheFactory = getCacheFactory();

--- a/ts/packages/dispatcher/src/translation/actionSchema.ts
+++ b/ts/packages/dispatcher/src/translation/actionSchema.ts
@@ -6,10 +6,7 @@ import {
     ActionSchemaTypeDefinition,
     parseActionSchemaFile,
 } from "action-schema";
-import {
-    TranslatorConfig,
-    TranslatorConfigProvider,
-} from "./agentTranslators.js";
+import { ActionConfig, ActionConfigProvider } from "./agentTranslators.js";
 import { getPackageFilePath } from "../utils/getPackageFilePath.js";
 import { AppAction } from "@typeagent/agent-sdk";
 import { DeepPartialUndefined } from "common-utils";
@@ -18,7 +15,7 @@ import { DeepPartialUndefined } from "common-utils";
 const translatorNameToActionInfo = new Map<string, ActionSchemaFile>();
 
 export function getTranslatorActionSchemas(
-    translatorConfig: TranslatorConfig,
+    translatorConfig: ActionConfig,
     translatorName: string,
 ): ActionSchemaFile {
     if (translatorNameToActionInfo.has(translatorName)) {
@@ -35,7 +32,7 @@ export function getTranslatorActionSchemas(
 
 export function getActionSchema(
     action: DeepPartialUndefined<AppAction>,
-    provider: TranslatorConfigProvider,
+    provider: ActionConfigProvider,
 ): ActionSchemaTypeDefinition | undefined {
     const { translatorName, actionName } = action;
     if (translatorName === undefined || actionName === undefined) {

--- a/ts/packages/dispatcher/src/translation/actionTemplate.ts
+++ b/ts/packages/dispatcher/src/translation/actionTemplate.ts
@@ -96,6 +96,9 @@ function toTemplateType(
             return toTemplateType(type.types[0], value);
         case "type-reference":
             // TODO: need to handle circular references (or error on circular references)
+            if (type.definition === undefined) {
+                throw new Error(`Unresolved type reference: ${type.name}`);
+            }
             return toTemplateType(type.definition.type, value);
         case "object":
             return toTemplateTypeObject(type, value);

--- a/ts/packages/dispatcher/src/translation/unknownSwitcher.ts
+++ b/ts/packages/dispatcher/src/translation/unknownSwitcher.ts
@@ -8,14 +8,17 @@ import {
 import { getTranslatorActionSchemas } from "./actionSchema.js";
 import { Result, success } from "typechat";
 import registerDebug from "debug";
-import { TranslatorConfigProvider } from "./agentTranslators.js";
-import { generateSchema, ActionSchemaCreator as sc } from "action-schema";
+import { ActionConfigProvider } from "./agentTranslators.js";
+import {
+    generateSchemaTypeDefinition,
+    ActionSchemaCreator as sc,
+} from "action-schema";
 
 const debugSwitchSearch = registerDebug("typeagent:switch:search");
 
 function createSelectionActionTypeDefinition(
     translatorName: string,
-    provider: TranslatorConfigProvider,
+    provider: ActionConfigProvider,
 ) {
     const translatorConfig = provider.getTranslatorConfig(translatorName);
     // Skip injected schemas except for chat; investigate whether we can get chat always on first pass
@@ -50,7 +53,7 @@ function createSelectionActionTypeDefinition(
                 sc.string(translatorName),
                 ` ${translatorConfig.description}`,
             ),
-            action: sc.field(sc.string(...actionNames), actionComments),
+            action: sc.field(sc.string(actionNames), actionComments),
         }),
     );
     return schema;
@@ -58,7 +61,7 @@ function createSelectionActionTypeDefinition(
 
 function createSelectionSchema(
     translatorName: string,
-    provider: TranslatorConfigProvider,
+    provider: ActionConfigProvider,
 ): InlineTranslatorSchemaDef | undefined {
     const schema = createSelectionActionTypeDefinition(
         translatorName,
@@ -71,7 +74,7 @@ function createSelectionSchema(
     return {
         kind: "inline",
         typeName,
-        schema: generateSchema([schema], typeName),
+        schema: generateSchemaTypeDefinition(schema),
     };
 }
 
@@ -81,7 +84,7 @@ const selectSchemaCache = new Map<
 >();
 function getSelectionSchema(
     translatorName: string,
-    provider: TranslatorConfigProvider,
+    provider: ActionConfigProvider,
 ): InlineTranslatorSchemaDef | undefined {
     if (selectSchemaCache.has(translatorName)) {
         return selectSchemaCache.get(translatorName);
@@ -108,7 +111,7 @@ type AssistantSelectionSchemaEntry = {
 };
 export function getAssistantSelectionSchemas(
     translatorNames: string[],
-    provider: TranslatorConfigProvider,
+    provider: ActionConfigProvider,
 ) {
     return translatorNames
         .map((name) => {
@@ -129,7 +132,7 @@ const assistantSelectionLimit = 8192 * 3;
 
 export function loadAssistantSelectionJsonTranslator(
     translatorNames: string[],
-    provider: TranslatorConfigProvider,
+    provider: ActionConfigProvider,
 ) {
     const schemas = getAssistantSelectionSchemas(translatorNames, provider);
 

--- a/ts/packages/dispatcher/src/utils/loadSchemaConfig.ts
+++ b/ts/packages/dispatcher/src/utils/loadSchemaConfig.ts
@@ -5,7 +5,7 @@ import { SchemaConfig } from "agent-cache";
 import fs from "node:fs";
 import path from "node:path";
 import { getPackageFilePath } from "../utils/getPackageFilePath.js";
-import { TranslatorConfigProvider } from "../translation/agentTranslators.js";
+import { ActionConfigProvider } from "../translation/agentTranslators.js";
 
 function loadSchemaConfig(schemaFile: string): SchemaConfig | undefined {
     const parseSchemaFile = path.parse(getPackageFilePath(schemaFile));
@@ -22,7 +22,7 @@ const schemaConfigCache = new Map<string, SchemaConfig | undefined>();
 
 export function loadTranslatorSchemaConfig(
     translatorName: string,
-    provider: TranslatorConfigProvider,
+    provider: ActionConfigProvider,
 ) {
     if (schemaConfigCache.has(translatorName)) {
         return schemaConfigCache.get(translatorName);


### PR DESCRIPTION
Inline switcher and multiple action schema to use dynamic action schema creation API, whether we use the in-memory validator or type script validate.   

Also, leveraging the above implemented a function to generate composite schema that is sent to the LLM (that includes the injected, inline switcher and multiple action) and wired that to `agent-cli schema --generated`.  It is not used in the actual action translation yet, and will be in a follow up PR.

Additional change:
- Add capability to have type reference that is not resolved (for the multiple action case), with the assumption that the definition will be somewhere.  
  - During generation, it will error out by default if there are unresolved type reference, but will ignore if { strict: false} is passed in to the generation function.
- Add template parameter for SchemaType types so that it can narrow the type of fields, etc.  Use to specify the shape of an `ActionSchema`, and has the compiler/intelligence know of the fields (`actionName` and `parameters`)
- Starting to transition the `translator` nomenclature to refer to a set of action schema for an app agent, and switch to `action` or `actionSchema` 
- Change the natural order of schema generation to be "depth" first so that type references are close to each other. 