### PR TITLE
knowpro: Natural Language querying

### DIFF
--- a/ts/examples/chat/src/memory/knowproCommon.ts
+++ b/ts/examples/chat/src/memory/knowproCommon.ts
@@ -18,7 +18,8 @@ export function textLocationToString(location: kp.TextLocation): string {
 export async function matchFilterToConversation(
     conversation: kp.IConversation,
     filter: knowLib.conversation.TermFilterV2,
-    knowledgeType?: kp.KnowledgeType | undefined,
+    knowledgeType: kp.KnowledgeType | undefined,
+    searchOptions: kp.SearchOptions,
     useAnd: boolean = false,
 ) {
     let termGroup: kp.SearchTermGroup = termFilterToSearchGroup(filter, useAnd);
@@ -36,6 +37,7 @@ export async function matchFilterToConversation(
         conversation,
         termGroup,
         when,
+        searchOptions,
     );
     if (useAnd && (!searchResults || searchResults.size === 0)) {
         // Try again with OR
@@ -103,9 +105,7 @@ export function actionFilterToSearchGroup(
         );
     }
     if (action.object) {
-        searchTermGroup.terms.push(
-            kp.createPropertySearchTerm(kp.PropertyNames.Object, action.object),
-        );
+        searchTermGroup.terms.push(kp.createSearchTerm(action.object));
     }
     return searchTermGroup;
 }

--- a/ts/examples/chat/src/memory/knowproMemory.ts
+++ b/ts/examples/chat/src/memory/knowproMemory.ts
@@ -555,7 +555,7 @@ export async function createKnowproCommands(
             const allValues = splitTermValues(keyValues[propertyName]);
             for (const value of allValues) {
                 propertySearchTerms.push(
-                    kp.propertySearchTermFromKeyValue(propertyName, value),
+                    kp.createPropertySearchTerm(propertyName, value),
                 );
             }
         }

--- a/ts/examples/chat/src/memory/knowproMemory.ts
+++ b/ts/examples/chat/src/memory/knowproMemory.ts
@@ -454,6 +454,7 @@ export async function createKnowproCommands(
             },
             options: {
                 maxToDisplay: argNum("Maximum matches to display", 25),
+                exact: argBool("Exact match only. No related terms", false),
                 ktype: arg("Knowledge type"),
             },
         };
