### PR TITLE
Improve player schema stability by almost 2%

### DIFF
--- a/ts/packages/agents/player/src/agent/playerSchema.ts
+++ b/ts/packages/agents/player/src/agent/playerSchema.ts
@@ -6,7 +6,6 @@ export type PlayerAction =
     | PlayTrackAction
     | PlayFromCurrentTrackListAction
     | PlayAlbumAction
-    | PlayAlbumTrackAction
     | PlayArtistAction
     | PlayGenreAction
     | StatusAction
@@ -41,6 +40,7 @@ export interface PlayTrackAction {
     actionName: "playTrack";
     parameters: {
         trackName: string;
+        albumName?: string;
         artists?: string[];
     };
 }
@@ -63,19 +63,11 @@ export interface PlayFromCurrentTrackListAction {
     };
 }
 
-export interface PlayAlbumTrackAction {
-    actionName: "playAlbumTrack";
-    parameters: {
-        albumName: string;
-        trackName: string;
-        artists?: string[];
-    };
-}
-
 export interface PlayArtistAction {
     actionName: "playArtist";
     parameters: {
         artist: string;
+        genre?: string; // option genre if specified.
         quantity?: number;
     };
 }

--- a/ts/packages/agents/player/src/endpoints.ts
+++ b/ts/packages/agents/player/src/endpoints.ts
@@ -139,13 +139,6 @@ export async function getTopUserTracks(service: SpotifyService, k = limitMax) {
     return getK(k, get);
 }
 
-export async function getGenreSeeds(service: SpotifyService) {
-    return callRestAPI<SpotifyApi.AvailableGenreSeedsResponse>(
-        service,
-        "https://api.spotify.com/v1/recommendations/available-genre-seeds",
-        {},
-    );
-}
 async function getKCursor<T>(
     k: number,
     get: (

--- a/ts/packages/dispatcher/test/data/calendar/v5/complex.json
+++ b/ts/packages/dispatcher/test/data/calendar/v5/complex.json
@@ -1,7 +1,7 @@
 {
   "version": 2,
   "schemaName": "calendar",
-  "sourceHash": "hwzLzZv/wViCFS4vx7+SF2rSdW9FaXQo34tFejL4Dxs=",
+  "sourceHash": "q89odXmST8U5DeqvXQL7XAkaPw0Efxj2FT391Xq3Vis=",
   "explainerName": "v5",
   "entries": [
     {
@@ -10,11 +10,10 @@
         "fullActionName": "calendar.addEvent",
         "parameters": {
           "event": {
-            "day": "December 10",
+            "day": "1/24/2025",
             "timeRange": {
               "startTime": "2:00 pm"
             },
-            "translatedDate": "12/10/2024",
             "description": "meeting with team",
             "participants": [
               "team"
@@ -33,20 +32,17 @@
           },
           {
             "name": "parameters.event.day",
-            "value": "December 10",
-            "isImplicit": true
+            "value": "1/24/2025",
+            "substrings": [
+              "today"
+            ]
           },
           {
             "name": "parameters.event.timeRange.startTime",
             "value": "2:00 pm",
             "substrings": [
-              "2"
+              "at 2"
             ]
-          },
-          {
-            "name": "parameters.event.translatedDate",
-            "value": "12/10/2024",
-            "isImplicit": true
           },
           {
             "name": "parameters.event.description",
@@ -75,8 +71,10 @@
           },
           {
             "text": "today",
-            "category": "date",
-            "propertyNames": []
+            "category": "time",
+            "propertyNames": [
+              "parameters.event.day"
+            ]
           },
           {
             "text": "at 2",
@@ -169,6 +167,33 @@
             ]
           },
           {
+            "propertyName": "parameters.event.day",
+            "propertyValue": "1/24/2025",
+            "propertySubPhrases": [
+              "today"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "1/25/2025",
+                "propertySubPhrases": [
+                  "tomorrow"
+                ]
+              },
+              {
+                "propertyValue": "1/26/2025",
+                "propertySubPhrases": [
+                  "day after tomorrow"
+                ]
+              },
+              {
+                "propertyValue": "1/31/2025",
+                "propertySubPhrases": [
+                  "next Friday"
+                ]
+              }
+            ]
+          },
+          {
             "propertyName": "parameters.event.timeRange.startTime",
             "propertyValue": "2:00 pm",
             "propertySubPhrases": [
@@ -188,9 +213,9 @@
                 ]
               },
               {
-                "propertyValue": "1:00 pm",
+                "propertyValue": "5:00 pm",
                 "propertySubPhrases": [
-                  "at 1"
+                  "at 5"
                 ]
               }
             ]
@@ -199,90 +224,16 @@
         "politePrefixes": [
           "Could you please",
           "Would you mind",
-          "If it's not too much trouble, could you"
+          "If it's not too much trouble, could you",
+          "I would appreciate it if you could"
         ],
         "politeSuffixes": [
           "Thank you!",
-          "I would appreciate it.",
-          "Thanks in advance!"
+          "Thanks a lot!",
+          "I appreciate it!",
+          "Much appreciated!"
         ]
-      },
-      "corrections": [
-        {
-          "data": {
-            "properties": [
-              {
-                "name": "fullActionName",
-                "value": "calendar.addEvent",
-                "substrings": [
-                  "Add meeting with team"
-                ]
-              },
-              {
-                "name": "parameters.event.day",
-                "value": "December 10",
-                "isImplicit": true
-              },
-              {
-                "name": "parameters.event.timeRange.startTime",
-                "value": "2:00 pm",
-                "substrings": [
-                  "2"
-                ]
-              },
-              {
-                "name": "parameters.event.translatedDate",
-                "value": "12/10/2024",
-                "isImplicit": true
-              },
-              {
-                "name": "parameters.event.description",
-                "value": "meeting with team",
-                "substrings": [
-                  "meeting with team"
-                ]
-              },
-              {
-                "name": "parameters.event.participants.0",
-                "value": "team",
-                "substrings": [
-                  "team"
-                ]
-              }
-            ],
-            "subPhrases": [
-              {
-                "text": "Add meeting with team",
-                "category": "action",
-                "propertyNames": [
-                  "fullActionName",
-                  "parameters.event.description",
-                  "parameters.event.participants.0"
-                ]
-              },
-              {
-                "text": "today",
-                "category": "date",
-                "propertyNames": [
-                  "parameters.event.day",
-                  "parameters.event.translatedDate"
-                ]
-              },
-              {
-                "text": "at 2",
-                "category": "time",
-                "propertyNames": [
-                  "parameters.event.timeRange.startTime"
-                ]
-              }
-            ]
-          },
-          "correction": [
-            "Property 'parameters.event.day' is expected to be implicit and should not be included as a property name in a sub-phrase",
-            "Property 'parameters.event.translatedDate' is expected to be implicit and should not be included as a property name in a sub-phrase"
-          ]
-        }
-      ]
+      }
     },
     {
       "request": "Do I have any plan with Rosy this month?",
@@ -290,10 +241,10 @@
         "fullActionName": "calendar.findEvents",
         "parameters": {
           "eventReference": {
-            "dayRange": "this month",
             "participants": [
               "Rosy"
-            ]
+            ],
+            "dayRange": "this month"
           }
         }
       },
@@ -302,14 +253,7 @@
           {
             "name": "fullActionName",
             "value": "calendar.findEvents",
-            "substrings": []
-          },
-          {
-            "name": "parameters.eventReference.dayRange",
-            "value": "this month",
-            "substrings": [
-              "this month"
-            ]
+            "isImplicit": true
           },
           {
             "name": "parameters.eventReference.participants.0",
@@ -317,13 +261,25 @@
             "substrings": [
               "Rosy"
             ]
+          },
+          {
+            "name": "parameters.eventReference.dayRange",
+            "value": "this month",
+            "substrings": [
+              "this month"
+            ]
           }
         ],
         "subPhrases": [
           {
             "text": "Do I have any plan with",
             "category": "query",
-            "propertyNames": []
+            "synonyms": [
+              "Do I have any event with",
+              "Do I have any meeting with",
+              "Do I have any appointment with"
+            ],
+            "isOptional": true
           },
           {
             "text": "Rosy",
@@ -334,7 +290,7 @@
           },
           {
             "text": "this month",
-            "category": "time",
+            "category": "time period",
             "propertyNames": [
               "parameters.eventReference.dayRange"
             ]
@@ -414,7 +370,70 @@
           "Thank you!",
           "I would appreciate it."
         ]
-      }
+      },
+      "corrections": [
+        {
+          "data": {
+            "properties": [
+              {
+                "name": "fullActionName",
+                "value": "calendar.findEvents",
+                "isImplicit": true
+              },
+              {
+                "name": "parameters.eventReference.participants.0",
+                "value": "Rosy",
+                "substrings": [
+                  "Rosy"
+                ]
+              },
+              {
+                "name": "parameters.eventReference.dayRange",
+                "value": "this month",
+                "substrings": [
+                  "this month"
+                ]
+              }
+            ],
+            "subPhrases": [
+              {
+                "text": "Do I have any plan with",
+                "category": "query",
+                "propertyNames": [
+                  "fullActionName"
+                ]
+              },
+              {
+                "text": "Rosy",
+                "category": "participant",
+                "propertyNames": [
+                  "parameters.eventReference.participants.0"
+                ]
+              },
+              {
+                "text": "this month",
+                "category": "time period",
+                "propertyNames": [
+                  "parameters.eventReference.dayRange"
+                ]
+              },
+              {
+                "text": "?",
+                "category": "punctuation",
+                "synonyms": [
+                  "",
+                  ".",
+                  "!"
+                ],
+                "isOptional": true
+              }
+            ]
+          },
+          "correction": [
+            "Property 'fullActionName' is expected to be implicit and should not be included as a property name in a sub-phrase"
+          ]
+        }
+      ]
     },
     {
       "request": "I need to add a meeting with my boss on Monday at 10am.",
@@ -422,12 +441,12 @@
         "fullActionName": "calendar.addEvent",
         "parameters": {
           "event": {
-            "day": "December 16",
+            "day": "1/27/2025",
             "timeRange": {
               "startTime": "10:00 am"
             },
-            "translatedDate": "12/16/2024",
-            "description": "meeting with my boss"
+            "description": "meeting with my boss",
+            "translatedDate": "1/27/2025"
           }
         }
       },
@@ -440,10 +459,8 @@
           },
           {
             "name": "parameters.event.day",
-            "value": "December 16",
-            "substrings": [
-              "Monday"
-            ]
+            "value": "1/27/2025",
+            "substrings": []
           },
           {
             "name": "parameters.event.timeRange.startTime",
@@ -453,21 +470,31 @@
             ]
           },
           {
-            "name": "parameters.event.translatedDate",
-            "value": "12/16/2024",
-            "isImplicit": true
-          },
-          {
             "name": "parameters.event.description",
             "value": "meeting with my boss",
             "substrings": [
               "meeting with my boss"
             ]
+          },
+          {
+            "name": "parameters.event.translatedDate",
+            "value": "1/27/2025",
+            "substrings": []
           }
         ],
         "subPhrases": [
           {
-            "text": "I need to add",
+            "text": "I need to",
+            "category": "politeness",
+            "synonyms": [
+              "Please",
+              "Can you",
+              "Could you"
+            ],
+            "isOptional": true
+          },
+          {
+            "text": "add",
             "category": "action",
             "propertyNames": [
               "fullActionName"
@@ -475,16 +502,17 @@
           },
           {
             "text": "a meeting with my boss",
-            "category": "description",
+            "category": "event description",
             "propertyNames": [
               "parameters.event.description"
             ]
           },
           {
             "text": "on Monday",
-            "category": "day",
+            "category": "date",
             "propertyNames": [
-              "parameters.event.day"
+              "parameters.event.day",
+              "parameters.event.translatedDate"
             ]
           },
           {
@@ -500,25 +528,25 @@
             "propertyName": "fullActionName",
             "propertyValue": "calendar.addEvent",
             "propertySubPhrases": [
-              "I need to add"
+              "add"
             ],
             "alternatives": [
               {
                 "propertyValue": "calendar.createEvent",
                 "propertySubPhrases": [
-                  "I want to create"
+                  "create"
                 ]
               },
               {
                 "propertyValue": "calendar.scheduleEvent",
                 "propertySubPhrases": [
-                  "I need to schedule"
+                  "schedule"
                 ]
               },
               {
                 "propertyValue": "calendar.insertEvent",
                 "propertySubPhrases": [
-                  "I need to insert"
+                  "insert"
                 ]
               }
             ]
@@ -531,15 +559,9 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "discussion with my manager",
+                "propertyValue": "discussion with my boss",
                 "propertySubPhrases": [
-                  "a discussion with my manager"
-                ]
-              },
-              {
-                "propertyValue": "conference with my supervisor",
-                "propertySubPhrases": [
-                  "a conference with my supervisor"
+                  "a discussion with my boss"
                 ]
               },
               {
@@ -547,30 +569,63 @@
                 "propertySubPhrases": [
                   "an appointment with my boss"
                 ]
+              },
+              {
+                "propertyValue": "conference with my boss",
+                "propertySubPhrases": [
+                  "a conference with my boss"
+                ]
               }
             ]
           },
           {
             "propertyName": "parameters.event.day",
-            "propertyValue": "December 16",
+            "propertyValue": "1/27/2025",
             "propertySubPhrases": [
               "on Monday"
             ],
             "alternatives": [
               {
-                "propertyValue": "December 17",
+                "propertyValue": "1/28/2025",
                 "propertySubPhrases": [
                   "on Tuesday"
                 ]
               },
               {
-                "propertyValue": "December 18",
+                "propertyValue": "1/29/2025",
                 "propertySubPhrases": [
                   "on Wednesday"
                 ]
               },
               {
-                "propertyValue": "December 19",
+                "propertyValue": "1/30/2025",
+                "propertySubPhrases": [
+                  "on Thursday"
+                ]
+              }
+            ]
+          },
+          {
+            "propertyName": "parameters.event.translatedDate",
+            "propertyValue": "1/27/2025",
+            "propertySubPhrases": [
+              "on Monday"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "1/28/2025",
+                "propertySubPhrases": [
+                  "on Tuesday"
+                ]
+              },
+              {
+                "propertyValue": "1/29/2025",
+                "propertySubPhrases": [
+                  "on Wednesday"
+                ]
+              },
+              {
+                "propertyValue": "1/30/2025",
                 "propertySubPhrases": [
                   "on Thursday"
                 ]
@@ -630,7 +685,7 @@
               "startTime": "12:00 pm",
               "endTime": "2:00 pm"
             },
-            "description": "get my tires changed"
+            "description": "Get my tires changed"
           }
         }
       },
@@ -664,7 +719,7 @@
           },
           {
             "name": "parameters.event.description",
-            "value": "get my tires changed",
+            "value": "Get my tires changed",
             "substrings": [
               "get my tires changed"
             ]
@@ -713,27 +768,27 @@
         "propertyAlternatives": [
           {
             "propertyName": "parameters.event.description",
-            "propertyValue": "get my tires changed",
+            "propertyValue": "Get my tires changed",
             "propertySubPhrases": [
               "get my tires changed"
             ],
             "alternatives": [
               {
-                "propertyValue": "get my oil changed",
+                "propertyValue": "Get my oil changed",
                 "propertySubPhrases": [
                   "get my oil changed"
                 ]
               },
               {
-                "propertyValue": "rotate my tires",
+                "propertyValue": "Get my car washed",
                 "propertySubPhrases": [
-                  "rotate my tires"
+                  "get my car washed"
                 ]
               },
               {
-                "propertyValue": "check my brakes",
+                "propertyValue": "Get my brakes checked",
                 "propertySubPhrases": [
-                  "check my brakes"
+                  "get my brakes checked"
                 ]
               }
             ]
@@ -822,11 +877,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If it's not too much trouble, could you",
+          "May I kindly ask you to"
         ],
         "politeSuffixes": [
-          "Thank you",
-          "I would appreciate it"
+          "Thank you!",
+          "I would appreciate it.",
+          "Thanks in advance.",
+          "Your help is much appreciated."
         ]
       }
     },
@@ -836,13 +895,13 @@
         "fullActionName": "calendar.addEvent",
         "parameters": {
           "event": {
-            "day": "December 10",
+            "day": "1/24/2025",
             "timeRange": {
               "startTime": "3:30 pm",
               "duration": "1 hour"
             },
-            "translatedDate": "12/10/2024",
-            "description": "Go to the dry cleaner"
+            "description": "Go to the dry cleaner",
+            "translatedDate": "1/24/2025"
           }
         }
       },
@@ -855,8 +914,8 @@
           },
           {
             "name": "parameters.event.day",
-            "value": "December 10",
-            "substrings": []
+            "value": "1/24/2025",
+            "isImplicit": true
           },
           {
             "name": "parameters.event.timeRange.startTime",
@@ -873,16 +932,16 @@
             ]
           },
           {
-            "name": "parameters.event.translatedDate",
-            "value": "12/10/2024",
-            "isImplicit": true
-          },
-          {
             "name": "parameters.event.description",
             "value": "Go to the dry cleaner",
             "substrings": [
               "I need to go to the dry cleaner"
             ]
+          },
+          {
+            "name": "parameters.event.translatedDate",
+            "value": "1/24/2025",
+            "isImplicit": true
           }
         ],
         "subPhrases": [
@@ -907,8 +966,13 @@
           },
           {
             "text": "for that",
-            "category": "reference",
-            "propertyNames": []
+            "category": "filler",
+            "synonyms": [
+              "for it",
+              "for the task",
+              "for the event"
+            ],
+            "isOptional": true
           },
           {
             "text": "starting at 3:30",
@@ -927,21 +991,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "Pick up groceries",
+                "propertyValue": "Pick up laundry",
                 "propertySubPhrases": [
-                  "I need to pick up groceries"
+                  "I need to pick up laundry"
                 ]
               },
               {
-                "propertyValue": "Visit the dentist",
+                "propertyValue": "Visit the tailor",
                 "propertySubPhrases": [
-                  "I need to visit the dentist"
+                  "I need to visit the tailor"
                 ]
               },
               {
-                "propertyValue": "Attend a meeting",
+                "propertyValue": "Drop off clothes",
                 "propertySubPhrases": [
-                  "I need to attend a meeting"
+                  "I need to drop off clothes"
                 ]
               }
             ]
@@ -987,15 +1051,15 @@
                 ]
               },
               {
-                "propertyValue": "2:00 pm",
+                "propertyValue": "3:00 pm",
                 "propertySubPhrases": [
-                  "starting at 2:00"
+                  "starting at 3:00"
                 ]
               },
               {
-                "propertyValue": "5:00 pm",
+                "propertyValue": "2:30 pm",
                 "propertySubPhrases": [
-                  "starting at 5:00"
+                  "starting at 2:30"
                 ]
               }
             ]
@@ -1004,12 +1068,14 @@
         "politePrefixes": [
           "Could you please",
           "Would you mind",
-          "If it's not too much trouble, could you"
+          "If it's not too much trouble, could you",
+          "I would appreciate it if you could"
         ],
         "politeSuffixes": [
           "Thank you!",
-          "I would really appreciate it.",
-          "Thanks in advance!"
+          "Thanks a lot!",
+          "I appreciate it!",
+          "Much appreciated!"
         ]
       }
     },
@@ -1019,12 +1085,14 @@
         "fullActionName": "calendar.addEvent",
         "parameters": {
           "event": {
-            "day": "December 10",
+            "day": "1/24/2025",
             "timeRange": {
               "startTime": "2:00 pm"
             },
-            "translatedDate": "12/10/2024",
-            "description": "meet with Jenny"
+            "description": "Meeting with Jenny",
+            "participants": [
+              "Jenny"
+            ]
           }
         }
       },
@@ -1033,11 +1101,11 @@
           {
             "name": "fullActionName",
             "value": "calendar.addEvent",
-            "isImplicit": true
+            "substrings": []
           },
           {
             "name": "parameters.event.day",
-            "value": "December 10",
+            "value": "1/24/2025",
             "isImplicit": true
           },
           {
@@ -1048,15 +1116,17 @@
             ]
           },
           {
-            "name": "parameters.event.translatedDate",
-            "value": "12/10/2024",
-            "isImplicit": true
-          },
-          {
             "name": "parameters.event.description",
-            "value": "meet with Jenny",
+            "value": "Meeting with Jenny",
             "substrings": [
               "meet with Jenny"
+            ]
+          },
+          {
+            "name": "parameters.event.participants.0",
+            "value": "Jenny",
+            "substrings": [
+              "Jenny"
             ]
           }
         ],
@@ -1080,17 +1150,17 @@
           },
           {
             "text": "this afternoon",
-            "category": "time of day",
+            "category": "time reference",
             "synonyms": [
-              "today in the afternoon",
+              "today afternoon",
               "later today",
-              "this PM"
+              "in the afternoon"
             ],
             "isOptional": true
           },
           {
             "text": "at 2pm",
-            "category": "start time",
+            "category": "time",
             "propertyNames": [
               "parameters.event.timeRange.startTime"
             ]
@@ -1099,27 +1169,27 @@
         "propertyAlternatives": [
           {
             "propertyName": "parameters.event.description",
-            "propertyValue": "meet with Jenny",
+            "propertyValue": "Meeting with Jenny",
             "propertySubPhrases": [
               "meet with Jenny"
             ],
             "alternatives": [
               {
-                "propertyValue": "discuss project with Jenny",
+                "propertyValue": "Discussion with Jenny",
                 "propertySubPhrases": [
-                  "discuss project with Jenny"
+                  "discussion with Jenny"
                 ]
               },
               {
-                "propertyValue": "have lunch with Jenny",
+                "propertyValue": "Appointment with Jenny",
                 "propertySubPhrases": [
-                  "have lunch with Jenny"
+                  "appointment with Jenny"
                 ]
               },
               {
-                "propertyValue": "catch up with Jenny",
+                "propertyValue": "Catch-up with Jenny",
                 "propertySubPhrases": [
-                  "catch up with Jenny"
+                  "catch-up with Jenny"
                 ]
               }
             ]
@@ -1154,11 +1224,13 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If it's not too much trouble, could you"
         ],
         "politeSuffixes": [
           "Thank you!",
-          "I appreciate it!"
+          "I would appreciate it.",
+          "Thanks in advance!"
         ]
       }
     },
@@ -1168,11 +1240,10 @@
         "fullActionName": "calendar.addEvent",
         "parameters": {
           "event": {
-            "day": "December 11",
+            "day": "1/25/2025",
             "timeRange": {
               "startTime": "3:00 pm"
             },
-            "translatedDate": "12/11/2024",
             "description": "appointment",
             "participants": [
               "Sally",
@@ -1187,12 +1258,12 @@
           {
             "name": "fullActionName",
             "value": "calendar.addEvent",
-            "substrings": []
+            "isImplicit": true
           },
           {
             "name": "parameters.event.day",
-            "value": "December 11",
-            "substrings": []
+            "value": "1/25/2025",
+            "isImplicit": true
           },
           {
             "name": "parameters.event.timeRange.startTime",
@@ -1202,15 +1273,10 @@
             ]
           },
           {
-            "name": "parameters.event.translatedDate",
-            "value": "12/11/2024",
-            "substrings": []
-          },
-          {
             "name": "parameters.event.description",
             "value": "appointment",
             "substrings": [
-              "appointment"
+              "an appointment"
             ]
           },
           {
@@ -1247,10 +1313,14 @@
             "isOptional": true
           },
           {
-            "text": "schedule an appointment",
+            "text": "schedule",
             "category": "action",
+            "propertyNames": []
+          },
+          {
+            "text": "an appointment",
+            "category": "description",
             "propertyNames": [
-              "fullActionName",
               "parameters.event.description"
             ]
           },
@@ -1265,11 +1335,8 @@
           },
           {
             "text": "tomorrow",
-            "category": "date",
-            "propertyNames": [
-              "parameters.event.day",
-              "parameters.event.translatedDate"
-            ]
+            "category": "day",
+            "propertyNames": []
           },
           {
             "text": "at 3pm",
@@ -1281,55 +1348,28 @@
         ],
         "propertyAlternatives": [
           {
-            "propertyName": "fullActionName",
-            "propertyValue": "calendar.addEvent",
-            "propertySubPhrases": [
-              "schedule an appointment"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "calendar.createMeeting",
-                "propertySubPhrases": [
-                  "schedule a meeting"
-                ]
-              },
-              {
-                "propertyValue": "calendar.bookEvent",
-                "propertySubPhrases": [
-                  "book an event"
-                ]
-              },
-              {
-                "propertyValue": "calendar.setAppointment",
-                "propertySubPhrases": [
-                  "set an appointment"
-                ]
-              }
-            ]
-          },
-          {
             "propertyName": "parameters.event.description",
             "propertyValue": "appointment",
             "propertySubPhrases": [
-              "schedule an appointment"
+              "an appointment"
             ],
             "alternatives": [
               {
                 "propertyValue": "meeting",
                 "propertySubPhrases": [
-                  "schedule a meeting"
+                  "a meeting"
                 ]
               },
               {
-                "propertyValue": "event",
+                "propertyValue": "consultation",
                 "propertySubPhrases": [
-                  "schedule an event"
+                  "a consultation"
                 ]
               },
               {
-                "propertyValue": "conference",
+                "propertyValue": "discussion",
                 "propertySubPhrases": [
-                  "schedule a conference"
+                  "a discussion"
                 ]
               }
             ]
@@ -1369,21 +1409,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "June",
-                "propertySubPhrases": [
-                  "with Sally, June, and Boris"
-                ]
-              },
-              {
-                "propertyValue": "April",
-                "propertySubPhrases": [
-                  "with Sally, April, and Boris"
-                ]
-              },
-              {
                 "propertyValue": "Jane",
                 "propertySubPhrases": [
                   "with Sally, Jane, and Boris"
+                ]
+              },
+              {
+                "propertyValue": "Tom",
+                "propertySubPhrases": [
+                  "with Sally, Tom, and Boris"
+                ]
+              },
+              {
+                "propertyValue": "Chris",
+                "propertySubPhrases": [
+                  "with Sally, Chris, and Boris"
                 ]
               }
             ]
@@ -1396,75 +1436,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "Tom",
+                "propertyValue": "David",
                 "propertySubPhrases": [
-                  "with Sally, May, and Tom"
+                  "with Sally, May, and David"
                 ]
               },
               {
-                "propertyValue": "Harry",
+                "propertyValue": "Nina",
                 "propertySubPhrases": [
-                  "with Sally, May, and Harry"
+                  "with Sally, May, and Nina"
                 ]
               },
               {
-                "propertyValue": "Jack",
+                "propertyValue": "Paul",
                 "propertySubPhrases": [
-                  "with Sally, May, and Jack"
-                ]
-              }
-            ]
-          },
-          {
-            "propertyName": "parameters.event.day",
-            "propertyValue": "December 11",
-            "propertySubPhrases": [
-              "tomorrow"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "December 12",
-                "propertySubPhrases": [
-                  "the day after tomorrow"
-                ]
-              },
-              {
-                "propertyValue": "December 10",
-                "propertySubPhrases": [
-                  "the day before"
-                ]
-              },
-              {
-                "propertyValue": "December 15",
-                "propertySubPhrases": [
-                  "next week"
-                ]
-              }
-            ]
-          },
-          {
-            "propertyName": "parameters.event.translatedDate",
-            "propertyValue": "12/11/2024",
-            "propertySubPhrases": [
-              "tomorrow"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "12/12/2024",
-                "propertySubPhrases": [
-                  "the day after tomorrow"
-                ]
-              },
-              {
-                "propertyValue": "12/10/2024",
-                "propertySubPhrases": [
-                  "the day before"
-                ]
-              },
-              {
-                "propertyValue": "12/15/2024",
-                "propertySubPhrases": [
-                  "next week"
+                  "with Sally, May, and Paul"
                 ]
               }
             ]
@@ -1500,16 +1486,169 @@
         "politePrefixes": [
           "Could you please",
           "Would you mind",
-          "If it's not too much trouble, could you",
-          "I would appreciate it if you could"
+          "If it's not too much trouble, could you"
         ],
         "politeSuffixes": [
           "Thank you!",
-          "Thanks in advance!",
-          "I appreciate it!",
-          "Much appreciated!"
+          "I would appreciate it.",
+          "Thanks in advance!"
         ]
-      }
+      },
+      "corrections": [
+        {
+          "data": {
+            "properties": [
+              {
+                "name": "fullActionName",
+                "value": "calendar.addEvent",
+                "isImplicit": true
+              },
+              {
+                "name": "parameters.event.timeRange.startTime",
+                "value": "3:00 pm",
+                "substrings": [
+                  "3pm"
+                ]
+              },
+              {
+                "name": "parameters.event.description",
+                "value": "appointment",
+                "substrings": [
+                  "an appointment"
+                ]
+              },
+              {
+                "name": "parameters.event.participants.0",
+                "value": "Sally",
+                "substrings": [
+                  "Sally"
+                ]
+              },
+              {
+                "name": "parameters.event.participants.1",
+                "value": "May",
+                "substrings": [
+                  "May"
+                ]
+              },
+              {
+                "name": "parameters.event.participants.2",
+                "value": "Boris",
+                "substrings": [
+                  "Boris"
+                ]
+              }
+            ]
+          },
+          "correction": [
+            "Missing parameter: parameter 'parameters.event.day' in the action is missing from explanation"
+          ]
+        },
+        {
+          "data": {
+            "properties": [
+              {
+                "name": "fullActionName",
+                "value": "calendar.addEvent",
+                "isImplicit": true
+              },
+              {
+                "name": "parameters.event.day",
+                "value": "1/25/2025",
+                "isImplicit": true
+              },
+              {
+                "name": "parameters.event.timeRange.startTime",
+                "value": "3:00 pm",
+                "substrings": [
+                  "3pm"
+                ]
+              },
+              {
+                "name": "parameters.event.description",
+                "value": "appointment",
+                "substrings": [
+                  "an appointment"
+                ]
+              },
+              {
+                "name": "parameters.event.participants.0",
+                "value": "Sally",
+                "substrings": [
+                  "Sally"
+                ]
+              },
+              {
+                "name": "parameters.event.participants.1",
+                "value": "May",
+                "substrings": [
+                  "May"
+                ]
+              },
+              {
+                "name": "parameters.event.participants.2",
+                "value": "Boris",
+                "substrings": [
+                  "Boris"
+                ]
+              }
+            ],
+            "subPhrases": [
+              {
+                "text": "make sure to",
+                "category": "politeness",
+                "synonyms": [
+                  "please",
+                  "kindly",
+                  "ensure"
+                ],
+                "isOptional": true
+              },
+              {
+                "text": "schedule",
+                "category": "action",
+                "propertyNames": [
+                  "fullActionName"
+                ]
+              },
+              {
+                "text": "an appointment",
+                "category": "description",
+                "propertyNames": [
+                  "parameters.event.description"
+                ]
+              },
+              {
+                "text": "with Sally, May, and Boris",
+                "category": "participants",
+                "propertyNames": [
+                  "parameters.event.participants.0",
+                  "parameters.event.participants.1",
+                  "parameters.event.participants.2"
+                ]
+              },
+              {
+                "text": "tomorrow",
+                "category": "day",
+                "propertyNames": [
+                  "parameters.event.day"
+                ]
+              },
+              {
+                "text": "at 3pm",
+                "category": "time",
+                "propertyNames": [
+                  "parameters.event.timeRange.startTime"
+                ]
+              }
+            ]
+          },
+          "correction": [
+            "Property 'fullActionName' is expected to be implicit and should not be included as a property name in a sub-phrase",
+            "Property 'parameters.event.day' is expected to be implicit and should not be included as a property name in a sub-phrase"
+          ]
+        }
+      ]
     },
     {
       "request": "Now just add  Jesse and Abby to the appointment with Sally",
@@ -1517,9 +1656,7 @@
         "fullActionName": "calendar.addParticipants",
         "parameters": {
           "eventReference": {
-            "participants": [
-              "Sally"
-            ],
+            "description": "appointment with Sally",
             "lookup": true
           },
           "participants": [
@@ -1534,14 +1671,14 @@
             "name": "fullActionName",
             "value": "calendar.addParticipants",
             "substrings": [
-              "Now just add  Jesse and Abby to the appointment with Sally"
+              "add  Jesse and Abby to the appointment with Sally"
             ]
           },
           {
-            "name": "parameters.eventReference.participants.0",
-            "value": "Sally",
+            "name": "parameters.eventReference.description",
+            "value": "appointment with Sally",
             "substrings": [
-              "Sally"
+              "appointment with Sally"
             ]
           },
           {
@@ -1566,22 +1703,12 @@
         ],
         "subPhrases": [
           {
-            "text": "Now",
+            "text": "Now just",
             "category": "filler",
             "synonyms": [
-              "Currently",
+              "Right now",
               "At this moment",
-              "Right now"
-            ],
-            "isOptional": true
-          },
-          {
-            "text": "just",
-            "category": "filler",
-            "synonyms": [
-              "simply",
-              "only",
-              "merely"
+              "Currently"
             ],
             "isOptional": true
           },
@@ -1603,9 +1730,9 @@
             "text": "and",
             "category": "conjunction",
             "synonyms": [
-              "as well as",
+              "plus",
               "along with",
-              "plus"
+              "together with"
             ],
             "isOptional": true
           },
@@ -1617,20 +1744,20 @@
             ]
           },
           {
-            "text": "to the appointment with",
+            "text": "to the",
             "category": "preposition",
             "synonyms": [
-              "for the meeting with",
-              "to the event with",
-              "for the appointment with"
+              "into the",
+              "onto the",
+              "towards the"
             ],
             "isOptional": true
           },
           {
-            "text": "Sally",
-            "category": "participant",
+            "text": "appointment with Sally",
+            "category": "event",
             "propertyNames": [
-              "parameters.eventReference.participants.0"
+              "parameters.eventReference.description"
             ]
           }
         ],
@@ -1655,9 +1782,9 @@
                 ]
               },
               {
-                "propertyValue": "calendar.appendParticipants",
+                "propertyValue": "calendar.addAttendees",
                 "propertySubPhrases": [
-                  "append"
+                  "add attendees"
                 ]
               }
             ]
@@ -1717,28 +1844,28 @@
             ]
           },
           {
-            "propertyName": "parameters.eventReference.participants.0",
-            "propertyValue": "Sally",
+            "propertyName": "parameters.eventReference.description",
+            "propertyValue": "appointment with Sally",
             "propertySubPhrases": [
-              "Sally"
+              "appointment with Sally"
             ],
             "alternatives": [
               {
-                "propertyValue": "Sarah",
+                "propertyValue": "meeting with Sally",
                 "propertySubPhrases": [
-                  "Sarah"
+                  "meeting with Sally"
                 ]
               },
               {
-                "propertyValue": "Samantha",
+                "propertyValue": "appointment with Sarah",
                 "propertySubPhrases": [
-                  "Samantha"
+                  "appointment with Sarah"
                 ]
               },
               {
-                "propertyValue": "Sophie",
+                "propertyValue": "appointment with Sam",
                 "propertySubPhrases": [
-                  "Sophie"
+                  "appointment with Sam"
                 ]
               }
             ]
@@ -1747,14 +1874,12 @@
         "politePrefixes": [
           "Could you please",
           "Would you mind",
-          "If it's not too much trouble, could you",
-          "May I kindly ask you to"
+          "If it's not too much trouble, could you"
         ],
         "politeSuffixes": [
           "Thank you!",
           "I would appreciate it.",
-          "Thanks a lot!",
-          "That would be great."
+          "Thanks a lot!"
         ]
       }
     },
@@ -1764,11 +1889,12 @@
         "fullActionName": "calendar.addEvent",
         "parameters": {
           "event": {
-            "day": "December 13",
+            "day": "January 24",
             "timeRange": {
               "startTime": "6:00 pm"
             },
-            "description": "Jeffs pizza party"
+            "description": "Jeffs pizza party",
+            "translatedDate": "1/24/2025"
           }
         }
       },
@@ -1777,13 +1903,11 @@
           {
             "name": "fullActionName",
             "value": "calendar.addEvent",
-            "substrings": [
-              "Set up an event"
-            ]
+            "substrings": []
           },
           {
             "name": "parameters.event.day",
-            "value": "December 13",
+            "value": "January 24",
             "substrings": [
               "friday"
             ]
@@ -1801,29 +1925,24 @@
             "substrings": [
               "Jeffs pizza party"
             ]
+          },
+          {
+            "name": "parameters.event.translatedDate",
+            "value": "1/24/2025",
+            "substrings": []
           }
         ],
         "subPhrases": [
           {
-            "text": "Set up an event",
+            "text": "Set up an event for",
             "category": "action",
             "propertyNames": [
               "fullActionName"
             ]
           },
           {
-            "text": "for",
-            "category": "preposition",
-            "synonyms": [
-              "to",
-              "on behalf of",
-              "in favor of"
-            ],
-            "isOptional": true
-          },
-          {
             "text": "friday",
-            "category": "day",
+            "category": "date",
             "propertyNames": [
               "parameters.event.day"
             ]
@@ -1834,7 +1953,7 @@
             "synonyms": [
               "called",
               "titled",
-              "known as"
+              "labelled"
             ],
             "isOptional": true
           },
@@ -1850,8 +1969,8 @@
             "category": "preposition",
             "synonyms": [
               "on",
-              "in",
-              "during"
+              "during",
+              "around"
             ],
             "isOptional": true
           },
@@ -1868,52 +1987,52 @@
             "propertyName": "fullActionName",
             "propertyValue": "calendar.addEvent",
             "propertySubPhrases": [
-              "Set up an event"
+              "Set up an event for"
             ],
             "alternatives": [
               {
-                "propertyValue": "calendar.createEvent",
+                "propertyValue": "calendar.scheduleEvent",
                 "propertySubPhrases": [
-                  "Create an event"
+                  "Schedule an event for"
                 ]
               },
               {
-                "propertyValue": "calendar.scheduleEvent",
+                "propertyValue": "calendar.createEvent",
                 "propertySubPhrases": [
-                  "Schedule an event"
+                  "Create an event for"
                 ]
               },
               {
                 "propertyValue": "calendar.planEvent",
                 "propertySubPhrases": [
-                  "Plan an event"
+                  "Plan an event for"
                 ]
               }
             ]
           },
           {
             "propertyName": "parameters.event.day",
-            "propertyValue": "December 13",
+            "propertyValue": "January 24",
             "propertySubPhrases": [
               "friday"
             ],
             "alternatives": [
               {
-                "propertyValue": "December 14",
+                "propertyValue": "January 25",
                 "propertySubPhrases": [
                   "saturday"
                 ]
               },
               {
-                "propertyValue": "December 12",
+                "propertyValue": "January 26",
                 "propertySubPhrases": [
-                  "thursday"
+                  "sunday"
                 ]
               },
               {
-                "propertyValue": "December 20",
+                "propertyValue": "January 27",
                 "propertySubPhrases": [
-                  "next friday"
+                  "monday"
                 ]
               }
             ]
@@ -1932,15 +2051,15 @@
                 ]
               },
               {
-                "propertyValue": "Office pizza party",
+                "propertyValue": "Jeffs graduation party",
                 "propertySubPhrases": [
-                  "Office pizza party"
+                  "Jeffs graduation party"
                 ]
               },
               {
-                "propertyValue": "Family pizza night",
+                "propertyValue": "Jeffs farewell party",
                 "propertySubPhrases": [
-                  "Family pizza night"
+                  "Jeffs farewell party"
                 ]
               }
             ]
@@ -1959,15 +2078,15 @@
                 ]
               },
               {
-                "propertyValue": "5:00 pm",
-                "propertySubPhrases": [
-                  "5pm"
-                ]
-              },
-              {
                 "propertyValue": "8:00 pm",
                 "propertySubPhrases": [
                   "8pm"
+                ]
+              },
+              {
+                "propertyValue": "5:00 pm",
+                "propertySubPhrases": [
+                  "5pm"
                 ]
               }
             ]
@@ -1976,14 +2095,12 @@
         "politePrefixes": [
           "Could you please",
           "Would you mind",
-          "If it's not too much trouble, could you",
-          "May I kindly ask you to"
+          "If it's not too much trouble, could you"
         ],
         "politeSuffixes": [
           "Thank you!",
           "I would appreciate it.",
-          "Thanks a lot!",
-          "That would be great, thanks!"
+          "Thanks in advance!"
         ]
       }
     },
@@ -1993,7 +2110,7 @@
         "fullActionName": "calendar.addEvent",
         "parameters": {
           "event": {
-            "day": "12/10/2024",
+            "day": "1/24/2025",
             "timeRange": {
               "startTime": "9:00 am",
               "duration": "2 hours"
@@ -2011,12 +2128,12 @@
             "name": "fullActionName",
             "value": "calendar.addEvent",
             "substrings": [
-              "Will you please add an appointment"
+              "Will you please add"
             ]
           },
           {
             "name": "parameters.event.day",
-            "value": "12/10/2024",
+            "value": "1/24/2025",
             "isImplicit": true
           },
           {
@@ -2050,20 +2167,21 @@
         ],
         "subPhrases": [
           {
-            "text": "Will you please",
+            "text": "Will you please add",
             "category": "politeness",
-            "synonyms": [
-              "Could you please",
-              "Would you kindly",
-              "Can you please"
+            "propertyNames": [
+              "fullActionName"
             ],
-            "isOptional": true
+            "synonyms": [
+              "Can you add",
+              "Could you please add",
+              "Would you add"
+            ]
           },
           {
-            "text": "add an appointment",
-            "category": "action",
+            "text": "an appointment",
+            "category": "description",
             "propertyNames": [
-              "fullActionName",
               "parameters.event.description"
             ]
           },
@@ -2094,25 +2212,25 @@
             "propertyName": "fullActionName",
             "propertyValue": "calendar.addEvent",
             "propertySubPhrases": [
-              "add an appointment"
+              "Will you please add"
             ],
             "alternatives": [
               {
-                "propertyValue": "calendar.scheduleMeeting",
-                "propertySubPhrases": [
-                  "schedule a meeting"
-                ]
-              },
-              {
                 "propertyValue": "calendar.createEvent",
                 "propertySubPhrases": [
-                  "create an event"
+                  "Can you create"
                 ]
               },
               {
-                "propertyValue": "calendar.bookAppointment",
+                "propertyValue": "calendar.scheduleEvent",
                 "propertySubPhrases": [
-                  "book an appointment"
+                  "Please schedule"
+                ]
+              },
+              {
+                "propertyValue": "calendar.insertEvent",
+                "propertySubPhrases": [
+                  "Insert"
                 ]
               }
             ]
@@ -2121,25 +2239,25 @@
             "propertyName": "parameters.event.description",
             "propertyValue": "appointment",
             "propertySubPhrases": [
-              "add an appointment"
+              "an appointment"
             ],
             "alternatives": [
               {
                 "propertyValue": "meeting",
                 "propertySubPhrases": [
-                  "schedule a meeting"
+                  "a meeting"
                 ]
               },
               {
-                "propertyValue": "event",
+                "propertyValue": "call",
                 "propertySubPhrases": [
-                  "create an event"
+                  "a call"
                 ]
               },
               {
-                "propertyValue": "consultation",
+                "propertyValue": "discussion",
                 "propertySubPhrases": [
-                  "book a consultation"
+                  "a discussion"
                 ]
               }
             ]
@@ -2164,9 +2282,9 @@
                 ]
               },
               {
-                "propertyValue": "Morgan Lee",
+                "propertyValue": "Jordan Lee",
                 "propertySubPhrases": [
-                  "with Morgan Lee"
+                  "with Jordan Lee"
                 ]
               }
             ]
@@ -2237,7 +2355,7 @@
                 "name": "fullActionName",
                 "value": "calendar.addEvent",
                 "substrings": [
-                  "Will you please add an appointment"
+                  "Will you please add"
                 ]
               },
               {

--- a/ts/packages/dispatcher/test/data/calendar/v5/simple.json
+++ b/ts/packages/dispatcher/test/data/calendar/v5/simple.json
@@ -1,7 +1,7 @@
 {
   "version": 2,
   "schemaName": "calendar",
-  "sourceHash": "hwzLzZv/wViCFS4vx7+SF2rSdW9FaXQo34tFejL4Dxs=",
+  "sourceHash": "q89odXmST8U5DeqvXQL7XAkaPw0Efxj2FT391Xq3Vis=",
   "explainerName": "v5",
   "entries": [
     {
@@ -10,7 +10,7 @@
         "fullActionName": "calendar.addEvent",
         "parameters": {
           "event": {
-            "day": "December 19",
+            "day": "January 30",
             "timeRange": {
               "startTime": "3:00 pm",
               "endTime": "4:00 pm"
@@ -24,13 +24,11 @@
           {
             "name": "fullActionName",
             "value": "calendar.addEvent",
-            "substrings": [
-              "add"
-            ]
+            "substrings": []
           },
           {
             "name": "parameters.event.day",
-            "value": "December 19",
+            "value": "January 30",
             "substrings": [
               "next Thursday"
             ]
@@ -199,27 +197,27 @@
           },
           {
             "propertyName": "parameters.event.day",
-            "propertyValue": "December 19",
+            "propertyValue": "January 30",
             "propertySubPhrases": [
               "next Thursday"
             ],
             "alternatives": [
               {
-                "propertyValue": "December 20",
+                "propertyValue": "January 31",
                 "propertySubPhrases": [
                   "next Friday"
                 ]
               },
               {
-                "propertyValue": "December 18",
+                "propertyValue": "January 29",
                 "propertySubPhrases": [
                   "next Wednesday"
                 ]
               },
               {
-                "propertyValue": "December 17",
+                "propertyValue": "February 6",
                 "propertySubPhrases": [
-                  "next Tuesday"
+                  "Thursday after next"
                 ]
               }
             ]
@@ -228,12 +226,14 @@
         "politePrefixes": [
           "Could you please",
           "Would you mind",
-          "If it's not too much trouble, could you"
+          "If it's not too much trouble,",
+          "May I ask you to"
         ],
         "politeSuffixes": [
           "Thank you!",
           "I would appreciate it.",
-          "Thanks in advance!"
+          "Thanks a lot!",
+          "That would be great!"
         ]
       }
     },
@@ -243,12 +243,11 @@
         "fullActionName": "calendar.addEvent",
         "parameters": {
           "event": {
-            "day": "December 12",
+            "day": "January 30",
             "timeRange": {
               "startTime": "4:00 pm",
               "duration": "30 minutes"
             },
-            "translatedDate": "12/12/2024",
             "description": "dentist appointment"
           }
         }
@@ -258,11 +257,11 @@
           {
             "name": "fullActionName",
             "value": "calendar.addEvent",
-            "isImplicit": true
+            "substrings": []
           },
           {
             "name": "parameters.event.day",
-            "value": "December 12",
+            "value": "January 30",
             "substrings": [
               "next Thursday"
             ]
@@ -282,13 +281,6 @@
             ]
           },
           {
-            "name": "parameters.event.translatedDate",
-            "value": "12/12/2024",
-            "substrings": [
-              "next Thursday"
-            ]
-          },
-          {
             "name": "parameters.event.description",
             "value": "dentist appointment",
             "substrings": [
@@ -300,7 +292,9 @@
           {
             "text": "add",
             "category": "action",
-            "propertyNames": []
+            "propertyNames": [
+              "fullActionName"
+            ]
           },
           {
             "text": "half hour",
@@ -337,12 +331,38 @@
             "text": "next Thursday",
             "category": "day",
             "propertyNames": [
-              "parameters.event.day",
-              "parameters.event.translatedDate"
+              "parameters.event.day"
             ]
           }
         ],
         "propertyAlternatives": [
+          {
+            "propertyName": "fullActionName",
+            "propertyValue": "calendar.addEvent",
+            "propertySubPhrases": [
+              "add"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "calendar.createEvent",
+                "propertySubPhrases": [
+                  "create"
+                ]
+              },
+              {
+                "propertyValue": "calendar.scheduleEvent",
+                "propertySubPhrases": [
+                  "schedule"
+                ]
+              },
+              {
+                "propertyValue": "calendar.insertEvent",
+                "propertySubPhrases": [
+                  "insert"
+                ]
+              }
+            ]
+          },
           {
             "propertyName": "parameters.event.timeRange.duration",
             "propertyValue": "30 minutes",
@@ -426,54 +446,27 @@
           },
           {
             "propertyName": "parameters.event.day",
-            "propertyValue": "December 12",
+            "propertyValue": "January 30",
             "propertySubPhrases": [
               "next Thursday"
             ],
             "alternatives": [
               {
-                "propertyValue": "December 13",
+                "propertyValue": "January 31",
                 "propertySubPhrases": [
                   "next Friday"
                 ]
               },
               {
-                "propertyValue": "December 11",
+                "propertyValue": "January 29",
                 "propertySubPhrases": [
                   "next Wednesday"
                 ]
               },
               {
-                "propertyValue": "December 10",
+                "propertyValue": "February 6",
                 "propertySubPhrases": [
-                  "next Tuesday"
-                ]
-              }
-            ]
-          },
-          {
-            "propertyName": "parameters.event.translatedDate",
-            "propertyValue": "12/12/2024",
-            "propertySubPhrases": [
-              "next Thursday"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "12/13/2024",
-                "propertySubPhrases": [
-                  "next Friday"
-                ]
-              },
-              {
-                "propertyValue": "12/11/2024",
-                "propertySubPhrases": [
-                  "next Wednesday"
-                ]
-              },
-              {
-                "propertyValue": "12/10/2024",
-                "propertySubPhrases": [
-                  "next Tuesday"
+                  "Thursday after next"
                 ]
               }
             ]
@@ -481,116 +474,13 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind",
-          "If it's not too much trouble, could you",
-          "May I kindly ask you to"
+          "Would you mind"
         ],
         "politeSuffixes": [
           "Thank you!",
-          "I would appreciate it.",
-          "Thanks in advance!",
-          "Your help is appreciated."
+          "I would appreciate it."
         ]
-      },
-      "corrections": [
-        {
-          "data": {
-            "properties": [
-              {
-                "name": "fullActionName",
-                "value": "calendar.addEvent",
-                "isImplicit": true
-              },
-              {
-                "name": "parameters.event.day",
-                "value": "December 12",
-                "substrings": [
-                  "next Thursday"
-                ]
-              },
-              {
-                "name": "parameters.event.timeRange.startTime",
-                "value": "4:00 pm",
-                "substrings": [
-                  "4pm"
-                ]
-              },
-              {
-                "name": "parameters.event.timeRange.duration",
-                "value": "30 minutes",
-                "substrings": [
-                  "half hour"
-                ]
-              },
-              {
-                "name": "parameters.event.translatedDate",
-                "value": "12/12/2024",
-                "substrings": [
-                  "next Thursday"
-                ]
-              },
-              {
-                "name": "parameters.event.description",
-                "value": "dentist appointment",
-                "substrings": [
-                  "dentist appointment"
-                ]
-              }
-            ],
-            "subPhrases": [
-              {
-                "text": "add",
-                "category": "action",
-                "propertyNames": [
-                  "fullActionName"
-                ]
-              },
-              {
-                "text": "half hour",
-                "category": "duration",
-                "propertyNames": [
-                  "parameters.event.timeRange.duration"
-                ]
-              },
-              {
-                "text": "dentist appointment",
-                "category": "description",
-                "propertyNames": [
-                  "parameters.event.description"
-                ]
-              },
-              {
-                "text": "starting at",
-                "category": "preposition",
-                "synonyms": [
-                  "beginning at",
-                  "commencing at",
-                  "from"
-                ],
-                "isOptional": true
-              },
-              {
-                "text": "4pm",
-                "category": "startTime",
-                "propertyNames": [
-                  "parameters.event.timeRange.startTime"
-                ]
-              },
-              {
-                "text": "next Thursday",
-                "category": "day",
-                "propertyNames": [
-                  "parameters.event.day",
-                  "parameters.event.translatedDate"
-                ]
-              }
-            ]
-          },
-          "correction": [
-            "Property 'fullActionName' is expected to be implicit and should not be included as a property name in a sub-phrase"
-          ]
-        }
-      ]
+      }
     },
     {
       "request": "add Isobel to the Wednesday ping pong game at 4pm",
@@ -674,7 +564,7 @@
             "synonyms": [
               "into the",
               "for the",
-              "in the"
+              "towards the"
             ],
             "isOptional": true
           },
@@ -698,7 +588,7 @@
             "synonyms": [
               "on",
               "during",
-              "in"
+              "by"
             ],
             "isOptional": true
           },
@@ -719,21 +609,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "calendar.createEvent",
+                "propertyValue": "calendar.addAttendees",
                 "propertySubPhrases": [
-                  "create"
+                  "add"
                 ]
               },
               {
-                "propertyValue": "calendar.updateEvent",
+                "propertyValue": "calendar.includeParticipants",
                 "propertySubPhrases": [
-                  "update"
+                  "add"
                 ]
               },
               {
-                "propertyValue": "calendar.removeParticipants",
+                "propertyValue": "calendar.addMembers",
                 "propertySubPhrases": [
-                  "remove"
+                  "add"
                 ]
               }
             ]
@@ -746,21 +636,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "John",
+                "propertyValue": "Isabella",
                 "propertySubPhrases": [
-                  "John"
+                  "Isobel"
                 ]
               },
               {
-                "propertyValue": "Emma",
+                "propertyValue": "Isabel",
                 "propertySubPhrases": [
-                  "Emma"
+                  "Isobel"
                 ]
               },
               {
-                "propertyValue": "Michael",
+                "propertyValue": "Izzy",
                 "propertySubPhrases": [
-                  "Michael"
+                  "Isobel"
                 ]
               }
             ]
@@ -773,21 +663,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "Monday",
+                "propertyValue": "Thursday",
                 "propertySubPhrases": [
-                  "Monday"
+                  "Wednesday"
+                ]
+              },
+              {
+                "propertyValue": "Tuesday",
+                "propertySubPhrases": [
+                  "Wednesday"
                 ]
               },
               {
                 "propertyValue": "Friday",
                 "propertySubPhrases": [
-                  "Friday"
-                ]
-              },
-              {
-                "propertyValue": "Sunday",
-                "propertySubPhrases": [
-                  "Sunday"
+                  "Wednesday"
                 ]
               }
             ]
@@ -802,19 +692,19 @@
               {
                 "propertyValue": "tennis match",
                 "propertySubPhrases": [
-                  "tennis match"
+                  "ping pong game"
                 ]
               },
               {
-                "propertyValue": "basketball game",
+                "propertyValue": "badminton game",
                 "propertySubPhrases": [
-                  "basketball game"
+                  "ping pong game"
                 ]
               },
               {
-                "propertyValue": "soccer match",
+                "propertyValue": "table tennis game",
                 "propertySubPhrases": [
-                  "soccer match"
+                  "ping pong game"
                 ]
               }
             ]
@@ -829,19 +719,19 @@
               {
                 "propertyValue": "3:00 pm",
                 "propertySubPhrases": [
-                  "3pm"
+                  "4pm"
                 ]
               },
               {
                 "propertyValue": "5:00 pm",
                 "propertySubPhrases": [
-                  "5pm"
+                  "4pm"
                 ]
               },
               {
                 "propertyValue": "6:00 pm",
                 "propertySubPhrases": [
-                  "6pm"
+                  "4pm"
                 ]
               }
             ]
@@ -849,15 +739,11 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind",
-          "If it's not too much trouble, could you",
-          "May I kindly ask you to"
+          "Would you mind"
         ],
         "politeSuffixes": [
           "Thank you!",
-          "Thanks a lot!",
-          "I would appreciate it!",
-          "That would be great!"
+          "I appreciate it!"
         ]
       }
     },
@@ -872,7 +758,7 @@
             "lookup": true
           },
           "participants": [
-            "Piali"
+            "piali"
           ]
         }
       },
@@ -906,7 +792,7 @@
           },
           {
             "name": "parameters.participants.0",
-            "value": "Piali",
+            "value": "piali",
             "substrings": [
               "piali"
             ]
@@ -914,16 +800,10 @@
         ],
         "subPhrases": [
           {
-            "text": "add",
+            "text": "add piali",
             "category": "action",
             "propertyNames": [
-              "fullActionName"
-            ]
-          },
-          {
-            "text": "piali",
-            "category": "participant",
-            "propertyNames": [
+              "fullActionName",
               "parameters.participants.0"
             ]
           },
@@ -946,7 +826,7 @@
           },
           {
             "text": "this week",
-            "category": "time range",
+            "category": "time reference",
             "propertyNames": [
               "parameters.eventReference.dayRange"
             ]
@@ -957,52 +837,52 @@
             "propertyName": "fullActionName",
             "propertyValue": "calendar.addParticipants",
             "propertySubPhrases": [
-              "add"
+              "add piali"
             ],
             "alternatives": [
               {
-                "propertyValue": "calendar.removeParticipants",
-                "propertySubPhrases": [
-                  "remove"
-                ]
-              },
-              {
-                "propertyValue": "calendar.updateParticipants",
-                "propertySubPhrases": [
-                  "update"
-                ]
-              },
-              {
                 "propertyValue": "calendar.inviteParticipants",
                 "propertySubPhrases": [
-                  "invite"
+                  "invite piali"
+                ]
+              },
+              {
+                "propertyValue": "calendar.includeParticipants",
+                "propertySubPhrases": [
+                  "include piali"
+                ]
+              },
+              {
+                "propertyValue": "calendar.addAttendees",
+                "propertySubPhrases": [
+                  "add attendees"
                 ]
               }
             ]
           },
           {
             "propertyName": "parameters.participants.0",
-            "propertyValue": "Piali",
+            "propertyValue": "piali",
             "propertySubPhrases": [
-              "piali"
+              "add piali"
             ],
             "alternatives": [
               {
-                "propertyValue": "John",
+                "propertyValue": "john",
                 "propertySubPhrases": [
-                  "john"
+                  "add john"
                 ]
               },
               {
-                "propertyValue": "Alice",
+                "propertyValue": "susan",
                 "propertySubPhrases": [
-                  "alice"
+                  "add susan"
                 ]
               },
               {
-                "propertyValue": "Michael",
+                "propertyValue": "michael",
                 "propertySubPhrases": [
-                  "michael"
+                  "add michael"
                 ]
               }
             ]
@@ -1015,21 +895,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "Project Kickoff",
+                "propertyValue": "AI Conference",
                 "propertySubPhrases": [
-                  "Project Kickoff"
+                  "AI Conference"
                 ]
               },
               {
-                "propertyValue": "Team Sync",
+                "propertyValue": "AI Workshop",
                 "propertySubPhrases": [
-                  "Team Sync"
+                  "AI Workshop"
                 ]
               },
               {
-                "propertyValue": "Client Presentation",
+                "propertyValue": "AI Symposium",
                 "propertySubPhrases": [
-                  "Client Presentation"
+                  "AI Symposium"
                 ]
               }
             ]
@@ -1066,13 +946,13 @@
           "Could you please",
           "Would you mind",
           "If it's not too much trouble, could you",
-          "May I kindly ask you to"
+          "I would appreciate it if you could"
         ],
         "politeSuffixes": [
           "Thank you!",
-          "I would appreciate it.",
-          "Thanks in advance!",
-          "Your help is much appreciated."
+          "Thanks a lot!",
+          "I appreciate it!",
+          "Much appreciated!"
         ]
       }
     },
@@ -1082,11 +962,14 @@
         "fullActionName": "calendar.addEvent",
         "parameters": {
           "event": {
-            "day": "December 13",
+            "day": "January 24",
             "timeRange": {
               "startTime": "12:00 pm"
             },
-            "description": "lunch with Luis"
+            "description": "Lunch with Luis",
+            "participants": [
+              "Luis"
+            ]
           }
         }
       },
@@ -1095,14 +978,14 @@
           {
             "name": "fullActionName",
             "value": "calendar.addEvent",
-            "substrings": []
+            "substrings": [
+              "can you record"
+            ]
           },
           {
             "name": "parameters.event.day",
-            "value": "December 13",
-            "substrings": [
-              "on Friday"
-            ]
+            "value": "January 24",
+            "isImplicit": true
           },
           {
             "name": "parameters.event.timeRange.startTime",
@@ -1113,25 +996,22 @@
           },
           {
             "name": "parameters.event.description",
-            "value": "lunch with Luis",
+            "value": "Lunch with Luis",
             "substrings": [
               "lunch with Luis"
+            ]
+          },
+          {
+            "name": "parameters.event.participants.0",
+            "value": "Luis",
+            "substrings": [
+              "Luis"
             ]
           }
         ],
         "subPhrases": [
           {
-            "text": "can you",
-            "category": "politeness",
-            "synonyms": [
-              "could you",
-              "would you",
-              "please"
-            ],
-            "isOptional": true
-          },
-          {
-            "text": "record",
+            "text": "can you record",
             "category": "action",
             "propertyNames": [
               "fullActionName"
@@ -1154,9 +1034,12 @@
           {
             "text": "on Friday",
             "category": "day",
-            "propertyNames": [
-              "parameters.event.day"
-            ]
+            "synonyms": [
+              "this Friday",
+              "coming Friday",
+              "next Friday"
+            ],
+            "isOptional": true
           }
         ],
         "propertyAlternatives": [
@@ -1164,52 +1047,52 @@
             "propertyName": "fullActionName",
             "propertyValue": "calendar.addEvent",
             "propertySubPhrases": [
-              "record"
+              "can you record"
             ],
             "alternatives": [
               {
                 "propertyValue": "calendar.createEvent",
                 "propertySubPhrases": [
-                  "create"
+                  "can you create"
                 ]
               },
               {
                 "propertyValue": "calendar.scheduleEvent",
                 "propertySubPhrases": [
-                  "schedule"
+                  "can you schedule"
                 ]
               },
               {
                 "propertyValue": "calendar.logEvent",
                 "propertySubPhrases": [
-                  "log"
+                  "can you log"
                 ]
               }
             ]
           },
           {
             "propertyName": "parameters.event.description",
-            "propertyValue": "lunch with Luis",
+            "propertyValue": "Lunch with Luis",
             "propertySubPhrases": [
               "lunch with Luis"
             ],
             "alternatives": [
               {
-                "propertyValue": "meeting with Luis",
+                "propertyValue": "Meeting with Luis",
                 "propertySubPhrases": [
                   "meeting with Luis"
                 ]
               },
               {
-                "propertyValue": "dinner with Luis",
+                "propertyValue": "Brunch with Luis",
                 "propertySubPhrases": [
-                  "dinner with Luis"
+                  "brunch with Luis"
                 ]
               },
               {
-                "propertyValue": "brunch with Luis",
+                "propertyValue": "Dinner with Luis",
                 "propertySubPhrases": [
-                  "brunch with Luis"
+                  "dinner with Luis"
                 ]
               }
             ]
@@ -1240,48 +1123,143 @@
                 ]
               }
             ]
-          },
-          {
-            "propertyName": "parameters.event.day",
-            "propertyValue": "December 13",
-            "propertySubPhrases": [
-              "on Friday"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "December 14",
-                "propertySubPhrases": [
-                  "on Saturday"
-                ]
-              },
-              {
-                "propertyValue": "December 12",
-                "propertySubPhrases": [
-                  "on Thursday"
-                ]
-              },
-              {
-                "propertyValue": "December 20",
-                "propertySubPhrases": [
-                  "next Friday"
-                ]
-              }
-            ]
           }
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind",
-          "If it's not too much trouble, could you",
-          "May I kindly ask you to"
+          "Would you mind"
         ],
         "politeSuffixes": [
           "Thank you!",
-          "I would appreciate it.",
-          "Thanks in advance!",
-          "Your help is appreciated."
+          "I would appreciate it."
         ]
-      }
+      },
+      "corrections": [
+        {
+          "data": {
+            "properties": [
+              {
+                "name": "fullActionName",
+                "value": "calendar.addEvent",
+                "substrings": [
+                  "can you record"
+                ]
+              },
+              {
+                "name": "parameters.event.day",
+                "value": "Friday",
+                "substrings": [
+                  "on Friday"
+                ]
+              },
+              {
+                "name": "parameters.event.timeRange.startTime",
+                "value": "12:00 pm",
+                "substrings": [
+                  "at 12pm"
+                ]
+              },
+              {
+                "name": "parameters.event.description",
+                "value": "Lunch with Luis",
+                "substrings": [
+                  "lunch with Luis"
+                ]
+              },
+              {
+                "name": "parameters.event.participants.0",
+                "value": "Luis",
+                "substrings": [
+                  "Luis"
+                ]
+              }
+            ]
+          },
+          "correction": [
+            "Mismatch parameter value: 'Friday' in the explanation is not the value of the parameter 'parameters.event.day' in the action"
+          ]
+        },
+        {
+          "data": {
+            "properties": [
+              {
+                "name": "fullActionName",
+                "value": "calendar.addEvent",
+                "substrings": [
+                  "can you record"
+                ]
+              },
+              {
+                "name": "parameters.event.day",
+                "value": "January 24",
+                "isImplicit": true
+              },
+              {
+                "name": "parameters.event.timeRange.startTime",
+                "value": "12:00 pm",
+                "substrings": [
+                  "at 12pm"
+                ]
+              },
+              {
+                "name": "parameters.event.description",
+                "value": "Lunch with Luis",
+                "substrings": [
+                  "lunch with Luis"
+                ]
+              },
+              {
+                "name": "parameters.event.participants.0",
+                "value": "Luis",
+                "substrings": [
+                  "Luis"
+                ]
+              }
+            ],
+            "subPhrases": [
+              {
+                "text": "can you record",
+                "category": "action",
+                "propertyNames": [
+                  "fullActionName"
+                ]
+              },
+              {
+                "text": "lunch with Luis",
+                "category": "event description",
+                "propertyNames": [
+                  "parameters.event.description"
+                ]
+              },
+              {
+                "text": "Luis",
+                "category": "participant",
+                "propertyNames": [
+                  "parameters.event.participants.0"
+                ]
+              },
+              {
+                "text": "at 12pm",
+                "category": "time",
+                "propertyNames": [
+                  "parameters.event.timeRange.startTime"
+                ]
+              },
+              {
+                "text": "on Friday",
+                "category": "day",
+                "propertyNames": [
+                  "parameters.event.day"
+                ]
+              }
+            ]
+          },
+          "correction": [
+            "Overlapping sub-phrase: explanation has overlapping text 'Luis'.",
+            "Property 'parameters.event.day' is expected to be implicit and should not be included as a property name in a sub-phrase"
+          ]
+        }
+      ]
     },
     {
       "request": "Please add Jennifer to the scrum next Thursday",
@@ -1289,7 +1267,7 @@
         "fullActionName": "calendar.addParticipants",
         "parameters": {
           "eventReference": {
-            "day": "12/19/2024",
+            "day": "1/30/2025",
             "description": "scrum",
             "lookup": true
           },
@@ -1309,10 +1287,8 @@
           },
           {
             "name": "parameters.eventReference.day",
-            "value": "12/19/2024",
-            "substrings": [
-              "next Thursday"
-            ]
+            "value": "1/30/2025",
+            "isImplicit": true
           },
           {
             "name": "parameters.eventReference.description",
@@ -1341,7 +1317,7 @@
             "synonyms": [
               "Kindly",
               "Would you mind",
-              "Could you please"
+              "Could you"
             ],
             "isOptional": true
           },
@@ -1364,24 +1340,27 @@
             "category": "preposition",
             "synonyms": [
               "into the",
-              "in the",
-              "for the"
+              "onto the",
+              "towards the"
             ],
             "isOptional": true
           },
           {
             "text": "scrum",
-            "category": "event description",
+            "category": "event",
             "propertyNames": [
               "parameters.eventReference.description"
             ]
           },
           {
             "text": "next Thursday",
-            "category": "event day",
-            "propertyNames": [
-              "parameters.eventReference.day"
-            ]
+            "category": "date",
+            "synonyms": [
+              "coming Thursday",
+              "this Thursday",
+              "the following Thursday"
+            ],
+            "isOptional": true
           }
         ],
         "propertyAlternatives": [
@@ -1405,9 +1384,9 @@
                 ]
               },
               {
-                "propertyValue": "calendar.inviteParticipants",
+                "propertyValue": "calendar.updateEvent",
                 "propertySubPhrases": [
-                  "invite"
+                  "update"
                 ]
               }
             ]
@@ -1420,21 +1399,21 @@
             ],
             "alternatives": [
               {
+                "propertyValue": "John",
+                "propertySubPhrases": [
+                  "John"
+                ]
+              },
+              {
+                "propertyValue": "Alice",
+                "propertySubPhrases": [
+                  "Alice"
+                ]
+              },
+              {
                 "propertyValue": "Michael",
                 "propertySubPhrases": [
                   "Michael"
-                ]
-              },
-              {
-                "propertyValue": "Sarah",
-                "propertySubPhrases": [
-                  "Sarah"
-                ]
-              },
-              {
-                "propertyValue": "David",
-                "propertySubPhrases": [
-                  "David"
                 ]
               }
             ]
@@ -1453,9 +1432,9 @@
                 ]
               },
               {
-                "propertyValue": "discussion",
+                "propertyValue": "standup",
                 "propertySubPhrases": [
-                  "discussion"
+                  "standup"
                 ]
               },
               {
@@ -1465,38 +1444,103 @@
                 ]
               }
             ]
-          },
-          {
-            "propertyName": "parameters.eventReference.day",
-            "propertyValue": "12/19/2024",
-            "propertySubPhrases": [
-              "next Thursday"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "12/20/2024",
-                "propertySubPhrases": [
-                  "next Friday"
-                ]
-              },
-              {
-                "propertyValue": "12/18/2024",
-                "propertySubPhrases": [
-                  "next Wednesday"
-                ]
-              },
-              {
-                "propertyValue": "12/17/2024",
-                "propertySubPhrases": [
-                  "next Tuesday"
-                ]
-              }
-            ]
           }
         ],
         "politePrefixes": [],
         "politeSuffixes": []
-      }
+      },
+      "corrections": [
+        {
+          "data": {
+            "properties": [
+              {
+                "name": "fullActionName",
+                "value": "calendar.addParticipants",
+                "substrings": [
+                  "add"
+                ]
+              },
+              {
+                "name": "parameters.eventReference.day",
+                "value": "1/30/2025",
+                "isImplicit": true
+              },
+              {
+                "name": "parameters.eventReference.description",
+                "value": "scrum",
+                "substrings": [
+                  "scrum"
+                ]
+              },
+              {
+                "name": "parameters.eventReference.lookup",
+                "value": true,
+                "isImplicit": true
+              },
+              {
+                "name": "parameters.participants.0",
+                "value": "Jennifer",
+                "substrings": [
+                  "Jennifer"
+                ]
+              }
+            ],
+            "subPhrases": [
+              {
+                "text": "Please",
+                "category": "politeness",
+                "synonyms": [
+                  "Kindly",
+                  "Would you mind",
+                  "Could you"
+                ],
+                "isOptional": true
+              },
+              {
+                "text": "add",
+                "category": "action",
+                "propertyNames": [
+                  "fullActionName"
+                ]
+              },
+              {
+                "text": "Jennifer",
+                "category": "participant",
+                "propertyNames": [
+                  "parameters.participants.0"
+                ]
+              },
+              {
+                "text": "to the",
+                "category": "preposition",
+                "synonyms": [
+                  "into the",
+                  "onto the",
+                  "towards the"
+                ],
+                "isOptional": true
+              },
+              {
+                "text": "scrum",
+                "category": "event",
+                "propertyNames": [
+                  "parameters.eventReference.description"
+                ]
+              },
+              {
+                "text": "next Thursday",
+                "category": "date",
+                "propertyNames": [
+                  "parameters.eventReference.day"
+                ]
+              }
+            ]
+          },
+          "correction": [
+            "Property 'parameters.eventReference.day' is expected to be implicit and should not be included as a property name in a sub-phrase"
+          ]
+        }
+      ]
     },
     {
       "request": "record bridge game Monday at 10 for one hour",
@@ -1504,12 +1548,11 @@
         "fullActionName": "calendar.addEvent",
         "parameters": {
           "event": {
-            "day": "December 16",
+            "day": "January 27",
             "timeRange": {
               "startTime": "10:00 am",
               "duration": "1 hour"
             },
-            "translatedDate": "12/16/2024",
             "description": "bridge game"
           }
         }
@@ -1519,16 +1562,12 @@
           {
             "name": "fullActionName",
             "value": "calendar.addEvent",
-            "substrings": [
-              "record"
-            ]
+            "substrings": []
           },
           {
             "name": "parameters.event.day",
-            "value": "December 16",
-            "substrings": [
-              "Monday"
-            ]
+            "value": "January 27",
+            "substrings": []
           },
           {
             "name": "parameters.event.timeRange.startTime",
@@ -1543,11 +1582,6 @@
             "substrings": [
               "one hour"
             ]
-          },
-          {
-            "name": "parameters.event.translatedDate",
-            "value": "12/16/2024",
-            "isImplicit": true
           },
           {
             "name": "parameters.event.description",
@@ -1580,34 +1614,14 @@
             ]
           },
           {
-            "text": "at",
-            "category": "preposition",
-            "synonyms": [
-              "on",
-              "during",
-              "in"
-            ],
-            "isOptional": true
-          },
-          {
-            "text": "10",
-            "category": "time",
+            "text": "at 10",
+            "category": "start time",
             "propertyNames": [
               "parameters.event.timeRange.startTime"
             ]
           },
           {
-            "text": "for",
-            "category": "preposition",
-            "synonyms": [
-              "lasting",
-              "during",
-              "over"
-            ],
-            "isOptional": true
-          },
-          {
-            "text": "one hour",
+            "text": "for one hour",
             "category": "duration",
             "propertyNames": [
               "parameters.event.timeRange.duration"
@@ -1662,34 +1676,34 @@
                 ]
               },
               {
-                "propertyValue": "tennis match",
+                "propertyValue": "board game",
                 "propertySubPhrases": [
-                  "tennis match"
+                  "board game"
                 ]
               }
             ]
           },
           {
             "propertyName": "parameters.event.day",
-            "propertyValue": "December 16",
+            "propertyValue": "January 27",
             "propertySubPhrases": [
               "Monday"
             ],
             "alternatives": [
               {
-                "propertyValue": "December 17",
+                "propertyValue": "January 28",
                 "propertySubPhrases": [
                   "Tuesday"
                 ]
               },
               {
-                "propertyValue": "December 18",
+                "propertyValue": "January 29",
                 "propertySubPhrases": [
                   "Wednesday"
                 ]
               },
               {
-                "propertyValue": "December 19",
+                "propertyValue": "January 30",
                 "propertySubPhrases": [
                   "Thursday"
                 ]
@@ -1700,25 +1714,25 @@
             "propertyName": "parameters.event.timeRange.startTime",
             "propertyValue": "10:00 am",
             "propertySubPhrases": [
-              "10"
+              "at 10"
             ],
             "alternatives": [
               {
-                "propertyValue": "9:00 am",
-                "propertySubPhrases": [
-                  "9"
-                ]
-              },
-              {
                 "propertyValue": "11:00 am",
                 "propertySubPhrases": [
-                  "11"
+                  "at 11"
                 ]
               },
               {
-                "propertyValue": "12:00 pm",
+                "propertyValue": "9:00 am",
                 "propertySubPhrases": [
-                  "12"
+                  "at 9"
+                ]
+              },
+              {
+                "propertyValue": "8:00 am",
+                "propertySubPhrases": [
+                  "at 8"
                 ]
               }
             ]
@@ -1727,25 +1741,25 @@
             "propertyName": "parameters.event.timeRange.duration",
             "propertyValue": "1 hour",
             "propertySubPhrases": [
-              "one hour"
+              "for one hour"
             ],
             "alternatives": [
               {
                 "propertyValue": "2 hours",
                 "propertySubPhrases": [
-                  "two hours"
+                  "for two hours"
                 ]
               },
               {
                 "propertyValue": "30 minutes",
                 "propertySubPhrases": [
-                  "thirty minutes"
+                  "for thirty minutes"
                 ]
               },
               {
-                "propertyValue": "90 minutes",
+                "propertyValue": "1.5 hours",
                 "propertySubPhrases": [
-                  "ninety minutes"
+                  "for one and a half hours"
                 ]
               }
             ]
@@ -1755,15 +1769,59 @@
           "Could you please",
           "Would you mind",
           "If it's not too much trouble, could you",
-          "May I kindly ask you to"
+          "I would appreciate it if you could"
         ],
         "politeSuffixes": [
           "Thank you!",
-          "I would appreciate it.",
-          "Thanks in advance.",
-          "Your help is appreciated."
+          "Thanks a lot!",
+          "I appreciate it!",
+          "Much appreciated!"
         ]
-      }
+      },
+      "corrections": [
+        {
+          "data": {
+            "properties": [
+              {
+                "name": "fullActionName",
+                "value": "calendar.addEvent",
+                "substrings": []
+              },
+              {
+                "name": "parameters.event.day",
+                "value": "Monday",
+                "substrings": [
+                  "Monday"
+                ]
+              },
+              {
+                "name": "parameters.event.timeRange.startTime",
+                "value": "10:00 am",
+                "substrings": [
+                  "10"
+                ]
+              },
+              {
+                "name": "parameters.event.timeRange.duration",
+                "value": "1 hour",
+                "substrings": [
+                  "one hour"
+                ]
+              },
+              {
+                "name": "parameters.event.description",
+                "value": "bridge game",
+                "substrings": [
+                  "bridge game"
+                ]
+              }
+            ]
+          },
+          "correction": [
+            "Mismatch parameter value: 'Monday' in the explanation is not the value of the parameter 'parameters.event.day' in the action"
+          ]
+        }
+      ]
     },
     {
       "request": "Search for any meetings with Gavin this week",
@@ -1774,8 +1832,7 @@
             "dayRange": "this week",
             "participants": [
               "Gavin"
-            ],
-            "lookup": false
+            ]
           }
         }
       },
@@ -1801,11 +1858,6 @@
             "substrings": [
               "Gavin"
             ]
-          },
-          {
-            "name": "parameters.eventReference.lookup",
-            "value": false,
-            "isImplicit": true
           }
         ],
         "subPhrases": [
@@ -1817,17 +1869,7 @@
             ]
           },
           {
-            "text": "with",
-            "category": "preposition",
-            "synonyms": [
-              "including",
-              "along with",
-              "together with"
-            ],
-            "isOptional": true
-          },
-          {
-            "text": "Gavin",
+            "text": "with Gavin",
             "category": "participant",
             "propertyNames": [
               "parameters.eventReference.participants.0"
@@ -1873,25 +1915,25 @@
             "propertyName": "parameters.eventReference.participants.0",
             "propertyValue": "Gavin",
             "propertySubPhrases": [
-              "Gavin"
+              "with Gavin"
             ],
             "alternatives": [
               {
                 "propertyValue": "John",
                 "propertySubPhrases": [
-                  "John"
+                  "with John"
                 ]
               },
               {
                 "propertyValue": "Emily",
                 "propertySubPhrases": [
-                  "Emily"
+                  "with Emily"
                 ]
               },
               {
-                "propertyValue": "Sophia",
+                "propertyValue": "Sarah",
                 "propertySubPhrases": [
-                  "Sophia"
+                  "with Sarah"
                 ]
               }
             ]
@@ -1926,73 +1968,17 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If it's not too much trouble, could you",
+          "May I kindly ask you to"
         ],
         "politeSuffixes": [
           "Thank you!",
-          "I would appreciate it."
+          "I would appreciate it.",
+          "Thanks a lot!",
+          "Your help is appreciated."
         ]
-      },
-      "corrections": [
-        {
-          "data": {
-            "properties": [
-              {
-                "name": "fullActionName",
-                "value": "calendar.findEvents",
-                "substrings": [
-                  "Search for any meetings"
-                ]
-              },
-              {
-                "name": "parameters.eventReference.dayRange",
-                "value": "this week",
-                "substrings": [
-                  "this week"
-                ]
-              },
-              {
-                "name": "parameters.eventReference.participants.0",
-                "value": "Gavin",
-                "substrings": [
-                  "Gavin"
-                ]
-              },
-              {
-                "name": "parameters.eventReference.lookup",
-                "value": false,
-                "isImplicit": true
-              }
-            ],
-            "subPhrases": [
-              {
-                "text": "Search for any meetings",
-                "category": "action",
-                "propertyNames": [
-                  "fullActionName"
-                ]
-              },
-              {
-                "text": "Gavin",
-                "category": "participant",
-                "propertyNames": [
-                  "parameters.eventReference.participants.0"
-                ]
-              },
-              {
-                "text": "this week",
-                "category": "time",
-                "propertyNames": [
-                  "parameters.eventReference.dayRange"
-                ]
-              }
-            ]
-          },
-          "correction": [
-            "Missing sub-phrase: explanation missing for 'with'"
-          ]
-        }
-      ]
+      }
     }
   ]
 }

--- a/ts/packages/dispatcher/test/data/player/v5/changeVolume.json
+++ b/ts/packages/dispatcher/test/data/player/v5/changeVolume.json
@@ -1,7 +1,7 @@
 {
   "version": 2,
   "schemaName": "player",
-  "sourceHash": "/coyfq1j8qYAwzuqFo38QLrP2X7DZ/U6UJRPEiLjn7Q=",
+  "sourceHash": "HrhZPog7XXm93zb5xwYtzWspziPTFgFnvgb4UUJ85a8=",
   "explainerName": "v5",
   "entries": [
     {
@@ -57,9 +57,9 @@
             "text": "in audio",
             "category": "context",
             "synonyms": [
-              "of the sound",
+              "in sound",
               "in volume",
-              "of the audio"
+              "in music"
             ],
             "isOptional": true
           },
@@ -67,9 +67,9 @@
             "text": "would be perfect.",
             "category": "politeness",
             "synonyms": [
-              "is fine",
-              "is good",
-              "is okay"
+              "please",
+              "if possible",
+              "that would be great"
             ],
             "isOptional": true
           }
@@ -111,12 +111,12 @@
           "Could you please",
           "Would you mind",
           "If it's not too much trouble,",
-          "May I kindly request"
+          "I would appreciate it if you could"
         ],
         "politeSuffixes": [
           "Thank you.",
-          "I would appreciate it.",
           "Thanks a lot.",
+          "I appreciate it.",
           "That would be great."
         ]
       },
@@ -172,7 +172,7 @@
         "subPhrases": [
           {
             "text": "Adjust the volume",
-            "category": "command",
+            "category": "action",
             "propertyNames": [
               "fullActionName"
             ]
@@ -181,9 +181,9 @@
             "text": "up by",
             "category": "preposition",
             "synonyms": [
-              "to",
               "increase by",
-              "raise by"
+              "raise by",
+              "boost by"
             ],
             "isOptional": true
           },
@@ -237,15 +237,15 @@
                 ]
               },
               {
-                "propertyValue": 50,
+                "propertyValue": 20,
                 "propertySubPhrases": [
-                  "50%"
+                  "20%"
                 ]
               },
               {
-                "propertyValue": 100,
+                "propertyValue": 50,
                 "propertySubPhrases": [
-                  "100%"
+                  "50%"
                 ]
               }
             ]
@@ -256,8 +256,8 @@
           "Would you mind"
         ],
         "politeSuffixes": [
-          "Thank you.",
-          "I appreciate it."
+          "Thank you!",
+          "I would appreciate it."
         ]
       }
     },
@@ -338,21 +338,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": 20,
-                "propertySubPhrases": [
-                  "increase it by 20%"
-                ]
-              },
-              {
                 "propertyValue": 5,
                 "propertySubPhrases": [
-                  "raise it by 5%"
+                  "increase it by 5%"
                 ]
               },
               {
                 "propertyValue": 15,
                 "propertySubPhrases": [
-                  "boost it by 15%"
+                  "raise it by 15%"
+                ]
+              },
+              {
+                "propertyValue": 20,
+                "propertySubPhrases": [
+                  "boost it by 20%"
                 ]
               }
             ]
@@ -360,13 +360,43 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If it's not too much trouble, could you",
+          "May I kindly ask you to"
         ],
         "politeSuffixes": [
-          "Thank you.",
-          "I would appreciate it."
+          "Thank you!",
+          "I would appreciate it.",
+          "Thanks a lot!",
+          "That would be great."
         ]
-      }
+      },
+      "corrections": [
+        {
+          "data": {
+            "properties": [
+              {
+                "name": "fullActionName",
+                "value": "player.changeVolume",
+                "substrings": [
+                  "Alter the sound level"
+                ]
+              },
+              {
+                "name": "volumeChangePercentage",
+                "value": 10,
+                "substrings": [
+                  "hike it up by 10%"
+                ]
+              }
+            ]
+          },
+          "correction": [
+            "Extraneous parameter: 'volumeChangePercentage' is not a parameter in the action",
+            "Missing parameter: parameter 'parameters.volumeChangePercentage' in the action is missing from explanation"
+          ]
+        }
+      ]
     },
     {
       "request": "Amplify the sound by 30%.",
@@ -402,18 +432,8 @@
             ]
           },
           {
-            "text": "by",
-            "category": "preposition",
-            "synonyms": [
-              "to",
-              "at",
-              "with"
-            ],
-            "isOptional": true
-          },
-          {
-            "text": "30%",
-            "category": "value",
+            "text": "by 30%",
+            "category": "parameter",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
@@ -451,25 +471,25 @@
             "propertyName": "parameters.volumeChangePercentage",
             "propertyValue": 30,
             "propertySubPhrases": [
-              "30%"
+              "by 30%"
             ],
             "alternatives": [
               {
                 "propertyValue": 20,
                 "propertySubPhrases": [
-                  "20%"
+                  "by 20%"
                 ]
               },
               {
                 "propertyValue": 50,
                 "propertySubPhrases": [
-                  "50%"
+                  "by 50%"
                 ]
               },
               {
                 "propertyValue": 10,
                 "propertySubPhrases": [
-                  "10%"
+                  "by 10%"
                 ]
               }
             ]
@@ -480,7 +500,7 @@
           "Would you mind"
         ],
         "politeSuffixes": [
-          "Thank you.",
+          "Thank you!",
           "I would appreciate it."
         ]
       }
@@ -513,7 +533,7 @@
         "subPhrases": [
           {
             "text": "Boost the volume",
-            "category": "command",
+            "category": "action",
             "propertyNames": [
               "fullActionName"
             ]
@@ -594,11 +614,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If it's not too much trouble,",
+          "Kindly"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it."
+          "Thank you.",
+          "Thanks a lot.",
+          "I appreciate it.",
+          "Much appreciated."
         ]
       }
     },
@@ -616,7 +640,7 @@
             "name": "fullActionName",
             "value": "player.changeVolume",
             "substrings": [
-              "get the sound level up"
+              "sound level up"
             ]
           },
           {
@@ -629,17 +653,17 @@
         ],
         "subPhrases": [
           {
-            "text": "Can we",
+            "text": "Can we get",
             "category": "politeness",
             "synonyms": [
-              "Could we",
-              "Would it be possible to",
-              "Is it okay if we"
+              "Could we have",
+              "May we get",
+              "Would it be possible to get"
             ],
             "isOptional": true
           },
           {
-            "text": "get the sound level up",
+            "text": "the sound level up",
             "category": "action",
             "propertyNames": [
               "fullActionName"
@@ -650,14 +674,14 @@
             "category": "filler",
             "synonyms": [
               "by a good",
-              "by an appropriate",
-              "by a suitable"
+              "by a reasonable",
+              "by an adequate"
             ],
             "isOptional": true
           },
           {
             "text": "10%",
-            "category": "volume change",
+            "category": "value",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
@@ -668,7 +692,7 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.changeVolume",
             "propertySubPhrases": [
-              "get the sound level up"
+              "the sound level up"
             ],
             "alternatives": [
               {
@@ -684,9 +708,9 @@
                 ]
               },
               {
-                "propertyValue": "player.turnUpVolume",
+                "propertyValue": "player.adjustVolume",
                 "propertySubPhrases": [
-                  "turn up the volume"
+                  "adjust the volume"
                 ]
               }
             ]
@@ -757,52 +781,32 @@
         ],
         "subPhrases": [
           {
-            "text": "Can",
+            "text": "Can we have",
             "category": "politeness",
             "synonyms": [
-              "Could",
-              "Would",
-              "May"
-            ],
-            "isOptional": true
-          },
-          {
-            "text": "we",
-            "category": "politeness",
-            "synonyms": [
-              "us",
-              "our",
-              "ourselves"
-            ],
-            "isOptional": true
-          },
-          {
-            "text": "have",
-            "category": "politeness",
-            "synonyms": [
-              "get",
-              "obtain",
-              "receive"
+              "Could we get",
+              "May we have",
+              "Would it be possible to get"
             ],
             "isOptional": true
           },
           {
             "text": "the audio",
-            "category": "action",
+            "category": "category",
             "propertyNames": [
               "fullActionName"
             ]
           },
           {
             "text": "20%",
-            "category": "volumeChange",
+            "category": "percentage",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
           },
           {
             "text": "down",
-            "category": "volumeChange",
+            "category": "direction",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
@@ -859,10 +863,10 @@
                 ]
               },
               {
-                "propertyValue": -50,
+                "propertyValue": 20,
                 "propertySubPhrases": [
-                  "50%",
-                  "down"
+                  "20%",
+                  "up"
                 ]
               }
             ]
@@ -873,8 +877,8 @@
           "Would you mind"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "If that's okay."
+          "Thank you.",
+          "I would appreciate it."
         ]
       },
       "corrections": [
@@ -936,23 +940,16 @@
             "synonyms": [
               "Could we",
               "Would it be possible to",
-              "Is it okay if we"
+              "Shall we"
             ],
             "isOptional": true
           },
           {
-            "text": "trim down",
+            "text": "trim down the volume",
             "category": "action",
             "propertyNames": [
               "fullActionName",
               "parameters.volumeChangePercentage"
-            ]
-          },
-          {
-            "text": "the volume",
-            "category": "action",
-            "propertyNames": [
-              "fullActionName"
             ]
           },
           {
@@ -967,7 +964,7 @@
           },
           {
             "text": "5%",
-            "category": "volume change",
+            "category": "percentage",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
@@ -978,29 +975,25 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.changeVolume",
             "propertySubPhrases": [
-              "trim down",
-              "the volume"
+              "trim down the volume"
             ],
             "alternatives": [
               {
-                "propertyValue": "player.decreaseVolume",
+                "propertyValue": "player.increaseVolume",
                 "propertySubPhrases": [
-                  "lower",
-                  "the volume"
+                  "increase the volume"
                 ]
               },
               {
-                "propertyValue": "player.reduceVolume",
+                "propertyValue": "player.muteVolume",
                 "propertySubPhrases": [
-                  "reduce",
-                  "the volume"
+                  "mute the volume"
                 ]
               },
               {
-                "propertyValue": "player.turnDownVolume",
+                "propertyValue": "player.setVolume",
                 "propertySubPhrases": [
-                  "turn down",
-                  "the volume"
+                  "set the volume"
                 ]
               }
             ]
@@ -1009,28 +1002,28 @@
             "propertyName": "parameters.volumeChangePercentage",
             "propertyValue": -5,
             "propertySubPhrases": [
-              "trim down",
+              "trim down the volume",
               "5%"
             ],
             "alternatives": [
               {
                 "propertyValue": -10,
                 "propertySubPhrases": [
-                  "trim down",
+                  "trim down the volume",
                   "10%"
                 ]
               },
               {
                 "propertyValue": -15,
                 "propertySubPhrases": [
-                  "trim down",
+                  "trim down the volume",
                   "15%"
                 ]
               },
               {
                 "propertyValue": -20,
                 "propertySubPhrases": [
-                  "trim down",
+                  "trim down the volume",
                   "20%"
                 ]
               }
@@ -1096,7 +1089,7 @@
                 "synonyms": [
                   "Could we",
                   "Would it be possible to",
-                  "Is it okay if we"
+                  "Shall we"
                 ],
                 "isOptional": true
               },
@@ -1119,7 +1112,7 @@
               },
               {
                 "text": "5%",
-                "category": "volume change",
+                "category": "percentage",
                 "propertyNames": [
                   "parameters.volumeChangePercentage"
                 ]
@@ -1187,7 +1180,7 @@
           },
           {
             "text": "10%",
-            "category": "value",
+            "category": "quantity",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
@@ -1214,9 +1207,9 @@
                 ]
               },
               {
-                "propertyValue": "player.turnUpVolume",
+                "propertyValue": "player.boostVolume",
                 "propertySubPhrases": [
-                  "turn up the volume"
+                  "boost the volume"
                 ]
               }
             ]
@@ -1441,7 +1434,7 @@
           },
           {
             "text": "from the volume",
-            "category": "context",
+            "category": "target",
             "propertyNames": [
               "fullActionName"
             ]
@@ -1457,24 +1450,24 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.increaseVolume",
-                "propertySubPhrases": [
-                  "increase",
-                  "the volume"
-                ]
-              },
-              {
                 "propertyValue": "player.decreaseVolume",
                 "propertySubPhrases": [
-                  "decrease",
-                  "the volume"
+                  "reduce",
+                  "from the volume"
                 ]
               },
               {
-                "propertyValue": "player.muteVolume",
+                "propertyValue": "player.lowerVolume",
                 "propertySubPhrases": [
-                  "mute",
-                  "the volume"
+                  "lower",
+                  "from the volume"
+                ]
+              },
+              {
+                "propertyValue": "player.dimVolume",
+                "propertySubPhrases": [
+                  "dim",
+                  "from the volume"
                 ]
               }
             ]
@@ -1516,7 +1509,7 @@
           "Would you mind"
         ],
         "politeSuffixes": [
-          "Thank you.",
+          "Thank you!",
           "I would appreciate it."
         ]
       },
@@ -1597,21 +1590,21 @@
             ],
             "alternatives": [
               {
+                "propertyValue": "player.increaseVolume",
+                "propertySubPhrases": [
+                  "Increase the volume"
+                ]
+              },
+              {
+                "propertyValue": "player.raiseVolume",
+                "propertySubPhrases": [
+                  "Raise the volume"
+                ]
+              },
+              {
                 "propertyValue": "player.adjustVolume",
                 "propertySubPhrases": [
                   "Adjust the volume"
-                ]
-              },
-              {
-                "propertyValue": "player.setVolume",
-                "propertySubPhrases": [
-                  "Set the volume"
-                ]
-              },
-              {
-                "propertyValue": "player.modifyVolume",
-                "propertySubPhrases": [
-                  "Modify the volume"
                 ]
               }
             ]
@@ -1626,19 +1619,19 @@
               {
                 "propertyValue": 5,
                 "propertySubPhrases": [
-                  "increase it by 5%"
+                  "bump it up by 5%"
                 ]
               },
               {
                 "propertyValue": 15,
                 "propertySubPhrases": [
-                  "raise it by 15%"
+                  "bump it up by 15%"
                 ]
               },
               {
                 "propertyValue": 20,
                 "propertySubPhrases": [
-                  "boost it by 20%"
+                  "bump it up by 20%"
                 ]
               }
             ]
@@ -1736,9 +1729,9 @@
                 ]
               },
               {
-                "propertyValue": "player.boostVolume",
+                "propertyValue": "player.turnUpVolume",
                 "propertySubPhrases": [
-                  "boost the volume"
+                  "turn up the volume"
                 ]
               }
             ]
@@ -1805,9 +1798,9 @@
             "text": "Could you",
             "category": "politeness",
             "synonyms": [
-              "Please",
-              "Would you mind",
-              "Can you"
+              "Can you",
+              "Would you",
+              "Will you"
             ],
             "isOptional": true
           },
@@ -1853,13 +1846,13 @@
               {
                 "propertyValue": "player.raiseVolume",
                 "propertySubPhrases": [
-                  "raise the audio level"
+                  "raise the volume"
                 ]
               },
               {
                 "propertyValue": "player.boostVolume",
                 "propertySubPhrases": [
-                  "boost the sound level"
+                  "boost the volume"
                 ]
               }
             ]
@@ -1934,18 +1927,11 @@
             "isOptional": true
           },
           {
-            "text": "snip",
+            "text": "snip the volume",
             "category": "action",
             "propertyNames": [
               "fullActionName",
               "parameters.volumeChangePercentage"
-            ]
-          },
-          {
-            "text": "the volume",
-            "category": "action",
-            "propertyNames": [
-              "fullActionName"
             ]
           },
           {
@@ -1960,7 +1946,7 @@
           },
           {
             "text": "5%",
-            "category": "volume change",
+            "category": "value",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
@@ -1971,29 +1957,25 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.changeVolume",
             "propertySubPhrases": [
-              "snip",
-              "the volume"
+              "snip the volume"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.increaseVolume",
                 "propertySubPhrases": [
-                  "increase",
-                  "the volume"
+                  "increase the volume"
                 ]
               },
               {
                 "propertyValue": "player.decreaseVolume",
                 "propertySubPhrases": [
-                  "decrease",
-                  "the volume"
+                  "decrease the volume"
                 ]
               },
               {
                 "propertyValue": "player.muteVolume",
                 "propertySubPhrases": [
-                  "mute",
-                  "the volume"
+                  "mute the volume"
                 ]
               }
             ]
@@ -2002,28 +1984,28 @@
             "propertyName": "parameters.volumeChangePercentage",
             "propertyValue": -5,
             "propertySubPhrases": [
-              "snip",
+              "snip the volume",
               "5%"
             ],
             "alternatives": [
               {
                 "propertyValue": -10,
                 "propertySubPhrases": [
-                  "snip",
+                  "snip the volume",
                   "10%"
                 ]
               },
               {
                 "propertyValue": -15,
                 "propertySubPhrases": [
-                  "snip",
+                  "snip the volume",
                   "15%"
                 ]
               },
               {
                 "propertyValue": -20,
                 "propertySubPhrases": [
-                  "snip",
+                  "snip the volume",
                   "20%"
                 ]
               }
@@ -2106,7 +2088,7 @@
               },
               {
                 "text": "5%",
-                "category": "volume change",
+                "category": "value",
                 "propertyNames": [
                   "parameters.volumeChangePercentage"
                 ]
@@ -2141,7 +2123,7 @@
             "value": -5,
             "substrings": [
               "down",
-              "5%"
+              "by 5%"
             ]
           }
         ],
@@ -2311,8 +2293,18 @@
             ]
           },
           {
-            "text": "by 10%",
-            "category": "specification",
+            "text": "by",
+            "category": "preposition",
+            "synonyms": [
+              "to",
+              "at",
+              "with"
+            ],
+            "isOptional": true
+          },
+          {
+            "text": "10%",
+            "category": "quantity",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
@@ -2339,9 +2331,9 @@
                 ]
               },
               {
-                "propertyValue": "player.adjustVolume",
+                "propertyValue": "player.turnUpVolume",
                 "propertySubPhrases": [
-                  "adjust the volume"
+                  "turn up the volume"
                 ]
               }
             ]
@@ -2350,25 +2342,25 @@
             "propertyName": "parameters.volumeChangePercentage",
             "propertyValue": 10,
             "propertySubPhrases": [
-              "by 10%"
+              "10%"
             ],
             "alternatives": [
               {
                 "propertyValue": 5,
                 "propertySubPhrases": [
-                  "by 5%"
+                  "5%"
                 ]
               },
               {
                 "propertyValue": 15,
                 "propertySubPhrases": [
-                  "by 15%"
+                  "15%"
                 ]
               },
               {
                 "propertyValue": 20,
                 "propertySubPhrases": [
-                  "by 20%"
+                  "20%"
                 ]
               }
             ]
@@ -2415,14 +2407,14 @@
           },
           {
             "text": "on the volume",
-            "category": "object",
+            "category": "context",
             "propertyNames": [
               "fullActionName"
             ]
           },
           {
             "text": "by 10%",
-            "category": "amount",
+            "category": "specification",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
@@ -2452,9 +2444,9 @@
                 ]
               },
               {
-                "propertyValue": "player.setVolume",
+                "propertyValue": "player.unmuteVolume",
                 "propertySubPhrases": [
-                  "Set",
+                  "Unmute",
                   "the volume"
                 ]
               }
@@ -2494,11 +2486,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If it's not too much trouble, could you",
+          "May I kindly ask you to"
         ],
         "politeSuffixes": [
           "Thank you.",
-          "I would appreciate it."
+          "Thanks a lot.",
+          "I would appreciate it.",
+          "That would be great."
         ]
       },
       "corrections": [
@@ -2770,21 +2766,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.mute",
-                "propertySubPhrases": [
-                  "mute"
-                ]
-              },
-              {
                 "propertyValue": "player.increaseVolume",
                 "propertySubPhrases": [
-                  "increase the volume"
+                  "the volume up"
                 ]
               },
               {
-                "propertyValue": "player.decreaseVolume",
+                "propertyValue": "player.muteVolume",
                 "propertySubPhrases": [
-                  "decrease the volume"
+                  "the volume to mute"
+                ]
+              },
+              {
+                "propertyValue": "player.setVolume",
+                "propertySubPhrases": [
+                  "the volume to a specific level"
                 ]
               }
             ]
@@ -2797,9 +2793,9 @@
           "May I kindly ask you to"
         ],
         "politeSuffixes": [
-          "Thank you.",
+          "Thank you!",
           "I would appreciate it.",
-          "Thanks a lot.",
+          "Thanks a lot!",
           "That would be great."
         ]
       },
@@ -2948,8 +2944,8 @@
           "Would you mind"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it."
+          "Thank you.",
+          "I appreciate it."
         ]
       },
       "corrections": [
@@ -3000,7 +2996,7 @@
             "value": -10,
             "substrings": [
               "Diminish",
-              "a small 10%"
+              "10%"
             ]
           }
         ],
@@ -3021,8 +3017,18 @@
             ]
           },
           {
-            "text": "by a small 10%",
-            "category": "modifier",
+            "text": "by a small",
+            "category": "filler",
+            "synonyms": [
+              "by a little",
+              "by a bit",
+              "by a tiny"
+            ],
+            "isOptional": true
+          },
+          {
+            "text": "10%",
+            "category": "value",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
@@ -3038,23 +3044,23 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.decreaseVolume",
+                "propertyValue": "player.increaseVolume",
                 "propertySubPhrases": [
-                  "Lower",
+                  "Increase",
                   "the volume"
                 ]
               },
               {
-                "propertyValue": "player.reduceVolume",
+                "propertyValue": "player.muteVolume",
                 "propertySubPhrases": [
-                  "Reduce",
+                  "Mute",
                   "the volume"
                 ]
               },
               {
-                "propertyValue": "player.turnDownVolume",
+                "propertyValue": "player.setVolume",
                 "propertySubPhrases": [
-                  "Turn down",
+                  "Set",
                   "the volume"
                 ]
               }
@@ -3065,28 +3071,28 @@
             "propertyValue": -10,
             "propertySubPhrases": [
               "Diminish",
-              "by a small 10%"
+              "10%"
             ],
             "alternatives": [
               {
                 "propertyValue": -5,
                 "propertySubPhrases": [
                   "Diminish",
-                  "by a small 5%"
-                ]
-              },
-              {
-                "propertyValue": -15,
-                "propertySubPhrases": [
-                  "Diminish",
-                  "by a small 15%"
+                  "5%"
                 ]
               },
               {
                 "propertyValue": -20,
                 "propertySubPhrases": [
                   "Diminish",
-                  "by a small 20%"
+                  "20%"
+                ]
+              },
+              {
+                "propertyValue": -15,
+                "propertySubPhrases": [
+                  "Diminish",
+                  "15%"
                 ]
               }
             ]
@@ -3097,7 +3103,7 @@
           "Would you mind"
         ],
         "politeSuffixes": [
-          "Thank you!",
+          "Thank you.",
           "I would appreciate it."
         ]
       },
@@ -3116,13 +3122,13 @@
                 "name": "parameters.volumeChangePercentage",
                 "value": -10,
                 "substrings": [
-                  "a small 10%"
+                  "10%"
                 ]
               }
             ]
           },
           "correction": [
-            "Value -10 for property 'parameters.volumeChangePercentage' doesn't match the number 10 in the substring 'a small 10%'. Missing other substring to explain the value."
+            "Value -10 for property 'parameters.volumeChangePercentage' doesn't match the number 10 in the substring '10%'. Missing other substring to explain the value."
           ]
         }
       ]
@@ -3148,25 +3154,18 @@
             "name": "parameters.volumeChangePercentage",
             "value": -10,
             "substrings": [
-              "Drop",
+              "Drop the volume",
               "10%"
             ]
           }
         ],
         "subPhrases": [
           {
-            "text": "Drop",
+            "text": "Drop the volume",
             "category": "command",
             "propertyNames": [
               "fullActionName",
               "parameters.volumeChangePercentage"
-            ]
-          },
-          {
-            "text": "the volume",
-            "category": "object",
-            "propertyNames": [
-              "fullActionName"
             ]
           },
           {
@@ -3181,7 +3180,7 @@
           },
           {
             "text": "10%",
-            "category": "quantity",
+            "category": "value",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
@@ -3192,29 +3191,25 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.changeVolume",
             "propertySubPhrases": [
-              "Drop",
-              "the volume"
+              "Drop the volume"
             ],
             "alternatives": [
               {
-                "propertyValue": "player.decreaseVolume",
+                "propertyValue": "player.increaseVolume",
                 "propertySubPhrases": [
-                  "Lower",
-                  "the volume"
+                  "Increase the volume"
                 ]
               },
               {
-                "propertyValue": "player.reduceVolume",
+                "propertyValue": "player.muteVolume",
                 "propertySubPhrases": [
-                  "Reduce",
-                  "the volume"
+                  "Mute the volume"
                 ]
               },
               {
-                "propertyValue": "player.turnDownVolume",
+                "propertyValue": "player.setVolume",
                 "propertySubPhrases": [
-                  "Turn down",
-                  "the volume"
+                  "Set the volume"
                 ]
               }
             ]
@@ -3223,29 +3218,29 @@
             "propertyName": "parameters.volumeChangePercentage",
             "propertyValue": -10,
             "propertySubPhrases": [
-              "Drop",
+              "Drop the volume",
               "10%"
             ],
             "alternatives": [
               {
+                "propertyValue": -20,
+                "propertySubPhrases": [
+                  "Drop the volume",
+                  "20%"
+                ]
+              },
+              {
                 "propertyValue": -5,
                 "propertySubPhrases": [
-                  "Drop",
+                  "Drop the volume",
                   "5%"
                 ]
               },
               {
                 "propertyValue": -15,
                 "propertySubPhrases": [
-                  "Drop",
+                  "Drop the volume",
                   "15%"
-                ]
-              },
-              {
-                "propertyValue": -20,
-                "propertySubPhrases": [
-                  "Drop",
-                  "20%"
                 ]
               }
             ]
@@ -3253,11 +3248,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If it's not too much trouble, could you",
+          "May I kindly ask you to"
         ],
         "politeSuffixes": [
           "Thank you!",
-          "I would appreciate it."
+          "I would appreciate it.",
+          "Thanks a lot!",
+          "That would be great, thanks!"
         ]
       },
       "corrections": [
@@ -3329,7 +3328,7 @@
           },
           {
             "text": "by 10%",
-            "category": "quantity",
+            "category": "specification",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
@@ -3355,14 +3354,14 @@
                 "propertyValue": "player.raiseVolume",
                 "propertySubPhrases": [
                   "Raise the audio level",
-                  "turn it up"
+                  "boost it"
                 ]
               },
               {
-                "propertyValue": "player.boostVolume",
+                "propertyValue": "player.amplifyVolume",
                 "propertySubPhrases": [
-                  "Boost the sound",
-                  "amplify it"
+                  "Amplify the sound",
+                  "turn it up"
                 ]
               }
             ]
@@ -3400,7 +3399,7 @@
           "Would you mind"
         ],
         "politeSuffixes": [
-          "Thank you!",
+          "Thank you.",
           "I would appreciate it."
         ]
       }
@@ -3434,21 +3433,31 @@
         "subPhrases": [
           {
             "text": "Enhance the audio level",
-            "category": "command",
+            "category": "action",
             "propertyNames": [
               "fullActionName"
             ]
           },
           {
             "text": "jack it up",
-            "category": "command",
+            "category": "action",
             "propertyNames": [
               "fullActionName"
             ]
           },
           {
-            "text": "by 10%",
-            "category": "specification",
+            "text": "by",
+            "category": "preposition",
+            "synonyms": [
+              "at",
+              "to",
+              "with"
+            ],
+            "isOptional": true
+          },
+          {
+            "text": "10%",
+            "category": "value",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
@@ -3490,25 +3499,25 @@
             "propertyName": "parameters.volumeChangePercentage",
             "propertyValue": 10,
             "propertySubPhrases": [
-              "by 10%"
+              "10%"
             ],
             "alternatives": [
               {
                 "propertyValue": 5,
                 "propertySubPhrases": [
-                  "by 5%"
+                  "5%"
                 ]
               },
               {
                 "propertyValue": 15,
                 "propertySubPhrases": [
-                  "by 15%"
+                  "15%"
                 ]
               },
               {
                 "propertyValue": 20,
                 "propertySubPhrases": [
-                  "by 20%"
+                  "20%"
                 ]
               }
             ]
@@ -3521,9 +3530,9 @@
           "May I kindly ask you to"
         ],
         "politeSuffixes": [
-          "Thank you.",
+          "Thank you!",
           "I would appreciate it.",
-          "Thanks a lot.",
+          "Thanks a lot!",
           "That would be great."
         ]
       }
@@ -3541,9 +3550,7 @@
           {
             "name": "fullActionName",
             "value": "player.changeVolume",
-            "substrings": [
-              "cranking up the volume"
-            ]
+            "isImplicit": true
           },
           {
             "name": "parameters.volumeChangePercentage",
@@ -3558,65 +3565,31 @@
             "text": "Fancy",
             "category": "filler",
             "synonyms": [
-              "Would you like",
               "How about",
+              "Would you like",
               "Do you want"
             ],
             "isOptional": true
           },
           {
-            "text": "cranking up the volume",
-            "category": "action",
-            "propertyNames": [
-              "fullActionName"
-            ]
-          },
-          {
-            "text": "by a notable",
+            "text": "cranking up the volume by a notable",
             "category": "filler",
             "synonyms": [
-              "by a significant",
-              "by an impressive",
-              "by a considerable"
+              "increasing the volume by",
+              "raising the volume by",
+              "turning up the volume by"
             ],
             "isOptional": true
           },
           {
             "text": "10%",
-            "category": "value",
+            "category": "parameter",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
           }
         ],
         "propertyAlternatives": [
-          {
-            "propertyName": "fullActionName",
-            "propertyValue": "player.changeVolume",
-            "propertySubPhrases": [
-              "cranking up the volume"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "player.increaseVolume",
-                "propertySubPhrases": [
-                  "turning up the volume"
-                ]
-              },
-              {
-                "propertyValue": "player.raiseVolume",
-                "propertySubPhrases": [
-                  "raising the volume"
-                ]
-              },
-              {
-                "propertyValue": "player.boostVolume",
-                "propertySubPhrases": [
-                  "boosting the volume"
-                ]
-              }
-            ]
-          },
           {
             "propertyName": "parameters.volumeChangePercentage",
             "propertyValue": 10,
@@ -3640,6 +3613,12 @@
                 "propertyValue": 20,
                 "propertySubPhrases": [
                   "20%"
+                ]
+              },
+              {
+                "propertyValue": 25,
+                "propertySubPhrases": [
+                  "25%"
                 ]
               }
             ]
@@ -3737,9 +3716,9 @@
                 ]
               },
               {
-                "propertyValue": "player.boostVolume",
+                "propertyValue": "player.volumeUp",
                 "propertySubPhrases": [
-                  "boosting the volume"
+                  "volume up"
                 ]
               }
             ]
@@ -3778,7 +3757,7 @@
         ],
         "politeSuffixes": [
           "Thank you!",
-          "Much appreciated!"
+          "I would appreciate it."
         ]
       }
     },
@@ -3811,11 +3790,11 @@
         "subPhrases": [
           {
             "text": "Gently",
-            "category": "filler",
+            "category": "politeness",
             "synonyms": [
-              "softly",
-              "carefully",
-              "gradually"
+              "Please",
+              "Kindly",
+              "Softly"
             ],
             "isOptional": true
           },
@@ -3836,7 +3815,7 @@
           },
           {
             "text": "by 20%",
-            "category": "quantity",
+            "category": "magnitude",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
@@ -3908,15 +3887,11 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind",
-          "If it's not too much trouble, could you",
-          "May I kindly ask you to"
+          "Would you mind"
         ],
         "politeSuffixes": [
           "Thank you.",
-          "I would appreciate it.",
-          "Thanks a lot.",
-          "That would be great."
+          "I would appreciate it."
         ]
       },
       "corrections": [
@@ -4068,14 +4043,8 @@
             ]
           }
         ],
-        "politePrefixes": [
-          "Could you please",
-          "Would you mind"
-        ],
-        "politeSuffixes": [
-          "Thank you",
-          "I appreciate it"
-        ]
+        "politePrefixes": [],
+        "politeSuffixes": []
       },
       "corrections": [
         {
@@ -4210,8 +4179,8 @@
             "text": "by a fair",
             "category": "filler",
             "synonyms": [
-              "by a reasonable",
               "by an appropriate",
+              "by a reasonable",
               "by a suitable"
             ],
             "isOptional": true
@@ -4282,15 +4251,11 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind",
-          "If it's not too much trouble,",
-          "May I kindly ask you to"
+          "Would you mind"
         ],
         "politeSuffixes": [
           "Thank you!",
-          "I would appreciate it.",
-          "Thanks a lot!",
-          "That would be great!"
+          "I would appreciate it."
         ]
       }
     },
@@ -4324,9 +4289,9 @@
             "text": "How about we",
             "category": "filler",
             "synonyms": [
-              "What if we",
               "Shall we",
-              "Let's"
+              "Let's",
+              "Why don't we"
             ],
             "isOptional": true
           },
@@ -4343,6 +4308,16 @@
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
+          },
+          {
+            "text": "?",
+            "category": "punctuation",
+            "synonyms": [
+              ".",
+              "!",
+              ""
+            ],
+            "isOptional": true
           }
         ],
         "propertyAlternatives": [
@@ -4536,9 +4511,9 @@
                 ]
               },
               {
-                "propertyValue": "player.maximizeVolume",
+                "propertyValue": "player.adjustVolume",
                 "propertySubPhrases": [
-                  "maximize",
+                  "adjust",
                   "in audio"
                 ]
               }
@@ -4547,11 +4522,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If it's not too much trouble, could you",
+          "May I kindly ask you to"
         ],
         "politeSuffixes": [
           "Thank you.",
-          "I appreciate it."
+          "I would appreciate it.",
+          "Thanks a lot.",
+          "That would be great."
         ]
       },
       "corrections": [
@@ -4593,13 +4572,15 @@
           {
             "name": "fullActionName",
             "value": "player.changeVolume",
-            "isImplicit": true
+            "substrings": [
+              "lift the volume"
+            ]
           },
           {
             "name": "parameters.volumeChangePercentage",
             "value": 25,
             "substrings": [
-              "lift the volume by 25%"
+              "25%"
             ]
           }
         ],
@@ -4610,13 +4591,20 @@
             "synonyms": [
               "please",
               "kindly",
-              "if you don't mind"
+              "would you mind"
             ],
             "isOptional": true
           },
           {
-            "text": "lift the volume by 25%",
-            "category": "volume change",
+            "text": "lift the volume",
+            "category": "action",
+            "propertyNames": [
+              "fullActionName"
+            ]
+          },
+          {
+            "text": "by 25%",
+            "category": "specification",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
@@ -4624,34 +4612,55 @@
         ],
         "propertyAlternatives": [
           {
+            "propertyName": "fullActionName",
+            "propertyValue": "player.changeVolume",
+            "propertySubPhrases": [
+              "lift the volume"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "player.increaseVolume",
+                "propertySubPhrases": [
+                  "increase the volume"
+                ]
+              },
+              {
+                "propertyValue": "player.raiseVolume",
+                "propertySubPhrases": [
+                  "raise the volume"
+                ]
+              },
+              {
+                "propertyValue": "player.turnUpVolume",
+                "propertySubPhrases": [
+                  "turn up the volume"
+                ]
+              }
+            ]
+          },
+          {
             "propertyName": "parameters.volumeChangePercentage",
             "propertyValue": 25,
             "propertySubPhrases": [
-              "lift the volume by 25%"
+              "by 25%"
             ],
             "alternatives": [
               {
                 "propertyValue": 10,
                 "propertySubPhrases": [
-                  "lift the volume by 10%"
+                  "by 10%"
                 ]
               },
               {
                 "propertyValue": 50,
                 "propertySubPhrases": [
-                  "lift the volume by 50%"
+                  "by 50%"
                 ]
               },
               {
                 "propertyValue": 75,
                 "propertySubPhrases": [
-                  "lift the volume by 75%"
-                ]
-              },
-              {
-                "propertyValue": 100,
-                "propertySubPhrases": [
-                  "lift the volume by 100%"
+                  "by 75%"
                 ]
               }
             ]
@@ -4691,9 +4700,9 @@
             "text": "I'd be grateful if you could",
             "category": "politeness",
             "synonyms": [
-              "Please",
-              "Kindly",
-              "Would you mind"
+              "please",
+              "kindly",
+              "would you mind"
             ],
             "isOptional": true
           },
@@ -4892,14 +4901,12 @@
         "politePrefixes": [
           "Could you please",
           "Would you kindly",
-          "If it's not too much trouble, could you",
-          "I would appreciate it if you could"
+          "If it's not too much trouble, could you"
         ],
         "politeSuffixes": [
           "Thank you!",
-          "I appreciate it!",
-          "Thanks a lot!",
-          "Much appreciated!"
+          "I would appreciate it.",
+          "Thanks in advance!"
         ]
       }
     },
@@ -4916,39 +4923,37 @@
           {
             "name": "fullActionName",
             "value": "player.changeVolume",
-            "substrings": [
-              "the audio"
-            ]
+            "isImplicit": true
           },
           {
             "name": "parameters.volumeChangePercentage",
             "value": -20,
             "substrings": [
-              "20% softer",
+              "20%",
               "softer"
             ]
           }
         ],
         "subPhrases": [
           {
-            "text": "I'd enjoy",
+            "text": "I'd enjoy the audio",
             "category": "politeness",
             "synonyms": [
-              "I would like",
-              "I want",
-              "I prefer"
+              "I would like the audio",
+              "I want the audio",
+              "Please make the audio"
             ],
             "isOptional": true
           },
           {
-            "text": "the audio",
-            "category": "object",
+            "text": "20%",
+            "category": "volume change",
             "propertyNames": [
-              "fullActionName"
+              "parameters.volumeChangePercentage"
             ]
           },
           {
-            "text": "20% softer",
+            "text": "softer",
             "category": "volume change",
             "propertyNames": [
               "parameters.volumeChangePercentage"
@@ -4959,63 +4964,40 @@
             "category": "politeness",
             "synonyms": [
               "if you can",
-              "if you don't mind",
-              "if it's okay"
+              "if it's not too much trouble",
+              "if you don't mind"
             ],
             "isOptional": true
           }
         ],
         "propertyAlternatives": [
           {
-            "propertyName": "fullActionName",
-            "propertyValue": "player.changeVolume",
-            "propertySubPhrases": [
-              "the audio"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "player.adjustVolume",
-                "propertySubPhrases": [
-                  "the sound"
-                ]
-              },
-              {
-                "propertyValue": "player.setVolume",
-                "propertySubPhrases": [
-                  "the volume"
-                ]
-              },
-              {
-                "propertyValue": "player.modifyVolume",
-                "propertySubPhrases": [
-                  "the audio level"
-                ]
-              }
-            ]
-          },
-          {
             "propertyName": "parameters.volumeChangePercentage",
             "propertyValue": -20,
             "propertySubPhrases": [
-              "20% softer"
+              "20%",
+              "softer"
             ],
             "alternatives": [
               {
                 "propertyValue": -10,
                 "propertySubPhrases": [
-                  "10% softer"
+                  "10%",
+                  "softer"
                 ]
               },
               {
                 "propertyValue": -30,
                 "propertySubPhrases": [
-                  "30% softer"
+                  "30%",
+                  "softer"
                 ]
               },
               {
                 "propertyValue": -50,
                 "propertySubPhrases": [
-                  "50% softer"
+                  "50%",
+                  "softer"
                 ]
               }
             ]
@@ -5027,7 +5009,7 @@
         ],
         "politeSuffixes": [
           "Thank you!",
-          "I would appreciate it."
+          "I appreciate it!"
         ]
       },
       "corrections": [
@@ -5037,9 +5019,7 @@
               {
                 "name": "fullActionName",
                 "value": "player.changeVolume",
-                "substrings": [
-                  "the audio"
-                ]
+                "isImplicit": true
               },
               {
                 "name": "parameters.volumeChangePercentage",
@@ -5154,8 +5134,8 @@
           "Would you mind"
         ],
         "politeSuffixes": [
-          "Thank you.",
-          "I appreciate it."
+          "Thank you!",
+          "I appreciate it!"
         ]
       },
       "corrections": [
@@ -5227,7 +5207,7 @@
           },
           {
             "text": "by 20%",
-            "category": "volume change",
+            "category": "value",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
@@ -5238,7 +5218,7 @@
             "synonyms": [
               "kindly",
               "if you don't mind",
-              "if you could"
+              "if you please"
             ],
             "isOptional": true
           }
@@ -5254,19 +5234,19 @@
               {
                 "propertyValue": "player.increaseVolume",
                 "propertySubPhrases": [
-                  "increase the audio level"
+                  "increase the volume"
                 ]
               },
               {
                 "propertyValue": "player.raiseVolume",
                 "propertySubPhrases": [
-                  "raise the audio level"
+                  "raise the volume"
                 ]
               },
               {
-                "propertyValue": "player.amplifyVolume",
+                "propertyValue": "player.amplifySound",
                 "propertySubPhrases": [
-                  "amplify the audio level"
+                  "amplify the sound"
                 ]
               }
             ]
@@ -5334,8 +5314,8 @@
             "category": "politeness",
             "synonyms": [
               "please",
-              "kindly",
-              "if you don't mind"
+              "if you don't mind",
+              "if possible"
             ],
             "isOptional": true
           },
@@ -5420,14 +5400,8 @@
             ]
           }
         ],
-        "politePrefixes": [
-          "Could you please",
-          "Would you mind"
-        ],
-        "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it."
-        ]
+        "politePrefixes": [],
+        "politeSuffixes": []
       }
     },
     {
@@ -5444,7 +5418,7 @@
             "name": "fullActionName",
             "value": "player.changeVolume",
             "substrings": [
-              "audio"
+              "the audio"
             ]
           },
           {
@@ -5462,14 +5436,14 @@
             "category": "politeness",
             "synonyms": [
               "I would like",
-              "I want",
-              "I wish"
+              "I prefer",
+              "I want"
             ],
             "isOptional": true
           },
           {
             "text": "the audio",
-            "category": "category",
+            "category": "object",
             "propertyNames": [
               "fullActionName"
             ]
@@ -5480,13 +5454,13 @@
             "synonyms": [
               "is",
               "be",
-              "become"
+              "to be"
             ],
             "isOptional": true
           },
           {
             "text": "20%",
-            "category": "percentage",
+            "category": "amount",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
@@ -5522,7 +5496,7 @@
               {
                 "propertyValue": "player.decreaseVolume",
                 "propertySubPhrases": [
-                  "the noise"
+                  "the music"
                 ]
               }
             ]
@@ -5561,15 +5535,11 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind",
-          "If it's not too much trouble,",
-          "May I ask you to"
+          "Would you mind"
         ],
         "politeSuffixes": [
           "Thank you.",
-          "I would appreciate it.",
-          "Thanks a lot.",
-          "That would be great."
+          "I appreciate it."
         ]
       },
       "corrections": [
@@ -5580,7 +5550,7 @@
                 "name": "fullActionName",
                 "value": "player.changeVolume",
                 "substrings": [
-                  "audio"
+                  "the audio"
                 ]
               },
               {
@@ -5611,7 +5581,9 @@
           {
             "name": "fullActionName",
             "value": "player.changeVolume",
-            "isImplicit": true
+            "substrings": [
+              "cut in the audio"
+            ]
           },
           {
             "name": "parameters.volumeChangePercentage",
@@ -5643,20 +5615,17 @@
           {
             "text": "in the audio",
             "category": "context",
-            "synonyms": [
-              "in the sound",
-              "in the volume",
-              "in the music"
-            ],
-            "isOptional": true
+            "propertyNames": [
+              "fullActionName"
+            ]
           },
           {
             "text": "would be nice.",
             "category": "politeness",
             "synonyms": [
               "please",
-              "if you could",
-              "that would be great"
+              "if possible",
+              "if you don't mind"
             ],
             "isOptional": true
           }
@@ -5688,15 +5657,46 @@
                 ]
               }
             ]
+          },
+          {
+            "propertyName": "fullActionName",
+            "propertyValue": "player.changeVolume",
+            "propertySubPhrases": [
+              "in the audio"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "player.mute",
+                "propertySubPhrases": [
+                  "mute the audio"
+                ]
+              },
+              {
+                "propertyValue": "player.increaseVolume",
+                "propertySubPhrases": [
+                  "increase the audio"
+                ]
+              },
+              {
+                "propertyValue": "player.decreaseVolume",
+                "propertySubPhrases": [
+                  "decrease the audio"
+                ]
+              }
+            ]
           }
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If it's not too much trouble, could you",
+          "I would appreciate it if you could"
         ],
         "politeSuffixes": [
           "Thank you!",
-          "I would appreciate it."
+          "Thanks a lot!",
+          "I appreciate it!",
+          "That would be great, thanks!"
         ]
       },
       "corrections": [
@@ -5706,7 +5706,9 @@
               {
                 "name": "fullActionName",
                 "value": "player.changeVolume",
-                "isImplicit": true
+                "substrings": [
+                  "cut in the audio"
+                ]
               },
               {
                 "name": "parameters.volumeChangePercentage",
@@ -5795,9 +5797,9 @@
                 ]
               },
               {
-                "propertyValue": "player.volumeUp",
+                "propertyValue": "player.boostVolume",
                 "propertySubPhrases": [
-                  "Volume up"
+                  "Boost the volume"
                 ]
               }
             ]
@@ -5952,8 +5954,8 @@
           "Would you mind"
         ],
         "politeSuffixes": [
-          "Thank you",
-          "I appreciate it"
+          "Thank you.",
+          "I would appreciate it."
         ]
       }
     },
@@ -5988,9 +5990,9 @@
             "text": "Kindly",
             "category": "politeness",
             "synonyms": [
-              "Please",
-              "Would you mind",
-              "Could you"
+              "please",
+              "if you could",
+              "would you mind"
             ],
             "isOptional": true
           },
@@ -6027,23 +6029,23 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.decreaseVolume",
+                "propertyValue": "player.increaseVolume",
                 "propertySubPhrases": [
-                  "decrease",
+                  "increase",
                   "the audio level"
                 ]
               },
               {
-                "propertyValue": "player.lowerVolume",
+                "propertyValue": "player.muteVolume",
                 "propertySubPhrases": [
-                  "lower",
+                  "mute",
                   "the audio level"
                 ]
               },
               {
-                "propertyValue": "player.turnDownVolume",
+                "propertyValue": "player.setVolume",
                 "propertySubPhrases": [
-                  "turn down",
+                  "set",
                   "the audio level"
                 ]
               }
@@ -6339,8 +6341,8 @@
           }
         ],
         "politePrefixes": [
-          "Could you please",
-          "Would you mind"
+          "Could we please",
+          "Would you mind if we"
         ],
         "politeSuffixes": [
           "Thank you!",
@@ -6412,7 +6414,7 @@
           },
           {
             "text": "15%",
-            "category": "value",
+            "category": "quantity",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
@@ -6428,23 +6430,23 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.decreaseVolume",
+                "propertyValue": "player.lowerVolume",
                 "propertySubPhrases": [
-                  "reduce",
+                  "lower",
                   "the volume"
                 ]
               },
               {
-                "propertyValue": "player.lowerVolume",
+                "propertyValue": "player.decreaseVolume",
                 "propertySubPhrases": [
-                  "lower",
+                  "decrease",
                   "the sound"
                 ]
               },
               {
-                "propertyValue": "player.turnDownVolume",
+                "propertyValue": "player.reduceVolume",
                 "propertySubPhrases": [
-                  "turn down",
+                  "reduce",
                   "the volume"
                 ]
               }
@@ -6461,21 +6463,21 @@
               {
                 "propertyValue": -10,
                 "propertySubPhrases": [
-                  "reduce",
+                  "dial back",
                   "10%"
                 ]
               },
               {
                 "propertyValue": -20,
                 "propertySubPhrases": [
-                  "lower",
+                  "dial back",
                   "20%"
                 ]
               },
               {
                 "propertyValue": -5,
                 "propertySubPhrases": [
-                  "turn down",
+                  "dial back",
                   "5%"
                 ]
               }
@@ -6484,11 +6486,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If it's not too much trouble,",
+          "May I kindly ask you to"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it."
+          "Thank you.",
+          "I would appreciate it.",
+          "Thanks a lot.",
+          "That would be great."
         ]
       },
       "corrections": [
@@ -6530,9 +6536,7 @@
           {
             "name": "fullActionName",
             "value": "player.changeVolume",
-            "substrings": [
-              "Let's have the sound"
-            ]
+            "substrings": []
           },
           {
             "name": "parameters.volumeChangePercentage",
@@ -6546,31 +6550,34 @@
         "subPhrases": [
           {
             "text": "Let's",
-            "category": "politeness",
+            "category": "filler",
             "synonyms": [
-              "Please",
-              "Kindly",
-              "Would you"
+              "Let us",
+              "We should",
+              "How about"
             ],
             "isOptional": true
           },
           {
             "text": "have the sound",
-            "category": "action",
-            "propertyNames": [
-              "fullActionName"
-            ]
+            "category": "filler",
+            "synonyms": [
+              "adjust the volume",
+              "change the sound",
+              "modify the audio"
+            ],
+            "isOptional": true
           },
           {
             "text": "15%",
-            "category": "volume",
+            "category": "volume change",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
           },
           {
             "text": "lower",
-            "category": "direction",
+            "category": "volume change",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
@@ -6587,33 +6594,6 @@
           }
         ],
         "propertyAlternatives": [
-          {
-            "propertyName": "fullActionName",
-            "propertyValue": "player.changeVolume",
-            "propertySubPhrases": [
-              "have the sound"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "player.adjustVolume",
-                "propertySubPhrases": [
-                  "adjust the sound"
-                ]
-              },
-              {
-                "propertyValue": "player.setVolume",
-                "propertySubPhrases": [
-                  "set the volume"
-                ]
-              },
-              {
-                "propertyValue": "player.modifyVolume",
-                "propertySubPhrases": [
-                  "modify the volume"
-                ]
-              }
-            ]
-          },
           {
             "propertyName": "parameters.volumeChangePercentage",
             "propertyValue": -15,
@@ -6637,9 +6617,9 @@
                 ]
               },
               {
-                "propertyValue": -5,
+                "propertyValue": -25,
                 "propertySubPhrases": [
-                  "5%",
+                  "25%",
                   "lower"
                 ]
               }
@@ -6656,9 +6636,7 @@
               {
                 "name": "fullActionName",
                 "value": "player.changeVolume",
-                "substrings": [
-                  "Let's have the sound"
-                ]
+                "substrings": []
               },
               {
                 "name": "parameters.volumeChangePercentage",
@@ -6745,21 +6723,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.raiseVolume",
+                "propertyValue": "player.decreaseVolume",
                 "propertySubPhrases": [
-                  "raise the volume"
+                  "decrease the volume"
                 ]
               },
               {
-                "propertyValue": "player.turnUpVolume",
+                "propertyValue": "player.muteVolume",
                 "propertySubPhrases": [
-                  "turn up the volume"
+                  "mute the volume"
                 ]
               },
               {
-                "propertyValue": "player.boostVolume",
+                "propertyValue": "player.maximizeVolume",
                 "propertySubPhrases": [
-                  "boost the volume"
+                  "maximize the volume"
                 ]
               }
             ]
@@ -6772,9 +6750,9 @@
             ],
             "alternatives": [
               {
-                "propertyValue": 20,
+                "propertyValue": 10,
                 "propertySubPhrases": [
-                  "20%"
+                  "10%"
                 ]
               },
               {
@@ -6784,9 +6762,9 @@
                 ]
               },
               {
-                "propertyValue": 10,
+                "propertyValue": 100,
                 "propertySubPhrases": [
-                  "10%"
+                  "100%"
                 ]
               }
             ]
@@ -6816,7 +6794,7 @@
             "name": "fullActionName",
             "value": "player.changeVolume",
             "substrings": [
-              "make the sound"
+              "Let's make the sound"
             ]
           },
           {
@@ -6831,11 +6809,11 @@
         "subPhrases": [
           {
             "text": "Let's",
-            "category": "filler",
+            "category": "politeness",
             "synonyms": [
               "Let us",
               "We should",
-              "How about"
+              "How about we"
             ],
             "isOptional": true
           },
@@ -6848,14 +6826,14 @@
           },
           {
             "text": "15%",
-            "category": "percentage",
+            "category": "quantity",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
           },
           {
             "text": "more chill",
-            "category": "description",
+            "category": "modifier",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
@@ -6938,7 +6916,7 @@
                 "name": "fullActionName",
                 "value": "player.changeVolume",
                 "substrings": [
-                  "make the sound"
+                  "Let's make the sound"
                 ]
               },
               {
@@ -6985,11 +6963,11 @@
         "subPhrases": [
           {
             "text": "Let's",
-            "category": "filler",
+            "category": "politeness",
             "synonyms": [
-              "Let us",
-              "We should",
-              "How about"
+              "Please",
+              "Kindly",
+              "Would you"
             ],
             "isOptional": true
           },
@@ -7005,8 +6983,8 @@
             "text": "by",
             "category": "preposition",
             "synonyms": [
+              "to",
               "with",
-              "using",
               "at"
             ],
             "isOptional": true
@@ -7084,7 +7062,7 @@
           "Would you mind"
         ],
         "politeSuffixes": [
-          "Thank you.",
+          "Thank you!",
           "I would appreciate it."
         ]
       },
@@ -7134,11 +7112,11 @@
             "subPhrases": [
               {
                 "text": "Let's",
-                "category": "filler",
+                "category": "politeness",
                 "synonyms": [
-                  "Let us",
-                  "We should",
-                  "How about"
+                  "Please",
+                  "Kindly",
+                  "Would you"
                 ],
                 "isOptional": true
               },
@@ -7153,8 +7131,8 @@
                 "text": "by",
                 "category": "preposition",
                 "synonyms": [
+                  "to",
                   "with",
-                  "using",
                   "at"
                 ],
                 "isOptional": true
@@ -7202,11 +7180,11 @@
         "subPhrases": [
           {
             "text": "Let's",
-            "category": "politeness",
+            "category": "filler",
             "synonyms": [
-              "Please",
-              "Kindly",
-              "Would you"
+              "Let us",
+              "We should",
+              "How about"
             ],
             "isOptional": true
           },
@@ -7222,8 +7200,8 @@
             "category": "filler",
             "synonyms": [
               "by exactly",
-              "by precisely",
-              "by"
+              "by a full",
+              "by a complete"
             ],
             "isOptional": true
           },
@@ -7293,11 +7271,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If it's not too much trouble,",
+          "May I kindly ask you to"
         ],
         "politeSuffixes": [
           "Thank you!",
-          "I would appreciate it."
+          "I would appreciate it.",
+          "Thanks a lot!",
+          "That would be great!"
         ]
       }
     },
@@ -7484,18 +7466,8 @@
             ]
           },
           {
-            "text": "by",
-            "category": "preposition",
-            "synonyms": [
-              "with",
-              "using",
-              "at"
-            ],
-            "isOptional": true
-          },
-          {
-            "text": "30%",
-            "category": "value",
+            "text": "by 30%",
+            "category": "parameter",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
@@ -7512,19 +7484,19 @@
               {
                 "propertyValue": "player.increaseVolume",
                 "propertySubPhrases": [
-                  "Increase the sound"
+                  "Increase the volume"
                 ]
               },
               {
                 "propertyValue": "player.raiseVolume",
                 "propertySubPhrases": [
-                  "Raise the sound"
+                  "Raise the volume"
                 ]
               },
               {
-                "propertyValue": "player.amplifyVolume",
+                "propertyValue": "player.boostVolume",
                 "propertySubPhrases": [
-                  "Amplify the sound"
+                  "Boost the volume"
                 ]
               }
             ]
@@ -7533,25 +7505,25 @@
             "propertyName": "parameters.volumeChangePercentage",
             "propertyValue": 30,
             "propertySubPhrases": [
-              "30%"
+              "by 30%"
             ],
             "alternatives": [
               {
                 "propertyValue": 20,
                 "propertySubPhrases": [
-                  "20%"
+                  "by 20%"
                 ]
               },
               {
                 "propertyValue": 50,
                 "propertySubPhrases": [
-                  "50%"
+                  "by 50%"
                 ]
               },
               {
                 "propertyValue": 10,
                 "propertySubPhrases": [
-                  "10%"
+                  "by 10%"
                 ]
               }
             ]
@@ -7596,21 +7568,21 @@
         "subPhrases": [
           {
             "text": "Make the sound",
-            "category": "command",
+            "category": "action",
             "propertyNames": [
               "fullActionName"
             ]
           },
           {
             "text": "15%",
-            "category": "percentage",
+            "category": "volume",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
           },
           {
             "text": "less loud",
-            "category": "description",
+            "category": "volume",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
@@ -7680,12 +7652,12 @@
           "Could you please",
           "Would you mind",
           "If it's not too much trouble, could you",
-          "Please"
+          "May I kindly ask you to"
         ],
         "politeSuffixes": [
           "Thank you.",
-          "Thanks a lot.",
           "I would appreciate it.",
+          "Thanks a lot.",
           "That would be great."
         ]
       },
@@ -7729,7 +7701,7 @@
             "name": "fullActionName",
             "value": "player.changeVolume",
             "substrings": [
-              "Make the volume"
+              "Make the volume softer"
             ]
           },
           {
@@ -7743,16 +7715,10 @@
         ],
         "subPhrases": [
           {
-            "text": "Make the volume",
+            "text": "Make the volume softer",
             "category": "command",
             "propertyNames": [
-              "fullActionName"
-            ]
-          },
-          {
-            "text": "softer",
-            "category": "volumeChange",
-            "propertyNames": [
+              "fullActionName",
               "parameters.volumeChangePercentage"
             ]
           },
@@ -7769,25 +7735,25 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.changeVolume",
             "propertySubPhrases": [
-              "Make the volume"
+              "Make the volume softer"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.increaseVolume",
                 "propertySubPhrases": [
-                  "Increase the volume"
-                ]
-              },
-              {
-                "propertyValue": "player.decreaseVolume",
-                "propertySubPhrases": [
-                  "Lower the volume"
+                  "Make the volume louder"
                 ]
               },
               {
                 "propertyValue": "player.muteVolume",
                 "propertySubPhrases": [
                   "Mute the volume"
+                ]
+              },
+              {
+                "propertyValue": "player.unmuteVolume",
+                "propertySubPhrases": [
+                  "Unmute the volume"
                 ]
               }
             ]
@@ -7796,28 +7762,28 @@
             "propertyName": "parameters.volumeChangePercentage",
             "propertyValue": -10,
             "propertySubPhrases": [
-              "softer",
+              "Make the volume softer",
               "by 10%"
             ],
             "alternatives": [
               {
                 "propertyValue": -20,
                 "propertySubPhrases": [
-                  "softer",
+                  "Make the volume softer",
                   "by 20%"
                 ]
               },
               {
                 "propertyValue": -5,
                 "propertySubPhrases": [
-                  "softer",
+                  "Make the volume softer",
                   "by 5%"
                 ]
               },
               {
                 "propertyValue": -15,
                 "propertySubPhrases": [
-                  "softer",
+                  "Make the volume softer",
                   "by 15%"
                 ]
               }
@@ -7841,20 +7807,107 @@
                 "name": "fullActionName",
                 "value": "player.changeVolume",
                 "substrings": [
-                  "Make the volume"
+                  "Make the volume softer"
                 ]
               },
               {
                 "name": "parameters.volumeChangePercentage",
                 "value": -10,
                 "substrings": [
-                  "softer by 10%"
+                  "10%"
                 ]
               }
             ]
           },
           "correction": [
-            "Value -10 for property 'parameters.volumeChangePercentage' doesn't match the number 10 in the substring 'softer by 10%'. Missing other substring to explain the value."
+            "Value -10 for property 'parameters.volumeChangePercentage' doesn't match the number 10 in the substring '10%'. Missing other substring to explain the value."
+          ]
+        },
+        {
+          "data": {
+            "properties": [
+              {
+                "name": "fullActionName",
+                "value": "player.changeVolume",
+                "substrings": [
+                  "Make the volume softer"
+                ]
+              },
+              {
+                "name": "parameters.volumeChangePercentage",
+                "value": -10,
+                "substrings": [
+                  "softer",
+                  "10%"
+                ]
+              }
+            ],
+            "subPhrases": [
+              {
+                "text": "Make the volume softer",
+                "category": "command",
+                "propertyNames": [
+                  "fullActionName"
+                ]
+              },
+              {
+                "text": "softer",
+                "category": "volumeChange",
+                "propertyNames": [
+                  "parameters.volumeChangePercentage"
+                ]
+              },
+              {
+                "text": "by 10%",
+                "category": "volumeChange",
+                "propertyNames": [
+                  "parameters.volumeChangePercentage"
+                ]
+              }
+            ]
+          },
+          "correction": [
+            "Overlapping sub-phrase: explanation has overlapping text 'softer'."
+          ]
+        },
+        {
+          "data": {
+            "properties": [
+              {
+                "name": "fullActionName",
+                "value": "player.changeVolume",
+                "substrings": [
+                  "Make the volume softer"
+                ]
+              },
+              {
+                "name": "parameters.volumeChangePercentage",
+                "value": -10,
+                "substrings": [
+                  "softer",
+                  "10%"
+                ]
+              }
+            ],
+            "subPhrases": [
+              {
+                "text": "Make the volume softer",
+                "category": "command",
+                "propertyNames": [
+                  "fullActionName"
+                ]
+              },
+              {
+                "text": "by 10%",
+                "category": "volumeChange",
+                "propertyNames": [
+                  "parameters.volumeChangePercentage"
+                ]
+              }
+            ]
+          },
+          "correction": [
+            "Explicit property 'parameters.volumeChangePercentage' must be included as property names for all subphrases that contain the substring 'softer'"
           ]
         }
       ]
@@ -7906,15 +7959,15 @@
             "text": "by a sturdy",
             "category": "filler",
             "synonyms": [
-              "by exactly",
-              "by around",
-              "by approximately"
+              "by a solid",
+              "by a good",
+              "by a decent"
             ],
             "isOptional": true
           },
           {
             "text": "10%",
-            "category": "value",
+            "category": "quantity",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
@@ -7978,13 +8031,43 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If it's not too much trouble,",
+          "May I kindly ask you to"
         ],
         "politeSuffixes": [
           "Thank you!",
-          "I would appreciate it."
+          "I would appreciate it.",
+          "Thanks a lot!",
+          "Much appreciated!"
         ]
-      }
+      },
+      "corrections": [
+        {
+          "data": {
+            "properties": [
+              {
+                "name": "fullActionName",
+                "value": "player.changeVolume",
+                "substrings": [
+                  "bumping up the volume"
+                ]
+              },
+              {
+                "name": "volumeChangePercentage",
+                "value": 10,
+                "substrings": [
+                  "10%"
+                ]
+              }
+            ]
+          },
+          "correction": [
+            "Extraneous parameter: 'volumeChangePercentage' is not a parameter in the action",
+            "Missing parameter: parameter 'parameters.volumeChangePercentage' in the action is missing from explanation"
+          ]
+        }
+      ]
     },
     {
       "request": "Mind cranking up the volume by 10%?",
@@ -8016,9 +8099,9 @@
             "text": "Mind",
             "category": "politeness",
             "synonyms": [
+              "Would you mind",
               "Could you",
-              "Would you",
-              "Do you mind"
+              "Can you"
             ],
             "isOptional": true
           },
@@ -8030,18 +8113,8 @@
             ]
           },
           {
-            "text": "by",
-            "category": "preposition",
-            "synonyms": [
-              "to",
-              "at",
-              "with"
-            ],
-            "isOptional": true
-          },
-          {
-            "text": "10%",
-            "category": "quantity",
+            "text": "by 10%",
+            "category": "parameter",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
@@ -8079,25 +8152,25 @@
             "propertyName": "parameters.volumeChangePercentage",
             "propertyValue": 10,
             "propertySubPhrases": [
-              "10%"
+              "by 10%"
             ],
             "alternatives": [
               {
-                "propertyValue": 5,
+                "propertyValue": 20,
                 "propertySubPhrases": [
-                  "5%"
+                  "by 20%"
                 ]
               },
               {
                 "propertyValue": 15,
                 "propertySubPhrases": [
-                  "15%"
+                  "by 15%"
                 ]
               },
               {
-                "propertyValue": 20,
+                "propertyValue": 5,
                 "propertySubPhrases": [
-                  "20%"
+                  "by 5%"
                 ]
               }
             ]
@@ -8109,7 +8182,7 @@
         ],
         "politeSuffixes": [
           "Thank you!",
-          "I would appreciate it."
+          "I would appreciate it!"
         ]
       }
     },
@@ -8165,19 +8238,19 @@
               {
                 "propertyValue": "player.adjustVolume",
                 "propertySubPhrases": [
-                  "Adjust the sound level"
+                  "Adjust the volume"
                 ]
               },
               {
                 "propertyValue": "player.setVolume",
                 "propertySubPhrases": [
-                  "Set the sound level"
+                  "Set the volume"
                 ]
               },
               {
-                "propertyValue": "player.volumeControl",
+                "propertyValue": "player.updateVolume",
                 "propertySubPhrases": [
-                  "Control the sound level"
+                  "Update the sound level"
                 ]
               }
             ]
@@ -8190,12 +8263,6 @@
             ],
             "alternatives": [
               {
-                "propertyValue": 20,
-                "propertySubPhrases": [
-                  "increase it by 20%"
-                ]
-              },
-              {
                 "propertyValue": 5,
                 "propertySubPhrases": [
                   "increase it by 5%"
@@ -8206,17 +8273,27 @@
                 "propertySubPhrases": [
                   "increase it by 15%"
                 ]
+              },
+              {
+                "propertyValue": 20,
+                "propertySubPhrases": [
+                  "increase it by 20%"
+                ]
               }
             ]
           }
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If it's not too much trouble, could you",
+          "May I kindly ask you to"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it."
+          "Thank you.",
+          "I would appreciate it.",
+          "Thanks a lot.",
+          "That would be great."
         ]
       }
     },
@@ -8256,18 +8333,8 @@
             ]
           },
           {
-            "text": "by",
-            "category": "preposition",
-            "synonyms": [
-              "at",
-              "with",
-              "to"
-            ],
-            "isOptional": true
-          },
-          {
-            "text": "15%",
-            "category": "percentage",
+            "text": "by 15%",
+            "category": "modifier",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
@@ -8284,19 +8351,19 @@
               {
                 "propertyValue": "player.lowerVolume",
                 "propertySubPhrases": [
-                  "Lower the volume"
+                  "Lower the sound"
                 ]
               },
               {
                 "propertyValue": "player.reduceVolume",
                 "propertySubPhrases": [
-                  "Reduce the volume"
+                  "Reduce the sound"
                 ]
               },
               {
                 "propertyValue": "player.decreaseVolume",
                 "propertySubPhrases": [
-                  "Decrease the volume"
+                  "Decrease the sound"
                 ]
               }
             ]
@@ -8306,28 +8373,28 @@
             "propertyValue": -15,
             "propertySubPhrases": [
               "Muffle the sound",
-              "15%"
+              "by 15%"
             ],
             "alternatives": [
               {
                 "propertyValue": -10,
                 "propertySubPhrases": [
                   "Muffle the sound",
-                  "10%"
+                  "by 10%"
                 ]
               },
               {
                 "propertyValue": -20,
                 "propertySubPhrases": [
                   "Muffle the sound",
-                  "20%"
+                  "by 20%"
                 ]
               },
               {
                 "propertyValue": -25,
                 "propertySubPhrases": [
                   "Muffle the sound",
-                  "25%"
+                  "by 25%"
                 ]
               }
             ]
@@ -8338,7 +8405,7 @@
           "Would you mind"
         ],
         "politeSuffixes": [
-          "Thank you!",
+          "Thank you.",
           "I would appreciate it."
         ]
       },
@@ -8364,56 +8431,6 @@
           },
           "correction": [
             "Value -15 for property 'parameters.volumeChangePercentage' doesn't match the number 15 in the substring '15%'. Missing other substring to explain the value."
-          ]
-        },
-        {
-          "data": {
-            "properties": [
-              {
-                "name": "fullActionName",
-                "value": "player.changeVolume",
-                "substrings": [
-                  "Muffle the sound"
-                ]
-              },
-              {
-                "name": "parameters.volumeChangePercentage",
-                "value": -15,
-                "substrings": [
-                  "Muffle the sound",
-                  "15%"
-                ]
-              }
-            ],
-            "subPhrases": [
-              {
-                "text": "Muffle the sound",
-                "category": "action",
-                "propertyNames": [
-                  "fullActionName"
-                ]
-              },
-              {
-                "text": "by",
-                "category": "preposition",
-                "synonyms": [
-                  "at",
-                  "with",
-                  "to"
-                ],
-                "isOptional": true
-              },
-              {
-                "text": "15%",
-                "category": "percentage",
-                "propertyNames": [
-                  "parameters.volumeChangePercentage"
-                ]
-              }
-            ]
-          },
-          "correction": [
-            "Explicit property 'parameters.volumeChangePercentage' must be included as property names for all subphrases that contain the substring 'Muffle the sound'"
           ]
         }
       ]
@@ -8490,9 +8507,9 @@
                 ]
               },
               {
-                "propertyValue": "player.turnUpVolume",
+                "propertyValue": "player.boostVolume",
                 "propertySubPhrases": [
-                  "Turn up the volume"
+                  "Boost the volume"
                 ]
               }
             ]
@@ -8580,7 +8597,7 @@
           },
           {
             "text": "by 25%",
-            "category": "volume change",
+            "category": "parameter",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
@@ -8799,7 +8816,7 @@
             "synonyms": [
               "Kindly",
               "Would you mind",
-              "Could you please"
+              "Could you"
             ],
             "isOptional": true
           },
@@ -8812,7 +8829,7 @@
           },
           {
             "text": "by 25%",
-            "category": "volume change",
+            "category": "parameter",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
@@ -8891,15 +8908,13 @@
           {
             "name": "fullActionName",
             "value": "player.changeVolume",
-            "substrings": [
-              "request the audio"
-            ]
+            "substrings": []
           },
           {
             "name": "parameters.volumeChangePercentage",
             "value": -20,
             "substrings": [
-              "20% softer",
+              "20%",
               "softer"
             ]
           }
@@ -8916,14 +8931,34 @@
             "isOptional": true
           },
           {
-            "text": "request the audio",
-            "category": "action",
+            "text": "request",
+            "category": "politeness",
+            "synonyms": [
+              "ask",
+              "inquire",
+              "demand"
+            ],
+            "isOptional": true
+          },
+          {
+            "text": "the audio to be",
+            "category": "preposition",
+            "synonyms": [
+              "the sound to be",
+              "the volume to be",
+              "the audio level to be"
+            ],
+            "isOptional": true
+          },
+          {
+            "text": "20%",
+            "category": "percentage",
             "propertyNames": [
-              "fullActionName"
+              "parameters.volumeChangePercentage"
             ]
           },
           {
-            "text": "to be 20% softer",
+            "text": "softer",
             "category": "volume change",
             "propertyNames": [
               "parameters.volumeChangePercentage"
@@ -8932,55 +8967,32 @@
         ],
         "propertyAlternatives": [
           {
-            "propertyName": "fullActionName",
-            "propertyValue": "player.changeVolume",
-            "propertySubPhrases": [
-              "request the audio"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "player.increaseVolume",
-                "propertySubPhrases": [
-                  "request the audio to be louder"
-                ]
-              },
-              {
-                "propertyValue": "player.mute",
-                "propertySubPhrases": [
-                  "request the audio to be muted"
-                ]
-              },
-              {
-                "propertyValue": "player.unmute",
-                "propertySubPhrases": [
-                  "request the audio to be unmuted"
-                ]
-              }
-            ]
-          },
-          {
             "propertyName": "parameters.volumeChangePercentage",
             "propertyValue": -20,
             "propertySubPhrases": [
-              "to be 20% softer"
+              "20%",
+              "softer"
             ],
             "alternatives": [
               {
                 "propertyValue": -10,
                 "propertySubPhrases": [
-                  "to be 10% softer"
+                  "10%",
+                  "softer"
                 ]
               },
               {
                 "propertyValue": -30,
                 "propertySubPhrases": [
-                  "to be 30% softer"
+                  "30%",
+                  "softer"
                 ]
               },
               {
                 "propertyValue": -50,
                 "propertySubPhrases": [
-                  "to be 50% softer"
+                  "50%",
+                  "softer"
                 ]
               }
             ]
@@ -8988,15 +9000,11 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind",
-          "If it's not too much trouble, could you",
-          "May I kindly ask you to"
+          "Would you mind"
         ],
         "politeSuffixes": [
           "Thank you.",
-          "I would appreciate it.",
-          "Thanks a lot.",
-          "That would be great."
+          "I would appreciate it."
         ]
       },
       "corrections": [
@@ -9006,9 +9014,7 @@
               {
                 "name": "fullActionName",
                 "value": "player.changeVolume",
-                "substrings": [
-                  "request the audio"
-                ]
+                "substrings": []
               },
               {
                 "name": "parameters.volumeChangePercentage",
@@ -9070,7 +9076,7 @@
           },
           {
             "text": "10%",
-            "category": "quantity",
+            "category": "value",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
@@ -9093,13 +9099,13 @@
               {
                 "propertyValue": "player.raiseVolume",
                 "propertySubPhrases": [
-                  "Raise the sound level"
+                  "Raise the volume"
                 ]
               },
               {
                 "propertyValue": "player.boostVolume",
                 "propertySubPhrases": [
-                  "Boost the sound"
+                  "Boost the volume"
                 ]
               }
             ]
@@ -9251,7 +9257,7 @@
         ],
         "politeSuffixes": [
           "Thank you.",
-          "I would appreciate it."
+          "I appreciate it."
         ]
       },
       "corrections": [
@@ -9396,7 +9402,7 @@
         "subPhrases": [
           {
             "text": "Set the sound",
-            "category": "command",
+            "category": "action",
             "propertyNames": [
               "fullActionName"
             ]
@@ -9405,9 +9411,9 @@
             "text": "to be",
             "category": "filler",
             "synonyms": [
+              "as",
               "to",
-              "be",
-              "as"
+              "become"
             ],
             "isOptional": true
           },
@@ -9441,15 +9447,15 @@
                 ]
               },
               {
-                "propertyValue": "player.muteVolume",
+                "propertyValue": "player.decreaseVolume",
                 "propertySubPhrases": [
-                  "Mute the sound"
+                  "Decrease the sound"
                 ]
               },
               {
-                "propertyValue": "player.unmuteVolume",
+                "propertyValue": "player.mute",
                 "propertySubPhrases": [
-                  "Unmute the sound"
+                  "Mute the sound"
                 ]
               }
             ]
@@ -9477,9 +9483,9 @@
                 ]
               },
               {
-                "propertyValue": -5,
+                "propertyValue": -30,
                 "propertySubPhrases": [
-                  "5%",
+                  "30%",
                   "quieter"
                 ]
               }
@@ -9488,11 +9494,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If it's not too much trouble, could you",
+          "May I ask you to"
         ],
         "politeSuffixes": [
           "Thank you.",
-          "I would appreciate it."
+          "I would appreciate it.",
+          "Thanks a lot.",
+          "That would be great."
         ]
       },
       "corrections": [
@@ -9517,6 +9527,53 @@
           },
           "correction": [
             "Value -15 for property 'parameters.volumeChangePercentage' doesn't match the number 15 in the substring '15% quieter'. Missing other substring to explain the value."
+          ]
+        },
+        {
+          "data": {
+            "properties": [
+              {
+                "name": "fullActionName",
+                "value": "player.changeVolume",
+                "substrings": [
+                  "Set the sound"
+                ]
+              },
+              {
+                "name": "parameters.volumeChangePercentage",
+                "value": -15,
+                "substrings": [
+                  "15%",
+                  "quieter"
+                ]
+              }
+            ],
+            "subPhrases": [
+              {
+                "text": "Set the sound",
+                "category": "action",
+                "propertyNames": [
+                  "fullActionName"
+                ]
+              },
+              {
+                "text": "15%",
+                "category": "percentage",
+                "propertyNames": [
+                  "parameters.volumeChangePercentage"
+                ]
+              },
+              {
+                "text": "quieter",
+                "category": "direction",
+                "propertyNames": [
+                  "parameters.volumeChangePercentage"
+                ]
+              }
+            ]
+          },
+          "correction": [
+            "Missing sub-phrase: explanation missing for 'to be'"
           ]
         }
       ]
@@ -9550,7 +9607,7 @@
         "subPhrases": [
           {
             "text": "Shave the volume",
-            "category": "command",
+            "category": "action",
             "propertyNames": [
               "fullActionName"
             ]
@@ -9559,9 +9616,9 @@
             "text": "by",
             "category": "preposition",
             "synonyms": [
-              "with",
-              "using",
-              "through"
+              "to",
+              "at",
+              "with"
             ],
             "isOptional": true
           },
@@ -9574,7 +9631,7 @@
           },
           {
             "text": "10%",
-            "category": "percentage",
+            "category": "value",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
@@ -9642,11 +9699,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If it's not too much trouble, could you",
+          "May I kindly ask you to"
         ],
         "politeSuffixes": [
           "Thank you.",
-          "I would appreciate it."
+          "I would appreciate it.",
+          "Thanks a lot.",
+          "That would be great."
         ]
       },
       "corrections": [
@@ -9791,15 +9852,11 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind",
-          "If it's not too much trouble, could you",
-          "May I kindly ask you to"
+          "Would you mind"
         ],
         "politeSuffixes": [
           "Thank you.",
-          "I would appreciate it.",
-          "Thanks a lot.",
-          "That would be great."
+          "I would appreciate it."
         ]
       },
       "corrections": [
@@ -9857,7 +9914,7 @@
         "subPhrases": [
           {
             "text": "Subdue the sound",
-            "category": "action",
+            "category": "command",
             "propertyNames": [
               "fullActionName"
             ]
@@ -9871,7 +9928,7 @@
           },
           {
             "text": "15%",
-            "category": "value",
+            "category": "percentage",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
@@ -10026,7 +10083,7 @@
           },
           {
             "text": "10%",
-            "category": "value",
+            "category": "quantity",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
@@ -10042,23 +10099,23 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.decreaseVolume",
+                "propertyValue": "player.increaseVolume",
                 "propertySubPhrases": [
-                  "Lower",
+                  "Increase",
                   "the volume"
                 ]
               },
               {
-                "propertyValue": "player.reduceVolume",
+                "propertyValue": "player.muteVolume",
                 "propertySubPhrases": [
-                  "Reduce",
+                  "Mute",
                   "the volume"
                 ]
               },
               {
-                "propertyValue": "player.turnDownVolume",
+                "propertyValue": "player.setVolume",
                 "propertySubPhrases": [
-                  "Turn down",
+                  "Set",
                   "the volume"
                 ]
               }
@@ -10073,6 +10130,13 @@
             ],
             "alternatives": [
               {
+                "propertyValue": -20,
+                "propertySubPhrases": [
+                  "Take down",
+                  "20%"
+                ]
+              },
+              {
                 "propertyValue": -5,
                 "propertySubPhrases": [
                   "Take down",
@@ -10085,24 +10149,21 @@
                   "Take down",
                   "15%"
                 ]
-              },
-              {
-                "propertyValue": -20,
-                "propertySubPhrases": [
-                  "Take down",
-                  "20%"
-                ]
               }
             ]
           }
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If it's not too much trouble, could you",
+          "May I kindly ask you to"
         ],
         "politeSuffixes": [
           "Thank you.",
-          "I would appreciate it."
+          "I would appreciate it.",
+          "Thanks a lot.",
+          "That would be great."
         ]
       },
       "corrections": [
@@ -10193,15 +10254,8 @@
               {
                 "propertyValue": "player.decreaseVolume",
                 "propertySubPhrases": [
-                  "Decrease",
-                  "the sound"
-                ]
-              },
-              {
-                "propertyValue": "player.lowerVolume",
-                "propertySubPhrases": [
                   "Lower",
-                  "the sound"
+                  "the volume"
                 ]
               },
               {
@@ -10209,6 +10263,13 @@
                 "propertySubPhrases": [
                   "Reduce",
                   "the sound"
+                ]
+              },
+              {
+                "propertyValue": "player.turnDownVolume",
+                "propertySubPhrases": [
+                  "Turn down",
+                  "the volume"
                 ]
               }
             ]
@@ -10236,10 +10297,10 @@
                 ]
               },
               {
-                "propertyValue": -5,
+                "propertyValue": -25,
                 "propertySubPhrases": [
                   "Tone down",
-                  "by 5%"
+                  "by 25%"
                 ]
               }
             ]
@@ -10247,11 +10308,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If it's not too much trouble,",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it."
+          "Thank you.",
+          "Thanks.",
+          "I appreciate it.",
+          "If you don't mind."
         ]
       },
       "corrections": [
@@ -10317,9 +10382,9 @@
             "text": "by",
             "category": "preposition",
             "synonyms": [
+              "to",
               "at",
-              "with",
-              "to"
+              "with"
             ],
             "isOptional": true
           },
@@ -10392,7 +10457,7 @@
           "Would you mind"
         ],
         "politeSuffixes": [
-          "Thank you!",
+          "Thank you.",
           "I would appreciate it."
         ]
       }
@@ -10410,9 +10475,7 @@
           {
             "name": "fullActionName",
             "value": "player.changeVolume",
-            "substrings": [
-              "slice the volume"
-            ]
+            "substrings": []
           },
           {
             "name": "parameters.volumeChangePercentage",
@@ -10435,26 +10498,25 @@
             "isOptional": true
           },
           {
-            "text": "slice the volume",
+            "text": "slice",
             "category": "action",
             "propertyNames": [
-              "fullActionName",
               "parameters.volumeChangePercentage"
             ]
           },
           {
-            "text": "by a neat",
+            "text": "the volume by a neat",
             "category": "filler",
             "synonyms": [
-              "by exactly",
-              "by precisely",
-              "by"
+              "the volume by",
+              "the volume",
+              "by a neat"
             ],
             "isOptional": true
           },
           {
             "text": "5%",
-            "category": "value",
+            "category": "percentage",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
@@ -10462,58 +10524,31 @@
         ],
         "propertyAlternatives": [
           {
-            "propertyName": "fullActionName",
-            "propertyValue": "player.changeVolume",
-            "propertySubPhrases": [
-              "slice the volume"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "player.increaseVolume",
-                "propertySubPhrases": [
-                  "increase the volume"
-                ]
-              },
-              {
-                "propertyValue": "player.decreaseVolume",
-                "propertySubPhrases": [
-                  "decrease the volume"
-                ]
-              },
-              {
-                "propertyValue": "player.muteVolume",
-                "propertySubPhrases": [
-                  "mute the volume"
-                ]
-              }
-            ]
-          },
-          {
             "propertyName": "parameters.volumeChangePercentage",
             "propertyValue": -5,
             "propertySubPhrases": [
-              "slice the volume",
+              "slice",
               "5%"
             ],
             "alternatives": [
               {
                 "propertyValue": -10,
                 "propertySubPhrases": [
-                  "slice the volume",
+                  "slice",
                   "10%"
                 ]
               },
               {
                 "propertyValue": -15,
                 "propertySubPhrases": [
-                  "slice the volume",
+                  "slice",
                   "15%"
                 ]
               },
               {
                 "propertyValue": -20,
                 "propertySubPhrases": [
-                  "slice the volume",
+                  "slice",
                   "20%"
                 ]
               }
@@ -10526,7 +10561,7 @@
         ],
         "politeSuffixes": [
           "Thank you!",
-          "If that's okay with you."
+          "I would appreciate it!"
         ]
       },
       "corrections": [
@@ -10536,9 +10571,7 @@
               {
                 "name": "fullActionName",
                 "value": "player.changeVolume",
-                "substrings": [
-                  "slice the volume"
-                ]
+                "substrings": []
               },
               {
                 "name": "parameters.volumeChangePercentage",
@@ -10551,66 +10584,6 @@
           },
           "correction": [
             "Value -5 for property 'parameters.volumeChangePercentage' doesn't match the number 5 in the substring '5%'. Missing other substring to explain the value."
-          ]
-        },
-        {
-          "data": {
-            "properties": [
-              {
-                "name": "fullActionName",
-                "value": "player.changeVolume",
-                "substrings": [
-                  "slice the volume"
-                ]
-              },
-              {
-                "name": "parameters.volumeChangePercentage",
-                "value": -5,
-                "substrings": [
-                  "slice",
-                  "5%"
-                ]
-              }
-            ],
-            "subPhrases": [
-              {
-                "text": "Wanna",
-                "category": "politeness",
-                "synonyms": [
-                  "Would you like to",
-                  "Do you want to",
-                  "Can you"
-                ],
-                "isOptional": true
-              },
-              {
-                "text": "slice the volume",
-                "category": "action",
-                "propertyNames": [
-                  "fullActionName"
-                ]
-              },
-              {
-                "text": "by a neat",
-                "category": "filler",
-                "synonyms": [
-                  "by exactly",
-                  "by precisely",
-                  "by"
-                ],
-                "isOptional": true
-              },
-              {
-                "text": "5%",
-                "category": "value",
-                "propertyNames": [
-                  "parameters.volumeChangePercentage"
-                ]
-              }
-            ]
-          },
-          "correction": [
-            "Explicit property 'parameters.volumeChangePercentage' must be included as property names for all subphrases that contain the substring 'slice'"
           ]
         }
       ]
@@ -10636,7 +10609,7 @@
             "name": "parameters.volumeChangePercentage",
             "value": 10,
             "substrings": [
-              "by 10%"
+              "10%"
             ]
           }
         ],
@@ -10664,6 +10637,16 @@
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
+          },
+          {
+            "text": "?",
+            "category": "punctuation",
+            "synonyms": [
+              ".",
+              "!",
+              ""
+            ],
+            "isOptional": true
           }
         ],
         "propertyAlternatives": [
@@ -10858,8 +10841,8 @@
             "name": "parameters.volumeChangePercentage",
             "value": -5,
             "substrings": [
-              "trim",
-              "5%"
+              "by 5%",
+              "trim"
             ]
           }
         ],
@@ -10961,12 +10944,12 @@
           }
         ],
         "politePrefixes": [
-          "Please",
-          "Could you kindly"
+          "Could you please",
+          "Would you mind"
         ],
         "politeSuffixes": [
           "Thank you",
-          "I would appreciate it"
+          "I appreciate it"
         ]
       },
       "corrections": [
@@ -10984,13 +10967,13 @@
                 "name": "parameters.volumeChangePercentage",
                 "value": -5,
                 "substrings": [
-                  "5%"
+                  "by 5%"
                 ]
               }
             ]
           },
           "correction": [
-            "Value -5 for property 'parameters.volumeChangePercentage' doesn't match the number 5 in the substring '5%'. Missing other substring to explain the value."
+            "Value -5 for property 'parameters.volumeChangePercentage' doesn't match the number 5 in the substring 'by 5%'. Missing other substring to explain the value."
           ]
         },
         {
@@ -11007,8 +10990,8 @@
                 "name": "parameters.volumeChangePercentage",
                 "value": -5,
                 "substrings": [
-                  "trim",
-                  "5%"
+                  "by 5%",
+                  "trim"
                 ]
               }
             ],
@@ -11093,18 +11076,11 @@
             "isOptional": true
           },
           {
-            "text": "drop",
+            "text": "drop the volume",
             "category": "action",
             "propertyNames": [
               "fullActionName",
               "parameters.volumeChangePercentage"
-            ]
-          },
-          {
-            "text": "the volume",
-            "category": "action",
-            "propertyNames": [
-              "fullActionName"
             ]
           },
           {
@@ -11130,29 +11106,25 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.changeVolume",
             "propertySubPhrases": [
-              "drop",
-              "the volume"
+              "drop the volume"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.increaseVolume",
                 "propertySubPhrases": [
-                  "raise",
-                  "the volume"
+                  "raise the volume"
                 ]
               },
               {
                 "propertyValue": "player.muteVolume",
                 "propertySubPhrases": [
-                  "mute",
-                  "the volume"
+                  "mute the volume"
                 ]
               },
               {
                 "propertyValue": "player.unmuteVolume",
                 "propertySubPhrases": [
-                  "unmute",
-                  "the volume"
+                  "unmute the volume"
                 ]
               }
             ]
@@ -11161,28 +11133,28 @@
             "propertyName": "parameters.volumeChangePercentage",
             "propertyValue": -5,
             "propertySubPhrases": [
-              "drop",
+              "drop the volume",
               "5%"
             ],
             "alternatives": [
               {
                 "propertyValue": -10,
                 "propertySubPhrases": [
-                  "drop",
+                  "drop the volume",
                   "10%"
                 ]
               },
               {
                 "propertyValue": -15,
                 "propertySubPhrases": [
-                  "drop",
+                  "drop the volume",
                   "15%"
                 ]
               },
               {
                 "propertyValue": -20,
                 "propertySubPhrases": [
-                  "drop",
+                  "drop the volume",
                   "20%"
                 ]
               }
@@ -11351,14 +11323,14 @@
             "category": "filler",
             "synonyms": [
               "by",
-              "by approximately",
-              "by around"
+              "around",
+              "approximately"
             ],
             "isOptional": true
           },
           {
             "text": "5%",
-            "category": "amount",
+            "category": "value",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]

--- a/ts/packages/dispatcher/test/data/player/v5/full.json
+++ b/ts/packages/dispatcher/test/data/player/v5/full.json
@@ -1,7 +1,7 @@
 {
   "version": 2,
   "schemaName": "player",
-  "sourceHash": "/coyfq1j8qYAwzuqFo38QLrP2X7DZ/U6UJRPEiLjn7Q=",
+  "sourceHash": "HrhZPog7XXm93zb5xwYtzWspziPTFgFnvgb4UUJ85a8=",
   "explainerName": "v5",
   "entries": [
     {
@@ -17,107 +17,15 @@
           {
             "name": "fullActionName",
             "value": "player.playTrack",
-            "isImplicit": true
+            "substrings": [
+              "get down to"
+            ]
           },
           {
             "name": "parameters.trackName",
             "value": "Sensual Seduction",
             "substrings": [
-              "Sensual Seduction"
-            ]
-          }
-        ],
-        "subPhrases": [
-          {
-            "text": "Aight,",
-            "category": "acknowledgement",
-            "synonyms": [
-              "Alright,",
-              "Okay,",
-              "Sure,"
-            ],
-            "isOptional": true
-          },
-          {
-            "text": "it's time to get down to some",
-            "category": "filler",
-            "synonyms": [
-              "let's play",
-              "time to listen to",
-              "let's hear"
-            ],
-            "isOptional": true
-          },
-          {
-            "text": "'Sensual Seduction'",
-            "category": "trackName",
-            "propertyNames": [
-              "parameters.trackName"
-            ]
-          },
-          {
-            "text": "ya feel me?",
-            "category": "filler",
-            "synonyms": [
-              "you know?",
-              "right?",
-              "got it?"
-            ],
-            "isOptional": true
-          }
-        ],
-        "propertyAlternatives": [
-          {
-            "propertyName": "parameters.trackName",
-            "propertyValue": "Sensual Seduction",
-            "propertySubPhrases": [
               "'Sensual Seduction'"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "Sexual Healing",
-                "propertySubPhrases": [
-                  "'Sexual Healing'"
-                ]
-              },
-              {
-                "propertyValue": "Let's Get It On",
-                "propertySubPhrases": [
-                  "'Let's Get It On'"
-                ]
-              },
-              {
-                "propertyValue": "Pony",
-                "propertySubPhrases": [
-                  "'Pony'"
-                ]
-              }
-            ]
-          }
-        ],
-        "politePrefixes": [
-          "Could you please",
-          "Would you mind"
-        ],
-        "politeSuffixes": [
-          "Thank you",
-          "I appreciate it"
-        ]
-      }
-    },
-    {
-      "request": "Aight, it's time to pump up the volume with some fresh beats!",
-      "action": {
-        "fullActionName": "player.playRandom"
-      },
-      "explanation": {
-        "properties": [
-          {
-            "name": "fullActionName",
-            "value": "player.playRandom",
-            "substrings": [
-              "pump up the volume",
-              "fresh beats"
             ]
           }
         ],
@@ -136,9 +44,146 @@
             "text": "it's time to",
             "category": "filler",
             "synonyms": [
-              "time to",
               "let's",
+              "time to",
               "we should"
+            ],
+            "isOptional": true
+          },
+          {
+            "text": "get down to",
+            "category": "action",
+            "propertyNames": [
+              "fullActionName"
+            ]
+          },
+          {
+            "text": "some 'Sensual Seduction'",
+            "category": "trackName",
+            "propertyNames": [
+              "parameters.trackName"
+            ]
+          },
+          {
+            "text": "ya feel me?",
+            "category": "confirmation",
+            "synonyms": [
+              "you know?",
+              "right?",
+              "do you understand?"
+            ],
+            "isOptional": true
+          }
+        ],
+        "propertyAlternatives": [
+          {
+            "propertyName": "fullActionName",
+            "propertyValue": "player.playTrack",
+            "propertySubPhrases": [
+              "get down to"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "player.pauseTrack",
+                "propertySubPhrases": [
+                  "pause"
+                ]
+              },
+              {
+                "propertyValue": "player.stopTrack",
+                "propertySubPhrases": [
+                  "stop"
+                ]
+              },
+              {
+                "propertyValue": "player.skipTrack",
+                "propertySubPhrases": [
+                  "skip"
+                ]
+              }
+            ]
+          },
+          {
+            "propertyName": "parameters.trackName",
+            "propertyValue": "Sensual Seduction",
+            "propertySubPhrases": [
+              "some 'Sensual Seduction'"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "Bohemian Rhapsody",
+                "propertySubPhrases": [
+                  "some 'Bohemian Rhapsody'"
+                ]
+              },
+              {
+                "propertyValue": "Shape of You",
+                "propertySubPhrases": [
+                  "some 'Shape of You'"
+                ]
+              },
+              {
+                "propertyValue": "Blinding Lights",
+                "propertySubPhrases": [
+                  "some 'Blinding Lights'"
+                ]
+              }
+            ]
+          }
+        ],
+        "politePrefixes": [
+          "Could you please",
+          "Would you mind"
+        ],
+        "politeSuffixes": [
+          "Thank you",
+          "I appreciate it"
+        ]
+      }
+    },
+    {
+      "request": "Aight, it's time to pump up the volume with some fresh beats!",
+      "action": {
+        "fullActionName": "player.setVolume",
+        "parameters": {
+          "newVolumeLevel": 100
+        }
+      },
+      "explanation": {
+        "properties": [
+          {
+            "name": "fullActionName",
+            "value": "player.setVolume",
+            "substrings": [
+              "pump up the volume"
+            ]
+          },
+          {
+            "name": "parameters.newVolumeLevel",
+            "value": 100,
+            "isImplicit": true
+          }
+        ],
+        "subPhrases": [
+          {
+            "text": "Aight,",
+            "category": "acknowledgement",
+            "synonyms": [
+              "Alright,",
+              "Okay,",
+              "Sure,",
+              "Got it,"
+            ],
+            "isOptional": true
+          },
+          {
+            "text": "it's time to",
+            "category": "filler",
+            "synonyms": [
+              "let's",
+              "time to",
+              "we should",
+              "let us"
             ],
             "isOptional": true
           },
@@ -150,51 +195,41 @@
             ]
           },
           {
-            "text": "with some",
-            "category": "preposition",
+            "text": "with some fresh beats!",
+            "category": "filler",
             "synonyms": [
-              "along with",
-              "featuring",
-              "including"
+              "with some music!",
+              "with some tunes!",
+              "with some sound!",
+              "with some audio!"
             ],
             "isOptional": true
-          },
-          {
-            "text": "fresh beats",
-            "category": "content",
-            "propertyNames": [
-              "fullActionName"
-            ]
           }
         ],
         "propertyAlternatives": [
           {
             "propertyName": "fullActionName",
-            "propertyValue": "player.playRandom",
+            "propertyValue": "player.setVolume",
             "propertySubPhrases": [
-              "pump up the volume",
-              "fresh beats"
+              "pump up the volume"
             ],
             "alternatives": [
               {
-                "propertyValue": "player.play",
+                "propertyValue": "player.increaseVolume",
                 "propertySubPhrases": [
-                  "turn up the music",
-                  "some tunes"
+                  "turn up the volume"
                 ]
               },
               {
-                "propertyValue": "player.shuffle",
+                "propertyValue": "player.raiseVolume",
                 "propertySubPhrases": [
-                  "mix it up",
-                  "random tracks"
+                  "crank up the volume"
                 ]
               },
               {
-                "propertyValue": "player.playPlaylist",
+                "propertyValue": "player.boostVolume",
                 "propertySubPhrases": [
-                  "play my playlist",
-                  "favorite songs"
+                  "boost the volume"
                 ]
               }
             ]
@@ -208,7 +243,31 @@
           "Thank you!",
           "I appreciate it!"
         ]
-      }
+      },
+      "corrections": [
+        {
+          "data": {
+            "properties": [
+              {
+                "name": "fullActionName",
+                "value": "player.setVolume",
+                "substrings": [
+                  "pump up the volume"
+                ]
+              },
+              {
+                "name": "newVolumeLevel",
+                "value": 100,
+                "isImplicit": true
+              }
+            ]
+          },
+          "correction": [
+            "Extraneous implicit parameter: 'newVolumeLevel' is not a parameter in the action",
+            "Missing parameter: parameter 'parameters.newVolumeLevel' in the action is missing from explanation"
+          ]
+        }
+      ]
     },
     {
       "request": "Ayo, DJ, drop that 'Gin and Juice' like it's hot, ya dig?",
@@ -231,28 +290,28 @@
             "name": "parameters.trackName",
             "value": "Gin and Juice",
             "substrings": [
-              "Gin and Juice"
+              "'Gin and Juice'"
             ]
           }
         ],
         "subPhrases": [
           {
-            "text": "Ayo",
+            "text": "Ayo,",
             "category": "greeting",
             "synonyms": [
-              "Hey",
-              "Hi",
-              "Hello"
+              "Hey,",
+              "Yo,",
+              "Hi,"
             ],
             "isOptional": true
           },
           {
-            "text": "DJ",
-            "category": "filler",
+            "text": "DJ,",
+            "category": "acknowledgement",
             "synonyms": [
-              "DJ",
-              "Disc Jockey",
-              "Music Mixer"
+              "DJ,",
+              "DJ,",
+              "DJ,"
             ],
             "isOptional": true
           },
@@ -265,28 +324,18 @@
           },
           {
             "text": "that 'Gin and Juice'",
-            "category": "trackName",
+            "category": "track",
             "propertyNames": [
               "parameters.trackName"
             ]
           },
           {
-            "text": "like it's hot",
+            "text": "like it's hot, ya dig?",
             "category": "filler",
             "synonyms": [
-              "right now",
-              "immediately",
-              "ASAP"
-            ],
-            "isOptional": true
-          },
-          {
-            "text": "ya dig?",
-            "category": "confirmation",
-            "synonyms": [
-              "you understand?",
-              "you get it?",
-              "you know?"
+              "like it's hot, you know?",
+              "like it's hot, right?",
+              "like it's hot, okay?"
             ],
             "isOptional": true
           }
@@ -306,15 +355,15 @@
                 ]
               },
               {
-                "propertyValue": "player.addTrackToPlaylist",
+                "propertyValue": "player.pauseTrack",
                 "propertySubPhrases": [
-                  "add"
+                  "pause"
                 ]
               },
               {
-                "propertyValue": "player.shufflePlay",
+                "propertyValue": "player.stopTrack",
                 "propertySubPhrases": [
-                  "shuffle"
+                  "stop"
                 ]
               }
             ]
@@ -339,9 +388,9 @@
                 ]
               },
               {
-                "propertyValue": "The Next Episode",
+                "propertyValue": "California Love",
                 "propertySubPhrases": [
-                  "that 'The Next Episode'"
+                  "that 'California Love'"
                 ]
               }
             ]
@@ -349,15 +398,11 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind",
-          "If it's not too much trouble,",
-          "May I kindly ask you to"
+          "Would you mind"
         ],
         "politeSuffixes": [
           "Thank you!",
-          "I would appreciate it.",
-          "Thanks a lot!",
-          "Much appreciated!"
+          "I would appreciate it!"
         ]
       }
     },
@@ -427,17 +472,7 @@
             "synonyms": [
               "track",
               "song",
-              "tune"
-            ],
-            "isOptional": true
-          },
-          {
-            "text": "!",
-            "category": "punctuation",
-            "synonyms": [
-              ".",
-              "?",
-              ""
+              "music"
             ],
             "isOptional": true
           }
@@ -451,21 +486,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.startArtist",
+                "propertyValue": "player.playSong",
                 "propertySubPhrases": [
-                  "start"
+                  "play"
                 ]
               },
               {
-                "propertyValue": "player.beginArtist",
+                "propertyValue": "player.playAlbum",
                 "propertySubPhrases": [
-                  "begin"
+                  "spin"
                 ]
               },
               {
-                "propertyValue": "player.launchArtist",
+                "propertyValue": "player.playPlaylist",
                 "propertySubPhrases": [
-                  "launch"
+                  "queue"
                 ]
               }
             ]
@@ -513,7 +548,7 @@
       "action": {
         "fullActionName": "player.playGenre",
         "parameters": {
-          "genre": "hip hop"
+          "genre": "hip-hop"
         }
       },
       "explanation": {
@@ -527,7 +562,7 @@
           },
           {
             "name": "parameters.genre",
-            "value": "hip hop",
+            "value": "hip-hop",
             "substrings": [
               "dope beats"
             ]
@@ -539,8 +574,8 @@
             "category": "greeting",
             "synonyms": [
               "Hey",
-              "Yo",
-              "Hi"
+              "Hi",
+              "Yo"
             ],
             "isOptional": true
           },
@@ -563,8 +598,8 @@
             "category": "filler",
             "synonyms": [
               "right now",
-              "in this place",
-              "here"
+              "here",
+              "in this place"
             ],
             "isOptional": true
           }
@@ -578,28 +613,28 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.playMusic",
+                "propertyValue": "player.playSong",
                 "propertySubPhrases": [
                   "let's play some"
                 ]
               },
               {
-                "propertyValue": "player.startPlaylist",
+                "propertyValue": "player.playAlbum",
                 "propertySubPhrases": [
-                  "let's start a playlist of"
+                  "let's spin some"
                 ]
               },
               {
-                "propertyValue": "player.queueSongs",
+                "propertyValue": "player.playArtist",
                 "propertySubPhrases": [
-                  "let's queue up some"
+                  "let's hear some"
                 ]
               }
             ]
           },
           {
             "propertyName": "parameters.genre",
-            "propertyValue": "hip hop",
+            "propertyValue": "hip-hop",
             "propertySubPhrases": [
               "dope beats"
             ],
@@ -631,7 +666,7 @@
         ],
         "politeSuffixes": [
           "Thank you!",
-          "I would appreciate it."
+          "I would appreciate it!"
         ]
       },
       "corrections": [
@@ -647,7 +682,7 @@
               },
               {
                 "name": "genre",
-                "value": "hip hop",
+                "value": "hip-hop",
                 "substrings": [
                   "dope beats"
                 ]
@@ -675,7 +710,7 @@
             "name": "fullActionName",
             "value": "player.playArtist",
             "substrings": [
-              "let's bump"
+              "Ayo, let's bump some of that classic Snoop Dogg, ya dig?"
             ]
           },
           {
@@ -698,19 +733,12 @@
             "isOptional": true
           },
           {
-            "text": "let's bump",
-            "category": "command",
-            "propertyNames": [
-              "fullActionName"
-            ]
-          },
-          {
-            "text": "some of that classic",
+            "text": "let's bump some of that classic",
             "category": "filler",
             "synonyms": [
-              "some",
-              "a bit of",
-              "a little"
+              "let's play some",
+              "let's listen to some",
+              "how about some"
             ],
             "isOptional": true
           },
@@ -723,7 +751,7 @@
           },
           {
             "text": "ya dig?",
-            "category": "confirmation",
+            "category": "filler",
             "synonyms": [
               "you know?",
               "right?",
@@ -733,33 +761,6 @@
           }
         ],
         "propertyAlternatives": [
-          {
-            "propertyName": "fullActionName",
-            "propertyValue": "player.playArtist",
-            "propertySubPhrases": [
-              "let's bump"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "player.playSong",
-                "propertySubPhrases": [
-                  "let's play"
-                ]
-              },
-              {
-                "propertyValue": "player.playAlbum",
-                "propertySubPhrases": [
-                  "let's listen to the album"
-                ]
-              },
-              {
-                "propertyValue": "player.playPlaylist",
-                "propertySubPhrases": [
-                  "let's put on the playlist"
-                ]
-              }
-            ]
-          },
           {
             "propertyName": "parameters.artist",
             "propertyValue": "Snoop Dogg",
@@ -780,9 +781,9 @@
                 ]
               },
               {
-                "propertyValue": "Eminem",
+                "propertyValue": "Ice Cube",
                 "propertySubPhrases": [
-                  "Eminem"
+                  "Ice Cube"
                 ]
               }
             ]
@@ -790,11 +791,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If it's not too much trouble,",
+          "May I kindly ask"
         ],
         "politeSuffixes": [
           "Thank you!",
-          "I would appreciate it."
+          "I would appreciate it.",
+          "Thanks a lot!",
+          "Much appreciated!"
         ]
       }
     },
@@ -831,7 +836,7 @@
             "synonyms": [
               "let us",
               "we should",
-              "how about"
+              "we will"
             ],
             "isOptional": true
           },
@@ -872,29 +877,22 @@
               {
                 "propertyValue": "player.playTopHits",
                 "propertySubPhrases": [
-                  "turn up the heat",
+                  "crank up the volume",
                   "with the top hits"
-                ]
-              },
-              {
-                "propertyValue": "player.playFavorites",
-                "propertySubPhrases": [
-                  "turn up the heat",
-                  "with my favorite tracks"
-                ]
-              },
-              {
-                "propertyValue": "player.playNewReleases",
-                "propertySubPhrases": [
-                  "turn up the heat",
-                  "with the latest releases"
                 ]
               },
               {
                 "propertyValue": "player.playChill",
                 "propertySubPhrases": [
-                  "turn up the heat",
+                  "set the mood",
                   "with some chill vibes"
+                ]
+              },
+              {
+                "propertyValue": "player.playParty",
+                "propertySubPhrases": [
+                  "get the party started",
+                  "with some party anthems"
                 ]
               }
             ]
@@ -902,15 +900,11 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind",
-          "If it's not too much trouble,",
-          "May I kindly ask"
+          "Would you mind"
         ],
         "politeSuffixes": [
           "Thank you!",
-          "I would appreciate it.",
-          "Thanks a lot!",
-          "Much appreciated!"
+          "I would appreciate it!"
         ]
       }
     },
@@ -927,45 +921,46 @@
           {
             "name": "fullActionName",
             "value": "player.playTrack",
-            "substrings": [
-              "let's get this party poppin'"
-            ]
+            "isImplicit": true
           },
           {
             "name": "parameters.trackName",
             "value": "Lay Low",
             "substrings": [
-              "'Lay Low'"
+              "Lay Low"
             ]
           }
         ],
         "subPhrases": [
           {
-            "text": "Ayo,",
+            "text": "Ayo",
             "category": "greeting",
             "synonyms": [
-              "Hey,",
-              "Hi,",
-              "Hello,"
+              "Hey",
+              "Hi",
+              "Hello"
             ],
             "isOptional": true
           },
           {
-            "text": "nephew,",
+            "text": "nephew",
             "category": "filler",
             "synonyms": [
-              "buddy,",
-              "friend,",
-              "mate,"
+              "buddy",
+              "pal",
+              "friend"
             ],
             "isOptional": true
           },
           {
             "text": "let's get this party poppin'",
-            "category": "action",
-            "propertyNames": [
-              "fullActionName"
-            ]
+            "category": "filler",
+            "synonyms": [
+              "let's start the music",
+              "let's begin the fun",
+              "let's get going"
+            ],
+            "isOptional": true
           },
           {
             "text": "with some",
@@ -983,46 +978,9 @@
             "propertyNames": [
               "parameters.trackName"
             ]
-          },
-          {
-            "text": "!",
-            "category": "punctuation",
-            "synonyms": [
-              ".",
-              "?",
-              ""
-            ],
-            "isOptional": true
           }
         ],
         "propertyAlternatives": [
-          {
-            "propertyName": "fullActionName",
-            "propertyValue": "player.playTrack",
-            "propertySubPhrases": [
-              "let's get this party poppin'"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "player.queueTrack",
-                "propertySubPhrases": [
-                  "let's add some tracks to the queue"
-                ]
-              },
-              {
-                "propertyValue": "player.pauseTrack",
-                "propertySubPhrases": [
-                  "let's take a break from the music"
-                ]
-              },
-              {
-                "propertyValue": "player.stopTrack",
-                "propertySubPhrases": [
-                  "let's stop the music"
-                ]
-              }
-            ]
-          },
           {
             "propertyName": "parameters.trackName",
             "propertyValue": "Lay Low",
@@ -1031,21 +989,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "In Da Club",
+                "propertyValue": "Still D.R.E.",
                 "propertySubPhrases": [
-                  "'In Da Club'"
+                  "'Still D.R.E.'"
                 ]
               },
               {
-                "propertyValue": "Yeah!",
+                "propertyValue": "Nuthin' but a 'G' Thang",
                 "propertySubPhrases": [
-                  "'Yeah!'"
+                  "'Nuthin' but a 'G' Thang'"
                 ]
               },
               {
-                "propertyValue": "Hotline Bling",
+                "propertyValue": "The Next Episode",
                 "propertySubPhrases": [
-                  "'Hotline Bling'"
+                  "'The Next Episode'"
                 ]
               }
             ]
@@ -1097,10 +1055,10 @@
         "subPhrases": [
           {
             "text": "Can I get a lil' bit of that",
-            "category": "filler",
+            "category": "politeness",
             "synonyms": [
               "Could you play",
-              "I would like to hear",
+              "Would you mind playing",
               "Please play"
             ],
             "isOptional": true
@@ -1114,17 +1072,17 @@
           },
           {
             "text": "featuring Pharrell",
-            "category": "artist",
+            "category": "artists",
             "propertyNames": [
               "parameters.artists.0"
             ]
           },
           {
             "text": "my main man",
-            "category": "filler",
+            "category": "acknowledgement",
             "synonyms": [
-              "my friend",
               "buddy",
+              "friend",
               "pal"
             ],
             "isOptional": true
@@ -1188,11 +1146,13 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If it's not too much trouble, could you"
         ],
         "politeSuffixes": [
           "Thank you!",
-          "I would appreciate it."
+          "I would really appreciate it.",
+          "Thanks a lot!"
         ]
       }
     },
@@ -1245,7 +1205,7 @@
             "synonyms": [
               "to a few",
               "to several",
-              "to various"
+              "to any"
             ],
             "isOptional": true
           },
@@ -1382,7 +1342,7 @@
             "synonyms": [
               "a bit of",
               "a little",
-              "any"
+              "some"
             ],
             "isOptional": true
           },
@@ -1413,21 +1373,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.pause",
+                "propertyValue": "player.playSong",
                 "propertySubPhrases": [
-                  "pause"
+                  "play"
                 ]
               },
               {
-                "propertyValue": "player.stop",
+                "propertyValue": "player.playAlbum",
                 "propertySubPhrases": [
-                  "stop"
+                  "play album"
                 ]
               },
               {
-                "propertyValue": "player.skip",
+                "propertyValue": "player.playPlaylist",
                 "propertySubPhrases": [
-                  "skip"
+                  "play playlist"
                 ]
               }
             ]
@@ -1446,27 +1406,25 @@
                 ]
               },
               {
-                "propertyValue": "classical",
-                "propertySubPhrases": [
-                  "classical"
-                ]
-              },
-              {
                 "propertyValue": "rock",
                 "propertySubPhrases": [
                   "rock"
+                ]
+              },
+              {
+                "propertyValue": "classical",
+                "propertySubPhrases": [
+                  "classical"
                 ]
               }
             ]
           }
         ],
         "politePrefixes": [
-          "Could you please",
-          "Would you mind"
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it."
+          "Thank you"
         ]
       }
     },
@@ -1484,7 +1442,7 @@
             "name": "fullActionName",
             "value": "player.playGenre",
             "substrings": [
-              "Can we listen to"
+              "listen to"
             ]
           },
           {
@@ -1497,8 +1455,18 @@
         ],
         "subPhrases": [
           {
-            "text": "Can we listen to",
-            "category": "action request",
+            "text": "Can we",
+            "category": "politeness",
+            "synonyms": [
+              "Could we",
+              "May we",
+              "Shall we"
+            ],
+            "isOptional": true
+          },
+          {
+            "text": "listen to",
+            "category": "action",
             "propertyNames": [
               "fullActionName"
             ]
@@ -1509,7 +1477,7 @@
             "synonyms": [
               "a bit of",
               "a little",
-              "any"
+              "some"
             ],
             "isOptional": true
           },
@@ -1521,12 +1489,12 @@
             ]
           },
           {
-            "text": "music?",
+            "text": "music",
             "category": "filler",
             "synonyms": [
-              "tunes?",
-              "songs?",
-              "tracks?"
+              "tunes",
+              "songs",
+              "melodies"
             ],
             "isOptional": true
           }
@@ -1536,25 +1504,25 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.playGenre",
             "propertySubPhrases": [
-              "Can we listen to"
+              "listen to"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.playSong",
                 "propertySubPhrases": [
-                  "Can we play"
+                  "play"
                 ]
               },
               {
                 "propertyValue": "player.playAlbum",
                 "propertySubPhrases": [
-                  "Can we listen to the album"
+                  "put on"
                 ]
               },
               {
-                "propertyValue": "player.playArtist",
+                "propertyValue": "player.playPlaylist",
                 "propertySubPhrases": [
-                  "Can we listen to songs by"
+                  "start"
                 ]
               }
             ]
@@ -1588,12 +1556,10 @@
           }
         ],
         "politePrefixes": [
-          "Could you please",
-          "Would you mind"
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it."
+          "Thank you"
         ]
       }
     },
@@ -1661,9 +1627,9 @@
             "text": "please?",
             "category": "politeness",
             "synonyms": [
-              "kindly?",
-              "if you don't mind?",
-              "if you could?"
+              "thank you",
+              "if you don't mind",
+              "if you could"
             ],
             "isOptional": true
           }
@@ -1742,7 +1708,7 @@
             "name": "fullActionName",
             "value": "player.playArtist",
             "substrings": [
-              "entertain me with some Bach music"
+              "entertain me with"
             ]
           },
           {
@@ -1765,11 +1731,21 @@
             "isOptional": true
           },
           {
-            "text": "entertain me with some",
+            "text": "entertain me with",
             "category": "action",
             "propertyNames": [
               "fullActionName"
             ]
+          },
+          {
+            "text": "some",
+            "category": "filler",
+            "synonyms": [
+              "a bit of",
+              "a little",
+              "any"
+            ],
+            "isOptional": true
           },
           {
             "text": "Bach",
@@ -1780,10 +1756,10 @@
           },
           {
             "text": "music",
-            "category": "context",
+            "category": "filler",
             "synonyms": [
-              "songs",
               "tunes",
+              "songs",
               "melodies"
             ],
             "isOptional": true
@@ -1794,7 +1770,7 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.playArtist",
             "propertySubPhrases": [
-              "entertain me with some"
+              "entertain me with"
             ],
             "alternatives": [
               {
@@ -1860,7 +1836,8 @@
       "action": {
         "fullActionName": "player.playGenre",
         "parameters": {
-          "genre": "80s hits"
+          "genre": "80s",
+          "quantity": 1
         }
       },
       "explanation": {
@@ -1874,10 +1851,15 @@
           },
           {
             "name": "parameters.genre",
-            "value": "80s hits",
+            "value": "80s",
             "substrings": [
-              "80s hits"
+              "80s"
             ]
+          },
+          {
+            "name": "parameters.quantity",
+            "value": 1,
+            "isImplicit": true
           }
         ],
         "subPhrases": [
@@ -1902,26 +1884,36 @@
             "text": "some fun",
             "category": "filler",
             "synonyms": [
-              "a bit of",
-              "a little",
-              "some"
+              "a few",
+              "some",
+              "a couple of"
             ],
             "isOptional": true
           },
           {
-            "text": "80s hits",
+            "text": "80s",
             "category": "genre",
             "propertyNames": [
               "parameters.genre"
             ]
           },
           {
+            "text": "hits",
+            "category": "filler",
+            "synonyms": [
+              "songs",
+              "tracks",
+              "tunes"
+            ],
+            "isOptional": true
+          },
+          {
             "text": "for us to enjoy",
             "category": "filler",
             "synonyms": [
               "for us",
-              "to enjoy",
-              "for our enjoyment"
+              "to listen to",
+              "to have fun with"
             ],
             "isOptional": true
           }
@@ -1956,27 +1948,27 @@
           },
           {
             "propertyName": "parameters.genre",
-            "propertyValue": "80s hits",
+            "propertyValue": "80s",
             "propertySubPhrases": [
-              "80s hits"
+              "80s"
             ],
             "alternatives": [
               {
-                "propertyValue": "90s hits",
+                "propertyValue": "90s",
                 "propertySubPhrases": [
-                  "90s hits"
+                  "90s"
                 ]
               },
               {
-                "propertyValue": "classic rock",
+                "propertyValue": "rock",
                 "propertySubPhrases": [
-                  "classic rock"
+                  "rock"
                 ]
               },
               {
-                "propertyValue": "pop music",
+                "propertyValue": "pop",
                 "propertySubPhrases": [
-                  "pop music"
+                  "pop"
                 ]
               }
             ]
@@ -2039,9 +2031,9 @@
             "text": "some music by",
             "category": "filler",
             "synonyms": [
-              "a song by",
-              "a piece by",
-              "a track by"
+              "music by",
+              "songs by",
+              "tracks by"
             ],
             "isOptional": true
           },
@@ -2115,7 +2107,7 @@
         ],
         "politeSuffixes": [
           "Thank you!",
-          "I would appreciate it."
+          "I would appreciate it!"
         ]
       }
     },
@@ -2237,12 +2229,10 @@
           }
         ],
         "politePrefixes": [
-          "Could you please",
-          "Would you mind"
+          "Could you please"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it."
+          "Thank you!"
         ]
       }
     },
@@ -2283,9 +2273,9 @@
             "text": "some pieces by",
             "category": "filler",
             "synonyms": [
-              "some songs by",
+              "some tracks by",
               "a few pieces by",
-              "some tracks by"
+              "some music by"
             ],
             "isOptional": true
           },
@@ -2368,7 +2358,8 @@
       "action": {
         "fullActionName": "player.playGenre",
         "parameters": {
-          "genre": "jazz"
+          "genre": "jazz",
+          "quantity": 1
         }
       },
       "explanation": {
@@ -2386,6 +2377,11 @@
             "substrings": [
               "jazz"
             ]
+          },
+          {
+            "name": "parameters.quantity",
+            "value": 1,
+            "isImplicit": true
           }
         ],
         "subPhrases": [
@@ -2496,7 +2492,7 @@
         ],
         "politeSuffixes": [
           "Thank you!",
-          "I would appreciate it."
+          "I would appreciate it!"
         ]
       }
     },
@@ -2547,7 +2543,11 @@
           {
             "text": "play",
             "category": "action",
-            "propertyNames": []
+            "synonyms": [
+              "start",
+              "put on",
+              "play"
+            ]
           },
           {
             "text": "some",
@@ -2616,15 +2616,15 @@
                 ]
               },
               {
-                "propertyValue": "Still D.R.E.",
-                "propertySubPhrases": [
-                  "'Still D.R.E.'"
-                ]
-              },
-              {
                 "propertyValue": "Drop It Like It's Hot",
                 "propertySubPhrases": [
                   "'Drop It Like It's Hot'"
+                ]
+              },
+              {
+                "propertyValue": "Still D.R.E.",
+                "propertySubPhrases": [
+                  "'Still D.R.E.'"
                 ]
               }
             ]
@@ -2801,13 +2801,13 @@
               {
                 "propertyValue": "player.playAlbum",
                 "propertySubPhrases": [
-                  "play album"
+                  "put on the album"
                 ]
               },
               {
                 "propertyValue": "player.playPlaylist",
                 "propertySubPhrases": [
-                  "play playlist"
+                  "play the playlist"
                 ]
               }
             ]
@@ -2845,8 +2845,8 @@
           "Would you mind"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it."
+          "Thank you",
+          "Please"
         ]
       }
     },
@@ -2878,7 +2878,7 @@
           },
           {
             "text": "put on some music",
-            "category": "action",
+            "category": "command",
             "propertyNames": [
               "fullActionName"
             ]
@@ -2893,39 +2893,31 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.playPlaylist",
+                "propertyValue": "player.play",
                 "propertySubPhrases": [
-                  "play a playlist"
+                  "play some music"
                 ]
               },
               {
-                "propertyValue": "player.playAlbum",
+                "propertyValue": "player.shuffle",
                 "propertySubPhrases": [
-                  "play an album"
+                  "shuffle the music"
                 ]
               },
               {
-                "propertyValue": "player.playSong",
+                "propertyValue": "player.startRadio",
                 "propertySubPhrases": [
-                  "play a song"
-                ]
-              },
-              {
-                "propertyValue": "player.playArtist",
-                "propertySubPhrases": [
-                  "play an artist"
+                  "start the radio"
                 ]
               }
             ]
           }
         ],
         "politePrefixes": [
-          "Could you please",
-          "Would you mind"
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you",
-          "if that's okay"
+          "Thank you"
         ]
       }
     },
@@ -2972,34 +2964,34 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.playMusic",
+                "propertyValue": "player.play",
                 "propertySubPhrases": [
                   "play some music"
                 ]
               },
               {
-                "propertyValue": "player.startPlaylist",
+                "propertyValue": "player.playPlaylist",
                 "propertySubPhrases": [
-                  "start a playlist"
+                  "play a playlist"
                 ]
               },
               {
-                "propertyValue": "player.playSongs",
+                "propertyValue": "player.playAlbum",
                 "propertySubPhrases": [
-                  "play some songs"
+                  "play an album"
+                ]
+              },
+              {
+                "propertyValue": "player.playArtist",
+                "propertySubPhrases": [
+                  "play some songs by"
                 ]
               }
             ]
           }
         ],
-        "politePrefixes": [
-          "Could you please",
-          "Would you mind"
-        ],
-        "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it."
-        ]
+        "politePrefixes": [],
+        "politeSuffixes": []
       }
     },
     {
@@ -3143,15 +3135,15 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "Pink Floyd",
-                "propertySubPhrases": [
-                  "Pink Floyd"
-                ]
-              },
-              {
                 "propertyValue": "The Beatles",
                 "propertySubPhrases": [
                   "The Beatles"
+                ]
+              },
+              {
+                "propertyValue": "Pink Floyd",
+                "propertySubPhrases": [
+                  "Pink Floyd"
                 ]
               },
               {
@@ -3228,23 +3220,13 @@
           },
           {
             "text": "'Thriller'",
-            "category": "albumName",
+            "category": "album name",
             "propertyNames": [
               "parameters.albumName"
             ]
           },
           {
-            "text": "by",
-            "category": "preposition",
-            "synonyms": [
-              "from",
-              "of",
-              "featuring"
-            ],
-            "isOptional": true
-          },
-          {
-            "text": "Michael Jackson",
+            "text": "by Michael Jackson",
             "category": "artist",
             "propertyNames": [
               "parameters.artists.0"
@@ -3272,9 +3254,9 @@
                 ]
               },
               {
-                "propertyValue": "player.playRecord",
+                "propertyValue": "player.playMusicAlbum",
                 "propertySubPhrases": [
-                  "play the record"
+                  "play the music album"
                 ]
               }
             ]
@@ -3310,25 +3292,25 @@
             "propertyName": "parameters.artists.0",
             "propertyValue": "Michael Jackson",
             "propertySubPhrases": [
-              "Michael Jackson"
+              "by Michael Jackson"
             ],
             "alternatives": [
               {
                 "propertyValue": "Prince",
                 "propertySubPhrases": [
-                  "Prince"
+                  "by Prince"
                 ]
               },
               {
                 "propertyValue": "Madonna",
                 "propertySubPhrases": [
-                  "Madonna"
+                  "by Madonna"
                 ]
               },
               {
                 "propertyValue": "Whitney Houston",
                 "propertySubPhrases": [
-                  "Whitney Houston"
+                  "by Whitney Houston"
                 ]
               }
             ]
@@ -3336,11 +3318,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If it's not too much trouble, could you",
+          "May I kindly ask you to"
         ],
         "politeSuffixes": [
           "Thank you!",
-          "I would appreciate it."
+          "I would appreciate it!",
+          "Thanks a lot!",
+          "That would be great!"
         ]
       }
     },
@@ -3426,19 +3412,19 @@
               {
                 "propertyValue": "player.playSong",
                 "propertySubPhrases": [
-                  "play a song"
+                  "play"
                 ]
               },
               {
                 "propertyValue": "player.playAlbum",
                 "propertySubPhrases": [
-                  "play an album"
+                  "play album"
                 ]
               },
               {
                 "propertyValue": "player.playPlaylist",
                 "propertySubPhrases": [
-                  "play a playlist"
+                  "play playlist"
                 ]
               }
             ]
@@ -3477,7 +3463,7 @@
         ],
         "politeSuffixes": [
           "Thank you!",
-          "I would appreciate it."
+          "I would appreciate it!"
         ]
       }
     },
@@ -3495,7 +3481,7 @@
             "name": "fullActionName",
             "value": "player.playArtist",
             "substrings": [
-              "entertain us"
+              "entertain us with"
             ]
           },
           {
@@ -3511,26 +3497,26 @@
             "text": "Could you be so good as to",
             "category": "politeness",
             "synonyms": [
+              "Would you kindly",
               "Please",
-              "Would you mind",
-              "Kindly"
+              "If you would be so kind"
             ],
             "isOptional": true
           },
           {
-            "text": "entertain us",
+            "text": "entertain us with",
             "category": "action",
             "propertyNames": [
               "fullActionName"
             ]
           },
           {
-            "text": "with a touch of",
-            "category": "preposition",
+            "text": "a touch of",
+            "category": "filler",
             "synonyms": [
-              "featuring",
-              "including",
-              "with"
+              "some",
+              "a bit of",
+              "a piece of"
             ],
             "isOptional": true
           },
@@ -3547,25 +3533,25 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.playArtist",
             "propertySubPhrases": [
-              "entertain us"
+              "entertain us with"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.playSong",
                 "propertySubPhrases": [
-                  "play us a song"
+                  "play us a song by"
                 ]
               },
               {
                 "propertyValue": "player.playAlbum",
                 "propertySubPhrases": [
-                  "play an album"
+                  "play an album by"
                 ]
               },
               {
                 "propertyValue": "player.playPlaylist",
                 "propertySubPhrases": [
-                  "play a playlist"
+                  "play a playlist by"
                 ]
               }
             ]
@@ -3632,8 +3618,8 @@
             "text": "Could you be so gracious as to",
             "category": "politeness",
             "synonyms": [
-              "Would you kindly",
               "Please",
+              "Would you kindly",
               "If you would be so kind"
             ],
             "isOptional": true
@@ -3662,15 +3648,15 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.playSong",
-                "propertySubPhrases": [
-                  "play a song for us"
-                ]
-              },
-              {
                 "propertyValue": "player.playAlbum",
                 "propertySubPhrases": [
                   "play an album for us"
+                ]
+              },
+              {
+                "propertyValue": "player.playSong",
+                "propertySubPhrases": [
+                  "play a song for us"
                 ]
               },
               {
@@ -3744,8 +3730,8 @@
             "category": "politeness",
             "synonyms": [
               "please",
-              "if you don't mind",
-              "would you be so kind"
+              "would you mind",
+              "if you could"
             ],
             "isOptional": true
           },
@@ -3904,21 +3890,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.playSong",
+                "propertyValue": "player.pauseArtist",
                 "propertySubPhrases": [
-                  "play a song"
+                  "pause"
                 ]
               },
               {
-                "propertyValue": "player.playAlbum",
+                "propertyValue": "player.stopArtist",
                 "propertySubPhrases": [
-                  "play an album"
+                  "stop"
                 ]
               },
               {
-                "propertyValue": "player.playPlaylist",
+                "propertyValue": "player.resumeArtist",
                 "propertySubPhrases": [
-                  "play a playlist"
+                  "resume"
                 ]
               }
             ]
@@ -3979,7 +3965,7 @@
             "name": "parameters.albumName",
             "value": "Hamilton",
             "substrings": [
-              "'Hamilton'"
+              "Hamilton"
             ]
           },
           {
@@ -4027,7 +4013,7 @@
           },
           {
             "text": "Original Broadway Cast",
-            "category": "artist",
+            "category": "artists",
             "propertyNames": [
               "parameters.artists.0"
             ]
@@ -4038,7 +4024,7 @@
             "synonyms": [
               "Album",
               "Soundtrack",
-              "Track"
+              "Music"
             ],
             "isOptional": true
           }
@@ -4157,12 +4143,22 @@
         ],
         "subPhrases": [
           {
-            "text": "Could you please",
+            "text": "Could you",
             "category": "politeness",
             "synonyms": [
-              "Can you please",
-              "Would you kindly",
-              "Please"
+              "Can you",
+              "Would you",
+              "Will you"
+            ],
+            "isOptional": true
+          },
+          {
+            "text": "please",
+            "category": "politeness",
+            "synonyms": [
+              "kindly",
+              "if you could",
+              "if you would"
             ],
             "isOptional": true
           },
@@ -4282,8 +4278,8 @@
             "category": "politeness",
             "synonyms": [
               "kindly",
-              "if you could",
-              "if you would"
+              "if you don't mind",
+              "if you could"
             ],
             "isOptional": true
           },
@@ -4299,7 +4295,7 @@
             "category": "filler",
             "synonyms": [
               "a few",
-              "any",
+              "a couple of",
               "several"
             ],
             "isOptional": true
@@ -4358,15 +4354,15 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "pop",
-                "propertySubPhrases": [
-                  "pop"
-                ]
-              },
-              {
                 "propertyValue": "jazz",
                 "propertySubPhrases": [
                   "jazz"
+                ]
+              },
+              {
+                "propertyValue": "pop",
+                "propertySubPhrases": [
+                  "pop"
                 ]
               },
               {
@@ -4541,7 +4537,7 @@
           },
           {
             "text": "put on",
-            "category": "action",
+            "category": "command",
             "propertyNames": [
               "fullActionName"
             ]
@@ -4583,9 +4579,9 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.startGenre",
+                "propertyValue": "player.startMusic",
                 "propertySubPhrases": [
-                  "start"
+                  "start playing"
                 ]
               },
               {
@@ -4639,7 +4635,8 @@
       "action": {
         "fullActionName": "player.playGenre",
         "parameters": {
-          "genre": "classical"
+          "genre": "classical",
+          "quantity": 1
         }
       },
       "explanation": {
@@ -4657,6 +4654,11 @@
             "substrings": [
               "classical"
             ]
+          },
+          {
+            "name": "parameters.quantity",
+            "value": 1,
+            "isImplicit": true
           }
         ],
         "subPhrases": [
@@ -4678,12 +4680,22 @@
             ]
           },
           {
-            "text": "some soothing",
+            "text": "some",
             "category": "filler",
             "synonyms": [
               "a bit of",
-              "some relaxing",
-              "a little"
+              "a little",
+              "any"
+            ],
+            "isOptional": true
+          },
+          {
+            "text": "soothing",
+            "category": "filler",
+            "synonyms": [
+              "relaxing",
+              "calming",
+              "peaceful"
             ],
             "isOptional": true
           },
@@ -4720,7 +4732,7 @@
                 ]
               },
               {
-                "propertyValue": "player.playMusic",
+                "propertyValue": "player.playType",
                 "propertySubPhrases": [
                   "play"
                 ]
@@ -4791,7 +4803,7 @@
           },
           {
             "text": "turn on the music",
-            "category": "command",
+            "category": "action",
             "propertyNames": []
           },
           {
@@ -4832,7 +4844,7 @@
               },
               {
                 "text": "turn on the music",
-                "category": "command",
+                "category": "action",
                 "propertyNames": [
                   "fullActionName"
                 ]
@@ -4875,7 +4887,7 @@
               },
               {
                 "text": "turn on the music",
-                "category": "command",
+                "category": "action",
                 "propertyNames": []
               },
               {
@@ -4892,27 +4904,54 @@
             "propertyAlternatives": [
               {
                 "propertyName": "action",
-                "propertyValue": "turn on the music",
+                "propertyValue": "turn on",
                 "propertySubPhrases": [
                   "turn on the music"
                 ],
                 "alternatives": [
                   {
-                    "propertyValue": "play some tunes",
+                    "propertyValue": "play",
                     "propertySubPhrases": [
-                      "play some tunes"
+                      "play the music"
                     ]
                   },
                   {
-                    "propertyValue": "start the playlist",
+                    "propertyValue": "start",
                     "propertySubPhrases": [
-                      "start the playlist"
+                      "start the music"
                     ]
                   },
                   {
-                    "propertyValue": "begin the music",
+                    "propertyValue": "activate",
                     "propertySubPhrases": [
-                      "begin the music"
+                      "activate the music"
+                    ]
+                  }
+                ]
+              },
+              {
+                "propertyName": "politeness",
+                "propertyValue": "please",
+                "propertySubPhrases": [
+                  "please"
+                ],
+                "alternatives": [
+                  {
+                    "propertyValue": "kindly",
+                    "propertySubPhrases": [
+                      "kindly"
+                    ]
+                  },
+                  {
+                    "propertyValue": "if you don't mind",
+                    "propertySubPhrases": [
+                      "if you don't mind"
+                    ]
+                  },
+                  {
+                    "propertyValue": "would you mind",
+                    "propertySubPhrases": [
+                      "would you mind"
                     ]
                   }
                 ]
@@ -4921,6 +4960,8 @@
           },
           "correction": [
             "Extraneous parameter: 'action' is not a parameter in the action",
+            "Implicit property shouldn't have alternatives",
+            "Extraneous parameter: 'politeness' is not a parameter in the action",
             "Implicit property shouldn't have alternatives"
           ]
         }
@@ -4939,7 +4980,9 @@
           {
             "name": "fullActionName",
             "value": "player.playArtist",
-            "isImplicit": true
+            "substrings": [
+              "Crank up"
+            ]
           },
           {
             "name": "parameters.artist",
@@ -4951,9 +4994,21 @@
         ],
         "subPhrases": [
           {
-            "text": "Crank up some",
+            "text": "Crank up",
             "category": "command",
-            "propertyNames": []
+            "propertyNames": [
+              "fullActionName"
+            ]
+          },
+          {
+            "text": "some",
+            "category": "filler",
+            "synonyms": [
+              "a bit of",
+              "a little",
+              "some of"
+            ],
+            "isOptional": true
           },
           {
             "text": "Snoop D-O-Double-G",
@@ -4968,12 +5023,39 @@
             "synonyms": [
               "kindly",
               "if you don't mind",
-              "would you mind"
+              "if you please"
             ],
             "isOptional": true
           }
         ],
         "propertyAlternatives": [
+          {
+            "propertyName": "fullActionName",
+            "propertyValue": "player.playArtist",
+            "propertySubPhrases": [
+              "Crank up"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "player.playSong",
+                "propertySubPhrases": [
+                  "Play"
+                ]
+              },
+              {
+                "propertyValue": "player.playAlbum",
+                "propertySubPhrases": [
+                  "Play the album"
+                ]
+              },
+              {
+                "propertyValue": "player.playPlaylist",
+                "propertySubPhrases": [
+                  "Play the playlist"
+                ]
+              }
+            ]
+          },
           {
             "propertyName": "parameters.artist",
             "propertyValue": "Snoop Dogg",
@@ -5004,76 +5086,27 @@
         ],
         "politePrefixes": [],
         "politeSuffixes": []
-      },
-      "corrections": [
-        {
-          "data": {
-            "properties": [
-              {
-                "name": "fullActionName",
-                "value": "player.playArtist",
-                "isImplicit": true
-              },
-              {
-                "name": "parameters.artist",
-                "value": "Snoop Dogg",
-                "substrings": [
-                  "Snoop D-O-Double-G"
-                ]
-              }
-            ],
-            "subPhrases": [
-              {
-                "text": "Crank up some",
-                "category": "command",
-                "propertyNames": [
-                  "fullActionName"
-                ]
-              },
-              {
-                "text": "Snoop D-O-Double-G",
-                "category": "artist",
-                "propertyNames": [
-                  "parameters.artist"
-                ]
-              },
-              {
-                "text": "please",
-                "category": "politeness",
-                "synonyms": [
-                  "kindly",
-                  "if you don't mind",
-                  "would you mind"
-                ],
-                "isOptional": true
-              }
-            ]
-          },
-          "correction": [
-            "Property 'fullActionName' is expected to be implicit and should not be included as a property name in a sub-phrase"
-          ]
-        }
-      ]
+      }
     },
     {
       "request": "Do you have any Bach pieces we could listen to?",
       "action": {
-        "fullActionName": "player.playArtist",
+        "fullActionName": "player.searchTracks",
         "parameters": {
-          "artist": "Bach"
+          "query": "Bach"
         }
       },
       "explanation": {
         "properties": [
           {
             "name": "fullActionName",
-            "value": "player.playArtist",
+            "value": "player.searchTracks",
             "substrings": [
-              "listen to"
+              "Do you have any Bach pieces we could listen to?"
             ]
           },
           {
-            "name": "parameters.artist",
+            "name": "parameters.query",
             "value": "Bach",
             "substrings": [
               "Bach"
@@ -5083,19 +5116,19 @@
         "subPhrases": [
           {
             "text": "Do you have any",
-            "category": "filler",
+            "category": "politeness",
             "synonyms": [
-              "Can you find",
-              "Is there any",
-              "Could you get"
+              "Could you provide",
+              "Would you happen to have",
+              "Can you offer"
             ],
             "isOptional": true
           },
           {
             "text": "Bach",
-            "category": "artist",
+            "category": "query",
             "propertyNames": [
-              "parameters.artist"
+              "parameters.query"
             ]
           },
           {
@@ -5108,7 +5141,7 @@
         ],
         "propertyAlternatives": [
           {
-            "propertyName": "parameters.artist",
+            "propertyName": "parameters.query",
             "propertyValue": "Bach",
             "propertySubPhrases": [
               "Bach"
@@ -5136,27 +5169,27 @@
           },
           {
             "propertyName": "fullActionName",
-            "propertyValue": "player.playArtist",
+            "propertyValue": "player.searchTracks",
             "propertySubPhrases": [
               "pieces we could listen to"
             ],
             "alternatives": [
               {
-                "propertyValue": "player.playAlbum",
+                "propertyValue": "player.playTrack",
                 "propertySubPhrases": [
-                  "albums we could listen to"
+                  "play a piece"
                 ]
               },
               {
-                "propertyValue": "player.playSong",
+                "propertyValue": "player.addToQueue",
                 "propertySubPhrases": [
-                  "songs we could listen to"
+                  "add a piece to the queue"
                 ]
               },
               {
-                "propertyValue": "player.playPlaylist",
+                "propertyValue": "player.shuffleTracks",
                 "propertySubPhrases": [
-                  "playlists we could listen to"
+                  "shuffle pieces"
                 ]
               }
             ]
@@ -5168,7 +5201,7 @@
         ],
         "politeSuffixes": [
           "Thank you!",
-          "I would appreciate it."
+          "I would appreciate it!"
         ]
       }
     },
@@ -5188,7 +5221,10 @@
           {
             "name": "fullActionName",
             "value": "player.playAlbum",
-            "isImplicit": true
+            "substrings": [
+              "let's get some of that",
+              "playin' up in here"
+            ]
           },
           {
             "name": "parameters.albumName",
@@ -5216,13 +5252,10 @@
           },
           {
             "text": "let's get some of that",
-            "category": "filler",
-            "synonyms": [
-              "let's play",
-              "let's hear",
-              "let's listen to"
-            ],
-            "isOptional": true
+            "category": "command",
+            "propertyNames": [
+              "fullActionName"
+            ]
           },
           {
             "text": "Doggystyle album",
@@ -5233,16 +5266,44 @@
           },
           {
             "text": "playin' up in here",
-            "category": "filler",
-            "synonyms": [
-              "playing here",
-              "playing now",
-              "playing in this place"
-            ],
-            "isOptional": true
+            "category": "command",
+            "propertyNames": [
+              "fullActionName"
+            ]
           }
         ],
         "propertyAlternatives": [
+          {
+            "propertyName": "fullActionName",
+            "propertyValue": "player.playAlbum",
+            "propertySubPhrases": [
+              "let's get some of that",
+              "playin' up in here"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "player.queueAlbum",
+                "propertySubPhrases": [
+                  "let's queue up some of that",
+                  "playin' up in here"
+                ]
+              },
+              {
+                "propertyValue": "player.shuffleAlbum",
+                "propertySubPhrases": [
+                  "let's shuffle some of that",
+                  "playin' up in here"
+                ]
+              },
+              {
+                "propertyValue": "player.repeatAlbum",
+                "propertySubPhrases": [
+                  "let's repeat some of that",
+                  "playin' up in here"
+                ]
+              }
+            ]
+          },
           {
             "propertyName": "parameters.albumName",
             "propertyValue": "Doggystyle",
@@ -5277,7 +5338,7 @@
         ],
         "politeSuffixes": [
           "Thank you!",
-          "I would appreciate it."
+          "I would appreciate it!"
         ]
       }
     },
@@ -5286,7 +5347,10 @@
       "action": {
         "fullActionName": "player.playTrack",
         "parameters": {
-          "trackName": "Drop It Like It's Hot"
+          "trackName": "Drop It Like It's Hot",
+          "artists": [
+            "Snoop Dogg"
+          ]
         }
       },
       "explanation": {
@@ -5294,16 +5358,19 @@
           {
             "name": "fullActionName",
             "value": "player.playTrack",
-            "substrings": [
-              "let's get this party bumpin'"
-            ]
+            "isImplicit": true
           },
           {
             "name": "parameters.trackName",
             "value": "Drop It Like It's Hot",
             "substrings": [
-              "'Drop It Like It's Hot'"
+              "Drop It Like It's Hot"
             ]
+          },
+          {
+            "name": "parameters.artists.0",
+            "value": "Snoop Dogg",
+            "isImplicit": true
           }
         ],
         "subPhrases": [
@@ -5311,88 +5378,74 @@
             "text": "Fo' shizzle, my nizzle,",
             "category": "filler",
             "synonyms": [
-              "hey",
-              "yo",
-              "what's up"
+              "Hey",
+              "Yo",
+              "Alright"
             ],
             "isOptional": true
           },
           {
-            "text": "let's get this party bumpin'",
-            "category": "fullActionName",
-            "propertyNames": [
-              "fullActionName"
-            ]
-          },
-          {
-            "text": "with some",
-            "category": "preposition",
+            "text": "let's get this party bumpin' with some",
+            "category": "filler",
             "synonyms": [
-              "featuring",
-              "including",
-              "along with"
+              "let's play",
+              "let's start",
+              "let's listen to"
             ],
             "isOptional": true
           },
           {
-            "text": "'Drop It Like It's Hot'",
-            "category": "parameters.trackName",
+            "text": "'",
+            "category": "punctuation",
+            "synonyms": [
+              "",
+              "",
+              ""
+            ],
+            "isOptional": true
+          },
+          {
+            "text": "Drop It Like It's Hot",
+            "category": "trackName",
             "propertyNames": [
               "parameters.trackName"
             ]
+          },
+          {
+            "text": "'",
+            "category": "punctuation",
+            "synonyms": [
+              "",
+              "",
+              ""
+            ],
+            "isOptional": true
           }
         ],
         "propertyAlternatives": [
           {
-            "propertyName": "fullActionName",
-            "propertyValue": "player.playTrack",
-            "propertySubPhrases": [
-              "let's get this party bumpin'"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "player.startMusic",
-                "propertySubPhrases": [
-                  "let's start the music"
-                ]
-              },
-              {
-                "propertyValue": "player.queueTrack",
-                "propertySubPhrases": [
-                  "add this to the queue"
-                ]
-              },
-              {
-                "propertyValue": "player.playSong",
-                "propertySubPhrases": [
-                  "play this song"
-                ]
-              }
-            ]
-          },
-          {
             "propertyName": "parameters.trackName",
             "propertyValue": "Drop It Like It's Hot",
             "propertySubPhrases": [
-              "'Drop It Like It's Hot'"
+              "Drop It Like It's Hot"
             ],
             "alternatives": [
               {
                 "propertyValue": "Gin and Juice",
                 "propertySubPhrases": [
-                  "'Gin and Juice'"
+                  "Gin and Juice"
                 ]
               },
               {
-                "propertyValue": "Nuthin' But a G Thang",
+                "propertyValue": "Nuthin' but a 'G' Thang",
                 "propertySubPhrases": [
-                  "'Nuthin' But a G Thang'"
+                  "Nuthin' but a 'G' Thang"
                 ]
               },
               {
-                "propertyValue": "Still D.R.E.",
+                "propertyValue": "Who Am I (What's My Name)?",
                 "propertySubPhrases": [
-                  "'Still D.R.E.'"
+                  "Who Am I (What's My Name)?"
                 ]
               }
             ]
@@ -5400,13 +5453,72 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If it's not too much trouble, could you"
         ],
         "politeSuffixes": [
           "Thank you!",
-          "I would appreciate it!"
+          "I would really appreciate it!",
+          "Thanks a lot!"
         ]
-      }
+      },
+      "corrections": [
+        {
+          "data": {
+            "properties": [
+              {
+                "name": "fullActionName",
+                "value": "player.playTrack",
+                "isImplicit": true
+              },
+              {
+                "name": "parameters.trackName",
+                "value": "Drop It Like It's Hot",
+                "substrings": [
+                  "Drop It Like It's Hot"
+                ]
+              },
+              {
+                "name": "parameters.artists.0",
+                "value": "Snoop Dogg",
+                "isImplicit": true
+              }
+            ],
+            "subPhrases": [
+              {
+                "text": "Fo' shizzle, my nizzle,",
+                "category": "filler",
+                "synonyms": [
+                  "Hey",
+                  "Yo",
+                  "Alright"
+                ],
+                "isOptional": true
+              },
+              {
+                "text": "let's get this party bumpin' with some",
+                "category": "filler",
+                "synonyms": [
+                  "let's play",
+                  "let's start",
+                  "let's listen to"
+                ],
+                "isOptional": true
+              },
+              {
+                "text": "Drop It Like It's Hot",
+                "category": "trackName",
+                "propertyNames": [
+                  "parameters.trackName"
+                ]
+              }
+            ]
+          },
+          "correction": [
+            "Missing sub-phrase: explanation missing for '''"
+          ]
+        }
+      ]
     },
     {
       "request": "Hey bot, can you please play some music by Bach for me?",
@@ -5450,7 +5562,7 @@
             "synonyms": [
               "could you please",
               "would you mind",
-              "please"
+              "can you"
             ],
             "isOptional": true
           },
@@ -5566,12 +5678,12 @@
         ],
         "subPhrases": [
           {
-            "text": "Hey nephew",
+            "text": "Hey nephew,",
             "category": "greeting",
             "synonyms": [
-              "Hello",
-              "Hi there",
-              "Greetings"
+              "Hello nephew,",
+              "Hi nephew,",
+              "Greetings nephew,"
             ],
             "isOptional": true
           },
@@ -5596,9 +5708,9 @@
             "text": "some of that smooth",
             "category": "filler",
             "synonyms": [
-              "some",
-              "a bit of",
-              "a little"
+              "some smooth",
+              "that smooth",
+              "smooth"
             ],
             "isOptional": true
           },
@@ -5610,12 +5722,12 @@
             ]
           },
           {
-            "text": "for me",
+            "text": "for me?",
             "category": "politeness",
             "synonyms": [
-              "please",
-              "if you don't mind",
-              "kindly"
+              "please?",
+              "if you could?",
+              "thanks?"
             ],
             "isOptional": true
           }
@@ -5641,9 +5753,9 @@
                 ]
               },
               {
-                "propertyValue": "player.beginGenre",
+                "propertyValue": "player.playMusic",
                 "propertySubPhrases": [
-                  "begin"
+                  "play"
                 ]
               }
             ]
@@ -5677,12 +5789,12 @@
           }
         ],
         "politePrefixes": [
-          "Please",
-          "Could you kindly"
+          "Could you please",
+          "Would you mind"
         ],
         "politeSuffixes": [
-          "Thank you",
-          "I would appreciate it"
+          "Thank you!",
+          "I would appreciate it."
         ]
       }
     },
@@ -5713,12 +5825,12 @@
         ],
         "subPhrases": [
           {
-            "text": "Hey nephew",
+            "text": "Hey nephew,",
             "category": "greeting",
             "synonyms": [
-              "Hello",
-              "Hi there",
-              "Greetings"
+              "Hello there,",
+              "Hi,",
+              "Hey,"
             ],
             "isOptional": true
           },
@@ -5741,8 +5853,8 @@
             "category": "filler",
             "synonyms": [
               "and let's have some fun!",
-              "and let's enjoy!",
-              "and let's party!"
+              "and let's enjoy the music!",
+              "and let's get the party started!"
             ],
             "isOptional": true
           }
@@ -5770,7 +5882,7 @@
               {
                 "propertyValue": "player.playSong",
                 "propertySubPhrases": [
-                  "play that"
+                  "play the song"
                 ]
               }
             ]
@@ -5827,7 +5939,9 @@
             "name": "fullActionName",
             "value": "player.playGenre",
             "substrings": [
-              "vibe out"
+              "vibe out",
+              "dope rhymes",
+              "ill beats"
             ]
           },
           {
@@ -5881,6 +5995,7 @@
             "text": "dope rhymes",
             "category": "genre",
             "propertyNames": [
+              "fullActionName",
               "parameters.genre"
             ]
           },
@@ -5898,6 +6013,7 @@
             "text": "ill beats",
             "category": "genre",
             "propertyNames": [
+              "fullActionName",
               "parameters.genre"
             ]
           }
@@ -5907,25 +6023,33 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.playGenre",
             "propertySubPhrases": [
-              "vibe out"
+              "vibe out",
+              "dope rhymes",
+              "ill beats"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.playMusic",
                 "propertySubPhrases": [
-                  "listen to"
+                  "listen to",
+                  "cool tunes",
+                  "sick beats"
                 ]
               },
               {
                 "propertyValue": "player.startPlaylist",
                 "propertySubPhrases": [
-                  "start a playlist"
+                  "start",
+                  "awesome tracks",
+                  "great rhythms"
                 ]
               },
               {
                 "propertyValue": "player.playSongs",
                 "propertySubPhrases": [
-                  "play some songs"
+                  "play",
+                  "amazing songs",
+                  "fantastic beats"
                 ]
               }
             ]
@@ -5939,36 +6063,34 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "jazz",
+                "propertyValue": "rap",
                 "propertySubPhrases": [
-                  "smooth tunes",
-                  "cool rhythms"
+                  "sick rhymes",
+                  "tight beats"
                 ]
               },
               {
-                "propertyValue": "rock",
+                "propertyValue": "R&B",
                 "propertySubPhrases": [
-                  "heavy riffs",
-                  "loud drums"
+                  "smooth vocals",
+                  "groovy beats"
                 ]
               },
               {
-                "propertyValue": "pop",
+                "propertyValue": "trap",
                 "propertySubPhrases": [
-                  "catchy melodies",
-                  "upbeat tracks"
+                  "hard-hitting lyrics",
+                  "heavy bass"
                 ]
               }
             ]
           }
         ],
         "politePrefixes": [
-          "Please",
-          "Kindly"
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you",
-          "If you don't mind"
+          "Thank you"
         ]
       }
     },
@@ -5988,7 +6110,9 @@
           {
             "name": "fullActionName",
             "value": "player.playTrack",
-            "isImplicit": true
+            "substrings": [
+              "vibe to"
+            ]
           },
           {
             "name": "parameters.trackName",
@@ -6018,21 +6142,28 @@
           },
           {
             "text": "can we",
-            "category": "filler",
+            "category": "politeness",
             "synonyms": [
               "could we",
-              "shall we",
-              "let's"
+              "may we",
+              "would we"
             ],
             "isOptional": true
           },
           {
-            "text": "vibe to some of that",
+            "text": "vibe to",
+            "category": "action",
+            "propertyNames": [
+              "fullActionName"
+            ]
+          },
+          {
+            "text": "some of that",
             "category": "filler",
             "synonyms": [
-              "listen to",
-              "play",
-              "hear"
+              "some",
+              "a bit of",
+              "a little of"
             ],
             "isOptional": true
           },
@@ -6062,6 +6193,33 @@
           }
         ],
         "propertyAlternatives": [
+          {
+            "propertyName": "fullActionName",
+            "propertyValue": "player.playTrack",
+            "propertySubPhrases": [
+              "vibe to"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "player.playSong",
+                "propertySubPhrases": [
+                  "listen to"
+                ]
+              },
+              {
+                "propertyValue": "player.startTrack",
+                "propertySubPhrases": [
+                  "play"
+                ]
+              },
+              {
+                "propertyValue": "player.queueTrack",
+                "propertySubPhrases": [
+                  "add to queue"
+                ]
+              }
+            ]
+          },
           {
             "propertyName": "parameters.trackName",
             "propertyValue": "Beautiful",
@@ -6149,22 +6307,12 @@
             "isOptional": true
           },
           {
-            "text": "how about",
+            "text": "how about we",
             "category": "filler",
             "synonyms": [
-              "what about",
-              "how's",
-              "how's about"
-            ],
-            "isOptional": true
-          },
-          {
-            "text": "we",
-            "category": "filler",
-            "synonyms": [
-              "us",
+              "what if we",
               "let's",
-              "let us"
+              "shall we"
             ],
             "isOptional": true
           },
@@ -6177,7 +6325,7 @@
           },
           {
             "text": "some fly jams",
-            "category": "object",
+            "category": "content",
             "propertyNames": [
               "fullActionName"
             ]
@@ -6217,23 +6365,17 @@
                 ]
               },
               {
-                "propertyValue": "player.start",
+                "propertyValue": "player.startRadio",
                 "propertySubPhrases": [
                   "start",
-                  "the tunes"
+                  "the radio"
                 ]
               }
             ]
           }
         ],
-        "politePrefixes": [
-          "Could you please",
-          "Would you mind"
-        ],
-        "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it."
-        ]
+        "politePrefixes": [],
+        "politeSuffixes": []
       }
     },
     {
@@ -6263,12 +6405,12 @@
         ],
         "subPhrases": [
           {
-            "text": "Hey,",
+            "text": "Hey",
             "category": "greeting",
             "synonyms": [
-              "Hi,",
-              "Hello,",
-              "Yo,"
+              "Hi",
+              "Hello",
+              "Hey there"
             ],
             "isOptional": true
           },
@@ -6293,9 +6435,9 @@
             "text": "vibes up in here!",
             "category": "filler",
             "synonyms": [
-              "music here!",
-              "tracks here!",
-              "songs here!"
+              "music here",
+              "tunes here",
+              "songs here"
             ],
             "isOptional": true
           }
@@ -6329,14 +6471,8 @@
             ]
           }
         ],
-        "politePrefixes": [
-          "Could you please",
-          "Would you mind"
-        ],
-        "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it!"
-        ]
+        "politePrefixes": [],
+        "politeSuffixes": []
       }
     },
     {
@@ -6352,9 +6488,7 @@
           {
             "name": "fullActionName",
             "value": "player.playGenre",
-            "substrings": [
-              "Hey, let's kick it old school with some classic jams on the stereo!"
-            ]
+            "substrings": []
           },
           {
             "name": "parameters.genre",
@@ -6371,7 +6505,7 @@
             "synonyms": [
               "Hi",
               "Hello",
-              "Greetings"
+              "Hey there"
             ],
             "isOptional": true
           },
@@ -6379,9 +6513,9 @@
             "text": "let's kick it old school with some",
             "category": "filler",
             "synonyms": [
-              "let's go with",
-              "how about",
-              "let's play"
+              "let's go retro with",
+              "let's enjoy some",
+              "how about some"
             ],
             "isOptional": true
           },
@@ -6396,9 +6530,9 @@
             "text": "jams on the stereo!",
             "category": "filler",
             "synonyms": [
-              "music on the speakers",
-              "songs on the sound system",
-              "tracks on the audio system"
+              "music on the stereo",
+              "tunes on the stereo",
+              "songs on the stereo"
             ],
             "isOptional": true
           }
@@ -6438,41 +6572,9 @@
             ]
           }
         ],
-        "politePrefixes": [
-          "Could you please",
-          "Would you mind"
-        ],
-        "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it!"
-        ]
-      },
-      "corrections": [
-        {
-          "data": {
-            "properties": [
-              {
-                "name": "fullActionName",
-                "value": "player.playGenre",
-                "substrings": [
-                  "Hey, let's kick it old school with some classic jams on the stereo!"
-                ]
-              },
-              {
-                "name": "genre",
-                "value": "classic",
-                "substrings": [
-                  "classic"
-                ]
-              }
-            ]
-          },
-          "correction": [
-            "Extraneous parameter: 'genre' is not a parameter in the action",
-            "Missing parameter: parameter 'parameters.genre' in the action is missing from explanation"
-          ]
-        }
-      ]
+        "politePrefixes": [],
+        "politeSuffixes": []
+      }
     },
     {
       "request": "Hey, spin some Snoop Dogg tracks for us!",
@@ -6512,7 +6614,7 @@
           },
           {
             "text": "spin",
-            "category": "command",
+            "category": "action",
             "propertyNames": [
               "fullActionName"
             ]
@@ -6523,7 +6625,7 @@
             "synonyms": [
               "a few",
               "some",
-              "a couple of"
+              "a couple"
             ],
             "isOptional": true
           },
@@ -6558,8 +6660,8 @@
             "text": "!",
             "category": "punctuation",
             "synonyms": [
-              "",
               ".",
+              "?",
               "!"
             ],
             "isOptional": true
@@ -6621,14 +6723,8 @@
             ]
           }
         ],
-        "politePrefixes": [
-          "Could you please",
-          "Would you mind"
-        ],
-        "politeSuffixes": [
-          "Thank you!",
-          "Thanks a lot!"
-        ]
+        "politePrefixes": [],
+        "politeSuffixes": []
       }
     },
     {
@@ -6661,9 +6757,9 @@
             "text": "How about we",
             "category": "filler",
             "synonyms": [
-              "What if we",
               "Let's",
-              "Shall we"
+              "Shall we",
+              "How about"
             ],
             "isOptional": true
           },
@@ -6682,12 +6778,12 @@
             ]
           },
           {
-            "text": "soundtrack",
+            "text": "soundtrack?",
             "category": "filler",
             "synonyms": [
-              "album",
-              "record",
-              "music"
+              "album?",
+              "record?",
+              "music?"
             ],
             "isOptional": true
           }
@@ -6709,13 +6805,13 @@
               {
                 "propertyValue": "player.playPlaylist",
                 "propertySubPhrases": [
-                  "play a playlist"
+                  "chill to the playlist"
                 ]
               },
               {
                 "propertyValue": "player.playArtist",
                 "propertySubPhrases": [
-                  "listen to some music by"
+                  "listen to some tracks by"
                 ]
               }
             ]
@@ -6753,8 +6849,8 @@
           "Would you mind"
         ],
         "politeSuffixes": [
-          "Thank you",
-          "I would appreciate it"
+          "Thank you!",
+          "I would appreciate it!"
         ]
       }
     },
@@ -6806,8 +6902,8 @@
             "category": "preposition",
             "synonyms": [
               "from",
-              "featuring",
-              "with"
+              "of",
+              "featuring"
             ],
             "isOptional": true
           },
@@ -6817,6 +6913,16 @@
             "propertyNames": [
               "parameters.artist"
             ]
+          },
+          {
+            "text": "?",
+            "category": "punctuation",
+            "synonyms": [
+              ".",
+              "!",
+              ""
+            ],
+            "isOptional": true
           }
         ],
         "propertyAlternatives": [
@@ -6881,7 +6987,7 @@
         ],
         "politeSuffixes": [
           "Thank you!",
-          "Please?"
+          "If that's okay with you."
         ]
       }
     },
@@ -6928,21 +7034,27 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.playSpecific",
+                "propertyValue": "player.playSong",
                 "propertySubPhrases": [
-                  "listen to a specific song"
+                  "play a song"
+                ]
+              },
+              {
+                "propertyValue": "player.playAlbum",
+                "propertySubPhrases": [
+                  "play an album"
                 ]
               },
               {
                 "propertyValue": "player.playPlaylist",
                 "propertySubPhrases": [
-                  "listen to a playlist"
+                  "play a playlist"
                 ]
               },
               {
-                "propertyValue": "player.playGenre",
+                "propertyValue": "player.playArtist",
                 "propertySubPhrases": [
-                  "listen to some jazz"
+                  "play an artist"
                 ]
               }
             ]
@@ -6953,8 +7065,8 @@
           "Could we please"
         ],
         "politeSuffixes": [
-          "please?",
-          "if that's okay?"
+          "Thank you!",
+          "Please?"
         ]
       }
     },
@@ -6972,7 +7084,7 @@
             "name": "fullActionName",
             "value": "player.playArtist",
             "substrings": [
-              "I do fancy a bit of Beethoven, could you please indulge me?"
+              "could you please indulge me?"
             ]
           },
           {
@@ -7005,9 +7117,9 @@
             "text": "could you please indulge me?",
             "category": "politeness",
             "synonyms": [
-              "could you please play it?",
               "would you mind playing it?",
-              "can you play it for me?"
+              "can you play it for me?",
+              "please play it for me"
             ],
             "isOptional": true
           }
@@ -7075,9 +7187,9 @@
             "text": "I should be most delighted if you could",
             "category": "politeness",
             "synonyms": [
+              "I would be very happy if you could",
               "It would be wonderful if you could",
-              "I would appreciate it if you could",
-              "It would be great if you could"
+              "I would appreciate it if you could"
             ],
             "isOptional": true
           },
@@ -7092,9 +7204,9 @@
             "text": "some enchanting",
             "category": "filler",
             "synonyms": [
-              "some lovely",
               "some beautiful",
-              "some delightful"
+              "some lovely",
+              "some wonderful"
             ],
             "isOptional": true
           },
@@ -7180,7 +7292,7 @@
             "name": "fullActionName",
             "value": "player.playArtist",
             "substrings": [
-              "regale us with some splendid"
+              "regale us with"
             ]
           },
           {
@@ -7203,11 +7315,21 @@
             "isOptional": true
           },
           {
-            "text": "regale us with some splendid",
+            "text": "regale us with",
             "category": "action",
             "propertyNames": [
               "fullActionName"
             ]
+          },
+          {
+            "text": "some splendid",
+            "category": "filler",
+            "synonyms": [
+              "some",
+              "a bit of",
+              "a little"
+            ],
+            "isOptional": true
           },
           {
             "text": "Vivaldi",
@@ -7222,25 +7344,25 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.playArtist",
             "propertySubPhrases": [
-              "regale us with some splendid"
+              "regale us with"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.playSong",
                 "propertySubPhrases": [
-                  "play a wonderful"
+                  "play us"
                 ]
               },
               {
                 "propertyValue": "player.playAlbum",
                 "propertySubPhrases": [
-                  "play the amazing album"
+                  "entertain us with"
                 ]
               },
               {
                 "propertyValue": "player.playPlaylist",
                 "propertySubPhrases": [
-                  "play the fantastic playlist"
+                  "delight us with"
                 ]
               }
             ]
@@ -7287,132 +7409,78 @@
           {
             "name": "fullActionName",
             "value": "player.playRandom",
-            "isImplicit": true
+            "substrings": [
+              "I want to hear some melodies"
+            ]
           }
         ],
         "subPhrases": [
           {
-            "text": "I want to",
-            "category": "politeness",
-            "synonyms": [
-              "I'd like to",
-              "I would like to",
-              "Please"
-            ],
-            "isOptional": true
+            "text": "I want to hear",
+            "category": "request",
+            "propertyNames": [
+              "fullActionName"
+            ]
           },
           {
-            "text": "hear some melodies",
-            "category": "action",
-            "propertyNames": []
+            "text": "some melodies",
+            "category": "content",
+            "propertyNames": [
+              "fullActionName"
+            ]
           }
         ],
-        "propertyAlternatives": [],
+        "propertyAlternatives": [
+          {
+            "propertyName": "fullActionName",
+            "propertyValue": "player.playRandom",
+            "propertySubPhrases": [
+              "I want to hear",
+              "some melodies"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "player.playSong",
+                "propertySubPhrases": [
+                  "I want to hear",
+                  "a song"
+                ]
+              },
+              {
+                "propertyValue": "player.playAlbum",
+                "propertySubPhrases": [
+                  "I want to hear",
+                  "an album"
+                ]
+              },
+              {
+                "propertyValue": "player.playPlaylist",
+                "propertySubPhrases": [
+                  "I want to hear",
+                  "a playlist"
+                ]
+              },
+              {
+                "propertyValue": "player.playGenre",
+                "propertySubPhrases": [
+                  "I want to hear",
+                  "some jazz"
+                ]
+              }
+            ]
+          }
+        ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If it's not too much trouble, could you"
         ],
         "politeSuffixes": [
-          "Thank you",
-          "if that's okay"
+          "Thank you!",
+          "I would appreciate it.",
+          "Thanks a lot!"
         ]
-      },
-      "corrections": [
-        {
-          "data": {
-            "properties": [
-              {
-                "name": "fullActionName",
-                "value": "player.playRandom",
-                "isImplicit": true
-              }
-            ],
-            "subPhrases": [
-              {
-                "text": "I want to",
-                "category": "politeness",
-                "synonyms": [
-                  "I'd like to",
-                  "I would like to",
-                  "Please"
-                ],
-                "isOptional": true
-              },
-              {
-                "text": "hear some melodies",
-                "category": "action",
-                "propertyNames": [
-                  "fullActionName"
-                ]
-              }
-            ]
-          },
-          "correction": [
-            "Property 'fullActionName' is expected to be implicit and should not be included as a property name in a sub-phrase"
-          ]
-        },
-        {
-          "data": {
-            "properties": [
-              {
-                "name": "fullActionName",
-                "value": "player.playRandom",
-                "isImplicit": true
-              }
-            ],
-            "subPhrases": [
-              {
-                "text": "I want to",
-                "category": "politeness",
-                "synonyms": [
-                  "I'd like to",
-                  "I would like to",
-                  "Please"
-                ],
-                "isOptional": true
-              },
-              {
-                "text": "hear some melodies",
-                "category": "action",
-                "propertyNames": []
-              }
-            ],
-            "propertyAlternatives": [
-              {
-                "propertyName": "action",
-                "propertyValue": "hear some melodies",
-                "propertySubPhrases": [
-                  "hear some melodies"
-                ],
-                "alternatives": [
-                  {
-                    "propertyValue": "listen to some tunes",
-                    "propertySubPhrases": [
-                      "listen to some tunes"
-                    ]
-                  },
-                  {
-                    "propertyValue": "play some music",
-                    "propertySubPhrases": [
-                      "play some music"
-                    ]
-                  },
-                  {
-                    "propertyValue": "enjoy some songs",
-                    "propertySubPhrases": [
-                      "enjoy some songs"
-                    ]
-                  }
-                ]
-              }
-            ]
-          },
-          "correction": [
-            "Extraneous parameter: 'action' is not a parameter in the action",
-            "Implicit property shouldn't have alternatives"
-          ]
-        }
-      ]
+      }
     },
     {
       "request": "I would be most obliged if you could perform some charming Chopin.",
@@ -7492,13 +7560,13 @@
               {
                 "propertyValue": "player.playAlbum",
                 "propertySubPhrases": [
-                  "play album"
+                  "play an album"
                 ]
               },
               {
                 "propertyValue": "player.playPlaylist",
                 "propertySubPhrases": [
-                  "play playlist"
+                  "play a playlist"
                 ]
               }
             ]
@@ -7549,7 +7617,7 @@
             "name": "fullActionName",
             "value": "player.playArtist",
             "substrings": [
-              "play some Bach music"
+              "play"
             ]
           },
           {
@@ -7572,26 +7640,26 @@
             "isOptional": true
           },
           {
-            "text": "play some",
+            "text": "play",
             "category": "action",
             "propertyNames": [
               "fullActionName"
             ]
           },
           {
-            "text": "Bach",
+            "text": "some Bach music",
             "category": "artist",
             "propertyNames": [
               "parameters.artist"
             ]
           },
           {
-            "text": "music for me",
-            "category": "filler",
+            "text": "for me",
+            "category": "politeness",
             "synonyms": [
               "please",
-              "if you can",
-              "if possible"
+              "if you don't mind",
+              "kindly"
             ],
             "isOptional": true
           }
@@ -7601,7 +7669,128 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.playArtist",
             "propertySubPhrases": [
-              "play some"
+              "play"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "player.playSong",
+                "propertySubPhrases": [
+                  "play a song"
+                ]
+              },
+              {
+                "propertyValue": "player.playAlbum",
+                "propertySubPhrases": [
+                  "play an album"
+                ]
+              },
+              {
+                "propertyValue": "player.playPlaylist",
+                "propertySubPhrases": [
+                  "play a playlist"
+                ]
+              }
+            ]
+          },
+          {
+            "propertyName": "parameters.artist",
+            "propertyValue": "Bach",
+            "propertySubPhrases": [
+              "some Bach music"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "Mozart",
+                "propertySubPhrases": [
+                  "some Mozart music"
+                ]
+              },
+              {
+                "propertyValue": "Beethoven",
+                "propertySubPhrases": [
+                  "some Beethoven music"
+                ]
+              },
+              {
+                "propertyValue": "Chopin",
+                "propertySubPhrases": [
+                  "some Chopin music"
+                ]
+              }
+            ]
+          }
+        ],
+        "politePrefixes": [],
+        "politeSuffixes": []
+      }
+    },
+    {
+      "request": "I'd appreciate it if you could play some Bach.",
+      "action": {
+        "fullActionName": "player.playArtist",
+        "parameters": {
+          "artist": "Bach"
+        }
+      },
+      "explanation": {
+        "properties": [
+          {
+            "name": "fullActionName",
+            "value": "player.playArtist",
+            "substrings": [
+              "play"
+            ]
+          },
+          {
+            "name": "parameters.artist",
+            "value": "Bach",
+            "substrings": [
+              "Bach"
+            ]
+          }
+        ],
+        "subPhrases": [
+          {
+            "text": "I'd appreciate it if you could",
+            "category": "politeness",
+            "synonyms": [
+              "please",
+              "kindly",
+              "would you mind"
+            ],
+            "isOptional": true
+          },
+          {
+            "text": "play",
+            "category": "action",
+            "propertyNames": [
+              "fullActionName"
+            ]
+          },
+          {
+            "text": "some",
+            "category": "filler",
+            "synonyms": [
+              "a bit of",
+              "a little",
+              "any"
+            ],
+            "isOptional": true
+          },
+          {
+            "text": "Bach",
+            "category": "artist",
+            "propertyNames": [
+              "parameters.artist"
+            ]
+          }
+        ],
+        "propertyAlternatives": [
+          {
+            "propertyName": "fullActionName",
+            "propertyValue": "player.playArtist",
+            "propertySubPhrases": [
+              "play"
             ],
             "alternatives": [
               {
@@ -7654,197 +7843,13 @@
         ],
         "politePrefixes": [],
         "politeSuffixes": []
-      },
-      "corrections": [
-        {
-          "data": {
-            "properties": [
-              {
-                "name": "fullActionName",
-                "value": "player.playArtist",
-                "substrings": [
-                  "play some Bach music"
-                ]
-              },
-              {
-                "name": "parameters.artist",
-                "value": "Bach",
-                "substrings": [
-                  "Bach"
-                ]
-              }
-            ],
-            "subPhrases": [
-              {
-                "text": "I'd appreciate it if you could",
-                "category": "politeness",
-                "synonyms": [
-                  "please",
-                  "kindly",
-                  "would you mind"
-                ],
-                "isOptional": true
-              },
-              {
-                "text": "play some Bach music",
-                "category": "action",
-                "propertyNames": [
-                  "fullActionName"
-                ]
-              },
-              {
-                "text": "Bach",
-                "category": "artist",
-                "propertyNames": [
-                  "parameters.artist"
-                ]
-              },
-              {
-                "text": "for me",
-                "category": "filler",
-                "synonyms": [
-                  "please",
-                  "if you can",
-                  "if possible"
-                ],
-                "isOptional": true
-              }
-            ]
-          },
-          "correction": [
-            "Overlapping sub-phrase: explanation has overlapping text 'Bach'."
-          ]
-        }
-      ]
-    },
-    {
-      "request": "I'd appreciate it if you could play some Bach.",
-      "action": {
-        "fullActionName": "player.playArtist",
-        "parameters": {
-          "artist": "Bach"
-        }
-      },
-      "explanation": {
-        "properties": [
-          {
-            "name": "fullActionName",
-            "value": "player.playArtist",
-            "substrings": [
-              "play"
-            ]
-          },
-          {
-            "name": "parameters.artist",
-            "value": "Bach",
-            "substrings": [
-              "Bach"
-            ]
-          }
-        ],
-        "subPhrases": [
-          {
-            "text": "I'd appreciate it if you could",
-            "category": "politeness",
-            "synonyms": [
-              "please",
-              "kindly",
-              "would you mind",
-              "could you please"
-            ],
-            "isOptional": true
-          },
-          {
-            "text": "play",
-            "category": "action",
-            "propertyNames": [
-              "fullActionName"
-            ]
-          },
-          {
-            "text": "some",
-            "category": "filler",
-            "synonyms": [
-              "a bit of",
-              "a little",
-              "any"
-            ],
-            "isOptional": true
-          },
-          {
-            "text": "Bach",
-            "category": "artist",
-            "propertyNames": [
-              "parameters.artist"
-            ]
-          }
-        ],
-        "propertyAlternatives": [
-          {
-            "propertyName": "fullActionName",
-            "propertyValue": "player.playArtist",
-            "propertySubPhrases": [
-              "play"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "player.pause",
-                "propertySubPhrases": [
-                  "pause"
-                ]
-              },
-              {
-                "propertyValue": "player.stop",
-                "propertySubPhrases": [
-                  "stop"
-                ]
-              },
-              {
-                "propertyValue": "player.resume",
-                "propertySubPhrases": [
-                  "resume"
-                ]
-              }
-            ]
-          },
-          {
-            "propertyName": "parameters.artist",
-            "propertyValue": "Bach",
-            "propertySubPhrases": [
-              "Bach"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "Mozart",
-                "propertySubPhrases": [
-                  "Mozart"
-                ]
-              },
-              {
-                "propertyValue": "Beethoven",
-                "propertySubPhrases": [
-                  "Beethoven"
-                ]
-              },
-              {
-                "propertyValue": "Chopin",
-                "propertySubPhrases": [
-                  "Chopin"
-                ]
-              }
-            ]
-          }
-        ],
-        "politePrefixes": [],
-        "politeSuffixes": []
       }
     },
     {
       "request": "I'd like to hear some classical music, perhaps Beethoven's Symphony No. 9.",
       "action": {
-        "fullActionName": "player.playAlbumTrack",
+        "fullActionName": "player.playTrack",
         "parameters": {
-          "albumName": "Symphony No. 9",
           "trackName": "Symphony No. 9",
           "artists": [
             "Beethoven"
@@ -7855,15 +7860,8 @@
         "properties": [
           {
             "name": "fullActionName",
-            "value": "player.playAlbumTrack",
+            "value": "player.playTrack",
             "isImplicit": true
-          },
-          {
-            "name": "parameters.albumName",
-            "value": "Symphony No. 9",
-            "substrings": [
-              "Symphony No. 9"
-            ]
           },
           {
             "name": "parameters.trackName",
@@ -7885,9 +7883,9 @@
             "text": "I'd like to hear some classical music, perhaps",
             "category": "filler",
             "synonyms": [
-              "I want to listen to",
-              "Can you play",
-              "Please play"
+              "I want to listen to some classical music",
+              "Can you play some classical music",
+              "Please play some classical music"
             ],
             "isOptional": true
           },
@@ -7900,9 +7898,8 @@
           },
           {
             "text": "Symphony No. 9",
-            "category": "album",
+            "category": "track",
             "propertyNames": [
-              "parameters.albumName",
               "parameters.trackName"
             ]
           }
@@ -7931,33 +7928,6 @@
                 "propertyValue": "Tchaikovsky",
                 "propertySubPhrases": [
                   "Tchaikovsky's"
-                ]
-              }
-            ]
-          },
-          {
-            "propertyName": "parameters.albumName",
-            "propertyValue": "Symphony No. 9",
-            "propertySubPhrases": [
-              "Symphony No. 9"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "Symphony No. 5",
-                "propertySubPhrases": [
-                  "Symphony No. 5"
-                ]
-              },
-              {
-                "propertyValue": "Symphony No. 6",
-                "propertySubPhrases": [
-                  "Symphony No. 6"
-                ]
-              },
-              {
-                "propertyValue": "Symphony No. 7",
-                "propertySubPhrases": [
-                  "Symphony No. 7"
                 ]
               }
             ]
@@ -8045,11 +8015,31 @@
             "isOptional": true
           },
           {
-            "text": "'Hotel California'",
+            "text": "'",
+            "category": "punctuation",
+            "synonyms": [
+              "\"",
+              "",
+              "“"
+            ],
+            "isOptional": true
+          },
+          {
+            "text": "Hotel California",
             "category": "trackName",
             "propertyNames": [
               "parameters.trackName"
             ]
+          },
+          {
+            "text": "'",
+            "category": "punctuation",
+            "synonyms": [
+              "\"",
+              "",
+              "”"
+            ],
+            "isOptional": true
           },
           {
             "text": "by",
@@ -8063,10 +8053,20 @@
           },
           {
             "text": "Eagles",
-            "category": "artist",
+            "category": "artistName",
             "propertyNames": [
               "parameters.artists.0"
             ]
+          },
+          {
+            "text": ".",
+            "category": "punctuation",
+            "synonyms": [
+              "",
+              "!",
+              "?"
+            ],
+            "isOptional": true
           }
         ],
         "propertyAlternatives": [
@@ -8074,25 +8074,25 @@
             "propertyName": "parameters.trackName",
             "propertyValue": "Hotel California",
             "propertySubPhrases": [
-              "'Hotel California'"
+              "Hotel California"
             ],
             "alternatives": [
               {
                 "propertyValue": "Bohemian Rhapsody",
                 "propertySubPhrases": [
-                  "'Bohemian Rhapsody'"
+                  "Bohemian Rhapsody"
                 ]
               },
               {
                 "propertyValue": "Stairway to Heaven",
                 "propertySubPhrases": [
-                  "'Stairway to Heaven'"
+                  "Stairway to Heaven"
                 ]
               },
               {
                 "propertyValue": "Imagine",
                 "propertySubPhrases": [
-                  "'Imagine'"
+                  "Imagine"
                 ]
               }
             ]
@@ -8133,7 +8133,73 @@
           "Thank you!",
           "I would appreciate it."
         ]
-      }
+      },
+      "corrections": [
+        {
+          "data": {
+            "properties": [
+              {
+                "name": "fullActionName",
+                "value": "player.playTrack",
+                "isImplicit": true
+              },
+              {
+                "name": "parameters.trackName",
+                "value": "Hotel California",
+                "substrings": [
+                  "Hotel California"
+                ]
+              },
+              {
+                "name": "parameters.artists.0",
+                "value": "Eagles",
+                "substrings": [
+                  "Eagles"
+                ]
+              }
+            ],
+            "subPhrases": [
+              {
+                "text": "I'd like to listen to",
+                "category": "politeness",
+                "synonyms": [
+                  "I want to hear",
+                  "Can you play",
+                  "Please play"
+                ],
+                "isOptional": true
+              },
+              {
+                "text": "Hotel California",
+                "category": "trackName",
+                "propertyNames": [
+                  "parameters.trackName"
+                ]
+              },
+              {
+                "text": "by",
+                "category": "preposition",
+                "synonyms": [
+                  "from",
+                  "performed by",
+                  "sung by"
+                ],
+                "isOptional": true
+              },
+              {
+                "text": "Eagles",
+                "category": "artistName",
+                "propertyNames": [
+                  "parameters.artists.0"
+                ]
+              }
+            ]
+          },
+          "correction": [
+            "Missing sub-phrase: explanation missing for '''"
+          ]
+        }
+      ]
     },
     {
       "request": "I'd like to listen to music now",
@@ -8145,9 +8211,7 @@
           {
             "name": "fullActionName",
             "value": "player.playRandom",
-            "substrings": [
-              "listen to music"
-            ]
+            "isImplicit": true
           }
         ],
         "subPhrases": [
@@ -8164,9 +8228,7 @@
           {
             "text": "listen to music",
             "category": "action",
-            "propertyNames": [
-              "fullActionName"
-            ]
+            "propertyNames": []
           },
           {
             "text": "now",
@@ -8179,50 +8241,161 @@
             "isOptional": true
           }
         ],
-        "propertyAlternatives": [
-          {
-            "propertyName": "fullActionName",
-            "propertyValue": "player.playRandom",
-            "propertySubPhrases": [
-              "listen to music"
+        "propertyAlternatives": [],
+        "politePrefixes": [
+          "Please",
+          "Could you"
+        ],
+        "politeSuffixes": [
+          "Thank you",
+          "if you don't mind"
+        ]
+      },
+      "corrections": [
+        {
+          "data": {
+            "properties": [
+              {
+                "name": "fullActionName",
+                "value": "player.playRandom",
+                "isImplicit": true
+              }
             ],
-            "alternatives": [
+            "subPhrases": [
               {
-                "propertyValue": "player.playSpecific",
-                "propertySubPhrases": [
-                  "play a specific song"
+                "text": "I'd like to",
+                "category": "politeness",
+                "synonyms": [
+                  "I would like to",
+                  "I want to",
+                  "I wish to"
+                ],
+                "isOptional": true
+              },
+              {
+                "text": "listen to music",
+                "category": "action",
+                "propertyNames": [
+                  "fullActionName"
                 ]
               },
               {
-                "propertyValue": "player.playPlaylist",
+                "text": "now",
+                "category": "time",
+                "synonyms": [
+                  "right now",
+                  "immediately",
+                  "at this moment"
+                ],
+                "isOptional": true
+              }
+            ]
+          },
+          "correction": [
+            "Property 'fullActionName' is expected to be implicit and should not be included as a property name in a sub-phrase"
+          ]
+        },
+        {
+          "data": {
+            "properties": [
+              {
+                "name": "fullActionName",
+                "value": "player.playRandom",
+                "isImplicit": true
+              }
+            ],
+            "subPhrases": [
+              {
+                "text": "I'd like to",
+                "category": "politeness",
+                "synonyms": [
+                  "I would like to",
+                  "I want to",
+                  "I wish to"
+                ],
+                "isOptional": true
+              },
+              {
+                "text": "listen to music",
+                "category": "action",
+                "propertyNames": []
+              },
+              {
+                "text": "now",
+                "category": "time",
+                "synonyms": [
+                  "right now",
+                  "immediately",
+                  "at this moment"
+                ],
+                "isOptional": true
+              }
+            ],
+            "propertyAlternatives": [
+              {
+                "propertyName": "action",
+                "propertyValue": "listen to music",
                 "propertySubPhrases": [
-                  "play a playlist"
+                  "listen to music"
+                ],
+                "alternatives": [
+                  {
+                    "propertyValue": "watch a movie",
+                    "propertySubPhrases": [
+                      "watch a movie"
+                    ]
+                  },
+                  {
+                    "propertyValue": "read a book",
+                    "propertySubPhrases": [
+                      "read a book"
+                    ]
+                  },
+                  {
+                    "propertyValue": "play a game",
+                    "propertySubPhrases": [
+                      "play a game"
+                    ]
+                  }
                 ]
               },
               {
-                "propertyValue": "player.playAlbum",
+                "propertyName": "time",
+                "propertyValue": "now",
                 "propertySubPhrases": [
-                  "play an album"
-                ]
-              },
-              {
-                "propertyValue": "player.playGenre",
-                "propertySubPhrases": [
-                  "play some jazz"
+                  "now"
+                ],
+                "alternatives": [
+                  {
+                    "propertyValue": "later",
+                    "propertySubPhrases": [
+                      "later"
+                    ]
+                  },
+                  {
+                    "propertyValue": "tomorrow",
+                    "propertySubPhrases": [
+                      "tomorrow"
+                    ]
+                  },
+                  {
+                    "propertyValue": "in an hour",
+                    "propertySubPhrases": [
+                      "in an hour"
+                    ]
+                  }
                 ]
               }
             ]
-          }
-        ],
-        "politePrefixes": [
-          "Could you please",
-          "Would you mind"
-        ],
-        "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it."
-        ]
-      }
+          },
+          "correction": [
+            "Extraneous parameter: 'action' is not a parameter in the action",
+            "Implicit property shouldn't have alternatives",
+            "Extraneous parameter: 'time' is not a parameter in the action",
+            "Implicit property shouldn't have alternatives"
+          ]
+        }
+      ]
     },
     {
       "request": "I'd like to listen to some Bach, can you play his music?",
@@ -8254,7 +8427,7 @@
             "synonyms": [
               "I would like to hear",
               "I want to listen to",
-              "Can I hear"
+              "Please play"
             ],
             "isOptional": true
           },
@@ -8267,7 +8440,7 @@
           },
           {
             "text": "can you play his music?",
-            "category": "request",
+            "category": "confirmation",
             "synonyms": [
               "could you play his music?",
               "will you play his music?",
@@ -8328,9 +8501,7 @@
           {
             "name": "fullActionName",
             "value": "player.playArtist",
-            "substrings": [
-              "can you play it?"
-            ]
+            "isImplicit": true
           },
           {
             "name": "parameters.artist",
@@ -8346,7 +8517,7 @@
             "category": "politeness",
             "synonyms": [
               "I would like to hear",
-              "Can I listen to",
+              "I want to listen to",
               "Please play"
             ],
             "isOptional": true
@@ -8360,10 +8531,13 @@
           },
           {
             "text": "can you play it?",
-            "category": "request",
-            "propertyNames": [
-              "fullActionName"
-            ]
+            "category": "confirmation",
+            "synonyms": [
+              "could you play it?",
+              "would you play it?",
+              "can you start it?"
+            ],
+            "isOptional": true
           }
         ],
         "propertyAlternatives": [
@@ -8375,48 +8549,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "Beethoven",
-                "propertySubPhrases": [
-                  "Beethoven"
-                ]
-              },
-              {
                 "propertyValue": "Mozart",
                 "propertySubPhrases": [
                   "Mozart"
                 ]
               },
               {
+                "propertyValue": "Beethoven",
+                "propertySubPhrases": [
+                  "Beethoven"
+                ]
+              },
+              {
                 "propertyValue": "Chopin",
                 "propertySubPhrases": [
                   "Chopin"
-                ]
-              }
-            ]
-          },
-          {
-            "propertyName": "fullActionName",
-            "propertyValue": "player.playArtist",
-            "propertySubPhrases": [
-              "can you play it?"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "player.playAlbum",
-                "propertySubPhrases": [
-                  "can you play the album?"
-                ]
-              },
-              {
-                "propertyValue": "player.playSong",
-                "propertySubPhrases": [
-                  "can you play the song?"
-                ]
-              },
-              {
-                "propertyValue": "player.playPlaylist",
-                "propertySubPhrases": [
-                  "can you play the playlist?"
                 ]
               }
             ]
@@ -8435,8 +8582,9 @@
     {
       "request": "I'd like to listen to some jazz music, maybe something by Miles Davis.",
       "action": {
-        "fullActionName": "player.playGenre",
+        "fullActionName": "player.playArtist",
         "parameters": {
+          "artist": "Miles Davis",
           "genre": "jazz"
         }
       },
@@ -8444,8 +8592,15 @@
         "properties": [
           {
             "name": "fullActionName",
-            "value": "player.playGenre",
+            "value": "player.playArtist",
             "substrings": []
+          },
+          {
+            "name": "parameters.artist",
+            "value": "Miles Davis",
+            "substrings": [
+              "Miles Davis"
+            ]
           },
           {
             "name": "parameters.genre",
@@ -8457,12 +8612,22 @@
         ],
         "subPhrases": [
           {
-            "text": "I'd like to listen to some",
+            "text": "I'd like to",
             "category": "politeness",
             "synonyms": [
-              "I would like to hear",
-              "I want to listen to",
-              "Please play"
+              "I would like to",
+              "I want to",
+              "I wish to"
+            ],
+            "isOptional": true
+          },
+          {
+            "text": "listen to some",
+            "category": "preposition",
+            "synonyms": [
+              "hear some",
+              "play some",
+              "enjoy some"
             ],
             "isOptional": true
           },
@@ -8474,14 +8639,21 @@
             ]
           },
           {
-            "text": "music, maybe something by Miles Davis.",
-            "category": "additional information",
+            "text": "music, maybe something by",
+            "category": "filler",
             "synonyms": [
-              "songs, perhaps by Miles Davis.",
-              "tracks, possibly by Miles Davis.",
-              "tunes, maybe by Miles Davis."
+              "music, perhaps something by",
+              "music, possibly something by",
+              "music, potentially something by"
             ],
             "isOptional": true
+          },
+          {
+            "text": "Miles Davis",
+            "category": "artist",
+            "propertyNames": [
+              "parameters.artist"
+            ]
           }
         ],
         "propertyAlternatives": [
@@ -8509,11 +8681,32 @@
                 "propertySubPhrases": [
                   "classical"
                 ]
+              }
+            ]
+          },
+          {
+            "propertyName": "parameters.artist",
+            "propertyValue": "Miles Davis",
+            "propertySubPhrases": [
+              "Miles Davis"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "John Coltrane",
+                "propertySubPhrases": [
+                  "John Coltrane"
+                ]
               },
               {
-                "propertyValue": "hip-hop",
+                "propertyValue": "Duke Ellington",
                 "propertySubPhrases": [
-                  "hip-hop"
+                  "Duke Ellington"
+                ]
+              },
+              {
+                "propertyValue": "Louis Armstrong",
+                "propertySubPhrases": [
+                  "Louis Armstrong"
                 ]
               }
             ]
@@ -8573,12 +8766,12 @@
             ]
           },
           {
-            "text": "tunes,",
+            "text": "tunes",
             "category": "filler",
             "synonyms": [
-              "songs,",
-              "music,",
-              "melodies,"
+              "songs",
+              "music",
+              "melodies"
             ],
             "isOptional": true
           },
@@ -8646,14 +8839,8 @@
             ]
           }
         ],
-        "politePrefixes": [
-          "Could you please",
-          "Would you mind"
-        ],
-        "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it."
-        ]
+        "politePrefixes": [],
+        "politeSuffixes": []
       }
     },
     {
@@ -8684,11 +8871,11 @@
         "subPhrases": [
           {
             "text": "I'd love to hear some",
-            "category": "politeness",
+            "category": "filler",
             "synonyms": [
               "I would like to listen to",
               "I want to hear",
-              "I would enjoy hearing"
+              "I feel like listening to"
             ],
             "isOptional": true
           },
@@ -8701,7 +8888,7 @@
           },
           {
             "text": "can you play it?",
-            "category": "request",
+            "category": "action request",
             "propertyNames": [
               "fullActionName"
             ]
@@ -8769,7 +8956,7 @@
         ],
         "politeSuffixes": [
           "Thank you!",
-          "I would appreciate it."
+          "I appreciate it!"
         ]
       }
     },
@@ -8805,7 +8992,7 @@
             "synonyms": [
               "I would like to listen to",
               "I want to hear",
-              "I wish to listen to"
+              "I would enjoy hearing"
             ],
             "isOptional": true
           },
@@ -8822,7 +9009,7 @@
             "synonyms": [
               "could you play some?",
               "would you play some?",
-              "can you play?"
+              "can you put on some?"
             ],
             "isOptional": false
           }
@@ -8856,14 +9043,8 @@
             ]
           }
         ],
-        "politePrefixes": [
-          "Could you please",
-          "Would you mind"
-        ],
-        "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it!"
-        ]
+        "politePrefixes": [],
+        "politeSuffixes": []
       }
     },
     {
@@ -8909,27 +9090,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.playSong",
+                "propertyValue": "player.playSpecific",
                 "propertySubPhrases": [
-                  "play a song"
+                  "play a specific song"
                 ]
               },
               {
-                "propertyValue": "player.playAlbum",
+                "propertyValue": "player.pause",
                 "propertySubPhrases": [
-                  "play an album"
+                  "pause the music"
                 ]
               },
               {
-                "propertyValue": "player.playPlaylist",
+                "propertyValue": "player.stop",
                 "propertySubPhrases": [
-                  "play a playlist"
-                ]
-              },
-              {
-                "propertyValue": "player.playArtist",
-                "propertySubPhrases": [
-                  "play an artist"
+                  "stop the music"
                 ]
               }
             ]
@@ -8958,13 +9133,15 @@
           {
             "name": "fullActionName",
             "value": "player.playTrack",
-            "isImplicit": true
+            "substrings": [
+              "can you play that for me?"
+            ]
           },
           {
             "name": "parameters.trackName",
             "value": "Sensual Seduction",
             "substrings": [
-              "Sensual Seduction"
+              "'Sensual Seduction'"
             ]
           }
         ],
@@ -8973,14 +9150,14 @@
             "text": "I'm in the mood for some",
             "category": "filler",
             "synonyms": [
-              "I would like to hear",
-              "I want to listen to",
-              "I feel like listening to"
+              "I feel like listening to",
+              "I want to hear",
+              "I would like to listen to"
             ],
             "isOptional": true
           },
           {
-            "text": " 'Sensual Seduction'",
+            "text": "'Sensual Seduction'",
             "category": "track name",
             "propertyNames": [
               "parameters.trackName"
@@ -8988,13 +9165,10 @@
           },
           {
             "text": "can you play that for me?",
-            "category": "politeness",
-            "synonyms": [
-              "please play that",
-              "could you play that",
-              "would you play that"
-            ],
-            "isOptional": true
+            "category": "action request",
+            "propertyNames": [
+              "fullActionName"
+            ]
           }
         ],
         "propertyAlternatives": [
@@ -9002,25 +9176,52 @@
             "propertyName": "parameters.trackName",
             "propertyValue": "Sensual Seduction",
             "propertySubPhrases": [
-              " 'Sensual Seduction'"
+              "'Sensual Seduction'"
             ],
             "alternatives": [
               {
                 "propertyValue": "Bohemian Rhapsody",
                 "propertySubPhrases": [
-                  " 'Bohemian Rhapsody'"
+                  "'Bohemian Rhapsody'"
                 ]
               },
               {
                 "propertyValue": "Shape of You",
                 "propertySubPhrases": [
-                  " 'Shape of You'"
+                  "'Shape of You'"
                 ]
               },
               {
-                "propertyValue": "Hotel California",
+                "propertyValue": "Blinding Lights",
                 "propertySubPhrases": [
-                  " 'Hotel California'"
+                  "'Blinding Lights'"
+                ]
+              }
+            ]
+          },
+          {
+            "propertyName": "fullActionName",
+            "propertyValue": "player.playTrack",
+            "propertySubPhrases": [
+              "can you play that for me?"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "player.pauseTrack",
+                "propertySubPhrases": [
+                  "can you pause that for me?"
+                ]
+              },
+              {
+                "propertyValue": "player.stopTrack",
+                "propertySubPhrases": [
+                  "can you stop that for me?"
+                ]
+              },
+              {
+                "propertyValue": "player.skipTrack",
+                "propertySubPhrases": [
+                  "can you skip that for me?"
                 ]
               }
             ]
@@ -9050,7 +9251,7 @@
             "name": "fullActionName",
             "value": "player.playArtist",
             "substrings": [
-              "can you play some?"
+              "can you play"
             ]
           },
           {
@@ -9082,9 +9283,12 @@
           {
             "text": "can you play some?",
             "category": "request",
-            "propertyNames": [
-              "fullActionName"
-            ]
+            "synonyms": [
+              "could you play some?",
+              "would you play some?",
+              "please play some?"
+            ],
+            "isOptional": false
           }
         ],
         "propertyAlternatives": [
@@ -9114,33 +9318,6 @@
                 ]
               }
             ]
-          },
-          {
-            "propertyName": "fullActionName",
-            "propertyValue": "player.playArtist",
-            "propertySubPhrases": [
-              "can you play some?"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "player.playAlbum",
-                "propertySubPhrases": [
-                  "can you play an album?"
-                ]
-              },
-              {
-                "propertyValue": "player.playSong",
-                "propertySubPhrases": [
-                  "can you play a song?"
-                ]
-              },
-              {
-                "propertyValue": "player.playPlaylist",
-                "propertySubPhrases": [
-                  "can you play a playlist?"
-                ]
-              }
-            ]
           }
         ],
         "politePrefixes": [
@@ -9158,7 +9335,8 @@
       "action": {
         "fullActionName": "player.playArtist",
         "parameters": {
-          "artist": "Bach"
+          "artist": "Bach",
+          "genre": "classical"
         }
       },
       "explanation": {
@@ -9176,22 +9354,36 @@
             "substrings": [
               "Bach"
             ]
+          },
+          {
+            "name": "parameters.genre",
+            "value": "classical",
+            "substrings": [
+              "classical music"
+            ]
           }
         ],
         "subPhrases": [
           {
-            "text": "I'm in the mood for some classical music",
+            "text": "I'm in the mood for some",
             "category": "filler",
             "synonyms": [
-              "I feel like listening to some classical music",
-              "I want to hear some classical music",
-              "I could go for some classical music"
+              "I feel like",
+              "I want to listen to",
+              "I would like to hear"
             ],
             "isOptional": true
           },
           {
+            "text": "classical music",
+            "category": "genre",
+            "propertyNames": [
+              "parameters.genre"
+            ]
+          },
+          {
             "text": "can you play",
-            "category": "action request",
+            "category": "action",
             "propertyNames": [
               "fullActionName"
             ]
@@ -9208,13 +9400,40 @@
           },
           {
             "text": "Bach",
-            "category": "artist name",
+            "category": "artist",
             "propertyNames": [
               "parameters.artist"
             ]
           }
         ],
         "propertyAlternatives": [
+          {
+            "propertyName": "parameters.genre",
+            "propertyValue": "classical",
+            "propertySubPhrases": [
+              "classical music"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "jazz",
+                "propertySubPhrases": [
+                  "jazz music"
+                ]
+              },
+              {
+                "propertyValue": "rock",
+                "propertySubPhrases": [
+                  "rock music"
+                ]
+              },
+              {
+                "propertyValue": "pop",
+                "propertySubPhrases": [
+                  "pop music"
+                ]
+              }
+            ]
+          },
           {
             "propertyName": "fullActionName",
             "propertyValue": "player.playArtist",
@@ -9262,9 +9481,9 @@
                 ]
               },
               {
-                "propertyValue": "Vivaldi",
+                "propertyValue": "Chopin",
                 "propertySubPhrases": [
-                  "Vivaldi"
+                  "Chopin"
                 ]
               }
             ]
@@ -9318,37 +9537,17 @@
           },
           {
             "text": "'Doggy Dogg World'",
-            "category": "track name",
+            "category": "trackName",
             "propertyNames": [
               "parameters.trackName"
             ]
           },
           {
-            "text": "so",
-            "category": "preposition",
-            "synonyms": [
-              "therefore",
-              "thus",
-              "hence"
-            ],
-            "isOptional": true
-          },
-          {
-            "text": "let's get it started",
-            "category": "action",
+            "text": "so let's get it started!",
+            "category": "fullActionName",
             "propertyNames": [
               "fullActionName"
             ]
-          },
-          {
-            "text": "!",
-            "category": "punctuation",
-            "synonyms": [
-              ".",
-              "?",
-              "..."
-            ],
-            "isOptional": true
           }
         ],
         "propertyAlternatives": [
@@ -9383,25 +9582,25 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.playTrack",
             "propertySubPhrases": [
-              "let's get it started"
+              "so let's get it started!"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.queueTrack",
                 "propertySubPhrases": [
-                  "add it to the queue"
+                  "so let's queue it up!"
                 ]
               },
               {
-                "propertyValue": "player.pauseTrack",
+                "propertyValue": "player.addTrackToPlaylist",
                 "propertySubPhrases": [
-                  "pause the music"
+                  "so let's add it to the playlist!"
                 ]
               },
               {
-                "propertyValue": "player.stopTrack",
+                "propertyValue": "player.shufflePlay",
                 "propertySubPhrases": [
-                  "stop the music"
+                  "so let's shuffle things up!"
                 ]
               }
             ]
@@ -9430,15 +9629,13 @@
           {
             "name": "fullActionName",
             "value": "player.playTrack",
-            "substrings": [
-              "Let's get this party started with some 'Drop It Like It's Hot', ya feel me?"
-            ]
+            "isImplicit": true
           },
           {
             "name": "parameters.trackName",
             "value": "Drop It Like It's Hot",
             "substrings": [
-              "'Drop It Like It's Hot'"
+              "Drop It Like It's Hot"
             ]
           }
         ],
@@ -9447,18 +9644,38 @@
             "text": "Let's get this party started with some",
             "category": "filler",
             "synonyms": [
-              "Let's begin with",
-              "How about we start with",
-              "Let's kick things off with"
+              "Let's begin the party with",
+              "Let's start the party with",
+              "Let's kick off the party with"
             ],
             "isOptional": true
           },
           {
-            "text": "'Drop It Like It's Hot'",
+            "text": "'",
+            "category": "punctuation",
+            "synonyms": [
+              "\"",
+              "",
+              "“"
+            ],
+            "isOptional": true
+          },
+          {
+            "text": "Drop It Like It's Hot",
             "category": "trackName",
             "propertyNames": [
               "parameters.trackName"
             ]
+          },
+          {
+            "text": "'",
+            "category": "punctuation",
+            "synonyms": [
+              "\"",
+              "",
+              "”"
+            ],
+            "isOptional": true
           },
           {
             "text": "ya feel me?",
@@ -9466,7 +9683,7 @@
             "synonyms": [
               "you know?",
               "right?",
-              "do you get it?"
+              "do you understand?"
             ],
             "isOptional": true
           }
@@ -9476,25 +9693,25 @@
             "propertyName": "parameters.trackName",
             "propertyValue": "Drop It Like It's Hot",
             "propertySubPhrases": [
-              "'Drop It Like It's Hot'"
+              "Drop It Like It's Hot"
             ],
             "alternatives": [
               {
                 "propertyValue": "Uptown Funk",
                 "propertySubPhrases": [
-                  "'Uptown Funk'"
+                  "Uptown Funk"
                 ]
               },
               {
                 "propertyValue": "Shape of You",
                 "propertySubPhrases": [
-                  "'Shape of You'"
+                  "Shape of You"
                 ]
               },
               {
                 "propertyValue": "Blinding Lights",
                 "propertySubPhrases": [
-                  "'Blinding Lights'"
+                  "Blinding Lights"
                 ]
               }
             ]
@@ -9502,13 +9719,69 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If it's not too much trouble,",
+          "May I kindly ask"
         ],
         "politeSuffixes": [
           "Thank you!",
-          "I would appreciate it!"
+          "I would appreciate it.",
+          "Thanks a lot!",
+          "Much appreciated!"
         ]
-      }
+      },
+      "corrections": [
+        {
+          "data": {
+            "properties": [
+              {
+                "name": "fullActionName",
+                "value": "player.playTrack",
+                "isImplicit": true
+              },
+              {
+                "name": "parameters.trackName",
+                "value": "Drop It Like It's Hot",
+                "substrings": [
+                  "Drop It Like It's Hot"
+                ]
+              }
+            ],
+            "subPhrases": [
+              {
+                "text": "Let's get this party started with some",
+                "category": "filler",
+                "synonyms": [
+                  "Let's begin the party with",
+                  "Let's start the party with",
+                  "Let's kick off the party with"
+                ],
+                "isOptional": true
+              },
+              {
+                "text": "Drop It Like It's Hot",
+                "category": "trackName",
+                "propertyNames": [
+                  "parameters.trackName"
+                ]
+              },
+              {
+                "text": "ya feel me?",
+                "category": "filler",
+                "synonyms": [
+                  "you know?",
+                  "right?",
+                  "do you understand?"
+                ],
+                "isOptional": true
+              }
+            ]
+          },
+          "correction": [
+            "Missing sub-phrase: explanation missing for '''"
+          ]
+        }
+      ]
     },
     {
       "request": "Let's get this place smokin' with some 'Vato', ya dig?",
@@ -9537,28 +9810,15 @@
         ],
         "subPhrases": [
           {
-            "text": "Let's",
-            "category": "filler",
-            "synonyms": [
-              "Let us",
-              "We should",
-              "How about we"
-            ],
-            "isOptional": true
-          },
-          {
-            "text": "get this place smokin' with some",
-            "category": "filler",
-            "synonyms": [
-              "make this place lively with",
-              "turn up the vibe with",
-              "energize this place with"
-            ],
-            "isOptional": true
+            "text": "Let's get this place smokin' with some",
+            "category": "action",
+            "propertyNames": [
+              "fullActionName"
+            ]
           },
           {
             "text": "'Vato'",
-            "category": "trackName",
+            "category": "track name",
             "propertyNames": [
               "parameters.trackName"
             ]
@@ -9569,12 +9829,39 @@
             "synonyms": [
               "you know?",
               "right?",
-              "understand?"
+              "got it?"
             ],
             "isOptional": true
           }
         ],
         "propertyAlternatives": [
+          {
+            "propertyName": "fullActionName",
+            "propertyValue": "player.playTrack",
+            "propertySubPhrases": [
+              "Let's get this place smokin' with some"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "player.startMusic",
+                "propertySubPhrases": [
+                  "Let's start the party with some"
+                ]
+              },
+              {
+                "propertyValue": "player.queueTrack",
+                "propertySubPhrases": [
+                  "Let's queue up some"
+                ]
+              },
+              {
+                "propertyValue": "player.playSong",
+                "propertySubPhrases": [
+                  "Let's play some"
+                ]
+              }
+            ]
+          },
           {
             "propertyName": "parameters.trackName",
             "propertyValue": "Vato",
@@ -9611,7 +9898,33 @@
           "Thank you",
           "Much appreciated"
         ]
-      }
+      },
+      "corrections": [
+        {
+          "data": {
+            "properties": [
+              {
+                "name": "fullActionName",
+                "value": "player.playTrack",
+                "substrings": [
+                  "Let's get this place smokin' with some 'Vato', ya dig?"
+                ]
+              },
+              {
+                "name": "trackName",
+                "value": "Vato",
+                "substrings": [
+                  "'Vato'"
+                ]
+              }
+            ]
+          },
+          "correction": [
+            "Extraneous parameter: 'trackName' is not a parameter in the action",
+            "Missing parameter: parameter 'parameters.trackName' in the action is missing from explanation"
+          ]
+        }
+      ]
     },
     {
       "request": "Let's groove to some Snoop Dogg tunes!",
@@ -9650,9 +9963,9 @@
             "text": "some",
             "category": "filler",
             "synonyms": [
-              "a bit of",
-              "a little",
-              "some"
+              "a few",
+              "several",
+              "a couple"
             ],
             "isOptional": true
           },
@@ -9667,9 +9980,9 @@
             "text": "tunes!",
             "category": "filler",
             "synonyms": [
-              "music",
               "songs",
-              "tracks"
+              "tracks",
+              "music"
             ],
             "isOptional": true
           }
@@ -9731,8 +10044,8 @@
           }
         ],
         "politePrefixes": [
-          "Could we please",
-          "Would you mind if we"
+          "Could you please",
+          "Would you mind"
         ],
         "politeSuffixes": [
           "Thank you!",
@@ -9756,13 +10069,15 @@
           {
             "name": "fullActionName",
             "value": "player.playTrack",
-            "isImplicit": true
+            "substrings": [
+              "Let's hear"
+            ]
           },
           {
             "name": "parameters.trackName",
             "value": "Drop It Like It's Hot",
             "substrings": [
-              "Drop It Like It's Hot"
+              "'Drop It Like It's Hot'"
             ]
           },
           {
@@ -9775,12 +10090,19 @@
         ],
         "subPhrases": [
           {
-            "text": "Let's hear some",
+            "text": "Let's hear",
+            "category": "command",
+            "propertyNames": [
+              "fullActionName"
+            ]
+          },
+          {
+            "text": "some",
             "category": "filler",
             "synonyms": [
-              "Play",
-              "I want to listen to",
-              "Can you play"
+              "a bit of",
+              "a little",
+              "some of"
             ],
             "isOptional": true
           },
@@ -9793,11 +10115,11 @@
           },
           {
             "text": "'s",
-            "category": "preposition",
+            "category": "possessive",
             "synonyms": [
+              "of",
               "by",
-              "from",
-              "of"
+              "from"
             ],
             "isOptional": true
           },
@@ -9810,6 +10132,33 @@
           }
         ],
         "propertyAlternatives": [
+          {
+            "propertyName": "fullActionName",
+            "propertyValue": "player.playTrack",
+            "propertySubPhrases": [
+              "Let's hear"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "player.queueTrack",
+                "propertySubPhrases": [
+                  "Queue up"
+                ]
+              },
+              {
+                "propertyValue": "player.addTrackToPlaylist",
+                "propertySubPhrases": [
+                  "Add"
+                ]
+              },
+              {
+                "propertyValue": "player.shufflePlay",
+                "propertySubPhrases": [
+                  "Shuffle"
+                ]
+              }
+            ]
+          },
           {
             "propertyName": "parameters.artists.0",
             "propertyValue": "Snoop Dogg",
@@ -9867,11 +10216,13 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If it's not too much trouble, could you"
         ],
         "politeSuffixes": [
           "Thank you!",
-          "I would appreciate it!"
+          "I would appreciate it!",
+          "Thanks a lot!"
         ]
       },
       "corrections": [
@@ -9881,13 +10232,15 @@
               {
                 "name": "fullActionName",
                 "value": "player.playTrack",
-                "isImplicit": true
+                "substrings": [
+                  "Let's hear"
+                ]
               },
               {
                 "name": "parameters.trackName",
                 "value": "Drop It Like It's Hot",
                 "substrings": [
-                  "Drop It Like It's Hot"
+                  "'Drop It Like It's Hot'"
                 ]
               },
               {
@@ -9900,12 +10253,19 @@
             ],
             "subPhrases": [
               {
-                "text": "Let's hear some",
+                "text": "Let's hear",
+                "category": "command",
+                "propertyNames": [
+                  "fullActionName"
+                ]
+              },
+              {
+                "text": "some",
                 "category": "filler",
                 "synonyms": [
-                  "Play",
-                  "I want to listen to",
-                  "Can you play"
+                  "a bit of",
+                  "a little",
+                  "some of"
                 ],
                 "isOptional": true
               },
@@ -9945,7 +10305,7 @@
             "name": "fullActionName",
             "value": "player.playArtist",
             "substrings": [
-              "Let's listen to some Bach, shall we?"
+              "Let's listen to"
             ]
           },
           {
@@ -9958,21 +10318,21 @@
         ],
         "subPhrases": [
           {
-            "text": "Let's",
-            "category": "politeness",
-            "synonyms": [
-              "Let us",
-              "We should",
-              "How about we"
-            ],
-            "isOptional": true
-          },
-          {
-            "text": "listen to some",
-            "category": "action",
+            "text": "Let's listen to",
+            "category": "command",
             "propertyNames": [
               "fullActionName"
             ]
+          },
+          {
+            "text": "some",
+            "category": "filler",
+            "synonyms": [
+              "a bit of",
+              "a little",
+              "some"
+            ],
+            "isOptional": true
           },
           {
             "text": "Bach",
@@ -9997,25 +10357,25 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.playArtist",
             "propertySubPhrases": [
-              "listen to some"
+              "Let's listen to"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.playSong",
                 "propertySubPhrases": [
-                  "listen to a song by"
+                  "Let's listen to a song by"
                 ]
               },
               {
                 "propertyValue": "player.playAlbum",
                 "propertySubPhrases": [
-                  "listen to an album by"
+                  "Let's listen to an album by"
                 ]
               },
               {
                 "propertyValue": "player.playPlaylist",
                 "propertySubPhrases": [
-                  "listen to a playlist by"
+                  "Let's listen to a playlist by"
                 ]
               }
             ]
@@ -10048,14 +10408,8 @@
             ]
           }
         ],
-        "politePrefixes": [
-          "Could we please",
-          "Would you mind if we"
-        ],
-        "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it."
-        ]
+        "politePrefixes": [],
+        "politeSuffixes": []
       }
     },
     {
@@ -10079,8 +10433,8 @@
             "category": "politeness",
             "synonyms": [
               "Let us",
-              "Allow us to",
-              "We should"
+              "We should",
+              "How about we"
             ],
             "isOptional": true
           },
@@ -10111,21 +10465,27 @@
             ],
             "alternatives": [
               {
+                "propertyValue": "player.play",
+                "propertySubPhrases": [
+                  "play some music"
+                ]
+              },
+              {
+                "propertyValue": "player.shuffle",
+                "propertySubPhrases": [
+                  "shuffle the music"
+                ]
+              },
+              {
+                "propertyValue": "player.startRadio",
+                "propertySubPhrases": [
+                  "start the radio"
+                ]
+              },
+              {
                 "propertyValue": "player.playPlaylist",
                 "propertySubPhrases": [
                   "play a playlist"
-                ]
-              },
-              {
-                "propertyValue": "player.playAlbum",
-                "propertySubPhrases": [
-                  "play an album"
-                ]
-              },
-              {
-                "propertyValue": "player.playSong",
-                "propertySubPhrases": [
-                  "play a song"
                 ]
               }
             ]
@@ -10146,17 +10506,17 @@
             "name": "fullActionName",
             "value": "player.playRandom",
             "substrings": [
-              "listen to some tunes"
+              "Let's listen to some tunes"
             ]
           }
         ],
         "subPhrases": [
           {
             "text": "Let's",
-            "category": "filler",
+            "category": "politeness",
             "synonyms": [
               "Let us",
-              "We should",
+              "Let's go",
               "How about we"
             ],
             "isOptional": true
@@ -10199,12 +10559,10 @@
           }
         ],
         "politePrefixes": [
-          "Please",
-          "Kindly"
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you",
-          "if you don't mind"
+          "Thank you"
         ]
       }
     },
@@ -10301,28 +10659,50 @@
                 ]
               },
               {
-                "propertyValue": "California Love",
+                "propertyValue": "Who Am I (What's My Name)?",
                 "propertySubPhrases": [
-                  "California Love"
+                  "Who Am I (What's My Name)?"
                 ]
               }
             ]
           }
         ],
         "politePrefixes": [
-          "Please",
-          "Kindly",
+          "Could you please",
           "Would you mind",
-          "Could you please"
+          "If it's not too much trouble,",
+          "Kindly"
         ],
         "politeSuffixes": [
-          "Thank you",
-          "Thanks",
-          "I appreciate it",
-          "If you don't mind"
+          "Thank you.",
+          "I would appreciate it.",
+          "Thanks a lot.",
+          "Much appreciated."
         ]
       },
       "corrections": [
+        {
+          "data": {
+            "properties": [
+              {
+                "name": "fullActionName",
+                "value": "player.playTrack",
+                "isImplicit": true
+              },
+              {
+                "name": "trackName",
+                "value": "Murder Was the Case",
+                "substrings": [
+                  "Murder Was the Case"
+                ]
+              }
+            ]
+          },
+          "correction": [
+            "Extraneous parameter: 'trackName' is not a parameter in the action",
+            "Missing parameter: parameter 'parameters.trackName' in the action is missing from explanation"
+          ]
+        },
         {
           "data": {
             "properties": [
@@ -10403,14 +10783,14 @@
         "subPhrases": [
           {
             "text": "Let's take it back to the old school with some",
-            "category": "fullActionName",
+            "category": "context",
             "propertyNames": [
               "fullActionName"
             ]
           },
           {
             "text": "'Who Am I (What's My Name)?'",
-            "category": "parameters.trackName",
+            "category": "trackName",
             "propertyNames": [
               "parameters.trackName"
             ]
@@ -10427,19 +10807,19 @@
               {
                 "propertyValue": "player.queueTrack",
                 "propertySubPhrases": [
-                  "Add to the queue"
+                  "Add to the queue some"
                 ]
               },
               {
                 "propertyValue": "player.pauseTrack",
                 "propertySubPhrases": [
-                  "Pause the music"
+                  "Pause the track"
                 ]
               },
               {
                 "propertyValue": "player.stopTrack",
                 "propertySubPhrases": [
-                  "Stop the music"
+                  "Stop playing"
                 ]
               }
             ]
@@ -10480,7 +10860,33 @@
           "Thank you!",
           "I would appreciate it!"
         ]
-      }
+      },
+      "corrections": [
+        {
+          "data": {
+            "properties": [
+              {
+                "name": "fullActionName",
+                "value": "player.playTrack",
+                "substrings": [
+                  "Let's take it back to the old school with some 'Who Am I (What's My Name)?'"
+                ]
+              },
+              {
+                "name": "trackName",
+                "value": "Who Am I (What's My Name)?",
+                "substrings": [
+                  "'Who Am I (What's My Name)?'"
+                ]
+              }
+            ]
+          },
+          "correction": [
+            "Extraneous parameter: 'trackName' is not a parameter in the action",
+            "Missing parameter: parameter 'parameters.trackName' in the action is missing from explanation"
+          ]
+        }
+      ]
     },
     {
       "request": "Might I request the pleasure of listening to some exquisite Bach?",
@@ -10496,7 +10902,7 @@
             "name": "fullActionName",
             "value": "player.playArtist",
             "substrings": [
-              "request"
+              "Might I request the pleasure of listening to"
             ]
           },
           {
@@ -10509,12 +10915,22 @@
         ],
         "subPhrases": [
           {
-            "text": "Might I request the pleasure of listening to some exquisite",
+            "text": "Might I request the pleasure of listening to",
             "category": "politeness",
             "synonyms": [
-              "Could I ask for",
-              "Would it be possible to hear",
-              "May I have the honor of listening to"
+              "Could I please listen to",
+              "I would like to hear",
+              "Please play"
+            ],
+            "isOptional": true
+          },
+          {
+            "text": "some exquisite",
+            "category": "filler",
+            "synonyms": [
+              "some",
+              "a bit of",
+              "a little"
             ],
             "isOptional": true
           },
@@ -10681,8 +11097,8 @@
           "Would you mind"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it."
+          "Thank you",
+          "I would appreciate it"
         ]
       }
     },
@@ -10700,7 +11116,7 @@
             "name": "fullActionName",
             "value": "player.playArtist",
             "substrings": [
-              "Play some songs"
+              "Play some songs by"
             ]
           },
           {
@@ -10713,21 +11129,11 @@
         ],
         "subPhrases": [
           {
-            "text": "Play some songs",
-            "category": "command",
+            "text": "Play some songs by",
+            "category": "action",
             "propertyNames": [
               "fullActionName"
             ]
-          },
-          {
-            "text": "by",
-            "category": "preposition",
-            "synonyms": [
-              "from",
-              "featuring",
-              "with"
-            ],
-            "isOptional": true
           },
           {
             "text": "The Beatles",
@@ -10742,7 +11148,7 @@
             "synonyms": [
               "kindly",
               "if you don't mind",
-              "would you mind"
+              "if you please"
             ],
             "isOptional": true
           }
@@ -10752,25 +11158,25 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.playArtist",
             "propertySubPhrases": [
-              "Play some songs"
+              "Play some songs by"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.playAlbum",
                 "propertySubPhrases": [
-                  "Play an album"
+                  "Play the album by"
                 ]
               },
               {
                 "propertyValue": "player.playPlaylist",
                 "propertySubPhrases": [
-                  "Play a playlist"
+                  "Play the playlist by"
                 ]
               },
               {
                 "propertyValue": "player.playTrack",
                 "propertySubPhrases": [
-                  "Play a track"
+                  "Play the track by"
                 ]
               }
             ]
@@ -10783,21 +11189,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "Elvis Presley",
+                "propertyValue": "The Rolling Stones",
                 "propertySubPhrases": [
-                  "Elvis Presley"
+                  "The Rolling Stones"
                 ]
               },
               {
-                "propertyValue": "Michael Jackson",
+                "propertyValue": "Queen",
                 "propertySubPhrases": [
-                  "Michael Jackson"
+                  "Queen"
                 ]
               },
               {
-                "propertyValue": "Madonna",
+                "propertyValue": "Led Zeppelin",
                 "propertySubPhrases": [
-                  "Madonna"
+                  "Led Zeppelin"
                 ]
               }
             ]
@@ -10812,7 +11218,8 @@
       "action": {
         "fullActionName": "player.playGenre",
         "parameters": {
-          "genre": "acoustic guitar"
+          "genre": "acoustic guitar",
+          "quantity": 10
         }
       },
       "explanation": {
@@ -10830,6 +11237,11 @@
             "substrings": [
               "acoustic guitar"
             ]
+          },
+          {
+            "name": "parameters.quantity",
+            "value": 10,
+            "isImplicit": true
           }
         ],
         "subPhrases": [
@@ -10841,12 +11253,22 @@
             ]
           },
           {
-            "text": "some soothing",
+            "text": "some",
             "category": "filler",
             "synonyms": [
               "a few",
-              "some",
+              "several",
               "a couple of"
+            ],
+            "isOptional": true
+          },
+          {
+            "text": "soothing",
+            "category": "filler",
+            "synonyms": [
+              "relaxing",
+              "calming",
+              "peaceful"
             ],
             "isOptional": true
           },
@@ -10877,21 +11299,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.playMusic",
+                "propertyValue": "player.pause",
                 "propertySubPhrases": [
-                  "Play"
+                  "Pause"
                 ]
               },
               {
-                "propertyValue": "player.startGenre",
+                "propertyValue": "player.stop",
                 "propertySubPhrases": [
-                  "Play"
+                  "Stop"
                 ]
               },
               {
-                "propertyValue": "player.beginGenre",
+                "propertyValue": "player.resume",
                 "propertySubPhrases": [
-                  "Play"
+                  "Resume"
                 ]
               }
             ]
@@ -10904,21 +11326,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "classical guitar",
+                "propertyValue": "classical",
                 "propertySubPhrases": [
-                  "classical guitar"
+                  "classical"
                 ]
               },
               {
-                "propertyValue": "electric guitar",
+                "propertyValue": "jazz",
                 "propertySubPhrases": [
-                  "electric guitar"
+                  "jazz"
                 ]
               },
               {
-                "propertyValue": "jazz guitar",
+                "propertyValue": "rock",
                 "propertySubPhrases": [
-                  "jazz guitar"
+                  "rock"
                 ]
               }
             ]
@@ -10994,21 +11416,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.pause",
+                "propertyValue": "player.playSong",
                 "propertySubPhrases": [
-                  "Pause"
+                  "Play a song"
                 ]
               },
               {
-                "propertyValue": "player.stop",
+                "propertyValue": "player.playAlbum",
                 "propertySubPhrases": [
-                  "Stop"
+                  "Play an album"
                 ]
               },
               {
-                "propertyValue": "player.skip",
+                "propertyValue": "player.playPlaylist",
                 "propertySubPhrases": [
-                  "Skip"
+                  "Play a playlist"
                 ]
               }
             ]
@@ -11033,9 +11455,9 @@
                 ]
               },
               {
-                "propertyValue": "jazz",
+                "propertyValue": "modern indie",
                 "propertySubPhrases": [
-                  "jazz"
+                  "modern indie"
                 ]
               }
             ]
@@ -11044,12 +11466,14 @@
         "politePrefixes": [
           "Could you please",
           "Would you mind",
-          "If it's not too much trouble, could you"
+          "If it's not too much trouble,",
+          "I would appreciate it if you could"
         ],
         "politeSuffixes": [
-          "thank you",
-          "please",
-          "if you don't mind"
+          "Thank you!",
+          "Thanks a lot!",
+          "I appreciate it!",
+          "That would be great!"
         ]
       }
     },
@@ -11147,21 +11571,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "We Will Rock You",
+                "propertyValue": "Stairway to Heaven",
                 "propertySubPhrases": [
-                  "'We Will Rock You'"
+                  "'Stairway to Heaven'"
                 ]
               },
               {
-                "propertyValue": "Another One Bites the Dust",
+                "propertyValue": "Hotel California",
                 "propertySubPhrases": [
-                  "'Another One Bites the Dust'"
+                  "'Hotel California'"
                 ]
               },
               {
-                "propertyValue": "Somebody to Love",
+                "propertyValue": "Imagine",
                 "propertySubPhrases": [
-                  "'Somebody to Love'"
+                  "'Imagine'"
                 ]
               }
             ]
@@ -11174,21 +11598,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "The Beatles",
-                "propertySubPhrases": [
-                  "by The Beatles"
-                ]
-              },
-              {
                 "propertyValue": "Led Zeppelin",
                 "propertySubPhrases": [
                   "by Led Zeppelin"
                 ]
               },
               {
-                "propertyValue": "Pink Floyd",
+                "propertyValue": "The Eagles",
                 "propertySubPhrases": [
-                  "by Pink Floyd"
+                  "by The Eagles"
+                ]
+              },
+              {
+                "propertyValue": "John Lennon",
+                "propertySubPhrases": [
+                  "by John Lennon"
                 ]
               }
             ]
@@ -11196,11 +11620,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If it's not too much trouble, could you",
+          "May I kindly ask you to"
         ],
         "politeSuffixes": [
           "Thank you!",
-          "I appreciate it!"
+          "I would appreciate it!",
+          "Thanks a lot!",
+          "That would be great!"
         ]
       }
     },
@@ -11233,7 +11661,7 @@
             "name": "parameters.quantity",
             "value": 10,
             "substrings": [
-              "10"
+              "top 10"
             ]
           }
         ],
@@ -11246,17 +11674,17 @@
             ]
           },
           {
-            "text": "the top",
+            "text": "the",
             "category": "filler",
             "synonyms": [
-              "the best",
-              "the most popular",
-              "the leading"
+              "a",
+              "an",
+              "some"
             ],
             "isOptional": true
           },
           {
-            "text": "10",
+            "text": "top 10",
             "category": "quantity",
             "propertyNames": [
               "parameters.quantity"
@@ -11289,21 +11717,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.pauseGenre",
+                "propertyValue": "player.pause",
                 "propertySubPhrases": [
                   "Pause"
                 ]
               },
               {
-                "propertyValue": "player.stopGenre",
+                "propertyValue": "player.stop",
                 "propertySubPhrases": [
                   "Stop"
                 ]
               },
               {
-                "propertyValue": "player.resumeGenre",
+                "propertyValue": "player.skip",
                 "propertySubPhrases": [
-                  "Resume"
+                  "Skip"
                 ]
               }
             ]
@@ -11312,25 +11740,25 @@
             "propertyName": "parameters.quantity",
             "propertyValue": 10,
             "propertySubPhrases": [
-              "10"
+              "top 10"
             ],
             "alternatives": [
               {
                 "propertyValue": 5,
                 "propertySubPhrases": [
-                  "5"
+                  "top 5"
                 ]
               },
               {
                 "propertyValue": 20,
                 "propertySubPhrases": [
-                  "20"
+                  "top 20"
                 ]
               },
               {
-                "propertyValue": 15,
+                "propertyValue": 50,
                 "propertySubPhrases": [
-                  "15"
+                  "top 50"
                 ]
               }
             ]
@@ -11369,7 +11797,7 @@
         ],
         "politeSuffixes": [
           "Thank you",
-          "I would appreciate it"
+          "I appreciate it"
         ]
       }
     },
@@ -11415,7 +11843,7 @@
             "synonyms": [
               "Kindly",
               "Could you",
-              "Would you mind"
+              "Would you"
             ],
             "isOptional": true
           },
@@ -11462,9 +11890,9 @@
                 ]
               },
               {
-                "propertyValue": "player.skipTrack",
+                "propertyValue": "player.resumeTrack",
                 "propertySubPhrases": [
-                  "skip"
+                  "resume"
                 ]
               }
             ]
@@ -11548,9 +11976,7 @@
           {
             "name": "parameters.quantity",
             "value": 3,
-            "substrings": [
-              "a few"
-            ]
+            "isImplicit": true
           }
         ],
         "subPhrases": [
@@ -11560,7 +11986,7 @@
             "synonyms": [
               "Kindly",
               "Would you mind",
-              "Could you"
+              "Could you please"
             ],
             "isOptional": true
           },
@@ -11572,20 +11998,9 @@
             ]
           },
           {
-            "text": "a few",
+            "text": "a few tracks",
             "category": "quantity",
-            "propertyNames": [
-              "parameters.quantity"
-            ]
-          },
-          {
-            "text": "tracks",
-            "category": "object",
-            "synonyms": [
-              "songs",
-              "tunes",
-              "pieces"
-            ],
+            "synonyms": [],
             "isOptional": false
           }
         ],
@@ -11616,38 +12031,60 @@
                 ]
               }
             ]
-          },
-          {
-            "propertyName": "parameters.quantity",
-            "propertyValue": 3,
-            "propertySubPhrases": [
-              "a few"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": 1,
-                "propertySubPhrases": [
-                  "one"
-                ]
-              },
-              {
-                "propertyValue": 5,
-                "propertySubPhrases": [
-                  "several"
-                ]
-              },
-              {
-                "propertyValue": 10,
-                "propertySubPhrases": [
-                  "a bunch"
-                ]
-              }
-            ]
           }
         ],
         "politePrefixes": [],
         "politeSuffixes": []
-      }
+      },
+      "corrections": [
+        {
+          "data": {
+            "properties": [
+              {
+                "name": "fullActionName",
+                "value": "player.playRandom",
+                "substrings": [
+                  "play"
+                ]
+              },
+              {
+                "name": "parameters.quantity",
+                "value": 3,
+                "isImplicit": true
+              }
+            ],
+            "subPhrases": [
+              {
+                "text": "Please",
+                "category": "politeness",
+                "synonyms": [
+                  "Kindly",
+                  "Would you mind",
+                  "Could you please"
+                ],
+                "isOptional": true
+              },
+              {
+                "text": "play",
+                "category": "action",
+                "propertyNames": [
+                  "fullActionName"
+                ]
+              },
+              {
+                "text": "a few tracks",
+                "category": "quantity",
+                "propertyNames": [
+                  "parameters.quantity"
+                ]
+              }
+            ]
+          },
+          "correction": [
+            "Property 'parameters.quantity' is expected to be implicit and should not be included as a property name in a sub-phrase"
+          ]
+        }
+      ]
     },
     {
       "request": "Please play some Bach masterpieces for me, bot.",
@@ -11701,11 +12138,11 @@
           },
           {
             "text": "for me, bot.",
-            "category": "filler",
+            "category": "acknowledgement",
             "synonyms": [
-              "for me",
-              "bot",
-              "please"
+              "for me, assistant.",
+              "for me, AI.",
+              "for me, please."
             ],
             "isOptional": true
           }
@@ -11784,7 +12221,7 @@
             "name": "fullActionName",
             "value": "player.playArtist",
             "substrings": [
-              "Please play some music"
+              "Please play some music composed by Bach."
             ]
           },
           {
@@ -11807,21 +12244,11 @@
             "isOptional": true
           },
           {
-            "text": "play some music",
+            "text": "play some music composed by",
             "category": "action",
             "propertyNames": [
               "fullActionName"
             ]
-          },
-          {
-            "text": "composed by",
-            "category": "preposition",
-            "synonyms": [
-              "by",
-              "from",
-              "of"
-            ],
-            "isOptional": true
           },
           {
             "text": "Bach",
@@ -11836,25 +12263,25 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.playArtist",
             "propertySubPhrases": [
-              "play some music"
+              "play some music composed by"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.playSong",
                 "propertySubPhrases": [
-                  "play a song"
+                  "play a song by"
                 ]
               },
               {
                 "propertyValue": "player.playAlbum",
                 "propertySubPhrases": [
-                  "play an album"
+                  "play an album by"
                 ]
               },
               {
                 "propertyValue": "player.playPlaylist",
                 "propertySubPhrases": [
-                  "play a playlist"
+                  "play a playlist by"
                 ]
               }
             ]
@@ -11922,7 +12349,7 @@
             "category": "politeness",
             "synonyms": [
               "Kindly",
-              "Would you please",
+              "Would you mind",
               "Could you please"
             ],
             "isOptional": true
@@ -11938,8 +12365,8 @@
             "text": "from the",
             "category": "preposition",
             "synonyms": [
+              "of the",
               "out of the",
-              "off the",
               "from"
             ],
             "isOptional": true
@@ -11983,9 +12410,9 @@
                 ]
               },
               {
-                "propertyValue": "player.playArtist",
+                "propertyValue": "player.playRadio",
                 "propertySubPhrases": [
-                  "play music by"
+                  "play the radio"
                 ]
               }
             ]
@@ -11998,21 +12425,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "The Greatest Showman",
+                "propertyValue": "The Beatles",
                 "propertySubPhrases": [
-                  "'The Greatest Showman'"
+                  "'The Beatles'"
                 ]
               },
               {
-                "propertyValue": "Hamilton",
+                "propertyValue": "Thriller",
                 "propertySubPhrases": [
-                  "'Hamilton'"
+                  "'Thriller'"
                 ]
               },
               {
-                "propertyValue": "Frozen",
+                "propertyValue": "Back in Black",
                 "propertySubPhrases": [
-                  "'Frozen'"
+                  "'Back in Black'"
                 ]
               }
             ]
@@ -12060,8 +12487,8 @@
             "category": "filler",
             "synonyms": [
               "a bit of",
-              "some",
-              "a little"
+              "some lively",
+              "a few"
             ],
             "isOptional": true
           },
@@ -12092,7 +12519,7 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.playPlaylist",
+                "propertyValue": "player.playSong",
                 "propertySubPhrases": [
                   "Play"
                 ]
@@ -12104,9 +12531,9 @@
                 ]
               },
               {
-                "propertyValue": "player.playSong",
+                "propertyValue": "player.playPlaylist",
                 "propertySubPhrases": [
-                  "Play the song"
+                  "Start the playlist"
                 ]
               }
             ]
@@ -12141,13 +12568,11 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind",
-          "If it's not too much trouble, could you"
+          "Would you mind"
         ],
         "politeSuffixes": [
-          "thank you",
-          "please",
-          "if you don't mind"
+          "Thank you",
+          "Thanks a lot"
         ]
       }
     },
@@ -12190,7 +12615,7 @@
             "synonyms": [
               "a bit of",
               "a little",
-              "some of"
+              "any"
             ],
             "isOptional": true
           },
@@ -12205,9 +12630,9 @@
             "text": "and let's get this party started!",
             "category": "filler",
             "synonyms": [
-              "and let's begin the celebration!",
-              "and let's start the fun!",
-              "and let's kick off the party!"
+              "and let's have fun!",
+              "and let's enjoy!",
+              "and let's begin the fun!"
             ],
             "isOptional": true
           }
@@ -12235,7 +12660,7 @@
               {
                 "propertyValue": "player.playPlaylist",
                 "propertySubPhrases": [
-                  "Start the playlist"
+                  "Play the playlist"
                 ]
               }
             ]
@@ -12274,7 +12699,7 @@
         ],
         "politeSuffixes": [
           "Thank you!",
-          "I would appreciate it."
+          "I would appreciate it!"
         ]
       }
     },
@@ -12292,7 +12717,7 @@
             "name": "fullActionName",
             "value": "player.getPlaylist",
             "substrings": [
-              "Start the"
+              "Start"
             ]
           },
           {
@@ -12305,11 +12730,21 @@
         ],
         "subPhrases": [
           {
-            "text": "Start the",
+            "text": "Start",
             "category": "command",
             "propertyNames": [
               "fullActionName"
             ]
+          },
+          {
+            "text": "the",
+            "category": "preposition",
+            "synonyms": [
+              "a",
+              "this",
+              "that"
+            ],
+            "isOptional": true
           },
           {
             "text": "80s dance party mix",
@@ -12324,25 +12759,25 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.getPlaylist",
             "propertySubPhrases": [
-              "Start the"
+              "Start"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.playPlaylist",
                 "propertySubPhrases": [
-                  "Play the"
+                  "Play"
+                ]
+              },
+              {
+                "propertyValue": "player.resumePlaylist",
+                "propertySubPhrases": [
+                  "Resume"
                 ]
               },
               {
                 "propertyValue": "player.queuePlaylist",
                 "propertySubPhrases": [
-                  "Queue the"
-                ]
-              },
-              {
-                "propertyValue": "player.shufflePlaylist",
-                "propertySubPhrases": [
-                  "Shuffle the"
+                  "Queue"
                 ]
               }
             ]
@@ -12377,11 +12812,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If it's not too much trouble, could you",
+          "May I kindly ask you to"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it."
+          "thank you",
+          "please",
+          "if you don't mind",
+          "thanks a lot"
         ]
       }
     },
@@ -12414,7 +12853,7 @@
         "subPhrases": [
           {
             "text": "Start",
-            "category": "action",
+            "category": "command",
             "propertyNames": [
               "fullActionName"
             ]
@@ -12425,13 +12864,13 @@
             "synonyms": [
               "a",
               "an",
-              "that"
+              "this"
             ],
             "isOptional": true
           },
           {
             "text": "classical symphony",
-            "category": "content",
+            "category": "playlist name",
             "propertyNames": [
               "parameters.name"
             ]
@@ -12468,9 +12907,9 @@
                 ]
               },
               {
-                "propertyValue": "player.shufflePlaylist",
+                "propertyValue": "player.queuePlaylist",
                 "propertySubPhrases": [
-                  "Shuffle",
+                  "Queue",
                   "playlist"
                 ]
               }
@@ -12527,7 +12966,9 @@
           {
             "name": "fullActionName",
             "value": "player.getPlaylist",
-            "isImplicit": true
+            "substrings": [
+              "Start the"
+            ]
           },
           {
             "name": "parameters.name",
@@ -12541,7 +12982,9 @@
           {
             "text": "Start the",
             "category": "command",
-            "propertyNames": []
+            "propertyNames": [
+              "fullActionName"
+            ]
           },
           {
             "text": "smooth R&B",
@@ -12553,10 +12996,42 @@
           {
             "text": "playlist",
             "category": "object",
-            "propertyNames": []
+            "synonyms": [
+              "tracklist",
+              "music list",
+              "song collection"
+            ],
+            "isOptional": true
           }
         ],
         "propertyAlternatives": [
+          {
+            "propertyName": "fullActionName",
+            "propertyValue": "player.getPlaylist",
+            "propertySubPhrases": [
+              "Start the"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "player.playPlaylist",
+                "propertySubPhrases": [
+                  "Play the"
+                ]
+              },
+              {
+                "propertyValue": "player.resumePlaylist",
+                "propertySubPhrases": [
+                  "Resume the"
+                ]
+              },
+              {
+                "propertyValue": "player.beginPlaylist",
+                "propertySubPhrases": [
+                  "Begin the"
+                ]
+              }
+            ]
+          },
           {
             "propertyName": "parameters.name",
             "propertyValue": "smooth R&B",
@@ -12577,12 +13052,6 @@
                 ]
               },
               {
-                "propertyValue": "jazz essentials",
-                "propertySubPhrases": [
-                  "jazz essentials"
-                ]
-              },
-              {
                 "propertyValue": "pop hits",
                 "propertySubPhrases": [
                   "pop hits"
@@ -12596,8 +13065,8 @@
           "Would you mind"
         ],
         "politeSuffixes": [
-          "thank you",
-          "if that's okay"
+          "Thank you",
+          "I would appreciate it"
         ]
       }
     },
@@ -12615,7 +13084,7 @@
             "name": "fullActionName",
             "value": "player.playArtist",
             "substrings": [
-              "Time to bump some Snoop Dogg, homie!"
+              "bump"
             ]
           },
           {
@@ -12628,11 +13097,31 @@
         ],
         "subPhrases": [
           {
-            "text": "Time to bump some",
-            "category": "command",
+            "text": "Time to",
+            "category": "filler",
+            "synonyms": [
+              "Let's",
+              "How about",
+              "It's time to"
+            ],
+            "isOptional": true
+          },
+          {
+            "text": "bump",
+            "category": "action",
             "propertyNames": [
               "fullActionName"
             ]
+          },
+          {
+            "text": "some",
+            "category": "filler",
+            "synonyms": [
+              "a bit of",
+              "a little",
+              "some of"
+            ],
+            "isOptional": true
           },
           {
             "text": "Snoop Dogg",
@@ -12645,9 +13134,9 @@
             "text": "homie!",
             "category": "filler",
             "synonyms": [
-              "buddy!",
-              "pal!",
-              "friend!"
+              "buddy",
+              "friend",
+              "pal"
             ],
             "isOptional": true
           }
@@ -12657,25 +13146,25 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.playArtist",
             "propertySubPhrases": [
-              "Time to bump some"
+              "bump"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.playSong",
                 "propertySubPhrases": [
-                  "Time to play some"
+                  "play"
                 ]
               },
               {
                 "propertyValue": "player.playAlbum",
                 "propertySubPhrases": [
-                  "Time to listen to the album"
+                  "spin"
                 ]
               },
               {
                 "propertyValue": "player.playPlaylist",
                 "propertySubPhrases": [
-                  "Time to enjoy the playlist"
+                  "queue up"
                 ]
               }
             ]
@@ -12723,7 +13212,8 @@
       "action": {
         "fullActionName": "player.playGenre",
         "parameters": {
-          "genre": "pop"
+          "genre": "pop",
+          "quantity": 1
         }
       },
       "explanation": {
@@ -12741,6 +13231,11 @@
             "substrings": [
               "pop"
             ]
+          },
+          {
+            "name": "parameters.quantity",
+            "value": 1,
+            "isImplicit": true
           }
         ],
         "subPhrases": [
@@ -12794,15 +13289,15 @@
                 ]
               },
               {
-                "propertyValue": "player.playAlbum",
+                "propertyValue": "player.startGenre",
                 "propertySubPhrases": [
                   "Start"
                 ]
               },
               {
-                "propertyValue": "player.playPlaylist",
+                "propertyValue": "player.activateGenre",
                 "propertySubPhrases": [
-                  "Queue up"
+                  "Activate"
                 ]
               }
             ]
@@ -12840,8 +13335,8 @@
           "Would you mind"
         ],
         "politeSuffixes": [
-          "thank you",
-          "please"
+          "Thank you",
+          "Thanks a lot"
         ]
       }
     },
@@ -12850,7 +13345,8 @@
       "action": {
         "fullActionName": "player.playGenre",
         "parameters": {
-          "genre": "dance"
+          "genre": "dance",
+          "quantity": 10
         }
       },
       "explanation": {
@@ -12868,6 +13364,11 @@
             "substrings": [
               "dance"
             ]
+          },
+          {
+            "name": "parameters.quantity",
+            "value": 10,
+            "isImplicit": true
           }
         ],
         "subPhrases": [
@@ -12894,7 +13395,7 @@
             "synonyms": [
               "a few",
               "several",
-              "various"
+              "many"
             ],
             "isOptional": true
           },
@@ -13008,7 +13509,7 @@
             "synonyms": [
               "Could you please",
               "Would you mind",
-              "If you don't mind"
+              "Can you"
             ],
             "isOptional": true
           },
@@ -13023,8 +13524,8 @@
             "text": "some",
             "category": "filler",
             "synonyms": [
-              "a bit of",
               "any",
+              "a bit of",
               "a little"
             ],
             "isOptional": true
@@ -13129,7 +13630,7 @@
             "synonyms": [
               "Could you please",
               "Would you mind",
-              "Can you"
+              "If you don't mind"
             ],
             "isOptional": true
           },
@@ -13189,9 +13690,9 @@
                 ]
               },
               {
-                "propertyValue": "player.resume",
+                "propertyValue": "player.skip",
                 "propertySubPhrases": [
-                  "resume"
+                  "skip"
                 ]
               }
             ]
@@ -13260,7 +13761,7 @@
             "synonyms": [
               "Could you please",
               "Would you kindly",
-              "May I ask you to"
+              "May I request"
             ],
             "isOptional": true
           },
@@ -13300,19 +13801,19 @@
               {
                 "propertyValue": "player.playSong",
                 "propertySubPhrases": [
-                  "playing a song"
+                  "playing a song by"
                 ]
               },
               {
                 "propertyValue": "player.playAlbum",
                 "propertySubPhrases": [
-                  "playing an album"
+                  "playing an album by"
                 ]
               },
               {
                 "propertyValue": "player.playPlaylist",
                 "propertySubPhrases": [
-                  "playing a playlist"
+                  "playing a playlist of"
                 ]
               }
             ]
@@ -13327,19 +13828,19 @@
               {
                 "propertyValue": "Beethoven",
                 "propertySubPhrases": [
-                  "Beethoven's finest"
+                  "Beethoven's masterpieces"
                 ]
               },
               {
                 "propertyValue": "Mozart",
                 "propertySubPhrases": [
-                  "Mozart's finest"
+                  "Mozart's greatest hits"
                 ]
               },
               {
                 "propertyValue": "Bach",
                 "propertySubPhrases": [
-                  "Bach's finest"
+                  "Bach's best works"
                 ]
               }
             ]
@@ -13393,31 +13894,11 @@
             ]
           },
           {
-            "text": "some",
-            "category": "filler",
-            "synonyms": [
-              "a bit of",
-              "a little",
-              "any"
-            ],
-            "isOptional": true
-          },
-          {
-            "text": "Bach",
+            "text": "some Bach music",
             "category": "artist",
             "propertyNames": [
               "parameters.artist"
             ]
-          },
-          {
-            "text": "music",
-            "category": "filler",
-            "synonyms": [
-              "tunes",
-              "songs",
-              "melodies"
-            ],
-            "isOptional": true
           }
         ],
         "propertyAlternatives": [
@@ -13452,25 +13933,25 @@
             "propertyName": "parameters.artist",
             "propertyValue": "Bach",
             "propertySubPhrases": [
-              "Bach"
+              "some Bach music"
             ],
             "alternatives": [
               {
-                "propertyValue": "Beethoven",
+                "propertyValue": "Mozart",
                 "propertySubPhrases": [
-                  "Beethoven"
+                  "some Mozart music"
                 ]
               },
               {
-                "propertyValue": "Mozart",
+                "propertyValue": "Beethoven",
                 "propertySubPhrases": [
-                  "Mozart"
+                  "some Beethoven music"
                 ]
               },
               {
                 "propertyValue": "Chopin",
                 "propertySubPhrases": [
-                  "Chopin"
+                  "some Chopin music"
                 ]
               }
             ]
@@ -13527,8 +14008,8 @@
             "text": "some music by",
             "category": "filler",
             "synonyms": [
-              "a song by",
-              "a piece by",
+              "a few tracks by",
+              "songs from",
               "music from"
             ],
             "isOptional": true
@@ -13632,8 +14113,8 @@
             "category": "politeness",
             "synonyms": [
               "Could you please",
-              "Do you mind",
-              "Would it be possible"
+              "Would it be possible",
+              "Can you"
             ],
             "isOptional": true
           },
@@ -13753,8 +14234,8 @@
             "category": "politeness",
             "synonyms": [
               "Could you please",
-              "Would it be possible",
-              "Can you"
+              "Do you mind",
+              "Would it be possible"
             ],
             "isOptional": true
           },
@@ -13769,9 +14250,9 @@
             "text": "some smooth",
             "category": "filler",
             "synonyms": [
-              "a few",
+              "a bit of",
               "some",
-              "a couple of"
+              "a little"
             ],
             "isOptional": true
           },
@@ -13787,8 +14268,8 @@
             "category": "filler",
             "synonyms": [
               "tracks",
-              "tunes",
-              "music"
+              "music",
+              "tunes"
             ],
             "isOptional": true
           }
@@ -13802,21 +14283,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.pause",
+                "propertyValue": "player.playSong",
                 "propertySubPhrases": [
-                  "pausing"
+                  "playing a song"
                 ]
               },
               {
-                "propertyValue": "player.stop",
+                "propertyValue": "player.playAlbum",
                 "propertySubPhrases": [
-                  "stopping"
+                  "playing an album"
                 ]
               },
               {
-                "propertyValue": "player.skip",
+                "propertyValue": "player.playPlaylist",
                 "propertySubPhrases": [
-                  "skipping"
+                  "playing a playlist"
                 ]
               }
             ]
@@ -13884,8 +14365,8 @@
             "category": "politeness",
             "synonyms": [
               "Could you please",
-              "Would it be possible",
-              "Can you"
+              "Do you mind",
+              "Would it be possible"
             ],
             "isOptional": true
           },
@@ -13998,7 +14479,7 @@
             "name": "fullActionName",
             "value": "player.playArtist",
             "substrings": [
-              "play"
+              "Would you play"
             ]
           },
           {
@@ -14011,18 +14492,8 @@
         ],
         "subPhrases": [
           {
-            "text": "Would you",
-            "category": "politeness",
-            "synonyms": [
-              "Could you",
-              "Can you",
-              "Will you"
-            ],
-            "isOptional": true
-          },
-          {
-            "text": "play",
-            "category": "action",
+            "text": "Would you play",
+            "category": "command",
             "propertyNames": [
               "fullActionName"
             ]
@@ -14070,25 +14541,25 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.playArtist",
             "propertySubPhrases": [
-              "play"
+              "Would you play"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.playSong",
                 "propertySubPhrases": [
-                  "play a song"
+                  "Would you play a song"
                 ]
               },
               {
                 "propertyValue": "player.playAlbum",
                 "propertySubPhrases": [
-                  "play an album"
+                  "Would you play an album"
                 ]
               },
               {
                 "propertyValue": "player.playPlaylist",
                 "propertySubPhrases": [
-                  "play a playlist"
+                  "Would you play a playlist"
                 ]
               }
             ]
@@ -14174,9 +14645,12 @@
           {
             "text": "let's get this place jumpin' with some",
             "category": "command",
-            "propertyNames": [
-              "fullActionName"
-            ]
+            "synonyms": [
+              "let's start the party with",
+              "let's play",
+              "let's hear"
+            ],
+            "isOptional": false
           },
           {
             "text": "'Young, Wild & Free'",
@@ -14188,39 +14662,18 @@
         ],
         "propertyAlternatives": [
           {
-            "propertyName": "fullActionName",
-            "propertyValue": "player.playTrack",
-            "propertySubPhrases": [
-              "let's get this place jumpin' with some"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "player.queueTrack",
-                "propertySubPhrases": [
-                  "add to the queue"
-                ]
-              },
-              {
-                "propertyValue": "player.pauseTrack",
-                "propertySubPhrases": [
-                  "pause the music"
-                ]
-              },
-              {
-                "propertyValue": "player.stopTrack",
-                "propertySubPhrases": [
-                  "stop the music"
-                ]
-              }
-            ]
-          },
-          {
             "propertyName": "parameters.trackName",
             "propertyValue": "Young, Wild & Free",
             "propertySubPhrases": [
               "'Young, Wild & Free'"
             ],
             "alternatives": [
+              {
+                "propertyValue": "Uptown Funk",
+                "propertySubPhrases": [
+                  "'Uptown Funk'"
+                ]
+              },
               {
                 "propertyValue": "Shape of You",
                 "propertySubPhrases": [
@@ -14231,12 +14684,6 @@
                 "propertyValue": "Blinding Lights",
                 "propertySubPhrases": [
                   "'Blinding Lights'"
-                ]
-              },
-              {
-                "propertyValue": "Uptown Funk",
-                "propertySubPhrases": [
-                  "'Uptown Funk'"
                 ]
               }
             ]
@@ -14265,34 +14712,53 @@
           {
             "name": "fullActionName",
             "value": "player.playTrack",
-            "isImplicit": true
+            "substrings": [
+              "groove to"
+            ]
           },
           {
             "name": "parameters.trackName",
             "value": "Gin and Juice",
             "substrings": [
-              "Gin and Juice"
+              "'Gin and Juice'"
             ]
           }
         ],
         "subPhrases": [
           {
-            "text": "Yo",
+            "text": "Yo,",
             "category": "greeting",
             "synonyms": [
-              "Hey",
-              "Hi",
-              "Hello"
+              "Hey,",
+              "Hi,",
+              "Hello,"
             ],
             "isOptional": true
           },
           {
-            "text": "how about we groove to some of that",
+            "text": "how about we",
             "category": "filler",
             "synonyms": [
-              "let's listen to",
-              "can we play",
-              "I want to hear"
+              "let's",
+              "why don't we",
+              "shall we"
+            ],
+            "isOptional": true
+          },
+          {
+            "text": "groove to",
+            "category": "action",
+            "propertyNames": [
+              "fullActionName"
+            ]
+          },
+          {
+            "text": "some of that",
+            "category": "filler",
+            "synonyms": [
+              "a bit of",
+              "some",
+              "a little of"
             ],
             "isOptional": true
           },
@@ -14304,17 +14770,44 @@
             ]
           },
           {
-            "text": "right now",
-            "category": "filler",
+            "text": "right now?",
+            "category": "confirmation",
             "synonyms": [
-              "immediately",
-              "at this moment",
-              "right away"
+              "immediately?",
+              "at this moment?",
+              "right away?"
             ],
             "isOptional": true
           }
         ],
         "propertyAlternatives": [
+          {
+            "propertyName": "fullActionName",
+            "propertyValue": "player.playTrack",
+            "propertySubPhrases": [
+              "groove to"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "player.startSong",
+                "propertySubPhrases": [
+                  "jam to"
+                ]
+              },
+              {
+                "propertyValue": "player.playMusic",
+                "propertySubPhrases": [
+                  "listen to"
+                ]
+              },
+              {
+                "propertyValue": "player.playTune",
+                "propertySubPhrases": [
+                  "vibe to"
+                ]
+              }
+            ]
+          },
           {
             "propertyName": "parameters.trackName",
             "propertyValue": "Gin and Juice",
@@ -14490,15 +14983,11 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind",
-          "If it's not too much trouble, could you",
-          "I would appreciate it if you could"
+          "Would you mind"
         ],
         "politeSuffixes": [
           "Thank you!",
-          "Thanks a lot!",
-          "I appreciate it!",
-          "Much appreciated!"
+          "I would appreciate it!"
         ]
       }
     },
@@ -14547,19 +15036,19 @@
               {
                 "propertyValue": "player.play",
                 "propertySubPhrases": [
-                  "play some music on the speakers"
+                  "let's play some music on the speakers"
                 ]
               },
               {
                 "propertyValue": "player.shuffle",
                 "propertySubPhrases": [
-                  "shuffle the playlist on the speakers"
+                  "let's shuffle some tracks on the speakers"
                 ]
               },
               {
-                "propertyValue": "player.playFavorites",
+                "propertyValue": "player.playPlaylist",
                 "propertySubPhrases": [
-                  "play my favorite songs on the speakers"
+                  "let's play a playlist on the speakers"
                 ]
               }
             ]
@@ -14567,13 +15056,11 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind",
-          "If it's not too much trouble, could you"
+          "Would you mind"
         ],
         "politeSuffixes": [
           "Thank you!",
-          "I would really appreciate it.",
-          "Thanks a lot!"
+          "I would appreciate it!"
         ]
       }
     },
@@ -14588,8 +15075,7 @@
             "name": "fullActionName",
             "value": "player.playRandom",
             "substrings": [
-              "let's get this party started",
-              "phat tracks"
+              "Yo, let's get this party started with some phat tracks!"
             ]
           }
         ],
@@ -14598,32 +15084,15 @@
             "text": "Yo",
             "category": "greeting",
             "synonyms": [
-              "Hey",
               "Hi",
-              "Hello"
+              "Hello",
+              "Hey"
             ],
             "isOptional": true
           },
           {
-            "text": "let's get this party started",
+            "text": "let's get this party started with some phat tracks!",
             "category": "command",
-            "propertyNames": [
-              "fullActionName"
-            ]
-          },
-          {
-            "text": "with some",
-            "category": "filler",
-            "synonyms": [
-              "including",
-              "featuring",
-              "along with"
-            ],
-            "isOptional": true
-          },
-          {
-            "text": "phat tracks",
-            "category": "music",
             "propertyNames": [
               "fullActionName"
             ]
@@ -14634,45 +15103,37 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.playRandom",
             "propertySubPhrases": [
-              "let's get this party started",
-              "phat tracks"
+              "let's get this party started with some phat tracks!"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.play",
                 "propertySubPhrases": [
-                  "let's get this party started",
-                  "some music"
+                  "let's play some music!"
                 ]
               },
               {
                 "propertyValue": "player.shuffle",
                 "propertySubPhrases": [
-                  "let's get this party started",
-                  "random tunes"
+                  "shuffle the playlist!"
                 ]
               },
               {
-                "propertyValue": "player.startPlaylist",
+                "propertyValue": "player.playFavorites",
                 "propertySubPhrases": [
-                  "let's get this party started",
-                  "a playlist"
+                  "play my favorite songs!"
                 ]
               }
             ]
           }
         ],
         "politePrefixes": [
-          "Please",
-          "Kindly",
-          "Would you mind",
-          "Could you please"
+          "Could you please",
+          "Would you mind"
         ],
         "politeSuffixes": [
-          "Thank you",
-          "Thanks",
-          "Much appreciated",
-          "If you don't mind"
+          "Thank you!",
+          "I would appreciate it!"
         ]
       }
     },
@@ -14690,7 +15151,7 @@
             "name": "fullActionName",
             "value": "player.playGenre",
             "substrings": [
-              "let's get this place jumpin' with some sick hip-hop beats!"
+              "let's get this place jumpin'"
             ]
           },
           {
@@ -14713,11 +15174,21 @@
             "isOptional": true
           },
           {
-            "text": "let's get this place jumpin' with some sick",
+            "text": "let's get this place jumpin'",
             "category": "action",
             "propertyNames": [
               "fullActionName"
             ]
+          },
+          {
+            "text": "with some sick",
+            "category": "filler",
+            "synonyms": [
+              "with some cool",
+              "with some awesome",
+              "with some great"
+            ],
+            "isOptional": true
           },
           {
             "text": "hip-hop",
@@ -14731,8 +15202,8 @@
             "category": "filler",
             "synonyms": [
               "music!",
-              "tunes!",
-              "tracks!"
+              "tracks!",
+              "songs!"
             ],
             "isOptional": true
           }
@@ -14742,25 +15213,25 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.playGenre",
             "propertySubPhrases": [
-              "let's get this place jumpin' with some sick"
+              "let's get this place jumpin'"
             ],
             "alternatives": [
               {
-                "propertyValue": "player.playSong",
+                "propertyValue": "player.startParty",
                 "propertySubPhrases": [
-                  "let's play a"
+                  "let's start the party"
                 ]
               },
               {
-                "propertyValue": "player.playAlbum",
+                "propertyValue": "player.activateDanceMode",
                 "propertySubPhrases": [
-                  "let's listen to the album"
+                  "let's activate dance mode"
                 ]
               },
               {
-                "propertyValue": "player.playArtist",
+                "propertyValue": "player.beginMusicSession",
                 "propertySubPhrases": [
-                  "let's hear some tracks by"
+                  "let's begin the music session"
                 ]
               }
             ]
@@ -14785,9 +15256,9 @@
                 ]
               },
               {
-                "propertyValue": "pop",
+                "propertyValue": "electronic",
                 "propertySubPhrases": [
-                  "pop"
+                  "electronic"
                 ]
               }
             ]
@@ -14799,35 +15270,9 @@
         ],
         "politeSuffixes": [
           "Thank you!",
-          "I would appreciate it!"
+          "I would appreciate it."
         ]
-      },
-      "corrections": [
-        {
-          "data": {
-            "properties": [
-              {
-                "name": "fullActionName",
-                "value": "player.playGenre",
-                "substrings": [
-                  "let's get this place jumpin' with some sick hip-hop beats!"
-                ]
-              },
-              {
-                "name": "genre",
-                "value": "hip-hop",
-                "substrings": [
-                  "hip-hop"
-                ]
-              }
-            ]
-          },
-          "correction": [
-            "Extraneous parameter: 'genre' is not a parameter in the action",
-            "Missing parameter: parameter 'parameters.genre' in the action is missing from explanation"
-          ]
-        }
-      ]
+      }
     },
     {
       "request": "Yo, play some of that classic Snoop Dogg!",
@@ -14867,7 +15312,7 @@
           },
           {
             "text": "play",
-            "category": "command",
+            "category": "action",
             "propertyNames": [
               "fullActionName"
             ]
@@ -14876,8 +15321,8 @@
             "text": "some of that classic",
             "category": "filler",
             "synonyms": [
-              "a bit of",
               "some",
+              "a bit of",
               "a little of"
             ],
             "isOptional": true

--- a/ts/packages/dispatcher/test/data/player/v5/nextAction.json
+++ b/ts/packages/dispatcher/test/data/player/v5/nextAction.json
@@ -1,7 +1,7 @@
 {
   "version": 2,
   "schemaName": "player",
-  "sourceHash": "/coyfq1j8qYAwzuqFo38QLrP2X7DZ/U6UJRPEiLjn7Q=",
+  "sourceHash": "HrhZPog7XXm93zb5xwYtzWspziPTFgFnvgb4UUJ85a8=",
   "explainerName": "v5",
   "entries": [
     {
@@ -59,15 +59,11 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind",
-          "If it's not too much trouble, could you",
-          "May I kindly ask you to"
+          "Would you mind"
         ],
         "politeSuffixes": [
           "Thank you.",
-          "I would appreciate it.",
-          "Thanks a lot.",
-          "That would be great."
+          "I appreciate it."
         ]
       }
     },
@@ -90,7 +86,9 @@
           {
             "text": "Bounce",
             "category": "command",
-            "propertyNames": []
+            "propertyNames": [
+              "fullActionName"
+            ]
           },
           {
             "text": "to the",
@@ -104,7 +102,7 @@
           },
           {
             "text": "next track",
-            "category": "action",
+            "category": "command",
             "propertyNames": [
               "fullActionName"
             ]
@@ -115,25 +113,29 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.next",
             "propertySubPhrases": [
+              "Bounce",
               "next track"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.previous",
                 "propertySubPhrases": [
+                  "Bounce",
                   "previous track"
                 ]
               },
               {
                 "propertyValue": "player.pause",
                 "propertySubPhrases": [
-                  "pause track"
+                  "Bounce",
+                  "pause"
                 ]
               },
               {
                 "propertyValue": "player.play",
                 "propertySubPhrases": [
-                  "play track"
+                  "Bounce",
+                  "play"
                 ]
               }
             ]
@@ -145,7 +147,7 @@
         ],
         "politeSuffixes": [
           "Thank you.",
-          "I appreciate it."
+          "I would appreciate it."
         ]
       }
     },
@@ -181,7 +183,7 @@
             "synonyms": [
               "move to the",
               "switch to the",
-              "go to the"
+              "advance to the"
             ],
             "isOptional": true
           },
@@ -218,12 +220,6 @@
                 "propertySubPhrases": [
                   "play track"
                 ]
-              },
-              {
-                "propertyValue": "player.stop",
-                "propertySubPhrases": [
-                  "stop track"
-                ]
               }
             ]
           }
@@ -233,8 +229,8 @@
           "Would you mind"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it."
+          "Thank you",
+          "I would appreciate it"
         ]
       }
     },
@@ -266,7 +262,7 @@
           },
           {
             "text": "hop to the",
-            "category": "preposition",
+            "category": "filler",
             "synonyms": [
               "jump to the",
               "move to the",
@@ -317,14 +313,8 @@
             ]
           }
         ],
-        "politePrefixes": [
-          "Could you please",
-          "Would you mind"
-        ],
-        "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it."
-        ]
+        "politePrefixes": [],
+        "politeSuffixes": []
       }
     },
     {
@@ -386,23 +376,15 @@
                 "propertySubPhrases": [
                   "play the song"
                 ]
-              },
-              {
-                "propertyValue": "player.stop",
-                "propertySubPhrases": [
-                  "stop the song"
-                ]
               }
             ]
           }
         ],
         "politePrefixes": [
-          "Could you please",
-          "Would you mind"
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it."
+          "Thank you"
         ]
       }
     },
@@ -434,11 +416,11 @@
           },
           {
             "text": "go to the",
-            "category": "preposition",
+            "category": "filler",
             "synonyms": [
               "move to the",
-              "switch to the",
-              "change to the"
+              "skip to the",
+              "advance to the"
             ],
             "isOptional": true
           },
@@ -475,24 +457,12 @@
                 "propertySubPhrases": [
                   "play track"
                 ]
-              },
-              {
-                "propertyValue": "player.stop",
-                "propertySubPhrases": [
-                  "stop track"
-                ]
               }
             ]
           }
         ],
-        "politePrefixes": [
-          "Could you please",
-          "Would you mind"
-        ],
-        "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it."
-        ]
+        "politePrefixes": [],
+        "politeSuffixes": []
       }
     },
     {
@@ -559,12 +529,10 @@
           }
         ],
         "politePrefixes": [
-          "Could you please",
-          "Would you mind"
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it."
+          "Thank you"
         ]
       }
     },
@@ -626,12 +594,6 @@
                 "propertyValue": "player.play",
                 "propertySubPhrases": [
                   "play the track"
-                ]
-              },
-              {
-                "propertyValue": "player.stop",
-                "propertySubPhrases": [
-                  "stop the track"
                 ]
               }
             ]
@@ -700,6 +662,12 @@
                 "propertySubPhrases": [
                   "play the track"
                 ]
+              },
+              {
+                "propertyValue": "player.stop",
+                "propertySubPhrases": [
+                  "stop the track"
+                ]
               }
             ]
           }
@@ -719,17 +687,37 @@
             "name": "fullActionName",
             "value": "player.next",
             "substrings": [
-              "Flick to the next tune."
+              "next"
             ]
           }
         ],
         "subPhrases": [
           {
-            "text": "Flick to the next tune.",
-            "category": "command",
+            "text": "Flick to the",
+            "category": "filler",
+            "synonyms": [
+              "Switch to the",
+              "Move to the",
+              "Change to the"
+            ],
+            "isOptional": true
+          },
+          {
+            "text": "next",
+            "category": "action",
             "propertyNames": [
               "fullActionName"
             ]
+          },
+          {
+            "text": "tune",
+            "category": "filler",
+            "synonyms": [
+              "song",
+              "track",
+              "music"
+            ],
+            "isOptional": true
           }
         ],
         "propertyAlternatives": [
@@ -737,25 +725,25 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.next",
             "propertySubPhrases": [
-              "Flick to the next tune."
+              "next"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.previous",
                 "propertySubPhrases": [
-                  "Flick to the previous tune."
+                  "previous"
                 ]
               },
               {
                 "propertyValue": "player.pause",
                 "propertySubPhrases": [
-                  "Pause the tune."
+                  "pause"
                 ]
               },
               {
                 "propertyValue": "player.play",
                 "propertySubPhrases": [
-                  "Play the tune."
+                  "play"
                 ]
               }
             ]
@@ -766,8 +754,8 @@
           "Would you mind"
         ],
         "politeSuffixes": [
-          "Thank you.",
-          "I appreciate it."
+          "Thank you!",
+          "I would appreciate it."
         ]
       }
     },
@@ -789,8 +777,13 @@
         "subPhrases": [
           {
             "text": "Flip to the",
-            "category": "command",
-            "propertyNames": []
+            "category": "filler",
+            "synonyms": [
+              "Switch to the",
+              "Change to the",
+              "Move to the"
+            ],
+            "isOptional": true
           },
           {
             "text": "next",
@@ -800,9 +793,14 @@
             ]
           },
           {
-            "text": "song.",
+            "text": "song",
             "category": "object",
-            "propertyNames": []
+            "synonyms": [
+              "track",
+              "tune",
+              "music"
+            ],
+            "isOptional": true
           }
         ],
         "propertyAlternatives": [
@@ -840,7 +838,7 @@
         ],
         "politeSuffixes": [
           "Thank you.",
-          "I appreciate it."
+          "I would appreciate it."
         ]
       }
     },
@@ -867,7 +865,7 @@
           },
           {
             "text": "next",
-            "category": "action",
+            "category": "command",
             "propertyNames": [
               "fullActionName"
             ]
@@ -898,6 +896,12 @@
                 "propertySubPhrases": [
                   "play"
                 ]
+              },
+              {
+                "propertyValue": "player.stop",
+                "propertySubPhrases": [
+                  "stop"
+                ]
               }
             ]
           }
@@ -907,8 +911,8 @@
           "Would you mind"
         ],
         "politeSuffixes": [
-          "thank you",
-          "please"
+          "Thank you.",
+          "I would appreciate it."
         ]
       }
     },
@@ -923,7 +927,7 @@
             "name": "fullActionName",
             "value": "player.next",
             "substrings": [
-              "next"
+              "listen to the next song"
             ]
           }
         ],
@@ -939,15 +943,8 @@
             "isOptional": true
           },
           {
-            "text": "listen to",
+            "text": "listen to the next song",
             "category": "action",
-            "propertyNames": [
-              "fullActionName"
-            ]
-          },
-          {
-            "text": "the next song",
-            "category": "object",
             "propertyNames": [
               "fullActionName"
             ]
@@ -958,36 +955,31 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.next",
             "propertySubPhrases": [
-              "listen to",
-              "the next song"
+              "listen to the next song"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.previous",
                 "propertySubPhrases": [
-                  "listen to",
-                  "the previous song"
+                  "listen to the previous song"
                 ]
               },
               {
                 "propertyValue": "player.pause",
                 "propertySubPhrases": [
-                  "pause",
-                  "the song"
+                  "pause the song"
                 ]
               },
               {
                 "propertyValue": "player.play",
                 "propertySubPhrases": [
-                  "play",
-                  "the song"
+                  "play the song"
                 ]
               },
               {
-                "propertyValue": "player.shuffle",
+                "propertyValue": "player.stop",
                 "propertySubPhrases": [
-                  "shuffle",
-                  "the songs"
+                  "stop the song"
                 ]
               }
             ]
@@ -1023,9 +1015,9 @@
             "text": "I'd appreciate",
             "category": "politeness",
             "synonyms": [
-              "I would be grateful",
+              "I would like",
               "I would appreciate",
-              "I would like"
+              "I want"
             ],
             "isOptional": true
           },
@@ -1038,7 +1030,7 @@
           },
           {
             "text": "now",
-            "category": "time",
+            "category": "confirmation",
             "synonyms": [
               "immediately",
               "right away",
@@ -1076,14 +1068,8 @@
             ]
           }
         ],
-        "politePrefixes": [
-          "Could you please",
-          "Would you mind"
-        ],
-        "politeSuffixes": [
-          "Thank you.",
-          "Thanks a lot."
-        ]
+        "politePrefixes": [],
+        "politeSuffixes": []
       }
     },
     {
@@ -1157,13 +1143,11 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind",
-          "If it's not too much trouble, could you"
+          "Would you mind"
         ],
         "politeSuffixes": [
           "Thank you!",
-          "I would appreciate it.",
-          "Thanks a lot!"
+          "I appreciate it!"
         ]
       }
     },
@@ -1232,11 +1216,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If it's not too much trouble,",
+          "May I kindly ask"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I appreciate it!"
+          "Thank you.",
+          "I appreciate it.",
+          "Thanks a lot.",
+          "Much appreciated."
         ]
       }
     },
@@ -1251,7 +1239,7 @@
             "name": "fullActionName",
             "value": "player.next",
             "substrings": [
-              "next track"
+              "next"
             ]
           }
         ],
@@ -1268,10 +1256,20 @@
           },
           {
             "text": "the next track",
-            "category": "action",
+            "category": "property",
             "propertyNames": [
               "fullActionName"
             ]
+          },
+          {
+            "text": ".",
+            "category": "punctuation",
+            "synonyms": [
+              ".",
+              "!",
+              ""
+            ],
+            "isOptional": true
           }
         ],
         "propertyAlternatives": [
@@ -1299,6 +1297,12 @@
                 "propertySubPhrases": [
                   "play the track"
                 ]
+              },
+              {
+                "propertyValue": "player.stop",
+                "propertySubPhrases": [
+                  "stop the track"
+                ]
               }
             ]
           }
@@ -1309,7 +1313,7 @@
         ],
         "politeSuffixes": [
           "Thank you",
-          "I appreciate it"
+          "If that's okay"
         ]
       }
     },
@@ -1334,8 +1338,8 @@
             "category": "filler",
             "synonyms": [
               "I am prepared for the",
-              "I am ready for the",
-              "I'm prepared for the"
+              "I am set for the",
+              "I am ready for the"
             ],
             "isOptional": true
           },
@@ -1391,8 +1395,8 @@
           "Would you mind"
         ],
         "politeSuffixes": [
-          "thank you",
-          "if that's okay"
+          "Thank you!",
+          "I appreciate it!"
         ]
       }
     },
@@ -1407,17 +1411,27 @@
             "name": "fullActionName",
             "value": "player.next",
             "substrings": [
-              "Jump to the next track."
+              "next"
             ]
           }
         ],
         "subPhrases": [
           {
-            "text": "Jump to the next track.",
+            "text": "Jump to the",
             "category": "command",
+            "propertyNames": []
+          },
+          {
+            "text": "next",
+            "category": "property",
             "propertyNames": [
               "fullActionName"
             ]
+          },
+          {
+            "text": "track.",
+            "category": "object",
+            "propertyNames": []
           }
         ],
         "propertyAlternatives": [
@@ -1425,31 +1439,25 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.next",
             "propertySubPhrases": [
-              "Jump to the next track."
+              "next"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.previous",
                 "propertySubPhrases": [
-                  "Jump to the previous track."
+                  "previous"
                 ]
               },
               {
                 "propertyValue": "player.pause",
                 "propertySubPhrases": [
-                  "Pause the track."
+                  "pause"
                 ]
               },
               {
                 "propertyValue": "player.play",
                 "propertySubPhrases": [
-                  "Play the track."
-                ]
-              },
-              {
-                "propertyValue": "player.stop",
-                "propertySubPhrases": [
-                  "Stop the track."
+                  "play"
                 ]
               }
             ]
@@ -1462,10 +1470,10 @@
           "May I kindly ask you to"
         ],
         "politeSuffixes": [
-          "Thank you!",
+          "Thank you.",
           "I would appreciate it.",
-          "Thanks a lot!",
-          "Much appreciated."
+          "Thanks a lot.",
+          "That would be great."
         ]
       }
     },
@@ -1537,12 +1545,6 @@
                 "propertyValue": "player.play",
                 "propertySubPhrases": [
                   "play track"
-                ]
-              },
-              {
-                "propertyValue": "player.stop",
-                "propertySubPhrases": [
-                  "stop track"
                 ]
               }
             ]
@@ -1616,12 +1618,12 @@
           }
         ],
         "politePrefixes": [
-          "Please",
-          "Kindly"
+          "Could we please",
+          "Would you mind if we"
         ],
         "politeSuffixes": [
-          "Thank you",
-          "If you don't mind"
+          "Thank you.",
+          "I would appreciate it."
         ]
       }
     },
@@ -1636,24 +1638,29 @@
             "name": "fullActionName",
             "value": "player.next",
             "substrings": [
-              "Let's hear the next one."
+              "next"
             ]
           }
         ],
         "subPhrases": [
           {
             "text": "Let's",
-            "category": "politeness",
+            "category": "filler",
             "synonyms": [
               "Let us",
-              "Allow us",
-              "Let's go"
+              "We should",
+              "How about we"
             ],
             "isOptional": true
           },
           {
-            "text": "hear the next one.",
-            "category": "command",
+            "text": "hear",
+            "category": "action",
+            "propertyNames": []
+          },
+          {
+            "text": "the next one",
+            "category": "action",
             "propertyNames": [
               "fullActionName"
             ]
@@ -1664,31 +1671,31 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.next",
             "propertySubPhrases": [
-              "hear the next one."
+              "the next one"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.previous",
                 "propertySubPhrases": [
-                  "hear the previous one."
+                  "the previous one"
                 ]
               },
               {
                 "propertyValue": "player.pause",
                 "propertySubPhrases": [
-                  "pause the music."
+                  "pause the music"
                 ]
               },
               {
                 "propertyValue": "player.play",
                 "propertySubPhrases": [
-                  "play the music."
+                  "play the music"
                 ]
               },
               {
                 "propertyValue": "player.stop",
                 "propertySubPhrases": [
-                  "stop the music."
+                  "stop the music"
                 ]
               }
             ]
@@ -1715,14 +1722,14 @@
             "name": "fullActionName",
             "value": "player.next",
             "substrings": [
-              "jump to the next"
+              "jump to the next tune"
             ]
           }
         ],
         "subPhrases": [
           {
             "text": "Let's",
-            "category": "politeness",
+            "category": "filler",
             "synonyms": [
               "Let us",
               "We should",
@@ -1731,16 +1738,11 @@
             "isOptional": true
           },
           {
-            "text": "jump to the next",
+            "text": "jump to the next tune",
             "category": "action",
             "propertyNames": [
               "fullActionName"
             ]
-          },
-          {
-            "text": "tune",
-            "category": "object",
-            "propertyNames": []
           }
         ],
         "propertyAlternatives": [
@@ -1748,43 +1750,43 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.next",
             "propertySubPhrases": [
-              "jump to the next"
+              "jump to the next tune"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.previous",
                 "propertySubPhrases": [
-                  "go back to the previous"
+                  "go back to the previous tune"
                 ]
               },
               {
                 "propertyValue": "player.pause",
                 "propertySubPhrases": [
-                  "pause the current"
+                  "pause the tune"
                 ]
               },
               {
                 "propertyValue": "player.play",
                 "propertySubPhrases": [
-                  "play the current"
+                  "play the tune"
                 ]
               },
               {
                 "propertyValue": "player.stop",
                 "propertySubPhrases": [
-                  "stop the current"
+                  "stop the tune"
                 ]
               }
             ]
           }
         ],
         "politePrefixes": [
-          "Could we please",
-          "Would you mind if we"
+          "Please",
+          "Kindly"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it."
+          "Thank you",
+          "if you don't mind"
         ]
       }
     },
@@ -1872,18 +1874,28 @@
             "name": "fullActionName",
             "value": "player.next",
             "substrings": [
-              "next song"
+              "next"
             ]
           }
         ],
         "subPhrases": [
           {
-            "text": "Let's roll to the",
+            "text": "Let's",
             "category": "filler",
             "synonyms": [
-              "Let's move to the",
-              "Let's switch to the",
-              "Let's go to the"
+              "Let us",
+              "We should",
+              "How about we"
+            ],
+            "isOptional": true
+          },
+          {
+            "text": "roll to the",
+            "category": "filler",
+            "synonyms": [
+              "move to the",
+              "go to the",
+              "proceed to the"
             ],
             "isOptional": true
           },
@@ -1920,19 +1932,13 @@
                 "propertySubPhrases": [
                   "play song"
                 ]
-              },
-              {
-                "propertyValue": "player.stop",
-                "propertySubPhrases": [
-                  "stop song"
-                ]
               }
             ]
           }
         ],
         "politePrefixes": [
-          "Could we please",
-          "Would you mind if we"
+          "Could you please",
+          "Would you mind"
         ],
         "politeSuffixes": [
           "Thank you!",
@@ -1962,7 +1968,7 @@
             "synonyms": [
               "Let us",
               "We should",
-              "How about"
+              "How about we"
             ],
             "isOptional": true
           },
@@ -2015,7 +2021,7 @@
         ],
         "politeSuffixes": [
           "Thank you!",
-          "I would appreciate it."
+          "Thanks!"
         ]
       }
     },
@@ -2030,19 +2036,14 @@
             "name": "fullActionName",
             "value": "player.next",
             "substrings": [
-              "next song"
+              "Move on to the next song."
             ]
           }
         ],
         "subPhrases": [
           {
-            "text": "Move on to",
+            "text": "Move on to the next song.",
             "category": "command",
-            "propertyNames": []
-          },
-          {
-            "text": "the next song",
-            "category": "action",
             "propertyNames": [
               "fullActionName"
             ]
@@ -2053,31 +2054,25 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.next",
             "propertySubPhrases": [
-              "the next song"
+              "Move on to the next song."
             ],
             "alternatives": [
               {
                 "propertyValue": "player.previous",
                 "propertySubPhrases": [
-                  "the previous song"
+                  "Go back to the previous song."
                 ]
               },
               {
                 "propertyValue": "player.pause",
                 "propertySubPhrases": [
-                  "pause the song"
+                  "Pause the music."
                 ]
               },
               {
                 "propertyValue": "player.play",
                 "propertySubPhrases": [
-                  "play the song"
-                ]
-              },
-              {
-                "propertyValue": "player.stop",
-                "propertySubPhrases": [
-                  "stop the song"
+                  "Play the music."
                 ]
               }
             ]
@@ -2118,10 +2113,13 @@
           },
           {
             "text": "hit",
-            "category": "action",
-            "propertyNames": [
-              "fullActionName"
-            ]
+            "category": "filler",
+            "synonyms": [
+              "track",
+              "song",
+              "item"
+            ],
+            "isOptional": true
           },
           {
             "text": "please",
@@ -2139,36 +2137,25 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.next",
             "propertySubPhrases": [
-              "Next",
-              "hit"
+              "Next"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.previous",
                 "propertySubPhrases": [
-                  "Previous",
-                  "hit"
+                  "Previous"
                 ]
               },
               {
                 "propertyValue": "player.pause",
                 "propertySubPhrases": [
-                  "Pause",
-                  "please"
+                  "Pause"
                 ]
               },
               {
                 "propertyValue": "player.play",
                 "propertySubPhrases": [
-                  "Play",
-                  "please"
-                ]
-              },
-              {
-                "propertyValue": "player.stop",
-                "propertySubPhrases": [
-                  "Stop",
-                  "please"
+                  "Play"
                 ]
               }
             ]
@@ -2196,7 +2183,7 @@
         "subPhrases": [
           {
             "text": "Next",
-            "category": "action",
+            "category": "command",
             "propertyNames": [
               "fullActionName"
             ]
@@ -2261,17 +2248,27 @@
             "name": "fullActionName",
             "value": "player.next",
             "substrings": [
-              "Next number, please."
+              "Next"
             ]
           }
         ],
         "subPhrases": [
           {
-            "text": "Next number",
-            "category": "command",
+            "text": "Next",
+            "category": "action",
             "propertyNames": [
               "fullActionName"
             ]
+          },
+          {
+            "text": "number",
+            "category": "filler",
+            "synonyms": [
+              "item",
+              "track",
+              "song"
+            ],
+            "isOptional": true
           },
           {
             "text": "please",
@@ -2289,13 +2286,13 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.next",
             "propertySubPhrases": [
-              "Next number"
+              "Next"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.previous",
                 "propertySubPhrases": [
-                  "Previous number"
+                  "Previous"
                 ]
               },
               {
@@ -2350,9 +2347,9 @@
             "text": "on the queue.",
             "category": "context",
             "synonyms": [
-              "in the queue",
-              "from the queue",
-              "within the queue"
+              "in the queue.",
+              "from the queue.",
+              "within the queue."
             ],
             "isOptional": true
           }
@@ -2388,15 +2385,11 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind",
-          "If it's not too much trouble, could you",
-          "May I kindly ask you to"
+          "Would you mind"
         ],
         "politeSuffixes": [
           "Thank you.",
-          "Thanks a lot.",
-          "I would appreciate it.",
-          "Much appreciated."
+          "I appreciate it."
         ]
       }
     },
@@ -2451,13 +2444,13 @@
               {
                 "propertyValue": "player.pause",
                 "propertySubPhrases": [
-                  "Pause song"
+                  "Pause the music"
                 ]
               },
               {
                 "propertyValue": "player.play",
                 "propertySubPhrases": [
-                  "Play song"
+                  "Play the music"
                 ]
               }
             ]
@@ -2485,7 +2478,7 @@
         "subPhrases": [
           {
             "text": "Next track",
-            "category": "action",
+            "category": "command",
             "propertyNames": [
               "fullActionName"
             ]
@@ -2545,14 +2538,14 @@
             "name": "fullActionName",
             "value": "player.next",
             "substrings": [
-              "Next tune"
+              "Next"
             ]
           }
         ],
         "subPhrases": [
           {
             "text": "Next tune",
-            "category": "command",
+            "category": "action",
             "propertyNames": [
               "fullActionName"
             ]
@@ -2612,27 +2605,22 @@
             "name": "fullActionName",
             "value": "player.next",
             "substrings": [
-              "Next"
+              "Next up"
             ]
           }
         ],
         "subPhrases": [
           {
-            "text": "Next",
+            "text": "Next up",
             "category": "action",
             "propertyNames": [
               "fullActionName"
             ]
           },
           {
-            "text": "up on the playlist.",
-            "category": "filler",
-            "synonyms": [
-              "following in the queue",
-              "coming up next",
-              "next in line"
-            ],
-            "isOptional": true
+            "text": "on the playlist",
+            "category": "context",
+            "propertyNames": []
           }
         ],
         "propertyAlternatives": [
@@ -2640,25 +2628,25 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.next",
             "propertySubPhrases": [
-              "Next"
+              "Next up"
             ],
             "alternatives": [
               {
-                "propertyValue": "player.previous",
+                "propertyValue": "player.skip",
                 "propertySubPhrases": [
-                  "Previous"
+                  "Skip to the next"
                 ]
               },
               {
-                "propertyValue": "player.pause",
+                "propertyValue": "player.forward",
                 "propertySubPhrases": [
-                  "Pause"
+                  "Forward to the next"
                 ]
               },
               {
-                "propertyValue": "player.play",
+                "propertyValue": "player.advance",
                 "propertySubPhrases": [
-                  "Play"
+                  "Advance to the next"
                 ]
               }
             ]
@@ -2666,13 +2654,11 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind",
-          "If it's not too much trouble, could you"
+          "Would you mind"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "Thanks a lot!",
-          "I appreciate it!"
+          "Thank you.",
+          "I appreciate it."
         ]
       }
     },
@@ -2694,7 +2680,7 @@
         "subPhrases": [
           {
             "text": "Next",
-            "category": "action",
+            "category": "command",
             "propertyNames": [
               "fullActionName"
             ]
@@ -2745,7 +2731,7 @@
         ],
         "politeSuffixes": [
           "Thank you!",
-          "Please!"
+          "Please"
         ]
       }
     },
@@ -2767,7 +2753,7 @@
         "subPhrases": [
           {
             "text": "On to the next one.",
-            "category": "action",
+            "category": "command",
             "propertyNames": [
               "fullActionName"
             ]
@@ -2790,13 +2776,13 @@
               {
                 "propertyValue": "player.pause",
                 "propertySubPhrases": [
-                  "Pause the music."
+                  "Pause the current one."
                 ]
               },
               {
-                "propertyValue": "player.play",
+                "propertyValue": "player.stop",
                 "propertySubPhrases": [
-                  "Start playing the music."
+                  "Stop the current one."
                 ]
               }
             ]
@@ -2907,7 +2893,7 @@
             "synonyms": [
               "Kindly",
               "Would you mind",
-              "Could you"
+              "Could you please"
             ],
             "isOptional": true
           },
@@ -2943,6 +2929,12 @@
                 "propertyValue": "player.play",
                 "propertySubPhrases": [
                   "play the track"
+                ]
+              },
+              {
+                "propertyValue": "player.stop",
+                "propertySubPhrases": [
+                  "stop the track"
                 ]
               }
             ]
@@ -3054,13 +3046,8 @@
           },
           {
             "text": "this one",
-            "category": "filler",
-            "synonyms": [
-              "this track",
-              "this song",
-              "this"
-            ],
-            "isOptional": true
+            "category": "object",
+            "propertyNames": []
           }
         ],
         "propertyAlternatives": [
@@ -3084,9 +3071,9 @@
                 ]
               },
               {
-                "propertyValue": "player.stop",
+                "propertyValue": "player.play",
                 "propertySubPhrases": [
-                  "stop"
+                  "play"
                 ]
               }
             ]
@@ -3107,27 +3094,17 @@
             "name": "fullActionName",
             "value": "player.next",
             "substrings": [
-              "next"
+              "Proceed to the next song."
             ]
           }
         ],
         "subPhrases": [
           {
-            "text": "Proceed to the",
+            "text": "Proceed to the next song.",
             "category": "command",
-            "propertyNames": []
-          },
-          {
-            "text": "next",
-            "category": "action",
             "propertyNames": [
               "fullActionName"
             ]
-          },
-          {
-            "text": "song.",
-            "category": "object",
-            "propertyNames": []
           }
         ],
         "propertyAlternatives": [
@@ -3135,25 +3112,31 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.next",
             "propertySubPhrases": [
-              "next"
+              "Proceed to the next song."
             ],
             "alternatives": [
               {
                 "propertyValue": "player.previous",
                 "propertySubPhrases": [
-                  "previous"
+                  "Go back to the previous song."
                 ]
               },
               {
                 "propertyValue": "player.pause",
                 "propertySubPhrases": [
-                  "pause"
+                  "Pause the song."
                 ]
               },
               {
                 "propertyValue": "player.play",
                 "propertySubPhrases": [
-                  "play"
+                  "Play the song."
+                ]
+              },
+              {
+                "propertyValue": "player.stop",
+                "propertySubPhrases": [
+                  "Stop the song."
                 ]
               }
             ]
@@ -3194,7 +3177,7 @@
           },
           {
             "text": "next.",
-            "category": "action",
+            "category": "command",
             "propertyNames": [
               "fullActionName"
             ]
@@ -3238,8 +3221,8 @@
           "Would you mind"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it."
+          "Thank you.",
+          "I appreciate it."
         ]
       }
     },
@@ -3276,21 +3259,21 @@
             ],
             "alternatives": [
               {
+                "propertyValue": "player.previous",
+                "propertySubPhrases": [
+                  "Queue up the previous song."
+                ]
+              },
+              {
+                "propertyValue": "player.pause",
+                "propertySubPhrases": [
+                  "Pause the song."
+                ]
+              },
+              {
                 "propertyValue": "player.play",
                 "propertySubPhrases": [
-                  "Play the next song."
-                ]
-              },
-              {
-                "propertyValue": "player.skip",
-                "propertySubPhrases": [
-                  "Skip to the next song."
-                ]
-              },
-              {
-                "propertyValue": "player.enqueue",
-                "propertySubPhrases": [
-                  "Add the next song to the queue."
+                  "Play the song."
                 ]
               }
             ]
@@ -3298,11 +3281,13 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If it's not too much trouble, could you"
         ],
         "politeSuffixes": [
-          "Thank you.",
-          "I appreciate it."
+          "Thank you!",
+          "I would appreciate it.",
+          "Thanks a lot!"
         ]
       }
     },
@@ -3371,7 +3356,7 @@
         ],
         "politeSuffixes": [
           "Thank you.",
-          "I appreciate it."
+          "I would appreciate it."
         ]
       }
     },
@@ -3416,13 +3401,13 @@
               {
                 "propertyValue": "player.pause",
                 "propertySubPhrases": [
-                  "Pause the music."
+                  "Pause the song."
                 ]
               },
               {
                 "propertyValue": "player.play",
                 "propertySubPhrases": [
-                  "Play the music."
+                  "Play the song."
                 ]
               }
             ]
@@ -3430,13 +3415,11 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind",
-          "If it's not too much trouble, could you"
+          "Would you mind"
         ],
         "politeSuffixes": [
-          "thank you",
-          "please",
-          "if you don't mind"
+          "Thank you!",
+          "I would appreciate it."
         ]
       }
     },
@@ -3505,13 +3488,11 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind",
-          "If it's not too much trouble, could you"
+          "Would you mind"
         ],
         "politeSuffixes": [
           "Thank you!",
-          "Thanks a lot!",
-          "I would appreciate it!"
+          "I would appreciate it."
         ]
       }
     },
@@ -3574,12 +3555,6 @@
                 "propertySubPhrases": [
                   "play track"
                 ]
-              },
-              {
-                "propertyValue": "player.stop",
-                "propertySubPhrases": [
-                  "stop track"
-                ]
               }
             ]
           }
@@ -3589,8 +3564,8 @@
           "Would you mind"
         ],
         "politeSuffixes": [
-          "thank you",
-          "if you don't mind"
+          "Thank you!",
+          "I would appreciate it."
         ]
       }
     },
@@ -3615,8 +3590,8 @@
             "category": "politeness",
             "synonyms": [
               "Could you please",
-              "Can you",
-              "Would it be possible to"
+              "Do you mind",
+              "Would it be possible"
             ],
             "isOptional": true
           },
@@ -3729,8 +3704,8 @@
           "Would you mind"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "Thanks!"
+          "Thank you",
+          "Please"
         ]
       }
     }

--- a/ts/packages/dispatcher/test/data/player/v5/param.json
+++ b/ts/packages/dispatcher/test/data/player/v5/param.json
@@ -1,7 +1,7 @@
 {
   "version": 2,
   "schemaName": "player",
-  "sourceHash": "/coyfq1j8qYAwzuqFo38QLrP2X7DZ/U6UJRPEiLjn7Q=",
+  "sourceHash": "HrhZPog7XXm93zb5xwYtzWspziPTFgFnvgb4UUJ85a8=",
   "explainerName": "v5",
   "entries": [
     {
@@ -109,7 +109,7 @@
             "synonyms": [
               "What about",
               "Why don't you",
-              "Maybe"
+              "How's this"
             ],
             "isOptional": true
           },
@@ -132,19 +132,25 @@
               {
                 "propertyValue": "player.playNext",
                 "propertySubPhrases": [
-                  "you choose the next song to play"
+                  "you play the next song"
                 ]
               },
               {
                 "propertyValue": "player.playPrevious",
                 "propertySubPhrases": [
-                  "you choose the previous song to play"
+                  "you play the previous song"
                 ]
               },
               {
                 "propertyValue": "player.playFavorite",
                 "propertySubPhrases": [
-                  "you choose a favorite song to play"
+                  "you play a favorite song"
+                ]
+              },
+              {
+                "propertyValue": "player.playTop",
+                "propertySubPhrases": [
+                  "you play a top song"
                 ]
               }
             ]
@@ -156,7 +162,7 @@
         ],
         "politeSuffixes": [
           "Thank you!",
-          "If you don't mind."
+          "I would appreciate it."
         ]
       }
     },
@@ -178,7 +184,7 @@
         "subPhrases": [
           {
             "text": "Play a song",
-            "category": "action",
+            "category": "command",
             "propertyNames": [
               "fullActionName"
             ]
@@ -189,7 +195,7 @@
             "synonyms": [
               "please",
               "if you could",
-              "would you mind"
+              "kindly"
             ],
             "isOptional": true
           }
@@ -219,23 +225,19 @@
                 "propertySubPhrases": [
                   "Play an album"
                 ]
-              },
-              {
-                "propertyValue": "player.playArtist",
-                "propertySubPhrases": [
-                  "Play music by"
-                ]
               }
             ]
           }
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If it's not too much trouble, could you"
         ],
         "politeSuffixes": [
-          "Thank you",
-          "I would appreciate it"
+          "Thank you!",
+          "I would appreciate it.",
+          "Thanks a lot!"
         ]
       }
     },
@@ -250,14 +252,22 @@
             "name": "fullActionName",
             "value": "player.playRandom",
             "substrings": [
-              "Play some tunes"
+              "Play",
+              "tunes"
             ]
           }
         ],
         "subPhrases": [
           {
-            "text": "Play some tunes",
+            "text": "Play",
             "category": "command",
+            "propertyNames": [
+              "fullActionName"
+            ]
+          },
+          {
+            "text": "some tunes",
+            "category": "content",
             "propertyNames": [
               "fullActionName"
             ]
@@ -278,25 +288,29 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.playRandom",
             "propertySubPhrases": [
-              "Play some tunes"
+              "Play",
+              "some tunes"
             ],
             "alternatives": [
               {
-                "propertyValue": "player.playMusic",
+                "propertyValue": "player.playPlaylist",
                 "propertySubPhrases": [
-                  "Play some music"
+                  "Play",
+                  "a playlist"
                 ]
               },
               {
-                "propertyValue": "player.playSongs",
+                "propertyValue": "player.playAlbum",
                 "propertySubPhrases": [
-                  "Play some songs"
+                  "Play",
+                  "an album"
                 ]
               },
               {
-                "propertyValue": "player.playTracks",
+                "propertyValue": "player.playSong",
                 "propertySubPhrases": [
-                  "Play some tracks"
+                  "Play",
+                  "a song"
                 ]
               }
             ]
@@ -308,7 +322,7 @@
         ],
         "politeSuffixes": [
           "Thank you",
-          "I would appreciate it"
+          "if that's okay"
         ]
       }
     },
@@ -330,11 +344,11 @@
         "subPhrases": [
           {
             "text": "Shall we",
-            "category": "politeness",
+            "category": "confirmation",
             "synonyms": [
               "Can we",
-              "Could we",
-              "Would you like to"
+              "Should we",
+              "Do we want to"
             ],
             "isOptional": true
           },
@@ -385,14 +399,8 @@
             ]
           }
         ],
-        "politePrefixes": [
-          "Would you mind if we",
-          "Could we please"
-        ],
-        "politeSuffixes": [
-          "if that's okay with you?",
-          "if you don't mind?"
-        ]
+        "politePrefixes": [],
+        "politeSuffixes": []
       }
     },
     {
@@ -433,21 +441,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.getPlaylist",
+                "propertyValue": "player.getTopHits",
                 "propertySubPhrases": [
-                  "my playlist"
+                  "top hits"
                 ]
               },
               {
                 "propertyValue": "player.getRecent",
                 "propertySubPhrases": [
-                  "my recent songs"
+                  "recently played songs"
                 ]
               },
               {
-                "propertyValue": "player.getTopHits",
+                "propertyValue": "player.getRecommended",
                 "propertySubPhrases": [
-                  "top hits"
+                  "recommended songs"
                 ]
               }
             ]
@@ -458,8 +466,8 @@
           "Would you mind"
         ],
         "politeSuffixes": [
-          "thank you",
-          "if you don't mind"
+          "Thank you",
+          "I would appreciate it"
         ]
       }
     },
@@ -473,62 +481,65 @@
           {
             "name": "fullActionName",
             "value": "player.playRandom",
-            "substrings": [
-              "Start the music"
-            ]
+            "isImplicit": true
           }
         ],
         "subPhrases": [
           {
             "text": "Start the music",
             "category": "command",
-            "propertyNames": [
-              "fullActionName"
-            ]
+            "propertyNames": []
           },
           {
             "text": "please",
             "category": "politeness",
             "synonyms": [
               "kindly",
-              "if you could",
-              "would you mind"
+              "if you would",
+              "if you please"
             ],
             "isOptional": true
           }
         ],
-        "propertyAlternatives": [
-          {
-            "propertyName": "fullActionName",
-            "propertyValue": "player.playRandom",
-            "propertySubPhrases": [
-              "Start the music"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "player.play",
-                "propertySubPhrases": [
-                  "Play the music"
-                ]
-              },
-              {
-                "propertyValue": "player.resume",
-                "propertySubPhrases": [
-                  "Resume the music"
-                ]
-              },
-              {
-                "propertyValue": "player.shuffle",
-                "propertySubPhrases": [
-                  "Shuffle the music"
-                ]
-              }
-            ]
-          }
-        ],
+        "propertyAlternatives": [],
         "politePrefixes": [],
         "politeSuffixes": []
-      }
+      },
+      "corrections": [
+        {
+          "data": {
+            "properties": [
+              {
+                "name": "fullActionName",
+                "value": "player.playRandom",
+                "isImplicit": true
+              }
+            ],
+            "subPhrases": [
+              {
+                "text": "Start the music",
+                "category": "command",
+                "propertyNames": [
+                  "fullActionName"
+                ]
+              },
+              {
+                "text": "please",
+                "category": "politeness",
+                "synonyms": [
+                  "kindly",
+                  "if you would",
+                  "if you please"
+                ],
+                "isOptional": true
+              }
+            ]
+          },
+          "correction": [
+            "Property 'fullActionName' is expected to be implicit and should not be included as a property name in a sub-phrase"
+          ]
+        }
+      ]
     },
     {
       "request": "Turn up the volume on the electronic dance music",
@@ -673,21 +684,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.playSpecific",
-                "propertySubPhrases": [
-                  "playing a specific song"
-                ]
-              },
-              {
-                "propertyValue": "player.playPlaylist",
-                "propertySubPhrases": [
-                  "playing a playlist"
-                ]
-              },
-              {
-                "propertyValue": "player.playGenre",
+                "propertyValue": "player.playJazz",
                 "propertySubPhrases": [
                   "playing some jazz"
+                ]
+              },
+              {
+                "propertyValue": "player.playRock",
+                "propertySubPhrases": [
+                  "playing some rock"
+                ]
+              },
+              {
+                "propertyValue": "player.playClassical",
+                "propertySubPhrases": [
+                  "playing some classical music"
                 ]
               }
             ]
@@ -742,11 +753,11 @@
           },
           {
             "text": "blastin' on these streets",
-            "category": "location",
+            "category": "context",
             "synonyms": [
-              "playing here",
-              "playing loudly",
-              "playing in this area"
+              "playing loudly here",
+              "blaring around",
+              "booming in this area"
             ],
             "isOptional": true
           }
@@ -762,7 +773,7 @@
               {
                 "propertyValue": "player.playRock",
                 "propertySubPhrases": [
-                  "some rock music"
+                  "some rock tunes"
                 ]
               },
               {
@@ -774,25 +785,25 @@
               {
                 "propertyValue": "player.playClassical",
                 "propertySubPhrases": [
-                  "some classical music"
+                  "some classical tunes"
                 ]
               },
               {
                 "propertyValue": "player.playHipHop",
                 "propertySubPhrases": [
-                  "some hip hop beats"
+                  "some hip-hop tunes"
                 ]
               }
             ]
           }
         ],
         "politePrefixes": [
-          "Could you please",
-          "Would you mind"
+          "Excuse me,",
+          "Could you please"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it!"
+          "Thank you.",
+          "I would appreciate it."
         ]
       }
     }

--- a/ts/packages/dispatcher/test/data/player/v5/pauseAction.json
+++ b/ts/packages/dispatcher/test/data/player/v5/pauseAction.json
@@ -1,7 +1,7 @@
 {
   "version": 2,
   "schemaName": "player",
-  "sourceHash": "/coyfq1j8qYAwzuqFo38QLrP2X7DZ/U6UJRPEiLjn7Q=",
+  "sourceHash": "HrhZPog7XXm93zb5xwYtzWspziPTFgFnvgb4UUJ85a8=",
   "explainerName": "v5",
   "entries": [
     {
@@ -26,7 +26,7 @@
             "synonyms": [
               "Could we have a quiet moment?",
               "May we have a quiet moment?",
-              "Would it be possible to have a quiet moment?"
+              "Let's have a quiet moment."
             ],
             "isOptional": true
           },
@@ -141,12 +141,12 @@
           }
         ],
         "politePrefixes": [
-          "Please",
+          "Could you please",
           "Would you mind"
         ],
         "politeSuffixes": [
-          "Thank you",
-          "If you don't mind"
+          "Thank you.",
+          "I would appreciate it."
         ]
       }
     },
@@ -249,7 +249,7 @@
             "text": "Can you give the play button a rest?",
             "category": "politeness",
             "synonyms": [
-              "Could you please stop the play button?",
+              "Could you stop the play button?",
               "Would you mind pausing the play button?",
               "Please pause the play button."
             ],
@@ -278,15 +278,21 @@
                 ]
               },
               {
-                "propertyValue": "player.resume",
-                "propertySubPhrases": [
-                  "Resume it."
-                ]
-              },
-              {
                 "propertyValue": "player.play",
                 "propertySubPhrases": [
                   "Play it."
+                ]
+              },
+              {
+                "propertyValue": "player.rewind",
+                "propertySubPhrases": [
+                  "Rewind it."
+                ]
+              },
+              {
+                "propertyValue": "player.fastForward",
+                "propertySubPhrases": [
+                  "Fast forward it."
                 ]
               }
             ]
@@ -376,12 +382,6 @@
                 "propertySubPhrases": [
                   "rewind"
                 ]
-              },
-              {
-                "propertyValue": "player.fastForward",
-                "propertySubPhrases": [
-                  "fast forward"
-                ]
               }
             ]
           }
@@ -461,22 +461,16 @@
                 ]
               },
               {
-                "propertyValue": "player.resume",
+                "propertyValue": "player.skip",
                 "propertySubPhrases": [
-                  "resume"
+                  "skip"
                 ]
               }
             ]
           }
         ],
-        "politePrefixes": [
-          "Could you please",
-          "Would you mind"
-        ],
-        "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it."
-        ]
+        "politePrefixes": [],
+        "politeSuffixes": []
       }
     },
     {
@@ -506,15 +500,15 @@
             "isOptional": true
           },
           {
-            "text": "put the music on hold?",
-            "category": "command",
+            "text": "put the music on hold",
+            "category": "action",
             "propertyNames": [
               "fullActionName"
             ]
           },
           {
             "text": "Pause it.",
-            "category": "command",
+            "category": "action",
             "propertyNames": [
               "fullActionName"
             ]
@@ -525,29 +519,29 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.pause",
             "propertySubPhrases": [
-              "put the music on hold?",
+              "put the music on hold",
               "Pause it."
             ],
             "alternatives": [
               {
                 "propertyValue": "player.stop",
                 "propertySubPhrases": [
-                  "stop the music?",
+                  "stop the music",
                   "Stop it."
                 ]
               },
               {
                 "propertyValue": "player.resume",
                 "propertySubPhrases": [
-                  "resume the music?",
+                  "resume the music",
                   "Resume it."
                 ]
               },
               {
-                "propertyValue": "player.play",
+                "propertyValue": "player.mute",
                 "propertySubPhrases": [
-                  "play the music?",
-                  "Play it."
+                  "mute the music",
+                  "Mute it."
                 ]
               }
             ]
@@ -619,7 +613,7 @@
               {
                 "propertyValue": "player.mute",
                 "propertySubPhrases": [
-                  "please"
+                  "Cease the sound"
                 ]
               },
               {
@@ -663,17 +657,14 @@
           },
           {
             "text": "give the song a break?",
-            "category": "filler",
-            "synonyms": [
-              "stop the music?",
-              "pause the song?",
-              "halt the track?"
-            ],
-            "isOptional": true
+            "category": "request",
+            "propertyNames": [
+              "fullActionName"
+            ]
           },
           {
             "text": "Pause it.",
-            "category": "command",
+            "category": "request",
             "propertyNames": [
               "fullActionName"
             ]
@@ -684,31 +675,29 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.pause",
             "propertySubPhrases": [
+              "give the song a break?",
               "Pause it."
             ],
             "alternatives": [
               {
                 "propertyValue": "player.stop",
                 "propertySubPhrases": [
+                  "stop the song?",
                   "Stop it."
                 ]
               },
               {
                 "propertyValue": "player.resume",
                 "propertySubPhrases": [
+                  "resume the song?",
                   "Resume it."
                 ]
               },
               {
                 "propertyValue": "player.rewind",
                 "propertySubPhrases": [
+                  "rewind the song?",
                   "Rewind it."
-                ]
-              },
-              {
-                "propertyValue": "player.fastForward",
-                "propertySubPhrases": [
-                  "Fast forward it."
                 ]
               }
             ]
@@ -768,7 +757,7 @@
             "synonyms": [
               "at the",
               "to the",
-              "for the"
+              "onto the"
             ],
             "isOptional": true
           },
@@ -886,31 +875,31 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.play",
-                "propertySubPhrases": [
-                  "start the music",
-                  "hit play"
-                ]
-              },
-              {
                 "propertyValue": "player.stop",
                 "propertySubPhrases": [
-                  "end the music",
-                  "hit stop"
+                  "stop the music",
+                  "stop playback"
                 ]
               },
               {
-                "propertyValue": "player.next",
+                "propertyValue": "player.mute",
                 "propertySubPhrases": [
-                  "skip the song",
-                  "hit next"
+                  "mute the music",
+                  "silence the audio"
                 ]
               },
               {
-                "propertyValue": "player.previous",
+                "propertyValue": "player.resume",
                 "propertySubPhrases": [
-                  "go back a song",
-                  "hit previous"
+                  "resume the music",
+                  "continue playback"
+                ]
+              },
+              {
+                "propertyValue": "player.play",
+                "propertySubPhrases": [
+                  "play the music",
+                  "start playback"
                 ]
               }
             ]
@@ -1011,20 +1000,25 @@
         "subPhrases": [
           {
             "text": "Give the music a break,",
-            "category": "filler",
-            "synonyms": [
-              "Stop the music for a moment,",
-              "Take a break from the music,",
-              "Pause the music for a bit,"
-            ],
-            "isOptional": true
+            "category": "command",
+            "propertyNames": []
           },
           {
-            "text": "pause it.",
+            "text": "pause",
             "category": "action",
             "propertyNames": [
               "fullActionName"
             ]
+          },
+          {
+            "text": "it.",
+            "category": "filler",
+            "synonyms": [
+              "this",
+              "that",
+              "the music"
+            ],
+            "isOptional": true
           }
         ],
         "propertyAlternatives": [
@@ -1032,25 +1026,25 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.pause",
             "propertySubPhrases": [
-              "pause it."
+              "pause"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.stop",
                 "propertySubPhrases": [
-                  "stop it."
+                  "stop"
                 ]
               },
               {
                 "propertyValue": "player.resume",
                 "propertySubPhrases": [
-                  "resume it."
+                  "resume"
                 ]
               },
               {
-                "propertyValue": "player.mute",
+                "propertyValue": "player.play",
                 "propertySubPhrases": [
-                  "mute it."
+                  "play"
                 ]
               }
             ]
@@ -1084,8 +1078,13 @@
         "subPhrases": [
           {
             "text": "Hit the",
-            "category": "command",
-            "propertyNames": []
+            "category": "filler",
+            "synonyms": [
+              "Press the",
+              "Tap the",
+              "Click the"
+            ],
+            "isOptional": true
           },
           {
             "text": "pause",
@@ -1096,16 +1095,21 @@
           },
           {
             "text": "button,",
-            "category": "object",
-            "propertyNames": []
+            "category": "filler",
+            "synonyms": [
+              "control,",
+              "key,",
+              "switch,"
+            ],
+            "isOptional": true
           },
           {
             "text": "will you?",
             "category": "politeness",
             "synonyms": [
-              "please",
-              "if you don't mind",
-              "could you"
+              "please?",
+              "could you?",
+              "would you?"
             ],
             "isOptional": true
           }
@@ -1134,6 +1138,12 @@
                 "propertyValue": "player.rewind",
                 "propertySubPhrases": [
                   "rewind"
+                ]
+              },
+              {
+                "propertyValue": "player.fastForward",
+                "propertySubPhrases": [
+                  "fast forward"
                 ]
               }
             ]
@@ -1207,15 +1217,15 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.play",
-                "propertySubPhrases": [
-                  "play"
-                ]
-              },
-              {
                 "propertyValue": "player.stop",
                 "propertySubPhrases": [
                   "stop"
+                ]
+              },
+              {
+                "propertyValue": "player.play",
+                "propertySubPhrases": [
+                  "play"
                 ]
               },
               {
@@ -1255,17 +1265,14 @@
         "subPhrases": [
           {
             "text": "Hold the tunes",
-            "category": "politeness",
-            "synonyms": [
-              "Stop the tunes",
-              "Halt the tunes",
-              "Pause the tunes"
-            ],
-            "isOptional": true
+            "category": "command",
+            "propertyNames": [
+              "fullActionName"
+            ]
           },
           {
             "text": "pause the music",
-            "category": "action",
+            "category": "command",
             "propertyNames": [
               "fullActionName"
             ]
@@ -1276,25 +1283,29 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.pause",
             "propertySubPhrases": [
+              "Hold the tunes",
               "pause the music"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.stop",
                 "propertySubPhrases": [
+                  "Stop the tunes",
                   "stop the music"
-                ]
-              },
-              {
-                "propertyValue": "player.mute",
-                "propertySubPhrases": [
-                  "mute the music"
                 ]
               },
               {
                 "propertyValue": "player.resume",
                 "propertySubPhrases": [
+                  "Resume the tunes",
                   "resume the music"
+                ]
+              },
+              {
+                "propertyValue": "player.mute",
+                "propertySubPhrases": [
+                  "Mute the tunes",
+                  "mute the music"
                 ]
               }
             ]
@@ -1306,7 +1317,7 @@
         ],
         "politeSuffixes": [
           "Thank you!",
-          "I would appreciate it."
+          "I appreciate it!"
         ]
       }
     },
@@ -1363,12 +1374,6 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.play",
-                "propertySubPhrases": [
-                  "play"
-                ]
-              },
-              {
                 "propertyValue": "player.stop",
                 "propertySubPhrases": [
                   "stop"
@@ -1378,6 +1383,12 @@
                 "propertyValue": "player.resume",
                 "propertySubPhrases": [
                   "resume"
+                ]
+              },
+              {
+                "propertyValue": "player.rewind",
+                "propertySubPhrases": [
+                  "rewind"
                 ]
               }
             ]
@@ -1411,8 +1422,13 @@
         "subPhrases": [
           {
             "text": "I need a moment of silence",
-            "category": "request",
-            "propertyNames": []
+            "category": "filler",
+            "synonyms": [
+              "I need some quiet",
+              "I need a break",
+              "I need some peace"
+            ],
+            "isOptional": true
           },
           {
             "text": "please",
@@ -1426,7 +1442,7 @@
           },
           {
             "text": "pause the music",
-            "category": "command",
+            "category": "action",
             "propertyNames": [
               "fullActionName"
             ]
@@ -1453,22 +1469,16 @@
                 ]
               },
               {
-                "propertyValue": "player.volumeDown",
+                "propertyValue": "player.resume",
                 "propertySubPhrases": [
-                  "lower the volume"
+                  "resume the music"
                 ]
               }
             ]
           }
         ],
-        "politePrefixes": [
-          "Could you please",
-          "Would you mind"
-        ],
-        "politeSuffixes": [
-          "Thank you.",
-          "I would appreciate it."
-        ]
+        "politePrefixes": [],
+        "politeSuffixes": []
       }
     },
     {
@@ -1482,7 +1492,7 @@
             "name": "fullActionName",
             "value": "player.pause",
             "substrings": [
-              "paused the song"
+              "paused"
             ]
           }
         ],
@@ -1491,18 +1501,23 @@
             "text": "I'd appreciate it if you",
             "category": "politeness",
             "synonyms": [
-              "Could you please",
-              "Would you mind",
-              "I would be grateful if you"
+              "please",
+              "kindly",
+              "if you don't mind"
             ],
             "isOptional": true
           },
           {
-            "text": "paused the song",
+            "text": "paused",
             "category": "action",
             "propertyNames": [
               "fullActionName"
             ]
+          },
+          {
+            "text": "the song",
+            "category": "object",
+            "propertyNames": []
           }
         ],
         "propertyAlternatives": [
@@ -1510,25 +1525,25 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.pause",
             "propertySubPhrases": [
-              "paused the song"
+              "paused"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.play",
                 "propertySubPhrases": [
-                  "played the song"
+                  "played"
                 ]
               },
               {
                 "propertyValue": "player.stop",
                 "propertySubPhrases": [
-                  "stopped the song"
+                  "stopped"
                 ]
               },
               {
                 "propertyValue": "player.resume",
                 "propertySubPhrases": [
-                  "resumed the song"
+                  "resumed"
                 ]
               }
             ]
@@ -1556,17 +1571,12 @@
         "subPhrases": [
           {
             "text": "Interrupt the rhythm",
-            "category": "filler",
-            "synonyms": [
-              "Stop the beat",
-              "Break the flow",
-              "Halt the music"
-            ],
-            "isOptional": true
+            "category": "command",
+            "propertyNames": []
           },
           {
             "text": "pause the track",
-            "category": "action",
+            "category": "command",
             "propertyNames": [
               "fullActionName"
             ]
@@ -1593,9 +1603,9 @@
                 ]
               },
               {
-                "propertyValue": "player.rewind",
+                "propertyValue": "player.skip",
                 "propertySubPhrases": [
-                  "rewind the track"
+                  "skip the track"
                 ]
               }
             ]
@@ -1643,7 +1653,7 @@
             "synonyms": [
               "stop the playlist",
               "halt the playlist",
-              "suspend the playlist"
+              "pause the playlist"
             ],
             "isOptional": true
           },
@@ -1676,12 +1686,6 @@
                 ]
               },
               {
-                "propertyValue": "player.skip",
-                "propertySubPhrases": [
-                  "skip the song"
-                ]
-              },
-              {
                 "propertyValue": "player.rewind",
                 "propertySubPhrases": [
                   "rewind the song"
@@ -1695,7 +1699,7 @@
           "Would you mind"
         ],
         "politeSuffixes": [
-          "Thank you!",
+          "Thank you.",
           "I would appreciate it."
         ]
       }
@@ -1737,9 +1741,9 @@
             "text": "in the music.",
             "category": "context",
             "synonyms": [
-              "during the music.",
-              "while the music is playing.",
-              "in the song."
+              "in the song.",
+              "in the audio.",
+              "in the playback."
             ],
             "isOptional": true
           }
@@ -1753,6 +1757,12 @@
             ],
             "alternatives": [
               {
+                "propertyValue": "player.play",
+                "propertySubPhrases": [
+                  "play"
+                ]
+              },
+              {
                 "propertyValue": "player.stop",
                 "propertySubPhrases": [
                   "stop"
@@ -1762,12 +1772,6 @@
                 "propertyValue": "player.resume",
                 "propertySubPhrases": [
                   "resume"
-                ]
-              },
-              {
-                "propertyValue": "player.mute",
-                "propertySubPhrases": [
-                  "mute"
                 ]
               }
             ]
@@ -1779,7 +1783,7 @@
         ],
         "politeSuffixes": [
           "Thank you.",
-          "if that's okay with you."
+          "I would appreciate it."
         ]
       }
     },
@@ -1800,21 +1804,51 @@
         ],
         "subPhrases": [
           {
-            "text": "Let's hold off on the music,",
+            "text": "Let's",
             "category": "filler",
             "synonyms": [
-              "Let's stop the music,",
-              "Let's take a break from the music,",
-              "Let's pause the music,"
+              "Let us",
+              "We should",
+              "How about"
             ],
             "isOptional": true
           },
           {
-            "text": "pause it.",
+            "text": "hold off on",
+            "category": "filler",
+            "synonyms": [
+              "stop",
+              "pause",
+              "halt"
+            ],
+            "isOptional": true
+          },
+          {
+            "text": "the music,",
+            "category": "filler",
+            "synonyms": [
+              "the song,",
+              "the audio,",
+              "the track,"
+            ],
+            "isOptional": true
+          },
+          {
+            "text": "pause",
             "category": "action",
             "propertyNames": [
               "fullActionName"
             ]
+          },
+          {
+            "text": "it.",
+            "category": "filler",
+            "synonyms": [
+              "this.",
+              "that.",
+              "the music."
+            ],
+            "isOptional": true
           }
         ],
         "propertyAlternatives": [
@@ -1822,25 +1856,25 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.pause",
             "propertySubPhrases": [
-              "pause it."
+              "pause"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.stop",
                 "propertySubPhrases": [
-                  "stop it."
-                ]
-              },
-              {
-                "propertyValue": "player.resume",
-                "propertySubPhrases": [
-                  "resume it."
+                  "stop"
                 ]
               },
               {
                 "propertyValue": "player.mute",
                 "propertySubPhrases": [
-                  "mute it."
+                  "mute"
+                ]
+              },
+              {
+                "propertyValue": "player.resume",
+                "propertySubPhrases": [
+                  "resume"
                 ]
               }
             ]
@@ -1915,12 +1949,6 @@
                 "propertySubPhrases": [
                   "rewind the track."
                 ]
-              },
-              {
-                "propertyValue": "player.fastForward",
-                "propertySubPhrases": [
-                  "fast forward the track."
-                ]
               }
             ]
           }
@@ -1928,12 +1956,14 @@
         "politePrefixes": [
           "Could you please",
           "Would you mind",
-          "If it's not too much trouble, could you"
+          "If it's not too much trouble, could you",
+          "May I kindly ask you to"
         ],
         "politeSuffixes": [
-          "Thank you!",
+          "Thank you.",
           "I would appreciate it.",
-          "Thanks a lot!"
+          "Thanks a lot.",
+          "Much appreciated."
         ]
       }
     },
@@ -1954,18 +1984,18 @@
         ],
         "subPhrases": [
           {
-            "text": "Let's put a pin in it,",
+            "text": "Let's put a pin in it",
             "category": "filler",
             "synonyms": [
               "hold on",
               "wait a moment",
-              "pause for a second"
+              "pause for now"
             ],
             "isOptional": true
           },
           {
             "text": "pause the music",
-            "category": "action",
+            "category": "command",
             "propertyNames": [
               "fullActionName"
             ]
@@ -2001,12 +2031,14 @@
           }
         ],
         "politePrefixes": [
-          "Please",
-          "Kindly"
+          "Could you please",
+          "Would you mind",
+          "If it's not too much trouble, could you"
         ],
         "politeSuffixes": [
-          "Thank you",
-          "if you don't mind"
+          "Thank you!",
+          "I would appreciate it.",
+          "Thanks a lot!"
         ]
       }
     },
@@ -2028,7 +2060,7 @@
         "subPhrases": [
           {
             "text": "Let's",
-            "category": "politeness",
+            "category": "filler",
             "synonyms": [
               "Let us",
               "We should",
@@ -2071,7 +2103,7 @@
               {
                 "propertyValue": "player.mute",
                 "propertySubPhrases": [
-                  "mute the player"
+                  "mute the sound"
                 ]
               },
               {
@@ -2089,7 +2121,7 @@
         ],
         "politeSuffixes": [
           "Thank you!",
-          "I appreciate it."
+          "I would appreciate it."
         ]
       }
     },
@@ -2114,8 +2146,8 @@
             "category": "filler",
             "synonyms": [
               "Let's take a break",
-              "Let's pause for a moment",
-              "Let's rest for a bit"
+              "Let's rest for a moment",
+              "Let's pause for a bit"
             ],
             "isOptional": true
           },
@@ -2162,7 +2194,7 @@
         ],
         "politeSuffixes": [
           "Thank you.",
-          "I would appreciate it."
+          "I appreciate it."
         ]
       }
     },
@@ -2215,27 +2247,27 @@
                 ]
               },
               {
-                "propertyValue": "player.mute",
+                "propertyValue": "player.play",
                 "propertySubPhrases": [
-                  "mute the sound"
+                  "start the music"
                 ]
               },
               {
-                "propertyValue": "player.play",
+                "propertyValue": "player.resume",
                 "propertySubPhrases": [
-                  "play the music"
+                  "resume the music"
                 ]
               }
             ]
           }
         ],
         "politePrefixes": [
-          "Could we please",
-          "Would you mind if we"
+          "Please",
+          "Kindly"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it."
+          "Thank you",
+          "if you don't mind"
         ]
       }
     },
@@ -2256,12 +2288,22 @@
         ],
         "subPhrases": [
           {
-            "text": "Let's take a",
+            "text": "Let's",
             "category": "filler",
             "synonyms": [
-              "Let's have a",
-              "Let's do a",
-              "Let's make a"
+              "Let us",
+              "We should",
+              "How about"
+            ],
+            "isOptional": true
+          },
+          {
+            "text": "take a",
+            "category": "filler",
+            "synonyms": [
+              "have a",
+              "make a",
+              "do a"
             ],
             "isOptional": true
           },
@@ -2273,12 +2315,12 @@
             ]
           },
           {
-            "text": "from the music.",
+            "text": "from the music",
             "category": "context",
             "synonyms": [
-              "from the song.",
-              "from the audio.",
-              "from the track."
+              "from playing",
+              "from the song",
+              "from the audio"
             ],
             "isOptional": true
           }
@@ -2298,15 +2340,15 @@
                 ]
               },
               {
-                "propertyValue": "player.mute",
-                "propertySubPhrases": [
-                  "mute"
-                ]
-              },
-              {
                 "propertyValue": "player.resume",
                 "propertySubPhrases": [
                   "resume"
+                ]
+              },
+              {
+                "propertyValue": "player.mute",
+                "propertySubPhrases": [
+                  "mute"
                 ]
               }
             ]
@@ -2339,22 +2381,12 @@
         ],
         "subPhrases": [
           {
-            "text": "Mind",
+            "text": "Mind suspending the tunes?",
             "category": "politeness",
             "synonyms": [
-              "Would you mind",
-              "Could you",
-              "Can you"
-            ],
-            "isOptional": true
-          },
-          {
-            "text": "suspending the tunes?",
-            "category": "politeness",
-            "synonyms": [
-              "pausing the music?",
-              "stopping the songs?",
-              "halting the tracks?"
+              "Could you stop the music?",
+              "Would you mind pausing the music?",
+              "Can you halt the tunes?"
             ],
             "isOptional": true
           },
@@ -2400,7 +2432,7 @@
           "Would you mind"
         ],
         "politeSuffixes": [
-          "Thank you!",
+          "Thank you.",
           "I would appreciate it."
         ]
       }
@@ -2416,25 +2448,30 @@
             "name": "fullActionName",
             "value": "player.pause",
             "substrings": [
-              "Pause the audio"
+              "Pause"
             ]
           }
         ],
         "subPhrases": [
           {
-            "text": "Pause the audio",
-            "category": "action",
+            "text": "Pause",
+            "category": "command",
             "propertyNames": [
               "fullActionName"
             ]
+          },
+          {
+            "text": "the audio",
+            "category": "object",
+            "propertyNames": []
           },
           {
             "text": "thanks",
             "category": "acknowledgement",
             "synonyms": [
               "thank you",
-              "thx",
-              "cheers"
+              "cheers",
+              "much appreciated"
             ],
             "isOptional": true
           }
@@ -2444,25 +2481,25 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.pause",
             "propertySubPhrases": [
-              "Pause the audio"
+              "Pause"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.stop",
                 "propertySubPhrases": [
-                  "Stop the audio"
+                  "Stop"
                 ]
               },
               {
                 "propertyValue": "player.resume",
                 "propertySubPhrases": [
-                  "Resume the audio"
+                  "Resume"
                 ]
               },
               {
                 "propertyValue": "player.mute",
                 "propertySubPhrases": [
-                  "Mute the audio"
+                  "Mute"
                 ]
               }
             ]
@@ -2515,8 +2552,8 @@
             "category": "politeness",
             "synonyms": [
               "kindly",
-              "if you could",
-              "would you mind"
+              "if you would",
+              "if you please"
             ],
             "isOptional": true
           }
@@ -2536,15 +2573,15 @@
                 ]
               },
               {
-                "propertyValue": "player.halt",
+                "propertyValue": "player.resume",
                 "propertySubPhrases": [
-                  "Halt"
+                  "Resume"
                 ]
               },
               {
-                "propertyValue": "player.suspend",
+                "propertyValue": "player.mute",
                 "propertySubPhrases": [
-                  "Suspend"
+                  "Mute"
                 ]
               }
             ]
@@ -2592,8 +2629,8 @@
             "category": "politeness",
             "synonyms": [
               "please",
-              "if you don't mind",
-              "kindly"
+              "kindly",
+              "if you don't mind"
             ],
             "isOptional": true
           }
@@ -2613,28 +2650,22 @@
                 ]
               },
               {
-                "propertyValue": "player.halt",
+                "propertyValue": "player.resume",
                 "propertySubPhrases": [
-                  "Halt"
+                  "Resume"
                 ]
               },
               {
-                "propertyValue": "player.suspend",
+                "propertyValue": "player.start",
                 "propertySubPhrases": [
-                  "Suspend"
+                  "Start"
                 ]
               }
             ]
           }
         ],
-        "politePrefixes": [
-          "Could you please",
-          "Would you mind"
-        ],
-        "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it."
-        ]
+        "politePrefixes": [],
+        "politeSuffixes": []
       }
     },
     {
@@ -2744,12 +2775,12 @@
             ]
           },
           {
-            "text": "I have an announcement",
+            "text": ", I have an announcement.",
             "category": "filler",
             "synonyms": [
-              "I need to say something",
-              "I have something to announce",
-              "I need to make an announcement"
+              ", I need to say something.",
+              ", I have something to announce.",
+              ", I need to make an announcement."
             ],
             "isOptional": true
           }
@@ -2817,12 +2848,12 @@
             ]
           },
           {
-            "text": ", it's too loud.",
+            "text": "it's too loud",
             "category": "explanation",
             "synonyms": [
-              ", it's very loud.",
-              ", the volume is too high.",
-              ", it's too noisy."
+              "the volume is high",
+              "it's very noisy",
+              "the sound is too much"
             ],
             "isOptional": true
           }
@@ -2861,8 +2892,8 @@
           "Would you mind"
         ],
         "politeSuffixes": [
-          "Thank you",
-          "I would appreciate it"
+          "Thank you.",
+          "I would appreciate it."
         ]
       }
     },
@@ -2877,27 +2908,27 @@
             "name": "fullActionName",
             "value": "player.pause",
             "substrings": [
-              "Pause"
+              "Pause the playback"
             ]
           }
         ],
         "subPhrases": [
           {
-            "text": "Pause",
+            "text": "Pause the playback",
             "category": "command",
             "propertyNames": [
               "fullActionName"
             ]
           },
           {
-            "text": "the playback",
-            "category": "object",
-            "propertyNames": []
-          },
-          {
             "text": "for a moment",
-            "category": "duration",
-            "propertyNames": []
+            "category": "filler",
+            "synonyms": [
+              "briefly",
+              "for a short while",
+              "temporarily"
+            ],
+            "isOptional": true
           }
         ],
         "propertyAlternatives": [
@@ -2905,25 +2936,25 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.pause",
             "propertySubPhrases": [
-              "Pause"
+              "Pause the playback"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.stop",
                 "propertySubPhrases": [
-                  "Stop"
+                  "Stop the playback"
                 ]
               },
               {
                 "propertyValue": "player.resume",
                 "propertySubPhrases": [
-                  "Resume"
+                  "Resume the playback"
                 ]
               },
               {
                 "propertyValue": "player.rewind",
                 "propertySubPhrases": [
-                  "Rewind"
+                  "Rewind the playback"
                 ]
               }
             ]
@@ -2957,7 +2988,7 @@
         "subPhrases": [
           {
             "text": "Pause",
-            "category": "action",
+            "category": "command",
             "propertyNames": [
               "fullActionName"
             ]
@@ -2971,9 +3002,9 @@
             "text": "if you don't mind",
             "category": "politeness",
             "synonyms": [
-              "if it's okay with you",
+              "if it's not too much trouble",
               "if you could",
-              "if you would"
+              "if you would be so kind"
             ],
             "isOptional": true
           }
@@ -2993,15 +3024,15 @@
                 ]
               },
               {
-                "propertyValue": "player.halt",
+                "propertyValue": "player.resume",
                 "propertySubPhrases": [
-                  "Halt"
+                  "Resume"
                 ]
               },
               {
-                "propertyValue": "player.freeze",
+                "propertyValue": "player.rewind",
                 "propertySubPhrases": [
-                  "Freeze"
+                  "Rewind"
                 ]
               }
             ]
@@ -3081,11 +3112,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If it's not too much trouble, could you",
+          "May I ask you to"
         ],
         "politeSuffixes": [
           "Thank you!",
-          "I would appreciate it."
+          "I would appreciate it.",
+          "Thanks a lot!",
+          "That would be great."
         ]
       }
     },
@@ -3100,27 +3135,27 @@
             "name": "fullActionName",
             "value": "player.pause",
             "substrings": [
-              "Pause"
+              "Pause the sound"
             ]
           }
         ],
         "subPhrases": [
           {
-            "text": "Pause",
+            "text": "Pause the sound",
             "category": "command",
             "propertyNames": [
               "fullActionName"
             ]
           },
           {
-            "text": "the sound",
-            "category": "object",
-            "propertyNames": []
-          },
-          {
-            "text": "I need to talk",
-            "category": "reason",
-            "propertyNames": []
+            "text": ", I need to talk.",
+            "category": "explanation",
+            "synonyms": [
+              ", I have to speak.",
+              ", I need to say something.",
+              ", I need to speak."
+            ],
+            "isOptional": true
           }
         ],
         "propertyAlternatives": [
@@ -3128,25 +3163,25 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.pause",
             "propertySubPhrases": [
-              "Pause"
+              "Pause the sound"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.stop",
                 "propertySubPhrases": [
-                  "Stop"
+                  "Stop the sound"
                 ]
               },
               {
                 "propertyValue": "player.mute",
                 "propertySubPhrases": [
-                  "Mute"
+                  "Mute the sound"
                 ]
               },
               {
                 "propertyValue": "player.resume",
                 "propertySubPhrases": [
-                  "Resume"
+                  "Resume the sound"
                 ]
               }
             ]
@@ -3195,7 +3230,7 @@
             "category": "politeness",
             "synonyms": [
               "kindly",
-              "if you don't mind",
+              "if you could",
               "would you mind"
             ],
             "isOptional": true
@@ -3216,15 +3251,15 @@
                 ]
               },
               {
-                "propertyValue": "player.resume",
+                "propertyValue": "player.play",
                 "propertySubPhrases": [
-                  "Resume"
+                  "Play"
                 ]
               },
               {
-                "propertyValue": "player.mute",
+                "propertyValue": "player.resume",
                 "propertySubPhrases": [
-                  "Mute"
+                  "Resume"
                 ]
               }
             ]
@@ -3261,9 +3296,9 @@
             "text": "the tunes for a moment.",
             "category": "filler",
             "synonyms": [
-              "the music for a bit.",
-              "the song for a while.",
-              "the audio for a second."
+              "the music for a bit",
+              "the song for a while",
+              "the audio for a second"
             ],
             "isOptional": true
           }
@@ -3303,7 +3338,7 @@
         ],
         "politeSuffixes": [
           "Thank you!",
-          "I would appreciate it."
+          "if that's okay."
         ]
       }
     },
@@ -3342,7 +3377,7 @@
           },
           {
             "text": "vibes",
-            "category": "filler",
+            "category": "object",
             "synonyms": [
               "music",
               "sound",
@@ -3352,11 +3387,11 @@
           },
           {
             "text": "for a second",
-            "category": "filler",
+            "category": "duration",
             "synonyms": [
               "for a moment",
               "for a bit",
-              "briefly"
+              "temporarily"
             ],
             "isOptional": true
           }
@@ -3392,11 +3427,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If it's not too much trouble, could you",
+          "May I kindly ask you to"
         ],
         "politeSuffixes": [
           "Thank you!",
-          "I would appreciate it."
+          "I would appreciate it.",
+          "Thanks a lot!",
+          "That would be great, thanks!"
         ]
       }
     },
@@ -3496,22 +3535,12 @@
             ]
           },
           {
-            "text": "on that",
-            "category": "preposition",
-            "synonyms": [
-              "on it",
-              "on this",
-              "on the thing"
-            ],
-            "isOptional": true
-          },
-          {
-            "text": "would you",
+            "text": "on that, would you?",
             "category": "politeness",
             "synonyms": [
               "please",
-              "if you could",
-              "if you don't mind"
+              "if you don't mind",
+              "kindly"
             ],
             "isOptional": true
           }
@@ -3592,19 +3621,19 @@
             "text": "on the music",
             "category": "context",
             "synonyms": [
-              "the music",
-              "this track",
-              "the song"
+              "the song",
+              "the track",
+              "the audio"
             ],
             "isOptional": true
           },
           {
             "text": "okay?",
-            "category": "acknowledgement",
+            "category": "confirmation",
             "synonyms": [
               "alright?",
-              "please?",
-              "if you can?"
+              "right?",
+              "is that okay?"
             ],
             "isOptional": true
           }
@@ -3618,15 +3647,15 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.stop",
-                "propertySubPhrases": [
-                  "stop"
-                ]
-              },
-              {
                 "propertyValue": "player.play",
                 "propertySubPhrases": [
                   "play"
+                ]
+              },
+              {
+                "propertyValue": "player.stop",
+                "propertySubPhrases": [
+                  "stop"
                 ]
               },
               {
@@ -3644,7 +3673,7 @@
         ],
         "politeSuffixes": [
           "Thank you!",
-          "if that's alright."
+          "I appreciate it!"
         ]
       }
     },
@@ -3665,29 +3694,29 @@
         ],
         "subPhrases": [
           {
-            "text": "Time out on the tunes",
+            "text": "Time out on the tunes,",
             "category": "filler",
             "synonyms": [
-              "stop the music",
-              "halt the tunes",
-              "cease the music"
+              "Stop the music,",
+              "Hold the tunes,",
+              "Pause the music,"
             ],
             "isOptional": true
           },
           {
             "text": "pause",
-            "category": "action",
+            "category": "command",
             "propertyNames": [
               "fullActionName"
             ]
           },
           {
-            "text": "them",
+            "text": "them.",
             "category": "filler",
             "synonyms": [
-              "it",
-              "the music",
-              "the tunes"
+              "it.",
+              "the music.",
+              "the tunes."
             ],
             "isOptional": true
           }
@@ -3723,11 +3752,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If it's not too much trouble, could you",
+          "May I kindly ask you to"
         ],
         "politeSuffixes": [
           "Thank you!",
-          "I appreciate it."
+          "I would appreciate it.",
+          "Thanks a lot!",
+          "Much appreciated."
         ]
       }
     },
@@ -3863,9 +3896,9 @@
                 ]
               },
               {
-                "propertyValue": "player.skip",
+                "propertyValue": "player.resume",
                 "propertySubPhrases": [
-                  "skip"
+                  "resume"
                 ]
               }
             ]
@@ -3876,8 +3909,8 @@
           "Would you mind"
         ],
         "politeSuffixes": [
-          "Thank you",
-          "Please"
+          "Thank you.",
+          "I would appreciate it."
         ]
       }
     }

--- a/ts/packages/dispatcher/test/data/player/v5/previousAction.json
+++ b/ts/packages/dispatcher/test/data/player/v5/previousAction.json
@@ -1,7 +1,7 @@
 {
   "version": 2,
   "schemaName": "player",
-  "sourceHash": "/coyfq1j8qYAwzuqFo38QLrP2X7DZ/U6UJRPEiLjn7Q=",
+  "sourceHash": "HrhZPog7XXm93zb5xwYtzWspziPTFgFnvgb4UUJ85a8=",
   "explainerName": "v5",
   "entries": [
     {
@@ -21,22 +21,12 @@
         ],
         "subPhrases": [
           {
-            "text": "Can",
+            "text": "Can we",
             "category": "politeness",
             "synonyms": [
-              "Could",
-              "Would",
-              "May"
-            ],
-            "isOptional": true
-          },
-          {
-            "text": "we",
-            "category": "politeness",
-            "synonyms": [
-              "you",
-              "I",
-              "they"
+              "Could we",
+              "May we",
+              "Shall we"
             ],
             "isOptional": true
           },
@@ -83,11 +73,11 @@
           }
         ],
         "politePrefixes": [
-          "Could you please",
+          "Please",
           "Would you mind"
         ],
         "politeSuffixes": [
-          "thank you",
+          "Thank you",
           "if that's okay"
         ]
       }
@@ -114,7 +104,7 @@
             "synonyms": [
               "Could we",
               "May we",
-              "Shall we"
+              "Would we"
             ],
             "isOptional": true
           },
@@ -176,14 +166,8 @@
             ]
           }
         ],
-        "politePrefixes": [
-          "Could you please",
-          "Would you mind"
-        ],
-        "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it."
-        ]
+        "politePrefixes": [],
+        "politeSuffixes": []
       }
     },
     {
@@ -197,8 +181,7 @@
             "name": "fullActionName",
             "value": "player.previous",
             "substrings": [
-              "revisit",
-              "last song"
+              "revisit the last song"
             ]
           }
         ],
@@ -214,18 +197,21 @@
             "isOptional": true
           },
           {
-            "text": "revisit",
+            "text": "revisit the last song",
             "category": "action",
             "propertyNames": [
               "fullActionName"
             ]
           },
           {
-            "text": "the last song",
-            "category": "object",
-            "propertyNames": [
-              "fullActionName"
-            ]
+            "text": "?",
+            "category": "punctuation",
+            "synonyms": [
+              "",
+              ".",
+              "!"
+            ],
+            "isOptional": true
           }
         ],
         "propertyAlternatives": [
@@ -233,48 +219,37 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.previous",
             "propertySubPhrases": [
-              "revisit",
-              "the last song"
+              "revisit the last song"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.next",
                 "propertySubPhrases": [
-                  "skip",
-                  "to the next song"
+                  "skip to the next song"
                 ]
               },
               {
                 "propertyValue": "player.pause",
                 "propertySubPhrases": [
-                  "pause",
-                  "the music"
+                  "pause the music"
                 ]
               },
               {
                 "propertyValue": "player.play",
                 "propertySubPhrases": [
-                  "play",
-                  "the music"
-                ]
-              },
-              {
-                "propertyValue": "player.stop",
-                "propertySubPhrases": [
-                  "stop",
-                  "the music"
+                  "play the music"
                 ]
               }
             ]
           }
         ],
         "politePrefixes": [
-          "Could you please",
-          "Would you mind"
+          "Please",
+          "Kindly"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "If that's okay."
+          "Thank you",
+          "If you don't mind"
         ]
       }
     },
@@ -309,8 +284,8 @@
             "category": "filler",
             "synonyms": [
               "press the",
-              "tap the",
-              "select the"
+              "select the",
+              "choose the"
             ],
             "isOptional": true
           },
@@ -356,12 +331,6 @@
                 "propertyValue": "player.play",
                 "propertySubPhrases": [
                   "play"
-                ]
-              },
-              {
-                "propertyValue": "player.stop",
-                "propertySubPhrases": [
-                  "stop"
                 ]
               }
             ]
@@ -445,8 +414,8 @@
           "Would you mind"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it."
+          "Thank you",
+          "I would appreciate it"
         ]
       }
     },
@@ -490,13 +459,13 @@
             "synonyms": [
               "to the track",
               "to the music",
-              "to the audio"
+              "to the tune"
             ],
             "isOptional": true
           },
           {
             "text": "before this one",
-            "category": "time",
+            "category": "specification",
             "propertyNames": [
               "fullActionName"
             ]
@@ -556,7 +525,7 @@
             "name": "fullActionName",
             "value": "player.previous",
             "substrings": [
-              "previous song"
+              "previous"
             ]
           }
         ],
@@ -575,18 +544,28 @@
             "text": "take it to the",
             "category": "filler",
             "synonyms": [
-              "move it to the",
-              "switch it to the",
-              "change it to the"
+              "move to the",
+              "switch to the",
+              "change to the"
             ],
             "isOptional": true
           },
           {
-            "text": "previous song",
+            "text": "previous",
             "category": "action",
             "propertyNames": [
               "fullActionName"
             ]
+          },
+          {
+            "text": "song",
+            "category": "object",
+            "synonyms": [
+              "track",
+              "tune",
+              "music"
+            ],
+            "isOptional": true
           }
         ],
         "propertyAlternatives": [
@@ -594,31 +573,31 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.previous",
             "propertySubPhrases": [
-              "previous song"
+              "previous"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.next",
                 "propertySubPhrases": [
-                  "next song"
+                  "next"
                 ]
               },
               {
                 "propertyValue": "player.pause",
                 "propertySubPhrases": [
-                  "pause the song"
+                  "pause"
                 ]
               },
               {
                 "propertyValue": "player.play",
                 "propertySubPhrases": [
-                  "play the song"
+                  "play"
                 ]
               },
               {
                 "propertyValue": "player.stop",
                 "propertySubPhrases": [
-                  "stop the song"
+                  "stop"
                 ]
               }
             ]
@@ -629,8 +608,8 @@
           "Would you mind"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it."
+          "Thank you",
+          "I would appreciate it"
         ]
       }
     },
@@ -662,7 +641,7 @@
           },
           {
             "text": "listen to the",
-            "category": "filler",
+            "category": "preposition",
             "synonyms": [
               "play the",
               "hear the",
@@ -683,7 +662,7 @@
             "synonyms": [
               "again",
               "one more time",
-              "replay"
+              "another time"
             ],
             "isOptional": true
           }
@@ -744,22 +723,12 @@
         ],
         "subPhrases": [
           {
-            "text": "Could you",
+            "text": "Could you please",
             "category": "politeness",
             "synonyms": [
-              "Can you",
-              "Would you",
-              "Will you"
-            ],
-            "isOptional": true
-          },
-          {
-            "text": "please",
-            "category": "politeness",
-            "synonyms": [
-              "kindly",
-              "if you don't mind",
-              "if you could"
+              "Can you please",
+              "Would you mind",
+              "Please"
             ],
             "isOptional": true
           },
@@ -800,7 +769,7 @@
               {
                 "propertyValue": "player.stop",
                 "propertySubPhrases": [
-                  "stop the song"
+                  "stop the music"
                 ]
               }
             ]
@@ -821,7 +790,7 @@
             "name": "fullActionName",
             "value": "player.previous",
             "substrings": [
-              "the previous track"
+              "previous track"
             ]
           }
         ],
@@ -837,29 +806,29 @@
             "isOptional": true
           },
           {
-            "text": "put",
+            "text": "put the",
             "category": "filler",
             "synonyms": [
-              "play",
-              "start",
-              "turn on"
+              "play the",
+              "start the",
+              "turn on the"
             ],
             "isOptional": true
           },
           {
-            "text": "the previous track",
+            "text": "previous track",
             "category": "action",
             "propertyNames": [
               "fullActionName"
             ]
           },
           {
-            "text": "on",
-            "category": "preposition",
+            "text": "on?",
+            "category": "filler",
             "synonyms": [
-              "up",
-              "now",
-              "please"
+              "now?",
+              "please?",
+              "right now?"
             ],
             "isOptional": true
           }
@@ -869,31 +838,25 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.previous",
             "propertySubPhrases": [
-              "the previous track"
+              "previous track"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.next",
                 "propertySubPhrases": [
-                  "the next track"
+                  "next track"
                 ]
               },
               {
                 "propertyValue": "player.pause",
                 "propertySubPhrases": [
-                  "pause the track"
+                  "pause track"
                 ]
               },
               {
                 "propertyValue": "player.play",
                 "propertySubPhrases": [
-                  "play the track"
-                ]
-              },
-              {
-                "propertyValue": "player.stop",
-                "propertySubPhrases": [
-                  "stop the track"
+                  "play track"
                 ]
               }
             ]
@@ -955,24 +918,24 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.rewind",
+                "propertyValue": "player.next",
                 "propertySubPhrases": [
-                  "rewind",
-                  "to the song before"
+                  "skip forward",
+                  "to the next song"
                 ]
               },
               {
-                "propertyValue": "player.restart",
+                "propertyValue": "player.pause",
                 "propertySubPhrases": [
-                  "restart",
-                  "to the song before"
+                  "pause",
+                  "the song"
                 ]
               },
               {
-                "propertyValue": "player.replay",
+                "propertyValue": "player.play",
                 "propertySubPhrases": [
-                  "replay",
-                  "to the song before"
+                  "play",
+                  "the song"
                 ]
               }
             ]
@@ -1012,8 +975,8 @@
             "text": "take us",
             "category": "filler",
             "synonyms": [
-              "bring us",
               "move us",
+              "bring us",
               "shift us"
             ],
             "isOptional": true
@@ -1114,11 +1077,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If it's not too much trouble, could you",
+          "May I kindly ask you to"
         ],
         "politeSuffixes": [
-          "Thank you.",
-          "I would appreciate it."
+          "Thank you!",
+          "Thanks a lot!",
+          "I would appreciate it!",
+          "That would be great!"
         ]
       }
     },
@@ -1188,17 +1155,28 @@
                   "play button",
                   "on the player"
                 ]
+              },
+              {
+                "propertyValue": "player.stop",
+                "propertySubPhrases": [
+                  "stop button",
+                  "on the player"
+                ]
               }
             ]
           }
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If it's not too much trouble, could you",
+          "May I kindly ask you to"
         ],
         "politeSuffixes": [
-          "Thank you.",
-          "I appreciate it."
+          "Thank you!",
+          "I would appreciate it.",
+          "Thanks a lot!",
+          "That would be great."
         ]
       }
     },
@@ -1240,8 +1218,8 @@
             "category": "politeness",
             "synonyms": [
               "kindly",
-              "if you could",
-              "would you mind"
+              "if you would",
+              "if you please"
             ],
             "isOptional": true
           }
@@ -1297,8 +1275,13 @@
         "subPhrases": [
           {
             "text": "Hit the",
-            "category": "command",
-            "propertyNames": []
+            "category": "filler",
+            "synonyms": [
+              "Press the",
+              "Tap the",
+              "Click the"
+            ],
+            "isOptional": true
           },
           {
             "text": "previous track",
@@ -1309,8 +1292,13 @@
           },
           {
             "text": "button.",
-            "category": "object",
-            "propertyNames": []
+            "category": "filler",
+            "synonyms": [
+              "control",
+              "key",
+              "icon"
+            ],
+            "isOptional": true
           }
         ],
         "propertyAlternatives": [
@@ -1344,116 +1332,76 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If it's not too much trouble, could you",
+          "May I kindly ask you to"
         ],
         "politeSuffixes": [
           "Thank you.",
-          "I would appreciate it."
+          "I would appreciate it.",
+          "Thanks a lot.",
+          "That would be great."
         ]
       }
     },
     {
       "request": "I wanna listen to the last track one more time.",
       "action": {
-        "fullActionName": "player.playFromCurrentTrackList",
-        "parameters": {
-          "trackNumber": -1
-        }
+        "fullActionName": "player.previous"
       },
       "explanation": {
         "properties": [
           {
             "name": "fullActionName",
-            "value": "player.playFromCurrentTrackList",
+            "value": "player.previous",
             "substrings": [
-              "I wanna listen to"
-            ]
-          },
-          {
-            "name": "parameters.trackNumber",
-            "value": -1,
-            "substrings": [
-              "the last track"
+              "listen to the last track one more time"
             ]
           }
         ],
         "subPhrases": [
           {
-            "text": "I wanna listen to",
+            "text": "I wanna",
+            "category": "filler",
+            "synonyms": [
+              "I want to",
+              "I'd like to",
+              "I would like to"
+            ],
+            "isOptional": true
+          },
+          {
+            "text": "listen to the last track one more time",
             "category": "action",
             "propertyNames": [
               "fullActionName"
             ]
-          },
-          {
-            "text": "the last track",
-            "category": "track",
-            "propertyNames": [
-              "parameters.trackNumber"
-            ]
-          },
-          {
-            "text": "one more time",
-            "category": "repetition",
-            "synonyms": [
-              "again",
-              "once more",
-              "another time"
-            ],
-            "isOptional": true
           }
         ],
         "propertyAlternatives": [
           {
             "propertyName": "fullActionName",
-            "propertyValue": "player.playFromCurrentTrackList",
+            "propertyValue": "player.previous",
             "propertySubPhrases": [
-              "I wanna listen to"
+              "listen to the last track one more time"
             ],
             "alternatives": [
               {
-                "propertyValue": "player.playNextTrack",
+                "propertyValue": "player.next",
                 "propertySubPhrases": [
-                  "Play the next track"
+                  "listen to the next track"
                 ]
               },
               {
-                "propertyValue": "player.playPreviousTrack",
+                "propertyValue": "player.pause",
                 "propertySubPhrases": [
-                  "Play the previous track"
+                  "pause the track"
                 ]
               },
               {
-                "propertyValue": "player.playSpecificTrack",
+                "propertyValue": "player.play",
                 "propertySubPhrases": [
-                  "Play a specific track"
-                ]
-              }
-            ]
-          },
-          {
-            "propertyName": "parameters.trackNumber",
-            "propertyValue": -1,
-            "propertySubPhrases": [
-              "the last track"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": 1,
-                "propertySubPhrases": [
-                  "the first track"
-                ]
-              },
-              {
-                "propertyValue": 2,
-                "propertySubPhrases": [
-                  "the second track"
-                ]
-              },
-              {
-                "propertyValue": 3,
-                "propertySubPhrases": [
-                  "the third track"
+                  "play the track"
                 ]
               }
             ]
@@ -1491,7 +1439,7 @@
             "synonyms": [
               "I'd like to",
               "I would like to",
-              "Please"
+              "Can you"
             ],
             "isOptional": true
           },
@@ -1535,14 +1483,14 @@
         "politePrefixes": [
           "Could you please",
           "Would you mind",
-          "If it's not too much trouble, could you",
+          "If it's not too much trouble,",
           "May I kindly ask you to"
         ],
         "politeSuffixes": [
-          "thank you.",
-          "please.",
-          "if you don't mind.",
-          "thanks a lot."
+          "Thank you.",
+          "I would appreciate it.",
+          "Thanks a lot.",
+          "That would be great."
         ]
       }
     },
@@ -1568,7 +1516,7 @@
             "synonyms": [
               "please",
               "kindly",
-              "would you mind"
+              "it would be great if"
             ],
             "isOptional": true
           },
@@ -1585,7 +1533,7 @@
             "synonyms": [
               "once more",
               "one more time",
-              "repeat"
+              "replay"
             ],
             "isOptional": true
           }
@@ -1640,8 +1588,7 @@
             "name": "fullActionName",
             "value": "player.previous",
             "substrings": [
-              "go back",
-              "last track"
+              "go back to the last track"
             ]
           }
         ],
@@ -1657,14 +1604,7 @@
             "isOptional": true
           },
           {
-            "text": "go back",
-            "category": "action",
-            "propertyNames": [
-              "fullActionName"
-            ]
-          },
-          {
-            "text": "to the last track",
+            "text": "go back to the last track",
             "category": "action",
             "propertyNames": [
               "fullActionName"
@@ -1675,8 +1615,8 @@
             "category": "politeness",
             "synonyms": [
               "kindly",
-              "if you please",
-              "if you would be so kind"
+              "if you don't mind",
+              "if you please"
             ],
             "isOptional": true
           }
@@ -1686,36 +1626,25 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.previous",
             "propertySubPhrases": [
-              "go back",
-              "to the last track"
+              "go back to the last track"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.next",
                 "propertySubPhrases": [
-                  "skip forward",
-                  "to the next track"
+                  "skip to the next track"
                 ]
               },
               {
                 "propertyValue": "player.pause",
                 "propertySubPhrases": [
-                  "pause",
-                  "the music"
+                  "pause the music"
                 ]
               },
               {
                 "propertyValue": "player.play",
                 "propertySubPhrases": [
-                  "play",
-                  "the music"
-                ]
-              },
-              {
-                "propertyValue": "player.stop",
-                "propertySubPhrases": [
-                  "stop",
-                  "the music"
+                  "play the music"
                 ]
               }
             ]
@@ -1743,8 +1672,13 @@
         "subPhrases": [
           {
             "text": "I'd like to hear",
-            "category": "request",
-            "propertyNames": []
+            "category": "politeness",
+            "synonyms": [
+              "I want to hear",
+              "I would like to hear",
+              "Can I hear"
+            ],
+            "isOptional": true
           },
           {
             "text": "the previous song",
@@ -1755,8 +1689,13 @@
           },
           {
             "text": "once more",
-            "category": "repetition",
-            "propertyNames": []
+            "category": "confirmation",
+            "synonyms": [
+              "again",
+              "one more time",
+              "repeat"
+            ],
+            "isOptional": true
           }
         ],
         "propertyAlternatives": [
@@ -1883,7 +1822,7 @@
             "value": "player.previous",
             "substrings": [
               "backtrack",
-              "previous song"
+              "previous"
             ]
           }
         ],
@@ -1910,17 +1849,27 @@
             "category": "preposition",
             "synonyms": [
               "towards the",
-              "heading to",
-              "moving to"
+              "back to the",
+              "return to the"
             ],
             "isOptional": true
           },
           {
-            "text": "previous song",
-            "category": "target",
+            "text": "previous",
+            "category": "descriptor",
             "propertyNames": [
               "fullActionName"
             ]
+          },
+          {
+            "text": "song",
+            "category": "object",
+            "synonyms": [
+              "track",
+              "tune",
+              "music"
+            ],
+            "isOptional": true
           }
         ],
         "propertyAlternatives": [
@@ -1929,35 +1878,28 @@
             "propertyValue": "player.previous",
             "propertySubPhrases": [
               "backtrack",
-              "previous song"
+              "previous"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.next",
                 "propertySubPhrases": [
                   "skip",
-                  "next song"
+                  "next"
                 ]
               },
               {
                 "propertyValue": "player.pause",
                 "propertySubPhrases": [
                   "pause",
-                  "the music"
+                  "current"
                 ]
               },
               {
                 "propertyValue": "player.play",
                 "propertySubPhrases": [
                   "play",
-                  "the song"
-                ]
-              },
-              {
-                "propertyValue": "player.stop",
-                "propertySubPhrases": [
-                  "stop",
-                  "the music"
+                  "current"
                 ]
               }
             ]
@@ -1965,15 +1907,11 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind",
-          "If it's not too much trouble, could you",
-          "May I kindly ask you to"
+          "Would you mind"
         ],
         "politeSuffixes": [
-          "thank you.",
-          "please.",
-          "if you don't mind.",
-          "thanks a lot."
+          "Thank you.",
+          "I appreciate it."
         ]
       }
     },
@@ -2046,21 +1984,30 @@
                 "propertyValue": "player.play",
                 "propertySubPhrases": [
                   "play",
-                  "the current song"
+                  "the music"
+                ]
+              },
+              {
+                "propertyValue": "player.stop",
+                "propertySubPhrases": [
+                  "stop",
+                  "the music"
                 ]
               }
             ]
           }
         ],
         "politePrefixes": [
-          "Could you please",
-          "Would you mind",
-          "If it's not too much trouble, could you"
+          "Could we please",
+          "Would you mind if we",
+          "If it's not too much trouble, let's",
+          "May I kindly ask you to"
         ],
         "politeSuffixes": [
           "Thank you!",
-          "I would appreciate it.",
-          "Thanks a lot!"
+          "Thanks a lot!",
+          "I appreciate it!",
+          "Much appreciated!"
         ]
       }
     },
@@ -2121,38 +2068,40 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.rewind",
+                "propertyValue": "player.next",
                 "propertySubPhrases": [
-                  "rewind",
-                  "before"
+                  "skip ahead",
+                  "next"
                 ]
               },
               {
-                "propertyValue": "player.replay",
+                "propertyValue": "player.pause",
                 "propertySubPhrases": [
-                  "replay",
-                  "before"
+                  "pause",
+                  "stop"
                 ]
               },
               {
-                "propertyValue": "player.restart",
+                "propertyValue": "player.play",
                 "propertySubPhrases": [
-                  "restart",
-                  "before"
+                  "play",
+                  "start"
                 ]
               }
             ]
           }
         ],
         "politePrefixes": [
-          "Could you please",
-          "Would you mind",
-          "If it's not too much trouble, could you"
+          "Could we please",
+          "Would you mind if we",
+          "May we kindly",
+          "If it's not too much trouble, could we"
         ],
         "politeSuffixes": [
-          "thank you",
-          "please",
-          "if you don't mind"
+          "thank you.",
+          "please.",
+          "if you don't mind.",
+          "thanks a lot."
         ]
       }
     },
@@ -2220,14 +2169,12 @@
           }
         ],
         "politePrefixes": [
-          "Could you please",
-          "Would you mind",
-          "If it's not too much trouble, could you"
+          "Could we please",
+          "Would you mind if we"
         ],
         "politeSuffixes": [
-          "thank you",
-          "please",
-          "if you don't mind"
+          "Thank you!",
+          "I would appreciate it."
         ]
       }
     },
@@ -2242,18 +2189,18 @@
             "name": "fullActionName",
             "value": "player.previous",
             "substrings": [
-              "preceding"
+              "the preceding song"
             ]
           }
         ],
         "subPhrases": [
           {
             "text": "Let's",
-            "category": "filler",
+            "category": "politeness",
             "synonyms": [
               "Let us",
-              "We should",
-              "How about"
+              "Allow us to",
+              "We should"
             ],
             "isOptional": true
           },
@@ -2317,13 +2264,11 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind",
-          "If it's not too much trouble, could you"
+          "Would you mind"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it.",
-          "Thanks a lot!"
+          "Thank you.",
+          "I would appreciate it."
         ]
       }
     },
@@ -2380,7 +2325,7 @@
               {
                 "propertyValue": "player.next",
                 "propertySubPhrases": [
-                  "skip ahead",
+                  "skip forward",
                   "one track"
                 ]
               },
@@ -2388,94 +2333,14 @@
                 "propertyValue": "player.pause",
                 "propertySubPhrases": [
                   "pause",
-                  "the music"
+                  "the track"
                 ]
               },
               {
                 "propertyValue": "player.play",
                 "propertySubPhrases": [
                   "play",
-                  "the music"
-                ]
-              },
-              {
-                "propertyValue": "player.stop",
-                "propertySubPhrases": [
-                  "stop",
-                  "the music"
-                ]
-              }
-            ]
-          }
-        ],
-        "politePrefixes": [
-          "Could you please",
-          "Would you mind"
-        ],
-        "politeSuffixes": [
-          "thank you",
-          "if that's okay"
-        ]
-      }
-    },
-    {
-      "request": "Let's replay the song that was on before this one.",
-      "action": {
-        "fullActionName": "player.previous"
-      },
-      "explanation": {
-        "properties": [
-          {
-            "name": "fullActionName",
-            "value": "player.previous",
-            "substrings": [
-              "replay the song that was on before this one"
-            ]
-          }
-        ],
-        "subPhrases": [
-          {
-            "text": "Let's",
-            "category": "politeness",
-            "synonyms": [
-              "Let us",
-              "We should",
-              "How about we"
-            ],
-            "isOptional": true
-          },
-          {
-            "text": "replay the song that was on before this one",
-            "category": "action",
-            "propertyNames": [
-              "fullActionName"
-            ]
-          }
-        ],
-        "propertyAlternatives": [
-          {
-            "propertyName": "fullActionName",
-            "propertyValue": "player.previous",
-            "propertySubPhrases": [
-              "replay the song that was on before this one"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "player.next",
-                "propertySubPhrases": [
-                  "play the next song"
-                ]
-              },
-              {
-                "propertyValue": "player.pause",
-                "propertySubPhrases": [
-                  "pause the song"
-                ]
-              },
-              {
-                "propertyValue": "player.stop",
-                "propertySubPhrases": [
-                  "stop the music"
+                  "the track"
                 ]
               }
             ]
@@ -2490,6 +2355,194 @@
           "I would appreciate it."
         ]
       }
+    },
+    {
+      "request": "Let's replay the song that was on before this one.",
+      "action": {
+        "fullActionName": "player.previous"
+      },
+      "explanation": {
+        "properties": [
+          {
+            "name": "fullActionName",
+            "value": "player.previous",
+            "substrings": [
+              "replay",
+              "before this one"
+            ]
+          }
+        ],
+        "subPhrases": [
+          {
+            "text": "Let's",
+            "category": "filler",
+            "synonyms": [
+              "Let us",
+              "We should",
+              "How about"
+            ],
+            "isOptional": true
+          },
+          {
+            "text": "replay",
+            "category": "action",
+            "propertyNames": [
+              "fullActionName"
+            ]
+          },
+          {
+            "text": "the song that was on",
+            "category": "object",
+            "propertyNames": [
+              "fullActionName"
+            ]
+          },
+          {
+            "text": "before this one",
+            "category": "time",
+            "propertyNames": [
+              "fullActionName"
+            ]
+          }
+        ],
+        "propertyAlternatives": [
+          {
+            "propertyName": "fullActionName",
+            "propertyValue": "player.previous",
+            "propertySubPhrases": [
+              "replay",
+              "the song that was on",
+              "before this one"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "player.replay",
+                "propertySubPhrases": [
+                  "replay",
+                  "the song that was on",
+                  "again"
+                ]
+              },
+              {
+                "propertyValue": "player.restart",
+                "propertySubPhrases": [
+                  "restart",
+                  "the song that was on",
+                  "from the beginning"
+                ]
+              },
+              {
+                "propertyValue": "player.repeat",
+                "propertySubPhrases": [
+                  "repeat",
+                  "the song that was on",
+                  "once more"
+                ]
+              }
+            ]
+          }
+        ],
+        "politePrefixes": [
+          "Could you please",
+          "Would you mind",
+          "If it's not too much trouble,",
+          "May I kindly ask you to"
+        ],
+        "politeSuffixes": [
+          "Thank you.",
+          "I would appreciate it.",
+          "Thanks a lot.",
+          "Much appreciated."
+        ]
+      },
+      "corrections": [
+        {
+          "data": {
+            "properties": [
+              {
+                "name": "fullActionName",
+                "value": "player.previous",
+                "substrings": [
+                  "replay",
+                  "before this one"
+                ]
+              }
+            ],
+            "subPhrases": [
+              {
+                "text": "Let's",
+                "category": "filler",
+                "synonyms": [
+                  "Let us",
+                  "We should",
+                  "How about"
+                ],
+                "isOptional": true
+              },
+              {
+                "text": "replay",
+                "category": "action",
+                "propertyNames": [
+                  "fullActionName"
+                ]
+              },
+              {
+                "text": "the song that was on",
+                "category": "object",
+                "propertyNames": [
+                  "fullActionName"
+                ]
+              },
+              {
+                "text": "before this one",
+                "category": "time",
+                "propertyNames": [
+                  "fullActionName"
+                ]
+              }
+            ],
+            "propertyAlternatives": [
+              {
+                "propertyName": "fullActionName",
+                "propertyValue": "player.previous",
+                "propertySubPhrases": [
+                  "replay",
+                  "the song that was on",
+                  "before this one"
+                ],
+                "alternatives": [
+                  {
+                    "propertyValue": "player.replay",
+                    "propertySubPhrases": [
+                      "replay",
+                      "the song"
+                    ]
+                  },
+                  {
+                    "propertyValue": "player.restart",
+                    "propertySubPhrases": [
+                      "restart",
+                      "the song"
+                    ]
+                  },
+                  {
+                    "propertyValue": "player.repeat",
+                    "propertySubPhrases": [
+                      "repeat",
+                      "the song"
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          "correction": [
+            "Mismatch number of sub-phrases: alternatives value 'player.replay' for property 'fullActionName' must have 3 sub-phrases",
+            "Mismatch number of sub-phrases: alternatives value 'player.restart' for property 'fullActionName' must have 3 sub-phrases",
+            "Mismatch number of sub-phrases: alternatives value 'player.repeat' for property 'fullActionName' must have 3 sub-phrases"
+          ]
+        }
+      ]
     },
     {
       "request": "Let's return to the last track.",
@@ -2509,7 +2562,7 @@
         "subPhrases": [
           {
             "text": "Let's",
-            "category": "filler",
+            "category": "politeness",
             "synonyms": [
               "Let us",
               "We should",
@@ -2550,16 +2603,26 @@
                 "propertySubPhrases": [
                   "play the track"
                 ]
+              },
+              {
+                "propertyValue": "player.stop",
+                "propertySubPhrases": [
+                  "stop the track"
+                ]
               }
             ]
           }
         ],
         "politePrefixes": [
           "Could we please",
-          "Would you mind if we"
+          "Would you mind if we",
+          "May we kindly",
+          "If it's not too much trouble, let's"
         ],
         "politeSuffixes": [
           "Thank you.",
+          "Please.",
+          "Thanks a lot.",
           "I would appreciate it."
         ]
       }
@@ -2582,11 +2645,11 @@
         "subPhrases": [
           {
             "text": "Let's",
-            "category": "filler",
+            "category": "politeness",
             "synonyms": [
               "Let us",
               "We should",
-              "How about"
+              "How about we"
             ],
             "isOptional": true
           },
@@ -2632,7 +2695,7 @@
           "Would you mind"
         ],
         "politeSuffixes": [
-          "Thank you.",
+          "Thank you!",
           "I would appreciate it."
         ]
       }
@@ -2701,7 +2764,7 @@
                 "propertySubPhrases": [
                   "skip",
                   "the track",
-                  "after this one"
+                  "to the next one"
                 ]
               },
               {
@@ -2709,7 +2772,7 @@
                 "propertySubPhrases": [
                   "pause",
                   "the track",
-                  "currently playing"
+                  "right now"
                 ]
               },
               {
@@ -2717,7 +2780,15 @@
                 "propertySubPhrases": [
                   "play",
                   "the track",
-                  "currently paused"
+                  "from the beginning"
+                ]
+              },
+              {
+                "propertyValue": "player.stop",
+                "propertySubPhrases": [
+                  "stop",
+                  "the track",
+                  "immediately"
                 ]
               }
             ]
@@ -2728,8 +2799,8 @@
           "Would you mind if we"
         ],
         "politeSuffixes": [
-          "if that's okay with you?",
-          "please?"
+          "Thank you!",
+          "I would appreciate it."
         ]
       }
     },
@@ -2810,15 +2881,11 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind",
-          "If it's not too much trouble,",
-          "May I kindly ask you to"
+          "Would you mind"
         ],
         "politeSuffixes": [
           "Thank you!",
-          "I would appreciate it.",
-          "Thanks a lot!",
-          "That would be great!"
+          "I would appreciate it."
         ]
       }
     },
@@ -2883,13 +2950,13 @@
               {
                 "propertyValue": "player.pause",
                 "propertySubPhrases": [
-                  "pause song"
+                  "pause the song"
                 ]
               },
               {
                 "propertyValue": "player.play",
                 "propertySubPhrases": [
-                  "play song"
+                  "play the song"
                 ]
               }
             ]
@@ -2940,31 +3007,11 @@
             ]
           },
           {
-            "text": "to the",
-            "category": "preposition",
-            "synonyms": [
-              "towards the",
-              "back to",
-              "return to"
-            ],
-            "isOptional": true
-          },
-          {
-            "text": "previous",
-            "category": "action",
+            "text": "to the previous song",
+            "category": "target",
             "propertyNames": [
               "fullActionName"
             ]
-          },
-          {
-            "text": "song",
-            "category": "object",
-            "synonyms": [
-              "track",
-              "tune",
-              "music"
-            ],
-            "isOptional": true
           }
         ],
         "propertyAlternatives": [
@@ -2973,28 +3020,28 @@
             "propertyValue": "player.previous",
             "propertySubPhrases": [
               "reversing",
-              "previous"
+              "to the previous song"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.next",
                 "propertySubPhrases": [
                   "advancing",
-                  "next"
+                  "to the next song"
                 ]
               },
               {
                 "propertyValue": "player.pause",
                 "propertySubPhrases": [
                   "pausing",
-                  "current"
+                  "the current song"
                 ]
               },
               {
                 "propertyValue": "player.play",
                 "propertySubPhrases": [
                   "playing",
-                  "current"
+                  "the current song"
                 ]
               }
             ]
@@ -3034,7 +3081,7 @@
             ]
           },
           {
-            "text": "the last song again",
+            "text": "the last song again.",
             "category": "object",
             "propertyNames": [
               "fullActionName"
@@ -3047,35 +3094,35 @@
             "propertyValue": "player.previous",
             "propertySubPhrases": [
               "Play",
-              "the last song again"
+              "the last song again."
             ],
             "alternatives": [
               {
                 "propertyValue": "player.next",
                 "propertySubPhrases": [
                   "Play",
-                  "the next song"
+                  "the next song."
                 ]
               },
               {
                 "propertyValue": "player.pause",
                 "propertySubPhrases": [
                   "Pause",
-                  "the song"
+                  "the song."
                 ]
               },
               {
                 "propertyValue": "player.stop",
                 "propertySubPhrases": [
                   "Stop",
-                  "the song"
+                  "the song."
                 ]
               },
               {
                 "propertyValue": "player.shuffle",
                 "propertySubPhrases": [
                   "Shuffle",
-                  "the playlist"
+                  "the playlist."
                 ]
               }
             ]
@@ -3083,11 +3130,13 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If it's not too much trouble, could you"
         ],
         "politeSuffixes": [
-          "Thank you",
-          "Thanks a lot"
+          "Thank you!",
+          "Thanks a lot!",
+          "I would appreciate it!"
         ]
       }
     },
@@ -3113,19 +3162,29 @@
             "propertyNames": []
           },
           {
-            "text": "the preceding track",
-            "category": "property",
+            "text": "the",
+            "category": "preposition",
+            "synonyms": [
+              "a",
+              "this",
+              "that"
+            ],
+            "isOptional": true
+          },
+          {
+            "text": "preceding track",
+            "category": "content",
             "propertyNames": [
               "fullActionName"
             ]
           },
           {
             "text": "once more",
-            "category": "filler",
+            "category": "repetition",
             "synonyms": [
               "again",
               "one more time",
-              "repeat"
+              "another time"
             ],
             "isOptional": true
           }
@@ -3135,25 +3194,31 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.previous",
             "propertySubPhrases": [
-              "the preceding track"
+              "preceding track"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.next",
                 "propertySubPhrases": [
-                  "the next track"
+                  "next track"
                 ]
               },
               {
                 "propertyValue": "player.pause",
                 "propertySubPhrases": [
-                  "pause the track"
+                  "pause"
                 ]
               },
               {
                 "propertyValue": "player.stop",
                 "propertySubPhrases": [
-                  "stop the track"
+                  "stop"
+                ]
+              },
+              {
+                "propertyValue": "player.play",
+                "propertySubPhrases": [
+                  "play"
                 ]
               }
             ]
@@ -3161,11 +3226,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If it's not too much trouble, could you",
+          "May I kindly ask you to"
         ],
         "politeSuffixes": [
-          "Thank you.",
-          "I would appreciate it."
+          "Thank you!",
+          "I would appreciate it.",
+          "Thanks a lot!",
+          "That would be great, thanks!"
         ]
       }
     },
@@ -3264,7 +3333,7 @@
         "subPhrases": [
           {
             "text": "Previous song",
-            "category": "action",
+            "category": "command",
             "propertyNames": [
               "fullActionName"
             ]
@@ -3274,7 +3343,7 @@
             "category": "politeness",
             "synonyms": [
               "please",
-              "if it's not too much trouble",
+              "if it's okay",
               "if you could"
             ],
             "isOptional": true
@@ -3297,13 +3366,13 @@
               {
                 "propertyValue": "player.pause",
                 "propertySubPhrases": [
-                  "Pause the song"
+                  "Pause the music"
                 ]
               },
               {
                 "propertyValue": "player.play",
                 "propertySubPhrases": [
-                  "Play the song"
+                  "Play the music"
                 ]
               }
             ]
@@ -3341,7 +3410,7 @@
             "category": "politeness",
             "synonyms": [
               "kindly",
-              "if you could",
+              "if you don't mind",
               "would you mind"
             ],
             "isOptional": true
@@ -3408,8 +3477,8 @@
             "category": "politeness",
             "synonyms": [
               "if you don't mind",
-              "if possible",
-              "if it's alright"
+              "if that's alright",
+              "if that's acceptable"
             ],
             "isOptional": true
           }
@@ -3465,7 +3534,7 @@
         "subPhrases": [
           {
             "text": "Previous track",
-            "category": "action",
+            "category": "command",
             "propertyNames": [
               "fullActionName"
             ]
@@ -3536,7 +3605,17 @@
             "propertyNames": []
           },
           {
-            "text": "the previous track",
+            "text": "the",
+            "category": "preposition",
+            "synonyms": [
+              "a",
+              "this",
+              "that"
+            ],
+            "isOptional": true
+          },
+          {
+            "text": "previous track",
             "category": "property",
             "propertyNames": [
               "fullActionName"
@@ -3545,7 +3624,12 @@
           {
             "text": "again",
             "category": "repetition",
-            "propertyNames": []
+            "synonyms": [
+              "once more",
+              "another time",
+              "one more time"
+            ],
+            "isOptional": true
           }
         ],
         "propertyAlternatives": [
@@ -3553,31 +3637,25 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.previous",
             "propertySubPhrases": [
-              "the previous track"
+              "previous track"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.next",
                 "propertySubPhrases": [
-                  "the next track"
+                  "next track"
                 ]
               },
               {
                 "propertyValue": "player.pause",
                 "propertySubPhrases": [
-                  "pause the track"
+                  "pause track"
                 ]
               },
               {
                 "propertyValue": "player.play",
                 "propertySubPhrases": [
-                  "play the track"
-                ]
-              },
-              {
-                "propertyValue": "player.stop",
-                "propertySubPhrases": [
-                  "stop the track"
+                  "play track"
                 ]
               }
             ]
@@ -3585,11 +3663,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If it's not too much trouble,",
+          "May I kindly ask you to"
         ],
         "politeSuffixes": [
-          "Thank you.",
-          "I appreciate it."
+          "thank you.",
+          "please.",
+          "if you don't mind.",
+          "thanks a lot."
         ]
       }
     },
@@ -3611,7 +3693,7 @@
         "subPhrases": [
           {
             "text": "Rewind to the last track.",
-            "category": "action",
+            "category": "command",
             "propertyNames": [
               "fullActionName"
             ]
@@ -3667,14 +3749,32 @@
             "name": "fullActionName",
             "value": "player.previous",
             "substrings": [
-              "Skip back to the former track"
+              "Skip back",
+              "former track"
             ]
           }
         ],
         "subPhrases": [
           {
-            "text": "Skip back to the former track",
-            "category": "action",
+            "text": "Skip back",
+            "category": "command",
+            "propertyNames": [
+              "fullActionName"
+            ]
+          },
+          {
+            "text": "to the",
+            "category": "preposition",
+            "synonyms": [
+              "towards the",
+              "in the direction of the",
+              "heading to the"
+            ],
+            "isOptional": true
+          },
+          {
+            "text": "former track",
+            "category": "object",
             "propertyNames": [
               "fullActionName"
             ]
@@ -3695,25 +3795,29 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.previous",
             "propertySubPhrases": [
-              "Skip back to the former track"
+              "Skip back",
+              "former track"
             ],
             "alternatives": [
               {
-                "propertyValue": "player.next",
+                "propertyValue": "player.rewind",
                 "propertySubPhrases": [
-                  "Skip to the next track"
+                  "Rewind",
+                  "to the previous track"
                 ]
               },
               {
-                "propertyValue": "player.pause",
+                "propertyValue": "player.restart",
                 "propertySubPhrases": [
-                  "Pause the track"
+                  "Restart",
+                  "the current track"
                 ]
               },
               {
-                "propertyValue": "player.play",
+                "propertyValue": "player.back",
                 "propertySubPhrases": [
-                  "Play the track"
+                  "Go back",
+                  "to the last track"
                 ]
               }
             ]
@@ -3775,7 +3879,7 @@
               {
                 "propertyValue": "player.replay",
                 "propertySubPhrases": [
-                  "Replay the track"
+                  "Play it again"
                 ]
               }
             ]
@@ -3809,8 +3913,13 @@
         "subPhrases": [
           {
             "text": "Take us to the",
-            "category": "command",
-            "propertyNames": []
+            "category": "filler",
+            "synonyms": [
+              "Bring us to the",
+              "Move us to the",
+              "Navigate to the"
+            ],
+            "isOptional": true
           },
           {
             "text": "previous song",
@@ -3820,12 +3929,12 @@
             ]
           },
           {
-            "text": "would you",
+            "text": "would you?",
             "category": "politeness",
             "synonyms": [
               "please",
-              "kindly",
-              "if you could"
+              "if you don't mind",
+              "could you?"
             ],
             "isOptional": true
           }
@@ -3999,7 +4108,7 @@
         ],
         "politeSuffixes": [
           "Thank you",
-          "Please"
+          "I appreciate it"
         ]
       }
     },
@@ -4014,7 +4123,7 @@
             "name": "fullActionName",
             "value": "player.previous",
             "substrings": [
-              "last track"
+              "throw that last track on again"
             ]
           }
         ],
@@ -4030,31 +4139,11 @@
             "isOptional": true
           },
           {
-            "text": "throw that",
-            "category": "filler",
-            "synonyms": [
-              "play",
-              "put on",
-              "start"
-            ],
-            "isOptional": true
-          },
-          {
-            "text": "last track",
-            "category": "action",
+            "text": "throw that last track on again",
+            "category": "command",
             "propertyNames": [
               "fullActionName"
             ]
-          },
-          {
-            "text": "on again",
-            "category": "confirmation",
-            "synonyms": [
-              "once more",
-              "repeat",
-              "replay"
-            ],
-            "isOptional": true
           }
         ],
         "propertyAlternatives": [
@@ -4062,25 +4151,25 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.previous",
             "propertySubPhrases": [
-              "last track"
+              "throw that last track on again"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.next",
                 "propertySubPhrases": [
-                  "next track"
+                  "play the next track"
                 ]
               },
               {
                 "propertyValue": "player.pause",
                 "propertySubPhrases": [
-                  "pause"
+                  "pause the music"
                 ]
               },
               {
                 "propertyValue": "player.play",
                 "propertySubPhrases": [
-                  "play"
+                  "start playing music"
                 ]
               }
             ]
@@ -4092,7 +4181,7 @@
         ],
         "politeSuffixes": [
           "Thank you",
-          "if that's okay"
+          "I would appreciate it"
         ]
       }
     }

--- a/ts/packages/dispatcher/test/data/player/v5/resumeAction.json
+++ b/ts/packages/dispatcher/test/data/player/v5/resumeAction.json
@@ -1,7 +1,7 @@
 {
   "version": 2,
   "schemaName": "player",
-  "sourceHash": "/coyfq1j8qYAwzuqFo38QLrP2X7DZ/U6UJRPEiLjn7Q=",
+  "sourceHash": "HrhZPog7XXm93zb5xwYtzWspziPTFgFnvgb4UUJ85a8=",
   "explainerName": "v5",
   "entries": [
     {
@@ -15,21 +15,30 @@
             "name": "fullActionName",
             "value": "player.resume",
             "substrings": [
-              "Activate the sound once more."
+              "Activate",
+              "the sound",
+              "once more"
             ]
           }
         ],
         "subPhrases": [
           {
-            "text": "Activate the sound",
-            "category": "command",
+            "text": "Activate",
+            "category": "action",
+            "propertyNames": [
+              "fullActionName"
+            ]
+          },
+          {
+            "text": "the sound",
+            "category": "object",
             "propertyNames": [
               "fullActionName"
             ]
           },
           {
             "text": "once more",
-            "category": "frequency",
+            "category": "time",
             "propertyNames": [
               "fullActionName"
             ]
@@ -40,29 +49,33 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.resume",
             "propertySubPhrases": [
-              "Activate the sound",
+              "Activate",
+              "the sound",
               "once more"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.play",
                 "propertySubPhrases": [
-                  "Start the sound",
+                  "Start",
+                  "the sound",
                   "again"
                 ]
               },
               {
                 "propertyValue": "player.unpause",
                 "propertySubPhrases": [
-                  "Unpause the sound",
-                  "one more time"
+                  "Unpause",
+                  "the audio",
+                  "again"
                 ]
               },
               {
                 "propertyValue": "player.continue",
                 "propertySubPhrases": [
-                  "Continue the sound",
-                  "once again"
+                  "Continue",
+                  "the music",
+                  "once more"
                 ]
               }
             ]
@@ -95,15 +108,8 @@
         ],
         "subPhrases": [
           {
-            "text": "Bring back the",
+            "text": "Bring back the beats.",
             "category": "command",
-            "propertyNames": [
-              "fullActionName"
-            ]
-          },
-          {
-            "text": "beats.",
-            "category": "object",
             "propertyNames": [
               "fullActionName"
             ]
@@ -114,29 +120,25 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.playRandom",
             "propertySubPhrases": [
-              "Bring back the",
-              "beats."
+              "Bring back the beats."
             ],
             "alternatives": [
               {
                 "propertyValue": "player.play",
                 "propertySubPhrases": [
-                  "Play the",
-                  "beats."
+                  "Play the music."
                 ]
               },
               {
                 "propertyValue": "player.resume",
                 "propertySubPhrases": [
-                  "Resume the",
-                  "beats."
+                  "Resume the music."
                 ]
               },
               {
                 "propertyValue": "player.shuffle",
                 "propertySubPhrases": [
-                  "Shuffle the",
-                  "beats."
+                  "Shuffle the tracks."
                 ]
               }
             ]
@@ -144,15 +146,11 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind",
-          "If it's not too much trouble, could you",
-          "May I kindly ask you to"
+          "Would you mind"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it.",
-          "Thanks a lot!",
-          "That would be great."
+          "Thank you.",
+          "I would appreciate it."
         ]
       }
     },
@@ -173,12 +171,22 @@
         ],
         "subPhrases": [
           {
-            "text": "Can we",
-            "category": "politeness",
+            "text": "Can",
+            "category": "confirmation",
             "synonyms": [
-              "Could we",
-              "Shall we",
-              "May we"
+              "Could",
+              "Would",
+              "Will"
+            ],
+            "isOptional": true
+          },
+          {
+            "text": "we",
+            "category": "filler",
+            "synonyms": [
+              "us",
+              "I",
+              "you"
             ],
             "isOptional": true
           },
@@ -211,31 +219,29 @@
               {
                 "propertyValue": "player.play",
                 "propertySubPhrases": [
+                  "play"
+                ]
+              },
+              {
+                "propertyValue": "player.start",
+                "propertySubPhrases": [
                   "start"
                 ]
               },
               {
-                "propertyValue": "player.pause",
+                "propertyValue": "player.begin",
                 "propertySubPhrases": [
-                  "pause"
-                ]
-              },
-              {
-                "propertyValue": "player.stop",
-                "propertySubPhrases": [
-                  "stop"
+                  "begin"
                 ]
               }
             ]
           }
         ],
         "politePrefixes": [
-          "Please",
-          "Kindly"
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you",
-          "If you don't mind"
+          "Thank you"
         ]
       }
     },
@@ -261,7 +267,7 @@
             "synonyms": [
               "Could",
               "Would",
-              "May"
+              "Will"
             ],
             "isOptional": true
           },
@@ -303,12 +309,10 @@
           }
         ],
         "politePrefixes": [
-          "Please",
-          "Kindly"
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you",
-          "Much appreciated"
+          "Thank you"
         ]
       }
     },
@@ -388,9 +392,9 @@
                 ]
               },
               {
-                "propertyValue": "player.continue",
+                "propertyValue": "player.unpause",
                 "propertySubPhrases": [
-                  "continue",
+                  "unpause",
                   "the tracks"
                 ]
               }
@@ -466,12 +470,6 @@
                 "propertySubPhrases": [
                   "continue the music"
                 ]
-              },
-              {
-                "propertyValue": "player.unpause",
-                "propertySubPhrases": [
-                  "unpause the music"
-                ]
               }
             ]
           }
@@ -533,32 +531,22 @@
                 ]
               },
               {
-                "propertyValue": "player.start",
+                "propertyValue": "player.stop",
                 "propertySubPhrases": [
-                  "start the music"
+                  "stop the music"
                 ]
               },
               {
-                "propertyValue": "player.replay",
+                "propertyValue": "player.pause",
                 "propertySubPhrases": [
-                  "replay the music"
-                ]
-              },
-              {
-                "propertyValue": "player.continue",
-                "propertySubPhrases": [
-                  "continue the music"
+                  "pause the music"
                 ]
               }
             ]
           }
         ],
-        "politePrefixes": [
-          "Please"
-        ],
-        "politeSuffixes": [
-          "Thank you"
-        ]
+        "politePrefixes": [],
+        "politeSuffixes": []
       }
     },
     {
@@ -624,14 +612,8 @@
             ]
           }
         ],
-        "politePrefixes": [
-          "Could you please",
-          "Would you mind"
-        ],
-        "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it."
-        ]
+        "politePrefixes": [],
+        "politeSuffixes": []
       }
     },
     {
@@ -670,12 +652,7 @@
           {
             "text": "tunes",
             "category": "object",
-            "synonyms": [
-              "music",
-              "songs",
-              "tracks"
-            ],
-            "isOptional": true
+            "propertyNames": []
           }
         ],
         "propertyAlternatives": [
@@ -693,15 +670,15 @@
                 ]
               },
               {
-                "propertyValue": "player.pause",
+                "propertyValue": "player.replay",
                 "propertySubPhrases": [
-                  "Pause"
+                  "Replay"
                 ]
               },
               {
-                "propertyValue": "player.stop",
+                "propertyValue": "player.continue",
                 "propertySubPhrases": [
-                  "Stop playing"
+                  "Keep playing"
                 ]
               }
             ]
@@ -713,7 +690,7 @@
         ],
         "politeSuffixes": [
           "Thank you.",
-          "I would appreciate it."
+          "I appreciate it."
         ]
       }
     },
@@ -777,9 +754,9 @@
                 ]
               },
               {
-                "propertyValue": "player.begin",
+                "propertyValue": "player.unpause",
                 "propertySubPhrases": [
-                  "Begin"
+                  "Unpause"
                 ]
               }
             ]
@@ -910,9 +887,9 @@
                 ]
               },
               {
-                "propertyValue": "player.restart",
+                "propertyValue": "player.unpause",
                 "propertySubPhrases": [
-                  "restart the music"
+                  "unpause the music"
                 ]
               },
               {
@@ -992,12 +969,6 @@
                 "propertySubPhrases": [
                   "continue"
                 ]
-              },
-              {
-                "propertyValue": "player.replay",
-                "propertySubPhrases": [
-                  "replay"
-                ]
               }
             ]
           }
@@ -1050,15 +1021,15 @@
                 ]
               },
               {
-                "propertyValue": "player.restart",
+                "propertyValue": "player.pause",
                 "propertySubPhrases": [
-                  "restart playing"
+                  "pause the music"
                 ]
               },
               {
-                "propertyValue": "player.continue",
+                "propertyValue": "player.stop",
                 "propertySubPhrases": [
-                  "continue playing"
+                  "stop the music"
                 ]
               }
             ]
@@ -1067,12 +1038,14 @@
         "politePrefixes": [
           "Could you please",
           "Would you mind",
-          "If it's not too much trouble, could you"
+          "If it's not too much trouble, could you",
+          "May I kindly ask you to"
         ],
         "politeSuffixes": [
           "Thank you!",
           "Thanks a lot!",
-          "I would appreciate it!"
+          "I would appreciate it!",
+          "That would be great!"
         ]
       }
     },
@@ -1111,13 +1084,7 @@
               {
                 "propertyValue": "player.play",
                 "propertySubPhrases": [
-                  "Start the tracks."
-                ]
-              },
-              {
-                "propertyValue": "player.unpause",
-                "propertySubPhrases": [
-                  "Unpause the tracks."
+                  "Start playing the tracks."
                 ]
               },
               {
@@ -1125,17 +1092,27 @@
                 "propertySubPhrases": [
                   "Continue the tracks."
                 ]
+              },
+              {
+                "propertyValue": "player.unpause",
+                "propertySubPhrases": [
+                  "Unpause the tracks."
+                ]
               }
             ]
           }
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If it's not too much trouble, could you",
+          "May I kindly ask you to"
         ],
         "politeSuffixes": [
           "Thank you.",
-          "I would appreciate it."
+          "I would appreciate it.",
+          "Thanks a lot.",
+          "That would be great."
         ]
       }
     },
@@ -1185,12 +1162,7 @@
           {
             "text": "the playlist",
             "category": "object",
-            "synonyms": [
-              "the music list",
-              "the song collection",
-              "the track list"
-            ],
-            "isOptional": false
+            "propertyNames": []
           }
         ],
         "propertyAlternatives": [
@@ -1223,12 +1195,12 @@
           }
         ],
         "politePrefixes": [
-          "Please",
-          "Kindly"
+          "Could you please",
+          "Would you mind"
         ],
         "politeSuffixes": [
-          "Thank you",
-          "if you don't mind"
+          "Thank you!",
+          "I would appreciate it."
         ]
       }
     },
@@ -1293,7 +1265,7 @@
               {
                 "propertyValue": "player.stop",
                 "propertySubPhrases": [
-                  "stop playing"
+                  "hit stop"
                 ]
               },
               {
@@ -1333,13 +1305,8 @@
         "subPhrases": [
           {
             "text": "Hit",
-            "category": "filler",
-            "synonyms": [
-              "Press",
-              "Tap",
-              "Click"
-            ],
-            "isOptional": true
+            "category": "command",
+            "propertyNames": []
           },
           {
             "text": "play again",
@@ -1399,28 +1366,42 @@
             "name": "fullActionName",
             "value": "player.resume",
             "substrings": [
-              "Hit the play button again."
+              "play",
+              "again"
             ]
           }
         ],
         "subPhrases": [
           {
-            "text": "Hit",
-            "category": "command",
+            "text": "Hit the",
+            "category": "filler",
+            "synonyms": [
+              "Press the",
+              "Tap the",
+              "Click the"
+            ],
+            "isOptional": true
+          },
+          {
+            "text": "play",
+            "category": "action",
             "propertyNames": [
               "fullActionName"
             ]
           },
           {
-            "text": "the play button",
+            "text": "button",
             "category": "object",
-            "propertyNames": [
-              "fullActionName"
-            ]
+            "synonyms": [
+              "key",
+              "control",
+              "switch"
+            ],
+            "isOptional": true
           },
           {
             "text": "again",
-            "category": "frequency",
+            "category": "repetition",
             "propertyNames": [
               "fullActionName"
             ]
@@ -1431,33 +1412,29 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.resume",
             "propertySubPhrases": [
-              "Hit",
-              "the play button",
+              "play",
               "again"
             ],
             "alternatives": [
               {
-                "propertyValue": "player.pause",
+                "propertyValue": "player.replay",
                 "propertySubPhrases": [
-                  "Hit",
-                  "the pause button",
-                  "now"
+                  "play",
+                  "again"
                 ]
               },
               {
-                "propertyValue": "player.stop",
+                "propertyValue": "player.restart",
                 "propertySubPhrases": [
-                  "Press",
-                  "the stop button",
-                  "immediately"
+                  "play",
+                  "again"
                 ]
               },
               {
-                "propertyValue": "player.start",
+                "propertyValue": "player.continue",
                 "propertySubPhrases": [
-                  "Press",
-                  "the start button",
-                  "now"
+                  "play",
+                  "again"
                 ]
               }
             ]
@@ -1470,12 +1447,99 @@
           "May I kindly ask you to"
         ],
         "politeSuffixes": [
-          "thank you.",
-          "please.",
-          "if you don't mind.",
-          "thanks a lot."
+          "Thank you.",
+          "Thanks a lot.",
+          "I would appreciate it.",
+          "That would be great."
         ]
-      }
+      },
+      "corrections": [
+        {
+          "data": {
+            "properties": [
+              {
+                "name": "fullActionName",
+                "value": "player.resume",
+                "substrings": [
+                  "play",
+                  "again"
+                ]
+              }
+            ],
+            "subPhrases": [
+              {
+                "text": "Hit the",
+                "category": "filler",
+                "synonyms": [
+                  "Press the",
+                  "Tap the",
+                  "Click the"
+                ],
+                "isOptional": true
+              },
+              {
+                "text": "play",
+                "category": "action",
+                "propertyNames": [
+                  "fullActionName"
+                ]
+              },
+              {
+                "text": "button",
+                "category": "object",
+                "synonyms": [
+                  "key",
+                  "control",
+                  "switch"
+                ],
+                "isOptional": true
+              },
+              {
+                "text": "again",
+                "category": "repetition",
+                "propertyNames": [
+                  "fullActionName"
+                ]
+              }
+            ],
+            "propertyAlternatives": [
+              {
+                "propertyName": "fullActionName",
+                "propertyValue": "player.resume",
+                "propertySubPhrases": [
+                  "play",
+                  "again"
+                ],
+                "alternatives": [
+                  {
+                    "propertyValue": "player.play",
+                    "propertySubPhrases": [
+                      "play"
+                    ]
+                  },
+                  {
+                    "propertyValue": "player.start",
+                    "propertySubPhrases": [
+                      "start"
+                    ]
+                  },
+                  {
+                    "propertyValue": "player.replay",
+                    "propertySubPhrases": [
+                      "replay"
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          "correction": [
+            "Mismatch number of sub-phrases: alternatives value 'player.play' for property 'fullActionName' must have 2 sub-phrases",
+            "Mismatch number of sub-phrases: alternatives value 'player.start' for property 'fullActionName' must have 2 sub-phrases",
+            "Mismatch number of sub-phrases: alternatives value 'player.replay' for property 'fullActionName' must have 2 sub-phrases"
+          ]
+        }
+      ]
     },
     {
       "request": "I'd appreciate it if you could play the music again.",
@@ -1499,7 +1563,7 @@
             "synonyms": [
               "please",
               "kindly",
-              "if you don't mind"
+              "would you mind"
             ],
             "isOptional": true
           },
@@ -1522,25 +1586,25 @@
               {
                 "propertyValue": "player.play",
                 "propertySubPhrases": [
+                  "play the music"
+                ]
+              },
+              {
+                "propertyValue": "player.start",
+                "propertySubPhrases": [
                   "start the music"
                 ]
               },
               {
-                "propertyValue": "player.stop",
+                "propertyValue": "player.replay",
                 "propertySubPhrases": [
-                  "stop the music"
+                  "replay the music"
                 ]
               },
               {
-                "propertyValue": "player.pause",
+                "propertyValue": "player.continue",
                 "propertySubPhrases": [
-                  "pause the music"
-                ]
-              },
-              {
-                "propertyValue": "player.next",
-                "propertySubPhrases": [
-                  "skip to the next song"
+                  "continue the music"
                 ]
               }
             ]
@@ -1599,15 +1663,21 @@
                 ]
               },
               {
-                "propertyValue": "player.replay",
+                "propertyValue": "player.pause",
                 "propertySubPhrases": [
-                  "replay that song"
+                  "pause that song"
                 ]
               },
               {
-                "propertyValue": "player.startOver",
+                "propertyValue": "player.stop",
                 "propertySubPhrases": [
-                  "start that song over"
+                  "stop that song"
+                ]
+              },
+              {
+                "propertyValue": "player.rewind",
+                "propertySubPhrases": [
+                  "rewind that song"
                 ]
               }
             ]
@@ -1618,8 +1688,8 @@
           "Would you mind"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it."
+          "Thank you.",
+          "I appreciate it."
         ]
       }
     },
@@ -1645,7 +1715,7 @@
             "synonyms": [
               "please",
               "kindly",
-              "if you don't mind"
+              "would you mind"
             ],
             "isOptional": true
           },
@@ -1668,12 +1738,6 @@
               {
                 "propertyValue": "player.play",
                 "propertySubPhrases": [
-                  "play the music"
-                ]
-              },
-              {
-                "propertyValue": "player.start",
-                "propertySubPhrases": [
                   "start the music"
                 ]
               },
@@ -1681,6 +1745,12 @@
                 "propertyValue": "player.unpause",
                 "propertySubPhrases": [
                   "unpause the music"
+                ]
+              },
+              {
+                "propertyValue": "player.replay",
+                "propertySubPhrases": [
+                  "replay the music"
                 ]
               }
             ]
@@ -1744,12 +1814,12 @@
           }
         ],
         "politePrefixes": [
-          "Please",
-          "Kindly"
+          "Could you please",
+          "Would you mind"
         ],
         "politeSuffixes": [
-          "Thank you",
-          "if you don't mind"
+          "Thank you!",
+          "I would appreciate it."
         ]
       }
     },
@@ -1796,22 +1866,22 @@
               {
                 "propertyValue": "player.playNext",
                 "propertySubPhrases": [
-                  "Continue the party",
-                  "with the next song."
+                  "Play the next song",
+                  "to keep the party going."
                 ]
               },
               {
                 "propertyValue": "player.playFavorite",
                 "propertySubPhrases": [
-                  "Keep the party alive",
-                  "with your favorite tracks."
+                  "Play my favorite tracks",
+                  "to keep the party alive."
                 ]
               },
               {
-                "propertyValue": "player.playPlaylist",
+                "propertyValue": "player.playGenre",
                 "propertySubPhrases": [
-                  "Keep the party going",
-                  "with the playlist."
+                  "Play some jazz",
+                  "to keep the mood."
                 ]
               }
             ]
@@ -1866,15 +1936,15 @@
                 ]
               },
               {
-                "propertyValue": "player.pause",
+                "propertyValue": "player.continue",
                 "propertySubPhrases": [
-                  "Pause the music."
+                  "Continue the music."
                 ]
               },
               {
-                "propertyValue": "player.stop",
+                "propertyValue": "player.unpause",
                 "propertySubPhrases": [
-                  "Stop the music."
+                  "Unpause the music."
                 ]
               }
             ]
@@ -1886,7 +1956,7 @@
         ],
         "politeSuffixes": [
           "Thank you",
-          "if you don't mind"
+          "Much appreciated"
         ]
       }
     },
@@ -1953,7 +2023,7 @@
               {
                 "propertyValue": "player.next",
                 "propertySubPhrases": [
-                  "skip to the next track"
+                  "skip to the next song"
                 ]
               }
             ]
@@ -1998,7 +2068,7 @@
               {
                 "propertyValue": "player.play",
                 "propertySubPhrases": [
-                  "Start the music again."
+                  "Start the music."
                 ]
               },
               {
@@ -2018,15 +2088,11 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind",
-          "If it's not too much trouble, could you",
-          "May I kindly ask you to"
+          "Would you mind"
         ],
         "politeSuffixes": [
-          "Thank you.",
-          "I would appreciate it.",
-          "Thanks a lot.",
-          "That would be great."
+          "Thank you!",
+          "I would appreciate it."
         ]
       }
     },
@@ -2057,15 +2123,8 @@
             "isOptional": true
           },
           {
-            "text": "get back to",
-            "category": "action",
-            "propertyNames": [
-              "fullActionName"
-            ]
-          },
-          {
-            "text": "the beats.",
-            "category": "object",
+            "text": "get back to the beats.",
+            "category": "command",
             "propertyNames": [
               "fullActionName"
             ]
@@ -2076,29 +2135,25 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.resume",
             "propertySubPhrases": [
-              "get back to",
-              "the beats."
+              "get back to the beats."
             ],
             "alternatives": [
               {
                 "propertyValue": "player.play",
                 "propertySubPhrases": [
-                  "start",
-                  "the music."
+                  "start the music."
                 ]
               },
               {
-                "propertyValue": "player.continue",
+                "propertyValue": "player.pause",
                 "propertySubPhrases": [
-                  "continue",
-                  "the tunes."
+                  "pause the beats."
                 ]
               },
               {
-                "propertyValue": "player.unpause",
+                "propertyValue": "player.stop",
                 "propertySubPhrases": [
-                  "unpause",
-                  "the tracks."
+                  "stop the music."
                 ]
               }
             ]
@@ -2163,27 +2218,27 @@
                 ]
               },
               {
-                "propertyValue": "player.restart",
-                "propertySubPhrases": [
-                  "restart the music"
-                ]
-              },
-              {
                 "propertyValue": "player.unpause",
                 "propertySubPhrases": [
                   "unpause the music"
+                ]
+              },
+              {
+                "propertyValue": "player.continue",
+                "propertySubPhrases": [
+                  "continue the music"
                 ]
               }
             ]
           }
         ],
         "politePrefixes": [
-          "Please",
-          "Could you"
+          "Could you please",
+          "Would you mind"
         ],
         "politeSuffixes": [
-          "thank you",
-          "if you don't mind"
+          "Thank you!",
+          "I would appreciate it."
         ]
       }
     },
@@ -2257,14 +2312,12 @@
           }
         ],
         "politePrefixes": [
-          "Could you please",
-          "Would you mind",
-          "If it's not too much trouble, could you"
+          "Please",
+          "Kindly"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it.",
-          "Thanks a lot!"
+          "Thank you",
+          "if you don't mind"
         ]
       }
     },
@@ -2286,7 +2339,7 @@
         "subPhrases": [
           {
             "text": "Let's",
-            "category": "politeness",
+            "category": "filler",
             "synonyms": [
               "Let us",
               "We should",
@@ -2318,19 +2371,19 @@
               {
                 "propertyValue": "player.play",
                 "propertySubPhrases": [
-                  "start playing"
+                  "start the music"
                 ]
               },
               {
-                "propertyValue": "player.pause",
+                "propertyValue": "player.continue",
                 "propertySubPhrases": [
-                  "pause the music"
+                  "continue the music"
                 ]
               },
               {
-                "propertyValue": "player.stop",
+                "propertyValue": "player.replay",
                 "propertySubPhrases": [
-                  "stop the music"
+                  "replay the music"
                 ]
               }
             ]
@@ -2342,7 +2395,7 @@
         ],
         "politeSuffixes": [
           "Thank you",
-          "if you don't mind"
+          "Much appreciated"
         ]
       }
     },
@@ -2400,27 +2453,27 @@
                 ]
               },
               {
-                "propertyValue": "player.pause",
+                "propertyValue": "player.start",
                 "propertySubPhrases": [
-                  "pause"
+                  "start"
                 ]
               },
               {
-                "propertyValue": "player.stop",
+                "propertyValue": "player.continue",
                 "propertySubPhrases": [
-                  "stop"
+                  "continue"
                 ]
               }
             ]
           }
         ],
         "politePrefixes": [
-          "Please",
-          "Kindly"
+          "Could you please",
+          "Would you mind"
         ],
         "politeSuffixes": [
-          "Thank you",
-          "if you don't mind"
+          "Thank you.",
+          "I would appreciate it."
         ]
       }
     },
@@ -2479,9 +2532,15 @@
                 ]
               },
               {
-                "propertyValue": "player.start",
+                "propertyValue": "player.next",
                 "propertySubPhrases": [
-                  "Start"
+                  "Next"
+                ]
+              },
+              {
+                "propertyValue": "player.previous",
+                "propertySubPhrases": [
+                  "Previous"
                 ]
               }
             ]
@@ -2560,7 +2619,7 @@
           "Would you mind"
         ],
         "politeSuffixes": [
-          "Thank you.",
+          "Thank you!",
           "I would appreciate it."
         ]
       }
@@ -2635,15 +2694,15 @@
     {
       "request": "Please hit play on the music.",
       "action": {
-        "fullActionName": "player.resume"
+        "fullActionName": "player.playRandom"
       },
       "explanation": {
         "properties": [
           {
             "name": "fullActionName",
-            "value": "player.resume",
+            "value": "player.playRandom",
             "substrings": [
-              "Please hit play"
+              "hit play"
             ]
           }
         ],
@@ -2654,7 +2713,7 @@
             "synonyms": [
               "Kindly",
               "Would you mind",
-              "Could you"
+              "Could you please"
             ],
             "isOptional": true
           },
@@ -2668,13 +2727,18 @@
           {
             "text": "on the music",
             "category": "context",
-            "propertyNames": []
+            "synonyms": [
+              "with the music",
+              "to the music",
+              "for the music"
+            ],
+            "isOptional": true
           }
         ],
         "propertyAlternatives": [
           {
             "propertyName": "fullActionName",
-            "propertyValue": "player.resume",
+            "propertyValue": "player.playRandom",
             "propertySubPhrases": [
               "hit play"
             ],
@@ -2695,6 +2759,12 @@
                 "propertyValue": "player.next",
                 "propertySubPhrases": [
                   "skip"
+                ]
+              },
+              {
+                "propertyValue": "player.previous",
+                "propertySubPhrases": [
+                  "go back"
                 ]
               }
             ]
@@ -2758,15 +2828,15 @@
                 ]
               },
               {
-                "propertyValue": "player.pause",
+                "propertyValue": "player.start",
                 "propertySubPhrases": [
-                  "pause"
+                  "start"
                 ]
               },
               {
-                "propertyValue": "player.stop",
+                "propertyValue": "player.continue",
                 "propertySubPhrases": [
-                  "stop"
+                  "continue"
                 ]
               }
             ]
@@ -2787,21 +2857,22 @@
             "name": "fullActionName",
             "value": "player.resume",
             "substrings": [
-              "Proceed with the audio playback."
+              "Proceed",
+              "with the audio playback"
             ]
           }
         ],
         "subPhrases": [
           {
-            "text": "Proceed with",
+            "text": "Proceed",
             "category": "command",
             "propertyNames": [
               "fullActionName"
             ]
           },
           {
-            "text": "the audio playback.",
-            "category": "object",
+            "text": "with the audio playback",
+            "category": "command detail",
             "propertyNames": [
               "fullActionName"
             ]
@@ -2812,36 +2883,29 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.resume",
             "propertySubPhrases": [
-              "Proceed with",
-              "the audio playback."
+              "Proceed",
+              "with the audio playback"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.play",
                 "propertySubPhrases": [
                   "Start",
-                  "the audio playback."
+                  "the audio playback"
                 ]
               },
               {
-                "propertyValue": "player.pause",
+                "propertyValue": "player.continue",
                 "propertySubPhrases": [
-                  "Pause",
-                  "the audio playback."
+                  "Continue",
+                  "the audio playback"
                 ]
               },
               {
-                "propertyValue": "player.stop",
+                "propertyValue": "player.begin",
                 "propertySubPhrases": [
-                  "Stop",
-                  "the audio playback."
-                ]
-              },
-              {
-                "propertyValue": "player.rewind",
-                "propertySubPhrases": [
-                  "Rewind",
-                  "the audio playback."
+                  "Begin",
+                  "the audio playback"
                 ]
               }
             ]
@@ -2890,8 +2954,8 @@
             "category": "politeness",
             "synonyms": [
               "kindly",
-              "if you would",
-              "if you could"
+              "if you could",
+              "would you mind"
             ],
             "isOptional": true
           }
@@ -2911,15 +2975,21 @@
                 ]
               },
               {
-                "propertyValue": "player.play",
-                "propertySubPhrases": [
-                  "Play"
-                ]
-              },
-              {
                 "propertyValue": "player.replay",
                 "propertySubPhrases": [
                   "Replay"
+                ]
+              },
+              {
+                "propertyValue": "player.restart",
+                "propertySubPhrases": [
+                  "Restart"
+                ]
+              },
+              {
+                "propertyValue": "player.continue",
+                "propertySubPhrases": [
+                  "Continue"
                 ]
               }
             ]
@@ -2947,7 +3017,7 @@
         "subPhrases": [
           {
             "text": "Resume",
-            "category": "action",
+            "category": "command",
             "propertyNames": [
               "fullActionName"
             ]
@@ -2962,8 +3032,8 @@
             "category": "politeness",
             "synonyms": [
               "kindly",
-              "if you could",
-              "would you mind"
+              "if you would",
+              "if you please"
             ],
             "isOptional": true
           }
@@ -3019,7 +3089,7 @@
         "subPhrases": [
           {
             "text": "Resume",
-            "category": "action",
+            "category": "command",
             "propertyNames": [
               "fullActionName"
             ]
@@ -3033,9 +3103,9 @@
             "text": "if you don't mind",
             "category": "politeness",
             "synonyms": [
-              "if it's okay with you",
-              "if you could",
-              "if you would"
+              "please",
+              "if it's not too much trouble",
+              "if you could"
             ],
             "isOptional": true
           }
@@ -3091,7 +3161,7 @@
         "subPhrases": [
           {
             "text": "Resume",
-            "category": "action",
+            "category": "command",
             "propertyNames": [
               "fullActionName"
             ]
@@ -3234,14 +3304,7 @@
         ],
         "subPhrases": [
           {
-            "text": "Start the music",
-            "category": "command",
-            "propertyNames": [
-              "fullActionName"
-            ]
-          },
-          {
-            "text": "up again",
+            "text": "Start the music up again.",
             "category": "command",
             "propertyNames": [
               "fullActionName"
@@ -3253,29 +3316,25 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.resume",
             "propertySubPhrases": [
-              "Start the music",
-              "up again"
+              "Start the music up again."
             ],
             "alternatives": [
               {
                 "propertyValue": "player.play",
                 "propertySubPhrases": [
-                  "Play the music",
-                  "again"
+                  "Play the music."
                 ]
               },
               {
-                "propertyValue": "player.start",
+                "propertyValue": "player.restart",
                 "propertySubPhrases": [
-                  "Begin the music",
-                  "once more"
+                  "Restart the music."
                 ]
               },
               {
                 "propertyValue": "player.continue",
                 "propertySubPhrases": [
-                  "Continue the music",
-                  "from where it left off"
+                  "Continue the music."
                 ]
               }
             ]
@@ -3283,13 +3342,11 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind",
-          "If it's not too much trouble, could you"
+          "Would you mind"
         ],
         "politeSuffixes": [
-          "thank you",
-          "please",
-          "if you don't mind"
+          "Thank you.",
+          "I would appreciate it."
         ]
       }
     },
@@ -3327,7 +3384,7 @@
             "synonyms": [
               "please",
               "if you don't mind",
-              "could you"
+              "kindly"
             ],
             "isOptional": true
           }
@@ -3463,8 +3520,8 @@
             "text": "Would you",
             "category": "politeness",
             "synonyms": [
-              "Can you",
               "Could you",
+              "Can you",
               "Will you"
             ],
             "isOptional": true
@@ -3482,7 +3539,7 @@
             "synonyms": [
               "the sound",
               "the playback",
-              "the track"
+              "the recording"
             ],
             "isOptional": true
           }
@@ -3653,30 +3710,23 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.play",
+                "propertyValue": "player.start",
                 "propertySubPhrases": [
                   "press play",
                   "on that"
                 ]
               },
               {
-                "propertyValue": "player.pause",
+                "propertyValue": "player.replay",
                 "propertySubPhrases": [
-                  "press pause",
-                  "on that"
+                  "press play",
+                  "on that again"
                 ]
               },
               {
-                "propertyValue": "player.stop",
+                "propertyValue": "player.continue",
                 "propertySubPhrases": [
-                  "stop",
-                  "on that"
-                ]
-              },
-              {
-                "propertyValue": "player.rewind",
-                "propertySubPhrases": [
-                  "rewind",
+                  "press play",
                   "on that"
                 ]
               }

--- a/ts/packages/dispatcher/test/data/player/v5/searchTracks.json
+++ b/ts/packages/dispatcher/test/data/player/v5/searchTracks.json
@@ -1,7 +1,7 @@
 {
   "version": 2,
   "schemaName": "player",
-  "sourceHash": "/coyfq1j8qYAwzuqFo38QLrP2X7DZ/U6UJRPEiLjn7Q=",
+  "sourceHash": "HrhZPog7XXm93zb5xwYtzWspziPTFgFnvgb4UUJ85a8=",
   "explainerName": "v5",
   "entries": [
     {
@@ -17,7 +17,9 @@
           {
             "name": "fullActionName",
             "value": "player.searchTracks",
-            "substrings": []
+            "substrings": [
+              "Find acoustic versions of popular songs"
+            ]
           },
           {
             "name": "parameters.query",
@@ -30,13 +32,10 @@
         "subPhrases": [
           {
             "text": "Find",
-            "category": "command",
-            "synonyms": [
-              "Search for",
-              "Look for",
-              "Locate"
-            ],
-            "isOptional": true
+            "category": "action",
+            "propertyNames": [
+              "fullActionName"
+            ]
           },
           {
             "text": "acoustic versions of popular songs",
@@ -48,6 +47,33 @@
         ],
         "propertyAlternatives": [
           {
+            "propertyName": "fullActionName",
+            "propertyValue": "player.searchTracks",
+            "propertySubPhrases": [
+              "Find"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "player.findTracks",
+                "propertySubPhrases": [
+                  "Search"
+                ]
+              },
+              {
+                "propertyValue": "player.lookupTracks",
+                "propertySubPhrases": [
+                  "Look up"
+                ]
+              },
+              {
+                "propertyValue": "player.browseTracks",
+                "propertySubPhrases": [
+                  "Browse"
+                ]
+              }
+            ]
+          },
+          {
             "propertyName": "parameters.query",
             "propertyValue": "acoustic versions of popular songs",
             "propertySubPhrases": [
@@ -55,27 +81,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "live versions of popular songs",
+                "propertyValue": "acoustic covers of hit songs",
                 "propertySubPhrases": [
-                  "live versions of popular songs"
+                  "acoustic covers of hit songs"
                 ]
               },
               {
-                "propertyValue": "cover versions of popular songs",
+                "propertyValue": "unplugged versions of famous tracks",
                 "propertySubPhrases": [
-                  "cover versions of popular songs"
+                  "unplugged versions of famous tracks"
                 ]
               },
               {
-                "propertyValue": "unplugged versions of popular songs",
+                "propertyValue": "acoustic renditions of top songs",
                 "propertySubPhrases": [
-                  "unplugged versions of popular songs"
-                ]
-              },
-              {
-                "propertyValue": "instrumental versions of popular songs",
-                "propertySubPhrases": [
-                  "instrumental versions of popular songs"
+                  "acoustic renditions of top songs"
                 ]
               }
             ]
@@ -89,7 +109,7 @@
         "politeSuffixes": [
           "Thank you!",
           "I would appreciate it.",
-          "Thanks a lot!"
+          "Thanks in advance!"
         ]
       }
     },
@@ -136,18 +156,28 @@
           },
           {
             "text": "music",
-            "category": "content",
+            "category": "command",
             "propertyNames": [
               "fullActionName"
             ]
           },
           {
-            "text": "for relaxation",
+            "text": "for",
+            "category": "preposition",
+            "synonyms": [
+              "to",
+              "in order to",
+              "so as to"
+            ],
+            "isOptional": true
+          },
+          {
+            "text": "relaxation",
             "category": "purpose",
             "synonyms": [
-              "to relax",
-              "for calming",
-              "for unwinding"
+              "calm",
+              "unwind",
+              "chill"
             ],
             "isOptional": true
           }
@@ -162,24 +192,24 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.searchGenre",
+                "propertyValue": "player.playSong",
                 "propertySubPhrases": [
-                  "Search",
-                  "music"
+                  "Play",
+                  "song"
                 ]
               },
               {
-                "propertyValue": "player.browseGenre",
+                "propertyValue": "player.playAlbum",
                 "propertySubPhrases": [
-                  "Browse",
-                  "music"
+                  "Play",
+                  "album"
                 ]
               },
               {
-                "propertyValue": "player.discoverGenre",
+                "propertyValue": "player.playPlaylist",
                 "propertySubPhrases": [
-                  "Discover",
-                  "music"
+                  "Play",
+                  "playlist"
                 ]
               }
             ]
@@ -192,11 +222,134 @@
             ],
             "alternatives": [
               {
+                "propertyValue": "jazz",
+                "propertySubPhrases": [
+                  "jazz"
+                ]
+              },
+              {
+                "propertyValue": "classical",
+                "propertySubPhrases": [
+                  "classical"
+                ]
+              },
+              {
                 "propertyValue": "ambient",
                 "propertySubPhrases": [
                   "ambient"
                 ]
+              }
+            ]
+          }
+        ],
+        "politePrefixes": [
+          "Could you please",
+          "Would you mind"
+        ],
+        "politeSuffixes": [
+          "Thank you",
+          "I would appreciate it"
+        ]
+      }
+    },
+    {
+      "request": "Find chillwave tracks for a laid-back evening",
+      "action": {
+        "fullActionName": "player.playGenre",
+        "parameters": {
+          "genre": "chillwave"
+        }
+      },
+      "explanation": {
+        "properties": [
+          {
+            "name": "fullActionName",
+            "value": "player.playGenre",
+            "substrings": [
+              "Find",
+              "tracks"
+            ]
+          },
+          {
+            "name": "parameters.genre",
+            "value": "chillwave",
+            "substrings": [
+              "chillwave"
+            ]
+          }
+        ],
+        "subPhrases": [
+          {
+            "text": "Find",
+            "category": "command",
+            "propertyNames": [
+              "fullActionName"
+            ]
+          },
+          {
+            "text": "chillwave",
+            "category": "genre",
+            "propertyNames": [
+              "parameters.genre"
+            ]
+          },
+          {
+            "text": "tracks",
+            "category": "object",
+            "propertyNames": [
+              "fullActionName"
+            ]
+          },
+          {
+            "text": "for a laid-back evening",
+            "category": "context",
+            "synonyms": [
+              "for a relaxing evening",
+              "for a calm night",
+              "for a peaceful evening"
+            ],
+            "isOptional": true
+          }
+        ],
+        "propertyAlternatives": [
+          {
+            "propertyName": "fullActionName",
+            "propertyValue": "player.playGenre",
+            "propertySubPhrases": [
+              "Find",
+              "tracks"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "player.playPlaylist",
+                "propertySubPhrases": [
+                  "Play",
+                  "playlist"
+                ]
               },
+              {
+                "propertyValue": "player.playAlbum",
+                "propertySubPhrases": [
+                  "Play",
+                  "album"
+                ]
+              },
+              {
+                "propertyValue": "player.playArtist",
+                "propertySubPhrases": [
+                  "Play",
+                  "artist"
+                ]
+              }
+            ]
+          },
+          {
+            "propertyName": "parameters.genre",
+            "propertyValue": "chillwave",
+            "propertySubPhrases": [
+              "chillwave"
+            ],
+            "alternatives": [
               {
                 "propertyValue": "lofi",
                 "propertySubPhrases": [
@@ -204,9 +357,15 @@
                 ]
               },
               {
-                "propertyValue": "downtempo",
+                "propertyValue": "ambient",
                 "propertySubPhrases": [
-                  "downtempo"
+                  "ambient"
+                ]
+              },
+              {
+                "propertyValue": "jazz",
+                "propertySubPhrases": [
+                  "jazz"
                 ]
               }
             ]
@@ -214,118 +373,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If it's not too much trouble,",
+          "May I kindly ask you to"
         ],
         "politeSuffixes": [
           "Thank you!",
-          "I would appreciate it."
-        ]
-      }
-    },
-    {
-      "request": "Find chillwave tracks for a laid-back evening",
-      "action": {
-        "fullActionName": "player.searchTracks",
-        "parameters": {
-          "query": "chillwave tracks for a laid-back evening"
-        }
-      },
-      "explanation": {
-        "properties": [
-          {
-            "name": "fullActionName",
-            "value": "player.searchTracks",
-            "substrings": [
-              "Find"
-            ]
-          },
-          {
-            "name": "parameters.query",
-            "value": "chillwave tracks for a laid-back evening",
-            "substrings": [
-              "chillwave tracks for a laid-back evening"
-            ]
-          }
-        ],
-        "subPhrases": [
-          {
-            "text": "Find",
-            "category": "action",
-            "propertyNames": [
-              "fullActionName"
-            ]
-          },
-          {
-            "text": "chillwave tracks for a laid-back evening",
-            "category": "query",
-            "propertyNames": [
-              "parameters.query"
-            ]
-          }
-        ],
-        "propertyAlternatives": [
-          {
-            "propertyName": "fullActionName",
-            "propertyValue": "player.searchTracks",
-            "propertySubPhrases": [
-              "Find"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "player.findSongs",
-                "propertySubPhrases": [
-                  "Find"
-                ]
-              },
-              {
-                "propertyValue": "player.lookupMusic",
-                "propertySubPhrases": [
-                  "Find"
-                ]
-              },
-              {
-                "propertyValue": "player.searchMusic",
-                "propertySubPhrases": [
-                  "Find"
-                ]
-              }
-            ]
-          },
-          {
-            "propertyName": "parameters.query",
-            "propertyValue": "chillwave tracks for a laid-back evening",
-            "propertySubPhrases": [
-              "chillwave tracks for a laid-back evening"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "chillwave songs for a relaxed night",
-                "propertySubPhrases": [
-                  "chillwave songs for a relaxed night"
-                ]
-              },
-              {
-                "propertyValue": "chillwave music for a calm evening",
-                "propertySubPhrases": [
-                  "chillwave music for a calm evening"
-                ]
-              },
-              {
-                "propertyValue": "chillwave tunes for a peaceful night",
-                "propertySubPhrases": [
-                  "chillwave tunes for a peaceful night"
-                ]
-              }
-            ]
-          }
-        ],
-        "politePrefixes": [
-          "Could you please",
-          "Would you mind"
-        ],
-        "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it!"
+          "I would appreciate it.",
+          "Thanks a lot!",
+          "That would be great."
         ]
       }
     },
@@ -385,13 +441,13 @@
                 ]
               },
               {
-                "propertyValue": "player.lookupTracks",
+                "propertyValue": "music.searchTracks",
                 "propertySubPhrases": [
                   "Find"
                 ]
               },
               {
-                "propertyValue": "player.searchMusic",
+                "propertyValue": "audio.searchTracks",
                 "propertySubPhrases": [
                   "Find"
                 ]
@@ -431,8 +487,8 @@
           "Would you mind"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I appreciate it!"
+          "Thank you",
+          "I would appreciate it"
         ]
       }
     },
@@ -492,15 +548,15 @@
                 ]
               },
               {
-                "propertyValue": "player.queueTracks",
+                "propertyValue": "player.addTracksToQueue",
                 "propertySubPhrases": [
                   "Queue"
                 ]
               },
               {
-                "propertyValue": "player.addTracks",
+                "propertyValue": "player.shuffleTracks",
                 "propertySubPhrases": [
-                  "Add"
+                  "Shuffle"
                 ]
               }
             ]
@@ -606,7 +662,7 @@
           },
           {
             "text": "The Eagles",
-            "category": "artist",
+            "category": "artistName",
             "propertyNames": [
               "parameters.artists.0"
             ]
@@ -621,15 +677,15 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "Stairway to Heaven",
-                "propertySubPhrases": [
-                  "Stairway to Heaven"
-                ]
-              },
-              {
                 "propertyValue": "Bohemian Rhapsody",
                 "propertySubPhrases": [
                   "Bohemian Rhapsody"
+                ]
+              },
+              {
+                "propertyValue": "Stairway to Heaven",
+                "propertySubPhrases": [
+                  "Stairway to Heaven"
                 ]
               },
               {
@@ -648,15 +704,15 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "Led Zeppelin",
-                "propertySubPhrases": [
-                  "Led Zeppelin"
-                ]
-              },
-              {
                 "propertyValue": "Queen",
                 "propertySubPhrases": [
                   "Queen"
+                ]
+              },
+              {
+                "propertyValue": "Led Zeppelin",
+                "propertySubPhrases": [
+                  "Led Zeppelin"
                 ]
               },
               {
@@ -670,11 +726,13 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If it's not too much trouble, could you"
         ],
         "politeSuffixes": [
-          "Thank you",
-          "I appreciate it"
+          "Thank you!",
+          "I would appreciate it.",
+          "Thanks a lot!"
         ]
       },
       "corrections": [
@@ -728,7 +786,7 @@
               },
               {
                 "text": "The Eagles",
-                "category": "artist",
+                "category": "artistName",
                 "propertyNames": [
                   "parameters.artists.0"
                 ]
@@ -793,19 +851,19 @@
               {
                 "propertyValue": "player.findSongs",
                 "propertySubPhrases": [
-                  "Search"
+                  "Find"
                 ]
               },
               {
                 "propertyValue": "player.lookupTracks",
                 "propertySubPhrases": [
-                  "Look up"
+                  "Find"
                 ]
               },
               {
-                "propertyValue": "player.discoverTracks",
+                "propertyValue": "player.searchMusic",
                 "propertySubPhrases": [
-                  "Discover"
+                  "Find"
                 ]
               }
             ]
@@ -840,11 +898,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If it's not too much trouble,",
+          "May I kindly ask you to"
         ],
         "politeSuffixes": [
           "Thank you!",
-          "I would appreciate it."
+          "I would appreciate it.",
+          "Thanks a lot!",
+          "Your help is much appreciated."
         ]
       }
     },
@@ -900,19 +962,19 @@
               {
                 "propertyValue": "player.findSongs",
                 "propertySubPhrases": [
-                  "Find"
+                  "Search"
                 ]
               },
               {
-                "propertyValue": "player.lookupTracks",
+                "propertyValue": "player.lookupMusic",
                 "propertySubPhrases": [
-                  "Find"
+                  "Look up"
                 ]
               },
               {
-                "propertyValue": "player.searchMusic",
+                "propertyValue": "player.discoverTracks",
                 "propertySubPhrases": [
-                  "Find"
+                  "Discover"
                 ]
               }
             ]
@@ -925,15 +987,15 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "chill study music",
+                "propertyValue": "chill music for focus",
                 "propertySubPhrases": [
-                  "chill study music"
+                  "chill music for focus"
                 ]
               },
               {
-                "propertyValue": "relaxing music for studying",
+                "propertyValue": "ambient sounds for concentration",
                 "propertySubPhrases": [
-                  "relaxing music for studying"
+                  "ambient sounds for concentration"
                 ]
               },
               {
@@ -950,103 +1012,139 @@
           "Would you mind"
         ],
         "politeSuffixes": [
-          "Thank you",
-          "I would appreciate it"
+          "Thank you!",
+          "I would appreciate it."
         ]
       }
     },
     {
       "request": "Find me some jazz tunes from the 60s",
       "action": {
-        "fullActionName": "player.searchTracks",
+        "fullActionName": "player.playGenre",
         "parameters": {
-          "query": "jazz tunes from the 60s"
+          "genre": "jazz",
+          "quantity": 60
         }
       },
       "explanation": {
         "properties": [
           {
             "name": "fullActionName",
-            "value": "player.searchTracks",
+            "value": "player.playGenre",
+            "substrings": []
+          },
+          {
+            "name": "parameters.genre",
+            "value": "jazz",
             "substrings": [
-              "Find me some jazz tunes from the 60s"
+              "jazz"
             ]
           },
           {
-            "name": "parameters.query",
-            "value": "jazz tunes from the 60s",
+            "name": "parameters.quantity",
+            "value": 60,
             "substrings": [
-              "jazz tunes from the 60s"
+              "60s"
             ]
           }
         ],
         "subPhrases": [
           {
-            "text": "Find me some",
-            "category": "command",
+            "text": "Find me",
+            "category": "politeness",
+            "synonyms": [
+              "Get me",
+              "Fetch me",
+              "Bring me"
+            ],
+            "isOptional": true
+          },
+          {
+            "text": "some",
+            "category": "filler",
+            "synonyms": [
+              "a few",
+              "a couple of",
+              "several"
+            ],
+            "isOptional": true
+          },
+          {
+            "text": "jazz",
+            "category": "genre",
             "propertyNames": [
-              "fullActionName"
+              "parameters.genre"
             ]
           },
           {
-            "text": "jazz tunes from the 60s",
-            "category": "query",
+            "text": "tunes",
+            "category": "filler",
+            "synonyms": [
+              "songs",
+              "tracks",
+              "melodies"
+            ],
+            "isOptional": true
+          },
+          {
+            "text": "from the 60s",
+            "category": "quantity",
             "propertyNames": [
-              "parameters.query"
+              "parameters.quantity"
             ]
           }
         ],
         "propertyAlternatives": [
           {
-            "propertyName": "fullActionName",
-            "propertyValue": "player.searchTracks",
+            "propertyName": "parameters.genre",
+            "propertyValue": "jazz",
             "propertySubPhrases": [
-              "Find me some"
+              "jazz"
             ],
             "alternatives": [
               {
-                "propertyValue": "player.playTracks",
+                "propertyValue": "blues",
                 "propertySubPhrases": [
-                  "Play me some"
+                  "blues"
                 ]
               },
               {
-                "propertyValue": "player.addTracksToQueue",
+                "propertyValue": "rock",
                 "propertySubPhrases": [
-                  "Queue up some"
+                  "rock"
                 ]
               },
               {
-                "propertyValue": "player.recommendTracks",
+                "propertyValue": "classical",
                 "propertySubPhrases": [
-                  "Recommend me some"
+                  "classical"
                 ]
               }
             ]
           },
           {
-            "propertyName": "parameters.query",
-            "propertyValue": "jazz tunes from the 60s",
+            "propertyName": "parameters.quantity",
+            "propertyValue": 60,
             "propertySubPhrases": [
-              "jazz tunes from the 60s"
+              "from the 60s"
             ],
             "alternatives": [
               {
-                "propertyValue": "rock songs from the 70s",
+                "propertyValue": 70,
                 "propertySubPhrases": [
-                  "rock songs from the 70s"
+                  "from the 70s"
                 ]
               },
               {
-                "propertyValue": "pop hits from the 80s",
+                "propertyValue": 80,
                 "propertySubPhrases": [
-                  "pop hits from the 80s"
+                  "from the 80s"
                 ]
               },
               {
-                "propertyValue": "classical music from the 90s",
+                "propertyValue": 90,
                 "propertySubPhrases": [
-                  "classical music from the 90s"
+                  "from the 90s"
                 ]
               }
             ]
@@ -1090,7 +1188,7 @@
         "subPhrases": [
           {
             "text": "Find music",
-            "category": "command",
+            "category": "action",
             "propertyNames": [
               "fullActionName"
             ]
@@ -1101,7 +1199,7 @@
             "synonyms": [
               "from",
               "of",
-              "with"
+              "featuring"
             ],
             "isOptional": true
           },
@@ -1182,14 +1280,12 @@
         "politePrefixes": [
           "Could you please",
           "Would you mind",
-          "If it's not too much trouble, could you",
-          "May I kindly ask you to"
+          "If it's not too much trouble, could you"
         ],
         "politeSuffixes": [
           "Thank you!",
-          "I would appreciate it!",
-          "Thanks a lot!",
-          "Much appreciated!"
+          "I would appreciate it.",
+          "Thanks a lot!"
         ]
       }
     },
@@ -1259,15 +1355,15 @@
                 ]
               },
               {
-                "propertyValue": "player.browseTracks",
+                "propertyValue": "player.pauseTracks",
                 "propertySubPhrases": [
-                  "Browse music"
+                  "Pause music"
                 ]
               },
               {
-                "propertyValue": "player.recommendTracks",
+                "propertyValue": "player.stopTracks",
                 "propertySubPhrases": [
-                  "Recommend music"
+                  "Stop music"
                 ]
               }
             ]
@@ -1286,15 +1382,136 @@
                 ]
               },
               {
+                "propertyValue": "classic artists",
+                "propertySubPhrases": [
+                  "classic artists"
+                ]
+              },
+              {
                 "propertyValue": "new releases",
                 "propertySubPhrases": [
                   "new releases"
                 ]
+              }
+            ]
+          }
+        ],
+        "politePrefixes": [
+          "Could you please",
+          "Would you mind",
+          "If it's not too much trouble, could you",
+          "May I kindly ask you to"
+        ],
+        "politeSuffixes": [
+          "Thank you!",
+          "I would appreciate it!",
+          "Thanks a lot!",
+          "Much appreciated!"
+        ]
+      }
+    },
+    {
+      "request": "Find music for a beach party",
+      "action": {
+        "fullActionName": "player.playGenre",
+        "parameters": {
+          "genre": "beach party"
+        }
+      },
+      "explanation": {
+        "properties": [
+          {
+            "name": "fullActionName",
+            "value": "player.playGenre",
+            "substrings": [
+              "Find music"
+            ]
+          },
+          {
+            "name": "parameters.genre",
+            "value": "beach party",
+            "substrings": [
+              "beach party"
+            ]
+          }
+        ],
+        "subPhrases": [
+          {
+            "text": "Find music",
+            "category": "command",
+            "propertyNames": [
+              "fullActionName"
+            ]
+          },
+          {
+            "text": "for a",
+            "category": "preposition",
+            "synonyms": [
+              "for the",
+              "for an",
+              "for"
+            ],
+            "isOptional": true
+          },
+          {
+            "text": "beach party",
+            "category": "genre",
+            "propertyNames": [
+              "parameters.genre"
+            ]
+          }
+        ],
+        "propertyAlternatives": [
+          {
+            "propertyName": "fullActionName",
+            "propertyValue": "player.playGenre",
+            "propertySubPhrases": [
+              "Find music"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "player.playSong",
+                "propertySubPhrases": [
+                  "Play a song"
+                ]
               },
               {
-                "propertyValue": "top charts",
+                "propertyValue": "player.playAlbum",
                 "propertySubPhrases": [
-                  "top charts"
+                  "Play an album"
+                ]
+              },
+              {
+                "propertyValue": "player.playPlaylist",
+                "propertySubPhrases": [
+                  "Play a playlist"
+                ]
+              }
+            ]
+          },
+          {
+            "propertyName": "parameters.genre",
+            "propertyValue": "beach party",
+            "propertySubPhrases": [
+              "beach party"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "rock",
+                "propertySubPhrases": [
+                  "rock"
+                ]
+              },
+              {
+                "propertyValue": "jazz",
+                "propertySubPhrases": [
+                  "jazz"
+                ]
+              },
+              {
+                "propertyValue": "classical",
+                "propertySubPhrases": [
+                  "classical"
                 ]
               }
             ]
@@ -1311,165 +1528,34 @@
       }
     },
     {
-      "request": "Find music for a beach party",
-      "action": {
-        "fullActionName": "player.searchTracks",
-        "parameters": {
-          "query": "beach party"
-        }
-      },
-      "explanation": {
-        "properties": [
-          {
-            "name": "fullActionName",
-            "value": "player.searchTracks",
-            "isImplicit": true
-          },
-          {
-            "name": "parameters.query",
-            "value": "beach party",
-            "substrings": [
-              "beach party"
-            ]
-          }
-        ],
-        "subPhrases": [
-          {
-            "text": "Find",
-            "category": "command",
-            "propertyNames": []
-          },
-          {
-            "text": "music for a",
-            "category": "context",
-            "propertyNames": []
-          },
-          {
-            "text": "beach party",
-            "category": "query",
-            "propertyNames": [
-              "parameters.query"
-            ]
-          }
-        ],
-        "propertyAlternatives": [
-          {
-            "propertyName": "parameters.query",
-            "propertyValue": "beach party",
-            "propertySubPhrases": [
-              "beach party"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "pool party",
-                "propertySubPhrases": [
-                  "pool party"
-                ]
-              },
-              {
-                "propertyValue": "summer party",
-                "propertySubPhrases": [
-                  "summer party"
-                ]
-              },
-              {
-                "propertyValue": "tropical party",
-                "propertySubPhrases": [
-                  "tropical party"
-                ]
-              },
-              {
-                "propertyValue": "island party",
-                "propertySubPhrases": [
-                  "island party"
-                ]
-              }
-            ]
-          }
-        ],
-        "politePrefixes": [
-          "Could you please",
-          "Would you mind"
-        ],
-        "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it."
-        ]
-      },
-      "corrections": [
-        {
-          "data": {
-            "properties": [
-              {
-                "name": "fullActionName",
-                "value": "player.searchTracks",
-                "isImplicit": true
-              },
-              {
-                "name": "parameters.query",
-                "value": "beach party",
-                "substrings": [
-                  "beach party"
-                ]
-              }
-            ],
-            "subPhrases": [
-              {
-                "text": "Find",
-                "category": "command",
-                "propertyNames": [
-                  "fullActionName"
-                ]
-              },
-              {
-                "text": "music for a",
-                "category": "context",
-                "propertyNames": []
-              },
-              {
-                "text": "beach party",
-                "category": "query",
-                "propertyNames": [
-                  "parameters.query"
-                ]
-              }
-            ]
-          },
-          "correction": [
-            "Property 'fullActionName' is expected to be implicit and should not be included as a property name in a sub-phrase"
-          ]
-        }
-      ]
-    },
-    {
       "request": "Find music from the Baroque period",
       "action": {
-        "fullActionName": "player.searchTracks",
+        "fullActionName": "player.playGenre",
         "parameters": {
-          "query": "Baroque period"
+          "genre": "Baroque"
         }
       },
       "explanation": {
         "properties": [
           {
             "name": "fullActionName",
-            "value": "player.searchTracks",
+            "value": "player.playGenre",
             "substrings": [
               "Find music"
             ]
           },
           {
-            "name": "parameters.query",
-            "value": "Baroque period",
+            "name": "parameters.genre",
+            "value": "Baroque",
             "substrings": [
-              "Baroque period"
+              "Baroque"
             ]
           }
         ],
         "subPhrases": [
           {
             "text": "Find music",
-            "category": "action",
+            "category": "command",
             "propertyNames": [
               "fullActionName"
             ]
@@ -1486,63 +1572,63 @@
           },
           {
             "text": "Baroque period",
-            "category": "query",
+            "category": "genre",
             "propertyNames": [
-              "parameters.query"
+              "parameters.genre"
             ]
           }
         ],
         "propertyAlternatives": [
           {
             "propertyName": "fullActionName",
-            "propertyValue": "player.searchTracks",
+            "propertyValue": "player.playGenre",
             "propertySubPhrases": [
               "Find music"
             ],
             "alternatives": [
               {
-                "propertyValue": "player.playTracks",
+                "propertyValue": "player.playSong",
                 "propertySubPhrases": [
-                  "Play music"
+                  "Play a song"
                 ]
               },
               {
-                "propertyValue": "player.pauseTracks",
+                "propertyValue": "player.playAlbum",
                 "propertySubPhrases": [
-                  "Pause music"
+                  "Play an album"
                 ]
               },
               {
-                "propertyValue": "player.stopTracks",
+                "propertyValue": "player.playPlaylist",
                 "propertySubPhrases": [
-                  "Stop music"
+                  "Play a playlist"
                 ]
               }
             ]
           },
           {
-            "propertyName": "parameters.query",
-            "propertyValue": "Baroque period",
+            "propertyName": "parameters.genre",
+            "propertyValue": "Baroque",
             "propertySubPhrases": [
               "Baroque period"
             ],
             "alternatives": [
               {
-                "propertyValue": "Classical period",
+                "propertyValue": "Classical",
                 "propertySubPhrases": [
                   "Classical period"
                 ]
               },
               {
-                "propertyValue": "Romantic period",
+                "propertyValue": "Romantic",
                 "propertySubPhrases": [
                   "Romantic period"
                 ]
               },
               {
-                "propertyValue": "Modern period",
+                "propertyValue": "Jazz",
                 "propertySubPhrases": [
-                  "Modern period"
+                  "Jazz era"
                 ]
               }
             ]
@@ -1553,8 +1639,8 @@
           "Would you mind"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it."
+          "Thank you",
+          "I appreciate it"
         ]
       }
     },
@@ -1563,7 +1649,7 @@
       "action": {
         "fullActionName": "player.playGenre",
         "parameters": {
-          "genre": "wedding reception"
+          "genre": "wedding"
         }
       },
       "explanation": {
@@ -1577,9 +1663,9 @@
           },
           {
             "name": "parameters.genre",
-            "value": "wedding reception",
+            "value": "wedding",
             "substrings": [
-              "wedding reception"
+              "wedding"
             ]
           }
         ],
@@ -1592,17 +1678,7 @@
             ]
           },
           {
-            "text": "at a",
-            "category": "preposition",
-            "synonyms": [
-              "during a",
-              "for a",
-              "in a"
-            ],
-            "isOptional": true
-          },
-          {
-            "text": "wedding reception",
+            "text": "at a wedding reception",
             "category": "genre",
             "propertyNames": [
               "parameters.genre"
@@ -1639,27 +1715,27 @@
           },
           {
             "propertyName": "parameters.genre",
-            "propertyValue": "wedding reception",
+            "propertyValue": "wedding",
             "propertySubPhrases": [
-              "wedding reception"
+              "at a wedding reception"
             ],
             "alternatives": [
               {
                 "propertyValue": "party",
                 "propertySubPhrases": [
-                  "party"
+                  "at a party"
                 ]
               },
               {
                 "propertyValue": "birthday",
                 "propertySubPhrases": [
-                  "birthday"
+                  "at a birthday party"
                 ]
               },
               {
-                "propertyValue": "corporate event",
+                "propertyValue": "corporate",
                 "propertySubPhrases": [
-                  "corporate event"
+                  "at a corporate event"
                 ]
               }
             ]
@@ -1668,14 +1744,12 @@
         "politePrefixes": [
           "Could you please",
           "Would you mind",
-          "If it's not too much trouble, could you",
-          "May I kindly ask you to"
+          "If it's not too much trouble, could you"
         ],
         "politeSuffixes": [
           "Thank you!",
-          "I would appreciate it!",
-          "Thanks a lot!",
-          "Much appreciated!"
+          "I would appreciate it.",
+          "Thanks in advance!"
         ]
       }
     },
@@ -1693,7 +1767,7 @@
             "name": "fullActionName",
             "value": "player.searchTracks",
             "substrings": [
-              "Find"
+              "Find punk rock songs by The Ramones"
             ]
           },
           {
@@ -1722,13 +1796,10 @@
           },
           {
             "text": "songs by",
-            "category": "filler",
-            "synonyms": [
-              "tracks by",
-              "music by",
-              "tunes by"
-            ],
-            "isOptional": true
+            "category": "music search",
+            "propertyNames": [
+              "fullActionName"
+            ]
           },
           {
             "text": "The Ramones",
@@ -1743,25 +1814,29 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.searchTracks",
             "propertySubPhrases": [
-              "Find"
+              "Find",
+              "songs by"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.findSongs",
                 "propertySubPhrases": [
-                  "Find"
+                  "Find",
+                  "songs by"
                 ]
               },
               {
-                "propertyValue": "player.lookupTracks",
+                "propertyValue": "music.searchTracks",
                 "propertySubPhrases": [
-                  "Find"
+                  "Find",
+                  "songs by"
                 ]
               },
               {
-                "propertyValue": "player.searchMusic",
+                "propertyValue": "audio.searchTracks",
                 "propertySubPhrases": [
-                  "Find"
+                  "Find",
+                  "songs by"
                 ]
               }
             ]
@@ -1775,17 +1850,17 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "punk rock Ramones",
-                "propertySubPhrases": [
-                  "punk rock",
-                  "The Ramones"
-                ]
-              },
-              {
                 "propertyValue": "rock The Ramones",
                 "propertySubPhrases": [
                   "rock",
                   "The Ramones"
+                ]
+              },
+              {
+                "propertyValue": "punk rock The Clash",
+                "propertySubPhrases": [
+                  "punk rock",
+                  "The Clash"
                 ]
               },
               {
@@ -1800,13 +1875,11 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind",
-          "If it's not too much trouble, could you"
+          "Would you mind"
         ],
         "politeSuffixes": [
           "Thank you!",
-          "I would appreciate it.",
-          "Thanks in advance!"
+          "I would appreciate it."
         ]
       }
     },
@@ -1815,7 +1888,7 @@
       "action": {
         "fullActionName": "player.searchTracks",
         "parameters": {
-          "query": "road trip playlist"
+          "query": "road trip"
         }
       },
       "explanation": {
@@ -1829,9 +1902,9 @@
           },
           {
             "name": "parameters.query",
-            "value": "road trip playlist",
+            "value": "road trip",
             "substrings": [
-              "road trip playlist"
+              "road trip"
             ]
           }
         ],
@@ -1854,11 +1927,21 @@
             "isOptional": true
           },
           {
-            "text": "road trip playlist",
+            "text": "road trip",
             "category": "query",
             "propertyNames": [
               "parameters.query"
             ]
+          },
+          {
+            "text": "playlist",
+            "category": "filler",
+            "synonyms": [
+              "list",
+              "collection",
+              "set"
+            ],
+            "isOptional": true
           }
         ],
         "propertyAlternatives": [
@@ -1870,48 +1953,48 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.findSongs",
+                "propertyValue": "player.searchAlbums",
                 "propertySubPhrases": [
-                  "Search for songs"
+                  "Find albums"
                 ]
               },
               {
-                "propertyValue": "player.lookupTracks",
+                "propertyValue": "player.searchArtists",
                 "propertySubPhrases": [
-                  "Look up songs"
+                  "Find artists"
                 ]
               },
               {
-                "propertyValue": "player.getTracks",
+                "propertyValue": "player.searchPlaylists",
                 "propertySubPhrases": [
-                  "Get songs"
+                  "Find playlists"
                 ]
               }
             ]
           },
           {
             "propertyName": "parameters.query",
-            "propertyValue": "road trip playlist",
+            "propertyValue": "road trip",
             "propertySubPhrases": [
-              "road trip playlist"
+              "road trip"
             ],
             "alternatives": [
               {
-                "propertyValue": "driving playlist",
+                "propertyValue": "workout",
                 "propertySubPhrases": [
-                  "driving playlist"
+                  "workout"
                 ]
               },
               {
-                "propertyValue": "travel playlist",
+                "propertyValue": "relaxation",
                 "propertySubPhrases": [
-                  "travel playlist"
+                  "relaxation"
                 ]
               },
               {
-                "propertyValue": "journey playlist",
+                "propertyValue": "party",
                 "propertySubPhrases": [
-                  "journey playlist"
+                  "party"
                 ]
               }
             ]
@@ -1919,11 +2002,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If it's not too much trouble,",
+          "I would appreciate it if you could"
         ],
         "politeSuffixes": [
           "Thank you!",
-          "I would appreciate it."
+          "Thanks a lot!",
+          "I appreciate it!",
+          "Much appreciated!"
         ]
       }
     },
@@ -1993,15 +2080,15 @@
                 ]
               },
               {
-                "propertyValue": "player.findTracks",
+                "propertyValue": "player.queueTracks",
                 "propertySubPhrases": [
-                  "Locate songs"
+                  "Queue songs"
                 ]
               },
               {
-                "propertyValue": "player.browseTracks",
+                "propertyValue": "player.recommendTracks",
                 "propertySubPhrases": [
-                  "Browse songs"
+                  "Recommend songs"
                 ]
               }
             ]
@@ -2014,21 +2101,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "dinner date",
+                "propertyValue": "party",
                 "propertySubPhrases": [
-                  "dinner date"
+                  "party"
                 ]
               },
               {
-                "propertyValue": "candlelight dinner",
+                "propertyValue": "workout",
                 "propertySubPhrases": [
-                  "candlelight dinner"
+                  "workout"
                 ]
               },
               {
-                "propertyValue": "intimate dinner",
+                "propertyValue": "study session",
                 "propertySubPhrases": [
-                  "intimate dinner"
+                  "study session"
                 ]
               }
             ]
@@ -2036,15 +2123,11 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind",
-          "If it's not too much trouble, could you",
-          "May I kindly ask you to"
+          "Would you mind"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it!",
-          "Thanks a lot!",
-          "Much appreciated!"
+          "Thank you",
+          "I would appreciate it"
         ]
       }
     },
@@ -2062,7 +2145,7 @@
             "name": "fullActionName",
             "value": "player.searchTracks",
             "substrings": [
-              "Find songs"
+              "Find songs from the soundtrack of The Greatest Showman"
             ]
           },
           {
@@ -2082,17 +2165,7 @@
             ]
           },
           {
-            "text": "from the",
-            "category": "preposition",
-            "synonyms": [
-              "of the",
-              "in the",
-              "from"
-            ],
-            "isOptional": true
-          },
-          {
-            "text": "soundtrack of The Greatest Showman",
+            "text": "from the soundtrack of The Greatest Showman",
             "category": "query",
             "propertyNames": [
               "parameters.query"
@@ -2114,15 +2187,15 @@
                 ]
               },
               {
-                "propertyValue": "player.addTracksToPlaylist",
+                "propertyValue": "player.addTracksToQueue",
                 "propertySubPhrases": [
-                  "Add songs to playlist"
+                  "Add songs to queue"
                 ]
               },
               {
-                "propertyValue": "player.queueTracks",
+                "propertyValue": "player.downloadTracks",
                 "propertySubPhrases": [
-                  "Queue songs"
+                  "Download songs"
                 ]
               }
             ]
@@ -2131,25 +2204,25 @@
             "propertyName": "parameters.query",
             "propertyValue": "soundtrack of The Greatest Showman",
             "propertySubPhrases": [
-              "soundtrack of The Greatest Showman"
+              "from the soundtrack of The Greatest Showman"
             ],
             "alternatives": [
               {
                 "propertyValue": "soundtrack of La La Land",
                 "propertySubPhrases": [
-                  "soundtrack of La La Land"
+                  "from the soundtrack of La La Land"
                 ]
               },
               {
                 "propertyValue": "soundtrack of Hamilton",
                 "propertySubPhrases": [
-                  "soundtrack of Hamilton"
+                  "from the soundtrack of Hamilton"
                 ]
               },
               {
-                "propertyValue": "soundtrack of Frozen",
+                "propertyValue": "soundtrack of Moana",
                 "propertySubPhrases": [
-                  "soundtrack of Frozen"
+                  "from the soundtrack of Moana"
                 ]
               }
             ]
@@ -2157,11 +2230,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If it's not too much trouble, could you",
+          "May I kindly ask you to"
         ],
         "politeSuffixes": [
           "Thank you!",
-          "I would appreciate it!"
+          "I would appreciate it!",
+          "Thanks a lot!",
+          "Much appreciated!"
         ]
       }
     },
@@ -2170,7 +2247,7 @@
       "action": {
         "fullActionName": "player.searchTracks",
         "parameters": {
-          "query": "songs that feature a saxophone"
+          "query": "saxophone"
         }
       },
       "explanation": {
@@ -2178,29 +2255,38 @@
           {
             "name": "fullActionName",
             "value": "player.searchTracks",
-            "substrings": []
+            "substrings": [
+              "Find songs"
+            ]
           },
           {
             "name": "parameters.query",
-            "value": "songs that feature a saxophone",
+            "value": "saxophone",
             "substrings": [
-              "songs that feature a saxophone"
+              "saxophone"
             ]
           }
         ],
         "subPhrases": [
           {
-            "text": "Find",
-            "category": "command",
+            "text": "Find songs",
+            "category": "action",
+            "propertyNames": [
+              "fullActionName"
+            ]
+          },
+          {
+            "text": "that feature a",
+            "category": "filler",
             "synonyms": [
-              "Search for",
-              "Look for",
-              "Locate"
+              "including",
+              "with",
+              "featuring"
             ],
             "isOptional": true
           },
           {
-            "text": "songs that feature a saxophone",
+            "text": "saxophone",
             "category": "query",
             "propertyNames": [
               "parameters.query"
@@ -2209,28 +2295,55 @@
         ],
         "propertyAlternatives": [
           {
-            "propertyName": "parameters.query",
-            "propertyValue": "songs that feature a saxophone",
+            "propertyName": "fullActionName",
+            "propertyValue": "player.searchTracks",
             "propertySubPhrases": [
-              "songs that feature a saxophone"
+              "Find songs"
             ],
             "alternatives": [
               {
-                "propertyValue": "songs with a saxophone solo",
+                "propertyValue": "player.searchAlbums",
                 "propertySubPhrases": [
-                  "songs with a saxophone solo"
+                  "Find albums"
                 ]
               },
               {
-                "propertyValue": "tracks featuring saxophone",
+                "propertyValue": "player.searchArtists",
                 "propertySubPhrases": [
-                  "tracks featuring saxophone"
+                  "Find artists"
                 ]
               },
               {
-                "propertyValue": "music with saxophone",
+                "propertyValue": "player.searchPlaylists",
                 "propertySubPhrases": [
-                  "music with saxophone"
+                  "Find playlists"
+                ]
+              }
+            ]
+          },
+          {
+            "propertyName": "parameters.query",
+            "propertyValue": "saxophone",
+            "propertySubPhrases": [
+              "saxophone"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "guitar",
+                "propertySubPhrases": [
+                  "guitar"
+                ]
+              },
+              {
+                "propertyValue": "piano",
+                "propertySubPhrases": [
+                  "piano"
+                ]
+              },
+              {
+                "propertyValue": "drums",
+                "propertySubPhrases": [
+                  "drums"
                 ]
               }
             ]
@@ -2238,11 +2351,13 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If it's not too much trouble, could you"
         ],
         "politeSuffixes": [
           "Thank you!",
-          "I would appreciate it!"
+          "I would appreciate it.",
+          "Thanks a lot!"
         ]
       }
     },
@@ -2274,7 +2389,7 @@
         "subPhrases": [
           {
             "text": "Find",
-            "category": "command",
+            "category": "action",
             "propertyNames": [
               "fullActionName"
             ]
@@ -2335,9 +2450,9 @@
                 ]
               },
               {
-                "propertyValue": "road trip sing-along songs",
+                "propertyValue": "road trip anthems",
                 "propertySubPhrases": [
-                  "road trip sing-along songs"
+                  "road trip anthems"
                 ]
               }
             ]
@@ -2349,7 +2464,7 @@
         ],
         "politeSuffixes": [
           "Thank you!",
-          "I would appreciate it."
+          "I would appreciate it!"
         ]
       }
     },
@@ -2358,7 +2473,7 @@
       "action": {
         "fullActionName": "player.searchTracks",
         "parameters": {
-          "query": "boost your mood"
+          "query": "songs to boost your mood"
         }
       },
       "explanation": {
@@ -2366,38 +2481,24 @@
           {
             "name": "fullActionName",
             "value": "player.searchTracks",
-            "substrings": [
-              "Find songs"
-            ]
+            "substrings": []
           },
           {
             "name": "parameters.query",
-            "value": "boost your mood",
+            "value": "songs to boost your mood",
             "substrings": [
-              "boost your mood"
+              "songs to boost your mood"
             ]
           }
         ],
         "subPhrases": [
           {
-            "text": "Find songs",
-            "category": "action",
-            "propertyNames": [
-              "fullActionName"
-            ]
+            "text": "Find",
+            "category": "command",
+            "propertyNames": []
           },
           {
-            "text": "to",
-            "category": "preposition",
-            "synonyms": [
-              "for",
-              "in order to",
-              "so as to"
-            ],
-            "isOptional": true
-          },
-          {
-            "text": "boost your mood",
+            "text": "songs to boost your mood",
             "category": "query",
             "propertyNames": [
               "parameters.query"
@@ -2406,55 +2507,34 @@
         ],
         "propertyAlternatives": [
           {
-            "propertyName": "fullActionName",
-            "propertyValue": "player.searchTracks",
-            "propertySubPhrases": [
-              "Find songs"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "player.findSongs",
-                "propertySubPhrases": [
-                  "Find songs"
-                ]
-              },
-              {
-                "propertyValue": "music.searchTracks",
-                "propertySubPhrases": [
-                  "Find songs"
-                ]
-              },
-              {
-                "propertyValue": "audio.searchTracks",
-                "propertySubPhrases": [
-                  "Find songs"
-                ]
-              }
-            ]
-          },
-          {
             "propertyName": "parameters.query",
-            "propertyValue": "boost your mood",
+            "propertyValue": "songs to boost your mood",
             "propertySubPhrases": [
-              "boost your mood"
+              "songs to boost your mood"
             ],
             "alternatives": [
               {
-                "propertyValue": "lift your spirits",
+                "propertyValue": "songs to relax",
                 "propertySubPhrases": [
-                  "lift your spirits"
+                  "songs to relax"
                 ]
               },
               {
-                "propertyValue": "cheer you up",
+                "propertyValue": "songs to energize",
                 "propertySubPhrases": [
-                  "cheer you up"
+                  "songs to energize"
                 ]
               },
               {
-                "propertyValue": "improve your mood",
+                "propertyValue": "songs to focus",
                 "propertySubPhrases": [
-                  "improve your mood"
+                  "songs to focus"
+                ]
+              },
+              {
+                "propertyValue": "songs to sleep",
+                "propertySubPhrases": [
+                  "songs to sleep"
                 ]
               }
             ]
@@ -2463,12 +2543,14 @@
         "politePrefixes": [
           "Could you please",
           "Would you mind",
-          "If it's not too much trouble, could you"
+          "Kindly",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it!",
-          "Thanks a lot!"
+          "Thank you",
+          "Thanks",
+          "I appreciate it",
+          "If you don't mind"
         ]
       }
     },
@@ -2549,21 +2631,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "songs for a shower",
+                "propertyValue": "shower songs",
                 "propertySubPhrases": [
-                  "songs for a shower"
+                  "shower songs"
                 ]
               },
               {
-                "propertyValue": "shower singing songs",
+                "propertyValue": "singing in the shower",
                 "propertySubPhrases": [
-                  "shower singing songs"
+                  "singing in the shower"
                 ]
               },
               {
-                "propertyValue": "music for shower time",
+                "propertyValue": "songs for shower time",
                 "propertySubPhrases": [
-                  "music for shower time"
+                  "songs for shower time"
                 ]
               }
             ]
@@ -2571,41 +2653,35 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If it's not too much trouble, could you"
         ],
         "politeSuffixes": [
           "Thank you!",
-          "I would appreciate it."
+          "I would appreciate it.",
+          "Thanks a lot!"
         ]
       }
     },
     {
       "request": "Find songs with the word love in the title",
       "action": {
-        "fullActionName": "player.filterTracks",
+        "fullActionName": "player.searchTracks",
         "parameters": {
-          "filterType": "name",
-          "filterValue": "love"
+          "query": "love"
         }
       },
       "explanation": {
         "properties": [
           {
             "name": "fullActionName",
-            "value": "player.filterTracks",
+            "value": "player.searchTracks",
             "substrings": [
               "Find songs"
             ]
           },
           {
-            "name": "parameters.filterType",
-            "value": "name",
-            "substrings": [
-              "in the title"
-            ]
-          },
-          {
-            "name": "parameters.filterValue",
+            "name": "parameters.query",
             "value": "love",
             "substrings": [
               "love"
@@ -2622,59 +2698,62 @@
           },
           {
             "text": "with the word",
-            "category": "preposition",
+            "category": "filler",
             "synonyms": [
-              "containing",
-              "including",
-              "featuring"
+              "containing the word",
+              "that includes the word",
+              "featuring the word"
             ],
             "isOptional": true
           },
           {
             "text": "love",
-            "category": "filterValue",
+            "category": "query",
             "propertyNames": [
-              "parameters.filterValue"
+              "parameters.query"
             ]
           },
           {
             "text": "in the title",
-            "category": "filterType",
-            "propertyNames": [
-              "parameters.filterType"
-            ]
+            "category": "filler",
+            "synonyms": [
+              "in the name",
+              "in the song title",
+              "in the track title"
+            ],
+            "isOptional": true
           }
         ],
         "propertyAlternatives": [
           {
             "propertyName": "fullActionName",
-            "propertyValue": "player.filterTracks",
+            "propertyValue": "player.searchTracks",
             "propertySubPhrases": [
               "Find songs"
             ],
             "alternatives": [
               {
-                "propertyValue": "player.searchTracks",
+                "propertyValue": "player.searchAlbums",
                 "propertySubPhrases": [
-                  "Search for songs"
+                  "Find albums"
                 ]
               },
               {
-                "propertyValue": "player.findTracks",
+                "propertyValue": "player.searchArtists",
                 "propertySubPhrases": [
-                  "Locate songs"
+                  "Find artists"
                 ]
               },
               {
-                "propertyValue": "player.getTracks",
+                "propertyValue": "player.searchPlaylists",
                 "propertySubPhrases": [
-                  "Get songs"
+                  "Find playlists"
                 ]
               }
             ]
           },
           {
-            "propertyName": "parameters.filterValue",
+            "propertyName": "parameters.query",
             "propertyValue": "love",
             "propertySubPhrases": [
               "love"
@@ -2699,42 +2778,19 @@
                 ]
               }
             ]
-          },
-          {
-            "propertyName": "parameters.filterType",
-            "propertyValue": "name",
-            "propertySubPhrases": [
-              "in the title"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "artist",
-                "propertySubPhrases": [
-                  "by the artist"
-                ]
-              },
-              {
-                "propertyValue": "album",
-                "propertySubPhrases": [
-                  "in the album"
-                ]
-              },
-              {
-                "propertyValue": "genre",
-                "propertySubPhrases": [
-                  "in the genre"
-                ]
-              }
-            ]
           }
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If it's not too much trouble, could you",
+          "May I kindly ask you to"
         ],
         "politeSuffixes": [
           "Thank you!",
-          "I would appreciate it."
+          "I would appreciate it!",
+          "Thanks a lot!",
+          "Much appreciated!"
         ]
       }
     },
@@ -2751,7 +2807,9 @@
           {
             "name": "fullActionName",
             "value": "player.searchTracks",
-            "substrings": []
+            "substrings": [
+              "Find"
+            ]
           },
           {
             "name": "parameters.query",
@@ -2764,11 +2822,23 @@
         "subPhrases": [
           {
             "text": "Find",
-            "category": "command",
-            "propertyNames": []
+            "category": "action",
+            "propertyNames": [
+              "fullActionName"
+            ]
           },
           {
-            "text": "the best of 90s R&B",
+            "text": "the",
+            "category": "filler",
+            "synonyms": [
+              "a",
+              "an",
+              "that"
+            ],
+            "isOptional": true
+          },
+          {
+            "text": "best of 90s R&B",
             "category": "query",
             "propertyNames": [
               "parameters.query"
@@ -2777,28 +2847,55 @@
         ],
         "propertyAlternatives": [
           {
-            "propertyName": "parameters.query",
-            "propertyValue": "best of 90s R&B",
+            "propertyName": "fullActionName",
+            "propertyValue": "player.searchTracks",
             "propertySubPhrases": [
-              "the best of 90s R&B"
+              "Find"
             ],
             "alternatives": [
               {
-                "propertyValue": "best of 80s R&B",
+                "propertyValue": "player.findTracks",
                 "propertySubPhrases": [
-                  "the best of 80s R&B"
+                  "Search"
                 ]
               },
               {
-                "propertyValue": "best of 2000s R&B",
+                "propertyValue": "player.lookupTracks",
                 "propertySubPhrases": [
-                  "the best of 2000s R&B"
+                  "Look up"
                 ]
               },
               {
-                "propertyValue": "best of 90s pop",
+                "propertyValue": "player.discoverTracks",
                 "propertySubPhrases": [
-                  "the best of 90s pop"
+                  "Discover"
+                ]
+              }
+            ]
+          },
+          {
+            "propertyName": "parameters.query",
+            "propertyValue": "best of 90s R&B",
+            "propertySubPhrases": [
+              "best of 90s R&B"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "top 90s R&B",
+                "propertySubPhrases": [
+                  "top 90s R&B"
+                ]
+              },
+              {
+                "propertyValue": "greatest 90s R&B",
+                "propertySubPhrases": [
+                  "greatest 90s R&B"
+                ]
+              },
+              {
+                "propertyValue": "90s R&B hits",
+                "propertySubPhrases": [
+                  "90s R&B hits"
                 ]
               }
             ]
@@ -2806,13 +2903,11 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind",
-          "If it's not too much trouble, could you"
+          "Would you mind"
         ],
         "politeSuffixes": [
           "Thank you!",
-          "I would appreciate it.",
-          "Thanks in advance!"
+          "I would appreciate it."
         ]
       }
     },
@@ -2829,7 +2924,9 @@
           {
             "name": "fullActionName",
             "value": "player.searchTracks",
-            "substrings": []
+            "substrings": [
+              "Find"
+            ]
           },
           {
             "name": "parameters.query",
@@ -2842,11 +2939,23 @@
         "subPhrases": [
           {
             "text": "Find",
-            "category": "command",
-            "propertyNames": []
+            "category": "action",
+            "propertyNames": [
+              "fullActionName"
+            ]
           },
           {
-            "text": "the best of country rock",
+            "text": "the",
+            "category": "filler",
+            "synonyms": [
+              "a",
+              "an",
+              "some"
+            ],
+            "isOptional": true
+          },
+          {
+            "text": "best of country rock",
             "category": "query",
             "propertyNames": [
               "parameters.query"
@@ -2855,28 +2964,55 @@
         ],
         "propertyAlternatives": [
           {
-            "propertyName": "parameters.query",
-            "propertyValue": "best of country rock",
+            "propertyName": "fullActionName",
+            "propertyValue": "player.searchTracks",
             "propertySubPhrases": [
-              "the best of country rock"
+              "Find"
             ],
             "alternatives": [
               {
-                "propertyValue": "top country rock hits",
+                "propertyValue": "player.playTracks",
                 "propertySubPhrases": [
-                  "the top country rock hits"
+                  "Play"
                 ]
               },
               {
-                "propertyValue": "greatest country rock songs",
+                "propertyValue": "player.addTracksToQueue",
                 "propertySubPhrases": [
-                  "the greatest country rock songs"
+                  "Queue"
                 ]
               },
               {
-                "propertyValue": "country rock classics",
+                "propertyValue": "player.shuffleTracks",
                 "propertySubPhrases": [
-                  "the country rock classics"
+                  "Shuffle"
+                ]
+              }
+            ]
+          },
+          {
+            "propertyName": "parameters.query",
+            "propertyValue": "best of country rock",
+            "propertySubPhrases": [
+              "best of country rock"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "top country rock",
+                "propertySubPhrases": [
+                  "top country rock"
+                ]
+              },
+              {
+                "propertyValue": "greatest country rock",
+                "propertySubPhrases": [
+                  "greatest country rock"
+                ]
+              },
+              {
+                "propertyValue": "country rock hits",
+                "propertySubPhrases": [
+                  "country rock hits"
                 ]
               }
             ]
@@ -2884,13 +3020,11 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind",
-          "If it's not too much trouble, could you"
+          "Would you mind"
         ],
         "politeSuffixes": [
           "Thank you!",
-          "I would appreciate it.",
-          "Thanks in advance!"
+          "I would appreciate it."
         ]
       }
     },
@@ -2946,19 +3080,19 @@
               {
                 "propertyValue": "player.findTracks",
                 "propertySubPhrases": [
-                  "Find"
+                  "Locate"
                 ]
               },
               {
                 "propertyValue": "player.lookupTracks",
                 "propertySubPhrases": [
-                  "Find"
+                  "Search for"
                 ]
               },
               {
-                "propertyValue": "player.locateTracks",
+                "propertyValue": "player.browseTracks",
                 "propertySubPhrases": [
-                  "Find"
+                  "Browse"
                 ]
               }
             ]
@@ -2973,19 +3107,19 @@
               {
                 "propertyValue": "top electronic trance music",
                 "propertySubPhrases": [
-                  "the best of electronic trance music"
+                  "the top electronic trance music"
                 ]
               },
               {
                 "propertyValue": "greatest electronic trance music",
                 "propertySubPhrases": [
-                  "the best of electronic trance music"
+                  "the greatest electronic trance music"
                 ]
               },
               {
-                "propertyValue": "finest electronic trance music",
+                "propertyValue": "popular electronic trance music",
                 "propertySubPhrases": [
-                  "the best of electronic trance music"
+                  "the popular electronic trance music"
                 ]
               }
             ]
@@ -2996,8 +3130,8 @@
           "Would you mind"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it."
+          "Thank you",
+          "I appreciate it"
         ]
       }
     },
@@ -3014,9 +3148,7 @@
           {
             "name": "fullActionName",
             "value": "player.searchTracks",
-            "substrings": [
-              "Find"
-            ]
+            "substrings": []
           },
           {
             "name": "parameters.query",
@@ -3029,23 +3161,11 @@
         "subPhrases": [
           {
             "text": "Find",
-            "category": "action",
-            "propertyNames": [
-              "fullActionName"
-            ]
+            "category": "command",
+            "propertyNames": []
           },
           {
-            "text": "the",
-            "category": "filler",
-            "synonyms": [
-              "a",
-              "an",
-              "some"
-            ],
-            "isOptional": true
-          },
-          {
-            "text": "best of reggaeton",
+            "text": "the best of reggaeton",
             "category": "query",
             "propertyNames": [
               "parameters.query"
@@ -3054,55 +3174,28 @@
         ],
         "propertyAlternatives": [
           {
-            "propertyName": "fullActionName",
-            "propertyValue": "player.searchTracks",
-            "propertySubPhrases": [
-              "Find"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "player.findSongs",
-                "propertySubPhrases": [
-                  "Find"
-                ]
-              },
-              {
-                "propertyValue": "player.lookupTracks",
-                "propertySubPhrases": [
-                  "Find"
-                ]
-              },
-              {
-                "propertyValue": "player.searchMusic",
-                "propertySubPhrases": [
-                  "Find"
-                ]
-              }
-            ]
-          },
-          {
             "propertyName": "parameters.query",
             "propertyValue": "best of reggaeton",
             "propertySubPhrases": [
-              "best of reggaeton"
+              "the best of reggaeton"
             ],
             "alternatives": [
               {
                 "propertyValue": "top reggaeton hits",
                 "propertySubPhrases": [
-                  "top reggaeton hits"
-                ]
-              },
-              {
-                "propertyValue": "reggaeton favorites",
-                "propertySubPhrases": [
-                  "reggaeton favorites"
+                  "the top reggaeton hits"
                 ]
               },
               {
                 "propertyValue": "popular reggaeton songs",
                 "propertySubPhrases": [
-                  "popular reggaeton songs"
+                  "the popular reggaeton songs"
+                ]
+              },
+              {
+                "propertyValue": "greatest reggaeton tracks",
+                "propertySubPhrases": [
+                  "the greatest reggaeton tracks"
                 ]
               }
             ]
@@ -3111,14 +3204,12 @@
         "politePrefixes": [
           "Could you please",
           "Would you mind",
-          "If it's not too much trouble, could you",
-          "Please"
+          "If it's not too much trouble, could you"
         ],
         "politeSuffixes": [
           "Thank you!",
-          "Thanks a lot!",
-          "I would appreciate it!",
-          "Much appreciated!"
+          "I would appreciate it.",
+          "Thanks in advance!"
         ]
       }
     },
@@ -3135,39 +3226,28 @@
           {
             "name": "fullActionName",
             "value": "player.searchTracks",
-            "substrings": []
+            "substrings": [
+              "Find"
+            ]
           },
           {
             "name": "parameters.query",
             "value": "best of synth-pop",
             "substrings": [
-              "best of synth-pop"
+              "the best of synth-pop"
             ]
           }
         ],
         "subPhrases": [
           {
             "text": "Find",
-            "category": "command",
-            "synonyms": [
-              "Search",
-              "Look for",
-              "Locate"
-            ],
-            "isOptional": true
+            "category": "action",
+            "propertyNames": [
+              "fullActionName"
+            ]
           },
           {
-            "text": "the",
-            "category": "preposition",
-            "synonyms": [
-              "a",
-              "an",
-              "some"
-            ],
-            "isOptional": true
-          },
-          {
-            "text": "best of synth-pop",
+            "text": "the best of synth-pop",
             "category": "query",
             "propertyNames": [
               "parameters.query"
@@ -3176,28 +3256,55 @@
         ],
         "propertyAlternatives": [
           {
+            "propertyName": "fullActionName",
+            "propertyValue": "player.searchTracks",
+            "propertySubPhrases": [
+              "Find"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "player.findTracks",
+                "propertySubPhrases": [
+                  "Find"
+                ]
+              },
+              {
+                "propertyValue": "music.searchTracks",
+                "propertySubPhrases": [
+                  "Find"
+                ]
+              },
+              {
+                "propertyValue": "audio.searchTracks",
+                "propertySubPhrases": [
+                  "Find"
+                ]
+              }
+            ]
+          },
+          {
             "propertyName": "parameters.query",
             "propertyValue": "best of synth-pop",
             "propertySubPhrases": [
-              "best of synth-pop"
+              "the best of synth-pop"
             ],
             "alternatives": [
               {
                 "propertyValue": "top synth-pop hits",
                 "propertySubPhrases": [
-                  "top synth-pop hits"
-                ]
-              },
-              {
-                "propertyValue": "greatest synth-pop songs",
-                "propertySubPhrases": [
-                  "greatest synth-pop songs"
+                  "the best of synth-pop"
                 ]
               },
               {
                 "propertyValue": "synth-pop classics",
                 "propertySubPhrases": [
-                  "synth-pop classics"
+                  "the best of synth-pop"
+                ]
+              },
+              {
+                "propertyValue": "greatest synth-pop songs",
+                "propertySubPhrases": [
+                  "the best of synth-pop"
                 ]
               }
             ]
@@ -3205,11 +3312,13 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If it's not too much trouble, could you"
         ],
         "politeSuffixes": [
           "Thank you!",
-          "I would appreciate it."
+          "I would appreciate it.",
+          "Thanks in advance!"
         ]
       }
     },
@@ -3226,9 +3335,7 @@
           {
             "name": "fullActionName",
             "value": "player.searchTracks",
-            "substrings": [
-              "Find"
-            ]
+            "isImplicit": true
           },
           {
             "name": "parameters.query",
@@ -3241,13 +3348,105 @@
         "subPhrases": [
           {
             "text": "Find",
+            "category": "command",
+            "propertyNames": []
+          },
+          {
+            "text": "the greatest hits of the 80s",
+            "category": "query",
+            "propertyNames": [
+              "parameters.query"
+            ]
+          }
+        ],
+        "propertyAlternatives": [
+          {
+            "propertyName": "parameters.query",
+            "propertyValue": "greatest hits of the 80s",
+            "propertySubPhrases": [
+              "the greatest hits of the 80s"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "greatest hits of the 90s",
+                "propertySubPhrases": [
+                  "the greatest hits of the 90s"
+                ]
+              },
+              {
+                "propertyValue": "top songs of the 80s",
+                "propertySubPhrases": [
+                  "the top songs of the 80s"
+                ]
+              },
+              {
+                "propertyValue": "best of the 80s",
+                "propertySubPhrases": [
+                  "the best of the 80s"
+                ]
+              }
+            ]
+          }
+        ],
+        "politePrefixes": [
+          "Could you please",
+          "Would you mind",
+          "If it's not too much trouble,",
+          "May I kindly ask you to"
+        ],
+        "politeSuffixes": [
+          "Thank you.",
+          "I would appreciate it.",
+          "Thanks a lot.",
+          "Much appreciated."
+        ]
+      }
+    },
+    {
+      "request": "Find the most iconic guitar solos",
+      "action": {
+        "fullActionName": "player.searchTracks",
+        "parameters": {
+          "query": "iconic guitar solos"
+        }
+      },
+      "explanation": {
+        "properties": [
+          {
+            "name": "fullActionName",
+            "value": "player.searchTracks",
+            "substrings": [
+              "Find"
+            ]
+          },
+          {
+            "name": "parameters.query",
+            "value": "iconic guitar solos",
+            "substrings": [
+              "iconic guitar solos"
+            ]
+          }
+        ],
+        "subPhrases": [
+          {
+            "text": "Find",
             "category": "action",
             "propertyNames": [
               "fullActionName"
             ]
           },
           {
-            "text": "the greatest hits of the 80s",
+            "text": "the most",
+            "category": "filler",
+            "synonyms": [
+              "the best",
+              "the greatest",
+              "the top"
+            ],
+            "isOptional": true
+          },
+          {
+            "text": "iconic guitar solos",
             "category": "query",
             "propertyNames": [
               "parameters.query"
@@ -3263,7 +3462,7 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.findSongs",
+                "propertyValue": "player.findTracks",
                 "propertySubPhrases": [
                   "Find"
                 ]
@@ -3275,7 +3474,7 @@
                 ]
               },
               {
-                "propertyValue": "player.searchMusic",
+                "propertyValue": "player.searchSongs",
                 "propertySubPhrases": [
                   "Find"
                 ]
@@ -3284,109 +3483,27 @@
           },
           {
             "propertyName": "parameters.query",
-            "propertyValue": "greatest hits of the 80s",
+            "propertyValue": "iconic guitar solos",
             "propertySubPhrases": [
-              "the greatest hits of the 80s"
+              "iconic guitar solos"
             ],
             "alternatives": [
-              {
-                "propertyValue": "top songs of the 80s",
-                "propertySubPhrases": [
-                  "the top songs of the 80s"
-                ]
-              },
-              {
-                "propertyValue": "best tracks of the 80s",
-                "propertySubPhrases": [
-                  "the best tracks of the 80s"
-                ]
-              },
-              {
-                "propertyValue": "80s hit songs",
-                "propertySubPhrases": [
-                  "80s hit songs"
-                ]
-              }
-            ]
-          }
-        ],
-        "politePrefixes": [
-          "Could you please",
-          "Would you mind"
-        ],
-        "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it."
-        ]
-      }
-    },
-    {
-      "request": "Find the most iconic guitar solos",
-      "action": {
-        "fullActionName": "player.searchTracks",
-        "parameters": {
-          "query": "most iconic guitar solos"
-        }
-      },
-      "explanation": {
-        "properties": [
-          {
-            "name": "fullActionName",
-            "value": "player.searchTracks",
-            "substrings": []
-          },
-          {
-            "name": "parameters.query",
-            "value": "most iconic guitar solos",
-            "substrings": [
-              "most iconic guitar solos"
-            ]
-          }
-        ],
-        "subPhrases": [
-          {
-            "text": "Find",
-            "category": "command",
-            "propertyNames": []
-          },
-          {
-            "text": "the most iconic guitar solos",
-            "category": "query",
-            "propertyNames": [
-              "parameters.query"
-            ]
-          }
-        ],
-        "propertyAlternatives": [
-          {
-            "propertyName": "parameters.query",
-            "propertyValue": "most iconic guitar solos",
-            "propertySubPhrases": [
-              "the most iconic guitar solos"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "best guitar solos",
-                "propertySubPhrases": [
-                  "the best guitar solos"
-                ]
-              },
               {
                 "propertyValue": "famous guitar solos",
                 "propertySubPhrases": [
-                  "the famous guitar solos"
+                  "famous guitar solos"
                 ]
               },
               {
                 "propertyValue": "legendary guitar solos",
                 "propertySubPhrases": [
-                  "the legendary guitar solos"
+                  "legendary guitar solos"
                 ]
               },
               {
-                "propertyValue": "greatest guitar solos",
+                "propertyValue": "classic guitar solos",
                 "propertySubPhrases": [
-                  "the greatest guitar solos"
+                  "classic guitar solos"
                 ]
               }
             ]
@@ -3394,11 +3511,13 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If it's not too much trouble, could you"
         ],
         "politeSuffixes": [
           "Thank you!",
-          "I would appreciate it."
+          "I would appreciate it.",
+          "Thanks in advance!"
         ]
       }
     },
@@ -3430,23 +3549,13 @@
         "subPhrases": [
           {
             "text": "Find",
-            "category": "command",
+            "category": "action",
             "propertyNames": [
               "fullActionName"
             ]
           },
           {
-            "text": "the",
-            "category": "filler",
-            "synonyms": [
-              "a",
-              "an",
-              "some"
-            ],
-            "isOptional": true
-          },
-          {
-            "text": "most relaxing songs ever",
+            "text": "the most relaxing songs ever",
             "category": "query",
             "propertyNames": [
               "parameters.query"
@@ -3464,13 +3573,13 @@
               {
                 "propertyValue": "player.findTracks",
                 "propertySubPhrases": [
-                  "Search"
+                  "Locate"
                 ]
               },
               {
                 "propertyValue": "player.lookupTracks",
                 "propertySubPhrases": [
-                  "Look up"
+                  "Search for"
                 ]
               },
               {
@@ -3485,25 +3594,25 @@
             "propertyName": "parameters.query",
             "propertyValue": "most relaxing songs ever",
             "propertySubPhrases": [
-              "most relaxing songs ever"
+              "the most relaxing songs ever"
             ],
             "alternatives": [
               {
-                "propertyValue": "most calming songs ever",
+                "propertyValue": "most calming music ever",
                 "propertySubPhrases": [
-                  "most calming songs ever"
+                  "the most calming music ever"
                 ]
               },
               {
-                "propertyValue": "most soothing songs ever",
+                "propertyValue": "most soothing tracks ever",
                 "propertySubPhrases": [
-                  "most soothing songs ever"
+                  "the most soothing tracks ever"
                 ]
               },
               {
-                "propertyValue": "most peaceful songs ever",
+                "propertyValue": "most peaceful melodies ever",
                 "propertySubPhrases": [
-                  "most peaceful songs ever"
+                  "the most peaceful melodies ever"
                 ]
               }
             ]
@@ -3516,7 +3625,7 @@
         ],
         "politeSuffixes": [
           "Thank you!",
-          "I would appreciate it.",
+          "I would really appreciate it.",
           "Thanks a lot!"
         ]
       }
@@ -3534,7 +3643,9 @@
           {
             "name": "fullActionName",
             "value": "player.searchTracks",
-            "substrings": []
+            "substrings": [
+              "Find the top 10 viral songs on TikTok"
+            ]
           },
           {
             "name": "parameters.query",
@@ -3546,12 +3657,14 @@
         ],
         "subPhrases": [
           {
-            "text": "Find the",
+            "text": "Find",
             "category": "command",
-            "propertyNames": []
+            "propertyNames": [
+              "fullActionName"
+            ]
           },
           {
-            "text": "top 10 viral songs on TikTok",
+            "text": "the top 10 viral songs on TikTok",
             "category": "query",
             "propertyNames": [
               "parameters.query"
@@ -3560,28 +3673,55 @@
         ],
         "propertyAlternatives": [
           {
+            "propertyName": "fullActionName",
+            "propertyValue": "player.searchTracks",
+            "propertySubPhrases": [
+              "Find"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "player.findTracks",
+                "propertySubPhrases": [
+                  "Find"
+                ]
+              },
+              {
+                "propertyValue": "player.lookupTracks",
+                "propertySubPhrases": [
+                  "Find"
+                ]
+              },
+              {
+                "propertyValue": "player.getTracks",
+                "propertySubPhrases": [
+                  "Find"
+                ]
+              }
+            ]
+          },
+          {
             "propertyName": "parameters.query",
             "propertyValue": "top 10 viral songs on TikTok",
             "propertySubPhrases": [
-              "top 10 viral songs on TikTok"
+              "the top 10 viral songs on TikTok"
             ],
             "alternatives": [
               {
                 "propertyValue": "top 10 trending songs on TikTok",
                 "propertySubPhrases": [
-                  "top 10 trending songs on TikTok"
+                  "the top 10 trending songs on TikTok"
                 ]
               },
               {
                 "propertyValue": "top 10 popular songs on TikTok",
                 "propertySubPhrases": [
-                  "top 10 popular songs on TikTok"
+                  "the top 10 popular songs on TikTok"
                 ]
               },
               {
                 "propertyValue": "top 10 hit songs on TikTok",
                 "propertySubPhrases": [
-                  "top 10 hit songs on TikTok"
+                  "the top 10 hit songs on TikTok"
                 ]
               }
             ]
@@ -3593,7 +3733,7 @@
         ],
         "politeSuffixes": [
           "Thank you!",
-          "I would appreciate it."
+          "I appreciate it!"
         ]
       }
     },
@@ -3624,7 +3764,9 @@
           {
             "text": "Find",
             "category": "command",
-            "propertyNames": []
+            "propertyNames": [
+              "fullActionName"
+            ]
           },
           {
             "text": "top hits from the 2000s",
@@ -3636,6 +3778,33 @@
         ],
         "propertyAlternatives": [
           {
+            "propertyName": "fullActionName",
+            "propertyValue": "player.searchTracks",
+            "propertySubPhrases": [
+              "Find"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "player.findSongs",
+                "propertySubPhrases": [
+                  "Find"
+                ]
+              },
+              {
+                "propertyValue": "music.searchTracks",
+                "propertySubPhrases": [
+                  "Find"
+                ]
+              },
+              {
+                "propertyValue": "audio.searchTracks",
+                "propertySubPhrases": [
+                  "Find"
+                ]
+              }
+            ]
+          },
+          {
             "propertyName": "parameters.query",
             "propertyValue": "top hits from the 2000s",
             "propertySubPhrases": [
@@ -3643,27 +3812,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "top hits from the 1990s",
+                "propertyValue": "top songs from the 2000s",
                 "propertySubPhrases": [
-                  "top hits from the 1990s"
+                  "top songs from the 2000s"
                 ]
               },
               {
-                "propertyValue": "top hits from the 2010s",
+                "propertyValue": "best hits from the 2000s",
                 "propertySubPhrases": [
-                  "top hits from the 2010s"
+                  "best hits from the 2000s"
                 ]
               },
               {
-                "propertyValue": "top rock hits from the 2000s",
+                "propertyValue": "popular tracks from the 2000s",
                 "propertySubPhrases": [
-                  "top rock hits from the 2000s"
-                ]
-              },
-              {
-                "propertyValue": "top pop hits from the 2000s",
-                "propertySubPhrases": [
-                  "top pop hits from the 2000s"
+                  "popular tracks from the 2000s"
                 ]
               }
             ]
@@ -3671,15 +3834,11 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind",
-          "If it's not too much trouble, could you",
-          "May I kindly ask you to"
+          "Would you mind"
         ],
         "politeSuffixes": [
           "Thank you!",
-          "I would appreciate it!",
-          "Thanks a lot!",
-          "Much appreciated!"
+          "I would appreciate it."
         ]
       }
     },
@@ -3697,7 +3856,7 @@
             "name": "fullActionName",
             "value": "player.searchTracks",
             "substrings": [
-              "Find tracks featuring"
+              "Find tracks"
             ]
           },
           {
@@ -3710,11 +3869,21 @@
         ],
         "subPhrases": [
           {
-            "text": "Find tracks featuring",
+            "text": "Find tracks",
             "category": "action",
             "propertyNames": [
               "fullActionName"
             ]
+          },
+          {
+            "text": "featuring",
+            "category": "preposition",
+            "synonyms": [
+              "with",
+              "including",
+              "starring"
+            ],
+            "isOptional": true
           },
           {
             "text": "Ariana Grande",
@@ -3729,25 +3898,25 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.searchTracks",
             "propertySubPhrases": [
-              "Find tracks featuring"
+              "Find tracks"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.findSongs",
                 "propertySubPhrases": [
-                  "Search for songs by"
+                  "Find songs"
                 ]
               },
               {
-                "propertyValue": "music.lookupTracks",
+                "propertyValue": "player.lookupTracks",
                 "propertySubPhrases": [
-                  "Look up tracks by"
+                  "Look up tracks"
                 ]
               },
               {
-                "propertyValue": "audio.searchMusic",
+                "propertyValue": "player.searchMusic",
                 "propertySubPhrases": [
-                  "Find music featuring"
+                  "Search music"
                 ]
               }
             ]
@@ -3807,7 +3976,7 @@
             "name": "fullActionName",
             "value": "player.playAlbum",
             "substrings": [
-              "Find tracks from the album Rumours by Fleetwood Mac"
+              "Find tracks from the album"
             ]
           },
           {
@@ -3835,7 +4004,7 @@
           },
           {
             "text": "Rumours",
-            "category": "albumName",
+            "category": "album name",
             "propertyNames": [
               "parameters.albumName"
             ]
@@ -3852,7 +4021,7 @@
           },
           {
             "text": "Fleetwood Mac",
-            "category": "artistName",
+            "category": "artist name",
             "propertyNames": [
               "parameters.artists.0"
             ]
@@ -3875,7 +4044,7 @@
               {
                 "propertyValue": "player.addAlbumToPlaylist",
                 "propertySubPhrases": [
-                  "Add tracks from the album"
+                  "Add tracks from the album to playlist"
                 ]
               },
               {
@@ -3945,12 +4114,12 @@
           "Could you please",
           "Would you mind",
           "If it's not too much trouble, could you",
-          "May I kindly ask you to"
+          "I would appreciate it if you could"
         ],
         "politeSuffixes": [
           "Thank you!",
-          "I would appreciate it!",
           "Thanks a lot!",
+          "I appreciate it!",
           "Much appreciated!"
         ]
       }
@@ -3968,9 +4137,7 @@
           {
             "name": "fullActionName",
             "value": "player.searchTracks",
-            "substrings": [
-              "Look for"
-            ]
+            "substrings": []
           },
           {
             "name": "parameters.query",
@@ -3984,46 +4151,22 @@
           {
             "text": "Look for",
             "category": "command",
-            "propertyNames": [
-              "fullActionName"
-            ]
+            "synonyms": [
+              "Search for",
+              "Find",
+              "Locate"
+            ],
+            "isOptional": true
           },
           {
             "text": "90s grunge bands like Nirvana",
-            "category": "searchQuery",
+            "category": "search query",
             "propertyNames": [
               "parameters.query"
             ]
           }
         ],
         "propertyAlternatives": [
-          {
-            "propertyName": "fullActionName",
-            "propertyValue": "player.searchTracks",
-            "propertySubPhrases": [
-              "Look for"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "player.findSongs",
-                "propertySubPhrases": [
-                  "Find"
-                ]
-              },
-              {
-                "propertyValue": "player.lookupTracks",
-                "propertySubPhrases": [
-                  "Search for"
-                ]
-              },
-              {
-                "propertyValue": "player.browseTracks",
-                "propertySubPhrases": [
-                  "Browse"
-                ]
-              }
-            ]
-          },
           {
             "propertyName": "parameters.query",
             "propertyValue": "90s grunge bands like Nirvana",
@@ -4032,21 +4175,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "90s alternative rock bands like Pearl Jam",
+                "propertyValue": "90s grunge bands like Pearl Jam",
                 "propertySubPhrases": [
-                  "90s alternative rock bands like Pearl Jam"
+                  "90s grunge bands like Pearl Jam"
                 ]
               },
               {
-                "propertyValue": "90s rock bands like Soundgarden",
+                "propertyValue": "90s grunge bands like Soundgarden",
                 "propertySubPhrases": [
-                  "90s rock bands like Soundgarden"
+                  "90s grunge bands like Soundgarden"
                 ]
               },
               {
-                "propertyValue": "90s punk bands like Green Day",
+                "propertyValue": "90s grunge bands like Alice in Chains",
                 "propertySubPhrases": [
-                  "90s punk bands like Green Day"
+                  "90s grunge bands like Alice in Chains"
                 ]
               }
             ]
@@ -4057,8 +4200,8 @@
           "Would you mind"
         ],
         "politeSuffixes": [
-          "Thank you",
-          "I appreciate it"
+          "Thank you!",
+          "I appreciate it!"
         ]
       }
     },
@@ -4090,7 +4233,7 @@
         "subPhrases": [
           {
             "text": "Look for",
-            "category": "command",
+            "category": "action",
             "propertyNames": [
               "fullActionName"
             ]
@@ -4161,11 +4304,13 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If it's not too much trouble, could you"
         ],
         "politeSuffixes": [
           "Thank you!",
-          "I would appreciate it."
+          "I would appreciate it.",
+          "Thanks a lot!"
         ]
       }
     },
@@ -4197,7 +4342,7 @@
         "subPhrases": [
           {
             "text": "Look for",
-            "category": "command",
+            "category": "action",
             "propertyNames": [
               "fullActionName"
             ]
@@ -4227,13 +4372,13 @@
               {
                 "propertyValue": "player.lookupTracks",
                 "propertySubPhrases": [
-                  "Lookup"
+                  "Search for"
                 ]
               },
               {
-                "propertyValue": "player.searchMusic",
+                "propertyValue": "player.browseTracks",
                 "propertySubPhrases": [
-                  "Search for"
+                  "Browse"
                 ]
               }
             ]
@@ -4246,21 +4391,21 @@
             ],
             "alternatives": [
               {
+                "propertyValue": "Jingle Bells by Frank Sinatra",
+                "propertySubPhrases": [
+                  "Jingle Bells by Frank Sinatra"
+                ]
+              },
+              {
                 "propertyValue": "Last Christmas by Wham!",
                 "propertySubPhrases": [
                   "Last Christmas by Wham!"
                 ]
               },
               {
-                "propertyValue": "Jingle Bell Rock by Bobby Helms",
+                "propertyValue": "Santa Claus Is Coming to Town by Bruce Springsteen",
                 "propertySubPhrases": [
-                  "Jingle Bell Rock by Bobby Helms"
-                ]
-              },
-              {
-                "propertyValue": "Feliz Navidad by José Feliciano",
-                "propertySubPhrases": [
-                  "Feliz Navidad by José Feliciano"
+                  "Santa Claus Is Coming to Town by Bruce Springsteen"
                 ]
               }
             ]
@@ -4304,7 +4449,7 @@
         "subPhrases": [
           {
             "text": "Look for",
-            "category": "action",
+            "category": "command",
             "propertyNames": [
               "fullActionName"
             ]
@@ -4338,9 +4483,9 @@
                 ]
               },
               {
-                "propertyValue": "player.browseTracks",
+                "propertyValue": "player.seekTracks",
                 "propertySubPhrases": [
-                  "Browse"
+                  "Seek"
                 ]
               }
             ]
@@ -4411,7 +4556,7 @@
         "subPhrases": [
           {
             "text": "Look for",
-            "category": "action",
+            "category": "command",
             "propertyNames": [
               "fullActionName"
             ]
@@ -4441,13 +4586,13 @@
               {
                 "propertyValue": "player.lookupTracks",
                 "propertySubPhrases": [
-                  "Lookup"
+                  "Search for"
                 ]
               },
               {
-                "propertyValue": "player.searchMusic",
+                "propertyValue": "player.browseTracks",
                 "propertySubPhrases": [
-                  "Search for"
+                  "Browse"
                 ]
               }
             ]
@@ -4486,7 +4631,7 @@
         ],
         "politeSuffixes": [
           "Thank you",
-          "I would appreciate it"
+          "I appreciate it"
         ]
       }
     },
@@ -4495,7 +4640,7 @@
       "action": {
         "fullActionName": "player.searchTracks",
         "parameters": {
-          "query": "Cant Help Falling in Love by Elvis Presley"
+          "query": "Can't Help Falling in Love by Elvis Presley"
         }
       },
       "explanation": {
@@ -4509,7 +4654,7 @@
           },
           {
             "name": "parameters.query",
-            "value": "Cant Help Falling in Love by Elvis Presley",
+            "value": "Can't Help Falling in Love by Elvis Presley",
             "substrings": [
               "Cant Help Falling in Love by Elvis Presley"
             ]
@@ -4561,7 +4706,7 @@
           },
           {
             "propertyName": "parameters.query",
-            "propertyValue": "Cant Help Falling in Love by Elvis Presley",
+            "propertyValue": "Can't Help Falling in Love by Elvis Presley",
             "propertySubPhrases": [
               "Cant Help Falling in Love by Elvis Presley"
             ],
@@ -4579,9 +4724,9 @@
                 ]
               },
               {
-                "propertyValue": "Love Me Tender by Elvis Presley",
+                "propertyValue": "Hound Dog by Elvis Presley",
                 "propertySubPhrases": [
-                  "Love Me Tender by Elvis Presley"
+                  "Hound Dog by Elvis Presley"
                 ]
               }
             ]
@@ -4592,8 +4737,8 @@
           "Would you mind"
         ],
         "politeSuffixes": [
-          "Thank you",
-          "I would appreciate it"
+          "Thank you!",
+          "I would appreciate it."
         ]
       }
     },
@@ -4625,7 +4770,7 @@
         "subPhrases": [
           {
             "text": "Look for",
-            "category": "command",
+            "category": "action",
             "propertyNames": [
               "fullActionName"
             ]
@@ -4655,7 +4800,7 @@
               {
                 "propertyValue": "player.lookupTracks",
                 "propertySubPhrases": [
-                  "Search for"
+                  "Lookup"
                 ]
               },
               {
@@ -4674,15 +4819,15 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "rock songs by Elvis Presley",
+                "propertyValue": "rock hits by Elvis Presley",
                 "propertySubPhrases": [
-                  "rock songs by Elvis Presley"
+                  "rock hits by Elvis Presley"
                 ]
               },
               {
-                "propertyValue": "pop tracks by Michael Jackson",
+                "propertyValue": "pop songs by Michael Jackson",
                 "propertySubPhrases": [
-                  "pop tracks by Michael Jackson"
+                  "pop songs by Michael Jackson"
                 ]
               },
               {
@@ -4717,9 +4862,7 @@
           {
             "name": "fullActionName",
             "value": "player.searchTracks",
-            "substrings": [
-              "Look for"
-            ]
+            "substrings": []
           },
           {
             "name": "parameters.query",
@@ -4733,46 +4876,22 @@
           {
             "text": "Look for",
             "category": "command",
-            "propertyNames": [
-              "fullActionName"
-            ]
+            "synonyms": [
+              "Search for",
+              "Find",
+              "Seek"
+            ],
+            "isOptional": true
           },
           {
             "text": "energetic workout playlists",
-            "category": "searchQuery",
+            "category": "query",
             "propertyNames": [
               "parameters.query"
             ]
           }
         ],
         "propertyAlternatives": [
-          {
-            "propertyName": "fullActionName",
-            "propertyValue": "player.searchTracks",
-            "propertySubPhrases": [
-              "Look for"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "player.findSongs",
-                "propertySubPhrases": [
-                  "Search for"
-                ]
-              },
-              {
-                "propertyValue": "player.lookupTracks",
-                "propertySubPhrases": [
-                  "Find"
-                ]
-              },
-              {
-                "propertyValue": "player.browseTracks",
-                "propertySubPhrases": [
-                  "Browse"
-                ]
-              }
-            ]
-          },
           {
             "propertyName": "parameters.query",
             "propertyValue": "energetic workout playlists",
@@ -4781,21 +4900,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "high-energy exercise playlists",
+                "propertyValue": "calm workout playlists",
                 "propertySubPhrases": [
-                  "high-energy exercise playlists"
-                ]
-              },
-              {
-                "propertyValue": "upbeat fitness playlists",
-                "propertySubPhrases": [
-                  "upbeat fitness playlists"
+                  "calm workout playlists"
                 ]
               },
               {
                 "propertyValue": "intense workout playlists",
                 "propertySubPhrases": [
                   "intense workout playlists"
+                ]
+              },
+              {
+                "propertyValue": "relaxing workout playlists",
+                "propertySubPhrases": [
+                  "relaxing workout playlists"
                 ]
               }
             ]
@@ -4873,9 +4992,9 @@
                 ]
               },
               {
-                "propertyValue": "player.searchMusic",
+                "propertyValue": "player.browseTracks",
                 "propertySubPhrases": [
-                  "Search for"
+                  "Browse"
                 ]
               }
             ]
@@ -4888,21 +5007,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "Grammy winners",
+                "propertyValue": "Grammy Award winners",
                 "propertySubPhrases": [
-                  "Grammy winners"
+                  "Grammy Award winners"
                 ]
               },
               {
-                "propertyValue": "Oscar winners",
+                "propertyValue": "Billboard Hot 100",
                 "propertySubPhrases": [
-                  "Oscar winners"
+                  "Billboard Hot 100"
                 ]
               },
               {
-                "propertyValue": "Nobel Prize winners",
+                "propertyValue": "MTV Music Award winners",
                 "propertySubPhrases": [
-                  "Nobel Prize winners"
+                  "MTV Music Award winners"
                 ]
               }
             ]
@@ -4976,7 +5095,7 @@
               {
                 "propertyValue": "player.lookupMusic",
                 "propertySubPhrases": [
-                  "Search for"
+                  "Look up"
                 ]
               },
               {
@@ -5075,15 +5194,15 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.findTracks",
+                "propertyValue": "player.findSongs",
                 "propertySubPhrases": [
                   "Find"
                 ]
               },
               {
-                "propertyValue": "player.locateTracks",
+                "propertyValue": "player.lookupTracks",
                 "propertySubPhrases": [
-                  "Locate"
+                  "Lookup"
                 ]
               },
               {
@@ -5108,15 +5227,15 @@
                 ]
               },
               {
-                "propertyValue": "Grammy winning albums",
+                "propertyValue": "Billboard top songs",
                 "propertySubPhrases": [
-                  "Grammy winning albums"
+                  "Billboard top songs"
                 ]
               },
               {
-                "propertyValue": "Grammy award-winning artists",
+                "propertyValue": "Top 40 hits",
                 "propertySubPhrases": [
-                  "Grammy award-winning artists"
+                  "Top 40 hits"
                 ]
               }
             ]
@@ -5209,15 +5328,15 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "Blinding Lights by The Weeknd",
-                "propertySubPhrases": [
-                  "Blinding Lights by The Weeknd"
-                ]
-              },
-              {
                 "propertyValue": "Shape of You by Ed Sheeran",
                 "propertySubPhrases": [
                   "Shape of You by Ed Sheeran"
+                ]
+              },
+              {
+                "propertyValue": "Blinding Lights by The Weeknd",
+                "propertySubPhrases": [
+                  "Blinding Lights by The Weeknd"
                 ]
               },
               {
@@ -5234,8 +5353,8 @@
           "Would you mind"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it."
+          "Thank you",
+          "I would appreciate it"
         ]
       }
     },
@@ -5269,7 +5388,7 @@
             "synonyms": [
               "Search for",
               "Find",
-              "Locate"
+              "Seek out"
             ],
             "isOptional": true
           },
@@ -5355,7 +5474,7 @@
           },
           {
             "text": "iconic 70s disco tracks",
-            "category": "query",
+            "category": "searchQuery",
             "propertyNames": [
               "parameters.query"
             ]
@@ -5376,13 +5495,13 @@
                 ]
               },
               {
-                "propertyValue": "player.lookupTracks",
+                "propertyValue": "player.lookupMusic",
                 "propertySubPhrases": [
                   "Find"
                 ]
               },
               {
-                "propertyValue": "player.browseMusic",
+                "propertyValue": "player.browseTracks",
                 "propertySubPhrases": [
                   "Browse"
                 ]
@@ -5403,15 +5522,15 @@
                 ]
               },
               {
-                "propertyValue": "popular 90s pop hits",
+                "propertyValue": "famous 90s pop hits",
                 "propertySubPhrases": [
-                  "popular 90s pop hits"
+                  "famous 90s pop hits"
                 ]
               },
               {
-                "propertyValue": "famous 60s jazz tunes",
+                "propertyValue": "popular 2000s hip hop tracks",
                 "propertySubPhrases": [
-                  "famous 60s jazz tunes"
+                  "popular 2000s hip hop tracks"
                 ]
               }
             ]
@@ -5422,8 +5541,8 @@
           "Would you mind"
         ],
         "politeSuffixes": [
-          "Thank you",
-          "I appreciate it"
+          "Thank you!",
+          "I would appreciate it."
         ]
       }
     },
@@ -5440,7 +5559,9 @@
           {
             "name": "fullActionName",
             "value": "player.searchTracks",
-            "isImplicit": true
+            "substrings": [
+              "Look for"
+            ]
           },
           {
             "name": "parameters.query",
@@ -5453,8 +5574,10 @@
         "subPhrases": [
           {
             "text": "Look for",
-            "category": "command",
-            "propertyNames": []
+            "category": "action",
+            "propertyNames": [
+              "fullActionName"
+            ]
           },
           {
             "text": "instrumental jazz music",
@@ -5466,6 +5589,33 @@
         ],
         "propertyAlternatives": [
           {
+            "propertyName": "fullActionName",
+            "propertyValue": "player.searchTracks",
+            "propertySubPhrases": [
+              "Look for"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "player.findSongs",
+                "propertySubPhrases": [
+                  "Find"
+                ]
+              },
+              {
+                "propertyValue": "player.locateTracks",
+                "propertySubPhrases": [
+                  "Locate"
+                ]
+              },
+              {
+                "propertyValue": "player.searchMusic",
+                "propertySubPhrases": [
+                  "Search for"
+                ]
+              }
+            ]
+          },
+          {
             "propertyName": "parameters.query",
             "propertyValue": "instrumental jazz music",
             "propertySubPhrases": [
@@ -5473,21 +5623,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "smooth jazz music",
+                "propertyValue": "classical music",
                 "propertySubPhrases": [
-                  "smooth jazz music"
+                  "classical music"
                 ]
               },
               {
-                "propertyValue": "classic jazz music",
+                "propertyValue": "rock music",
                 "propertySubPhrases": [
-                  "classic jazz music"
+                  "rock music"
                 ]
               },
               {
-                "propertyValue": "modern jazz music",
+                "propertyValue": "pop music",
                 "propertySubPhrases": [
-                  "modern jazz music"
+                  "pop music"
                 ]
               }
             ]
@@ -5495,11 +5645,13 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If it's not too much trouble, could you"
         ],
         "politeSuffixes": [
           "Thank you!",
-          "I would appreciate it."
+          "I would appreciate it.",
+          "Thanks a lot!"
         ]
       }
     },
@@ -5638,7 +5790,7 @@
         "subPhrases": [
           {
             "text": "Look for",
-            "category": "action",
+            "category": "command",
             "propertyNames": [
               "fullActionName"
             ]
@@ -5712,8 +5864,8 @@
           "Would you mind"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it."
+          "Thank you",
+          "I would appreciate it"
         ]
       }
     },
@@ -5806,9 +5958,9 @@
                 ]
               },
               {
-                "propertyValue": "Rolling in the Deep by Adele",
+                "propertyValue": "Thriller by Michael Jackson",
                 "propertySubPhrases": [
-                  "Rolling in the Deep by Adele"
+                  "Thriller by Michael Jackson"
                 ]
               }
             ]
@@ -5816,11 +5968,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "Kindly",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it."
+          "Thank you",
+          "Thanks",
+          "I would appreciate it",
+          "If you don't mind"
         ]
       }
     },
@@ -5927,7 +6083,7 @@
         ],
         "politeSuffixes": [
           "Thank you!",
-          "I would appreciate it."
+          "I would appreciate it!"
         ]
       }
     },
@@ -5959,7 +6115,7 @@
         "subPhrases": [
           {
             "text": "Look for",
-            "category": "command",
+            "category": "action",
             "propertyNames": [
               "fullActionName"
             ]
@@ -5993,7 +6149,7 @@
                 ]
               },
               {
-                "propertyValue": "player.browseMusic",
+                "propertyValue": "player.browseTracks",
                 "propertySubPhrases": [
                   "Browse"
                 ]
@@ -6030,11 +6186,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "Kindly",
+          "Please"
         ],
         "politeSuffixes": [
           "Thank you",
-          "Thanks a lot"
+          "Thanks a lot",
+          "I appreciate it",
+          "Much appreciated"
         ]
       }
     },
@@ -6094,13 +6254,13 @@
                 ]
               },
               {
-                "propertyValue": "player.lookupTracks",
+                "propertyValue": "player.lookupMusic",
                 "propertySubPhrases": [
-                  "Search for"
+                  "Lookup"
                 ]
               },
               {
-                "propertyValue": "player.browseMusic",
+                "propertyValue": "player.browseTracks",
                 "propertySubPhrases": [
                   "Browse"
                 ]
@@ -6137,14 +6297,10 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind",
-          "If it's not too much trouble, could you",
-          "May I kindly ask you to"
+          "Would you mind"
         ],
         "politeSuffixes": [
-          "thank you",
-          "please",
-          "if you don't mind",
+          "Thank you",
           "I would appreciate it"
         ]
       }
@@ -6226,21 +6382,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "pop hits from the 80s",
+                "propertyValue": "90s rock hits",
                 "propertySubPhrases": [
-                  "pop hits from the 80s"
+                  "90s rock hits"
                 ]
               },
               {
-                "propertyValue": "jazz classics from the 70s",
+                "propertyValue": "rock classics from the 90s",
                 "propertySubPhrases": [
-                  "jazz classics from the 70s"
+                  "rock classics from the 90s"
                 ]
               },
               {
-                "propertyValue": "hip hop tracks from the 2000s",
+                "propertyValue": "90s rock anthems",
                 "propertySubPhrases": [
-                  "hip hop tracks from the 2000s"
+                  "90s rock anthems"
                 ]
               }
             ]
@@ -6251,8 +6407,8 @@
           "Would you mind"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it."
+          "Thank you",
+          "I would appreciate it"
         ]
       }
     },
@@ -6284,7 +6440,7 @@
         "subPhrases": [
           {
             "text": "Look for",
-            "category": "command",
+            "category": "action",
             "propertyNames": [
               "fullActionName"
             ]
@@ -6358,8 +6514,8 @@
           "Would you mind"
         ],
         "politeSuffixes": [
-          "Thank you",
-          "I would appreciate it"
+          "Thank you!",
+          "I would appreciate it."
         ]
       }
     },
@@ -6376,9 +6532,7 @@
           {
             "name": "fullActionName",
             "value": "player.searchTracks",
-            "substrings": [
-              "Look for"
-            ]
+            "isImplicit": true
           },
           {
             "name": "parameters.query",
@@ -6392,9 +6546,12 @@
           {
             "text": "Look for",
             "category": "command",
-            "propertyNames": [
-              "fullActionName"
-            ]
+            "synonyms": [
+              "Find",
+              "Search for",
+              "Seek"
+            ],
+            "isOptional": true
           },
           {
             "text": "salsa music to dance to",
@@ -6406,33 +6563,6 @@
         ],
         "propertyAlternatives": [
           {
-            "propertyName": "fullActionName",
-            "propertyValue": "player.searchTracks",
-            "propertySubPhrases": [
-              "Look for"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "player.findSongs",
-                "propertySubPhrases": [
-                  "Find"
-                ]
-              },
-              {
-                "propertyValue": "player.lookupTracks",
-                "propertySubPhrases": [
-                  "Search for"
-                ]
-              },
-              {
-                "propertyValue": "player.browseMusic",
-                "propertySubPhrases": [
-                  "Browse"
-                ]
-              }
-            ]
-          },
-          {
             "propertyName": "parameters.query",
             "propertyValue": "salsa music to dance to",
             "propertySubPhrases": [
@@ -6440,21 +6570,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "jazz music to relax to",
+                "propertyValue": "bachata music to dance to",
                 "propertySubPhrases": [
-                  "jazz music to relax to"
+                  "bachata music to dance to"
                 ]
               },
               {
-                "propertyValue": "rock music to workout to",
+                "propertyValue": "merengue music to dance to",
                 "propertySubPhrases": [
-                  "rock music to workout to"
+                  "merengue music to dance to"
                 ]
               },
               {
-                "propertyValue": "classical music to study to",
+                "propertyValue": "reggaeton music to dance to",
                 "propertySubPhrases": [
-                  "classical music to study to"
+                  "reggaeton music to dance to"
                 ]
               }
             ]
@@ -6462,11 +6592,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If it's not too much trouble, could you",
+          "May I kindly ask you to"
         ],
         "politeSuffixes": [
           "Thank you!",
-          "I would appreciate it."
+          "I would appreciate it.",
+          "Thanks a lot!",
+          "Your help is appreciated."
         ]
       }
     },
@@ -6605,7 +6739,7 @@
         "subPhrases": [
           {
             "text": "Look for",
-            "category": "command",
+            "category": "action",
             "propertyNames": [
               "fullActionName"
             ]
@@ -6635,13 +6769,13 @@
               {
                 "propertyValue": "player.lookupTracks",
                 "propertySubPhrases": [
-                  "Lookup"
+                  "Search for"
                 ]
               },
               {
-                "propertyValue": "player.searchMusic",
+                "propertyValue": "player.browseTracks",
                 "propertySubPhrases": [
-                  "Search for"
+                  "Browse"
                 ]
               }
             ]
@@ -6679,8 +6813,8 @@
           "Would you mind"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it."
+          "Thank you",
+          "Please"
         ]
       }
     },
@@ -6712,7 +6846,7 @@
         "subPhrases": [
           {
             "text": "Look for",
-            "category": "command",
+            "category": "action",
             "propertyNames": [
               "fullActionName"
             ]
@@ -6742,13 +6876,13 @@
               {
                 "propertyValue": "player.lookupTracks",
                 "propertySubPhrases": [
-                  "Search for"
+                  "Lookup"
                 ]
               },
               {
-                "propertyValue": "player.browseTracks",
+                "propertyValue": "player.searchMusic",
                 "propertySubPhrases": [
-                  "Browse"
+                  "Search for"
                 ]
               }
             ]
@@ -6787,7 +6921,7 @@
         ],
         "politeSuffixes": [
           "Thank you!",
-          "I would appreciate it."
+          "I appreciate it!"
         ]
       }
     },
@@ -6819,7 +6953,7 @@
         "subPhrases": [
           {
             "text": "Look for",
-            "category": "action",
+            "category": "command",
             "propertyNames": [
               "fullActionName"
             ]
@@ -6893,8 +7027,8 @@
           "Would you mind"
         ],
         "politeSuffixes": [
-          "Thank you",
-          "I would appreciate it"
+          "Thank you!",
+          "I would appreciate it!"
         ]
       }
     },
@@ -7001,7 +7135,7 @@
         ],
         "politeSuffixes": [
           "Thank you",
-          "I would appreciate it"
+          "I appreciate it"
         ]
       }
     },
@@ -7026,7 +7160,7 @@
             "name": "parameters.query",
             "value": "latest hip-hop releases",
             "substrings": [
-              "latest hip-hop releases"
+              "the latest hip-hop releases"
             ]
           }
         ],
@@ -7039,17 +7173,7 @@
             ]
           },
           {
-            "text": "the",
-            "category": "filler",
-            "synonyms": [
-              "a",
-              "an",
-              "that"
-            ],
-            "isOptional": true
-          },
-          {
-            "text": "latest hip-hop releases",
+            "text": "the latest hip-hop releases",
             "category": "query",
             "propertyNames": [
               "parameters.query"
@@ -7071,15 +7195,15 @@
                 ]
               },
               {
-                "propertyValue": "player.lookupTracks",
-                "propertySubPhrases": [
-                  "Search for"
-                ]
-              },
-              {
                 "propertyValue": "player.browseMusic",
                 "propertySubPhrases": [
                   "Browse"
+                ]
+              },
+              {
+                "propertyValue": "player.discoverTracks",
+                "propertySubPhrases": [
+                  "Discover"
                 ]
               }
             ]
@@ -7088,25 +7212,25 @@
             "propertyName": "parameters.query",
             "propertyValue": "latest hip-hop releases",
             "propertySubPhrases": [
-              "latest hip-hop releases"
+              "the latest hip-hop releases"
             ],
             "alternatives": [
               {
-                "propertyValue": "new hip-hop tracks",
+                "propertyValue": "new rap songs",
                 "propertySubPhrases": [
-                  "new hip-hop tracks"
+                  "new rap songs"
                 ]
               },
               {
-                "propertyValue": "recent hip-hop songs",
+                "propertyValue": "recent hip-hop tracks",
                 "propertySubPhrases": [
-                  "recent hip-hop songs"
+                  "recent hip-hop tracks"
                 ]
               },
               {
-                "propertyValue": "current hip-hop hits",
+                "propertyValue": "fresh hip-hop music",
                 "propertySubPhrases": [
-                  "current hip-hop hits"
+                  "fresh hip-hop music"
                 ]
               }
             ]
@@ -7117,8 +7241,8 @@
           "Would you mind"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it."
+          "Thank you",
+          "I appreciate it"
         ]
       }
     },
@@ -7150,23 +7274,13 @@
         "subPhrases": [
           {
             "text": "Look for",
-            "category": "command",
+            "category": "action",
             "propertyNames": [
               "fullActionName"
             ]
           },
           {
-            "text": "the",
-            "category": "filler",
-            "synonyms": [
-              "a",
-              "an",
-              "some"
-            ],
-            "isOptional": true
-          },
-          {
-            "text": "most streamed songs this week",
+            "text": "the most streamed songs this week",
             "category": "query",
             "propertyNames": [
               "parameters.query"
@@ -7184,13 +7298,13 @@
               {
                 "propertyValue": "player.findTracks",
                 "propertySubPhrases": [
-                  "Find"
+                  "Search for"
                 ]
               },
               {
                 "propertyValue": "player.lookupTracks",
                 "propertySubPhrases": [
-                  "Look up"
+                  "Find"
                 ]
               },
               {
@@ -7205,25 +7319,25 @@
             "propertyName": "parameters.query",
             "propertyValue": "most streamed songs this week",
             "propertySubPhrases": [
-              "most streamed songs this week"
+              "the most streamed songs this week"
             ],
             "alternatives": [
               {
                 "propertyValue": "top songs this week",
                 "propertySubPhrases": [
-                  "top songs this week"
+                  "the top songs this week"
                 ]
               },
               {
-                "propertyValue": "most popular tracks this week",
+                "propertyValue": "popular songs this week",
                 "propertySubPhrases": [
-                  "most popular tracks this week"
+                  "the popular songs this week"
                 ]
               },
               {
-                "propertyValue": "most played songs this week",
+                "propertyValue": "trending songs this week",
                 "propertySubPhrases": [
-                  "most played songs this week"
+                  "the trending songs this week"
                 ]
               }
             ]
@@ -7338,13 +7452,11 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind",
-          "If it's not too much trouble, could you"
+          "Would you mind"
         ],
         "politeSuffixes": [
           "Thank you!",
-          "I would appreciate it.",
-          "Thanks a lot!"
+          "I would appreciate it."
         ]
       }
     },
@@ -7373,17 +7485,12 @@
         ],
         "subPhrases": [
           {
-            "text": "Look for the",
+            "text": "Look for",
             "category": "command",
-            "synonyms": [
-              "Search for the",
-              "Find the",
-              "Get the"
-            ],
-            "isOptional": true
+            "propertyNames": []
           },
           {
-            "text": "ultimate workout mix",
+            "text": "the ultimate workout mix",
             "category": "query",
             "propertyNames": [
               "parameters.query"
@@ -7395,25 +7502,25 @@
             "propertyName": "parameters.query",
             "propertyValue": "ultimate workout mix",
             "propertySubPhrases": [
-              "ultimate workout mix"
+              "the ultimate workout mix"
             ],
             "alternatives": [
               {
                 "propertyValue": "best workout playlist",
                 "propertySubPhrases": [
-                  "best workout playlist"
+                  "the best workout playlist"
                 ]
               },
               {
                 "propertyValue": "top gym songs",
                 "propertySubPhrases": [
-                  "top gym songs"
+                  "the top gym songs"
                 ]
               },
               {
-                "propertyValue": "high energy music",
+                "propertyValue": "high energy exercise music",
                 "propertySubPhrases": [
-                  "high energy music"
+                  "the high energy exercise music"
                 ]
               }
             ]
@@ -7424,8 +7531,8 @@
           "Would you mind"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it."
+          "Thank you",
+          "I would appreciate it"
         ]
       }
     },
@@ -7457,7 +7564,7 @@
         "subPhrases": [
           {
             "text": "Look for",
-            "category": "command",
+            "category": "action",
             "propertyNames": [
               "fullActionName"
             ]
@@ -7487,13 +7594,13 @@
               {
                 "propertyValue": "player.lookupTracks",
                 "propertySubPhrases": [
-                  "Search for"
+                  "Lookup"
                 ]
               },
               {
-                "propertyValue": "player.browseTracks",
+                "propertyValue": "player.searchMusic",
                 "propertySubPhrases": [
-                  "Browse"
+                  "Search for"
                 ]
               }
             ]
@@ -7531,8 +7638,8 @@
           "Would you mind"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it."
+          "Thank you",
+          "I appreciate it"
         ]
       }
     },
@@ -7613,21 +7720,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "relaxing music for meditation",
+                "propertyValue": "relaxing music for yoga",
                 "propertySubPhrases": [
-                  "relaxing music for meditation"
+                  "relaxing music for yoga"
                 ]
               },
               {
-                "propertyValue": "calm sounds for meditation",
+                "propertyValue": "calm sounds for sleep",
                 "propertySubPhrases": [
-                  "calm sounds for meditation"
+                  "calm sounds for sleep"
                 ]
               },
               {
-                "propertyValue": "meditation background music",
+                "propertyValue": "nature sounds for relaxation",
                 "propertySubPhrases": [
-                  "meditation background music"
+                  "nature sounds for relaxation"
                 ]
               }
             ]
@@ -7638,8 +7745,8 @@
           "Would you mind"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it."
+          "Thank you",
+          "I would appreciate it"
         ]
       }
     },
@@ -7671,7 +7778,7 @@
         "subPhrases": [
           {
             "text": "Search for",
-            "category": "command",
+            "category": "action",
             "propertyNames": [
               "fullActionName"
             ]
@@ -7695,19 +7802,19 @@
               {
                 "propertyValue": "player.searchAlbums",
                 "propertySubPhrases": [
-                  "Find albums by"
+                  "Find"
                 ]
               },
               {
                 "propertyValue": "player.searchArtists",
                 "propertySubPhrases": [
-                  "Look up artists like"
+                  "Look up"
                 ]
               },
               {
                 "propertyValue": "player.searchPlaylists",
                 "propertySubPhrases": [
-                  "Search for playlists containing"
+                  "Browse"
                 ]
               }
             ]
@@ -7720,15 +7827,15 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "jazz albums from Miles Davis",
-                "propertySubPhrases": [
-                  "jazz albums from Miles Davis"
-                ]
-              },
-              {
                 "propertyValue": "rock albums from The Beatles",
                 "propertySubPhrases": [
                   "rock albums from The Beatles"
+                ]
+              },
+              {
+                "propertyValue": "jazz albums from Miles Davis",
+                "propertySubPhrases": [
+                  "jazz albums from Miles Davis"
                 ]
               },
               {
@@ -7742,11 +7849,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "Kindly",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you",
-          "I would appreciate it"
+          "Thank you.",
+          "Thanks a lot.",
+          "I appreciate it.",
+          "Much appreciated."
         ]
       }
     },
@@ -7833,15 +7944,15 @@
                 ]
               },
               {
-                "propertyValue": "pop songs",
+                "propertyValue": "jazz standards",
                 "propertySubPhrases": [
-                  "pop songs"
+                  "jazz standards"
                 ]
               },
               {
-                "propertyValue": "jazz tunes",
+                "propertyValue": "pop hits",
                 "propertySubPhrases": [
-                  "jazz tunes"
+                  "pop hits"
                 ]
               }
             ]
@@ -7850,14 +7961,12 @@
         "politePrefixes": [
           "Could you please",
           "Would you mind",
-          "If it's not too much trouble, could you",
-          "May I kindly ask you to"
+          "If it's not too much trouble, could you"
         ],
         "politeSuffixes": [
           "Thank you!",
-          "I would appreciate it!",
-          "Thanks a lot!",
-          "Much appreciated!"
+          "I would appreciate it.",
+          "Thanks a lot!"
         ]
       }
     },
@@ -7911,13 +8020,13 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.findSongs",
+                "propertyValue": "player.findTracks",
                 "propertySubPhrases": [
                   "Find"
                 ]
               },
               {
-                "propertyValue": "player.lookupMusic",
+                "propertyValue": "player.lookupTracks",
                 "propertySubPhrases": [
                   "Look up"
                 ]
@@ -7938,9 +8047,9 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "symphonies by Beethoven",
+                "propertyValue": "Beethoven's symphonies",
                 "propertySubPhrases": [
-                  "symphonies by Beethoven"
+                  "Beethoven's symphonies"
                 ]
               },
               {
@@ -7950,9 +8059,9 @@
                 ]
               },
               {
-                "propertyValue": "Beethoven's orchestral works",
+                "propertyValue": "Beethoven's string quartets",
                 "propertySubPhrases": [
-                  "Beethoven's orchestral works"
+                  "Beethoven's string quartets"
                 ]
               }
             ]
@@ -7963,8 +8072,8 @@
           "Would you mind"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it."
+          "Thank you",
+          "I appreciate it"
         ]
       }
     },
@@ -8045,21 +8154,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "acoustic covers by popular YouTubers",
+                "propertyValue": "cover songs by popular YouTubers",
                 "propertySubPhrases": [
-                  "acoustic covers by popular YouTubers"
+                  "cover songs by popular YouTubers"
                 ]
               },
               {
-                "propertyValue": "piano covers by well-known YouTubers",
+                "propertyValue": "cover songs by well-known YouTubers",
                 "propertySubPhrases": [
-                  "piano covers by well-known YouTubers"
+                  "cover songs by well-known YouTubers"
                 ]
               },
               {
-                "propertyValue": "guitar covers by trending YouTubers",
+                "propertyValue": "cover songs by top YouTubers",
                 "propertySubPhrases": [
-                  "guitar covers by trending YouTubers"
+                  "cover songs by top YouTubers"
                 ]
               }
             ]
@@ -8174,11 +8283,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If it's not too much trouble, could you",
+          "May I kindly ask you to"
         ],
         "politeSuffixes": [
-          "Thank you",
-          "I would appreciate it"
+          "Thank you!",
+          "I would appreciate it!",
+          "Thanks a lot!",
+          "Much appreciated!"
         ]
       }
     },
@@ -8187,7 +8300,7 @@
       "action": {
         "fullActionName": "player.searchTracks",
         "parameters": {
-          "query": "Dont Stop Believin by Journey"
+          "query": "Don't Stop Believin by Journey"
         }
       },
       "explanation": {
@@ -8201,7 +8314,7 @@
           },
           {
             "name": "parameters.query",
-            "value": "Dont Stop Believin by Journey",
+            "value": "Don't Stop Believin by Journey",
             "substrings": [
               "Dont Stop Believin by Journey"
             ]
@@ -8253,7 +8366,7 @@
           },
           {
             "propertyName": "parameters.query",
-            "propertyValue": "Dont Stop Believin by Journey",
+            "propertyValue": "Don't Stop Believin by Journey",
             "propertySubPhrases": [
               "Dont Stop Believin by Journey"
             ],
@@ -8282,14 +8395,14 @@
         "politePrefixes": [
           "Could you please",
           "Would you mind",
-          "If it's not too much trouble, could you",
-          "May I kindly ask you to"
+          "Kindly",
+          "Please"
         ],
         "politeSuffixes": [
-          "thank you.",
-          "please.",
-          "if you don't mind.",
-          "thanks a lot."
+          "Thank you",
+          "Thanks",
+          "I appreciate it",
+          "Much appreciated"
         ]
       }
     },
@@ -8355,9 +8468,9 @@
                 ]
               },
               {
-                "propertyValue": "player.searchMusic",
+                "propertyValue": "player.querySongs",
                 "propertySubPhrases": [
-                  "Search music for"
+                  "Query"
                 ]
               }
             ]
@@ -8396,7 +8509,7 @@
         ],
         "politeSuffixes": [
           "Thank you",
-          "I would appreciate it"
+          "I appreciate it"
         ]
       }
     },
@@ -8499,11 +8612,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If it's not too much trouble,",
+          "May I kindly ask you to"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it."
+          "Thank you.",
+          "I would appreciate it.",
+          "Thanks a lot.",
+          "Much appreciated."
         ]
       }
     },
@@ -8559,19 +8676,19 @@
               {
                 "propertyValue": "player.findSongs",
                 "propertySubPhrases": [
-                  "Find"
+                  "Find songs"
                 ]
               },
               {
                 "propertyValue": "player.lookupMusic",
                 "propertySubPhrases": [
-                  "Look up"
+                  "Look up music"
                 ]
               },
               {
                 "propertyValue": "player.browseTracks",
                 "propertySubPhrases": [
-                  "Browse"
+                  "Browse tracks"
                 ]
               }
             ]
@@ -8584,21 +8701,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "traditional music from different countries",
+                "propertyValue": "traditional music globally",
                 "propertySubPhrases": [
-                  "traditional music from different countries"
+                  "traditional music globally"
                 ]
               },
               {
-                "propertyValue": "world folk songs",
+                "propertyValue": "worldwide folk songs",
                 "propertySubPhrases": [
-                  "world folk songs"
+                  "worldwide folk songs"
                 ]
               },
               {
-                "propertyValue": "global folk music",
+                "propertyValue": "international folk tunes",
                 "propertySubPhrases": [
-                  "global folk music"
+                  "international folk tunes"
                 ]
               }
             ]
@@ -8609,8 +8726,8 @@
           "Would you mind"
         ],
         "politeSuffixes": [
-          "Thank you",
-          "I would appreciate it"
+          "Thank you!",
+          "I would appreciate it."
         ]
       }
     },
@@ -8676,9 +8793,9 @@
                 ]
               },
               {
-                "propertyValue": "player.browseTracks",
+                "propertyValue": "player.discoverTracks",
                 "propertySubPhrases": [
-                  "Browse"
+                  "Discover"
                 ]
               }
             ]
@@ -8716,8 +8833,8 @@
           "Would you mind"
         ],
         "politeSuffixes": [
-          "Thank you",
-          "I would appreciate it"
+          "Thank you!",
+          "I would appreciate it."
         ]
       }
     },
@@ -8783,9 +8900,9 @@
                 ]
               },
               {
-                "propertyValue": "player.discoverTracks",
+                "propertyValue": "player.querySongs",
                 "propertySubPhrases": [
-                  "Discover"
+                  "Query"
                 ]
               }
             ]
@@ -8810,9 +8927,9 @@
                 ]
               },
               {
-                "propertyValue": "Irreplaceable by Beyoncé",
+                "propertyValue": "Formation by Beyoncé",
                 "propertySubPhrases": [
-                  "Irreplaceable by Beyoncé"
+                  "Formation by Beyoncé"
                 ]
               }
             ]
@@ -8821,12 +8938,14 @@
         "politePrefixes": [
           "Could you please",
           "Would you mind",
-          "If it's not too much trouble, could you"
+          "If it's not too much trouble,",
+          "May I kindly ask you to"
         ],
         "politeSuffixes": [
           "Thank you!",
           "I would appreciate it.",
-          "Thanks a lot!"
+          "Thanks a lot!",
+          "Much appreciated!"
         ]
       }
     },
@@ -8892,9 +9011,9 @@
                 ]
               },
               {
-                "propertyValue": "player.browseTracks",
+                "propertyValue": "player.querySongs",
                 "propertySubPhrases": [
-                  "Browse"
+                  "Query"
                 ]
               }
             ]
@@ -8929,11 +9048,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "Kindly",
+          "Please"
         ],
         "politeSuffixes": [
           "Thank you",
-          "I would appreciate it"
+          "Thanks",
+          "I appreciate it",
+          "Much appreciated"
         ]
       }
     },
@@ -8965,7 +9088,7 @@
         "subPhrases": [
           {
             "text": "Search for",
-            "category": "action",
+            "category": "command",
             "propertyNames": [
               "fullActionName"
             ]
@@ -9049,7 +9172,7 @@
       "action": {
         "fullActionName": "player.searchTracks",
         "parameters": {
-          "query": "Imagine by John Lennon"
+          "query": "Imagine John Lennon"
         }
       },
       "explanation": {
@@ -9063,7 +9186,7 @@
           },
           {
             "name": "parameters.query",
-            "value": "Imagine by John Lennon",
+            "value": "Imagine John Lennon",
             "substrings": [
               "Imagine by John Lennon"
             ]
@@ -9106,34 +9229,34 @@
                 ]
               },
               {
-                "propertyValue": "player.browseTracks",
+                "propertyValue": "player.locateTracks",
                 "propertySubPhrases": [
-                  "Browse"
+                  "Locate"
                 ]
               }
             ]
           },
           {
             "propertyName": "parameters.query",
-            "propertyValue": "Imagine by John Lennon",
+            "propertyValue": "Imagine John Lennon",
             "propertySubPhrases": [
               "Imagine by John Lennon"
             ],
             "alternatives": [
               {
-                "propertyValue": "Hey Jude by The Beatles",
+                "propertyValue": "Hey Jude The Beatles",
                 "propertySubPhrases": [
                   "Hey Jude by The Beatles"
                 ]
               },
               {
-                "propertyValue": "Bohemian Rhapsody by Queen",
+                "propertyValue": "Bohemian Rhapsody Queen",
                 "propertySubPhrases": [
                   "Bohemian Rhapsody by Queen"
                 ]
               },
               {
-                "propertyValue": "Hotel California by Eagles",
+                "propertyValue": "Hotel California Eagles",
                 "propertySubPhrases": [
                   "Hotel California by Eagles"
                 ]
@@ -9213,9 +9336,9 @@
                 ]
               },
               {
-                "propertyValue": "player.discoverMusic",
+                "propertyValue": "player.browseMusic",
                 "propertySubPhrases": [
-                  "Discover music"
+                  "Browse music"
                 ]
               }
             ]
@@ -9228,21 +9351,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "alternative rock bands like The Strokes",
+                "propertyValue": "alternative bands like The Strokes",
                 "propertySubPhrases": [
-                  "alternative rock bands like The Strokes"
+                  "alternative bands like The Strokes"
                 ]
               },
               {
-                "propertyValue": "indie pop bands like Vampire Weekend",
+                "propertyValue": "rock bands like The Black Keys",
                 "propertySubPhrases": [
-                  "indie pop bands like Vampire Weekend"
+                  "rock bands like The Black Keys"
                 ]
               },
               {
-                "propertyValue": "garage rock bands like The White Stripes",
+                "propertyValue": "indie artists like Tame Impala",
                 "propertySubPhrases": [
-                  "garage rock bands like The White Stripes"
+                  "indie artists like Tame Impala"
                 ]
               }
             ]
@@ -9250,11 +9373,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If it's not too much trouble,",
+          "May I kindly ask you to"
         ],
         "politeSuffixes": [
-          "Thank you",
-          "I would appreciate it"
+          "Thank you!",
+          "I would appreciate it.",
+          "Thanks a lot!",
+          "That would be great!"
         ]
       }
     },
@@ -9271,7 +9398,9 @@
           {
             "name": "fullActionName",
             "value": "player.searchTracks",
-            "isImplicit": true
+            "substrings": [
+              "Search for"
+            ]
           },
           {
             "name": "parameters.query",
@@ -9285,7 +9414,9 @@
           {
             "text": "Search for",
             "category": "action",
-            "propertyNames": []
+            "propertyNames": [
+              "fullActionName"
+            ]
           },
           {
             "text": "Italian opera classics",
@@ -9297,6 +9428,33 @@
         ],
         "propertyAlternatives": [
           {
+            "propertyName": "fullActionName",
+            "propertyValue": "player.searchTracks",
+            "propertySubPhrases": [
+              "Search for"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "player.findSongs",
+                "propertySubPhrases": [
+                  "Find"
+                ]
+              },
+              {
+                "propertyValue": "player.lookupMusic",
+                "propertySubPhrases": [
+                  "Look up"
+                ]
+              },
+              {
+                "propertyValue": "player.browseTracks",
+                "propertySubPhrases": [
+                  "Browse"
+                ]
+              }
+            ]
+          },
+          {
             "propertyName": "parameters.query",
             "propertyValue": "Italian opera classics",
             "propertySubPhrases": [
@@ -9304,27 +9462,21 @@
             ],
             "alternatives": [
               {
+                "propertyValue": "Italian classical music",
+                "propertySubPhrases": [
+                  "Italian classical music"
+                ]
+              },
+              {
+                "propertyValue": "Italian opera hits",
+                "propertySubPhrases": [
+                  "Italian opera hits"
+                ]
+              },
+              {
                 "propertyValue": "Italian opera arias",
                 "propertySubPhrases": [
                   "Italian opera arias"
-                ]
-              },
-              {
-                "propertyValue": "Italian opera overtures",
-                "propertySubPhrases": [
-                  "Italian opera overtures"
-                ]
-              },
-              {
-                "propertyValue": "Italian opera duets",
-                "propertySubPhrases": [
-                  "Italian opera duets"
-                ]
-              },
-              {
-                "propertyValue": "Italian opera choruses",
-                "propertySubPhrases": [
-                  "Italian opera choruses"
                 ]
               }
             ]
@@ -9335,49 +9487,10 @@
           "Would you mind"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it."
+          "Thank you",
+          "I appreciate it"
         ]
-      },
-      "corrections": [
-        {
-          "data": {
-            "properties": [
-              {
-                "name": "fullActionName",
-                "value": "player.searchTracks",
-                "isImplicit": true
-              },
-              {
-                "name": "parameters.query",
-                "value": "Italian opera classics",
-                "substrings": [
-                  "Italian opera classics"
-                ]
-              }
-            ],
-            "subPhrases": [
-              {
-                "text": "Search for",
-                "category": "action",
-                "propertyNames": [
-                  "fullActionName"
-                ]
-              },
-              {
-                "text": "Italian opera classics",
-                "category": "query",
-                "propertyNames": [
-                  "parameters.query"
-                ]
-              }
-            ]
-          },
-          "correction": [
-            "Property 'fullActionName' is expected to be implicit and should not be included as a property name in a sub-phrase"
-          ]
-        }
-      ]
+      }
     },
     {
       "request": "Search for Let It Be by The Beatles",
@@ -9441,9 +9554,9 @@
                 ]
               },
               {
-                "propertyValue": "player.queryTracks",
+                "propertyValue": "player.browseTracks",
                 "propertySubPhrases": [
-                  "Query"
+                  "Browse"
                 ]
               }
             ]
@@ -9575,9 +9688,9 @@
                 ]
               },
               {
-                "propertyValue": "Adele's ballads",
+                "propertyValue": "Adele ballads",
                 "propertySubPhrases": [
-                  "Adele's ballads"
+                  "Adele ballads"
                 ]
               }
             ]
@@ -9588,8 +9701,8 @@
           "Would you mind"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it."
+          "Thank you",
+          "I appreciate it"
         ]
       }
     },
@@ -9621,7 +9734,7 @@
         "subPhrases": [
           {
             "text": "Search for",
-            "category": "command",
+            "category": "action",
             "propertyNames": [
               "fullActionName"
             ]
@@ -9655,9 +9768,9 @@
                 ]
               },
               {
-                "propertyValue": "player.searchMusic",
+                "propertyValue": "player.querySongs",
                 "propertySubPhrases": [
-                  "Search music for"
+                  "Query"
                 ]
               }
             ]
@@ -9695,8 +9808,8 @@
           "Would you mind"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it!"
+          "Thank you",
+          "I appreciate it"
         ]
       }
     },
@@ -9803,7 +9916,7 @@
         ],
         "politeSuffixes": [
           "Thank you",
-          "I would appreciate it"
+          "I appreciate it"
         ]
       }
     },
@@ -9869,7 +9982,7 @@
                 ]
               },
               {
-                "propertyValue": "player.browseTracks",
+                "propertyValue": "player.browseSongs",
                 "propertySubPhrases": [
                   "Browse"
                 ]
@@ -9906,15 +10019,11 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind",
-          "Kindly",
-          "If it's not too much trouble"
+          "Would you mind"
         ],
         "politeSuffixes": [
-          "Thank you",
-          "Thanks a lot",
-          "I appreciate it",
-          "Much appreciated"
+          "Thank you!",
+          "I would appreciate it."
         ]
       }
     },
@@ -9980,7 +10089,7 @@
                 ]
               },
               {
-                "propertyValue": "player.queryTracks",
+                "propertyValue": "player.querySongs",
                 "propertySubPhrases": [
                   "Query"
                 ]
@@ -10017,11 +10126,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "Kindly",
+          "If it's not too much trouble"
         ],
         "politeSuffixes": [
           "Thank you!",
-          "I would appreciate it!"
+          "I would appreciate it.",
+          "Thanks a lot!",
+          "Much appreciated!"
         ]
       }
     },
@@ -10128,7 +10241,7 @@
         ],
         "politeSuffixes": [
           "Thank you",
-          "I would appreciate it"
+          "I appreciate it"
         ]
       }
     },
@@ -10192,21 +10305,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.searchAlbums",
+                "propertyValue": "player.findSongs",
                 "propertySubPhrases": [
-                  "Search for albums"
+                  "Find songs"
                 ]
               },
               {
-                "propertyValue": "player.searchArtists",
+                "propertyValue": "player.lookupTracks",
                 "propertySubPhrases": [
-                  "Search for artists"
+                  "Look up songs"
                 ]
               },
               {
-                "propertyValue": "player.searchPlaylists",
+                "propertyValue": "player.discoverTracks",
                 "propertySubPhrases": [
-                  "Search for playlists"
+                  "Discover songs"
                 ]
               }
             ]
@@ -10219,12 +10332,6 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "Elvis Presley",
-                "propertySubPhrases": [
-                  "Elvis Presley"
-                ]
-              },
-              {
                 "propertyValue": "The Rolling Stones",
                 "propertySubPhrases": [
                   "The Rolling Stones"
@@ -10235,6 +10342,12 @@
                 "propertySubPhrases": [
                   "Queen"
                 ]
+              },
+              {
+                "propertyValue": "Led Zeppelin",
+                "propertySubPhrases": [
+                  "Led Zeppelin"
+                ]
               }
             ]
           }
@@ -10244,8 +10357,8 @@
           "Would you mind"
         ],
         "politeSuffixes": [
-          "Thank you",
-          "I would appreciate it"
+          "Thank you!",
+          "I would appreciate it."
         ]
       }
     },
@@ -10456,12 +10569,14 @@
         "politePrefixes": [
           "Could you please",
           "Would you mind",
-          "If it's not too much trouble, could you"
+          "If it's not too much trouble, could you",
+          "May I kindly ask you to"
         ],
         "politeSuffixes": [
           "Thank you!",
-          "I would appreciate it.",
-          "Thanks a lot!"
+          "I would appreciate it!",
+          "Thanks a lot!",
+          "Much appreciated!"
         ]
       }
     },
@@ -10527,9 +10642,9 @@
                 ]
               },
               {
-                "propertyValue": "player.discoverTracks",
+                "propertyValue": "player.searchMusic",
                 "propertySubPhrases": [
-                  "Discover"
+                  "Search music for"
                 ]
               }
             ]
@@ -10568,7 +10683,7 @@
         ],
         "politeSuffixes": [
           "Thank you",
-          "I would appreciate it"
+          "I appreciate it"
         ]
       }
     },
@@ -10577,7 +10692,7 @@
       "action": {
         "fullActionName": "player.searchTracks",
         "parameters": {
-          "query": "Thriller album by Michael Jackson"
+          "query": "Thriller by Michael Jackson"
         }
       },
       "explanation": {
@@ -10586,44 +10701,28 @@
             "name": "fullActionName",
             "value": "player.searchTracks",
             "substrings": [
-              "Search for"
+              "Search for the album"
             ]
           },
           {
             "name": "parameters.query",
-            "value": "Thriller album by Michael Jackson",
+            "value": "Thriller by Michael Jackson",
             "substrings": [
-              "Thriller",
-              "album",
-              "by Michael Jackson"
+              "Thriller by Michael Jackson"
             ]
           }
         ],
         "subPhrases": [
           {
-            "text": "Search for",
+            "text": "Search for the album",
             "category": "action",
             "propertyNames": [
               "fullActionName"
             ]
           },
           {
-            "text": "the album",
-            "category": "object",
-            "propertyNames": [
-              "parameters.query"
-            ]
-          },
-          {
-            "text": "Thriller",
-            "category": "title",
-            "propertyNames": [
-              "parameters.query"
-            ]
-          },
-          {
-            "text": "by Michael Jackson",
-            "category": "artist",
+            "text": "Thriller by Michael Jackson",
+            "category": "query",
             "propertyNames": [
               "parameters.query"
             ]
@@ -10634,60 +10733,52 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.searchTracks",
             "propertySubPhrases": [
-              "Search for"
+              "Search for the album"
             ],
             "alternatives": [
               {
-                "propertyValue": "player.findTracks",
+                "propertyValue": "player.searchAlbums",
                 "propertySubPhrases": [
-                  "Find"
+                  "Find the album"
                 ]
               },
               {
-                "propertyValue": "player.lookupTracks",
+                "propertyValue": "player.searchSongs",
                 "propertySubPhrases": [
-                  "Look up"
+                  "Search for the song"
                 ]
               },
               {
-                "propertyValue": "player.browseTracks",
+                "propertyValue": "player.searchArtists",
                 "propertySubPhrases": [
-                  "Browse"
+                  "Look for the artist"
                 ]
               }
             ]
           },
           {
             "propertyName": "parameters.query",
-            "propertyValue": "Thriller album by Michael Jackson",
+            "propertyValue": "Thriller by Michael Jackson",
             "propertySubPhrases": [
-              "the album",
-              "Thriller",
-              "by Michael Jackson"
+              "Thriller by Michael Jackson"
             ],
             "alternatives": [
               {
-                "propertyValue": "Bad album by Michael Jackson",
+                "propertyValue": "Bad by Michael Jackson",
                 "propertySubPhrases": [
-                  "the album",
-                  "Bad",
-                  "by Michael Jackson"
+                  "Bad by Michael Jackson"
                 ]
               },
               {
-                "propertyValue": "Dangerous album by Michael Jackson",
+                "propertyValue": "Dangerous by Michael Jackson",
                 "propertySubPhrases": [
-                  "the album",
-                  "Dangerous",
-                  "by Michael Jackson"
+                  "Dangerous by Michael Jackson"
                 ]
               },
               {
-                "propertyValue": "Off the Wall album by Michael Jackson",
+                "propertyValue": "Off the Wall by Michael Jackson",
                 "propertySubPhrases": [
-                  "the album",
-                  "Off the Wall",
-                  "by Michael Jackson"
+                  "Off the Wall by Michael Jackson"
                 ]
               }
             ]
@@ -10698,8 +10789,8 @@
           "Would you mind"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it."
+          "Thank you",
+          "I would appreciate it"
         ]
       }
     },
@@ -10803,14 +10894,14 @@
         "politePrefixes": [
           "Could you please",
           "Would you mind",
-          "If it's not too much trouble, could you",
-          "May I kindly ask you to"
+          "Kindly",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it!",
-          "Thanks a lot!",
-          "Much appreciated!"
+          "Thank you",
+          "Thanks a lot",
+          "I appreciate it",
+          "Much appreciated"
         ]
       }
     },
@@ -10876,7 +10967,7 @@
                 ]
               },
               {
-                "propertyValue": "player.browseTracks",
+                "propertyValue": "player.browseSongs",
                 "propertySubPhrases": [
                   "Browse"
                 ]
@@ -10913,11 +11004,13 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If it's not too much trouble, could you"
         ],
         "politeSuffixes": [
           "Thank you!",
-          "I would appreciate it."
+          "I would appreciate it.",
+          "Thanks a lot!"
         ]
       }
     },
@@ -11020,15 +11113,11 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind",
-          "If it's not too much trouble, could you",
-          "May I kindly ask you to"
+          "Would you mind"
         ],
         "politeSuffixes": [
-          "thank you",
-          "please",
-          "if you don't mind",
-          "I would appreciate it"
+          "Thank you",
+          "I appreciate it"
         ]
       }
     },
@@ -11135,7 +11224,7 @@
         ],
         "politeSuffixes": [
           "Thank you",
-          "I appreciate it"
+          "I would appreciate it"
         ]
       }
     },
@@ -11201,9 +11290,9 @@
                 ]
               },
               {
-                "propertyValue": "player.discoverTracks",
+                "propertyValue": "player.searchMusic",
                 "propertySubPhrases": [
-                  "Discover"
+                  "Search music for"
                 ]
               }
             ]
@@ -11241,8 +11330,8 @@
           "Would you mind"
         ],
         "politeSuffixes": [
-          "Thank you",
-          "I would appreciate it"
+          "Thank you!",
+          "I would appreciate it."
         ]
       }
     },
@@ -11346,12 +11435,14 @@
         "politePrefixes": [
           "Could you please",
           "Would you mind",
-          "If it's not too much trouble, could you"
+          "If it's not too much trouble,",
+          "May I kindly ask you to"
         ],
         "politeSuffixes": [
-          "Thank you!",
+          "Thank you.",
           "I would appreciate it.",
-          "Thanks a lot!"
+          "Thanks a lot.",
+          "Much appreciated."
         ]
       }
     }

--- a/ts/packages/dispatcher/test/data/player/v5/simple.json
+++ b/ts/packages/dispatcher/test/data/player/v5/simple.json
@@ -1,7 +1,7 @@
 {
   "version": 2,
   "schemaName": "player",
-  "sourceHash": "/coyfq1j8qYAwzuqFo38QLrP2X7DZ/U6UJRPEiLjn7Q=",
+  "sourceHash": "HrhZPog7XXm93zb5xwYtzWspziPTFgFnvgb4UUJ85a8=",
   "explainerName": "v5",
   "entries": [
     {
@@ -17,9 +17,7 @@
           {
             "name": "fullActionName",
             "value": "player.playArtist",
-            "substrings": [
-              "could you play"
-            ]
+            "isImplicit": true
           },
           {
             "name": "parameters.artist",
@@ -52,10 +50,8 @@
           },
           {
             "text": "could you play",
-            "category": "action",
-            "propertyNames": [
-              "fullActionName"
-            ]
+            "category": "request",
+            "propertyNames": []
           },
           {
             "text": "um",
@@ -78,9 +74,9 @@
             "text": "aa...like songs",
             "category": "filler",
             "synonyms": [
-              "um...like songs",
-              "uh...like songs",
-              "er...like songs"
+              "like",
+              "such as",
+              "for example"
             ],
             "isOptional": true
           },
@@ -97,33 +93,6 @@
         ],
         "propertyAlternatives": [
           {
-            "propertyName": "fullActionName",
-            "propertyValue": "player.playArtist",
-            "propertySubPhrases": [
-              "could you play"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "player.playSong",
-                "propertySubPhrases": [
-                  "could you play a song by"
-                ]
-              },
-              {
-                "propertyValue": "player.playAlbum",
-                "propertySubPhrases": [
-                  "could you play an album by"
-                ]
-              },
-              {
-                "propertyValue": "player.playPlaylist",
-                "propertySubPhrases": [
-                  "could you play a playlist by"
-                ]
-              }
-            ]
-          },
-          {
             "propertyName": "parameters.artist",
             "propertyValue": "Paul Simon",
             "propertySubPhrases": [
@@ -131,21 +100,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "Elton John",
-                "propertySubPhrases": [
-                  "Elton John"
-                ]
-              },
-              {
                 "propertyValue": "Bob Dylan",
                 "propertySubPhrases": [
                   "Bob Dylan"
                 ]
               },
               {
-                "propertyValue": "Stevie Wonder",
+                "propertyValue": "Elton John",
                 "propertySubPhrases": [
-                  "Stevie Wonder"
+                  "Elton John"
+                ]
+              },
+              {
+                "propertyValue": "Bruce Springsteen",
+                "propertySubPhrases": [
+                  "Bruce Springsteen"
                 ]
               }
             ]
@@ -153,7 +122,96 @@
         ],
         "politePrefixes": [],
         "politeSuffixes": []
-      }
+      },
+      "corrections": [
+        {
+          "data": {
+            "properties": [
+              {
+                "name": "fullActionName",
+                "value": "player.playArtist",
+                "isImplicit": true
+              },
+              {
+                "name": "parameters.artist",
+                "value": "Paul Simon",
+                "substrings": [
+                  "Paul Simon"
+                ]
+              }
+            ],
+            "subPhrases": [
+              {
+                "text": "ah",
+                "category": "filler",
+                "synonyms": [
+                  "um",
+                  "uh",
+                  "er"
+                ],
+                "isOptional": true
+              },
+              {
+                "text": "yes",
+                "category": "confirmation",
+                "synonyms": [
+                  "yeah",
+                  "yep",
+                  "sure"
+                ],
+                "isOptional": true
+              },
+              {
+                "text": "could you play",
+                "category": "request",
+                "propertyNames": [
+                  "fullActionName"
+                ]
+              },
+              {
+                "text": "um",
+                "category": "filler",
+                "synonyms": [
+                  "ah",
+                  "uh",
+                  "er"
+                ],
+                "isOptional": true
+              },
+              {
+                "text": "Paul Simon",
+                "category": "artist",
+                "propertyNames": [
+                  "parameters.artist"
+                ]
+              },
+              {
+                "text": "aa...like songs",
+                "category": "filler",
+                "synonyms": [
+                  "like",
+                  "such as",
+                  "for example"
+                ],
+                "isOptional": true
+              },
+              {
+                "text": "please",
+                "category": "politeness",
+                "synonyms": [
+                  "kindly",
+                  "if you could",
+                  "would you mind"
+                ],
+                "isOptional": true
+              }
+            ]
+          },
+          "correction": [
+            "Property 'fullActionName' is expected to be implicit and should not be included as a property name in a sub-phrase"
+          ]
+        }
+      ]
     },
     {
       "request": "all right buddy, lets hear some, ahh, I guess Debussy Preludes",
@@ -201,11 +259,11 @@
           },
           {
             "text": "lets hear some",
-            "category": "filler",
+            "category": "command",
             "synonyms": [
-              "let's listen to",
-              "how about",
-              "let's play"
+              "play",
+              "put on",
+              "start"
             ],
             "isOptional": true
           },
@@ -238,7 +296,7 @@
           },
           {
             "text": "Preludes",
-            "category": "trackName",
+            "category": "track",
             "propertyNames": [
               "parameters.trackName"
             ]
@@ -315,7 +373,7 @@
       "action": {
         "fullActionName": "player.playArtist",
         "parameters": {
-          "artist": "katie perry",
+          "artist": "Katy Perry",
           "quantity": 2
         }
       },
@@ -324,13 +382,11 @@
           {
             "name": "fullActionName",
             "value": "player.playArtist",
-            "substrings": [
-              "can I hear"
-            ]
+            "isImplicit": true
           },
           {
             "name": "parameters.artist",
-            "value": "katie perry",
+            "value": "Katy Perry",
             "substrings": [
               "katie perry"
             ]
@@ -346,10 +402,13 @@
         "subPhrases": [
           {
             "text": "can I hear",
-            "category": "request",
-            "propertyNames": [
-              "fullActionName"
-            ]
+            "category": "politeness",
+            "synonyms": [
+              "could I listen to",
+              "may I hear",
+              "would I be able to hear"
+            ],
+            "isOptional": true
           },
           {
             "text": "katie perry",
@@ -369,17 +428,7 @@
             "isOptional": true
           },
           {
-            "text": "like",
-            "category": "filler",
-            "synonyms": [
-              "such as",
-              "for example",
-              "similar to"
-            ],
-            "isOptional": true
-          },
-          {
-            "text": "a couple of",
+            "text": "like a couple of",
             "category": "quantity",
             "propertyNames": [
               "parameters.quantity"
@@ -387,7 +436,7 @@
           },
           {
             "text": "songs",
-            "category": "object",
+            "category": "confirmation",
             "synonyms": [
               "tracks",
               "tunes",
@@ -398,55 +447,28 @@
         ],
         "propertyAlternatives": [
           {
-            "propertyName": "fullActionName",
-            "propertyValue": "player.playArtist",
-            "propertySubPhrases": [
-              "can I hear"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "player.playSong",
-                "propertySubPhrases": [
-                  "can I listen to"
-                ]
-              },
-              {
-                "propertyValue": "player.playAlbum",
-                "propertySubPhrases": [
-                  "can I play"
-                ]
-              },
-              {
-                "propertyValue": "player.playPlaylist",
-                "propertySubPhrases": [
-                  "can I queue up"
-                ]
-              }
-            ]
-          },
-          {
             "propertyName": "parameters.artist",
-            "propertyValue": "katie perry",
+            "propertyValue": "Katy Perry",
             "propertySubPhrases": [
               "katie perry"
             ],
             "alternatives": [
               {
-                "propertyValue": "taylor swift",
+                "propertyValue": "Taylor Swift",
                 "propertySubPhrases": [
                   "taylor swift"
                 ]
               },
               {
-                "propertyValue": "ed sheeran",
+                "propertyValue": "Ariana Grande",
                 "propertySubPhrases": [
-                  "ed sheeran"
+                  "ariana grande"
                 ]
               },
               {
-                "propertyValue": "bruno mars",
+                "propertyValue": "Ed Sheeran",
                 "propertySubPhrases": [
-                  "bruno mars"
+                  "ed sheeran"
                 ]
               }
             ]
@@ -455,7 +477,7 @@
             "propertyName": "parameters.quantity",
             "propertyValue": 2,
             "propertySubPhrases": [
-              "a couple of"
+              "like a couple of"
             ],
             "alternatives": [
               {
@@ -467,13 +489,13 @@
               {
                 "propertyValue": 3,
                 "propertySubPhrases": [
-                  "a few"
+                  "three"
                 ]
               },
               {
                 "propertyValue": 5,
                 "propertySubPhrases": [
-                  "several"
+                  "five"
                 ]
               }
             ]
@@ -502,7 +524,9 @@
           {
             "name": "fullActionName",
             "value": "player.playArtist",
-            "isImplicit": true
+            "substrings": [
+              "hear"
+            ]
           },
           {
             "name": "parameters.artist",
@@ -515,7 +539,7 @@
         "subPhrases": [
           {
             "text": "can I",
-            "category": "politeness",
+            "category": "filler",
             "synonyms": [
               "could I",
               "may I",
@@ -524,12 +548,19 @@
             "isOptional": true
           },
           {
-            "text": "hear some",
+            "text": "hear",
+            "category": "action",
+            "propertyNames": [
+              "fullActionName"
+            ]
+          },
+          {
+            "text": "some",
             "category": "filler",
             "synonyms": [
-              "listen to",
-              "play some",
-              "put on"
+              "a bit of",
+              "a little",
+              "any"
             ],
             "isOptional": true
           },
@@ -542,6 +573,33 @@
           }
         ],
         "propertyAlternatives": [
+          {
+            "propertyName": "fullActionName",
+            "propertyValue": "player.playArtist",
+            "propertySubPhrases": [
+              "hear"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "player.playSong",
+                "propertySubPhrases": [
+                  "play"
+                ]
+              },
+              {
+                "propertyValue": "player.playAlbum",
+                "propertySubPhrases": [
+                  "listen to"
+                ]
+              },
+              {
+                "propertyValue": "player.playPlaylist",
+                "propertySubPhrases": [
+                  "queue up"
+                ]
+              }
+            ]
+          },
           {
             "propertyName": "parameters.artist",
             "propertyValue": "Katy Perry",
@@ -593,9 +651,7 @@
           {
             "name": "fullActionName",
             "value": "player.playArtist",
-            "substrings": [
-              "cue up"
-            ]
+            "isImplicit": true
           },
           {
             "name": "parameters.artist",
@@ -607,21 +663,14 @@
         ],
         "subPhrases": [
           {
-            "text": "cue up",
+            "text": "cue up some",
             "category": "command",
-            "propertyNames": [
-              "fullActionName"
-            ]
-          },
-          {
-            "text": "some",
-            "category": "filler",
             "synonyms": [
-              "a bit of",
-              "a little",
-              "some of"
+              "play",
+              "start",
+              "put on"
             ],
-            "isOptional": true
+            "isOptional": false
           },
           {
             "text": "Taylor Swift",
@@ -632,33 +681,6 @@
           }
         ],
         "propertyAlternatives": [
-          {
-            "propertyName": "fullActionName",
-            "propertyValue": "player.playArtist",
-            "propertySubPhrases": [
-              "cue up"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "player.queueArtist",
-                "propertySubPhrases": [
-                  "queue up"
-                ]
-              },
-              {
-                "propertyValue": "player.startArtist",
-                "propertySubPhrases": [
-                  "start playing"
-                ]
-              },
-              {
-                "propertyValue": "player.beginArtist",
-                "propertySubPhrases": [
-                  "begin playing"
-                ]
-              }
-            ]
-          },
           {
             "propertyName": "parameters.artist",
             "propertyValue": "Taylor Swift",
@@ -679,9 +701,9 @@
                 ]
               },
               {
-                "propertyValue": "Drake",
+                "propertyValue": "Beyoncé",
                 "propertySubPhrases": [
-                  "Drake"
+                  "Beyoncé"
                 ]
               }
             ]
@@ -693,7 +715,7 @@
         ],
         "politeSuffixes": [
           "Thank you!",
-          "I would appreciate it."
+          "Thanks a lot!"
         ]
       }
     },
@@ -727,9 +749,9 @@
             "text": "how about we",
             "category": "filler",
             "synonyms": [
-              "what if we",
               "let's",
-              "shall we"
+              "shall we",
+              "why don't we"
             ],
             "isOptional": true
           },
@@ -741,29 +763,19 @@
             ]
           },
           {
-            "text": "the",
-            "category": "filler",
-            "synonyms": [
-              "some",
-              "a bit of",
-              "a little"
-            ],
-            "isOptional": true
-          },
-          {
-            "text": "Bach",
+            "text": "the Bach vibes",
             "category": "artist",
             "propertyNames": [
               "parameters.artist"
             ]
           },
           {
-            "text": "vibes",
-            "category": "filler",
+            "text": "?",
+            "category": "punctuation",
             "synonyms": [
-              "music",
-              "tunes",
-              "melodies"
+              "",
+              ".",
+              "!"
             ],
             "isOptional": true
           }
@@ -777,21 +789,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.startArtist",
+                "propertyValue": "player.startMusic",
                 "propertySubPhrases": [
-                  "start"
+                  "start the music"
                 ]
               },
               {
-                "propertyValue": "player.beginArtist",
+                "propertyValue": "player.beginPlayback",
                 "propertySubPhrases": [
-                  "begin"
+                  "begin playback"
                 ]
               },
               {
-                "propertyValue": "player.initiateArtist",
+                "propertyValue": "player.initiateTunes",
                 "propertySubPhrases": [
-                  "initiate"
+                  "initiate the tunes"
                 ]
               }
             ]
@@ -800,25 +812,25 @@
             "propertyName": "parameters.artist",
             "propertyValue": "Bach",
             "propertySubPhrases": [
-              "Bach"
+              "the Bach vibes"
             ],
             "alternatives": [
               {
                 "propertyValue": "Mozart",
                 "propertySubPhrases": [
-                  "Mozart"
+                  "the Mozart vibes"
                 ]
               },
               {
                 "propertyValue": "Beethoven",
                 "propertySubPhrases": [
-                  "Beethoven"
+                  "the Beethoven vibes"
                 ]
               },
               {
                 "propertyValue": "Chopin",
                 "propertySubPhrases": [
-                  "Chopin"
+                  "the Chopin vibes"
                 ]
               }
             ]
@@ -890,7 +902,7 @@
             "synonyms": [
               "from",
               "of",
-              "by the artist"
+              "featuring"
             ],
             "isOptional": true
           },
@@ -1040,7 +1052,7 @@
           },
           {
             "text": "Pretzel Logic",
-            "category": "album name",
+            "category": "albumName",
             "propertyNames": [
               "parameters.albumName"
             ]
@@ -1057,7 +1069,7 @@
           },
           {
             "text": "Steely Dan",
-            "category": "artist name",
+            "category": "artist",
             "propertyNames": [
               "parameters.artists.0"
             ]
@@ -1074,13 +1086,13 @@
               {
                 "propertyValue": "player.playSong",
                 "propertySubPhrases": [
-                  "lets listen to the song"
+                  "lets play the song"
                 ]
               },
               {
                 "propertyValue": "player.playPlaylist",
                 "propertySubPhrases": [
-                  "lets listen to the playlist"
+                  "lets play the playlist"
                 ]
               },
               {
@@ -1204,8 +1216,8 @@
             "category": "filler",
             "synonyms": [
               "some music by",
-              "a few pieces by",
-              "some tracks by"
+              "songs by",
+              "tracks by"
             ],
             "isOptional": true
           },
@@ -1259,15 +1271,15 @@
                 ]
               },
               {
-                "propertyValue": "Mozart",
-                "propertySubPhrases": [
-                  "Mozart"
-                ]
-              },
-              {
                 "propertyValue": "Beethoven",
                 "propertySubPhrases": [
                   "Beethoven"
+                ]
+              },
+              {
+                "propertyValue": "Mozart",
+                "propertySubPhrases": [
+                  "Mozart"
                 ]
               }
             ]
@@ -1286,28 +1298,30 @@
     {
       "request": "Ok, next I wanna hear, aa, um... yeah, some Def Leppard. Armageddon It.",
       "action": {
-        "fullActionName": "player.playAlbumTrack",
+        "fullActionName": "player.playTrack",
         "parameters": {
-          "albumName": "Armageddon It",
-          "trackName": "Def Leppard"
+          "trackName": "Armageddon It",
+          "artists": [
+            "Def Leppard"
+          ]
         }
       },
       "explanation": {
         "properties": [
           {
             "name": "fullActionName",
-            "value": "player.playAlbumTrack",
+            "value": "player.playTrack",
             "isImplicit": true
           },
           {
-            "name": "parameters.albumName",
+            "name": "parameters.trackName",
             "value": "Armageddon It",
             "substrings": [
               "Armageddon It"
             ]
           },
           {
-            "name": "parameters.trackName",
+            "name": "parameters.artists.0",
             "value": "Def Leppard",
             "substrings": [
               "Def Leppard"
@@ -1316,122 +1330,101 @@
         ],
         "subPhrases": [
           {
-            "text": "Ok",
+            "text": "Ok,",
             "category": "acknowledgement",
             "synonyms": [
-              "Alright",
-              "Okay",
-              "Sure",
-              "Got it"
+              "Alright,",
+              "Okay,",
+              "Sure,"
             ],
             "isOptional": true
           },
           {
-            "text": "next I wanna hear",
+            "text": "next I wanna hear,",
             "category": "filler",
             "synonyms": [
-              "next I would like to hear",
-              "next I want to hear",
-              "next I wish to hear"
+              "next I want to hear,",
+              "next I would like to hear,",
+              "next I wanna listen to,"
             ],
             "isOptional": true
           },
           {
-            "text": "aa",
+            "text": "aa, um... yeah,",
             "category": "filler",
             "synonyms": [
-              "ah",
-              "uh",
-              "oh"
+              "uh, um... yeah,",
+              "uh, um... sure,",
+              "uh, um... okay,"
             ],
             "isOptional": true
           },
           {
-            "text": "um",
-            "category": "filler",
-            "synonyms": [
-              "uh",
-              "ah",
-              "er"
-            ],
-            "isOptional": true
-          },
-          {
-            "text": "yeah",
-            "category": "acknowledgement",
-            "synonyms": [
-              "yes",
-              "yep",
-              "sure"
-            ],
-            "isOptional": true
-          },
-          {
-            "text": "some Def Leppard",
+            "text": "some Def Leppard.",
             "category": "property",
             "propertyNames": [
-              "parameters.trackName"
+              "parameters.artists.0"
             ]
           },
           {
-            "text": "Armageddon It",
+            "text": "Armageddon It.",
             "category": "property",
             "propertyNames": [
-              "parameters.albumName"
+              "parameters.trackName"
             ]
           }
         ],
         "propertyAlternatives": [
           {
-            "propertyName": "parameters.trackName",
+            "propertyName": "parameters.artists.0",
             "propertyValue": "Def Leppard",
             "propertySubPhrases": [
-              "some Def Leppard"
+              "some Def Leppard."
             ],
             "alternatives": [
               {
-                "propertyValue": "Pour Some Sugar On Me",
+                "propertyValue": "AC/DC",
                 "propertySubPhrases": [
-                  "some Pour Some Sugar On Me"
+                  "some AC/DC."
                 ]
               },
               {
-                "propertyValue": "Hysteria",
+                "propertyValue": "Queen",
                 "propertySubPhrases": [
-                  "some Hysteria"
+                  "some Queen."
                 ]
               },
               {
-                "propertyValue": "Love Bites",
+                "propertyValue": "Led Zeppelin",
                 "propertySubPhrases": [
-                  "some Love Bites"
+                  "some Led Zeppelin."
                 ]
               }
             ]
           },
           {
-            "propertyName": "parameters.albumName",
+            "propertyName": "parameters.trackName",
             "propertyValue": "Armageddon It",
             "propertySubPhrases": [
-              "Armageddon It"
+              "Armageddon It."
             ],
             "alternatives": [
               {
+                "propertyValue": "Pour Some Sugar On Me",
+                "propertySubPhrases": [
+                  "Pour Some Sugar On Me."
+                ]
+              },
+              {
                 "propertyValue": "Hysteria",
                 "propertySubPhrases": [
-                  "Hysteria"
+                  "Hysteria."
                 ]
               },
               {
-                "propertyValue": "Pyromania",
+                "propertyValue": "Love Bites",
                 "propertySubPhrases": [
-                  "Pyromania"
-                ]
-              },
-              {
-                "propertyValue": "Adrenalize",
-                "propertySubPhrases": [
-                  "Adrenalize"
+                  "Love Bites."
                 ]
               }
             ]
@@ -1439,11 +1432,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If it's not too much trouble, could you",
+          "I would appreciate it if you could"
         ],
         "politeSuffixes": [
           "Thank you!",
-          "I would appreciate it!"
+          "Thanks a lot!",
+          "I appreciate it!",
+          "Much appreciated!"
         ]
       }
     },
@@ -1582,15 +1579,15 @@
                 ]
               },
               {
-                "propertyValue": "Soundgarden",
-                "propertySubPhrases": [
-                  "Soundgarden"
-                ]
-              },
-              {
                 "propertyValue": "Pearl Jam",
                 "propertySubPhrases": [
                   "Pearl Jam"
+                ]
+              },
+              {
+                "propertyValue": "Soundgarden",
+                "propertySubPhrases": [
+                  "Soundgarden"
                 ]
               }
             ]
@@ -1601,8 +1598,8 @@
           "Would you mind"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it."
+          "Thank you",
+          "I would appreciate it"
         ]
       }
     },
@@ -1612,6 +1609,7 @@
         "fullActionName": "player.playArtist",
         "parameters": {
           "artist": "Bach",
+          "genre": "fugue",
           "quantity": 2
         }
       },
@@ -1632,10 +1630,17 @@
             ]
           },
           {
+            "name": "parameters.genre",
+            "value": "fugue",
+            "substrings": [
+              "fugues"
+            ]
+          },
+          {
             "name": "parameters.quantity",
             "value": 2,
             "substrings": [
-              "a couple"
+              "a couple of"
             ]
           }
         ],
@@ -1658,19 +1663,26 @@
             ]
           },
           {
-            "text": "a couple",
+            "text": "a couple of",
             "category": "quantity",
             "propertyNames": [
               "parameters.quantity"
             ]
           },
           {
-            "text": "of fugues by",
-            "category": "filler",
+            "text": "fugues",
+            "category": "genre",
+            "propertyNames": [
+              "parameters.genre"
+            ]
+          },
+          {
+            "text": "by",
+            "category": "preposition",
             "synonyms": [
-              "some pieces by",
-              "a few compositions by",
-              "several works by"
+              "from",
+              "of",
+              "composed by"
             ],
             "isOptional": true
           },
@@ -1714,7 +1726,7 @@
             "propertyName": "parameters.quantity",
             "propertyValue": 2,
             "propertySubPhrases": [
-              "a couple"
+              "a couple of"
             ],
             "alternatives": [
               {
@@ -1733,6 +1745,33 @@
                 "propertyValue": 5,
                 "propertySubPhrases": [
                   "several"
+                ]
+              }
+            ]
+          },
+          {
+            "propertyName": "parameters.genre",
+            "propertyValue": "fugue",
+            "propertySubPhrases": [
+              "fugues"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "symphony",
+                "propertySubPhrases": [
+                  "symphonies"
+                ]
+              },
+              {
+                "propertyValue": "concerto",
+                "propertySubPhrases": [
+                  "concertos"
+                ]
+              },
+              {
+                "propertyValue": "sonata",
+                "propertySubPhrases": [
+                  "sonatas"
                 ]
               }
             ]
@@ -1839,21 +1878,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.pause",
+                "propertyValue": "player.playAlbum",
                 "propertySubPhrases": [
-                  "pause"
+                  "play album"
                 ]
               },
               {
-                "propertyValue": "player.stop",
+                "propertyValue": "player.playPlaylist",
                 "propertySubPhrases": [
-                  "stop"
+                  "play playlist"
                 ]
               },
               {
-                "propertyValue": "player.skip",
+                "propertyValue": "player.playSong",
                 "propertySubPhrases": [
-                  "skip"
+                  "play song"
                 ]
               }
             ]
@@ -1872,9 +1911,9 @@
                 ]
               },
               {
-                "propertyValue": "Billy Joel",
+                "propertyValue": "Bob Dylan",
                 "propertySubPhrases": [
-                  "Billy Joel"
+                  "Bob Dylan"
                 ]
               },
               {
@@ -2004,21 +2043,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "Bob Dylan",
-                "propertySubPhrases": [
-                  "Bob Dylan"
-                ]
-              },
-              {
                 "propertyValue": "Elton John",
                 "propertySubPhrases": [
                   "Elton John"
                 ]
               },
               {
-                "propertyValue": "Bruce Springsteen",
+                "propertyValue": "Bob Dylan",
                 "propertySubPhrases": [
-                  "Bruce Springsteen"
+                  "Bob Dylan"
+                ]
+              },
+              {
+                "propertyValue": "Stevie Wonder",
+                "propertySubPhrases": [
+                  "Stevie Wonder"
                 ]
               }
             ]
@@ -2031,21 +2070,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "The Wall",
+                "propertyValue": "The Stranger",
                 "propertySubPhrases": [
-                  "The Wall"
-                ]
-              },
-              {
-                "propertyValue": "Abbey Road",
-                "propertySubPhrases": [
-                  "Abbey Road"
+                  "The Stranger"
                 ]
               },
               {
                 "propertyValue": "Thriller",
                 "propertySubPhrases": [
                   "Thriller"
+                ]
+              },
+              {
+                "propertyValue": "Rumours",
+                "propertySubPhrases": [
+                  "Rumours"
                 ]
               }
             ]
@@ -2083,7 +2122,7 @@
         "subPhrases": [
           {
             "text": "que up",
-            "category": "command",
+            "category": "action",
             "propertyNames": [
               "fullActionName"
             ]
@@ -2127,7 +2166,7 @@
                 ]
               },
               {
-                "propertyValue": "player.shufflePlay",
+                "propertyValue": "player.shuffleArtist",
                 "propertySubPhrases": [
                   "shuffle"
                 ]
@@ -2164,11 +2203,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If it's not too much trouble, could you",
+          "May I kindly ask you to"
         ],
         "politeSuffixes": [
-          "Thank you",
-          "Thanks a lot"
+          "thank you",
+          "please",
+          "if you don't mind",
+          "thanks a lot"
         ]
       }
     },
@@ -2244,9 +2287,9 @@
                 ]
               },
               {
-                "propertyValue": "player.beginArtist",
+                "propertyValue": "player.playMusic",
                 "propertySubPhrases": [
-                  "begin"
+                  "play"
                 ]
               }
             ]
@@ -2259,15 +2302,15 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "Dr. Dre",
-                "propertySubPhrases": [
-                  "Dr. Dre"
-                ]
-              },
-              {
                 "propertyValue": "Eminem",
                 "propertySubPhrases": [
                   "Eminem"
+                ]
+              },
+              {
+                "propertyValue": "Dr. Dre",
+                "propertySubPhrases": [
+                  "Dr. Dre"
                 ]
               },
               {
@@ -2281,11 +2324,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If it's not too much trouble, could you",
+          "May I kindly ask you to"
         ],
         "politeSuffixes": [
           "thank you",
-          "if that's okay"
+          "please",
+          "if you don't mind",
+          "thanks a lot"
         ]
       }
     },
@@ -2324,7 +2371,7 @@
           },
           {
             "text": "Highway to Hell",
-            "category": "track name",
+            "category": "trackName",
             "propertyNames": [
               "parameters.trackName"
             ]
@@ -2391,8 +2438,8 @@
           "Would you mind"
         ],
         "politeSuffixes": [
-          "thank you",
-          "if that's okay"
+          "Thank you",
+          "I would appreciate it"
         ]
       }
     },
@@ -2424,7 +2471,7 @@
         "subPhrases": [
           {
             "text": "start some music",
-            "category": "action",
+            "category": "command",
             "propertyNames": [
               "fullActionName"
             ]
@@ -2434,7 +2481,7 @@
             "category": "preposition",
             "synonyms": [
               "from",
-              "of",
+              "featuring",
               "with"
             ],
             "isOptional": true
@@ -2470,7 +2517,7 @@
               {
                 "propertyValue": "player.playPlaylist",
                 "propertySubPhrases": [
-                  "play a playlist"
+                  "start a playlist"
                 ]
               }
             ]
@@ -2489,15 +2536,15 @@
                 ]
               },
               {
-                "propertyValue": "Mozart",
-                "propertySubPhrases": [
-                  "Mozart"
-                ]
-              },
-              {
                 "propertyValue": "Beethoven",
                 "propertySubPhrases": [
                   "Beethoven"
+                ]
+              },
+              {
+                "propertyValue": "Mozart",
+                "propertySubPhrases": [
+                  "Mozart"
                 ]
               }
             ]
@@ -2505,11 +2552,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If it's not too much trouble, could you",
+          "May I kindly ask you to"
         ],
         "politeSuffixes": [
           "thank you",
-          "if that's okay"
+          "please",
+          "if you don't mind",
+          "I would appreciate it"
         ]
       }
     },
@@ -2540,12 +2591,12 @@
         ],
         "subPhrases": [
           {
-            "text": "thanks",
+            "text": "thanks,",
             "category": "acknowledgement",
             "synonyms": [
               "thank you",
-              "cheers",
-              "much appreciated"
+              "thanks a lot",
+              "thank you very much"
             ],
             "isOptional": true
           },
@@ -2572,7 +2623,7 @@
             "synonyms": [
               "a bit of",
               "a little",
-              "a few"
+              "some of"
             ],
             "isOptional": true
           },
@@ -2696,14 +2747,14 @@
             ]
           },
           {
-            "text": "a couple of",
+            "text": "a couple",
             "category": "quantity",
             "propertyNames": [
               "parameters.quantity"
             ]
           },
           {
-            "text": "Duran Duran",
+            "text": "of Duran Duran",
             "category": "artist",
             "propertyNames": [
               "parameters.artist"
@@ -2715,7 +2766,7 @@
             "synonyms": [
               "tracks",
               "tunes",
-              "pieces"
+              "music"
             ],
             "isOptional": true
           }
@@ -2729,21 +2780,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.pause",
+                "propertyValue": "player.playSong",
                 "propertySubPhrases": [
-                  "pause"
+                  "play a song"
                 ]
               },
               {
-                "propertyValue": "player.stop",
+                "propertyValue": "player.playAlbum",
                 "propertySubPhrases": [
-                  "stop"
+                  "play an album"
                 ]
               },
               {
-                "propertyValue": "player.skip",
+                "propertyValue": "player.playPlaylist",
                 "propertySubPhrases": [
-                  "skip"
+                  "play a playlist"
                 ]
               }
             ]
@@ -2752,13 +2803,13 @@
             "propertyName": "parameters.quantity",
             "propertyValue": 2,
             "propertySubPhrases": [
-              "a couple of"
+              "a couple"
             ],
             "alternatives": [
               {
                 "propertyValue": 1,
                 "propertySubPhrases": [
-                  "one"
+                  "a single"
                 ]
               },
               {
@@ -2779,25 +2830,25 @@
             "propertyName": "parameters.artist",
             "propertyValue": "Duran Duran",
             "propertySubPhrases": [
-              "Duran Duran"
+              "of Duran Duran"
             ],
             "alternatives": [
               {
                 "propertyValue": "The Beatles",
                 "propertySubPhrases": [
-                  "The Beatles"
+                  "of The Beatles"
                 ]
               },
               {
                 "propertyValue": "Queen",
                 "propertySubPhrases": [
-                  "Queen"
+                  "of Queen"
                 ]
               },
               {
                 "propertyValue": "Madonna",
                 "propertySubPhrases": [
-                  "Madonna"
+                  "of Madonna"
                 ]
               }
             ]
@@ -2823,9 +2874,7 @@
           {
             "name": "fullActionName",
             "value": "player.playAlbum",
-            "substrings": [
-              "play"
-            ]
+            "isImplicit": true
           },
           {
             "name": "parameters.albumName",
@@ -2856,9 +2905,7 @@
           {
             "text": "play",
             "category": "action",
-            "propertyNames": [
-              "fullActionName"
-            ]
+            "propertyNames": []
           },
           {
             "text": "Aja",
@@ -2887,33 +2934,6 @@
         ],
         "propertyAlternatives": [
           {
-            "propertyName": "fullActionName",
-            "propertyValue": "player.playAlbum",
-            "propertySubPhrases": [
-              "play"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "player.playSong",
-                "propertySubPhrases": [
-                  "play the song"
-                ]
-              },
-              {
-                "propertyValue": "player.playPlaylist",
-                "propertySubPhrases": [
-                  "play the playlist"
-                ]
-              },
-              {
-                "propertyValue": "player.playPodcast",
-                "propertySubPhrases": [
-                  "play the podcast"
-                ]
-              }
-            ]
-          },
-          {
             "propertyName": "parameters.albumName",
             "propertyValue": "Aja",
             "propertySubPhrases": [
@@ -2921,21 +2941,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "Thriller",
+                "propertyValue": "Gaucho",
                 "propertySubPhrases": [
-                  "Thriller"
+                  "Gaucho"
                 ]
               },
               {
-                "propertyValue": "Back in Black",
+                "propertyValue": "Pretzel Logic",
                 "propertySubPhrases": [
-                  "Back in Black"
+                  "Pretzel Logic"
                 ]
               },
               {
-                "propertyValue": "The Dark Side of the Moon",
+                "propertyValue": "Countdown to Ecstasy",
                 "propertySubPhrases": [
-                  "The Dark Side of the Moon"
+                  "Countdown to Ecstasy"
                 ]
               }
             ]
@@ -2948,15 +2968,15 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "Michael Jackson",
+                "propertyValue": "The Beatles",
                 "propertySubPhrases": [
-                  "Michael Jackson"
+                  "The Beatles"
                 ]
               },
               {
-                "propertyValue": "AC/DC",
+                "propertyValue": "Fleetwood Mac",
                 "propertySubPhrases": [
-                  "AC/DC"
+                  "Fleetwood Mac"
                 ]
               },
               {
@@ -2970,14 +2990,87 @@
         ],
         "politePrefixes": [],
         "politeSuffixes": []
-      }
+      },
+      "corrections": [
+        {
+          "data": {
+            "properties": [
+              {
+                "name": "fullActionName",
+                "value": "player.playAlbum",
+                "isImplicit": true
+              },
+              {
+                "name": "parameters.albumName",
+                "value": "Aja",
+                "substrings": [
+                  "Aja"
+                ]
+              },
+              {
+                "name": "parameters.artists.0",
+                "value": "Steely Dan",
+                "substrings": [
+                  "Steely Dan"
+                ]
+              }
+            ],
+            "subPhrases": [
+              {
+                "text": "would you please",
+                "category": "politeness",
+                "synonyms": [
+                  "could you please",
+                  "can you please",
+                  "would you mind"
+                ],
+                "isOptional": true
+              },
+              {
+                "text": "play",
+                "category": "action",
+                "propertyNames": [
+                  "fullActionName"
+                ]
+              },
+              {
+                "text": "Aja",
+                "category": "albumName",
+                "propertyNames": [
+                  "parameters.albumName"
+                ]
+              },
+              {
+                "text": "by",
+                "category": "preposition",
+                "synonyms": [
+                  "from",
+                  "performed by",
+                  "sung by"
+                ],
+                "isOptional": true
+              },
+              {
+                "text": "Steely Dan",
+                "category": "artist",
+                "propertyNames": [
+                  "parameters.artists.0"
+                ]
+              }
+            ]
+          },
+          "correction": [
+            "Property 'fullActionName' is expected to be implicit and should not be included as a property name in a sub-phrase"
+          ]
+        }
+      ]
     },
     {
       "request": "would you please play Graceland by Paul Simon",
       "action": {
-        "fullActionName": "player.playAlbum",
+        "fullActionName": "player.playTrack",
         "parameters": {
-          "albumName": "Graceland",
+          "trackName": "Graceland",
           "artists": [
             "Paul Simon"
           ]
@@ -2987,13 +3080,13 @@
         "properties": [
           {
             "name": "fullActionName",
-            "value": "player.playAlbum",
+            "value": "player.playTrack",
             "substrings": [
               "play"
             ]
           },
           {
-            "name": "parameters.albumName",
+            "name": "parameters.trackName",
             "value": "Graceland",
             "substrings": [
               "Graceland"
@@ -3027,9 +3120,9 @@
           },
           {
             "text": "Graceland",
-            "category": "albumName",
+            "category": "trackName",
             "propertyNames": [
-              "parameters.albumName"
+              "parameters.trackName"
             ]
           },
           {
@@ -3053,54 +3146,54 @@
         "propertyAlternatives": [
           {
             "propertyName": "fullActionName",
-            "propertyValue": "player.playAlbum",
+            "propertyValue": "player.playTrack",
             "propertySubPhrases": [
               "play"
             ],
             "alternatives": [
               {
-                "propertyValue": "player.playSong",
+                "propertyValue": "player.pauseTrack",
                 "propertySubPhrases": [
-                  "play the song"
+                  "pause"
                 ]
               },
               {
-                "propertyValue": "player.playPlaylist",
+                "propertyValue": "player.stopTrack",
                 "propertySubPhrases": [
-                  "play the playlist"
+                  "stop"
                 ]
               },
               {
-                "propertyValue": "player.playPodcast",
+                "propertyValue": "player.resumeTrack",
                 "propertySubPhrases": [
-                  "play the podcast"
+                  "resume"
                 ]
               }
             ]
           },
           {
-            "propertyName": "parameters.albumName",
+            "propertyName": "parameters.trackName",
             "propertyValue": "Graceland",
             "propertySubPhrases": [
               "Graceland"
             ],
             "alternatives": [
               {
-                "propertyValue": "Thriller",
+                "propertyValue": "The Sound of Silence",
                 "propertySubPhrases": [
-                  "Thriller"
+                  "The Sound of Silence"
                 ]
               },
               {
-                "propertyValue": "The Wall",
+                "propertyValue": "Bridge Over Troubled Water",
                 "propertySubPhrases": [
-                  "The Wall"
+                  "Bridge Over Troubled Water"
                 ]
               },
               {
-                "propertyValue": "Abbey Road",
+                "propertyValue": "You Can Call Me Al",
                 "propertySubPhrases": [
-                  "Abbey Road"
+                  "You Can Call Me Al"
                 ]
               }
             ]
@@ -3113,21 +3206,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "Michael Jackson",
+                "propertyValue": "Simon & Garfunkel",
                 "propertySubPhrases": [
-                  "Michael Jackson"
+                  "Simon & Garfunkel"
                 ]
               },
               {
-                "propertyValue": "Pink Floyd",
+                "propertyValue": "Art Garfunkel",
                 "propertySubPhrases": [
-                  "Pink Floyd"
+                  "Art Garfunkel"
                 ]
               },
               {
-                "propertyValue": "The Beatles",
+                "propertyValue": "Bob Dylan",
                 "propertySubPhrases": [
-                  "The Beatles"
+                  "Bob Dylan"
                 ]
               }
             ]
@@ -3207,21 +3300,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.pause",
+                "propertyValue": "player.playSong",
                 "propertySubPhrases": [
-                  "pause"
+                  "play a song"
                 ]
               },
               {
-                "propertyValue": "player.stop",
+                "propertyValue": "player.playAlbum",
                 "propertySubPhrases": [
-                  "stop"
+                  "play an album"
                 ]
               },
               {
-                "propertyValue": "player.skip",
+                "propertyValue": "player.playPlaylist",
                 "propertySubPhrases": [
-                  "skip"
+                  "play a playlist"
                 ]
               }
             ]
@@ -3240,15 +3333,15 @@
                 ]
               },
               {
-                "propertyValue": "Madonna",
+                "propertyValue": "Queen",
                 "propertySubPhrases": [
-                  "Madonna"
+                  "Queen"
                 ]
               },
               {
-                "propertyValue": "Michael Jackson",
+                "propertyValue": "Madonna",
                 "propertySubPhrases": [
-                  "Michael Jackson"
+                  "Madonna"
                 ]
               }
             ]
@@ -3296,20 +3389,16 @@
             "text": "yo",
             "category": "greeting",
             "synonyms": [
-              "hey",
               "hi",
+              "hey",
               "hello"
             ],
             "isOptional": true
           },
           {
             "text": "play",
-            "category": "command",
-            "synonyms": [
-              "start",
-              "begin",
-              "put on"
-            ]
+            "category": "action",
+            "propertyNames": []
           },
           {
             "text": "some",
@@ -3398,7 +3487,7 @@
         ],
         "politeSuffixes": [
           "Thank you",
-          "I would appreciate it"
+          "Thanks a lot"
         ]
       },
       "corrections": [
@@ -3430,15 +3519,15 @@
                 "text": "yo",
                 "category": "greeting",
                 "synonyms": [
-                  "hey",
                   "hi",
+                  "hey",
                   "hello"
                 ],
                 "isOptional": true
               },
               {
                 "text": "play",
-                "category": "command",
+                "category": "action",
                 "propertyNames": [
                   "fullActionName"
                 ]
@@ -3515,9 +3604,9 @@
             "text": "yo, yo",
             "category": "greeting",
             "synonyms": [
+              "hey",
               "hi",
-              "hello",
-              "hey"
+              "hello"
             ],
             "isOptional": true
           },
@@ -3649,9 +3738,7 @@
           {
             "name": "fullActionName",
             "value": "player.playArtist",
-            "substrings": [
-              "spin me some"
-            ]
+            "isImplicit": true
           },
           {
             "name": "parameters.artist",
@@ -3675,9 +3762,7 @@
           {
             "text": "spin me some",
             "category": "command",
-            "propertyNames": [
-              "fullActionName"
-            ]
+            "propertyNames": []
           },
           {
             "text": "Snoop Dogg",
@@ -3698,33 +3783,6 @@
           }
         ],
         "propertyAlternatives": [
-          {
-            "propertyName": "fullActionName",
-            "propertyValue": "player.playArtist",
-            "propertySubPhrases": [
-              "spin me some"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "player.playSong",
-                "propertySubPhrases": [
-                  "play me the track"
-                ]
-              },
-              {
-                "propertyValue": "player.playAlbum",
-                "propertySubPhrases": [
-                  "spin the album"
-                ]
-              },
-              {
-                "propertyValue": "player.playPlaylist",
-                "propertySubPhrases": [
-                  "put on the playlist"
-                ]
-              }
-            ]
-          },
           {
             "propertyName": "parameters.artist",
             "propertyValue": "Snoop Dogg",
@@ -3753,15 +3811,68 @@
             ]
           }
         ],
-        "politePrefixes": [
-          "Could you please",
-          "Would you mind"
-        ],
-        "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it!"
-        ]
-      }
+        "politePrefixes": [],
+        "politeSuffixes": []
+      },
+      "corrections": [
+        {
+          "data": {
+            "properties": [
+              {
+                "name": "fullActionName",
+                "value": "player.playArtist",
+                "isImplicit": true
+              },
+              {
+                "name": "parameters.artist",
+                "value": "Snoop Dogg",
+                "substrings": [
+                  "Snoop Dogg"
+                ]
+              }
+            ],
+            "subPhrases": [
+              {
+                "text": "yo, yo,",
+                "category": "greeting",
+                "synonyms": [
+                  "hey",
+                  "hi",
+                  "hello"
+                ],
+                "isOptional": true
+              },
+              {
+                "text": "spin me some",
+                "category": "command",
+                "propertyNames": [
+                  "fullActionName"
+                ]
+              },
+              {
+                "text": "Snoop Dogg",
+                "category": "artist",
+                "propertyNames": [
+                  "parameters.artist"
+                ]
+              },
+              {
+                "text": "you know what I am sayin?",
+                "category": "filler",
+                "synonyms": [
+                  "you get me?",
+                  "you feel me?",
+                  "you understand?"
+                ],
+                "isOptional": true
+              }
+            ]
+          },
+          "correction": [
+            "Property 'fullActionName' is expected to be implicit and should not be included as a property name in a sub-phrase"
+          ]
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
Allow genre to be specified with playArtist action.
Merge `playAlbumTrack` action with `playTrack` action to avoid confusion.

Also spotify deprecated genre APIs.  Turn genre specification to just a query for now.