### PR TITLE
Combine all schema when all agent switching methods are off

### DIFF
--- a/ts/packages/commonUtils/src/jsonTranslator.ts
+++ b/ts/packages/commonUtils/src/jsonTranslator.ts
@@ -212,8 +212,8 @@ export function createJsonTranslatorFromSchemaDef<T extends object>(
 
 export interface TypeAgentJsonValidator<T extends object>
     extends TypeChatJsonValidator<T> {
-    getSchemaText: () => string;
-    getTypeName: () => string;
+    getSchemaText(): string;
+    getTypeName(): string;
     validate(jsonObject: object): Result<T>;
     getJsonSchema?: () => CompletionJsonSchema | undefined;
 }

--- a/ts/packages/dispatcher/src/agentProvider/agentProviderUtils.ts
+++ b/ts/packages/dispatcher/src/agentProvider/agentProviderUtils.ts
@@ -51,7 +51,7 @@ export async function createActionConfigProvider(
             return config;
         },
         getActionConfigs() {
-            return Object.entries(actionConfigs);
+            return Object.values(actionConfigs);
         },
         getActionSchemaFileForConfig(actionConfig: ActionConfig) {
             return actionSchemaFileCache.getActionSchemaFile(actionConfig);
@@ -64,5 +64,7 @@ export async function createActionConfigProvider(
 export function getSchemaNamesForActionConfigProvider(
     provider: ActionConfigProvider,
 ): string[] {
-    return provider.getActionConfigs().map(([name]) => name);
+    return provider
+        .getActionConfigs()
+        .map((actionConfig) => actionConfig.schemaName);
 }

--- a/ts/packages/dispatcher/src/command/command.ts
+++ b/ts/packages/dispatcher/src/command/command.ts
@@ -193,7 +193,7 @@ async function parseCommand(
         } catch (e: any) {
             const command = getParsedCommand(result);
             throw new Error(
-                `${e.message}\n\n${chalk.black(getUsage(command, result.descriptor))}`,
+                `${e.message}\n\n${chalk.reset(getUsage(command, result.descriptor))}`,
             );
         }
     }
@@ -219,7 +219,7 @@ async function parseCommand(
               : `'${result.suffix}' is not a subcommand for '@${command}'.`;
 
     throw new Error(
-        `${message}\n\n${chalk.black(getHandlerTableUsage(result.table, command, context))}`,
+        `${message}\n\n${chalk.reset(getHandlerTableUsage(result.table, command, context))}`,
     );
 }
 

--- a/ts/packages/dispatcher/src/command/handlerUtils.ts
+++ b/ts/packages/dispatcher/src/command/handlerUtils.ts
@@ -3,7 +3,10 @@
 
 import { ActionContext } from "@typeagent/agent-sdk";
 import { CommandHandlerContext } from "../context/commandHandlerContext.js";
-import { CommandHandlerTable } from "@typeagent/agent-sdk/helpers/command";
+import {
+    CommandHandlerNoParams,
+    CommandHandlerTable,
+} from "@typeagent/agent-sdk/helpers/command";
 import { displaySuccess } from "@typeagent/agent-sdk/helpers/display";
 
 export function getToggleCommandHandlers(
@@ -12,7 +15,7 @@ export function getToggleCommandHandlers(
         context: ActionContext<CommandHandlerContext>,
         enable: boolean,
     ) => Promise<void>,
-) {
+): Record<string, CommandHandlerNoParams> {
     return {
         on: {
             description: `Turn on ${name}`,

--- a/ts/packages/dispatcher/src/context/appAgentManager.ts
+++ b/ts/packages/dispatcher/src/context/appAgentManager.ts
@@ -363,10 +363,6 @@ export class AppAgentManager implements ActionConfigProvider {
         return Array.from(this.actionConfigs.values());
     }
 
-    public getInjectedSchemaForActionName(actionName: string) {
-        return this.injectedSchemaForActionName.get(actionName);
-    }
-
     public getAppAgent(appAgentName: string): AppAgent {
         const record = this.getRecord(appAgentName);
         if (record.appAgent === undefined) {

--- a/ts/packages/dispatcher/src/context/appAgentManager.ts
+++ b/ts/packages/dispatcher/src/context/appAgentManager.ts
@@ -360,7 +360,7 @@ export class AppAgentManager implements ActionConfigProvider {
         return Array.from(this.actionConfigs.keys());
     }
     public getActionConfigs() {
-        return Array.from(this.actionConfigs.entries());
+        return Array.from(this.actionConfigs.values());
     }
 
     public getInjectedSchemaForActionName(actionName: string) {

--- a/ts/packages/dispatcher/src/context/dispatcher/handlers/requestCommandHandler.ts
+++ b/ts/packages/dispatcher/src/context/dispatcher/handlers/requestCommandHandler.ts
@@ -42,7 +42,7 @@ const debugExplain = registerDebug("typeagent:explain");
 
 async function canTranslateWithoutContext(
     requestAction: RequestAction,
-    usedTranslators: Map<string, TypeAgentTranslator<object>>,
+    usedTranslators: Map<string, TypeAgentTranslator>,
     logger?: Logger,
 ) {
     if (requestAction.history === undefined) {
@@ -60,7 +60,7 @@ async function canTranslateWithoutContext(
             if (!result.success) {
                 throw new Error("Failed to translate without history context");
             }
-            const newActions = result.data as TranslatedAction;
+            const newActions = result.data;
             const count = isMultipleAction(newActions)
                 ? newActions.parameters.requests.length
                 : 1;
@@ -68,7 +68,7 @@ async function canTranslateWithoutContext(
             if (count !== oldActions.length) {
                 throw new Error("Action count mismatch without context");
             }
-            translations.set(translatorName, result.data as TranslatedAction);
+            translations.set(translatorName, result.data);
         }
 
         let index = 0;
@@ -85,8 +85,16 @@ async function canTranslateWithoutContext(
             } else {
                 newAction = newTranslatedActions;
             }
+            const schemaName = usedTranslators
+                .get(translatorName)!
+                .getSchemaName(newAction.actionName);
+            if (schemaName === undefined) {
+                throw new Error(
+                    `Unable to match schema name for action '${newAction.actionName}'`,
+                );
+            }
             newActions.push({
-                translatorName,
+                translatorName: schemaName,
                 ...newAction,
             });
         }
@@ -156,7 +164,7 @@ function getExplainerOptions(
     }
 
     if (hasAdditionalInstructions(requestAction.history)) {
-        // Translation with additional instructions are not cachable.
+        // Translation with additional instructions are not cacheable.
         return undefined;
     }
 
@@ -168,7 +176,7 @@ function getExplainerOptions(
         return undefined;
     }
 
-    const usedTranslators = new Map<string, TypeAgentTranslator<object>>();
+    const usedTranslators = new Map<string, TypeAgentTranslator>();
     const actions = requestAction.actions;
     for (const { action } of actions) {
         if (isUnknownAction(action)) {

--- a/ts/packages/dispatcher/src/context/dispatcher/handlers/requestCommandHandler.ts
+++ b/ts/packages/dispatcher/src/context/dispatcher/handlers/requestCommandHandler.ts
@@ -89,8 +89,9 @@ async function canTranslateWithoutContext(
                 .get(translatorName)!
                 .getSchemaName(newAction.actionName);
             if (schemaName === undefined) {
+                // Should not happen
                 throw new Error(
-                    `Unable to match schema name for action '${newAction.actionName}'`,
+                    `Internal Error: Unable to match schema name for action '${newAction.actionName}'`,
                 );
             }
             newActions.push({

--- a/ts/packages/dispatcher/src/context/system/action/historyActionHandler.ts
+++ b/ts/packages/dispatcher/src/context/system/action/historyActionHandler.ts
@@ -15,20 +15,20 @@ export async function executeHistoryAction(
 ) {
     const historyAction = action as HistoryAction;
     switch (historyAction.actionName) {
-        case "delete":
+        case "deleteHistory":
             const deleteAction = historyAction as DeleteHistoryAction;
             await processCommandNoLock(
                 `@history delete ${deleteAction.parameters.messageNumber}`,
                 context.sessionContext.agentContext,
             );
             break;
-        case "clear":
+        case "clearHistory":
             await processCommandNoLock(
                 `@history clear`,
                 context.sessionContext.agentContext,
             );
             break;
-        case "list":
+        case "listHistory":
             await processCommandNoLock(
                 `@history list`,
                 context.sessionContext.agentContext,

--- a/ts/packages/dispatcher/src/context/system/action/notificationActionHandler.ts
+++ b/ts/packages/dispatcher/src/context/system/action/notificationActionHandler.ts
@@ -15,20 +15,20 @@ export async function executeNotificationAction(
 ) {
     const notificationAction = action as NotificationAction;
     switch (notificationAction.actionName) {
-        case "show":
+        case "showNotifications":
             const showAction = notificationAction as ShowNotificationsAction;
             await processCommandNoLock(
                 `@notify show ${showAction.parameters.filter}`,
                 context.sessionContext.agentContext,
             );
             break;
-        case "summary":
+        case "showNotificationSummary":
             await processCommandNoLock(
                 `@notify info`,
                 context.sessionContext.agentContext,
             );
             break;
-        case "clear":
+        case "clearNotifications":
             await processCommandNoLock(
                 `@notify clear`,
                 context.sessionContext.agentContext,

--- a/ts/packages/dispatcher/src/context/system/action/sessionActionHandler.ts
+++ b/ts/packages/dispatcher/src/context/system/action/sessionActionHandler.ts
@@ -11,27 +11,21 @@ export async function executeSessionAction(
     context: ActionContext<CommandHandlerContext>,
 ) {
     switch (action.actionName) {
-        case "new":
+        case "newSession":
             await processCommandNoLock(
                 `@session new ${action.parameters.name ?? ""}`,
                 context.sessionContext.agentContext,
             );
             break;
-        case "list":
+        case "listSession":
             await processCommandNoLock(
                 "@session list",
                 context.sessionContext.agentContext,
             );
             break;
-        case "showInfo":
+        case "showSessionInfo":
             await processCommandNoLock(
                 "@session info",
-                context.sessionContext.agentContext,
-            );
-            break;
-        case "toggleHistory":
-            await processCommandNoLock(
-                `@session history ${action.parameters.enable ? "on" : "off"}`,
                 context.sessionContext.agentContext,
             );
             break;

--- a/ts/packages/dispatcher/src/context/system/handlers/configCommandHandlers.ts
+++ b/ts/packages/dispatcher/src/context/system/handlers/configCommandHandlers.ts
@@ -730,7 +730,7 @@ const configTranslationCommandHandlers: CommandHandlerTable = {
                     },
                 ),
                 search: getToggleHandlerTable(
-                    "inject inline switch",
+                    "search switch",
                     async (context, enable: boolean) => {
                         await changeContextConfig(
                             {

--- a/ts/packages/dispatcher/src/context/system/schema/historyActionSchema.ts
+++ b/ts/packages/dispatcher/src/context/system/schema/historyActionSchema.ts
@@ -8,17 +8,17 @@ export type HistoryAction =
 
 // Shows the chat history
 export type ListHistoryAction = {
-    actionName: "list";
+    actionName: "listHistory";
 };
 
 // Clears the chat history
 export type ClearHistoryAction = {
-    actionName: "clear";
+    actionName: "clearHistory";
 };
 
 // Deletes a specific message from the chat history
 export type DeleteHistoryAction = {
-    actionName: "delete";
+    actionName: "deleteHistory";
     parameters: {
         messageNumber: number;
     };

--- a/ts/packages/dispatcher/src/context/system/schema/notificationActionSchema.ts
+++ b/ts/packages/dispatcher/src/context/system/schema/notificationActionSchema.ts
@@ -8,7 +8,7 @@ export type NotificationAction =
 
 // Shows notifications based on the supplied filter
 export type ShowNotificationsAction = {
-    actionName: "show";
+    actionName: "showNotifications";
     parameters: {
         filter: NotificationFilter;
     };
@@ -18,10 +18,10 @@ export type NotificationFilter = "all" | "unread";
 
 // Shows notification summary
 export type ShowNotificationSummaryAction = {
-    actionName: "summary";
+    actionName: "showNotificationSummary";
 };
 
 // Clears the notifications
 export type ClearNotificationsAction = {
-    actionName: "clear";
+    actionName: "clearNotifications";
 };

--- a/ts/packages/dispatcher/src/context/system/schema/sessionActionSchema.ts
+++ b/ts/packages/dispatcher/src/context/system/schema/sessionActionSchema.ts
@@ -2,33 +2,24 @@
 // Licensed under the MIT License.
 
 export type SessionAction =
-    | NewAction
-    | ListAction
-    | ShowInfoAction
-    | ToggleHistoryAction;
+    | NewSessionAction
+    | ListSessionAction
+    | ShowSessionInfoAction;
 
 // Create a new session.
-export type NewAction = {
-    actionName: "new";
+export type NewSessionAction = {
+    actionName: "newSession";
     parameters: {
         name?: string;
     };
 };
 
 // List all sessions.
-export type ListAction = {
-    actionName: "list";
+export type ListSessionAction = {
+    actionName: "listSession";
 };
 
 // Show information about a session.
-export type ShowInfoAction = {
-    actionName: "showInfo";
-};
-
-// Toggle history flag for the session.
-export type ToggleHistoryAction = {
-    actionName: "toggleHistory";
-    parameters: {
-        enable: boolean;
-    };
+export type ShowSessionInfoAction = {
+    actionName: "showSessionInfo";
 };

--- a/ts/packages/dispatcher/src/internal.ts
+++ b/ts/packages/dispatcher/src/internal.ts
@@ -22,10 +22,7 @@ export { getAssistantSelectionSchemas } from "./translation/unknownSwitcher.js";
 export { getActionSchema } from "./translation/actionSchemaFileCache.js";
 export { getFullSchemaText } from "./translation/agentTranslators.js";
 
-export {
-    loadAgentJsonTranslator,
-    getAppAgentName,
-} from "./translation/agentTranslators.js";
+export { getAppAgentName } from "./translation/agentTranslators.js";
 export { createSchemaInfoProvider } from "./translation/actionSchemaFileCache.js";
 export {
     createActionConfigProvider,

--- a/ts/packages/dispatcher/src/translation/actionConfigProvider.ts
+++ b/ts/packages/dispatcher/src/translation/actionConfigProvider.ts
@@ -7,6 +7,6 @@ import { ActionConfig } from "./actionConfig.js";
 export interface ActionConfigProvider {
     tryGetActionConfig(schemaName: string): ActionConfig | undefined;
     getActionConfig(schemaName: string): ActionConfig;
-    getActionConfigs(): [string, ActionConfig][];
+    getActionConfigs(): ActionConfig[];
     getActionSchemaFileForConfig(config: ActionConfig): ActionSchemaFile;
 }

--- a/ts/packages/dispatcher/src/translation/actionSchemaJsonTranslator.ts
+++ b/ts/packages/dispatcher/src/translation/actionSchemaJsonTranslator.ts
@@ -47,7 +47,7 @@ function convertJsonSchemaOutput(
     return (jsonObject as any).response;
 }
 
-function createActionSchemaJsonValidator<T extends TranslatedAction>(
+export function createActionSchemaJsonValidator<T extends TranslatedAction>(
     actionSchemaGroup: ActionSchemaGroup,
     generateOptions?: GenerateSchemaOptions,
 ): TypeAgentJsonValidator<T> {
@@ -219,21 +219,20 @@ export function composeActionSchema(
 
 export function composeSelectedActionSchema(
     definitions: ActionSchemaTypeDefinition[],
-    actionConfigs: ActionConfig[],
+    actionConfig: ActionConfig,
+    additionalActionConfigs: ActionConfig[],
     switchActionConfigs: ActionConfig[],
-    schemaName: string,
     provider: ActionConfigProvider,
     multipleActionOptions: MultipleActionOptions,
 ) {
     const builder = new ActionSchemaBuilder(provider);
     const union = sc.union(definitions.map((definition) => sc.ref(definition)));
-    const config = provider.getActionConfig(schemaName);
-    const typeName = `Partial${config.schemaType}`;
-    const comments = `${typeName} is a partial list of actions available in schema group '${schemaName}'.`;
+    const typeName = `Partial${actionConfig.schemaType}`;
+    const comments = `${typeName} is a partial list of actions available in schema group '${actionConfig.schemaName}'.`;
 
     const entry = sc.type(typeName, union, comments);
     builder.addTypeDefinition(entry);
-    builder.addActionConfig(...actionConfigs);
+    builder.addActionConfig(...additionalActionConfigs);
     return finalizeActionSchemaBuilder(
         builder,
         switchActionConfigs,

--- a/ts/packages/dispatcher/src/translation/agentTranslators.ts
+++ b/ts/packages/dispatcher/src/translation/agentTranslators.ts
@@ -103,14 +103,14 @@ export function createChangeAssistantActionSchema(
 }
 
 function getChangeAssistantSchemaDef(
-    currentTranslatorName: string,
+    currentSchemaName: string,
     provider: ActionConfigProvider,
-    activeTranslators: { [key: string]: boolean },
+    activeSchemas: { [key: string]: boolean },
 ): TranslatorSchemaDef | undefined {
     const definition = createChangeAssistantActionSchema(
         provider,
-        currentTranslatorName,
-        activeTranslators,
+        currentSchemaName,
+        activeSchemas,
     );
     if (definition === undefined) {
         return undefined;
@@ -147,34 +147,34 @@ function getTranslatorSchemaDef(
 }
 
 export function getInjectedActionConfigs(
-    translatorName: string,
+    currentSchemaName: string,
     provider: ActionConfigProvider,
-    activeTranslators: { [key: string]: boolean },
+    activeSchemas: { [key: string]: boolean },
 ) {
     return provider
         .getActionConfigs()
         .filter(
             ([name, config]) =>
                 config.injected &&
-                name !== translatorName && // don't include itself
-                (activeTranslators[name] ?? false),
+                name !== currentSchemaName && // don't include itself
+                (activeSchemas[name] ?? false),
         )
         .map(([_, config]) => config);
 }
 
 function getInjectedSchemaDefs(
     type: string,
-    translatorName: string,
+    currentSchemaName: string,
     provider: ActionConfigProvider,
-    activeTranslators: { [key: string]: boolean },
+    activeSchemas: { [key: string]: boolean },
     changeAgentAction: boolean,
     multipleActionOptions: MultipleActionOptions,
 ): TranslatorSchemaDef[] {
     // Add all injected schemas
     const injectedActionConfigs = getInjectedActionConfigs(
-        translatorName,
+        currentSchemaName,
         provider,
-        activeTranslators,
+        activeSchemas,
     );
     const injectedSchemaDefs = injectedActionConfigs.map(
         getTranslatorSchemaDef,
@@ -186,9 +186,9 @@ function getInjectedSchemaDefs(
     // Add change assistant schema if needed
     const changeAssistantSchemaDef = changeAgentAction
         ? getChangeAssistantSchemaDef(
-              translatorName,
+              currentSchemaName,
               provider,
-              activeTranslators,
+              activeSchemas,
           )
         : undefined;
 
@@ -212,7 +212,7 @@ function getInjectedSchemaDefs(
 function getTranslatorSchemaDefs(
     schemaName: string,
     provider: ActionConfigProvider,
-    activeTranslators: { [key: string]: boolean },
+    activeSchemas: { [key: string]: boolean },
     changeAgentAction: boolean,
     multipleActionOptions: MultipleActionOptions,
 ): TranslatorSchemaDef[] {
@@ -223,7 +223,7 @@ function getTranslatorSchemaDefs(
             actionConfig.schemaType,
             schemaName,
             provider,
-            activeTranslators,
+            activeSchemas,
             changeAgentAction,
             multipleActionOptions,
         ),
@@ -248,31 +248,31 @@ export interface TranslatedAction {
 
 /**
  *
- * @param translatorName name to get the translator for.
- * @param activeTranslators The set of active translators to include for injected and change assistant actions. Default to false if undefined.
+ * @param schemaName name to get the translator for.
+ * @param activeSchemas The set of active translators to include for injected and change assistant actions. Default to false if undefined.
  * @param multipleActions Add the multiple action schema if true. Default to false.
  * @returns
  */
 export function loadAgentJsonTranslator<
     T extends TranslatedAction = TranslatedAction,
 >(
-    translatorName: string,
+    schemaName: string,
     provider: ActionConfigProvider,
-    activeTranslators: { [key: string]: boolean } = {},
+    activeSchemas: { [key: string]: boolean } = {},
     changeAgentAction: boolean = false,
     multipleActionOptions: MultipleActionOptions,
-    regenerateSchema: boolean = true,
+    generated: boolean = true,
     model?: string,
     generateOptions?: GenerateSchemaOptions,
 ): TypeAgentTranslator<T> {
     const options = { model };
-    const translator = regenerateSchema
+    const translator = generated
         ? createJsonTranslatorFromActionSchema<T>(
               "AllActions",
               composeActionSchema(
-                  translatorName,
+                  schemaName,
                   provider,
-                  activeTranslators,
+                  activeSchemas,
                   changeAgentAction,
                   multipleActionOptions,
               ),
@@ -282,9 +282,9 @@ export function loadAgentJsonTranslator<
         : createJsonTranslatorFromSchemaDef<T>(
               "AllActions",
               getTranslatorSchemaDefs(
-                  translatorName,
+                  schemaName,
                   provider,
-                  activeTranslators,
+                  activeSchemas,
                   changeAgentAction,
                   multipleActionOptions,
               ),
@@ -362,7 +362,7 @@ export function createTypeAgentTranslatorForSelectedActions<
     definitions: ActionSchemaTypeDefinition[],
     schemaName: string,
     provider: ActionConfigProvider,
-    activeTranslators: { [key: string]: boolean },
+    activeSchemas: { [key: string]: boolean },
     changeAgentAction: boolean,
     multipleActionOptions: MultipleActionOptions,
     model?: string,
@@ -374,7 +374,7 @@ export function createTypeAgentTranslatorForSelectedActions<
             definitions,
             schemaName,
             provider,
-            activeTranslators,
+            activeSchemas,
             changeAgentAction,
             multipleActionOptions,
         ),

--- a/ts/packages/dispatcher/src/translation/translateRequest.ts
+++ b/ts/packages/dispatcher/src/translation/translateRequest.ts
@@ -556,8 +556,9 @@ async function finalizeAction(
     );
 
     if (currentActionSchemaName === undefined) {
+        // Should not happen
         throw new Error(
-            `Unable to match schema name for action ${currentAction.actionName}`,
+            `Internal Error: Unable to match schema name for action ${currentAction.actionName}`,
         );
     }
 

--- a/ts/packages/dispatcher/src/translation/translateRequest.ts
+++ b/ts/packages/dispatcher/src/translation/translateRequest.ts
@@ -49,23 +49,28 @@ import registerDebug from "debug";
 import { confirmTranslation } from "./confirmTranslation.js";
 import { ActionConfig } from "./actionConfig.js";
 import { AppAgentManager } from "../context/appAgentManager.js";
+import { DispatcherConfig } from "../context/session.js";
 
 const debugTranslate = registerDebug("typeagent:translate");
 const debugSemanticSearch = registerDebug("typeagent:translate:semantic");
 
 /**
- * Gather active action configs for injection and switch.
- * If firstSchemaName is specified, it will be included for injection first regardless of whether config or it is active or not.
+ * Gather active action configs that are injected to include for translation and switching.
+ * If firstSchemaName is specified, it will be included first regardless of whether it is injected/active or not.
+ * If switchEnabled is false, all active schemas will be included regardless of whether it is injected or not.
+ * If switchAgentAction is true, also collect action config that is not included in a separate array `switchActionConfigs`.
  *
  * @param agents the app agent manager
- * @param changeAgentAction whether to generate the switch actions.
+ * @param switchEnabled whether to enable the switch action.
+ * @param switchAgentAction whether to generate the switch actions.
  * @param firstSchemaName the first schema name to include for injection
  * @returns
  */
 
 function getTranslationActionConfigs(
     agents: AppAgentManager,
-    changeAgentAction: boolean,
+    switchEnabled: boolean,
+    switchAgentAction: boolean,
     firstSchemaName?: string,
 ) {
     const actionConfigs: ActionConfig[] = [];
@@ -78,9 +83,10 @@ function getTranslationActionConfigs(
         if (firstSchemaName === name || !agents.isSchemaActive(name)) {
             continue;
         }
-        if (actionConfig.injected) {
+        // Include the schemas for injection if switch is disabled or it is injected.
+        if (!switchEnabled || actionConfig.injected) {
             actionConfigs.push(actionConfig);
-        } else if (changeAgentAction) {
+        } else if (switchAgentAction) {
             switchActionConfigs.push(actionConfig);
         }
     }
@@ -90,10 +96,20 @@ function getTranslationActionConfigs(
     };
 }
 
+function isSwitchEnabled(config: DispatcherConfig) {
+    return (
+        config.translation.switch.embedding ||
+        config.translation.switch.inline ||
+        config.translation.switch.search
+    );
+}
+
 export function getTranslatorForSchema(
     context: CommandHandlerContext,
     schemaName: string,
 ) {
+    const switchEnabled = isSwitchEnabled(context.session.getConfig());
+    const translatorName = switchEnabled ? schemaName : ""; // Use empty string to represent the one and only translator that combines all schemas.
     const translator = context.translatorCache.get(schemaName);
     if (translator !== undefined) {
         return translator;
@@ -101,6 +117,7 @@ export function getTranslatorForSchema(
     const config = context.session.getConfig().translation;
     const { actionConfigs, switchActionConfigs } = getTranslationActionConfigs(
         context.agents,
+        switchEnabled,
         config.switch.inline,
         schemaName,
     );
@@ -120,7 +137,7 @@ export function getTranslatorForSchema(
             jsonSchemaValidate: config.schema.generation.jsonSchemaValidate,
         },
     );
-    context.translatorCache.set(schemaName, newTranslator);
+    context.translatorCache.set(translatorName, newTranslator);
     return newTranslator;
 }
 
@@ -130,6 +147,9 @@ async function getTranslatorForSelectedActions(
     request: string,
     numActions: number,
 ): Promise<TypeAgentTranslator | undefined> {
+    if (!isSwitchEnabled(context.session.getConfig())) {
+        return undefined;
+    }
     const actionSchemaFile = context.agents.tryGetActionSchemaFile(schemaName);
     if (
         actionSchemaFile === undefined ||
@@ -147,16 +167,16 @@ async function getTranslatorForSelectedActions(
         return undefined;
     }
     const config = context.session.getConfig().translation;
-
     const { actionConfigs, switchActionConfigs } = getTranslationActionConfigs(
         context.agents,
+        true,
         config.switch.inline,
     );
     return createTypeAgentTranslatorForSelectedActions(
         nearestNeighbors.map((e) => e.item.definition),
+        context.agents.getActionConfig(schemaName),
         actionConfigs,
         switchActionConfigs,
-        schemaName,
         context.agents,
         config.multiple,
         config.model,
@@ -222,6 +242,12 @@ function needAllAction(translatedAction: TranslatedAction, schemaName: string) {
             translatedAction.parameters.schemaName === schemaName)
     );
 }
+
+type TranslateStepResult<T = TranslatedAction> = {
+    translatedAction: T;
+    translator: TypeAgentTranslator;
+};
+
 async function translateRequestWithSchema(
     schemaName: string,
     request: string,
@@ -229,14 +255,19 @@ async function translateRequestWithSchema(
     history?: HistoryContext,
     attachments?: CachedImageWithDetails[],
     streamingActionIndex?: number,
-) {
+    disableOptimize: boolean = false,
+): Promise<TranslateStepResult | undefined> {
     const systemContext = context.sessionContext.agentContext;
     const config = systemContext.session.getConfig();
     const prefix = getSchemaNamePrefix(schemaName, systemContext);
     displayStatus(`${prefix}Translating '${request}'`, context);
 
     const optimize = config.translation.schema.optimize;
-    if (optimize.enabled && optimize.numInitialActions > 0) {
+    if (
+        !disableOptimize &&
+        optimize.enabled &&
+        optimize.numInitialActions > 0
+    ) {
         const selectedActionTranslator = await getTranslatorForSelectedActions(
             systemContext,
             schemaName,
@@ -246,7 +277,6 @@ async function translateRequestWithSchema(
         if (selectedActionTranslator) {
             const translatedAction = await translateWithTranslator(
                 selectedActionTranslator,
-                schemaName,
                 request,
                 history,
                 attachments,
@@ -258,53 +288,33 @@ async function translateRequestWithSchema(
             }
 
             if (!needAllAction(translatedAction, schemaName)) {
-                if (isMultipleAction(translatedAction)) {
-                    const requests = translatedAction.parameters.requests;
-                    for (const subRequest of requests) {
-                        if (
-                            isPendingRequest(subRequest) ||
-                            !needAllAction(subRequest.action, schemaName)
-                        ) {
-                            continue;
-                        }
-                        // REVIEW: the subaction may not be
-                        const translator = getTranslatorForSchema(
-                            systemContext,
-                            schemaName,
-                        );
-                        const action = await translateWithTranslator(
-                            translator,
-                            schemaName,
-                            subRequest.request,
-                            history,
-                            attachments,
-                            context,
-                        );
-                        if (action === undefined) {
-                            return undefined;
-                        }
-                        subRequest.action = action;
-                    }
-                }
-                return translatedAction;
+                return {
+                    translatedAction,
+                    translator: selectedActionTranslator,
+                };
             }
         }
     }
     const translator = getTranslatorForSchema(systemContext, schemaName);
-    return translateWithTranslator(
+    const translatedAction = await translateWithTranslator(
         translator,
-        schemaName,
         request,
         history,
         attachments,
         context,
         streamingActionIndex,
     );
+
+    return translatedAction
+        ? {
+              translatedAction,
+              translator,
+          }
+        : undefined;
 }
 
 async function translateWithTranslator(
     translator: TypeAgentTranslator,
-    schemaName: string,
     request: string,
     history: HistoryContext | undefined,
     attachments: CachedImageWithDetails[] | undefined,
@@ -331,15 +341,13 @@ async function translateWithTranslator(
                       value !== "unknown" &&
                       delta === undefined
                   ) {
-                      const actionSchemaName =
-                          systemContext.agents.getInjectedSchemaForActionName(
-                              value,
-                          ) ?? schemaName;
+                      const actionSchemaName = translator.getSchemaName(value);
 
                       if (
+                          actionSchemaName === undefined ||
                           !systemContext.agents.isActionActive(actionSchemaName)
                       ) {
-                          // don't stream if action is not active for the schema
+                          // don't stream if action not part of the translator or not active for the schema
                           return;
                       }
                       const prefix = getSchemaNamePrefix(
@@ -386,7 +394,7 @@ async function translateWithTranslator(
             displayError(response.message, context);
             return undefined;
         }
-        return response.data as TranslatedAction;
+        return response.data;
     } finally {
         profiler?.stop();
     }
@@ -442,7 +450,7 @@ async function findAssistantForRequest(
 
 async function getNextTranslation(
     action: TranslatedAction,
-    translatorName: string,
+    schemaName: string,
     context: ActionContext<CommandHandlerContext>,
     forceSearch: boolean,
 ): Promise<NextTranslation | undefined> {
@@ -464,27 +472,29 @@ async function getNextTranslation(
 
     const config = context.sessionContext.agentContext.session.getConfig();
     return config.translation.switch.search
-        ? findAssistantForRequest(request, translatorName, context)
+        ? findAssistantForRequest(request, schemaName, context)
         : undefined;
 }
 
 async function finalizeAction(
     action: TranslatedAction,
-    translatorName: string,
+    translator: TypeAgentTranslator,
+    schemaName: string,
     context: ActionContext<CommandHandlerContext>,
     history?: HistoryContext,
     attachments?: CachedImageWithDetails[],
     resultEntityId?: string,
     streamingActionIndex?: number,
 ): Promise<ExecutableAction | ExecutableAction[] | undefined> {
-    let currentAction: TranslatedAction | undefined = action;
-    let currentTranslatorName: string = translatorName;
+    let currentAction = action;
+    let currentTranslator = translator;
+    let currentSchemaName: string = schemaName;
     const systemContext = context.sessionContext.agentContext;
     while (true) {
         const forceSearch = currentAction !== action; // force search if we have switched once
         const nextTranslation = await getNextTranslation(
             currentAction,
-            currentTranslatorName,
+            currentSchemaName,
             context,
             forceSearch,
         );
@@ -500,19 +510,22 @@ async function finalizeAction(
             );
         }
 
-        currentAction = await translateRequestWithSchema(
+        const result = await translateRequestWithSchema(
             nextSchemaName,
             request,
             context,
             history,
             attachments,
             streamingActionIndex,
+            nextSchemaName === currentSchemaName, // If we are retrying the same schema, then disable optimize
         );
-        if (currentAction === undefined) {
+        if (result === undefined) {
             return undefined;
         }
 
-        currentTranslatorName = nextSchemaName;
+        currentAction = result.translatedAction;
+        currentTranslator = result.translator;
+        currentSchemaName = nextSchemaName;
         // Don't keep on switching after we searched, just return unknown
         if (searched) {
             break;
@@ -522,7 +535,8 @@ async function finalizeAction(
     if (isMultipleAction(currentAction)) {
         return finalizeMultipleActions(
             currentAction,
-            currentTranslatorName,
+            currentTranslator,
+            currentSchemaName,
             context,
             history,
         );
@@ -537,10 +551,18 @@ async function finalizeAction(
         currentAction = unknownAction;
     }
 
+    const currentActionSchemaName = currentTranslator.getSchemaName(
+        currentAction.actionName,
+    );
+
+    if (currentActionSchemaName === undefined) {
+        throw new Error(
+            `Unable to match schema name for action ${currentAction.actionName}`,
+        );
+    }
+
     return createExecutableAction(
-        systemContext.agents.getInjectedSchemaForActionName(
-            currentAction.actionName,
-        ) ?? currentTranslatorName,
+        currentActionSchemaName,
         currentAction.actionName,
         currentAction.parameters,
         resultEntityId,
@@ -549,6 +571,7 @@ async function finalizeAction(
 
 async function finalizeMultipleActions(
     action: MultipleAction,
+    translator: TypeAgentTranslator,
     translatorName: string,
     context: ActionContext<CommandHandlerContext>,
     history?: HistoryContext,
@@ -568,6 +591,7 @@ async function finalizeMultipleActions(
 
         const finalizedActions = await finalizeAction(
             request.action,
+            translator,
             translatorName,
             context,
             history,
@@ -639,7 +663,7 @@ export async function translateRequest(
     // Start with the last translator used
     const startTime = performance.now();
     const schemaName = await pickInitialSchema(request, systemContext);
-    const action = await translateRequestWithSchema(
+    const result = await translateRequestWithSchema(
         schemaName,
         request,
         context,
@@ -647,30 +671,34 @@ export async function translateRequest(
         attachments,
         streamingActionIndex,
     );
-    if (action === undefined) {
+    if (result === undefined) {
         return undefined;
     }
 
-    const translatedAction = isMultipleAction(action)
+    const { translatedAction, translator } = result;
+
+    const executableAction = isMultipleAction(translatedAction)
         ? await finalizeMultipleActions(
-              action,
+              translatedAction,
+              translator,
               schemaName,
               context,
               history,
               attachments,
           )
         : await finalizeAction(
-              action,
+              translatedAction,
+              translator,
               schemaName,
               context,
               history,
               attachments,
           );
 
-    if (translatedAction === undefined) {
+    if (executableAction === undefined) {
         return undefined;
     }
-    const translated = RequestAction.create(request, translatedAction, history);
+    const translated = RequestAction.create(request, executableAction, history);
 
     const elapsedMs = performance.now() - startTime;
     const { requestAction, replacedAction } = await confirmTranslation(

--- a/ts/packages/dispatcher/src/utils/test/explanationTestData.ts
+++ b/ts/packages/dispatcher/src/utils/test/explanationTestData.ts
@@ -28,6 +28,7 @@ import {
     isMultipleAction,
     isPendingRequest,
 } from "../../translation/multipleActionSchema.js";
+import { DispatcherName } from "../../context/dispatcher/dispatcherUtils.js";
 
 const testDataJSONVersion = 2;
 export type ExplanationTestDataEntry<T extends object = object> =
@@ -280,12 +281,14 @@ function getSafeTranslateFn(
     model?: string,
 ) {
     const translator = loadAgentJsonTranslator<TranslatedAction>(
-        schemaName,
+        [
+            provider.getActionConfig(schemaName),
+            provider.getActionConfig(DispatcherName), // make sure we have "unknown" action
+        ],
+        [],
         provider,
-        {},
-        false,
-        false,
-        true,
+        false, // multiple
+        true, // generated
         model,
     );
     return async (request: string): Promise<Result<TranslatedAction>> => {


### PR DESCRIPTION
- If embedding, inline and search switching are off, we will try to combine all the active schema into one single prompt.
- For now, we will error out if there are type name or action name that conflicts between the schemas.
- Require the translator keep track of the `actionName` -> `schemaName` mapping.  The steps to translate the request will keep track of the translator the action is from so that it can resolve the schema name after finalizing.  (This will allow us to do mix and match later).

Additionally:
- Refactor TypeAgentTranslator construction to be more flexible by passing in the inject/switch action config instead of the state to compute it internally.
- Skip the translation optimization of using embedding to choose a subset of action to prompt first when we retry the same schema during the translation in the case where LLM want to look at other actions from the same schema, removing the need to do an explicit pass without optimization on multiple actions.
- Fix the @ command error output to use the default color instead of black which could lead to "black on black".