### PR TITLE
Cleanup cross package relative path import

### DIFF
--- a/ts/examples/chat/src/memory/imageMemory.ts
+++ b/ts/examples/chat/src/memory/imageMemory.ts
@@ -26,8 +26,9 @@ import * as knowLib from "knowledge-processor";
 import path from "node:path";
 import { sqlite } from "memory-providers";
 import { isImageFileType } from "common-utils";
-import { TokenCounter } from "aiclient";
-import { CompletionUsageStats } from "../../../../packages/aiclient/dist/openai.js";
+import { TokenCounter, openai } from "aiclient";
+
+type CompletionUsageStats = openai.CompletionUsageStats;
 
 export async function createImageMemory(
     models: Models,

--- a/ts/examples/memoryProviders/src/elastic/simplifiedTextIndex.ts
+++ b/ts/examples/memoryProviders/src/elastic/simplifiedTextIndex.ts
@@ -9,15 +9,16 @@ import {
     TextIndexSettings,
     ValueDataType,
     ValueType,
+    sets,
 } from "knowledge-processor";
 import { generateTextId, toValidIndexName } from "./common.js";
 import { ScoredItem, generateEmbedding } from "typeagent";
-import {
-    ModelType,
-    createEmbeddingModel,
-} from "../../../../packages/aiclient/dist/openai.js";
+import { openai } from "aiclient";
+
+const { ModelType, createEmbeddingModel } = openai;
+
 import { openAIApiSettingsFromEnv } from "../../../../packages/aiclient/dist/openaiSettings.js";
-import { HitTable } from "../../../../packages/knowledgeProcessor/dist/setOperations.js";
+type HitTable<T = any> = sets.HitTable<T>;
 
 export async function createTextIndex<
     TTexId extends ValueType = string,

--- a/ts/examples/memoryProviders/test/sqlite.textTable.spec.ts
+++ b/ts/examples/memoryProviders/test/sqlite.textTable.spec.ts
@@ -25,11 +25,13 @@ import {
 } from "./testCore.js";
 import * as knowLib from "knowledge-processor";
 import { asyncArray, ScoredItem } from "typeagent";
-import { HitTable } from "../../../packages/knowledgeProcessor/dist/setOperations.js";
+
 import {
     createTemporalLogTable,
     TemporalTable,
 } from "../src/sqlite/temporalTable.js";
+
+type HitTable<T = any> = knowLib.sets.HitTable<T>;
 
 describe("sqlite.textTable", () => {
     const testTimeout = 1000 * 60 * 5;

--- a/ts/packages/agents/browser/src/extension/serviceWorker.ts
+++ b/ts/packages/agents/browser/src/extension/serviceWorker.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import { AppAction } from "@typeagent/agent-sdk";
-import { WebSocketMessageV2 } from "../../../../commonUtils/dist/indexBrowser";
+import { WebSocketMessageV2 } from "common-utils";
 import {
     isWebAgentMessage,
     isWebAgentMessageFromDispatcher,

--- a/ts/packages/agents/browser/src/extension/webTypeAgentMain.ts
+++ b/ts/packages/agents/browser/src/extension/webTypeAgentMain.ts
@@ -10,7 +10,6 @@ import { createRpc } from "agent-rpc/rpc";
 import { createAgentRpcServer } from "agent-rpc/server";
 import { isWebAgentMessageFromDispatcher } from "../../dist/common/webAgentMessageTypes.mjs";
 import {
-    WebAgentDisconnectMessageFromDispatcher,
     WebAgentRegisterMessage,
     WebAgentRpcMessage,
 } from "../common/webAgentMessageTypes.mjs";

--- a/ts/packages/agents/greeting/src/greetingCommandHandler.ts
+++ b/ts/packages/agents/greeting/src/greetingCommandHandler.ts
@@ -26,8 +26,6 @@ import {
     GreetingAction,
     PersonalizedGreetingAction,
 } from "./greetingActionSchema.js";
-//import { getLookupInstructions, getLookupSettings, LookupSettings } from "../../chat/dist/chatResponseHandler.js";
-//import { StopWatch } from "telemetry";
 import { conversation as Conversation } from "knowledge-processor";
 
 export function instantiate(): AppAgent {

--- a/ts/packages/knowPro/src/importImages.ts
+++ b/ts/packages/knowPro/src/importImages.ts
@@ -30,12 +30,13 @@ import path from "node:path";
 import { isImageFileType } from "common-utils";
 import { ChatModel } from "aiclient";
 import { AddressOutput } from "@azure-rest/maps-search";
-import { ConcreteEntity } from "../../knowledgeProcessor/dist/conversation/knowledgeSchema.js";
 import { IPropertyToSemanticRefIndex } from "./secondaryIndexes.js";
-import { Topic } from "../../knowledgeProcessor/dist/conversation/topicSchema.js";
 import { IConversationThreadData } from "./conversationThread.js";
 import { createPodcastSettings, PodcastSettings } from "./import.js";
 import { isDirectoryPath } from "typeagent";
+
+type ConcreteEntity = conversation.ConcreteEntity;
+type Topic = conversation.Topic;
 
 export interface ImageCollectionData extends IConversationData<Image> {
     relatedTermsIndexData?: ITermsToRelatedTermsIndexData | undefined;

--- a/ts/packages/knowledgeProcessor/src/temporal.ts
+++ b/ts/packages/knowledgeProcessor/src/temporal.ts
@@ -14,10 +14,11 @@ import {
     //generateMonotonicName,
 } from "typeagent";
 import { intersectMultiple, setFrom } from "./setOperations.js";
-import { DateRange } from "../../typeagent/dist/dateTime.js";
 import { pathToFileURL } from "url";
 import path from "path";
 import { valueToString } from "./text.js";
+
+type DateRange = dateTime.DateRange;
 
 export type TemporalLogSettings = {
     concurrency: number;


### PR DESCRIPTION
There is still one import for `openAIApiSettingsFromEnv` in  `examples/memoryProviders/src/elastic/simplifiedTextIndex.ts` pending reworking the model creation API.