### PR TITLE
Remove Action and Actions class and use FullAction and the new ExecutableActions.

### DIFF
--- a/ts/packages/agentRpc/src/client.ts
+++ b/ts/packages/agentRpc/src/client.ts
@@ -15,6 +15,7 @@ import {
     ClientAction,
     AppAgentManifest,
     Entity,
+    AppAction,
 } from "@typeagent/agent-sdk";
 import {
     AgentCallFunctions,
@@ -311,7 +312,7 @@ export async function createAgentRpcClient(
             });
         },
         executeAction(
-            action: any,
+            action: AppAction,
             context: ActionContext<ShimContext>,
             entityMap: Map<string, Entity>,
         ) {
@@ -324,7 +325,7 @@ export async function createAgentRpcClient(
             );
         },
         validateWildcardMatch(
-            action: any,
+            action: AppAction,
             context: SessionContext<ShimContext>,
         ) {
             return rpc.invoke("validateWildcardMatch", {

--- a/ts/packages/agentRpc/src/server.ts
+++ b/ts/packages/agentRpc/src/server.ts
@@ -26,26 +26,10 @@ import {
     AgentContextInvokeFunctions,
     AgentInvokeFunctions,
     ContextParams,
-    JSONAction,
 } from "./types.js";
 import { createRpc } from "./rpc.js";
 import { ChannelProvider } from "./common.js";
 import { createLimiter } from "common-utils";
-
-// TODO: Duplicate code from agent-cache
-function parseActionNameParts(fullActionName: string) {
-    const parts = fullActionName.split(".");
-    const translatorName = parts.slice(0, -1).join(".");
-    const actionName = parts.at(-1)!;
-    return { translatorName, actionName };
-}
-
-function fromJSONAction(action: JSONAction): AppAction {
-    return {
-        ...parseActionNameParts(action.fullActionName),
-        parameters: action.parameters,
-    };
-}
 
 export function createAgentRpcServer(
     name: string,
@@ -80,7 +64,7 @@ export function createAgentRpcServer(
         },
         async executeAction(
             param: Partial<ActionContextParams> & {
-                action: JSONAction;
+                action: AppAction;
                 entityMap: [string, Entity][];
             },
         ): Promise<any> {
@@ -88,10 +72,7 @@ export function createAgentRpcServer(
                 throw new Error("Invalid invocation of executeAction");
             }
             return agent.executeAction(
-                // REVIEW: blah!
-                param.action.fullActionName !== undefined
-                    ? fromJSONAction(param.action)
-                    : (param.action as unknown as AppAction),
+                param.action,
                 getActionContextShim(param),
                 new Map(param.entityMap),
             );
@@ -101,7 +82,7 @@ export function createAgentRpcServer(
                 throw new Error("Invalid invocation of validateWildcardMatch");
             }
             return agent.validateWildcardMatch(
-                fromJSONAction(param.action),
+                param.action,
                 getSessionContextShim(param),
             );
         },

--- a/ts/packages/agentRpc/src/types.ts
+++ b/ts/packages/agentRpc/src/types.ts
@@ -19,12 +19,6 @@ import {
     TemplateSchema,
 } from "@typeagent/agent-sdk";
 
-// TODO: Duplicate code from agent-cache
-export interface JSONAction {
-    fullActionName: string;
-    parameters?: Record<string, unknown> | undefined;
-}
-
 export type AgentContextCallFunctions = {
     notify(param: {
         contextId: number;
@@ -122,12 +116,12 @@ export type AgentInvokeFunctions = {
     ) => Promise<void>;
     executeAction: (
         param: Partial<ActionContextParams> & {
-            action: JSONAction;
+            action: AppAction;
             entityMap: [string, Entity][];
         },
     ) => Promise<ActionResult | undefined>;
     validateWildcardMatch: (
-        param: Partial<ContextParams> & { action: JSONAction },
+        param: Partial<ContextParams> & { action: AppAction },
     ) => Promise<boolean>;
     getDynamicDisplay: (
         param: Partial<ContextParams> & {

--- a/ts/packages/cache/src/cache/cache.ts
+++ b/ts/packages/cache/src/cache/cache.ts
@@ -4,7 +4,10 @@
 import { DeepPartialUndefined } from "common-utils";
 import * as Telemetry from "telemetry";
 import { ExplanationData } from "../explanation/explanationData.js";
-import { RequestAction } from "../explanation/requestAction.js";
+import {
+    getTranslationNamesForActions,
+    RequestAction,
+} from "../explanation/requestAction.js";
 import {
     SchemaInfoProvider,
     doCacheAction,
@@ -169,7 +172,7 @@ export class AgentCache {
                     message = `Explainer '${this.explainerName}' doesn't support constructions.`;
                 } else {
                     const namespaceKeys = this.getNamespaceKeys(
-                        actions.translatorNames,
+                        getTranslationNamesForActions(actions),
                     );
                     const result = await store.addConstruction(
                         namespaceKeys,

--- a/ts/packages/cache/src/cache/cache.ts
+++ b/ts/packages/cache/src/cache/cache.ts
@@ -5,6 +5,7 @@ import { DeepPartialUndefined } from "common-utils";
 import * as Telemetry from "telemetry";
 import { ExplanationData } from "../explanation/explanationData.js";
 import {
+    getFullActionName,
     getTranslationNamesForActions,
     RequestAction,
 } from "../explanation/requestAction.js";
@@ -134,7 +135,7 @@ export class AgentCache {
 
                     if (!cacheAction) {
                         return getFailedResult(
-                            `Caching disabled in schema config for action '${action.fullActionName}'`,
+                            `Caching disabled in schema config for action '${getFullActionName(action)}'`,
                         );
                     }
                 }

--- a/ts/packages/cache/src/cache/explainWorkQueue.ts
+++ b/ts/packages/cache/src/cache/explainWorkQueue.ts
@@ -3,6 +3,7 @@
 
 import { QueueObject, queue } from "async";
 import {
+    getTranslationNamesForActions,
     normalizeParamString,
     RequestAction,
 } from "../explanation/requestAction.js";
@@ -111,7 +112,7 @@ export class ExplainWorkQueue {
             const startTime = performance.now();
             const actions = requestAction.actions;
             const explainer = this.getExplainerForTranslator(
-                actions.translatorNames,
+                getTranslationNamesForActions(actions),
                 model,
             );
             const explainerConfig = {

--- a/ts/packages/cache/src/cache/explainWorkQueue.ts
+++ b/ts/packages/cache/src/cache/explainWorkQueue.ts
@@ -25,7 +25,7 @@ function checkExplainableValues(
     const normalizedRequest = normalizeParamString(requestAction.request);
     const pending: unknown[] = [];
 
-    for (const action of requestAction.actions) {
+    for (const { action } of requestAction.actions) {
         pending.push(action.parameters);
     }
 

--- a/ts/packages/cache/src/constructions/constructions.ts
+++ b/ts/packages/cache/src/constructions/constructions.ts
@@ -5,7 +5,7 @@ import {
     RequestAction,
     ParamValueType,
     HistoryContext,
-    actionsFromJson,
+    fromJsonActions,
 } from "../explanation/requestAction.js";
 import { MatchConfig, matchParts } from "./constructionMatch.js";
 import {
@@ -126,7 +126,7 @@ export class Construction {
                 construction: this,
                 match: new RequestAction(
                     request,
-                    actionsFromJson(actionProps),
+                    fromJsonActions(actionProps),
                     config.history,
                 ),
                 conflictValues: matchedValues.conflictValues,

--- a/ts/packages/cache/src/constructions/constructions.ts
+++ b/ts/packages/cache/src/constructions/constructions.ts
@@ -4,8 +4,8 @@
 import {
     RequestAction,
     ParamValueType,
-    Actions,
     HistoryContext,
+    actionsFromJson,
 } from "../explanation/requestAction.js";
 import { MatchConfig, matchParts } from "./constructionMatch.js";
 import {
@@ -126,7 +126,7 @@ export class Construction {
                 construction: this,
                 match: new RequestAction(
                     request,
-                    Actions.fromJSON(actionProps),
+                    actionsFromJson(actionProps),
                     config.history,
                 ),
                 conflictValues: matchedValues.conflictValues,

--- a/ts/packages/cache/src/constructions/importConstructions.ts
+++ b/ts/packages/cache/src/constructions/importConstructions.ts
@@ -3,7 +3,11 @@
 
 import { SchemaInfoProvider } from "../explanation/schemaInfoProvider.js";
 import { Construction } from "./constructions.js";
-import { Actions, RequestAction } from "../explanation/requestAction.js";
+import {
+    actionsFromJson,
+    getTranslationNamesForActions,
+    RequestAction,
+} from "../explanation/requestAction.js";
 import {
     ConstructionFactory,
     GenericExplainer,
@@ -62,7 +66,7 @@ function createConstructions(
     for (const entry of data.entries) {
         const requestAction = new RequestAction(
             entry.request,
-            Actions.fromJSON(entry.action),
+            actionsFromJson(entry.action),
         );
 
         try {
@@ -76,7 +80,7 @@ function createConstructions(
             }
             const explanation = entry.explanation;
             const namespaceKeys = getSchemaNamespaceKeys(
-                actions.translatorNames,
+                getTranslationNamesForActions(actions),
                 schemaInfoProvider,
             );
             const construction = createConstruction(

--- a/ts/packages/cache/src/constructions/importConstructions.ts
+++ b/ts/packages/cache/src/constructions/importConstructions.ts
@@ -4,7 +4,7 @@
 import { SchemaInfoProvider } from "../explanation/schemaInfoProvider.js";
 import { Construction } from "./constructions.js";
 import {
-    actionsFromJson,
+    fromJsonActions,
     getTranslationNamesForActions,
     RequestAction,
 } from "../explanation/requestAction.js";
@@ -66,12 +66,12 @@ function createConstructions(
     for (const entry of data.entries) {
         const requestAction = new RequestAction(
             entry.request,
-            actionsFromJson(entry.action),
+            fromJsonActions(entry.action),
         );
 
         try {
             const actions = requestAction.actions;
-            for (const action of actions) {
+            for (const { action } of actions) {
                 if (!dataSchemaNames.has(action.translatorName)) {
                     throw new Error(
                         `Schema name '${action.translatorName}' not found in data header`,

--- a/ts/packages/cache/src/explanation/explainer.ts
+++ b/ts/packages/cache/src/explanation/explainer.ts
@@ -1,7 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { RequestAction, HistoryContext } from "./requestAction.js";
+import {
+    RequestAction,
+    HistoryContext,
+    actionsToJson,
+} from "./requestAction.js";
 import {
     GenericExplanationResult,
     ConstructionFactory,
@@ -34,7 +38,7 @@ function getContextPart(history?: HistoryContext) {
 
 export function getActionDescription(requestAction: RequestAction) {
     const actions = requestAction.actions;
-    const leafPropertyNames = getLeafNames(actions.toJSON());
+    const leafPropertyNames = getLeafNames(actionsToJson(actions));
     let propertyPart = "";
     if (leafPropertyNames.length > 0) {
         propertyPart = `The property name${

--- a/ts/packages/cache/src/explanation/explainer.ts
+++ b/ts/packages/cache/src/explanation/explainer.ts
@@ -4,7 +4,7 @@
 import {
     RequestAction,
     HistoryContext,
-    actionsToJson,
+    toJsonActions,
 } from "./requestAction.js";
 import {
     GenericExplanationResult,
@@ -38,7 +38,7 @@ function getContextPart(history?: HistoryContext) {
 
 export function getActionDescription(requestAction: RequestAction) {
     const actions = requestAction.actions;
-    const leafPropertyNames = getLeafNames(actionsToJson(actions));
+    const leafPropertyNames = getLeafNames(toJsonActions(actions));
     let propertyPart = "";
     if (leafPropertyNames.length > 0) {
         propertyPart = `The property name${

--- a/ts/packages/cache/src/explanation/requestAction.ts
+++ b/ts/packages/cache/src/explanation/requestAction.ts
@@ -64,155 +64,46 @@ export interface FullAction extends AppAction {
 export interface JSONAction {
     fullActionName: string;
     parameters?: ParamObjectType;
+    resultEntityId?: string;
 }
 
-function parseActionNameParts(fullActionName: string) {
+export interface ExecutableAction {
+    action: FullAction;
+    resultEntityId?: string;
+}
+
+export function createExecutableAction(
+    translatorName: string,
+    actionName: string,
+    parameters?: ParamObjectType,
+    resultEntityId?: string,
+): ExecutableAction {
+    const action: FullAction = {
+        translatorName,
+        actionName,
+    };
+    if (parameters !== undefined) {
+        action.parameters = parameters;
+    }
+
+    const executableAction: ExecutableAction = {
+        action,
+    };
+    if (resultEntityId !== undefined) {
+        executableAction.resultEntityId = resultEntityId;
+    }
+    return executableAction;
+}
+
+const format =
+    "'<request> => translator.action(<parameters>)' or '<request> => [ translator.action1(<parameters1>), translator.action2(<parameters2>), ... ]'";
+
+function parseFullActionNameParts(fullActionName: string) {
     const parts = fullActionName.split(".");
     const translatorName = parts.slice(0, -1).join(".");
     const actionName = parts.at(-1)!;
     return { translatorName, actionName };
 }
-
-export class Action {
-    constructor(
-        public readonly translatorName: string,
-        public readonly actionName: string,
-        public readonly parameters: ParamObjectType | undefined,
-        public readonly resultEntityId?: string,
-    ) {}
-
-    public get fullActionName() {
-        return `${this.translatorNameString}.${this.actionName}`;
-    }
-
-    public get translatorNameString(): string {
-        return this.translatorName;
-    }
-    public toString() {
-        return `${this.fullActionName}(${this.parameters ? JSON.stringify(this.parameters) : ""})`;
-    }
-    public toJSON(): JSONAction {
-        const result: JSONAction = { fullActionName: this.fullActionName };
-        if (this.parameters) {
-            result.parameters = this.parameters;
-        }
-        return result;
-    }
-
-    public static fromJSONObject(actionJSON: JSONAction): Action {
-        const { translatorName, actionName } = parseActionNameParts(
-            actionJSON.fullActionName,
-        );
-        return new Action(translatorName, actionName, actionJSON.parameters);
-    }
-
-    public toFullAction(): FullAction {
-        const result: FullAction = {
-            translatorName: this.translatorName,
-            actionName: this.actionName,
-        };
-        if (this.parameters) {
-            result.parameters = this.parameters;
-        }
-        return result;
-    }
-    public static fromFullAction(fullAction: FullAction): Action {
-        return new Action(
-            fullAction.translatorName,
-            fullAction.actionName,
-            fullAction.parameters,
-        );
-    }
-}
-
-/*
-export class Actions {
-    constructor(private readonly actions: Action | Action[]) {}
-
-    public get data() {
-        return this.actions;
-    }
-    public get action() {
-        return Array.isArray(this.actions) ? undefined : this.actions;
-    }
-
-    // Sorted array of unique translator names
-    public get translatorNames(): string[] {
-        return Array.isArray(this.actions)
-            ? Array.from(
-                  new Set(
-                      this.actions.map((a) => a.translatorNameString),
-                  ).values(),
-              ).sort() // sort it so that it is stable.
-            : [this.actions.translatorNameString];
-    }
-
-    public get(index: number) {
-        return Array.isArray(this.actions)
-            ? this.actions[index]
-            : index === 0
-              ? this.action
-              : undefined;
-    }
-    public [Symbol.iterator](): Iterator<Action> {
-        if (Array.isArray(this.actions)) {
-            return this.actions[Symbol.iterator]();
-        }
-        let action: Action | undefined = this.actions;
-        return {
-            next() {
-                if (action !== undefined) {
-                    const ret = { value: action, done: false };
-                    action = undefined;
-                    return ret;
-                }
-                return { value: undefined, done: true };
-            },
-        };
-    }
-
-    public static fromJSON(actionJSON: JSONAction | JSONAction[]): Actions {
-        return new Actions(
-            Array.isArray(actionJSON)
-                ? actionJSON.map((a) => Action.fromJSONObject(a))
-                : Action.fromJSONObject(actionJSON),
-        );
-    }
-
-    public toJSON() {
-        return Array.isArray(this.actions)
-            ? this.actions.map((a) => a.toJSON())
-            : this.actions.toJSON();
-    }
-
-    public toFullActions(): FullAction[] {
-        return Array.isArray(this.actions)
-            ? this.actions.map((a) => a.toFullAction())
-            : [this.actions.toFullAction()];
-    }
-
-    public static fromFullActions(fullAction: FullAction[]): Actions {
-        return new Actions(
-            fullAction.length === 1
-                ? Action.fromFullAction(fullAction[0])
-                : fullAction.map((a) => Action.fromFullAction(a)),
-        );
-    }
-    public toString() {
-        return Array.isArray(this.actions)
-            ? `[${this.actions.join(",")}]`
-            : this.actions.toString();
-    }
-    public static fromString(actions: string) {
-        return new Actions(
-            actions[0] === "[" ? parseActions(actions) : parseAction(actions),
-        );
-    }
-}
-*/
-
-const format =
-    "'<request> => translator.action(<parameters>)' or '<request> => [ translator.action1(<parameters1>), translator.action2(<parameters2>), ... ]'";
 
 function parseAction(action: string, index: number = -1) {
     const leftParan = action.indexOf("(");
@@ -222,7 +113,8 @@ function parseAction(action: string, index: number = -1) {
         );
     }
     const functionName = action.substring(0, leftParan);
-    const { translatorName, actionName } = parseActionNameParts(functionName);
+    const { translatorName, actionName } =
+        parseFullActionNameParts(functionName);
     if (!actionName) {
         throw new Error(
             `${index !== -1 ? `Action ${index}: ` : ""}Unable to parse action name from '${functionName}'. Input must be in the form of ${format}`,
@@ -244,14 +136,14 @@ function parseAction(action: string, index: number = -1) {
             );
         }
     }
-    return new Action(translatorName, actionName, parameters);
+    return createExecutableAction(translatorName, actionName, parameters);
 }
 
 function parseActions(actionStr: string) {
     if (actionStr[actionStr.length - 1] !== "]") {
         `Missing terminating ']'. Input must be in the form of ${format}`;
     }
-    const actions: Action[] = [];
+    const actions: ExecutableAction[] = [];
     // Remove the brackets
     let curr = actionStr.substring(1, actionStr.length - 1);
 
@@ -279,39 +171,76 @@ function parseActions(actionStr: string) {
     return actions;
 }
 
-function parseActionsString(actions: string): Action[] {
+export function getFullActionName(action: ExecutableAction) {
+    return `${action.action.translatorName}.${action.action.actionName}`;
+}
+
+function parseExecutableActionsString(actions: string): ExecutableAction[] {
     return actions[0] === "[" ? parseActions(actions) : [parseAction(actions)];
 }
 
-function actionsToString(actions: Action[]): string {
-    return actions.length !== 1
-        ? `[${actions.join(",")}]`
-        : actions[0].toString();
+function executableActionToString(action: ExecutableAction): string {
+    return `${getFullActionName(action)}(${action.action.parameters ? JSON.stringify(action.action.parameters) : ""})`;
 }
 
-export function actionsFromJson(actions: JSONAction | JSONAction[]): Action[] {
+function executableActionsToString(actions: ExecutableAction[]): string {
+    return actions.length !== 1
+        ? `[${actions.map(executableActionToString).join(",")}]`
+        : executableActionToString(actions[0]);
+}
+
+function fromJsonAction(actionJSON: JSONAction) {
+    const { translatorName, actionName } = parseFullActionNameParts(
+        actionJSON.fullActionName,
+    );
+    return createExecutableAction(
+        translatorName,
+        actionName,
+        actionJSON.parameters,
+        actionJSON.resultEntityId,
+    );
+}
+
+export function fromJsonActions(
+    actions: JSONAction | JSONAction[],
+): ExecutableAction[] {
     return Array.isArray(actions)
-        ? actions.map((a) => Action.fromJSONObject(a))
-        : [Action.fromJSONObject(actions)];
+        ? actions.map((a) => fromJsonAction(a))
+        : [fromJsonAction(actions)];
 }
 
-export function actionsToJson(actions: Action[]): JSONAction | JSONAction[] {
+function toJsonAction(action: ExecutableAction): JSONAction {
+    const result: JSONAction = { fullActionName: getFullActionName(action) };
+    if (action.action.parameters) {
+        result.parameters = action.action.parameters;
+    }
+    if (action.resultEntityId) {
+        result.resultEntityId = action.resultEntityId;
+    }
+    return result;
+}
+
+export function toJsonActions(
+    actions: ExecutableAction[],
+): JSONAction | JSONAction[] {
     return actions.length !== 1
-        ? actions.map((a) => a.toJSON())
-        : actions[0].toJSON();
+        ? actions.map(toJsonAction)
+        : toJsonAction(actions[0]);
 }
 
-export function actionsFromFullActions(fullActions: FullAction[]): Action[] {
-    return fullActions.map((a) => Action.fromFullAction(a));
+export function toExecutableActions(actions: FullAction[]): ExecutableAction[] {
+    return actions.map((action) => ({ action }));
 }
 
-export function actionsToFullActions(actions: Action[]): FullAction[] {
-    return actions.map((a) => a.toFullAction());
+export function toFullActions(actions: ExecutableAction[]): FullAction[] {
+    return actions.map((a) => a.action);
 }
 
-export function getTranslationNamesForActions(actions: Action[]): string[] {
+export function getTranslationNamesForActions(
+    actions: ExecutableAction[],
+): string[] {
     return Array.from(
-        new Set(actions.map((a) => a.translatorNameString)),
+        new Set(actions.map((a) => a.action.translatorName)),
     ).sort();
 }
 
@@ -320,12 +249,12 @@ export class RequestAction {
 
     constructor(
         public readonly request: string,
-        public readonly actions: Action[],
+        public readonly actions: ExecutableAction[],
         public readonly history?: HistoryContext,
     ) {}
 
     public toString() {
-        return `${this.request}${RequestAction.Separator}${actionsToString(this.actions)}`;
+        return `${this.request}${RequestAction.Separator}${executableActionsToString(this.actions)}`;
     }
 
     public toPromptString() {
@@ -352,12 +281,15 @@ export class RequestAction {
             .substring(separator + RequestAction.Separator.length)
             .trim();
 
-        return new RequestAction(request, parseActionsString(actions));
+        return new RequestAction(
+            request,
+            parseExecutableActionsString(actions),
+        );
     }
 
     public static create(
         request: string,
-        actions: Action | Action[],
+        actions: ExecutableAction | ExecutableAction[],
         history?: HistoryContext,
     ) {
         return new RequestAction(

--- a/ts/packages/cache/src/explanation/schemaInfoProvider.ts
+++ b/ts/packages/cache/src/explanation/schemaInfoProvider.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import { ParamSpec } from "action-schema";
-import { Action } from "./requestAction.js";
+import { ExecutableAction, FullAction } from "./requestAction.js";
 
 export type ParamRange = {
     min: string;
@@ -23,17 +23,17 @@ export function getParamRange(spec: ParamSpec): ParamRange | undefined {
 }
 
 export function doCacheAction(
-    action: Action,
+    action: ExecutableAction,
     schemaInfoProvider?: SchemaInfoProvider,
 ) {
     return schemaInfoProvider?.getActionCacheEnabled(
-        action.translatorName,
-        action.actionName,
+        action.action.translatorName,
+        action.action.actionName,
     );
 }
 
 export function getParamSpec(
-    action: Action,
+    action: FullAction,
     paramName: string,
     schemaInfoProvider?: SchemaInfoProvider,
 ): ParamSpec | undefined {

--- a/ts/packages/cache/src/explanation/v5/alternativesExplanationV5.ts
+++ b/ts/packages/cache/src/explanation/v5/alternativesExplanationV5.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import { createJsonTranslatorFromFile } from "common-utils";
-import { actionsToJson, RequestAction } from "../requestAction.js";
+import { toJsonActions, RequestAction } from "../requestAction.js";
 import { TypeChatAgent } from "../typeChatAgent.js";
 import {
     checkActionProperty,
@@ -44,7 +44,7 @@ function createInstructions([
         }
     }
 
-    const actionProps = actionsToJson(requestAction.actions);
+    const actionProps = toJsonActions(requestAction.actions);
     const propertySubPhraseDescription = Array.from(
         propertySubPhraseMap.entries(),
     ).map(([propertyName, subPhrases]) => {
@@ -120,7 +120,7 @@ export function validateAlternativesExplanationV5(
         }
     }
 
-    const actionProps = actionsToJson(requestAction.actions);
+    const actionProps = toJsonActions(requestAction.actions);
     // Validate parameters
     const corrections: string[] = [];
     const propertyNameSet = new Set<string>();

--- a/ts/packages/cache/src/explanation/v5/alternativesExplanationV5.ts
+++ b/ts/packages/cache/src/explanation/v5/alternativesExplanationV5.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import { createJsonTranslatorFromFile } from "common-utils";
-import { RequestAction } from "../requestAction.js";
+import { actionsToJson, RequestAction } from "../requestAction.js";
 import { TypeChatAgent } from "../typeChatAgent.js";
 import {
     checkActionProperty,
@@ -44,7 +44,7 @@ function createInstructions([
         }
     }
 
-    const actionProps = requestAction.actions.toJSON();
+    const actionProps = actionsToJson(requestAction.actions);
     const propertySubPhraseDescription = Array.from(
         propertySubPhraseMap.entries(),
     ).map(([propertyName, subPhrases]) => {
@@ -120,7 +120,7 @@ export function validateAlternativesExplanationV5(
         }
     }
 
-    const actionProps = requestAction.actions.toJSON();
+    const actionProps = actionsToJson(requestAction.actions);
     // Validate parameters
     const corrections: string[] = [];
     const propertyNameSet = new Set<string>();

--- a/ts/packages/cache/src/explanation/v5/explanationV5.ts
+++ b/ts/packages/cache/src/explanation/v5/explanationV5.ts
@@ -30,7 +30,6 @@ import {
 } from "./propertyExplanationSchemaV5WithContext.js";
 import {
     Action,
-    Actions,
     normalizeParamString,
     RequestAction,
 } from "../requestAction.js";
@@ -231,7 +230,7 @@ interface ParameterVariationResult {
 
 function getPropertyInfo(
     propertyName: string,
-    actions: Actions,
+    actions: Action[],
 ): { action: Action; parameterName?: string; actionIndex: number | undefined } {
     const parts = propertyName.split(".");
     let firstPart = parts.shift();
@@ -239,13 +238,13 @@ function getPropertyInfo(
         throw new Error(`Invalid property name '${propertyName}'`);
     }
 
-    let action = actions.action;
+    let action: Action | undefined;
     let actionIndex: number | undefined;
-    if (action === undefined) {
+    if (actions.length > 1) {
         // Multiple actions
         actionIndex = parseInt(firstPart);
         if (!isNaN(actionIndex) && actionIndex.toString() === firstPart) {
-            action = actions.get(actionIndex);
+            action = actions[actionIndex];
         }
         if (action === undefined) {
             throw new Error(
@@ -253,6 +252,8 @@ function getPropertyInfo(
             );
         }
         firstPart = parts.shift();
+    } else {
+        action = actions[0];
     }
     if (firstPart === "fullActionName" && parts.length === 0) {
         return { action, actionIndex };
@@ -265,7 +266,7 @@ function getPropertyInfo(
 
 function getPropertySpec(
     propertyName: string,
-    actions: Actions,
+    actions: Action[],
     schemaInfoProvider?: SchemaInfoProvider,
 ): ParamSpec | undefined {
     const { action, parameterName } = getPropertyInfo(propertyName, actions);
@@ -278,7 +279,7 @@ function getPropertySpec(
 
 function getPropertyTransformInfo(
     propertyName: string,
-    actions: Actions,
+    actions: Action[],
     schemaInfoProvider?: SchemaInfoProvider,
 ): TransformInfo {
     const { action, parameterName, actionIndex } = getPropertyInfo(
@@ -418,7 +419,7 @@ function collectAltParamMatches(
 
 function getParserForPropertyValue(
     propertyValue: PropertyValue,
-    actions: Actions,
+    actions: Action[],
     schemaInfoProvider?: SchemaInfoProvider,
 ) {
     if (propertyValue.propertySubPhrases.length !== 1) {

--- a/ts/packages/cache/src/explanation/v5/propertyExplainationV5.ts
+++ b/ts/packages/cache/src/explanation/v5/propertyExplainationV5.ts
@@ -11,7 +11,7 @@ import {
 } from "./propertyExplanationSchemaV5WithContext.js";
 import { getPackageFilePath } from "../../utils/getPackageFilePath.js";
 import {
-    actionsToJson,
+    toJsonActions,
     normalizeParamString,
     RequestAction,
 } from "../requestAction.js";
@@ -85,7 +85,7 @@ function validatePropertyExplanation(
 ): string[] | undefined {
     const corrections: string[] = [];
     const propertyNameSet = new Set<string>();
-    const actionProps = actionsToJson(requestAction.actions);
+    const actionProps = toJsonActions(requestAction.actions);
     for (const prop of actionExplanation.properties) {
         if (propertyNameSet.has(prop.name)) {
             corrections.push(

--- a/ts/packages/cache/src/explanation/v5/propertyExplainationV5.ts
+++ b/ts/packages/cache/src/explanation/v5/propertyExplainationV5.ts
@@ -10,7 +10,11 @@ import {
     EntityProperty,
 } from "./propertyExplanationSchemaV5WithContext.js";
 import { getPackageFilePath } from "../../utils/getPackageFilePath.js";
-import { normalizeParamString, RequestAction } from "../requestAction.js";
+import {
+    actionsToJson,
+    normalizeParamString,
+    RequestAction,
+} from "../requestAction.js";
 import {
     getActionDescription,
     getExactStringRequirementMessage,
@@ -81,7 +85,7 @@ function validatePropertyExplanation(
 ): string[] | undefined {
     const corrections: string[] = [];
     const propertyNameSet = new Set<string>();
-    const actionProps = requestAction.actions.toJSON();
+    const actionProps = actionsToJson(requestAction.actions);
     for (const prop of actionExplanation.properties) {
         if (propertyNameSet.has(prop.name)) {
             corrections.push(

--- a/ts/packages/cache/src/explanation/v5/subPhraseExplanationV5.ts
+++ b/ts/packages/cache/src/explanation/v5/subPhraseExplanationV5.ts
@@ -2,7 +2,11 @@
 // Licensed under the MIT License.
 
 import { PromptSection } from "typechat";
-import { normalizeParamString, RequestAction } from "../requestAction.js";
+import {
+    actionsToJson,
+    normalizeParamString,
+    RequestAction,
+} from "../requestAction.js";
 import { PropertyExplanation } from "./propertyExplanationSchemaV5WithContext.js";
 import { form } from "./explanationV5.js";
 import {
@@ -94,7 +98,7 @@ function validateSubPhraseExplanationV5(
     // Verify parameter names
 
     const corrections: string[] = result ? [result] : [];
-    const actionProps = requestAction.actions.toJSON();
+    const actionProps = actionsToJson(requestAction.actions);
     const propertyToSubPhrase = new Map<string, SubPhrase[]>();
     for (const phrase of explanation.subPhrases) {
         // check if the parameter name is valid

--- a/ts/packages/cache/src/explanation/v5/subPhraseExplanationV5.ts
+++ b/ts/packages/cache/src/explanation/v5/subPhraseExplanationV5.ts
@@ -3,7 +3,7 @@
 
 import { PromptSection } from "typechat";
 import {
-    actionsToJson,
+    toJsonActions,
     normalizeParamString,
     RequestAction,
 } from "../requestAction.js";
@@ -98,7 +98,7 @@ function validateSubPhraseExplanationV5(
     // Verify parameter names
 
     const corrections: string[] = result ? [result] : [];
-    const actionProps = actionsToJson(requestAction.actions);
+    const actionProps = toJsonActions(requestAction.actions);
     const propertyToSubPhrase = new Map<string, SubPhrase[]>();
     for (const phrase of explanation.subPhrases) {
         // check if the parameter name is valid

--- a/ts/packages/cache/src/index.ts
+++ b/ts/packages/cache/src/index.ts
@@ -33,16 +33,18 @@ export type { SchemaInfoProvider } from "./explanation/schemaInfoProvider.js";
 
 // Functionalities
 export {
-    Action,
+    ExecutableAction,
     RequestAction,
     normalizeParamValue,
     normalizeParamString,
     equalNormalizedParamValue,
     equalNormalizedParamObject,
-    actionsFromFullActions,
-    actionsToFullActions,
-    actionsToJson,
-    actionsFromJson,
+    toJsonActions,
+    fromJsonActions,
+    getFullActionName,
+    createExecutableAction,
+    toExecutableActions,
+    toFullActions,
 } from "./explanation/requestAction.js";
 export { AgentCacheFactory, getDefaultExplainerName } from "./cache/factory.js";
 export { MatchResult } from "./constructions/constructions.js";

--- a/ts/packages/cache/src/index.ts
+++ b/ts/packages/cache/src/index.ts
@@ -34,12 +34,15 @@ export type { SchemaInfoProvider } from "./explanation/schemaInfoProvider.js";
 // Functionalities
 export {
     Action,
-    Actions,
     RequestAction,
     normalizeParamValue,
     normalizeParamString,
     equalNormalizedParamValue,
     equalNormalizedParamObject,
+    actionsFromFullActions,
+    actionsToFullActions,
+    actionsToJson,
+    actionsFromJson,
 } from "./explanation/requestAction.js";
 export { AgentCacheFactory, getDefaultExplainerName } from "./cache/factory.js";
 export { MatchResult } from "./constructions/constructions.js";

--- a/ts/packages/cli/src/commands/data/regenerate.ts
+++ b/ts/packages/cli/src/commands/data/regenerate.ts
@@ -20,7 +20,8 @@ import {
     getAppAgentName,
 } from "agent-dispatcher/internal";
 import {
-    Actions,
+    Action,
+    actionsFromJson,
     getDefaultExplainerName,
     HistoryContext,
     printImportConstructionResult,
@@ -39,7 +40,7 @@ const provider = await createActionConfigProvider(
 );
 const schemaInfoProvider = createSchemaInfoProvider(provider);
 
-function toEntities(actions: Actions): PromptEntity[] {
+function toEntities(actions: Action[]): PromptEntity[] {
     const entities: PromptEntity[] = [];
     for (const action of actions) {
         if (action.parameters === undefined) {
@@ -459,7 +460,7 @@ export default class ExplanationDataRegenerateCommand extends Command {
                         if (e.action === undefined) {
                             return undefined;
                         }
-                        const entities = toEntities(Actions.fromJSON(e.action));
+                        const entities = toEntities(actionsFromJson(e.action));
                         if (entities.length === 0) {
                             return undefined;
                         }
@@ -469,7 +470,7 @@ export default class ExplanationDataRegenerateCommand extends Command {
                     const requestAction = e.action
                         ? new RequestAction(
                               e.request,
-                              Actions.fromJSON(e.action),
+                              actionsFromJson(e.action),
                               history,
                           )
                         : undefined;

--- a/ts/packages/cli/src/commands/data/regenerate.ts
+++ b/ts/packages/cli/src/commands/data/regenerate.ts
@@ -20,8 +20,8 @@ import {
     getAppAgentName,
 } from "agent-dispatcher/internal";
 import {
-    Action,
-    actionsFromJson,
+    ExecutableAction,
+    fromJsonActions,
     getDefaultExplainerName,
     HistoryContext,
     printImportConstructionResult,
@@ -40,9 +40,9 @@ const provider = await createActionConfigProvider(
 );
 const schemaInfoProvider = createSchemaInfoProvider(provider);
 
-function toEntities(actions: Action[]): PromptEntity[] {
+function toEntities(actions: ExecutableAction[]): PromptEntity[] {
     const entities: PromptEntity[] = [];
-    for (const action of actions) {
+    for (const { action } of actions) {
         if (action.parameters === undefined) {
             continue;
         }
@@ -460,7 +460,7 @@ export default class ExplanationDataRegenerateCommand extends Command {
                         if (e.action === undefined) {
                             return undefined;
                         }
-                        const entities = toEntities(actionsFromJson(e.action));
+                        const entities = toEntities(fromJsonActions(e.action));
                         if (entities.length === 0) {
                             return undefined;
                         }
@@ -470,7 +470,7 @@ export default class ExplanationDataRegenerateCommand extends Command {
                     const requestAction = e.action
                         ? new RequestAction(
                               e.request,
-                              actionsFromJson(e.action),
+                              fromJsonActions(e.action),
                               history,
                           )
                         : undefined;

--- a/ts/packages/cli/src/commands/run/explain.ts
+++ b/ts/packages/cli/src/commands/run/explain.ts
@@ -3,7 +3,7 @@
 
 import { Args, Command, Flags } from "@oclif/core";
 import chalk from "chalk";
-import { RequestAction, actionsFromJson } from "agent-cache";
+import { RequestAction, fromJsonActions } from "agent-cache";
 import {
     createActionConfigProvider,
     getCacheFactory,
@@ -17,7 +17,7 @@ import { ClientIO, createDispatcher } from "agent-dispatcher";
 // Default test case, that include multiple phrase action name (out of order) and implicit parameters (context)
 const testRequest = new RequestAction(
     "do some player blah",
-    actionsFromJson({
+    fromJsonActions({
         fullActionName: "player.do",
         parameters: {
             value: "blah",

--- a/ts/packages/cli/src/commands/run/explain.ts
+++ b/ts/packages/cli/src/commands/run/explain.ts
@@ -3,7 +3,7 @@
 
 import { Args, Command, Flags } from "@oclif/core";
 import chalk from "chalk";
-import { RequestAction, Actions } from "agent-cache";
+import { RequestAction, actionsFromJson } from "agent-cache";
 import {
     createActionConfigProvider,
     getCacheFactory,
@@ -17,7 +17,7 @@ import { ClientIO, createDispatcher } from "agent-dispatcher";
 // Default test case, that include multiple phrase action name (out of order) and implicit parameters (context)
 const testRequest = new RequestAction(
     "do some player blah",
-    Actions.fromJSON({
+    actionsFromJson({
         fullActionName: "player.do",
         parameters: {
             value: "blah",

--- a/ts/packages/cli/src/commands/test/translate.ts
+++ b/ts/packages/cli/src/commands/test/translate.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import { Args, Command, Flags } from "@oclif/core";
-import { actionsFromJson, actionsToFullActions, FullAction } from "agent-cache";
+import { fromJsonActions, toFullActions, FullAction } from "agent-cache";
 import { createDispatcher } from "agent-dispatcher";
 import {
     readTestData,
@@ -209,9 +209,7 @@ export default class TestTranslateCommand extends Command {
                 .flatMap((input) =>
                     input.data.entries.map((e) => ({
                         request: e.request,
-                        actions: actionsToFullActions(
-                            actionsFromJson(e.action),
-                        ),
+                        actions: toFullActions(fromJsonActions(e.action)),
                     })),
                 )
                 .map((entry) => entry.request);

--- a/ts/packages/cli/src/commands/test/translate.ts
+++ b/ts/packages/cli/src/commands/test/translate.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import { Args, Command, Flags } from "@oclif/core";
-import { Actions, FullAction } from "agent-cache";
+import { actionsFromJson, actionsToFullActions, FullAction } from "agent-cache";
 import { createDispatcher } from "agent-dispatcher";
 import {
     readTestData,
@@ -209,7 +209,9 @@ export default class TestTranslateCommand extends Command {
                 .flatMap((input) =>
                     input.data.entries.map((e) => ({
                         request: e.request,
-                        actions: Actions.fromJSON(e.action).toFullActions(),
+                        actions: actionsToFullActions(
+                            actionsFromJson(e.action),
+                        ),
                     })),
                 )
                 .map((entry) => entry.request);

--- a/ts/packages/defaultAgentProvider/test/construction.spec.ts
+++ b/ts/packages/defaultAgentProvider/test/construction.spec.ts
@@ -10,7 +10,7 @@ import {
     readTestData,
     createActionConfigProvider,
 } from "agent-dispatcher/internal";
-import { actionsFromJson, RequestAction } from "agent-cache";
+import { fromJsonActions, RequestAction } from "agent-cache";
 import { getDefaultAppAgentProviders } from "../src/defaultAgentProviders.js";
 import { glob } from "glob";
 
@@ -24,7 +24,7 @@ const testInput = inputs.flatMap((f) =>
     f.entries.map<[string, string, RequestAction, object, string[]]>((data) => [
         f.schemaName,
         f.explainerName,
-        new RequestAction(data.request, actionsFromJson(data.action)),
+        new RequestAction(data.request, fromJsonActions(data.action)),
         data.explanation,
         data.tags ?? [],
     ]),

--- a/ts/packages/defaultAgentProvider/test/construction.spec.ts
+++ b/ts/packages/defaultAgentProvider/test/construction.spec.ts
@@ -10,7 +10,7 @@ import {
     readTestData,
     createActionConfigProvider,
 } from "agent-dispatcher/internal";
-import { Actions, RequestAction } from "agent-cache";
+import { actionsFromJson, RequestAction } from "agent-cache";
 import { getDefaultAppAgentProviders } from "../src/defaultAgentProviders.js";
 import { glob } from "glob";
 
@@ -24,7 +24,7 @@ const testInput = inputs.flatMap((f) =>
     f.entries.map<[string, string, RequestAction, object, string[]]>((data) => [
         f.schemaName,
         f.explainerName,
-        new RequestAction(data.request, Actions.fromJSON(data.action)),
+        new RequestAction(data.request, actionsFromJson(data.action)),
         data.explanation,
         data.tags ?? [],
     ]),

--- a/ts/packages/defaultAgentProvider/test/constructionCacheTestCommon.ts
+++ b/ts/packages/defaultAgentProvider/test/constructionCacheTestCommon.ts
@@ -14,7 +14,6 @@ import {
     createSchemaInfoProvider,
 } from "agent-dispatcher/internal";
 import {
-    Actions,
     AgentCache,
     JSONAction,
     ParamValueType,
@@ -23,6 +22,9 @@ import {
     createActionProps,
     normalizeParamValue,
     normalizeParamString,
+    actionsFromJson,
+    actionsToJson,
+    Action,
 } from "agent-cache";
 import { glob } from "glob";
 import { fileURLToPath } from "node:url";
@@ -72,7 +74,7 @@ const testInput = inputs.flatMap(([f]) =>
     f.entries.map<[string, string, RequestAction, object, string[]]>((data) => [
         f.schemaName,
         f.explainerName,
-        new RequestAction(data.request, Actions.fromJSON(data.action)),
+        new RequestAction(data.request, actionsFromJson(data.action)),
         data.explanation,
         data.tags ?? [],
     ]),
@@ -144,8 +146,8 @@ function normalizeParams(action: JSONAction) {
     }
 }
 
-function normalizeActions(actions: Actions) {
-    const actionJSON = actions.toJSON();
+function normalizeActions(actions: Action[]) {
+    const actionJSON = actionsToJson(actions);
 
     if (Array.isArray(actionJSON)) {
         actionJSON.forEach(normalizeParams);
@@ -156,7 +158,7 @@ function normalizeActions(actions: Actions) {
 }
 
 function expandActions(
-    actions: Actions,
+    actions: Action[],
     conflictValues?: [string, ParamValueType[]][],
 ) {
     const actionJSON = normalizeActions(actions);

--- a/ts/packages/defaultAgentProvider/test/constructionCacheTestCommon.ts
+++ b/ts/packages/defaultAgentProvider/test/constructionCacheTestCommon.ts
@@ -22,9 +22,9 @@ import {
     createActionProps,
     normalizeParamValue,
     normalizeParamString,
-    actionsFromJson,
-    actionsToJson,
-    Action,
+    fromJsonActions,
+    toJsonActions,
+    ExecutableAction,
 } from "agent-cache";
 import { glob } from "glob";
 import { fileURLToPath } from "node:url";
@@ -74,7 +74,7 @@ const testInput = inputs.flatMap(([f]) =>
     f.entries.map<[string, string, RequestAction, object, string[]]>((data) => [
         f.schemaName,
         f.explainerName,
-        new RequestAction(data.request, actionsFromJson(data.action)),
+        new RequestAction(data.request, fromJsonActions(data.action)),
         data.explanation,
         data.tags ?? [],
     ]),
@@ -146,8 +146,8 @@ function normalizeParams(action: JSONAction) {
     }
 }
 
-function normalizeActions(actions: Action[]) {
-    const actionJSON = actionsToJson(actions);
+function normalizeActions(actions: ExecutableAction[]) {
+    const actionJSON = toJsonActions(actions);
 
     if (Array.isArray(actionJSON)) {
         actionJSON.forEach(normalizeParams);
@@ -158,7 +158,7 @@ function normalizeActions(actions: Action[]) {
 }
 
 function expandActions(
-    actions: Action[],
+    actions: ExecutableAction[],
     conflictValues?: [string, ParamValueType[]][],
 ) {
     const actionJSON = normalizeActions(actions);

--- a/ts/packages/defaultAgentProvider/test/requestAction.spec.ts
+++ b/ts/packages/defaultAgentProvider/test/requestAction.spec.ts
@@ -3,7 +3,7 @@
 
 import { getPackageFilePath } from "../src/utils/getPackageFilePath.js";
 import { readTestData } from "agent-dispatcher/internal";
-import { RequestAction, actionsFromJson } from "agent-cache";
+import { RequestAction, fromJsonActions } from "agent-cache";
 import { glob } from "glob";
 
 const dataFiles = ["test/data/explanations/**/**/*.json"];
@@ -14,7 +14,7 @@ const inputs = await Promise.all(
 
 const testInput = inputs.flatMap((f) =>
     f.entries.map(
-        (data) => new RequestAction(data.request, actionsFromJson(data.action)),
+        (data) => new RequestAction(data.request, fromJsonActions(data.action)),
     ),
 );
 

--- a/ts/packages/defaultAgentProvider/test/requestAction.spec.ts
+++ b/ts/packages/defaultAgentProvider/test/requestAction.spec.ts
@@ -3,7 +3,7 @@
 
 import { getPackageFilePath } from "../src/utils/getPackageFilePath.js";
 import { readTestData } from "agent-dispatcher/internal";
-import { Actions, RequestAction } from "agent-cache";
+import { RequestAction, actionsFromJson } from "agent-cache";
 import { glob } from "glob";
 
 const dataFiles = ["test/data/explanations/**/**/*.json"];
@@ -14,8 +14,7 @@ const inputs = await Promise.all(
 
 const testInput = inputs.flatMap((f) =>
     f.entries.map(
-        (data) =>
-            new RequestAction(data.request, Actions.fromJSON(data.action)),
+        (data) => new RequestAction(data.request, actionsFromJson(data.action)),
     ),
 );
 

--- a/ts/packages/defaultAgentProvider/test/validateExplanationTestData.spec.ts
+++ b/ts/packages/defaultAgentProvider/test/validateExplanationTestData.spec.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import { getPackageFilePath } from "../src/utils/getPackageFilePath.js";
-import { Actions, RequestAction } from "agent-cache";
+import { actionsFromJson, RequestAction } from "agent-cache";
 import { getCacheFactory, readTestData } from "agent-dispatcher/internal";
 import { glob } from "glob";
 
@@ -16,7 +16,7 @@ const testInput = inputs.flatMap((f) =>
     f.entries.map<[string, string, RequestAction, any]>((data) => [
         f.schemaName,
         f.explainerName,
-        new RequestAction(data.request, Actions.fromJSON(data.action)),
+        new RequestAction(data.request, actionsFromJson(data.action)),
         data.explanation,
     ]),
 );

--- a/ts/packages/defaultAgentProvider/test/validateExplanationTestData.spec.ts
+++ b/ts/packages/defaultAgentProvider/test/validateExplanationTestData.spec.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import { getPackageFilePath } from "../src/utils/getPackageFilePath.js";
-import { actionsFromJson, RequestAction } from "agent-cache";
+import { fromJsonActions, RequestAction } from "agent-cache";
 import { getCacheFactory, readTestData } from "agent-dispatcher/internal";
 import { glob } from "glob";
 
@@ -16,7 +16,7 @@ const testInput = inputs.flatMap((f) =>
     f.entries.map<[string, string, RequestAction, any]>((data) => [
         f.schemaName,
         f.explainerName,
-        new RequestAction(data.request, actionsFromJson(data.action)),
+        new RequestAction(data.request, fromJsonActions(data.action)),
         data.explanation,
     ]),
 );

--- a/ts/packages/dispatcher/src/context/dispatcher/handlers/requestCommandHandler.ts
+++ b/ts/packages/dispatcher/src/context/dispatcher/handlers/requestCommandHandler.ts
@@ -10,6 +10,7 @@ import {
     ProcessRequestActionResult,
     ExplanationOptions,
     equalNormalizedParamObject,
+    actionsToFullActions,
 } from "agent-cache";
 
 import {
@@ -52,7 +53,9 @@ async function canTranslateWithoutContext(
     }
 
     // Do the retranslation check, which will also check the action.
-    const oldActions: FullAction[] = requestAction.actions.toFullActions();
+    const oldActions: FullAction[] = actionsToFullActions(
+        requestAction.actions,
+    );
     const newActions: (FullAction | undefined)[] = [];
     const request = requestAction.request;
     try {
@@ -164,7 +167,7 @@ function getExplainerOptions(
 
     if (
         !context.session.getConfig().explainer.filter.multiple &&
-        requestAction.actions.action === undefined
+        requestAction.actions.length > 1
     ) {
         // filter multiple
         return undefined;

--- a/ts/packages/dispatcher/src/context/dispatcher/handlers/requestCommandHandler.ts
+++ b/ts/packages/dispatcher/src/context/dispatcher/handlers/requestCommandHandler.ts
@@ -10,7 +10,7 @@ import {
     ProcessRequestActionResult,
     ExplanationOptions,
     equalNormalizedParamObject,
-    actionsToFullActions,
+    toFullActions,
 } from "agent-cache";
 
 import {
@@ -53,9 +53,7 @@ async function canTranslateWithoutContext(
     }
 
     // Do the retranslation check, which will also check the action.
-    const oldActions: FullAction[] = actionsToFullActions(
-        requestAction.actions,
-    );
+    const oldActions: FullAction[] = toFullActions(requestAction.actions);
     const newActions: (FullAction | undefined)[] = [];
     const request = requestAction.request;
     try {
@@ -77,7 +75,7 @@ async function canTranslateWithoutContext(
         }
 
         let index = 0;
-        for (const action of requestAction.actions) {
+        for (const { action } of requestAction.actions) {
             const translatorName = action.translatorName;
             const newTranslatedActions = translations.get(translatorName)!;
             let newAction: TranslatedAction;
@@ -175,7 +173,7 @@ function getExplainerOptions(
 
     const usedTranslators = new Map<string, TypeAgentTranslator<object>>();
     const actions = requestAction.actions;
-    for (const action of actions) {
+    for (const { action } of actions) {
         if (isUnknownAction(action)) {
             // can't explain unknown actions
             return undefined;

--- a/ts/packages/dispatcher/src/context/system/systemAgent.ts
+++ b/ts/packages/dispatcher/src/context/system/systemAgent.ts
@@ -51,7 +51,7 @@ import {
     getSystemTemplateSchema,
 } from "../../translation/actionTemplate.js";
 import { getTokenCommandHandlers } from "./handlers/tokenCommandHandler.js";
-import { actionsFromFullActions, FullAction } from "agent-cache";
+import { toExecutableActions, FullAction } from "agent-cache";
 import { getActionSchema } from "../../translation/actionSchemaFileCache.js";
 import { executeActions } from "../../execute/actionHandlers.js";
 import { getObjectProperty } from "common-utils";
@@ -231,7 +231,7 @@ class ActionCommandHandler implements CommandHandler {
         validateAction(actionSchema, action, true);
 
         return executeActions(
-            actionsFromFullActions([action as FullAction]),
+            toExecutableActions([action as FullAction]),
             undefined,
             context,
         );

--- a/ts/packages/dispatcher/src/context/system/systemAgent.ts
+++ b/ts/packages/dispatcher/src/context/system/systemAgent.ts
@@ -51,7 +51,7 @@ import {
     getSystemTemplateSchema,
 } from "../../translation/actionTemplate.js";
 import { getTokenCommandHandlers } from "./handlers/tokenCommandHandler.js";
-import { Actions, FullAction } from "agent-cache";
+import { actionsFromFullActions, FullAction } from "agent-cache";
 import { getActionSchema } from "../../translation/actionSchemaFileCache.js";
 import { executeActions } from "../../execute/actionHandlers.js";
 import { getObjectProperty } from "common-utils";
@@ -231,7 +231,7 @@ class ActionCommandHandler implements CommandHandler {
         validateAction(actionSchema, action, true);
 
         return executeActions(
-            Actions.fromFullActions([action as FullAction]),
+            actionsFromFullActions([action as FullAction]),
             undefined,
             context,
         );

--- a/ts/packages/dispatcher/src/execute/actionHandlers.ts
+++ b/ts/packages/dispatcher/src/execute/actionHandlers.ts
@@ -2,9 +2,10 @@
 // Licensed under the MIT License.
 
 import {
-    Action,
-    actionsToFullActions,
+    ExecutableAction,
+    toFullActions,
     FullAction,
+    getFullActionName,
     normalizeParamString,
 } from "agent-cache";
 import { CommandHandlerContext } from "../context/commandHandlerContext.js";
@@ -262,11 +263,12 @@ function getStreamingActionContext(
 }
 
 async function executeAction(
-    action: Action,
+    executableAction: ExecutableAction,
     context: ActionContext<CommandHandlerContext>,
     actionIndex: number,
     entityMap?: Map<string, Entity>,
 ): Promise<ActionResult> {
+    const action = executableAction.action;
     const translatorName = action.translatorName;
 
     if (translatorName === undefined) {
@@ -297,20 +299,20 @@ async function executeAction(
         }
     }
     // Reuse the same streaming action context if one is available.
-    const fullAction = action.toFullAction();
+
     const { actionContext, closeActionContext } =
         getStreamingActionContext(
             appAgentName,
             actionIndex,
             systemContext,
-            fullAction,
+            action,
         ) ??
         getActionContext(
             appAgentName,
             systemContext,
             systemContext.requestId!,
             actionIndex,
-            fullAction,
+            action,
         );
 
     actionContext.profiler = systemContext.commandProfiler?.measure(
@@ -325,7 +327,7 @@ async function executeAction(
             systemContext,
         );
         displayStatus(
-            `${prefix}Executing action ${action.fullActionName}`,
+            `${prefix}Executing action ${getFullActionName(executableAction)}`,
             context,
         );
         returnedResult = await appAgent.executeAction(
@@ -341,7 +343,7 @@ async function executeAction(
     let result: ActionResult;
     if (returnedResult === undefined) {
         result = createActionResult(
-            `Action ${action.fullActionName} completed.`,
+            `Action ${getFullActionName(executableAction)} completed.`,
         );
     } else {
         if (
@@ -364,7 +366,7 @@ async function executeAction(
     if (result.error !== undefined) {
         displayError(result.error, actionContext);
         systemContext.chatHistory.addAssistantEntry(
-            `Action ${action.fullActionName} failed: ${result.error}`,
+            `Action ${getFullActionName(executableAction)} failed: ${result.error}`,
             systemContext.requestId,
             appAgentName,
         );
@@ -388,7 +390,7 @@ async function executeAction(
         systemContext.chatHistory.addAssistantEntry(
             result.literalText
                 ? result.literalText
-                : `Action ${action.fullActionName} completed.`,
+                : `Action ${getFullActionName(executableAction)} completed.`,
             systemContext.requestId,
             appAgentName,
             combinedEntities,
@@ -401,13 +403,13 @@ async function executeAction(
 }
 
 async function canExecute(
-    actions: Action[],
+    actions: ExecutableAction[],
     context: ActionContext<CommandHandlerContext>,
 ): Promise<boolean> {
     const systemContext = context.sessionContext.agentContext;
     const unknown: UnknownAction[] = [];
     const disabled = new Set<string>();
-    for (const action of actions) {
+    for (const { action } of actions) {
         if (isUnknownAction(action)) {
             unknown.push(action);
         }
@@ -507,7 +509,7 @@ function getStringValues(params: unknown) {
 }
 
 function getActionEntityMap(
-    action: Action,
+    action: FullAction,
     resultEntityMap: Map<string, PromptEntity>,
     promptEntityMap: Map<string, PromptEntity> | undefined,
 ) {
@@ -535,14 +537,14 @@ function getActionEntityMap(
 }
 
 type PendingAction = {
-    action: Action;
+    executableAction: ExecutableAction;
     promptEntityMap: Map<string, PromptEntity> | undefined;
 };
 
 function toPendingActions(
-    actions: Action[],
+    actions: ExecutableAction[],
     entities: PromptEntity[] | undefined,
-) {
+): PendingAction[] {
     const promptEntityMap = entities
         ? new Map<string, PromptEntity>(
               entities.map(
@@ -552,24 +554,24 @@ function toPendingActions(
               ),
           )
         : undefined;
-    return Array.from(actions).map((action) => ({
-        action,
+    return Array.from(actions).map((executableAction) => ({
+        executableAction,
         promptEntityMap,
     }));
 }
 
 export async function executeActions(
-    actions: Action[],
+    actions: ExecutableAction[],
     entities: PromptEntity[] | undefined,
     context: ActionContext<CommandHandlerContext>,
 ) {
     const systemContext = context.sessionContext.agentContext;
     if (systemContext.commandResult === undefined) {
         systemContext.commandResult = {
-            actions: actionsToFullActions(actions),
+            actions: toFullActions(actions),
         };
     } else {
-        systemContext.commandResult.actions = actionsToFullActions(actions);
+        systemContext.commandResult.actions = toFullActions(actions);
     }
 
     if (!(await canExecute(actions, context))) {
@@ -581,7 +583,8 @@ export async function executeActions(
     const actionQueue: PendingAction[] = toPendingActions(actions, entities);
 
     while (actionQueue.length !== 0) {
-        const { action, promptEntityMap } = actionQueue.shift()!;
+        const { executableAction, promptEntityMap } = actionQueue.shift()!;
+        const action = executableAction.action;
         if (isPendingRequestAction(action)) {
             const translationResult = await translatePendingRequestAction(
                 action,
@@ -602,15 +605,15 @@ export async function executeActions(
             continue;
         }
         const result = await executeAction(
-            action,
+            executableAction,
             context,
             actionIndex,
             getActionEntityMap(action, resultEntityMap, promptEntityMap),
         );
         if (result.error === undefined) {
-            if (result.resultEntity && action.resultEntityId) {
+            if (result.resultEntity && executableAction.resultEntityId) {
                 resultEntityMap.set(
-                    normalizeParamString(action.resultEntityId),
+                    normalizeParamString(executableAction.resultEntityId),
                     {
                         ...result.resultEntity,
                         sourceAppAgentName: getAppAgentName(
@@ -629,7 +632,7 @@ export async function validateWildcardMatch(
     context: CommandHandlerContext,
 ) {
     const actions = match.match.actions;
-    for (const action of actions) {
+    for (const { action } of actions) {
         const translatorName = action.translatorName;
         if (translatorName === undefined) {
             continue;

--- a/ts/packages/dispatcher/src/translation/actionTemplate.ts
+++ b/ts/packages/dispatcher/src/translation/actionTemplate.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { Action, Actions } from "agent-cache";
+import { Action } from "agent-cache";
 import { getActionSchema } from "./actionSchemaFileCache.js";
 import { CommandHandlerContext } from "../context/commandHandlerContext.js";
 import {
@@ -157,7 +157,7 @@ function toTemplate(
 
 export function getActionTemplateEditConfig(
     context: CommandHandlerContext,
-    actions: Actions,
+    actions: Action[],
     preface: string,
     editPreface: string,
 ): TemplateEditConfig {

--- a/ts/packages/dispatcher/src/translation/actionTemplate.ts
+++ b/ts/packages/dispatcher/src/translation/actionTemplate.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { Action } from "agent-cache";
+import { ExecutableAction } from "agent-cache";
 import { getActionSchema } from "./actionSchemaFileCache.js";
 import { CommandHandlerContext } from "../context/commandHandlerContext.js";
 import {
@@ -114,17 +114,17 @@ function toTemplateType(type: ActionParamType): TemplateType | undefined {
 function toTemplate(
     context: CommandHandlerContext,
     translators: string[],
-    action: Action,
+    action: ExecutableAction,
 ) {
     const actionSchemaFile = context.agents.tryGetActionSchemaFile(
-        action.translatorName,
+        action.action.translatorName,
     );
     if (actionSchemaFile === undefined) {
         return getDefaultActionTemplate(translators);
     }
     const template = getDefaultActionTemplate(
         translators,
-        action.translatorName,
+        action.action.translatorName,
     );
     const actionSchemas = actionSchemaFile.actionSchemas;
     const actionName: TemplateFieldStringUnion = {
@@ -136,11 +136,11 @@ function toTemplate(
         type: actionName,
     };
 
-    const actionSchema = actionSchemas.get(action.actionName);
+    const actionSchema = actionSchemas.get(action.action.actionName);
     if (actionSchema === undefined) {
         return template;
     }
-    actionName.discriminator = action.actionName;
+    actionName.discriminator = action.action.actionName;
 
     const parameterType = actionSchema.type.fields.parameters?.type;
     if (parameterType) {
@@ -157,7 +157,7 @@ function toTemplate(
 
 export function getActionTemplateEditConfig(
     context: CommandHandlerContext,
-    actions: Action[],
+    actions: ExecutableAction[],
     preface: string,
     editPreface: string,
 ): TemplateEditConfig {
@@ -167,7 +167,7 @@ export function getActionTemplateEditConfig(
     for (const action of actions) {
         templateData.push({
             schema: toTemplate(context, translators, action),
-            data: action.toFullAction(),
+            data: action.action,
         });
     }
 

--- a/ts/packages/dispatcher/src/translation/confirmTranslation.ts
+++ b/ts/packages/dispatcher/src/translation/confirmTranslation.ts
@@ -4,8 +4,8 @@
 import { ActionContext } from "@typeagent/agent-sdk";
 import { displayInfo } from "@typeagent/agent-sdk/helpers/display";
 import {
-    Action,
-    actionsFromFullActions,
+    toExecutableActions,
+    ExecutableAction,
     FullAction,
     RequestAction,
 } from "agent-cache";
@@ -52,7 +52,7 @@ export async function confirmTranslation(
     context: ActionContext<CommandHandlerContext>,
 ): Promise<{
     requestAction: RequestAction | undefined | null;
-    replacedAction?: Action[];
+    replacedAction?: ExecutableAction[];
 }> {
     const actions = requestAction.actions;
     const systemContext = context.sessionContext.agentContext;
@@ -92,7 +92,7 @@ export async function confirmTranslation(
         ? {
               requestAction: new RequestAction(
                   requestAction.request,
-                  actionsFromFullActions(newActions),
+                  toExecutableActions(newActions),
                   requestAction.history,
               ),
               replacedAction: actions,

--- a/ts/packages/dispatcher/src/translation/confirmTranslation.ts
+++ b/ts/packages/dispatcher/src/translation/confirmTranslation.ts
@@ -3,7 +3,12 @@
 
 import { ActionContext } from "@typeagent/agent-sdk";
 import { displayInfo } from "@typeagent/agent-sdk/helpers/display";
-import { Actions, FullAction, RequestAction } from "agent-cache";
+import {
+    Action,
+    actionsFromFullActions,
+    FullAction,
+    RequestAction,
+} from "agent-cache";
 import chalk from "chalk";
 import { getColorElapsedString } from "common-utils";
 import { getActionTemplateEditConfig } from "./actionTemplate.js";
@@ -47,7 +52,7 @@ export async function confirmTranslation(
     context: ActionContext<CommandHandlerContext>,
 ): Promise<{
     requestAction: RequestAction | undefined | null;
-    replacedAction?: Actions;
+    replacedAction?: Action[];
 }> {
     const actions = requestAction.actions;
     const systemContext = context.sessionContext.agentContext;
@@ -87,7 +92,7 @@ export async function confirmTranslation(
         ? {
               requestAction: new RequestAction(
                   requestAction.request,
-                  Actions.fromFullActions(newActions),
+                  actionsFromFullActions(newActions),
                   requestAction.history,
               ),
               replacedAction: actions,

--- a/ts/packages/dispatcher/src/translation/pendingRequest.ts
+++ b/ts/packages/dispatcher/src/translation/pendingRequest.ts
@@ -4,7 +4,7 @@
 import { AppAction } from "@typeagent/agent-sdk";
 import { DispatcherName } from "../context/interactiveIO.js";
 import { PendingRequestEntry } from "./multipleActionSchema.js";
-import { Action } from "agent-cache";
+import { createExecutableAction } from "agent-cache";
 
 export type PendingRequestAction = {
     actionName: "pendingRequestAction";
@@ -24,7 +24,7 @@ export function isPendingRequestAction(
 }
 
 export function createPendingRequestAction(entry: PendingRequestEntry) {
-    return new Action(DispatcherName, "pendingRequestAction", {
+    return createExecutableAction(DispatcherName, "pendingRequestAction", {
         pendingRequest: entry.request,
         pendingResultEntityId: entry.pendingResultEntityId,
     });

--- a/ts/packages/dispatcher/src/translation/translateRequest.ts
+++ b/ts/packages/dispatcher/src/translation/translateRequest.ts
@@ -11,7 +11,12 @@ import {
     getTranslatorForSelectedActions,
 } from "../context/commandHandlerContext.js";
 import { ActionContext } from "@typeagent/agent-sdk";
-import { Action, HistoryContext, RequestAction } from "agent-cache";
+import {
+    createExecutableAction,
+    ExecutableAction,
+    HistoryContext,
+    RequestAction,
+} from "agent-cache";
 import {
     CachedImageWithDetails,
     IncrementalJsonValueCallBack,
@@ -353,7 +358,7 @@ async function finalizeAction(
     attachments?: CachedImageWithDetails[],
     resultEntityId?: string,
     streamingActionIndex?: number,
-): Promise<Action | Action[] | undefined> {
+): Promise<ExecutableAction | ExecutableAction[] | undefined> {
     let currentAction: TranslatedAction | undefined = action;
     let currentTranslatorName: string = translatorName;
     const systemContext = context.sessionContext.agentContext;
@@ -414,7 +419,7 @@ async function finalizeAction(
         currentAction = unknownAction;
     }
 
-    return new Action(
+    return createExecutableAction(
         systemContext.agents.getInjectedSchemaForActionName(
             currentAction.actionName,
         ) ?? currentTranslatorName,
@@ -430,13 +435,13 @@ async function finalizeMultipleActions(
     context: ActionContext<CommandHandlerContext>,
     history?: HistoryContext,
     attachments?: CachedImageWithDetails[],
-): Promise<Action[] | undefined> {
+): Promise<ExecutableAction[] | undefined> {
     if (attachments !== undefined && attachments.length !== 0) {
         // TODO: What to do with attachments with multiple actions?
         throw new Error("Attachments with multiple actions not supported");
     }
     const requests = action.parameters.requests;
-    const actions: Action[] = [];
+    const actions: ExecutableAction[] = [];
     for (const request of requests) {
         if (isPendingRequest(request)) {
             actions.push(createPendingRequestAction(request));


### PR DESCRIPTION
- Reduce the number of types we need to deal with related to actions.
- Remove the use of implicit toJson() and toString() from the Action and Actions class.
- Remove hack in RPC to naturally marshal the actions as `FullAction` instead of `JSONAction`
- `JSONAction` preserve `resultEntityId` as well