### PR TITLE
Improve embedding heuristics and pared downed prompt context

### DIFF
--- a/ts/packages/agents/calendar/src/calendarActionsSchema.ts
+++ b/ts/packages/agents/calendar/src/calendarActionsSchema.ts
@@ -9,6 +9,7 @@ export type CalendarAction =
     | ChangeDescriptionAction
     | FindEventsAction;
 
+// Add an event to the calendar
 export type AddEventAction = {
     actionName: "addEvent";
     parameters: {
@@ -16,43 +17,49 @@ export type AddEventAction = {
     };
 };
 
+// Remove the event from the calendar
 export type RemoveEventAction = {
     actionName: "removeEvent";
     parameters: {
+        // calendar event to remove
         eventReference: EventReference;
     };
 };
 
+// Add participants to an event on the calendar
 export type AddParticipantsAction = {
     actionName: "addParticipants";
     parameters: {
-        // event to be augmented; if not specified assume last event discussed
+        // calendar event to be augmented; if not specified assume last event discussed
         eventReference?: EventReference;
         // new participants (one or more)
         participants: string[];
     };
 };
 
+// Change the time of an event on the calendar
 export type ChangeTimeAction = {
     actionName: "changeTime";
     parameters: {
-        // event to be changed
+        // calendar event to be changed
         eventReference?: EventReference;
         // new time range for the event
         timeRange: EventTimeRange;
     };
 };
 
+// Change the description of an event on the calendar
 export type ChangeDescriptionAction = {
     actionName: "changeDescription";
     parameters: {
-        // event to be changed
+        // calendar event to be changed
         eventReference?: EventReference;
         // new description for the event
         description: string;
     };
 };
 
+// Find an event on the calendar
 export type FindEventsAction = {
     actionName: "findEvents";
     parameters: {

--- a/ts/packages/dispatcher/src/context/dispatcher/handlers/requestCommandHandler.ts
+++ b/ts/packages/dispatcher/src/context/dispatcher/handlers/requestCommandHandler.ts
@@ -573,8 +573,10 @@ async function pickInitialSchema(
     if (embedding && request.length > 0) {
         debugSemanticSearch(`Using embedding for schema selection`);
         // Use embedding to determine the most likely action schema and use the schema name for that.
-        const result =
-            await systemContext.agents.semanticSearchActionSchema(request);
+        const result = await systemContext.agents.semanticSearchActionSchema(
+            request,
+            debugSemanticSearch.enabled ? 5 : 1,
+        );
         if (result) {
             debugSemanticSearch(
                 `Semantic search result: ${result
@@ -585,7 +587,11 @@ async function pickInitialSchema(
                     .join("\n")}`,
             );
             if (result.length > 0) {
-                schemaName = result[0].item.actionSchemaFile.schemaName;
+                const found = result[0].item.actionSchemaFile.schemaName;
+                // If it is close to dispatcher actions (unknown and clarify), just use the last used action schema
+                if (found !== DispatcherName) {
+                    schemaName = result[0].item.actionSchemaFile.schemaName;
+                }
             }
         }
     }

--- a/ts/packages/dispatcher/src/translation/actionSchemaJsonTranslator.ts
+++ b/ts/packages/dispatcher/src/translation/actionSchemaJsonTranslator.ts
@@ -90,7 +90,7 @@ class ActionSchemaBuilder {
         }
     }
 
-    addTypeDefinition(definition: ActionSchemaTypeDefinition) {
+    addTypeDefinition(definition: ActionSchemaEntryTypeDefinition) {
         this.definitions.push(definition);
     }
 
@@ -193,9 +193,12 @@ export function composeSelectedActionSchema(
     multipleActions: boolean,
 ) {
     const builder = new ActionSchemaBuilder(provider);
-    for (const definition of definitions) {
-        builder.addTypeDefinition(definition);
-    }
+    const union = sc.union(definitions.map((definition) => sc.ref(definition)));
+    const config = provider.getActionConfig(schemaName);
+    const comment = `${config.schemaType} includes a partial list of actions available in schema group '${schemaName}' - ${config.description}`;
+    const entry = sc.type(config.schemaType, union, comment);
+    builder.addTypeDefinition(entry);
+
     return finalizeActionSchemaBuilder(
         builder,
         schemaName,

--- a/ts/packages/dispatcher/src/translation/actionSchemaSemanticMap.ts
+++ b/ts/packages/dispatcher/src/translation/actionSchemaSemanticMap.ts
@@ -47,7 +47,7 @@ export class ActionSchemaSemanticMap {
         this.actionSemanticMaps.set(config.schemaName, actionSemanticMap);
 
         for (const [name, definition] of actionSchemaFile.actionSchemas) {
-            const key = `${config.schemaName} ${config.description} ${name} ${definition.comments?.[0] ?? ""}`;
+            const key = `${config.schemaName} ${name} ${definition.comments?.[0] ?? ""}`;
             const embedding = cache?.get(key);
             if (embedding) {
                 actionSemanticMap.set(key, {


### PR DESCRIPTION
Fix the scenario: 
- `add the ingredients for chess pie to my grocery list`
- `don't need the sugar`  


Couple of issues:
1. When picking the initial schema group to use, both request's embedding matches the calendar actions because the calendar schema description with the embedding is included in the embedding, and the action itself doesn't have description.  That diluted the focus and let it match much different range of requests.
2. Even if the initial pick is wrong, the actual translation prompt ends up choosing the "removeEvent" action, instead of switching to calendar.   The issue here is that when we pare down the schema to only the top 5 likely actions, it loses the context that these are calendar actions.
  
The changes are:
1. Remove descriptions from the action embedding. (Fixes 1 and 2).
2. Add comments to the calendar actions. (Fixes 1 and 2)
3. Regenerate the type alias for the schema group for a union of the pared down actions and add the description of the schema group along with it to give it context (Fixes #2).

With these fixes, the initial pick correctly choose the `list` agent.  Also even when `calendar` was picked (without fix 1 and 2), it will be able switch back to the `list` agent instead of get stuck with calendar agent.

