### PR TITLE
Switch to turn off initial schema pick using embedding.

### DIFF
--- a/ts/packages/aiclient/src/restClient.ts
+++ b/ts/packages/aiclient/src/restClient.ts
@@ -247,15 +247,15 @@ export async function fetchWithRetry(
                 !isTransientHttpError(result.status) ||
                 retryCount >= retryMaxAttempts
             ) {
-                return error(`fetch error\n${await getErrorMessage(result)}`);
+                return error(`fetch error: ${await getErrorMessage(result)}`);
             }
             // See if the service tells how long to wait to retry
             const pauseMs = getRetryAfterMs(result, retryPauseMs);
             await sleep(pauseMs);
             retryCount++;
         }
-    } catch (e) {
-        return error(`fetch error:\n${e}`);
+    } catch (e: any) {
+        return error(`fetch error: ${e.cause?.message ?? e.message}`);
     }
 }
 

--- a/ts/packages/cli/src/commands/schema.ts
+++ b/ts/packages/cli/src/commands/schema.ts
@@ -18,8 +18,12 @@ export default class Schema extends Command {
     static flags = {
         active: Flags.string({
             description:
-                "Active schemas to include in the inlined change assistant schema",
+                "Active schemas to include for consideration (inject and inline switch)",
             multiple: true,
+        }),
+        change: Flags.boolean({
+            description: "Include inline change assistant schema",
+            default: false,
         }),
         multiple: Flags.boolean({
             description: "Include multiple action schema",
@@ -74,6 +78,7 @@ export default class Schema extends Command {
                     args.translator,
                     provider,
                     flags.active,
+                    flags.change,
                     flags.multiple,
                     flags.generated,
                 ),

--- a/ts/packages/dispatcher/src/context/commandHandlerContext.ts
+++ b/ts/packages/dispatcher/src/context/commandHandlerContext.ts
@@ -122,10 +122,11 @@ export function getTranslatorForSchema(
     const newTranslator = loadAgentJsonTranslator(
         translatorName,
         context.agents,
-        config.model,
-        config.switch.inline ? getActiveTranslators(context) : undefined,
+        getActiveTranslators(context),
+        config.switch.inline,
         config.multipleActions,
         config.schema.generation,
+        config.model,
         !config.schema.optimize.enabled,
     );
     context.translatorCache.set(translatorName, newTranslator);
@@ -159,9 +160,10 @@ export async function getTranslatorForSelectedActions(
         nearestNeighbors.map((e) => e.item.definition),
         schemaName,
         context.agents,
-        config.model,
-        config.switch.inline ? getActiveTranslators(context) : undefined,
+        getActiveTranslators(context),
+        config.switch.inline,
         config.multipleActions,
+        config.model,
     );
 }
 

--- a/ts/packages/dispatcher/src/context/dispatcher/dispatcherAgent.ts
+++ b/ts/packages/dispatcher/src/context/dispatcher/dispatcherAgent.ts
@@ -39,7 +39,11 @@ async function executeDispatcherAction(
     action: DispatcherActions | ClarifyRequestAction,
     context: ActionContext<CommandHandlerContext>,
 ) {
-    if (action.actionName === "clarifyRequest") {
+    if (
+        action.actionName === "clarifyMultiplePossibleActionName" ||
+        action.actionName === "clarifyMissingParameter" ||
+        action.actionName === "clarifyUnresolvedReference"
+    ) {
         return clarifyRequestAction(action, context);
     }
 

--- a/ts/packages/dispatcher/src/context/dispatcher/schema/clarifyActionSchema.ts
+++ b/ts/packages/dispatcher/src/context/dispatcher/schema/clarifyActionSchema.ts
@@ -1,18 +1,42 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-// Ask the user for clarification for the request that has ambiguities such as missing parameters, multiple possible actions, multiple interpretations, unresolved references, etc.
-// The translation must be based only on the user request and may consider available information in chat history.
-// Do not make assumptions and generate parameters that are not in the user request or chat history.
-export interface ClarifyRequestAction {
-    actionName: "clarifyRequest";
+export type ClarifyRequestAction =
+    | ClarifyMultiplePossibleActionName
+    | ClarifyMissingParameter
+    | ClarifyUnresolvedReference;
+// Ask the user for clarification for ambiguous request that have multiple possible action as interpretation
+export interface ClarifyMultiplePossibleActionName {
+    actionName: "clarifyMultiplePossibleActionName";
     parameters: {
         // the current understood user request that needs to be clarified
         request: string;
+        possibleActionNames: string[];
+        clarifyingQuestion: string;
+    };
+}
 
-        // Possible action name that can be matched to the request.
-        possibleActionName: string[];
-        ambiguity: string[]; // multiple possible actions, multiple interpretations, unresolved pronoun or references, missing parameters, non-typical parameters, etc.
+// Ask the user for clarification for request is missing parameter in the action
+export interface ClarifyMissingParameter {
+    actionName: "clarifyMissingParameter";
+    parameters: {
+        // the current understood user request that needs to be clarified
+        request: string;
+        actionName: string;
+        parameterName: string;
+        clarifyingQuestion: string;
+    };
+}
+
+// Ask the user for clarification for the request that parameters are referring to unresolved pronouns or references.
+export interface ClarifyUnresolvedReference {
+    actionName: "clarifyUnresolvedReference";
+    parameters: {
+        // the current understood user request that needs to be clarified
+        request: string;
+        actionName: string;
+        parameterName: string;
+        reference: string; // words of the unresolved pronoun or reference
         clarifyingQuestion: string;
     };
 }

--- a/ts/packages/dispatcher/src/context/session.ts
+++ b/ts/packages/dispatcher/src/context/session.ts
@@ -108,6 +108,7 @@ type DispatcherConfig = {
             additionalInstructions: boolean;
         };
         switch: {
+            embedding: boolean; // use embedding to determine the first schema to use.
             inline: boolean;
             search: boolean;
         };
@@ -115,7 +116,6 @@ type DispatcherConfig = {
         history: boolean;
         schema: {
             generation: boolean;
-            firstUseEmbedding: boolean; // use embedding to determine the first schema to use.
             optimize: {
                 enabled: boolean;
                 numInitialActions: number; // 0 means no limit
@@ -165,6 +165,7 @@ const defaultSessionConfig: SessionConfig = {
             additionalInstructions: true,
         },
         switch: {
+            embedding: true,
             inline: true,
             search: true,
         },
@@ -172,7 +173,6 @@ const defaultSessionConfig: SessionConfig = {
         history: true,
         schema: {
             generation: true,
-            firstUseEmbedding: true,
             optimize: {
                 enabled: true,
                 numInitialActions: 5,

--- a/ts/packages/dispatcher/src/translation/actionSchemaJsonTranslator.ts
+++ b/ts/packages/dispatcher/src/translation/actionSchemaJsonTranslator.ts
@@ -127,7 +127,7 @@ class ActionSchemaBuilder {
                     for (const t of currentType.types) {
                         if (t.definition === undefined) {
                             throw new Error(
-                                `Schema Builder Error: unresolved type reference '${t.name}' in entry tryp union`,
+                                `Schema Builder Error: unresolved type reference '${t.name}' in entry type union`,
                             );
                         }
                         pending.push(t.definition);
@@ -136,7 +136,7 @@ class ActionSchemaBuilder {
                 case "type-reference":
                     if (currentType.definition === undefined) {
                         throw new Error(
-                            `Schema Builder Error: unresolved type reference '${currentType.name}' in entry tryp union`,
+                            `Schema Builder Error: unresolved type reference '${currentType.name}' in entry type union`,
                         );
                     }
                     pending.push(currentType.definition);
@@ -167,8 +167,9 @@ class ActionSchemaBuilder {
 export function composeActionSchema(
     schemaName: string,
     provider: ActionConfigProvider,
-    activeSchemas: { [key: string]: boolean } | undefined,
-    multipleActions: boolean = false,
+    activeSchemas: { [key: string]: boolean },
+    changeAgentAction: boolean,
+    multipleActions: boolean,
 ) {
     const builder = new ActionSchemaBuilder(provider);
     builder.addActionConfig(provider.getActionConfig(schemaName));
@@ -177,6 +178,7 @@ export function composeActionSchema(
         schemaName,
         provider,
         activeSchemas,
+        changeAgentAction,
         multipleActions,
         false,
     );
@@ -186,8 +188,9 @@ export function composeSelectedActionSchema(
     definitions: ActionSchemaTypeDefinition[],
     schemaName: string,
     provider: ActionConfigProvider,
-    activeSchemas: { [key: string]: boolean } | undefined,
-    multipleActions: boolean = false,
+    activeSchemas: { [key: string]: boolean },
+    changeAgentAction: boolean,
+    multipleActions: boolean,
 ) {
     const builder = new ActionSchemaBuilder(provider);
     for (const definition of definitions) {
@@ -198,6 +201,7 @@ export function composeSelectedActionSchema(
         schemaName,
         provider,
         activeSchemas,
+        changeAgentAction,
         multipleActions,
         true,
     );
@@ -207,7 +211,8 @@ function finalizeActionSchemaBuilder(
     builder: ActionSchemaBuilder,
     schemaName: string,
     provider: ActionConfigProvider,
-    activeSchemas: { [key: string]: boolean } | undefined,
+    activeSchemas: { [key: string]: boolean },
+    changeAgentAction: boolean,
     multipleActions: boolean,
     partial: boolean,
 ) {
@@ -215,7 +220,7 @@ function finalizeActionSchemaBuilder(
         ...getInjectedActionConfigs(schemaName, provider, activeSchemas),
     );
 
-    if (activeSchemas) {
+    if (changeAgentAction) {
         const changeAssistantActionSchema = createChangeAssistantActionSchema(
             provider,
             schemaName,

--- a/ts/packages/dispatcher/src/translation/agentTranslators.ts
+++ b/ts/packages/dispatcher/src/translation/agentTranslators.ts
@@ -230,11 +230,8 @@ function getTranslatorSchemaDef(
 export function getInjectedActionConfigs(
     translatorName: string,
     provider: ActionConfigProvider,
-    activeTranslators: { [key: string]: boolean } | undefined,
+    activeTranslators: { [key: string]: boolean },
 ) {
-    if (activeTranslators === undefined) {
-        return [];
-    }
     return provider
         .getActionConfigs()
         .filter(
@@ -250,8 +247,9 @@ function getInjectedSchemaDefs(
     type: string,
     translatorName: string,
     provider: ActionConfigProvider,
-    activeTranslators: { [key: string]: boolean } | undefined,
-    multipleActions: boolean = false,
+    activeTranslators: { [key: string]: boolean },
+    changeAgentAction: boolean,
+    multipleActions: boolean,
 ): TranslatorSchemaDef[] {
     // Add all injected schemas
     const injectedActionConfigs = getInjectedActionConfigs(
@@ -267,7 +265,7 @@ function getInjectedSchemaDefs(
     const subActionType = [type, ...injectedSchemaDefs.map((s) => s.typeName)];
 
     // Add change assistant schema if needed
-    const changeAssistantSchemaDef = activeTranslators
+    const changeAssistantSchemaDef = changeAgentAction
         ? getChangeAssistantSchemaDef(
               translatorName,
               provider,
@@ -295,8 +293,9 @@ function getInjectedSchemaDefs(
 function getTranslatorSchemaDefs(
     schemaName: string,
     provider: ActionConfigProvider,
-    activeTranslators: { [key: string]: boolean } | undefined,
-    multipleActions: boolean = false,
+    activeTranslators: { [key: string]: boolean },
+    changeAgentAction: boolean,
+    multipleActions: boolean,
 ): TranslatorSchemaDef[] {
     const actionConfig = provider.getActionConfig(schemaName);
     return [
@@ -306,6 +305,7 @@ function getTranslatorSchemaDefs(
             schemaName,
             provider,
             activeTranslators,
+            changeAgentAction,
             multipleActions,
         ),
     ];
@@ -338,10 +338,11 @@ export function loadAgentJsonTranslator<
 >(
     translatorName: string,
     provider: ActionConfigProvider,
-    model?: string,
-    activeTranslators?: { [key: string]: boolean },
+    activeTranslators: { [key: string]: boolean } = {},
+    changeAgentAction: boolean = false,
     multipleActions: boolean = false,
-    regenerateSchema: boolean = false,
+    regenerateSchema: boolean = true,
+    model?: string,
     exact: boolean = true,
 ): TypeAgentTranslator<T> {
     const translator = regenerateSchema
@@ -351,6 +352,7 @@ export function loadAgentJsonTranslator<
                   translatorName,
                   provider,
                   activeTranslators,
+                  changeAgentAction,
                   multipleActions,
               ),
               { model },
@@ -362,6 +364,7 @@ export function loadAgentJsonTranslator<
                   translatorName,
                   provider,
                   activeTranslators,
+                  changeAgentAction,
                   multipleActions,
               ),
               { model },
@@ -414,9 +417,10 @@ export function createTypeAgentTranslatorForSelectedActions<
     definitions: ActionSchemaTypeDefinition[],
     schemaName: string,
     provider: ActionConfigProvider,
+    activeTranslators: { [key: string]: boolean },
+    changeAgentAction: boolean,
+    multipleActions: boolean,
     model?: string,
-    activeTranslators?: { [key: string]: boolean },
-    multipleActions: boolean = false,
 ) {
     const translator = createActionJsonTranslatorFromSchemaDef<T>(
         "AllActions",
@@ -425,6 +429,7 @@ export function createTypeAgentTranslatorForSelectedActions<
             schemaName,
             provider,
             activeTranslators,
+            changeAgentAction,
             multipleActions,
         ),
         { model },
@@ -436,19 +441,22 @@ export function createTypeAgentTranslatorForSelectedActions<
 export function getFullSchemaText(
     translatorName: string,
     provider: ActionConfigProvider,
-    activeSchemas: string[] | undefined,
+    activeSchemas: string[] = [],
+    changeAgentAction: boolean,
     multipleActions: boolean,
     generated: boolean,
 ): string {
-    const active = activeSchemas
-        ? Object.fromEntries(activeSchemas.map((name) => [name, true]))
-        : undefined;
+    const active = Object.fromEntries(
+        activeSchemas.map((name) => [name, true]),
+    );
+
     if (generated) {
         return generateActionSchema(
             composeActionSchema(
                 translatorName,
                 provider,
                 active,
+                changeAgentAction,
                 multipleActions,
             ),
             { exact: true },
@@ -458,6 +466,7 @@ export function getFullSchemaText(
         translatorName,
         provider,
         active,
+        changeAgentAction,
         multipleActions,
     );
     return composeTranslatorSchemas("AllActions", schemaDefs);

--- a/ts/packages/dispatcher/src/utils/test/testData.ts
+++ b/ts/packages/dispatcher/src/utils/test/testData.ts
@@ -278,6 +278,10 @@ function getSafeTranslateFn(
     const translator = loadAgentJsonTranslator<TranslatedAction>(
         schemaName,
         provider,
+        {},
+        false,
+        false,
+        true,
         model,
     );
     return async (request: string): Promise<Result<TranslatedAction>> => {


### PR DESCRIPTION
- `@config translation switch embedding [on|off]` to toggle the initial schema pick using embedding
- `@config translation switch fix <agentName>` command to turn off switching and set the schema to use.
- Fix the problem of missing injected schema (including `unknown`) when inline switcher is off, 
- Split the clarify schema into 3 to better drive change of thought for each case for the clarification question. This also help make sure it doesn't overly generalized and generate clarification when it should just go to `unknown` action.
- Add additional message to the unknown action to indicate if the likely action for the request (using embedding) is not active, or if the switching of action is completely off.
- Improve fetch error by pulling out the inner exception's message (e.g. Connection time out)