### PR TITLE
Add flags to cli test translate

### DIFF
--- a/ts/packages/cli/README.md
+++ b/ts/packages/cli/README.md
@@ -148,10 +148,10 @@ This command is used for explanation data management:
 
 Examples:
 
-1. Adding a single request to a new test data file. Note that a translator needs to be specified
+1. Adding a single request to a new test data file. Note that a schema needs to be specified
 
    ```bash
-   $ agent-cli data add -o blah.json "play some bach" --translator player
+   $ agent-cli data add -o blah.json "play some bach" --schema player
    Processing 1 inputs... Concurrency 40
    [player|v5] blah.json: Processing 1/1 (1 added)
    [1/1][ 19.062s] Generated: play some bach
@@ -195,7 +195,7 @@ Examples:
 
 ### Switching Translator and Explainer on command Line
 
-Most command on the CLI accept the `--translator` option to select the translator and `--explainer` option to select
+Most command on the CLI accept the `--schema` option to select the schema and `--explainer` option to select
 the explainer.
 
 ## Trademarks

--- a/ts/packages/cli/src/commands/data/add.ts
+++ b/ts/packages/cli/src/commands/data/add.ts
@@ -50,7 +50,7 @@ export default class ExplanationDataAddCommand extends Command {
                 "Batch processing, only save to file once the file is done",
             default: false,
         }),
-        translator: Flags.string({
+        schema: Flags.string({
             description: "Translator name",
             options: schemaNames,
         }),
@@ -110,11 +110,11 @@ export default class ExplanationDataAddCommand extends Command {
             ) {
                 existingData = await readTestData(flags.output);
                 if (
-                    flags.translator !== undefined &&
-                    flags.translator !== existingData.schemaName
+                    flags.schema !== undefined &&
+                    flags.schema !== existingData.schemaName
                 ) {
                     throw new Error(
-                        `Existing data is for translator '${existingData.schemaName}' but input is for translator '${flags.translator}'`,
+                        `Existing data is for schema '${existingData.schemaName}' but input is for schema '${flags.schema}'`,
                     );
                 }
 
@@ -147,7 +147,7 @@ export default class ExplanationDataAddCommand extends Command {
                         `${existingData.entries.length} existing entries loaded`,
                     );
                 }
-            } else if (flags.translator) {
+            } else if (flags.schema) {
                 const config = provider.getActionConfig(flags.schemaName);
                 const sourceHash =
                     provider.getActionSchemaFileForConfig(config).sourceHash;
@@ -159,7 +159,7 @@ export default class ExplanationDataAddCommand extends Command {
                 );
             } else {
                 throw new Error(
-                    `Translator name is not specified.  Please specify a translator name with --translator`,
+                    `Schema name is not specified.  Please specify a schema name with --schema`,
                 );
             }
 

--- a/ts/packages/cli/src/commands/data/stat.ts
+++ b/ts/packages/cli/src/commands/data/stat.ts
@@ -157,7 +157,7 @@ export default class ExplanationDataStatCommmand extends Command {
         }),
     };
     static flags = {
-        translator: Flags.string({
+        schema: Flags.string({
             description: "Filter by translator",
             options: schemaNames,
             multiple: true,
@@ -291,8 +291,7 @@ export default class ExplanationDataStatCommmand extends Command {
             try {
                 const data = await readTestData(file);
                 if (
-                    (flags.translator &&
-                        !flags.translator.includes(data.schemaName)) ||
+                    (flags.schema && !flags.schema.includes(data.schemaName)) ||
                     (flags.explainer &&
                         !flags.explainer.includes(data.explainerName))
                 ) {

--- a/ts/packages/cli/src/commands/interactive.ts
+++ b/ts/packages/cli/src/commands/interactive.ts
@@ -30,7 +30,7 @@ const schemaNames = getSchemaNamesForActionConfigProvider(
 export default class Interactive extends Command {
     static description = "Interactive mode";
     static flags = {
-        translator: Flags.string({
+        schema: Flags.string({
             description: "Schema names",
             options: schemaNames,
             multiple: true,
@@ -72,8 +72,8 @@ export default class Interactive extends Command {
             inspector.open(undefined, undefined, true);
         }
 
-        const schemas = flags.translator
-            ? Object.fromEntries(flags.translator.map((name) => [name, true]))
+        const schemas = flags.schema
+            ? Object.fromEntries(flags.schema.map((name) => [name, true]))
             : undefined;
 
         await withConsoleClientIO(async (clientIO) => {

--- a/ts/packages/cli/src/commands/run/explain.ts
+++ b/ts/packages/cli/src/commands/run/explain.ts
@@ -39,7 +39,7 @@ export default class ExplainCommand extends Command {
     };
 
     static flags = {
-        translator: Flags.string({
+        schema: Flags.string({
             description: "Translator names",
             options: schemaNames,
             multiple: true,
@@ -72,8 +72,8 @@ export default class ExplainCommand extends Command {
 
     async run(): Promise<void> {
         const { args, flags } = await this.parse(ExplainCommand);
-        const schemas = flags.translator
-            ? Object.fromEntries(flags.translator.map((name) => [name, true]))
+        const schemas = flags.schema
+            ? Object.fromEntries(flags.schema.map((name) => [name, true]))
             : undefined;
 
         const command = ["@dispatcher explain"];

--- a/ts/packages/cli/src/commands/run/request.ts
+++ b/ts/packages/cli/src/commands/run/request.ts
@@ -33,7 +33,7 @@ export default class RequestCommand extends Command {
     };
 
     static flags = {
-        translator: Flags.string({
+        schema: Flags.string({
             description: "Schema name",
             options: schemaNames,
             multiple: true,
@@ -57,8 +57,8 @@ export default class RequestCommand extends Command {
 
     async run(): Promise<void> {
         const { args, flags } = await this.parse(RequestCommand);
-        const schemas = flags.translator
-            ? Object.fromEntries(flags.translator.map((name) => [name, true]))
+        const schemas = flags.schema
+            ? Object.fromEntries(flags.schema.map((name) => [name, true]))
             : undefined;
         const dispatcher = await createDispatcher("cli run request", {
             appAgentProviders: defaultAppAgentProviders,

--- a/ts/packages/cli/src/commands/run/translate.ts
+++ b/ts/packages/cli/src/commands/run/translate.ts
@@ -28,7 +28,7 @@ export default class TranslateCommand extends Command {
     };
 
     static flags = {
-        translator: Flags.string({
+        schema: Flags.string({
             description: "Translator name",
             options: schemaNames,
             multiple: true,
@@ -54,8 +54,8 @@ export default class TranslateCommand extends Command {
 
     async run(): Promise<void> {
         const { args, flags } = await this.parse(TranslateCommand);
-        const schemas = flags.translator
-            ? Object.fromEntries(flags.translator.map((name) => [name, true]))
+        const schemas = flags.schema
+            ? Object.fromEntries(flags.schema.map((name) => [name, true]))
             : undefined;
 
         await withConsoleClientIO(async (clientIO: ClientIO) => {

--- a/ts/packages/dispatcher/src/context/system/systemAgent.ts
+++ b/ts/packages/dispatcher/src/context/system/systemAgent.ts
@@ -194,8 +194,8 @@ class ActionCommandHandler implements CommandHandler {
     public readonly description = "Execute an action";
     public readonly parameters = {
         args: {
-            translatorName: {
-                description: "Action translator name",
+            schemaName: {
+                description: "Action schema name",
             },
             actionName: {
                 description: "Action name",
@@ -214,22 +214,22 @@ class ActionCommandHandler implements CommandHandler {
         params: ParsedCommandParams<typeof this.parameters>,
     ) {
         const systemContext = context.sessionContext.agentContext;
-        const { translatorName, actionName } = params.args;
+        const { schemaName, actionName } = params.args;
         const actionSchemaFile =
-            systemContext.agents.tryGetActionSchemaFile(translatorName);
+            systemContext.agents.tryGetActionSchemaFile(schemaName);
         if (actionSchemaFile === undefined) {
-            throw new Error(`Invalid schema name ${translatorName}`);
+            throw new Error(`Invalid schema name ${schemaName}`);
         }
 
         const actionSchema = actionSchemaFile.actionSchemas.get(actionName);
         if (actionSchema === undefined) {
             throw new Error(
-                `Invalid action name ${actionName} for schema ${translatorName}`,
+                `Invalid action name ${actionName} for schema ${schemaName}`,
             );
         }
 
         const action: AppAction = {
-            translatorName,
+            translatorName: schemaName,
             actionName,
         };
 
@@ -260,12 +260,12 @@ class ActionCommandHandler implements CommandHandler {
             }
 
             if (name === "actionName") {
-                const translatorName = params.args?.translatorName;
-                if (translatorName === undefined) {
+                const schemaName = params.args?.schemaName;
+                if (schemaName === undefined) {
                     continue;
                 }
                 const actionSchemaFile =
-                    systemContext.agents.tryGetActionSchemaFile(translatorName);
+                    systemContext.agents.tryGetActionSchemaFile(schemaName);
                 if (actionSchemaFile === undefined) {
                     continue;
                 }
@@ -276,7 +276,7 @@ class ActionCommandHandler implements CommandHandler {
             if (name === "--parameters.") {
                 // complete the flag name for json properties
                 const action = {
-                    translatorName: params.args?.translatorName,
+                    translatorName: params.args?.schemaName,
                     actionName: params.args?.actionName,
                     parameters: params.flags?.parameters,
                 };
@@ -306,7 +306,7 @@ class ActionCommandHandler implements CommandHandler {
                 // complete the flag values for json properties
 
                 const action = {
-                    translatorName: params.args?.translatorName,
+                    translatorName: params.args?.schemaName,
                     actionName: params.args?.actionName,
                     parameters: params.flags?.parameters,
                 };


### PR DESCRIPTION
Mirror flags with `cli run translate`
- Add `--jsonSchema` to turn on JSON schema mode
- Add `--multiple` (and `--no-multiple`) to turn on/off multiple actions.
- Add `--model` to config the model to use.

Add other flags
- Add `--success` to rerun successful tests.

Add execution time to `cli run translate`