### PR TITLE
`cli run explain` use `createDispatcher` API

### DIFF
--- a/ts/packages/cache/src/cache/cache.ts
+++ b/ts/packages/cache/src/cache/cache.ts
@@ -1,30 +1,22 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { QueueObject, queue } from "async";
 import { DeepPartialUndefined } from "common-utils";
 import * as Telemetry from "telemetry";
 import { ExplanationData } from "../explanation/explanationData.js";
-import {
-    Actions,
-    normalizeParamString,
-    RequestAction,
-} from "../explanation/requestAction.js";
+import { RequestAction } from "../explanation/requestAction.js";
 import {
     SchemaInfoProvider,
     doCacheAction,
 } from "../explanation/schemaInfoProvider.js";
-import { GenericExplanationResult } from "../index.js";
 import { ConstructionStore, ConstructionStoreImpl } from "./store.js";
 import { ExplainerFactory } from "./factory.js";
-import { getLanguageTools } from "../utils/language.js";
 import { NamespaceKeyFilter } from "../constructions/constructionCache.js";
-
-export type ProcessExplanationResult = {
-    explanation: GenericExplanationResult;
-    elapsedMs: number;
-    toPrettyString?: ((explanation: object) => string) | undefined;
-};
+import {
+    ExplainWorkQueue,
+    ExplanationOptions,
+    ProcessExplanationResult,
+} from "./explainWorkQueue.js";
 
 export type ProcessRequestActionResult = {
     explanationResult: ProcessExplanationResult;
@@ -53,63 +45,6 @@ function getFailedResult(message: string): ProcessRequestActionResult {
     };
 }
 
