### PR TITLE
[Spelunker] Improve formatting ("preparation") of summaries sent to oracle

### DIFF
--- a/ts/packages/agents/spelunker/src/searchCode.ts
+++ b/ts/packages/agents/spelunker/src/searchCode.ts
@@ -398,10 +398,20 @@ function prepareChunks(chunks: Chunk[]): string {
 }
 
 function prepareSummaries(db: sqlite.Database): string {
+    const languageCommentMap: { [key: string]: string } = {
+        python: "#",
+        typescript: "//",
+    };
     const selectAllSummaries = db.prepare(`SELECT * FROM Summaries`);
     const summaryRows: any[] = selectAllSummaries.all();
-    // TODO: format as code: # <summary> / <signature>
-    return JSON.stringify(summaryRows, undefined, 2);
+    const lines: string[] = [];
+    for (const summaryRow of summaryRows) {
+        const comment = languageCommentMap[summaryRow.language] ?? "#";
+        lines.push("");
+        lines.push(`${comment} ${summaryRow.summary}`);
+        lines.push(summaryRow.signature);
+    }
+    return lines.join("\n");
 }
 
 function createTranslator<T extends object>(
@@ -660,8 +670,8 @@ CREATE TABLE IF NOT EXISTS Blobs (
 );
 CREATE TABLE IF NOT EXISTS Summaries (
     chunkId TEXT PRIMARY KEY REFERENCES chunks(chunkId),
+    language TEXT, -- "python", "typescript", etc.
     summary TEXT,
-    shortName TEXT,
     signature TEXT
 )
 `;
@@ -753,7 +763,7 @@ async function summarizeChunkSlice(
     // Enter them into the database
     const db = context.queryContext!.database!;
     const prepInsertSummary = db.prepare(`
-        INSERT OR REPLACE INTO Summaries (chunkId, summary, signature) VALUES (?, ?, ?)
+        INSERT OR REPLACE INTO Summaries (chunkId, language, summary, signature) VALUES (?, ?, ?, ?)
     `);
     let errors = 0;
     for (const summary of summarizeSpecs.summaries) {
@@ -761,6 +771,7 @@ async function summarizeChunkSlice(
         try {
             prepInsertSummary.run(
                 summary.chunkId,
+                summary.language,
                 summary.summary,
                 summary.signature,
             );

--- a/ts/packages/agents/spelunker/src/searchCode.ts
+++ b/ts/packages/agents/spelunker/src/searchCode.ts
@@ -126,12 +126,15 @@ export async function searchCode(
             .prepare(`SELECT * FROM blobs WHERE chunkId = ?`)
             .all(chunkRow.chunkId);
         for (const blob of blobRows) {
-            blob.lines = blob.lines.match(/.*(?:\r?\n|$)/g) ?? [];
+            blob.lines = blob.lines.split("\n");
             while (
                 blob.lines.length &&
                 !blob.lines[blob.lines.length - 1].trim()
             ) {
                 blob.lines.pop();
+            }
+            for (let i = 0; i < blob.lines.length; i++) {
+                blob.lines[i] = blob.lines[i] + "\n";
             }
         }
         const childRows: any[] = db

--- a/ts/packages/agents/spelunker/src/summarizerSchema.ts
+++ b/ts/packages/agents/spelunker/src/summarizerSchema.ts
@@ -5,7 +5,8 @@
 export type ChunkId = string;
 
 export type Summary = {
-    chunkId: ChunkId;
+    chunkId: ChunkId; // The unique identifier of the chunk
+    language: string; // The language of the chunk, e.g. 'python' or 'typescript' (all lowercase)
     summary: string; // A one-line summary of the chunk, explaining what it does at a high level, concisely but with attention for detail. Do not duplicate the signature
     signature: string; // For functions, 'def foo(bar: int) -> str:'; for classes, 'class Foo:'; for modules, 'module foo.bar'
 };


### PR DESCRIPTION
This requires adding a "language" field to the Summaries interface/table (filled in by the AI during summary creation).

Also tweak the translation of the single text string in the Blob table back into a list of lines, all ending in a newline.