### PR TITLE
Provide a different root of electron-build

### DIFF
--- a/ts/packages/shell/electron.vite.preload-cjs.config.mts
+++ b/ts/packages/shell/electron.vite.preload-cjs.config.mts
@@ -11,7 +11,7 @@ export default defineConfig({
             sourcemap: true,
             rollupOptions: {
                 input: {
-                    webview: resolve(__dirname, "./webView.ts"),
+                    webview: resolve(__dirname, "./src/preload/webView.ts"),
                 },
                 output: {
                     // For the CJS preload

--- a/ts/packages/shell/package.json
+++ b/ts/packages/shell/package.json
@@ -15,8 +15,8 @@
   "scripts": {
     "build": "concurrently npm:typecheck npm:build:electron",
     "build:electron": "concurrently npm:build:electron:esm npm:build:electron:cjs",
-    "build:electron:cjs": "electron-vite build --config src/preload/electron.vite.preload-cjs.config.mts --logLevel error",
-    "build:electron:esm": "electron-vite build --config electron.vite.config.mts",
+    "build:electron:cjs": "electron-vite build src/preload --config electron.vite.preload-cjs.config.mts --logLevel error",
+    "build:electron:esm": "electron-vite build . --config electron.vite.config.mts",
     "build:linux": "npm run build && electron-builder --linux --config",
     "build:mac": "npm run build && electron-builder --mac --config",
     "build:win": "npm run build && electron-builder --win --config",


### PR DESCRIPTION
- Provide a different root for cjs and esm so the temporary file doesn't overwrite each other.