### PR TITLE
Add JSON Schema support as an options.

### DIFF
--- a/ts/packages/actionSchema/src/generator.ts
+++ b/ts/packages/actionSchema/src/generator.ts
@@ -15,6 +15,7 @@ function generateSchemaType(
     type: SchemaType,
     pending: SchemaTypeDefinition[],
     indent: number,
+    jsonSchema: boolean,
     strict: boolean,
     paren: boolean = false,
 ): string {
@@ -26,17 +27,20 @@ function generateSchemaType(
                 type.fields,
                 pending,
                 indent + 1,
+                jsonSchema,
                 strict,
             );
             return `{\n${lines.join("\n")}\n${"    ".repeat(indent)}}`;
         case "array":
-            return `${generateSchemaType(type.elementType, pending, indent, strict, true)}[]`;
+            return `${generateSchemaType(type.elementType, pending, indent, jsonSchema, strict, true)}[]`;
         case "string-union":
             const stringUnion = type.typeEnum.map((v) => `"${v}"`).join(" | ");
             return paren ? `(${stringUnion})` : stringUnion;
         case "type-union":
             const typeUnion = type.types
-                .map((t) => generateSchemaType(t, pending, indent, strict))
+                .map((t) =>
+                    generateSchemaType(t, pending, indent, jsonSchema, strict),
+                )
                 .join(" | ");
             return paren ? `(${typeUnion})` : typeUnion;
         case "type-reference":
@@ -46,7 +50,12 @@ function generateSchemaType(
                 throw new Error(`Unresolved type reference: ${type.name}`);
             }
             return type.name;
-
+        case "undefined":
+            if (jsonSchema) {
+                // When jsonSchema is enabled, emit "null" for optional fields to match the json schema.
+                // translator will convert it to "undefined" because of stripNulls is enabled
+                return "null";
+            }
         default:
             return type.type;
     }
@@ -69,14 +78,21 @@ function generateSchemaObjectFields(
     fields: SchemaObjectFields,
     pending: SchemaTypeDefinition[],
     indent: number,
+    jsonSchema: boolean,
     strict: boolean,
 ) {
     const indentStr = "    ".repeat(indent);
     for (const [key, field] of Object.entries(fields)) {
         generateComments(lines, field.comments, indentStr);
-        const optional = field.optional ? "?" : "";
+        const optional = field.optional && !jsonSchema ? "?" : "";
+
+        // When jsonSchema is enabled, emit "null" for optional fields to match the json schema.
+        // translator will convert it to "undefined" because of stripNulls is enabled
+        const jsonSchemaOptional =
+            field.optional && jsonSchema ? " | null" : "";
+
         lines.push(
-            `${indentStr}${key}${optional}: ${generateSchemaType(field.type, pending, indent, strict)};${field.trailingComments ? ` //${field.trailingComments.join(" ")}` : ""}`,
+            `${indentStr}${key}${optional}: ${generateSchemaType(field.type, pending, indent, jsonSchema, strict)}${jsonSchemaOptional};${field.trailingComments ? ` //${field.trailingComments.join(" ")}` : ""}`,
         );
     }
 }
