### PR TITLE
[Spelunker] Better batch creation (dynamic size, allows getting closer to actual limits without worries)

### DIFF
--- a/ts/packages/agents/spelunker/src/searchCode.ts
+++ b/ts/packages/agents/spelunker/src/searchCode.ts
@@ -50,8 +50,16 @@ export interface QueryContext {
     database: sqlite.Database | undefined;
 }
 
+function captureTokenStats(req: any, response: any): void {
+    console_log(
+        `    [Tokens used: prompt=${response.usage.prompt_tokens}, ` +
+            `completion=${response.usage.completion_tokens}]`,
+    );
+}
+
 function createQueryContext(): QueryContext {
     const chatModel = openai.createChatModelDefault("spelunkerChat");
+    chatModel.completionCallback = captureTokenStats;
     const oracle = createTranslator<OracleSpecs>(
         chatModel,
         "oracleSchema.ts",
@@ -63,6 +71,7 @@ function createQueryContext(): QueryContext {
         undefined,
         ["spelunkerMini"],
     );
+    miniModel.completionCallback = captureTokenStats;
     const chunkSelector = createTranslator<SelectorSpecs>(
         miniModel,
         "selectorSchema.ts",
@@ -153,25 +162,17 @@ export async function searchCode(
     }
     console_log(`  [Loaded ${allChunks.length} chunks]`);
 
-    // 3. Ask a fast LLM for the most relevant chunks, rank them, and keep the best N.
-    // This is done concurrently for real-time speed.
-    const keep = 50; // N
-    console_log(`[Step 3: Select ${keep} most relevant chunks]`);
-    const chunkDescs: ChunkDescription[] = await selectChunks(
-        context,
-        allChunks,
-        input,
-        50,
-    );
-    if (!chunkDescs.length) {
+    // 3. Ask a fast LLM for the most relevant chunks, rank them, and keep the best ones.
+    // The selection is done concurrently for real-time speed.
+    console_log(`[Step 3: Select most relevant chunks]`);
+    const chunks: Chunk[] = await selectChunks(context, allChunks, input);
+    if (!chunks.length) {
+        // TODO: Return an ActionResult with an error message
         throw new Error("No chunks selected");
     }
 
     // 4. Construct a prompt from those chunks.
     console_log(`[Step 4: Construct a prompt for the oracle]`);
-    const preppedChunks: Chunk[] = chunkDescs
-        .map((chunkDesc) => prepChunk(chunkDesc, allChunks))
-        .filter(Boolean) as Chunk[];
     // TODO: Prompt engineering
     // TODO: Include summaries in the prompt
     const prompt = `\
@@ -179,7 +180,7 @@ export async function searchCode(
 
         User question: "${input}"
 
-        Context: ${prepareChunks(preppedChunks)}
+        Context: ${prepareChunks(chunks)}
 
         User question: "${input}"
         `;
@@ -241,34 +242,21 @@ export async function searchCode(
     );
 }
 
-function prepChunk(
-    chunkDesc: ChunkDescription,
-    allChunks: Chunk[],
-): Chunk | undefined {
-    const chunks = allChunks.filter(
-        (chunk) => chunk.chunkId === chunkDesc.chunkId,
-    );
-    if (chunks.length !== 1) return undefined;
-    return chunks[0];
-}
-
 async function selectChunks(
     context: SpelunkerContext,
-    chunks: Chunk[],
+    allChunks: Chunk[],
     input: string,
-    keep: number,
-): Promise<ChunkDescription[]> {
+): Promise<Chunk[]> {
     console_log(`  [Starting chunk selection ...]`);
     const promises: Promise<ChunkDescription[]>[] = [];
     const maxConcurrency =
-        parseInt(process.env.AZURE_OPENAI_MAX_CONCURRENCY ?? "0") ?? 40;
+        parseInt(process.env.AZURE_OPENAI_MAX_CONCURRENCY ?? "0") ?? 5;
     const limiter = createLimiter(maxConcurrency);
-    const chunksPerJob = 30;
-    const numJobs = Math.ceil(chunks.length / chunksPerJob);
+    const batches = makeBatches(allChunks, 250000); // TODO: Tune this more
     console_log(
-        `  [maxConcurrency = ${maxConcurrency}, chunksPerJob = ${chunksPerJob}, numJobs = ${numJobs}]`,
+        `  [maxConcurrency = ${maxConcurrency}, ${batches.length} batches]`,
     );
-    for (const batch of makeBatches(chunks, 50000)) {
+    for (const batch of batches) {
         const p = limiter(() =>
             selectRelevantChunks(
                 context.queryContext!.chunkSelector,
@@ -290,10 +278,16 @@ async function selectChunks(
 
     allChunkDescs.sort((a, b) => b.relevance - a.relevance);
     // console_log(`  [${allChunks.map((c) => (c.relevance)).join(", ")}]`);
-    allChunkDescs.splice(keep);
-    console_log(`  [Keeping ${allChunkDescs.length} chunks]`);
-    // console_log(`  [${allChunks.map((c) => [c.chunkId, c.relevance])}]`);
-    return allChunkDescs;
+    const chunks = keepBestChunks(allChunkDescs, allChunks, 250000); // TODO: Tune this more
+    console_log(`  [Keeping ${chunks.length} chunks]`);
+    for (let i = 0; i < chunks.length; i++) {
+        const chunk = chunks[i];
+        const chunkDesc = allChunkDescs[i];
+        console_log(
+            `    [${chunkDesc.relevance} ${path.basename(chunk.fileName)}:${chunk.codeName} ${chunk.chunkId}]`,
+        );
+    }
+    return chunks;
 }
 
 async function selectRelevantChunks(
@@ -809,6 +803,26 @@ async function retryTranslateOn429<T>(
     return wrappedResult.data;
 }
 
+function keepBestChunks(
+    chunkDescs: ChunkDescription[], // Sorted by descending relevance
+    allChunks: Chunk[],
+    batchSize: number, // In characters
+): Chunk[] {
+    const chunks: Chunk[] = [];
+    let size = 0;
+    for (const chunkDesc of chunkDescs) {
+        const chunk = allChunks.find((c) => c.chunkId === chunkDesc.chunkId);
+        if (!chunk) continue;
+        const chunkSize = getChunkSize(chunk);
+        if (size + chunkSize > batchSize && chunks.length) {
+            break;
+        }
+        chunks.push(chunk);
+        size += chunkSize;
+    }
+    return chunks;
+}
+
 function makeBatches(
     chunks: Chunk[],
     batchSize: number, // In characters
@@ -816,24 +830,24 @@ function makeBatches(
     const batches: Chunk[][] = [];
     let batch: Chunk[] = [];
     let size = 0;
+    function flush(): void {
+        batches.push(batch);
+        console_log(
+            `    [Batch ${batches.length} has ${batch.length} chunks and ${size} bytes]`,
+        );
+        batch = [];
+        size = 0;
+    }
     for (const chunk of chunks) {
         const chunkSize = getChunkSize(chunk);
         if (size + chunkSize > batchSize && batch.length) {
-            batches.push(batch);
-            console_log(
-                `    [Batch ${batches.length} has ${batch.length} chunks and ${size} bytes]`,
-            );
-            batch = [];
-            size = 0;
+            flush();
         }
         batch.push(chunk);
         size += chunkSize;
     }
     if (batch.length) {
-        batches.push(batch);
-        console_log(
-            `    [Batch ${batches.length} has ${batch.length} chunks and ${size} bytes (last)]`,
-        );
+        flush();
     }
     return batches;
 }


### PR DESCRIPTION
We now create batches dynamically instead of using a fixed number of chunks per batch. Based on an approximate (hopefully slightly over-) estimate of chunk sizes, create batches that are up to 250k characters. Similarly, keep 250k characters worth of chunks to send to the oracle.

We also report the actual token usage for each call.

I am trying to satisfy two constraints:

1. There's a limit of 256k characters somewhere (above that you get nasty warnings)
2. I'm not sure what the input buffer token limit is, but it seems 50-55k tokens is acceptable.

Some example output:
```
 0.000 [searchCode question='compare chunker.py and typechatChunker.ts']
 0.000 [Step 1: Load database]
 0.000   [Using database at /home/gvanrossum/.typeagent/agents/spelunker/codeSearchDatabase.db]
 0.000 [Step 1a: Find source files (of supported languages)]
 0.015   [No files to update out of 532, yay cache!]
 0.015 [Step 2: Load chunks from database]
 1.744   [Loaded 3410 chunks]
 1.745 [Step 3: Select most relevant chunks]
 1.746     [Batch 1 has 181 chunks and 249934 bytes]
 1.746     [Batch 2 has 173 chunks and 244719 bytes]
 1.746     [Batch 3 has 181 chunks and 248892 bytes]
 ,,,
 1.752     [Batch 14 has 112 chunks and 247954 bytes]
 1.753     [Batch 15 has 299 chunks and 249837 bytes]
 1.753     [Batch 16 has 242 chunks and 215517 bytes]
 1.753   [maxConcurrency = 20, 16 batches]
12.105     [Tokens used: prompt=53040, completion=181]
14.393     [Tokens used: prompt=53447, completion=181]
15.013     [Tokens used: prompt=52982, completion=517]
...
28.184     [Tokens used: prompt=52743, completion=853]
29.013     [Tokens used: prompt=50624, completion=853]
29.751     [Tokens used: prompt=55406, completion=853]
29.756   [Total 255 chunks selected]
29.765   [Keeping 244 chunks]
29.765     [1 chunker.py:chunker 20250207-165820.500904]
29.765     [1 typescriptChunker.ts:chunkifyTypeScriptFiles 1738976301.065002]
29.765     [0.9 chunker.py:Blob 20250207-165820.501117]
...
29.778     [0.7 searchCode.ts:createActionResultFromMarkdownDisplay 1738979225.550002]
29.778     [0.7 searchCode.ts:loadDatabase 1738979225.550003]
29.778     [0.65 searchCode.ts:getDbOptions 1738979225.555000]
29.778 [Step 4: Construct a prompt for the oracle]
29.782 [Step 5: Ask the oracle]
47.578     [Tokens used: prompt=52227, completion=633]
47.582   [It's a success]
47.582   [References: 20250207-165820.500904, 1738976301.065002]
47.582   [Entities returned:]
47.585     [chunker (code,module) 20250207-165820.500904 /home/gvanrossum/TypeAgent/ts/packages/agents/spelunker/src/chunker.py#1]
47.586     [chunkifyTypeScriptFiles (code,functiondeclaration) 1738976301.065002 /home/gvanrossum/TypeAgent/ts/packages/agents/spelunker/src/typescriptChunker.ts#27]
```