@@ -485,6 +486,9 @@ export async function createKnowproCommands(
                 context.conversation!,
                 filter,
                 namedArgs.ktype,
+                {
+                    exactMatch: namedArgs.exact,
+                },
             );
             if (searchResults) {
                 context.printer.writeSearchResults(

--- a/ts/examples/chat/src/memory/knowproMemory.ts
+++ b/ts/examples/chat/src/memory/knowproMemory.ts
@@ -67,8 +67,8 @@ export async function createKnowproCommands(
     commands.kpPodcastSave = podcastSave;
     commands.kpPodcastLoad = podcastLoad;
     commands.kpSearchTerms = searchTerms;
+    commands.kpSearchV1 = searchV1;
     commands.kpSearch = search;
-    commands.kpSearchNew = searchNew;
     commands.kpEntities = entities;
     commands.kpPodcastBuildIndex = podcastBuildIndex;
 
@@ -463,7 +463,7 @@ export async function createKnowproCommands(
         };
     }
     commands.kpSearch.metadata = searchDef();
-    async function search(args: string[]): Promise<void> {
+    async function searchV1(args: string[]): Promise<void> {
         if (!ensureConversationLoaded()) {
             return;
         }
@@ -511,8 +511,8 @@ export async function createKnowproCommands(
         return def;
     }
 
-    commands.kpSearchNew.metadata = searchDefNew();
-    async function searchNew(args: string[]): Promise<void> {
+    commands.kpSearch.metadata = searchDefNew();
+    async function search(args: string[]): Promise<void> {
         if (!ensureConversationLoaded()) {
             return;
         }

--- a/ts/packages/knowPro/src/dateTimeSchema.ts
+++ b/ts/packages/knowPro/src/dateTimeSchema.ts
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+export type DateVal = {
+    day: number;
+    month: number;
+    year: number;
+};
+
+export type TimeVal = {
+    // In 24 hour form
+    hour: number;
+    minute: number;
+    seconds: number;
+};
+
+export type DateTime = {
+    date: DateVal;
+    time?: TimeVal | undefined;
+};
+
+export type DateTimeRange = {
+    startDate: DateTime;
+    stopDate?: DateTime | undefined;
+};

--- a/ts/packages/knowPro/src/index.ts
+++ b/ts/packages/knowPro/src/index.ts
@@ -12,3 +12,6 @@ export * from "./fuzzyIndex.js";
 export * from "./propertyIndex.js";
 export * from "./timestampIndex.js";
 export * from "./serialization.js";
+export * from "./dateTimeSchema.js";
+export * from "./searchSchema.js";
+export * from "./searchTranslator.js";

--- a/ts/packages/knowPro/src/search.ts
+++ b/ts/packages/knowPro/src/search.ts
@@ -70,13 +70,37 @@ export type PropertySearchTerm = {
     propertyValue: SearchTerm;
 };
 
-function createSearchTerm(text: string, score?: number): SearchTerm {
+export function createSearchTerm(text: string, score?: number): SearchTerm {
     return {
         term: {
             text,
             weight: score,
         },
     };
+}
+
+export function createPropertySearchTerm(
+    key: string,
+    value: string,
+): PropertySearchTerm {
+    let propertyName: KnowledgePropertyName | SearchTerm;
+    let propertyValue: SearchTerm;
+    switch (key) {
+        default:
+            propertyName = createSearchTerm(key);
+            break;
+        case "name":
+        case "type":
+        case "verb":
+        case "subject":
+        case "object":
+        case "indirectObject":
+        case "tag":
+            propertyName = key;
+            break;
+    }
+    propertyValue = createSearchTerm(value);
+    return { propertyName, propertyValue };
 }
 
 export type WhenFilter = {
@@ -411,30 +435,6 @@ class SearchQueryBuilder {
         }
         return scoredRef;
     }
-}
-
-export function propertySearchTermFromKeyValue(
-    key: string,
-    value: string,
-): PropertySearchTerm {
-    let propertyName: KnowledgePropertyName | SearchTerm;
-    let propertyValue: SearchTerm;
-    switch (key) {
-        default:
-            propertyName = createSearchTerm(key);
-            break;
-        case "name":
-        case "type":
-        case "verb":
-        case "subject":
-        case "object":
-        case "indirectObject":
-        case "tag":
-            propertyName = key;
-            break;
-    }
-    propertyValue = createSearchTerm(value);
-    return { propertyName, propertyValue };
 }
 
 function isPropertyTerm(

--- a/ts/packages/knowPro/src/searchSchema.ts
+++ b/ts/packages/knowPro/src/searchSchema.ts
@@ -1,0 +1,60 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { DateTimeRange } from "./dateTimeSchema.js";
+
+export type FacetTerm = {
+    name: string;
+    // Very concise values.
+    value: string;
+};
+
+// Specific, tangible people, places, institutions or things only
+// Abstract concepts or topics are not entityTerms. Use SearchTerm for them
+// Any terms will match fuzzily.
+export type EntityTerm = {
+    // the name of the entity or thing such as "Bach", "Great Gatsby", "frog" or "piano"
+    name: string;
+    // the types of the entity such as "speaker", "person", "artist", "animal", "object", "instrument", "school", "room", "museum", "food" etc.
+    // An entity can have multiple types; entity types should be single words
+    type: string[];
+    // A specific, inherent, defining, or non-immediate facet of the entity such as "blue", "old", "famous", "sister", "aunt_of", "weight: 4 kg"
+    // trivial actions or state changes are not facets
+    // facets are concise "properties"
+    facets?: FacetTerm[];
+};
+
+export type VerbsTerm = {
+    words: string[]; // individual words in single or compound verb
+};
+
+export type SourceTerm = {
+    text: string;
+    // true only if subject is a pronoun, such as "I", "Me", "Us", "They"
+    isPronoun: boolean;
+};
+
+// ActionTerm
+// - "from" refers to the origin of the action or information, typically the entity performing the action
+// - "to" refers to the recipient or target of the action or information
+export type ActionTerm = {
+    verbs?: VerbsTerm | undefined; // action verbs
+    from: SourceTerm | "none";
+    to?: SourceTerm | undefined;
+};
+
+export type SearchTerm = string;
+
+// Search indexes for following search terms: typically single word keywords.
+export type SearchFilter = {
+    action?: ActionTerm;
+    entities?: EntityTerm[];
+    // searchTerms:
+    // Concepts, topics or other terms that don't fit ActionTerms or EntityTerms
+    // - Remove generic terms like "topic/s", "subject", "discussion" etc
+    // - Phrases like 'email address' or 'first name' are a single term
+    // - use empty searchTerms array when use asks for summaries
+    searchTerms?: SearchTerm[];
+    // Use only if request explicitly asks for time range, particular year, month etc.
+    timeRange?: DateTimeRange | undefined; // in this time range
+};

--- a/ts/packages/knowPro/src/searchSchema.ts
+++ b/ts/packages/knowPro/src/searchSchema.ts
@@ -43,8 +43,6 @@ export type ActionTerm = {
     to?: SourceTerm | undefined;
 };
 
-export type SearchTerm = string;
-
 // Search indexes for following search terms: typically single word keywords.
 export type SearchFilter = {
     action?: ActionTerm;
@@ -54,7 +52,7 @@ export type SearchFilter = {
     // - Remove generic terms like "topic/s", "subject", "discussion" etc
     // - Phrases like 'email address' or 'first name' are a single term
     // - use empty searchTerms array when use asks for summaries
-    searchTerms?: SearchTerm[];
+    searchTerms?: string[];
     // Use only if request explicitly asks for time range, particular year, month etc.
     timeRange?: DateTimeRange | undefined; // in this time range
 };

--- a/ts/packages/knowPro/src/searchTranslator.ts
+++ b/ts/packages/knowPro/src/searchTranslator.ts
@@ -13,7 +13,7 @@ import { loadSchema } from "typeagent";
 export function createSearchTranslator(
     model: TypeChatLanguageModel,
 ): TypeChatJsonTranslator<SearchFilter> {
-    const typeName = "SearchAction";
+    const typeName = "SearchFilter";
     const searchActionSchema = loadSchema(
         ["dateTimeSchema.ts", "searchSchema.ts"],
         import.meta.url,

--- a/ts/packages/knowPro/src/searchTranslator.ts
+++ b/ts/packages/knowPro/src/searchTranslator.ts
@@ -1,0 +1,27 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import {
+    TypeChatJsonTranslator,
+    TypeChatLanguageModel,
+    createJsonTranslator,
+} from "typechat";
+import { createTypeScriptJsonValidator } from "typechat/ts";
+import { SearchFilter } from "./searchSchema.js";
+import { loadSchema } from "typeagent";
+
+export function createSearchTranslator(
+    model: TypeChatLanguageModel,
+): TypeChatJsonTranslator<SearchFilter> {
+    const typeName = "SearchAction";
+    const searchActionSchema = loadSchema(
+        ["dateTimeSchema.ts", "searchSchema.ts"],
+        import.meta.url,
+    );
+
+    const validator = createTypeScriptJsonValidator<SearchFilter>(
+        searchActionSchema,
+        typeName,
+    );
+    return createJsonTranslator<SearchFilter>(model, validator);
+}

--- a/ts/packages/knowPro/src/searchTranslator.ts
+++ b/ts/packages/knowPro/src/searchTranslator.ts
@@ -7,8 +7,17 @@ import {
     createJsonTranslator,
 } from "typechat";
 import { createTypeScriptJsonValidator } from "typechat/ts";
-import { SearchFilter } from "./searchSchema.js";
+import { ActionTerm, EntityTerm, SearchFilter } from "./searchSchema.js";
 import { loadSchema } from "typeagent";
+import {
+    createPropertySearchTerm,
+    createSearchTerm,
+    PropertySearchTerm,
+    SearchTermGroup,
+    WhenFilter,
+} from "./search.js";
+import { PropertyNames } from "./propertyIndex.js";
+import { conversation as kpLib } from "knowledge-processor";
 
 export function createSearchTranslator(
     model: TypeChatLanguageModel,
@@ -24,4 +33,92 @@ export function createSearchTranslator(
         typeName,
     );
     return createJsonTranslator<SearchFilter>(model, validator);
+}
+
+export function createSearchGroupFromSearchFilter(
+    filter: SearchFilter,
+): SearchTermGroup {
+    const searchGroup: SearchTermGroup = { booleanOp: "or", terms: [] };
+    if (filter.entities) {
+        for (const entityFilter of filter.entities) {
+            searchGroup.terms.push(
+                ...createPropertySearchTermsFromEntityTerm(entityFilter),
+            );
+        }
+    }
+    if (filter.action) {
+        searchGroup.terms.push(
+            ...createPropertySearchTermFromActionTerm(filter.action),
+        );
+    }
+    if (filter.searchTerms) {
+        for (const term of filter.searchTerms) {
+            searchGroup.terms.push(createSearchTerm(term));
+        }
+    }
+    return searchGroup;
+}
+
+export function createWhenFromSearchFilter(filter: SearchFilter): WhenFilter {
+    const when: WhenFilter = {};
+    if (filter.timeRange) {
+        when.dateRange = {
+            start: kpLib.toStartDate(filter.timeRange.startDate),
+            end: kpLib.toStopDate(filter.timeRange.stopDate),
+        };
+    }
+    return when;
+}
+
+function createPropertySearchTermsFromEntityTerm(
+    entityTerm: EntityTerm,
+): PropertySearchTerm[] {
+    const terms: PropertySearchTerm[] = [];
+    if (entityTerm.name) {
+        terms.push(
+            createPropertySearchTerm(PropertyNames.EntityName, entityTerm.name),
+        );
+    }
+    if (entityTerm.type) {
+        terms.push(
+            ...entityTerm.type.map((t) =>
+                createPropertySearchTerm(PropertyNames.EntityType, t),
+            ),
+        );
+    }
+    if (entityTerm.facets && entityTerm.facets.length > 0) {
+        terms.push(
+            ...entityTerm.facets.map((f) =>
+                createPropertySearchTerm(f.name, f.value),
+            ),
+        );
+    }
+    return terms;
+}
+
+function createPropertySearchTermFromActionTerm(
+    actionTerm: ActionTerm,
+): PropertySearchTerm[] {
+    const terms: PropertySearchTerm[] = [];
+    if (actionTerm.verbs) {
+        terms.push(
+            ...actionTerm.verbs.words.map((w) =>
+                createPropertySearchTerm(PropertyNames.Verb, w),
+            ),
+        );
+    }
+    if (actionTerm.from !== "none") {
+        terms.push(
+            createPropertySearchTerm(
+                PropertyNames.Subject,
+                actionTerm.from.text,
+            ),
+        );
+    }
+    if (actionTerm.to) {
+        terms.push(
+            createPropertySearchTerm(PropertyNames.Object, actionTerm.to.text),
+        );
+    }
+    return terms;
 }


### PR DESCRIPTION
First cut of natural language querying natively in knowpro:
* searchSchema.ts, searchTranslator.ts to translate natural language to query filter
* Compile/transform returned filter to knowpro terms and 'when/scope' filter (time ranges etc.)
* kpSearch command in test app
* Ongoing work, testing/refinement

Testing:
* Also implemented natural language search for knowpro using V1 translators and kpSearchV1 command  