### PR TITLE
[Spelunker] Fix mini model endpoint

### DIFF
--- a/ts/packages/agents/spelunker/src/searchCode.ts
+++ b/ts/packages/agents/spelunker/src/searchCode.ts
@@ -55,7 +55,7 @@ function createQueryContext(): QueryContext {
         "AnswerSpecs",
     );
     const miniModel = openai.createChatModel(
-        "GPT_4_0_MINI",
+        undefined, // "GPT_4_O_MINI" is slower than default model?!
         undefined,
         undefined,
         ["spelunkerMini"],


### PR DESCRIPTION
The endpoint name for the mini model was misspelled, so we quietly got the default model (gpt-4-o-2).

After fixing it, I noticed that the summarizing and selecting phases (which use the mini model) became significantly *slower*. (There's a lot of variability in the measurements but the difference was pretty consistent).

So now the fix is to set the mini model endpoint name to `undefined`, which means it's the same old default model, but there's no misleading misspelled endpoint name, and a comment explaining the reason.