### PR TITLE
Remove tsc compiler reference same source twice

### DIFF
--- a/ts/examples/memoryProviders/test/tsconfig.json
+++ b/ts/examples/memoryProviders/test/tsconfig.json
@@ -6,7 +6,7 @@
     "outDir": "../dist/test",
     "types": ["node", "jest"],
   },
-  "include": ["./**/*", "../src/conversation/testData.ts"],
+  "include": ["./**/*"],
   "ts-node": {
     "esm": true
   },

--- a/ts/packages/knowledgeProcessor/test/tsconfig.json
+++ b/ts/packages/knowledgeProcessor/test/tsconfig.json
@@ -6,7 +6,7 @@
     "outDir": "../dist/test",
     "types": ["node", "jest"],
   },
-  "include": ["./**/*", "../src/conversation/testData.ts"],
+  "include": ["./**/*"],
   "ts-node": {
     "esm": true
   },


### PR DESCRIPTION
testData.ts don't need to be rebuild in the test directory in memory provider and knowledge processor.
It interferes with incremental building.