### PR TITLE
Prompt rebalancing

### DIFF
--- a/ts/packages/agents/chat/src/chatResponseActionSchema.ts
+++ b/ts/packages/agents/chat/src/chatResponseActionSchema.ts
@@ -76,6 +76,7 @@ export interface LookupAndGenerateResponseAction {
 }
 
 // this is the way to handle requests for known information that is not stored in application memory or conversation memory, such as facts, definitions, explanations, captioning, or other information that can be generated without a lookup
+// if the user request is a known phrase that is unrelated to the context, use this action to generate an explanation for the known phrase.
 // this action is never used when the request is for private information from past conversations including private events, plans, projects in progress, and other items from discussions with team members or the assistant, unless the information is present in the chat history
 export interface GenerateResponseAction {
     actionName: "generateResponse";


### PR DESCRIPTION
Adjust the comment for `chat.generateResponse` to make the scenario that explain common phrase the user type more stable.
Add prompt instruction to avoid clarifying unresolve resolution if there is a possible match (which also currently stop it from activate if there are multiple ambiguity. Will continue to rebalance over time). 
