### PR TITLE
[spelunker] Prompt engineering and limited conversation history

### DIFF
--- a/ts/examples/spelunker/package.json
+++ b/ts/examples/spelunker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spelunker-example",
-  "version": "0.0.1",
+  "version": "0.1",
   "private": true,
   "description": "Spelunker Example",
   "homepage": "https://github.com/microsoft/TypeAgent#readme",

--- a/ts/examples/spelunker/src/chunkyIndex.ts
+++ b/ts/examples/spelunker/src/chunkyIndex.ts
@@ -30,6 +30,7 @@ export class ChunkyIndex {
 
     // The rest are asynchronously initialized by reInitialize(rootDir).
     rootDir!: string;
+    answerFolder!: ObjectFolder<AnswerSpecs>;
     chunkFolder!: ObjectFolder<Chunk>;
     summariesIndex!: knowLib.TextIndex<string, ChunkId>;
     keywordsIndex!: knowLib.TextIndex<string, ChunkId>;
@@ -59,6 +60,10 @@ export class ChunkyIndex {
         instance.rootDir = rootDir;
         instance.chunkFolder = await createObjectFolder<Chunk>(
             instance.rootDir + "/chunks",
+            { serializer: (obj) => JSON.stringify(obj, null, 2) },
+        );
+        instance.answerFolder = await createObjectFolder<AnswerSpecs>(
+            instance.rootDir + "/answers",
             { serializer: (obj) => JSON.stringify(obj, null, 2) },
         );
         instance.summariesIndex = await makeIndex("summaries");

--- a/ts/examples/spelunker/src/makeQuerySchema.ts
+++ b/ts/examples/spelunker/src/makeQuerySchema.ts
@@ -3,18 +3,17 @@
 
 // Proposed query for one index.
 export type QuerySpec = {
-    query: string;
-    maxHits?: number;
-    minScore?: number;
+    query: string; // Ask the index for nearest neighbors to this
+    maxHits?: number; // 0 means skip; omit uses system default
 };
 
-// Proposed queries for all indexes (or unknownText if none apply).
+// Proposed queries for all indexes (use message if none apply).
 export type QuerySpecs = {
-    summaries: QuerySpec;
-    keywords: QuerySpec;
-    topics: QuerySpec;
-    goals: QuerySpec;
-    dependencies: QuerySpec;
+    summaries: QuerySpec; // A paragraph describing the code chunk
+    keywords: QuerySpec; // Short key words and phrases extracted from the code
+    topics: QuerySpec; // Slightly longer phrases relating to the code
+    goals: QuerySpec; // What the code is trying to achhieve (a shorter summary)
+    dependencies: QuerySpec; // External dependencies (actually not very useful)
 
-    unknownText?: string; // Fallback if nothing applies
+    message?: string; // Optional message to the user (notably for low confidence). Might request more input.
 };

--- a/ts/examples/spelunker/src/pythonImporter.ts
+++ b/ts/examples/spelunker/src/pythonImporter.ts
@@ -1,32 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-/*
-
-Now what to do with these chunks?
-
-Each chunk needs to be stored in a database, with embeddings from the blobs and
-their lines, and possibly other things that might be useful to search for.
-
-We should support indexing many files this way (given by glob patterns).
-
-Then we can define search over that database.
-
-A search should report the relevant chunks, and possibly the relevant lines
-within those chunks.
-
-Hopefully we can reuse the indexing and searching also used by codeMemory.ts.
-
-After that we should allow the model to send search queries to the database, and
-store conclusions (e.g. summaries or architectural notes) back there.
-
-It's too bad that we don't have a language server to help us with this, but we
-can add one for sure.
-
-We should also generalize the chunking to other languages, notably C (and
-TypeScript, of course).
-
-*/
+// TODO: Most of this is not Python specific; generalize to other languages.
 
 import chalk, { ChalkInstance } from "chalk";
 import * as fs from "fs";
@@ -176,11 +151,13 @@ async function importPythonFiles(
             }
             const t1 = Date.now();
 
-            log(
-                io,
-                `  [Documented ${chunkedFile.chunks.length} chunks in ${((t1 - t0) * 0.001).toFixed(3)} seconds for ${chunkedFile.fileName}]`,
-                chalk.grey,
-            );
+            if (verbose) {
+                log(
+                    io,
+                    `  [Documented ${chunkedFile.chunks.length} chunks in ${((t1 - t0) * 0.001).toFixed(3)} seconds for ${chunkedFile.fileName}]`,
+                    chalk.grey,
+                );
+            }
             documentedFiles.push(docs);
         },
     );
@@ -231,11 +208,13 @@ export async function embedChunkedFile(
         await embedChunk(chunk, chunkyIndex, io, verbose);
     }
     const t1 = Date.now();
-    log(
-        io,
-        `  [Embedded ${chunks.length} chunks in ${((t1 - t0) * 0.001).toFixed(3)} seconds for ${chunkedFile.fileName}]`,
-        chalk.grey,
-    );
+    if (verbose) {
+        log(
+            io,
+            `  [Embedded ${chunks.length} chunks in ${((t1 - t0) * 0.001).toFixed(3)} seconds for ${chunkedFile.fileName}]`,
+            chalk.grey,
+        );
+    }
 }
 
 async function embedChunk(
@@ -295,7 +274,7 @@ async function embedChunk(
     if (verbose) {
         log(
             io,
-            `  [Embedded ${chunk.id} (${lineCount} lines @ ${chunk.blobs[0].start}) ` +
+            `  [Embedded ${chunk.id} (${lineCount} lines @ ${chunk.blobs[0].start + 1}) ` +
                 `in ${((t1 - t0) * 0.001).toFixed(3)} seconds for ${chunk.fileName}]`,
             chalk.gray,
         );

--- a/ts/examples/spelunker/src/queryInterface.ts
+++ b/ts/examples/spelunker/src/queryInterface.ts
@@ -758,16 +758,20 @@ async function generateAnswer(
     writeNote(io, `\n[Overall ${scoredChunkIds.length} unique chunk ids]`);
 
     scoredChunkIds.sort((a, b) => b.score - a.score);
-    scoredChunkIds.splice(20); // Arbitrary number. (TODO: Make it an option.)
 
     // Step 3b: Get the chunks themselves.
     const chunks: Chunk[] = [];
-
+    const maxChunks = 20;
+    // Take the top N chunks that actually exist.
     for (const chunkId of scoredChunkIds) {
         const maybeChunk = await chunkyIndex.chunkFolder.get(chunkId.item);
-        if (maybeChunk) chunks.push(maybeChunk);
-        else {
-            writeWarning(io, `[Chunk ${chunkId.item} not found]`);
+        if (maybeChunk) {
+            chunks.push(maybeChunk);
+            if (chunks.length >= maxChunks) {
+                break;
+            }
+        } else {
+            writeNote(io, `[Chunk ${chunkId.item} not found]`);
         }
     }
 


### PR DESCRIPTION
Redesigned how we provide context to the LLM: use PromptSection[] instead of one big string, and reduce amount of data sent.

Conversation context is modeled by sending the 5 most recent user queries and answers (without extra fluff) as "user" and "assistant" prompt sections.

Also rewrote wordWrap without copilot's or ChatGPT's misguided "help".

There's also a check for missing chunks (i.e., chunks mentioned in an index but not found in the chunks folder -- this can happen if a purge operation was interrupted). I now count until I have 20 *existing* chunks rather than 20 unverified chunk IDs.

Also reorder purge so that situation shoudn't happen anymore.

Various logging tweaks.