### PR TITLE
knowpro: make secondary indexes optional

### DIFF
--- a/ts/examples/chat/src/memory/knowproMemory.ts
+++ b/ts/examples/chat/src/memory/knowproMemory.ts
@@ -12,6 +12,7 @@ import {
     NamedArgs,
     parseNamedArguments,
     ProgressBar,
+    StopWatch,
 } from "interactive-app";
 import { ChatContext } from "./chatMemory.js";
 import { ChatModel } from "aiclient";
@@ -226,6 +227,10 @@ export async function createKnowproCommands(
                     "Use property index while searching",
                     false,
                 ),
+                useTimestampIndex: argBool(
+                    "Use timestamp index while searching",
+                    false,
+                ),
             },
         };
         if (kType === undefined) {
@@ -255,6 +260,8 @@ export async function createKnowproCommands(
                 `Searching ${conversation.nameTag}...`,
             );
 
+            const timer = new StopWatch();
+            timer.start();
             const matches = await kp.searchConversation(
                 conversation,
                 terms,
@@ -265,18 +272,19 @@ export async function createKnowproCommands(
                     usePropertyIndex: namedArgs.usePropertyIndex,
                 },
             );
-            if (matches === undefined || matches.size === 0) {
+            timer.stop();
+            if (matches && matches.size > 0) {
+                context.printer.writeLine();
+                context.printer.writeSearchResults(
+                    conversation,
+                    matches,
+                    namedArgs.maxToDisplay,
+                );
+            } else {
                 context.printer.writeLine("No matches");
-                return;
             }
-            context.printer.writeLine();
-            context.printer.writeSearchResults(
-                conversation,
-                matches,
-                namedArgs.maxToDisplay,
-            );
+            context.printer.writeTiming(chalk.gray, timer);
         } else {
-            ``;
             context.printer.writeError("Conversation is not indexed");
         }
     }

