### PR TITLE
Translation test improvements

### DIFF
--- a/ts/packages/defaultAgentProvider/test/data/translate-history-e2e.json
+++ b/ts/packages/defaultAgentProvider/test/data/translate-history-e2e.json
@@ -214,5 +214,50 @@
         }
       }
     }
+  ],
+  [
+    {
+      "request": "add eggs to the grocery list",
+      "action": {
+        "translatorName": "list",
+        "actionName": "addItems",
+        "parameters": {
+          "items": ["eggs"],
+          "listName": "grocery"
+        }
+      },
+      "history": {
+        "text": "Added items: eggs to list grocery",
+        "source": "list",
+        "entities": [
+          {
+            "name": "grocery",
+            "type": ["list"]
+          },
+          {
+            "name": "eggs",
+            "type": ["item"]
+          }
+        ]
+      }
+    },
+    {
+      "request": "add cheese",
+      "action": {
+        "translatorName": "list",
+        "actionName": "addItems",
+        "parameters": {
+          "items": ["cheese"],
+          "listName": "grocery"
+        },
+        "entities": {
+          "listName": {
+            "name": "grocery",
+            "sourceAppAgentName": "list",
+            "type": ["list"]
+          }
+        }
+      }
+    }
   ]
 ]

--- a/ts/packages/defaultAgentProvider/test/translateTestCommon.ts
+++ b/ts/packages/defaultAgentProvider/test/translateTestCommon.ts
@@ -6,10 +6,12 @@ dotenv.config({ path: new URL("../../../../.env", import.meta.url) });
 
 import { getPackageFilePath } from "../src/utils/getPackageFilePath.js";
 import { getDefaultAppAgentProviders } from "../src/defaultAgentProviders.js";
