### PR TITLE
Clean up all the states when adding dynamic agent failed

### DIFF
--- a/ts/packages/agentRpc/src/client.ts
+++ b/ts/packages/agentRpc/src/client.ts
@@ -158,11 +158,17 @@ export async function createAgentRpcClient(
             manifest: AppAgentManifest;
         }) => {
             const context = contextMap.get(param.contextId);
-            return context.addDynamicAgent(
-                param.name,
-                param.manifest,
-                await createAgentRpcClient(param.name, channelProvider),
-            );
+            try {
+                await context.addDynamicAgent(
+                    param.name,
+                    param.manifest,
+                    await createAgentRpcClient(param.name, channelProvider),
+                );
+            } catch (e: any) {
+                // Clean up the channel if adding the agent fails
+                channelProvider.deleteChannel(param.name);
+                throw e;
+            }
         },
         removeDynamicAgent: async (param: {
             contextId: number;

--- a/ts/packages/agents/browser/package.json
+++ b/ts/packages/agents/browser/package.json
@@ -34,6 +34,7 @@
     "agent-rpc": "workspace:*",
     "aiclient": "workspace:*",
     "common-utils": "workspace:*",
+    "debug": "^4.3.4",
     "dompurify": "^3.1.6",
     "html-to-text": "^9.0.5",
     "jsonpath": "^1.1.1",
@@ -49,6 +50,7 @@
   },
   "devDependencies": {
     "@types/chrome": "^0.0.256",
+    "@types/debug": "^4.1.10",
     "@types/dompurify": "^3.0.5",
     "@types/html-to-text": "^9.0.4",
     "@types/jquery": "^3.5.14",

--- a/ts/packages/dispatcher/src/translation/actionSchemaSemanticMap.ts
+++ b/ts/packages/dispatcher/src/translation/actionSchemaSemanticMap.ts
@@ -74,9 +74,6 @@ export class ActionSchemaSemanticMap {
     }
 
     public removeActionSchemaFile(schemaName: string) {
-        if (!this.actionSemanticMaps.has(schemaName)) {
-            throw new Error(`Internal Error: Invalid schemaName ${schemaName}`);
-        }
         this.actionSemanticMaps.delete(schemaName);
     }
 

--- a/ts/pnpm-lock.yaml
+++ b/ts/pnpm-lock.yaml
@@ -629,6 +629,9 @@ importers:
       common-utils:
         specifier: workspace:*
         version: link:../../commonUtils
+      debug:
+        specifier: ^4.3.4
+        version: 4.3.4(supports-color@8.1.1)
       dompurify:
         specifier: ^3.1.6
         version: 3.1.6
@@ -669,6 +672,9 @@ importers:
       '@types/chrome':
         specifier: ^0.0.256
         version: 0.0.256
+      '@types/debug':
+        specifier: ^4.1.10
+        version: 4.1.10
       '@types/dompurify':
         specifier: ^3.0.5
         version: 3.0.5


### PR DESCRIPTION
Make sure all the state that got modified are cleaned up, including the channel we created.
Make sure the browser agent process doesn't crash when an unexpected disconnect web agent message comes in.