### PR TITLE
[Spelunker] Try to work with entities

### DIFF
--- a/ts/.vscode/launch.json
+++ b/ts/.vscode/launch.json
@@ -53,7 +53,7 @@
           "cwd": "${workspaceFolder}/packages/cli",
           "program": "./bin/run.js",
           "args": [ "interactive" ],
-          "console": "externalTerminal",
+          "console": "integratedTerminal",
           //"preLaunchTask": "pnpm: build",
           "outFiles": [
               "${workspaceFolder}/**/*.js"

--- a/ts/packages/agents/spelunker/TODO.md
+++ b/ts/packages/agents/spelunker/TODO.md
@@ -1,5 +1,0 @@
-# TODO
-
-- Refactor more things into functions (e.g. db setup)
-- Move db schema to a global var? Or to a function
-- Possibly initialize db more eagerly, e.g. in updateSpelunkerContext

--- a/ts/packages/agents/spelunker/src/pythonChunker.ts
+++ b/ts/packages/agents/spelunker/src/pythonChunker.ts
@@ -28,6 +28,7 @@ export interface Chunk {
     // Names here must match names in chunker.py.
     chunkId: ChunkId;
     treeName: string;
+    codeName: string;
     blobs: Blob[];
     parentId: ChunkId;
     children: ChunkId[];

--- a/ts/packages/agents/spelunker/src/searchCode.ts
+++ b/ts/packages/agents/spelunker/src/searchCode.ts
@@ -216,12 +216,8 @@ export async function searchCode(
             // TODO: Include summary and signature somehow?
         };
         entities.push(entity);
-        const additionalText = entity.additionalEntityText.replace(
-            process.env.HOME ?? "%%DEADBEEF%%",
-            "~",
-        );
         console_log(
-            `    [${entity.name} (${entity.type}) ${entity.uniqueId} ${additionalText}]`,
+            `    [${entity.name} (${entity.type}) ${entity.uniqueId} ${entity.additionalEntityText}]`,
         );
     }
 

--- a/ts/packages/agents/spelunker/src/searchCode.ts
+++ b/ts/packages/agents/spelunker/src/searchCode.ts
@@ -102,11 +102,12 @@ function createQueryContext(): QueryContext {
 export async function searchCode(
     context: SpelunkerContext,
     input: string,
+    entityUniqueIds: string[],
     inputEntities: Entity[],
 ): Promise<ActionResult> {
     epoch = 0; // Reset logging clock
     console_log(
-        `[searchCode question='${input}', entities=${JSON.stringify(inputEntities)}]`,
+        `[searchCode question='${input}', entityUniqueIds=${JSON.stringify(entityUniqueIds)}, entities=${JSON.stringify(inputEntities)}]`,
     );
 
     // 0. Check if the focus is set.

--- a/ts/packages/agents/spelunker/src/searchCode.ts
+++ b/ts/packages/agents/spelunker/src/searchCode.ts
@@ -190,8 +190,8 @@ export async function searchCode(
     const answer = result.answer;
 
     // 7. Produce an action result from that.
-    // TODO: Better entities
     const entities: Entity[] = [];
+    console_log(`  [Entities returned:]`);
     for (const ref of result.references) {
         const chunk = allChunks.find((c) => c.chunkId === ref);
         if (!chunk) continue;
@@ -206,18 +206,18 @@ export async function searchCode(
             lines: string;
             breadcrumb: number;
         } = blobRow;
-        entities.push({
+        const entity = {
             name: chunk.codeName,
-            type: ["code"],
+            type: ["code", chunk.treeName.replace(/Def$/, "").toLowerCase()],
             uniqueId: ref,
             additionalEntityText: `${chunk.fileName}#${blob.start + 1}`,
             // TODO: Include summary and signature somehow
-        });
+        };
+        entities.push(entity);
+        const additionalText = entity.additionalEntityText.replace(process.env.HOME ?? "%%NONSENSE%%", "~");
+        console_log(`    [${entity.name} (${entity.type}) ${entity.uniqueId} ${additionalText}]`);
     }
 
-    console_log(
-        `  [Entities returned: ${JSON.stringify(entities, undefined, 2)}]`,
-    );
     return createActionResultFromMarkdownDisplay(answer, entities);
 }
 

--- a/ts/packages/agents/spelunker/src/spelunkerActionHandler.ts
+++ b/ts/packages/agents/spelunker/src/spelunkerActionHandler.ts
@@ -52,6 +52,7 @@ class RequestCommandHandler implements CommandHandler {
                 actionContext.sessionContext.agentContext,
                 params.args.question,
                 [],
+                [],
             );
             if (typeof result.error == "string") {
                 actionContext.actionIO.appendDisplay({
@@ -138,7 +139,9 @@ async function executeSpelunkerAction(
     entityMap?: Map<string, Entity>,
 ): Promise<ActionResult> {
     const entities = entityMap ? Array.from(entityMap.values()) : [];
-    console.log(`  [spelunker] executeSpelunkerAction: ${action.actionName}, entityMap: ${[...entityMap?.values() ?? []]}, entities: ${entities}]`);
+    console.log(
+        `  [spelunker] executeSpelunkerAction: ${action.actionName}, entityMap: ${[...(entityMap?.values() ?? [])]}, entities: ${entities}]`,
+    );
     const result = await handleSpelunkerAction(
         action as SpelunkerAction,
         context.sessionContext,
@@ -161,6 +164,7 @@ async function handleSpelunkerAction(
                 return await searchCode(
                     context.agentContext,
                     action.parameters.question,
+                    action.parameters.entityUniqueIds,
                     entities,
                 );
             }

--- a/ts/packages/agents/spelunker/src/spelunkerActionHandler.ts
+++ b/ts/packages/agents/spelunker/src/spelunkerActionHandler.ts
@@ -135,10 +135,14 @@ async function saveContext(
 async function executeSpelunkerAction(
     action: AppAction,
     context: ActionContext<SpelunkerContext>,
+    entityMap?: Map<string, Entity>,
 ): Promise<ActionResult> {
-    let result = await handleSpelunkerAction(
+    const entities = entityMap ? Array.from(entityMap.values()) : [];
+    console.log(`  [spelunker] executeSpelunkerAction: ${action.actionName}, entityMap: ${[...entityMap?.values() ?? []]}, entities: ${entities}]`);
+    const result = await handleSpelunkerAction(
         action as SpelunkerAction,
         context.sessionContext,
+        entities,
     );
     return result;
 }
@@ -146,6 +150,7 @@ async function executeSpelunkerAction(
 async function handleSpelunkerAction(
     action: SpelunkerAction,
     context: SessionContext<SpelunkerContext>,
+    entities: Entity[],
 ): Promise<ActionResult> {
     switch (action.actionName) {
         case "searchCode": {
@@ -156,7 +161,7 @@ async function handleSpelunkerAction(
                 return await searchCode(
                     context.agentContext,
                     action.parameters.question,
-                    action.parameters.entities,
+                    entities,
                 );
             }
             return createActionResultFromError("I see no question to answer");

--- a/ts/packages/agents/spelunker/src/spelunkerActionHandler.ts
+++ b/ts/packages/agents/spelunker/src/spelunkerActionHandler.ts
@@ -51,6 +51,7 @@ class RequestCommandHandler implements CommandHandler {
             const result: ActionResult = await searchCode(
                 actionContext.sessionContext.agentContext,
                 params.args.question,
+                [],
             );
             if (typeof result.error == "string") {
                 actionContext.actionIO.appendDisplay({
@@ -155,6 +156,7 @@ async function handleSpelunkerAction(
                 return await searchCode(
                     context.agentContext,
                     action.parameters.question,
+                    action.parameters.entities,
                 );
             }
             return createActionResultFromError("I see no question to answer");

--- a/ts/packages/agents/spelunker/src/spelunkerSchema.ts
+++ b/ts/packages/agents/spelunker/src/spelunkerSchema.ts
@@ -1,6 +1,18 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+// An entity from memory.ts
+export interface SpelunkerEntity {
+    // the name of the entity such as "Bach" or "frog"
+    name: string;
+    // the types of the entity such as "artist" or "animal"; an entity can have multiple types; entity types should be single words
+    type: string[];
+    // source link, '<file name>#<line number>'
+    additionalEntityText?: string;
+    // unique id for the entity (typically a ChunkId)
+    uniqueId: string;
+}
+
 export type SpelunkerAction =
     | SetFocusAction
     | GetFocusAction
@@ -24,5 +36,6 @@ export type SearchCodeAction = {
     actionName: "searchCode";
     parameters: {
         question: string; // Question to answer
+        entities: SpelunkerEntity[]; // Entities to prioritize in the search
     };
 };

--- a/ts/packages/agents/spelunker/src/spelunkerSchema.ts
+++ b/ts/packages/agents/spelunker/src/spelunkerSchema.ts
@@ -36,6 +36,5 @@ export type SearchCodeAction = {
     actionName: "searchCode";
     parameters: {
         question: string; // Question to answer
-        entities: SpelunkerEntity[]; // Entities to prioritize in the search
     };
 };

--- a/ts/packages/agents/spelunker/src/spelunkerSchema.ts
+++ b/ts/packages/agents/spelunker/src/spelunkerSchema.ts
@@ -1,18 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-// An entity from memory.ts
-export interface SpelunkerEntity {
-    // the name of the entity such as "Bach" or "frog"
-    name: string;
-    // the types of the entity such as "artist" or "animal"; an entity can have multiple types; entity types should be single words
-    type: string[];
-    // source link, '<file name>#<line number>'
-    additionalEntityText?: string;
-    // unique id for the entity (typically a ChunkId)
-    uniqueId: string;
-}
-
 export type SpelunkerAction =
     | SetFocusAction
     | GetFocusAction
@@ -22,7 +10,8 @@ export type SpelunkerAction =
 export type SetFocusAction = {
     actionName: "setFocus";
     parameters: {
-        folders: string[]; // Focus exclusively on these folders (may be empty to clear focus)
+        // Focus exclusively on these folders (may be empty to clear focus)
+        folders: string[];
     };
 };
 
@@ -35,6 +24,9 @@ export type GetFocusAction = {
 export type SearchCodeAction = {
     actionName: "searchCode";
     parameters: {
-        question: string; // Question to answer
+        // Question to answer
+        question: string;
+        // Unique Ids of entities relevant to the question, taken from the entities' uniqueId fields
+        entityUniqueIds: string[];
     };
 };


### PR DESCRIPTION
Includes an update to the chunker to return the function/class/module name as a new field (codeName).

The entity work is incomplete, I produce entities, and they end up in the session history, but I am having a hard time having them passed back into spelunker. At least they can be used by the translator sometimes.

Example of what works:
- "spelunker describe tracing in more detail": produces a long bullet list, and some entities
- "spelunker describe the first two bullets in more detail" : makes two separate calls to Spelunker:
  - "Describe the initialization and loading in the ConfigurationReader class in more detail."
  - "Describe the flattening and merging in the ConfigurationReader class in more detail."
 
It is passing stuff to each of the last two spelunker calls, but it uses the filename/lineno instead of the unique chunk ID that I want.

I will leave finishing this for another day, but I want this set of changes merged since it does work to some extent.