-export type ExplanationOptions = {
-    concurrent?: boolean; // whether to limit to run one at a time, require cache to be false
-    valueInRequest?: boolean;
-    noReferences?: boolean;
-    checkExplainable?:
-        | ((requestAction: RequestAction) => Promise<void>)
-        | undefined; // throw exception if not explainable
-};
-
-const langTool = getLanguageTools("en");
-
-function checkExplainableValues(
-    requestAction: RequestAction,
-    valueInRequest: boolean,
-    noReferences: boolean,
-) {
-    // Do a cheap parameter check first.
-    const normalizedRequest = normalizeParamString(requestAction.request);
-    const pending: unknown[] = [];
-
-    for (const action of requestAction.actions) {
-        pending.push(action.parameters);
-    }
-
-    while (pending.length > 0) {
-        const value = pending.pop();
-        if (!value) {
-            continue;
-        }
-
-        // TODO: check number too.
-        if (typeof value === "string") {
-            if (noReferences && langTool?.possibleReferentialPhrase(value)) {
-                throw new Error(
-                    "Request contains a possible referential phrase used for property values.",
-                );
-            }
-            if (
-                valueInRequest &&
-                !normalizedRequest.includes(normalizeParamString(value))
-            ) {
-                throw new Error(
-                    `Action parameter value '${value}' not found in the request`,
-                );
-            }
-            continue;
-        }
-        if (typeof value === "object") {
-            if (Array.isArray(value)) {
-                pending.push(...value);
-            } else {
-                pending.push(...Object.values(value));
-            }
-        }
-    }
-}
-
 // Construction namespace policy
 export function getSchemaNamespaceKeys(
     schemaNames: string[],
@@ -126,18 +61,13 @@ export function getSchemaNamespaceKeys(
 
 export class AgentCache {
     private _constructionStore: ConstructionStoreImpl;
-    private queue: QueueObject<{
-        task: () => Promise<ProcessRequestActionResult>;
-        resolve: (value: ProcessRequestActionResult) => void;
-        reject: (reason?: any) => void;
-    }>;
-
+    private readonly explainWorkQueue: ExplainWorkQueue;
     private readonly namespaceKeyFilter?: NamespaceKeyFilter;
     private readonly logger: Telemetry.Logger | undefined;
     public model?: string;
     constructor(
         public readonly explainerName: string,
-        private readonly getExplainerForTranslator: ExplainerFactory,
+        getExplainerForTranslator: ExplainerFactory,
         private readonly schemaInfoProvider?: SchemaInfoProvider,
         cacheOptions?: CacheOptions,
         logger?: Telemetry.Logger,
@@ -147,13 +77,7 @@ export class AgentCache {
             cacheOptions,
         );
 
-        this.queue = queue(async (item, callback) => {
-            try {
-                item.resolve(await item.task());
-            } catch (e: any) {
-                item.reject(e);
-            }
-        });
+        this.explainWorkQueue = new ExplainWorkQueue(getExplainerForTranslator);
 
         this.logger = logger
             ? new Telemetry.ChildLogger(logger, "cache", {
@@ -190,56 +114,43 @@ export class AgentCache {
 
         return this._constructionStore.prune(this.namespaceKeyFilter);
     }
-    private getExplainerForActions(actions: Actions) {
-        return this.getExplainerForTranslator(
-            actions.translatorNames,
-            this.model,
-        );
-    }
 
-    private async queueTask(
+    public async processRequestAction(
         requestAction: RequestAction,
-        cache: boolean,
+        cache: boolean = true,
         options?: ExplanationOptions,
     ): Promise<ProcessRequestActionResult> {
-        const concurrent = options?.concurrent ?? false;
-        const valueInRequest = options?.valueInRequest ?? true;
-        const noReferences = options?.noReferences ?? true;
-        const checkExplainable = options?.checkExplainable;
-        const actions = requestAction.actions;
-        for (const action of actions) {
-            const cacheAction = doCacheAction(action, this.schemaInfoProvider);
-
-            if (!cacheAction) {
-                return getFailedResult(
-                    `Caching disabled in schema config for action '${action.fullActionName}'`,
-                );
-            }
-        }
-
-        checkExplainableValues(requestAction, valueInRequest, noReferences);
-
-        const task = async () => {
-            const store = this._constructionStore;
-            const generateConstruction = cache && store.isEnabled();
-            const startTime = performance.now();
+        try {
             const actions = requestAction.actions;
-            const explainer = this.getExplainerForActions(actions);
-            const constructionCreationConfig = {
-                schemaInfoProvider: this.schemaInfoProvider,
-            };
+            if (cache) {
+                for (const action of actions) {
+                    const cacheAction = doCacheAction(
+                        action,
+                        this.schemaInfoProvider,
+                    );
 
-            const explainerConfig = {
-                constructionCreationConfig,
-            };
+                    if (!cacheAction) {
+                        return getFailedResult(
+                            `Caching disabled in schema config for action '${action.fullActionName}'`,
+                        );
+                    }
+                }
+            }
 
-            await checkExplainable?.(requestAction);
-            const explanation = await explainer.generate(
+            const constructionCreationConfig = cache
+                ? {
+                      schemaInfoProvider: this.schemaInfoProvider,
+                  }
+                : undefined;
+            const explanationResult = await this.explainWorkQueue.queueTask(
                 requestAction,
-                explainerConfig,
+                cache,
+                options,
+                constructionCreationConfig,
+                this.model,
             );
-            const elapsedMs = performance.now() - startTime;
 
+            const { explanation, elapsedMs } = explanationResult;
             this.logger?.logEvent("explanation", {
                 request: requestAction.request,
                 actions,
@@ -248,11 +159,8 @@ export class AgentCache {
                 elapsedMs,
             });
 
-            const explanationResult = {
-                explanation,
-                elapsedMs,
-                toPrettyString: explainer.toPrettyString,
-            };
+            const store = this._constructionStore;
+            const generateConstruction = cache && store.isEnabled();
             if (generateConstruction && explanation.success) {
                 const construction = explanation.construction;
                 let added = false;
@@ -299,27 +207,6 @@ export class AgentCache {
             return {
                 explanationResult,
             };
-        };
-
-        if (concurrent && !cache) {
-            return task();
-        }
-        return new Promise((resolve, reject) => {
-            this.queue.push({
-                task,
-                resolve,
-                reject,
-            });
-        });
-    }
-
-    public async processRequestAction(
-        requestAction: RequestAction,
-        cache: boolean = true,
-        options?: ExplanationOptions,
-    ): Promise<ProcessRequestActionResult> {
-        try {
-            return await this.queueTask(requestAction, cache, options);
         } catch (e: any) {
             this.logger?.logEvent("error", {
                 request: requestAction.request,
@@ -340,7 +227,7 @@ export class AgentCache {
     ) {
         return this._constructionStore.import(
             data,
-            this.getExplainerForTranslator,
+            this.explainWorkQueue.getExplainerForTranslator,
             this.schemaInfoProvider,
             ignoreSourceHash,
         );

--- a/ts/packages/cache/src/cache/explainWorkQueue.ts
+++ b/ts/packages/cache/src/cache/explainWorkQueue.ts
@@ -1,0 +1,146 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { QueueObject, queue } from "async";
+import {
+    normalizeParamString,
+    RequestAction,
+} from "../explanation/requestAction.js";
+import { ExplainerFactory } from "./factory.js";
+import { getLanguageTools } from "../utils/language.js";
+import {
+    ConstructionCreationConfig,
+    GenericExplanationResult,
+} from "../explanation/genericExplainer.js";
+
+const langTool = getLanguageTools("en");
+
+function checkExplainableValues(
+    requestAction: RequestAction,
+    valueInRequest: boolean,
+    noReferences: boolean,
+) {
+    // Do a cheap parameter check first.
+    const normalizedRequest = normalizeParamString(requestAction.request);
+    const pending: unknown[] = [];
+
+    for (const action of requestAction.actions) {
+        pending.push(action.parameters);
+    }
+
+    while (pending.length > 0) {
+        const value = pending.pop();
+        if (!value) {
+            continue;
+        }
+
+        // TODO: check number too.
+        if (typeof value === "string") {
+            if (noReferences && langTool?.possibleReferentialPhrase(value)) {
+                throw new Error(
+                    "Request contains a possible referential phrase used for property values.",
+                );
+            }
+            if (
+                valueInRequest &&
+                !normalizedRequest.includes(normalizeParamString(value))
+            ) {
+                throw new Error(
+                    `Action parameter value '${value}' not found in the request`,
+                );
+            }
+            continue;
+        }
+        if (typeof value === "object") {
+            if (Array.isArray(value)) {
+                pending.push(...value);
+            } else {
+                pending.push(...Object.values(value));
+            }
+        }
+    }
+}
+
+export type ExplanationOptions = {
+    concurrent?: boolean; // whether to limit to run one at a time, require cache to be false
+    valueInRequest?: boolean;
+    noReferences?: boolean;
+    checkExplainable?:
+        | ((requestAction: RequestAction) => Promise<void>)
+        | undefined; // throw exception if not explainable
+};
+
+export type ProcessExplanationResult = {
+    explanation: GenericExplanationResult;
+    elapsedMs: number;
+    toPrettyString?: ((explanation: object) => string) | undefined;
+};
+
+export class ExplainWorkQueue {
+    private queue: QueueObject<{
+        task: () => Promise<ProcessExplanationResult>;
+        resolve: (value: ProcessExplanationResult) => void;
+        reject: (reason?: any) => void;
+    }>;
+
+    constructor(public readonly getExplainerForTranslator: ExplainerFactory) {
+        this.queue = queue(async (item, callback) => {
+            try {
+                item.resolve(await item.task());
+            } catch (e: any) {
+                item.reject(e);
+            }
+        });
+    }
+
+    public async queueTask(
+        requestAction: RequestAction,
+        cache: boolean,
+        options?: ExplanationOptions,
+        constructionCreationConfig?: ConstructionCreationConfig,
+        model?: string,
+    ): Promise<ProcessExplanationResult> {
+        const concurrent = options?.concurrent ?? false;
+        const valueInRequest = options?.valueInRequest ?? true;
+        const noReferences = options?.noReferences ?? true;
+        const checkExplainable = options?.checkExplainable;
+
+        checkExplainableValues(requestAction, valueInRequest, noReferences);
+
+        const task = async () => {
+            const startTime = performance.now();
+            const actions = requestAction.actions;
+            const explainer = this.getExplainerForTranslator(
+                actions.translatorNames,
+                model,
+            );
+            const explainerConfig = {
+                constructionCreationConfig,
+            };
+
+            await checkExplainable?.(requestAction);
+            const explanation = await explainer.generate(
+                requestAction,
+                explainerConfig,
+            );
+            const elapsedMs = performance.now() - startTime;
+
+            return {
+                explanation,
+                elapsedMs,
+                toPrettyString: explainer.toPrettyString,
+            };
+        };
+
+        if (concurrent && !cache) {
+            return task();
+        }
+        return new Promise((resolve, reject) => {
+            this.queue.push({
+                task,
+                resolve,
+                reject,
+            });
+        });
+    }
+}

--- a/ts/packages/cache/src/explanation/explainer.ts
+++ b/ts/packages/cache/src/explanation/explainer.ts
@@ -14,8 +14,8 @@ export function getExactStringRequirementMessage(
     subphraseText: boolean = true,
 ) {
     const name: string = subphraseText ? "Sub-phrase text" : "Substring";
-    const wholdWords = subphraseText ? ", include whole words and" : "and";
-    return `${name} must be exact copy of part of the original request ${wholdWords} is not changed by correcting misspelling or grammar.`;
+    const wholeWords = subphraseText ? ", include whole words and" : "and";
+    return `${name} must be exact copy of part of the original request ${wholeWords} is not changed by correcting misspelling or grammar.`;
 }
 
 export function getSubphraseExplanationInstruction() {

--- a/ts/packages/cache/src/index.ts
+++ b/ts/packages/cache/src/index.ts
@@ -26,8 +26,8 @@ export type {
     AgentCache,
     CacheConfig,
     ProcessRequestActionResult,
-    ExplanationOptions,
 } from "./cache/cache.js";
+export type { ExplanationOptions } from "./cache/explainWorkQueue.js";
 export type { SchemaInfoProvider } from "./explanation/schemaInfoProvider.js";
 
 // Functionalities

--- a/ts/packages/cache/src/utils/print.ts
+++ b/ts/packages/cache/src/utils/print.ts
@@ -3,12 +3,10 @@
 
 import { getElapsedString, getColorElapsedString } from "common-utils";
 import chalk from "chalk";
-import {
-    ProcessExplanationResult,
-    ProcessRequestActionResult,
-} from "../cache/cache.js";
+import { ProcessRequestActionResult } from "../cache/cache.js";
 import { ImportConstructionResult } from "../index.js";
 import { Transforms } from "../constructions/transforms.js";
+import { ProcessExplanationResult } from "../cache/explainWorkQueue.js";
 
 export function printProcessExplanationResult(
     result: ProcessExplanationResult,
@@ -27,9 +25,7 @@ export function printProcessExplanationResult(
         log(`Explanation${suffix}: ${getColorElapsedString(result.elapsedMs)}`);
 
         if (result.toPrettyString) {
-            console.log(
-                chalk.cyanBright(result.toPrettyString(explanation.data)),
-            );
+            log(chalk.cyanBright(result.toPrettyString(explanation.data)));
         }
     } else {
         log(

--- a/ts/packages/cli/src/commands/run/explain.ts
+++ b/ts/packages/cli/src/commands/run/explain.ts
@@ -77,7 +77,9 @@ export default class ExplainCommand extends Command {
         }
         if (flags.repeat > 1) {
             command.push(`--repeat ${flags.repeat}`);
+            command.push(`--concurrency ${flags.concurrency}`);
         }
+
         if (args.request) {
             command.push(args.request);
         } else {

--- a/ts/packages/cli/src/commands/run/explain.ts
+++ b/ts/packages/cli/src/commands/run/explain.ts
@@ -3,20 +3,14 @@
 
 import { Args, Command, Flags } from "@oclif/core";
 import chalk from "chalk";
-import { createLimiter, getElapsedString } from "common-utils";
-import {
-    RequestAction,
-    Actions,
-    printProcessRequestActionResult,
-} from "agent-cache";
+import { RequestAction, Actions } from "agent-cache";
 import {
     getCacheFactory,
     getSchemaNamesFromDefaultAppAgentProviders,
-    initializeCommandHandlerContext,
-    closeCommandHandlerContext,
     getDefaultAppAgentProviders,
 } from "agent-dispatcher/internal";
 import { createConsoleClientIO } from "agent-dispatcher/helpers/console";
+import { createDispatcher } from "agent-dispatcher";
 
 // Default test case, that include multiple phrase action name (out of order) and implicit parameters (context)
 const testRequest = new RequestAction(
@@ -73,102 +67,34 @@ export default class ExplainCommand extends Command {
         const schemas = flags.translator
             ? Object.fromEntries(flags.translator.map((name) => [name, true]))
             : undefined;
-        const context = await initializeCommandHandlerContext(
-            "cli run explain",
-            {
-                appAgentProviders: getDefaultAppAgentProviders(),
-                schemas,
-                actions: null, // We don't need any actions
-                commands: null,
-                explainer: {
-                    name: flags.explainer,
-                },
-                cache: { enabled: false },
-                clientIO:
-                    flags.repeat > 1 ? undefined : createConsoleClientIO(),
-            },
-        );
 
-        if (args.request === undefined) {
-            console.log(chalk.yellow("Request not specified, using default."));
+        const command = ["@dispatcher explain"];
+        if (flags.filter?.includes("refValue")) {
+            command.push("--filterValueInRequest");
         }
-
-        const requestAction = args.request
-            ? RequestAction.fromString(args.request)
-            : testRequest;
-
-        const options = {
-            valueInRequest: flags.filter?.includes("refvalue") ?? false,
-            noReferences: flags.filter?.includes("reflist") ?? false,
-        };
-        console.log(chalk.grey(`Generate explanation for '${requestAction}'`));
-        if (flags.repeat > 1) {
-            console.log(
-                `Repeating ${flags.repeat} times with concurrency ${flags.concurrency}...`,
-            );
-            const limiter = createLimiter(
-                flags.concurrency > 0 ? flags.concurrency : 1,
-            );
-            const startTime = performance.now();
-            const promises = [];
-            let iteration = 1;
-            for (let i = 0; i < flags.repeat; i++) {
-                promises.push(
-                    limiter(async () => {
-                        const current = iteration++;
-                        console.log(`Iteration #${current} started.`);
-                        const result =
-                            await context.agentCache.processRequestAction(
-                                requestAction,
-                                false,
-                                { concurrent: true, ...options },
-                            );
-                        console.log(
-                            result.explanationResult.explanation.success
-                                ? chalk.green(
-                                      `Iteration #${current} succeeded. [${getElapsedString(result.explanationResult.elapsedMs)}]`,
-                                  )
-                                : chalk.red(
-                                      `Iteration #${current} failed. [${getElapsedString(result.explanationResult.elapsedMs)}]`,
-                                  ),
-                        );
-
-                        return result;
-                    }),
-                );
-            }
-            const results = await Promise.all(promises);
-
-            const actualElapsedMs = performance.now() - startTime;
-            let successCount = 0;
-            let correctionCount = 0;
-            let elapsedMs = 0;
-            for (const result of results) {
-                if (result.explanationResult.explanation.success) {
-                    successCount++;
-                }
-                correctionCount +=
-                    result.explanationResult.explanation.corrections?.length ??
-                    0;
-                elapsedMs += result.explanationResult.elapsedMs;
-            }
-            const attemptCount = correctionCount + flags.repeat;
-            console.log(
-                `Result: ${successCount} (${(successCount / flags.repeat).toFixed(3)}), ${attemptCount} attempts (${(attemptCount / successCount).toFixed(3)})`,
-            );
-            console.log(`Total elapsed Time: ${getElapsedString(elapsedMs)}`);
-            console.log(
-                `Actual elapsed Time: ${getElapsedString(actualElapsedMs)}`,
-            );
+        if (flags.filter?.includes("refList")) {
+            command.push("--filterReference");
+        }
+        if (args.request) {
+            command.push(args.request);
         } else {
-            const result = await context.agentCache.processRequestAction(
-                requestAction,
-                false,
-                options,
-            );
-
-            printProcessRequestActionResult(result);
+            console.log(chalk.yellow("Request not specified, using default."));
+            command.push(testRequest.toString());
         }
-        await closeCommandHandlerContext(context);
+
+        const dispatcher = await createDispatcher("cli run explain", {
+            appAgentProviders: getDefaultAppAgentProviders(),
+            schemas,
+            actions: null, // We don't need any actions
+            commands: null,
+            explainer: {
+                name: flags.explainer,
+            },
+            cache: { enabled: false },
+            clientIO: createConsoleClientIO(),
+        });
+
+        await dispatcher.processCommand(command.join(" "));
+        await dispatcher.close();
     }
 }

--- a/ts/packages/cli/src/commands/run/explain.ts
+++ b/ts/packages/cli/src/commands/run/explain.ts
@@ -86,7 +86,7 @@ export default class ExplainCommand extends Command {
             appAgentProviders: getDefaultAppAgentProviders(),
             schemas,
             actions: null, // We don't need any actions
-            commands: null,
+            commands: { dispatcher: true },
             explainer: {
                 name: flags.explainer,
             },

--- a/ts/packages/cli/src/commands/run/explain.ts
+++ b/ts/packages/cli/src/commands/run/explain.ts
@@ -75,6 +75,9 @@ export default class ExplainCommand extends Command {
         if (flags.filter?.includes("refList")) {
             command.push("--filterReference");
         }
+        if (flags.repeat > 1) {
+            command.push(`--repeat ${flags.repeat}`);
+        }
         if (args.request) {
             command.push(args.request);
         } else {

--- a/ts/packages/dispatcher/src/command/command.ts
+++ b/ts/packages/dispatcher/src/command/command.ts
@@ -26,8 +26,10 @@ const debugCommand = registerDebug("typeagent:dispatcher:command");
 const debugCommandError = registerDebug("typeagent:dispatcher:command:error");
 
 export type ResolveCommandResult = {
-    // The resolved app agent name
+    // the app agent name parsed from the input.
     parsedAppAgentName: string | undefined;
+
+    // The actual app agent name that is resolved.
     actualAppAgentName: string;
 
     // The resolved commands.
@@ -63,8 +65,6 @@ export async function resolveCommand(
     input: string,
     context: CommandHandlerContext,
 ): Promise<ResolveCommandResult> {
-    let parsedAppAgentName: string | undefined;
-
     let prev: string | undefined = undefined;
     let curr = input;
     const nextToken = () => {
@@ -86,14 +86,22 @@ export async function resolveCommand(
     };
 
     const first = nextToken();
-    if (first !== undefined) {
-        if (context.agents.isCommandEnabled(first)) {
-            parsedAppAgentName = first;
-        } else {
-            rollbackToken();
-        }
+
+    const appAgentName =
+        first !== undefined && context.agents.isAppAgentName(first)
+            ? first
+            : undefined;
+    let actualAppAgentName: string;
+    const useParsedAppAgentName =
+        appAgentName !== undefined &&
+        context.agents.isCommandEnabled(appAgentName);
+    if (useParsedAppAgentName) {
+        actualAppAgentName = appAgentName;
+    } else {
+        actualAppAgentName = "system";
+        rollbackToken();
     }
-    const actualAppAgentName = parsedAppAgentName ?? "system";
+
     const appAgent = context.agents.getAppAgent(actualAppAgentName);
     const sessionContext = context.agents.getSessionContext(actualAppAgentName);
     const descriptors = await appAgent.getCommands?.(sessionContext);
@@ -126,14 +134,15 @@ export async function resolveCommand(
             }
             table = current;
         }
-
-        table = table;
-        descriptor = descriptor;
     }
 
+    const parsedAppAgentName =
+        useParsedAppAgentName || commands.length === 0
+            ? appAgentName
+            : undefined;
     const result: ResolveCommandResult = {
         parsedAppAgentName,
-        actualAppAgentName,
+        actualAppAgentName: parsedAppAgentName ?? actualAppAgentName,
         commands,
         suffix: curr.trim(),
         table,
@@ -187,6 +196,15 @@ async function parseCommand(
         }
     }
     const command = getParsedCommand(result);
+
+    if (
+        result.parsedAppAgentName !== undefined &&
+        !context.agents.isCommandEnabled(result.parsedAppAgentName)
+    ) {
+        throw new Error(
+            `Command for '${result.parsedAppAgentName}' is not disabled.`,
+        );
+    }
 
     if (result.table === undefined) {
         throw new Error(`Unknown command '${input}'`);

--- a/ts/packages/dispatcher/src/context/appAgentManager.ts
+++ b/ts/packages/dispatcher/src/context/appAgentManager.ts
@@ -168,12 +168,18 @@ export class AppAgentManager implements ActionConfigProvider {
         return record.manifest.description;
     }
 
+    public isAppAgentName(appAgentName: string) {
+        return this.agents.get(appAgentName) !== undefined;
+    }
+
+    // Throws if schemaName is invalid.
     public isSchemaEnabled(schemaName: string) {
         const appAgentName = getAppAgentName(schemaName);
         const record = this.getRecord(appAgentName);
         return record.schemas.has(schemaName);
     }
 
+    // Throws if schemaName is invalid.
     public isSchemaActive(schemaName: string) {
         return (
             this.isSchemaEnabled(schemaName) &&
@@ -187,6 +193,7 @@ export class AppAgentManager implements ActionConfigProvider {
         );
     }
 
+    // Throws if schemaName is invalid.
     public isActionActive(schemaName: string) {
         return (
             this.isActionEnabled(schemaName) &&
@@ -194,24 +201,25 @@ export class AppAgentManager implements ActionConfigProvider {
         );
     }
 
+    // Throws if schemaName is invalid.
     public isActionEnabled(schemaName: string) {
         const appAgentName = getAppAgentName(schemaName);
         const record = this.getRecord(appAgentName);
         return record.actions.has(schemaName);
     }
 
+    // Throws if appAgentName is invalid.
     public isCommandEnabled(appAgentName: string) {
-        const record = this.agents.get(appAgentName);
-        return record !== undefined
-            ? record.commands && record.appAgent?.executeCommand !== undefined
-            : false;
+        const record = this.getRecord(appAgentName);
+        return record.commands && record.appAgent?.executeCommand !== undefined;
     }
 
     // Return undefined if we don't know because the agent isn't loaded yet.
     // Return null if the agent doesn't support commands.
+    // Throws if appAgentName is invalid.
     public getCommandEnabledState(appAgentName: string) {
-        const record = this.agents.get(appAgentName);
-        return record !== undefined && record.appAgent !== undefined
+        const record = this.getRecord(appAgentName);
+        return record.appAgent !== undefined
             ? record.appAgent.executeCommand !== undefined
                 ? record.commands
                 : null

--- a/ts/packages/dispatcher/src/context/dispatcher/handlers/explainCommandHandler.ts
+++ b/ts/packages/dispatcher/src/context/dispatcher/handlers/explainCommandHandler.ts
@@ -8,6 +8,8 @@ import {
 } from "@typeagent/agent-sdk/helpers/display";
 import { CommandHandlerContext } from "../../commandHandlerContext.js";
 import { RequestAction, printProcessRequestActionResult } from "agent-cache";
+import { createLimiter, getElapsedString } from "common-utils";
+import chalk from "chalk";
 
 export class ExplainCommandHandler implements CommandHandler {
     public readonly description = "Explain a translated request with action";
@@ -18,22 +20,116 @@ export class ExplainCommandHandler implements CommandHandler {
                 implicitQuotes: true,
             },
         },
+        flags: {
+            repeat: {
+                description: "Number of times to repeat the explanation",
+                default: 1,
+            },
+            filterValueInRequest: {
+                description: "Filter reference value for the explanation",
+                default: false,
+            },
+            filterReference: {
+                description: "Filter reference words",
+                default: false,
+            },
+            concurrency: {
+                description: "Number of concurrent requests",
+                default: 5,
+            },
+        },
     } as const;
     public async run(
         context: ActionContext<CommandHandlerContext>,
         params: ParsedCommandParams<typeof this.parameters>,
     ) {
-        const requestAction = RequestAction.fromString(
-            params.args.requestAction,
-        );
-        displayStatus(`Generating explanation for '${requestAction}'`, context);
+        const { args, flags } = params;
+
+        const options = {
+            valueInRequest: flags.filterValueInRequest,
+            noReferences: flags.filterReference,
+        };
+        const requestAction = RequestAction.fromString(args.requestAction);
+        displayResult(`Generating explanation for '${requestAction}'`, context);
         const systemContext = context.sessionContext.agentContext;
-        const result = await systemContext.agentCache.processRequestAction(
-            requestAction,
-            false,
-        );
-        displayResult((log) => {
-            printProcessRequestActionResult(result, log);
-        }, context);
+
+        if (flags.repeat > 1) {
+            console.log(
+                `Repeating ${flags.repeat} times with concurrency ${flags.concurrency}...`,
+            );
+            const limiter = createLimiter(
+                flags.concurrency > 0 ? flags.concurrency : 1,
+            );
+            const startTime = performance.now();
+            const promises = [];
+            let iteration = 1;
+            for (let i = 0; i < flags.repeat; i++) {
+                promises.push(
+                    limiter(async () => {
+                        const current = iteration++;
+                        displayResult(
+                            `Iteration #${current} started.`,
+                            context,
+                        );
+                        const result =
+                            await systemContext.agentCache.processRequestAction(
+                                requestAction,
+                                false,
+                                { concurrent: true, ...options },
+                            );
+                        displayResult(
+                            result.explanationResult.explanation.success
+                                ? chalk.green(
+                                      `Iteration #${current} succeeded. [${getElapsedString(result.explanationResult.elapsedMs)}]`,
+                                  )
+                                : chalk.red(
+                                      `Iteration #${current} failed. [${getElapsedString(result.explanationResult.elapsedMs)}]`,
+                                  ),
+                            context,
+                        );
+
+                        return result;
+                    }),
+                );
+            }
+            const results = await Promise.all(promises);
+
+            const actualElapsedMs = performance.now() - startTime;
+            let successCount = 0;
+            let correctionCount = 0;
+            let elapsedMs = 0;
+            for (const result of results) {
+                if (result.explanationResult.explanation.success) {
+                    successCount++;
+                }
+                correctionCount +=
+                    result.explanationResult.explanation.corrections?.length ??
+                    0;
+                elapsedMs += result.explanationResult.elapsedMs;
+            }
+            const attemptCount = correctionCount + flags.repeat;
+            displayResult(
+                `Result: ${successCount} (${(successCount / flags.repeat).toFixed(3)}), ${attemptCount} attempts (${(attemptCount / successCount).toFixed(3)})`,
+                context,
+            );
+            displayResult(
+                `Total elapsed Time: ${getElapsedString(elapsedMs)}`,
+                context,
+            );
+            displayResult(
+                `Actual elapsed Time: ${getElapsedString(actualElapsedMs)}`,
+                context,
+            );
+        } else {
+            const result = await systemContext.agentCache.processRequestAction(
+                requestAction,
+                false,
+                options,
+            );
+
+            displayResult((log) => {
+                printProcessRequestActionResult(result, log);
+            }, context);
+        }
     }
 }

--- a/ts/packages/dispatcher/src/context/dispatcher/handlers/explainCommandHandler.ts
+++ b/ts/packages/dispatcher/src/context/dispatcher/handlers/explainCommandHandler.ts
@@ -54,8 +54,9 @@ export class ExplainCommandHandler implements CommandHandler {
         const systemContext = context.sessionContext.agentContext;
 
         if (flags.repeat > 1) {
-            console.log(
+            displayResult(
                 `Repeating ${flags.repeat} times with concurrency ${flags.concurrency}...`,
+                context,
             );
             const limiter = createLimiter(
                 flags.concurrency > 0 ? flags.concurrency : 1,

--- a/ts/packages/dispatcher/src/context/system/handlers/displayCommandHandler.ts
+++ b/ts/packages/dispatcher/src/context/system/handlers/displayCommandHandler.ts
@@ -3,7 +3,7 @@
 
 import { ActionContext, ParsedCommandParams } from "@typeagent/agent-sdk";
 import { CommandHandler } from "@typeagent/agent-sdk/helpers/command";
-import { CommandHandlerContext } from "../../../internal.js";
+import { CommandHandlerContext } from "../../commandHandlerContext.js";
 
 export class DisplayCommandHandler implements CommandHandler {
     public readonly description = "Send text to display";

--- a/ts/packages/dispatcher/src/helpers/console.ts
+++ b/ts/packages/dispatcher/src/helpers/console.ts
@@ -61,8 +61,7 @@ function messageContentToText(message: MessageContent): string {
     return displayRows.join("\n");
 }
 
-export function createConsoleClientIO(): ClientIO {
-    initializeConsole();
+function createConsoleClientIO(): ClientIO {
     let lastAppendMode: DisplayAppendMode | undefined;
     function displayContent(
         content: DisplayContent,
@@ -185,13 +184,24 @@ import readline from "readline";
 function initializeConsole() {
     // set the input back to raw mode and resume the input to drain key press during action and not echo them
     process.stdin.setRawMode(true);
-    process.stdin.on("keypress", (str, key) => {
+    process.stdin.on("keypress", (_, key) => {
         if (key?.ctrl && key.name === "c") {
             process.emit("SIGINT");
         }
     });
     process.stdin.resume();
     readline.emitKeypressEvents(process.stdin);
+}
+
+export async function withConsoleClientIO(
+    callback: (clientIO: ClientIO) => Promise<void>,
+) {
+    try {
+        initializeConsole();
+        await callback(createConsoleClientIO());
+    } finally {
+        process.stdin.pause();
+    }
 }
 
 import { createInterface } from "readline/promises";

--- a/ts/packages/dispatcher/src/helpers/console.ts
+++ b/ts/packages/dispatcher/src/helpers/console.ts
@@ -193,14 +193,20 @@ function initializeConsole() {
     readline.emitKeypressEvents(process.stdin);
 }
 
+let usingConsole = false;
 export async function withConsoleClientIO(
     callback: (clientIO: ClientIO) => Promise<void>,
 ) {
+    if (usingConsole) {
+        throw new Error("Cannot have multiple console clients");
+    }
+    usingConsole = true;
     try {
         initializeConsole();
         await callback(createConsoleClientIO());
     } finally {
         process.stdin.pause();
+        usingConsole = false;
     }
 }
 

--- a/ts/packages/dispatcher/src/internal.ts
+++ b/ts/packages/dispatcher/src/internal.ts
@@ -3,11 +3,6 @@
 
 // Internal exports for CLI/testing/debugging purposes
 
-export {
-    initializeCommandHandlerContext,
-    closeCommandHandlerContext,
-    CommandHandlerContext,
-} from "./context/commandHandlerContext.js";
 export { getCacheFactory } from "./utils/cacheFactory.js";
 export {
     GenerateTestDataResult,


### PR DESCRIPTION
- Stop exposing internal `CommandHandlerContext` APIs. 
- Switch to use `createDispatcher` and use the `@dispatcher explain` command
- Move some of the additional functionality from the CLI to the command handler.
- Fix consoleIO input hanging the CLI in `run explain`