### PR TITLE
Capture screenshot and HTML for recorded actions

### DIFF
--- a/ts/packages/agents/browser/src/extension/serviceWorker.ts
+++ b/ts/packages/agents/browser/src/extension/serviceWorker.ts
@@ -1543,7 +1543,9 @@ chrome.runtime.onMessage.addListener(
                         {
                             type: "startRecording",
                         },
+                        { frameId: 0 }, // Limit action recording to the top frame for now
                     );
+                    sendResponse({});
                     break;
                 }
                 case "stopRecording": {
@@ -1553,6 +1555,7 @@ chrome.runtime.onMessage.addListener(
                         {
                             type: "stopRecording",
                         },
+                        { frameId: 0 },
                     );
 
                     sendResponse(response);
@@ -1562,6 +1565,7 @@ chrome.runtime.onMessage.addListener(
                     const screenshotUrl = await chrome.tabs.captureVisibleTab({
                         format: "png",
                     });
+
                     sendResponse(screenshotUrl);
                     break;
                 }
@@ -1569,6 +1573,7 @@ chrome.runtime.onMessage.addListener(
                     await chrome.storage.local.set({
                         annotatedScreenshot: message.screenshot,
                     });
+                    sendResponse({});
                     break;
                 }
                 case "getAnnotatedScreenshot": {
@@ -1582,6 +1587,7 @@ chrome.runtime.onMessage.addListener(
                     await chrome.storage.local.set({
                         recordedActionPageHTML: message.html,
                     });
+                    sendResponse({});
                     break;
                 }
                 case "getRecordedActionPageHTML": {
@@ -1593,8 +1599,19 @@ chrome.runtime.onMessage.addListener(
                 }
                 case "saveRecordedActions": {
                     await chrome.storage.local.set({
-                        recordedActions: message.actions,
+                        recordedActions: message.recordedActions,
                     });
+                    sendResponse({});
+                    break;
+                }
+                case "recordingStopped": {
+                    await chrome.storage.local.set({
+                        recordedActions: message.recordedActions,
+                        recordedActionPageHTML: message.recordedActionPageHTML,
+                        annotatedScreenshot: message.recordedActionScreenshot,
+                    });
+
+                    sendResponse({});
                     break;
                 }
                 case "getRecordedActions": {

--- a/ts/packages/agents/browser/src/extension/sidepanel.html
+++ b/ts/packages/agents/browser/src/extension/sidepanel.html
@@ -195,7 +195,7 @@
       <!-- Timeline -->
       <div id="userActionsListContainer" class="mt-3 accordion"></div>
 
-      <div id="screenshotContainer" class="hidden"></div>
+      <div id="screenshotContainer"></div>
 
       <div class="d-flex gap-2 mt-3">
         <button
@@ -262,7 +262,7 @@
             </button>
             <button
               id="stopRecording"
-              class="btn btn-sm btn-outline-primary hidden"
+              class="btn btn-sm btn-primary hidden"
               title="Stop Recording"
             >
               <i class="bi bi-stop-circle"></i> Stop recording


### PR DESCRIPTION
- Ensure relevant HTML elements have IDs set before action recording starts
- Limit action recording to the top frame on a page. I'll need to generalize the solution to deal with multi-frame pages later.