### PR TITLE
[spelunker] Add @files; add @purgeFile (call from @import); colorize output

### DIFF
--- a/ts/examples/spelunker/package.json
+++ b/ts/examples/spelunker/package.json
@@ -28,6 +28,7 @@
   },
   "dependencies": {
     "aiclient": "workspace:*",
+    "chalk": "^5.3.0",
     "code-processor": "workspace:*",
     "dotenv": "^16.3.1",
     "interactive-app": "workspace:*",

--- a/ts/examples/spelunker/src/chunkyIndex.ts
+++ b/ts/examples/spelunker/src/chunkyIndex.ts
@@ -18,10 +18,7 @@ export type IndexType =
     | "topics"
     | "goals"
     | "dependencies";
-export type NamedIndex = {
-    name: IndexType;
-    index: knowLib.TextIndex<string, ChunkId>;
-};
+export type NamedIndex = [IndexType, knowLib.TextIndex<string, ChunkId>];
 
 // A bundle of object stores and indexes etc.
 export class ChunkyIndex {
@@ -31,7 +28,7 @@ export class ChunkyIndex {
     queryMaker: TypeChatJsonTranslator<QuerySpecs>;
     answerMaker: TypeChatJsonTranslator<AnswerSpecs>;
 
-    // The rest are asynchronously initialized by initialize().
+    // The rest are asynchronously initialized by reInitialize(rootDir).
     rootDir!: string;
     chunkFolder!: ObjectFolder<Chunk>;
     summariesIndex!: knowLib.TextIndex<string, ChunkId>;
@@ -85,22 +82,22 @@ export class ChunkyIndex {
         }
     }
 
-    getIndexByName(name: IndexType): knowLib.TextIndex<string, ChunkId> {
-        for (const pair of this.allIndexes()) {
-            if (pair.name === name) {
-                return pair.index;
+    getIndexByName(indexName: IndexType): knowLib.TextIndex<string, ChunkId> {
+        for (const [name, index] of this.allIndexes()) {
+            if (name === indexName) {
+                return index;
             }
         }
-        throw new Error(`Unknown index: ${name}`);
+        throw new Error(`Unknown index: ${indexName}`);
     }
 
     allIndexes(): NamedIndex[] {
         return [
-            { name: "summaries", index: this.summariesIndex },
-            { name: "keywords", index: this.keywordsIndex },
-            { name: "topics", index: this.topicsIndex },
-            { name: "goals", index: this.goalsIndex },
-            { name: "dependencies", index: this.dependenciesIndex },
+            ["summaries", this.summariesIndex],
+            ["keywords", this.keywordsIndex],
+            ["topics", this.topicsIndex],
+            ["goals", this.goalsIndex],
+            ["dependencies", this.dependenciesIndex],
         ];
     }
 }

--- a/ts/examples/spelunker/src/pythonImporter.ts
+++ b/ts/examples/spelunker/src/pythonImporter.ts
@@ -43,6 +43,7 @@ import {
     chunkifyPythonFiles,
     ErrorItem,
 } from "./pythonChunker.js";
+import { purgeNormalizedFile } from "./queryInterface.js";
 
 function log(
     io: iapp.InteractiveIo | undefined,
@@ -86,6 +87,11 @@ async function importPythonFiles(
     let filenames = files.map((file) =>
         fs.existsSync(file) ? fs.realpathSync(file) : file,
     );
+
+    // Purge previous occurrences of these files.
+    for (const fileName of filenames) {
+        await purgeNormalizedFile(io, chunkyIndex, fileName, verbose);
+    }
 
     // Chunkify Python files using a helper program. (TODO: Make generic over languages)
     const t0 = Date.now();

--- a/ts/examples/spelunker/src/queryInterface.ts
+++ b/ts/examples/spelunker/src/queryInterface.ts
@@ -327,9 +327,9 @@ export async function interactiveQueryLoop(
         return {
             description: "Show all recorded file names.",
             options: {
-                verbose: {
-                    description: "More verbose output",
-                    type: "boolean",
+                filter: {
+                    description: "Only show files containing this string",
+                    type: "string",
                 },
             },
         };

--- a/ts/pnpm-lock.yaml
+++ b/ts/pnpm-lock.yaml
@@ -220,6 +220,9 @@ importers:
       aiclient:
         specifier: workspace:*
         version: link:../../packages/aiclient
+      chalk:
+        specifier: ^5.3.0
+        version: 5.3.0
       code-processor:
         specifier: workspace:*
         version: link:../../packages/codeProcessor


### PR DESCRIPTION
- Colorize output from most commands and operations
- New command: `@files` lists all files found in the chunks; `--filter` limits output to files containing a substring.
- New command: `@purgeFile` removes all mention of a file from the indexes.
- Update `@import` to call the guts of `@purgeFile` before re-importing a file, to avoid duplicates.