### PR TITLE
Pending action support in multiple actions

### DIFF
--- a/ts/packages/defaultAgentProvider/test/data/translate-e2e.json
+++ b/ts/packages/defaultAgentProvider/test/data/translate-e2e.json
@@ -10,5 +10,9 @@
     {
         "request": "get my top 50 favorite songs, filter the current list to Bach pieces, and create a playlist call test",
         "action": ["player.getFavorites", "player.filterTracks", "player.createPlaylist"]
+    },
+    {
+        "request": "look up information about Oregon and write a poem using what you found",
+        "action": ["chat.lookupAndGenerateResponse", "dispatcher.pendingRequestAction"]
     }
 ]

--- a/ts/packages/dispatcher/src/context/commandHandlerContext.ts
+++ b/ts/packages/dispatcher/src/context/commandHandlerContext.ts
@@ -54,7 +54,10 @@ import {
     ConstructionProvider,
 } from "../agentProvider/agentProvider.js";
 import { RequestMetricsManager } from "../utils/metrics.js";
-import { getSchemaNamePrefix } from "../execute/actionHandlers.js";
+import {
+    ActionContextWithClose,
+    getSchemaNamePrefix,
+} from "../execute/actionHandlers.js";
 import { displayError } from "@typeagent/agent-sdk/helpers/display";
 
 import {
@@ -77,11 +80,6 @@ export type SetSettingFunction = (name: string, value: any) => void;
 export interface ClientSettingsProvider {
     set: SetSettingFunction | null;
 }
-
-type ActionContextWithClose = {
-    actionContext: ActionContext<unknown>;
-    closeActionContext: () => void;
-};
 
 // Command Handler Context definition.
 export type CommandHandlerContext = {
@@ -133,7 +131,7 @@ export function getTranslatorForSchema(
         context.agents,
         getActiveTranslators(context),
         config.switch.inline,
-        config.multipleActions,
+        config.multiple,
         config.schema.generation,
         config.model,
         !config.schema.optimize.enabled,
@@ -171,7 +169,7 @@ export async function getTranslatorForSelectedActions(
         context.agents,
         getActiveTranslators(context),
         config.switch.inline,
-        config.multipleActions,
+        config.multiple,
         config.model,
     );
 }
@@ -540,7 +538,7 @@ export async function changeContextConfig(
         translatorChanged ||
         changed.translation?.model !== undefined ||
         changed.translation?.switch?.inline !== undefined ||
-        changed.translation?.multipleActions !== undefined ||
+        changed.translation?.multiple !== undefined ||
         changed.translation?.schema?.generation !== undefined ||
         changed.translation?.schema?.optimize?.enabled !== undefined
     ) {

--- a/ts/packages/dispatcher/src/context/dispatcher/handlers/requestCommandHandler.ts
+++ b/ts/packages/dispatcher/src/context/dispatcher/handlers/requestCommandHandler.ts
@@ -4,9 +4,7 @@
 import chalk from "chalk";
 import {
     RequestAction,
-    Action,
     printProcessRequestActionResult,
-    Actions,
     HistoryContext,
     FullAction,
     ProcessRequestActionResult,
@@ -14,721 +12,36 @@ import {
     equalNormalizedParamObject,
 } from "agent-cache";
 
-import { validateAction } from "action-schema";
 import {
     CommandHandlerContext,
     getTranslatorForSchema,
-    getTranslatorForSelectedActions,
 } from "../../commandHandlerContext.js";
 
-import {
-    CachedImageWithDetails,
-    getColorElapsedString,
-    IncrementalJsonValueCallBack,
-} from "common-utils";
+import { CachedImageWithDetails } from "common-utils";
 import { Logger } from "telemetry";
+import { executeActions } from "../../../execute/actionHandlers.js";
 import {
-    executeActions,
-    getSchemaNamePrefix,
-    startStreamPartialAction,
-    validateWildcardMatch,
-} from "../../../execute/actionHandlers.js";
-import { unicodeChar } from "../../../command/command.js";
-import {
-    isAdditionalActionLookupAction,
     TypeAgentTranslator,
     TranslatedAction,
 } from "../../../translation/agentTranslators.js";
-import { loadAssistantSelectionJsonTranslator } from "../../../translation/unknownSwitcher.js";
 import {
-    MultipleAction,
     isMultipleAction,
+    isPendingRequest,
 } from "../../../translation/multipleActionSchema.js";
-import { MatchResult } from "agent-cache";
 import registerDebug from "debug";
 import ExifReader from "exifreader";
 import { ProfileNames } from "../../../utils/profileNames.js";
 import { ActionContext, ParsedCommandParams } from "@typeagent/agent-sdk";
 import { CommandHandler } from "@typeagent/agent-sdk/helpers/command";
-import {
-    displayError,
-    displayInfo,
-    displayStatus,
-    displayWarn,
-} from "@typeagent/agent-sdk/helpers/display";
 import { DispatcherName } from "../../interactiveIO.js";
-import { getActionTemplateEditConfig } from "../../../translation/actionTemplate.js";
-import { getActionSchema } from "../../../translation/actionSchemaFileCache.js";
-import { UnknownAction } from "../schema/dispatcherActionSchema.js";
 import { isUnknownAction } from "../dispatcherUtils.js";
+import {
+    getChatHistoryForTranslation,
+    translateRequest,
+} from "../../../translation/translateRequest.js";
+import { matchRequest } from "../../../translation/matchRequest.js";
 
-const debugTranslate = registerDebug("typeagent:translate");
-const debugSemanticSearch = registerDebug("typeagent:translate:semantic");
 const debugExplain = registerDebug("typeagent:explain");
-const debugConstValidation = registerDebug("typeagent:const:validation");
-
-function validateReplaceActions(
-    actions: unknown,
-    systemContext: CommandHandlerContext,
-): actions is FullAction[] {
-    if (actions === null) {
-        throw new Error("Request cancelled");
-    }
-    if (actions === undefined) {
-        return false;
-    }
-    if (!Array.isArray(actions)) {
-        throw new Error("Invalid replacement");
-    }
-    for (const action of actions) {
-        if (typeof action !== "object") {
-            throw new Error("Invalid replacement");
-        }
-        const actionInfo = getActionSchema(action, systemContext.agents);
-        if (actionInfo === undefined) {
-            throw new Error("Invalid replacement");
-        }
-
-        validateAction(actionInfo, action);
-    }
-
-    return true;
-}
-
-async function confirmTranslation(
-    elapsedMs: number,
-    source: string,
-    requestAction: RequestAction,
-    context: ActionContext<CommandHandlerContext>,
-): Promise<{
-    requestAction: RequestAction | undefined | null;
-    replacedAction?: Actions;
-}> {
-    const actions = requestAction.actions;
-    const systemContext = context.sessionContext.agentContext;
-    if (!systemContext.developerMode || systemContext.batchMode) {
-        const messages = [];
-
-        messages.push(
-            `${source}: ${chalk.blueBright(
-                ` ${requestAction.toString()}`,
-            )} ${getColorElapsedString(elapsedMs)}`,
-        );
-        messages.push();
-
-        const prettyStr = JSON.stringify(actions, undefined, 2);
-        messages.push(`${chalk.italic(chalk.cyanBright(prettyStr))}`);
-        displayInfo(messages.join("\n"), context);
-        return { requestAction };
-    }
-    const preface =
-        "Use the buttons to run or cancel the following action(s). You can also press [Enter] to run it, [Del] to edit it, or [Escape] to cancel it.";
-    const editPreface = `Edit the following action(s) to match your requests.  Click on the values to start editing. Use the ➕/✕ buttons to add/delete optional fields.`;
-
-    const templateSequence = getActionTemplateEditConfig(
-        systemContext,
-        actions,
-        preface,
-        editPreface,
-    );
-
-    const newActions = await systemContext.clientIO.proposeAction(
-        templateSequence,
-        systemContext.requestId,
-        DispatcherName,
-    );
-
-    return validateReplaceActions(newActions, systemContext)
-        ? {
-              requestAction: new RequestAction(
-                  requestAction.request,
-                  Actions.fromFullActions(newActions),
-                  requestAction.history,
-              ),
-              replacedAction: actions,
-          }
-        : { requestAction };
-}
-
-async function getValidatedMatch(
-    matches: MatchResult[],
-    context: CommandHandlerContext,
-) {
-    for (const match of matches) {
-        if (match.wildcardCharCount === 0) {
-            return match;
-        }
-        if (await validateWildcardMatch(match, context)) {
-            debugConstValidation(
-                `Wildcard match accepted: ${match.match.actions}`,
-            );
-            return match;
-        }
-        debugConstValidation(`Wildcard match rejected: ${match.match.actions}`);
-    }
-    return undefined;
-}
-
-type TranslationResult = {
-    requestAction: RequestAction;
-    elapsedMs: number;
-    fromUser: boolean;
-    fromCache: boolean;
-};
-async function matchRequest(
-    request: string,
-    context: ActionContext<CommandHandlerContext>,
-    history?: HistoryContext,
-): Promise<TranslationResult | undefined | null> {
-    const systemContext = context.sessionContext.agentContext;
-    const constructionStore = systemContext.agentCache.constructionStore;
-    if (constructionStore.isEnabled()) {
-        const startTime = performance.now();
-        const config = systemContext.session.getConfig();
-        const activeSchemaNames = systemContext.agents.getActiveSchemas();
-        const matches = constructionStore.match(request, {
-            wildcard: config.cache.matchWildcard,
-            rejectReferences: config.explainer.filter.reference.list,
-            namespaceKeys:
-                systemContext.agentCache.getNamespaceKeys(activeSchemaNames),
-            history,
-        });
-
-        const elapsedMs = performance.now() - startTime;
-
-        const match = await getValidatedMatch(matches, systemContext);
-        if (match !== undefined) {
-            const { requestAction, replacedAction } = await confirmTranslation(
-                elapsedMs,
-                unicodeChar.constructionSign,
-                match.match,
-                context,
-            );
-
-            if (requestAction) {
-                if (!systemContext.batchMode) {
-                    systemContext.logger?.logEvent("match", {
-                        elapsedMs,
-                        request,
-                        actions: requestAction.actions,
-                        replacedAction,
-                        developerMode: systemContext.developerMode,
-                        translators: activeSchemaNames,
-                        explainerName: systemContext.agentCache.explainerName,
-                        matchWildcard: config.cache.matchWildcard,
-                        allMatches: matches.map((m) => {
-                            const { construction: _, match, ...rest } = m;
-                            return { action: match.actions, ...rest };
-                        }),
-                        history,
-                    });
-                }
-                return {
-                    requestAction,
-                    elapsedMs,
-                    fromUser: replacedAction !== undefined,
-                    fromCache: true,
-                };
-            }
-            return requestAction;
-        }
-    }
-    return undefined;
-}
-
-function needAllAction(translatedAction: TranslatedAction, schemaName: string) {
-    return (
-        isUnknownAction(translatedAction) ||
-        (isAdditionalActionLookupAction(translatedAction) &&
-            translatedAction.parameters.schemaName === schemaName)
-    );
-}
-async function translateRequestWithSchema(
-    schemaName: string,
-    request: string,
-    context: ActionContext<CommandHandlerContext>,
-    history?: HistoryContext,
-    attachments?: CachedImageWithDetails[],
-) {
-    const systemContext = context.sessionContext.agentContext;
-    const config = systemContext.session.getConfig();
-    const prefix = getSchemaNamePrefix(schemaName, systemContext);
-    displayStatus(`${prefix}Translating '${request}'`, context);
-
-    const optimize = config.translation.schema.optimize;
-    if (optimize.enabled && optimize.numInitialActions > 0) {
-        const selectedActionTranslator = await getTranslatorForSelectedActions(
-            systemContext,
-            schemaName,
-            request,
-            optimize.numInitialActions,
-        );
-        if (selectedActionTranslator) {
-            const translatedAction = await translateWithTranslator(
-                selectedActionTranslator,
-                schemaName,
-                request,
-                history,
-                attachments,
-                context,
-            );
-            if (translatedAction === undefined) {
-                return undefined;
-            }
-
-            if (!needAllAction(translatedAction, schemaName)) {
-                if (isMultipleAction(translatedAction)) {
-                    for (const subaction of translatedAction.parameters
-                        .requests) {
-                        if (!needAllAction(subaction.action, schemaName)) {
-                            continue;
-                        }
-                        // REVIEW: the subaction may not be
-                        const translator = getTranslatorForSchema(
-                            systemContext,
-                            schemaName,
-                        );
-                        const action = await translateWithTranslator(
-                            translator,
-                            schemaName,
-                            subaction.request,
-                            history,
-                            attachments,
-                            context,
-                        );
-                        if (action === undefined) {
-                            return undefined;
-                        }
-                        subaction.action = action;
-                    }
-                }
-                return translatedAction;
-            }
-        }
-    }
-    const translator = getTranslatorForSchema(systemContext, schemaName);
-    return translateWithTranslator(
-        translator,
-        schemaName,
-        request,
-        history,
-        attachments,
-        context,
-    );
-}
-
-async function translateWithTranslator(
-    translator: TypeAgentTranslator,
-    schemaName: string,
-    request: string,
-    history: HistoryContext | undefined,
-    attachments: CachedImageWithDetails[] | undefined,
-    context: ActionContext<CommandHandlerContext>,
-) {
-    const systemContext = context.sessionContext.agentContext;
-    const config = systemContext.session.getConfig();
-    const profiler = systemContext.commandProfiler?.measure(
-        ProfileNames.translate,
-    );
-
-    let firstToken = true;
-    let streamFunction: IncrementalJsonValueCallBack | undefined;
-    systemContext.streamingActionContext = undefined;
-    const onProperty: IncrementalJsonValueCallBack | undefined = config
-        .translation.stream
-        ? (prop: string, value: any, delta: string | undefined) => {
-              // TODO: streaming currently doesn't not support multiple actions
-              if (
-                  prop === "actionName" &&
-                  value !== "unknown" &&
-                  delta === undefined
-              ) {
-                  const actionSchemaName =
-                      systemContext.agents.getInjectedSchemaForActionName(
-                          value,
-                      ) ?? schemaName;
-
-                  if (!systemContext.agents.isActionActive(actionSchemaName)) {
-                      // don't stream if action is not active for the schema
-                      return;
-                  }
-                  const prefix = getSchemaNamePrefix(
-                      actionSchemaName,
-                      systemContext,
-                  );
-                  displayStatus(
-                      `${prefix}Translating '${request}' into action '${value}'`,
-                      context,
-                  );
-                  const actionConfig =
-                      systemContext.agents.getActionConfig(actionSchemaName);
-                  if (actionConfig.streamingActions?.includes(value)) {
-                      streamFunction = startStreamPartialAction(
-                          actionSchemaName,
-                          value,
-                          systemContext,
-                      );
-                  }
-              }
-
-              if (firstToken) {
-                  profiler?.mark(ProfileNames.firstToken);
-                  firstToken = false;
-              }
-
-              if (streamFunction) {
-                  streamFunction(prop, value, delta);
-              }
-          }
-        : undefined;
-    try {
-        const response = await translator.translate(
-            request,
-            history,
-            attachments,
-            onProperty,
-        );
-
-        if (!response.success) {
-            displayError(response.message, context);
-            return undefined;
-        }
-        return response.data as TranslatedAction;
-    } finally {
-        profiler?.stop();
-    }
-}
-
-type NextTranslation = {
-    request: string;
-    nextSchemaName: string;
-    searched: boolean;
-};
-
-async function findAssistantForRequest(
-    request: string,
-    translatorName: string,
-    context: ActionContext<CommandHandlerContext>,
-): Promise<NextTranslation | undefined> {
-    displayStatus(
-        `[↔️ (switcher)] Looking for another assistant to handle request '${request}'`,
-        context,
-    );
-    const systemContext = context.sessionContext.agentContext;
-    const selectTranslator = loadAssistantSelectionJsonTranslator(
-        systemContext.agents
-            .getActiveSchemas()
-            .filter(
-                (enabledTranslatorName) =>
-                    translatorName !== enabledTranslatorName,
-            ),
-        systemContext.agents,
-    );
-
-    const result = await selectTranslator.translate(request);
-    if (!result.success) {
-        displayWarn(`Failed to switch assistant: ${result.message}`, context);
-        return undefined;
-    }
-
-    const nextSchemaName = result.data.assistant;
-    if (nextSchemaName !== "unknown") {
-        return {
-            request,
-            nextSchemaName,
-            searched: true,
-        };
-    }
-    return undefined;
-}
-
-async function getNextTranslation(
-    action: TranslatedAction,
-    translatorName: string,
-    context: ActionContext<CommandHandlerContext>,
-    forceSearch: boolean,
-): Promise<NextTranslation | undefined> {
-    let request: string;
-    if (isAdditionalActionLookupAction(action)) {
-        if (!forceSearch) {
-            return {
-                request: action.parameters.request,
-                nextSchemaName: action.parameters.schemaName,
-                searched: false,
-            };
-        }
-        request = action.parameters.request;
-    } else if (isUnknownAction(action)) {
-        request = action.parameters.request;
-    } else {
-        return undefined;
-    }
-
-    const config = context.sessionContext.agentContext.session.getConfig();
-    return config.translation.switch.search
-        ? findAssistantForRequest(request, translatorName, context)
-        : undefined;
-}
-
-async function finalizeAction(
-    action: TranslatedAction,
-    translatorName: string,
-    context: ActionContext<CommandHandlerContext>,
-    history?: HistoryContext,
-    resultEntityId?: string,
-): Promise<Action | Action[] | undefined> {
-    let currentAction: TranslatedAction | undefined = action;
-    let currentTranslatorName: string = translatorName;
-    const systemContext = context.sessionContext.agentContext;
-    while (true) {
-        const forceSearch = currentAction !== action; // force search if we have switched once
-        const nextTranslation = await getNextTranslation(
-            currentAction,
-            currentTranslatorName,
-            context,
-            forceSearch,
-        );
-        if (nextTranslation === undefined) {
-            break;
-        }
-
-        const { request, nextSchemaName, searched } = nextTranslation;
-        if (!systemContext.agents.isSchemaActive(nextSchemaName)) {
-            // this is a bug. May be the translator cache didn't get updated when state change?
-            throw new Error(
-                `Internal error: switch to disabled translator ${nextSchemaName}`,
-            );
-        }
-
-        currentAction = await translateRequestWithSchema(
-            nextSchemaName,
-            request,
-            context,
-            history,
-        );
-        if (currentAction === undefined) {
-            return undefined;
-        }
-
-        currentTranslatorName = nextSchemaName;
-        // Don't keep on switching after we searched, just return unknown
-        if (searched) {
-            break;
-        }
-    }
-
-    if (isMultipleAction(currentAction)) {
-        return finalizeMultipleActions(
-            currentAction,
-            currentTranslatorName,
-            context,
-            history,
-        );
-    }
-
-    if (isAdditionalActionLookupAction(currentAction)) {
-        // This is the second change, stop it and return unknown
-        const unknownAction: UnknownAction = {
-            actionName: "unknown",
-            parameters: { request: currentAction.parameters.request },
-        };
-        currentAction = unknownAction;
-    }
-
-    return new Action(
-        systemContext.agents.getInjectedSchemaForActionName(
-            currentAction.actionName,
-        ) ?? currentTranslatorName,
-        currentAction.actionName,
-        currentAction.parameters,
-        resultEntityId,
-    );
-}
-
-async function finalizeMultipleActions(
-    action: MultipleAction,
-    translatorName: string,
-    context: ActionContext<CommandHandlerContext>,
-    history?: HistoryContext,
-): Promise<Action[] | undefined> {
-    const requests = action.parameters.requests;
-    const actions: Action[] = [];
-    for (const request of requests) {
-        const finalizedActions = await finalizeAction(
-            request.action,
-            translatorName,
-            context,
-            history,
-            request.resultEntityId,
-        );
-        if (finalizedActions === undefined) {
-            return undefined;
-        }
-        if (Array.isArray(finalizedActions)) {
-            actions.push(...finalizedActions);
-        } else {
-            actions.push(finalizedActions);
-        }
-    }
-    return actions;
-}
-
-function getChatHistoryForTranslation(
-    context: CommandHandlerContext,
-): HistoryContext {
-    const promptSections = context.chatHistory.getPromptSections();
-    if (promptSections.length !== 0) {
-        promptSections.unshift({
-            content:
-                "The following is a history of the conversation with the user that can be used to translate user requests",
-            role: "system",
-        });
-    }
-    const entities = context.chatHistory.getTopKEntities(20);
-    const additionalInstructions = context.session.getConfig().translation
-        .promptConfig.additionalInstructions
-        ? context.chatHistory.getCurrentInstructions()
-        : undefined;
-    return { promptSections, entities, additionalInstructions };
-}
-
-function hasAdditionalInstructions(history?: HistoryContext) {
-    return (
-        history &&
-        history.additionalInstructions !== undefined &&
-        history.additionalInstructions.length > 0
-    );
-}
-
-async function pickInitialSchema(
-    request: string,
-    systemContext: CommandHandlerContext,
-) {
-    // Start with the last translator used
-    let schemaName = systemContext.lastActionSchemaName;
-
-    const embedding =
-        systemContext.session.getConfig().translation.switch.embedding;
-    if (embedding && request.length > 0) {
-        debugSemanticSearch(`Using embedding for schema selection`);
-        // Use embedding to determine the most likely action schema and use the schema name for that.
-        const result = await systemContext.agents.semanticSearchActionSchema(
-            request,
-            debugSemanticSearch.enabled ? 5 : 1,
-        );
-        if (result) {
-            debugSemanticSearch(
-                `Semantic search result: ${result
-                    .map(
-                        (r) =>
-                            `${r.item.actionSchemaFile.schemaName}.${r.item.definition.name} (${r.score})`,
-                    )
-                    .join("\n")}`,
-            );
-            if (result.length > 0) {
-                const found = result[0].item.actionSchemaFile.schemaName;
-                // If it is close to dispatcher actions (unknown and clarify), just use the last used action schema
-                if (found !== DispatcherName) {
-                    schemaName = result[0].item.actionSchemaFile.schemaName;
-                }
-            }
-        }
-    }
-
-    if (!systemContext.agents.isSchemaActive(schemaName)) {
-        debugTranslate(
-            `Translating request using default translator: ${schemaName} not active`,
-        );
-        // REVIEW: Just pick the first one.
-        schemaName = systemContext.agents.getActiveSchemas()[0];
-        if (schemaName === undefined) {
-            throw new Error("No active translator available");
-        }
-    } else {
-        debugTranslate(
-            `Translating request using current translator: ${schemaName}`,
-        );
-    }
-    return schemaName;
-}
-
-export async function translateRequest(
-    request: string,
-    context: ActionContext<CommandHandlerContext>,
-    history?: HistoryContext,
-    attachments?: CachedImageWithDetails[],
-): Promise<TranslationResult | undefined | null> {
-    const systemContext = context.sessionContext.agentContext;
-    const config = systemContext.session.getConfig();
-    if (!config.translation.enabled) {
-        displayError("Translation is disabled.", context);
-        return;
-    }
-
-    if (history) {
-        debugTranslate(
-            `Using history for translation. Entities: ${JSON.stringify(history.entities)}`,
-        );
-    }
-
-    // Start with the last translator used
-    const startTime = performance.now();
-    const schemaName = await pickInitialSchema(request, systemContext);
-    const action = await translateRequestWithSchema(
-        schemaName,
-        request,
-        context,
-        history,
-        attachments,
-    );
-    if (action === undefined) {
-        return undefined;
-    }
-
-    const translatedAction = isMultipleAction(action)
-        ? await finalizeMultipleActions(action, schemaName, context, history)
-        : await finalizeAction(action, schemaName, context, history);
-
-    if (translatedAction === undefined) {
-        return undefined;
-    }
-    const translated = RequestAction.create(request, translatedAction, history);
-
-    const elapsedMs = performance.now() - startTime;
-    const { requestAction, replacedAction } = await confirmTranslation(
-        elapsedMs,
-        unicodeChar.robotFace,
-        translated,
-        context,
-    );
-
-    if (requestAction) {
-        if (!systemContext.batchMode) {
-            systemContext.logger?.logEvent("translation", {
-                elapsedMs,
-                translatorName: schemaName,
-                request,
-                actions: requestAction.actions,
-                replacedAction,
-                developerMode: systemContext.developerMode,
-                history,
-                config: systemContext.session.getConfig().translation,
-                metrics: systemContext.metricsManager?.getMeasures(
-                    systemContext.requestId!,
-                    ProfileNames.translate,
-                ),
-            });
-        }
-        return {
-            requestAction,
-            elapsedMs,
-            fromCache: false,
-            fromUser: replacedAction !== undefined,
-        };
-    }
-
-    return requestAction;
-}
 
 async function canTranslateWithoutContext(
     requestAction: RequestAction,
@@ -765,9 +78,16 @@ async function canTranslateWithoutContext(
         for (const action of requestAction.actions) {
             const translatorName = action.translatorName;
             const newTranslatedActions = translations.get(translatorName)!;
-            const newAction = isMultipleAction(newTranslatedActions)
-                ? newTranslatedActions.parameters.requests[index].action
-                : newTranslatedActions;
+            let newAction: TranslatedAction;
+            if (isMultipleAction(newTranslatedActions)) {
+                const entry = newTranslatedActions.parameters.requests[index];
+                if (isPendingRequest(entry)) {
+                    throw new Error("Pending request in multiple action");
+                }
+                newAction = entry.action;
+            } else {
+                newAction = newTranslatedActions;
+            }
             newActions.push({
                 translatorName,
                 ...newAction,
@@ -819,6 +139,14 @@ async function canTranslateWithoutContext(
         });
         throw e;
     }
+}
+
+function hasAdditionalInstructions(history?: HistoryContext) {
+    return (
+        history &&
+        history.additionalInstructions !== undefined &&
+        history.additionalInstructions.length > 0
+    );
 }
 
 function getExplainerOptions(
@@ -1011,6 +339,7 @@ export class RequestCommandHandler implements CommandHandler {
             );
 
             // Make sure we clear any left over streaming context
+            systemContext.streamingActionContext?.closeActionContext();
             systemContext.streamingActionContext = undefined;
 
             const canUseCacheMatch =
@@ -1027,6 +356,7 @@ export class RequestCommandHandler implements CommandHandler {
                           context,
                           history,
                           cachedAttachments,
+                          0,
                       )
                     : match; // result or null
 

--- a/ts/packages/dispatcher/src/context/dispatcher/handlers/translateCommandHandler.ts
+++ b/ts/packages/dispatcher/src/context/dispatcher/handlers/translateCommandHandler.ts
@@ -2,11 +2,11 @@
 // Licensed under the MIT License.
 
 import { CommandHandlerContext } from "../../commandHandlerContext.js";
-import { translateRequest } from "./requestCommandHandler.js";
 import { ActionContext, ParsedCommandParams } from "@typeagent/agent-sdk";
 import { CommandHandler } from "@typeagent/agent-sdk/helpers/command";
 import { displayResult } from "@typeagent/agent-sdk/helpers/display";
 import { getColorElapsedString } from "common-utils";
+import { translateRequest } from "../../../translation/translateRequest.js";
 
 export class TranslateCommandHandler implements CommandHandler {
     public readonly description = "Translate a request";

--- a/ts/packages/dispatcher/src/context/session.ts
+++ b/ts/packages/dispatcher/src/context/session.ts
@@ -13,6 +13,7 @@ import { cloneConfig, mergeConfig } from "./options.js";
 import { TokenCounter, TokenCounterData } from "aiclient";
 import { DispatcherName } from "./interactiveIO.js";
 import { ConstructionProvider } from "../agentProvider/agentProvider.js";
+import { MultipleActionConfig } from "../translation/multipleActionSchema.js";
 
 const debugSession = registerDebug("typeagent:session");
 
@@ -80,7 +81,7 @@ type DispatcherConfig = {
             inline: boolean;
             search: boolean;
         };
-        multipleActions: boolean;
+        multiple: MultipleActionConfig;
         history: boolean;
         schema: {
             generation: boolean;
@@ -137,7 +138,11 @@ const defaultSessionConfig: SessionConfig = {
             inline: true,
             search: true,
         },
-        multipleActions: true,
+        multiple: {
+            enabled: true,
+            result: true,
+            pending: true,
+        },
         history: true,
         schema: {
             generation: true,

--- a/ts/packages/dispatcher/src/context/system/handlers/configCommandHandlers.ts
+++ b/ts/packages/dispatcher/src/context/system/handlers/configCommandHandlers.ts
@@ -627,15 +627,38 @@ const configTranslationCommandHandlers: CommandHandlerTable = {
             );
         }),
         model: new ConfigModelSetCommandHandler("translation"),
-        multi: getToggleHandlerTable(
-            "multiple action translation",
-            async (context, enable: boolean) => {
-                await changeContextConfig(
-                    { translation: { multipleActions: enable } },
-                    context,
-                );
+        multi: {
+            description: "multiple actions",
+            commands: {
+                ...getToggleCommandHandlers(
+                    "multiple action translation",
+                    async (context, enable: boolean) => {
+                        await changeContextConfig(
+                            { translation: { multiple: { enabled: enable } } },
+                            context,
+                        );
+                    },
+                ),
+                result: getToggleHandlerTable(
+                    "result id in multiple action",
+                    async (context, enable: boolean) => {
+                        await changeContextConfig(
+                            { translation: { multiple: { result: enable } } },
+                            context,
+                        );
+                    },
+                ),
+                pending: getToggleHandlerTable(
+                    "pending request in multiple action",
+                    async (context, enable: boolean) => {
+                        await changeContextConfig(
+                            { translation: { multiple: { pending: enable } } },
+                            context,
+                        );
+                    },
+                ),
             },
-        ),
+        },
         switch: {
             description: "auto switch schemas",
             commands: {

--- a/ts/packages/dispatcher/src/translation/actionSchemaJsonTranslator.ts
+++ b/ts/packages/dispatcher/src/translation/actionSchemaJsonTranslator.ts
@@ -22,7 +22,10 @@ import {
     createChangeAssistantActionSchema,
     TranslatedAction,
 } from "./agentTranslators.js";
-import { createMultipleActionSchema } from "./multipleActionSchema.js";
+import {
+    createMultipleActionSchema,
+    MultipleActionOptions,
+} from "./multipleActionSchema.js";
 import { ActionConfig } from "./actionConfig.js";
 import { ActionConfigProvider } from "./actionConfigProvider.js";
 
@@ -169,7 +172,7 @@ export function composeActionSchema(
     provider: ActionConfigProvider,
     activeSchemas: { [key: string]: boolean },
     changeAgentAction: boolean,
-    multipleActions: boolean,
+    multipleActionOptions: MultipleActionOptions,
 ) {
     const builder = new ActionSchemaBuilder(provider);
     builder.addActionConfig(provider.getActionConfig(schemaName));
@@ -179,7 +182,7 @@ export function composeActionSchema(
         provider,
         activeSchemas,
         changeAgentAction,
-        multipleActions,
+        multipleActionOptions,
         false,
     );
 }
@@ -190,7 +193,7 @@ export function composeSelectedActionSchema(
     provider: ActionConfigProvider,
     activeSchemas: { [key: string]: boolean },
     changeAgentAction: boolean,
-    multipleActions: boolean,
+    multipleActionOptions: MultipleActionOptions,
 ) {
     const builder = new ActionSchemaBuilder(provider);
     const union = sc.union(definitions.map((definition) => sc.ref(definition)));
@@ -207,7 +210,7 @@ export function composeSelectedActionSchema(
         provider,
         activeSchemas,
         changeAgentAction,
-        multipleActions,
+        multipleActionOptions,
         true,
     );
 }
@@ -218,7 +221,7 @@ function finalizeActionSchemaBuilder(
     provider: ActionConfigProvider,
     activeSchemas: { [key: string]: boolean },
     changeAgentAction: boolean,
-    multipleActions: boolean,
+    multipleActionOptions: MultipleActionOptions,
     partial: boolean,
 ) {
     builder.addActionConfig(
@@ -237,9 +240,16 @@ function finalizeActionSchemaBuilder(
         }
     }
 
-    if (multipleActions) {
+    if (
+        multipleActionOptions === true ||
+        (multipleActionOptions !== false &&
+            multipleActionOptions.enabled === true)
+    ) {
         builder.addTypeDefinition(
-            createMultipleActionSchema(builder.getTypeUnion()),
+            createMultipleActionSchema(
+                builder.getTypeUnion(),
+                multipleActionOptions,
+            ),
         );
     }
     return builder.build();

--- a/ts/packages/dispatcher/src/translation/agentTranslators.ts
+++ b/ts/packages/dispatcher/src/translation/agentTranslators.ts
@@ -9,7 +9,10 @@ import {
 import { AppAction } from "@typeagent/agent-sdk";
 import { Result, TypeChatJsonTranslator } from "typechat";
 import { getPackageFilePath } from "../utils/getPackageFilePath.js";
-import { getMultipleActionSchemaDef } from "./multipleActionSchema.js";
+import {
+    getMultipleActionSchemaDef,
+    MultipleActionOptions,
+} from "./multipleActionSchema.js";
 import {
     TranslatorSchemaDef,
     composeTranslatorSchemas,
@@ -162,7 +165,7 @@ function getInjectedSchemaDefs(
     provider: ActionConfigProvider,
     activeTranslators: { [key: string]: boolean },
     changeAgentAction: boolean,
-    multipleActions: boolean,
+    multipleActionOptions: MultipleActionOptions,
 ): TranslatorSchemaDef[] {
     // Add all injected schemas
     const injectedActionConfigs = getInjectedActionConfigs(
@@ -192,8 +195,8 @@ function getInjectedSchemaDefs(
     }
 
     // Add multiple action schema
-    const multipleActionSchemaDef = multipleActions
-        ? getMultipleActionSchemaDef(subActionType)
+    const multipleActionSchemaDef = multipleActionOptions
+        ? getMultipleActionSchemaDef(subActionType, multipleActionOptions)
         : undefined;
 
     if (multipleActionSchemaDef) {
@@ -208,7 +211,7 @@ function getTranslatorSchemaDefs(
     provider: ActionConfigProvider,
     activeTranslators: { [key: string]: boolean },
     changeAgentAction: boolean,
-    multipleActions: boolean,
+    multipleActionOptions: MultipleActionOptions,
 ): TranslatorSchemaDef[] {
     const actionConfig = provider.getActionConfig(schemaName);
     return [
@@ -219,7 +222,7 @@ function getTranslatorSchemaDefs(
             provider,
             activeTranslators,
             changeAgentAction,
-            multipleActions,
+            multipleActionOptions,
         ),
     ];
 }
@@ -253,7 +256,7 @@ export function loadAgentJsonTranslator<
     provider: ActionConfigProvider,
     activeTranslators: { [key: string]: boolean } = {},
     changeAgentAction: boolean = false,
-    multipleActions: boolean = false,
+    multipleActionOptions: MultipleActionOptions,
     regenerateSchema: boolean = true,
     model?: string,
     exact: boolean = true,
@@ -266,7 +269,7 @@ export function loadAgentJsonTranslator<
                   provider,
                   activeTranslators,
                   changeAgentAction,
-                  multipleActions,
+                  multipleActionOptions,
               ),
               { model },
               { exact },
@@ -278,7 +281,7 @@ export function loadAgentJsonTranslator<
                   provider,
                   activeTranslators,
                   changeAgentAction,
-                  multipleActions,
+                  multipleActionOptions,
               ),
               { model },
           );
@@ -332,7 +335,7 @@ export function createTypeAgentTranslatorForSelectedActions<
     provider: ActionConfigProvider,
     activeTranslators: { [key: string]: boolean },
     changeAgentAction: boolean,
-    multipleActions: boolean,
+    multipleActionOptions: MultipleActionOptions,
     model?: string,
 ) {
     const translator = createActionJsonTranslatorFromSchemaDef<T>(
@@ -343,7 +346,7 @@ export function createTypeAgentTranslatorForSelectedActions<
             provider,
             activeTranslators,
             changeAgentAction,
-            multipleActions,
+            multipleActionOptions,
         ),
         { model },
     );
@@ -356,7 +359,7 @@ export function getFullSchemaText(
     provider: ActionConfigProvider,
     activeSchemas: string[] = [],
     changeAgentAction: boolean,
-    multipleActions: boolean,
+    multipleActionOptions: MultipleActionOptions,
     generated: boolean,
 ): string {
     const active = Object.fromEntries(
@@ -370,7 +373,7 @@ export function getFullSchemaText(
                 provider,
                 active,
                 changeAgentAction,
-                multipleActions,
+                multipleActionOptions,
             ),
             { exact: true },
         );
@@ -380,7 +383,7 @@ export function getFullSchemaText(
         provider,
         active,
         changeAgentAction,
-        multipleActions,
+        multipleActionOptions,
     );
     return composeTranslatorSchemas("AllActions", schemaDefs);
 }

--- a/ts/packages/dispatcher/src/translation/confirmTranslation.ts
+++ b/ts/packages/dispatcher/src/translation/confirmTranslation.ts
@@ -1,0 +1,96 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { ActionContext } from "@typeagent/agent-sdk";
+import { displayInfo } from "@typeagent/agent-sdk/helpers/display";
+import { Actions, FullAction, RequestAction } from "agent-cache";
+import chalk from "chalk";
+import { getColorElapsedString } from "common-utils";
+import { getActionTemplateEditConfig } from "./actionTemplate.js";
+import { DispatcherName } from "../context/interactiveIO.js";
+import { CommandHandlerContext } from "../context/commandHandlerContext.js";
+import { validateAction } from "action-schema";
+import { getActionSchema } from "./actionSchemaFileCache.js";
+
+function validateReplaceActions(
+    actions: unknown,
+    systemContext: CommandHandlerContext,
+): actions is FullAction[] {
+    if (actions === null) {
+        throw new Error("Request cancelled");
+    }
+    if (actions === undefined) {
+        return false;
+    }
+    if (!Array.isArray(actions)) {
+        throw new Error("Invalid replacement");
+    }
+    for (const action of actions) {
+        if (typeof action !== "object") {
+            throw new Error("Invalid replacement");
+        }
+        const actionInfo = getActionSchema(action, systemContext.agents);
+        if (actionInfo === undefined) {
+            throw new Error("Invalid replacement");
+        }
+
+        validateAction(actionInfo, action);
+    }
+
+    return true;
+}
+
+export async function confirmTranslation(
+    elapsedMs: number,
+    source: string,
+    requestAction: RequestAction,
+    context: ActionContext<CommandHandlerContext>,
+): Promise<{
+    requestAction: RequestAction | undefined | null;
+    replacedAction?: Actions;
+}> {
+    const actions = requestAction.actions;
+    const systemContext = context.sessionContext.agentContext;
+    if (!systemContext.developerMode || systemContext.batchMode) {
+        const messages = [];
+
+        messages.push(
+            `${source}: ${chalk.blueBright(
+                ` ${requestAction.toString()}`,
+            )} ${getColorElapsedString(elapsedMs)}`,
+        );
+        messages.push();
+
+        const prettyStr = JSON.stringify(actions, undefined, 2);
+        messages.push(`${chalk.italic(chalk.cyanBright(prettyStr))}`);
+        displayInfo(messages.join("\n"), context);
+        return { requestAction };
+    }
+    const preface =
+        "Use the buttons to run or cancel the following action(s). You can also press [Enter] to run it, [Del] to edit it, or [Escape] to cancel it.";
+    const editPreface = `Edit the following action(s) to match your requests.  Click on the values to start editing. Use the ➕/✕ buttons to add/delete optional fields.`;
+
+    const templateSequence = getActionTemplateEditConfig(
+        systemContext,
+        actions,
+        preface,
+        editPreface,
+    );
+
+    const newActions = await systemContext.clientIO.proposeAction(
+        templateSequence,
+        systemContext.requestId,
+        DispatcherName,
+    );
+
+    return validateReplaceActions(newActions, systemContext)
+        ? {
+              requestAction: new RequestAction(
+                  requestAction.request,
+                  Actions.fromFullActions(newActions),
+                  requestAction.history,
+              ),
+              replacedAction: actions,
+          }
+        : { requestAction };
+}

--- a/ts/packages/dispatcher/src/translation/matchRequest.ts
+++ b/ts/packages/dispatcher/src/translation/matchRequest.ts
@@ -1,0 +1,93 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { HistoryContext, MatchResult } from "agent-cache";
+import { CommandHandlerContext } from "../context/commandHandlerContext.js";
+import { validateWildcardMatch } from "../execute/actionHandlers.js";
+import { ActionContext } from "@typeagent/agent-sdk";
+import { TranslationResult } from "./translateRequest.js";
+
+import registerDebug from "debug";
+import { unicodeChar } from "../command/command.js";
+import { confirmTranslation } from "./confirmTranslation.js";
+const debugConstValidation = registerDebug("typeagent:const:validation");
+
+async function getValidatedMatch(
+    matches: MatchResult[],
+    context: CommandHandlerContext,
+) {
+    for (const match of matches) {
+        if (match.wildcardCharCount === 0) {
+            return match;
+        }
+        if (await validateWildcardMatch(match, context)) {
+            debugConstValidation(
+                `Wildcard match accepted: ${match.match.actions}`,
+            );
+            return match;
+        }
+        debugConstValidation(`Wildcard match rejected: ${match.match.actions}`);
+    }
+    return undefined;
+}
+
+export async function matchRequest(
+    request: string,
+    context: ActionContext<CommandHandlerContext>,
+    history?: HistoryContext,
+): Promise<TranslationResult | undefined | null> {
+    const systemContext = context.sessionContext.agentContext;
+    const constructionStore = systemContext.agentCache.constructionStore;
+    if (constructionStore.isEnabled()) {
+        const startTime = performance.now();
+        const config = systemContext.session.getConfig();
+        const activeSchemaNames = systemContext.agents.getActiveSchemas();
+        const matches = constructionStore.match(request, {
+            wildcard: config.cache.matchWildcard,
+            rejectReferences: config.explainer.filter.reference.list,
+            namespaceKeys:
+                systemContext.agentCache.getNamespaceKeys(activeSchemaNames),
+            history,
+        });
+
+        const elapsedMs = performance.now() - startTime;
+
+        const match = await getValidatedMatch(matches, systemContext);
+        if (match !== undefined) {
+            const { requestAction, replacedAction } = await confirmTranslation(
+                elapsedMs,
+                unicodeChar.constructionSign,
+                match.match,
+                context,
+            );
+
+            if (requestAction) {
+                if (!systemContext.batchMode) {
+                    systemContext.logger?.logEvent("match", {
+                        elapsedMs,
+                        request,
+                        actions: requestAction.actions,
+                        replacedAction,
+                        developerMode: systemContext.developerMode,
+                        translators: activeSchemaNames,
+                        explainerName: systemContext.agentCache.explainerName,
+                        matchWildcard: config.cache.matchWildcard,
+                        allMatches: matches.map((m) => {
+                            const { construction: _, match, ...rest } = m;
+                            return { action: match.actions, ...rest };
+                        }),
+                        history,
+                    });
+                }
+                return {
+                    requestAction,
+                    elapsedMs,
+                    fromUser: replacedAction !== undefined,
+                    fromCache: true,
+                };
+            }
+            return requestAction;
+        }
+    }
+    return undefined;
+}

--- a/ts/packages/dispatcher/src/translation/multipleActionSchema.ts
+++ b/ts/packages/dispatcher/src/translation/multipleActionSchema.ts
@@ -14,15 +14,31 @@ import { ActionSchemaCreator as sc } from "action-schema";
 // Multiple Action is what is used and returned from the LLM
 const multipleActionName = "multiple";
 const multipleActionType = "MultipleAction";
+
+export type PendingRequestEntry = {
+    request: string;
+    pendingResultEntityId: string;
+};
+
+type ActionRequestEntry = {
+    request: string;
+    action: TranslatedAction;
+    // if the action has a result, the result entity id can be used in future action parameters
+    resultEntityId?: string;
+};
+
+export type RequestEntry = ActionRequestEntry | PendingRequestEntry;
+
+export function isPendingRequest(
+    entry: RequestEntry,
+): entry is PendingRequestEntry {
+    return "pendingResultEntityId" in entry;
+}
+
 export type MultipleAction = {
     actionName: "multiple";
     parameters: {
-        requests: {
-            request: string;
-            action: TranslatedAction;
-            // if the action has a result, the result entity id can be used in future action parameters
-            resultEntityId?: string;
-        }[];
+        requests: RequestEntry[];
     };
 };
 
@@ -30,24 +46,60 @@ export function isMultipleAction(action: AppAction): action is MultipleAction {
     return action.actionName === multipleActionName;
 }
 
+export type MultipleActionConfig = {
+    enabled: boolean;
+    result: boolean;
+    pending: boolean;
+};
+
+export type MultipleActionOptions = MultipleActionConfig | boolean;
+
 export function createMultipleActionSchema(
     types: ActionSchemaUnion,
+    multipleActionOptions: MultipleActionOptions,
 ): ActionSchemaTypeDefinition {
+    const result =
+        typeof multipleActionOptions === "object"
+            ? multipleActionOptions.result
+            : true;
+    const pending =
+        result &&
+        (typeof multipleActionOptions === "object"
+            ? multipleActionOptions.pending
+            : true);
+
+    const actionRequestEntryFields: any = {
+        request: sc.string(),
+        action: types,
+    };
+    if (result) {
+        actionRequestEntryFields.resultEntityId = sc.optional(
+            sc.string(),
+            "if the action has a result, the result entity id can be used in future action parameters",
+        );
+    }
+
+    const actionRequestEntryType = sc.obj(actionRequestEntryFields);
+
+    let requestEntryType = pending
+        ? sc.union(
+              actionRequestEntryType,
+              sc.obj({
+                  request: sc.string(),
+                  pendingResultEntityId: sc.field(
+                      sc.string(),
+                      "The request references result of previous action, but the content of the result will be needed to generate an action for the request.",
+                  ),
+              }),
+          )
+        : actionRequestEntryType;
+
     const schema = sc.type(
         multipleActionType,
         sc.obj({
             actionName: sc.string(multipleActionName),
             parameters: sc.obj({
-                requests: sc.array(
-                    sc.obj({
-                        request: sc.string(),
-                        action: types,
-                        resultEntityId: sc.optional(
-                            sc.string(),
-                            "if the action has a result, the result entity id can be used in future action parameters",
-                        ),
-                    }),
-                ),
+                requests: sc.array(requestEntryType),
             }),
         }),
         undefined,
@@ -57,11 +109,15 @@ export function createMultipleActionSchema(
 }
 export function getMultipleActionSchemaDef(
     types: string[],
+    multipleActionOptions: MultipleActionOptions,
 ): TranslatorSchemaDef {
     const union: ActionSchemaUnion = sc.union(
         types.map((type) => sc.ref<ActionSchemaTypeDefinition>(type)),
     );
-    const multipleActionSchema = createMultipleActionSchema(union);
+    const multipleActionSchema = createMultipleActionSchema(
+        union,
+        multipleActionOptions,
+    );
     return {
         kind: "inline",
         typeName: multipleActionType,

--- a/ts/packages/dispatcher/src/translation/pendingRequest.ts
+++ b/ts/packages/dispatcher/src/translation/pendingRequest.ts
@@ -1,0 +1,31 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { AppAction } from "@typeagent/agent-sdk";
+import { DispatcherName } from "../context/interactiveIO.js";
+import { PendingRequestEntry } from "./multipleActionSchema.js";
+import { Action } from "agent-cache";
+
+export type PendingRequestAction = {
+    actionName: "pendingRequestAction";
+    parameters: {
+        pendingRequest: string;
+        pendingResultEntityId: string;
+    };
+};
+
+export function isPendingRequestAction(
+    action: AppAction,
+): action is PendingRequestAction {
+    return (
+        action.translatorName === DispatcherName &&
+        action.actionName === "pendingRequestAction"
+    );
+}
+
+export function createPendingRequestAction(entry: PendingRequestEntry) {
+    return new Action(DispatcherName, "pendingRequestAction", {
+        pendingRequest: entry.request,
+        pendingResultEntityId: entry.pendingResultEntityId,
+    });
+}

--- a/ts/packages/dispatcher/src/translation/translateRequest.ts
+++ b/ts/packages/dispatcher/src/translation/translateRequest.ts
@@ -1,0 +1,599 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+import {
+    displayError,
+    displayStatus,
+    displayWarn,
+} from "@typeagent/agent-sdk/helpers/display";
+import {
+    CommandHandlerContext,
+    getTranslatorForSchema,
+    getTranslatorForSelectedActions,
+} from "../context/commandHandlerContext.js";
+import { ActionContext } from "@typeagent/agent-sdk";
+import { Action, HistoryContext, RequestAction } from "agent-cache";
+import {
+    CachedImageWithDetails,
+    IncrementalJsonValueCallBack,
+} from "common-utils";
+import { DispatcherName } from "../context/interactiveIO.js";
+import {
+    isMultipleAction,
+    isPendingRequest,
+    MultipleAction,
+} from "./multipleActionSchema.js";
+import {
+    isAdditionalActionLookupAction,
+    TranslatedAction,
+    TypeAgentTranslator,
+} from "./agentTranslators.js";
+import { UnknownAction } from "../context/dispatcher/schema/dispatcherActionSchema.js";
+import { isUnknownAction } from "../context/dispatcher/dispatcherUtils.js";
+import { loadAssistantSelectionJsonTranslator } from "./unknownSwitcher.js";
+import {
+    getSchemaNamePrefix,
+    startStreamPartialAction,
+} from "../execute/actionHandlers.js";
+import { ProfileNames } from "../utils/profileNames.js";
+import {
+    createPendingRequestAction,
+    PendingRequestAction,
+} from "./pendingRequest.js";
+import { unicodeChar } from "../command/command.js";
+import registerDebug from "debug";
+import { confirmTranslation } from "./confirmTranslation.js";
+const debugTranslate = registerDebug("typeagent:translate");
+const debugSemanticSearch = registerDebug("typeagent:translate:semantic");
+
+async function pickInitialSchema(
+    request: string,
+    systemContext: CommandHandlerContext,
+) {
+    // Start with the last translator used
+    let schemaName = systemContext.lastActionSchemaName;
+
+    const embedding =
+        systemContext.session.getConfig().translation.switch.embedding;
+    if (embedding && request.length > 0) {
+        debugSemanticSearch(`Using embedding for schema selection`);
+        // Use embedding to determine the most likely action schema and use the schema name for that.
+        const result = await systemContext.agents.semanticSearchActionSchema(
+            request,
+            debugSemanticSearch.enabled ? 5 : 1,
+        );
+        if (result) {
+            debugSemanticSearch(
+                `Semantic search result: ${result
+                    .map(
+                        (r) =>
+                            `${r.item.actionSchemaFile.schemaName}.${r.item.definition.name} (${r.score})`,
+                    )
+                    .join("\n")}`,
+            );
+            if (result.length > 0) {
+                const found = result[0].item.actionSchemaFile.schemaName;
+                // If it is close to dispatcher actions (unknown and clarify), just use the last used action schema
+                if (found !== DispatcherName) {
+                    schemaName = result[0].item.actionSchemaFile.schemaName;
+                }
+            }
+        }
+    }
+
+    if (!systemContext.agents.isSchemaActive(schemaName)) {
+        debugTranslate(
+            `Translating request using default translator: ${schemaName} not active`,
+        );
+        // REVIEW: Just pick the first one.
+        schemaName = systemContext.agents.getActiveSchemas()[0];
+        if (schemaName === undefined) {
+            throw new Error("No active translator available");
+        }
+    } else {
+        debugTranslate(
+            `Translating request using current translator: ${schemaName}`,
+        );
+    }
+    return schemaName;
+}
+
+function needAllAction(translatedAction: TranslatedAction, schemaName: string) {
+    return (
+        isUnknownAction(translatedAction) ||
+        (isAdditionalActionLookupAction(translatedAction) &&
+            translatedAction.parameters.schemaName === schemaName)
+    );
+}
+async function translateRequestWithSchema(
+    schemaName: string,
+    request: string,
+    context: ActionContext<CommandHandlerContext>,
+    history?: HistoryContext,
+    attachments?: CachedImageWithDetails[],
+    streamingActionIndex?: number,
+) {
+    const systemContext = context.sessionContext.agentContext;
+    const config = systemContext.session.getConfig();
+    const prefix = getSchemaNamePrefix(schemaName, systemContext);
+    displayStatus(`${prefix}Translating '${request}'`, context);
+
+    const optimize = config.translation.schema.optimize;
+    if (optimize.enabled && optimize.numInitialActions > 0) {
+        const selectedActionTranslator = await getTranslatorForSelectedActions(
+            systemContext,
+            schemaName,
+            request,
+            optimize.numInitialActions,
+        );
+        if (selectedActionTranslator) {
+            const translatedAction = await translateWithTranslator(
+                selectedActionTranslator,
+                schemaName,
+                request,
+                history,
+                attachments,
+                context,
+                streamingActionIndex,
+            );
+            if (translatedAction === undefined) {
+                return undefined;
+            }
+
+            if (!needAllAction(translatedAction, schemaName)) {
+                if (isMultipleAction(translatedAction)) {
+                    const requests = translatedAction.parameters.requests;
+                    for (const subRequest of requests) {
+                        if (
+                            isPendingRequest(subRequest) ||
+                            !needAllAction(subRequest.action, schemaName)
+                        ) {
+                            continue;
+                        }
+                        // REVIEW: the subaction may not be
+                        const translator = getTranslatorForSchema(
+                            systemContext,
+                            schemaName,
+                        );
+                        const action = await translateWithTranslator(
+                            translator,
+                            schemaName,
+                            subRequest.request,
+                            history,
+                            attachments,
+                            context,
+                        );
+                        if (action === undefined) {
+                            return undefined;
+                        }
+                        subRequest.action = action;
+                    }
+                }
+                return translatedAction;
+            }
+        }
+    }
+    const translator = getTranslatorForSchema(systemContext, schemaName);
+    return translateWithTranslator(
+        translator,
+        schemaName,
+        request,
+        history,
+        attachments,
+        context,
+        streamingActionIndex,
+    );
+}
+
+async function translateWithTranslator(
+    translator: TypeAgentTranslator,
+    schemaName: string,
+    request: string,
+    history: HistoryContext | undefined,
+    attachments: CachedImageWithDetails[] | undefined,
+    context: ActionContext<CommandHandlerContext>,
+    streamingActionIndex?: number,
+) {
+    const systemContext = context.sessionContext.agentContext;
+    const config = systemContext.session.getConfig();
+    const enableStreaming = config.translation.stream;
+    const profiler = systemContext.commandProfiler?.measure(
+        ProfileNames.translate,
+    );
+
+    let firstToken = true;
+    let streamFunction: IncrementalJsonValueCallBack | undefined;
+    systemContext.streamingActionContext?.closeActionContext();
+    systemContext.streamingActionContext = undefined;
+    const onProperty: IncrementalJsonValueCallBack | undefined =
+        enableStreaming && streamingActionIndex !== undefined
+            ? (prop: string, value: any, delta: string | undefined) => {
+                  // TODO: streaming currently doesn't not support multiple actions
+                  if (
+                      prop === "actionName" &&
+                      value !== "unknown" &&
+                      delta === undefined
+                  ) {
+                      const actionSchemaName =
+                          systemContext.agents.getInjectedSchemaForActionName(
+                              value,
+                          ) ?? schemaName;
+
+                      if (
+                          !systemContext.agents.isActionActive(actionSchemaName)
+                      ) {
+                          // don't stream if action is not active for the schema
+                          return;
+                      }
+                      const prefix = getSchemaNamePrefix(
+                          actionSchemaName,
+                          systemContext,
+                      );
+                      displayStatus(
+                          `${prefix}Translating '${request}' into action '${value}'`,
+                          context,
+                      );
+                      const actionConfig =
+                          systemContext.agents.getActionConfig(
+                              actionSchemaName,
+                          );
+                      if (actionConfig.streamingActions?.includes(value)) {
+                          streamFunction = startStreamPartialAction(
+                              actionSchemaName,
+                              value,
+                              systemContext,
+                              streamingActionIndex,
+                          );
+                      }
+                  }
+
+                  if (firstToken) {
+                      profiler?.mark(ProfileNames.firstToken);
+                      firstToken = false;
+                  }
+
+                  if (streamFunction) {
+                      streamFunction(prop, value, delta);
+                  }
+              }
+            : undefined;
+    try {
+        const response = await translator.translate(
+            request,
+            history,
+            attachments,
+            onProperty,
+        );
+
+        if (!response.success) {
+            displayError(response.message, context);
+            return undefined;
+        }
+        return response.data as TranslatedAction;
+    } finally {
+        profiler?.stop();
+    }
+}
+
+type NextTranslation = {
+    request: string;
+    nextSchemaName: string;
+    searched: boolean;
+};
+
+async function findAssistantForRequest(
+    request: string,
+    translatorName: string,
+    context: ActionContext<CommandHandlerContext>,
+): Promise<NextTranslation | undefined> {
+    displayStatus(
+        `[↔️ (switcher)] Looking for another assistant to handle request '${request}'`,
+        context,
+    );
+    const systemContext = context.sessionContext.agentContext;
+    const selectTranslator = loadAssistantSelectionJsonTranslator(
+        systemContext.agents
+            .getActiveSchemas()
+            .filter(
+                (enabledTranslatorName) =>
+                    translatorName !== enabledTranslatorName,
+            ),
+        systemContext.agents,
+    );
+
+    const result = await selectTranslator.translate(request);
+    if (!result.success) {
+        displayWarn(`Failed to switch assistant: ${result.message}`, context);
+        return undefined;
+    }
+
+    const nextSchemaName = result.data.assistant;
+    if (nextSchemaName !== "unknown") {
+        return {
+            request,
+            nextSchemaName,
+            searched: true,
+        };
+    }
+    return undefined;
+}
+
+async function getNextTranslation(
+    action: TranslatedAction,
+    translatorName: string,
+    context: ActionContext<CommandHandlerContext>,
+    forceSearch: boolean,
+): Promise<NextTranslation | undefined> {
+    let request: string;
+    if (isAdditionalActionLookupAction(action)) {
+        if (!forceSearch) {
+            return {
+                request: action.parameters.request,
+                nextSchemaName: action.parameters.schemaName,
+                searched: false,
+            };
+        }
+        request = action.parameters.request;
+    } else if (isUnknownAction(action)) {
+        request = action.parameters.request;
+    } else {
+        return undefined;
+    }
+
+    const config = context.sessionContext.agentContext.session.getConfig();
+    return config.translation.switch.search
+        ? findAssistantForRequest(request, translatorName, context)
+        : undefined;
+}
+
+async function finalizeAction(
+    action: TranslatedAction,
+    translatorName: string,
+    context: ActionContext<CommandHandlerContext>,
+    history?: HistoryContext,
+    attachments?: CachedImageWithDetails[],
+    resultEntityId?: string,
+    streamingActionIndex?: number,
+): Promise<Action | Action[] | undefined> {
+    let currentAction: TranslatedAction | undefined = action;
+    let currentTranslatorName: string = translatorName;
+    const systemContext = context.sessionContext.agentContext;
+    while (true) {
+        const forceSearch = currentAction !== action; // force search if we have switched once
+        const nextTranslation = await getNextTranslation(
+            currentAction,
+            currentTranslatorName,
+            context,
+            forceSearch,
+        );
+        if (nextTranslation === undefined) {
+            break;
+        }
+
+        const { request, nextSchemaName, searched } = nextTranslation;
+        if (!systemContext.agents.isSchemaActive(nextSchemaName)) {
+            // this is a bug. May be the translator cache didn't get updated when state change?
+            throw new Error(
+                `Internal error: switch to disabled translator ${nextSchemaName}`,
+            );
+        }
+
+        currentAction = await translateRequestWithSchema(
+            nextSchemaName,
+            request,
+            context,
+            history,
+            attachments,
+            streamingActionIndex,
+        );
+        if (currentAction === undefined) {
+            return undefined;
+        }
+
+        currentTranslatorName = nextSchemaName;
+        // Don't keep on switching after we searched, just return unknown
+        if (searched) {
+            break;
+        }
+    }
+
+    if (isMultipleAction(currentAction)) {
+        return finalizeMultipleActions(
+            currentAction,
+            currentTranslatorName,
+            context,
+            history,
+        );
+    }
+
+    if (isAdditionalActionLookupAction(currentAction)) {
+        // This is the second change, stop it and return unknown
+        const unknownAction: UnknownAction = {
+            actionName: "unknown",
+            parameters: { request: currentAction.parameters.request },
+        };
+        currentAction = unknownAction;
+    }
+
+    return new Action(
+        systemContext.agents.getInjectedSchemaForActionName(
+            currentAction.actionName,
+        ) ?? currentTranslatorName,
+        currentAction.actionName,
+        currentAction.parameters,
+        resultEntityId,
+    );
+}
+
+async function finalizeMultipleActions(
+    action: MultipleAction,
+    translatorName: string,
+    context: ActionContext<CommandHandlerContext>,
+    history?: HistoryContext,
+    attachments?: CachedImageWithDetails[],
+): Promise<Action[] | undefined> {
+    if (attachments !== undefined && attachments.length !== 0) {
+        // TODO: What to do with attachments with multiple actions?
+        throw new Error("Attachments with multiple actions not supported");
+    }
+    const requests = action.parameters.requests;
+    const actions: Action[] = [];
+    for (const request of requests) {
+        if (isPendingRequest(request)) {
+            actions.push(createPendingRequestAction(request));
+            continue;
+        }
+
+        const finalizedActions = await finalizeAction(
+            request.action,
+            translatorName,
+            context,
+            history,
+            undefined, // TODO: What to do with attachments with multiple actions?
+            request.resultEntityId,
+        );
+        if (finalizedActions === undefined) {
+            return undefined;
+        }
+        if (Array.isArray(finalizedActions)) {
+            actions.push(...finalizedActions);
+        } else {
+            actions.push(finalizedActions);
+        }
+    }
+    return actions;
+}
+
+export function getChatHistoryForTranslation(
+    context: CommandHandlerContext,
+): HistoryContext {
+    const promptSections = context.chatHistory.getPromptSections();
+    if (promptSections.length !== 0) {
+        promptSections.unshift({
+            content:
+                "The following is a history of the conversation with the user that can be used to translate user requests",
+            role: "system",
+        });
+    }
+    const entities = context.chatHistory.getTopKEntities(20);
+    const additionalInstructions = context.session.getConfig().translation
+        .promptConfig.additionalInstructions
+        ? context.chatHistory.getCurrentInstructions()
+        : undefined;
+    return { promptSections, entities, additionalInstructions };
+}
+
+export type TranslationResult = {
+    requestAction: RequestAction;
+    elapsedMs: number;
+    fromUser: boolean;
+    fromCache: boolean;
+};
+
+// null means cancelled because of replacement parse error.
+export async function translateRequest(
+    request: string,
+    context: ActionContext<CommandHandlerContext>,
+    history?: HistoryContext,
+    attachments?: CachedImageWithDetails[],
+    streamingActionIndex?: number,
+): Promise<TranslationResult | undefined | null> {
+    const systemContext = context.sessionContext.agentContext;
+    const config = systemContext.session.getConfig();
+    if (!config.translation.enabled) {
+        displayError("Translation is disabled.", context);
+        return;
+    }
+
+    if (history) {
+        debugTranslate(
+            `Using history for translation. Entities: ${JSON.stringify(history.entities)}`,
+        );
+    }
+
+    // Start with the last translator used
+    const startTime = performance.now();
+    const schemaName = await pickInitialSchema(request, systemContext);
+    const action = await translateRequestWithSchema(
+        schemaName,
+        request,
+        context,
+        history,
+        attachments,
+        streamingActionIndex,
+    );
+    if (action === undefined) {
+        return undefined;
+    }
+
+    const translatedAction = isMultipleAction(action)
+        ? await finalizeMultipleActions(
+              action,
+              schemaName,
+              context,
+              history,
+              attachments,
+          )
+        : await finalizeAction(
+              action,
+              schemaName,
+              context,
+              history,
+              attachments,
+          );
+
+    if (translatedAction === undefined) {
+        return undefined;
+    }
+    const translated = RequestAction.create(request, translatedAction, history);
+
+    const elapsedMs = performance.now() - startTime;
+    const { requestAction, replacedAction } = await confirmTranslation(
+        elapsedMs,
+        unicodeChar.robotFace,
+        translated,
+        context,
+    );
+
+    if (requestAction) {
+        if (!systemContext.batchMode) {
+            systemContext.logger?.logEvent("translation", {
+                elapsedMs,
+                translatorName: schemaName,
+                request,
+                actions: requestAction.actions,
+                replacedAction,
+                developerMode: systemContext.developerMode,
+                history,
+                config: systemContext.session.getConfig().translation,
+                metrics: systemContext.metricsManager?.getMeasures(
+                    systemContext.requestId!,
+                    ProfileNames.translate,
+                ),
+            });
+        }
+        return {
+            requestAction,
+            elapsedMs,
+            fromCache: false,
+            fromUser: replacedAction !== undefined,
+        };
+    }
+
+    return requestAction;
+}
+
+export function translatePendingRequestAction(
+    action: PendingRequestAction,
+    context: ActionContext<CommandHandlerContext>,
+    actionIndex?: number,
+) {
+    const systemContext = context.sessionContext.agentContext;
+    const history = getChatHistoryForTranslation(systemContext);
+    return translateRequest(
+        action.parameters.pendingRequest,
+        context,
+        history,
+        undefined,
+        actionIndex,
+    );
+}

--- a/ts/packages/dispatcher/src/utils/test/testData.ts
+++ b/ts/packages/dispatcher/src/utils/test/testData.ts
@@ -23,7 +23,10 @@ import {
 import { getElapsedString, createLimiter, Limiter } from "common-utils";
 import { getCacheFactory } from "../cacheFactory.js";
 import { Result } from "typechat";
-import { isMultipleAction } from "../../translation/multipleActionSchema.js";
+import {
+    isMultipleAction,
+    isPendingRequest,
+} from "../../translation/multipleActionSchema.js";
 
 const testDataJSONVersion = 2;
 export type TestDataEntry<T extends object = object> =
@@ -362,20 +365,32 @@ function getGenerateTestDataFn(
             }
             const newActions = result.data as TranslatedAction;
 
-            action = isMultipleAction(newActions)
-                ? newActions.parameters.requests.map(
-                      (e) =>
-                          new Action(
-                              schemaName,
-                              e.action.actionName,
-                              e.action.parameters,
-                          ),
-                  )
-                : new Action(
-                      schemaName,
-                      newActions.actionName,
-                      newActions.parameters,
-                  );
+            if (isMultipleAction(newActions)) {
+                const actions: Action[] = [];
+                for (const e of newActions.parameters.requests) {
+                    if (isPendingRequest(e)) {
+                        return toFailedResult({
+                            request,
+                            message: "Failed translation: Pending action",
+                            tags,
+                        });
+                    }
+                    actions.push(
+                        new Action(
+                            schemaName,
+                            e.action.actionName,
+                            e.action.parameters,
+                        ),
+                    );
+                }
+                action = actions;
+            } else {
+                action = new Action(
+                    schemaName,
+                    newActions.actionName,
+                    newActions.parameters,
+                );
+            }
         }
 
         const requestAction = RequestAction.create(request, action, history);


### PR DESCRIPTION
If an action requires the content of the result from previous action, multiple action will generate a pending request entry.
The pending request entry is converted into a "PendingRequestAction", and during execute, the request will be translated again with the current history context.

- A lot of the diff is from breaking apart the file `requestCommandHandler.ts`
- `executeActions` is not a queue to allow pending request action to be expanded to more actions.
- streaming now allow different `actionIndex` as the streaming target so that translation for pending request can be streamed too, but if the translation is not a multiple action.
- Add toggles for result id and pending for multiple actions.