### PR TITLE
Disable partial schema group optimization by default.

### DIFF
--- a/ts/packages/agentRpc/src/client.ts
+++ b/ts/packages/agentRpc/src/client.ts
@@ -292,7 +292,8 @@ export async function createAgentRpcClient(
         AgentContextCallFunctions
     >(channel, agentContextInvokeHandlers, agentContextCallHandlers);
 
-    // The shim needs to implement all the APIs
+    // The shim needs to implement all the APIs regardless whether the actual agent
+    // has that API.  We remove remove it the one that is not necessary below.
     const agent: Required<AppAgent> = {
         initializeAgentContext() {
             return rpc.invoke("initializeAgentContext", undefined);

--- a/ts/packages/dispatcher/src/context/dispatcher/handlers/requestCommandHandler.ts
+++ b/ts/packages/dispatcher/src/context/dispatcher/handlers/requestCommandHandler.ts
@@ -284,7 +284,7 @@ async function translateRequestWithSchema(
                         if (!needAllAction(subaction.action, schemaName)) {
                             continue;
                         }
-                        // REVIEW: the subaction may not be 
+                        // REVIEW: the subaction may not be
                         const translator = getTranslatorForSchema(
                             systemContext,
                             schemaName,

--- a/ts/packages/dispatcher/src/context/dispatcher/handlers/requestCommandHandler.ts
+++ b/ts/packages/dispatcher/src/context/dispatcher/handlers/requestCommandHandler.ts
@@ -36,7 +36,7 @@ import {
 } from "../../../execute/actionHandlers.js";
 import { unicodeChar } from "../../../command/command.js";
 import {
-    isChangeAssistantAction,
+    isAdditionalActionLookupAction,
     TypeAgentTranslator,
     TranslatedAction,
 } from "../../../translation/agentTranslators.js";
@@ -237,6 +237,13 @@ async function matchRequest(
     return undefined;
 }
 
+function needAllAction(translatedAction: TranslatedAction, schemaName: string) {
+    return (
+        isUnknownAction(translatedAction) ||
+        (isAdditionalActionLookupAction(translatedAction) &&
+            translatedAction.parameters.schemaName === schemaName)
+    );
+}
 async function translateRequestWithSchema(
     schemaName: string,
     request: string,
@@ -270,11 +277,32 @@ async function translateRequestWithSchema(
                 return undefined;
             }
 
-            if (
-                !isUnknownAction(translatedAction) &&
-                (!isChangeAssistantAction(translatedAction) ||
-                    translatedAction.parameters.assistant !== schemaName)
-            ) {
+            if (!needAllAction(translatedAction, schemaName)) {
+                if (isMultipleAction(translatedAction)) {
+                    for (const subaction of translatedAction.parameters
+                        .requests) {
+                        if (!needAllAction(subaction.action, schemaName)) {
+                            continue;
+                        }
+                        // REVIEW: the subaction may not be 
+                        const translator = getTranslatorForSchema(
+                            systemContext,
+                            schemaName,
+                        );
+                        const action = await translateWithTranslator(
+                            translator,
+                            schemaName,
+                            subaction.request,
+                            history,
+                            attachments,
+                            context,
+                        );
+                        if (action === undefined) {
+                            return undefined;
+                        }
+                        subaction.action = action;
+                    }
+                }
                 return translatedAction;
             }
         }
@@ -311,7 +339,11 @@ async function translateWithTranslator(
         .translation.stream
         ? (prop: string, value: any, delta: string | undefined) => {
               // TODO: streaming currently doesn't not support multiple actions
-              if (prop === "actionName" && delta === undefined) {
+              if (
+                  prop === "actionName" &&
+                  value !== "unknown" &&
+                  delta === undefined
+              ) {
                   const actionSchemaName =
                       systemContext.agents.getInjectedSchemaForActionName(
                           value,
@@ -414,11 +446,11 @@ async function getNextTranslation(
     forceSearch: boolean,
 ): Promise<NextTranslation | undefined> {
     let request: string;
-    if (isChangeAssistantAction(action)) {
+    if (isAdditionalActionLookupAction(action)) {
         if (!forceSearch) {
             return {
                 request: action.parameters.request,
-                nextSchemaName: action.parameters.assistant,
+                nextSchemaName: action.parameters.schemaName,
                 searched: false,
             };
         }
@@ -490,7 +522,8 @@ async function finalizeAction(
         );
     }
 
-    if (isChangeAssistantAction(currentAction)) {
+    if (isAdditionalActionLookupAction(currentAction)) {
+        // This is the second change, stop it and return unknown
         const unknownAction: UnknownAction = {
             actionName: "unknown",
             parameters: { request: currentAction.parameters.request },

--- a/ts/packages/dispatcher/src/context/dispatcher/schema/clarifyActionSchema.ts
+++ b/ts/packages/dispatcher/src/context/dispatcher/schema/clarifyActionSchema.ts
@@ -5,23 +5,27 @@ export type ClarifyRequestAction =
     | ClarifyMultiplePossibleActionName
     | ClarifyMissingParameter
     | ClarifyUnresolvedReference;
-// Ask the user for clarification for ambiguous request that have multiple possible action as interpretation
+
+// Ask the user for clarification for ambiguous request that have multiple possible known action as interpretation.
+// Don't clarify "unknown" action.
 export interface ClarifyMultiplePossibleActionName {
     actionName: "clarifyMultiplePossibleActionName";
     parameters: {
         // the current understood user request that needs to be clarified
         request: string;
+        // Known actionNames to be clarify.  Don't clarify "unknown" action.
         possibleActionNames: string[];
         clarifyingQuestion: string;
     };
 }
 
-// Ask the user for clarification for request is missing parameter in the action
+// Ask the user for clarification for request is missing parameter of an known action. Don't clarify unknown action.
 export interface ClarifyMissingParameter {
     actionName: "clarifyMissingParameter";
     parameters: {
         // the current understood user request that needs to be clarified
         request: string;
+        // A known actionName to be clarify.  Don't clarify "unknown" action.
         actionName: string;
         parameterName: string;
         clarifyingQuestion: string;

--- a/ts/packages/dispatcher/src/context/dispatcher/schema/dispatcherActionSchema.ts
+++ b/ts/packages/dispatcher/src/context/dispatcher/schema/dispatcherActionSchema.ts
@@ -3,11 +3,11 @@
 
 export type DispatcherActions = UnknownAction;
 
-// the user request isn't any of the action available
+// user request isn't any of the action available and no schema group that may have potential actions to look up from.
 export interface UnknownAction {
     actionName: "unknown";
     parameters: {
-        // user request that couldn't be matched to any action
+        // user request that couldn't be matched to any action or schema group to look up from.
         request: string;
     };
 }

--- a/ts/packages/dispatcher/src/context/session.ts
+++ b/ts/packages/dispatcher/src/context/session.ts
@@ -147,7 +147,7 @@ const defaultSessionConfig: SessionConfig = {
         schema: {
             generation: true,
             optimize: {
-                enabled: true,
+                enabled: false,
                 numInitialActions: 5,
             },
         },

--- a/ts/packages/dispatcher/src/context/system/handlers/traceCommandHandler.ts
+++ b/ts/packages/dispatcher/src/context/system/handlers/traceCommandHandler.ts
@@ -59,6 +59,14 @@ export class TraceCommandHandler implements CommandHandler {
             );
         }
 
+        if (registerDebug.inspectOpts === undefined) {
+            registerDebug.inspectOpts = {};
+        }
+
+        (registerDebug.inspectOpts as any).maxStringLength = null;
+        (registerDebug.inspectOpts as any).maxArrayLength = null;
+        (registerDebug.inspectOpts as any).depth = null;
+
         displaySuccess(
             `Current trace settings: ${getCurrentTraceSettings().join(",")}`,
             context,

--- a/ts/packages/dispatcher/src/translation/actionSchemaJsonTranslator.ts
+++ b/ts/packages/dispatcher/src/translation/actionSchemaJsonTranslator.ts
@@ -23,7 +23,6 @@ import {
     ActionConfig,
     createChangeAssistantActionSchema,
     TranslatedAction,
-    additionalActionLookup,
 } from "./agentTranslators.js";
 import { createMultipleActionSchema } from "./multipleActionSchema.js";
 
@@ -197,10 +196,7 @@ export function composeSelectedActionSchema(
     const union = sc.union(definitions.map((definition) => sc.ref(definition)));
     const config = provider.getActionConfig(schemaName);
     const typeName = `Partial${config.schemaType}`;
-    const comments = [
-        `${typeName} is a partial list of actions available in schema group '${schemaName}'.`,
-        `Use '${additionalActionLookup}' action to get the full list of actions for '${schemaName}'.`,
-    ];
+    const comments = `${typeName} is a partial list of actions available in schema group '${schemaName}'.`;
 
     const entry = sc.type(typeName, union, comments);
     builder.addTypeDefinition(entry);

--- a/ts/packages/dispatcher/src/translation/actionSchemaJsonTranslator.ts
+++ b/ts/packages/dispatcher/src/translation/actionSchemaJsonTranslator.ts
@@ -23,6 +23,7 @@ import {
     ActionConfig,
     createChangeAssistantActionSchema,
     TranslatedAction,
+    additionalActionLookup,
 } from "./agentTranslators.js";
 import { createMultipleActionSchema } from "./multipleActionSchema.js";
 
@@ -195,8 +196,13 @@ export function composeSelectedActionSchema(
     const builder = new ActionSchemaBuilder(provider);
     const union = sc.union(definitions.map((definition) => sc.ref(definition)));
     const config = provider.getActionConfig(schemaName);
-    const comment = `${config.schemaType} includes a partial list of actions available in schema group '${schemaName}' - ${config.description}`;
-    const entry = sc.type(config.schemaType, union, comment);
+    const typeName = `Partial${config.schemaType}`;
+    const comments = [
+        `${typeName} is a partial list of actions available in schema group '${schemaName}'.`,
+        `Use '${additionalActionLookup}' action to get the full list of actions for '${schemaName}'.`,
+    ];
+
+    const entry = sc.type(typeName, union, comments);
     builder.addTypeDefinition(entry);
 
     return finalizeActionSchemaBuilder(

--- a/ts/packages/dispatcher/src/translation/agentTranslators.ts
+++ b/ts/packages/dispatcher/src/translation/agentTranslators.ts
@@ -138,25 +138,25 @@ export function getAppAgentName(schemaName: string) {
     return schemaName.split(".")[0];
 }
 
-const changeAssistantActionTypeName = "ChangeAssistantAction";
-const changeAssistantActionName = "changeAssistantAction";
-export type ChangeAssistantAction = {
-    actionName: "changeAssistantAction";
+const additionalActionLookupTypeName = "AdditionalActionLookupAction";
+export const additionalActionLookup = "additionalActionLookup";
+export type AdditionalActionLookupAction = {
+    actionName: "additionalActionLookup";
     parameters: {
-        assistant: string;
+        schemaName: string;
         request: string; // this is constrained to active translators in the LLM schema
     };
 };
 
-export function isChangeAssistantAction(
+export function isAdditionalActionLookupAction(
     action: AppAction,
-): action is ChangeAssistantAction {
-    return action.actionName === changeAssistantActionName;
+): action is AdditionalActionLookupAction {
+    return action.actionName === additionalActionLookup;
 }
 
-const changeAssistantTypeComments = [
-    ` Use this ${changeAssistantActionTypeName} if the request is for an action that should be handled by a different assistant.`,
-    " The assistant will be chosen based on the assistant parameter",
+const additionalActionLookupTypeComments = [
+    ` Use this ${additionalActionLookupTypeName} to look up additional actions in schema groups`,
+    " The schema group will be chosen based on the schemaName parameter",
 ];
 export function createChangeAssistantActionSchema(
     provider: ActionConfigProvider,
@@ -176,23 +176,23 @@ export function createChangeAssistantActionSchema(
         return undefined;
     }
 
-    const assistantParameterComments = translators.map(
+    const schemaNameParameterComments = translators.map(
         ([name, translator]) => ` ${name} - ${translator.description}`,
     );
     const obj: ActionSchemaObject = sc.obj({
-        actionName: sc.string(changeAssistantActionName),
+        actionName: sc.string(additionalActionLookup),
         parameters: sc.obj({
-            assistant: sc.field(
+            schemaName: sc.field(
                 sc.string(translators.map(([name]) => name)),
-                assistantParameterComments,
+                schemaNameParameterComments,
             ),
             request: sc.string(),
         }),
     } as const);
     return sc.intf(
-        changeAssistantActionTypeName,
+        additionalActionLookupTypeName,
         obj,
-        changeAssistantTypeComments,
+        additionalActionLookupTypeComments,
         true,
     );
 }
@@ -212,7 +212,7 @@ function getChangeAssistantSchemaDef(
     }
     return {
         kind: "inline",
-        typeName: changeAssistantActionTypeName,
+        typeName: additionalActionLookupTypeName,
         schema: generateSchemaTypeDefinition(definition, { exact: true }),
     };
 }

--- a/ts/packages/dispatcher/src/translation/agentTranslators.ts
+++ b/ts/packages/dispatcher/src/translation/agentTranslators.ts
@@ -139,7 +139,7 @@ export function getAppAgentName(schemaName: string) {
 }
 
 const additionalActionLookupTypeName = "AdditionalActionLookupAction";
-export const additionalActionLookup = "additionalActionLookup";
+const additionalActionLookup = "additionalActionLookup";
 export type AdditionalActionLookupAction = {
     actionName: "additionalActionLookup";
     parameters: {


### PR DESCRIPTION
- Disable partial schema group optimization by default.
- Add `Partial` to the type name when we do translation with partial schema group.  
- Make sure we retry the full current schema for subactions in multiple action if needed.
- Rename `changeAssistantAction` to `additionalActionLookup` to be more direct with what it does.
- Make sure clarify flow doesn't try to clarify unknown actions.
- trace command will automatically set `maxStringLength`, `depth` and `maxArrayLength` to `null` to show everything.
