### PR TITLE
Stop serializing all configs

### DIFF
--- a/ts/packages/cli/src/commands/interactive.ts
+++ b/ts/packages/cli/src/commands/interactive.ts
@@ -30,7 +30,7 @@ const schemaNames = getSchemaNamesForActionConfigProvider(
 export default class Interactive extends Command {
     static description = "Interactive mode";
     static flags = {
-        schema: Flags.string({
+        agent: Flags.string({
             description: "Schema names",
             options: schemaNames,
             multiple: true,
@@ -72,15 +72,11 @@ export default class Interactive extends Command {
             inspector.open(undefined, undefined, true);
         }
 
-        const schemas = flags.schema
-            ? Object.fromEntries(flags.schema.map((name) => [name, true]))
-            : undefined;
-
         await withConsoleClientIO(async (clientIO) => {
             const dispatcher = await createDispatcher("cli interactive", {
                 appAgentProviders: defaultAppAgentProviders,
                 agentInstaller: getDefaultAppAgentInstaller(instanceDir),
-                schemas,
+                agents: flags.agent,
                 translation: { model: flags.model },
                 explainer: { name: flags.explainer },
                 persistSession: !flags.memory,

--- a/ts/packages/cli/src/commands/run/explain.ts
+++ b/ts/packages/cli/src/commands/run/explain.ts
@@ -72,9 +72,6 @@ export default class ExplainCommand extends Command {
 
     async run(): Promise<void> {
         const { args, flags } = await this.parse(ExplainCommand);
-        const schemas = flags.schema
-            ? Object.fromEntries(flags.schema.map((name) => [name, true]))
-            : undefined;
 
         const command = ["@dispatcher explain"];
         if (flags.filter?.includes("refValue")) {
@@ -98,9 +95,11 @@ export default class ExplainCommand extends Command {
         await withConsoleClientIO(async (clientIO: ClientIO) => {
             const dispatcher = await createDispatcher("cli run explain", {
                 appAgentProviders: defaultAgentProviders,
-                schemas,
-                actions: null, // We don't need any actions
-                commands: { dispatcher: true },
+                agents: {
+                    schemas: flags.schema,
+                    actions: false, // We don't need any actions
+                    commands: ["dispatcher"],
+                },
                 explainer: {
                     name: flags.explainer,
                 },

--- a/ts/packages/cli/src/commands/run/request.ts
+++ b/ts/packages/cli/src/commands/run/request.ts
@@ -57,14 +57,13 @@ export default class RequestCommand extends Command {
 
     async run(): Promise<void> {
         const { args, flags } = await this.parse(RequestCommand);
-        const schemas = flags.schema
-            ? Object.fromEntries(flags.schema.map((name) => [name, true]))
-            : undefined;
         const dispatcher = await createDispatcher("cli run request", {
             appAgentProviders: defaultAppAgentProviders,
-            schemas,
-            actions: schemas,
-            commands: { dispatcher: true },
+            agents: {
+                schemas: flags.schema,
+                actions: flags.schema,
+                commands: ["dispatcher"],
+            },
             translation: { model: flags.model },
             explainer: flags.explainer
                 ? { enabled: true, name: flags.explainer }

--- a/ts/packages/cli/src/commands/run/translate.ts
+++ b/ts/packages/cli/src/commands/run/translate.ts
@@ -65,16 +65,14 @@ export default class TranslateCommand extends Command {
 
     async run(): Promise<void> {
         const { args, flags } = await this.parse(TranslateCommand);
-        const schemas = flags.schema
-            ? Object.fromEntries(flags.schema.map((name) => [name, true]))
-            : undefined;
-
         await withConsoleClientIO(async (clientIO: ClientIO) => {
             const dispatcher = await createDispatcher("cli run translate", {
                 appAgentProviders: defaultAppAgentProviders,
-                schemas,
-                actions: null,
-                commands: { dispatcher: true },
+                agents: {
+                    schemas: flags.schema,
+                    actions: false,
+                    commands: ["dispatcher"],
+                },
                 translation: {
                     model: flags.model,
                     multiple: { enabled: flags.multiple },

--- a/ts/packages/cli/src/commands/test/translate.ts
+++ b/ts/packages/cli/src/commands/test/translate.ts
@@ -289,9 +289,6 @@ export default class TestTranslateCommand extends Command {
             countStr = `${requests.length}/${countStr}`;
         }
 
-        const schemas = flags.schema
-            ? Object.fromEntries(flags.schema.map((name) => [name, true]))
-            : undefined;
         let failedTotal = 0;
         let noActions = 0;
         let processed = 0;
@@ -314,9 +311,11 @@ export default class TestTranslateCommand extends Command {
         async function worker() {
             const dispatcher = await createDispatcher("cli test translate", {
                 appAgentProviders: defaultAppAgentProviders,
-                schemas,
-                actions: null,
-                commands: { dispatcher: true },
+                agents: {
+                    schemas: flags.schema,
+                    actions: false,
+                    commands: ["dispatcher"],
+                },
                 translation: {
                     stream: flags.stream,
                     history: { enabled: false },

--- a/ts/packages/defaultAgentProvider/test/translateTestCommon.ts
+++ b/ts/packages/defaultAgentProvider/test/translateTestCommon.ts
@@ -52,8 +52,10 @@ export async function defineTranslateTest(name: string, dataFiles: string[]) {
                 dispatcherP.push(
                     createDispatcher("cli test translate", {
                         appAgentProviders: defaultAppAgentProviders,
-                        actions: null,
-                        commands: { dispatcher: true },
+                        agents: {
+                            actions: false,
+                            commands: ["dispatcher"],
+                        },
                         execution: { history: false }, // don't generate chat history, the test manually imports them
                         explainer: { enabled: false },
                         cache: { enabled: false },

--- a/ts/packages/dispatcher/src/context/appAgentManager.ts
+++ b/ts/packages/dispatcher/src/context/appAgentManager.ts
@@ -16,10 +16,6 @@ import { getAppAgentName } from "../translation/agentTranslators.js";
 import { createSessionContext } from "../execute/actionHandlers.js";
 import { AppAgentProvider } from "../agentProvider/agentProvider.js";
 import registerDebug from "debug";
-import {
-    DeepPartialUndefined,
-    DeepPartialUndefinedAndNull,
-} from "common-utils";
 import { DispatcherName } from "./dispatcher/dispatcherUtils.js";
 import {
     ActionSchemaSemanticMap,
@@ -54,9 +50,7 @@ export type AppAgentStateConfig = {
 
 export const appAgentStateKeys = ["schemas", "actions", "commands"] as const;
 
-export type AppAgentStateSettings = DeepPartialUndefined<AppAgentStateConfig>;
-export type AppAgentStateOptions =
-    DeepPartialUndefinedAndNull<AppAgentStateConfig>;
+export type AppAgentStateSettings = Partial<AppAgentStateConfig>;
 
 function computeStateChange(
     settings: AppAgentStateSettings | undefined,

--- a/ts/packages/dispatcher/src/context/commandHandlerContext.ts
+++ b/ts/packages/dispatcher/src/context/commandHandlerContext.ts
@@ -39,7 +39,6 @@ import { conversation as Conversation } from "knowledge-processor";
 import {
     AppAgentManager,
     AppAgentStateInitSettings,
-    AppAgentStateOptions,
     AppAgentStateSettings,
     getAppAgentStateSettings,
     SetStateResult,
@@ -431,7 +430,7 @@ async function setAppAgentStates(context: CommandHandlerContext) {
 
 async function updateAppAgentStates(
     context: ActionContext<CommandHandlerContext>,
-): Promise<AppAgentStateOptions> {
+): Promise<AppAgentStateSettings> {
     const systemContext = context.sessionContext.agentContext;
     const result = await systemContext.agents.setState(
         systemContext,
@@ -447,10 +446,10 @@ async function updateAppAgentStates(
     if (rollback) {
         systemContext.session.updateConfig(rollback);
     }
-    const resultState: AppAgentStateOptions = {};
+    const resultState: AppAgentStateSettings = {};
     for (const [stateName, changed] of Object.entries(result.changed)) {
         if (changed.length !== 0) {
-            resultState[stateName as keyof AppAgentStateOptions] =
+            resultState[stateName as keyof AppAgentStateSettings] =
                 Object.fromEntries(changed);
         }
     }

--- a/ts/packages/dispatcher/src/context/commandHandlerContext.ts
+++ b/ts/packages/dispatcher/src/context/commandHandlerContext.ts
@@ -513,6 +513,9 @@ export async function changeContextConfig(
     const systemContext = context.sessionContext.agentContext;
     const session = systemContext.session;
     const changed = session.setConfig(options);
+    if (changed === undefined) {
+        return undefined;
+    }
 
     const translatorChanged = changed.hasOwnProperty("schemas");
     const actionsChanged = changed.hasOwnProperty("actions");

--- a/ts/packages/dispatcher/src/context/commandHandlerContext.ts
+++ b/ts/packages/dispatcher/src/context/commandHandlerContext.ts
@@ -528,12 +528,12 @@ export async function changeContextConfig(
         return undefined;
     }
 
-    const translatorChanged = changed.hasOwnProperty("schemas");
+    const schemasChanged = changed.hasOwnProperty("schemas");
     const actionsChanged = changed.hasOwnProperty("actions");
     const commandsChanged = changed.hasOwnProperty("commands");
 
     if (
-        translatorChanged ||
+        schemasChanged ||
         changed.translation?.model !== undefined ||
         changed.translation?.switch?.inline !== undefined ||
         changed.translation?.multiple !== undefined ||
@@ -544,7 +544,7 @@ export async function changeContextConfig(
         systemContext.translatorCache.clear();
     }
 
-    if (translatorChanged || actionsChanged || commandsChanged) {
+    if (schemasChanged || actionsChanged || commandsChanged) {
         Object.assign(changed, await updateAppAgentStates(context));
     }
 

--- a/ts/packages/dispatcher/src/context/options.ts
+++ b/ts/packages/dispatcher/src/context/options.ts
@@ -24,23 +24,6 @@ type ConfigChanged = DeepPartialUndefined<ConfigObject> | undefined;
 // Changes to be applied to the settings, with null values indicating removal and undefined indicating no change.
 type ConfigOptions = DeepPartialUndefinedAndNull<ConfigObject>;
 
-export function setConfigSettings(
-    config: ConfigSettings,
-    options: ConfigOptions,
-    overwrite: string[] | boolean = false,
-) {
-    return mergeConfig(config, options, overwrite);
-}
-
-export function setConfigObject(
-    config: ConfigObject,
-    options: ConfigOptions,
-    defaultConfig: ConfigObject,
-    overwrite: string[] | boolean = false,
-) {
-    return mergeConfig(config, options, overwrite, defaultConfig);
-}
-
 /**
  * Merge options into config.
  *
@@ -123,45 +106,3 @@ export function mergeConfig(
     return Object.keys(changed).length !== 0 ? changed : undefined;
 }
 
-export function sanitizeConfig(
-    config: ConfigSettings,
-    options: ConfigOptions,
-    strict: string[] | boolean = true,
-    prefix: string = "",
-) {
-    let changed = false;
-    for (const [key, value] of Object.entries(options)) {
-        if (value === null) {
-            // Serialized options can't have a null value.
-            throw new Error(`Invalid option: '${prefix}${key}' cannot be null`);
-        }
-        if (value === undefined || !config.hasOwnProperty(key)) {
-            // Ignore options with no effect and extraneous options.
-            continue;
-        }
-        const existingValue = config[key];
-        const strictKey = Array.isArray(strict)
-            ? !strict.includes(key)
-            : strict;
-        if (strictKey && typeof existingValue !== typeof value) {
-            // Clear value for mismatched types.
-            delete options[key];
-            changed = true;
-            continue;
-        }
-
-        if (typeof existingValue === "object" && typeof value === "object") {
-            if (
-                sanitizeConfig(
-                    existingValue,
-                    value,
-                    strictKey,
-                    `${prefix}${key}.`,
-                )
-            ) {
-                changed = true;
-            }
-        }
-    }
-    return changed;
-}

--- a/ts/packages/dispatcher/src/context/options.ts
+++ b/ts/packages/dispatcher/src/context/options.ts
@@ -46,12 +46,14 @@ export function mergeConfig(
     // process option properties.
     const keys = Object.keys(options !== null ? options : config);
     for (const key of keys) {
-        if (overwrite !== true && !config.hasOwnProperty(key)) {
+        const overwriteKey = Array.isArray(overwrite)
+            ? overwrite.includes(key)
+            : overwrite;
+        if (!overwriteKey && !config.hasOwnProperty(key)) {
             continue;
         }
 
         const optionValue = options !== null ? options[key] : null;
-
         // undefined means no change
         if (optionValue === undefined) {
             continue;
@@ -63,9 +65,6 @@ export function mergeConfig(
             );
         }
 
-        const overwriteKey = Array.isArray(overwrite)
-            ? overwrite.includes(key)
-            : overwrite;
         // null means set it to default value (overwrite keys default value is always undefined)
         const defaultValue = defaultConfig?.[key];
         const value =
@@ -74,8 +73,8 @@ export function mergeConfig(
                     ? undefined
                     : defaultValue
                 : optionValue;
-        let existingValue = config[key];
 
+        let existingValue = config[key];
         if (!overwriteKey && typeof existingValue !== typeof value) {
             throw new Error(
                 `Invalid option '${prefix}${key}': type mismatch (expected: ${typeof existingValue}, actual: ${typeof value})`,

--- a/ts/packages/dispatcher/src/context/options.ts
+++ b/ts/packages/dispatcher/src/context/options.ts
@@ -12,49 +12,113 @@ type ConfigObject = {
 };
 
 type ConfigOptions = DeepPartialUndefinedAndNull<ConfigObject>;
+/**
+ * Merge options into config.
+ *
+ * @param config Config to merge into
+ * @param options Options to change the config with
+ * @param overwrite whether to overwrite the config even if the type mismatch. If an array is given, then those keys that the nested object will be overwritten when new types.
+ * @param prefix Prefix for error message (for nested object)
+ * @returns
+ */
 export function mergeConfig(
     config: ConfigObject,
     options: ConfigOptions,
-    strict: boolean = true,
-    flexKeys?: string[],
+    overwrite: string[] | boolean = false,
+    prefix: string = "",
 ) {
     const changed: ConfigOptions = {};
-    const keys = strict ? Object.keys(config) : Object.keys(options);
+
+    // Ignore extra properties when not overwrite by using the keys in config to
+    // process option properties.
+    const keys = Object.keys(overwrite === true ? options : config);
     for (const key of keys) {
-        if (options.hasOwnProperty(key)) {
-            const optionValue = options[key];
+        if (overwrite !== true && !options.hasOwnProperty(key)) {
+            continue;
+        }
 
-            if (optionValue === undefined) {
-                continue;
-            }
-            // null means undefined
-            const value = optionValue === null ? undefined : optionValue;
-            let configValue = config[key];
-            const strictKey = flexKeys ? !flexKeys.includes(key) : strict;
-            if (strictKey && typeof configValue !== typeof value) {
-                // Ignore invalid options.
-                continue;
-            }
-            if (typeof value === "object") {
-                if (typeof configValue !== "object") {
-                    configValue = {};
-                    config[key] = configValue;
-                }
+        const optionValue = options[key];
 
-                const changedValue = mergeConfig(configValue, value, strictKey);
-                if (Object.keys(changedValue).length !== 0) {
-                    changed[key] = changedValue;
-                }
-            } else if (
-                configValue !== value &&
-                (!strict || config.hasOwnProperty(key))
+        // undefined means no change
+        if (optionValue === undefined) {
+            continue;
+        }
+        // null means set it to undefined
+        const value = optionValue === null ? undefined : optionValue;
+        let existingValue = config[key];
+        const overwriteKey = Array.isArray(overwrite)
+            ? overwrite.includes(key)
+            : overwrite;
+        if (!overwriteKey && typeof existingValue !== typeof value) {
+            throw new Error(
+                `Invalid option '${key}': type mismatch (expected: ${typeof existingValue}, actual: ${typeof value})`,
+            );
+        }
+        if (typeof value === "object") {
+            if (typeof existingValue !== "object") {
+                // overwrite existing config as an object. for non-strictKey
+                existingValue = {};
+                config[key] = existingValue;
+            }
+
+            const changedValue = mergeConfig(
+                existingValue,
+                value,
+                overwriteKey,
+                `${prefix}${key}.`,
+            );
+            if (Object.keys(changedValue).length !== 0) {
+                changed[key] = changedValue;
+            }
+        } else if (existingValue !== value) {
+            if (!overwriteKey && value === undefined) {
+                delete config[key];
+            } else {
+                config[key] = value;
+            }
+            changed[key] = optionValue;
+        }
+    }
+    return changed;
+}
+
+export function sanitizeConfig(
+    config: ConfigObject,
+    options: ConfigOptions,
+    strict: string[] | boolean = true,
+    prefix: string = "",
+) {
+    let changed = false;
+    for (const [key, value] of Object.entries(options)) {
+        if (value === null) {
+            // Serialized options can't have a null value.
+            throw new Error(`Invalid option: '${prefix}${key}' cannot be null`);
+        }
+        if (value === undefined || !config.hasOwnProperty(key)) {
+            // Ignore options with no effect and extraneous options.
+            continue;
+        }
+        const existingValue = config[key];
+        const strictKey = Array.isArray(strict)
+            ? !strict.includes(key)
+            : strict;
+        if (strictKey && typeof existingValue !== typeof value) {
+            // Clear value for mismatched types.
+            delete options[key];
+            changed = true;
+            continue;
+        }
+
+        if (typeof existingValue === "object" && typeof value === "object") {
+            if (
+                sanitizeConfig(
+                    existingValue,
+                    value,
+                    strictKey,
+                    `${prefix}${key}.`,
+                )
             ) {
-                if (!strict && value === undefined) {
-                    delete config[key];
-                } else {
-                    config[key] = value;
-                }
-                changed[key] = optionValue;
+                changed = true;
             }
         }
     }

--- a/ts/packages/dispatcher/src/context/session.ts
+++ b/ts/packages/dispatcher/src/context/session.ts
@@ -225,7 +225,7 @@ function ensureSessionData(data: any): SessionData {
 
     const existingData = data.config;
     data.config = cloneConfig(defaultSessionConfig);
-    mergeConfig(data.config, existingData, true, flexKeys);
+    mergeConfig(data.config, existingData, flexKeys);
 
     if (data.cacheData === undefined) {
         data.cacheData = {};
@@ -330,7 +330,7 @@ export class Session {
     }
 
     public setConfig(options: SessionOptions): SessionOptions {
-        const changed = mergeConfig(this.config, options, true, flexKeys);
+        const changed = mergeConfig(this.config, options, flexKeys);
         if (Object.keys(changed).length > 0) {
             this.save();
         }

--- a/ts/packages/dispatcher/src/context/session.ts
+++ b/ts/packages/dispatcher/src/context/session.ts
@@ -229,7 +229,7 @@ function ensureSessionData(data: any): SessionData {
     }
 
     if (data.settings !== undefined) {
-        data.settings = sanitizeConfig(defaultSessionConfig, data.settings);
+        sanitizeConfig(defaultSessionConfig, data.settings, appAgentStateKeys);
     }
     if (data.cacheData === undefined) {
         data.cacheData = {};

--- a/ts/packages/dispatcher/src/context/session.ts
+++ b/ts/packages/dispatcher/src/context/session.ts
@@ -1,14 +1,17 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { DeepPartialUndefined } from "common-utils";
+import {
+    DeepPartialUndefined,
+    DeepPartialUndefinedAndNull,
+} from "common-utils";
 import { CacheConfig, AgentCache, getDefaultExplainerName } from "agent-cache";
 import registerDebug from "debug";
 import fs from "node:fs";
 import path from "node:path";
 import { getUniqueFileName, getYMDPrefix } from "../utils/userData.js";
 import ExifReader from "exifreader";
-import { AppAgentState, AppAgentStateOptions } from "./appAgentManager.js";
+import { AppAgentState } from "./appAgentManager.js";
 import { cloneConfig, mergeConfig } from "./options.js";
 import { TokenCounter, TokenCounterData } from "aiclient";
 import { DispatcherName } from "./dispatcher/dispatcherUtils.js";
@@ -127,9 +130,9 @@ type DispatcherConfig = {
 };
 
 export type SessionConfig = AppAgentState & DispatcherConfig;
-
-export type SessionOptions = AppAgentStateOptions &
-    DeepPartialUndefined<DispatcherConfig>;
+export type SessionSettings = DeepPartialUndefined<SessionConfig>;
+export type SessionOptions = DeepPartialUndefinedAndNull<SessionConfig>;
+export type SessionChanged = DeepPartialUndefined<SessionConfig> | undefined;
 
 const defaultSessionConfig: SessionConfig = {
     schemas: undefined,
@@ -329,9 +332,9 @@ export class Session {
         return this.config;
     }
 
-    public setConfig(options: SessionOptions): SessionOptions {
+    public setConfig(options: SessionOptions): SessionChanged {
         const changed = mergeConfig(this.config, options, flexKeys);
-        if (Object.keys(changed).length > 0) {
+        if (changed) {
             this.save();
         }
         return changed;

--- a/ts/packages/dispatcher/src/context/session.ts
+++ b/ts/packages/dispatcher/src/context/session.ts
@@ -11,7 +11,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { getUniqueFileName, getYMDPrefix } from "../utils/userData.js";
 import ExifReader from "exifreader";
-import { AppAgentState } from "./appAgentManager.js";
+import { AppAgentState, appAgentStateKeys } from "./appAgentManager.js";
 import { cloneConfig, mergeConfig } from "./options.js";
 import { TokenCounter, TokenCounterData } from "aiclient";
 import { DispatcherName } from "./dispatcher/dispatcherUtils.js";
@@ -70,7 +70,7 @@ async function newSessionDir(instanceDir: string) {
     return fullDir;
 }
 
-type DispatcherConfig = {
+export type DispatcherConfig = {
     request: string;
     translation: {
         enabled: boolean;
@@ -228,7 +228,7 @@ function ensureSessionData(data: any): SessionData {
 
     const existingData = data.config;
     data.config = cloneConfig(defaultSessionConfig);
-    mergeConfig(data.config, existingData, flexKeys);
+    mergeConfig(data.config, existingData, appAgentStateKeys);
 
     if (data.cacheData === undefined) {
         data.cacheData = {};
@@ -257,8 +257,6 @@ async function readSessionData(dirPath: string) {
     }
     return ensureSessionData(data);
 }
-
-const flexKeys = ["schemas", "actions", "commands"];
 export class Session {
     private config: SessionConfig;
     private cacheData: SessionCacheData;
@@ -333,7 +331,7 @@ export class Session {
     }
 
     public setConfig(options: SessionOptions): SessionChanged {
-        const changed = mergeConfig(this.config, options, flexKeys);
+        const changed = mergeConfig(this.config, options, appAgentStateKeys);
         if (changed) {
             this.save();
         }

--- a/ts/packages/dispatcher/src/context/session.ts
+++ b/ts/packages/dispatcher/src/context/session.ts
@@ -207,10 +207,6 @@ const defaultSessionConfig: SessionConfig = {
     },
 };
 
-export function getDefaultSessionConfig() {
-    return defaultSessionConfig;
-}
-
 // explainer name as key, cache file path as value
 type SessionCacheData = {
     [key: string]: string | undefined;
@@ -225,6 +221,7 @@ type SessionData = {
 // Fill in missing fields when loading sessions from disk
 function ensureSessionData(data: any): SessionData {
     if (data.config !== undefined) {
+        // back compat
         data.settings = data.config;
     }
 

--- a/ts/packages/dispatcher/src/context/system/handlers/configCommandHandlers.ts
+++ b/ts/packages/dispatcher/src/context/system/handlers/configCommandHandlers.ts
@@ -369,10 +369,7 @@ class AgentToggleCommandHandler implements CommandHandler {
             context,
         );
 
-        const changedEntries = Object.entries(changed).filter(
-            ([_, value]) => value !== undefined,
-        );
-        if (changedEntries.length === 0) {
+        if (changed === undefined) {
             displayWarn("No change", context);
         } else {
             showAgentStatus(this.toggle, context, changed);
@@ -428,11 +425,13 @@ class ExplainerCommandHandler implements CommandHandler {
             { explainer: { name: params.args.explainerName } },
             context,
         );
-        if (changed.explainer?.name === params.args.explainerName) {
+        if (changed?.explainer?.name === params.args.explainerName) {
             displayResult(
                 `Explainer is set to ${params.args.explainerName}`,
                 context,
             );
+        } else {
+            displayWarn(`Explainer is unchanged`, context);
         }
     }
 

--- a/ts/packages/dispatcher/src/context/system/handlers/sessionCommandHandlers.ts
+++ b/ts/packages/dispatcher/src/context/system/handlers/sessionCommandHandlers.ts
@@ -265,7 +265,7 @@ class SessionInfoCommandHandler implements CommandHandlerNoParams {
         );
 
         const table: string[][] = [["Name", "Value"]];
-        const addConfig = (options: any, settings: any, prefix: number = 2) => {
+        const addConfig = (options: any, settings: any, prefix: number = 0) => {
             for (const [key, value] of Object.entries(options)) {
                 const name = `${" ".repeat(prefix)}${key.padEnd(20 - prefix)}`;
                 const currentSetting = settings?.[key];

--- a/ts/packages/dispatcher/src/translation/actionTemplate.ts
+++ b/ts/packages/dispatcher/src/translation/actionTemplate.ts
@@ -37,19 +37,19 @@ export type TemplateEditConfig = {
 };
 
 function getDefaultActionTemplate(
-    translators: string[],
+    schemas: string[],
     discriminator: string = "",
 ): TemplateSchema {
-    const translatorName: TemplateFieldStringUnion = {
+    const schemaNames: TemplateFieldStringUnion = {
         type: "string-union",
-        typeEnum: translators,
+        typeEnum: schemas,
         discriminator,
     };
     const template: TemplateSchema = {
         type: "object",
         fields: {
             translatorName: {
-                type: translatorName,
+                type: schemaNames,
             },
         },
     };
@@ -113,17 +113,17 @@ function toTemplateType(type: ActionParamType): TemplateType | undefined {
 }
 function toTemplate(
     context: CommandHandlerContext,
-    translators: string[],
+    schemas: string[],
     action: ExecutableAction,
 ) {
     const actionSchemaFile = context.agents.tryGetActionSchemaFile(
         action.action.translatorName,
     );
     if (actionSchemaFile === undefined) {
-        return getDefaultActionTemplate(translators);
+        return getDefaultActionTemplate(schemas);
     }
     const template = getDefaultActionTemplate(
-        translators,
+        schemas,
         action.action.translatorName,
     );
     const actionSchemas = actionSchemaFile.actionSchemas;
@@ -163,10 +163,10 @@ export function getActionTemplateEditConfig(
 ): TemplateEditConfig {
     const templateData: TemplateData[] = [];
 
-    const translators = context.agents.getActiveSchemas();
+    const schemas = context.agents.getActiveSchemas();
     for (const action of actions) {
         templateData.push({
-            schema: toTemplate(context, translators, action),
+            schema: toTemplate(context, schemas, action),
             data: action.action,
         });
     }
@@ -178,7 +178,7 @@ export function getActionTemplateEditConfig(
         editPreface,
         templateData,
         completion: true,
-        defaultTemplate: getDefaultActionTemplate(translators),
+        defaultTemplate: getDefaultActionTemplate(schemas),
     };
 }
 
@@ -203,8 +203,8 @@ export async function getSystemTemplateSchema(
         data.actionName = "";
     }
 
-    const translators = systemContext.agents.getActiveSchemas();
-    return toTemplate(systemContext, translators, data);
+    const schemas = systemContext.agents.getActiveSchemas();
+    return toTemplate(systemContext, schemas, data);
 }
 
 export async function getSystemTemplateCompletion(

--- a/ts/packages/dispatcher/test/options.spec.ts
+++ b/ts/packages/dispatcher/test/options.spec.ts
@@ -1,0 +1,154 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { mergeConfig, sanitizeConfig } from "../src/context/options.js";
+
+describe("mergeConfig", () => {
+    describe("strict", () => {
+        it("should merge options into config", () => {
+            const config = { a: 1, b: 2 };
+            const options = { a: 10 };
+            const changed = mergeConfig(config, options);
+            expect(config).toEqual({ a: 10, b: 2 });
+            expect(changed).toEqual({ a: 10 });
+        });
+        it("should merge options into config nested", () => {
+            const config = { a: { b: 1, c: 2 }, d: 3 };
+            const options = { a: { b: 10 } };
+            const changed = mergeConfig(config, options);
+            expect(config).toEqual({ a: { b: 10, c: 2 }, d: 3 });
+            expect(changed).toEqual({ a: { b: 10 } });
+        });
+        it("should skip same value in changed", () => {
+            const config = { a: 1 };
+            const options = { a: 1 };
+            const changed = mergeConfig(config, options);
+            expect(config).toEqual({ a: 1 });
+            expect(changed).toEqual({});
+        });
+        it("should ignore extra value", () => {
+            const config = { a: 1 };
+            const options = { b: "str" };
+            const changed = mergeConfig(config, options);
+            expect(config).toEqual({ a: 1 });
+            expect(changed).toEqual({});
+        });
+        it("should throw on mismatch value type", () => {
+            expect(() => {
+                mergeConfig({ a: 1 }, { a: "str" });
+            }).toThrow(
+                "Invalid option 'a': type mismatch (expected: number, actual: string)",
+            );
+        });
+        it("should throw on mismatched with nested value", () => {
+            expect(() => {
+                mergeConfig({ a: 1 }, { a: { b: 1 } });
+            }).toThrow(
+                "Invalid option 'a': type mismatch (expected: number, actual: object)",
+            );
+        });
+        it("should add nested flex key", () => {
+            const config = { a: { b: 0 } };
+            const options = { a: { c: 1 } };
+            const changed = mergeConfig(config, options, ["a"]);
+            expect(config).toEqual({ a: { b: 0, c: 1 } });
+            expect(changed).toEqual({ a: { c: 1 } });
+        });
+        it("should delete nested flex key", () => {
+            const config = { a: { b: 0, c: 1 } };
+            const options = { a: { c: null } };
+            const changed = mergeConfig(config, options, ["a"]);
+            expect(config).toEqual({ a: { b: 0 } });
+            expect(changed).toEqual({ a: { c: null } });
+        });
+        it("should overwrite flex key mismatched with nested value", () => {
+            const config = { a: 1 };
+            const options = { a: { b: 1 } };
+            const changed = mergeConfig(config, options, ["a"]);
+            expect(config).toEqual({ a: { b: 1 } });
+            expect(changed).toEqual({ a: { b: 1 } });
+        });
+    });
+    describe("non-strict", () => {
+        it("should merge options into config", () => {
+            const config = { a: 1, b: 2 };
+            const options = { a: 10 };
+            const changed = mergeConfig(config, options, true);
+            expect(config).toEqual({ a: 10, b: 2 });
+            expect(changed).toEqual({ a: 10 });
+        });
+        it("should merge options into config nested", () => {
+            const config = { a: { b: 1, c: 2 }, d: 3 };
+            const options = { a: { b: 10 } };
+            const changed = mergeConfig(config, options, true);
+            expect(config).toEqual({ a: { b: 10, c: 2 }, d: 3 });
+            expect(changed).toEqual({ a: { b: 10 } });
+        });
+        it("should skip same value in changed", () => {
+            const config = { a: 1 };
+            const options = { a: 1 };
+            const changed = mergeConfig(config, options, true);
+            expect(config).toEqual({ a: 1 });
+            expect(changed).toEqual({});
+        });
+        it("should add extra value", () => {
+            const config = { a: 1 };
+            const options = { b: "str" };
+            const changed = mergeConfig(config, options, true);
+            expect(config).toEqual({ a: 1, b: "str" });
+            expect(changed).toEqual({ b: "str" });
+        });
+        it("should overwrite mismatch value type", () => {
+            const config = { a: 1 };
+            const options = { a: "str" };
+            const changed = mergeConfig(config, options, true);
+            expect(config).toEqual({ a: "str" });
+            expect(changed).toEqual({ a: "str" });
+        });
+        it("should overwrite with nested value", () => {
+            const config = { a: 1 };
+            const options = { a: { b: 1 } };
+            const changed = mergeConfig(config, options, true);
+            expect(config).toEqual({ a: { b: 1 } });
+            expect(changed).toEqual({ a: { b: 1 } });
+        });
+    });
+});
+
+describe("sanitizeConfig", () => {
+    it("should error on null value", () => {
+        expect(() => {
+            sanitizeConfig({ a: 1 }, { a: null });
+        }).toThrow("Invalid option: 'a' cannot be null");
+    });
+    it("should ignore extraneous options", () => {
+        const options = { b: undefined, c: 3 };
+        const changed = sanitizeConfig({ a: 1 }, options);
+        expect(changed).toEqual(false);
+        expect(options).toEqual({ b: undefined, c: 3 });
+    });
+    it("should clear mismatch types", () => {
+        const options = { a: "str", b: 2 };
+        const changed = sanitizeConfig({ a: 1, b: 2 }, options);
+        expect(changed).toEqual(true);
+        expect(options).toEqual({ b: 2 });
+    });
+
+    it("should error on null value in nested objects", () => {
+        expect(() => {
+            sanitizeConfig({ d: { a: 1 } }, { d: { a: null } });
+        }).toThrow("Invalid option: 'd.a' cannot be null");
+    });
+    it("should ignore extraneous options in nested objects", () => {
+        const options = { d: { b: undefined, c: 3 } };
+        const changed = sanitizeConfig({ a: 1 }, options);
+        expect(changed).toEqual(false);
+        expect(options).toEqual({ d: { b: undefined, c: 3 } });
+    });
+    it("should clear mismatch types in nested objects", () => {
+        const options = { d: { a: "str", b: 2 } };
+        const changed = sanitizeConfig({ d: { a: 1, b: 2 } }, options);
+        expect(changed).toEqual(true);
+        expect(options).toEqual({ d: { b: 2 } });
+    });
+});

--- a/ts/packages/dispatcher/test/options.spec.ts
+++ b/ts/packages/dispatcher/test/options.spec.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { mergeConfig, sanitizeConfig } from "../src/context/options.js";
+import { mergeConfig } from "../src/context/options.js";
 
 describe("mergeConfig", () => {
     describe("strict", () => {
@@ -112,43 +112,5 @@ describe("mergeConfig", () => {
             expect(config).toEqual({ a: { b: 1 } });
             expect(changed).toEqual({ a: { b: 1 } });
         });
-    });
-});
-
-describe("sanitizeConfig", () => {
-    it("should error on null value", () => {
-        expect(() => {
-            sanitizeConfig({ a: 1 }, { a: null });
-        }).toThrow("Invalid option: 'a' cannot be null");
-    });
-    it("should ignore extraneous options", () => {
-        const options = { b: undefined, c: 3 };
-        const changed = sanitizeConfig({ a: 1 }, options);
-        expect(changed).toEqual(false);
-        expect(options).toEqual({ b: undefined, c: 3 });
-    });
-    it("should clear mismatch types", () => {
-        const options = { a: "str", b: 2 };
-        const changed = sanitizeConfig({ a: 1, b: 2 }, options);
-        expect(changed).toEqual(true);
-        expect(options).toEqual({ b: 2 });
-    });
-
-    it("should error on null value in nested objects", () => {
-        expect(() => {
-            sanitizeConfig({ d: { a: 1 } }, { d: { a: null } });
-        }).toThrow("Invalid option: 'd.a' cannot be null");
-    });
-    it("should ignore extraneous options in nested objects", () => {
-        const options = { d: { b: undefined, c: 3 } };
-        const changed = sanitizeConfig({ a: 1 }, options);
-        expect(changed).toEqual(false);
-        expect(options).toEqual({ d: { b: undefined, c: 3 } });
-    });
-    it("should clear mismatch types in nested objects", () => {
-        const options = { d: { a: "str", b: 2 } };
-        const changed = sanitizeConfig({ d: { a: 1, b: 2 } }, options);
-        expect(changed).toEqual(true);
-        expect(options).toEqual({ d: { b: 2 } });
     });
 });

--- a/ts/packages/dispatcher/test/options.spec.ts
+++ b/ts/packages/dispatcher/test/options.spec.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { mergeConfig } from "../src/context/options.js";
+import { mergeConfig, sanitizeConfig } from "../src/context/options.js";
 
 describe("mergeConfig", () => {
     describe("strict", () => {
@@ -121,5 +121,43 @@ describe("mergeConfig", () => {
             expect(config).toEqual({ a: { b: 1 } });
             expect(changed).toEqual({ a: { b: 1 } });
         });
+    });
+});
+
+describe("sanitizeConfig", () => {
+    it("should error on null value", () => {
+        expect(() => {
+            sanitizeConfig({ a: 1 }, { a: null });
+        }).toThrow("Invalid option: 'a' cannot be null");
+    });
+    it("should ignore extraneous options", () => {
+        const options = { b: undefined, c: 3 };
+        const changed = sanitizeConfig({ a: 1 }, options);
+        expect(changed).toEqual(false);
+        expect(options).toEqual({ b: undefined, c: 3 });
+    });
+    it("should clear mismatch types", () => {
+        const options = { a: "str", b: 2 };
+        const changed = sanitizeConfig({ a: 1, b: 2 }, options);
+        expect(changed).toEqual(true);
+        expect(options).toEqual({ b: 2 });
+    });
+
+    it("should error on null value in nested objects", () => {
+        expect(() => {
+            sanitizeConfig({ d: { a: 1 } }, { d: { a: null } });
+        }).toThrow("Invalid option: 'd.a' cannot be null");
+    });
+    it("should ignore extraneous options in nested objects", () => {
+        const options = { d: { b: undefined, c: 3 } };
+        const changed = sanitizeConfig({ a: 1 }, options);
+        expect(changed).toEqual(false);
+        expect(options).toEqual({ d: { b: undefined, c: 3 } });
+    });
+    it("should clear mismatch types in nested objects", () => {
+        const options = { d: { a: "str", b: 2 } };
+        const changed = sanitizeConfig({ d: { a: 1, b: 2 } }, options);
+        expect(changed).toEqual(true);
+        expect(options).toEqual({ d: { b: 2 } });
     });
 });

--- a/ts/packages/dispatcher/test/options.spec.ts
+++ b/ts/packages/dispatcher/test/options.spec.ts
@@ -47,6 +47,21 @@ describe("mergeConfig", () => {
                 "Invalid option 'a': type mismatch (expected: number, actual: object)",
             );
         });
+
+        it("should add flex key", () => {
+            const config = {};
+            const options = { a: { c: 1 } };
+            const changed = mergeConfig(config, options, ["a"]);
+            expect(config).toStrictEqual({ a: { c: 1 } });
+            expect(changed).toStrictEqual({ a: { c: 1 } });
+        });
+        it("should delete flex key", () => {
+            const config = { a: { c: 1 } };
+            const options = { a: null };
+            const changed = mergeConfig(config, options, ["a"]);
+            expect(config).toStrictEqual({});
+            expect(changed).toStrictEqual({ a: undefined });
+        });
         it("should add nested flex key", () => {
             const config = { a: { b: 0 } };
             const options = { a: { c: 1 } };
@@ -54,7 +69,6 @@ describe("mergeConfig", () => {
             expect(config).toStrictEqual({ a: { b: 0, c: 1 } });
             expect(changed).toStrictEqual({ a: { c: 1 } });
         });
-
         it("should delete nested flex key", () => {
             const config = { a: { b: 0, c: 1 } };
             const options = { a: { c: null } };
@@ -107,6 +121,13 @@ describe("mergeConfig", () => {
             expect(config).toStrictEqual({ a: 1, b: "str" });
             expect(changed).toStrictEqual({ b: "str" });
         });
+        it("should delete value", () => {
+            const config = { a: 1 };
+            const options = { a: null };
+            const changed = mergeConfig(config, options, true);
+            expect(config).toStrictEqual({});
+            expect(changed).toStrictEqual({ a: undefined });
+        });
         it("should overwrite mismatch value type", () => {
             const config = { a: 1 };
             const options = { a: "str" };
@@ -114,7 +135,7 @@ describe("mergeConfig", () => {
             expect(config).toStrictEqual({ a: "str" });
             expect(changed).toStrictEqual({ a: "str" });
         });
-        it("should overwrite with nested value", () => {
+        it("should overwrite mismatch value type with nested value", () => {
             const config = { a: 1 };
             const options = { a: { b: 1 } };
             const changed = mergeConfig(config, options, true);

--- a/ts/packages/dispatcher/test/options.spec.ts
+++ b/ts/packages/dispatcher/test/options.spec.ts
@@ -54,6 +54,7 @@ describe("mergeConfig", () => {
             expect(config).toEqual({ a: { b: 0, c: 1 } });
             expect(changed).toEqual({ a: { c: 1 } });
         });
+
         it("should delete nested flex key", () => {
             const config = { a: { b: 0, c: 1 } };
             const options = { a: { c: null } };
@@ -67,6 +68,14 @@ describe("mergeConfig", () => {
             const changed = mergeConfig(config, options, ["a"]);
             expect(config).toEqual({ a: { b: 1 } });
             expect(changed).toEqual({ a: { b: 1 } });
+        });
+
+        it("should overwrite flex key mismatched with non-nested value", () => {
+            const config = { a: { b: 1 } };
+            const options = { a: 1 };
+            const changed = mergeConfig(config, options, ["a"]);
+            expect(config).toEqual({ a: 1 });
+            expect(changed).toEqual({ a: 1 });
         });
     });
     describe("non-strict", () => {

--- a/ts/packages/dispatcher/test/options.spec.ts
+++ b/ts/packages/dispatcher/test/options.spec.ts
@@ -9,28 +9,28 @@ describe("mergeConfig", () => {
             const config = { a: 1, b: 2 };
             const options = { a: 10 };
             const changed = mergeConfig(config, options);
-            expect(config).toEqual({ a: 10, b: 2 });
-            expect(changed).toEqual({ a: 10 });
+            expect(config).toStrictEqual({ a: 10, b: 2 });
+            expect(changed).toStrictEqual({ a: 10 });
         });
         it("should merge options into config nested", () => {
             const config = { a: { b: 1, c: 2 }, d: 3 };
             const options = { a: { b: 10 } };
             const changed = mergeConfig(config, options);
-            expect(config).toEqual({ a: { b: 10, c: 2 }, d: 3 });
-            expect(changed).toEqual({ a: { b: 10 } });
+            expect(config).toStrictEqual({ a: { b: 10, c: 2 }, d: 3 });
+            expect(changed).toStrictEqual({ a: { b: 10 } });
         });
         it("should skip same value in changed", () => {
             const config = { a: 1 };
             const options = { a: 1 };
             const changed = mergeConfig(config, options);
-            expect(config).toEqual({ a: 1 });
+            expect(config).toStrictEqual({ a: 1 });
             expect(changed).toBeUndefined();
         });
         it("should ignore extra value", () => {
             const config = { a: 1 };
             const options = { b: "str" };
             const changed = mergeConfig(config, options);
-            expect(config).toEqual({ a: 1 });
+            expect(config).toStrictEqual({ a: 1 });
             expect(changed).toBeUndefined();
         });
         it("should throw on mismatch value type", () => {
@@ -51,31 +51,31 @@ describe("mergeConfig", () => {
             const config = { a: { b: 0 } };
             const options = { a: { c: 1 } };
             const changed = mergeConfig(config, options, ["a"]);
-            expect(config).toEqual({ a: { b: 0, c: 1 } });
-            expect(changed).toEqual({ a: { c: 1 } });
+            expect(config).toStrictEqual({ a: { b: 0, c: 1 } });
+            expect(changed).toStrictEqual({ a: { c: 1 } });
         });
 
         it("should delete nested flex key", () => {
             const config = { a: { b: 0, c: 1 } };
             const options = { a: { c: null } };
             const changed = mergeConfig(config, options, ["a"]);
-            expect(config).toEqual({ a: { b: 0 } });
-            expect(changed).toEqual({ a: { c: undefined } });
+            expect(config).toStrictEqual({ a: { b: 0 } });
+            expect(changed).toStrictEqual({ a: { c: undefined } });
         });
         it("should overwrite flex key mismatched with nested value", () => {
             const config = { a: 1 };
             const options = { a: { b: 1 } };
             const changed = mergeConfig(config, options, ["a"]);
-            expect(config).toEqual({ a: { b: 1 } });
-            expect(changed).toEqual({ a: { b: 1 } });
+            expect(config).toStrictEqual({ a: { b: 1 } });
+            expect(changed).toStrictEqual({ a: { b: 1 } });
         });
 
         it("should overwrite flex key mismatched with non-nested value", () => {
             const config = { a: { b: 1 } };
             const options = { a: 1 };
             const changed = mergeConfig(config, options, ["a"]);
-            expect(config).toEqual({ a: 1 });
-            expect(changed).toEqual({ a: 1 });
+            expect(config).toStrictEqual({ a: 1 });
+            expect(changed).toStrictEqual({ a: 1 });
         });
     });
     describe("non-strict", () => {
@@ -83,43 +83,43 @@ describe("mergeConfig", () => {
             const config = { a: 1, b: 2 };
             const options = { a: 10 };
             const changed = mergeConfig(config, options, true);
-            expect(config).toEqual({ a: 10, b: 2 });
-            expect(changed).toEqual({ a: 10 });
+            expect(config).toStrictEqual({ a: 10, b: 2 });
+            expect(changed).toStrictEqual({ a: 10 });
         });
         it("should merge options into config nested", () => {
             const config = { a: { b: 1, c: 2 }, d: 3 };
             const options = { a: { b: 10 } };
             const changed = mergeConfig(config, options, true);
-            expect(config).toEqual({ a: { b: 10, c: 2 }, d: 3 });
-            expect(changed).toEqual({ a: { b: 10 } });
+            expect(config).toStrictEqual({ a: { b: 10, c: 2 }, d: 3 });
+            expect(changed).toStrictEqual({ a: { b: 10 } });
         });
         it("should skip same value in changed", () => {
             const config = { a: 1 };
             const options = { a: 1 };
             const changed = mergeConfig(config, options, true);
-            expect(config).toEqual({ a: 1 });
+            expect(config).toStrictEqual({ a: 1 });
             expect(changed).toBeUndefined();
         });
         it("should add extra value", () => {
             const config = { a: 1 };
             const options = { b: "str" };
             const changed = mergeConfig(config, options, true);
-            expect(config).toEqual({ a: 1, b: "str" });
-            expect(changed).toEqual({ b: "str" });
+            expect(config).toStrictEqual({ a: 1, b: "str" });
+            expect(changed).toStrictEqual({ b: "str" });
         });
         it("should overwrite mismatch value type", () => {
             const config = { a: 1 };
             const options = { a: "str" };
             const changed = mergeConfig(config, options, true);
-            expect(config).toEqual({ a: "str" });
-            expect(changed).toEqual({ a: "str" });
+            expect(config).toStrictEqual({ a: "str" });
+            expect(changed).toStrictEqual({ a: "str" });
         });
         it("should overwrite with nested value", () => {
             const config = { a: 1 };
             const options = { a: { b: 1 } };
             const changed = mergeConfig(config, options, true);
-            expect(config).toEqual({ a: { b: 1 } });
-            expect(changed).toEqual({ a: { b: 1 } });
+            expect(config).toStrictEqual({ a: { b: 1 } });
+            expect(changed).toStrictEqual({ a: { b: 1 } });
         });
     });
 });
@@ -133,14 +133,14 @@ describe("sanitizeConfig", () => {
     it("should ignore extraneous options", () => {
         const options = { b: undefined, c: 3 };
         const changed = sanitizeConfig({ a: 1 }, options);
-        expect(changed).toEqual(false);
-        expect(options).toEqual({ b: undefined, c: 3 });
+        expect(changed).toStrictEqual(false);
+        expect(options).toStrictEqual({ b: undefined, c: 3 });
     });
     it("should clear mismatch types", () => {
         const options = { a: "str", b: 2 };
         const changed = sanitizeConfig({ a: 1, b: 2 }, options);
-        expect(changed).toEqual(true);
-        expect(options).toEqual({ b: 2 });
+        expect(changed).toStrictEqual(true);
+        expect(options).toStrictEqual({ b: 2 });
     });
 
     it("should error on null value in nested objects", () => {
@@ -151,13 +151,13 @@ describe("sanitizeConfig", () => {
     it("should ignore extraneous options in nested objects", () => {
         const options = { d: { b: undefined, c: 3 } };
         const changed = sanitizeConfig({ a: 1 }, options);
-        expect(changed).toEqual(false);
-        expect(options).toEqual({ d: { b: undefined, c: 3 } });
+        expect(changed).toStrictEqual(false);
+        expect(options).toStrictEqual({ d: { b: undefined, c: 3 } });
     });
     it("should clear mismatch types in nested objects", () => {
         const options = { d: { a: "str", b: 2 } };
         const changed = sanitizeConfig({ d: { a: 1, b: 2 } }, options);
-        expect(changed).toEqual(true);
-        expect(options).toEqual({ d: { b: 2 } });
+        expect(changed).toStrictEqual(true);
+        expect(options).toStrictEqual({ d: { b: 2 } });
     });
 });

--- a/ts/packages/dispatcher/test/options.spec.ts
+++ b/ts/packages/dispatcher/test/options.spec.ts
@@ -24,14 +24,14 @@ describe("mergeConfig", () => {
             const options = { a: 1 };
             const changed = mergeConfig(config, options);
             expect(config).toEqual({ a: 1 });
-            expect(changed).toEqual({});
+            expect(changed).toBeUndefined();
         });
         it("should ignore extra value", () => {
             const config = { a: 1 };
             const options = { b: "str" };
             const changed = mergeConfig(config, options);
             expect(config).toEqual({ a: 1 });
-            expect(changed).toEqual({});
+            expect(changed).toBeUndefined();
         });
         it("should throw on mismatch value type", () => {
             expect(() => {
@@ -59,7 +59,7 @@ describe("mergeConfig", () => {
             const options = { a: { c: null } };
             const changed = mergeConfig(config, options, ["a"]);
             expect(config).toEqual({ a: { b: 0 } });
-            expect(changed).toEqual({ a: { c: null } });
+            expect(changed).toEqual({ a: { c: undefined } });
         });
         it("should overwrite flex key mismatched with nested value", () => {
             const config = { a: 1 };
@@ -89,7 +89,7 @@ describe("mergeConfig", () => {
             const options = { a: 1 };
             const changed = mergeConfig(config, options, true);
             expect(config).toEqual({ a: 1 });
-            expect(changed).toEqual({});
+            expect(changed).toBeUndefined();
         });
         it("should add extra value", () => {
             const config = { a: 1 };

--- a/ts/packages/dispatcher/test/provider.spec.ts
+++ b/ts/packages/dispatcher/test/provider.spec.ts
@@ -39,7 +39,9 @@ describe("dispatcher", () => {
             beforeAll(async () => {
                 dispatcher = await createDispatcher("test", {
                     appAgentProviders: [testAppAgentProvider],
-                    commands: { test: true },
+                    agents: {
+                        commands: ["test"],
+                    },
                     clientIO: createTestClientIO(output),
                 });
             });


### PR DESCRIPTION
- Only serialize options that user explicit modified, allow the default to change from builds.
- Dispatcher initialization options are treated as change to the default, where persisted setting can override.
- Improve Dispatcher initialization options to enable/disable agents/schemas/actions/commands.
