### PR TITLE
[Spelunker] Adjust breadcrumbs using summaries

### DIFF
--- a/ts/packages/agents/spelunker/src/oracleSchema.ts
+++ b/ts/packages/agents/spelunker/src/oracleSchema.ts
@@ -9,7 +9,7 @@ export type OracleSpecs = {
     question: string; // Original question (e.g. "How can items be related")
     answer: string; // Answer to the question. It is readable and complete, with suitable formatting (line breaks, bullet points etc)
 
-    references: ChunkId[]; // Unique chunk ids that support this answer
-    confidence: number; // Between 0 and 1
+    references: ChunkId[]; // Up to 30 unique chunk ids that support this answer
+    confidence: number; // Your confidence in the answer, between 0 and 1
     message?: string; // Optional message to the user (e.g. for low confidence); might request more input
 };


### PR DESCRIPTION
The intention is to make breadcrumbs embedded in a class, module or outer function more informative even when the chunk which it represents is not included in the context.

This applies to chunk selection and oracle requests; not to summarize requests (or we'd have a chicken/egg problem).

For example, a breadcrumb of the form
```ts
    function beginRefresh ...
```
is replaced with
```ts
     // Prevents multiple calls to refresh while one is pending.
    function beginRefresh(): Promise<Result<string>> ...
```
Note how the indentation is preserved.

Also made many logging tweaks and one small schema tweak.