### PR TITLE
Bug fix when handling promises.

### DIFF
--- a/ts/packages/coda/src/handleCodeEditorActions.ts
+++ b/ts/packages/coda/src/handleCodeEditorActions.ts
@@ -412,15 +412,22 @@ export async function handleVSCodeActions(action: any) {
         action.actionName ?? action.fullActionName.split(".").at(-1);
 
     if (actionName) {
-        const promises = [
-            handleBaseEditorActions(action),
-            handleGeneralKBActions(action),
-            handleDisplayKBActions(action),
-            handleDebugActions(action),
+        const handlers = [
+            handleBaseEditorActions,
+            handleGeneralKBActions,
+            handleDisplayKBActions,
+            handleDebugActions,
         ];
 
-        const actionResult = await Promise.race(promises);
-        if (!actionResult.handled) {
+        const results = await Promise.all(
+            handlers.map((handler: any) => handler(action)),
+        );
+
+        const handledResult = results.find((result: any) => result.handled);
+        if (handledResult) {
+            actionResult = handledResult;
+        } else {
+            actionResult.handled = false;
             actionResult.message = `Did not handle the action: "${actionName}"`;
         }
     }

--- a/ts/packages/coda/src/wsConnect.ts
+++ b/ts/packages/coda/src/wsConnect.ts
@@ -45,7 +45,7 @@ async function ensureWebsocketConnected() {
             if (schema == "code") {
                 const message = await handleVSCodeActions({
                     actionName: actionName,
-                    parameters: data.params,
+                    parameters: data?.params ?? {},
                 });
 
                 webSocket?.send(


### PR DESCRIPTION
- Was using Promise.race which causes non-deterministic behavior. The code path uses separate async function to handle actions, updated to Promise.all.
- Fixed code handle actions objects where parameter property is undefined.