### PR TITLE
Add json schema validate flag

### DIFF
--- a/ts/packages/actionSchema/src/index.ts
+++ b/ts/packages/actionSchema/src/index.ts
@@ -21,7 +21,9 @@ export {
 } from "./generator.js";
 export {
     generateActionJsonSchema,
-    generateActionJsonSchemaFunctions,
+    generateActionActionFunctionJsonSchemas,
+    ActionObjectJsonSchema,
+    ActionFunctionJsonSchema,
 } from "./jsonSchemaGenerator.js";
 export { validateAction } from "./validate.js";
 export { getParameterType, getParameterNames } from "./utils.js";

--- a/ts/packages/actionSchema/src/jsonSchemaGenerator.ts
+++ b/ts/packages/actionSchema/src/jsonSchemaGenerator.ts
@@ -61,14 +61,14 @@ type JsonSchemaReference = {
     description?: string;
 };
 
-type JsonSchemaRoot = {
+export type ActionObjectJsonSchema = {
     name: string;
     description?: string;
     strict: true;
-    schema: JsonSchemaTop;
+    schema: JsonSchemaRoot;
 };
 
-type JsonSchemaTop = JsonSchema & { $defs?: Record<string, JsonSchema> }; // REVIEW should be JsonSchemaObject;
+type JsonSchemaRoot = JsonSchema & { $defs?: Record<string, JsonSchema> }; // REVIEW should be JsonSchemaObject;
 
 type JsonSchema =
     | JsonSchemaObject
@@ -161,7 +161,11 @@ function generateJsonSchemaTypeWithDefs(
     strict: boolean = true,
 ) {
     const pending: SchemaTypeDefinition[] = [];
-    const schema: JsonSchemaTop = generateJsonSchemaType(type, pending, strict);
+    const schema: JsonSchemaRoot = generateJsonSchemaType(
+        type,
+        pending,
+        strict,
+    );
     if (pending.length !== 0) {
         const $defs: Record<string, JsonSchema> = {};
         do {
@@ -186,8 +190,8 @@ function generateJsonSchemaTypeWithDefs(
 function generateJsonSchemaTypeDefinition(
     def: SchemaTypeDefinition,
     strict: boolean = true,
-): JsonSchemaRoot {
-    const root: JsonSchemaRoot = {
+): ActionObjectJsonSchema {
+    const root: ActionObjectJsonSchema = {
         name: def.name,
         strict: true,
         schema: generateJsonSchemaTypeWithDefs(def.type, strict),
@@ -205,28 +209,28 @@ export function generateActionJsonSchema(actionSchemaGroup: ActionSchemaGroup) {
     return generateJsonSchemaTypeDefinition(type);
 }
 
-type JsonSchemaFunctions = {
+export type ActionFunctionJsonSchema = {
     type: "function";
     function: {
         name: string;
         description?: string;
-        parameters?: JsonSchemaTop;
+        parameters?: JsonSchemaRoot;
         strict: true;
     };
 };
 
-export function generateActionJsonSchemaFunctions(
+export function generateActionActionFunctionJsonSchemas(
     actionSchemaGroup: ActionSchemaGroup,
     strict: boolean = true,
 ) {
     const entry = actionSchemaGroup.entry;
     const definitions: ActionSchemaEntryTypeDefinition[] = [entry];
-    const tools: JsonSchemaFunctions[] = [];
+    const tools: ActionFunctionJsonSchema[] = [];
     while (definitions.length !== 0) {
         const def = definitions.shift()!;
         switch (def.type.type) {
             case "object":
-                const tool: JsonSchemaFunctions = {
+                const tool: ActionFunctionJsonSchema = {
                     type: "function",
                     function: {
                         name: def.type.fields.actionName.type.typeEnum[0],

--- a/ts/packages/aiclient/src/models.ts
+++ b/ts/packages/aiclient/src/models.ts
@@ -25,16 +25,26 @@ export type CompletionSettings = {
 export interface ChatModel extends TypeChatLanguageModel {
     completionSettings: CompletionSettings;
     completionCallback?: ((request: any, response: any) => void) | undefined;
+    /**
+     * Complete the prompt
+     * @param prompt prompt or prompt sections to complete
+     * @param jsonSchema optional json schema. If the json schema is an object, then it uses structured output. If the json schema is an array, then it is function calling.
+     */
     complete(
         prompt: string | PromptSection[],
-        jsonSchema?: JsonSchema,
+        jsonSchema?: JsonSchema | JsonSchema[],
     ): Promise<Result<string>>;
 }
 
 export interface ChatModelWithStreaming extends ChatModel {
+    /**
+     * Complete the prompt with streaming
+     * @param prompt prompt or prompt sections to complete
+     * @param jsonSchema optional json schema. If the json schema is an object, then it uses structured output. If the json schema is an array, then it is function calling.
+     */
     completeStream(
         prompt: string | PromptSection[],
-        jsonSchema?: JsonSchema,
+        jsonSchema?: JsonSchema | JsonSchema[],
     ): Promise<Result<AsyncIterableIterator<string>>>;
 }
 

--- a/ts/packages/aiclient/src/openai.ts
+++ b/ts/packages/aiclient/src/openai.ts
@@ -300,13 +300,15 @@ type ChatCompletion = {
     usage: CompletionUsageStats;
 };
 
+export type ToolCallOutput = {
+    name: string;
+    arguments: any;
+};
+
 type ToolCall = {
     id: string;
     type: "function";
-    function: {
-        name: string;
-        arguments: any;
-    };
+    function: ToolCallOutput;
 };
 
 type ChatCompletionChoice = {
@@ -528,14 +530,7 @@ function createAzureOpenAIChatModel(
             if (c.type !== "function") {
                 return error("Invalid tool call type");
             }
-
-            // Fake the response to look like structured output, see createActionSchemaJsonValidator
-            const parameters = c.function.arguments;
-            const result =
-                parameters === "{}"
-                    ? `{"response":{"actionName":"${c.function.name}"}}`
-                    : `{"response":{"actionName":"${c.function.name}","parameters":${parameters}}}`;
-            return success(result);
+            return success(JSON.stringify(c.function));
         }
         return success(data.choices[0].message?.content ?? "");
     }

--- a/ts/packages/cli/src/commands/run/translate.ts
+++ b/ts/packages/cli/src/commands/run/translate.ts
@@ -48,6 +48,13 @@ export default class TranslateCommand extends Command {
         jsonSchemaFunction: Flags.boolean({
             description: "Output JSON schema function",
             allowNo: true,
+            exclusive: ["jsonSchema"],
+        }),
+        jsonSchemaValidate: Flags.boolean({
+            description: "Validate the output when JSON schema is enabled",
+            relationships: [
+                { type: "some", flags: ["jsonSchema", "jsonSchemaFunction"] },
+            ],
         }),
     };
 
@@ -75,6 +82,7 @@ export default class TranslateCommand extends Command {
                         generation: {
                             jsonSchema: flags.jsonSchema,
                             jsonSchemaFunction: flags.jsonSchemaFunction,
+                            jsonSchemaValidate: flags.jsonSchemaValidate,
                         },
                     },
                 },

--- a/ts/packages/cli/src/commands/test/translate.ts
+++ b/ts/packages/cli/src/commands/test/translate.ts
@@ -118,6 +118,13 @@ export default class TestTranslateCommand extends Command {
         jsonSchemaFunction: Flags.boolean({
             description: "Output JSON schema function",
             allowNo: true,
+            exclusive: ["jsonSchema"],
+        }),
+        jsonSchemaValidate: Flags.boolean({
+            description: "Validate the output when JSON schema is enabled",
+            relationships: [
+                { type: "some", flags: ["jsonSchema", "jsonSchemaFunction"] },
+            ],
         }),
         concurrency: Flags.integer({
             char: "c",
@@ -313,6 +320,7 @@ export default class TestTranslateCommand extends Command {
                         generation: {
                             jsonSchema: flags.jsonSchema,
                             jsonSchemaFunction: flags.jsonSchemaFunction,
+                            jsonSchemaValidate: flags.jsonSchemaValidate,
                         },
                     },
                 },


### PR DESCRIPTION
- Add `--jsonSchemaValidate` flags to validate the output from the LLM for `cli test translate` and `cli run translate`
- Move the conversion of the LLM output for function calling to the validator.