### PR TITLE
Enable history in translation test

### DIFF
--- a/ts/packages/agents/player/src/defaultTokenProvider.ts
+++ b/ts/packages/agents/player/src/defaultTokenProvider.ts
@@ -46,7 +46,9 @@ export async function createTokenProvider(storage?: Storage) {
 
     const port = parseInt(defaultPort);
     if (port.toString() !== defaultPort) {
-        throw new Error(`SPOTIFY_APP_PORT has invalid port number ${defaultPort}`)
+        throw new Error(
+            `SPOTIFY_APP_PORT has invalid port number ${defaultPort}`,
+        );
     }
 
     // Legacy: clean up old files

--- a/ts/packages/agents/player/src/tokenProvider.ts
+++ b/ts/packages/agents/player/src/tokenProvider.ts
@@ -30,7 +30,7 @@ export class TokenProvider {
         private readonly redirectPort: number,
         private readonly scopes: string[],
         private readonly tokenCachePersistence?: TokenCachePersistence,
-    ) { }
+    ) {}
 
     private getAxiosRequestConfig(
         authorization: boolean = false,
@@ -202,7 +202,7 @@ export class TokenProvider {
                     const tokenCache: TokenCache = JSON.parse(tokenCacheString);
                     this.userRefreshToken = tokenCache.refreshToken;
                 }
-            } catch (e) { }
+            } catch (e) {}
         }
         return this.userRefreshToken;
     }

