### PR TITLE
Correct session directory

### DIFF
--- a/ts/packages/dispatcher/src/context/session.ts
+++ b/ts/packages/dispatcher/src/context/session.ts
@@ -68,7 +68,7 @@ async function newSessionDir(instanceDir: string) {
         JSON.stringify(sessions, undefined, 2),
     );
     debugSession(`New session: ${dir}`);
-    return dir;
+    return fullDir;
 }
 
 type DispatcherConfig = {


### PR DESCRIPTION
The `Session` constructor expects the full path to the sessions dir. `newSessionDir` was only returning the session name, causing an error when trying to create the session file. This fix corrects the issue by returning the full session directory from `newSessionDir`