### PR TITLE
Add function calling support

### DIFF
--- a/ts/packages/actionSchema/src/generator.ts
+++ b/ts/packages/actionSchema/src/generator.ts
@@ -124,16 +124,22 @@ export type GenerateSchemaOptions = {
     strict?: boolean; // default true
     exact?: boolean; // default false
     jsonSchema?: boolean; // default false
-    jsonSchemaWithTs?: boolean; // default false, applies only when jsonSchema is true.
+    jsonSchemaFunction?: boolean; // default false
+    jsonSchemaWithTs?: boolean; // default false, applies only when jsonSchema or jsonSchemaFunction is true.
+    jsonSchemaValidate?: boolean; //default false, applies only when jsonSchema or jsonSchemaFunction is true.
 };
 
+function isJsonSchemaEnabled(options?: GenerateSchemaOptions): boolean {
+    return options?.jsonSchema === true || options?.jsonSchemaFunction === true;
+}
 export function generateSchemaTypeDefinition(
     definition: SchemaTypeDefinition,
     options?: GenerateSchemaOptions,
     order?: Map<string, number>,
 ): string {
     // wrap the action schema when json schema is active.
-    const jsonSchema = options?.jsonSchema ?? false;
+    const jsonSchema = isJsonSchemaEnabled(options);
+
     const includeTs = !jsonSchema || (options?.jsonSchemaWithTs ?? false);
     if (!includeTs) {
         return "";
@@ -192,7 +198,7 @@ export function generateActionSchema(
     options?: GenerateSchemaOptions,
 ): string {
     return generateSchemaTypeDefinition(
-        options?.jsonSchema
+        isJsonSchemaEnabled(options)
             ? wrapTypeWithJsonSchema(actionSchemaGroup.entry)
             : actionSchemaGroup.entry,
         options,

--- a/ts/packages/actionSchema/src/index.ts
+++ b/ts/packages/actionSchema/src/index.ts
@@ -19,7 +19,10 @@ export {
     generateActionSchema,
     generateSchemaTypeDefinition,
 } from "./generator.js";
-export { generateActionJsonSchema } from "./jsonSchemaGenerator.js";
+export {
+    generateActionJsonSchema,
+    generateActionJsonSchemaFunctions,
+} from "./jsonSchemaGenerator.js";
 export { validateAction } from "./validate.js";
 export { getParameterType, getParameterNames } from "./utils.js";
 

--- a/ts/packages/actionSchema/src/jsonSchemaGenerator.ts
+++ b/ts/packages/actionSchema/src/jsonSchemaGenerator.ts
@@ -65,8 +65,10 @@ type JsonSchemaRoot = {
     name: string;
     description?: string;
     strict: true;
-    schema: JsonSchema & { $defs?: Record<string, JsonSchema> }; // REVIEW should be JsonSchemaObject;
+    schema: JsonSchemaTop;
 };
+
+type JsonSchemaTop = JsonSchema & { $defs?: Record<string, JsonSchema> }; // REVIEW should be JsonSchemaObject;
 
 type JsonSchema =
     | JsonSchemaObject
@@ -83,7 +85,7 @@ function fieldComments(field: SchemaObjectField): string | undefined {
         ...(field.comments ?? []),
         ...(field.trailingComments ?? []),
     ];
-    return combined.length > 0 ? combined.join("\n") : undefined;
+    return combined.length > 0 ? combined.join("\n").trim() : undefined;
 }
 
 function generateJsonSchemaType(
@@ -103,8 +105,12 @@ function generateJsonSchemaType(
                             strict,
                         );
                         const comments = fieldComments(field);
-                        if (comments) {
-                            fieldType.description = comments;
+                        // BUG: missing comment on fields with type references.
+                        // See Issue https://github.com/OAI/OpenAPI-Specification/issues/1514
+                        if (field.type.type !== "type-reference") {
+                            if (comments) {
+                                fieldType.description = comments;
+                            }
                         }
                         return [key, fieldType];
                     }),
@@ -149,20 +155,13 @@ function generateJsonSchemaType(
             return { type: type.type };
     }
 }
-function generateJsonSchemaTypeDefinition(
-    def: SchemaTypeDefinition,
-    strict: boolean = true,
-): JsonSchemaRoot {
-    const pending: SchemaTypeDefinition[] = [];
-    const schema: JsonSchemaRoot = {
-        name: def.name,
-        strict: true,
-        schema: generateJsonSchemaType(def.type, pending, strict),
-    };
-    if (def.comments) {
-        schema.schema.description = def.comments.join("\n");
-    }
 
+function generateJsonSchemaTypeWithDefs(
+    type: SchemaType,
+    strict: boolean = true,
+) {
+    const pending: SchemaTypeDefinition[] = [];
+    const schema: JsonSchemaTop = generateJsonSchemaType(type, pending, strict);
     if (pending.length !== 0) {
         const $defs: Record<string, JsonSchema> = {};
         do {
@@ -180,13 +179,106 @@ function generateJsonSchemaTypeDefinition(
                     definition.comments.join("\n");
             }
         } while (pending.length > 0);
-        schema.schema.$defs = $defs;
+        schema.$defs = $defs;
     }
     return schema;
+}
+function generateJsonSchemaTypeDefinition(
+    def: SchemaTypeDefinition,
+    strict: boolean = true,
+): JsonSchemaRoot {
+    const root: JsonSchemaRoot = {
+        name: def.name,
+        strict: true,
+        schema: generateJsonSchemaTypeWithDefs(def.type, strict),
+    };
+    if (def.comments) {
+        root.schema.description = def.comments.join("\n");
+    }
+
+    return root;
 }
 
 export function generateActionJsonSchema(actionSchemaGroup: ActionSchemaGroup) {
     const type = wrapTypeWithJsonSchema(actionSchemaGroup.entry);
 
     return generateJsonSchemaTypeDefinition(type);
+}
+
+type JsonSchemaFunctions = {
+    type: "function";
+    function: {
+        name: string;
+        description?: string;
+        parameters?: JsonSchemaTop;
+        strict: true;
+    };
+};
+
+export function generateActionJsonSchemaFunctions(
+    actionSchemaGroup: ActionSchemaGroup,
+    strict: boolean = true,
+) {
+    const entry = actionSchemaGroup.entry;
+    const definitions: ActionSchemaEntryTypeDefinition[] = [entry];
+    const tools: JsonSchemaFunctions[] = [];
+    while (definitions.length !== 0) {
+        const def = definitions.shift()!;
+        switch (def.type.type) {
+            case "object":
+                const tool: JsonSchemaFunctions = {
+                    type: "function",
+                    function: {
+                        name: def.type.fields.actionName.type.typeEnum[0],
+                        strict: true,
+                    },
+                };
+
+                const parameters = def.type.fields.parameters;
+                if (parameters !== undefined) {
+                    tool.function.parameters = generateJsonSchemaTypeWithDefs(
+                        parameters.type,
+                        strict,
+                    );
+
+                    const comments = fieldComments(parameters);
+                    if (comments) {
+                        tool.function.description = comments;
+                    }
+                } else {
+                    tool.function.parameters = {
+                        type: "object",
+                        properties: {},
+                        required: [],
+                        additionalProperties: false,
+                    };
+                }
+                tools.push(tool);
+                break;
+            case "type-union":
+                for (const type of def.type.types) {
+                    if (type.definition === undefined) {
+                        if (strict && type.definition === undefined) {
+                            throw new Error(
+                                `Unresolved type reference: ${type.name}`,
+                            );
+                        }
+                        continue;
+                    }
+                    definitions.push(type.definition);
+                }
+                break;
+            case "type-reference":
+                if (def.type.definition) {
+                    definitions.push(def.type.definition);
+                } else if (strict) {
+                    throw new Error(
+                        `Unresolved type reference: ${def.type.name}`,
+                    );
+                }
+                break;
+        }
+    }
+
+    return tools;
 }

--- a/ts/packages/cli/src/commands/run/translate.ts
+++ b/ts/packages/cli/src/commands/run/translate.ts
@@ -45,6 +45,10 @@ export default class TranslateCommand extends Command {
             description: "Output JSON schema",
             allowNo: true,
         }),
+        jsonSchemaFunction: Flags.boolean({
+            description: "Output JSON schema function",
+            allowNo: true,
+        }),
     };
 
     static description = "Translate a request into action";
@@ -67,7 +71,12 @@ export default class TranslateCommand extends Command {
                 translation: {
                     model: flags.model,
                     multiple: { enabled: flags.multiple },
-                    schema: { generation: { jsonSchema: flags.jsonSchema } },
+                    schema: {
+                        generation: {
+                            jsonSchema: flags.jsonSchema,
+                            jsonSchemaFunction: flags.jsonSchemaFunction,
+                        },
+                    },
                 },
                 cache: { enabled: false },
                 clientIO,

--- a/ts/packages/cli/src/commands/test/translate.ts
+++ b/ts/packages/cli/src/commands/test/translate.ts
@@ -186,24 +186,29 @@ export default class TestTranslateCommand extends Command {
                 throw new Error("Result file is empty. No tests to rerun.");
             }
 
-            // determine repeat
-            if (input.pass.length !== 0) {
-                repeat = input.pass[0].actions.length;
-            } else {
-                const e = input.fail.find((e) => e.actions !== undefined);
-                if (e === undefined) {
-                    repeat = flags.repeat ?? defaultRepeat;
-                } else {
-                    repeat = e?.actions!.length;
-                }
-            }
-
-            if (flags.repeat !== undefined && flags.repeat !== repeat) {
-                throw new Error("Specified repeat doesn't match result file");
-            }
-
             const includeAll =
                 !flags.succeeded && !flags.failed && !flags.skipped;
+
+            if (includeAll) {
+                repeat = flags.repeat ?? defaultRepeat;
+            } else {
+                // determine repeat
+                if (input.pass.length !== 0) {
+                    repeat = input.pass[0].actions.length;
+                } else {
+                    const e = input.fail.find((e) => e.actions !== undefined);
+                    if (e === undefined) {
+                        repeat = flags.repeat ?? defaultRepeat;
+                    } else {
+                        repeat = e?.actions!.length;
+                    }
+                }
+                if (flags.repeat !== undefined && flags.repeat !== repeat) {
+                    throw new Error(
+                        "Specified repeat doesn't match result file",
+                    );
+                }
+            }
 
             if (includeAll || flags.succeeded) {
                 requests = requests.concat(
@@ -250,6 +255,10 @@ export default class TestTranslateCommand extends Command {
                 .map((entry) => entry.request);
         }
 
+        if (repeat <= 0) {
+            throw new Error("Repeat must be greater than 0");
+        }
+
         let countStr = requests.length.toString();
         if (flags.sample !== undefined) {
             output.skipped = [];
@@ -261,11 +270,9 @@ export default class TestTranslateCommand extends Command {
                     ),
                 );
             }
-            countStr = `${flags.sample}/${countStr}`;
+            countStr = `${requests.length}/${countStr}`;
         }
-        if (flags.failed && flags.input !== undefined) {
-            countStr = `${countStr} failed`;
-        }
+
         const schemas = flags.schema
             ? Object.fromEntries(flags.schema.map((name) => [name, true]))
             : undefined;

--- a/ts/packages/cli/src/commands/test/translate.ts
+++ b/ts/packages/cli/src/commands/test/translate.ts
@@ -115,6 +115,10 @@ export default class TestTranslateCommand extends Command {
             description: "Output JSON schema",
             allowNo: true,
         }),
+        jsonSchemaFunction: Flags.boolean({
+            description: "Output JSON schema function",
+            allowNo: true,
+        }),
         concurrency: Flags.integer({
             char: "c",
             description: "Number of concurrent requests (default to 4)",
@@ -301,10 +305,16 @@ export default class TestTranslateCommand extends Command {
                 actions: null,
                 commands: { dispatcher: true },
                 translation: {
+                    stream: false,
                     history: { enabled: false },
                     model: flags.model,
                     multiple: { enabled: flags.multiple },
-                    schema: { generation: { jsonSchema: flags.jsonSchema } },
+                    schema: {
+                        generation: {
+                            jsonSchema: flags.jsonSchema,
+                            jsonSchemaFunction: flags.jsonSchemaFunction,
+                        },
+                    },
                 },
                 explainer: { enabled: false },
                 cache: { enabled: false },

--- a/ts/packages/dispatcher/src/context/chatHistoryPrompt.ts
+++ b/ts/packages/dispatcher/src/context/chatHistoryPrompt.ts
@@ -14,7 +14,7 @@ export function createTypeAgentRequestPrompt(
     request: string,
     history: HistoryContext | undefined,
     attachments: CachedImageWithDetails[] | undefined,
-    context: boolean = true,
+    context: boolean = true, // set to false to totally remove any context information (e.g. today's date), not just history
 ) {
     if (attachments !== undefined && attachments?.length > 0) {
         if (request.length == 0) {

--- a/ts/packages/dispatcher/src/context/dispatcher/handlers/requestCommandHandler.ts
+++ b/ts/packages/dispatcher/src/context/dispatcher/handlers/requestCommandHandler.ts
@@ -322,7 +322,7 @@ export class RequestCommandHandler implements CommandHandler {
             }
 
             const history = systemContext.session.getConfig().translation
-                .history
+                .history.enabled
                 ? getChatHistoryForTranslation(systemContext)
                 : undefined;
 

--- a/ts/packages/dispatcher/src/context/session.ts
+++ b/ts/packages/dispatcher/src/context/session.ts
@@ -90,7 +90,9 @@ type DispatcherConfig = {
             generation: {
                 enabled: boolean;
                 jsonSchema: boolean;
-                jsonSchemaWithTs: boolean; // only applies when jsonSchema is true
+                jsonSchemaFunction: boolean;
+                jsonSchemaWithTs: boolean; // only applies when jsonSchema or jsonSchemaFunction is true
+                jsonSchemaValidate: boolean; // only applies when jsonSchema or jsonSchemaFunction is true
             };
             optimize: {
                 enabled: boolean;
@@ -158,7 +160,9 @@ const defaultSessionConfig: SessionConfig = {
             generation: {
                 enabled: true,
                 jsonSchema: false,
-                jsonSchemaWithTs: true,
+                jsonSchemaFunction: false,
+                jsonSchemaWithTs: false,
+                jsonSchemaValidate: false,
             },
             optimize: {
                 enabled: false,

--- a/ts/packages/dispatcher/src/context/system/handlers/configCommandHandlers.ts
+++ b/ts/packages/dispatcher/src/context/system/handlers/configCommandHandlers.ts
@@ -827,6 +827,23 @@ const configTranslationCommandHandlers: CommandHandlerTable = {
                                 );
                             },
                         ),
+                        jsonFunc: getToggleHandlerTable(
+                            "use generate json schema function if model supports it",
+                            async (context, enable: boolean) => {
+                                await changeContextConfig(
+                                    {
+                                        translation: {
+                                            schema: {
+                                                generation: {
+                                                    jsonSchemaFunction: enable,
+                                                },
+                                            },
+                                        },
+                                    },
+                                    context,
+                                );
+                            },
+                        ),
                     },
                 },
                 optimize: {

--- a/ts/packages/dispatcher/src/translation/translateRequest.ts
+++ b/ts/packages/dispatcher/src/translation/translateRequest.ts
@@ -76,7 +76,9 @@ export function getTranslatorForSchema(
         {
             exact: !config.schema.optimize.enabled,
             jsonSchema: config.schema.generation.jsonSchema,
+            jsonSchemaFunction: config.schema.generation.jsonSchemaFunction,
             jsonSchemaWithTs: config.schema.generation.jsonSchemaWithTs,
+            jsonSchemaValidate: config.schema.generation.jsonSchemaValidate,
         },
     );
     context.translatorCache.set(translatorName, newTranslator);


### PR DESCRIPTION
- Add function calling support (in addition to structure output).  They are very similar except for a little bit different between the schemas, the REST call param and the output location (note that streaming is not implemented yet)
- Fix JSON schema with $ref subschema, where description is not supported (that means that we will miss comments for fields with a type reference).
- When Json schema (either structured output or function calling) is enabled, don't inject the typescript schema from the main prompt and also don't validate the output (assuming the service have validated them already since we have strict mode on).
- Also with `cli test translate` allow number of repeat to change if we process all the data from the `-i` input if specified.
- Fix the incorrect check if history is enabled/disabled or not.