### PR TITLE
[python/knowpro] Change class structure to suit Python's type system better

### DIFF
--- a/python/kp/knowpro/convindex.py
+++ b/python/kp/knowpro/convindex.py
@@ -42,8 +42,8 @@ type KnowledgeValidator = Callable[
 ]
 
 
-def add_metadata_to_index(
-    messages: list[IMessage],
+def add_metadata_to_index[TMessage: IMessage](
+    messages: list[TMessage],
     semantic_refs: list[SemanticRef],
     semantic_ref_index: ITermToSemanticRefIndex,
     knowledge_validator: KnowledgeValidator | None = None,

--- a/python/kp/knowpro/interfaces.py
+++ b/python/kp/knowpro/interfaces.py
@@ -267,10 +267,10 @@ class IConversationSecondaryIndexes(Protocol):
 
 
 @runtime_checkable
-class IConversation(Protocol):
+class IConversation[TMessage: IMessage = Any](Protocol):
     name_tag: str
     tags: list[str]
-    messages: list[IMessage]
+    messages: list[TMessage]
     semantic_refs: list[SemanticRef] | None
     semantic_ref_index: ITermToSemanticRefIndex | None
     secondary_indexes: IConversationSecondaryIndexes | None

--- a/python/kp/knowpro/interfaces.py
+++ b/python/kp/knowpro/interfaces.py
@@ -36,7 +36,7 @@ type MessageIndex = int
 
 
 @runtime_checkable
-class IMessage(IKnowledgeSource):
+class IMessage(IKnowledgeSource, Protocol):
     # The text of the message, split into chunks.
     text_chunks: list[str]
     timestamp: str | None = None

--- a/python/kp/knowpro/interfaces.py
+++ b/python/kp/knowpro/interfaces.py
@@ -36,12 +36,9 @@ type MessageIndex = int
 
 
 @runtime_checkable
-class IMessage[TMeta: IKnowledgeSource = Any](Protocol):
+class IMessage(IKnowledgeSource):
     # The text of the message, split into chunks.
     text_chunks: list[str]
-    # For example, e-mail has subject, from and to fields;
-    # a chat message has a sender and a recipient.
-    metadata: TMeta
     timestamp: str | None = None
     tags: list[str]
     deletion_info: DeletionInfo | None = None
@@ -270,10 +267,10 @@ class IConversationSecondaryIndexes(Protocol):
 
 
 @runtime_checkable
-class IConversation[TMeta: IKnowledgeSource = Any](Protocol):
+class IConversation(Protocol):
     name_tag: str
     tags: list[str]
-    messages: list[IMessage[TMeta]]
+    messages: list[IMessage]
     semantic_refs: list[SemanticRef] | None
     semantic_ref_index: ITermToSemanticRefIndex | None
     secondary_indexes: IConversationSecondaryIndexes | None

--- a/python/kp/memconv/import_podcasts.py
+++ b/python/kp/memconv/import_podcasts.py
@@ -91,9 +91,7 @@ class Podcast(interfaces.IConversation[PodcastMessage]):
 
     # __init__() parameters, in that order (via `@dataclass`).
     name_tag: str = field(default="")
-    messages: list[PodcastMessage] = field(
-        default_factory=list
-    )
+    messages: list[PodcastMessage] = field(default_factory=list)
     tags: list[str] = field(default_factory=list)
     semantic_refs: list[interfaces.SemanticRef] | None = field(default_factory=list)
 

--- a/python/kp/memconv/import_podcasts.py
+++ b/python/kp/memconv/import_podcasts.py
@@ -73,7 +73,7 @@ class PodcastMessage(interfaces.IMessage, PodcastMessageBase):
 
 
 @dataclass
-class Podcast(interfaces.IConversation):
+class Podcast(interfaces.IConversation[PodcastMessage]):
     # Instance variables not passed to `__init__()`.
     # TODO
     # settings: ConversationSettings = field(

--- a/python/kp/memconv/import_podcasts.py
+++ b/python/kp/memconv/import_podcasts.py
@@ -65,17 +65,17 @@ class PodcastMessageMeta(interfaces.IKnowledgeSource):
 
 
 def assign_message_listeners(
-    msgs: Sequence[interfaces.IMessage[PodcastMessageMeta]],
+    msgs: Sequence[PodcastMessage],
     participants: set[str],
 ) -> None:
     for msg in msgs:
         if msg.metadata.speaker:
-            listeners = [p for p in participants if p != msg.metadata.speaker]
-            msg.metadata.listeners = listeners
+            listeners = [p for p in participants if p != msg.speaker]
+            msg.listeners = listeners
 
 
 @dataclass
-class PodcastMessage(interfaces.IMessage[PodcastMessageMeta]):
+class PodcastMessage(interfaces.IMessage, PodcastMessageMeta):
     timestamp: str | None = field(init=False, default=None)
     text_chunks: list[str]
     metadata: PodcastMessageMeta
@@ -108,7 +108,7 @@ class Podcast(interfaces.IConversation[PodcastMessageMeta]):
     # __init__() parameters, in that order (via `@dataclass`).
     name_tag: str = field(default="")
     # NOTE: `messages: list[PodcastMessage]` doesn't work because of invariance.
-    messages: list[interfaces.IMessage[PodcastMessageMeta]] = field(
+    messages: list[PodcastMessage] = field(
         default_factory=list
     )
     tags: list[str] = field(default_factory=list)
@@ -195,7 +195,7 @@ def import_podcast(
     transcript_lines = [line.rstrip() for line in transcript_lines if line.strip()]
     turn_parse_regex = re.compile(r"^(?P<speaker>[A-Z0-9 ]+:)?(?P<speech>.*)$")
     participants: set[str] = set()
-    msgs: list[interfaces.IMessage[PodcastMessageMeta]] = []
+    msgs: list[PodcastMessage] = []
     cur_msg: PodcastMessage | None = None
     for line in transcript_lines:
         match = turn_parse_regex.match(line)

--- a/python/kp/memconv/import_podcasts.py
+++ b/python/kp/memconv/import_podcasts.py
@@ -91,7 +91,7 @@ class Podcast(interfaces.IConversation[PodcastMessage]):
 
     # __init__() parameters, in that order (via `@dataclass`).
     name_tag: str = field(default="")
-    messages: list[PodcastMessage] = field(  # type: ignore
+    messages: list[PodcastMessage] = field(
         default_factory=list
     )
     tags: list[str] = field(default_factory=list)
@@ -101,7 +101,7 @@ class Podcast(interfaces.IConversation[PodcastMessage]):
         if self.semantic_ref_index:
             assert self.semantic_refs is not None
             convindex.add_metadata_to_index(
-                self.messages,  # type: ignore
+                self.messages,
                 self.semantic_refs,
                 self.semantic_ref_index,
             )


### PR DESCRIPTION
(This is only for the Python port.)

Change TMeta into a base class. We then get:

- IMessage has IKnowledgeSource as a base class, and no longer has a metadata field -- you just call message.get_knowledge().
- IConversation is generic in the message type (TMessage) and its messages field is a list of TMessage.
- add_metadata_to_index() is generic in the message type (I think there's a pattern here :-).
- PodcastMessageMeta becomes base class PodcastMessageBase (but it could easily be just blended into PodcastMessage).
- PodcastMessage derives both from PodcastMessageBase and IMessage.
- Podcast derives from IConversation[PodcastMessage] and its messages field is a list of PodcastMessage.
- assign_message() takes a sequence of PodcastMessage.