### PR TITLE
[Spelunker] Be less eager to get comments before a declaration

### DIFF
--- a/ts/packages/agents/spelunker/src/typescriptChunker.ts
+++ b/ts/packages/agents/spelunker/src/typescriptChunker.ts
@@ -192,6 +192,19 @@ function makeBlobs(
     const lineStarts = sourceFile.getLineStarts(); // TODO: Move to caller?
     let startLoc = sourceFile.getLineAndCharacterOfPosition(startPos);
     const endLoc = sourceFile.getLineAndCharacterOfPosition(endPos);
+    if (startLoc.character) {
+        // Adjust start: if in the middle of a line, move to start of next line.
+        // This is still a heuristic that will fail e.g. with `; function ...`.
+        // But we don't want to support that; a more likely scenario is:
+        // ```
+        // type A = ...; // comment
+        // function ...
+        // ```
+        // Here getFullStart() points to the start of the comment on A,
+        // but we must start at the function.
+        startPos = lineStarts[startLoc.line + 1];
+        startLoc = sourceFile.getLineAndCharacterOfPosition(startPos);
+    }
     // console.log(
     //     `Start and end: ${startPos}=${startLoc.line + 1}:${startLoc.character}, ` +
     //         `${endPos}=${endLoc.line + 1}:${endLoc.character}`,


### PR DESCRIPTION
We were failing an assertion when splicing child nodes out of parent nodes in the following case:
```ts
type Foo = ...; // comment

function bar() { 
    ...
}
```
The TSC `node.getFullStart() ` API would return the location of Foo's comment, and our strategy for moving to the next line didn't work. (This makes `getFullStart()` pretty stupid IMO, but we can't change that.)

This PR is a quick hack to fix this by always moving to the start of the next line if the start position points in the middle of a line (i.e., `character` is > 0).