### PR TITLE
Alternate natural language request handler

### DIFF
--- a/ts/packages/agents/calendar/src/calendarActionHandler.ts
+++ b/ts/packages/agents/calendar/src/calendarActionHandler.ts
@@ -52,7 +52,7 @@ export class CalendarClientLoginCommandHandler
 }
 
 const handlers: CommandHandlerTable = {
-    description: "Calendar login commmand",
+    description: "Calendar login command",
     defaultSubCommand: "login",
     commands: {
         login: new CalendarClientLoginCommandHandler(),

--- a/ts/packages/agents/test/src/handler.ts
+++ b/ts/packages/agents/test/src/handler.ts
@@ -1,13 +1,46 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { ActionContext, AppAgent } from "@typeagent/agent-sdk";
+import {
+    ActionContext,
+    AppAgent,
+    ParsedCommandParams,
+} from "@typeagent/agent-sdk";
 import { AddAction } from "./schema.js";
 import { createActionResult } from "@typeagent/agent-sdk/helpers/action";
+import {
+    CommandHandler,
+    getCommandInterface,
+} from "@typeagent/agent-sdk/helpers/command";
 
+class RequestCommandHandler implements CommandHandler {
+    public readonly description = "Request a test";
+    public readonly parameters = {
+        args: {
+            test: {
+                description: "Test to request",
+                implicitQuotes: true,
+            },
+        },
+    } as const;
+    public async run(
+        context: ActionContext<void>,
+        params: ParsedCommandParams<typeof this.parameters>,
+    ) {
+        context.actionIO.setDisplay(params.args.test);
+    }
+}
+
+const handlers = {
+    description: "Test App Agent Commands",
+    commands: {
+        request: new RequestCommandHandler(),
+    },
+};
 export function instantiate(): AppAgent {
     return {
         executeAction,
+        ...getCommandInterface(handlers),
     };
 }
 

--- a/ts/packages/dispatcher/src/command/command.ts
+++ b/ts/packages/dispatcher/src/command/command.ts
@@ -157,8 +157,8 @@ async function parseCommand(
 ) {
     let input = originalInput.trim();
     if (!input.startsWith("@")) {
-        // default to dispatcher request
-        input = `dispatcher request ${input}`;
+        const requestHandlerAgent = context.session.getConfig().request;
+        input = `${requestHandlerAgent} request ${input}`;
     } else {
         input = input.substring(1);
     }
@@ -281,6 +281,10 @@ export const enum unicodeChar {
     convert = "🔄",
 }
 export function getSettingSummary(context: CommandHandlerContext) {
+    if (context.session.getConfig().request !== DispatcherName) {
+        const requestAgentName = context.session.getConfig().request;
+        return `{{${context.agents.getActionConfig(requestAgentName).emojiChar} ${requestAgentName.toUpperCase()}}}`;
+    }
     const prompt: string[] = [unicodeChar.robotFace];
 
     const names = context.agents.getActiveSchemas();

--- a/ts/packages/dispatcher/src/handlers/common/commandHandlerContext.ts
+++ b/ts/packages/dispatcher/src/handlers/common/commandHandlerContext.ts
@@ -241,7 +241,7 @@ function getLoggerSink(isDbEnabled: () => boolean, clientIO: ClientIO) {
     );
 }
 
-async function addAppAgentProvidres(
+async function addAppAgentProviders(
     context: CommandHandlerContext,
     appAgentProviders?: AppAgentProvider[],
     cacheDirPath?: string,
@@ -335,7 +335,7 @@ export async function initializeCommandHandlerContext(
         // Runtime context
         commandLock: createLimiter(1), // Make sure we process one command at a time.
         agentCache: await getAgentCache(session, agents, logger),
-        lastActionSchemaName: "",
+        lastActionSchemaName: DispatcherName,
         translatorCache: new Map<string, TypeAgentTranslator>(),
         currentScriptDir: process.cwd(),
         chatHistory: createChatHistory(),
@@ -345,7 +345,7 @@ export async function initializeCommandHandlerContext(
         batchMode: false,
     };
 
-    await addAppAgentProvidres(
+    await addAppAgentProviders(
         context,
         options?.appAgentProviders,
         cacheDirPath,

--- a/ts/packages/dispatcher/src/session/session.ts
+++ b/ts/packages/dispatcher/src/session/session.ts
@@ -21,6 +21,7 @@ import {
 } from "../agent/appAgentManager.js";
 import { cloneConfig, mergeConfig } from "./options.js";
 import { TokenCounter, TokenCounterData } from "aiclient";
+import { DispatcherName } from "../handlers/common/interactiveIO.js";
 
 const debugSession = registerDebug("typeagent:session");
 
@@ -101,6 +102,7 @@ async function newSessionDir() {
 }
 
 type DispatcherConfig = {
+    request: string;
     translation: {
         enabled: boolean;
         model: string;
@@ -156,6 +158,8 @@ const defaultSessionConfig: SessionConfig = {
     actions: undefined,
     commands: undefined,
 
+    // default to dispatcher
+    request: DispatcherName,
     translation: {
         enabled: true,
         model: "",

--- a/ts/packages/dispatcher/test/basic.spec.ts
+++ b/ts/packages/dispatcher/test/basic.spec.ts
@@ -5,8 +5,33 @@ import { createNpmAppAgentProvider } from "../src/agent/npmAgentProvider.js";
 import { createDispatcher } from "../src/dispatcher/dispatcher.js";
 import { fileURLToPath } from "node:url";
 import { getBuiltinAppAgentProvider } from "../src/utils/defaultAppProviders.js";
+import {
+    ClientIO,
+    IAgentMessage,
+    nullClientIO,
+} from "../src/handlers/common/interactiveIO.js";
 
-describe("basic", () => {
+const testAppAgentProvider = createNpmAppAgentProvider(
+    {
+        test: {
+            name: "test-agent",
+            path: fileURLToPath(
+                new URL("../../../agents/test", import.meta.url),
+            ),
+        },
+    },
+    import.meta.url,
+);
+
+function createTestClientIO(data: IAgentMessage[]): ClientIO {
+    return {
+        ...nullClientIO,
+        setDisplay: (message: IAgentMessage) => data.push(message),
+        appendDisplay: (message: IAgentMessage) => data.push(message),
+    };
+}
+
+describe("dispatcher", () => {
     it("startup and shutdown", async () => {
         const dispatcher = await createDispatcher("test", {
             appAgentProviders: [getBuiltinAppAgentProvider()],
@@ -14,28 +39,33 @@ describe("basic", () => {
         await dispatcher.close();
     });
     it("Custom NPM App Agent Provider", async () => {
+        const output: IAgentMessage[] = [];
         const dispatcher = await createDispatcher("test", {
-            appAgentProviders: [
-                createNpmAppAgentProvider(
-                    {
-                        test: {
-                            name: "test-agent",
-                            path: fileURLToPath(
-                                new URL(
-                                    "../../../agents/test",
-                                    import.meta.url,
-                                ),
-                            ),
-                        },
-                    },
-                    import.meta.url,
-                ),
-            ],
+            appAgentProviders: [testAppAgentProvider],
+            clientIO: createTestClientIO(output),
         });
-        dispatcher.processCommand(
+        await dispatcher.processCommand(
             '@action test add --parameters \'{"a": 1, "b": 2}\'',
         );
-        // TODO: check for the output
         await dispatcher.close();
+
+        expect(output.length).toBe(2);
+        expect(output[1].message).toBe("The sum of 1 and 2 is 3");
+    });
+    it("Alternate request handler", async () => {
+        const output: IAgentMessage[] = [];
+        const dispatcher = await createDispatcher("test", {
+            appAgentProviders: [testAppAgentProvider],
+            clientIO: createTestClientIO(output),
+        });
+        await dispatcher.processCommand("@config request test");
+        await dispatcher.processCommand("test");
+        await dispatcher.close();
+
+        expect(output.length).toBe(2);
+        expect(output[0].message).toBe(
+            "Natural langue request handling agent is set to 'test'",
+        );
+        expect(output[1].message).toBe("test");
     });
 });


### PR DESCRIPTION
Add command to set a different agent to totally to take over natural language request, bypassing dispatcher.
The agent implements `request` command handler at the top level with a single `implicitQuotes` parameter.
User can use the command `@config request <appAgentName>` to switch to direct natural language request to that agent.

Also, add output validation for dispatcher tests.