### PR TITLE
Account for incrementally loading pages that have placeholders

### DIFF
--- a/ts/packages/agents/browser/src/agent/instacart/actionHandler.mts
+++ b/ts/packages/agents/browser/src/agent/instacart/actionHandler.mts
@@ -140,7 +140,6 @@ export async function handleInstacartAction(
       )) as AllListsInfo;
 
       if (targetList) {
-        // se
         await browser.clickOn(targetList.lists[0].cssSelector);
         await browser.clickOn(targetList.submitButtonCssSelector);
       }
@@ -185,7 +184,7 @@ export async function handleInstacartAction(
     )) as StoreInfo;
 
     await browser.clickOn(targetStore.storeLinkCssSelector);
-    await browser.awaitPageInteraction();
+    await browser.awaitPageInteraction(1000);
     await browser.awaitPageLoad(5000);
   }
 
@@ -252,6 +251,7 @@ export async function handleInstacartAction(
 
     if (navigationLink) {
       await browser.clickOn(navigationLink.linkCssSelector);
+      await browser.awaitPageInteraction();
       await browser.awaitPageLoad();
 
       const request = `List name: ${action.listName}`;
@@ -287,19 +287,24 @@ export async function handleInstacartAction(
       "BuyItAgainNavigationLink",
     )) as BuyItAgainNavigationLink;
 
+    console.log(navigationLink);
+
     if (navigationLink) {
       await browser.clickOn(navigationLink.linkCssSelector);
+      await browser.awaitPageInteraction();
       await browser.awaitPageLoad();
 
       const headerSection = (await getComponentFromPage(
         "BuyItAgainHeaderSection",
       )) as BuyItAgainHeaderSection;
+      console.log(headerSection);
 
       if (headerSection && headerSection.products) {
         if (action.parameters.allItems) {
           for (let product of headerSection.products) {
             if (product.addToCartButton) {
               await browser.clickOn(product.addToCartButton.cssSelector);
+              await browser.awaitPageInteraction();
             }
           }
         } else {
@@ -310,6 +315,7 @@ export async function handleInstacartAction(
           )) as ProductTile;
           if (targetProduct && targetProduct.addToCartButton) {
             await browser.clickOn(targetProduct.addToCartButton.cssSelector);
+            await browser.awaitPageInteraction();
           }
         }
       }

--- a/ts/packages/agents/browser/src/agent/instacart/actionHandler.mts
+++ b/ts/packages/agents/browser/src/agent/instacart/actionHandler.mts
@@ -196,7 +196,7 @@ export async function handleInstacartAction(
   }
 
   async function searchForRecipe(recipeKeywords: string) {
-    // await goToHomepage();
+    await goToHomepage();
     const selector = (await getComponentFromPage("SearchInput")) as SearchInput;
     const searchSelector = selector.cssSelector;
 
@@ -254,7 +254,7 @@ export async function handleInstacartAction(
       await browser.awaitPageInteraction();
       await browser.awaitPageLoad();
 
-      const request = `List name: ${action.listName}`;
+      const request = `List name: ${action.parameters.listName}`;
       const targetList = (await getComponentFromPage(
         "ListInfo",
         request,
@@ -270,8 +270,8 @@ export async function handleInstacartAction(
 
         if (listDetails && listDetails.products) {
           for (let product of listDetails.products) {
-            if (product.addToCartButton) {
-              await browser.clickOn(product.addToCartButton.cssSelector);
+            if (product.addToCartButtonCssSelector) {
+              await browser.clickOn(product.addToCartButtonCssSelector);
             }
           }
         }
@@ -279,9 +279,27 @@ export async function handleInstacartAction(
     }
   }
 
+  async function selectStore(storeName: string) {
+    await goToHomepage();
+    const request = `Store name: ${storeName}`;
+    const targetStore = (await getComponentFromPage(
+      "StoreInfo",
+      request,
+    )) as StoreInfo;
+
+    console.log(targetStore);
+
+    if (!targetStore) {
+      return;
+    }
+
+    await browser.clickOn(targetStore.storeLinkCssSelector);
+    await browser.awaitPageInteraction();
+    await browser.awaitPageLoad();
+  }
+
   async function handleBuyItAgain(action: any) {
-    await searchForStore(action.parameters.storeName);
-    await selectStoreSearchResult(action.parameters.storeName);
+    await selectStore(action.parameters.storeName);
 
     const navigationLink = (await getComponentFromPage(
       "BuyItAgainNavigationLink",
@@ -302,8 +320,8 @@ export async function handleInstacartAction(
       if (headerSection && headerSection.products) {
         if (action.parameters.allItems) {
           for (let product of headerSection.products) {
-            if (product.addToCartButton) {
-              await browser.clickOn(product.addToCartButton.cssSelector);
+            if (product.addToCartButtonCssSelector) {
+              await browser.clickOn(product.addToCartButtonCssSelector);
               await browser.awaitPageInteraction();
             }
           }
@@ -313,8 +331,8 @@ export async function handleInstacartAction(
             "ProductTile",
             request,
           )) as ProductTile;
-          if (targetProduct && targetProduct.addToCartButton) {
-            await browser.clickOn(targetProduct.addToCartButton.cssSelector);
+          if (targetProduct && targetProduct.addToCartButtonCssSelector) {
+            await browser.clickOn(targetProduct.addToCartButtonCssSelector);
             await browser.awaitPageInteraction();
           }
         }

--- a/ts/packages/agents/browser/src/agent/instacart/schema/pageComponents.mts
+++ b/ts/packages/agents/browser/src/agent/instacart/schema/pageComponents.mts
@@ -10,10 +10,8 @@ export type ProductTile = {
   // Construct the selector based on the element's Id attribute if the id is present.
   detailsLinkSelector: string;
 
-  addToCartButton?: {
-    // css selector for the add to cart button
-    cssSelector: string;
-  };
+  // css selector for the add to cart button
+  addToCartButtonCssSelector: string;
 };
 
 // This is only present on the Product Details Page

--- a/ts/packages/agents/browser/src/extension/contentScript.ts
+++ b/ts/packages/agents/browser/src/extension/contentScript.ts
@@ -519,24 +519,26 @@ function setIdsOnAllElements(frameId: number, useTimestampIds?: boolean) {
     }
 }
 
-async function awaitPageIncrementalUpdates(){
+async function awaitPageIncrementalUpdates() {
     return new Promise<string | undefined>((resolve, reject) => {
         const detector = new SkeletonLoadingDetector({
-            stabilityThresholdMs: 500
-          });
-          
-        detector.detect()
-        .then(() => {
-            console.log("Page incremental load completed.")
-            resolve("true");
-        })
-        .catch((error: Error) => {
-            console.error('Failed to detect page load completion:', error);
-            resolve("false");
+            stabilityThresholdMs: 500,
+            // Consider elements visible when they're at least 10% in view
+            intersectionThreshold: 0.1,
         });
+
+        detector
+            .detect()
+            .then(() => {
+                console.log("Page incremental load completed.");
+                resolve("true");
+            })
+            .catch((error: Error) => {
+                console.error("Failed to detect page load completion:", error);
+                resolve("false");
+            });
     });
 }
-
 
 function sendPaleoDbRequest(data: any) {
     document.dispatchEvent(
@@ -714,14 +716,10 @@ async function handleScriptAction(
 }
 
 chrome.runtime?.onMessage.addListener(
-    (
-        message: any,
-        sender: chrome.runtime.MessageSender,
-        sendResponse,
-    ) => {
+    (message: any, sender: chrome.runtime.MessageSender, sendResponse) => {
         const handleMessage = async () => {
             await handleScriptAction(message, sendResponse);
-        }
+        };
 
         handleMessage();
         return true; // Important: indicates we'll send response asynchronously

--- a/ts/packages/agents/browser/src/extension/loadingDetector.ts
+++ b/ts/packages/agents/browser/src/extension/loadingDetector.ts
@@ -1,0 +1,122 @@
+export interface DetectorConfig {
+    // CSS selectors that identify skeleton elements
+    skeletonSelectors: string[];
+    // How long to wait after last skeleton disappears before confirming loading is complete
+    stabilityThresholdMs: number;
+    // Maximum time to wait before giving up
+    timeoutMs: number;
+}
+
+const DEFAULT_CONFIG: DetectorConfig = {
+    skeletonSelectors: [
+        '[role="progressbar"]',
+        ".skeleton",
+        '[aria-busy="true"]',
+    ],
+    stabilityThresholdMs: 1000,
+    timeoutMs: 30000,
+};
+
+export class SkeletonLoadingDetector {
+    private config: DetectorConfig;
+    private observer: MutationObserver | null;
+    private stabilityTimeout: number | null;
+    private maxTimeout: number | null;
+
+    constructor(config: Partial<DetectorConfig> = {}) {
+        this.config = { ...DEFAULT_CONFIG, ...config };
+        this.observer = null;
+        this.stabilityTimeout = null;
+        this.maxTimeout = null;
+    }
+
+    /**
+     * Starts monitoring the page for skeleton elements
+     * @returns Promise that resolves when loading is complete
+     */
+    public detect(): Promise<void> {
+        return new Promise((resolve, reject) => {
+            // Set maximum timeout
+            this.maxTimeout = window.setTimeout(() => {
+                this.cleanup();
+                reject(new Error("Skeleton detection timed out"));
+            }, this.config.timeoutMs);
+
+            // Check if there are any skeletons initially
+            if (!this.hasSkeletons()) {
+                this.cleanup();
+                resolve();
+                return;
+            }
+
+            // Start observing DOM changes
+            this.observer = new MutationObserver(() => {
+                if (!this.hasSkeletons()) {
+                    // Clear any existing stability timeout
+                    if (this.stabilityTimeout) {
+                        window.clearTimeout(this.stabilityTimeout);
+                    }
+
+                    // Start stability timer
+                    this.stabilityTimeout = window.setTimeout(() => {
+                        // Double-check that no new skeletons appeared
+                        if (!this.hasSkeletons()) {
+                            this.cleanup();
+                            resolve();
+                        }
+                    }, this.config.stabilityThresholdMs);
+                }
+            });
+
+            // Start observing the entire document
+            this.observer.observe(document.body, {
+                childList: true,
+                subtree: true,
+                attributes: true,
+                attributeFilter: ["class", "role", "aria-busy", "aria-label"],
+            });
+        });
+    }
+
+    /**
+     * Checks if any skeleton elements are currently present
+     * @returns boolean indicating if skeletons are present
+     */
+    private hasSkeletons(): boolean {
+        return this.config.skeletonSelectors.some((selector) => {
+            const element = document.querySelector(selector);
+            if (element) {
+                var html = document.documentElement;
+                var rect = element.getBoundingClientRect();
+
+                return (
+                    !!rect &&
+                    rect.bottom >= 0 &&
+                    rect.right >= 0 &&
+                    rect.left <= html.clientWidth &&
+                    rect.top <= html.clientHeight
+                );
+            } else {
+                return false;
+            }
+        });
+    }
+
+    /**
+     * Cleans up observers and timeouts
+     */
+    private cleanup(): void {
+        if (this.observer) {
+            this.observer.disconnect();
+            this.observer = null;
+        }
+        if (this.stabilityTimeout) {
+            window.clearTimeout(this.stabilityTimeout);
+            this.stabilityTimeout = null;
+        }
+        if (this.maxTimeout) {
+            window.clearTimeout(this.maxTimeout);
+            this.maxTimeout = null;
+        }
+    }
+}

--- a/ts/packages/agents/browser/src/extension/loadingDetector.ts
+++ b/ts/packages/agents/browser/src/extension/loadingDetector.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 export interface DetectorConfig {
     // CSS selectors that identify skeleton elements
     skeletonSelectors: string[];

--- a/ts/packages/agents/browser/src/extension/loadingDetector.ts
+++ b/ts/packages/agents/browser/src/extension/loadingDetector.ts
@@ -5,34 +5,116 @@ export interface DetectorConfig {
     stabilityThresholdMs: number;
     // Maximum time to wait before giving up
     timeoutMs: number;
+    // Margin around viewport for detection
+    rootMargin?: string;
+    // Intersection threshold for visibility detection
+    intersectionThreshold?: number;
 }
 
 const DEFAULT_CONFIG: DetectorConfig = {
     skeletonSelectors: [
         '[role="progressbar"]',
         ".skeleton",
+        ".placeholder",
         '[aria-busy="true"]',
     ],
     stabilityThresholdMs: 1000,
     timeoutMs: 30000,
+    rootMargin: "50px",
+    intersectionThreshold: 0,
 };
+
+class ViewportMutationObserver {
+    private mutationObserver: MutationObserver;
+    private intersectionObserver: IntersectionObserver;
+    private visibleElements: Set<Element>;
+    private callback: MutationCallback;
+    private options: MutationObserverInit & {
+        root?: Element | Document | null;
+        rootMargin?: string;
+        intersectionThreshold?: number | number[];
+    };
+
+    constructor(callback: MutationCallback, options = {}) {
+        this.callback = callback;
+        this.options = options;
+        this.visibleElements = new Set();
+
+        this.mutationObserver = new MutationObserver((mutations) => {
+            const visibleMutations = mutations.filter((mutation) =>
+                this.isElementOrParentVisible(mutation.target as Element),
+            );
+            if (visibleMutations.length > 0) {
+                this.callback(visibleMutations, this.mutationObserver);
+            }
+        });
+
+        this.intersectionObserver = new IntersectionObserver(
+            (entries) => {
+                entries.forEach((entry) => {
+                    if (entry.isIntersecting) {
+                        this.visibleElements.add(entry.target);
+                    } else {
+                        this.visibleElements.delete(entry.target);
+                    }
+                });
+            },
+            {
+                root: this.options.root,
+                rootMargin: this.options.rootMargin,
+                threshold: this.options.intersectionThreshold,
+            },
+        );
+    }
+
+    public observe(targetNode: Element): void {
+        this.mutationObserver.observe(targetNode, this.options);
+        this.trackElementAndChildren(targetNode);
+    }
+
+    public disconnect(): void {
+        this.mutationObserver.disconnect();
+        this.intersectionObserver.disconnect();
+        this.visibleElements.clear();
+    }
+
+    private trackElementAndChildren(element: Element): void {
+        this.intersectionObserver.observe(element);
+        element.querySelectorAll("*").forEach((child) => {
+            this.intersectionObserver.observe(child);
+        });
+    }
+
+    private isElementOrParentVisible(element: Element | null): boolean {
+        while (element) {
+            if (this.visibleElements.has(element)) {
+                return true;
+            }
+            element = element.parentElement;
+        }
+        return false;
+    }
+}
 
 export class SkeletonLoadingDetector {
     private config: DetectorConfig;
-    private observer: MutationObserver | null;
+    private observer: ViewportMutationObserver | null;
     private stabilityTimeout: number | null;
     private maxTimeout: number | null;
+    private intersectionObserver: IntersectionObserver | null;
+    private visibleSkeletons: Set<Element>;
 
     constructor(config: Partial<DetectorConfig> = {}) {
         this.config = { ...DEFAULT_CONFIG, ...config };
         this.observer = null;
         this.stabilityTimeout = null;
         this.maxTimeout = null;
+        this.intersectionObserver = null;
+        this.visibleSkeletons = new Set();
     }
 
     /**
-     * Starts monitoring the page for skeleton elements
-     * @returns Promise that resolves when loading is complete
+     * Starts monitoring the page for skeleton elements in the viewport
      */
     public detect(): Promise<void> {
         return new Promise((resolve, reject) => {
@@ -42,64 +124,85 @@ export class SkeletonLoadingDetector {
                 reject(new Error("Skeleton detection timed out"));
             }, this.config.timeoutMs);
 
-            // Check if there are any skeletons initially
-            if (!this.hasSkeletons()) {
-                this.cleanup();
-                resolve();
-                return;
-            }
+            // Initialize intersection observer for skeletons
+            this.intersectionObserver = new IntersectionObserver(
+                (entries) => {
+                    entries.forEach((entry) => {
+                        if (entry.isIntersecting) {
+                            this.visibleSkeletons.add(entry.target);
+                        } else {
+                            this.visibleSkeletons.delete(entry.target);
+                        }
+                    });
+
+                    // Check if all visible skeletons are gone
+                    if (this.visibleSkeletons.size === 0) {
+                        this.handleNoSkeletons(resolve);
+                    }
+                },
+                {
+                    rootMargin: this.config.rootMargin,
+                    threshold: this.config.intersectionThreshold,
+                },
+            );
+
+            // Start observing mutations and visibility
+            this.observer = new ViewportMutationObserver(
+                () => {
+                    this.updateSkeletonTracking();
+                },
+                {
+                    childList: true,
+                    subtree: true,
+                    attributes: true,
+                    attributeFilter: ["class", "role", "aria-busy"],
+                    rootMargin: this.config.rootMargin,
+                    intersectionThreshold: this.config.intersectionThreshold,
+                },
+            );
+
+            // Start tracking existing skeletons
+            this.updateSkeletonTracking();
 
             // Start observing DOM changes
-            this.observer = new MutationObserver(() => {
-                if (!this.hasSkeletons()) {
-                    // Clear any existing stability timeout
-                    if (this.stabilityTimeout) {
-                        window.clearTimeout(this.stabilityTimeout);
-                    }
+            this.observer.observe(document.body);
 
-                    // Start stability timer
-                    this.stabilityTimeout = window.setTimeout(() => {
-                        // Double-check that no new skeletons appeared
-                        if (!this.hasSkeletons()) {
-                            this.cleanup();
-                            resolve();
-                        }
-                    }, this.config.stabilityThresholdMs);
-                }
-            });
+            // Check initial state
+            if (this.visibleSkeletons.size === 0) {
+                this.handleNoSkeletons(resolve);
+            }
+        });
+    }
 
-            // Start observing the entire document
-            this.observer.observe(document.body, {
-                childList: true,
-                subtree: true,
-                attributes: true,
-                attributeFilter: ["class", "role", "aria-busy", "aria-label"],
+    /**
+     * Updates tracking of skeleton elements
+     */
+    private updateSkeletonTracking(): void {
+        if (!this.intersectionObserver) return;
+
+        // Find all skeleton elements
+        this.config.skeletonSelectors.forEach((selector) => {
+            document.querySelectorAll(selector).forEach((element) => {
+                this.intersectionObserver!.observe(element);
             });
         });
     }
 
     /**
-     * Checks if any skeleton elements are currently present
-     * @returns boolean indicating if skeletons are present
+     * Handles the case when no skeletons are detected
      */
-    private hasSkeletons(): boolean {
-        return this.config.skeletonSelectors.some((selector) => {
-            const element = document.querySelector(selector);
-            if (element) {
-                var html = document.documentElement;
-                var rect = element.getBoundingClientRect();
+    private handleNoSkeletons(resolve: () => void): void {
+        if (this.stabilityTimeout) {
+            window.clearTimeout(this.stabilityTimeout);
+        }
 
-                return (
-                    !!rect &&
-                    rect.bottom >= 0 &&
-                    rect.right >= 0 &&
-                    rect.left <= html.clientWidth &&
-                    rect.top <= html.clientHeight
-                );
-            } else {
-                return false;
+        this.stabilityTimeout = window.setTimeout(() => {
+            // Double-check that no new skeletons appeared and are visible
+            if (this.visibleSkeletons.size === 0) {
+                this.cleanup();
+                resolve();
             }
-        });
+        }, this.config.stabilityThresholdMs);
     }
 
     /**
@@ -110,6 +213,10 @@ export class SkeletonLoadingDetector {
             this.observer.disconnect();
             this.observer = null;
         }
+        if (this.intersectionObserver) {
+            this.intersectionObserver.disconnect();
+            this.intersectionObserver = null;
+        }
         if (this.stabilityTimeout) {
             window.clearTimeout(this.stabilityTimeout);
             this.stabilityTimeout = null;
@@ -118,5 +225,6 @@ export class SkeletonLoadingDetector {
             window.clearTimeout(this.maxTimeout);
             this.maxTimeout = null;
         }
+        this.visibleSkeletons.clear();
     }
 }

--- a/ts/packages/agents/browser/src/extension/serviceWorker.ts
+++ b/ts/packages/agents/browser/src/extension/serviceWorker.ts
@@ -230,16 +230,19 @@ async function awaitPageLoad(targetTab: chrome.tabs.Tab) {
     });
 }
 
-async function awaitPageIncrementalUpdates(targetTab: chrome.tabs.Tab){
-    const loadingCompleted = await chrome.tabs.sendMessage(targetTab.id!, {
-        type: "await_page_incremental_load",
-    },{ frameId: 0 },);
+async function awaitPageIncrementalUpdates(targetTab: chrome.tabs.Tab) {
+    const loadingCompleted = await chrome.tabs.sendMessage(
+        targetTab.id!,
+        {
+            type: "await_page_incremental_load",
+        },
+        { frameId: 0 },
+    );
 
-    if(!loadingCompleted){
+    if (!loadingCompleted) {
         console.error("Incremental loading did not complete for this page.");
     }
 }
-
 
 async function getLatLongForLocation(locationName: string) {
     const vals = await getConfigValues();

--- a/ts/packages/agents/browser/src/extension/serviceWorker.ts
+++ b/ts/packages/agents/browser/src/extension/serviceWorker.ts
@@ -230,6 +230,17 @@ async function awaitPageLoad(targetTab: chrome.tabs.Tab) {
     });
 }
 
+async function awaitPageIncrementalUpdates(targetTab: chrome.tabs.Tab){
+    const loadingCompleted = await chrome.tabs.sendMessage(targetTab.id!, {
+        type: "await_page_incremental_load",
+    },{ frameId: 0 },);
+
+    if(!loadingCompleted){
+        console.error("Incremental loading did not complete for this page.");
+    }
+}
+
+
 async function getLatLongForLocation(locationName: string) {
     const vals = await getConfigValues();
     const mapsApiKey = vals["BING_MAPS_API_KEY"];
@@ -1162,6 +1173,7 @@ async function runBrowserAction(action: any) {
         case "awaitPageLoad": {
             const targetTab = await getActiveTab();
             await awaitPageLoad(targetTab);
+            await awaitPageIncrementalUpdates(targetTab);
             responseObject = targetTab.url;
             break;
         }


### PR DESCRIPTION
- use a mutation observer to check for page elements that are placeholders (e.g. elements with the aria-busy="true" acccessibility attribute).
- use an intersection observer to ensure we only consider placeholder elements that are visible in the viewport. Many websites would have placeholders for product lists or search results until the user scrolls the page section into view.
