### PR TITLE
More switches for options to CLI translate commands

### DIFF
--- a/ts/packages/cli/src/commands/run/translate.ts
+++ b/ts/packages/cli/src/commands/run/translate.ts
@@ -57,6 +57,25 @@ export default class TranslateCommand extends Command {
             default: true, // follow DispatcherOptions default
             allowNo: true,
         }),
+        schemaOptimization: Flags.boolean({
+            description: "Enable schema optimization",
+        }),
+        switchEmbedding: Flags.boolean({
+            description: "Use embedding to determine the first schema to use",
+            default: true, // follow DispatcherOptions default
+            allowNo: true,
+        }),
+        switchInline: Flags.boolean({
+            description: "Use inline switch schema to select schema group",
+            default: true, // follow DispatcherOptions default
+            allowNo: true,
+        }),
+        switchSearch: Flags.boolean({
+            description:
+                "Enable second chance full switch schema to find schema group",
+            default: true, // follow DispatcherOptions default
+            allowNo: true,
+        }),
     };
 
     static description = "Translate a request into action";
@@ -83,6 +102,14 @@ export default class TranslateCommand extends Command {
                             jsonSchemaFunction: flags.jsonSchemaFunction,
                             jsonSchemaValidate: flags.jsonSchemaValidate,
                         },
+                        optimize: {
+                            enabled: flags.schemaOptimization,
+                        },
+                    },
+                    switch: {
+                        embedding: flags.switchEmbedding,
+                        inline: flags.switchInline,
+                        search: flags.switchSearch,
                     },
                 },
                 cache: { enabled: false },

--- a/ts/packages/cli/src/commands/test/translate.ts
+++ b/ts/packages/cli/src/commands/test/translate.ts
@@ -126,6 +126,25 @@ export default class TestTranslateCommand extends Command {
             default: true, // follow DispatcherOptions default
             allowNo: true,
         }),
+        schemaOptimization: Flags.boolean({
+            description: "Enable schema optimization",
+        }),
+        switchEmbedding: Flags.boolean({
+            description: "Use embedding to determine the first schema to use",
+            default: true, // follow DispatcherOptions default
+            allowNo: true,
+        }),
+        switchInline: Flags.boolean({
+            description: "Use inline switch schema to select schema group",
+            default: true, // follow DispatcherOptions default
+            allowNo: true,
+        }),
+        switchSearch: Flags.boolean({
+            description:
+                "Enable second chance full switch schema to find schema group",
+            default: true, // follow DispatcherOptions default
+            allowNo: true,
+        }),
         stream: Flags.boolean({
             description: "Enable streaming",
             default: true, // follow DispatcherOptions default
@@ -327,6 +346,14 @@ export default class TestTranslateCommand extends Command {
                             jsonSchemaFunction: flags.jsonSchemaFunction,
                             jsonSchemaValidate: flags.jsonSchemaValidate,
                         },
+                        optimize: {
+                            enabled: flags.schemaOptimization,
+                        },
+                    },
+                    switch: {
+                        embedding: flags.switchEmbedding,
+                        inline: flags.switchInline,
+                        search: flags.switchSearch,
                     },
                 },
                 explainer: { enabled: false },


### PR DESCRIPTION
Add the following flags for `cli run translate` and `cli test translate`

- `--switchOptimization` - Enable schema optimization by only present partial schema group based on embedding.  (default: off)
- `--switchEmbedding` - Enable picking the first schema group to use for translation using embedding.   (default: on)
- `--switchInline` - Enable injection of the inline switcher for the translation to choose another schema group (default: on)
- `--switchSearch` - Enable second chance search for schema group if the first translation or inline switcher failed. (default: on)
