### PR TITLE
Add clientIO to set the source and action for a message container.

### DIFF
--- a/ts/packages/dispatcher/src/context/interactiveIO.ts
+++ b/ts/packages/dispatcher/src/context/interactiveIO.ts
@@ -26,7 +26,6 @@ export interface IAgentMessage {
     source: string;
     actionIndex?: number | undefined;
     metrics?: RequestMetrics | undefined;
-    actionName?: string | undefined;
 }
 
 export type NotifyExplainedData = {
@@ -46,7 +45,7 @@ export interface ClientIO {
         source: string,
         requestId: RequestId,
         actionIndex?: number,
-        action?: AppAction,
+        action?: AppAction | string[],
     ): void;
     setDisplay(message: IAgentMessage): void;
     appendDisplay(message: IAgentMessage, mode: DisplayAppendMode): void;
@@ -94,7 +93,6 @@ export function makeClientIOMessage(
     requestId: RequestId,
     source: string,
     actionIndex?: number,
-    actionName?: string,
 ): IAgentMessage {
     return {
         message,
@@ -105,7 +103,6 @@ export function makeClientIOMessage(
             requestId !== undefined
                 ? context?.metricsManager?.getMetrics(requestId)
                 : undefined,
-        actionName,
     };
 }
 

--- a/ts/packages/dispatcher/src/context/interactiveIO.ts
+++ b/ts/packages/dispatcher/src/context/interactiveIO.ts
@@ -3,7 +3,11 @@
 
 import { TemplateEditConfig } from "../translation/actionTemplate.js";
 import { CommandHandlerContext } from "./commandHandlerContext.js";
-import { DisplayContent, DisplayAppendMode } from "@typeagent/agent-sdk";
+import {
+    DisplayContent,
+    DisplayAppendMode,
+    AppAction,
+} from "@typeagent/agent-sdk";
 import { RequestMetrics } from "../utils/metrics.js";
 
 export const DispatcherName = "dispatcher";
@@ -38,6 +42,12 @@ export interface ClientIO {
     exit(): void;
 
     // Display
+    setDisplayInfo(
+        source: string,
+        requestId: RequestId,
+        actionIndex?: number,
+        action?: AppAction,
+    ): void;
     setDisplay(message: IAgentMessage): void;
     appendDisplay(message: IAgentMessage, mode: DisplayAppendMode): void;
     setDynamicDisplay(
@@ -112,6 +122,7 @@ export async function askYesNoWithContext(
 export const nullClientIO: ClientIO = {
     clear: () => {},
     exit: () => process.exit(0),
+    setDisplayInfo: () => {},
     setDisplay: () => {},
     appendDisplay: () => {},
     setDynamicDisplay: () => {},

--- a/ts/packages/dispatcher/src/helpers/console.ts
+++ b/ts/packages/dispatcher/src/helpers/console.ts
@@ -118,6 +118,9 @@ function createConsoleClientIO(): ClientIO {
         },
 
         // Display
+        setDisplayInfo() {
+            // Ignored
+        },
         setDisplay(message: IAgentMessage): void {
             displayContent(message.message);
         },

--- a/ts/packages/dispatcher/src/rpc/clientIOClient.ts
+++ b/ts/packages/dispatcher/src/rpc/clientIOClient.ts
@@ -13,7 +13,7 @@ import {
 } from "./clientIOTypes.js";
 import { TemplateEditConfig } from "../translation/actionTemplate.js";
 import { RpcChannel } from "agent-rpc/channel";
-import { DisplayAppendMode } from "@typeagent/agent-sdk";
+import { DisplayAppendMode, AppAction } from "@typeagent/agent-sdk";
 
 export function createClientIORpcClient(channel: RpcChannel): ClientIO {
     const rpc = createRpc<ClientIOInvokeFunctions, ClientIOCallFunctions>(
@@ -28,6 +28,19 @@ export function createClientIORpcClient(channel: RpcChannel): ClientIO {
         },
 
         // Display
+        setDisplayInfo(
+            source: string,
+            requestId: RequestId,
+            actionIndex?: number,
+            action?: AppAction,
+        ): void {
+            return rpc.send("setDisplayInfo", {
+                source,
+                requestId,
+                actionIndex,
+                action,
+            });
+        },
         setDisplay(message: IAgentMessage): void {
             return rpc.send("setDisplay", { message });
         },

--- a/ts/packages/dispatcher/src/rpc/clientIOServer.ts
+++ b/ts/packages/dispatcher/src/rpc/clientIOServer.ts
@@ -33,6 +33,13 @@ export function createClientIORpcServer(
     const clientIOCallFunctions: ClientIOCallFunctions = {
         clear: () => clientIO.clear(),
         exit: () => clientIO.exit(),
+        setDisplayInfo: (params) =>
+            clientIO.setDisplayInfo(
+                params.source,
+                params.requestId,
+                params.actionIndex,
+                params.action,
+            ),
         setDisplay: (params) => clientIO.setDisplay(params.message),
         appendDisplay: (params) =>
             clientIO.appendDisplay(params.message, params.mode),

--- a/ts/packages/dispatcher/src/rpc/clientIOTypes.ts
+++ b/ts/packages/dispatcher/src/rpc/clientIOTypes.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { DisplayAppendMode } from "@typeagent/agent-sdk";
+import { AppAction, DisplayAppendMode } from "@typeagent/agent-sdk";
 import { IAgentMessage, RequestId } from "../context/interactiveIO.js";
 import { TemplateEditConfig } from "../translation/actionTemplate.js";
 
@@ -22,6 +22,12 @@ export type ClientIOCallFunctions = {
     clear(): void;
     exit(): void;
 
+    setDisplayInfo(params: {
+        source: string;
+        requestId: RequestId;
+        actionIndex?: number | undefined;
+        action?: AppAction | undefined;
+    }): void;
     setDisplay(params: { message: IAgentMessage }): void;
     appendDisplay(params: {
         message: IAgentMessage;

--- a/ts/packages/shell/src/renderer/assets/styles.less
+++ b/ts/packages/shell/src/renderer/assets/styles.less
@@ -438,6 +438,22 @@ table.table-message td {
   margin-right: 8px;
 }
 
+.agent-name[action-data]:hover:after {
+  content: attr(action-data);
+  position: absolute;
+  top: 30px;
+  left: 10px;
+  white-space: pre-wrap;
+  background-color: #86d9fd;
+  color: gray;
+  border: 1px solid #d6f3ff;
+  border-radius: 5px;
+  padding: 5px;
+  font-size: 100%;
+  font-family: "Courier New", Courier, monospace;
+  z-index: 100;
+}
+
 .timeString {
   font-style: normal;
 }

--- a/ts/packages/shell/src/renderer/src/chatView.ts
+++ b/ts/packages/shell/src/renderer/src/chatView.ts
@@ -5,6 +5,7 @@ import { IdGenerator, getDispatcher } from "./main";
 import { ChatInput, ExpandableTextarea } from "./chatInput";
 import { iconCheckMarkCircle, iconX } from "./icon";
 import {
+    AppAction,
     DisplayAppendMode,
     DisplayContent,
     DynamicDisplay,
@@ -441,6 +442,19 @@ export class ChatView {
         }
     }
 
+    setDisplayInfo(
+        source: string,
+        requestId: RequestId,
+        actionIndex?: number,
+        action?: AppAction | string[],
+    ) {
+        this.getMessageGroup(requestId)?.setDisplayInfo(
+            source,
+            actionIndex,
+            action,
+        );
+    }
+
     addAgentMessage(
         msg: IAgentMessage,
         options?: {
@@ -459,12 +473,7 @@ export class ChatView {
             return;
         }
 
-        agentMessage.setMessage(
-            content,
-            msg.source,
-            options?.appendMode,
-            msg.actionName,
-        );
+        agentMessage.setMessage(content, msg.source, options?.appendMode);
 
         if (!dynamicUpdate) {
             this.updateScroll();

--- a/ts/packages/shell/src/renderer/src/main.ts
+++ b/ts/packages/shell/src/renderer/src/main.ts
@@ -70,6 +70,9 @@ function addEvents(
         exit: () => {
             window.close();
         },
+        setDisplayInfo: (source, requestId, actionIndex, action) => {
+            chatView.setDisplayInfo(source, requestId, actionIndex, action);
+        },
         setDisplay: (message) => {
             chatView.addAgentMessage(message);
         },
@@ -283,9 +286,8 @@ function showNotifications(
     chatView.addAgentMessage(
         {
             message: { type: "html", content: html },
-            source: "shell",
+            source: "shell.showNotifications",
             requestId: requestId,
-            actionName: "shell.showNotifications",
         },
         { notification: true },
     );
@@ -325,8 +327,7 @@ function summarizeNotifications(
             content: summary,
         },
         requestId: requestId,
-        source: "shell",
-        actionName: "shell.notificationSummary",
+        source: "shell.notificationSummary",
     });
 }
 

--- a/ts/packages/shell/src/renderer/src/messageContainer.ts
+++ b/ts/packages/shell/src/renderer/src/messageContainer.ts
@@ -149,9 +149,16 @@ export class MessageContainer {
         if (this.iconDiv !== undefined) {
             // set source and source icon
             const sourceLabel = this.sourceLabel;
+            const label = this.timestampDiv.firstChild as HTMLSpanElement;
             if (sourceLabel !== undefined && sourceLabel.length > 0) {
-                (this.timestampDiv.firstChild as HTMLDivElement).innerText =
-                    sourceLabel;
+                label.innerText = sourceLabel;
+            }
+
+            if (this.action !== undefined && !Array.isArray(this.action)) {
+                label.setAttribute(
+                    "action-data",
+                    JSON.stringify(this.action, undefined, 2),
+                );
             }
 
             this.iconDiv.innerText = this.sourceIcon;

--- a/ts/packages/shell/src/renderer/src/messageGroup.ts
+++ b/ts/packages/shell/src/renderer/src/messageGroup.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { DisplayContent } from "@typeagent/agent-sdk";
+import { AppAction, DisplayContent } from "@typeagent/agent-sdk";
 import { IAgentMessage, NotifyExplainedData } from "agent-dispatcher";
 import { RequestMetrics } from "agent-dispatcher";
 
@@ -31,14 +31,14 @@ export class MessageGroup {
             chatView,
             settingsView,
             "user",
-            "",
+            chatView.userGivenName,
             agents,
             container,
             hideMetrics,
             this.start,
         );
 
-        this.userMessage.setMessage(request, "");
+        this.userMessage.setMessage(request, chatView.userGivenName);
 
         if (container.firstChild) {
             container.firstChild.before(this.userMessage.div);
@@ -65,6 +65,20 @@ export class MessageGroup {
             agentMessage.setMetricsVisible(visible);
         }
     }
+
+    public setDisplayInfo(
+        source: string,
+        actionIndex?: number,
+        action?: AppAction | string[],
+    ) {
+        const agentMessage = this.ensureAgentMessage({
+            message: "",
+            source,
+            actionIndex,
+        });
+        agentMessage.setDisplayInfo(source, action);
+    }
+
     private requestCompleted(metrics: RequestMetrics | undefined) {
         this.updateMetrics(metrics);
         if (this.statusMessage === undefined) {
@@ -163,7 +177,7 @@ export class MessageGroup {
                         this.chatView,
                         this.settingsView,
                         "agent",
-                        msg.actionName ?? msg.source,
+                        msg.source,
                         this.agents,
                         beforeElem.div,
                         this.hideMetrics,
@@ -185,7 +199,7 @@ export class MessageGroup {
     }
 
     public updateUserMessage(message: string) {
-        this.userMessage.setMessage(message, "");
+        this.userMessage.setMessage(message, this.chatView.userGivenName);
     }
 
     public notifyExplained(data: NotifyExplainedData) {


### PR DESCRIPTION
Instead of adding the action name to every message.

Now, the whole action object is provided, so the shell can display it when hovering the source.