### PR TITLE
Shell close dispatcher on exit

### DIFF
--- a/ts/packages/dispatcher/src/handlers/common/commandHandlerContext.ts
+++ b/ts/packages/dispatcher/src/handlers/common/commandHandlerContext.ts
@@ -459,6 +459,8 @@ export async function closeCommandHandlerContext(
     context: CommandHandlerContext,
 ) {
     context.serviceHost?.kill();
+    // Save the session because the token count is in it.
+    context.session.save();
     await context.agents.close();
 }
 

--- a/ts/packages/dispatcher/src/handlers/common/interactiveIO.ts
+++ b/ts/packages/dispatcher/src/handlers/common/interactiveIO.ts
@@ -3,11 +3,7 @@
 
 import { TemplateEditConfig } from "../../translation/actionTemplate.js";
 import { CommandHandlerContext } from "./commandHandlerContext.js";
-import {
-    AppAgentEvent,
-    DisplayContent,
-    DisplayAppendMode,
-} from "@typeagent/agent-sdk";
+import { DisplayContent, DisplayAppendMode } from "@typeagent/agent-sdk";
 import { RequestMetrics } from "../../utils/metrics.js";
 
 export const DispatcherName = "dispatcher";


### PR DESCRIPTION
Ensure orderly shutdown. Also move the session save inside the close instead of using the unsupported API that exposed CommandHandlerContext.