-import fs from "node:fs";
 import { createDispatcher, Dispatcher } from "agent-dispatcher";
 import { ChatHistoryInput } from "agent-dispatcher/internal";
 import { FullAction } from "agent-cache";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 
 type TranslateTestStep = {
     request: string;
@@ -24,7 +26,7 @@ type TranslateTestFile = TranslateTestEntry[];
 
 const repeat = 5;
 const defaultAppAgentProviders = getDefaultAppAgentProviders(undefined);
-
+const embeddingCacheDir = path.join(os.tmpdir(), ".typeagent", "cache");
 export async function defineTranslateTest(name: string, dataFiles: string[]) {
     const inputs: TranslateTestEntry[] = (
         await Promise.all(
@@ -46,12 +48,20 @@ export async function defineTranslateTest(name: string, dataFiles: string[]) {
             ] as const,
     );
     describe(`${name} action stability`, () => {
-        let dispatchers: Dispatcher[];
+        let dispatchers: Dispatcher[] = [];
+        async function runOnDispatchers(
+            fn: (dispatcher: Dispatcher) => Promise<void>,
+        ) {
+            const p = dispatchers.map(fn);
+            // Make sure all promise finished before checking the result
+            await Promise.allSettled(p);
+            // Propagate any errors
+            await Promise.all(p);
+        }
         beforeAll(async () => {
-            const dispatcherP: Promise<Dispatcher>[] = [];
             for (let i = 0; i < repeat; i++) {
-                dispatcherP.push(
-                    createDispatcher("cli test translate", {
+                dispatchers.push(
+                    await createDispatcher("cli test translate", {
                         appAgentProviders: defaultAppAgentProviders,
                         agents: {
                             actions: false,
@@ -60,77 +70,73 @@ export async function defineTranslateTest(name: string, dataFiles: string[]) {
                         execution: { history: false }, // don't generate chat history, the test manually imports them
                         explainer: { enabled: false },
                         cache: { enabled: false },
+                        embeddingCacheDir, // Cache the embedding to avoid recomputation.
                         collectCommandResult: true,
                     }),
                 );
             }
-            dispatchers = await Promise.all(dispatcherP);
         });
         beforeEach(async () => {
-            await Promise.all(
-                dispatchers.map(async (dispatcher) => {
-                    const result =
-                        await dispatcher.processCommand("@history clear");
-                    expect(result?.hasError).toBeFalsy();
-                }),
-            );
+            await runOnDispatchers(async (dispatcher) => {
+                const result =
+                    await dispatcher.processCommand("@history clear");
+                expect(result?.hasError).toBeFalsy();
+            });
         });
         it.each(inputsWithName)(`${name} %p`, async (_, test) => {
             const steps = Array.isArray(test) ? test : [test];
-            await Promise.all(
-                dispatchers.map(async (dispatcher) => {
-                    for (const step of steps) {
-                        const { request, action, match, history, attachments } =
-                            step;
+            await runOnDispatchers(async (dispatcher) => {
+                for (const step of steps) {
+                    const { request, action, match, history, attachments } =
+                        step;
 
-                        const result = await dispatcher.processCommand(
-                            request,
-                            undefined,
-                            attachments,
-                        );
-                        expect(result?.hasError).toBeFalsy();
+                    const result = await dispatcher.processCommand(
+                        request,
+                        undefined,
+                        attachments,
+                    );
+                    expect(result?.hasError).toBeFalsy();
 
-                        const actions = result?.actions;
-                        expect(actions).toBeDefined();
+                    const actions = result?.actions;
+                    expect(actions).toBeDefined();
 
-                        const expectedValues = Array.isArray(action)
-                            ? action
-                            : [action];
-                        expect(actions).toHaveLength(expectedValues.length);
-                        for (let i = 0; i < expectedValues.length; i++) {
-                            const action = actions![i];
-                            const expected = expectedValues[i];
-                            if (typeof expected === "string") {
-                                const actualFullActionName = `${action.translatorName}.${action.actionName}`;
-                                if (match === "partial") {
-                                    expect(actualFullActionName).toContain(
-                                        expected,
-                                    );
-                                } else {
-                                    expect(actualFullActionName).toBe(expected);
-                                }
+                    const expectedValues = Array.isArray(action)
+                        ? action
+                        : [action];
+                    expect(actions).toHaveLength(expectedValues.length);
+
+                    for (let i = 0; i < expectedValues.length; i++) {
+                        const action = actions![i];
+                        const expected = expectedValues[i];
+                        if (typeof expected === "string") {
+                            const actualFullActionName = `${action.translatorName}.${action.actionName}`;
+                            if (match === "partial") {
+                                expect(actualFullActionName).toContain(
+                                    expected,
+                                );
                             } else {
-                                if (match === "partial") {
-                                    expect(action).toMatchObject(expected);
-                                } else {
-                                    expect(action).toEqual(expected);
-                                }
+                                expect(actualFullActionName).toBe(expected);
+                            }
+                        } else {
+                            if (match === "partial") {
+                                expect(action).toMatchObject(expected);
+                            } else {
+                                expect(action).toEqual(expected);
                             }
                         }
-
-                        if (history !== undefined) {
-                            const insertResult =
-                                await dispatcher.processCommand(
-                                    `@history insert ${JSON.stringify({ user: request, assistant: history })}`,
-                                );
-                            expect(insertResult?.hasError).toBeFalsy();
-                        }
                     }
-                }),
-            );
+
+                    if (history !== undefined) {
+                        const insertResult = await dispatcher.processCommand(
+                            `@history insert ${JSON.stringify({ user: request, assistant: history })}`,
+                        );
+                        expect(insertResult?.hasError).toBeFalsy();
+                    }
+                }
+            });
         });
         afterAll(async () => {
-            await Promise.all(dispatchers.map((d) => d.close()));
+            await runOnDispatchers((d) => d.close());
             dispatchers = [];
         });
     });

--- a/ts/packages/dispatcher/src/context/appAgentManager.ts
+++ b/ts/packages/dispatcher/src/context/appAgentManager.ts
@@ -99,10 +99,10 @@ export class AppAgentManager implements ActionConfigProvider {
     private readonly actionSemanticMap?: ActionSchemaSemanticMap;
     private readonly actionSchemaFileCache: ActionSchemaFileCache;
 
-    public constructor(cacheDirPath: string | undefined) {
+    public constructor(cacheDir: string | undefined) {
         this.actionSchemaFileCache = new ActionSchemaFileCache(
-            cacheDirPath
-                ? path.join(cacheDirPath, "actionSchemaFileCache.json")
+            cacheDir
+                ? path.join(cacheDir, "actionSchemaFileCache.json")
                 : undefined,
         );
 

--- a/ts/packages/dispatcher/src/context/commandHandlerContext.ts
+++ b/ts/packages/dispatcher/src/context/commandHandlerContext.ts
@@ -28,7 +28,11 @@ import { createServiceHost } from "./system/handlers/serviceHost/serviceHostComm
 import { ClientIO, RequestId, nullClientIO } from "./interactiveIO.js";
 import { ChatHistory, createChatHistory } from "./chatHistory.js";
 
-import { ensureCacheDir, lockInstanceDir } from "../utils/fsUtils.js";
+import {
+    ensureCacheDir,
+    ensureDirectory,
+    lockInstanceDir,
+} from "../utils/fsUtils.js";
 import { ActionContext, AppAgentEvent } from "@typeagent/agent-sdk";
 import { Profiler } from "telemetry";
 import { conversation as Conversation } from "knowledge-processor";
@@ -63,6 +67,7 @@ import { createSchemaInfoProvider } from "../translation/actionSchemaFileCache.j
 import { createInlineAppAgentProvider } from "./inlineAgentProvider.js";
 import { CommandResult } from "../dispatcher.js";
 import { DispatcherName } from "./dispatcher/dispatcherUtils.js";
+import lockfile from "proper-lockfile";
 
 const debug = registerDebug("typeagent:dispatcher:init");
 const debugError = registerDebug("typeagent:dispatcher:init:error");
@@ -93,12 +98,14 @@ export function ensureCommandResult(
 
 // Command Handler Context definition.
 export type CommandHandlerContext = {
-    agents: AppAgentManager;
-    agentInstaller: AppAgentInstaller | undefined;
+    readonly agents: AppAgentManager;
+    readonly agentInstaller: AppAgentInstaller | undefined;
     session: Session;
 
-    instanceDir?: string | undefined;
-    cacheDirPath?: string | undefined;
+    readonly persistDir: string | undefined;
+    readonly cacheDir: string | undefined;
+    readonly embeddingCacheDir: string | undefined;
+
     conversationManager?: Conversation.ConversationManager | undefined;
     // Per activation configs
     developerMode?: boolean;
@@ -158,18 +165,23 @@ async function getAgentCache(
 
 export type DispatcherOptions = DeepPartialUndefined<DispatcherConfig> & {
     appAgentProviders?: AppAgentProvider[];
-    explanationAsynchronousMode?: boolean; // default to false
-    persistSession?: boolean; // default to false,
     persistDir?: string | undefined;
+    persistSession?: boolean; // default to false,
     clientId?: string;
     clientIO?: ClientIO | undefined; // undefined to disable any IO.
+
+    agentInstaller?: AppAgentInstaller;
+    agents?: AppAgentStateInitSettings;
     enableServiceHost?: boolean; // default to false,
     metrics?: boolean; // default to false
     dblogging?: boolean; // default to false
+
     constructionProvider?: ConstructionProvider;
-    agentInstaller?: AppAgentInstaller;
+    explanationAsynchronousMode?: boolean; // default to false
     collectCommandResult?: boolean; // default to false
-    agents?: AppAgentStateInitSettings;
+
+    // Use for tests so that embedding can be cached without 'persistDir'
+    embeddingCacheDir?: string | undefined; // default to 'cache' under 'persistDir' if specified
 };
 
 async function getSession(instanceDir?: string) {
@@ -222,6 +234,20 @@ function getLoggerSink(isDbEnabled: () => boolean, clientIO: ClientIO) {
     );
 }
 
+async function lockEmbeddingCacheDir(context: CommandHandlerContext) {
+    return context.embeddingCacheDir
+        ? await lockfile.lock(context.embeddingCacheDir, {
+              retries: {
+                  minTimeout: 50,
+                  maxTimeout: 1000,
+                  randomize: true,
+                  forever: true, // embedding cache dir is used for test, so only to retry forever.
+                  maxRetryTime: 1000 * 60 * 5, // but place a time limit of 5 minutes
+              },
+          })
+        : undefined;
+}
+
 async function addAppAgentProviders(
     context: CommandHandlerContext,
     appAgentProviders?: AppAgentProvider[],
@@ -229,35 +255,40 @@ async function addAppAgentProviders(
     const embeddingCachePath = getEmbeddingCachePath(context);
     let embeddingCache: EmbeddingCache | undefined;
 
-    if (embeddingCachePath) {
-        try {
-            embeddingCache = await readEmbeddingCache(embeddingCachePath);
-            debug(
-                `Action Schema Embedding cache loaded: ${embeddingCachePath}`,
-            );
-        } catch {
-            // Ignore error
+    const unlock = await lockEmbeddingCacheDir(context);
+    try {
+        if (embeddingCachePath) {
+            try {
+                embeddingCache = await readEmbeddingCache(embeddingCachePath);
+                debug(
+                    `Action Schema Embedding cache loaded: ${embeddingCachePath}`,
+                );
+            } catch {
+                // Ignore error
+            }
         }
-    }
 
-    const inlineAppProvider = createInlineAppAgentProvider(context);
-    await context.agents.addProvider(inlineAppProvider, embeddingCache);
+        const inlineAppProvider = createInlineAppAgentProvider(context);
+        await context.agents.addProvider(inlineAppProvider, embeddingCache);
 
-    if (appAgentProviders) {
-        for (const provider of appAgentProviders) {
-            await context.agents.addProvider(provider, embeddingCache);
+        if (appAgentProviders) {
+            for (const provider of appAgentProviders) {
+                await context.agents.addProvider(provider, embeddingCache);
+            }
         }
-    }
-    if (embeddingCachePath) {
-        return saveActionEmbeddings(context, embeddingCachePath);
+        if (embeddingCachePath) {
+            return saveActionEmbeddings(context, embeddingCachePath);
+        }
+    } finally {
+        if (unlock) {
+            await unlock();
+        }
     }
 }
 
 function getEmbeddingCachePath(context: CommandHandlerContext) {
-    const cacheDirPath = context.cacheDirPath;
-    return cacheDirPath
-        ? path.join(cacheDirPath, "embeddingCache.json")
-        : undefined;
+    const cacheDir = context.embeddingCacheDir ?? context.cacheDir;
+    return cacheDir ? path.join(cacheDir, "embeddingCache.json") : undefined;
 }
 
 async function saveActionEmbeddings(
@@ -286,7 +317,14 @@ export async function installAppProvider(
 
     const embeddingCachePath = getEmbeddingCachePath(context);
     if (embeddingCachePath !== undefined) {
-        await saveActionEmbeddings(context, embeddingCachePath);
+        const unlock = await lockEmbeddingCacheDir(context);
+        try {
+            await saveActionEmbeddings(context, embeddingCachePath);
+        } finally {
+            if (unlock) {
+                await unlock();
+            }
+        }
     }
 }
 
@@ -299,20 +337,21 @@ export async function initializeCommandHandlerContext(
         options?.explanationAsynchronousMode ?? false;
 
     const persistSession = options?.persistSession ?? false;
-    const instanceDir = options?.persistDir;
+    const persistDir = options?.persistDir;
 
-    if (instanceDir === undefined && persistSession) {
+    if (persistDir === undefined && persistSession) {
         throw new Error(
             "Persist session requires persistDir to be set in options.",
         );
     }
-    const instanceDirLock = instanceDir
-        ? await lockInstanceDir(instanceDir)
+
+    const instanceDirLock = persistDir
+        ? await lockInstanceDir(persistDir)
         : undefined;
 
     try {
         const session = await getSession(
-            persistSession ? instanceDir : undefined,
+            persistSession ? persistDir : undefined,
         );
 
         // initialization options set the default, but persisted configuration will still overrides it.
@@ -347,17 +386,20 @@ export async function initializeCommandHandlerContext(
             serviceHost = await createServiceHost();
         }
 
-        const cacheDirPath = instanceDir
-            ? ensureCacheDir(instanceDir)
-            : undefined;
-        const agents = new AppAgentManager(cacheDirPath);
+        const cacheDir = persistDir ? ensureCacheDir(persistDir) : undefined;
+        const embeddingCacheDir = options?.embeddingCacheDir;
+        if (embeddingCacheDir) {
+            ensureDirectory(embeddingCacheDir);
+        }
+        const agents = new AppAgentManager(cacheDir);
         const constructionProvider = options?.constructionProvider;
         const context: CommandHandlerContext = {
             agents,
             agentInstaller: options?.agentInstaller,
             session,
-            instanceDir,
-            cacheDirPath,
+            persistDir,
+            cacheDir,
+            embeddingCacheDir,
             conversationManager,
             explanationAsynchronousMode,
             dblogging: options?.dblogging ?? false,
@@ -515,7 +557,7 @@ export async function reloadSessionOnCommandHandlerContext(
     context: CommandHandlerContext,
     persist: boolean,
 ) {
-    const session = await getSession(persist ? context.instanceDir : undefined);
+    const session = await getSession(persist ? context.persistDir : undefined);
     await setSessionOnCommandHandlerContext(context, session);
 }
 

--- a/ts/packages/dispatcher/src/context/session.ts
+++ b/ts/packages/dispatcher/src/context/session.ts
@@ -416,17 +416,15 @@ export class Session {
 
     private async newCacheDataFilePath() {
         if (this.sessionDirPath) {
-            const cacheDirPath = getSessionConstructionDirPath(
-                this.sessionDirPath,
-            );
-            await fs.promises.mkdir(cacheDirPath, { recursive: true });
+            const cacheDir = getSessionConstructionDirPath(this.sessionDirPath);
+            await fs.promises.mkdir(cacheDir, { recursive: true });
             const filePath = getUniqueFileName(
-                cacheDirPath,
+                cacheDir,
                 `${this.explainerName}_${getYMDPrefix()}`,
                 ".json",
             );
             this.setConstructionDataFilePath(filePath);
-            return path.join(cacheDirPath, filePath);
+            return path.join(cacheDir, filePath);
         }
         return undefined;
     }

--- a/ts/packages/dispatcher/src/context/system/handlers/sessionCommandHandlers.ts
+++ b/ts/packages/dispatcher/src/context/system/handlers/sessionCommandHandlers.ts
@@ -53,7 +53,7 @@ class SessionNewCommandHandler implements CommandHandler {
     ) {
         const systemContext = context.sessionContext.agentContext;
         const { flags } = params;
-        if (flags.persist && systemContext.instanceDir === undefined) {
+        if (flags.persist && systemContext.persistDir === undefined) {
             throw new Error("User data storage disabled.");
         }
         await setSessionOnCommandHandlerContext(
@@ -62,7 +62,7 @@ class SessionNewCommandHandler implements CommandHandler {
                 flags.keep ? systemContext.session.getConfig() : undefined,
                 flags.persist ??
                     systemContext.session.sessionDirPath !== undefined
-                    ? systemContext.instanceDir
+                    ? systemContext.persistDir
                     : undefined,
             ),
         );
@@ -94,11 +94,11 @@ class SessionOpenCommandHandler implements CommandHandler {
         params: ParsedCommandParams<typeof this.parameters>,
     ) {
         const systemContext = context.sessionContext.agentContext;
-        if (systemContext.instanceDir === undefined) {
+        if (systemContext.persistDir === undefined) {
             throw new Error("User data storage disabled.");
         }
         const session = await Session.load(
-            systemContext.instanceDir,
+            systemContext.persistDir,
             params.args.session,
         );
         await setSessionOnCommandHandlerContext(systemContext, session);
@@ -166,7 +166,7 @@ class SessionDeleteCommandHandler implements CommandHandler {
         params: ParsedCommandParams<typeof this.parameters>,
     ) {
         const systemContext = context.sessionContext.agentContext;
-        if (systemContext.instanceDir === undefined) {
+        if (systemContext.persistDir === undefined) {
             throw new Error("Persist profile disabled.");
         }
         const persist = systemContext.session.sessionDirPath !== undefined;
@@ -181,7 +181,7 @@ class SessionDeleteCommandHandler implements CommandHandler {
                 displayWarn("Cancelled!", context);
                 return;
             }
-            await deleteAllSessions(systemContext.instanceDir);
+            await deleteAllSessions(systemContext.persistDir);
             displaySuccess("All session deleted.", context);
         } else {
             const currentSessionName = systemContext.session.sessionDirPath
@@ -194,7 +194,7 @@ class SessionDeleteCommandHandler implements CommandHandler {
                 );
             }
             const sessionNames = await getSessionNames(
-                systemContext.instanceDir,
+                systemContext.persistDir,
             );
             if (!sessionNames.includes(del)) {
                 throw new Error(`'${del}' is not a session name`);
@@ -209,7 +209,7 @@ class SessionDeleteCommandHandler implements CommandHandler {
                 displayWarn("Cancelled!", context);
                 return;
             }
-            await deleteSession(systemContext.instanceDir, del);
+            await deleteSession(systemContext.persistDir, del);
             displaySuccess(`Session '${del}' deleted.`, context);
             if (del !== currentSessionName) {
                 return;
@@ -224,10 +224,10 @@ class SessionListCommandHandler implements CommandHandlerNoParams {
         "List all sessions. The current session is marked green.";
     public async run(context: ActionContext<CommandHandlerContext>) {
         const systemContext = context.sessionContext.agentContext;
-        if (systemContext.instanceDir === undefined) {
+        if (systemContext.persistDir === undefined) {
             throw new Error("User data storage disabled.");
         }
-        const names = await getSessionNames(systemContext.instanceDir);
+        const names = await getSessionNames(systemContext.persistDir);
         displayResult(
             names
                 .map((n) =>
@@ -252,7 +252,7 @@ class SessionInfoCommandHandler implements CommandHandlerNoParams {
             : [];
 
         displayResult(
-            `${chalk.bold("Instance Dir:")} ${systemContext.instanceDir}`,
+            `${chalk.bold("Instance Dir:")} ${systemContext.persistDir}`,
             context,
         );
         const session = systemContext.session;

--- a/ts/packages/dispatcher/src/execute/actionHandlers.ts
+++ b/ts/packages/dispatcher/src/execute/actionHandlers.ts
@@ -157,8 +157,8 @@ export function createSessionContext<T = unknown>(
     const storage = sessionDirPath
         ? getStorage(name, sessionDirPath)
         : undefined;
-    const instanceStorage = context.instanceDir
-        ? getStorage(name, context.instanceDir)
+    const instanceStorage = context.persistDir
+        ? getStorage(name, context.persistDir)
         : undefined;
     const addDynamicAgent = allowDynamicAgent
         ? (agentName: string, manifest: AppAgentManifest, appAgent: AppAgent) =>


### PR DESCRIPTION
- Use embedding caching to only generate embedding once (instead of 5 times per test file).
- Make sure all the promise is settled before moving on to the next test.
- Add additional history test.