### PR TITLE
Fix vscode agent hang

### DIFF
--- a/ts/packages/agents/code/src/codeActionHandler.ts
+++ b/ts/packages/agents/code/src/codeActionHandler.ts
@@ -62,7 +62,6 @@ async function updateCodeContext(
             };
             webSocket.onmessage = async (event: any) => {
                 const text = event.data.toString();
-                console.log(`Received message: ${text}`);
                 const data = JSON.parse(text) as WebSocketMessageV2;
 
                 if (data.id !== undefined && data.result !== undefined) {

--- a/ts/packages/agents/code/src/codeActionHandler.ts
+++ b/ts/packages/agents/code/src/codeActionHandler.ts
@@ -62,9 +62,10 @@ async function updateCodeContext(
             };
             webSocket.onmessage = async (event: any) => {
                 const text = event.data.toString();
+                console.log(`Received message: ${text}`);
                 const data = JSON.parse(text) as WebSocketMessageV2;
 
-                if (data.id && data.result) {
+                if (data.id !== undefined && data.result !== undefined) {
                     const pendingCall = agentContext.pendingCall.get(
                         Number(data.id),
                     );


### PR DESCRIPTION
Fix regression from #583 

The `data.id` is actually a number in this case (which is just round trip from the agent), and a plain "truthy" check would reject call id of 0, causing the remote call to not be resolved.

Do an explicit `undefined` check instead.