--- a/ts/packages/cli/src/commands/constructions.ts
+++ b/ts/packages/cli/src/commands/constructions.ts
@@ -3,7 +3,7 @@
 
 import { Args, Command, Flags } from "@oclif/core";
 import {
-    readTestData,
+    readExplanationTestData,
     getCacheFactory,
     convertTestDataToExplanationData,
     createActionConfigProvider,
@@ -42,7 +42,7 @@ export default class ConstructionsCommand extends Command {
     async run(): Promise<void> {
         const { args, flags } = await this.parse(ConstructionsCommand);
 
-        const testDataFile = await readTestData(args.input);
+        const testDataFile = await readExplanationTestData(args.input);
 
         const agentCache = getCacheFactory().create(
             testDataFile.explainerName,

--- a/ts/packages/cli/src/commands/data/add.ts
+++ b/ts/packages/cli/src/commands/data/add.ts
@@ -5,11 +5,11 @@ import { Args, Flags, Command } from "@oclif/core";
 import fs from "node:fs";
 import {
     readLineData,
-    readTestData,
-    TestData,
-    generateTestDataFiles,
-    printTestDataStats,
-    getEmptyTestData,
+    readExplanationTestData,
+    ExplanationTestData,
+    generateExplanationTestDataFiles,
+    printExplanationTestDataStats,
+    getEmptyExplanationTestData,
     getCacheFactory,
     createActionConfigProvider,
     getSchemaNamesForActionConfigProvider,
@@ -89,10 +89,10 @@ export default class ExplanationDataAddCommand extends Command {
 
         const inputs = flags.input
             ? (
-                  await Promise.all(
-                      flags.input.map((input) => readLineData(input)),
-                  )
-              ).flat()
+                await Promise.all(
+                    flags.input.map((input) => readLineData(input)),
+                )
+            ).flat()
             : [];
 
         if (args.request) {
@@ -102,13 +102,13 @@ export default class ExplanationDataAddCommand extends Command {
             inputs.push(args.request);
         }
         if (inputs.length !== 0) {
-            let existingData: TestData;
+            let existingData: ExplanationTestData;
             if (
                 !flags.overwrite &&
                 flags.output &&
                 fs.existsSync(flags.output)
             ) {
-                existingData = await readTestData(flags.output);
+                existingData = await readExplanationTestData(flags.output);
                 if (
                     flags.schema !== undefined &&
                     flags.schema !== existingData.schemaName
@@ -152,7 +152,7 @@ export default class ExplanationDataAddCommand extends Command {
                 const sourceHash =
                     provider.getActionSchemaFileForConfig(config).sourceHash;
                 // Create an empty existing data.
-                existingData = getEmptyTestData(
+                existingData = getEmptyExplanationTestData(
                     flags.schemaName,
                     sourceHash,
                     flags.explainer ?? getDefaultExplainerName(),
@@ -172,7 +172,7 @@ export default class ExplanationDataAddCommand extends Command {
                 `Processing ${inputs.length} inputs... Concurrency ${concurrency}`,
             );
             const startTime = performance.now();
-            const testData = await generateTestDataFiles(
+            const testData = await generateExplanationTestDataFiles(
                 [
                     {
                         inputs,
@@ -187,7 +187,7 @@ export default class ExplanationDataAddCommand extends Command {
                 false,
             );
             const elapsedTime = (performance.now() - startTime) / 1000;
-            printTestDataStats(testData);
+            printExplanationTestDataStats(testData);
             console.log(`Total Elapsed Time: ${elapsedTime.toFixed(3)}s`);
 
             if (!flags.output) {
@@ -197,10 +197,10 @@ export default class ExplanationDataAddCommand extends Command {
         } else {
             console.log(chalk.yellow("No request specified. Nothing added."));
             if (flags.output && fs.existsSync(flags.output)) {
-                printTestDataStats([
+                printExplanationTestDataStats([
                     {
                         fileName: flags.output,
-                        testData: await readTestData(flags.output),
+                        testData: await readExplanationTestData(flags.output),
                         elapsedMs: 0,
                     },
                 ]);

--- a/ts/packages/cli/src/commands/data/add.ts
+++ b/ts/packages/cli/src/commands/data/add.ts
@@ -89,10 +89,10 @@ export default class ExplanationDataAddCommand extends Command {
 
         const inputs = flags.input
             ? (
-                await Promise.all(
-                    flags.input.map((input) => readLineData(input)),
-                )
-            ).flat()
+                  await Promise.all(
+                      flags.input.map((input) => readLineData(input)),
+                  )
+              ).flat()
             : [];
 
         if (args.request) {

--- a/ts/packages/cli/src/commands/data/diff.ts
+++ b/ts/packages/cli/src/commands/data/diff.ts
@@ -6,7 +6,7 @@ import path from "node:path";
 import os from "node:os";
 import child_process from "node:child_process";
 import { Args, Command } from "@oclif/core";
-import { readTestData } from "agent-dispatcher/internal";
+import { readExplanationTestData } from "agent-dispatcher/internal";
 
 export default class ExplanationDataDiffCommand extends Command {
     static args = {
@@ -39,7 +39,7 @@ export default class ExplanationDataDiffCommand extends Command {
             }
         };
 
-        const currData = await readTestData(args.file);
+        const currData = await readExplanationTestData(args.file);
         stripProperties(currData, properties);
 
         let prevData;
@@ -50,7 +50,7 @@ export default class ExplanationDataDiffCommand extends Command {
                 .toString();
             prevData = JSON.parse(prevVersion);
         } else {
-            prevData = await readTestData(args.diff);
+            prevData = await readExplanationTestData(args.diff);
         }
         stripProperties(prevData, properties);
 

--- a/ts/packages/cli/src/commands/data/list.ts
+++ b/ts/packages/cli/src/commands/data/list.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import { Args, Command } from "@oclif/core";
-import { readTestData } from "agent-dispatcher/internal";
+import { readExplanationTestData } from "agent-dispatcher/internal";
 
 export default class ExplanationDataListCommand extends Command {
     static args = {
@@ -15,7 +15,7 @@ export default class ExplanationDataListCommand extends Command {
 
     async run(): Promise<void> {
         const { args } = await this.parse(ExplanationDataListCommand);
-        const data = await readTestData(args.file!);
+        const data = await readExplanationTestData(args.file!);
         for (const entry of data.entries) {
             console.log(entry.request);
         }

--- a/ts/packages/cli/src/commands/data/regenerate.ts
+++ b/ts/packages/cli/src/commands/data/regenerate.ts
@@ -5,14 +5,14 @@ import fs from "node:fs";
 import { Args, Command, Flags } from "@oclif/core";
 import chalk from "chalk";
 import {
-    generateTestDataFiles,
-    readTestData,
-    printTestDataStats,
-    TestDataEntry,
-    FailedTestDataEntry,
+    generateExplanationTestDataFiles,
+    readExplanationTestData,
+    printExplanationTestDataStats,
+    ExplanationTestDataEntry,
+    FailedExplanationTestDataEntry,
     getCacheFactory,
     GenerateDataInput,
-    getEmptyTestData,
+    getEmptyExplanationTestData,
     convertTestDataToExplanationData,
     createActionConfigProvider,
     createSchemaInfoProvider,
@@ -202,8 +202,8 @@ export default class ExplanationDataRegenerateCommand extends Command {
 
         const builtinConstructionConfig = flags.builtin
             ? getDefaultConstructionProvider().getBuiltinConstructionConfig(
-                  flags.builtin,
-              )
+                flags.builtin,
+            )
             : undefined;
 
         let files;
@@ -222,15 +222,15 @@ export default class ExplanationDataRegenerateCommand extends Command {
         }
         const inputs = await Promise.all(
             files.map(async (file) => {
-                return { file, data: await readTestData(file) };
+                return { file, data: await readExplanationTestData(file) };
             }),
         );
 
         const explainerFilter = flags.explainer;
         let pending = explainerFilter
             ? inputs.filter((e) =>
-                  explainerFilter.includes(e.data.explainerName),
-              )
+                explainerFilter.includes(e.data.explainerName),
+            )
             : inputs;
 
         if (pending.length === 0) {
@@ -257,14 +257,14 @@ export default class ExplanationDataRegenerateCommand extends Command {
 
         if (flags.output) {
             // Combine the data to the output now
-            const failed: FailedTestDataEntry[] = [];
+            const failed: FailedExplanationTestDataEntry[] = [];
 
             const targetSchemaName = pending[0].data.schemaName;
             const config = provider.getActionConfig(targetSchemaName);
             const sourceHash =
                 provider.getActionSchemaFileForConfig(config).sourceHash;
 
-            const combinedData = getEmptyTestData(
+            const combinedData = getEmptyExplanationTestData(
                 targetSchemaName,
                 sourceHash,
                 explainerOverride ?? pending[0].data.explainerName,
@@ -386,7 +386,7 @@ export default class ExplanationDataRegenerateCommand extends Command {
         for (const { file, data } of pending) {
             const inputs: (string | RequestAction)[] = [];
             if (!flags.none && !flags.constructions) {
-                const filter = (e: TestDataEntry | FailedTestDataEntry) => {
+                const filter = (e: ExplanationTestDataEntry | FailedExplanationTestDataEntry) => {
                     if (flags.resume) {
                         if ((e as any).message !== "Not processed") {
                             return undefined;
@@ -469,10 +469,10 @@ export default class ExplanationDataRegenerateCommand extends Command {
 
                     const requestAction = e.action
                         ? new RequestAction(
-                              e.request,
-                              fromJsonActions(e.action),
-                              history,
-                          )
+                            e.request,
+                            fromJsonActions(e.action),
+                            history,
+                        )
                         : undefined;
 
                     if (flags.validate) {
@@ -529,7 +529,7 @@ export default class ExplanationDataRegenerateCommand extends Command {
                 outputFile: flags.output ?? file,
             });
         }
-        const results = await generateTestDataFiles(
+        const results = await generateExplanationTestDataFiles(
             dataInput,
             provider,
             !flags.batch,
@@ -570,7 +570,7 @@ export default class ExplanationDataRegenerateCommand extends Command {
 
         console.log("=".repeat(80));
         const elapsedMs = performance.now() - startTime;
-        printTestDataStats(results, "Total ");
+        printExplanationTestDataStats(results, "Total ");
         console.log(`Total Elapsed Time: ${getElapsedString(elapsedMs)}`);
     }
 }

--- a/ts/packages/cli/src/commands/data/regenerate.ts
+++ b/ts/packages/cli/src/commands/data/regenerate.ts
@@ -202,8 +202,8 @@ export default class ExplanationDataRegenerateCommand extends Command {
 
         const builtinConstructionConfig = flags.builtin
             ? getDefaultConstructionProvider().getBuiltinConstructionConfig(
-                flags.builtin,
-            )
+                  flags.builtin,
+              )
             : undefined;
 
         let files;
@@ -229,8 +229,8 @@ export default class ExplanationDataRegenerateCommand extends Command {
         const explainerFilter = flags.explainer;
         let pending = explainerFilter
             ? inputs.filter((e) =>
-                explainerFilter.includes(e.data.explainerName),
-            )
+                  explainerFilter.includes(e.data.explainerName),
+              )
             : inputs;
 
         if (pending.length === 0) {
@@ -386,7 +386,11 @@ export default class ExplanationDataRegenerateCommand extends Command {
         for (const { file, data } of pending) {
             const inputs: (string | RequestAction)[] = [];
             if (!flags.none && !flags.constructions) {
-                const filter = (e: ExplanationTestDataEntry | FailedExplanationTestDataEntry) => {
+                const filter = (
+                    e:
+                        | ExplanationTestDataEntry
+                        | FailedExplanationTestDataEntry,
+                ) => {
                     if (flags.resume) {
                         if ((e as any).message !== "Not processed") {
                             return undefined;
@@ -469,10 +473,10 @@ export default class ExplanationDataRegenerateCommand extends Command {
 
                     const requestAction = e.action
                         ? new RequestAction(
-                            e.request,
-                            fromJsonActions(e.action),
-                            history,
-                        )
+                              e.request,
+                              fromJsonActions(e.action),
+                              history,
+                          )
                         : undefined;
 
                     if (flags.validate) {

--- a/ts/packages/cli/src/commands/data/split.ts
+++ b/ts/packages/cli/src/commands/data/split.ts
@@ -4,9 +4,9 @@
 import { Args, Command, Flags } from "@oclif/core";
 import chalk from "chalk";
 import {
-    TestData,
-    getEmptyTestData,
-    readTestData,
+    ExplanationTestData,
+    getEmptyExplanationTestData,
+    readExplanationTestData,
 } from "agent-dispatcher/internal";
 import fs from "node:fs";
 import path from "node:path";
@@ -33,7 +33,7 @@ export default class ExplanationDataSplitCommmand extends Command {
 
         const files = argv as string[];
         for (const file of files) {
-            const data = await readTestData(file);
+            const data = await readExplanationTestData(file);
             const failedCount = data.failed?.length ?? 0;
             const total = data.entries.length + failedCount;
             if (total <= flags.limit) {
@@ -45,14 +45,14 @@ export default class ExplanationDataSplitCommmand extends Command {
                 continue;
             }
 
-            const splitData: TestData[] = [];
+            const splitData: ExplanationTestData[] = [];
             let currEntry = 0;
             let currFailed = 0;
             while (
                 currEntry < data.entries.length ||
                 currFailed < failedCount
             ) {
-                const newData = getEmptyTestData(
+                const newData = getEmptyExplanationTestData(
                     data.schemaName,
                     data.sourceHash,
                     data.explainerName,

--- a/ts/packages/cli/src/commands/data/stat.ts
+++ b/ts/packages/cli/src/commands/data/stat.ts
@@ -6,7 +6,7 @@ import chalk from "chalk";
 import { CorrectionRecord } from "agent-cache";
 import {
     getCacheFactory,
-    readTestData,
+    readExplanationTestData,
     getSchemaNamesForActionConfigProvider,
     createActionConfigProvider,
     getInstanceDir,
@@ -289,7 +289,7 @@ export default class ExplanationDataStatCommmand extends Command {
         };
         for (const file of files) {
             try {
-                const data = await readTestData(file);
+                const data = await readExplanationTestData(file);
                 if (
                     (flags.schema && !flags.schema.includes(data.schemaName)) ||
                     (flags.explainer &&

--- a/ts/packages/cli/src/commands/test/translate.ts
+++ b/ts/packages/cli/src/commands/test/translate.ts
@@ -399,7 +399,7 @@ export default class TestTranslateCommand extends Command {
                     for (let i = 0; i < actual.length; i++) {
                         if (
                             actual[i].translatorName !==
-                            expected[i].translatorName ||
+                                expected[i].translatorName ||
                             actual[i].actionName !== expected[i].actionName
                         ) {
                             print(

--- a/ts/packages/cli/src/commands/test/translate.ts
+++ b/ts/packages/cli/src/commands/test/translate.ts
@@ -5,7 +5,7 @@ import { Args, Command, Flags } from "@oclif/core";
 import { fromJsonActions, toFullActions, FullAction } from "agent-cache";
 import { createDispatcher } from "agent-dispatcher";
 import {
-    readTestData,
+    readExplanationTestData,
     getSchemaNamesForActionConfigProvider,
     createActionConfigProvider,
     getInstanceDir,
@@ -260,7 +260,7 @@ export default class TestTranslateCommand extends Command {
 
             const inputs = await Promise.all(
                 files.map(async (file) => {
-                    return { file, data: await readTestData(file) };
+                    return { file, data: await readExplanationTestData(file) };
                 }),
             );
 
@@ -399,7 +399,7 @@ export default class TestTranslateCommand extends Command {
                     for (let i = 0; i < actual.length; i++) {
                         if (
                             actual[i].translatorName !==
-                                expected[i].translatorName ||
+                            expected[i].translatorName ||
                             actual[i].actionName !== expected[i].actionName
                         ) {
                             print(

--- a/ts/packages/defaultAgentProvider/test/construction.spec.ts
+++ b/ts/packages/defaultAgentProvider/test/construction.spec.ts
@@ -7,7 +7,7 @@ dotenv.config({ path: new URL("../../../../.env", import.meta.url) });
 import {
     createSchemaInfoProvider,
     getCacheFactory,
-    readTestData,
+    readExplanationTestData,
     createActionConfigProvider,
 } from "agent-dispatcher/internal";
 import { fromJsonActions, RequestAction } from "agent-cache";
@@ -17,7 +17,7 @@ import { glob } from "glob";
 const dataFiles = ["test/data/explanations/**/v5/*.json"];
 
 const inputs = await Promise.all(
-    (await glob(dataFiles)).map((f) => readTestData(f)),
+    (await glob(dataFiles)).map((f) => readExplanationTestData(f)),
 );
 
 const testInput = inputs.flatMap((f) =>

--- a/ts/packages/defaultAgentProvider/test/constructionCacheTestCommon.ts
+++ b/ts/packages/defaultAgentProvider/test/constructionCacheTestCommon.ts
@@ -9,7 +9,7 @@ import fs from "node:fs";
 import {
     getCacheFactory,
     convertTestDataToExplanationData,
-    readTestData,
+    readExplanationTestData,
     createActionConfigProvider,
     createSchemaInfoProvider,
 } from "agent-dispatcher/internal";
@@ -66,7 +66,7 @@ const dataFiles =
 // Sort by file name to make the test result deterministic.
 const inputs = await Promise.all(
     (await glob(dataFiles)).sort().map(async (f) => {
-        return [await readTestData(f), f] as const;
+        return [await readExplanationTestData(f), f] as const;
     }),
 );
 

--- a/ts/packages/defaultAgentProvider/test/requestAction.spec.ts
+++ b/ts/packages/defaultAgentProvider/test/requestAction.spec.ts
@@ -9,7 +9,9 @@ import { glob } from "glob";
 const dataFiles = ["test/data/explanations/**/**/*.json"];
 
 const inputs = await Promise.all(
-    (await glob(dataFiles)).map((f) => readExplanationTestData(getPackageFilePath(f))),
+    (await glob(dataFiles)).map((f) =>
+        readExplanationTestData(getPackageFilePath(f)),
+    ),
 );
 
 const testInput = inputs.flatMap((f) =>

--- a/ts/packages/defaultAgentProvider/test/requestAction.spec.ts
+++ b/ts/packages/defaultAgentProvider/test/requestAction.spec.ts
@@ -2,14 +2,14 @@
 // Licensed under the MIT License.
 
 import { getPackageFilePath } from "../src/utils/getPackageFilePath.js";
-import { readTestData } from "agent-dispatcher/internal";
+import { readExplanationTestData } from "agent-dispatcher/internal";
 import { RequestAction, fromJsonActions } from "agent-cache";
 import { glob } from "glob";
 
 const dataFiles = ["test/data/explanations/**/**/*.json"];
 
 const inputs = await Promise.all(
-    (await glob(dataFiles)).map((f) => readTestData(getPackageFilePath(f))),
+    (await glob(dataFiles)).map((f) => readExplanationTestData(getPackageFilePath(f))),
 );
 
 const testInput = inputs.flatMap((f) =>

--- a/ts/packages/defaultAgentProvider/test/translateTestCommon.ts
+++ b/ts/packages/defaultAgentProvider/test/translateTestCommon.ts
@@ -43,7 +43,6 @@ export async function defineTranslateTest(name: string, dataFiles: string[]) {
                         appAgentProviders: defaultAppAgentProviders,
                         actions: null,
                         commands: { dispatcher: true },
-                        translation: { history: { enabled: false } },
                         explainer: { enabled: false },
                         cache: { enabled: false },
                         collectCommandResult: true,
@@ -51,6 +50,15 @@ export async function defineTranslateTest(name: string, dataFiles: string[]) {
                 );
             }
             dispatchers = await Promise.all(dispatcherP);
+        });
+        beforeEach(async () => {
+            await Promise.all(
+                dispatchers.map(async (dispatcher) => {
+                    const result =
+                        await dispatcher.processCommand("@history clear");
+                    expect(result?.hasError).toBeFalsy();
+                }),
+            );
         });
         it.each(inputs)(`${name} '$request'`, async (test) => {
             const requests = Array.isArray(test) ? test : [test];

--- a/ts/packages/defaultAgentProvider/test/validateExplanationTestData.spec.ts
+++ b/ts/packages/defaultAgentProvider/test/validateExplanationTestData.spec.ts
@@ -3,13 +3,18 @@
 
 import { getPackageFilePath } from "../src/utils/getPackageFilePath.js";
 import { fromJsonActions, RequestAction } from "agent-cache";
-import { getCacheFactory, readExplanationTestData } from "agent-dispatcher/internal";
+import {
+    getCacheFactory,
+    readExplanationTestData,
+} from "agent-dispatcher/internal";
 import { glob } from "glob";
 
 const dataFiles = ["test/data/explanations/**/**/*.json"];
 
 const inputs = await Promise.all(
-    (await glob(dataFiles)).map((f) => readExplanationTestData(getPackageFilePath(f))),
+    (await glob(dataFiles)).map((f) =>
+        readExplanationTestData(getPackageFilePath(f)),
+    ),
 );
 
 const testInput = inputs.flatMap((f) =>

--- a/ts/packages/defaultAgentProvider/test/validateExplanationTestData.spec.ts
+++ b/ts/packages/defaultAgentProvider/test/validateExplanationTestData.spec.ts
@@ -3,13 +3,13 @@
 
 import { getPackageFilePath } from "../src/utils/getPackageFilePath.js";
 import { fromJsonActions, RequestAction } from "agent-cache";
-import { getCacheFactory, readTestData } from "agent-dispatcher/internal";
+import { getCacheFactory, readExplanationTestData } from "agent-dispatcher/internal";
 import { glob } from "glob";
 
 const dataFiles = ["test/data/explanations/**/**/*.json"];
 
 const inputs = await Promise.all(
-    (await glob(dataFiles)).map((f) => readTestData(getPackageFilePath(f))),
+    (await glob(dataFiles)).map((f) => readExplanationTestData(getPackageFilePath(f))),
 );
 
 const testInput = inputs.flatMap((f) =>

--- a/ts/packages/dispatcher/src/context/system/handlers/constructionCommandHandlers.ts
+++ b/ts/packages/dispatcher/src/context/system/handlers/constructionCommandHandlers.ts
@@ -349,9 +349,9 @@ class ConstructionImportCommandHandler implements CommandHandler {
             args.file !== undefined
                 ? await expandPaths(args.file)
                 : await getImportTranslationFiles(
-                    systemContext,
-                    flags.extended,
-                );
+                      systemContext,
+                      flags.extended,
+                  );
 
         if (inputs.length === 0) {
             if (args.file === undefined) {

--- a/ts/packages/dispatcher/src/context/system/handlers/constructionCommandHandlers.ts
+++ b/ts/packages/dispatcher/src/context/system/handlers/constructionCommandHandlers.ts
@@ -11,8 +11,8 @@ import {
 } from "../../commandHandlerContext.js";
 import {
     convertTestDataToExplanationData,
-    readTestData,
-} from "../../../utils/test/testData.js";
+    readExplanationTestData,
+} from "../../../utils/test/explanationTestData.js";
 import { ConstructionStore, printImportConstructionResult } from "agent-cache";
 import { getSessionConstructionDirPath } from "../../session.js";
 import { askYesNoWithContext } from "../../interactiveIO.js";
@@ -349,9 +349,9 @@ class ConstructionImportCommandHandler implements CommandHandler {
             args.file !== undefined
                 ? await expandPaths(args.file)
                 : await getImportTranslationFiles(
-                      systemContext,
-                      flags.extended,
-                  );
+                    systemContext,
+                    flags.extended,
+                );
 
         if (inputs.length === 0) {
             if (args.file === undefined) {
@@ -369,7 +369,7 @@ class ConstructionImportCommandHandler implements CommandHandler {
             inputs.map(async (input) => {
                 return {
                     file: input,
-                    data: await readTestData(input),
+                    data: await readExplanationTestData(input),
                 };
             }),
         );

--- a/ts/packages/dispatcher/src/internal.ts
+++ b/ts/packages/dispatcher/src/internal.ts
@@ -7,16 +7,16 @@ export { getCacheFactory } from "./utils/cacheFactory.js";
 export {
     GenerateTestDataResult,
     GenerateDataInput,
-    generateTestDataFiles,
-    TestData,
+    generateExplanationTestDataFiles,
+    ExplanationTestData,
     readLineData,
-    getEmptyTestData,
-    readTestData,
-    printTestDataStats,
-    TestDataEntry,
-    FailedTestDataEntry,
+    getEmptyExplanationTestData,
+    readExplanationTestData,
+    printExplanationTestDataStats,
+    ExplanationTestDataEntry,
+    FailedExplanationTestDataEntry,
     convertTestDataToExplanationData,
-} from "./utils/test/testData.js";
+} from "./utils/test/explanationTestData.js";
 
 export { getAssistantSelectionSchemas } from "./translation/unknownSwitcher.js";
 export { getActionSchema } from "./translation/actionSchemaFileCache.js";

--- a/ts/packages/dispatcher/src/utils/test/explanationTestData.ts
+++ b/ts/packages/dispatcher/src/utils/test/explanationTestData.ts
@@ -268,8 +268,8 @@ function toExceptionMessage(e: any) {
         ? typeof e.cause === "string"
             ? e.cause
             : typeof e.cause === "object"
-                ? e.cause.message
-                : undefined
+              ? e.cause.message
+              : undefined
         : undefined;
     return `Exception: ${e.message}${suffix ? `: ${suffix}` : ""}`;
 }
@@ -323,15 +323,15 @@ function getSafeExplainFn(
 
 type AddResult =
     | {
-        success: true;
-        elapsedMs: number;
-        entry: ExplanationTestDataEntry;
-    }
+          success: true;
+          elapsedMs: number;
+          entry: ExplanationTestDataEntry;
+      }
     | {
-        success: false;
-        elapsedMs: number;
-        entry: FailedExplanationTestDataEntry;
-    };
+          success: false;
+          elapsedMs: number;
+          entry: FailedExplanationTestDataEntry;
+      };
 
 function getGenerateTestDataFn(
     schemaName: string,
@@ -348,7 +348,9 @@ function getGenerateTestDataFn(
         tags: string[] | undefined,
     ): Promise<AddResult> => {
         const startTime = performance.now();
-        const toFailedResult = (entry: FailedExplanationTestDataEntry): AddResult => {
+        const toFailedResult = (
+            entry: FailedExplanationTestDataEntry,
+        ): AddResult => {
             return {
                 success: false,
                 elapsedMs: performance.now() - startTime,
@@ -546,7 +548,8 @@ async function generateTestDataFile(
             testData.entries.push(entry);
             console.log(
                 chalk.grey(
-                    `${statusPrefix} Generated${outputType}: ${entry.request}${attempts != 1 ? ` (+${attempts - 1} corrections)` : ""
+                    `${statusPrefix} Generated${outputType}: ${entry.request}${
+                        attempts != 1 ? ` (+${attempts - 1} corrections)` : ""
                     }`,
                 ),
             );
@@ -656,8 +659,8 @@ export function printExplanationTestDataStats(
     const failedStr =
         totalFailed !== 0
             ? chalk.red(
-                ` ${totalFailed} (${((totalFailed / totalEntries) * 100).toFixed(3)}%) failed.`,
-            )
+                  ` ${totalFailed} (${((totalFailed / totalEntries) * 100).toFixed(3)}%) failed.`,
+              )
             : "";
     console.log(
         `${prefix}Result: ${totalSuccess}/${totalEntries} entries, ${totalAttempt} attempts (${(


### PR DESCRIPTION
- Enable history in translation test, but clear them before each test.
- Rename `TestData` and associated functions/types to `ExplanationTestData`
