### PR TITLE
Fix electron app path

### DIFF
--- a/ts/packages/shell/test/simple.spec.ts
+++ b/ts/packages/shell/test/simple.spec.ts
@@ -10,23 +10,25 @@ import test, {
 } from "@playwright/test";
 import {
     exitApplication,
+    getAppPath,
     getLaunchArgs,
     sendUserRequestAndWaitForResponse,
     startShell,
 } from "./testHelper";
-
-test("dummy", async () => {
-    // do nothing
-});
+import { fileURLToPath } from "node:url";
 
 test("simple", { tag: "@smoke" }, async ({}, testInfo) => {
-    console.log(`Running test '${testInfo.title}`);
     const app: ElectronApplication = await electron.launch({
         args: getLaunchArgs(),
     });
     const mainWindow: Page = await app.firstWindow();
     await mainWindow.bringToFront();
+    expect(fileURLToPath(mainWindow.url())).toContain(getAppPath());
     await app.close();
+});
+
+test("startShell", { tag: "@smoke" }, async ({}) => {
+    await startShell();
 });
 
 test.skip("why is the sky blue?", { tag: "@smoke" }, async ({}, testInfo) => {

--- a/ts/packages/shell/test/testHelper.ts
+++ b/ts/packages/shell/test/testHelper.ts
@@ -2,14 +2,11 @@
 // Licensed under the MIT License.
 
 import {
-    _electron,
     _electron as electron,
     ElectronApplication,
     Locator,
     Page,
-    TestDetails,
 } from "@playwright/test";
-import { profile } from "node:console";
 import fs from "node:fs";
 import path from "node:path";
 import os from "node:os";
@@ -138,11 +135,11 @@ export async function exitApplication(page: Page): Promise<void> {
  */
 function getAppPath(): string {
     const packagePath = fileURLToPath(new URL("..", import.meta.url));
-    const appPath = packagePath.endsWith("/")
+    const appPath = packagePath.endsWith(path.sep)
         ? packagePath.slice(0, -1)
         : packagePath;
 
-    return appPath.includes(":") ? `file://${appPath}` : appPath;
+    return appPath;
 }
 
 /**

--- a/ts/packages/shell/test/testHelper.ts
+++ b/ts/packages/shell/test/testHelper.ts
@@ -147,8 +147,7 @@ function getAppPath(): string {
  * @returns The arguments to pass to the electron application
  */
 export function getLaunchArgs(): string[] {
-    const appPath = getAppPath();
-    console.log(appPath);
+    const appPath = getAppPath();    
     // Ubuntu 24.04+ needs --no-sandbox, see https://github.com/electron/electron/issues/18265
     return os.platform() === "linux" ? [appPath, "--no-sandbox"] : [appPath];
 }

--- a/ts/packages/shell/test/testHelper.ts
+++ b/ts/packages/shell/test/testHelper.ts
@@ -147,7 +147,7 @@ export function getAppPath(): string {
  * @returns The arguments to pass to the electron application
  */
 export function getLaunchArgs(): string[] {
-    const appPath = getAppPath();    
+    const appPath = getAppPath();
     // Ubuntu 24.04+ needs --no-sandbox, see https://github.com/electron/electron/issues/18265
     return os.platform() === "linux" ? [appPath, "--no-sandbox"] : [appPath];
 }

--- a/ts/packages/shell/test/testHelper.ts
+++ b/ts/packages/shell/test/testHelper.ts
@@ -133,7 +133,7 @@ export async function exitApplication(page: Page): Promise<void> {
  * Gets the shell package path.
  * @returns The root path to the project containing the playwright configuration
  */
-function getAppPath(): string {
+export function getAppPath(): string {
     const packagePath = fileURLToPath(new URL("..", import.meta.url));
     const appPath = packagePath.endsWith(path.sep)
         ? packagePath.slice(0, -1)

--- a/ts/packages/shell/test/testHelper.ts
+++ b/ts/packages/shell/test/testHelper.ts
@@ -137,7 +137,12 @@ export async function exitApplication(page: Page): Promise<void> {
  * @returns The root path to the project containing the playwright configuration
  */
 function getAppPath(): string {
-    return fileURLToPath(new URL("..", import.meta.url));
+    const packagePath = fileURLToPath(new URL("..", import.meta.url));
+    const appPath = packagePath.endsWith("/")
+        ? packagePath.slice(0, -1)
+        : packagePath;
+
+    return appPath.includes(":") ? `file://${appPath}` : appPath;
 }
 
 /**


### PR DESCRIPTION
- It doesn't like the trailing path separator.
- Add check in simple smoke test to make sure we catch the load error in the future by checking the URL that is loaded.
- Add smoke test to exercise `startShell` which the nightly shell test depends on.