### PR TITLE
[Spelunker] Add .focus command to set focus directory

### DIFF
--- a/ts/packages/agents/spelunker/src/searchCode.ts
+++ b/ts/packages/agents/spelunker/src/searchCode.ts
@@ -168,7 +168,7 @@ export async function searchCode(
     }
 
     // 4. Construct a prompt from those chunks.
-    console_log(`[Step 4: Construct a prompt for the smart LLM]`);
+    console_log(`[Step 4: Construct a prompt for the oracle]`);
     const preppedChunks: Chunk[] = chunkDescs
         .map((chunkDesc) => prepChunk(chunkDesc, allChunks))
         .filter(Boolean) as Chunk[];


### PR DESCRIPTION
In a Spelunker session (after `@config request spelunker`) you can now ask to see the focus by typing `.focus` or change the focus using `focus <folder>`. Folders can start with `~` indicating `$HOME`, or be absolute paths or relative paths (relative to whatever the CLI or Shell uses as its current directory).