### PR TITLE
Ensure error object on initialization

### DIFF
--- a/ts/packages/actionSchema/src/validate.ts
+++ b/ts/packages/actionSchema/src/validate.ts
@@ -123,6 +123,7 @@ function validateObject(
     expected: SchemaTypeObject,
     actual: Record<string, unknown>,
     coerce: boolean,
+    ignoreExtraneous?: string[],
 ) {
     for (const field of Object.entries(expected.fields)) {
         const [fieldName, fieldInfo] = field;
@@ -141,8 +142,12 @@ function validateObject(
     }
 
     for (const actualField of Object.keys(actual)) {
-        if (!expected.fields[actualField]) {
-            throw new Error(`Extraneous property ${name}.${actualField}`);
+        if (
+            !expected.fields[actualField] &&
+            ignoreExtraneous?.includes(actualField) !== true
+        ) {
+            const fullName = name ? `${name}.${actualField}` : actualField;
+            throw new Error(`Extraneous property ${fullName}`);
         }
     }
 }
@@ -152,5 +157,5 @@ export function validateAction(
     action: any,
     coerce: boolean = false,
 ) {
-    validateObject("", actionSchema.type, action, coerce);
+    validateObject("", actionSchema.type, action, coerce, ["translatorName"]);
 }

--- a/ts/packages/agents/markdown/src/agent/markdownActionHandler.ts
+++ b/ts/packages/agents/markdown/src/agent/markdownActionHandler.ts
@@ -167,7 +167,10 @@ export async function createViewServiceHost(filePath: string) {
     let timeoutHandle: NodeJS.Timeout;
 
     const timeoutPromise = new Promise<undefined>((_resolve, reject) => {
-        timeoutHandle = setTimeout(() => reject(undefined), 10000);
+        timeoutHandle = setTimeout(
+            () => reject(new Error("Markdown view service creation timed out")),
+            10000,
+        );
     });
 
     const viewServicePromise = new Promise<ChildProcess | undefined>(

--- a/ts/packages/dispatcher/src/handlers/common/appAgentManager.ts
+++ b/ts/packages/dispatcher/src/handlers/common/appAgentManager.ts
@@ -25,6 +25,7 @@ import {
 import { ActionSchemaFileCache } from "../../translation/actionSchemaFileCache.js";
 import { ActionSchemaFile } from "action-schema";
 import path from "path";
+import { callEnsureError } from "../../utils/exceptions.js";
 
 const debug = registerDebug("typeagent:agents");
 const debugError = registerDebug("typeagent:agents:error");
@@ -491,10 +492,12 @@ export class AppAgentManager implements ActionConfigProvider {
                     record,
                     context,
                 );
-                await record.appAgent!.updateAgentContext?.(
-                    enable,
-                    sessionContext,
-                    schemaName,
+                await callEnsureError(() =>
+                    record.appAgent!.updateAgentContext?.(
+                        enable,
+                        sessionContext,
+                        schemaName,
+                    ),
                 );
             } catch (e) {
                 // Rollback if there is a exception
@@ -509,10 +512,12 @@ export class AppAgentManager implements ActionConfigProvider {
             record.actions.delete(schemaName);
             const sessionContext = await record.sessionContextP!;
             try {
-                await record.appAgent!.updateAgentContext?.(
-                    enable,
-                    sessionContext,
-                    schemaName,
+                await callEnsureError(() =>
+                    record.appAgent!.updateAgentContext?.(
+                        enable,
+                        sessionContext,
+                        schemaName,
+                    ),
                 );
             } finally {
                 // Assume that it is disabled even when there is an exception
@@ -540,7 +545,9 @@ export class AppAgentManager implements ActionConfigProvider {
         context: CommandHandlerContext,
     ) {
         const appAgent = await this.ensureAppAgent(record);
-        const agentContext = await appAgent.initializeAgentContext?.();
+        const agentContext = await callEnsureError(() =>
+            appAgent.initializeAgentContext?.(),
+        );
         record.sessionContext = createSessionContext(
             record.name,
             agentContext,

--- a/ts/packages/dispatcher/src/utils/exceptions.ts
+++ b/ts/packages/dispatcher/src/utils/exceptions.ts
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+function throwEnsureError(e: any): never {
+    if (typeof e === "string") {
+        throw new Error(e);
+    }
+    if (typeof e === "object") {
+        if (e instanceof Error) {
+            throw e;
+        }
+        const mayBeErrorLike = e as any;
+        if (
+            typeof mayBeErrorLike.message === "string" &&
+            mayBeErrorLike.stack === "string"
+        ) {
+            throw e;
+        }
+    }
+    throw new Error(`Unknown error: ${JSON.stringify(e)}`);
+}
+
+export function callEnsureError<T>(fn: () => T) {
+    try {
+        return fn();
+    } catch (e) {
+        throwEnsureError(e);
+    }
+}

--- a/ts/packages/dispatcher/src/utils/exceptions.ts
+++ b/ts/packages/dispatcher/src/utils/exceptions.ts
@@ -11,8 +11,9 @@ function throwEnsureError(e: any): never {
         }
         const mayBeErrorLike = e as any;
         if (
+            typeof mayBeErrorLike.name === "string" &&
             typeof mayBeErrorLike.message === "string" &&
-            mayBeErrorLike.stack === "string"
+            typeof mayBeErrorLike.stack === "string"
         ) {
             throw e;
         }


### PR DESCRIPTION
Agent implementation might not always throw `Error` as exception.  Make sure we convert wherever they throw during initialization.

Ensure markdown agent initialization rejects the promise with an error on timeout.

Also on action validation, allow "translatorName" that is not part of the schema.