--- a/ts/examples/chat/src/memory/knowproPrinter.ts
+++ b/ts/examples/chat/src/memory/knowproPrinter.ts
@@ -119,10 +119,15 @@ export class KnowProPrinter extends ChatPrinter {
         if (this.sortAsc) {
             this.writeLine(`Sorted in ascending order (lowest first)`);
         }
-        const displayItems = semanticRefMatches.slice(0, maxToDisplay);
-        for (let i = 0; i < displayItems.length; ++i) {
-            let pos = this.sortAsc ? displayItems.length - (i + 1) : i;
-            this.writeScoredRef(pos, displayItems[pos], semanticRefs);
+        const matchesToDisplay = semanticRefMatches.slice(0, maxToDisplay);
+        for (let i = 0; i < matchesToDisplay.length; ++i) {
+            let pos = this.sortAsc ? matchesToDisplay.length - (i + 1) : i;
+            this.writeScoredRef(
+                pos,
+                matchesToDisplay.length,
+                matchesToDisplay[pos],
+                semanticRefs,
+            );
         }
 
         return this;
@@ -130,13 +135,14 @@ export class KnowProPrinter extends ChatPrinter {
 
     private writeScoredRef(
         matchNumber: number,
+        totalMatches: number,
         scoredRef: kp.ScoredSemanticRef,
         semanticRefs: kp.SemanticRef[],
     ) {
         const semanticRef = semanticRefs[scoredRef.semanticRefIndex];
         this.writeInColor(
             chalk.green,
-            `#${matchNumber + 1}: <${scoredRef.semanticRefIndex}> ${semanticRef.knowledgeType} [${scoredRef.score}]`,
+            `#${matchNumber + 1} / ${totalMatches}: <${scoredRef.semanticRefIndex}> ${semanticRef.knowledgeType} [${scoredRef.score}]`,
         );
         this.writeSemanticRef(semanticRef);
         this.writeLine();

--- a/ts/packages/knowPro/src/dataFormat.ts
+++ b/ts/packages/knowPro/src/dataFormat.ts
@@ -49,19 +49,6 @@ export interface ITermToSemanticRefIndex {
     lookupTerm(term: string): ScoredSemanticRef[] | undefined;
 }
 
-export interface IPropertyToSemanticRefIndex {
-    getValues(): string[];
-    addProperty(
-        propertyName: string,
-        value: string,
-        semanticRefIndex: SemanticRefIndex | ScoredSemanticRef,
-    ): void;
-    lookupProperty(
-        propertyName: string,
-        value: string,
-    ): ScoredSemanticRef[] | undefined;
-}
-
 export type KnowledgeType = "entity" | "action" | "topic" | "tag";
 export type Knowledge =
     | conversation.ConcreteEntity
@@ -88,9 +75,7 @@ export interface IConversation<TMeta extends IKnowledgeSource = any> {
     messages: IMessage<TMeta>[];
     semanticRefs: SemanticRef[] | undefined;
     semanticRefIndex?: ITermToSemanticRefIndex | undefined;
-    propertyToSemanticRefIndex: IPropertyToSemanticRefIndex | undefined;
     termToRelatedTermsIndex?: ITermToRelatedTermsIndex | undefined;
-    timestampIndex?: ITimestampToTextRangeIndex | undefined;
 }
 
 export type MessageIndex = number;
@@ -182,12 +167,3 @@ export type DateRange = {
     start: Date;
     end?: Date | undefined;
 };
-
-export type TimestampedTextRange = {
-    timestamp: string;
-    range: TextRange;
-};
-
-export interface ITimestampToTextRangeIndex {
-    lookupRange(dateRange: DateRange): TimestampedTextRange[];
-}

--- a/ts/packages/knowPro/src/import.ts
+++ b/ts/packages/knowPro/src/import.ts
@@ -7,8 +7,6 @@ import {
     IKnowledgeSource,
     SemanticRef,
     IConversationData,
-    ITimestampToTextRangeIndex,
-    IPropertyToSemanticRefIndex,
 } from "./dataFormat.js";
 import { conversation, split } from "knowledge-processor";
 import { collections, dateTime, getFileName, readAllText } from "typeagent";
@@ -26,8 +24,16 @@ import {
     TermsToRelatedTermIndexSettings,
 } from "./relatedTermsIndex.js";
 import { createTextEmbeddingIndexSettings } from "./fuzzyIndex.js";
-import { TimestampToTextRangeIndex } from "./timestampIndex.js";
-import { addPropertiesToIndex, PropertyIndex } from "./propertyIndex.js";
+import {
+    ITimestampToTextRangeIndex,
+    TimestampToTextRangeIndex,
+} from "./timestampIndex.js";
+import {
+    addPropertiesToIndex,
+    IPropertyToSemanticRefIndex,
+    PropertyIndex,
+} from "./propertyIndex.js";
+import { ISecondaryConversationIndexes } from "./search.js";
 
 // metadata for podcast messages
 export class PodcastMessageMeta implements IKnowledgeSource {
@@ -117,7 +123,9 @@ export function createPodcastSettings(): PodcastSettings {
     };
 }
 
-export class Podcast implements IConversation<PodcastMessageMeta> {
+export class Podcast
+    implements IConversation<PodcastMessageMeta>, ISecondaryConversationIndexes
+{
     public settings: PodcastSettings;
     constructor(
         public nameTag: string,

--- a/ts/packages/knowPro/src/import.ts
+++ b/ts/packages/knowPro/src/import.ts
@@ -138,7 +138,7 @@ export class Podcast implements IConversation<PodcastMessageMeta> {
         this.settings = createPodcastSettings();
     }
 
-    addMetadataToIndex() {
+    public addMetadataToIndex() {
         for (let i = 0; i < this.messages.length; i++) {
             const msg = this.messages[i];
             const knowlegeResponse = msg.metadata.getKnowledge();
@@ -189,19 +189,8 @@ export class Podcast implements IConversation<PodcastMessageMeta> {
     ): Promise<ConversationIndexingResult> {
         const result = await buildConversationIndex(this, progressCallback);
         this.addMetadataToIndex();
-        this.buildPropertyIndex();
-        this.buildTimestampIndex();
+        this.buildSecondaryIndexes();
         return result;
-    }
-
-    public buildPropertyIndex() {
-        if (this.semanticRefs && this.semanticRefs.length > 0) {
-            this.propertyToSemanticRefIndex = new PropertyIndex();
-            addPropertiesToIndex(
-                this.semanticRefs,
-                this.propertyToSemanticRefIndex,
-            );
-        }
     }
 
     public async buildRelatedTermsIndex(
@@ -224,8 +213,9 @@ export class Podcast implements IConversation<PodcastMessageMeta> {
         }
     }
 
-    public buildTimestampIndex(): void {
-        this.timestampIndex = new TimestampToTextRangeIndex(this.messages);
+    public buildSecondaryIndexes() {
+        this.buildPropertyIndex();
+        this.buildTimestampIndex();
     }
 
     public serialize(): PodcastData {
@@ -253,8 +243,21 @@ export class Podcast implements IConversation<PodcastMessageMeta> {
                 data.relatedTermsIndexData,
             );
         }
-        this.buildPropertyIndex();
-        this.buildTimestampIndex();
+        this.buildSecondaryIndexes();
+    }
+
+    private buildPropertyIndex() {
+        if (this.semanticRefs && this.semanticRefs.length > 0) {
+            this.propertyToSemanticRefIndex = new PropertyIndex();
+            addPropertiesToIndex(
+                this.semanticRefs,
+                this.propertyToSemanticRefIndex,
+            );
+        }
+    }
+
+    private buildTimestampIndex(): void {
+        this.timestampIndex = new TimestampToTextRangeIndex(this.messages);
     }
 }
 

--- a/ts/packages/knowPro/src/propertyIndex.ts
+++ b/ts/packages/knowPro/src/propertyIndex.ts
@@ -2,12 +2,24 @@
 // Licensed under the MIT License.
 
 import {
-    IPropertyToSemanticRefIndex,
     ScoredSemanticRef,
     SemanticRef,
     SemanticRefIndex,
 } from "./dataFormat.js";
 import { conversation } from "knowledge-processor";
+
+export interface IPropertyToSemanticRefIndex {
+    getValues(): string[];
+    addProperty(
+        propertyName: string,
+        value: string,
+        semanticRefIndex: SemanticRefIndex | ScoredSemanticRef,
+    ): void;
+    lookupProperty(
+        propertyName: string,
+        value: string,
+    ): ScoredSemanticRef[] | undefined;
+}
 
 export enum PropertyNames {
     EntityName = "name",

--- a/ts/packages/knowPro/src/query.ts
+++ b/ts/packages/knowPro/src/query.ts
@@ -7,6 +7,7 @@ import {
     IMessage,
     IPropertyToSemanticRefIndex,
     ITermToSemanticRefIndex,
+    ITimestampToTextRangeIndex,
     KnowledgeType,
     ScoredSemanticRef,
     SemanticRef,
@@ -31,6 +32,7 @@ import {
 import { PropertyNames } from "./propertyIndex.js";
 import { conversation } from "knowledge-processor";
 import { collections } from "typeagent";
+import { textRangeFromLocation } from "./conversationIndex.js";
 
 export function isConversationSearchable(conversation: IConversation): boolean {
     return (
@@ -132,7 +134,7 @@ export function compareDates(x: Date, y: Date): number {
     return x.getTime() - y.getTime();
 }
 
-export function isDateInRange(outerRange: DateRange, date: Date): boolean {
+export function isInDateRange(outerRange: DateRange, date: Date): boolean {
     // outer start must be <= date
     // date must be <= outer end
     let cmpStart = compareDates(outerRange.start, date);
@@ -372,10 +374,16 @@ export class QueryEvalContext {
     constructor(
         public conversation: IConversation,
         /**
-         * If a property index is available, the query processor will use it
+         * If a property secondary index is available, the query processor will use it
          */
         public propertyIndex:
             | IPropertyToSemanticRefIndex
+            | undefined = undefined,
+        /**
+         * If a timestamp secondary index is available, the query processor will use it
+         */
+        public timestampIndex:
+            | ITimestampToTextRangeIndex
             | undefined = undefined,
     ) {
         if (!isConversationSearchable(conversation)) {
@@ -850,22 +858,40 @@ export interface IQuerySelectScopeExpr {
 }
 
 export class TimestampScopeExpr implements IQuerySelectScopeExpr {
-    constructor(public dateRange: DateRange) {}
+    constructor(public dateRangeInScope: DateRange) {}
 
-    public eval(
-        context: QueryEvalContext,
-        semanticRefs: SemanticRefAccumulator,
-    ): TextRangeCollection | undefined {
-        const index = context.conversation.timestampIndex;
-        if (index) {
-            const timeRanges = index.lookupRange(this.dateRange);
-            const textRangesInScope = new TextRangeCollection();
+    public eval(context: QueryEvalContext): TextRangeCollection | undefined {
+        const textRangesInScope = new TextRangeCollection();
+        if (context.timestampIndex) {
+            const timeRanges = context.timestampIndex.lookupRange(
+                this.dateRangeInScope,
+            );
             for (const timeRange of timeRanges) {
                 textRangesInScope.addRange(timeRange.range);
             }
             return textRangesInScope;
+        } else {
+            const messages = context.conversation.messages;
+            for (
+                let messageIndex = 0;
+                messageIndex < messages.length;
+                ++messageIndex
+            ) {
+                const message = messages[messageIndex];
+                if (
+                    message.timestamp &&
+                    isInDateRange(
+                        this.dateRangeInScope,
+                        new Date(message.timestamp),
+                    )
+                ) {
+                    textRangesInScope.addRange(
+                        textRangeFromLocation(messageIndex),
+                    );
+                }
+            }
         }
-        return undefined;
+        return textRangesInScope;
     }
 }
 

--- a/ts/packages/knowPro/src/query.ts
+++ b/ts/packages/knowPro/src/query.ts
@@ -5,9 +5,7 @@ import {
     DateRange,
     IConversation,
     IMessage,
-    IPropertyToSemanticRefIndex,
     ITermToSemanticRefIndex,
-    ITimestampToTextRangeIndex,
     KnowledgeType,
     ScoredSemanticRef,
     SemanticRef,
@@ -29,10 +27,11 @@ import {
     TermSet,
     TextRangeCollection,
 } from "./collections.js";
-import { PropertyNames } from "./propertyIndex.js";
+import { IPropertyToSemanticRefIndex, PropertyNames } from "./propertyIndex.js";
 import { conversation } from "knowledge-processor";
 import { collections } from "typeagent";
 import { textRangeFromLocation } from "./conversationIndex.js";
+import { ITimestampToTextRangeIndex } from "./timestampIndex.js";
 
 export function isConversationSearchable(conversation: IConversation): boolean {
     return (

--- a/ts/packages/knowPro/src/search.ts
+++ b/ts/packages/knowPro/src/search.ts
@@ -62,6 +62,7 @@ export type SearchOptions = {
     maxMatches?: number | undefined;
     minHitCount?: number | undefined;
     usePropertyIndex?: boolean | undefined;
+    useTimestampIndex?: boolean | undefined;
 };
 /**
  * Searches conversation for terms
@@ -88,6 +89,9 @@ export async function searchConversation(
             conversation,
             options?.usePropertyIndex
                 ? conversation.propertyToSemanticRefIndex
+                : undefined,
+            options?.useTimestampIndex
+                ? conversation.timestampIndex
                 : undefined,
         ),
     );

--- a/ts/packages/knowPro/src/search.ts
+++ b/ts/packages/knowPro/src/search.ts
@@ -9,8 +9,10 @@ import {
     ScoredSemanticRef,
     Term,
 } from "./dataFormat.js";
+import { IPropertyToSemanticRefIndex } from "./propertyIndex.js";
 import * as q from "./query.js";
 import { resolveRelatedTerms } from "./relatedTermsIndex.js";
+import { ITimestampToTextRangeIndex } from "./timestampIndex.js";
 
 export type SearchTerm = {
     /**
@@ -64,6 +66,11 @@ export type SearchOptions = {
     usePropertyIndex?: boolean | undefined;
     useTimestampIndex?: boolean | undefined;
 };
+
+export interface ISecondaryConversationIndexes {
+    propertyToSemanticRefIndex: IPropertyToSemanticRefIndex | undefined;
+    timestampIndex?: ITimestampToTextRangeIndex | undefined;
+}
 /**
  * Searches conversation for terms
  */
@@ -84,14 +91,15 @@ export async function searchConversation(
         filter,
         options,
     );
+    const secondaryIndexes: ISecondaryConversationIndexes = conversation as any;
     const queryResults = query.eval(
         new q.QueryEvalContext(
             conversation,
             options?.usePropertyIndex
-                ? conversation.propertyToSemanticRefIndex
+                ? secondaryIndexes.propertyToSemanticRefIndex
                 : undefined,
             options?.useTimestampIndex
-                ? conversation.timestampIndex
+                ? secondaryIndexes.timestampIndex
                 : undefined,
         ),
     );

--- a/ts/packages/knowPro/src/timestampIndex.ts
+++ b/ts/packages/knowPro/src/timestampIndex.ts
@@ -2,14 +2,17 @@
 // Licensed under the MIT License.
 
 import { collections, dateTime } from "typeagent";
-import {
-    DateRange,
-    IMessage,
-    ITimestampToTextRangeIndex,
-    MessageIndex,
-    TimestampedTextRange,
-} from "./dataFormat.js";
+import { DateRange, IMessage, MessageIndex, TextRange } from "./dataFormat.js";
 import { textRangeFromLocation } from "./conversationIndex.js";
+
+export type TimestampedTextRange = {
+    timestamp: string;
+    range: TextRange;
+};
+
+export interface ITimestampToTextRangeIndex {
+    lookupRange(dateRange: DateRange): TimestampedTextRange[];
+}
 
 /**
  * An index of timestamp => TextRanges.


### PR DESCRIPTION
- Timestamp Scopes without secondary index (now optional)
- Command line improvements. 