### PR TITLE
Enable dispatcher to be created without any persistence

### DIFF
--- a/ts/examples/viewList/src/route/route.ts
+++ b/ts/examples/viewList/src/route/route.ts
@@ -3,11 +3,11 @@
 
 import Server from "webpack-dev-server";
 import fs from "fs";
-import { getSessionsDirPath } from "agent-dispatcher/explorer";
+import { getInstanceSessionsDirPath } from "agent-dispatcher/explorer";
 import path from "node:path";
 
 function getListFilePath() {
-    const sessionsDir = getSessionsDirPath();
+    const sessionsDir = getInstanceSessionsDirPath();
     const dirent = fs.readdirSync(sessionsDir, { withFileTypes: true });
     const sessions = dirent.filter((d) => d.isDirectory()).map((d) => d.name);
 
@@ -22,7 +22,12 @@ function getListFilePath() {
         }
     });
 
-    return path.join(getSessionsDirPath(), sessions[0], "list", "lists.json");
+    return path.join(
+        getInstanceSessionsDirPath(),
+        sessions[0],
+        "list",
+        "lists.json",
+    );
 }
 
 export function setupMiddlewares(

--- a/ts/packages/agentSdk/README.md
+++ b/ts/packages/agentSdk/README.md
@@ -64,9 +64,9 @@ Display message is of type `DisplayContent` and can be simple `MessageContent` o
 
 Helper functions is available to help craft the `DisplayContent` object imported from `@typeagent/agent-sdk/helpers/display`. See [displayHelpers.ts](./src/helpers/displayHelpers.ts).
 
-#### Storage (ActionContext.profileStorage and ActionContext.sessionStorage)
+#### Storage (ActionContext.instanceStorage and ActionContext.sessionStorage)
 
-During execution of action or command, an `ActionContext` is provided with `profileStorage` and optionally `sessionStorage` to persist data. Agent may be running in a isolated environment that doesn't have permanent storage or access to storage.
+During execution of action or command, an `ActionContext` is provided with `instanceStorage` and optionally `sessionStorage` to persist data. Agent may be running in a isolated environment that doesn't have permanent storage or access to storage.
 
 ## Trademarks
 

--- a/ts/packages/agentSdk/src/agentInterface.ts
+++ b/ts/packages/agentSdk/src/agentInterface.ts
@@ -107,7 +107,7 @@ export enum AppAgentEvent {
 export interface SessionContext<T = unknown> {
     readonly agentContext: T;
     readonly sessionStorage: Storage | undefined;
-    readonly profileStorage: Storage; // storage that are preserved across sessions
+    readonly instanceStorage: Storage | undefined; // storage that are preserved across sessions
 
     notify(event: AppAgentEvent, message: string): void;
 

--- a/ts/packages/agents/desktop/src/actionHandler.ts
+++ b/ts/packages/agents/desktop/src/actionHandler.ts
@@ -33,7 +33,7 @@ async function updateDesktopContext(
 ): Promise<void> {
     const agentContext = context.agentContext;
     if (enable) {
-        await setupDesktopActionContext(agentContext, context.profileStorage);
+        await setupDesktopActionContext(agentContext, context.instanceStorage);
     } else {
         await disableDesktopActionContext(agentContext);
     }

--- a/ts/packages/agents/desktop/src/connector.ts
+++ b/ts/packages/agents/desktop/src/connector.ts
@@ -334,7 +334,7 @@ async function ensureProgramNameIndex(
 
 export async function setupDesktopActionContext(
     agentContext: DesktopActionContext,
-    storage: Storage,
+    storage?: Storage,
 ) {
     await ensureAutomationProcess(agentContext);
     return ensureProgramNameIndex(agentContext, storage);

--- a/ts/packages/agents/player/src/agent/playerCommands.ts
+++ b/ts/packages/agents/player/src/agent/playerCommands.ts
@@ -33,10 +33,14 @@ const loadHandler: CommandHandler = {
         if (agentContext.spotify === undefined) {
             throw new Error("Spotify integration is not enabled.");
         }
+
+        if (sessionContext.instanceStorage === undefined) {
+            throw new Error("User data storage disabled.");
+        }
         context.actionIO.setDisplay("Loading Spotify user data...");
 
         await loadHistoryFile(
-            sessionContext.profileStorage,
+            sessionContext.instanceStorage,
             params.args.file,
             agentContext.spotify,
         );

--- a/ts/packages/agents/player/src/agent/playerHandlers.ts
+++ b/ts/packages/agents/player/src/agent/playerHandlers.ts
@@ -88,7 +88,7 @@ async function updatePlayerContext(
 }
 
 async function enableSpotify(context: SessionContext<PlayerActionContext>) {
-    const clientContext = await getClientContext(context.profileStorage);
+    const clientContext = await getClientContext(context.instanceStorage);
     context.agentContext.spotify = clientContext;
 
     return clientContext.service.retrieveUser().username;

--- a/ts/packages/agents/player/src/client.ts
+++ b/ts/packages/agents/player/src/client.ts
@@ -171,18 +171,18 @@ function getIdPart(uri: string) {
 }
 
 export async function loadHistoryFile(
-    profileStorage: Storage,
+    instanceStorage: Storage,
     historyPath: string,
     context: IClientContext,
 ) {
-    if (!(await profileStorage.exists(historyPath))) {
+    if (!(await instanceStorage.exists(historyPath))) {
         throw new Error(`History file not found: ${historyPath}`);
     }
     if (!context.userData) {
         throw new Error("User data not enabled");
     }
     try {
-        const rawData = await profileStorage.read(historyPath, "utf8");
+        const rawData = await instanceStorage.read(historyPath, "utf8");
         let data: SpotifyRecord[] = JSON.parse(rawData);
         for (const record of data) {
             console.log(`${record.master_metadata_track_name}`);
@@ -199,7 +199,7 @@ export async function loadHistoryFile(
                 id: getIdPart(r.spotify_track_uri),
             })),
         );
-        await saveUserData(profileStorage, context.userData.data);
+        await saveUserData(instanceStorage, context.userData.data);
     } catch (e: any) {
         throw new Error(`Error reading history file: ${e.message}`);
     }
@@ -337,10 +337,10 @@ async function updateTrackListAndPrint(
 }
 
 export async function getClientContext(
-    profileStorage?: Storage,
+    instanceStorage?: Storage,
 ): Promise<IClientContext> {
     const service = new SpotifyService(
-        await createTokenProvider(profileStorage),
+        await createTokenProvider(instanceStorage),
     );
     await service.init();
     debugSpotify("Service initialized");
@@ -361,8 +361,8 @@ export async function getClientContext(
     return {
         deviceId,
         service,
-        userData: profileStorage
-            ? await initializeUserData(profileStorage, service)
+        userData: instanceStorage
+            ? await initializeUserData(instanceStorage, service)
             : undefined,
     };
 }

--- a/ts/packages/agents/player/src/userData.ts
+++ b/ts/packages/agents/player/src/userData.ts
@@ -43,10 +43,12 @@ function getUserDataFilePath() {
     return "userdata.json";
 }
 
-async function loadUserData(profileStorage: Storage): Promise<SpotifyUserData> {
+async function loadUserData(
+    instanceStorage: Storage,
+): Promise<SpotifyUserData> {
     const userDataPath = getUserDataFilePath();
-    if (await profileStorage.exists(userDataPath)) {
-        const content = await profileStorage.read(userDataPath, "utf8");
+    if (await instanceStorage.exists(userDataPath)) {
+        const content = await instanceStorage.read(userDataPath, "utf8");
         const json: SpotifyUserDataJSON = JSON.parse(content);
         return {
             lastUpdated: json.lastUpdated,
@@ -329,18 +331,18 @@ export type UserData = {
 
 const updateFrequency = 24 * 60 * 60 * 1000; // 24 hours
 export async function initializeUserData(
-    profileStorage: Storage,
+    instanceStorage: Storage,
     service: SpotifyService,
 ) {
     debugData("Loading saved user data");
-    const data = await loadUserData(profileStorage);
+    const data = await loadUserData(instanceStorage);
     const result: UserData = { data };
     debugData(
         `Tracks: ${data.tracks.size}, Artists: ${data.artists.size}, Albums: ${data.albums.size}`,
     );
     // Update once a day
     const update = async () => {
-        await updateUserData(profileStorage, service, data);
+        await updateUserData(instanceStorage, service, data);
         result.timeoutId = setTimeout(update, updateFrequency);
     };
     const newUpdateTime = data.lastUpdated + updateFrequency;

--- a/ts/packages/cacheExplorer/src/route/route.ts
+++ b/ts/packages/cacheExplorer/src/route/route.ts
@@ -3,9 +3,10 @@
 
 import Server from "webpack-dev-server";
 import {
-    getSessionNames,
-    getSessionCaches,
-    getSessionCacheDirPath,
+    getInstanceSessionNames,
+    getSessionConstructionDirPaths,
+    getSessionConstructionDirPath,
+    getInstanceSessionDirPath,
 } from "agent-dispatcher/explorer";
 import path from "node:path";
 import fs from "node:fs";
@@ -16,14 +17,15 @@ export function setupMiddlewares(
 ) {
     const app = devServer.app!;
     app.get("/sessions", async (req, res) => {
-        const sessions = await getSessionNames();
+        const sessions = await getInstanceSessionNames();
         res.json(sessions);
     });
 
     app.get("/session/:session/caches", async (req, res) => {
         try {
-            const sessionDir = req.params.session;
-            const caches = await getSessionCaches(sessionDir);
+            const sessionName = req.params.session;
+            const sessionDir = getInstanceSessionDirPath(sessionName);
+            const caches = await getSessionConstructionDirPaths(sessionDir);
             res.json(caches);
         } catch (e: any) {
             res.json([]);
@@ -31,7 +33,8 @@ export function setupMiddlewares(
     });
 
     app.get("/session/:session/cache/:cache", async (req, res) => {
-        const cacheDir = getSessionCacheDirPath(req.params.session);
+        const sessionDir = getInstanceSessionDirPath(req.params.session);
+        const cacheDir = getSessionConstructionDirPath(sessionDir);
         res.json(
             JSON.parse(
                 await fs.promises.readFile(

--- a/ts/packages/cli/src/commands/run/explain.ts
+++ b/ts/packages/cli/src/commands/run/explain.ts
@@ -98,6 +98,7 @@ export default class ExplainCommand extends Command {
                 },
                 cache: { enabled: false },
                 clientIO,
+                persist: true,
             });
             try {
                 await dispatcher.processCommand(command.join(" "));

--- a/ts/packages/cli/src/commands/run/request.ts
+++ b/ts/packages/cli/src/commands/run/request.ts
@@ -64,6 +64,7 @@ export default class RequestCommand extends Command {
                 ? { enabled: true, name: flags.explainer }
                 : { enabled: false },
             cache: { enabled: false },
+            persist: true,
         });
         await dispatcher.processCommand(
             `@dispatcher request ${args.request}`,

--- a/ts/packages/cli/src/commands/run/translate.ts
+++ b/ts/packages/cli/src/commands/run/translate.ts
@@ -49,6 +49,7 @@ export default class TranslateCommand extends Command {
             commands: { dispatcher: true },
             translation: { model: flags.model },
             cache: { enabled: false },
+            persist: true,
         });
         await dispatcher.processCommand(
             `@dispatcher translate ${args.request}`,

--- a/ts/packages/dispatcher/src/agentProvider/process/agentProcessShim.ts
+++ b/ts/packages/dispatcher/src/agentProvider/process/agentProcessShim.ts
@@ -99,6 +99,7 @@ export async function createAgentProcess(
     ): ContextParams {
         return {
             contextId: contextMap.getId(context),
+            hasInstanceStorage: context.instanceStorage !== undefined,
             hasSessionStorage: context.sessionStorage !== undefined,
             agentContextId: context.agentContext?.contextId,
         };
@@ -139,7 +140,7 @@ export async function createAgentProcess(
     ) {
         const storage = param.session
             ? context.sessionStorage
-            : context.profileStorage;
+            : context.instanceStorage;
         if (storage === undefined) {
             throw new Error("Storage not available");
         }

--- a/ts/packages/dispatcher/src/agentProvider/process/agentProcessTypes.ts
+++ b/ts/packages/dispatcher/src/agentProvider/process/agentProcessTypes.ts
@@ -159,6 +159,7 @@ export type InitializeMessage = {
 
 export type ContextParams = {
     contextId: number;
+    hasInstanceStorage: boolean;
     hasSessionStorage: boolean;
     agentContextId: number | undefined;
 };

--- a/ts/packages/dispatcher/src/context/session.ts
+++ b/ts/packages/dispatcher/src/context/session.ts
@@ -9,8 +9,7 @@ import path from "node:path";
 import lockfile from "proper-lockfile";
 import { getBuiltinConstructionConfig } from "../utils/config.js";
 import {
-    ensureUserProfileDir,
-    getUserProfileDir,
+    ensureDirectory,
     getUniqueFileName,
     getYMDPrefix,
 } from "../utils/userData.js";
@@ -26,57 +25,28 @@ type Sessions = {
     lastSession?: string;
 };
 
-function getSessionsFilePath() {
-    return path.join(getUserProfileDir(), "sessions.json");
+function getSessionsFilePath(instanceDir: string) {
+    return path.join(instanceDir, "sessions.json");
 }
 
-export function getSessionsDirPath() {
-    return path.join(getUserProfileDir(), "sessions");
+export function getSessionsDirPath(instanceDir: string) {
+    return path.join(instanceDir, "sessions");
 }
 
-export function getSessionDirPath(dir: string) {
-    return path.join(getSessionsDirPath(), dir);
+export function getSessionDirPath(instanceDir: string, dir: string) {
+    return path.join(getSessionsDirPath(instanceDir), dir);
 }
 
-function getSessionDataFilePath(dir: string) {
-    return path.join(getSessionDirPath(dir), "data.json");
+function getSessionDataFilePath(sessionDirPath: string) {
+    return path.join(sessionDirPath, "data.json");
 }
 
-export function getSessionCacheDirPath(dir: string) {
-    return path.join(getSessionDirPath(dir), "constructions");
+export function getSessionConstructionDirPath(sessionDirPath: string) {
+    return path.join(sessionDirPath, "constructions");
 }
 
-let releaseLock: () => Promise<void> | undefined;
-
-async function loadSessions(): Promise<Sessions> {
-    // If we ever load the session config, we lock it until the process exits
-    if (releaseLock === undefined) {
-        const userProfileDir = ensureUserProfileDir();
-        try {
-            let isExiting = false;
-            process.on("exit", () => {
-                isExiting = true;
-            });
-            releaseLock = await lockfile.lock(userProfileDir, {
-                onCompromised: (err) => {
-                    if (isExiting) {
-                        // We are exiting, just ignore the error
-                        return;
-                    }
-                    console.error(
-                        `\nERROR: User profile lock ${userProfileDir} compromised. Only one client per profile can be active at a time.\n  ${err}`,
-                    );
-                    process.exit(-1);
-                },
-            });
-        } catch (e) {
-            throw new Error(
-                `Unable to lock profile ${userProfileDir}. Only one client per profile can be active at a time.`,
-            );
-        }
-    }
-
-    const sessionFilePath = getSessionsFilePath();
+async function loadSessions(instanceDir: string): Promise<Sessions> {
+    const sessionFilePath = getSessionsFilePath(instanceDir);
     if (fs.existsSync(sessionFilePath)) {
         const content = await fs.promises.readFile(sessionFilePath, "utf-8");
         return JSON.parse(content);
@@ -84,14 +54,17 @@ async function loadSessions(): Promise<Sessions> {
     return {};
 }
 
-async function newSessionDir() {
-    const sessions = await loadSessions();
-    const dir = getUniqueFileName(getSessionsDirPath(), getYMDPrefix());
-    const fullDir = getSessionDirPath(dir);
+async function newSessionDir(instanceDir: string) {
+    const sessions = await loadSessions(instanceDir);
+    const dir = getUniqueFileName(
+        getSessionsDirPath(instanceDir),
+        getYMDPrefix(),
+    );
+    const fullDir = getSessionDirPath(instanceDir, dir);
     await fs.promises.mkdir(fullDir, { recursive: true });
     sessions.lastSession = dir;
     await fs.promises.writeFile(
-        getSessionsFilePath(),
+        getSessionsFilePath(instanceDir),
         JSON.stringify(sessions, undefined, 2),
     );
     debugSession(`New session: ${dir}`);
@@ -236,17 +209,23 @@ function ensureSessionData(data: any): SessionData {
     return data;
 }
 
+export function getSessionName(dirPath: string) {
+    return path.basename(dirPath);
+}
+
 const sessionVersion = 2;
-async function readSessionData(dir: string) {
-    const sessionDataFilePath = getSessionDataFilePath(dir);
+async function readSessionData(dirPath: string) {
+    const sessionDataFilePath = getSessionDataFilePath(dirPath);
     if (!fs.existsSync(sessionDataFilePath)) {
-        throw new Error(`Session '${dir}' does not exist.`);
+        const sessionName = getSessionName(dirPath);
+        throw new Error(`Session '${sessionName}' does not exist.`);
     }
     const content = await fs.promises.readFile(sessionDataFilePath, "utf-8");
     const data = JSON.parse(content);
     if (data.version !== sessionVersion) {
+        const sessionName = getSessionName(dirPath);
         throw new Error(
-            `Unsupported session version (${data.version}) in '${dir}'`,
+            `Unsupported session version (${data.version}) in '${sessionName}'`,
         );
     }
     return ensureSessionData(data);
@@ -259,31 +238,32 @@ export class Session {
 
     public static async create(
         config: SessionConfig = defaultSessionConfig,
-        persist: boolean,
+        instanceDir?: string,
     ) {
         const session = new Session(
             { config: cloneConfig(config), cacheData: {} },
-            persist ? await newSessionDir() : undefined,
+            instanceDir ? await newSessionDir(instanceDir) : undefined,
         );
         await session.save();
         return session;
     }
 
-    public static async load(dir: string) {
-        const sessionData = await readSessionData(dir);
+    public static async load(instanceDir: string, dir: string) {
+        const dirPath = getSessionDirPath(instanceDir, dir);
+        const sessionData = await readSessionData(dirPath);
         debugSession(`Loading session: ${dir}`);
         debugSession(
             `Config: ${JSON.stringify(sessionData.config, undefined, 2)}`,
         );
 
-        return new Session(sessionData, dir);
+        return new Session(sessionData, dirPath);
     }
 
-    public static async restoreLastSession() {
-        const sessionDir = (await loadSessions())?.lastSession;
+    public static async restoreLastSession(instanceDir: string) {
+        const sessionDir = (await loadSessions(instanceDir))?.lastSession;
         if (sessionDir !== undefined) {
             try {
-                return this.load(sessionDir);
+                return this.load(instanceDir, sessionDir);
             } catch (e: any) {
                 throw new Error(
                     `Unable to restore last session '${sessionDir}': ${e.message}`,
@@ -295,7 +275,7 @@ export class Session {
 
     private constructor(
         sessionData: SessionData,
-        public readonly dir?: string,
+        public readonly sessionDirPath?: string,
     ) {
         this.config = sessionData.config;
         this.cacheData = sessionData.cacheData;
@@ -334,27 +314,35 @@ export class Session {
     }
 
     public getSessionDirPath(): string | undefined {
-        return this.dir ? getSessionDirPath(this.dir) : undefined;
+        return this.sessionDirPath;
     }
 
-    public getCacheDataFilePath() {
+    public getConstructionDataFilePath() {
         const filePath = this.cacheData[this.explainerName];
 
-        return filePath && this.dir && !path.isAbsolute(filePath)
-            ? path.join(getSessionCacheDirPath(this.dir), filePath)
+        return filePath && this.sessionDirPath && !path.isAbsolute(filePath)
+            ? path.join(
+                  getSessionConstructionDirPath(this.sessionDirPath),
+                  filePath,
+              )
             : filePath;
     }
 
-    public setCacheDataFilePath(
+    public setConstructionDataFilePath(
         filePath: string | undefined,
         explainerName?: string,
     ) {
         const filePathRel =
             filePath &&
-            this.dir &&
+            this.sessionDirPath &&
             path.isAbsolute(filePath) &&
-            filePath.startsWith(getSessionCacheDirPath(this.dir))
-                ? path.relative(getSessionCacheDirPath(this.dir), filePath)
+            filePath.startsWith(
+                getSessionConstructionDirPath(this.sessionDirPath),
+            )
+                ? path.relative(
+                      getSessionConstructionDirPath(this.sessionDirPath),
+                      filePath,
+                  )
                 : filePath;
 
         this.cacheData[explainerName ?? this.explainerName] = filePathRel;
@@ -363,45 +351,53 @@ export class Session {
     }
 
     public async ensureCacheDataFilePath() {
-        const filePath = this.getCacheDataFilePath();
+        const filePath = this.getConstructionDataFilePath();
         return filePath ?? this.newCacheDataFilePath();
     }
 
     public async clear() {
-        if (this.dir) {
-            const sessionDir = getSessionDirPath(this.dir);
-            await fs.promises.rm(sessionDir, { recursive: true, force: true });
-            await fs.promises.mkdir(sessionDir, { recursive: true });
+        if (this.sessionDirPath) {
+            await fs.promises.rm(this.sessionDirPath, {
+                recursive: true,
+                force: true,
+            });
+            await fs.promises.mkdir(this.sessionDirPath, { recursive: true });
             this.cacheData = {};
             await this.save();
         }
     }
 
     private async newCacheDataFilePath() {
-        if (this.dir) {
-            const cacheDirPath = getSessionCacheDirPath(this.dir);
+        if (this.sessionDirPath) {
+            const cacheDirPath = getSessionConstructionDirPath(
+                this.sessionDirPath,
+            );
             await fs.promises.mkdir(cacheDirPath, { recursive: true });
             const filePath = getUniqueFileName(
                 cacheDirPath,
                 `${this.explainerName}_${getYMDPrefix()}`,
                 ".json",
             );
-            this.setCacheDataFilePath(filePath);
+            this.setConstructionDataFilePath(filePath);
             return path.join(cacheDirPath, filePath);
         }
         return undefined;
     }
 
     public save() {
-        if (this.dir) {
-            const sessionDataFilePath = getSessionDataFilePath(this.dir);
+        if (this.sessionDirPath) {
+            const sessionDataFilePath = getSessionDataFilePath(
+                this.sessionDirPath,
+            );
             const data = {
                 version: sessionVersion,
                 config: this.config,
                 cacheData: this.cacheData,
                 tokens: TokenCounter.getInstance(),
             };
-            debugSession(`Saving session: ${this.dir}`);
+            debugSession(
+                `Saving session: ${getSessionName(this.sessionDirPath)}`,
+            );
             debugSession(
                 `Config: ${JSON.stringify(data.config, undefined, 2)}`,
             );
@@ -415,8 +411,11 @@ export class Session {
     public async storeUserSuppliedFile(
         file: string,
     ): Promise<[string, ExifReader.Tags]> {
-        const sessionDir = getSessionDirPath(this.dir as string);
-        const filesDir = path.join(sessionDir, "user_files");
+        if (this.sessionDirPath === undefined) {
+            throw new Error("Unable to store file without persisting session");
+        }
+
+        const filesDir = path.join(this.sessionDirPath, "user_files");
         await fs.promises.mkdir(filesDir, { recursive: true });
 
         // get the extension for the  mime type for the supplied file
@@ -464,7 +463,7 @@ export async function setupAgentCache(
     agentCache.model = config.explainer.model;
     agentCache.constructionStore.clear();
     if (config.cache.enabled) {
-        const cacheData = session.getCacheDataFilePath();
+        const cacheData = session.getConstructionDataFilePath();
         if (cacheData !== undefined) {
             // Load if there is an existing path.
             if (fs.existsSync(cacheData)) {
@@ -510,31 +509,31 @@ export async function setupBuiltInCache(
     }
 }
 
-export async function deleteSession(dir: string) {
+export async function deleteSession(instanceDir: string, dir: string) {
     if (dir === "") {
         return;
     }
-    const sessionDir = getSessionDirPath(dir);
+    const sessionDir = getSessionDirPath(instanceDir, dir);
     return fs.promises.rm(sessionDir, { recursive: true, force: true });
 }
 
-export async function deleteAllSessions() {
-    const sessionsDir = getSessionsDirPath();
+export async function deleteAllSessions(instanceDir: string) {
+    const sessionsDir = getSessionsDirPath(instanceDir);
     return fs.promises.rm(sessionsDir, { recursive: true, force: true });
 }
 
-export async function getSessionNames() {
-    const sessionsDir = getSessionsDirPath();
+export async function getSessionNames(instanceDir: string) {
+    const sessionsDir = getSessionsDirPath(instanceDir);
     const dirent = await fs.promises.readdir(sessionsDir, {
         withFileTypes: true,
     });
     return dirent.filter((d) => d.isDirectory()).map((d) => d.name);
 }
 
-export async function getSessionCaches(dir: string) {
-    const cacheDir = getSessionCacheDirPath(dir);
+export async function getSessionConstructionDirPaths(dirPath: string) {
+    const cacheDir = getSessionConstructionDirPath(dirPath);
     const dirent = await fs.promises.readdir(cacheDir, { withFileTypes: true });
-    const sessionCacheData = (await readSessionData(dir))?.cacheData;
+    const sessionCacheData = (await readSessionData(dirPath))?.cacheData;
     const ret: {
         explainer: string;
         name: string;

--- a/ts/packages/dispatcher/src/execute/actionHandlers.ts
+++ b/ts/packages/dispatcher/src/execute/actionHandlers.ts
@@ -27,7 +27,6 @@ import {
 } from "@typeagent/agent-sdk/helpers/display";
 import { MatchResult } from "agent-cache";
 import { getStorage } from "./storageImpl.js";
-import { getUserProfileDir } from "../utils/userData.js";
 import { IncrementalJsonValueCallBack } from "common-utils";
 import { ProfileNames } from "../utils/profileNames.js";
 import { conversation } from "knowledge-processor";
@@ -124,7 +123,9 @@ export function createSessionContext<T = unknown>(
     const storage = sessionDirPath
         ? getStorage(name, sessionDirPath)
         : undefined;
-    const profileStorage = getStorage(name, getUserProfileDir());
+    const instanceStorage = context.instanceDir
+        ? getStorage(name, context.instanceDir)
+        : undefined;
     const sessionContext: SessionContext<T> = {
         get agentContext() {
             return agentContext;
@@ -132,8 +133,8 @@ export function createSessionContext<T = unknown>(
         get sessionStorage() {
             return storage;
         },
-        get profileStorage() {
-            return profileStorage;
+        get instanceStorage() {
+            return instanceStorage;
         },
         notify(event: AppAgentEvent, message: string) {
             context.clientIO.notify(event, undefined, message, name);

--- a/ts/packages/dispatcher/src/explorer.ts
+++ b/ts/packages/dispatcher/src/explorer.ts
@@ -1,10 +1,26 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-export {
+import {
     getSessionNames,
-    getSessionCaches,
-    getSessionCacheDirPath,
-    getSessionsDirPath,
     getSessionDirPath,
+    getSessionsDirPath,
+} from "./context/session.js";
+import { getInstanceDir } from "./utils/userData.js";
+
+export function getInstanceSessionNames() {
+    return getSessionNames(getInstanceDir());
+}
+
+export function getInstanceSessionsDirPath() {
+    return getSessionsDirPath(getInstanceDir());
+}
+
+export function getInstanceSessionDirPath(sessionName: string) {
+    return getSessionDirPath(getInstanceDir(), sessionName);
+}
+
+export {
+    getSessionConstructionDirPaths,
+    getSessionConstructionDirPath,
 } from "./context/session.js";

--- a/ts/packages/knowledgeVisualizer/src/route/visualizationNotifier.ts
+++ b/ts/packages/knowledgeVisualizer/src/route/visualizationNotifier.ts
@@ -1,7 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { getSessionNames, getSessionsDirPath } from "agent-dispatcher/explorer";
+import {
+    getInstanceSessionNames,
+    getInstanceSessionsDirPath,
+} from "agent-dispatcher/explorer";
 import fs from "node:fs";
 import path from "node:path";
 
@@ -101,7 +104,7 @@ export class VisualizationNotifier {
 
         // file watchers
         fs.watch(
-            getSessionsDirPath(),
+            getInstanceSessionsDirPath(),
             { recursive: true },
             async (_, fileName) => {
                 if (fileName?.endsWith("lists.json")) {
@@ -121,7 +124,7 @@ export class VisualizationNotifier {
 
         const kDir: string = path.join("conversation", "knowledge");
         fs.watch(
-            getSessionsDirPath(),
+            getInstanceSessionsDirPath(),
             { recursive: true },
             async (_, fileName) => {
                 if (fileName && fileName?.indexOf(kDir) > -1) {
@@ -197,7 +200,7 @@ export class VisualizationNotifier {
             new Array<TypeAgentList>(),
         );
 
-        const sessions: string[] = await getSessionNames();
+        const sessions: string[] = await getInstanceSessionNames();
 
         // get all the sessions
         sessions.map((n) => {
@@ -211,7 +214,12 @@ export class VisualizationNotifier {
             // get the lists for all sessions
             try {
                 const listsRaw: Buffer = fs.readFileSync(
-                    path.join(getSessionsDirPath(), n, "list", "lists.json"),
+                    path.join(
+                        getInstanceSessionsDirPath(),
+                        n,
+                        "list",
+                        "lists.json",
+                    ),
                 );
                 const lists: TypeAgentList[] = JSON.parse(listsRaw.toString());
 
@@ -234,7 +242,7 @@ export class VisualizationNotifier {
             retValue.push(new Array<KnowledgeGraph>());
         }
 
-        const sessions: string[] = await getSessionNames();
+        const sessions: string[] = await getInstanceSessionNames();
         const lastSession: string = sessions[sessions.length - 1];
 
         // level 0
@@ -246,7 +254,7 @@ export class VisualizationNotifier {
             Knowledge
         >();
         const knowledgeDir: string = path.join(
-            getSessionsDirPath(),
+            getInstanceSessionsDirPath(),
             lastSession,
             "conversation",
             "knowledge",
@@ -374,7 +382,7 @@ export class VisualizationNotifier {
         retValue.push({ name: "knowledge.type", imports: [] });
         retValue.push({ name: "knowledge.param", imports: [] });
 
-        const sessions: string[] = await getSessionNames();
+        const sessions: string[] = await getInstanceSessionNames();
         const lastSession: string = sessions[sessions.length - 1];
 
         // get the knowledge for this session
@@ -383,7 +391,7 @@ export class VisualizationNotifier {
             Knowledge
         >();
         const knowledgeDir: string = path.join(
-            getSessionsDirPath(),
+            getInstanceSessionsDirPath(),
             lastSession,
             "conversation",
             "knowledge",
@@ -516,7 +524,7 @@ export class VisualizationNotifier {
     public async enumerateKnowledgeForWordCloud(): Promise<string[]> {
         let retValue: string[] = new Array<string>();
 
-        const sessions: string[] = await getSessionNames();
+        const sessions: string[] = await getInstanceSessionNames();
         const lastSession: string = sessions[sessions.length - 1];
 
         // get the knowledge for this session
@@ -525,7 +533,7 @@ export class VisualizationNotifier {
             Knowledge
         >();
         const knowledgeDir: string = path.join(
-            getSessionsDirPath(),
+            getInstanceSessionsDirPath(),
             lastSession,
             "conversation",
             "knowledge",


### PR DESCRIPTION
Enable e2e tests to create dispatcher without any persistence to avoid conflicting lock.