### PR TITLE
Skip the Typescript schema by default when JsonSchema is enabled.

### DIFF
--- a/ts/packages/actionSchema/src/generator.ts
+++ b/ts/packages/actionSchema/src/generator.ts
@@ -124,14 +124,21 @@ export type GenerateSchemaOptions = {
     strict?: boolean; // default true
     exact?: boolean; // default false
     jsonSchema?: boolean; // default false
+    jsonSchemaWithTs?: boolean; // default false, applies only when jsonSchema is true.
 };
 
 export function generateSchemaTypeDefinition(
     definition: SchemaTypeDefinition,
     options?: GenerateSchemaOptions,
     order?: Map<string, number>,
-) {
+): string {
+    // wrap the action schema when json schema is active.
     const jsonSchema = options?.jsonSchema ?? false;
+    const includeTs = !jsonSchema || (options?.jsonSchemaWithTs ?? false);
+    if (!includeTs) {
+        return "";
+    }
+
     const strict = options?.strict ?? true;
     const exact = options?.exact ?? false;
     const emitted = new Map<

--- a/ts/packages/dispatcher/src/context/chatHistoryPrompt.ts
+++ b/ts/packages/dispatcher/src/context/chatHistoryPrompt.ts
@@ -22,12 +22,21 @@ export function createTypeAgentRequestPrompt(
         }
     }
 
-    const prompts: string[] = [
-        `You are a service that translates user requests into JSON objects of type "${translator.validator.getTypeName()}" according to the following TypeScript definitions:`,
-        `\`\`\``,
-        translator.validator.getSchemaText(),
-        `\`\`\``,
-    ];
+    const prompts: string[] = [];
+    if (translator.validator.getSchemaText() === "") {
+        // If the schema is empty, we are skipping the type script schema because of json schema.
+        prompts.push(
+            `You are a service that translates user requests into JSON objects`,
+        );
+    } else {
+        prompts.push(
+            `You are a service that translates user requests into JSON objects of type "${translator.validator.getTypeName()}" according to the following TypeScript definitions:`,
+            `\`\`\``,
+            translator.validator.getSchemaText(),
+            `\`\`\``,
+        );
+    }
+
     if (context) {
         if (history !== undefined) {
             const promptSections: PromptSection[] = history.promptSections;

--- a/ts/packages/dispatcher/src/context/session.ts
+++ b/ts/packages/dispatcher/src/context/session.ts
@@ -90,6 +90,7 @@ type DispatcherConfig = {
             generation: {
                 enabled: boolean;
                 jsonSchema: boolean;
+                jsonSchemaWithTs: boolean; // only applies when jsonSchema is true
             };
             optimize: {
                 enabled: boolean;
@@ -157,6 +158,7 @@ const defaultSessionConfig: SessionConfig = {
             generation: {
                 enabled: true,
                 jsonSchema: false,
+                jsonSchemaWithTs: true,
             },
             optimize: {
                 enabled: false,

--- a/ts/packages/dispatcher/src/translation/actionSchemaJsonTranslator.ts
+++ b/ts/packages/dispatcher/src/translation/actionSchemaJsonTranslator.ts
@@ -70,7 +70,7 @@ function createActionSchemaJsonValidator<T extends TranslatedAction>(
     };
 }
 
-export function createActionJsonTranslatorFromSchemaDef<
+export function createJsonTranslatorFromActionSchema<
     T extends TranslatedAction,
 >(
     typeName: string,

--- a/ts/packages/dispatcher/src/translation/agentTranslators.ts
+++ b/ts/packages/dispatcher/src/translation/agentTranslators.ts
@@ -26,7 +26,7 @@ import { createTypeAgentRequestPrompt } from "../context/chatHistoryPrompt.js";
 import {
     composeActionSchema,
     composeSelectedActionSchema,
-    createActionJsonTranslatorFromSchemaDef,
+    createJsonTranslatorFromActionSchema,
 } from "./actionSchemaJsonTranslator.js";
 import {
     ActionSchemaTypeDefinition,
@@ -34,6 +34,7 @@ import {
     generateSchemaTypeDefinition,
     ActionSchemaObject,
     ActionSchemaCreator as sc,
+    GenerateSchemaOptions,
 } from "action-schema";
 import { ActionConfig } from "./actionConfig.js";
 import { ActionConfigProvider } from "./actionConfigProvider.js";
@@ -262,12 +263,11 @@ export function loadAgentJsonTranslator<
     multipleActionOptions: MultipleActionOptions,
     regenerateSchema: boolean = true,
     model?: string,
-    exact: boolean = true,
-    jsonSchema: boolean = false,
+    generateOptions?: GenerateSchemaOptions,
 ): TypeAgentTranslator<T> {
     const options = { model };
     const translator = regenerateSchema
-        ? createActionJsonTranslatorFromSchemaDef<T>(
+        ? createJsonTranslatorFromActionSchema<T>(
               "AllActions",
               composeActionSchema(
                   translatorName,
@@ -277,7 +277,7 @@ export function loadAgentJsonTranslator<
                   multipleActionOptions,
               ),
               options,
-              { exact, jsonSchema },
+              generateOptions,
           )
         : createJsonTranslatorFromSchemaDef<T>(
               "AllActions",
@@ -368,7 +368,7 @@ export function createTypeAgentTranslatorForSelectedActions<
     model?: string,
 ) {
     const options = { model };
-    const translator = createActionJsonTranslatorFromSchemaDef<T>(
+    const translator = createJsonTranslatorFromActionSchema<T>(
         "AllActions",
         composeSelectedActionSchema(
             definitions,

--- a/ts/packages/dispatcher/src/translation/translateRequest.ts
+++ b/ts/packages/dispatcher/src/translation/translateRequest.ts
@@ -73,8 +73,11 @@ export function getTranslatorForSchema(
         config.multiple,
         config.schema.generation.enabled,
         config.model,
-        !config.schema.optimize.enabled,
-        config.schema.generation.jsonSchema,
+        {
+            exact: !config.schema.optimize.enabled,
+            jsonSchema: config.schema.generation.jsonSchema,
+            jsonSchemaWithTs: config.schema.generation.jsonSchemaWithTs,
+        },
     );
     context.translatorCache.set(translatorName, newTranslator);
     return newTranslator;


### PR DESCRIPTION
- Skip including the typescript schema in the main prompt when JsonSchema is enabled.
- Add the schema comments as descriptions to Json schema.
- `cli test translate`, separate skipped requests in its only category that can be controlled using --skipped to regenerate.
- Fix `cli test translate` to count all failed case as processed.