### PR TITLE
Fix completion rollback

### DIFF
--- a/ts/packages/dispatcher/src/command/command.ts
+++ b/ts/packages/dispatcher/src/command/command.ts
@@ -99,7 +99,9 @@ export async function resolveCommand(
         actualAppAgentName = appAgentName;
     } else {
         actualAppAgentName = "system";
-        rollbackToken();
+        if (first !== undefined) {
+            rollbackToken();
+        }
     }
 
     const appAgent = context.agents.getAppAgent(actualAppAgentName);


### PR DESCRIPTION
Don't rollback if there is no app agent name parsed.