@@ -85,6 +101,7 @@ function generateTypeDefinition(
     lines: string[],
     definition: SchemaTypeDefinition,
     pending: SchemaTypeDefinition[],
+    jsonSchema: boolean,
     strict: boolean,
     exact: boolean,
 ) {
@@ -94,6 +111,7 @@ function generateTypeDefinition(
         definition.type,
         pending,
         0,
+        jsonSchema,
         strict,
     );
     const line = definition.alias
@@ -113,6 +131,7 @@ export function generateSchemaTypeDefinition(
     options?: GenerateSchemaOptions,
     order?: Map<string, number>,
 ) {
+    const jsonSchema = options?.jsonSchema ?? false;
     const strict = options?.strict ?? true;
     const exact = options?.exact ?? false;
     const emitted = new Map<
@@ -131,7 +150,14 @@ export function generateSchemaTypeDefinition(
                 emitOrder: emitted.size,
             });
             const dep: SchemaTypeDefinition[] = [];
-            generateTypeDefinition(lines, definition, dep, strict, exact);
+            generateTypeDefinition(
+                lines,
+                definition,
+                dep,
+                jsonSchema,
+                strict,
+                exact,
+            );
 
             // Generate the dependencies first to be close to the usage
             pending.unshift(...dep);

--- a/ts/packages/actionSchema/src/generator.ts
+++ b/ts/packages/actionSchema/src/generator.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+import { wrapTypeWithJsonSchema } from "./jsonSchemaGenerator.js";
 import {
     SchemaType,
     SchemaObjectFields,
@@ -158,12 +159,10 @@ export function generateActionSchema(
     options?: GenerateSchemaOptions,
 ): string {
     return generateSchemaTypeDefinition(
-        actionSchemaGroup.entry,
+        options?.jsonSchema
+            ? wrapTypeWithJsonSchema(actionSchemaGroup.entry)
+            : actionSchemaGroup.entry,
         options,
         actionSchemaGroup.order,
     );
-}
-
-export function generateActionJsonSchema(actionSchemaGroup: ActionSchemaGroup) {
-    return undefined;
 }

--- a/ts/packages/actionSchema/src/generator.ts
+++ b/ts/packages/actionSchema/src/generator.ts
@@ -104,6 +104,7 @@ function generateTypeDefinition(
 export type GenerateSchemaOptions = {
     strict?: boolean; // default true
     exact?: boolean; // default false
+    jsonSchema?: boolean; // default false
 };
 
 export function generateSchemaTypeDefinition(
@@ -161,4 +162,8 @@ export function generateActionSchema(
         options,
         actionSchemaGroup.order,
     );
+}
+
+export function generateActionJsonSchema(actionSchemaGroup: ActionSchemaGroup) {
+    return undefined;
 }

--- a/ts/packages/actionSchema/src/index.ts
+++ b/ts/packages/actionSchema/src/index.ts
@@ -18,8 +18,8 @@ export {
     GenerateSchemaOptions,
     generateActionSchema,
     generateSchemaTypeDefinition,
-    generateActionJsonSchema,
 } from "./generator.js";
+export { generateActionJsonSchema } from "./jsonSchemaGenerator.js";
 export { validateAction } from "./validate.js";
 export { getParameterType, getParameterNames } from "./utils.js";
 

--- a/ts/packages/actionSchema/src/index.ts
+++ b/ts/packages/actionSchema/src/index.ts
@@ -18,6 +18,7 @@ export {
     GenerateSchemaOptions,
     generateActionSchema,
     generateSchemaTypeDefinition,
+    generateActionJsonSchema,
 } from "./generator.js";
 export { validateAction } from "./validate.js";
 export { getParameterType, getParameterNames } from "./utils.js";

--- a/ts/packages/actionSchema/src/jsonSchemaGenerator.ts
+++ b/ts/packages/actionSchema/src/jsonSchemaGenerator.ts
@@ -11,12 +11,9 @@ import {
 export function wrapTypeWithJsonSchema(
     type: ActionSchemaEntryTypeDefinition,
 ): SchemaTypeDefinition {
-    return sc.type(
-        "AllActions",
-        sc.obj({ response: type.type }),
-        undefined,
-        true,
-    );
+    // The root of a Json schema is always an object
+    // place the root type definition with an object with a response field of the type.
+    return sc.type(type.name, sc.obj({ response: type.type }), undefined, true);
 }
 
 type JsonSchemaObject = {
@@ -120,6 +117,7 @@ function generateJsonSchemaType(
                 $ref: `#/$defs/${type.name}`,
             };
         case "undefined": {
+            // Note: undefined is presented by null in JSON schema
             return { type: "null" };
         }
         default:

--- a/ts/packages/actionSchema/src/jsonSchemaGenerator.ts
+++ b/ts/packages/actionSchema/src/jsonSchemaGenerator.ts
@@ -150,7 +150,6 @@ function generateJsonSchemaTypeDefinition(
         } while (pending.length > 0);
         schema.schema.$defs = $defs;
     }
-    console.log(JSON.stringify(schema, undefined, 2));
     return schema;
 }
 

--- a/ts/packages/actionSchema/src/jsonSchemaGenerator.ts
+++ b/ts/packages/actionSchema/src/jsonSchemaGenerator.ts
@@ -1,0 +1,163 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import * as sc from "./creator.js";
+import {
+    ActionSchemaEntryTypeDefinition,
+    ActionSchemaGroup,
+    SchemaType,
+    SchemaTypeDefinition,
+} from "./type.js";
+export function wrapTypeWithJsonSchema(
+    type: ActionSchemaEntryTypeDefinition,
+): SchemaTypeDefinition {
+    return sc.type(
+        "AllActions",
+        sc.obj({ response: type.type }),
+        undefined,
+        true,
+    );
+}
+
+type JsonSchemaObject = {
+    type: "object";
+    properties: Record<string, JsonSchema>;
+    required: string[];
+    additionalProperties: false;
+};
+type JsonSchemaArray = {
+    type: "array";
+    items: JsonSchema;
+};
+
+type JsonSchemaString = {
+    type: "string";
+    enum?: string[];
+};
+
+type JsonSchemaNumber = {
+    type: "number";
+};
+
+type JsonSchemaBoolean = {
+    type: "boolean";
+};
+
+type JsonSchemaUnion = {
+    anyOf: JsonSchema[];
+};
+
+type JsonSchemaNull = {
+    type: "null";
+};
+
+type JsonSchemaReference = {
+    $ref: string;
+};
+
+type JsonSchemaRoot = {
+    name: string;
+    description?: string;
+    strict: true;
+    schema: JsonSchema & { $defs?: Record<string, JsonSchema> }; // REVIEW should be JsonSchemaObject;
+};
+
+type JsonSchema =
+    | JsonSchemaObject
+    | JsonSchemaArray
+    | JsonSchemaString
+    | JsonSchemaNumber
+    | JsonSchemaBoolean
+    | JsonSchemaNull
+    | JsonSchemaUnion
+    | JsonSchemaReference;
+
+function generateJsonSchemaType(
+    type: SchemaType,
+    pending: SchemaTypeDefinition[],
+    strict: boolean,
+): JsonSchema {
+    switch (type.type) {
+        case "object":
+            return {
+                type: "object",
+                properties: Object.fromEntries(
+                    Object.entries(type.fields).map(([key, field]) => [
+                        key,
+                        generateJsonSchemaType(field.type, pending, strict),
+                    ]),
+                ),
+                required: Object.keys(type.fields),
+                additionalProperties: false,
+            };
+        case "array":
+            return {
+                type: "array",
+                items: generateJsonSchemaType(
+                    type.elementType,
+                    pending,
+                    strict,
+                ),
+            };
+        case "string-union":
+            return {
+                type: "string",
+                enum: type.typeEnum,
+            };
+        case "type-union":
+            return {
+                anyOf: type.types.map((t) =>
+                    generateJsonSchemaType(t, pending, strict),
+                ),
+            };
+        case "type-reference":
+            if (type.definition) {
+                pending.push(type.definition);
+            } else if (strict) {
+                throw new Error(`Unresolved type reference: ${type.name}`);
+            }
+            return {
+                $ref: `#/$defs/${type.name}`,
+            };
+        case "undefined": {
+            return { type: "null" };
+        }
+        default:
+            return { type: type.type };
+    }
+}
+function generateJsonSchemaTypeDefinition(
+    def: SchemaTypeDefinition,
+    strict: boolean = true,
+): JsonSchemaRoot {
+    const pending: SchemaTypeDefinition[] = [];
+    const schema: JsonSchemaRoot = {
+        name: def.name,
+        strict: true,
+        schema: generateJsonSchemaType(def.type, pending, strict),
+    };
+
+    if (pending.length !== 0) {
+        const $defs: Record<string, JsonSchema> = {};
+        do {
+            const definition = pending.shift()!;
+            if ($defs[definition.name]) {
+                continue;
+            }
+            $defs[definition.name] = generateJsonSchemaType(
+                definition.type,
+                pending,
+                strict,
+            );
+        } while (pending.length > 0);
+        schema.schema.$defs = $defs;
+    }
+    console.log(JSON.stringify(schema, undefined, 2));
+    return schema;
+}
+
+export function generateActionJsonSchema(actionSchemaGroup: ActionSchemaGroup) {
+    const type = wrapTypeWithJsonSchema(actionSchemaGroup.entry);
+
+    return generateJsonSchemaTypeDefinition(type);
+}

--- a/ts/packages/aiclient/src/models.ts
+++ b/ts/packages/aiclient/src/models.ts
@@ -3,6 +3,8 @@
 
 import { PromptSection, Result, TypeChatLanguageModel } from "typechat";
 
+export type JsonSchema = any;
+
 /**
  * Translation settings for Chat models
  */
@@ -11,6 +13,7 @@ export type CompletionSettings = {
     temperature?: number;
     max_tokens?: number;
     response_format?: { type: "json_object" };
+
     // Use fixed seed parameter to improve determinism
     //https://cookbook.openai.com/examples/reproducible_outputs_with_the_seed_parameter
     seed?: number;
@@ -22,12 +25,16 @@ export type CompletionSettings = {
 export interface ChatModel extends TypeChatLanguageModel {
     completionSettings: CompletionSettings;
     completionCallback?: ((request: any, response: any) => void) | undefined;
-    complete(prompt: string | PromptSection[]): Promise<Result<string>>;
+    complete(
+        prompt: string | PromptSection[],
+        jsonSchema?: JsonSchema,
+    ): Promise<Result<string>>;
 }
 
 export interface ChatModelWithStreaming extends ChatModel {
     completeStream(
         prompt: string | PromptSection[],
+        jsonSchema?: JsonSchema,
     ): Promise<Result<AsyncIterableIterator<string>>>;
 }
 

--- a/ts/packages/aiclient/src/openai.ts
+++ b/ts/packages/aiclient/src/openai.ts
@@ -398,7 +398,11 @@ function createAzureOpenAIChatModel(
     completionSettings ??= {};
     completionSettings.n ??= 1;
     completionSettings.temperature ??= 0;
-    if (!settings.supportsResponseFormat) {
+
+    const disableResponseFormat =
+        !settings.supportsResponseFormat &&
+        completionSettings.response_format !== undefined;
+    if (disableResponseFormat) {
         // Remove it even if user specify it.
         delete completionSettings.response_format;
     }
@@ -429,6 +433,11 @@ function createAzureOpenAIChatModel(
             ...additionalParams,
         };
         if (jsonSchema !== undefined) {
+            if (disableResponseFormat) {
+                throw new Error(
+                    `Json schema not supported by model '${settings.modelName}'`,
+                );
+            }
             if (params.response_format?.type === "json_object") {
                 params.response_format = {
                     type: "json_schema",

--- a/ts/packages/aiclient/src/restClient.ts
+++ b/ts/packages/aiclient/src/restClient.ts
@@ -247,6 +247,7 @@ export async function fetchWithRetry(
             if (result === undefined) {
                 throw new Error("fetch: No response");
             }
+            debugHeader(result.status, result.statusText);
             debugHeader(result.headers);
             if (result.status === 200) {
                 return success(result);
@@ -256,7 +257,10 @@ export async function fetchWithRetry(
                 retryCount >= retryMaxAttempts
             ) {
                 return error(`fetch error: ${await getErrorMessage(result)}`);
+            } else if (debugHeader.enabled) {
+                debugHeader(await getErrorMessage(result));
             }
+
             // See if the service tells how long to wait to retry
             const pauseMs = getRetryAfterMs(result, retryPauseMs);
             await sleep(pauseMs);

--- a/ts/packages/commonUtils/src/indexNode.ts
+++ b/ts/packages/commonUtils/src/indexNode.ts
@@ -11,7 +11,7 @@ export {
     composeTranslatorSchemas,
     enableJsonTranslatorStreaming,
     TypeChatJsonTranslatorWithStreaming,
-    createJsonTranslatorWithValidator as createTypeAgentJsonTranslator,
+    createJsonTranslatorWithValidator,
     TypeAgentJsonValidator,
     JsonTranslatorOptions,
 } from "./jsonTranslator.js";

--- a/ts/packages/commonUtils/src/indexNode.ts
+++ b/ts/packages/commonUtils/src/indexNode.ts
@@ -11,7 +11,8 @@ export {
     composeTranslatorSchemas,
     enableJsonTranslatorStreaming,
     TypeChatJsonTranslatorWithStreaming,
-    createJsonTranslatorWithValidator,
+    createJsonTranslatorWithValidator as createTypeAgentJsonTranslator,
+    TypeAgentJsonValidator,
     JsonTranslatorOptions,
 } from "./jsonTranslator.js";
 export { IncrementalJsonValueCallBack } from "./incrementalJsonParser.js";

--- a/ts/packages/commonUtils/src/jsonTranslator.ts
+++ b/ts/packages/commonUtils/src/jsonTranslator.ts
@@ -283,18 +283,29 @@ export function createJsonTranslatorWithValidator<T extends object>(
     );
 
     const debugPrompt = registerDebug(`typeagent:translate:${name}:prompt`);
+    const debugJsonSchema = registerDebug(
+        `typeagent:translate:${name}:jsonschema`,
+    );
     const debugResult = registerDebug(`typeagent:translate:${name}:result`);
     const complete = model.complete.bind(model);
     model.complete = async (prompt: string | PromptSection[]) => {
         debugPrompt(prompt);
-        return complete(prompt, validator.getJsonSchema?.());
+        const jsonSchema = validator.getJsonSchema?.();
+        if (jsonSchema !== undefined) {
+            debugJsonSchema(jsonSchema);
+        }
+        return complete(prompt, jsonSchema);
     };
 
     if (ai.supportsStreaming(model)) {
         const completeStream = model.completeStream.bind(model);
         model.completeStream = async (prompt: string | PromptSection[]) => {
             debugPrompt(prompt);
-            return completeStream(prompt, validator.getJsonSchema?.());
+            const jsonSchema = validator.getJsonSchema?.();
+            if (jsonSchema !== undefined) {
+                debugJsonSchema(jsonSchema);
+            }
+            return completeStream(prompt, jsonSchema);
         };
     }
 

--- a/ts/packages/commonUtils/src/jsonTranslator.ts
+++ b/ts/packages/commonUtils/src/jsonTranslator.ts
@@ -14,7 +14,7 @@ import {
 import { createTypeScriptJsonValidator } from "typechat/ts";
 import { TypeChatConstraintsValidator } from "./constraints.js";
 import registerDebug from "debug";
-import { openai as ai } from "aiclient";
+import { openai as ai, JsonSchema } from "aiclient";
 import {
     createIncrementalJsonParser,
     IncrementalJsonParser,
@@ -260,9 +260,17 @@ export function createJsonTranslatorFromSchemaDef<T extends object>(
     );
 }
 
+export interface TypeAgentJsonValidator<T extends object>
+    extends TypeChatJsonValidator<T> {
+    getSchemaText: () => string;
+    getTypeName: () => string;
+    validate(jsonObject: object): Result<T>;
+    getJsonSchema?: () => JsonSchema | undefined;
+}
+
 export function createJsonTranslatorWithValidator<T extends object>(
     name: string,
-    validator: TypeChatJsonValidator<T>,
+    validator: TypeAgentJsonValidator<T>,
     options?: JsonTranslatorOptions<T>,
 ) {
     const model = ai.createChatModel(
@@ -279,14 +287,14 @@ export function createJsonTranslatorWithValidator<T extends object>(
     const complete = model.complete.bind(model);
     model.complete = async (prompt: string | PromptSection[]) => {
         debugPrompt(prompt);
-        return complete(prompt);
+        return complete(prompt, validator.getJsonSchema?.());
     };
 
     if (ai.supportsStreaming(model)) {
         const completeStream = model.completeStream.bind(model);
         model.completeStream = async (prompt: string | PromptSection[]) => {
             debugPrompt(prompt);
-            return completeStream(prompt);
+            return completeStream(prompt, validator.getJsonSchema?.());
         };
     }
 

--- a/ts/packages/dispatcher/src/context/commandHandlerContext.ts
+++ b/ts/packages/dispatcher/src/context/commandHandlerContext.ts
@@ -132,9 +132,10 @@ export function getTranslatorForSchema(
         getActiveTranslators(context),
         config.switch.inline,
         config.multiple,
-        config.schema.generation,
+        config.schema.generation.enabled,
         config.model,
         !config.schema.optimize.enabled,
+        config.schema.generation.jsonSchema,
     );
     context.translatorCache.set(translatorName, newTranslator);
     return newTranslator;

--- a/ts/packages/dispatcher/src/context/session.ts
+++ b/ts/packages/dispatcher/src/context/session.ts
@@ -84,7 +84,10 @@ type DispatcherConfig = {
         multiple: MultipleActionConfig;
         history: boolean;
         schema: {
-            generation: boolean;
+            generation: {
+                enabled: boolean;
+                jsonSchema: boolean;
+            };
             optimize: {
                 enabled: boolean;
                 numInitialActions: number; // 0 means no limit
@@ -145,7 +148,10 @@ const defaultSessionConfig: SessionConfig = {
         },
         history: true,
         schema: {
-            generation: true,
+            generation: {
+                enabled: true,
+                jsonSchema: false,
+            },
             optimize: {
                 enabled: false,
                 numInitialActions: 5,

--- a/ts/packages/dispatcher/src/context/system/handlers/configCommandHandlers.ts
+++ b/ts/packages/dispatcher/src/context/system/handlers/configCommandHandlers.ts
@@ -748,21 +748,45 @@ const configTranslationCommandHandlers: CommandHandlerTable = {
         schema: {
             description: "Action schema configuration",
             commands: {
-                generation: getToggleHandlerTable(
-                    "generated action schema",
-                    async (context, enable: boolean) => {
-                        await changeContextConfig(
-                            {
-                                translation: {
-                                    schema: {
-                                        generation: enable,
+                generation: {
+                    description: "Generated action schema",
+                    commands: {
+                        ...getToggleCommandHandlers(
+                            "generated action schema",
+                            async (context, enable: boolean) => {
+                                await changeContextConfig(
+                                    {
+                                        translation: {
+                                            schema: {
+                                                generation: {
+                                                    enabled: enable,
+                                                },
+                                            },
+                                        },
                                     },
-                                },
+                                    context,
+                                );
                             },
-                            context,
-                        );
+                        ),
+                        json: getToggleHandlerTable(
+                            "use generate json schema if model supports it",
+                            async (context, enable: boolean) => {
+                                await changeContextConfig(
+                                    {
+                                        translation: {
+                                            schema: {
+                                                generation: {
+                                                    jsonSchema: enable,
+                                                },
+                                            },
+                                        },
+                                    },
+                                    context,
+                                );
+                            },
+                        ),
                     },
-                ),
+                },
                 optimize: {
                     description: "Optimize schema",
                     commands: {

--- a/ts/packages/dispatcher/src/translation/actionSchemaJsonTranslator.ts
+++ b/ts/packages/dispatcher/src/translation/actionSchemaJsonTranslator.ts
@@ -12,10 +12,12 @@ import {
     ActionSchemaUnion,
     ActionSchemaGroup,
     GenerateSchemaOptions,
+    generateActionJsonSchema,
 } from "action-schema";
 import {
-    createJsonTranslatorWithValidator,
+    createTypeAgentJsonTranslator,
     JsonTranslatorOptions,
+    TypeAgentJsonValidator,
 } from "common-utils";
 import {
     getInjectedActionConfigs,
@@ -32,11 +34,15 @@ import { ActionConfigProvider } from "./actionConfigProvider.js";
 function createActionSchemaJsonValidator<T extends TranslatedAction>(
     actionSchemaGroup: ActionSchemaGroup,
     generateOptions?: GenerateSchemaOptions,
-): TypeChatJsonValidator<T> {
+): TypeAgentJsonValidator<T> {
     const schema = generateActionSchema(actionSchemaGroup, generateOptions);
+    const jsonSchema = generateOptions?.jsonSchema
+        ? generateActionJsonSchema(actionSchemaGroup)
+        : undefined;
     return {
         getSchemaText: () => schema,
         getTypeName: () => actionSchemaGroup.entry.name,
+        getJsonSchema: () => jsonSchema,
         validate(jsonObject: object): Result<T> {
             const value: any = jsonObject;
             if (value.actionName === undefined) {
@@ -72,7 +78,7 @@ export function createActionJsonTranslatorFromSchemaDef<
         generateOptions,
     );
 
-    return createJsonTranslatorWithValidator(
+    return createTypeAgentJsonTranslator(
         typeName.toLowerCase(),
         validator,
         options,

--- a/ts/packages/dispatcher/src/translation/actionSchemaJsonTranslator.ts
+++ b/ts/packages/dispatcher/src/translation/actionSchemaJsonTranslator.ts
@@ -15,7 +15,7 @@ import {
     generateActionJsonSchema,
 } from "action-schema";
 import {
-    createTypeAgentJsonTranslator,
+    createJsonTranslatorWithValidator,
     JsonTranslatorOptions,
     TypeAgentJsonValidator,
 } from "common-utils";
@@ -83,7 +83,7 @@ export function createActionJsonTranslatorFromSchemaDef<
         generateOptions,
     );
 
-    return createTypeAgentJsonTranslator(
+    return createJsonTranslatorWithValidator(
         typeName.toLowerCase(),
         validator,
         options,

--- a/ts/packages/dispatcher/src/translation/agentTranslators.ts
+++ b/ts/packages/dispatcher/src/translation/agentTranslators.ts
@@ -4,7 +4,7 @@
 import {
     CachedImageWithDetails,
     createJsonTranslatorFromSchemaDef,
-    createJsonTranslatorWithValidator,
+    createTypeAgentJsonTranslator,
     enableJsonTranslatorStreaming,
     JsonTranslatorOptions,
 } from "common-utils";
@@ -263,6 +263,7 @@ export function loadAgentJsonTranslator<
     regenerateSchema: boolean = true,
     model?: string,
     exact: boolean = true,
+    jsonSchema: boolean = false,
 ): TypeAgentTranslator<T> {
     const options = { model };
     const translator = regenerateSchema
@@ -276,7 +277,7 @@ export function loadAgentJsonTranslator<
                   multipleActionOptions,
               ),
               options,
-              { exact },
+              { exact, jsonSchema },
           )
         : createJsonTranslatorFromSchemaDef<T>(
               "AllActions",
@@ -309,7 +310,7 @@ function createTypeAgentTranslator<
 
     // Create another translator so that we can have a different
     // debug/token count tag
-    const altTranslator = createJsonTranslatorWithValidator(
+    const altTranslator = createTypeAgentJsonTranslator(
         "check",
         translator.validator,
         options,

--- a/ts/packages/dispatcher/src/translation/agentTranslators.ts
+++ b/ts/packages/dispatcher/src/translation/agentTranslators.ts
@@ -4,7 +4,7 @@
 import {
     CachedImageWithDetails,
     createJsonTranslatorFromSchemaDef,
-    createTypeAgentJsonTranslator,
+    createJsonTranslatorWithValidator,
     enableJsonTranslatorStreaming,
     JsonTranslatorOptions,
 } from "common-utils";
@@ -310,7 +310,7 @@ function createTypeAgentTranslator<
 
     // Create another translator so that we can have a different
     // debug/token count tag
-    const altTranslator = createTypeAgentJsonTranslator(
+    const altTranslator = createJsonTranslatorWithValidator(
         "check",
         translator.validator,
         options,


### PR DESCRIPTION
Initial support to generate JSON schema for OAI's structure output. Off by default since the performance hit isn't great, and TS schema in the prompt with json mode already have high accuracy rate. (40s+ with cache miss, 1-2s with cache hit, and cache miss vs cache hit rate is about 50%).