### PR TITLE
Fix typo in translator request prompt

### DIFF
--- a/ts/packages/commonUtils/src/jsonTranslator.ts
+++ b/ts/packages/commonUtils/src/jsonTranslator.ts
@@ -336,7 +336,7 @@ export function createJsonTranslatorWithValidator<T extends object>(
             `\`\`\`\n${validator.getSchemaText()}\`\`\`\n` +
             `The following is the latest user request:\n` +
             `"""\n${request}\n"""\n` +
-            `Based on all available information in our chat history including images previoiusly provided, the following is the latest user request translated into a JSON object with 2 spaces of indentation and no properties with the value undefined:\n`
+            `Based on all available information in our chat history including images previously provided, the following is the latest user request translated into a JSON object with 2 spaces of indentation and no properties with the value undefined:\n`
         );
     };
     return translator;


### PR DESCRIPTION
This pull request includes a small but important correction to a typo in the `createJsonTranslatorWithValidator` function within the `jsonTranslator.ts` file. The typo fix improves the clarity of the message provided to the LLM.

Typo correction:

* [`ts/packages/commonUtils/src/jsonTranslator.ts`](diffhunk://#diff-bb6ecd66e24575fbb78e5f5d6474b8feff1845f9e15c2fb23450fb3fb5fe7f29L339-R339): Corrected the word "previoiusly" to "previously" in the user request translation message.