### PR TITLE
Entity with uniqueId roundtrip

### DIFF
--- a/ts/packages/agents/player/src/agent/playerHandlers.ts
+++ b/ts/packages/agents/player/src/agent/playerHandlers.ts
@@ -54,7 +54,7 @@ async function initializePlayerContext() {
 async function executePlayerAction(
     action: PlayerAction,
     context: ActionContext<PlayerActionContext>,
-    entityMap: Map<string, Entity>,
+    entityMap?: Map<string, Entity>,
 ) {
     if (context.sessionContext.agentContext.spotify) {
         return handleCall(

--- a/ts/packages/agents/player/src/client.ts
+++ b/ts/packages/agents/player/src/client.ts
@@ -234,18 +234,21 @@ async function htmlTrackNames(
                 actionResult.entities.push({
                     name: track.name,
                     type: ["track", "song"],
+                    uniqueId: track.id,
                 });
                 // make an entity for each artist
                 for (const artist of track.artists) {
                     actionResult.entities.push({
                         name: artist.name,
                         type: ["artist"],
+                        uniqueId: artist.id,
                     });
                 }
                 // make an entity for the album
                 actionResult.entities.push({
                     name: track.album.name,
                     type: ["album"],
+                    uniqueId: track.album.id,
                 });
                 entCount++;
             }
@@ -286,18 +289,21 @@ async function htmlTrackNames(
         actionResult.entities.push({
             name: track.name,
             type: ["track", "song"],
+            uniqueId: track.id,
         });
         // make an entity for each artist
         for (const artist of track.artists) {
             actionResult.entities.push({
                 name: artist.name,
                 type: ["artist"],
+                uniqueId: artist.id,
             });
         }
         // make an entity for the album
         actionResult.entities.push({
             name: track.album.name,
             type: ["album"],
+            uniqueId: track.album.id,
         });
         const litArtistsPrefix =
             track.artists.length > 1 ? "artists: " : "artist ";
@@ -462,14 +468,16 @@ async function playRandomAction(
 async function playTrackAction(
     clientContext: IClientContext,
     action: PlayTrackAction,
+    entityMap: Map<string, Entity>,
 ): Promise<ActionResult> {
     if (action.parameters.albumName) {
-        return playTrackWithAlbum(clientContext, action);
+        return playTrackWithAlbum(clientContext, action, entityMap);
     }
     const tracks = await findTracks(
         clientContext,
         action.parameters.trackName,
         action.parameters.artists,
+        entityMap,
         3,
     );
 
@@ -483,11 +491,13 @@ async function playTrackAction(
 async function playTrackWithAlbum(
     clientContext: IClientContext,
     action: PlayTrackAction,
+    entityMap: Map<string, Entity>,
 ): Promise<ActionResult> {
     const albums = await findAlbums(
         action.parameters.albumName!,
         action.parameters.artists,
         clientContext,
+        entityMap,
     );
 
     const trackName = action.parameters.trackName;
@@ -538,11 +548,13 @@ async function playFromCurrentTrackListAction(
 async function playAlbumAction(
     clientContext: IClientContext,
     action: PlayAlbumAction,
+    entityMap: Map<string, Entity>,
 ): Promise<ActionResult> {
     const albums = await findAlbums(
         action.parameters.albumName,
         action.parameters.artists,
         clientContext,
+        entityMap,
     );
 
     const album = albums[0];
@@ -576,17 +588,19 @@ async function playAlbumAction(
 async function playArtistAction(
     clientContext: IClientContext,
     action: PlayArtistAction,
+    entityMap: Map<string, Entity>,
 ): Promise<ActionResult> {
     const tracks = await (action.parameters.genre
         ? findArtistTracksWithGenre(
               action.parameters.artist,
               action.parameters.genre,
               clientContext,
+              entityMap,
           )
         : findArtistTopTracks(
               action.parameters.artist,
-
               clientContext,
+              entityMap,
           ));
 
     const quantity = action.parameters.quantity ?? 0;
@@ -731,13 +745,13 @@ export async function handleCall(
         case "playRandom":
             return playRandomAction(clientContext, action);
         case "playTrack":
-            return playTrackAction(clientContext, action);
+            return playTrackAction(clientContext, action, entityMap);
         case "playFromCurrentTrackList":
             return playFromCurrentTrackListAction(clientContext, action);
         case "playAlbum":
-            return playAlbumAction(clientContext, action);
+            return playAlbumAction(clientContext, action, entityMap);
         case "playArtist":
-            return playArtistAction(clientContext, action);
+            return playArtistAction(clientContext, action, entityMap);
         case "playGenre":
             return playGenreAction(clientContext, action);
         case "status": {

--- a/ts/packages/agents/player/src/endpoints.ts
+++ b/ts/packages/agents/player/src/endpoints.ts
@@ -593,7 +593,7 @@ export async function getTrack(
         },
     };
 
-    const albumUrl = `https://api.spotify.com/v1/track/${encodeURIComponent(id)}`;
+    const albumUrl = `https://api.spotify.com/v1/tracks/${encodeURIComponent(id)}`;
     try {
         const spotifyResult = await axios.get(albumUrl, config);
         return spotifyResult.data as SpotifyApi.SingleTrackResponse;

--- a/ts/packages/agents/player/src/endpoints.ts
+++ b/ts/packages/agents/player/src/endpoints.ts
@@ -214,7 +214,7 @@ export async function getArtist(service: SpotifyService, id: string) {
         },
     };
 
-    const artistsUrl = `https://api.spotify.com/v1/artist/${encodeURIComponent(id)}`;
+    const artistsUrl = `https://api.spotify.com/v1/artists/${encodeURIComponent(id)}`;
 
     try {
         const spotifyResult = await axios.get(artistsUrl, config);
@@ -581,6 +581,25 @@ export async function getAlbumTracks(service: SpotifyService, albumId: string) {
         translateAxiosError(e);
     }
     return undefined;
+}
+
+export async function getTrack(
+    service: SpotifyService,
+    id: string,
+): Promise<SpotifyApi.SingleTrackResponse | undefined> {
+    const config = {
+        headers: {
+            Authorization: `Bearer ${await service.tokenProvider.getAccessToken()}`,
+        },
+    };
+
+    const albumUrl = `https://api.spotify.com/v1/track/${encodeURIComponent(id)}`;
+    try {
+        const spotifyResult = await axios.get(albumUrl, config);
+        return spotifyResult.data as SpotifyApi.SingleTrackResponse;
+    } catch (e) {
+        translateAxiosError(e);
+    }
 }
 
 export async function getTracksFromIdsBatch(

--- a/ts/packages/agents/player/src/playback.ts
+++ b/ts/packages/agents/player/src/playback.ts
@@ -77,12 +77,14 @@ function htmlPlaybackStatus(
             actionResult.entities.push({
                 name: status.item.name,
                 type: ["track"],
+                uniqueId: status.item.id,
             });
             // make an entity for each artist
             for (const artist of status.item.artists) {
                 actionResult.entities.push({
                     name: artist.name,
                     type: ["artist"],
+                    uniqueId: artist.id,
                 });
             }
             const plainArtists = "    A" + artists.substring(1);
@@ -91,6 +93,7 @@ function htmlPlaybackStatus(
             actionResult.entities.push({
                 name: album,
                 type: ["album"],
+                uniqueId: status.item.album.id,
             });
         }
     }

--- a/ts/packages/agents/player/src/search.ts
+++ b/ts/packages/agents/player/src/search.ts
@@ -3,12 +3,21 @@
 
 import registerDebug from "debug";
 import { IClientContext } from "./client.js";
-import { getAlbums, getArtistTopTracks, search } from "./endpoints.js";
+import {
+    getAlbum,
+    getAlbums,
+    getArtist,
+    getArtistTopTracks,
+    getTrack,
+    search,
+} from "./endpoints.js";
 import { MusicItemInfo, SpotifyUserData } from "./userData.js";
 import chalk from "chalk";
 import { SpotifyService } from "./service.js";
+import { Entity } from "@typeagent/agent-sdk";
 
 const debug = registerDebug("typeagent:spotify:search");
+const debugReuse = registerDebug("typeagent:spotify:search:reuse");
 const debugVerbose = registerDebug("typeagent:spotify-verbose:search");
 const debugError = registerDebug("typeagent:spotify:search:error");
 
@@ -81,7 +90,40 @@ async function searchAlbums(
     return result.albums.items;
 }
 
-async function searchArtistSorted(artistName: string, context: IClientContext) {
+async function getArtistFromEntity(
+    artistName: string,
+    context: IClientContext,
+    entityMap: Map<string, Entity>,
+) {
+    const entity = entityMap.get(artistName);
+    if (
+        entity !== undefined &&
+        entity.type.includes("artist") &&
+        entity.uniqueId !== undefined
+    ) {
+        debugReuse(`Reusing artist entity: ${artistName}: ${entity.uniqueId}`);
+        return getArtist(context.service, entity.uniqueId);
+    }
+    return undefined;
+}
+
+async function searchArtistSorted(
+    artistName: string,
+    context: IClientContext,
+    entityMap?: Map<string, Entity>,
+): Promise<SpotifyApi.ArtistObjectFull[] | undefined> {
+    if (entityMap) {
+        const artist = await getArtistFromEntity(
+            artistName,
+            context,
+            entityMap,
+        );
+
+        if (artist !== undefined) {
+            return [artist];
+        }
+    }
+
     const data = await searchArtists(artistName, context);
     if (data && data.artists && data.artists.items.length > 0) {
         // Prefer the known one, then exact match, and then popularity.
@@ -118,11 +160,41 @@ async function getAlbumsByIds(service: SpotifyService, ids: string[]) {
 
     return albums.length === 0 ? undefined : albums;
 }
+
+async function getAlbumFromEntity(
+    albumName: string,
+    context: IClientContext,
+    entityMap: Map<string, Entity>,
+) {
+    const entity = entityMap.get(albumName);
+    if (
+        entity !== undefined &&
+        entity.type.includes("album") &&
+        entity.uniqueId !== undefined
+    ) {
+        debugReuse(`Reusing album entity: ${albumName}: ${entity.uniqueId}`);
+        return getAlbum(context.service, entity.uniqueId);
+    }
+    return undefined;
+}
+
 async function searchAlbumSorted(
     albumName: string,
     artists: SpotifyApi.ArtistObjectFull[] | undefined,
     context: IClientContext,
+    entityMap: Map<string, Entity>,
 ) {
+    const albumFromEntity = await getAlbumFromEntity(
+        albumName,
+        context,
+        entityMap,
+    );
+    if (albumFromEntity) {
+        if (filterByArtists([albumFromEntity], artists) !== undefined) {
+            return [albumFromEntity];
+        }
+    }
+
     const artistNames = artists?.map((a) => a.name);
     const albumsResult = await searchAlbums(albumName, artistNames, context);
     const albums = filterByArtists(albumsResult, artists);
@@ -227,9 +299,10 @@ function compareKnownTracks(
 export async function resolveArtists(
     artistNames: string[],
     context: IClientContext,
+    entityMap?: Map<string, Entity>,
 ): Promise<SpotifyApi.ArtistObjectFull[] | undefined> {
     try {
-        return await findArtists(artistNames, context);
+        return await findArtists(artistNames, context, entityMap);
     } catch {
         return undefined;
     }
@@ -238,9 +311,10 @@ export async function resolveArtists(
 async function findArtists(
     artistNames: string[],
     context: IClientContext,
+    entityMap?: Map<string, Entity>,
 ): Promise<SpotifyApi.ArtistObjectFull[]> {
     const matches = await Promise.all(
-        artistNames.map((a) => searchArtistSorted(a, context)),
+        artistNames.map((a) => searchArtistSorted(a, context, entityMap)),
     );
 
     const artists: SpotifyApi.ArtistObjectFull[] = [];
@@ -259,9 +333,15 @@ async function searchAlbumsWithTrackArtists(
     albumName: string,
     artists: SpotifyApi.ArtistObjectFull[],
     context: IClientContext,
+    entityMap: Map<string, Entity>,
 ) {
     // Try again without artist, as the artist on the album might not match the one in the tracks.
-    let albums = await searchAlbumSorted(albumName, undefined, context);
+    let albums = await searchAlbumSorted(
+        albumName,
+        undefined,
+        context,
+        entityMap,
+    );
     if (albums === undefined) {
         return undefined;
     }
@@ -281,8 +361,9 @@ export async function findArtistTracksWithGenre(
     artistName: string,
     genre: string,
     context: IClientContext,
+    entityMap: Map<string, Entity>,
 ) {
-    const artists = await searchArtistSorted(artistName, context);
+    const artists = await searchArtistSorted(artistName, context, entityMap);
     if (artists === undefined) {
         throw new Error(`Unable to find artist '${artistName}'`);
     }
@@ -314,8 +395,9 @@ export async function findArtistTracksWithGenre(
 export async function findArtistTopTracks(
     artistName: string,
     context: IClientContext,
+    entityMap: Map<string, Entity>,
 ): Promise<SpotifyApi.TrackObjectFull[]> {
-    const artists = await searchArtistSorted(artistName, context);
+    const artists = await searchArtistSorted(artistName, context, entityMap);
     if (artists === undefined) {
         throw new Error(`Unable to find artist '${artistName}'`);
     }
@@ -334,18 +416,29 @@ export async function findAlbums(
     albumName: string,
     artistNames: string[] | undefined,
     context: IClientContext,
+    entityMap: Map<string, Entity>,
 ): Promise<SpotifyApi.AlbumObjectFull[]> {
     let albums: SpotifyApi.AlbumObjectFull[] | undefined;
     if (artistNames !== undefined) {
         // try search for the most likely artist names.
-        const matchedArtists = await findArtists(artistNames, context);
-        albums = await searchAlbumSorted(albumName, matchedArtists, context);
+        const matchedArtists = await findArtists(
+            artistNames,
+            context,
+            entityMap,
+        );
+        albums = await searchAlbumSorted(
+            albumName,
+            matchedArtists,
+            context,
+            entityMap,
+        );
 
         if (albums === undefined) {
             albums = await searchAlbumsWithTrackArtists(
                 albumName,
                 matchedArtists,
                 context,
+                entityMap,
             );
             if (albums === undefined) {
                 throw new Error(
@@ -354,7 +447,12 @@ export async function findAlbums(
             }
         }
     } else {
-        albums = await searchAlbumSorted(albumName, undefined, context);
+        albums = await searchAlbumSorted(
+            albumName,
+            undefined,
+            context,
+            entityMap,
+        );
         if (albums === undefined) {
             throw new Error(`Unable to find album '${albumName}'`);
         }
@@ -476,7 +574,7 @@ function filterByArtists<
     items: T[] | undefined,
     artists: SpotifyApi.ArtistObjectFull[] | undefined,
 ): T[] | undefined {
-    if (items === undefined || artists == undefined) {
+    if (items === undefined || artists === undefined) {
         return items;
     }
     const result = items.filter((track) =>
@@ -487,16 +585,46 @@ function filterByArtists<
     return result.length === 0 ? undefined : result;
 }
 
+async function getTrackFromEntity(
+    trackName: string,
+    context: IClientContext,
+    entityMap: Map<string, Entity>,
+) {
+    const entity = entityMap.get(trackName);
+    if (
+        entity !== undefined &&
+        entity.type.includes("track") &&
+        entity.uniqueId !== undefined
+    ) {
+        debugReuse(`Reusing track entity: ${trackName}: ${entity.uniqueId}`);
+        return getTrack(context.service, entity.uniqueId);
+    }
+    return undefined;
+}
+
 export async function findTracks(
     context: IClientContext,
     trackName: string,
     artistNames: string[] | undefined,
+    entityMap: Map<string, Entity>,
     quantity: number = 0,
 ): Promise<SpotifyApi.TrackObjectFull[]> {
     // try search for the most likely artist names.
     const matchedArtists = artistNames
-        ? await findArtists(artistNames, context)
+        ? await findArtists(artistNames, context, entityMap)
         : undefined;
+
+    const trackFromEntity = await getTrackFromEntity(
+        trackName,
+        context,
+        entityMap,
+    );
+
+    if (trackFromEntity) {
+        if (filterByArtists([trackFromEntity], matchedArtists) !== undefined) {
+            return [trackFromEntity];
+        }
+    }
 
     const matchedArtistNames = matchedArtists?.map((a) => a.name);
     const query: SpotifyQuery = {

--- a/ts/packages/agents/player/src/search.ts
+++ b/ts/packages/agents/player/src/search.ts
@@ -110,7 +110,7 @@ async function getArtistFromEntity(
 async function searchArtistSorted(
     artistName: string,
     context: IClientContext,
-    entityMap?: Map<string, Entity>,
+    entityMap: Map<string, Entity> | undefined,
 ): Promise<SpotifyApi.ArtistObjectFull[] | undefined> {
     if (entityMap) {
         const artist = await getArtistFromEntity(
@@ -164,9 +164,9 @@ async function getAlbumsByIds(service: SpotifyService, ids: string[]) {
 async function getAlbumFromEntity(
     albumName: string,
     context: IClientContext,
-    entityMap: Map<string, Entity>,
+    entityMap: Map<string, Entity> | undefined,
 ) {
-    const entity = entityMap.get(albumName);
+    const entity = entityMap?.get(albumName);
     if (
         entity !== undefined &&
         entity.type.includes("album") &&
@@ -182,7 +182,7 @@ async function searchAlbumSorted(
     albumName: string,
     artists: SpotifyApi.ArtistObjectFull[] | undefined,
     context: IClientContext,
-    entityMap: Map<string, Entity>,
+    entityMap: Map<string, Entity> | undefined,
 ) {
     const albumFromEntity = await getAlbumFromEntity(
         albumName,
@@ -333,7 +333,7 @@ async function searchAlbumsWithTrackArtists(
     albumName: string,
     artists: SpotifyApi.ArtistObjectFull[],
     context: IClientContext,
-    entityMap: Map<string, Entity>,
+    entityMap: Map<string, Entity> | undefined,
 ) {
     // Try again without artist, as the artist on the album might not match the one in the tracks.
     let albums = await searchAlbumSorted(
@@ -361,7 +361,7 @@ export async function findArtistTracksWithGenre(
     artistName: string,
     genre: string,
     context: IClientContext,
-    entityMap: Map<string, Entity>,
+    entityMap: Map<string, Entity> | undefined,
 ) {
     const artists = await searchArtistSorted(artistName, context, entityMap);
     if (artists === undefined) {
@@ -395,7 +395,7 @@ export async function findArtistTracksWithGenre(
 export async function findArtistTopTracks(
     artistName: string,
     context: IClientContext,
-    entityMap: Map<string, Entity>,
+    entityMap: Map<string, Entity> | undefined,
 ): Promise<SpotifyApi.TrackObjectFull[]> {
     const artists = await searchArtistSorted(artistName, context, entityMap);
     if (artists === undefined) {
@@ -416,7 +416,7 @@ export async function findAlbums(
     albumName: string,
     artistNames: string[] | undefined,
     context: IClientContext,
-    entityMap: Map<string, Entity>,
+    entityMap: Map<string, Entity> | undefined,
 ): Promise<SpotifyApi.AlbumObjectFull[]> {
     let albums: SpotifyApi.AlbumObjectFull[] | undefined;
     if (artistNames !== undefined) {
@@ -585,12 +585,12 @@ function filterByArtists<
     return result.length === 0 ? undefined : result;
 }
 
-async function getTrackFromEntity(
+export async function getTrackFromEntity(
     trackName: string,
     context: IClientContext,
-    entityMap: Map<string, Entity>,
+    entityMap: Map<string, Entity> | undefined,
 ) {
-    const entity = entityMap.get(trackName);
+    const entity = entityMap?.get(trackName);
     if (
         entity !== undefined &&
         entity.type.includes("track") &&
@@ -606,7 +606,7 @@ export async function findTracks(
     context: IClientContext,
     trackName: string,
     artistNames: string[] | undefined,
-    entityMap: Map<string, Entity>,
+    entityMap: Map<string, Entity> | undefined,
     quantity: number = 0,
 ): Promise<SpotifyApi.TrackObjectFull[]> {
     // try search for the most likely artist names.

--- a/ts/packages/cache/src/explanation/requestAction.ts
+++ b/ts/packages/cache/src/explanation/requestAction.ts
@@ -3,9 +3,14 @@
 
 import { PromptSection } from "typechat";
 import { AppAction, Entity } from "@typeagent/agent-sdk";
+
+export type PromptEntity = Entity & {
+    sourceAppAgentName: string;
+};
+
 export type HistoryContext = {
     promptSections: PromptSection[];
-    entities: Entity[];
+    entities: PromptEntity[];
     additionalInstructions?: string[] | undefined;
 };
 

--- a/ts/packages/cache/src/index.ts
+++ b/ts/packages/cache/src/index.ts
@@ -8,6 +8,7 @@ export type {
     ParamValueType,
     ParamObjectType,
     HistoryContext,
+    PromptEntity,
 } from "./explanation/requestAction.js";
 
 export type { ConstructionStore } from "./cache/store.js";

--- a/ts/packages/cli/src/commands/data/regenerate.ts
+++ b/ts/packages/cli/src/commands/data/regenerate.ts
@@ -17,17 +17,18 @@ import {
     createActionConfigProvider,
     createSchemaInfoProvider,
     getInstanceDir,
+    getAppAgentName,
 } from "agent-dispatcher/internal";
 import {
     Actions,
     getDefaultExplainerName,
     HistoryContext,
     printImportConstructionResult,
+    PromptEntity,
     RequestAction,
 } from "agent-cache";
 import { createLimiter, getElapsedString } from "common-utils";
 import { getChatModelMaxConcurrency, getChatModelNames } from "aiclient";
-import { Entity } from "@typeagent/agent-sdk";
 import {
     getDefaultAppAgentProviders,
     getDefaultConstructionProvider,
@@ -38,8 +39,8 @@ const provider = await createActionConfigProvider(
 );
 const schemaInfoProvider = createSchemaInfoProvider(provider);
 
-function toEntities(actions: Actions): Entity[] {
-    const entities: Entity[] = [];
+function toEntities(actions: Actions): PromptEntity[] {
+    const entities: PromptEntity[] = [];
     for (const action of actions) {
         if (action.parameters === undefined) {
             continue;
@@ -49,6 +50,7 @@ function toEntities(actions: Actions): Entity[] {
                 entities.push({
                     name: value,
                     type: [key],
+                    sourceAppAgentName: getAppAgentName(action.translatorName),
                 });
             }
         }

--- a/ts/packages/dispatcher/src/context/chatHistoryPrompt.ts
+++ b/ts/packages/dispatcher/src/context/chatHistoryPrompt.ts
@@ -24,7 +24,6 @@ export function createTypeAgentRequestPrompt(
     if (context && history !== undefined) {
         promptSections = history.promptSections;
         entities = history.entities;
-
         if (entities.length > 0) {
             for (let i = 0; i < entities.length; ++i) {
                 const entity = entities[i];

--- a/ts/packages/dispatcher/src/execute/actionHandlers.ts
+++ b/ts/packages/dispatcher/src/execute/actionHandlers.ts
@@ -488,14 +488,14 @@ function getStringValues(params: any) {
     const pending: object[] = [params];
     while (pending.length > 0) {
         const current = pending.pop()!;
-        for (const value of Object.values(current)) {
-            if (typeof value === "object") {
+        if (typeof current === "object") {
+            for (const value of Object.values(current)) {
                 pending.push(value);
-            } else if (typeof value === "function") {
-                throw new Error("Function is not supported as an action value");
-            } else if (typeof value === "string") {
-                values.push(value);
             }
+        } else if (typeof current === "function") {
+            throw new Error("Function is not supported as an action value");
+        } else if (typeof current === "string") {
+            values.push(current);
         }
     }
     return values;

--- a/ts/packages/dispatcher/src/execute/actionHandlers.ts
+++ b/ts/packages/dispatcher/src/execute/actionHandlers.ts
@@ -526,7 +526,7 @@ function getActionEntityMap(
             }
         }
     }
-    return entityMap;
+    return entityMap.size === 0 ? undefined : entityMap;
 }
 
 export async function executeActions(

--- a/ts/packages/dispatcher/src/execute/actionHandlers.ts
+++ b/ts/packages/dispatcher/src/execute/actionHandlers.ts
@@ -483,12 +483,12 @@ async function canExecute(
     return true;
 }
 
-function getStringValues(params: any) {
+function getStringValues(params: unknown) {
     const values: string[] = [];
-    const pending: object[] = [params];
+    const pending: unknown[] = [params];
     while (pending.length > 0) {
         const current = pending.pop()!;
-        if (typeof current === "object") {
+        if (typeof current === "object" && current !== null) {
             for (const value of Object.values(current)) {
                 pending.push(value);
             }

--- a/ts/packages/dispatcher/src/internal.ts
+++ b/ts/packages/dispatcher/src/internal.ts
@@ -22,7 +22,10 @@ export { getAssistantSelectionSchemas } from "./translation/unknownSwitcher.js";
 export { getActionSchema } from "./translation/actionSchemaFileCache.js";
 export { getFullSchemaText } from "./translation/agentTranslators.js";
 
-export { loadAgentJsonTranslator } from "./translation/agentTranslators.js";
+export {
+    loadAgentJsonTranslator,
+    getAppAgentName,
+} from "./translation/agentTranslators.js";
 export { createSchemaInfoProvider } from "./translation/actionSchemaFileCache.js";
 export {
     createActionConfigProvider,


### PR DESCRIPTION
- If the agent returns entities with uniqueId, and the same "name" is used in the following action, we will put the entity in the EntityMap.   Only entity with uniqueId from the same agent will be populated.
- For the result id reference, change the entity map to include only result that are from the same agent and referenced in the action.
- Change how we determine uniqueness of entities based on name and type only.  Attach a `v<num>` suffix to entities that have same name and type to distinguish each other.  Therefore, entity with the same name and type but different uniqueId will have different suffix.  
  -  LLM may change lower/upper case or add/remove diacritical.  When lookup the action result with the entity, use a normalized form that remove those difference for look up.
  -  Future investigate of whether we need to do more to associate the entities with the original conversation so that the LLM will know about the context and make better choices
- Player agent now populate the entity with id and make use of them when returned.

