### PR TITLE
Fix graph client login regression

### DIFF
--- a/ts/packages/agents/agentUtils/graphUtils/package.json
+++ b/ts/packages/agents/agentUtils/graphUtils/package.json
@@ -27,7 +27,7 @@
     "tsc": "tsc -p src"
   },
   "dependencies": {
-    "@azure/identity": "^4.5.0",
+    "@azure/identity": "4.2.1",
     "@azure/identity-cache-persistence": "^1.1.1",
     "@azure/logger": "^1.1.0",
     "@microsoft/microsoft-graph-client": "^3.0.7",

--- a/ts/packages/aiclient/package.json
+++ b/ts/packages/aiclient/package.json
@@ -28,7 +28,7 @@
     "tsc": "tsc -b"
   },
   "dependencies": {
-    "@azure/identity": "^4.5.0",
+    "@azure/identity": "4.2.1",
     "async": "^3.2.5",
     "debug": "^4.3.4",
     "telemetry": "workspace:*",

--- a/ts/packages/api/package.json
+++ b/ts/packages/api/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@aws-sdk/client-s3": "^3.726.0",
     "@aws-sdk/lib-storage": "^3.726.0",
-    "@azure/identity": "^4.5.0",
+    "@azure/identity": "4.2.1",
     "@azure/storage-blob": "^12.26.0",
     "@typeagent/agent-sdk": "workspace:*",
     "agent-cache": "workspace:*",

--- a/ts/pnpm-lock.yaml
+++ b/ts/pnpm-lock.yaml
@@ -371,7 +371,7 @@ importers:
         version: 18.18.7
       copy-webpack-plugin:
         specifier: ^12.0.1
-        version: 12.0.2(webpack@5.94.0)
+        version: 12.0.2(webpack@5.94.0(webpack-cli@5.1.4))
       jest:
         specifier: ^29.7.0
         version: 29.7.0(@types/node@18.18.7)(ts-node@10.9.2(@types/node@18.18.7)(typescript@5.4.3))
@@ -383,7 +383,7 @@ importers:
         version: 5.0.5
       ts-loader:
         specifier: ^9.5.1
-        version: 9.5.1(typescript@5.4.3)(webpack@5.94.0)
+        version: 9.5.1(typescript@5.4.3)(webpack@5.94.0(webpack-cli@5.1.4))
       typescript:
         specifier: ^5.4.2
         version: 5.4.3
@@ -457,7 +457,7 @@ importers:
         version: 18.18.7
       copy-webpack-plugin:
         specifier: ^12.0.1
-        version: 12.0.2(webpack@5.94.0)
+        version: 12.0.2(webpack@5.94.0(webpack-cli@5.1.4))
       jest:
         specifier: ^29.7.0
         version: 29.7.0(@types/node@18.18.7)(ts-node@10.9.2(@types/node@18.18.7)(typescript@5.4.3))
@@ -469,7 +469,7 @@ importers:
         version: 5.0.5
       ts-loader:
         specifier: ^9.5.1
-        version: 9.5.1(typescript@5.4.3)(webpack@5.94.0)
+        version: 9.5.1(typescript@5.4.3)(webpack@5.94.0(webpack-cli@5.1.4))
       typescript:
         specifier: ^5.4.2
         version: 5.4.3
@@ -573,8 +573,8 @@ importers:
   packages/agents/agentUtils/graphUtils:
     dependencies:
       '@azure/identity':
-        specifier: ^4.5.0
-        version: 4.5.0
+        specifier: 4.2.1
+        version: 4.2.1
       '@azure/identity-cache-persistence':
         specifier: ^1.1.1
         version: 1.1.1
@@ -583,7 +583,7 @@ importers:
         version: 1.1.1
       '@microsoft/microsoft-graph-client':
         specifier: ^3.0.7
-        version: 3.0.7(@azure/identity@4.5.0)
+        version: 3.0.7(@azure/identity@4.2.1)
       aiclient:
         specifier: workspace:*
         version: link:../../../aiclient
@@ -696,7 +696,7 @@ importers:
         version: 1.1.1
       node-polyfill-webpack-plugin:
         specifier: ^3.0.0
-        version: 3.0.0(webpack@5.94.0)
+        version: 3.0.0(webpack@5.94.0(webpack-cli@5.1.4))
       puppeteer:
         specifier: ^23.8.0
         version: 23.8.0(typescript@5.4.3)
@@ -745,13 +745,13 @@ importers:
         version: 8.5.10
       copy-webpack-plugin:
         specifier: ^12.0.1
-        version: 12.0.2(webpack@5.94.0)
+        version: 12.0.2(webpack@5.94.0(webpack-cli@5.1.4))
       rimraf:
         specifier: ^5.0.5
         version: 5.0.5
       ts-loader:
         specifier: ^9.5.1
-        version: 9.5.1(typescript@5.4.3)(webpack@5.94.0)
+        version: 9.5.1(typescript@5.4.3)(webpack@5.94.0(webpack-cli@5.1.4))
       typescript:
         specifier: ^5.4.2
         version: 5.4.3
@@ -1099,7 +1099,7 @@ importers:
         version: 18.18.7
       copy-webpack-plugin:
         specifier: ^12.0.1
-        version: 12.0.2(webpack@5.94.0)
+        version: 12.0.2(webpack@5.94.0(webpack-cli@5.1.4))
       copyfiles:
         specifier: ^2.4.1
         version: 2.4.1
@@ -1114,7 +1114,7 @@ importers:
         version: 5.0.5
       ts-loader:
         specifier: ^9.5.1
-        version: 9.5.1(typescript@5.4.3)(webpack@5.94.0)
+        version: 9.5.1(typescript@5.4.3)(webpack@5.94.0(webpack-cli@5.1.4))
       typescript:
         specifier: ^5.4.2
         version: 5.4.3
@@ -1282,7 +1282,7 @@ importers:
         version: 18.18.7
       copy-webpack-plugin:
         specifier: ^12.0.1
-        version: 12.0.2(webpack@5.94.0)
+        version: 12.0.2(webpack@5.94.0(webpack-cli@5.1.4))
       jest:
         specifier: ^29.7.0
         version: 29.7.0(@types/node@18.18.7)(ts-node@10.9.2(@types/node@18.18.7)(typescript@5.4.3))
@@ -1294,7 +1294,7 @@ importers:
         version: 5.0.5
       ts-loader:
         specifier: ^9.5.1
-        version: 9.5.1(typescript@5.4.3)(webpack@5.94.0)
+        version: 9.5.1(typescript@5.4.3)(webpack@5.94.0(webpack-cli@5.1.4))
       typescript:
         specifier: ^5.4.2
         version: 5.4.3
@@ -1311,8 +1311,8 @@ importers:
   packages/aiclient:
     dependencies:
       '@azure/identity':
-        specifier: ^4.5.0
-        version: 4.5.0
+        specifier: 4.2.1
+        version: 4.2.1
       async:
         specifier: ^3.2.5
         version: 3.2.5
@@ -1360,8 +1360,8 @@ importers:
         specifier: ^3.726.0
         version: 3.726.1(@aws-sdk/client-s3@3.726.1)
       '@azure/identity':
-        specifier: ^4.5.0
-        version: 4.5.0
+        specifier: 4.2.1
+        version: 4.2.1
       '@azure/storage-blob':
         specifier: ^12.26.0
         version: 12.26.0
@@ -1523,7 +1523,7 @@ importers:
         version: 18.18.7
       html-webpack-plugin:
         specifier: ^5.6.0
-        version: 5.6.0(webpack@5.94.0)
+        version: 5.6.0(webpack@5.94.0(webpack-cli@5.1.4))
       jest:
         specifier: ^29.7.0
         version: 29.7.0(@types/node@18.18.7)(ts-node@10.9.2(@types/node@18.18.7)(typescript@5.4.3))
@@ -1535,7 +1535,7 @@ importers:
         version: 5.0.5
       ts-loader:
         specifier: ^9.5.1
-        version: 9.5.1(typescript@5.4.3)(webpack@5.94.0)
+        version: 9.5.1(typescript@5.4.3)(webpack@5.94.0(webpack-cli@5.1.4))
       typescript:
         specifier: ^5.4.2
         version: 5.4.3
@@ -2056,7 +2056,7 @@ importers:
         version: 18.18.7
       copy-webpack-plugin:
         specifier: ^12.0.1
-        version: 12.0.2(webpack@5.94.0)
+        version: 12.0.2(webpack@5.94.0(webpack-cli@5.1.4))
       jest:
         specifier: ^29.7.0
         version: 29.7.0(@types/node@18.18.7)(ts-node@10.9.2(@types/node@18.18.7)(typescript@5.4.3))
@@ -2068,7 +2068,7 @@ importers:
         version: 5.0.5
       ts-loader:
         specifier: ^9.5.1
-        version: 9.5.1(typescript@5.4.3)(webpack@5.94.0)
+        version: 9.5.1(typescript@5.4.3)(webpack@5.94.0(webpack-cli@5.1.4))
       typescript:
         specifier: ^5.4.2
         version: 5.4.3
@@ -2190,7 +2190,7 @@ importers:
         version: 30.0.1
       electron-builder:
         specifier: ^24.13.2
-        version: 24.13.3(electron-builder-squirrel-windows@24.13.3)
+        version: 24.13.3(electron-builder-squirrel-windows@24.13.3(dmg-builder@24.13.3))
       electron-vite:
         specifier: ^2.1.0
         version: 2.3.0(vite@5.4.12(@types/node@18.18.7)(less@4.2.0)(terser@5.27.0))
@@ -2305,8 +2305,8 @@ importers:
         specifier: ^9.0.0
         version: 9.0.0
       '@azure/identity':
-        specifier: ^4.5.0
-        version: 4.5.0
+        specifier: 4.2.1
+        version: 4.2.1
       chalk:
         specifier: ^5.3.0
         version: 5.3.0
@@ -2579,8 +2579,8 @@ packages:
     resolution: {integrity: sha512-GqR8oDSk92aUl02XLDhJuvZFwtcefgTjTRi9gMIpI1rECsE8A7wIm3CdkBTNO5BMh0S/2TCYF+nSYb2HKOUyCA==}
     engines: {node: '>=18.0.0'}
 
-  '@azure/identity@4.5.0':
-    resolution: {integrity: sha512-EknvVmtBuSIic47xkOqyNabAme0RYTw52BTMz8eBgU1ysTyMrD1uOoM+JdS0J/4Yfp98IBT3osqq3BfwSaNaGQ==}
+  '@azure/identity@4.2.1':
+    resolution: {integrity: sha512-U8hsyC9YPcEIzoaObJlRDvp7KiF0MGS7xcWbyJSVvXRkC/HXo1f0oYeBYmEvVgRfacw7GHf6D6yAoh9JHz6A5Q==}
     engines: {node: '>=18.0.0'}
 
   '@azure/logger@1.1.1':
@@ -9674,8 +9674,8 @@ snapshots:
   '@azure/core-auth@1.7.1':
     dependencies:
       '@azure/abort-controller': 2.1.2
-      '@azure/core-util': 1.8.1
-      tslib: 2.6.2
+      '@azure/core-util': 1.11.0
+      tslib: 2.8.1
 
   '@azure/core-auth@1.9.0':
     dependencies:
@@ -9778,7 +9778,7 @@ snapshots:
   '@azure/identity-cache-persistence@1.1.1':
     dependencies:
       '@azure/core-auth': 1.7.1
-      '@azure/identity': 4.5.0
+      '@azure/identity': 4.2.1
       '@azure/msal-node': 2.9.2
       '@azure/msal-node-extensions': 1.5.0
       keytar: 7.9.0
@@ -9786,9 +9786,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@azure/identity@4.5.0':
+  '@azure/identity@4.2.1':
     dependencies:
-      '@azure/abort-controller': 2.1.2
+      '@azure/abort-controller': 1.1.0
       '@azure/core-auth': 1.9.0
       '@azure/core-client': 1.9.2
       '@azure/core-rest-pipeline': 1.18.2
@@ -10450,7 +10450,7 @@ snapshots:
       msgpack-lite: 0.1.26
       pako: 2.1.0
       typescript: 5.1.6
-      webpack: 5.94.0(webpack-cli@5.1.4)
+      webpack: 5.94.0
     transitivePeerDependencies:
       - '@swc/core'
       - esbuild
@@ -10772,12 +10772,12 @@ snapshots:
       jju: 1.4.0
       read-yaml-file: 1.1.0
 
-  '@microsoft/microsoft-graph-client@3.0.7(@azure/identity@4.5.0)':
+  '@microsoft/microsoft-graph-client@3.0.7(@azure/identity@4.2.1)':
     dependencies:
       '@babel/runtime': 7.23.2
       tslib: 2.6.2
     optionalDependencies:
-      '@azure/identity': 4.5.0
+      '@azure/identity': 4.2.1
 
   '@microsoft/microsoft-graph-types@2.40.0': {}
 
@@ -11977,7 +11977,7 @@ snapshots:
 
   '@vscode/vsce@3.2.1':
     dependencies:
-      '@azure/identity': 4.5.0
+      '@azure/identity': 4.2.1
       '@vscode/vsce-sign': 2.0.5
       azure-devops-node-api: 12.5.0
       chalk: 2.4.2
@@ -12082,24 +12082,34 @@ snapshots:
       '@webassemblyjs/ast': 1.12.1
       '@xtuc/long': 4.2.2
 
-  '@webpack-cli/configtest@2.1.1(webpack-cli@5.1.4)(webpack@5.94.0)':
+  '@webpack-cli/configtest@2.1.1(webpack-cli@5.1.4(webpack-dev-server@5.2.0)(webpack@5.94.0))(webpack@5.94.0(webpack-cli@5.1.4))':
     dependencies:
       webpack: 5.94.0(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack-dev-server@5.2.0)(webpack@5.94.0)
 
-  '@webpack-cli/info@2.0.2(webpack-cli@5.1.4)(webpack@5.94.0)':
+  '@webpack-cli/configtest@2.1.1(webpack-cli@5.1.4(webpack@5.94.0))(webpack@5.94.0(webpack-cli@5.1.4))':
+    dependencies:
+      webpack: 5.94.0(webpack-cli@5.1.4)
+      webpack-cli: 5.1.4(webpack@5.94.0)
+
+  '@webpack-cli/info@2.0.2(webpack-cli@5.1.4(webpack-dev-server@5.2.0)(webpack@5.94.0))(webpack@5.94.0(webpack-cli@5.1.4))':
     dependencies:
       webpack: 5.94.0(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack-dev-server@5.2.0)(webpack@5.94.0)
 
-  '@webpack-cli/serve@2.0.5(webpack-cli@5.1.4)(webpack-dev-server@5.2.0)(webpack@5.94.0)':
+  '@webpack-cli/info@2.0.2(webpack-cli@5.1.4(webpack@5.94.0))(webpack@5.94.0(webpack-cli@5.1.4))':
+    dependencies:
+      webpack: 5.94.0(webpack-cli@5.1.4)
+      webpack-cli: 5.1.4(webpack@5.94.0)
+
+  '@webpack-cli/serve@2.0.5(webpack-cli@5.1.4(webpack-dev-server@5.2.0)(webpack@5.94.0))(webpack-dev-server@5.2.0(debug@4.3.4)(webpack-cli@5.1.4)(webpack@5.94.0))(webpack@5.94.0(webpack-cli@5.1.4))':
     dependencies:
       webpack: 5.94.0(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack-dev-server@5.2.0)(webpack@5.94.0)
     optionalDependencies:
       webpack-dev-server: 5.2.0(debug@4.3.4)(webpack-cli@5.1.4)(webpack@5.94.0)
 
-  '@webpack-cli/serve@2.0.5(webpack-cli@5.1.4)(webpack@5.94.0)':
+  '@webpack-cli/serve@2.0.5(webpack-cli@5.1.4(webpack@5.94.0))(webpack@5.94.0(webpack-cli@5.1.4))':
     dependencies:
       webpack: 5.94.0(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack@5.94.0)
@@ -12221,7 +12231,7 @@ snapshots:
 
   app-builder-bin@4.0.0: {}
 
-  app-builder-lib@24.13.3(dmg-builder@24.13.3)(electron-builder-squirrel-windows@24.13.3):
+  app-builder-lib@24.13.3(dmg-builder@24.13.3(electron-builder-squirrel-windows@24.13.3))(electron-builder-squirrel-windows@24.13.3(dmg-builder@24.13.3)):
     dependencies:
       '@develar/schema-utils': 2.6.5
       '@electron/notarize': 2.2.1
@@ -13001,7 +13011,7 @@ snapshots:
     dependencies:
       is-what: 3.14.1
 
-  copy-webpack-plugin@12.0.2(webpack@5.94.0):
+  copy-webpack-plugin@12.0.2(webpack@5.94.0(webpack-cli@5.1.4)):
     dependencies:
       fast-glob: 3.3.2
       glob-parent: 6.0.2
@@ -13492,7 +13502,7 @@ snapshots:
 
   dmg-builder@24.13.3(electron-builder-squirrel-windows@24.13.3):
     dependencies:
-      app-builder-lib: 24.13.3(dmg-builder@24.13.3)(electron-builder-squirrel-windows@24.13.3)
+      app-builder-lib: 24.13.3(dmg-builder@24.13.3(electron-builder-squirrel-windows@24.13.3))(electron-builder-squirrel-windows@24.13.3(dmg-builder@24.13.3))
       builder-util: 24.13.1
       builder-util-runtime: 9.2.4
       fs-extra: 10.1.0
@@ -13587,7 +13597,7 @@ snapshots:
 
   electron-builder-squirrel-windows@24.13.3(dmg-builder@24.13.3):
     dependencies:
-      app-builder-lib: 24.13.3(dmg-builder@24.13.3)(electron-builder-squirrel-windows@24.13.3)
+      app-builder-lib: 24.13.3(dmg-builder@24.13.3(electron-builder-squirrel-windows@24.13.3))(electron-builder-squirrel-windows@24.13.3(dmg-builder@24.13.3))
       archiver: 5.3.2
       builder-util: 24.13.1
       fs-extra: 10.1.0
@@ -13595,9 +13605,9 @@ snapshots:
       - dmg-builder
       - supports-color
 
-  electron-builder@24.13.3(electron-builder-squirrel-windows@24.13.3):
+  electron-builder@24.13.3(electron-builder-squirrel-windows@24.13.3(dmg-builder@24.13.3)):
     dependencies:
-      app-builder-lib: 24.13.3(dmg-builder@24.13.3)(electron-builder-squirrel-windows@24.13.3)
+      app-builder-lib: 24.13.3(dmg-builder@24.13.3(electron-builder-squirrel-windows@24.13.3))(electron-builder-squirrel-windows@24.13.3(dmg-builder@24.13.3))
       builder-util: 24.13.1
       builder-util-runtime: 9.2.4
       chalk: 4.1.2
@@ -14395,7 +14405,7 @@ snapshots:
       htmlparser2: 8.0.2
       selderee: 0.11.0
 
-  html-webpack-plugin@5.6.0(webpack@5.94.0):
+  html-webpack-plugin@5.6.0(webpack@5.94.0(webpack-cli@5.1.4)):
     dependencies:
       '@types/html-minifier-terser': 6.1.0
       html-minifier-terser: 6.1.0
@@ -15760,7 +15770,7 @@ snapshots:
 
   node-int64@0.4.0: {}
 
-  node-polyfill-webpack-plugin@3.0.0(webpack@5.94.0):
+  node-polyfill-webpack-plugin@3.0.0(webpack@5.94.0(webpack-cli@5.1.4)):
     dependencies:
       assert: 2.1.0
       browserify-zlib: 0.2.0
@@ -16988,7 +16998,7 @@ snapshots:
       async-exit-hook: 2.0.1
       fs-extra: 10.1.0
 
-  terser-webpack-plugin@5.3.10(webpack@5.94.0):
+  terser-webpack-plugin@5.3.10(webpack@5.94.0(webpack-cli@5.1.4)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
       jest-worker: 27.5.1
@@ -16996,6 +17006,15 @@ snapshots:
       serialize-javascript: 6.0.2
       terser: 5.27.0
       webpack: 5.94.0(webpack-cli@5.1.4)
+
+  terser-webpack-plugin@5.3.10(webpack@5.94.0):
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.25
+      jest-worker: 27.5.1
+      schema-utils: 3.3.0
+      serialize-javascript: 6.0.2
+      terser: 5.27.0
+      webpack: 5.94.0
 
   terser@5.27.0:
     dependencies:
@@ -17077,7 +17096,7 @@ snapshots:
     dependencies:
       utf8-byte-length: 1.0.4
 
-  ts-loader@9.5.1(typescript@5.4.3)(webpack@5.94.0):
+  ts-loader@9.5.1(typescript@5.4.3)(webpack@5.94.0(webpack-cli@5.1.4)):
     dependencies:
       chalk: 4.1.2
       enhanced-resolve: 5.15.0
@@ -17341,9 +17360,9 @@ snapshots:
   webpack-cli@5.1.4(webpack-dev-server@5.2.0)(webpack@5.94.0):
     dependencies:
       '@discoveryjs/json-ext': 0.5.7
-      '@webpack-cli/configtest': 2.1.1(webpack-cli@5.1.4)(webpack@5.94.0)
-      '@webpack-cli/info': 2.0.2(webpack-cli@5.1.4)(webpack@5.94.0)
-      '@webpack-cli/serve': 2.0.5(webpack-cli@5.1.4)(webpack-dev-server@5.2.0)(webpack@5.94.0)
+      '@webpack-cli/configtest': 2.1.1(webpack-cli@5.1.4(webpack-dev-server@5.2.0)(webpack@5.94.0))(webpack@5.94.0(webpack-cli@5.1.4))
+      '@webpack-cli/info': 2.0.2(webpack-cli@5.1.4(webpack-dev-server@5.2.0)(webpack@5.94.0))(webpack@5.94.0(webpack-cli@5.1.4))
+      '@webpack-cli/serve': 2.0.5(webpack-cli@5.1.4(webpack-dev-server@5.2.0)(webpack@5.94.0))(webpack-dev-server@5.2.0(debug@4.3.4)(webpack-cli@5.1.4)(webpack@5.94.0))(webpack@5.94.0(webpack-cli@5.1.4))
       colorette: 2.0.20
       commander: 10.0.1
       cross-spawn: 7.0.6
@@ -17360,9 +17379,9 @@ snapshots:
   webpack-cli@5.1.4(webpack@5.94.0):
     dependencies:
       '@discoveryjs/json-ext': 0.5.7
-      '@webpack-cli/configtest': 2.1.1(webpack-cli@5.1.4)(webpack@5.94.0)
-      '@webpack-cli/info': 2.0.2(webpack-cli@5.1.4)(webpack@5.94.0)
-      '@webpack-cli/serve': 2.0.5(webpack-cli@5.1.4)(webpack@5.94.0)
+      '@webpack-cli/configtest': 2.1.1(webpack-cli@5.1.4(webpack@5.94.0))(webpack@5.94.0(webpack-cli@5.1.4))
+      '@webpack-cli/info': 2.0.2(webpack-cli@5.1.4(webpack@5.94.0))(webpack@5.94.0(webpack-cli@5.1.4))
+      '@webpack-cli/serve': 2.0.5(webpack-cli@5.1.4(webpack@5.94.0))(webpack@5.94.0(webpack-cli@5.1.4))
       colorette: 2.0.20
       commander: 10.0.1
       cross-spawn: 7.0.6
@@ -17374,7 +17393,7 @@ snapshots:
       webpack: 5.94.0(webpack-cli@5.1.4)
       webpack-merge: 5.10.0
 
-  webpack-dev-middleware@7.4.2(webpack@5.94.0):
+  webpack-dev-middleware@7.4.2(webpack@5.94.0(webpack-cli@5.1.4)):
     dependencies:
       colorette: 2.0.20
       memfs: 4.9.3
@@ -17412,7 +17431,7 @@ snapshots:
       serve-index: 1.9.1
       sockjs: 0.3.24
       spdy: 4.0.2
-      webpack-dev-middleware: 7.4.2(webpack@5.94.0)
+      webpack-dev-middleware: 7.4.2(webpack@5.94.0(webpack-cli@5.1.4))
       ws: 8.18.0
     optionalDependencies:
       webpack: 5.94.0(webpack-cli@5.1.4)
@@ -17430,6 +17449,36 @@ snapshots:
       wildcard: 2.0.1
 
   webpack-sources@3.2.3: {}
+
+  webpack@5.94.0:
+    dependencies:
+      '@types/estree': 1.0.6
+      '@webassemblyjs/ast': 1.12.1
+      '@webassemblyjs/wasm-edit': 1.12.1
+      '@webassemblyjs/wasm-parser': 1.12.1
+      acorn: 8.11.1
+      acorn-import-attributes: 1.9.5(acorn@8.11.1)
+      browserslist: 4.23.0
+      chrome-trace-event: 1.0.3
+      enhanced-resolve: 5.17.1
+      es-module-lexer: 1.4.1
+      eslint-scope: 5.1.1
+      events: 3.3.0
+      glob-to-regexp: 0.4.1
+      graceful-fs: 4.2.11
+      json-parse-even-better-errors: 2.3.1
+      loader-runner: 4.3.0
+      mime-types: 2.1.35
+      neo-async: 2.6.2
+      schema-utils: 3.3.0
+      tapable: 2.2.1
+      terser-webpack-plugin: 5.3.10(webpack@5.94.0)
+      watchpack: 2.4.2
+      webpack-sources: 3.2.3
+    transitivePeerDependencies:
+      - '@swc/core'
+      - esbuild
+      - uglify-js
 
   webpack@5.94.0(webpack-cli@5.1.4):
     dependencies:
@@ -17453,7 +17502,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 3.3.0
       tapable: 2.2.1
-      terser-webpack-plugin: 5.3.10(webpack@5.94.0)
+      terser-webpack-plugin: 5.3.10(webpack@5.94.0(webpack-cli@5.1.4))
       watchpack: 2.4.2
       webpack-sources: 3.2.3
     optionalDependencies:

--- a/ts/tools/package.json
+++ b/ts/tools/package.json
@@ -13,7 +13,7 @@
   "author": "Microsoft",
   "dependencies": {
     "@azure/arm-authorization": "^9.0.0",
-    "@azure/identity": "^4.5.0",
+    "@azure/identity": "4.2.1",
     "chalk": "^5.3.0",
     "sort-package-json": "^2.10.0",
     "validate-npm-package-name": "^5.0.1"


### PR DESCRIPTION
- Change version of `@azure/identity` to version 4.2.1 instead of 4.5.0.
- The issue with version 4.5.0 is documented in AzureAD [issues](https://github.com/AzureAD/microsoft-authentication-library-for-js/issues/7303)
- Without this fix the token is not being read from the cache and we need to login every single time event. (Even when the token is valid and does not need to be refreshed.)