### PR TITLE
Sidepanel: persisting type definitions in local storage

### DIFF
--- a/ts/packages/agents/browser/src/agent/actionHandler.mts
+++ b/ts/packages/agents/browser/src/agent/actionHandler.mts
@@ -176,7 +176,8 @@ async function updateBrowserContext(
                             break;
                         }
 
-                        case "initializePageSchema":
+                        case "detectPageActions":
+                        case "registerPageDynamicAgent":
                         case "getIntentFromRecording": {
                             const discoveryResult =
                                 await handleSchemaDiscoveryAction(

--- a/ts/packages/agents/browser/src/agent/browserConnector.mts
+++ b/ts/packages/agents/browser/src/agent/browserConnector.mts
@@ -180,6 +180,33 @@ export class BrowserConnector {
         return this.sendActionToBrowser(schemaAction, "browser");
     }
 
+    async getCurrentPageStoredProperty(url: string, key: string) {
+        const timeoutPromise = new Promise((f) => setTimeout(f, 3000));
+        const action = {
+            actionName: "getPageStoredProperty",
+            parameters: {
+                url: url,
+                key: key,
+            },
+        };
+
+        const actionPromise = this.getPageDataFromBrowser(action);
+        return Promise.race([actionPromise, timeoutPromise]);
+    }
+
+    async setCurrentPageStoredProperty(url: string, key: string, value: any) {
+        const schemaAction = {
+            actionName: "setPageStoredProperty",
+            parameters: {
+                url: url,
+                key: key,
+                value: value,
+            },
+        };
+
+        return this.sendActionToBrowser(schemaAction, "browser");
+    }
+
     async getPageUrl() {
         const action = {
             actionName: "getPageUrl",

--- a/ts/packages/agents/browser/src/agent/discovery/schema/discoveryActions.mts
+++ b/ts/packages/agents/browser/src/agent/discovery/schema/discoveryActions.mts
@@ -5,8 +5,8 @@ export type FindPageComponents = {
     actionName: "findPageComponents";
 };
 
-export type FindUserActions = {
-    actionName: "findUserActions";
+export type DetectPageActions = {
+    actionName: "detectPageActions";
     parameters: {
         registerAgent?: boolean;
         agentName?: string;
@@ -25,10 +25,9 @@ export type SummarizePage = {
     actionName: "summarizePage";
 };
 
-export type InitializePageSchema = {
-    actionName: "initializePageSchema";
+export type RegisterPageDynamicAgent = {
+    actionName: "registerPageDynamicAgent";
     parameters: {
-        registerAgent?: boolean;
         agentName?: string;
     };
 };
@@ -70,10 +69,10 @@ export type GetIntentFromRecording = {
 
 export type SchemaDiscoveryActions =
     | FindPageComponents
-    | FindUserActions
+    | DetectPageActions
     | GetSiteType
     | GetPageType
-    | InitializePageSchema
+    | RegisterPageDynamicAgent
     | SummarizePage
     | SaveUserActions
     | AddUserAction

--- a/ts/packages/agents/browser/src/extension/sidepanel.ts
+++ b/ts/packages/agents/browser/src/extension/sidepanel.ts
@@ -118,22 +118,32 @@ function copySchemaToClipboard() {
 async function registerTempSchema() {
     const button = document.getElementById("trySchema") as HTMLButtonElement;
     const originalContent = button.innerHTML;
+    const originalClass = button.className;
+
+    function showTemporaryStatus(text: string, newClass: string) {
+        button.innerHTML = text;
+        button.className = `btn btn-sm ${newClass}`;
+
+        setTimeout(() => {
+            button.innerHTML = originalContent;
+            button.className = originalClass;
+            button.disabled = false;
+        }, 5000);
+    }
 
     button.innerHTML = `<span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span> Processing...`;
     button.disabled = true;
-
-    const response = await chrome.runtime.sendMessage({
-        type: "registerTempSchema",
-    });
+    try {
+        const response = await chrome.runtime.sendMessage({
+            type: "registerTempSchema",
+        });
+    } catch {}
     if (chrome.runtime.lastError) {
         console.error("Error fetching schema:", chrome.runtime.lastError);
-        button.innerHTML = originalContent;
-        button.disabled = false;
-        return;
+        showTemporaryStatus("✖ Failed", "btn-outline-danger");
+    } else {
+        showTemporaryStatus("✔ Succeeded", "btn-outline-success");
     }
-
-    button.innerHTML = originalContent;
-    button.disabled = false;
 }
 
 function toggleActionForm() {

--- a/ts/packages/agents/browser/src/extension/storage.ts
+++ b/ts/packages/agents/browser/src/extension/storage.ts
@@ -1,0 +1,56 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+export async function setStoredPageProperty(
+    url: string,
+    key: string,
+    value: any,
+): Promise<void> {
+    try {
+        const result = await chrome.storage.local.get([url]);
+        const urlData = result[url] || {};
+        urlData[key] = value;
+
+        await chrome.storage.local.set({ [url]: urlData });
+        console.log(`Saved property '${key}' for ${url}`);
+    } catch (error) {
+        console.error("Error saving data:", error);
+    }
+}
+
+export async function getStoredPageProperty(
+    url: string,
+    key: string,
+): Promise<any | null> {
+    try {
+        const result = await chrome.storage.local.get([url]);
+        return result[url]?.[key] ?? null;
+    } catch (error) {
+        console.error("Error retrieving data:", error);
+        return null;
+    }
+}
+
+export async function deleteStoredPageProperty(
+    url: string,
+    key: string,
+): Promise<void> {
+    try {
+        const result = await chrome.storage.local.get([url]);
+        const urlData = result[url] || {};
+
+        if (key in urlData) {
+            delete urlData[key];
+
+            if (Object.keys(urlData).length === 0) {
+                await chrome.storage.local.remove(url);
+                console.log(`All properties deleted for ${url}`);
+            } else {
+                await chrome.storage.local.set({ [url]: urlData });
+                console.log(`Deleted property '${key}' for ${url}`);
+            }
+        }
+    } catch (error) {
+        console.error("Error deleting data:", error);
+    }
+}


### PR DESCRIPTION
- Enable saving type definitions in chrome local storage, per URL
- include use-authored actions in the registered dynamic agent schema
- simplify schema registration