### PR TITLE
knowpro: natural language querying (phase 1)

### DIFF
--- a/ts/examples/chat/src/memory/knowproCommon.ts
+++ b/ts/examples/chat/src/memory/knowproCommon.ts
@@ -1,22 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+import * as knowLib from "knowledge-processor";
 import * as kp from "knowpro";
-
-export function getTimeRangeForConversation(
-    conversation: kp.IConversation,
-): kp.DateRange | undefined {
-    const messages = conversation.messages;
-    const start = messages[0].timestamp;
-    const end = messages[messages.length - 1].timestamp;
-    if (start !== undefined) {
-        return {
-            start: new Date(start),
-            end: end ? new Date(end) : undefined,
-        };
-    }
-    return undefined;
-}
 
 export function textLocationToString(location: kp.TextLocation): string {
     let text = `MessageIndex: ${location.messageIndex}`;
@@ -27,4 +13,62 @@ export function textLocationToString(location: kp.TextLocation): string {
         text += `\nCharIndex: ${location.charIndex}`;
     }
     return text;
+}
+
+export async function matchFilterToConversation(
+    conversation: kp.IConversation,
+    filter: knowLib.conversation.TermFilterV2,
+    knowledgeType?: kp.KnowledgeType | undefined,
+    useAnd: boolean = false,
+) {
+    let searchTermGroup: kp.SearchTermGroup = termFilterToSearchGroup(
+        filter,
+        useAnd,
+    );
+    let when: kp.WhenFilter = termFilterToWhenFilter(filter);
+    when.knowledgeType = knowledgeType;
+    let searchResults = await kp.searchConversation(
+        conversation,
+        searchTermGroup,
+        when,
+    );
+    if (useAnd && (!searchResults || searchResults.size === 0)) {
+        // Try again with OR
+        searchTermGroup = termFilterToSearchGroup(filter, false);
+        searchResults = await kp.searchConversation(
+            conversation,
+            searchTermGroup,
+            when,
+        );
+    }
+    return searchResults;
+}
+
+export function termFilterToSearchGroup(
+    filter: knowLib.conversation.TermFilterV2,
+    and: boolean,
+): kp.SearchTermGroup {
+    const searchTermGroup: kp.SearchTermGroup = {
+        booleanOp: and ? "and" : "or",
+        terms: [],
+    };
+    if (filter.searchTerms && filter.searchTerms.length > 0) {
+        for (const st of filter.searchTerms) {
+            searchTermGroup.terms.push({ term: { text: st } });
+        }
+    }
+    return searchTermGroup;
+}
+
+export function termFilterToWhenFilter(
+    filter: knowLib.conversation.TermFilterV2,
+) {
+    let when: kp.WhenFilter = {};
+    if (filter.timeRange) {
+        when.dateRange = {
+            start: knowLib.conversation.toStartDate(filter.timeRange.startDate),
+            end: knowLib.conversation.toStopDate(filter.timeRange.stopDate),
+        };
+    }
+    return when;
 }

--- a/ts/examples/chat/src/memory/knowproPrinter.ts
+++ b/ts/examples/chat/src/memory/knowproPrinter.ts
@@ -5,10 +5,7 @@ import * as kp from "knowpro";
 import * as knowLib from "knowledge-processor";
 import { ChatPrinter } from "../chatPrinter.js";
 import chalk from "chalk";
-import {
-    getTimeRangeForConversation,
-    textLocationToString,
-} from "./knowproCommon.js";
+import { textLocationToString } from "./knowproCommon.js";
 import * as cm from "conversation-memory";
 import * as im from "image-memory";
 
@@ -298,7 +295,7 @@ export class KnowProPrinter extends ChatPrinter {
 
     public writeConversationInfo(conversation: kp.IConversation) {
         this.writeTitle(conversation.nameTag);
-        const timeRange = getTimeRangeForConversation(conversation);
+        const timeRange = kp.getTimeRangeForConversation(conversation);
         if (timeRange) {
             this.write("Time range: ");
             this.writeDateRange(timeRange);
@@ -333,6 +330,17 @@ export class KnowProPrinter extends ChatPrinter {
             this.writeError(results.error);
         }
         return this;
+    }
+
+    public writeSearchFilter(
+        action: knowLib.conversation.GetAnswerWithTermsActionV2,
+    ) {
+        this.writeInColor(
+            chalk.cyanBright,
+            `Question: ${action.parameters.question}`,
+        );
+        this.writeLine();
+        this.writeJson(action.parameters.filters);
     }
 }
 

--- a/ts/packages/knowPro/src/search.ts
+++ b/ts/packages/knowPro/src/search.ts
@@ -17,6 +17,7 @@ import * as q from "./query.js";
 import { IQueryOpExpr } from "./query.js";
 import { resolveRelatedTerms } from "./relatedTermsIndex.js";
 import { conversation as kpLib } from "knowledge-processor";
+import { PromptSection } from "typechat";
 
 export type SearchTerm = {
     /**
@@ -465,4 +466,34 @@ function isActionPropertyTerm(term: PropertySearchTerm): boolean {
     }
 
     return false;
+}
+
+export function getTimeRangeForConversation(
+    conversation: IConversation,
+): DateRange | undefined {
+    const messages = conversation.messages;
+    const start = messages[0].timestamp;
+    const end = messages[messages.length - 1].timestamp;
+    if (start !== undefined) {
+        return {
+            start: new Date(start),
+            end: end ? new Date(end) : undefined,
+        };
+    }
+    return undefined;
+}
+
+export function getTimeRangeSectionForConversation(
+    conversation: IConversation,
+): PromptSection[] {
+    const timeRange = getTimeRangeForConversation(conversation);
+    if (timeRange) {
+        return [
+            {
+                role: "system",
+                content: `ONLY IF user request explicitly asks for time ranges, THEN use the CONVERSATION TIME RANGE: "${timeRange.start} to ${timeRange.end}"`,
+            },
+        ];
+    }
+    return [];
 }


### PR DESCRIPTION
Part 1:
- Start by using knowlege-processor to translate natural language queries into TermFilters
- Transforms term filters (terms, date ranges) into know-pro **searchConversation** call
- Execute query

Next check-in will also transform actions. 