### PR TITLE
Parameter name based Entity look up 

### DIFF
--- a/ts/packages/agentRpc/src/client.ts
+++ b/ts/packages/agentRpc/src/client.ts
@@ -14,8 +14,8 @@ import {
     ParameterDefinitions,
     ClientAction,
     AppAgentManifest,
-    Entity,
     AppAction,
+    TypeAgentAction,
 } from "@typeagent/agent-sdk";
 import {
     AgentCallFunctions,
@@ -312,15 +312,13 @@ export async function createAgentRpcClient(
             });
         },
         executeAction(
-            action: AppAction,
+            action: TypeAgentAction,
             context: ActionContext<ShimContext>,
-            entityMap: Map<string, Entity>,
         ) {
             return withActionContextAsync(context, (contextParams) =>
                 rpc.invoke("executeAction", {
                     ...contextParams,
                     action,
-                    entityMap: entityMap ? Array.from(entityMap.entries()) : [],
                 }),
             );
         },

--- a/ts/packages/agentRpc/src/server.ts
+++ b/ts/packages/agentRpc/src/server.ts
@@ -14,9 +14,8 @@ import {
     DisplayAppendMode,
     AppAgentEvent,
     ClientAction,
-    AppAction,
     AppAgentManifest,
-    Entity,
+    TypeAgentAction,
 } from "@typeagent/agent-sdk";
 
 import {
@@ -64,8 +63,7 @@ export function createAgentRpcServer(
         },
         async executeAction(
             param: Partial<ActionContextParams> & {
-                action: AppAction;
-                entityMap: [string, Entity][];
+                action: TypeAgentAction;
             },
         ): Promise<any> {
             if (agent.executeAction === undefined) {
@@ -74,7 +72,6 @@ export function createAgentRpcServer(
             return agent.executeAction(
                 param.action,
                 getActionContextShim(param),
-                new Map(param.entityMap),
             );
         },
         async validateWildcardMatch(param): Promise<any> {

--- a/ts/packages/agentRpc/src/types.ts
+++ b/ts/packages/agentRpc/src/types.ts
@@ -12,11 +12,11 @@ import {
     DisplayContent,
     DisplayType,
     DynamicDisplay,
-    Entity,
     ParameterDefinitions,
     ParsedCommandParams,
     StorageListOptions,
     TemplateSchema,
+    TypeAgentAction,
 } from "@typeagent/agent-sdk";
 
 export type AgentContextCallFunctions = {
@@ -116,8 +116,7 @@ export type AgentInvokeFunctions = {
     ) => Promise<void>;
     executeAction: (
         param: Partial<ActionContextParams> & {
-            action: AppAction;
-            entityMap: [string, Entity][];
+            action: TypeAgentAction;
         },
     ) => Promise<ActionResult | undefined>;
     validateWildcardMatch: (

--- a/ts/packages/agentSdk/src/action.ts
+++ b/ts/packages/agentSdk/src/action.ts
@@ -40,3 +40,27 @@ export type ActionResult =
     | ActionResultSuccessNoDisplay
     | ActionResultSuccess
     | ActionResultError;
+
+type EntityField<T> = T extends string
+    ? Entity
+    : T extends any[]
+      ? (EntityField<Required<T[number]>> | undefined)[]
+      : T extends object
+        ? EntityField<T>
+        : undefined;
+
+export type EntityMap<T> = {
+    [Property in keyof T]?: EntityField<T[Property]>;
+};
+
+export type ActionEntities<T extends AppAction = AppAction> =
+    T["parameters"] extends undefined
+        ? undefined
+        : EntityMap<Required<T["parameters"]>>;
+
+export type AppActionEx<T extends AppAction> = T extends AppAction
+    ? T & {
+          translatorName: string;
+          entities: ActionEntities<T>;
+      }
+    : never;

--- a/ts/packages/agentSdk/src/action.ts
+++ b/ts/packages/agentSdk/src/action.ts
@@ -58,10 +58,12 @@ export type ActionEntities<T extends AppAction = AppAction> =
         ? undefined
         : EntityMap<Required<T["parameters"]>>;
 
-export type TypeAgentAction<T extends AppAction = AppAction> =
-    T extends AppAction
-        ? T & {
-              translatorName: string;
-              entities?: ActionEntities<T>;
-          }
-        : never;
+export type TypeAgentAction<
+    T extends AppAction = AppAction,
+    Name extends string = string,
+> = T extends AppAction
+    ? T & {
+          translatorName: Name;
+          entities?: ActionEntities<T>;
+      }
+    : never;

--- a/ts/packages/agentSdk/src/action.ts
+++ b/ts/packages/agentSdk/src/action.ts
@@ -58,9 +58,10 @@ export type ActionEntities<T extends AppAction = AppAction> =
         ? undefined
         : EntityMap<Required<T["parameters"]>>;
 
-export type AppActionEx<T extends AppAction> = T extends AppAction
-    ? T & {
-          translatorName: string;
-          entities: ActionEntities<T>;
-      }
-    : never;
+export type TypeAgentAction<T extends AppAction = AppAction> =
+    T extends AppAction
+        ? T & {
+              translatorName: string;
+              entities?: ActionEntities<T>;
+          }
+        : never;

--- a/ts/packages/agentSdk/src/agentInterface.ts
+++ b/ts/packages/agentSdk/src/agentInterface.ts
@@ -1,8 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { AppAction, ActionResult } from "./action.js";
-import { Entity } from "./memory.js";
+import { AppAction, ActionResult, TypeAgentAction } from "./action.js";
 import { AppAgentCommandInterface } from "./command.js";
 import { ActionIO, DisplayType, DynamicDisplay } from "./display.js";
 import { Profiler } from "./profiler.js";
@@ -59,9 +58,8 @@ export interface AppAgent extends Partial<AppAgentCommandInterface> {
         context: ActionContext<unknown>,
     ): void;
     executeAction?(
-        action: AppAction,
+        action: TypeAgentAction,
         context: ActionContext<unknown>,
-        entityMap?: Map<string, Entity>,
     ): Promise<ActionResult | undefined>;
 
     // Cache extensions

--- a/ts/packages/agentSdk/src/index.ts
+++ b/ts/packages/agentSdk/src/index.ts
@@ -43,6 +43,7 @@ export {
 
 export {
     AppAction,
+    AppActionEx,
     ActionResultError,
     ActionResultSuccessNoDisplay,
     ActionResultSuccess,

--- a/ts/packages/agentSdk/src/index.ts
+++ b/ts/packages/agentSdk/src/index.ts
@@ -43,7 +43,7 @@ export {
 
 export {
     AppAction,
-    AppActionEx,
+    TypeAgentAction,
     ActionResultError,
     ActionResultSuccessNoDisplay,
     ActionResultSuccess,

--- a/ts/packages/agents/androidMobile/src/androidMobileActionHandler.ts
+++ b/ts/packages/agents/androidMobile/src/androidMobileActionHandler.ts
@@ -7,6 +7,7 @@ import {
     AppAgent,
     SessionContext,
     ActionResult,
+    TypeAgentAction,
 } from "@typeagent/agent-sdk";
 import { createActionResult } from "@typeagent/agent-sdk/helpers/action";
 import {
@@ -32,10 +33,10 @@ type PhotoActionContext = {
 };
 
 async function executeAction(
-    action: AppAction,
+    action: TypeAgentAction<AndroidMobileAction>,
     context: ActionContext<PhotoActionContext>,
 ) {
-    let result = await handlePhotoAction(action as SetAlarmAction, context);
+    let result = await handlePhotoAction(action, context);
     return result;
 }
 

--- a/ts/packages/agents/browser/src/agent/actionHandler.mts
+++ b/ts/packages/agents/browser/src/agent/actionHandler.mts
@@ -5,10 +5,10 @@ import { createWebSocket } from "common-utils/ws";
 import { WebSocket } from "ws";
 import {
   ActionContext,
-  AppAction,
   AppAgent,
   AppAgentEvent,
   SessionContext,
+  TypeAgentAction,
 } from "@typeagent/agent-sdk";
 import { createActionResult } from "@typeagent/agent-sdk/helpers/action";
 import { Crossword } from "./crossword/schema/pageSchema.mjs";
@@ -36,6 +36,12 @@ import { handleInstacartAction } from "./instacart/planHandler.mjs";
 import { processWebAgentMessage, WebAgentChannels } from "./webTypeAgent.mjs";
 import { isWebAgentMessage } from "../common/webAgentMessageTypes.mjs";
 import { handleSchemaDiscoveryAction } from "./discovery/actionHandler.mjs";
+import { BrowserActions } from "./actionsSchema.mjs";
+import { PaleoBioDbActions } from "./paleoBioDb/schema.mjs";
+import { CrosswordActions } from "./crossword/schema/userActions.mjs";
+import { InstacartActions } from "./instacart/schema/userActions.mjs";
+import { ShoppingActions } from "./commerce/schema/userActions.mjs";
+import { SchemaDiscoveryActions } from "./discovery/schema/discoveryActions.mjs";
 
 export function instantiate(): AppAgent {
   return {
@@ -182,7 +188,14 @@ async function updateBrowserContext(
 }
 
 async function executeBrowserAction(
-  action: AppAction,
+  action:
+    | TypeAgentAction<BrowserActions, "browser">
+    | TypeAgentAction<PaleoBioDbActions, "browser.paleoBioDb">
+    | TypeAgentAction<CrosswordActions, "browser.crossword">
+    | TypeAgentAction<ShoppingActions, "browser.commerce">
+    | TypeAgentAction<InstacartActions, "browser.instacart">
+    | TypeAgentAction<SchemaDiscoveryActions, "browser.schemaFinder">,
+
   context: ActionContext<BrowserActionContext>,
 ) {
   const webSocketEndpoint = context.sessionContext.agentContext.webSocket;

--- a/ts/packages/agents/browser/src/agent/commerce/actionHandler.mts
+++ b/ts/packages/agents/browser/src/agent/commerce/actionHandler.mts
@@ -11,9 +11,10 @@ import {
   SearchInput,
   StoreLocation,
 } from "./schema/pageComponents.mjs";
+import { ShoppingActions } from "./schema/userActions.mjs";
 
 export async function handleCommerceAction(
-  action: any,
+  action: ShoppingActions,
   context: ActionContext<BrowserActionContext>,
 ) {
   let message = "OK";
@@ -31,6 +32,9 @@ export async function handleCommerceAction(
       await searchForProduct(action.parameters.productName);
       break;
     case "selectSearchResult":
+      if (action.parameters.productName === undefined) {
+        throw new Error("Missing product name");
+      }
       await selectSearchResult(action.parameters.productName);
       break;
     case "addToCartAction":

--- a/ts/packages/agents/browser/src/agent/discovery/actionHandler.mts
+++ b/ts/packages/agents/browser/src/agent/discovery/actionHandler.mts
@@ -15,9 +15,10 @@ import path from "path";
 import fs from "fs";
 import { fileURLToPath } from "url";
 import { UserActionsList } from "./schema/userActionsPool.mjs";
+import { SchemaDiscoveryActions } from "./schema/discoveryActions.mjs";
 
 export async function handleSchemaDiscoveryAction(
-  action: any,
+  action: SchemaDiscoveryActions,
   context: ActionContext<BrowserActionContext>,
 ) {
   let message = "OK";

--- a/ts/packages/agents/browser/src/agent/instacart/planHandler.mts
+++ b/ts/packages/agents/browser/src/agent/instacart/planHandler.mts
@@ -11,9 +11,10 @@ import {
 } from "../commerce/schema/shoppingResults.mjs";
 
 import { setupPageActions, UIElementSchemas } from "./pageActions.mjs";
+import { InstacartActions } from "./schema/userActions.mjs";
 
 export async function handleInstacartAction(
-  action: any,
+  action: InstacartActions,
   context: ActionContext<BrowserActionContext>,
 ) {
   let message = "OK";

--- a/ts/packages/agents/chat/src/chatResponseHandler.ts
+++ b/ts/packages/agents/chat/src/chatResponseHandler.ts
@@ -25,6 +25,7 @@ import {
     AppAction,
     ActionResult,
     ActionResultSuccess,
+    TypeAgentAction,
 } from "@typeagent/agent-sdk";
 import {
     createActionResult,
@@ -53,11 +54,13 @@ function isChatResponseAction(action: AppAction): action is ChatResponseAction {
 }
 
 export async function executeChatResponseAction(
-    chatAction: AppAction,
+    chatAction: TypeAgentAction<ChatResponseAction>,
     context: ActionContext,
 ) {
     if (!isChatResponseAction(chatAction)) {
-        throw new Error(`Invalid chat action: ${chatAction.actionName}`);
+        throw new Error(
+            `Invalid chat action: ${(chatAction as TypeAgentAction).actionName}`,
+        );
     }
     return handleChatResponse(chatAction, context);
 }

--- a/ts/packages/agents/email/src/emailActionHandler.ts
+++ b/ts/packages/agents/email/src/emailActionHandler.ts
@@ -10,7 +10,12 @@ import {
 } from "./emailActionsSchema.js";
 import { generateNotes } from "typeagent";
 import { openai } from "aiclient";
-import { ActionContext, AppAgent, SessionContext } from "@typeagent/agent-sdk";
+import {
+    ActionContext,
+    AppAgent,
+    SessionContext,
+    TypeAgentAction,
+} from "@typeagent/agent-sdk";
 import { createActionResultFromHtmlDisplay } from "@typeagent/agent-sdk/helpers/action";
 import {
     CommandHandlerNoParams,
@@ -99,7 +104,7 @@ async function updateEmailContext(
 }
 
 async function executeEmailAction(
-    action: EmailAction,
+    action: TypeAgentAction<EmailAction>,
     context: ActionContext<EmailActionContext>,
 ) {
     const { mailClient } = context.sessionContext.agentContext;

--- a/ts/packages/agents/list/src/listActionHandler.ts
+++ b/ts/packages/agents/list/src/listActionHandler.ts
@@ -3,11 +3,11 @@
 
 import {
     ActionContext,
-    AppAction,
     AppAgent,
     SessionContext,
     Storage,
     ActionResult,
+    TypeAgentAction,
 } from "@typeagent/agent-sdk";
 import {
     createActionResultFromTextDisplay,
@@ -30,11 +30,11 @@ type ListActionContext = {
 };
 
 async function executeListAction(
-    action: AppAction,
+    action: TypeAgentAction<ListAction>,
     context: ActionContext<ListActionContext>,
 ) {
     let result = await handleListAction(
-        action as ListAction,
+        action,
         context.sessionContext.agentContext,
     );
     return result;

--- a/ts/packages/agents/photo/src/photoActionHandler.ts
+++ b/ts/packages/agents/photo/src/photoActionHandler.ts
@@ -7,6 +7,7 @@ import {
     AppAgent,
     SessionContext,
     ActionResult,
+    TypeAgentAction,
 } from "@typeagent/agent-sdk";
 import { createActionResult } from "@typeagent/agent-sdk/helpers/action";
 import { PhotoAction } from "./photoSchema.js";
@@ -25,7 +26,7 @@ type PhotoActionContext = {
 };
 
 async function executePhotoAction(
-    action: PhotoAction,
+    action: TypeAgentAction<PhotoAction>,
     context: ActionContext<PhotoActionContext>,
 ) {
     let result = await handlePhotoAction(action, context);

--- a/ts/packages/agents/player/src/agent/playerHandlers.ts
+++ b/ts/packages/agents/player/src/agent/playerHandlers.ts
@@ -16,8 +16,7 @@ import {
     DisplayType,
     AppAgentEvent,
     DynamicDisplay,
-    Entity,
-    AppActionEx,
+    TypeAgentAction,
 } from "@typeagent/agent-sdk";
 import { createActionResultFromError } from "@typeagent/agent-sdk/helpers/action";
 import { searchAlbum, searchTracks } from "../client.js";
@@ -53,16 +52,14 @@ async function initializePlayerContext() {
 }
 
 async function executePlayerAction(
-    action: AppActionEx<PlayerAction>,
+    action: TypeAgentAction<PlayerAction>,
     context: ActionContext<PlayerActionContext>,
-    entityMap?: Map<string, Entity>,
 ) {
     if (context.sessionContext.agentContext.spotify) {
         return handleCall(
             action,
             context.sessionContext.agentContext.spotify,
             context.actionIO,
-            entityMap,
         );
     }
 

--- a/ts/packages/agents/player/src/agent/playerHandlers.ts
+++ b/ts/packages/agents/player/src/agent/playerHandlers.ts
@@ -17,6 +17,7 @@ import {
     AppAgentEvent,
     DynamicDisplay,
     Entity,
+    AppActionEx,
 } from "@typeagent/agent-sdk";
 import { createActionResultFromError } from "@typeagent/agent-sdk/helpers/action";
 import { searchAlbum, searchTracks } from "../client.js";
@@ -52,13 +53,13 @@ async function initializePlayerContext() {
 }
 
 async function executePlayerAction(
-    action: PlayerAction,
+    action: AppActionEx<PlayerAction>,
     context: ActionContext<PlayerActionContext>,
     entityMap?: Map<string, Entity>,
 ) {
     if (context.sessionContext.agentContext.spotify) {
         return handleCall(
-            action as PlayerAction,
+            action,
             context.sessionContext.agentContext.spotify,
             context.actionIO,
             entityMap,

--- a/ts/packages/agents/test/src/handler.ts
+++ b/ts/packages/agents/test/src/handler.ts
@@ -5,6 +5,7 @@ import {
     ActionContext,
     AppAgent,
     ParsedCommandParams,
+    TypeAgentAction,
 } from "@typeagent/agent-sdk";
 import { TestActions } from "./schema.js";
 import { createActionResult } from "@typeagent/agent-sdk/helpers/action";
@@ -45,7 +46,7 @@ export function instantiate(): AppAgent {
 }
 
 async function executeAction(
-    action: TestActions,
+    action: TypeAgentAction<TestActions>,
     context: ActionContext<void>,
 ) {
     switch (action.actionName) {

--- a/ts/packages/agents/turtle/src/site/turtleAgent.ts
+++ b/ts/packages/agents/turtle/src/site/turtleAgent.ts
@@ -1,13 +1,16 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { AppAgent, AppAction } from "@typeagent/agent-sdk";
+import { AppAgent, TypeAgentAction } from "@typeagent/agent-sdk";
 import { Turtle } from "./turtleTypes";
 import { TurtleAction } from "./turtleActionSchema";
 
 export function createTurtleAgent(turtle: Turtle): AppAgent {
     return {
-        async executeAction(action: TurtleAction, context): Promise<undefined> {
+        async executeAction(
+            action: TypeAgentAction<TurtleAction>,
+            context,
+        ): Promise<undefined> {
             console.log(`Executing action: ${action.actionName}`);
             switch (action.actionName) {
                 case "forward":
@@ -27,7 +30,7 @@ export function createTurtleAgent(turtle: Turtle): AppAgent {
                     break;
                 default:
                     throw new Error(
-                        `Unknown action: ${(action as AppAction).actionName}`,
+                        `Unknown action: ${(action as TypeAgentAction).actionName}`,
                     );
             }
         },

--- a/ts/packages/cache/src/explanation/requestAction.ts
+++ b/ts/packages/cache/src/explanation/requestAction.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import { PromptSection } from "typechat";
-import { AppAction, Entity } from "@typeagent/agent-sdk";
+import { AppAction, TypeAgentAction, Entity } from "@typeagent/agent-sdk";
 
 export type PromptEntity = Entity & {
     sourceAppAgentName: string;
@@ -68,7 +68,7 @@ export interface JSONAction {
 }
 
 export interface ExecutableAction {
-    action: FullAction;
+    action: TypeAgentAction<FullAction>;
     resultEntityId?: string;
 }
 
@@ -78,7 +78,7 @@ export function createExecutableAction(
     parameters?: ParamObjectType,
     resultEntityId?: string,
 ): ExecutableAction {
-    const action: FullAction = {
+    const action: TypeAgentAction<FullAction> = {
         translatorName,
         actionName,
     };

--- a/ts/packages/dispatcher/src/context/dispatcher/dispatcherAgent.ts
+++ b/ts/packages/dispatcher/src/context/dispatcher/dispatcherAgent.ts
@@ -12,6 +12,7 @@ import {
     ActionContext,
     AppAgent,
     AppAgentManifest,
+    TypeAgentAction,
 } from "@typeagent/agent-sdk";
 import { CommandHandlerContext } from "../commandHandlerContext.js";
 import { createActionResultNoDisplay } from "@typeagent/agent-sdk/helpers/action";
@@ -28,7 +29,7 @@ const dispatcherHandlers: CommandHandlerTable = {
 };
 
 async function executeDispatcherAction(
-    action: DispatcherActions | ClarifyRequestAction,
+    action: TypeAgentAction<DispatcherActions | ClarifyRequestAction>,
     context: ActionContext<CommandHandlerContext>,
 ) {
     if (

--- a/ts/packages/dispatcher/src/context/interactiveIO.ts
+++ b/ts/packages/dispatcher/src/context/interactiveIO.ts
@@ -6,7 +6,7 @@ import { CommandHandlerContext } from "./commandHandlerContext.js";
 import {
     DisplayContent,
     DisplayAppendMode,
-    AppAction,
+    TypeAgentAction,
 } from "@typeagent/agent-sdk";
 import { RequestMetrics } from "../utils/metrics.js";
 
@@ -45,7 +45,7 @@ export interface ClientIO {
         source: string,
         requestId: RequestId,
         actionIndex?: number,
-        action?: AppAction | string[],
+        action?: TypeAgentAction | string[],
     ): void;
     setDisplay(message: IAgentMessage): void;
     appendDisplay(message: IAgentMessage, mode: DisplayAppendMode): void;

--- a/ts/packages/dispatcher/src/context/system/action/sessionActionHandler.ts
+++ b/ts/packages/dispatcher/src/context/system/action/sessionActionHandler.ts
@@ -4,17 +4,16 @@
 import { processCommandNoLock } from "../../../command/command.js";
 import { CommandHandlerContext } from "../../commandHandlerContext.js";
 import { SessionAction } from "../schema/sessionActionSchema.js";
-import { AppAction, ActionContext } from "@typeagent/agent-sdk";
+import { ActionContext, TypeAgentAction } from "@typeagent/agent-sdk";
 
 export async function executeSessionAction(
-    action: AppAction,
+    action: TypeAgentAction<SessionAction>,
     context: ActionContext<CommandHandlerContext>,
 ) {
-    const sessionAction = action as SessionAction;
-    switch (sessionAction.actionName) {
+    switch (action.actionName) {
         case "new":
             await processCommandNoLock(
-                `@session new ${sessionAction.parameters.name ?? ""}`,
+                `@session new ${action.parameters.name ?? ""}`,
                 context.sessionContext.agentContext,
             );
             break;
@@ -32,12 +31,14 @@ export async function executeSessionAction(
             break;
         case "toggleHistory":
             await processCommandNoLock(
-                `@session history ${sessionAction.parameters.enable ? "on" : "off"}`,
+                `@session history ${action.parameters.enable ? "on" : "off"}`,
                 context.sessionContext.agentContext,
             );
             break;
         default:
-            throw new Error(`Invalid action name: ${action.actionName}`);
+            throw new Error(
+                `Invalid action name: ${(action as TypeAgentAction).actionName}`,
+            );
     }
     return undefined;
 }

--- a/ts/packages/dispatcher/src/context/system/systemAgent.ts
+++ b/ts/packages/dispatcher/src/context/system/systemAgent.ts
@@ -11,6 +11,7 @@ import {
     SessionContext,
     PartialParsedCommandParams,
     AppAgentManifest,
+    TypeAgentAction,
 } from "@typeagent/agent-sdk";
 import {
     CommandHandler,
@@ -63,13 +64,21 @@ import {
 import { getEnvCommandHandlers } from "./handlers/envCommandHandler.js";
 import { executeNotificationAction } from "./action/notificationActionHandler.js";
 import { executeHistoryAction } from "./action/historyActionHandler.js";
+import { ConfigAction } from "./schema/configActionSchema.js";
+import { NotificationAction } from "./schema/notificationActionSchema.js";
+import { HistoryAction } from "./schema/historyActionSchema.js";
+import { SessionAction } from "./schema/sessionActionSchema.js";
 
 function executeSystemAction(
-    action: AppAction,
+    action:
+        | TypeAgentAction<SessionAction, "system.session">
+        | TypeAgentAction<ConfigAction, "system.config">
+        | TypeAgentAction<NotificationAction, "system.notify">
+        | TypeAgentAction<HistoryAction, "system.history">,
     context: ActionContext<CommandHandlerContext>,
 ) {
     switch (action.translatorName) {
-        case "system.session":
+        case "system.session":            
             return executeSessionAction(action, context);
         case "system.config":
             return executeConfigAction(action, context);
@@ -77,9 +86,11 @@ function executeSystemAction(
             return executeNotificationAction(action, context);
         case "system.history":
             return executeHistoryAction(action, context);
+        default:
+            throw new Error(
+                `Invalid system sub-translator: ${(action as TypeAgentAction).translatorName}`,
+            );
     }
-
-    throw new Error(`Invalid system sub-translator: ${action.translatorName}`);
 }
 
 class HelpCommandHandler implements CommandHandler {

--- a/ts/packages/dispatcher/src/context/system/systemAgent.ts
+++ b/ts/packages/dispatcher/src/context/system/systemAgent.ts
@@ -78,7 +78,7 @@ function executeSystemAction(
     context: ActionContext<CommandHandlerContext>,
 ) {
     switch (action.translatorName) {
-        case "system.session":            
+        case "system.session":
             return executeSessionAction(action, context);
         case "system.config":
             return executeConfigAction(action, context);

--- a/ts/packages/dispatcher/src/rpc/clientIOClient.ts
+++ b/ts/packages/dispatcher/src/rpc/clientIOClient.ts
@@ -13,7 +13,7 @@ import {
 } from "./clientIOTypes.js";
 import { TemplateEditConfig } from "../translation/actionTemplate.js";
 import { RpcChannel } from "agent-rpc/channel";
-import { DisplayAppendMode, AppAction } from "@typeagent/agent-sdk";
+import { DisplayAppendMode, TypeAgentAction } from "@typeagent/agent-sdk";
 
 export function createClientIORpcClient(channel: RpcChannel): ClientIO {
     const rpc = createRpc<ClientIOInvokeFunctions, ClientIOCallFunctions>(
@@ -32,7 +32,7 @@ export function createClientIORpcClient(channel: RpcChannel): ClientIO {
             source: string,
             requestId: RequestId,
             actionIndex?: number,
-            action?: AppAction,
+            action?: TypeAgentAction,
         ): void {
             return rpc.send("setDisplayInfo", {
                 source,

--- a/ts/packages/dispatcher/src/rpc/clientIOTypes.ts
+++ b/ts/packages/dispatcher/src/rpc/clientIOTypes.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { AppAction, DisplayAppendMode } from "@typeagent/agent-sdk";
+import { DisplayAppendMode, TypeAgentAction } from "@typeagent/agent-sdk";
 import { IAgentMessage, RequestId } from "../context/interactiveIO.js";
 import { TemplateEditConfig } from "../translation/actionTemplate.js";
 
@@ -26,7 +26,7 @@ export type ClientIOCallFunctions = {
         source: string;
         requestId: RequestId;
         actionIndex?: number | undefined;
-        action?: AppAction | undefined;
+        action?: TypeAgentAction | undefined;
     }): void;
     setDisplay(params: { message: IAgentMessage }): void;
     appendDisplay(params: {

--- a/ts/packages/shell/src/renderer/src/chatView.ts
+++ b/ts/packages/shell/src/renderer/src/chatView.ts
@@ -5,10 +5,10 @@ import { IdGenerator, getDispatcher } from "./main";
 import { ChatInput, ExpandableTextarea } from "./chatInput";
 import { iconCheckMarkCircle, iconX } from "./icon";
 import {
-    AppAction,
     DisplayAppendMode,
     DisplayContent,
     DynamicDisplay,
+    TypeAgentAction,
 } from "@typeagent/agent-sdk";
 import { TTS } from "./tts/tts";
 import {
@@ -454,7 +454,7 @@ export class ChatView {
         source: string,
         requestId: RequestId,
         actionIndex?: number,
-        action?: AppAction | string[],
+        action?: TypeAgentAction | string[],
     ) {
         this.getMessageGroup(requestId)?.setDisplayInfo(
             source,

--- a/ts/packages/shell/src/renderer/src/messageContainer.ts
+++ b/ts/packages/shell/src/renderer/src/messageContainer.ts
@@ -2,9 +2,9 @@
 // Licensed under the MIT License.
 
 import {
-    AppAction,
     DisplayAppendMode,
     DisplayContent,
+    TypeAgentAction,
 } from "@typeagent/agent-sdk";
 import { TTS, TTSMetrics } from "./tts/tts";
 import {
@@ -118,9 +118,9 @@ export class MessageContainer {
     private completed = false;
     private pendingSpeakText: string = "";
     private defaultSource?: string;
-    private action?: AppAction | string[];
+    private action?: TypeAgentAction | string[];
 
-    public setDisplayInfo(source: string, action?: AppAction | string[]) {
+    public setDisplayInfo(source: string, action?: TypeAgentAction | string[]) {
         this.defaultSource = source;
         this.action = action;
         this.updateSource();

--- a/ts/packages/shell/src/renderer/src/messageGroup.ts
+++ b/ts/packages/shell/src/renderer/src/messageGroup.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { AppAction, DisplayContent } from "@typeagent/agent-sdk";
+import { DisplayContent, TypeAgentAction } from "@typeagent/agent-sdk";
 import {
     CommandResult,
     IAgentMessage,
@@ -73,7 +73,7 @@ export class MessageGroup {
     public setDisplayInfo(
         source: string,
         actionIndex?: number,
-        action?: AppAction | string[],
+        action?: TypeAgentAction | string[],
     ) {
         const agentMessage = this.ensureAgentMessage({
             message: "",


### PR DESCRIPTION
Instead of looking up based on the parameter value, (which might have conflict with duplicate values), dispatcher will resolve the entity and put it in the "entity" field in the actions, with the same structure as parameter object where the string properties will contain the entity if there is a match.