### PR TITLE
Improve IntelliSense with json parameters

### DIFF
--- a/ts/packages/actionSchema/src/parser.ts
+++ b/ts/packages/actionSchema/src/parser.ts
@@ -506,8 +506,18 @@ class ActionParser {
         };
     }
 
-    private parseTypeUnionType(node: ts.UnionTypeNode): SchemaTypeUnion {
+    private parseTypeUnionType(
+        node: ts.UnionTypeNode,
+    ): SchemaTypeUnion | SchemaTypeStringUnion {
         const types = node.types.map((type) => this.parseType(type));
+        if (types.every((type) => type.type === "string-union")) {
+            return {
+                type: "string-union",
+                typeEnum: types
+                    .map((type) => (type as SchemaTypeStringUnion).typeEnum)
+                    .flat(),
+            };
+        }
         return {
             type: "type-union",
             types,

--- a/ts/packages/dispatcher/src/command/completion.ts
+++ b/ts/packages/dispatcher/src/command/completion.ts
@@ -70,10 +70,18 @@ function getPendingFlag(
     }
     const lastToken = params.tokens[params.tokens.length - 1];
     const resolvedFlag = resolveFlag(flags, lastToken);
-    return resolvedFlag !== undefined &&
-        getFlagType(resolvedFlag[1]) !== "boolean"
-        ? `--${resolvedFlag[0]}` // use the full flag name in case it was a short flag
-        : undefined;
+    if (resolvedFlag === undefined) {
+        return undefined;
+    }
+    const type = getFlagType(resolvedFlag[1]);
+    if (type === "boolean") {
+        return undefined;
+    }
+    if (type === "json") {
+        return `${lastToken}`;
+    }
+
+    return `--${resolvedFlag[0]}`; // use the full flag name in case it was a short flag
 }
 
 async function getCommandParameterCompletion(

--- a/ts/packages/dispatcher/src/translation/actionSchemaFileCache.ts
+++ b/ts/packages/dispatcher/src/translation/actionSchemaFileCache.ts
@@ -31,7 +31,7 @@ function hashStrings(...str: string[]) {
     return hash.digest("base64");
 }
 
-const ActionSchemaFileCacheVersion = 1;
+const ActionSchemaFileCacheVersion = 2;
 type ActionSchemaFileCacheJSON = {
     version: number;
     entries: [string, ActionSchemaFileJSON][];

--- a/ts/packages/shell/src/renderer/src/messageContainer.ts
+++ b/ts/packages/shell/src/renderer/src/messageContainer.ts
@@ -210,6 +210,9 @@ export class MessageContainer {
         this.div = div;
 
         this.updateSource();
+
+        // Don't show initialize without any messages.
+        this.hide();
     }
 
     public getMessage() {


### PR DESCRIPTION
- Json parameters should do completion of the full "parameter name" instead of the prefix.
- Optimize type-unions that are only string literals into string-unions when parsing (also bump the cache version to invalidate)
- Shell output message container is hidden when first created.