### PR TITLE
Add back explanation message accidentally removed

### DIFF
--- a/ts/packages/shell/src/renderer/assets/styles.less
+++ b/ts/packages/shell/src/renderer/assets/styles.less
@@ -521,6 +521,20 @@ table.table-message td {
   font-size: 80%;
 }
 
+.chat-message-explained[data-expl]:hover:after {
+  content: attr(data-expl);
+  position: absolute;
+  text-align: right;
+  top: -10px;
+  right: 0px;
+  white-space: nowrap;
+  color: gray;
+  background-color: lightyellow;
+  border: 1px solid black;
+  padding: 1px 5px 1px 5px;
+  font-size: 70%;
+}
+
 .chat-input-button {
   align-self: flex-end;
   border: none;


### PR DESCRIPTION
Removed in #688, the style is needed to show the explanation message.

Change the original style a little bit to look more like a "tooltip"