### PR TITLE
knowpro secondary indexes: refactoring etc. 

### DIFF
--- a/ts/examples/chat/src/memory/knowproMemory.ts
+++ b/ts/examples/chat/src/memory/knowproMemory.ts
@@ -323,12 +323,29 @@ export async function createKnowproCommands(
         const propertyNames = nameFilter
             ? Object.keys(keyValues).filter(nameFilter)
             : Object.keys(keyValues);
+        const propertySearchTerms: kp.PropertySearchTerm[] = [];
+        for (const propertyName of propertyNames) {
+            const allValues = splitTermValues(keyValues[propertyName]);
+            for (const value of allValues) {
+                propertySearchTerms.push(
+                    kp.propertySearchTermFromKeyValue(
+                        nameModifier
+                            ? nameModifier(propertyName)
+                            : propertyName,
+                        value,
+                    ),
+                );
+            }
+        }
+        return propertySearchTerms;
+        /*
         return propertyNames.map((propertyName) =>
             kp.propertySearchTermFromKeyValue(
                 nameModifier ? nameModifier(propertyName) : propertyName,
                 keyValues[propertyName],
             ),
         );
+        */
     }
 
     function filterFromNamedArgs(
@@ -487,10 +504,7 @@ export async function createKnowproCommands(
 export function parseQueryTerms(args: string[]): kp.SearchTerm[] {
     const queryTerms: kp.SearchTerm[] = [];
     for (const arg of args) {
-        let allTermStrings = knowLib.split(arg, ";", {
-            trim: true,
-            removeEmpty: true,
-        });
+        let allTermStrings = splitTermValues(arg);
         if (allTermStrings.length > 0) {
             allTermStrings = allTermStrings.map((t) => t.toLowerCase());
             const queryTerm: kp.SearchTerm = {
@@ -506,4 +520,12 @@ export function parseQueryTerms(args: string[]): kp.SearchTerm[] {
         }
     }
     return queryTerms;
+}
+
+function splitTermValues(term: string): string[] {
+    let allTermStrings = knowLib.split(term, ";", {
+        trim: true,
+        removeEmpty: true,
+    });
+    return allTermStrings;
 }

--- a/ts/packages/knowPro/src/dataFormat.ts
+++ b/ts/packages/knowPro/src/dataFormat.ts
@@ -75,7 +75,6 @@ export interface IConversation<TMeta extends IKnowledgeSource = any> {
     messages: IMessage<TMeta>[];
     semanticRefs: SemanticRef[] | undefined;
     semanticRefIndex?: ITermToSemanticRefIndex | undefined;
-    termToRelatedTermsIndex?: ITermToRelatedTermsIndex | undefined;
 }
 
 export type MessageIndex = number;
@@ -103,7 +102,6 @@ export interface IConversationData<TMessage> {
     tags: string[];
     semanticRefs: SemanticRef[];
     semanticIndexData?: ITermToSemanticRefIndexData | undefined;
-    relatedTermsIndexData?: ITermsToRelatedTermsIndexData | undefined;
 }
 
 export type Term = {
@@ -113,55 +111,6 @@ export type Term = {
      */
     weight?: number | undefined;
 };
-
-export interface ITermToRelatedTermsIndex {
-    get aliases(): ITermToRelatedTerms | undefined;
-    get termEditDistanceIndex(): ITermToRelatedTermsFuzzy | undefined;
-    get termVectorIndex(): ITermToRelatedTermsFuzzy | undefined;
-    serialize(): ITermsToRelatedTermsIndexData;
-    deserialize(data?: ITermsToRelatedTermsIndexData): void;
-}
-
-export interface ITermsToRelatedTermsIndexData {
-    aliasData?: ITermToRelatedTermsData | undefined;
-    textEmbeddingData?: ITextEmbeddingIndexData | undefined;
-}
-
-export interface ITermToRelatedTermsData {
-    relatedTerms?: ITermsToRelatedTermsDataItem[] | undefined;
-}
-
-export interface ITermsToRelatedTermsDataItem {
-    termText: string;
-    relatedTerms: Term[];
-}
-
-export interface ITermToRelatedTerms {
-    lookupTerm(text: string): Term[] | undefined;
-}
-
-export interface ITermToRelatedTermsFuzzy {
-    lookupTerm(
-        text: string,
-        maxMatches?: number,
-        thresholdScore?: number,
-    ): Promise<Term[]>;
-    lookupTerms(
-        textArray: string[],
-        maxMatches?: number,
-        thresholdScore?: number,
-    ): Promise<Term[][]>;
-}
-
-export interface ITextEmbeddingIndexData {
-    modelName?: string | undefined;
-    embeddingData?: ITextEmbeddingDataItem[] | undefined;
-}
-
-export interface ITextEmbeddingDataItem {
-    text: string;
-    embedding: number[];
-}
 
 export type DateRange = {
     start: Date;

--- a/ts/packages/knowPro/src/dataFormat.ts
+++ b/ts/packages/knowPro/src/dataFormat.ts
@@ -116,3 +116,5 @@ export type DateRange = {
     start: Date;
     end?: Date | undefined;
 };
+
+// See secondaryIndex.ts for (optional) secondaryIndex interfaces & types

--- a/ts/packages/knowPro/src/fuzzyIndex.ts
+++ b/ts/packages/knowPro/src/fuzzyIndex.ts
@@ -15,7 +15,7 @@ import {
 import {
     ITextEmbeddingIndexData,
     ITextEmbeddingDataItem,
-} from "./dataFormat.js";
+} from "./secondaryIndexes.js";
 import { openai, TextEmbeddingModel } from "aiclient";
 import * as levenshtein from "fast-levenshtein";
 import { createEmbeddingCache } from "knowledge-processor";

--- a/ts/packages/knowPro/src/import.ts
+++ b/ts/packages/knowPro/src/import.ts
@@ -29,11 +29,8 @@ import {
     ITimestampToTextRangeIndex,
     TimestampToTextRangeIndex,
 } from "./timestampIndex.js";
-import {
-    addPropertiesToIndex,
-    IPropertyToSemanticRefIndex,
-    PropertyIndex,
-} from "./propertyIndex.js";
+import { addPropertiesToIndex, PropertyIndex } from "./propertyIndex.js";
+import { IPropertyToSemanticRefIndex } from "./search.js";
 import { ISecondaryConversationIndexes } from "./search.js";
 
 // metadata for podcast messages

--- a/ts/packages/knowPro/src/import.ts
+++ b/ts/packages/knowPro/src/import.ts
@@ -26,10 +26,13 @@ import {
 } from "./relatedTermsIndex.js";
 import { createTextEmbeddingIndexSettings } from "./fuzzyIndex.js";
 import { TimestampToTextRangeIndex } from "./timestampIndex.js";
-import { ITimestampToTextRangeIndex } from "./search.js";
+import {
+    ITermsToRelatedTermsIndexData,
+    ITimestampToTextRangeIndex,
+} from "./secondaryIndexes.js";
 import { addPropertiesToIndex, PropertyIndex } from "./propertyIndex.js";
-import { IPropertyToSemanticRefIndex } from "./search.js";
-import { ISecondaryConversationIndexes } from "./search.js";
+import { IPropertyToSemanticRefIndex } from "./secondaryIndexes.js";
+import { IConversationSecondaryIndexes } from "./secondaryIndexes.js";
 
 // metadata for podcast messages
 export class PodcastMessageMeta implements IKnowledgeSource {
@@ -120,7 +123,7 @@ export function createPodcastSettings(): PodcastSettings {
 }
 
 export class Podcast
-    implements IConversation<PodcastMessageMeta>, ISecondaryConversationIndexes
+    implements IConversation<PodcastMessageMeta>, IConversationSecondaryIndexes
 {
     public settings: PodcastSettings;
     constructor(
@@ -309,7 +312,9 @@ export class Podcast
     }
 }
 
-export interface PodcastData extends IConversationData<PodcastMessage> {}
+export interface PodcastData extends IConversationData<PodcastMessage> {
+    relatedTermsIndexData?: ITermsToRelatedTermsIndexData | undefined;
+}
 
 export async function importPodcast(
     transcriptFilePath: string,

--- a/ts/packages/knowPro/src/import.ts
+++ b/ts/packages/knowPro/src/import.ts
@@ -25,10 +25,8 @@ import {
     TermsToRelatedTermIndexSettings,
 } from "./relatedTermsIndex.js";
 import { createTextEmbeddingIndexSettings } from "./fuzzyIndex.js";
-import {
-    ITimestampToTextRangeIndex,
-    TimestampToTextRangeIndex,
-} from "./timestampIndex.js";
+import { TimestampToTextRangeIndex } from "./timestampIndex.js";
+import { ITimestampToTextRangeIndex } from "./search.js";
 import { addPropertiesToIndex, PropertyIndex } from "./propertyIndex.js";
 import { IPropertyToSemanticRefIndex } from "./search.js";
 import { ISecondaryConversationIndexes } from "./search.js";

--- a/ts/packages/knowPro/src/propertyIndex.ts
+++ b/ts/packages/knowPro/src/propertyIndex.ts
@@ -7,7 +7,7 @@ import {
     SemanticRefIndex,
 } from "./dataFormat.js";
 import { conversation } from "knowledge-processor";
-import { IPropertyToSemanticRefIndex } from "./search.js";
+import { IPropertyToSemanticRefIndex } from "./secondaryIndexes.js";
 
 export enum PropertyNames {
     EntityName = "name",

--- a/ts/packages/knowPro/src/propertyIndex.ts
+++ b/ts/packages/knowPro/src/propertyIndex.ts
@@ -7,19 +7,7 @@ import {
     SemanticRefIndex,
 } from "./dataFormat.js";
 import { conversation } from "knowledge-processor";
-
-export interface IPropertyToSemanticRefIndex {
-    getValues(): string[];
-    addProperty(
-        propertyName: string,
-        value: string,
-        semanticRefIndex: SemanticRefIndex | ScoredSemanticRef,
-    ): void;
-    lookupProperty(
-        propertyName: string,
-        value: string,
-    ): ScoredSemanticRef[] | undefined;
-}
+import { IPropertyToSemanticRefIndex } from "./search.js";
 
 export enum PropertyNames {
     EntityName = "name",

--- a/ts/packages/knowPro/src/query.ts
+++ b/ts/packages/knowPro/src/query.ts
@@ -32,7 +32,7 @@ import { IPropertyToSemanticRefIndex } from "./search.js";
 import { conversation } from "knowledge-processor";
 import { collections } from "typeagent";
 import { textRangeFromLocation } from "./conversationIndex.js";
-import { ITimestampToTextRangeIndex } from "./timestampIndex.js";
+import { ITimestampToTextRangeIndex } from "./search.js";
 
 export function isConversationSearchable(conversation: IConversation): boolean {
     return (

--- a/ts/packages/knowPro/src/query.ts
+++ b/ts/packages/knowPro/src/query.ts
@@ -27,7 +27,8 @@ import {
     TermSet,
     TextRangeCollection,
 } from "./collections.js";
-import { IPropertyToSemanticRefIndex, PropertyNames } from "./propertyIndex.js";
+import { PropertyNames } from "./propertyIndex.js";
+import { IPropertyToSemanticRefIndex } from "./search.js";
 import { conversation } from "knowledge-processor";
 import { collections } from "typeagent";
 import { textRangeFromLocation } from "./conversationIndex.js";

--- a/ts/packages/knowPro/src/query.ts
+++ b/ts/packages/knowPro/src/query.ts
@@ -28,11 +28,11 @@ import {
     TextRangeCollection,
 } from "./collections.js";
 import { PropertyNames } from "./propertyIndex.js";
-import { IPropertyToSemanticRefIndex } from "./search.js";
+import { IPropertyToSemanticRefIndex } from "./secondaryIndexes.js";
 import { conversation } from "knowledge-processor";
 import { collections } from "typeagent";
 import { textRangeFromLocation } from "./conversationIndex.js";
-import { ITimestampToTextRangeIndex } from "./search.js";
+import { ITimestampToTextRangeIndex } from "./secondaryIndexes.js";
 
 export function isConversationSearchable(conversation: IConversation): boolean {
     return (

--- a/ts/packages/knowPro/src/relatedTermsIndex.ts
+++ b/ts/packages/knowPro/src/relatedTermsIndex.ts
@@ -88,7 +88,7 @@ export class TermToRelatedTermsIndex implements ITermToRelatedTermsIndex {
         return this.editDistanceIndex;
     }
 
-    public get termVectorIndex() {
+    public get fuzzyIndex() {
         return this.embeddingIndex;
     }
 
@@ -168,12 +168,9 @@ export async function resolveRelatedTerms(
             searchTermsNeedingRelated.push(searchTerm);
         }
     }
-    if (
-        relatedTermsIndex.termVectorIndex &&
-        searchTermsNeedingRelated.length > 0
-    ) {
+    if (relatedTermsIndex.fuzzyIndex && searchTermsNeedingRelated.length > 0) {
         const relatedTermsForSearchTerms =
-            await relatedTermsIndex.termVectorIndex.lookupTerms(
+            await relatedTermsIndex.fuzzyIndex.lookupTerms(
                 searchTermsNeedingRelated.map((st) => st.term.text),
             );
         for (let i = 0; i < searchTermsNeedingRelated.length; ++i) {

--- a/ts/packages/knowPro/src/relatedTermsIndex.ts
+++ b/ts/packages/knowPro/src/relatedTermsIndex.ts
@@ -2,8 +2,8 @@
 // Licensed under the MIT License.
 
 import { collections, ScoredItem } from "typeagent";
+import { Term } from "./dataFormat.js";
 import {
-    Term,
     ITextEmbeddingIndexData,
     ITermsToRelatedTermsDataItem,
     ITermToRelatedTermsData,
@@ -11,7 +11,7 @@ import {
     ITermsToRelatedTermsIndexData,
     ITermToRelatedTermsFuzzy,
     ITermToRelatedTerms,
-} from "./dataFormat.js";
+} from "./secondaryIndexes.js";
 import { SearchTerm } from "./search.js";
 import { isSearchTermWildcard } from "./query.js";
 import { TermSet } from "./collections.js";
@@ -138,7 +138,7 @@ export class TermToRelatedTermsIndex implements ITermToRelatedTermsIndex {
 /**
  * Give searchTerms, resolves related terms for those searchTerms that don't already have them
  * Optionally ensures that related terms are not duplicated across search terms because this can
- * skew how semantic references are scored during search
+ * skew how semantic references are scored during search (over-counting)
  * @param relatedTermsIndex
  * @param searchTerms
  */
@@ -163,8 +163,7 @@ export async function resolveRelatedTerms(
             searchTerm.relatedTerms =
                 relatedTermsIndex.aliases.lookupTerm(termText);
         }
-        // If no hard-coded mappings, lookup any fuzzy related terms
-        // Future: do this in batch
+        // If no hard-coded mappings, add this to the list of things for which we do fuzzy retrieval
         if (!searchTerm.relatedTerms || searchTerm.relatedTerms.length === 0) {
             searchTermsNeedingRelated.push(searchTerm);
         }

--- a/ts/packages/knowPro/src/search.ts
+++ b/ts/packages/knowPro/src/search.ts
@@ -7,9 +7,9 @@ import {
     IConversation,
     KnowledgeType,
     ScoredSemanticRef,
+    SemanticRefIndex,
     Term,
 } from "./dataFormat.js";
-import { IPropertyToSemanticRefIndex } from "./propertyIndex.js";
 import * as q from "./query.js";
 import { resolveRelatedTerms } from "./relatedTermsIndex.js";
 import { ITimestampToTextRangeIndex } from "./timestampIndex.js";
@@ -66,6 +66,19 @@ export type SearchOptions = {
     usePropertyIndex?: boolean | undefined;
     useTimestampIndex?: boolean | undefined;
 };
+
+export interface IPropertyToSemanticRefIndex {
+    getValues(): string[];
+    addProperty(
+        propertyName: string,
+        value: string,
+        semanticRefIndex: SemanticRefIndex | ScoredSemanticRef,
+    ): void;
+    lookupProperty(
+        propertyName: string,
+        value: string,
+    ): ScoredSemanticRef[] | undefined;
+}
 
 export interface ISecondaryConversationIndexes {
     propertyToSemanticRefIndex: IPropertyToSemanticRefIndex | undefined;

--- a/ts/packages/knowPro/src/search.ts
+++ b/ts/packages/knowPro/src/search.ts
@@ -9,10 +9,10 @@ import {
     ScoredSemanticRef,
     SemanticRefIndex,
     Term,
+    TextRange,
 } from "./dataFormat.js";
 import * as q from "./query.js";
 import { resolveRelatedTerms } from "./relatedTermsIndex.js";
-import { ITimestampToTextRangeIndex } from "./timestampIndex.js";
 
 export type SearchTerm = {
     /**
@@ -67,6 +67,17 @@ export type SearchOptions = {
     useTimestampIndex?: boolean | undefined;
 };
 
+/**
+ * Secondary indexes are currently optional, allowing us to experiment
+ */
+export interface ISecondaryConversationIndexes {
+    propertyToSemanticRefIndex: IPropertyToSemanticRefIndex | undefined;
+    timestampIndex?: ITimestampToTextRangeIndex | undefined;
+}
+
+/**
+ * Allows for faster retrieval of name, value properties
+ */
 export interface IPropertyToSemanticRefIndex {
     getValues(): string[];
     addProperty(
@@ -80,10 +91,18 @@ export interface IPropertyToSemanticRefIndex {
     ): ScoredSemanticRef[] | undefined;
 }
 
-export interface ISecondaryConversationIndexes {
-    propertyToSemanticRefIndex: IPropertyToSemanticRefIndex | undefined;
-    timestampIndex?: ITimestampToTextRangeIndex | undefined;
+export type TimestampedTextRange = {
+    timestamp: string;
+    range: TextRange;
+};
+
+/**
+ * Return text ranges in the given date range
+ */
+export interface ITimestampToTextRangeIndex {
+    lookupRange(dateRange: DateRange): TimestampedTextRange[];
 }
+
 /**
  * Searches conversation for terms
  */

--- a/ts/packages/knowPro/src/secondaryIndexes.ts
+++ b/ts/packages/knowPro/src/secondaryIndexes.ts
@@ -28,16 +28,17 @@ export type TimestampedTextRange = {
     timestamp: string;
     range: TextRange;
 };
+
 /**
  * Return text ranges in the given date range
  */
-
 export interface ITimestampToTextRangeIndex {
     lookupRange(dateRange: DateRange): TimestampedTextRange[];
-} /**
+}
+
+/**
  * Secondary indexes are currently optional, allowing us to experiment
  */
-
 export interface IConversationSecondaryIndexes {
     termToRelatedTermsIndex?: ITermToRelatedTermsIndex | undefined;
     propertyToSemanticRefIndex: IPropertyToSemanticRefIndex | undefined;

--- a/ts/packages/knowPro/src/secondaryIndexes.ts
+++ b/ts/packages/knowPro/src/secondaryIndexes.ts
@@ -10,6 +10,15 @@ import {
 } from "./dataFormat.js";
 
 /**
+ * Optional secondary indexes that can help the query processor produce better results, but are not required
+ */
+export interface IConversationSecondaryIndexes {
+    termToRelatedTermsIndex?: ITermToRelatedTermsIndex | undefined;
+    propertyToSemanticRefIndex: IPropertyToSemanticRefIndex | undefined;
+    timestampIndex?: ITimestampToTextRangeIndex | undefined;
+}
+
+/**
  * Allows for faster retrieval of name, value properties
  */
 export interface IPropertyToSemanticRefIndex {
@@ -24,6 +33,7 @@ export interface IPropertyToSemanticRefIndex {
         value: string,
     ): ScoredSemanticRef[] | undefined;
 }
+
 export type TimestampedTextRange = {
     timestamp: string;
     range: TextRange;
@@ -34,15 +44,6 @@ export type TimestampedTextRange = {
  */
 export interface ITimestampToTextRangeIndex {
     lookupRange(dateRange: DateRange): TimestampedTextRange[];
-}
-
-/**
- * Secondary indexes are currently optional, allowing us to experiment
- */
-export interface IConversationSecondaryIndexes {
-    termToRelatedTermsIndex?: ITermToRelatedTermsIndex | undefined;
-    propertyToSemanticRefIndex: IPropertyToSemanticRefIndex | undefined;
-    timestampIndex?: ITimestampToTextRangeIndex | undefined;
 }
 
 /**

--- a/ts/packages/knowPro/src/secondaryIndexes.ts
+++ b/ts/packages/knowPro/src/secondaryIndexes.ts
@@ -49,7 +49,7 @@ export interface IConversationSecondaryIndexes {
  */
 export interface ITermToRelatedTermsIndex {
     get aliases(): ITermToRelatedTerms | undefined;
-    get termVectorIndex(): ITermToRelatedTermsFuzzy | undefined;
+    get fuzzyIndex(): ITermToRelatedTermsFuzzy | undefined;
     serialize(): ITermsToRelatedTermsIndexData;
     deserialize(data?: ITermsToRelatedTermsIndexData): void;
 }

--- a/ts/packages/knowPro/src/secondaryIndexes.ts
+++ b/ts/packages/knowPro/src/secondaryIndexes.ts
@@ -1,0 +1,96 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import {
+    SemanticRefIndex,
+    ScoredSemanticRef,
+    DateRange,
+    TextRange,
+    Term,
+} from "./dataFormat.js";
+
+/**
+ * Allows for faster retrieval of name, value properties
+ */
+export interface IPropertyToSemanticRefIndex {
+    getValues(): string[];
+    addProperty(
+        propertyName: string,
+        value: string,
+        semanticRefIndex: SemanticRefIndex | ScoredSemanticRef,
+    ): void;
+    lookupProperty(
+        propertyName: string,
+        value: string,
+    ): ScoredSemanticRef[] | undefined;
+}
+export type TimestampedTextRange = {
+    timestamp: string;
+    range: TextRange;
+};
+/**
+ * Return text ranges in the given date range
+ */
+
+export interface ITimestampToTextRangeIndex {
+    lookupRange(dateRange: DateRange): TimestampedTextRange[];
+} /**
+ * Secondary indexes are currently optional, allowing us to experiment
+ */
+
+export interface IConversationSecondaryIndexes {
+    termToRelatedTermsIndex?: ITermToRelatedTermsIndex | undefined;
+    propertyToSemanticRefIndex: IPropertyToSemanticRefIndex | undefined;
+    timestampIndex?: ITimestampToTextRangeIndex | undefined;
+}
+
+/**
+ * Work in progress.
+ */
+export interface ITermToRelatedTermsIndex {
+    get aliases(): ITermToRelatedTerms | undefined;
+    get termVectorIndex(): ITermToRelatedTermsFuzzy | undefined;
+    serialize(): ITermsToRelatedTermsIndexData;
+    deserialize(data?: ITermsToRelatedTermsIndexData): void;
+}
+
+export interface ITermToRelatedTermsFuzzy {
+    lookupTerm(
+        text: string,
+        maxMatches?: number,
+        thresholdScore?: number,
+    ): Promise<Term[]>;
+    lookupTerms(
+        textArray: string[],
+        maxMatches?: number,
+        thresholdScore?: number,
+    ): Promise<Term[][]>;
+}
+
+export interface ITermsToRelatedTermsIndexData {
+    aliasData?: ITermToRelatedTermsData | undefined;
+    textEmbeddingData?: ITextEmbeddingIndexData | undefined;
+}
+
+export interface ITermToRelatedTermsData {
+    relatedTerms?: ITermsToRelatedTermsDataItem[] | undefined;
+}
+
+export interface ITermsToRelatedTermsDataItem {
+    termText: string;
+    relatedTerms: Term[];
+}
+
+export interface ITermToRelatedTerms {
+    lookupTerm(text: string): Term[] | undefined;
+}
+
+export interface ITextEmbeddingIndexData {
+    modelName?: string | undefined;
+    embeddingData?: ITextEmbeddingDataItem[] | undefined;
+}
+
+export interface ITextEmbeddingDataItem {
+    text: string;
+    embedding: number[];
+}

--- a/ts/packages/knowPro/src/timestampIndex.ts
+++ b/ts/packages/knowPro/src/timestampIndex.ts
@@ -4,7 +4,10 @@
 import { collections, dateTime } from "typeagent";
 import { DateRange, IMessage, MessageIndex } from "./dataFormat.js";
 import { textRangeFromLocation } from "./conversationIndex.js";
-import { ITimestampToTextRangeIndex, TimestampedTextRange } from "./search.js";
+import {
+    ITimestampToTextRangeIndex,
+    TimestampedTextRange,
+} from "./secondaryIndexes.js";
 
 /**
  * An index of timestamp => TextRanges.

--- a/ts/packages/knowPro/src/timestampIndex.ts
+++ b/ts/packages/knowPro/src/timestampIndex.ts
@@ -2,17 +2,9 @@
 // Licensed under the MIT License.
 
 import { collections, dateTime } from "typeagent";
-import { DateRange, IMessage, MessageIndex, TextRange } from "./dataFormat.js";
+import { DateRange, IMessage, MessageIndex } from "./dataFormat.js";
 import { textRangeFromLocation } from "./conversationIndex.js";
-
-export type TimestampedTextRange = {
-    timestamp: string;
-    range: TextRange;
-};
-
-export interface ITimestampToTextRangeIndex {
-    lookupRange(dateRange: DateRange): TimestampedTextRange[];
-}
+import { ITimestampToTextRangeIndex, TimestampedTextRange } from "./search.js";
 
 /**
  * An index of timestamp => TextRanges.


### PR DESCRIPTION
* All secondary index interfaces are optional. 
  * Moved interfaces from dataFormat.ts to **secondaryIndex.ts**
  * dataFormat.ts goes back to being minimal
* Related term secondary indexes also now fully optional (including embeddings).
* Query processor works when secondary indexes are not available
* Related term resolution skipped when not available. 