### PR TITLE
Turn on strict checks when parsing action schema

### DIFF
--- a/ts/packages/actionSchema/src/parser.ts
+++ b/ts/packages/actionSchema/src/parser.ts
@@ -183,7 +183,7 @@ export function createActionSchemaFile(
 ): ActionSchemaFile {
     if (strict && !entry.exported) {
         throw new Error(
-            `Schema Error: ${schemaName}: Type ${entry.name} must be exported`,
+            `Schema Error: ${schemaName}: Type '${entry.name}' must be exported`,
         );
     }
 
@@ -208,7 +208,7 @@ export function createActionSchemaFile(
             case "type-union":
                 if (strict && current.comments) {
                     throw new Error(
-                        `Schema Error: ${schemaName}: entry type comments for '${current.name}' are not supported`,
+                        `Schema Error: ${schemaName}: entry type comments for '${current.name}' are not used for prompts. Remove from the action schema file.\n${current.comments.map((s) => `  - ${s}`).join("\n")}`,
                     );
                 }
                 for (const t of current.type.types) {
@@ -229,7 +229,7 @@ export function createActionSchemaFile(
                 // Definition that references another type is the same as a union type with a single type.
                 if (strict && current.comments) {
                     throw new Error(
-                        `Schema Error: ${schemaName}: entry type comments for '${current.name}' are not supported`,
+                        `Schema Error: ${schemaName}: entry type comments for '${current.name}' are not used for prompts. Remove from the action schema file.\n${current.comments.map((s) => `  - ${s}`).join("\n")}`,
                     );
                 }
                 if (current.type.definition === undefined) {
@@ -241,7 +241,7 @@ export function createActionSchemaFile(
                 break;
             default:
                 throw new Error(
-                    `Schema Error: ${schemaName}: invalid type ${current.type.type} in action schema type ${current.name}`,
+                    `Schema Error: ${schemaName}: invalid type '${current.type.type}' in action schema type ${current.name}`,
                 );
         }
     }

--- a/ts/packages/actionSchema/src/parser.ts
+++ b/ts/packages/actionSchema/src/parser.ts
@@ -229,19 +229,19 @@ export function createActionSchemaFile(
                 // Definition that references another type is the same as a union type with a single type.
                 if (strict && current.comments) {
                     throw new Error(
-                        `Schema Error: ${schemaName}:  entry type comments for '${current.name} are not supported`,
+                        `Schema Error: ${schemaName}: entry type comments for '${current.name}' are not supported`,
                     );
                 }
                 if (current.type.definition === undefined) {
                     throw new Error(
-                        `Schema Error: ${schemaName}:  unresolved type reference '${current.type.name}' in the entry type union`,
+                        `Schema Error: ${schemaName}: unresolved type reference '${current.type.name}' in the entry type union`,
                     );
                 }
                 pending.push(current.type.definition);
                 break;
             default:
                 throw new Error(
-                    `Schema Error: ${schemaName}:  invalid type ${current.type.type} in action schema type ${current.name}`,
+                    `Schema Error: ${schemaName}: invalid type ${current.type.type} in action schema type ${current.name}`,
                 );
         }
     }

--- a/ts/packages/actionSchema/test/parse.spec.ts
+++ b/ts/packages/actionSchema/test/parse.spec.ts
@@ -1,0 +1,66 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { parseActionSchemaSource } from "../src/parser.js";
+
+describe("Action Schema Strict Checks", () => {
+    it("Error on entry type not exported", async () =>
+        expect(async () =>
+            parseActionSchemaSource(
+                `type SomeAction = { actionName: "someAction" }`,
+                "test",
+                "",
+                "SomeAction",
+                "",
+                undefined,
+                true,
+            ),
+        ).rejects.toThrow(
+            "Error parsing test: Schema Error: test: Type 'SomeAction' must be exported",
+        ));
+
+    it("Error on entry type comment", async () =>
+        expect(async () =>
+            parseActionSchemaSource(
+                `// comments\nexport type AllActions = SomeAction;\ntype SomeAction = { actionName: "someAction" }`,
+                "test",
+                "",
+                "AllActions",
+                "",
+                undefined,
+                true,
+            ),
+        ).rejects.toThrow(
+            "Error parsing test: Schema Error: test: entry type comments for 'AllActions' are not used for prompts. Remove from the action schema file.",
+        ));
+
+    it("Error on duplicate action name", async () =>
+        expect(async () =>
+            parseActionSchemaSource(
+                `export type AllActions = SomeAction | SomeAction2;\ntype SomeAction = { actionName: "someAction" }\ntype SomeAction2 = { actionName: "someAction" }`,
+                "test",
+                "",
+                "AllActions",
+                "",
+                undefined,
+                true,
+            ),
+        ).rejects.toThrow(
+            "Error parsing test: Schema Error: test: Duplicate action name 'someAction'",
+        ));
+
+    it("Error on anonymous types", async () =>
+        expect(async () =>
+            parseActionSchemaSource(
+                `export type AllActions = SomeAction | { actionName: "someAction2" };\ntype SomeAction = { actionName: "someAction" }`,
+                "test",
+                "",
+                "AllActions",
+                "",
+                undefined,
+                true,
+            ),
+        ).rejects.toThrow(
+            "Error parsing test: Schema Error: test: expected type reference in the entry type union",
+        ));
+});

--- a/ts/packages/agents/test/src/handler.ts
+++ b/ts/packages/agents/test/src/handler.ts
@@ -6,7 +6,7 @@ import {
     AppAgent,
     ParsedCommandParams,
 } from "@typeagent/agent-sdk";
-import { AddAction } from "./schema.js";
+import { TestActions } from "./schema.js";
 import { createActionResult } from "@typeagent/agent-sdk/helpers/action";
 import {
     CommandHandler,
@@ -44,7 +44,10 @@ export function instantiate(): AppAgent {
     };
 }
 
-async function executeAction(action: AddAction, context: ActionContext<void>) {
+async function executeAction(
+    action: TestActions,
+    context: ActionContext<void>,
+) {
     switch (action.actionName) {
         case "add":
             const { a, b } = action.parameters;

--- a/ts/packages/agents/test/src/manifest.json
+++ b/ts/packages/agents/test/src/manifest.json
@@ -4,6 +4,6 @@
   "schema": {
     "description": "Math agent with action to do addition",
     "schemaFile": "./schema.ts",
-    "schemaType": "AddAction"
+    "schemaType": "TestActions"
   }
 }

--- a/ts/packages/agents/test/src/schema.ts
+++ b/ts/packages/agents/test/src/schema.ts
@@ -1,7 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-export type AddAction = {
+export type TestActions = AddAction;
+type AddAction = {
     actionName: "add";
     parameters: {
         a: number;

--- a/ts/packages/dispatcher/src/translation/actionSchemaFileCache.ts
+++ b/ts/packages/dispatcher/src/translation/actionSchemaFileCache.ts
@@ -117,6 +117,7 @@ export class ActionSchemaFileCache {
             actionConfig.schemaType,
             fullPath,
             schemaConfig,
+            true,
         );
         this.actionSchemaFiles.set(actionConfig.schemaName, parsed);
 


### PR DESCRIPTION
We already have strict checks on cached schemas.  Turns it on when we first parse as well to have consistent behavior between parsing and loading from cache.

Improve error message for entry comment error.
Added test for some of the error conditions.
