### PR TITLE
Composed Action Schema

### DIFF
--- a/ts/packages/actionSchema/src/creator.ts
+++ b/ts/packages/actionSchema/src/creator.ts
@@ -17,6 +17,8 @@ import {
     SchemaTypeUnion,
 } from "./type.js";
 
+export function string(): SchemaTypeString;
+export function string(...union: (string | string[])[]): SchemaTypeStringUnion;
 export function string(
     ...union: (string | string[])[]
 ): SchemaTypeString | SchemaTypeStringUnion {

--- a/ts/packages/actionSchema/src/index.ts
+++ b/ts/packages/actionSchema/src/index.ts
@@ -14,6 +14,7 @@ export {
 
 export { parseActionSchemaFile, parseActionSchemaSource } from "./parser.js";
 export {
+    GenerateSchemaOptions,
     generateActionSchema,
     generateSchemaTypeDefinition,
 } from "./generator.js";

--- a/ts/packages/actionSchema/src/type.ts
+++ b/ts/packages/actionSchema/src/type.ts
@@ -106,7 +106,7 @@ export type SchemaType =
 
 export interface ActionSchemaObject extends SchemaTypeObject {
     fields: {
-        actionName: SchemaObjectField<SchemaTypeString | SchemaTypeStringUnion>;
+        actionName: SchemaObjectField<SchemaTypeStringUnion>;
         parameters: SchemaObjectField<
             | SchemaTypeObject
             | SchemaTypeReference<
@@ -132,8 +132,12 @@ type ActionSchemaTypeReference =
 export type ActionSchemaUnion = SchemaTypeUnion<ActionSchemaTypeReference>;
 
 export type ActionSchemaFile = {
+    // The entry type definition for the action schema.
     entry: ActionSchemaEntryTypeDefinition;
+    // Map action name to action type definition
     actionSchemas: Map<string, ActionSchemaTypeDefinition>;
+    // Schema name
     schemaName?: string;
+    // Order for the type definitions
     order?: Map<string, number>; // for exact regen
 };

--- a/ts/packages/actionSchema/src/type.ts
+++ b/ts/packages/actionSchema/src/type.ts
@@ -87,7 +87,6 @@ export type SchemaTypeAliasDefinition<T extends SchemaType = SchemaType> = {
     type: T;
     comments?: string[] | undefined;
     exported?: boolean | undefined; // for exact regen
-    order?: number; // for exact regen
 };
 
 export type SchemaTypeDefinition =
@@ -133,7 +132,8 @@ type ActionSchemaTypeReference =
 export type ActionSchemaUnion = SchemaTypeUnion<ActionSchemaTypeReference>;
 
 export type ActionSchemaFile = {
-    translatorName: string;
-    actionSchemaMap: Map<string, ActionSchemaTypeDefinition>;
-    definition: ActionSchemaEntryTypeDefinition;
+    entry: ActionSchemaEntryTypeDefinition;
+    actionSchemas: Map<string, ActionSchemaTypeDefinition>;
+    schemaName?: string;
+    order?: Map<string, number>; // for exact regen
 };

--- a/ts/packages/agents/player/src/trackFilter.ts
+++ b/ts/packages/agents/player/src/trackFilter.ts
@@ -217,7 +217,6 @@ export function parseFilter(filter: string): IFilterResult {
             }
         } else if (token.type === FilterTokenType.Value) {
             if (!pendingConstraint) {
-                console.log(token.rawValue);
                 return {
                     diagnostics: [
                         "Unexpected: value without constraint prefix",

--- a/ts/packages/cli/src/commands/schema.ts
+++ b/ts/packages/cli/src/commands/schema.ts
@@ -31,6 +31,7 @@ export default class Schema extends Command {
         }),
         generated: Flags.boolean({
             description: "Generated schema",
+            allowNo: true,
             default: true,
         }),
     };

--- a/ts/packages/dispatcher/src/agent/inlineAgentHandlers.ts
+++ b/ts/packages/dispatcher/src/agent/inlineAgentHandlers.ts
@@ -209,7 +209,7 @@ class ActionCommandHandler implements CommandHandler {
             config,
             translatorName,
         );
-        const actionSchema = actionSchemaFile.actionSchemaMap.get(actionName);
+        const actionSchema = actionSchemaFile.actionSchemas.get(actionName);
         if (actionSchema === undefined) {
             throw new Error(
                 `Invalid action name ${actionName} for translator ${translatorName}`,
@@ -259,7 +259,7 @@ class ActionCommandHandler implements CommandHandler {
                     translatorName,
                 );
 
-                completions.push(...actionSchemaFile.actionSchemaMap.keys());
+                completions.push(...actionSchemaFile.actionSchemas.keys());
                 continue;
             }
 

--- a/ts/packages/dispatcher/src/handlers/common/appAgentManager.ts
+++ b/ts/packages/dispatcher/src/handlers/common/appAgentManager.ts
@@ -218,7 +218,7 @@ export class AppAgentManager implements ActionConfigProvider {
                         config,
                         name,
                     );
-                    for (const actionName of actionSchemaFile.actionSchemaMap.keys()) {
+                    for (const actionName of actionSchemaFile.actionSchemas.keys()) {
                         this.injectedTranslatorForActionName.set(
                             actionName,
                             name,

--- a/ts/packages/dispatcher/src/translation/actionSchema.ts
+++ b/ts/packages/dispatcher/src/translation/actionSchema.ts
@@ -44,5 +44,5 @@ export function getActionSchema(
     }
 
     const actionSchemaFile = getTranslatorActionSchemas(config, translatorName);
-    return actionSchemaFile.actionSchemaMap.get(actionName);
+    return actionSchemaFile.actionSchemas.get(actionName);
 }

--- a/ts/packages/dispatcher/src/translation/actionTemplate.ts
+++ b/ts/packages/dispatcher/src/translation/actionTemplate.ts
@@ -127,11 +127,11 @@ function toTemplate(
         translators,
         action.translatorName,
     );
-    const actionInfos = getTranslatorActionSchemas(
+    const actionSchemaFile = getTranslatorActionSchemas(
         config,
         action.translatorName,
     );
-    const actionSchemas = actionInfos.actionSchemaMap;
+    const actionSchemas = actionSchemaFile.actionSchemas;
     const actionName: TemplateFieldStringUnion = {
         type: "string-union",
         typeEnum: Array.from(actionSchemas.keys()),

--- a/ts/packages/dispatcher/src/translation/agentTranslators.ts
+++ b/ts/packages/dispatcher/src/translation/agentTranslators.ts
@@ -30,6 +30,7 @@ import {
 import { TranslatedAction } from "../handlers/requestCommandHandler.js";
 import {
     ActionSchemaTypeDefinition,
+    generateActionSchema,
     generateSchemaTypeDefinition,
     ActionSchemaCreator as sc,
 } from "action-schema";
@@ -418,16 +419,19 @@ export function getFullSchemaText(
     activeSchemas: string[] | undefined,
     multipleActions: boolean,
     generated: boolean,
-) {
+): string {
     const active = activeSchemas
         ? Object.fromEntries(activeSchemas.map((name) => [name, true]))
         : undefined;
     if (generated) {
-        return composeActionSchema(
-            translatorName,
-            provider,
-            active,
-            multipleActions,
+        return generateActionSchema(
+            composeActionSchema(
+                translatorName,
+                provider,
+                active,
+                multipleActions,
+            ),
+            { exact: true },
         );
     }
     const translatorConfig = provider.getTranslatorConfig(translatorName);

--- a/ts/packages/dispatcher/src/translation/agentTranslators.ts
+++ b/ts/packages/dispatcher/src/translation/agentTranslators.ts
@@ -362,20 +362,28 @@ export function loadAgentJsonTranslator<
 ): TypeAgentTranslator<T> {
     const translatorConfig = provider.getTranslatorConfig(translatorName);
 
-    const createTranslator = regenerateSchema
-        ? createActionJsonTranslatorFromSchemaDef<T>
-        : createJsonTranslatorFromSchemaDef<T>;
-    const translator = createTranslator(
-        "AllActions",
-        getTranslatorSchemaDefs(
-            translatorConfig,
-            translatorName,
-            provider,
-            activeTranslators,
-            multipleActions,
-        ),
-        { model },
-    );
+    const translator = regenerateSchema
+        ? createActionJsonTranslatorFromSchemaDef<T>(
+              "AllActions",
+              composeActionSchema(
+                  translatorName,
+                  provider,
+                  activeTranslators,
+                  multipleActions,
+              ),
+              { model },
+          )
+        : createJsonTranslatorFromSchemaDef<T>(
+              "AllActions",
+              getTranslatorSchemaDefs(
+                  translatorConfig,
+                  translatorName,
+                  provider,
+                  activeTranslators,
+                  multipleActions,
+              ),
+              { model },
+          );
 
     const streamingTranslator = enableJsonTranslatorStreaming(translator);
 

--- a/ts/packages/dispatcher/src/translation/unknownSwitcher.ts
+++ b/ts/packages/dispatcher/src/translation/unknownSwitcher.ts
@@ -33,7 +33,7 @@ function createSelectionActionTypeDefinition(
 
     const actionNames: string[] = [];
     const actionComments: string[] = [];
-    for (const [name, info] of actionSchemaFile.actionSchemaMap.entries()) {
+    for (const [name, info] of actionSchemaFile.actionSchemas.entries()) {
         actionNames.push(name);
         actionComments.push(
             ` "${name}"${info.comments ? ` - ${info.comments[0].trim()}` : ""}`,


### PR DESCRIPTION
Use dynamically composed action schema in the main code path, instead of generating the composed schema text and parse.

- Add capability to maintain order for composed schema.
- Separate out the order information from the schema, so that we can remap the order for the composite.
- Detect duplicate type and duplicate action names.
