### PR TITLE
Fix electron preview in linux/wsl2

### DIFF
--- a/.github/workflows/shell-tests.yml
+++ b/.github/workflows/shell-tests.yml
@@ -40,9 +40,9 @@ jobs:
       - name: Setup Git LF
         run: |
           git config --global core.autocrlf false
-      
+
       - uses: actions/checkout@v4
-      
+
       - uses: dorny/paths-filter@v3
         id: filter
         with:
@@ -50,49 +50,49 @@ jobs:
             ts:
               - "ts/**"
               - ".github/workflows/build-ts.yml"
-      
+
       - uses: pnpm/action-setup@v4
         name: Install pnpm
         with:
           package_json_file: ts/package.json
-      
+
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.version }}
           cache: "pnpm"
           cache-dependency-path: ts/pnpm-lock.yaml
-      
+
       - name: Install dependencies (pnpm)
         working-directory: ts
         run: |
           pnpm install --frozen-lockfile --strict-peer-dependencies
-      
+
       - name: Install Playwright Browsers
         run: pnpm exec playwright install --with-deps
         working-directory: ts/packages/shell
-      
+
       - name: Build repo
         working-directory: ts
         run: |
           npm run build
-      
+
       - name: Login to Azure
         uses: azure/login@v2.2.0
         with:
           client-id: ${{ secrets.AZUREAPPSERVICE_CLIENTID_5B0D2D6BA40F4710B45721D2112356DD }}
           tenant-id: ${{ secrets.AZUREAPPSERVICE_TENANTID_39BB903136F14B6EAD8F53A8AB78E3AA }}
           subscription-id: ${{ secrets.AZUREAPPSERVICE_SUBSCRIPTIONID_F36C1F2C4B2C49CA8DD5C52FAB98FA30 }}
-      
+
       - name: Get Keys
         run: |
           node tools/scripts/getKeys.mjs --vault build-pipeline-kv
         working-directory: ts
-      
+
       - name: Test CLI - verify .env & endpoint connectivity
         run: |
           npm run start:dev 'prompt' 'why is the sky blue'
         working-directory: ts/packages/cli
-      
+
       - name: Shell Tests (windows)
         if: ${{ runner.os == 'windows' }}
         timeout-minutes: 60
@@ -110,10 +110,10 @@ jobs:
           sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0 
           Xvfb :99 -screen 0 1600x1200x24 & export DISPLAY=:99
           npm run shell:test
-          rm ../../.env          
+          rm ../../.env
         working-directory: ts/packages/shell
         continue-on-error: true
-  
+
       - uses: actions/upload-artifact@v4
         if: ${{ !cancelled() }}
         with:

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -12,7 +12,7 @@ on:
   # pull_request:
   #   branches: ["main"]
   pull_request_target:
-    branches: ["main"]    
+    branches: ["main"]
   merge_group:
     branches: ["main"]
 
@@ -31,7 +31,7 @@ env:
 
 jobs:
   shell_and_cli:
-    #environment: ${{ github.event_name == 'pull_request_target' && 'development-fork' || 'development' }}      # required for federated credentials 
+    #environment: ${{ github.event_name == 'pull_request_target' && 'development-fork' || 'development' }}      # required for federated credentials
     environment: development-fork
     strategy:
       fail-fast: false
@@ -42,7 +42,7 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     steps:
-      - if: runner.os == 'Linux'        
+      - if: runner.os == 'Linux'
         run: |
           sudo apt install libsecret-1-0
 
@@ -54,9 +54,9 @@ jobs:
         uses: actions/checkout@v4
 
       - if: ${{ github.event_name == 'pull_request_target'}}
-        uses: actions/checkout@v4 
+        uses: actions/checkout@v4
         with:
-            ref: ${{ github.event.pull_request.head.sha }}      
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - uses: dorny/paths-filter@v3
         id: filter
@@ -114,33 +114,18 @@ jobs:
         timeout-minutes: 60
         run: |
           npm run shell:smoke
-          rm ../../.env
         working-directory: ts/packages/shell
         continue-on-error: true
 
       - name: Shell Tests - smoke (linux)
         if: ${{ runner.os == 'Linux' }}
         timeout-minutes: 60
-        # https://github.com/microsoft/playwright/issues/34251 - sysctl command
         run: |
-          sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0 
           Xvfb :99 -screen 0 1600x1200x24 & export DISPLAY=:99
           npm run shell:smoke
-          rm ../../.env          
         working-directory: ts/packages/shell
         continue-on-error: true
 
-      # - name: Shell Tests - smoke (linux)
-      #   if: ${{ runner.os == 'Linux' }}
-      #   timeout-minutes: 60
-      #   # https://github.com/microsoft/playwright/issues/34251 - sysctl command
-      #   run: |
-      #     sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0 
-      #     xvfb-run --auto-servernum --server-args="-screen 0 16001200x24" -- npm run shell:smoke
-      #     rm ../../.env          
-      #   working-directory: ts/packages/shell
-      #   continue-on-error: true        
-      
       - name: Live Tests
         if: ${{ runner.os == 'linux' }}
         timeout-minutes: 60
@@ -148,3 +133,9 @@ jobs:
           npm run test:live
         working-directory: ts
         continue-on-error: true
+
+      - name: Clean up Keys
+        run: |
+          rm ./.env
+        working-directory: ts
+        if: always()

--- a/ts/packages/shell/test/simple.spec.ts
+++ b/ts/packages/shell/test/simple.spec.ts
@@ -10,7 +10,7 @@ import test, {
 } from "@playwright/test";
 import {
     exitApplication,
-    getAppPath,
+    getLaunchArgs,
     sendUserRequestAndWaitForResponse,
     startShell,
 } from "./testHelper";
@@ -21,9 +21,8 @@ test("dummy", async () => {
 
 test("simple", { tag: "@smoke" }, async ({}, testInfo) => {
     console.log(`Running test '${testInfo.title}`);
-
     const app: ElectronApplication = await electron.launch({
-        args: [getAppPath()],
+        args: getLaunchArgs(),
     });
     const mainWindow: Page = await app.firstWindow();
     await mainWindow.bringToFront();


### PR DESCRIPTION
Fixes `pnpm run start` for Linux/WSL2 for shell.  Should fix the playwright shell test as well.

- Need to use `WebContent.loadFile` instead of `WebContent.loadUrl` API.
- Ubuntu 24.04 needs `--no-sandbox`
- Make sure we catch any error from loading those files instead of just hanging.
- Fix the smoke test pipeline to clean up the .env file after everything is done (instead of right after the shell test)