### PR TITLE
createDispatcher API default to not do dblogging

### DIFF
--- a/ts/packages/api/src/webDispatcher.ts
+++ b/ts/packages/api/src/webDispatcher.ts
@@ -30,6 +30,7 @@ export async function createWebDispatcher(): Promise<WebDispatcher> {
         persistSession: true,
         enableServiceHost: true,
         metrics: true,
+        dblogging: true,
         clientIO: clientIO,
     });
 

--- a/ts/packages/cli/src/commands/interactive.ts
+++ b/ts/packages/cli/src/commands/interactive.ts
@@ -75,6 +75,7 @@ export default class Interactive extends Command {
                 persistSession: !flags.memory,
                 enableServiceHost: true,
                 clientIO,
+                dblogging: true,
             });
             try {
                 if (args.input) {

--- a/ts/packages/cli/src/commands/run/explain.ts
+++ b/ts/packages/cli/src/commands/run/explain.ts
@@ -99,6 +99,7 @@ export default class ExplainCommand extends Command {
                 cache: { enabled: false },
                 clientIO,
                 persist: true,
+                dblogging: true,
             });
             try {
                 await dispatcher.processCommand(command.join(" "));

--- a/ts/packages/cli/src/commands/run/request.ts
+++ b/ts/packages/cli/src/commands/run/request.ts
@@ -65,6 +65,7 @@ export default class RequestCommand extends Command {
                 : { enabled: false },
             cache: { enabled: false },
             persist: true,
+            dblogging: true,
         });
         await dispatcher.processCommand(
             `@dispatcher request ${args.request}`,

--- a/ts/packages/cli/src/commands/run/translate.ts
+++ b/ts/packages/cli/src/commands/run/translate.ts
@@ -50,6 +50,7 @@ export default class TranslateCommand extends Command {
             translation: { model: flags.model },
             cache: { enabled: false },
             persist: true,
+            dblogging: true,
         });
         await dispatcher.processCommand(
             `@dispatcher translate ${args.request}`,

--- a/ts/packages/dispatcher/src/context/commandHandlerContext.ts
+++ b/ts/packages/dispatcher/src/context/commandHandlerContext.ts
@@ -205,6 +205,7 @@ export type InitializeCommandHandlerContextOptions = SessionOptions & {
     clientIO?: ClientIO | undefined; // undefined to disable any IO.
     enableServiceHost?: boolean; // default to false,
     metrics?: boolean; // default to false
+    dblogging?: boolean; // default to false
 };
 
 async function getSession(instanceDir?: string) {
@@ -232,6 +233,14 @@ function getLoggerSink(isDbEnabled: () => boolean, clientIO: ClientIO) {
             "telemetrydb",
             "dispatcherlogs",
             isDbEnabled,
+            (e: string) => {
+                clientIO.notify(
+                    AppAgentEvent.Warning,
+                    undefined,
+                    e,
+                    DispatcherName,
+                );
+            },
         );
     } catch (e) {
         clientIO.notify(
@@ -353,7 +362,7 @@ export async function initializeCommandHandlerContext(
             instanceDir,
             conversationManager,
             explanationAsynchronousMode,
-            dblogging: true,
+            dblogging: options?.dblogging ?? false,
             clientIO,
 
             // Runtime context

--- a/ts/packages/shell/src/main/index.ts
+++ b/ts/packages/shell/src/main/index.ts
@@ -494,6 +494,7 @@ async function initializeDispatcher(
         persistSession: true,
         enableServiceHost: true,
         metrics: true,
+        dblogging: true,
         clientIO,
     });
 


### PR DESCRIPTION
Stop tests from logging.  Only shell and CLI explicitly turn logging on.

Also detect invalid key error when doing db logging to disable logging and notify client.