### PR TITLE
Spelunker: Pass '-X utf8' to python3 to avoid coding errors on Windows

### DIFF
--- a/ts/examples/spelunker/src/pythonChunker.ts
+++ b/ts/examples/spelunker/src/pythonChunker.ts
@@ -55,7 +55,7 @@ export async function chunkifyPythonFiles(
     try {
         const chunkerPath = path.join(__dirname, "chunker.py");
         let { stdout, stderr } = await execPromise(
-            `python3 ${chunkerPath} ${filenames.join(" ")}`,
+            `python3 -X utf8 ${chunkerPath} ${filenames.join(" ")}`,
             { maxBuffer: 64 * 1024 * 1024 }, // Super large buffer
         );
         output = stdout;

--- a/ts/packages/agents/spelunker/src/pythonChunker.ts
+++ b/ts/packages/agents/spelunker/src/pythonChunker.ts
@@ -55,7 +55,7 @@ export async function chunkifyPythonFiles(
     try {
         const chunkerPath = path.join(__dirname, "chunker.py");
         let { stdout, stderr } = await execPromise(
-            `python3 ${chunkerPath} ${filenames.join(" ")}`,
+            `python3 -X utf8 ${chunkerPath} ${filenames.join(" ")}`,
             { maxBuffer: 64 * 1024 * 1024 }, // Super large buffer
         );
         output = stdout;


### PR DESCRIPTION
(Note: there are two copies of the files related to python chunking. TODO: Refactor to share the code.)