### PR TITLE
Cache fixes and improvements

### DIFF
--- a/ts/packages/cache/src/constructions/constructionCache.ts
+++ b/ts/packages/cache/src/constructions/constructionCache.ts
@@ -199,6 +199,7 @@ export class ConstructionCache {
         const newConstruction = new Construction(
             mergedParts,
             this.transformNamespaces,
+            construction.emptyArrayParameters,
             construction.implicitParameters,
             construction.implicitActionName,
             constructionNamespace.maxId++,

--- a/ts/packages/cache/src/constructions/constructionValue.ts
+++ b/ts/packages/cache/src/constructions/constructionValue.ts
@@ -135,12 +135,20 @@ export function matchedValues(
 
 export function createActionProps(
     values: [string, ParamValueType][],
+    emptyArrayParameters?: string[],
     initial?: JSONAction | JSONAction[],
 ) {
     const result: any = { actionProps: structuredClone(initial) };
     for (const [name, value] of values) {
         setObjectProperty(result, "actionProps", name, value);
     }
+
+    if (emptyArrayParameters) {
+        for (const name of emptyArrayParameters) {
+            setObjectProperty(result, "actionProps", name, []);
+        }
+    }
+
     const actionProps = result.actionProps;
     // validate fullActionName
     if (Array.isArray(actionProps)) {

--- a/ts/packages/cache/src/constructions/constructions.ts
+++ b/ts/packages/cache/src/constructions/constructions.ts
@@ -123,7 +123,10 @@ export class Construction {
             return [];
         }
         this.collectImplicitProperties(matchedValues.values);
-        const actionProps = createActionProps(matchedValues.values, this.emptyArrayParameters);
+        const actionProps = createActionProps(
+            matchedValues.values,
+            this.emptyArrayParameters,
+        );
         return [
             {
                 construction: this,

--- a/ts/packages/cache/src/constructions/constructions.ts
+++ b/ts/packages/cache/src/constructions/constructions.ts
@@ -80,12 +80,14 @@ export class Construction {
     public static create(
         parts: ConstructionPart[],
         transformNamespaces: Map<string, Transforms>,
+        emptyArrayParameters?: string[],
         implicitParameters?: ImplicitParameter[],
         implicitActionName?: string,
     ) {
         return new Construction(
             parts,
             transformNamespaces,
+            emptyArrayParameters,
             implicitParameters,
             implicitActionName,
             -1,
@@ -95,6 +97,7 @@ export class Construction {
     constructor(
         public readonly parts: ConstructionPart[],
         public readonly transformNamespaces: Map<string, Transforms>,
+        public readonly emptyArrayParameters: string[] | undefined,
         public readonly implicitParameters: ImplicitParameter[] | undefined,
         public readonly implicitActionName: string | undefined,
         public readonly id: number, // runtime Id
@@ -120,7 +123,7 @@ export class Construction {
             return [];
         }
         this.collectImplicitProperties(matchedValues.values);
-        const actionProps = createActionProps(matchedValues.values);
+        const actionProps = createActionProps(matchedValues.values, this.emptyArrayParameters);
         return [
             {
                 construction: this,
@@ -263,6 +266,7 @@ export class Construction {
                 );
             }),
             transformNamespaces,
+            construction.emptyArrayParameters,
             construction.implicitParameters,
             construction.implicitActionName,
             index,
@@ -289,6 +293,7 @@ function isParsePartJSON(part: ConstructionPartJSON): part is ParsePartJSON {
 
 export type ConstructionJSON = {
     parts: ConstructionPartJSON[];
+    emptyArrayParameters?: string[];
     implicitParameters?: ImplicitParameter[];
     implicitActionName?: string;
 };

--- a/ts/packages/cache/src/explanation/requestAction.ts
+++ b/ts/packages/cache/src/explanation/requestAction.ts
@@ -257,16 +257,6 @@ export class RequestAction {
         return `${this.request}${RequestAction.Separator}${executableActionsToString(this.actions)}`;
     }
 
-    public toPromptString() {
-        return JSON.stringify(
-            {
-                request: this.request,
-                actions: this.actions,
-            },
-            undefined,
-            2,
-        );
-    }
     public static fromString(input: string) {
         // Very simplistic parser for request/action.
         const trimmed = input.trim();

--- a/ts/packages/cache/src/explanation/v5/alternativesExplanationV5.ts
+++ b/ts/packages/cache/src/explanation/v5/alternativesExplanationV5.ts
@@ -13,7 +13,7 @@ import { PropertyExplanation } from "./propertyExplanationSchemaV5WithContext.js
 import { SubPhraseExplanation } from "./subPhraseExplanationSchemaV5.js";
 import { getPackageFilePath } from "../../utils/getPackageFilePath.js";
 import { PromptSection } from "typechat";
-import { form } from "./explanationV5.js";
+import { form, requestActionToPromptString } from "./explanationV5.js";
 import { hasPropertyNames } from "./subPhraseExplanationV5.js";
 import { ExplainerConfig } from "../genericExplainer.js";
 
@@ -92,7 +92,7 @@ export function createAlternativesExplainer(
             );
         },
         createInstructions,
-        ([requestAction]) => requestAction.toPromptString(),
+        ([requestAction]) => requestActionToPromptString(requestAction),
         validateAlternativesExplanationV5,
     );
 }

--- a/ts/packages/cache/src/explanation/v5/explanationV5.ts
+++ b/ts/packages/cache/src/explanation/v5/explanationV5.ts
@@ -769,6 +769,7 @@ export function createConstructionV5(
     return Construction.create(
         parts,
         transformNamespaces,
+        getEmptyArrayPropertyNames(toJsonActions(actions)),
         implicitProperties.map((e) => {
             return {
                 paramName: e.name,
@@ -776,6 +777,25 @@ export function createConstructionV5(
             };
         }),
     );
+}
+
+function getEmptyArrayPropertyNames(obj: any): string[] | undefined {
+    const names: string[] = [];
+    for (const [key, value] of Object.entries(obj)) {
+        if (typeof value === "object") {
+            if (Array.isArray(value) && value.length === 0) {
+                names.push(key);
+            } else {
+                const children = getEmptyArrayPropertyNames(value);
+                if (children !== undefined) {
+                    for (const child of children) {
+                        names.push(`${key}.${child}`);
+                    }
+                }
+            }
+        }
+    }
+    return names.length > 0 ? names : undefined;
 }
 
 function toPrettyString(explanation: Explanation) {

--- a/ts/packages/cache/src/explanation/v5/explanationV5.ts
+++ b/ts/packages/cache/src/explanation/v5/explanationV5.ts
@@ -33,6 +33,7 @@ import {
     FullAction,
     normalizeParamString,
     RequestAction,
+    toJsonActions,
 } from "../requestAction.js";
 import {
     Construction,
@@ -77,7 +78,7 @@ import { Transforms } from "../../constructions/transforms.js";
 import { getLanguageTools } from "../../utils/language.js";
 import {
     createPolitenessGeneralizer,
-    PolitenessGenerializer,
+    PolitenessGeneralizer,
 } from "./politenessGeneralizationV5.js";
 import { PolitenessGeneralization } from "./politenessGeneralizationSchemaV5.js";
 
@@ -92,12 +93,23 @@ export type ExplanationResult = GenericExplanationResult<Explanation>;
 export const form =
     "The user request is a JSON object containing a request string and the translated action";
 
+export function requestActionToPromptString(requestAction: RequestAction) {
+    return JSON.stringify(
+        {
+            request: requestAction.request,
+            actions: toJsonActions(requestAction.actions),
+        },
+        undefined,
+        2,
+    );
+}
+
 class ExplanationV5TypeChatAgent {
     private readonly propertyExplainerWithoutContext: PropertyExplainer;
     private readonly propertyExplainerWithContext: PropertyExplainer;
     private readonly subPhrasesExplainer: SubPhraseExplainer;
     private readonly alternativesExplainer: AlternativesExplainer;
-    private readonly politenessGeneralizer: PolitenessGenerializer;
+    private readonly politenessGeneralizer: PolitenessGeneralizer;
     constructor(model?: string) {
         this.propertyExplainerWithoutContext = createPropertyExplainer(
             false,

--- a/ts/packages/cache/src/explanation/v5/politenessGeneralizationV5.ts
+++ b/ts/packages/cache/src/explanation/v5/politenessGeneralizationV5.ts
@@ -6,14 +6,14 @@ import { RequestAction } from "../requestAction.js";
 import { TypeChatAgent } from "../typeChatAgent.js";
 import { getPackageFilePath } from "../../utils/getPackageFilePath.js";
 import { PromptSection } from "typechat";
-import { form } from "./explanationV5.js";
+import { form, requestActionToPromptString } from "./explanationV5.js";
 import { ExplainerConfig } from "../genericExplainer.js";
 import { PolitenessGeneralization } from "./politenessGeneralizationSchemaV5.js";
 
 function createInstructions(requestAction: RequestAction): PromptSection[] {
     const instructions: string[] = [
-        form,
-        "Generate 4 request with added politeness prefix and suffix that doesn't change the action",
+        `${form} with the following value:\n${requestActionToPromptString(requestAction)}`,
+        "Generate 4 politeness prefix and suffix that can be added to the request but doesn't change the action",
     ];
 
     return [
@@ -24,7 +24,7 @@ function createInstructions(requestAction: RequestAction): PromptSection[] {
     ];
 }
 
-export type PolitenessGenerializer = TypeChatAgent<
+export type PolitenessGeneralizer = TypeChatAgent<
     RequestAction,
     PolitenessGeneralization,
     ExplainerConfig
@@ -32,7 +32,7 @@ export type PolitenessGenerializer = TypeChatAgent<
 
 export function createPolitenessGeneralizer(
     model?: string,
-): PolitenessGenerializer {
+): PolitenessGeneralizer {
     return new TypeChatAgent(
         "politeness generalization",
         () => {
@@ -45,6 +45,6 @@ export function createPolitenessGeneralizer(
             );
         },
         createInstructions,
-        (requestAction) => requestAction.toPromptString(),
+        (requestAction) => requestActionToPromptString(requestAction),
     );
 }

--- a/ts/packages/cache/src/explanation/v5/propertyExplainationV5.ts
+++ b/ts/packages/cache/src/explanation/v5/propertyExplainationV5.ts
@@ -23,7 +23,7 @@ import {
     checkActionProperty,
     ensureProperties,
 } from "../validateExplanation.js";
-import { form } from "./explanationV5.js";
+import { form, requestActionToPromptString } from "./explanationV5.js";
 import { ExplainerConfig } from "../genericExplainer.js";
 
 export type PropertyExplainer = TypeChatAgent<
@@ -51,14 +51,14 @@ export function createPropertyExplainer(
         },
         (requestAction: RequestAction) => {
             return (
-                `${form} with the following value:\n${requestAction.toPromptString()}\n` +
+                `${form} with the following value:\n${requestActionToPromptString(requestAction)}\n` +
                 (enableContext
                     ? `For each property, explain which substring of the request or entities in the conversation history is used to compute the value. ${substringRequirement}\n`
                     : `For each property, explain which substring of the request is used to compute the value. ${substringRequirement}\n`) +
                 getActionDescription(requestAction)
             );
         },
-        (requestAction) => requestAction.toPromptString(),
+        (requestAction) => requestActionToPromptString(requestAction),
         validatePropertyExplanation,
     );
 }

--- a/ts/packages/cache/src/explanation/v5/subPhraseExplanationV5.ts
+++ b/ts/packages/cache/src/explanation/v5/subPhraseExplanationV5.ts
@@ -8,7 +8,7 @@ import {
     RequestAction,
 } from "../requestAction.js";
 import { PropertyExplanation } from "./propertyExplanationSchemaV5WithContext.js";
-import { form } from "./explanationV5.js";
+import { form, requestActionToPromptString } from "./explanationV5.js";
 import {
     getActionDescription,
     getSubphraseExplanationInstruction,
@@ -72,7 +72,7 @@ export function createSubPhraseExplainer(model?: string) {
             );
         },
         createInstructions,
-        ([requestAction]) => requestAction.toPromptString(),
+        ([requestAction]) => requestActionToPromptString(requestAction),
         validateSubPhraseExplanationV5,
     );
 }

--- a/ts/packages/cli/src/commands/data/regenerate.ts
+++ b/ts/packages/cli/src/commands/data/regenerate.ts
@@ -14,7 +14,7 @@ import {
     GenerateDataInput,
     getEmptyExplanationTestData,
     convertTestDataToExplanationData,
-    createActionConfigProvider,
+    getAllActionConfigProvider,
     createSchemaInfoProvider,
     getAppAgentName,
 } from "agent-dispatcher/internal";
@@ -35,7 +35,7 @@ import {
     getDefaultConstructionProvider,
 } from "default-agent-provider";
 
-const provider = await createActionConfigProvider(
+const provider = await getAllActionConfigProvider(
     getDefaultAppAgentProviders(getInstanceDir()),
 );
 const schemaInfoProvider = createSchemaInfoProvider(provider);

--- a/ts/packages/cli/src/commands/test/translate.ts
+++ b/ts/packages/cli/src/commands/test/translate.ts
@@ -83,6 +83,7 @@ function summarizeResult(result: TestResultFile) {
 
 const modelNames = await getChatModelNames();
 const defaultAppAgentProviders = getDefaultAppAgentProviders(getInstanceDir());
+const defaultConstructionProvider = getDefaultConstructionProvider();
 const schemaNames = getAllSchemaNames(
     await createActionConfigProvider(defaultAppAgentProviders),
 );
@@ -161,6 +162,10 @@ export default class TestTranslateCommand extends Command {
             description: "Enable streaming",
             default: true, // follow DispatcherOptions default
             allowNo: true,
+        }),
+        cache: Flags.boolean({
+            description: "Enable caching",
+            default: false,
         }),
         concurrency: Flags.integer({
             char: "c",
@@ -374,9 +379,13 @@ export default class TestTranslateCommand extends Command {
                     },
                 },
                 explainer: { enabled: false },
-                cache: { enabled: false },
+                cache: { enabled: flags.cache },
                 collectCommandResult: true,
+                constructionProvider: defaultConstructionProvider,
             });
+            if (flags.cache) {
+                await dispatcher.processCommand("@const import -t");
+            }
             while (requests.length > 0) {
                 const request = requests.shift()!;
 

--- a/ts/packages/defaultAgentProvider/test/data/explanations/calendar/v5/complex.json
+++ b/ts/packages/defaultAgentProvider/test/data/explanations/calendar/v5/complex.json
@@ -1,7 +1,7 @@
 {
   "version": 2,
   "schemaName": "calendar",
-  "sourceHash": "q89odXmST8U5DeqvXQL7XAkaPw0Efxj2FT391Xq3Vis=",
+  "sourceHash": "0eh5kxCn5ytPu5T9xJ+Tk3xs547AP5ncz7uiQ5mu1Lo=",
   "explainerName": "v5",
   "entries": [
     {
@@ -10,11 +10,17 @@
         "fullActionName": "calendar.addEvent",
         "parameters": {
           "event": {
-            "day": "1/24/2025",
             "timeRange": {
-              "startTime": "2:00 pm"
+              "startDateTime": {
+                "day": "today",
+                "hms": "14:00:00"
+              },
+              "endDateTime": {
+                "day": "today",
+                "hms": "14:00:00"
+              }
             },
-            "description": "meeting with team",
+            "description": "meeting",
             "participants": [
               "team"
             ]
@@ -27,28 +33,42 @@
             "name": "fullActionName",
             "value": "calendar.addEvent",
             "substrings": [
-              "Add meeting with team"
+              "Add meeting with team today at 2"
             ]
           },
           {
-            "name": "parameters.event.day",
-            "value": "1/24/2025",
+            "name": "parameters.event.timeRange.startDateTime.day",
+            "value": "today",
             "substrings": [
               "today"
             ]
           },
           {
-            "name": "parameters.event.timeRange.startTime",
-            "value": "2:00 pm",
+            "name": "parameters.event.timeRange.startDateTime.hms",
+            "value": "14:00:00",
             "substrings": [
-              "at 2"
+              "2"
+            ]
+          },
+          {
+            "name": "parameters.event.timeRange.endDateTime.day",
+            "value": "today",
+            "substrings": [
+              "today"
+            ]
+          },
+          {
+            "name": "parameters.event.timeRange.endDateTime.hms",
+            "value": "14:00:00",
+            "substrings": [
+              "2"
             ]
           },
           {
             "name": "parameters.event.description",
-            "value": "meeting with team",
+            "value": "meeting",
             "substrings": [
-              "meeting with team"
+              "meeting"
             ]
           },
           {
@@ -61,26 +81,40 @@
         ],
         "subPhrases": [
           {
-            "text": "Add meeting with team",
+            "text": "Add",
             "category": "action",
             "propertyNames": [
-              "fullActionName",
-              "parameters.event.description",
+              "fullActionName"
+            ]
+          },
+          {
+            "text": "meeting",
+            "category": "event",
+            "propertyNames": [
+              "parameters.event.description"
+            ]
+          },
+          {
+            "text": "with team",
+            "category": "participants",
+            "propertyNames": [
               "parameters.event.participants.0"
             ]
           },
           {
             "text": "today",
-            "category": "time",
+            "category": "date",
             "propertyNames": [
-              "parameters.event.day"
+              "parameters.event.timeRange.startDateTime.day",
+              "parameters.event.timeRange.endDateTime.day"
             ]
           },
           {
             "text": "at 2",
             "category": "time",
             "propertyNames": [
-              "parameters.event.timeRange.startTime"
+              "parameters.event.timeRange.startDateTime.hms",
+              "parameters.event.timeRange.endDateTime.hms"
             ]
           }
         ],
@@ -89,52 +123,52 @@
             "propertyName": "fullActionName",
             "propertyValue": "calendar.addEvent",
             "propertySubPhrases": [
-              "Add meeting with team"
+              "Add"
             ],
             "alternatives": [
               {
-                "propertyValue": "calendar.scheduleMeeting",
-                "propertySubPhrases": [
-                  "Schedule meeting with team"
-                ]
-              },
-              {
                 "propertyValue": "calendar.createEvent",
                 "propertySubPhrases": [
-                  "Create meeting with team"
+                  "Create"
                 ]
               },
               {
-                "propertyValue": "calendar.planEvent",
+                "propertyValue": "calendar.scheduleEvent",
                 "propertySubPhrases": [
-                  "Plan meeting with team"
+                  "Schedule"
+                ]
+              },
+              {
+                "propertyValue": "calendar.insertEvent",
+                "propertySubPhrases": [
+                  "Insert"
                 ]
               }
             ]
           },
           {
             "propertyName": "parameters.event.description",
-            "propertyValue": "meeting with team",
+            "propertyValue": "meeting",
             "propertySubPhrases": [
-              "Add meeting with team"
+              "meeting"
             ],
             "alternatives": [
               {
-                "propertyValue": "discussion with team",
+                "propertyValue": "conference",
                 "propertySubPhrases": [
-                  "Add discussion with team"
+                  "conference"
                 ]
               },
               {
-                "propertyValue": "conference with team",
+                "propertyValue": "discussion",
                 "propertySubPhrases": [
-                  "Add conference with team"
+                  "discussion"
                 ]
               },
               {
-                "propertyValue": "session with team",
+                "propertyValue": "appointment",
                 "propertySubPhrases": [
-                  "Add session with team"
+                  "appointment"
                 ]
               }
             ]
@@ -143,79 +177,133 @@
             "propertyName": "parameters.event.participants.0",
             "propertyValue": "team",
             "propertySubPhrases": [
-              "Add meeting with team"
+              "with team"
             ],
             "alternatives": [
               {
                 "propertyValue": "colleagues",
                 "propertySubPhrases": [
-                  "Add meeting with colleagues"
+                  "with colleagues"
                 ]
               },
               {
                 "propertyValue": "staff",
                 "propertySubPhrases": [
-                  "Add meeting with staff"
+                  "with staff"
                 ]
               },
               {
                 "propertyValue": "group",
                 "propertySubPhrases": [
-                  "Add meeting with group"
+                  "with group"
                 ]
               }
             ]
           },
           {
-            "propertyName": "parameters.event.day",
-            "propertyValue": "1/24/2025",
+            "propertyName": "parameters.event.timeRange.startDateTime.day",
+            "propertyValue": "today",
             "propertySubPhrases": [
               "today"
             ],
             "alternatives": [
               {
-                "propertyValue": "1/25/2025",
+                "propertyValue": "tomorrow",
                 "propertySubPhrases": [
                   "tomorrow"
                 ]
               },
               {
-                "propertyValue": "1/26/2025",
+                "propertyValue": "next Monday",
                 "propertySubPhrases": [
-                  "day after tomorrow"
+                  "next Monday"
                 ]
               },
               {
-                "propertyValue": "1/31/2025",
+                "propertyValue": "next week",
                 "propertySubPhrases": [
-                  "next Friday"
+                  "next week"
                 ]
               }
             ]
           },
           {
-            "propertyName": "parameters.event.timeRange.startTime",
-            "propertyValue": "2:00 pm",
+            "propertyName": "parameters.event.timeRange.endDateTime.day",
+            "propertyValue": "today",
+            "propertySubPhrases": [
+              "today"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "tomorrow",
+                "propertySubPhrases": [
+                  "tomorrow"
+                ]
+              },
+              {
+                "propertyValue": "next Monday",
+                "propertySubPhrases": [
+                  "next Monday"
+                ]
+              },
+              {
+                "propertyValue": "next week",
+                "propertySubPhrases": [
+                  "next week"
+                ]
+              }
+            ]
+          },
+          {
+            "propertyName": "parameters.event.timeRange.startDateTime.hms",
+            "propertyValue": "14:00:00",
             "propertySubPhrases": [
               "at 2"
             ],
             "alternatives": [
               {
-                "propertyValue": "3:00 pm",
+                "propertyValue": "15:00:00",
                 "propertySubPhrases": [
                   "at 3"
                 ]
               },
               {
-                "propertyValue": "4:00 pm",
+                "propertyValue": "16:00:00",
                 "propertySubPhrases": [
                   "at 4"
                 ]
               },
               {
-                "propertyValue": "5:00 pm",
+                "propertyValue": "13:00:00",
                 "propertySubPhrases": [
-                  "at 5"
+                  "at 1"
+                ]
+              }
+            ]
+          },
+          {
+            "propertyName": "parameters.event.timeRange.endDateTime.hms",
+            "propertyValue": "14:00:00",
+            "propertySubPhrases": [
+              "at 2"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "15:00:00",
+                "propertySubPhrases": [
+                  "at 3"
+                ]
+              },
+              {
+                "propertyValue": "16:00:00",
+                "propertySubPhrases": [
+                  "at 4"
+                ]
+              },
+              {
+                "propertyValue": "13:00:00",
+                "propertySubPhrases": [
+                  "at 1"
                 ]
               }
             ]
@@ -224,14 +312,14 @@
         "politePrefixes": [
           "Could you please",
           "Would you mind",
-          "If it's not too much trouble, could you",
-          "I would appreciate it if you could"
+          "I would appreciate it if you could",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "Thanks a lot!",
-          "I appreciate it!",
-          "Much appreciated!"
+          "Thank you",
+          "Thanks in advance",
+          "I appreciate your help",
+          "If you could do this, that would be great"
         ]
       }
     },
@@ -244,7 +332,9 @@
             "participants": [
               "Rosy"
             ],
-            "dayRange": "this month"
+            "timeRange": {
+              "month": "March"
+            }
           }
         }
       },
@@ -253,7 +343,7 @@
           {
             "name": "fullActionName",
             "value": "calendar.findEvents",
-            "isImplicit": true
+            "substrings": []
           },
           {
             "name": "parameters.eventReference.participants.0",
@@ -263,8 +353,8 @@
             ]
           },
           {
-            "name": "parameters.eventReference.dayRange",
-            "value": "this month",
+            "name": "parameters.eventReference.timeRange.month",
+            "value": "March",
             "substrings": [
               "this month"
             ]
@@ -272,17 +362,14 @@
         ],
         "subPhrases": [
           {
-            "text": "Do I have any plan with",
+            "text": "Do I have any plan",
             "category": "query",
-            "synonyms": [
-              "Do I have any event with",
-              "Do I have any meeting with",
-              "Do I have any appointment with"
-            ],
-            "isOptional": true
+            "propertyNames": [
+              "fullActionName"
+            ]
           },
           {
-            "text": "Rosy",
+            "text": "with Rosy",
             "category": "participant",
             "propertyNames": [
               "parameters.eventReference.participants.0"
@@ -290,150 +377,108 @@
           },
           {
             "text": "this month",
-            "category": "time period",
+            "category": "time",
             "propertyNames": [
-              "parameters.eventReference.dayRange"
+              "parameters.eventReference.timeRange.month"
             ]
-          },
-          {
-            "text": "?",
-            "category": "punctuation",
-            "synonyms": [
-              "",
-              ".",
-              "!"
-            ],
-            "isOptional": true
           }
         ],
         "propertyAlternatives": [
           {
-            "propertyName": "parameters.eventReference.participants.0",
-            "propertyValue": "Rosy",
+            "propertyName": "fullActionName",
+            "propertyValue": "calendar.findEvents",
             "propertySubPhrases": [
-              "Rosy"
+              "Do I have any plan"
             ],
             "alternatives": [
               {
-                "propertyValue": "John",
+                "propertyValue": "calendar.checkAvailability",
                 "propertySubPhrases": [
-                  "John"
+                  "Am I free"
                 ]
               },
               {
-                "propertyValue": "Alice",
+                "propertyValue": "calendar.listEvents",
                 "propertySubPhrases": [
-                  "Alice"
+                  "What events do I have"
                 ]
               },
               {
-                "propertyValue": "Michael",
+                "propertyValue": "calendar.getSchedule",
                 "propertySubPhrases": [
-                  "Michael"
+                  "Show my schedule"
                 ]
               }
             ]
           },
           {
-            "propertyName": "parameters.eventReference.dayRange",
-            "propertyValue": "this month",
+            "propertyName": "parameters.eventReference.participants.0",
+            "propertyValue": "Rosy",
+            "propertySubPhrases": [
+              "with Rosy"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "John",
+                "propertySubPhrases": [
+                  "with John"
+                ]
+              },
+              {
+                "propertyValue": "Alice",
+                "propertySubPhrases": [
+                  "with Alice"
+                ]
+              },
+              {
+                "propertyValue": "Michael",
+                "propertySubPhrases": [
+                  "with Michael"
+                ]
+              }
+            ]
+          },
+          {
+            "propertyName": "parameters.eventReference.timeRange.month",
+            "propertyValue": "March",
             "propertySubPhrases": [
               "this month"
             ],
             "alternatives": [
               {
-                "propertyValue": "next week",
+                "propertyValue": "April",
                 "propertySubPhrases": [
-                  "next week"
+                  "next month"
                 ]
               },
               {
-                "propertyValue": "today",
+                "propertyValue": "February",
                 "propertySubPhrases": [
-                  "today"
+                  "last month"
                 ]
               },
               {
-                "propertyValue": "this year",
+                "propertyValue": "May",
                 "propertySubPhrases": [
-                  "this year"
+                  "in May"
                 ]
               }
             ]
           }
         ],
         "politePrefixes": [
-          "Could you please",
-          "Would you mind"
+          "Could you please tell me,",
+          "Would you mind checking,",
+          "May I ask,",
+          "If it's not too much trouble,"
         ],
         "politeSuffixes": [
           "Thank you!",
-          "I would appreciate it."
+          "I appreciate it!",
+          "Thanks in advance!",
+          "Your help is appreciated!"
         ]
-      },
-      "corrections": [
-        {
-          "data": {
-            "properties": [
-              {
-                "name": "fullActionName",
-                "value": "calendar.findEvents",
-                "isImplicit": true
-              },
-              {
-                "name": "parameters.eventReference.participants.0",
-                "value": "Rosy",
-                "substrings": [
-                  "Rosy"
-                ]
-              },
-              {
-                "name": "parameters.eventReference.dayRange",
-                "value": "this month",
-                "substrings": [
-                  "this month"
-                ]
-              }
-            ],
-            "subPhrases": [
-              {
-                "text": "Do I have any plan with",
-                "category": "query",
-                "propertyNames": [
-                  "fullActionName"
-                ]
-              },
-              {
-                "text": "Rosy",
-                "category": "participant",
-                "propertyNames": [
-                  "parameters.eventReference.participants.0"
-                ]
-              },
-              {
-                "text": "this month",
-                "category": "time period",
-                "propertyNames": [
-                  "parameters.eventReference.dayRange"
-                ]
-              },
-              {
-                "text": "?",
-                "category": "punctuation",
-                "synonyms": [
-                  "",
-                  ".",
-                  "!"
-                ],
-                "isOptional": true
-              }
-            ]
-          },
-          "correction": [
-            "Property 'fullActionName' is expected to be implicit and should not be included as a property name in a sub-phrase"
-          ]
-        }
-      ]
+      }
     },
     {
       "request": "I need to add a meeting with my boss on Monday at 10am.",
@@ -441,12 +486,17 @@
         "fullActionName": "calendar.addEvent",
         "parameters": {
           "event": {
-            "day": "1/27/2025",
             "timeRange": {
-              "startTime": "10:00 am"
+              "startDateTime": {
+                "day": "Monday",
+                "hms": "10:00:00"
+              },
+              "endDateTime": {
+                "day": "Monday",
+                "hms": "10:00:00"
+              }
             },
-            "description": "meeting with my boss",
-            "translatedDate": "1/27/2025"
+            "description": "meeting with my boss"
           }
         }
       },
@@ -455,16 +505,34 @@
           {
             "name": "fullActionName",
             "value": "calendar.addEvent",
-            "substrings": []
+            "substrings": [
+              "I need to add a meeting"
+            ]
           },
           {
-            "name": "parameters.event.day",
-            "value": "1/27/2025",
-            "substrings": []
+            "name": "parameters.event.timeRange.startDateTime.day",
+            "value": "Monday",
+            "substrings": [
+              "Monday"
+            ]
           },
           {
-            "name": "parameters.event.timeRange.startTime",
-            "value": "10:00 am",
+            "name": "parameters.event.timeRange.startDateTime.hms",
+            "value": "10:00:00",
+            "substrings": [
+              "10am"
+            ]
+          },
+          {
+            "name": "parameters.event.timeRange.endDateTime.day",
+            "value": "Monday",
+            "substrings": [
+              "Monday"
+            ]
+          },
+          {
+            "name": "parameters.event.timeRange.endDateTime.hms",
+            "value": "10:00:00",
             "substrings": [
               "10am"
             ]
@@ -475,51 +543,37 @@
             "substrings": [
               "meeting with my boss"
             ]
-          },
-          {
-            "name": "parameters.event.translatedDate",
-            "value": "1/27/2025",
-            "substrings": []
           }
         ],
         "subPhrases": [
           {
-            "text": "I need to",
-            "category": "politeness",
-            "synonyms": [
-              "Please",
-              "Can you",
-              "Could you"
-            ],
-            "isOptional": true
-          },
-          {
-            "text": "add",
+            "text": "I need to add a meeting",
             "category": "action",
             "propertyNames": [
               "fullActionName"
             ]
           },
           {
-            "text": "a meeting with my boss",
-            "category": "event description",
+            "text": "with my boss",
+            "category": "description",
             "propertyNames": [
               "parameters.event.description"
             ]
           },
           {
             "text": "on Monday",
-            "category": "date",
+            "category": "time",
             "propertyNames": [
-              "parameters.event.day",
-              "parameters.event.translatedDate"
+              "parameters.event.timeRange.startDateTime.day",
+              "parameters.event.timeRange.endDateTime.day"
             ]
           },
           {
             "text": "at 10am",
             "category": "time",
             "propertyNames": [
-              "parameters.event.timeRange.startTime"
+              "parameters.event.timeRange.startDateTime.hms",
+              "parameters.event.timeRange.endDateTime.hms"
             ]
           }
         ],
@@ -528,25 +582,25 @@
             "propertyName": "fullActionName",
             "propertyValue": "calendar.addEvent",
             "propertySubPhrases": [
-              "add"
+              "I need to add a meeting"
             ],
             "alternatives": [
               {
+                "propertyValue": "calendar.scheduleMeeting",
+                "propertySubPhrases": [
+                  "I need to schedule a meeting"
+                ]
+              },
+              {
                 "propertyValue": "calendar.createEvent",
                 "propertySubPhrases": [
-                  "create"
+                  "I need to create an event"
                 ]
               },
               {
-                "propertyValue": "calendar.scheduleEvent",
+                "propertyValue": "calendar.bookAppointment",
                 "propertySubPhrases": [
-                  "schedule"
-                ]
-              },
-              {
-                "propertyValue": "calendar.insertEvent",
-                "propertySubPhrases": [
-                  "insert"
+                  "I need to book an appointment"
                 ]
               }
             ]
@@ -555,50 +609,50 @@
             "propertyName": "parameters.event.description",
             "propertyValue": "meeting with my boss",
             "propertySubPhrases": [
-              "a meeting with my boss"
+              "with my boss"
             ],
             "alternatives": [
               {
-                "propertyValue": "discussion with my boss",
+                "propertyValue": "meeting with the manager",
                 "propertySubPhrases": [
-                  "a discussion with my boss"
+                  "with the manager"
                 ]
               },
               {
-                "propertyValue": "appointment with my boss",
+                "propertyValue": "meeting with the team lead",
                 "propertySubPhrases": [
-                  "an appointment with my boss"
+                  "with the team lead"
                 ]
               },
               {
-                "propertyValue": "conference with my boss",
+                "propertyValue": "meeting with the supervisor",
                 "propertySubPhrases": [
-                  "a conference with my boss"
+                  "with the supervisor"
                 ]
               }
             ]
           },
           {
-            "propertyName": "parameters.event.day",
-            "propertyValue": "1/27/2025",
+            "propertyName": "parameters.event.timeRange.startDateTime.day",
+            "propertyValue": "Monday",
             "propertySubPhrases": [
               "on Monday"
             ],
             "alternatives": [
               {
-                "propertyValue": "1/28/2025",
+                "propertyValue": "Tuesday",
                 "propertySubPhrases": [
                   "on Tuesday"
                 ]
               },
               {
-                "propertyValue": "1/29/2025",
+                "propertyValue": "Wednesday",
                 "propertySubPhrases": [
                   "on Wednesday"
                 ]
               },
               {
-                "propertyValue": "1/30/2025",
+                "propertyValue": "Thursday",
                 "propertySubPhrases": [
                   "on Thursday"
                 ]
@@ -606,26 +660,26 @@
             ]
           },
           {
-            "propertyName": "parameters.event.translatedDate",
-            "propertyValue": "1/27/2025",
+            "propertyName": "parameters.event.timeRange.endDateTime.day",
+            "propertyValue": "Monday",
             "propertySubPhrases": [
               "on Monday"
             ],
             "alternatives": [
               {
-                "propertyValue": "1/28/2025",
+                "propertyValue": "Tuesday",
                 "propertySubPhrases": [
                   "on Tuesday"
                 ]
               },
               {
-                "propertyValue": "1/29/2025",
+                "propertyValue": "Wednesday",
                 "propertySubPhrases": [
                   "on Wednesday"
                 ]
               },
               {
-                "propertyValue": "1/30/2025",
+                "propertyValue": "Thursday",
                 "propertySubPhrases": [
                   "on Thursday"
                 ]
@@ -633,26 +687,53 @@
             ]
           },
           {
-            "propertyName": "parameters.event.timeRange.startTime",
-            "propertyValue": "10:00 am",
+            "propertyName": "parameters.event.timeRange.startDateTime.hms",
+            "propertyValue": "10:00:00",
             "propertySubPhrases": [
               "at 10am"
             ],
             "alternatives": [
               {
-                "propertyValue": "11:00 am",
-                "propertySubPhrases": [
-                  "at 11am"
-                ]
-              },
-              {
-                "propertyValue": "9:00 am",
+                "propertyValue": "09:00:00",
                 "propertySubPhrases": [
                   "at 9am"
                 ]
               },
               {
-                "propertyValue": "2:00 pm",
+                "propertyValue": "11:00:00",
+                "propertySubPhrases": [
+                  "at 11am"
+                ]
+              },
+              {
+                "propertyValue": "14:00:00",
+                "propertySubPhrases": [
+                  "at 2pm"
+                ]
+              }
+            ]
+          },
+          {
+            "propertyName": "parameters.event.timeRange.endDateTime.hms",
+            "propertyValue": "10:00:00",
+            "propertySubPhrases": [
+              "at 10am"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "09:00:00",
+                "propertySubPhrases": [
+                  "at 9am"
+                ]
+              },
+              {
+                "propertyValue": "11:00:00",
+                "propertySubPhrases": [
+                  "at 11am"
+                ]
+              },
+              {
+                "propertyValue": "14:00:00",
                 "propertySubPhrases": [
                   "at 2pm"
                 ]
@@ -663,11 +744,11 @@
         "politePrefixes": [
           "Could you please",
           "Would you mind",
-          "If it's not too much trouble, could you",
-          "May I kindly ask you to"
+          "May I kindly ask",
+          "If it's not too much trouble"
         ],
         "politeSuffixes": [
-          "Thank you.",
+          "Thank you!",
           "I would appreciate it.",
           "Thanks in advance.",
           "Your help is appreciated."
@@ -680,12 +761,21 @@
         "fullActionName": "calendar.addEvent",
         "parameters": {
           "event": {
-            "day": "March 15, 2024",
             "timeRange": {
-              "startTime": "12:00 pm",
-              "endTime": "2:00 pm"
+              "startDateTime": {
+                "year": "2024",
+                "month": "March",
+                "day": "15",
+                "hms": "12:00:00"
+              },
+              "endDateTime": {
+                "year": "2024",
+                "month": "March",
+                "day": "15",
+                "hms": "14:00:00"
+              }
             },
-            "description": "Get my tires changed"
+            "description": "get my tires changed"
           }
         }
       },
@@ -697,29 +787,64 @@
             "substrings": []
           },
           {
-            "name": "parameters.event.day",
-            "value": "March 15, 2024",
+            "name": "parameters.event.timeRange.startDateTime.year",
+            "value": "2024",
             "substrings": [
-              "March 15, 2024"
+              "2024"
             ]
           },
           {
-            "name": "parameters.event.timeRange.startTime",
-            "value": "12:00 pm",
+            "name": "parameters.event.timeRange.startDateTime.month",
+            "value": "March",
+            "substrings": [
+              "March"
+            ]
+          },
+          {
+            "name": "parameters.event.timeRange.startDateTime.day",
+            "value": "15",
+            "substrings": [
+              "15"
+            ]
+          },
+          {
+            "name": "parameters.event.timeRange.startDateTime.hms",
+            "value": "12:00:00",
             "substrings": [
               "12:00"
             ]
           },
           {
-            "name": "parameters.event.timeRange.endTime",
-            "value": "2:00 pm",
+            "name": "parameters.event.timeRange.endDateTime.year",
+            "value": "2024",
             "substrings": [
-              "2:00 pm"
+              "2024"
+            ]
+          },
+          {
+            "name": "parameters.event.timeRange.endDateTime.month",
+            "value": "March",
+            "substrings": [
+              "March"
+            ]
+          },
+          {
+            "name": "parameters.event.timeRange.endDateTime.day",
+            "value": "15",
+            "substrings": [
+              "15"
+            ]
+          },
+          {
+            "name": "parameters.event.timeRange.endDateTime.hms",
+            "value": "14:00:00",
+            "substrings": [
+              "2:00"
             ]
           },
           {
             "name": "parameters.event.description",
-            "value": "Get my tires changed",
+            "value": "get my tires changed",
             "substrings": [
               "get my tires changed"
             ]
@@ -730,9 +855,11 @@
             "text": "I need to",
             "category": "politeness",
             "synonyms": [
-              "I would like to",
-              "I want to",
-              "I have to"
+              "please",
+              "could you",
+              "would you mind",
+              "can you",
+              "I would like to"
             ],
             "isOptional": true
           },
@@ -747,129 +874,279 @@
             "text": "from 12:00",
             "category": "time",
             "propertyNames": [
-              "parameters.event.timeRange.startTime"
+              "parameters.event.timeRange.startDateTime.hms"
             ]
           },
           {
             "text": "to 2:00 pm",
             "category": "time",
             "propertyNames": [
-              "parameters.event.timeRange.endTime"
+              "parameters.event.timeRange.endDateTime.hms"
             ]
           },
           {
-            "text": "on Friday March 15, 2024",
+            "text": "on Friday",
+            "category": "day",
+            "synonyms": [
+              "this Friday",
+              "next Friday",
+              "Friday"
+            ],
+            "isOptional": true
+          },
+          {
+            "text": "March 15, 2024",
             "category": "date",
             "propertyNames": [
-              "parameters.event.day"
+              "parameters.event.timeRange.startDateTime.year",
+              "parameters.event.timeRange.startDateTime.month",
+              "parameters.event.timeRange.startDateTime.day",
+              "parameters.event.timeRange.endDateTime.year",
+              "parameters.event.timeRange.endDateTime.month",
+              "parameters.event.timeRange.endDateTime.day"
             ]
           }
         ],
         "propertyAlternatives": [
           {
             "propertyName": "parameters.event.description",
-            "propertyValue": "Get my tires changed",
+            "propertyValue": "get my tires changed",
             "propertySubPhrases": [
               "get my tires changed"
             ],
             "alternatives": [
               {
-                "propertyValue": "Get my oil changed",
+                "propertyValue": "get my oil changed",
                 "propertySubPhrases": [
                   "get my oil changed"
                 ]
               },
               {
-                "propertyValue": "Get my car washed",
+                "propertyValue": "get my brakes checked",
                 "propertySubPhrases": [
-                  "get my car washed"
+                  "get my brakes checked"
                 ]
               },
               {
-                "propertyValue": "Get my brakes checked",
+                "propertyValue": "get my car washed",
                 "propertySubPhrases": [
-                  "get my brakes checked"
+                  "get my car washed"
                 ]
               }
             ]
           },
           {
-            "propertyName": "parameters.event.timeRange.startTime",
-            "propertyValue": "12:00 pm",
+            "propertyName": "parameters.event.timeRange.startDateTime.hms",
+            "propertyValue": "12:00:00",
             "propertySubPhrases": [
               "from 12:00"
             ],
             "alternatives": [
               {
-                "propertyValue": "10:00 am",
+                "propertyValue": "10:00:00",
                 "propertySubPhrases": [
                   "from 10:00"
                 ]
               },
               {
-                "propertyValue": "1:00 pm",
+                "propertyValue": "11:00:00",
                 "propertySubPhrases": [
-                  "from 1:00"
+                  "from 11:00"
                 ]
               },
               {
-                "propertyValue": "3:00 pm",
+                "propertyValue": "13:00:00",
                 "propertySubPhrases": [
-                  "from 3:00"
+                  "from 1:00 pm"
                 ]
               }
             ]
           },
           {
-            "propertyName": "parameters.event.timeRange.endTime",
-            "propertyValue": "2:00 pm",
+            "propertyName": "parameters.event.timeRange.endDateTime.hms",
+            "propertyValue": "14:00:00",
             "propertySubPhrases": [
               "to 2:00 pm"
             ],
             "alternatives": [
               {
-                "propertyValue": "1:00 pm",
-                "propertySubPhrases": [
-                  "to 1:00 pm"
-                ]
-              },
-              {
-                "propertyValue": "3:00 pm",
+                "propertyValue": "15:00:00",
                 "propertySubPhrases": [
                   "to 3:00 pm"
                 ]
               },
               {
-                "propertyValue": "4:00 pm",
+                "propertyValue": "16:00:00",
                 "propertySubPhrases": [
                   "to 4:00 pm"
+                ]
+              },
+              {
+                "propertyValue": "13:00:00",
+                "propertySubPhrases": [
+                  "to 1:00 pm"
                 ]
               }
             ]
           },
           {
-            "propertyName": "parameters.event.day",
-            "propertyValue": "March 15, 2024",
+            "propertyName": "parameters.event.timeRange.startDateTime.year",
+            "propertyValue": "2024",
             "propertySubPhrases": [
-              "on Friday March 15, 2024"
+              "March 15, 2024"
             ],
             "alternatives": [
               {
-                "propertyValue": "March 16, 2024",
+                "propertyValue": "2023",
                 "propertySubPhrases": [
-                  "on Saturday March 16, 2024"
+                  "March 15, 2023"
                 ]
               },
               {
-                "propertyValue": "March 17, 2024",
+                "propertyValue": "2025",
                 "propertySubPhrases": [
-                  "on Sunday March 17, 2024"
+                  "March 15, 2025"
                 ]
               },
               {
-                "propertyValue": "March 18, 2024",
+                "propertyValue": "2022",
                 "propertySubPhrases": [
-                  "on Monday March 18, 2024"
+                  "March 15, 2022"
+                ]
+              }
+            ]
+          },
+          {
+            "propertyName": "parameters.event.timeRange.startDateTime.month",
+            "propertyValue": "March",
+            "propertySubPhrases": [
+              "March 15, 2024"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "April",
+                "propertySubPhrases": [
+                  "April 15, 2024"
+                ]
+              },
+              {
+                "propertyValue": "February",
+                "propertySubPhrases": [
+                  "February 15, 2024"
+                ]
+              },
+              {
+                "propertyValue": "May",
+                "propertySubPhrases": [
+                  "May 15, 2024"
+                ]
+              }
+            ]
+          },
+          {
+            "propertyName": "parameters.event.timeRange.startDateTime.day",
+            "propertyValue": "15",
+            "propertySubPhrases": [
+              "March 15, 2024"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "16",
+                "propertySubPhrases": [
+                  "March 16, 2024"
+                ]
+              },
+              {
+                "propertyValue": "14",
+                "propertySubPhrases": [
+                  "March 14, 2024"
+                ]
+              },
+              {
+                "propertyValue": "17",
+                "propertySubPhrases": [
+                  "March 17, 2024"
+                ]
+              }
+            ]
+          },
+          {
+            "propertyName": "parameters.event.timeRange.endDateTime.year",
+            "propertyValue": "2024",
+            "propertySubPhrases": [
+              "March 15, 2024"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "2023",
+                "propertySubPhrases": [
+                  "March 15, 2023"
+                ]
+              },
+              {
+                "propertyValue": "2025",
+                "propertySubPhrases": [
+                  "March 15, 2025"
+                ]
+              },
+              {
+                "propertyValue": "2022",
+                "propertySubPhrases": [
+                  "March 15, 2022"
+                ]
+              }
+            ]
+          },
+          {
+            "propertyName": "parameters.event.timeRange.endDateTime.month",
+            "propertyValue": "March",
+            "propertySubPhrases": [
+              "March 15, 2024"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "April",
+                "propertySubPhrases": [
+                  "April 15, 2024"
+                ]
+              },
+              {
+                "propertyValue": "February",
+                "propertySubPhrases": [
+                  "February 15, 2024"
+                ]
+              },
+              {
+                "propertyValue": "May",
+                "propertySubPhrases": [
+                  "May 15, 2024"
+                ]
+              }
+            ]
+          },
+          {
+            "propertyName": "parameters.event.timeRange.endDateTime.day",
+            "propertyValue": "15",
+            "propertySubPhrases": [
+              "March 15, 2024"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "16",
+                "propertySubPhrases": [
+                  "March 16, 2024"
+                ]
+              },
+              {
+                "propertyValue": "14",
+                "propertySubPhrases": [
+                  "March 14, 2024"
+                ]
+              },
+              {
+                "propertyValue": "17",
+                "propertySubPhrases": [
+                  "March 17, 2024"
                 ]
               }
             ]
@@ -878,14 +1155,14 @@
         "politePrefixes": [
           "Could you please",
           "Would you mind",
-          "If it's not too much trouble, could you",
-          "May I kindly ask you to"
+          "I would appreciate it if you could",
+          "If possible, could you"
         ],
         "politeSuffixes": [
           "Thank you!",
-          "I would appreciate it.",
-          "Thanks in advance.",
-          "Your help is much appreciated."
+          "Thanks in advance!",
+          "I appreciate your help!",
+          "Your assistance is appreciated!"
         ]
       }
     },
@@ -895,13 +1172,19 @@
         "fullActionName": "calendar.addEvent",
         "parameters": {
           "event": {
-            "day": "1/24/2025",
             "timeRange": {
-              "startTime": "3:30 pm",
-              "duration": "1 hour"
+              "startDateTime": {
+                "day": "17",
+                "hms": "15:30:00"
+              },
+              "endDateTime": {
+                "day": "17",
+                "hms": "16:30:00"
+              }
             },
             "description": "Go to the dry cleaner",
-            "translatedDate": "1/24/2025"
+            "location": "",
+            "participants": []
           }
         }
       },
@@ -913,22 +1196,27 @@
             "substrings": []
           },
           {
-            "name": "parameters.event.day",
-            "value": "1/24/2025",
-            "isImplicit": true
+            "name": "parameters.event.timeRange.startDateTime.day",
+            "value": "17",
+            "substrings": []
           },
           {
-            "name": "parameters.event.timeRange.startTime",
-            "value": "3:30 pm",
+            "name": "parameters.event.timeRange.startDateTime.hms",
+            "value": "15:30:00",
             "substrings": [
               "starting at 3:30"
             ]
           },
           {
-            "name": "parameters.event.timeRange.duration",
-            "value": "1 hour",
+            "name": "parameters.event.timeRange.endDateTime.day",
+            "value": "17",
+            "substrings": []
+          },
+          {
+            "name": "parameters.event.timeRange.endDateTime.hms",
+            "value": "16:30:00",
             "substrings": [
-              "Leave an hour"
+              "Leave an hour for that starting at 3:30"
             ]
           },
           {
@@ -939,9 +1227,9 @@
             ]
           },
           {
-            "name": "parameters.event.translatedDate",
-            "value": "1/24/2025",
-            "isImplicit": true
+            "name": "parameters.event.location",
+            "value": "",
+            "substrings": []
           }
         ],
         "subPhrases": [
@@ -958,27 +1246,11 @@
             "propertyNames": []
           },
           {
-            "text": "Leave an hour",
-            "category": "duration",
+            "text": "Leave an hour for that starting at 3:30",
+            "category": "time",
             "propertyNames": [
-              "parameters.event.timeRange.duration"
-            ]
-          },
-          {
-            "text": "for that",
-            "category": "filler",
-            "synonyms": [
-              "for it",
-              "for the task",
-              "for the event"
-            ],
-            "isOptional": true
-          },
-          {
-            "text": "starting at 3:30",
-            "category": "startTime",
-            "propertyNames": [
-              "parameters.event.timeRange.startTime"
+              "parameters.event.timeRange.startDateTime.hms",
+              "parameters.event.timeRange.endDateTime.hms"
             ]
           }
         ],
@@ -991,75 +1263,75 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "Pick up laundry",
+                "propertyValue": "Visit the dry cleaner",
                 "propertySubPhrases": [
-                  "I need to pick up laundry"
+                  "I need to visit the dry cleaner"
                 ]
               },
               {
-                "propertyValue": "Visit the tailor",
+                "propertyValue": "Drop off clothes at the dry cleaner",
                 "propertySubPhrases": [
-                  "I need to visit the tailor"
+                  "I need to drop off clothes at the dry cleaner"
                 ]
               },
               {
-                "propertyValue": "Drop off clothes",
+                "propertyValue": "Pick up clothes from the dry cleaner",
                 "propertySubPhrases": [
-                  "I need to drop off clothes"
+                  "I need to pick up clothes from the dry cleaner"
                 ]
               }
             ]
           },
           {
-            "propertyName": "parameters.event.timeRange.duration",
-            "propertyValue": "1 hour",
+            "propertyName": "parameters.event.timeRange.startDateTime.hms",
+            "propertyValue": "15:30:00",
             "propertySubPhrases": [
-              "Leave an hour"
+              "Leave an hour for that starting at 3:30"
             ],
             "alternatives": [
               {
-                "propertyValue": "30 minutes",
+                "propertyValue": "14:30:00",
                 "propertySubPhrases": [
-                  "Leave 30 minutes"
+                  "Leave an hour for that starting at 2:30"
                 ]
               },
               {
-                "propertyValue": "2 hours",
+                "propertyValue": "16:00:00",
                 "propertySubPhrases": [
-                  "Leave 2 hours"
+                  "Leave an hour for that starting at 4:00"
                 ]
               },
               {
-                "propertyValue": "45 minutes",
+                "propertyValue": "17:00:00",
                 "propertySubPhrases": [
-                  "Leave 45 minutes"
+                  "Leave an hour for that starting at 5:00"
                 ]
               }
             ]
           },
           {
-            "propertyName": "parameters.event.timeRange.startTime",
-            "propertyValue": "3:30 pm",
+            "propertyName": "parameters.event.timeRange.endDateTime.hms",
+            "propertyValue": "16:30:00",
             "propertySubPhrases": [
-              "starting at 3:30"
+              "Leave an hour for that starting at 3:30"
             ],
             "alternatives": [
               {
-                "propertyValue": "4:00 pm",
+                "propertyValue": "15:30:00",
                 "propertySubPhrases": [
-                  "starting at 4:00"
+                  "Leave an hour for that starting at 2:30"
                 ]
               },
               {
-                "propertyValue": "3:00 pm",
+                "propertyValue": "17:00:00",
                 "propertySubPhrases": [
-                  "starting at 3:00"
+                  "Leave an hour for that starting at 4:00"
                 ]
               },
               {
-                "propertyValue": "2:30 pm",
+                "propertyValue": "18:00:00",
                 "propertySubPhrases": [
-                  "starting at 2:30"
+                  "Leave an hour for that starting at 5:00"
                 ]
               }
             ]
@@ -1068,13 +1340,13 @@
         "politePrefixes": [
           "Could you please",
           "Would you mind",
-          "If it's not too much trouble, could you",
-          "I would appreciate it if you could"
+          "I would appreciate it if you could",
+          "If it's not too much trouble"
         ],
         "politeSuffixes": [
           "Thank you!",
-          "Thanks a lot!",
-          "I appreciate it!",
+          "Thanks in advance!",
+          "I appreciate your help!",
           "Much appreciated!"
         ]
       }
@@ -1085,11 +1357,18 @@
         "fullActionName": "calendar.addEvent",
         "parameters": {
           "event": {
-            "day": "1/24/2025",
             "timeRange": {
-              "startTime": "2:00 pm"
+              "startDateTime": {
+                "day": "17",
+                "hms": "14:00:00"
+              },
+              "endDateTime": {
+                "day": "17",
+                "hms": "15:00:00"
+              }
             },
             "description": "Meeting with Jenny",
+            "location": "",
             "participants": [
               "Jenny"
             ]
@@ -1104,16 +1383,26 @@
             "substrings": []
           },
           {
-            "name": "parameters.event.day",
-            "value": "1/24/2025",
-            "isImplicit": true
+            "name": "parameters.event.timeRange.startDateTime.day",
+            "value": "17",
+            "substrings": []
           },
           {
-            "name": "parameters.event.timeRange.startTime",
-            "value": "2:00 pm",
+            "name": "parameters.event.timeRange.startDateTime.hms",
+            "value": "14:00:00",
             "substrings": [
               "2pm"
             ]
+          },
+          {
+            "name": "parameters.event.timeRange.endDateTime.day",
+            "value": "17",
+            "substrings": []
+          },
+          {
+            "name": "parameters.event.timeRange.endDateTime.hms",
+            "value": "15:00:00",
+            "substrings": []
           },
           {
             "name": "parameters.event.description",
@@ -1121,6 +1410,11 @@
             "substrings": [
               "meet with Jenny"
             ]
+          },
+          {
+            "name": "parameters.event.location",
+            "value": "",
+            "substrings": []
           },
           {
             "name": "parameters.event.participants.0",
@@ -1133,11 +1427,11 @@
         "subPhrases": [
           {
             "text": "I said I'd",
-            "category": "filler",
+            "category": "acknowledgement",
             "synonyms": [
               "I mentioned",
               "I told you",
-              "I stated"
+              "I indicated"
             ],
             "isOptional": true
           },
@@ -1150,9 +1444,9 @@
           },
           {
             "text": "this afternoon",
-            "category": "time reference",
+            "category": "time indication",
             "synonyms": [
-              "today afternoon",
+              "today",
               "later today",
               "in the afternoon"
             ],
@@ -1160,9 +1454,9 @@
           },
           {
             "text": "at 2pm",
-            "category": "time",
+            "category": "start time",
             "propertyNames": [
-              "parameters.event.timeRange.startTime"
+              "parameters.event.timeRange.startDateTime.hms"
             ]
           }
         ],
@@ -1181,42 +1475,42 @@
                 ]
               },
               {
-                "propertyValue": "Appointment with Jenny",
+                "propertyValue": "Catch up with Jenny",
                 "propertySubPhrases": [
-                  "appointment with Jenny"
+                  "catch up with Jenny"
                 ]
               },
               {
-                "propertyValue": "Catch-up with Jenny",
+                "propertyValue": "Appointment with Jenny",
                 "propertySubPhrases": [
-                  "catch-up with Jenny"
+                  "appointment with Jenny"
                 ]
               }
             ]
           },
           {
-            "propertyName": "parameters.event.timeRange.startTime",
-            "propertyValue": "2:00 pm",
+            "propertyName": "parameters.event.timeRange.startDateTime.hms",
+            "propertyValue": "14:00:00",
             "propertySubPhrases": [
               "at 2pm"
             ],
             "alternatives": [
               {
-                "propertyValue": "3:00 pm",
+                "propertyValue": "15:00:00",
                 "propertySubPhrases": [
                   "at 3pm"
                 ]
               },
               {
-                "propertyValue": "4:00 pm",
+                "propertyValue": "13:00:00",
                 "propertySubPhrases": [
-                  "at 4pm"
+                  "at 1pm"
                 ]
               },
               {
-                "propertyValue": "1:00 pm",
+                "propertyValue": "16:00:00",
                 "propertySubPhrases": [
-                  "at 1pm"
+                  "at 4pm"
                 ]
               }
             ]
@@ -1225,14 +1519,116 @@
         "politePrefixes": [
           "Could you please",
           "Would you mind",
-          "If it's not too much trouble, could you"
+          "I would appreciate it if you could",
+          "If it's not too much trouble"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it.",
-          "Thanks in advance!"
+          "Thank you",
+          "Thanks in advance",
+          "I appreciate your help",
+          "Much appreciated"
         ]
-      }
+      },
+      "corrections": [
+        {
+          "data": {
+            "properties": [
+              {
+                "name": "fullActionName",
+                "value": "calendar.addEvent",
+                "substrings": []
+              },
+              {
+                "name": "parameters.event.timeRange.startDateTime.day",
+                "value": "17",
+                "substrings": []
+              },
+              {
+                "name": "parameters.event.timeRange.startDateTime.hms",
+                "value": "14:00:00",
+                "substrings": [
+                  "2pm"
+                ]
+              },
+              {
+                "name": "parameters.event.timeRange.endDateTime.day",
+                "value": "17",
+                "substrings": []
+              },
+              {
+                "name": "parameters.event.timeRange.endDateTime.hms",
+                "value": "15:00:00",
+                "substrings": []
+              },
+              {
+                "name": "parameters.event.description",
+                "value": "Meeting with Jenny",
+                "substrings": [
+                  "meet with Jenny"
+                ]
+              },
+              {
+                "name": "parameters.event.location",
+                "value": "",
+                "substrings": []
+              },
+              {
+                "name": "parameters.event.participants.0",
+                "value": "Jenny",
+                "substrings": [
+                  "Jenny"
+                ]
+              }
+            ],
+            "subPhrases": [
+              {
+                "text": "I said I'd",
+                "category": "acknowledgement",
+                "synonyms": [
+                  "I mentioned",
+                  "I told you",
+                  "I indicated"
+                ],
+                "isOptional": true
+              },
+              {
+                "text": "meet with Jenny",
+                "category": "event description",
+                "propertyNames": [
+                  "parameters.event.description"
+                ]
+              },
+              {
+                "text": "Jenny",
+                "category": "participant",
+                "propertyNames": [
+                  "parameters.event.participants.0"
+                ]
+              },
+              {
+                "text": "this afternoon",
+                "category": "time indication",
+                "synonyms": [
+                  "today",
+                  "later today",
+                  "in the afternoon"
+                ],
+                "isOptional": true
+              },
+              {
+                "text": "at 2pm",
+                "category": "start time",
+                "propertyNames": [
+                  "parameters.event.timeRange.startDateTime.hms"
+                ]
+              }
+            ]
+          },
+          "correction": [
+            "Overlapping sub-phrase: explanation has overlapping text 'Jenny'."
+          ]
+        }
+      ]
     },
     {
       "request": "make sure to schedule an appointment with Sally, May, and Boris tomorrow at 3pm.",
@@ -1240,9 +1636,15 @@
         "fullActionName": "calendar.addEvent",
         "parameters": {
           "event": {
-            "day": "1/25/2025",
             "timeRange": {
-              "startTime": "3:00 pm"
+              "startDateTime": {
+                "day": "+1d",
+                "hms": "15:00:00"
+              },
+              "endDateTime": {
+                "day": "+1d",
+                "hms": "15:00:00"
+              }
             },
             "description": "appointment",
             "participants": [
@@ -1258,16 +1660,34 @@
           {
             "name": "fullActionName",
             "value": "calendar.addEvent",
-            "isImplicit": true
+            "substrings": [
+              "make sure to schedule an appointment"
+            ]
           },
           {
-            "name": "parameters.event.day",
-            "value": "1/25/2025",
-            "isImplicit": true
+            "name": "parameters.event.timeRange.startDateTime.day",
+            "value": "+1d",
+            "substrings": [
+              "tomorrow"
+            ]
           },
           {
-            "name": "parameters.event.timeRange.startTime",
-            "value": "3:00 pm",
+            "name": "parameters.event.timeRange.startDateTime.hms",
+            "value": "15:00:00",
+            "substrings": [
+              "3pm"
+            ]
+          },
+          {
+            "name": "parameters.event.timeRange.endDateTime.day",
+            "value": "+1d",
+            "substrings": [
+              "tomorrow"
+            ]
+          },
+          {
+            "name": "parameters.event.timeRange.endDateTime.hms",
+            "value": "15:00:00",
             "substrings": [
               "3pm"
             ]
@@ -1276,7 +1696,7 @@
             "name": "parameters.event.description",
             "value": "appointment",
             "substrings": [
-              "an appointment"
+              "appointment"
             ]
           },
           {
@@ -1308,68 +1728,80 @@
             "synonyms": [
               "please",
               "kindly",
-              "ensure"
+              "ensure",
+              "be sure to"
             ],
             "isOptional": true
           },
           {
-            "text": "schedule",
+            "text": "schedule an appointment",
             "category": "action",
-            "propertyNames": []
-          },
-          {
-            "text": "an appointment",
-            "category": "description",
             "propertyNames": [
-              "parameters.event.description"
+              "fullActionName"
             ]
           },
           {
-            "text": "with Sally, May, and Boris",
-            "category": "participants",
+            "text": "with Sally",
+            "category": "participant",
             "propertyNames": [
-              "parameters.event.participants.0",
-              "parameters.event.participants.1",
+              "parameters.event.participants.0"
+            ]
+          },
+          {
+            "text": "May",
+            "category": "participant",
+            "propertyNames": [
+              "parameters.event.participants.1"
+            ]
+          },
+          {
+            "text": "and Boris",
+            "category": "participant",
+            "propertyNames": [
               "parameters.event.participants.2"
             ]
           },
           {
             "text": "tomorrow",
-            "category": "day",
-            "propertyNames": []
+            "category": "time",
+            "propertyNames": [
+              "parameters.event.timeRange.startDateTime.day",
+              "parameters.event.timeRange.endDateTime.day"
+            ]
           },
           {
             "text": "at 3pm",
             "category": "time",
             "propertyNames": [
-              "parameters.event.timeRange.startTime"
+              "parameters.event.timeRange.startDateTime.hms",
+              "parameters.event.timeRange.endDateTime.hms"
             ]
           }
         ],
         "propertyAlternatives": [
           {
-            "propertyName": "parameters.event.description",
-            "propertyValue": "appointment",
+            "propertyName": "fullActionName",
+            "propertyValue": "calendar.addEvent",
             "propertySubPhrases": [
-              "an appointment"
+              "schedule an appointment"
             ],
             "alternatives": [
               {
-                "propertyValue": "meeting",
+                "propertyValue": "calendar.createMeeting",
                 "propertySubPhrases": [
-                  "a meeting"
+                  "schedule a meeting"
                 ]
               },
               {
-                "propertyValue": "consultation",
+                "propertyValue": "calendar.setReminder",
                 "propertySubPhrases": [
-                  "a consultation"
+                  "set a reminder"
                 ]
               },
               {
-                "propertyValue": "discussion",
+                "propertyValue": "calendar.bookEvent",
                 "propertySubPhrases": [
-                  "a discussion"
+                  "book an event"
                 ]
               }
             ]
@@ -1378,25 +1810,25 @@
             "propertyName": "parameters.event.participants.0",
             "propertyValue": "Sally",
             "propertySubPhrases": [
-              "with Sally, May, and Boris"
+              "with Sally"
             ],
             "alternatives": [
               {
                 "propertyValue": "Alice",
                 "propertySubPhrases": [
-                  "with Alice, May, and Boris"
+                  "with Alice"
                 ]
               },
               {
                 "propertyValue": "John",
                 "propertySubPhrases": [
-                  "with John, May, and Boris"
+                  "with John"
                 ]
               },
               {
                 "propertyValue": "Emma",
                 "propertySubPhrases": [
-                  "with Emma, May, and Boris"
+                  "with Emma"
                 ]
               }
             ]
@@ -1405,25 +1837,25 @@
             "propertyName": "parameters.event.participants.1",
             "propertyValue": "May",
             "propertySubPhrases": [
-              "with Sally, May, and Boris"
+              "May"
             ],
             "alternatives": [
               {
-                "propertyValue": "Jane",
+                "propertyValue": "June",
                 "propertySubPhrases": [
-                  "with Sally, Jane, and Boris"
+                  "June"
                 ]
               },
               {
-                "propertyValue": "Tom",
+                "propertyValue": "April",
                 "propertySubPhrases": [
-                  "with Sally, Tom, and Boris"
+                  "April"
                 ]
               },
               {
-                "propertyValue": "Chris",
+                "propertyValue": "July",
                 "propertySubPhrases": [
-                  "with Sally, Chris, and Boris"
+                  "July"
                 ]
               }
             ]
@@ -1432,52 +1864,133 @@
             "propertyName": "parameters.event.participants.2",
             "propertyValue": "Boris",
             "propertySubPhrases": [
-              "with Sally, May, and Boris"
+              "and Boris"
             ],
             "alternatives": [
               {
-                "propertyValue": "David",
+                "propertyValue": "Tom",
                 "propertySubPhrases": [
-                  "with Sally, May, and David"
+                  "and Tom"
                 ]
               },
               {
-                "propertyValue": "Nina",
+                "propertyValue": "Jerry",
                 "propertySubPhrases": [
-                  "with Sally, May, and Nina"
+                  "and Jerry"
                 ]
               },
               {
-                "propertyValue": "Paul",
+                "propertyValue": "Sam",
                 "propertySubPhrases": [
-                  "with Sally, May, and Paul"
+                  "and Sam"
                 ]
               }
             ]
           },
           {
-            "propertyName": "parameters.event.timeRange.startTime",
-            "propertyValue": "3:00 pm",
+            "propertyName": "parameters.event.timeRange.startDateTime.day",
+            "propertyValue": "+1d",
+            "propertySubPhrases": [
+              "tomorrow"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "+2d",
+                "propertySubPhrases": [
+                  "the day after tomorrow"
+                ]
+              },
+              {
+                "propertyValue": "+3d",
+                "propertySubPhrases": [
+                  "in three days"
+                ]
+              },
+              {
+                "propertyValue": "+7d",
+                "propertySubPhrases": [
+                  "next week"
+                ]
+              }
+            ]
+          },
+          {
+            "propertyName": "parameters.event.timeRange.endDateTime.day",
+            "propertyValue": "+1d",
+            "propertySubPhrases": [
+              "tomorrow"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "+2d",
+                "propertySubPhrases": [
+                  "the day after tomorrow"
+                ]
+              },
+              {
+                "propertyValue": "+3d",
+                "propertySubPhrases": [
+                  "in three days"
+                ]
+              },
+              {
+                "propertyValue": "+7d",
+                "propertySubPhrases": [
+                  "next week"
+                ]
+              }
+            ]
+          },
+          {
+            "propertyName": "parameters.event.timeRange.startDateTime.hms",
+            "propertyValue": "15:00:00",
             "propertySubPhrases": [
               "at 3pm"
             ],
             "alternatives": [
               {
-                "propertyValue": "4:00 pm",
-                "propertySubPhrases": [
-                  "at 4pm"
-                ]
-              },
-              {
-                "propertyValue": "2:00 pm",
+                "propertyValue": "14:00:00",
                 "propertySubPhrases": [
                   "at 2pm"
                 ]
               },
               {
-                "propertyValue": "5:00 pm",
+                "propertyValue": "16:00:00",
                 "propertySubPhrases": [
-                  "at 5pm"
+                  "at 4pm"
+                ]
+              },
+              {
+                "propertyValue": "10:00:00",
+                "propertySubPhrases": [
+                  "at 10am"
+                ]
+              }
+            ]
+          },
+          {
+            "propertyName": "parameters.event.timeRange.endDateTime.hms",
+            "propertyValue": "15:00:00",
+            "propertySubPhrases": [
+              "at 3pm"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "14:00:00",
+                "propertySubPhrases": [
+                  "at 2pm"
+                ]
+              },
+              {
+                "propertyValue": "16:00:00",
+                "propertySubPhrases": [
+                  "at 4pm"
+                ]
+              },
+              {
+                "propertyValue": "10:00:00",
+                "propertySubPhrases": [
+                  "at 10am"
                 ]
               }
             ]
@@ -1486,169 +1999,16 @@
         "politePrefixes": [
           "Could you please",
           "Would you mind",
-          "If it's not too much trouble, could you"
+          "If you could",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you!",
+          "Thank you.",
           "I would appreciate it.",
-          "Thanks in advance!"
+          "Thanks in advance.",
+          "That would be great."
         ]
-      },
-      "corrections": [
-        {
-          "data": {
-            "properties": [
-              {
-                "name": "fullActionName",
-                "value": "calendar.addEvent",
-                "isImplicit": true
-              },
-              {
-                "name": "parameters.event.timeRange.startTime",
-                "value": "3:00 pm",
-                "substrings": [
-                  "3pm"
-                ]
-              },
-              {
-                "name": "parameters.event.description",
-                "value": "appointment",
-                "substrings": [
-                  "an appointment"
-                ]
-              },
-              {
-                "name": "parameters.event.participants.0",
-                "value": "Sally",
-                "substrings": [
-                  "Sally"
-                ]
-              },
-              {
-                "name": "parameters.event.participants.1",
-                "value": "May",
-                "substrings": [
-                  "May"
-                ]
-              },
-              {
-                "name": "parameters.event.participants.2",
-                "value": "Boris",
-                "substrings": [
-                  "Boris"
-                ]
-              }
-            ]
-          },
-          "correction": [
-            "Missing parameter: parameter 'parameters.event.day' in the action is missing from explanation"
-          ]
-        },
-        {
-          "data": {
-            "properties": [
-              {
-                "name": "fullActionName",
-                "value": "calendar.addEvent",
-                "isImplicit": true
-              },
-              {
-                "name": "parameters.event.day",
-                "value": "1/25/2025",
-                "isImplicit": true
-              },
-              {
-                "name": "parameters.event.timeRange.startTime",
-                "value": "3:00 pm",
-                "substrings": [
-                  "3pm"
-                ]
-              },
-              {
-                "name": "parameters.event.description",
-                "value": "appointment",
-                "substrings": [
-                  "an appointment"
-                ]
-              },
-              {
-                "name": "parameters.event.participants.0",
-                "value": "Sally",
-                "substrings": [
-                  "Sally"
-                ]
-              },
-              {
-                "name": "parameters.event.participants.1",
-                "value": "May",
-                "substrings": [
-                  "May"
-                ]
-              },
-              {
-                "name": "parameters.event.participants.2",
-                "value": "Boris",
-                "substrings": [
-                  "Boris"
-                ]
-              }
-            ],
-            "subPhrases": [
-              {
-                "text": "make sure to",
-                "category": "politeness",
-                "synonyms": [
-                  "please",
-                  "kindly",
-                  "ensure"
-                ],
-                "isOptional": true
-              },
-              {
-                "text": "schedule",
-                "category": "action",
-                "propertyNames": [
-                  "fullActionName"
-                ]
-              },
-              {
-                "text": "an appointment",
-                "category": "description",
-                "propertyNames": [
-                  "parameters.event.description"
-                ]
-              },
-              {
-                "text": "with Sally, May, and Boris",
-                "category": "participants",
-                "propertyNames": [
-                  "parameters.event.participants.0",
-                  "parameters.event.participants.1",
-                  "parameters.event.participants.2"
-                ]
-              },
-              {
-                "text": "tomorrow",
-                "category": "day",
-                "propertyNames": [
-                  "parameters.event.day"
-                ]
-              },
-              {
-                "text": "at 3pm",
-                "category": "time",
-                "propertyNames": [
-                  "parameters.event.timeRange.startTime"
-                ]
-              }
-            ]
-          },
-          "correction": [
-            "Property 'fullActionName' is expected to be implicit and should not be included as a property name in a sub-phrase",
-            "Property 'parameters.event.day' is expected to be implicit and should not be included as a property name in a sub-phrase"
-          ]
-        }
-      ]
+      }
     },
     {
       "request": "Now just add  Jesse and Abby to the appointment with Sally",
@@ -1656,8 +2016,8 @@
         "fullActionName": "calendar.addParticipants",
         "parameters": {
           "eventReference": {
-            "description": "appointment with Sally",
-            "lookup": true
+            "lookup": true,
+            "description": "appointment with Sally"
           },
           "participants": [
             "Jesse",
@@ -1675,16 +2035,16 @@
             ]
           },
           {
+            "name": "parameters.eventReference.lookup",
+            "value": true,
+            "isImplicit": true
+          },
+          {
             "name": "parameters.eventReference.description",
             "value": "appointment with Sally",
             "substrings": [
               "appointment with Sally"
             ]
-          },
-          {
-            "name": "parameters.eventReference.lookup",
-            "value": true,
-            "isImplicit": true
           },
           {
             "name": "parameters.participants.0",
@@ -1706,9 +2066,10 @@
             "text": "Now just",
             "category": "filler",
             "synonyms": [
-              "Right now",
-              "At this moment",
-              "Currently"
+              "right now",
+              "simply",
+              "at this moment",
+              "currently"
             ],
             "isOptional": true
           },
@@ -1770,21 +2131,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "calendar.inviteParticipants",
+                "propertyValue": "calendar.scheduleMeeting",
                 "propertySubPhrases": [
-                  "invite"
+                  "schedule"
                 ]
               },
               {
-                "propertyValue": "calendar.includeParticipants",
+                "propertyValue": "calendar.createEvent",
                 "propertySubPhrases": [
-                  "include"
+                  "create"
                 ]
               },
               {
-                "propertyValue": "calendar.addAttendees",
+                "propertyValue": "calendar.updateEvent",
                 "propertySubPhrases": [
-                  "add attendees"
+                  "update"
                 ]
               }
             ]
@@ -1803,15 +2164,15 @@
                 ]
               },
               {
-                "propertyValue": "James",
+                "propertyValue": "Michael",
                 "propertySubPhrases": [
-                  "James"
+                  "Michael"
                 ]
               },
               {
-                "propertyValue": "Jordan",
+                "propertyValue": "David",
                 "propertySubPhrases": [
-                  "Jordan"
+                  "David"
                 ]
               }
             ]
@@ -1824,21 +2185,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "Alice",
+                "propertyValue": "Emily",
                 "propertySubPhrases": [
-                  "Alice"
+                  "Emily"
                 ]
               },
               {
-                "propertyValue": "Anna",
+                "propertyValue": "Sophia",
                 "propertySubPhrases": [
-                  "Anna"
+                  "Sophia"
                 ]
               },
               {
-                "propertyValue": "Amy",
+                "propertyValue": "Olivia",
                 "propertySubPhrases": [
-                  "Amy"
+                  "Olivia"
                 ]
               }
             ]
@@ -1857,15 +2218,15 @@
                 ]
               },
               {
-                "propertyValue": "appointment with Sarah",
+                "propertyValue": "call with Sally",
                 "propertySubPhrases": [
-                  "appointment with Sarah"
+                  "call with Sally"
                 ]
               },
               {
-                "propertyValue": "appointment with Sam",
+                "propertyValue": "discussion with Sally",
                 "propertySubPhrases": [
-                  "appointment with Sam"
+                  "discussion with Sally"
                 ]
               }
             ]
@@ -1874,12 +2235,14 @@
         "politePrefixes": [
           "Could you please",
           "Would you mind",
-          "If it's not too much trouble, could you"
+          "If you don't mind",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it.",
-          "Thanks a lot!"
+          "Thank you",
+          "Thanks",
+          "I appreciate it",
+          "If that's okay"
         ]
       }
     },
@@ -1889,12 +2252,19 @@
         "fullActionName": "calendar.addEvent",
         "parameters": {
           "event": {
-            "day": "January 24",
             "timeRange": {
-              "startTime": "6:00 pm"
+              "startDateTime": {
+                "day": "Friday",
+                "hms": "18:00:00"
+              },
+              "endDateTime": {
+                "day": "Friday",
+                "hms": "18:00:00"
+              }
             },
             "description": "Jeffs pizza party",
-            "translatedDate": "1/24/2025"
+            "location": "",
+            "participants": []
           }
         }
       },
@@ -1903,18 +2273,34 @@
           {
             "name": "fullActionName",
             "value": "calendar.addEvent",
-            "substrings": []
+            "substrings": [
+              "Set up an event"
+            ]
           },
           {
-            "name": "parameters.event.day",
-            "value": "January 24",
+            "name": "parameters.event.timeRange.startDateTime.day",
+            "value": "Friday",
             "substrings": [
               "friday"
             ]
           },
           {
-            "name": "parameters.event.timeRange.startTime",
-            "value": "6:00 pm",
+            "name": "parameters.event.timeRange.startDateTime.hms",
+            "value": "18:00:00",
+            "substrings": [
+              "6pm"
+            ]
+          },
+          {
+            "name": "parameters.event.timeRange.endDateTime.day",
+            "value": "Friday",
+            "substrings": [
+              "friday"
+            ]
+          },
+          {
+            "name": "parameters.event.timeRange.endDateTime.hms",
+            "value": "18:00:00",
             "substrings": [
               "6pm"
             ]
@@ -1927,58 +2313,40 @@
             ]
           },
           {
-            "name": "parameters.event.translatedDate",
-            "value": "1/24/2025",
-            "substrings": []
+            "name": "parameters.event.location",
+            "value": "",
+            "isImplicit": true
           }
         ],
         "subPhrases": [
           {
-            "text": "Set up an event for",
+            "text": "Set up an event",
             "category": "action",
             "propertyNames": [
               "fullActionName"
             ]
           },
           {
-            "text": "friday",
+            "text": "for friday",
             "category": "date",
             "propertyNames": [
-              "parameters.event.day"
+              "parameters.event.timeRange.startDateTime.day",
+              "parameters.event.timeRange.endDateTime.day"
             ]
           },
           {
-            "text": "named",
-            "category": "preposition",
-            "synonyms": [
-              "called",
-              "titled",
-              "labelled"
-            ],
-            "isOptional": true
-          },
-          {
-            "text": "Jeffs pizza party",
+            "text": "named Jeffs pizza party",
             "category": "description",
             "propertyNames": [
               "parameters.event.description"
             ]
           },
           {
-            "text": "at",
-            "category": "preposition",
-            "synonyms": [
-              "on",
-              "during",
-              "around"
-            ],
-            "isOptional": true
-          },
-          {
-            "text": "6pm",
+            "text": "at 6pm",
             "category": "time",
             "propertyNames": [
-              "parameters.event.timeRange.startTime"
+              "parameters.event.timeRange.startDateTime.hms",
+              "parameters.event.timeRange.endDateTime.hms"
             ]
           }
         ],
@@ -1987,52 +2355,79 @@
             "propertyName": "fullActionName",
             "propertyValue": "calendar.addEvent",
             "propertySubPhrases": [
-              "Set up an event for"
+              "Set up an event"
             ],
             "alternatives": [
               {
-                "propertyValue": "calendar.scheduleEvent",
+                "propertyValue": "calendar.scheduleMeeting",
                 "propertySubPhrases": [
-                  "Schedule an event for"
+                  "Schedule a meeting"
                 ]
               },
               {
-                "propertyValue": "calendar.createEvent",
+                "propertyValue": "calendar.createAppointment",
                 "propertySubPhrases": [
-                  "Create an event for"
+                  "Create an appointment"
                 ]
               },
               {
-                "propertyValue": "calendar.planEvent",
+                "propertyValue": "calendar.bookEvent",
                 "propertySubPhrases": [
-                  "Plan an event for"
+                  "Book an event"
                 ]
               }
             ]
           },
           {
-            "propertyName": "parameters.event.day",
-            "propertyValue": "January 24",
+            "propertyName": "parameters.event.timeRange.startDateTime.day",
+            "propertyValue": "Friday",
             "propertySubPhrases": [
-              "friday"
+              "for friday"
             ],
             "alternatives": [
               {
-                "propertyValue": "January 25",
+                "propertyValue": "Monday",
                 "propertySubPhrases": [
-                  "saturday"
+                  "for monday"
                 ]
               },
               {
-                "propertyValue": "January 26",
+                "propertyValue": "Wednesday",
                 "propertySubPhrases": [
-                  "sunday"
+                  "for wednesday"
                 ]
               },
               {
-                "propertyValue": "January 27",
+                "propertyValue": "Sunday",
                 "propertySubPhrases": [
-                  "monday"
+                  "for sunday"
+                ]
+              }
+            ]
+          },
+          {
+            "propertyName": "parameters.event.timeRange.endDateTime.day",
+            "propertyValue": "Friday",
+            "propertySubPhrases": [
+              "for friday"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "Monday",
+                "propertySubPhrases": [
+                  "for monday"
+                ]
+              },
+              {
+                "propertyValue": "Wednesday",
+                "propertySubPhrases": [
+                  "for wednesday"
+                ]
+              },
+              {
+                "propertyValue": "Sunday",
+                "propertySubPhrases": [
+                  "for sunday"
                 ]
               }
             ]
@@ -2041,52 +2436,79 @@
             "propertyName": "parameters.event.description",
             "propertyValue": "Jeffs pizza party",
             "propertySubPhrases": [
-              "Jeffs pizza party"
+              "named Jeffs pizza party"
             ],
             "alternatives": [
               {
-                "propertyValue": "Jeffs birthday party",
+                "propertyValue": "Jeffs birthday bash",
                 "propertySubPhrases": [
-                  "Jeffs birthday party"
+                  "named Jeffs birthday bash"
                 ]
               },
               {
-                "propertyValue": "Jeffs graduation party",
+                "propertyValue": "Office pizza party",
                 "propertySubPhrases": [
-                  "Jeffs graduation party"
+                  "named Office pizza party"
                 ]
               },
               {
-                "propertyValue": "Jeffs farewell party",
+                "propertyValue": "Family pizza night",
                 "propertySubPhrases": [
-                  "Jeffs farewell party"
+                  "named Family pizza night"
                 ]
               }
             ]
           },
           {
-            "propertyName": "parameters.event.timeRange.startTime",
-            "propertyValue": "6:00 pm",
+            "propertyName": "parameters.event.timeRange.startDateTime.hms",
+            "propertyValue": "18:00:00",
             "propertySubPhrases": [
-              "6pm"
+              "at 6pm"
             ],
             "alternatives": [
               {
-                "propertyValue": "7:00 pm",
+                "propertyValue": "19:00:00",
                 "propertySubPhrases": [
-                  "7pm"
+                  "at 7pm"
                 ]
               },
               {
-                "propertyValue": "8:00 pm",
+                "propertyValue": "20:00:00",
                 "propertySubPhrases": [
-                  "8pm"
+                  "at 8pm"
                 ]
               },
               {
-                "propertyValue": "5:00 pm",
+                "propertyValue": "17:00:00",
                 "propertySubPhrases": [
-                  "5pm"
+                  "at 5pm"
+                ]
+              }
+            ]
+          },
+          {
+            "propertyName": "parameters.event.timeRange.endDateTime.hms",
+            "propertyValue": "18:00:00",
+            "propertySubPhrases": [
+              "at 6pm"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "19:00:00",
+                "propertySubPhrases": [
+                  "at 7pm"
+                ]
+              },
+              {
+                "propertyValue": "20:00:00",
+                "propertySubPhrases": [
+                  "at 8pm"
+                ]
+              },
+              {
+                "propertyValue": "17:00:00",
+                "propertySubPhrases": [
+                  "at 5pm"
                 ]
               }
             ]
@@ -2095,12 +2517,14 @@
         "politePrefixes": [
           "Could you please",
           "Would you mind",
-          "If it's not too much trouble, could you"
+          "I would appreciate it if you could",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it.",
-          "Thanks in advance!"
+          "Thank you",
+          "Thanks in advance",
+          "I appreciate your help",
+          "If you could do this, that would be great"
         ]
       }
     },
@@ -2110,10 +2534,12 @@
         "fullActionName": "calendar.addEvent",
         "parameters": {
           "event": {
-            "day": "1/24/2025",
             "timeRange": {
-              "startTime": "9:00 am",
-              "duration": "2 hours"
+              "startDateTime": {
+                "day": "17",
+                "hms": "09:00:00"
+              },
+              "duration": "2:00:00"
             },
             "description": "appointment",
             "participants": [
@@ -2128,24 +2554,24 @@
             "name": "fullActionName",
             "value": "calendar.addEvent",
             "substrings": [
-              "Will you please add"
+              "Will you please add an appointment"
             ]
           },
           {
-            "name": "parameters.event.day",
-            "value": "1/24/2025",
-            "isImplicit": true
+            "name": "parameters.event.timeRange.startDateTime.day",
+            "value": "17",
+            "substrings": []
           },
           {
-            "name": "parameters.event.timeRange.startTime",
-            "value": "9:00 am",
+            "name": "parameters.event.timeRange.startDateTime.hms",
+            "value": "09:00:00",
             "substrings": [
               "at 9 am"
             ]
           },
           {
             "name": "parameters.event.timeRange.duration",
-            "value": "2 hours",
+            "value": "2:00:00",
             "substrings": [
               "last 2 hours"
             ]
@@ -2167,21 +2593,20 @@
         ],
         "subPhrases": [
           {
-            "text": "Will you please add",
+            "text": "Will you please",
             "category": "politeness",
-            "propertyNames": [
-              "fullActionName"
-            ],
             "synonyms": [
-              "Can you add",
-              "Could you please add",
-              "Would you add"
-            ]
+              "Could you please",
+              "Would you mind",
+              "Can you please"
+            ],
+            "isOptional": true
           },
           {
-            "text": "an appointment",
-            "category": "description",
+            "text": "add an appointment",
+            "category": "action",
             "propertyNames": [
+              "fullActionName",
               "parameters.event.description"
             ]
           },
@@ -2196,7 +2621,7 @@
             "text": "at 9 am",
             "category": "time",
             "propertyNames": [
-              "parameters.event.timeRange.startTime"
+              "parameters.event.timeRange.startDateTime.hms"
             ]
           },
           {
@@ -2212,25 +2637,25 @@
             "propertyName": "fullActionName",
             "propertyValue": "calendar.addEvent",
             "propertySubPhrases": [
-              "Will you please add"
+              "add an appointment"
             ],
             "alternatives": [
               {
+                "propertyValue": "calendar.scheduleMeeting",
+                "propertySubPhrases": [
+                  "schedule a meeting"
+                ]
+              },
+              {
                 "propertyValue": "calendar.createEvent",
                 "propertySubPhrases": [
-                  "Can you create"
+                  "create an event"
                 ]
               },
               {
-                "propertyValue": "calendar.scheduleEvent",
+                "propertyValue": "calendar.bookAppointment",
                 "propertySubPhrases": [
-                  "Please schedule"
-                ]
-              },
-              {
-                "propertyValue": "calendar.insertEvent",
-                "propertySubPhrases": [
-                  "Insert"
+                  "book an appointment"
                 ]
               }
             ]
@@ -2239,25 +2664,25 @@
             "propertyName": "parameters.event.description",
             "propertyValue": "appointment",
             "propertySubPhrases": [
-              "an appointment"
+              "add an appointment"
             ],
             "alternatives": [
               {
                 "propertyValue": "meeting",
                 "propertySubPhrases": [
-                  "a meeting"
+                  "schedule a meeting"
+                ]
+              },
+              {
+                "propertyValue": "event",
+                "propertySubPhrases": [
+                  "create an event"
                 ]
               },
               {
                 "propertyValue": "call",
                 "propertySubPhrases": [
-                  "a call"
-                ]
-              },
-              {
-                "propertyValue": "discussion",
-                "propertySubPhrases": [
-                  "a discussion"
+                  "set up a call"
                 ]
               }
             ]
@@ -2270,46 +2695,46 @@
             ],
             "alternatives": [
               {
+                "propertyValue": "John Doe",
+                "propertySubPhrases": [
+                  "with John Doe"
+                ]
+              },
+              {
+                "propertyValue": "Jane Smith",
+                "propertySubPhrases": [
+                  "with Jane Smith"
+                ]
+              },
+              {
                 "propertyValue": "Alex Johnson",
                 "propertySubPhrases": [
                   "with Alex Johnson"
-                ]
-              },
-              {
-                "propertyValue": "Taylor Smith",
-                "propertySubPhrases": [
-                  "with Taylor Smith"
-                ]
-              },
-              {
-                "propertyValue": "Jordan Lee",
-                "propertySubPhrases": [
-                  "with Jordan Lee"
                 ]
               }
             ]
           },
           {
-            "propertyName": "parameters.event.timeRange.startTime",
-            "propertyValue": "9:00 am",
+            "propertyName": "parameters.event.timeRange.startDateTime.hms",
+            "propertyValue": "09:00:00",
             "propertySubPhrases": [
               "at 9 am"
             ],
             "alternatives": [
               {
-                "propertyValue": "10:00 am",
+                "propertyValue": "10:00:00",
                 "propertySubPhrases": [
                   "at 10 am"
                 ]
               },
               {
-                "propertyValue": "11:00 am",
+                "propertyValue": "11:00:00",
                 "propertySubPhrases": [
                   "at 11 am"
                 ]
               },
               {
-                "propertyValue": "8:00 am",
+                "propertyValue": "08:00:00",
                 "propertySubPhrases": [
                   "at 8 am"
                 ]
@@ -2318,81 +2743,45 @@
           },
           {
             "propertyName": "parameters.event.timeRange.duration",
-            "propertyValue": "2 hours",
+            "propertyValue": "2:00:00",
             "propertySubPhrases": [
               "I need it to last 2 hours"
             ],
             "alternatives": [
               {
-                "propertyValue": "1 hour",
+                "propertyValue": "1:00:00",
                 "propertySubPhrases": [
                   "I need it to last 1 hour"
                 ]
               },
               {
-                "propertyValue": "3 hours",
+                "propertyValue": "3:00:00",
                 "propertySubPhrases": [
                   "I need it to last 3 hours"
                 ]
               },
               {
-                "propertyValue": "30 minutes",
+                "propertyValue": "4:00:00",
                 "propertySubPhrases": [
-                  "I need it to last 30 minutes"
+                  "I need it to last 4 hours"
                 ]
               }
             ]
           }
         ],
-        "politePrefixes": [],
-        "politeSuffixes": []
-      },
-      "corrections": [
-        {
-          "data": {
-            "properties": [
-              {
-                "name": "fullActionName",
-                "value": "calendar.addEvent",
-                "substrings": [
-                  "Will you please add"
-                ]
-              },
-              {
-                "name": "parameters.event.timeRange.startTime",
-                "value": "9:00 am",
-                "substrings": [
-                  "at 9 am"
-                ]
-              },
-              {
-                "name": "parameters.event.timeRange.duration",
-                "value": "2 hours",
-                "substrings": [
-                  "last 2 hours"
-                ]
-              },
-              {
-                "name": "parameters.event.description",
-                "value": "appointment",
-                "substrings": [
-                  "add an appointment"
-                ]
-              },
-              {
-                "name": "parameters.event.participants.0",
-                "value": "Jerri Skinner",
-                "substrings": [
-                  "with Jerri Skinner"
-                ]
-              }
-            ]
-          },
-          "correction": [
-            "Missing parameter: parameter 'parameters.event.day' in the action is missing from explanation"
-          ]
-        }
-      ]
+        "politePrefixes": [
+          "Could you kindly",
+          "Would you be so kind",
+          "May I request",
+          "If you don't mind"
+        ],
+        "politeSuffixes": [
+          "Thank you very much.",
+          "I would appreciate it.",
+          "Thanks in advance.",
+          "Your help is appreciated."
+        ]
+      }
     }
   ]
 }

--- a/ts/packages/defaultAgentProvider/test/data/explanations/calendar/v5/simple.json
+++ b/ts/packages/defaultAgentProvider/test/data/explanations/calendar/v5/simple.json
@@ -1,7 +1,7 @@
 {
   "version": 2,
   "schemaName": "calendar",
-  "sourceHash": "q89odXmST8U5DeqvXQL7XAkaPw0Efxj2FT391Xq3Vis=",
+  "sourceHash": "0eh5kxCn5ytPu5T9xJ+Tk3xs547AP5ncz7uiQ5mu1Lo=",
   "explainerName": "v5",
   "entries": [
     {
@@ -10,12 +10,19 @@
         "fullActionName": "calendar.addEvent",
         "parameters": {
           "event": {
-            "day": "January 30",
             "timeRange": {
-              "startTime": "3:00 pm",
-              "endTime": "4:00 pm"
+              "startDateTime": {
+                "day": "+4d",
+                "hms": "15:00:00"
+              },
+              "endDateTime": {
+                "day": "+4d",
+                "hms": "16:00:00"
+              }
             },
-            "description": "dentist appointment"
+            "description": "dentist appointment",
+            "location": "",
+            "participants": []
           }
         }
       },
@@ -24,25 +31,34 @@
           {
             "name": "fullActionName",
             "value": "calendar.addEvent",
-            "substrings": []
+            "substrings": [
+              "add"
+            ]
           },
           {
-            "name": "parameters.event.day",
-            "value": "January 30",
+            "name": "parameters.event.timeRange.startDateTime.day",
+            "value": "+4d",
             "substrings": [
               "next Thursday"
             ]
           },
           {
-            "name": "parameters.event.timeRange.startTime",
-            "value": "3:00 pm",
+            "name": "parameters.event.timeRange.startDateTime.hms",
+            "value": "15:00:00",
             "substrings": [
               "3-4pm"
             ]
           },
           {
-            "name": "parameters.event.timeRange.endTime",
-            "value": "4:00 pm",
+            "name": "parameters.event.timeRange.endDateTime.day",
+            "value": "+4d",
+            "substrings": [
+              "next Thursday"
+            ]
+          },
+          {
+            "name": "parameters.event.timeRange.endDateTime.hms",
+            "value": "16:00:00",
             "substrings": [
               "3-4pm"
             ]
@@ -53,6 +69,11 @@
             "substrings": [
               "dentist appointment"
             ]
+          },
+          {
+            "name": "parameters.event.location",
+            "value": "",
+            "isImplicit": true
           }
         ],
         "subPhrases": [
@@ -72,17 +93,18 @@
           },
           {
             "text": "3-4pm",
-            "category": "timeRange",
+            "category": "time",
             "propertyNames": [
-              "parameters.event.timeRange.startTime",
-              "parameters.event.timeRange.endTime"
+              "parameters.event.timeRange.startDateTime.hms",
+              "parameters.event.timeRange.endDateTime.hms"
             ]
           },
           {
             "text": "next Thursday",
             "category": "day",
             "propertyNames": [
-              "parameters.event.day"
+              "parameters.event.timeRange.startDateTime.day",
+              "parameters.event.timeRange.endDateTime.day"
             ]
           }
         ],
@@ -95,21 +117,21 @@
             ],
             "alternatives": [
               {
+                "propertyValue": "calendar.scheduleMeeting",
+                "propertySubPhrases": [
+                  "schedule"
+                ]
+              },
+              {
                 "propertyValue": "calendar.createEvent",
                 "propertySubPhrases": [
                   "create"
                 ]
               },
               {
-                "propertyValue": "calendar.scheduleEvent",
+                "propertyValue": "calendar.setAppointment",
                 "propertySubPhrases": [
-                  "schedule"
-                ]
-              },
-              {
-                "propertyValue": "calendar.insertEvent",
-                "propertySubPhrases": [
-                  "insert"
+                  "set"
                 ]
               }
             ]
@@ -142,26 +164,26 @@
             ]
           },
           {
-            "propertyName": "parameters.event.timeRange.startTime",
-            "propertyValue": "3:00 pm",
+            "propertyName": "parameters.event.timeRange.startDateTime.hms",
+            "propertyValue": "15:00:00",
             "propertySubPhrases": [
               "3-4pm"
             ],
             "alternatives": [
               {
-                "propertyValue": "2:00 pm",
+                "propertyValue": "14:00:00",
                 "propertySubPhrases": [
                   "2-3pm"
                 ]
               },
               {
-                "propertyValue": "4:00 pm",
+                "propertyValue": "16:00:00",
                 "propertySubPhrases": [
                   "4-5pm"
                 ]
               },
               {
-                "propertyValue": "5:00 pm",
+                "propertyValue": "17:00:00",
                 "propertySubPhrases": [
                   "5-6pm"
                 ]
@@ -169,26 +191,26 @@
             ]
           },
           {
-            "propertyName": "parameters.event.timeRange.endTime",
-            "propertyValue": "4:00 pm",
+            "propertyName": "parameters.event.timeRange.endDateTime.hms",
+            "propertyValue": "16:00:00",
             "propertySubPhrases": [
               "3-4pm"
             ],
             "alternatives": [
               {
-                "propertyValue": "3:00 pm",
+                "propertyValue": "15:00:00",
                 "propertySubPhrases": [
                   "2-3pm"
                 ]
               },
               {
-                "propertyValue": "5:00 pm",
+                "propertyValue": "17:00:00",
                 "propertySubPhrases": [
                   "4-5pm"
                 ]
               },
               {
-                "propertyValue": "6:00 pm",
+                "propertyValue": "18:00:00",
                 "propertySubPhrases": [
                   "5-6pm"
                 ]
@@ -196,28 +218,55 @@
             ]
           },
           {
-            "propertyName": "parameters.event.day",
-            "propertyValue": "January 30",
+            "propertyName": "parameters.event.timeRange.startDateTime.day",
+            "propertyValue": "+4d",
             "propertySubPhrases": [
               "next Thursday"
             ],
             "alternatives": [
               {
-                "propertyValue": "January 31",
-                "propertySubPhrases": [
-                  "next Friday"
-                ]
-              },
-              {
-                "propertyValue": "January 29",
+                "propertyValue": "+3d",
                 "propertySubPhrases": [
                   "next Wednesday"
                 ]
               },
               {
-                "propertyValue": "February 6",
+                "propertyValue": "+5d",
                 "propertySubPhrases": [
-                  "Thursday after next"
+                  "next Friday"
+                ]
+              },
+              {
+                "propertyValue": "+7d",
+                "propertySubPhrases": [
+                  "next Sunday"
+                ]
+              }
+            ]
+          },
+          {
+            "propertyName": "parameters.event.timeRange.endDateTime.day",
+            "propertyValue": "+4d",
+            "propertySubPhrases": [
+              "next Thursday"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "+3d",
+                "propertySubPhrases": [
+                  "next Wednesday"
+                ]
+              },
+              {
+                "propertyValue": "+5d",
+                "propertySubPhrases": [
+                  "next Friday"
+                ]
+              },
+              {
+                "propertyValue": "+7d",
+                "propertySubPhrases": [
+                  "next Sunday"
                 ]
               }
             ]
@@ -226,14 +275,14 @@
         "politePrefixes": [
           "Could you please",
           "Would you mind",
-          "If it's not too much trouble,",
-          "May I ask you to"
+          "I would appreciate it if you could",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it.",
-          "Thanks a lot!",
-          "That would be great!"
+          "Thank you",
+          "Thanks in advance",
+          "I appreciate it",
+          "If you could do this, that would be great"
         ]
       }
     },
@@ -243,10 +292,15 @@
         "fullActionName": "calendar.addEvent",
         "parameters": {
           "event": {
-            "day": "January 30",
             "timeRange": {
-              "startTime": "4:00 pm",
-              "duration": "30 minutes"
+              "startDateTime": {
+                "day": "+5d",
+                "hms": "16:00:00"
+              },
+              "endDateTime": {
+                "day": "+5d",
+                "hms": "16:30:00"
+              }
             },
             "description": "dentist appointment"
           }
@@ -257,25 +311,34 @@
           {
             "name": "fullActionName",
             "value": "calendar.addEvent",
-            "substrings": []
+            "substrings": [
+              "add half hour dentist appointment starting at 4pm next Thursday"
+            ]
           },
           {
-            "name": "parameters.event.day",
-            "value": "January 30",
+            "name": "parameters.event.timeRange.startDateTime.day",
+            "value": "+5d",
             "substrings": [
               "next Thursday"
             ]
           },
           {
-            "name": "parameters.event.timeRange.startTime",
-            "value": "4:00 pm",
+            "name": "parameters.event.timeRange.startDateTime.hms",
+            "value": "16:00:00",
             "substrings": [
               "4pm"
             ]
           },
           {
-            "name": "parameters.event.timeRange.duration",
-            "value": "30 minutes",
+            "name": "parameters.event.timeRange.endDateTime.day",
+            "value": "+5d",
+            "substrings": [
+              "next Thursday"
+            ]
+          },
+          {
+            "name": "parameters.event.timeRange.endDateTime.hms",
+            "value": "16:30:00",
             "substrings": [
               "half hour"
             ]
@@ -300,7 +363,7 @@
             "text": "half hour",
             "category": "duration",
             "propertyNames": [
-              "parameters.event.timeRange.duration"
+              "parameters.event.timeRange.endDateTime.hms"
             ]
           },
           {
@@ -316,22 +379,23 @@
             "synonyms": [
               "beginning at",
               "commencing at",
-              "from"
+              "initiating at"
             ],
             "isOptional": true
           },
           {
             "text": "4pm",
-            "category": "startTime",
+            "category": "time",
             "propertyNames": [
-              "parameters.event.timeRange.startTime"
+              "parameters.event.timeRange.startDateTime.hms"
             ]
           },
           {
             "text": "next Thursday",
             "category": "day",
             "propertyNames": [
-              "parameters.event.day"
+              "parameters.event.timeRange.startDateTime.day",
+              "parameters.event.timeRange.endDateTime.day"
             ]
           }
         ],
@@ -344,48 +408,48 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "calendar.createEvent",
-                "propertySubPhrases": [
-                  "create"
-                ]
-              },
-              {
                 "propertyValue": "calendar.scheduleEvent",
                 "propertySubPhrases": [
                   "schedule"
                 ]
               },
               {
-                "propertyValue": "calendar.insertEvent",
+                "propertyValue": "calendar.createEvent",
                 "propertySubPhrases": [
-                  "insert"
+                  "create"
+                ]
+              },
+              {
+                "propertyValue": "calendar.bookEvent",
+                "propertySubPhrases": [
+                  "book"
                 ]
               }
             ]
           },
           {
-            "propertyName": "parameters.event.timeRange.duration",
-            "propertyValue": "30 minutes",
+            "propertyName": "parameters.event.timeRange.endDateTime.hms",
+            "propertyValue": "16:30:00",
             "propertySubPhrases": [
               "half hour"
             ],
             "alternatives": [
               {
-                "propertyValue": "15 minutes",
+                "propertyValue": "16:15:00",
                 "propertySubPhrases": [
-                  "quarter hour"
+                  "15 minutes"
                 ]
               },
               {
-                "propertyValue": "45 minutes",
+                "propertyValue": "16:45:00",
                 "propertySubPhrases": [
-                  "three quarters of an hour"
+                  "45 minutes"
                 ]
               },
               {
-                "propertyValue": "1 hour",
+                "propertyValue": "17:00:00",
                 "propertySubPhrases": [
-                  "one hour"
+                  "1 hour"
                 ]
               }
             ]
@@ -418,55 +482,82 @@
             ]
           },
           {
-            "propertyName": "parameters.event.timeRange.startTime",
-            "propertyValue": "4:00 pm",
+            "propertyName": "parameters.event.timeRange.startDateTime.hms",
+            "propertyValue": "16:00:00",
             "propertySubPhrases": [
               "4pm"
             ],
             "alternatives": [
               {
-                "propertyValue": "3:00 pm",
+                "propertyValue": "15:00:00",
                 "propertySubPhrases": [
                   "3pm"
                 ]
               },
               {
-                "propertyValue": "5:00 pm",
+                "propertyValue": "17:00:00",
                 "propertySubPhrases": [
                   "5pm"
                 ]
               },
               {
-                "propertyValue": "6:00 pm",
+                "propertyValue": "14:00:00",
                 "propertySubPhrases": [
-                  "6pm"
+                  "2pm"
                 ]
               }
             ]
           },
           {
-            "propertyName": "parameters.event.day",
-            "propertyValue": "January 30",
+            "propertyName": "parameters.event.timeRange.startDateTime.day",
+            "propertyValue": "+5d",
             "propertySubPhrases": [
               "next Thursday"
             ],
             "alternatives": [
               {
-                "propertyValue": "January 31",
+                "propertyValue": "+6d",
                 "propertySubPhrases": [
                   "next Friday"
                 ]
               },
               {
-                "propertyValue": "January 29",
+                "propertyValue": "+4d",
                 "propertySubPhrases": [
                   "next Wednesday"
                 ]
               },
               {
-                "propertyValue": "February 6",
+                "propertyValue": "+7d",
                 "propertySubPhrases": [
-                  "Thursday after next"
+                  "next Saturday"
+                ]
+              }
+            ]
+          },
+          {
+            "propertyName": "parameters.event.timeRange.endDateTime.day",
+            "propertyValue": "+5d",
+            "propertySubPhrases": [
+              "next Thursday"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "+6d",
+                "propertySubPhrases": [
+                  "next Friday"
+                ]
+              },
+              {
+                "propertyValue": "+4d",
+                "propertySubPhrases": [
+                  "next Wednesday"
+                ]
+              },
+              {
+                "propertyValue": "+7d",
+                "propertySubPhrases": [
+                  "next Saturday"
                 ]
               }
             ]
@@ -474,11 +565,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "I would appreciate it if you could",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it."
+          "Thank you",
+          "Thanks in advance",
+          "I appreciate it",
+          "If you could do this, that would be great"
         ]
       }
     },
@@ -488,9 +583,11 @@
         "fullActionName": "calendar.addParticipants",
         "parameters": {
           "eventReference": {
-            "day": "Wednesday",
             "timeRange": {
-              "startTime": "4:00 pm"
+              "startDateTime": {
+                "day": "Wednesday",
+                "hms": "16:00:00"
+              }
             },
             "description": "ping pong game",
             "lookup": true
@@ -510,15 +607,15 @@
             ]
           },
           {
-            "name": "parameters.eventReference.day",
+            "name": "parameters.eventReference.timeRange.startDateTime.day",
             "value": "Wednesday",
             "substrings": [
               "Wednesday"
             ]
           },
           {
-            "name": "parameters.eventReference.timeRange.startTime",
-            "value": "4:00 pm",
+            "name": "parameters.eventReference.timeRange.startDateTime.hms",
+            "value": "16:00:00",
             "substrings": [
               "4pm"
             ]
@@ -563,7 +660,7 @@
             "category": "preposition",
             "synonyms": [
               "into the",
-              "for the",
+              "onto the",
               "towards the"
             ],
             "isOptional": true
@@ -572,7 +669,7 @@
             "text": "Wednesday",
             "category": "day",
             "propertyNames": [
-              "parameters.eventReference.day"
+              "parameters.eventReference.timeRange.startDateTime.day"
             ]
           },
           {
@@ -587,8 +684,8 @@
             "category": "preposition",
             "synonyms": [
               "on",
-              "during",
-              "by"
+              "by",
+              "around"
             ],
             "isOptional": true
           },
@@ -596,7 +693,7 @@
             "text": "4pm",
             "category": "time",
             "propertyNames": [
-              "parameters.eventReference.timeRange.startTime"
+              "parameters.eventReference.timeRange.startDateTime.hms"
             ]
           }
         ],
@@ -609,21 +706,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "calendar.addAttendees",
+                "propertyValue": "calendar.inviteParticipants",
                 "propertySubPhrases": [
-                  "add"
+                  "invite"
                 ]
               },
               {
                 "propertyValue": "calendar.includeParticipants",
                 "propertySubPhrases": [
-                  "add"
+                  "include"
                 ]
               },
               {
-                "propertyValue": "calendar.addMembers",
+                "propertyValue": "calendar.insertParticipants",
                 "propertySubPhrases": [
-                  "add"
+                  "insert"
                 ]
               }
             ]
@@ -633,769 +730,6 @@
             "propertyValue": "Isobel",
             "propertySubPhrases": [
               "Isobel"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "Isabella",
-                "propertySubPhrases": [
-                  "Isobel"
-                ]
-              },
-              {
-                "propertyValue": "Isabel",
-                "propertySubPhrases": [
-                  "Isobel"
-                ]
-              },
-              {
-                "propertyValue": "Izzy",
-                "propertySubPhrases": [
-                  "Isobel"
-                ]
-              }
-            ]
-          },
-          {
-            "propertyName": "parameters.eventReference.day",
-            "propertyValue": "Wednesday",
-            "propertySubPhrases": [
-              "Wednesday"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "Thursday",
-                "propertySubPhrases": [
-                  "Wednesday"
-                ]
-              },
-              {
-                "propertyValue": "Tuesday",
-                "propertySubPhrases": [
-                  "Wednesday"
-                ]
-              },
-              {
-                "propertyValue": "Friday",
-                "propertySubPhrases": [
-                  "Wednesday"
-                ]
-              }
-            ]
-          },
-          {
-            "propertyName": "parameters.eventReference.description",
-            "propertyValue": "ping pong game",
-            "propertySubPhrases": [
-              "ping pong game"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "tennis match",
-                "propertySubPhrases": [
-                  "ping pong game"
-                ]
-              },
-              {
-                "propertyValue": "badminton game",
-                "propertySubPhrases": [
-                  "ping pong game"
-                ]
-              },
-              {
-                "propertyValue": "table tennis game",
-                "propertySubPhrases": [
-                  "ping pong game"
-                ]
-              }
-            ]
-          },
-          {
-            "propertyName": "parameters.eventReference.timeRange.startTime",
-            "propertyValue": "4:00 pm",
-            "propertySubPhrases": [
-              "4pm"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "3:00 pm",
-                "propertySubPhrases": [
-                  "4pm"
-                ]
-              },
-              {
-                "propertyValue": "5:00 pm",
-                "propertySubPhrases": [
-                  "4pm"
-                ]
-              },
-              {
-                "propertyValue": "6:00 pm",
-                "propertySubPhrases": [
-                  "4pm"
-                ]
-              }
-            ]
-          }
-        ],
-        "politePrefixes": [
-          "Could you please",
-          "Would you mind"
-        ],
-        "politeSuffixes": [
-          "Thank you!",
-          "I appreciate it!"
-        ]
-      }
-    },
-    {
-      "request": "add piali to the AI Systems meeting this week",
-      "action": {
-        "fullActionName": "calendar.addParticipants",
-        "parameters": {
-          "eventReference": {
-            "dayRange": "this week",
-            "description": "AI Systems meeting",
-            "lookup": true
-          },
-          "participants": [
-            "piali"
-          ]
-        }
-      },
-      "explanation": {
-        "properties": [
-          {
-            "name": "fullActionName",
-            "value": "calendar.addParticipants",
-            "substrings": [
-              "add piali to the AI Systems meeting this week"
-            ]
-          },
-          {
-            "name": "parameters.eventReference.dayRange",
-            "value": "this week",
-            "substrings": [
-              "this week"
-            ]
-          },
-          {
-            "name": "parameters.eventReference.description",
-            "value": "AI Systems meeting",
-            "substrings": [
-              "AI Systems meeting"
-            ]
-          },
-          {
-            "name": "parameters.eventReference.lookup",
-            "value": true,
-            "isImplicit": true
-          },
-          {
-            "name": "parameters.participants.0",
-            "value": "piali",
-            "substrings": [
-              "piali"
-            ]
-          }
-        ],
-        "subPhrases": [
-          {
-            "text": "add piali",
-            "category": "action",
-            "propertyNames": [
-              "fullActionName",
-              "parameters.participants.0"
-            ]
-          },
-          {
-            "text": "to the",
-            "category": "preposition",
-            "synonyms": [
-              "into the",
-              "for the",
-              "towards the"
-            ],
-            "isOptional": true
-          },
-          {
-            "text": "AI Systems meeting",
-            "category": "event description",
-            "propertyNames": [
-              "parameters.eventReference.description"
-            ]
-          },
-          {
-            "text": "this week",
-            "category": "time reference",
-            "propertyNames": [
-              "parameters.eventReference.dayRange"
-            ]
-          }
-        ],
-        "propertyAlternatives": [
-          {
-            "propertyName": "fullActionName",
-            "propertyValue": "calendar.addParticipants",
-            "propertySubPhrases": [
-              "add piali"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "calendar.inviteParticipants",
-                "propertySubPhrases": [
-                  "invite piali"
-                ]
-              },
-              {
-                "propertyValue": "calendar.includeParticipants",
-                "propertySubPhrases": [
-                  "include piali"
-                ]
-              },
-              {
-                "propertyValue": "calendar.addAttendees",
-                "propertySubPhrases": [
-                  "add attendees"
-                ]
-              }
-            ]
-          },
-          {
-            "propertyName": "parameters.participants.0",
-            "propertyValue": "piali",
-            "propertySubPhrases": [
-              "add piali"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "john",
-                "propertySubPhrases": [
-                  "add john"
-                ]
-              },
-              {
-                "propertyValue": "susan",
-                "propertySubPhrases": [
-                  "add susan"
-                ]
-              },
-              {
-                "propertyValue": "michael",
-                "propertySubPhrases": [
-                  "add michael"
-                ]
-              }
-            ]
-          },
-          {
-            "propertyName": "parameters.eventReference.description",
-            "propertyValue": "AI Systems meeting",
-            "propertySubPhrases": [
-              "AI Systems meeting"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "AI Conference",
-                "propertySubPhrases": [
-                  "AI Conference"
-                ]
-              },
-              {
-                "propertyValue": "AI Workshop",
-                "propertySubPhrases": [
-                  "AI Workshop"
-                ]
-              },
-              {
-                "propertyValue": "AI Symposium",
-                "propertySubPhrases": [
-                  "AI Symposium"
-                ]
-              }
-            ]
-          },
-          {
-            "propertyName": "parameters.eventReference.dayRange",
-            "propertyValue": "this week",
-            "propertySubPhrases": [
-              "this week"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "next week",
-                "propertySubPhrases": [
-                  "next week"
-                ]
-              },
-              {
-                "propertyValue": "tomorrow",
-                "propertySubPhrases": [
-                  "tomorrow"
-                ]
-              },
-              {
-                "propertyValue": "today",
-                "propertySubPhrases": [
-                  "today"
-                ]
-              }
-            ]
-          }
-        ],
-        "politePrefixes": [
-          "Could you please",
-          "Would you mind",
-          "If it's not too much trouble, could you",
-          "I would appreciate it if you could"
-        ],
-        "politeSuffixes": [
-          "Thank you!",
-          "Thanks a lot!",
-          "I appreciate it!",
-          "Much appreciated!"
-        ]
-      }
-    },
-    {
-      "request": "can you record lunch with Luis at 12pm on Friday",
-      "action": {
-        "fullActionName": "calendar.addEvent",
-        "parameters": {
-          "event": {
-            "day": "January 24",
-            "timeRange": {
-              "startTime": "12:00 pm"
-            },
-            "description": "Lunch with Luis",
-            "participants": [
-              "Luis"
-            ]
-          }
-        }
-      },
-      "explanation": {
-        "properties": [
-          {
-            "name": "fullActionName",
-            "value": "calendar.addEvent",
-            "substrings": [
-              "can you record"
-            ]
-          },
-          {
-            "name": "parameters.event.day",
-            "value": "January 24",
-            "isImplicit": true
-          },
-          {
-            "name": "parameters.event.timeRange.startTime",
-            "value": "12:00 pm",
-            "substrings": [
-              "at 12pm"
-            ]
-          },
-          {
-            "name": "parameters.event.description",
-            "value": "Lunch with Luis",
-            "substrings": [
-              "lunch with Luis"
-            ]
-          },
-          {
-            "name": "parameters.event.participants.0",
-            "value": "Luis",
-            "substrings": [
-              "Luis"
-            ]
-          }
-        ],
-        "subPhrases": [
-          {
-            "text": "can you record",
-            "category": "action",
-            "propertyNames": [
-              "fullActionName"
-            ]
-          },
-          {
-            "text": "lunch with Luis",
-            "category": "event description",
-            "propertyNames": [
-              "parameters.event.description"
-            ]
-          },
-          {
-            "text": "at 12pm",
-            "category": "time",
-            "propertyNames": [
-              "parameters.event.timeRange.startTime"
-            ]
-          },
-          {
-            "text": "on Friday",
-            "category": "day",
-            "synonyms": [
-              "this Friday",
-              "coming Friday",
-              "next Friday"
-            ],
-            "isOptional": true
-          }
-        ],
-        "propertyAlternatives": [
-          {
-            "propertyName": "fullActionName",
-            "propertyValue": "calendar.addEvent",
-            "propertySubPhrases": [
-              "can you record"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "calendar.createEvent",
-                "propertySubPhrases": [
-                  "can you create"
-                ]
-              },
-              {
-                "propertyValue": "calendar.scheduleEvent",
-                "propertySubPhrases": [
-                  "can you schedule"
-                ]
-              },
-              {
-                "propertyValue": "calendar.logEvent",
-                "propertySubPhrases": [
-                  "can you log"
-                ]
-              }
-            ]
-          },
-          {
-            "propertyName": "parameters.event.description",
-            "propertyValue": "Lunch with Luis",
-            "propertySubPhrases": [
-              "lunch with Luis"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "Meeting with Luis",
-                "propertySubPhrases": [
-                  "meeting with Luis"
-                ]
-              },
-              {
-                "propertyValue": "Brunch with Luis",
-                "propertySubPhrases": [
-                  "brunch with Luis"
-                ]
-              },
-              {
-                "propertyValue": "Dinner with Luis",
-                "propertySubPhrases": [
-                  "dinner with Luis"
-                ]
-              }
-            ]
-          },
-          {
-            "propertyName": "parameters.event.timeRange.startTime",
-            "propertyValue": "12:00 pm",
-            "propertySubPhrases": [
-              "at 12pm"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "1:00 pm",
-                "propertySubPhrases": [
-                  "at 1pm"
-                ]
-              },
-              {
-                "propertyValue": "11:00 am",
-                "propertySubPhrases": [
-                  "at 11am"
-                ]
-              },
-              {
-                "propertyValue": "2:00 pm",
-                "propertySubPhrases": [
-                  "at 2pm"
-                ]
-              }
-            ]
-          }
-        ],
-        "politePrefixes": [
-          "Could you please",
-          "Would you mind"
-        ],
-        "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it."
-        ]
-      },
-      "corrections": [
-        {
-          "data": {
-            "properties": [
-              {
-                "name": "fullActionName",
-                "value": "calendar.addEvent",
-                "substrings": [
-                  "can you record"
-                ]
-              },
-              {
-                "name": "parameters.event.day",
-                "value": "Friday",
-                "substrings": [
-                  "on Friday"
-                ]
-              },
-              {
-                "name": "parameters.event.timeRange.startTime",
-                "value": "12:00 pm",
-                "substrings": [
-                  "at 12pm"
-                ]
-              },
-              {
-                "name": "parameters.event.description",
-                "value": "Lunch with Luis",
-                "substrings": [
-                  "lunch with Luis"
-                ]
-              },
-              {
-                "name": "parameters.event.participants.0",
-                "value": "Luis",
-                "substrings": [
-                  "Luis"
-                ]
-              }
-            ]
-          },
-          "correction": [
-            "Mismatch parameter value: 'Friday' in the explanation is not the value of the parameter 'parameters.event.day' in the action"
-          ]
-        },
-        {
-          "data": {
-            "properties": [
-              {
-                "name": "fullActionName",
-                "value": "calendar.addEvent",
-                "substrings": [
-                  "can you record"
-                ]
-              },
-              {
-                "name": "parameters.event.day",
-                "value": "January 24",
-                "isImplicit": true
-              },
-              {
-                "name": "parameters.event.timeRange.startTime",
-                "value": "12:00 pm",
-                "substrings": [
-                  "at 12pm"
-                ]
-              },
-              {
-                "name": "parameters.event.description",
-                "value": "Lunch with Luis",
-                "substrings": [
-                  "lunch with Luis"
-                ]
-              },
-              {
-                "name": "parameters.event.participants.0",
-                "value": "Luis",
-                "substrings": [
-                  "Luis"
-                ]
-              }
-            ],
-            "subPhrases": [
-              {
-                "text": "can you record",
-                "category": "action",
-                "propertyNames": [
-                  "fullActionName"
-                ]
-              },
-              {
-                "text": "lunch with Luis",
-                "category": "event description",
-                "propertyNames": [
-                  "parameters.event.description"
-                ]
-              },
-              {
-                "text": "Luis",
-                "category": "participant",
-                "propertyNames": [
-                  "parameters.event.participants.0"
-                ]
-              },
-              {
-                "text": "at 12pm",
-                "category": "time",
-                "propertyNames": [
-                  "parameters.event.timeRange.startTime"
-                ]
-              },
-              {
-                "text": "on Friday",
-                "category": "day",
-                "propertyNames": [
-                  "parameters.event.day"
-                ]
-              }
-            ]
-          },
-          "correction": [
-            "Overlapping sub-phrase: explanation has overlapping text 'Luis'.",
-            "Property 'parameters.event.day' is expected to be implicit and should not be included as a property name in a sub-phrase"
-          ]
-        }
-      ]
-    },
-    {
-      "request": "Please add Jennifer to the scrum next Thursday",
-      "action": {
-        "fullActionName": "calendar.addParticipants",
-        "parameters": {
-          "eventReference": {
-            "day": "1/30/2025",
-            "description": "scrum",
-            "lookup": true
-          },
-          "participants": [
-            "Jennifer"
-          ]
-        }
-      },
-      "explanation": {
-        "properties": [
-          {
-            "name": "fullActionName",
-            "value": "calendar.addParticipants",
-            "substrings": [
-              "add"
-            ]
-          },
-          {
-            "name": "parameters.eventReference.day",
-            "value": "1/30/2025",
-            "isImplicit": true
-          },
-          {
-            "name": "parameters.eventReference.description",
-            "value": "scrum",
-            "substrings": [
-              "scrum"
-            ]
-          },
-          {
-            "name": "parameters.eventReference.lookup",
-            "value": true,
-            "isImplicit": true
-          },
-          {
-            "name": "parameters.participants.0",
-            "value": "Jennifer",
-            "substrings": [
-              "Jennifer"
-            ]
-          }
-        ],
-        "subPhrases": [
-          {
-            "text": "Please",
-            "category": "politeness",
-            "synonyms": [
-              "Kindly",
-              "Would you mind",
-              "Could you"
-            ],
-            "isOptional": true
-          },
-          {
-            "text": "add",
-            "category": "action",
-            "propertyNames": [
-              "fullActionName"
-            ]
-          },
-          {
-            "text": "Jennifer",
-            "category": "participant",
-            "propertyNames": [
-              "parameters.participants.0"
-            ]
-          },
-          {
-            "text": "to the",
-            "category": "preposition",
-            "synonyms": [
-              "into the",
-              "onto the",
-              "towards the"
-            ],
-            "isOptional": true
-          },
-          {
-            "text": "scrum",
-            "category": "event",
-            "propertyNames": [
-              "parameters.eventReference.description"
-            ]
-          },
-          {
-            "text": "next Thursday",
-            "category": "date",
-            "synonyms": [
-              "coming Thursday",
-              "this Thursday",
-              "the following Thursday"
-            ],
-            "isOptional": true
-          }
-        ],
-        "propertyAlternatives": [
-          {
-            "propertyName": "fullActionName",
-            "propertyValue": "calendar.addParticipants",
-            "propertySubPhrases": [
-              "add"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "calendar.scheduleMeeting",
-                "propertySubPhrases": [
-                  "schedule"
-                ]
-              },
-              {
-                "propertyValue": "calendar.createEvent",
-                "propertySubPhrases": [
-                  "create"
-                ]
-              },
-              {
-                "propertyValue": "calendar.updateEvent",
-                "propertySubPhrases": [
-                  "update"
-                ]
-              }
-            ]
-          },
-          {
-            "propertyName": "parameters.participants.0",
-            "propertyValue": "Jennifer",
-            "propertySubPhrases": [
-              "Jennifer"
             ],
             "alternatives": [
               {
@@ -1419,35 +753,881 @@
             ]
           },
           {
-            "propertyName": "parameters.eventReference.description",
-            "propertyValue": "scrum",
+            "propertyName": "parameters.eventReference.timeRange.startDateTime.day",
+            "propertyValue": "Wednesday",
             "propertySubPhrases": [
-              "scrum"
+              "Wednesday"
             ],
             "alternatives": [
               {
-                "propertyValue": "meeting",
+                "propertyValue": "Monday",
                 "propertySubPhrases": [
-                  "meeting"
+                  "Monday"
                 ]
               },
               {
-                "propertyValue": "standup",
+                "propertyValue": "Friday",
                 "propertySubPhrases": [
-                  "standup"
+                  "Friday"
                 ]
               },
               {
-                "propertyValue": "review",
+                "propertyValue": "Sunday",
                 "propertySubPhrases": [
-                  "review"
+                  "Sunday"
+                ]
+              }
+            ]
+          },
+          {
+            "propertyName": "parameters.eventReference.description",
+            "propertyValue": "ping pong game",
+            "propertySubPhrases": [
+              "ping pong game"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "tennis match",
+                "propertySubPhrases": [
+                  "tennis match"
+                ]
+              },
+              {
+                "propertyValue": "badminton game",
+                "propertySubPhrases": [
+                  "badminton game"
+                ]
+              },
+              {
+                "propertyValue": "soccer game",
+                "propertySubPhrases": [
+                  "soccer game"
+                ]
+              }
+            ]
+          },
+          {
+            "propertyName": "parameters.eventReference.timeRange.startDateTime.hms",
+            "propertyValue": "16:00:00",
+            "propertySubPhrases": [
+              "4pm"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "15:00:00",
+                "propertySubPhrases": [
+                  "3pm"
+                ]
+              },
+              {
+                "propertyValue": "17:00:00",
+                "propertySubPhrases": [
+                  "5pm"
+                ]
+              },
+              {
+                "propertyValue": "18:00:00",
+                "propertySubPhrases": [
+                  "6pm"
                 ]
               }
             ]
           }
         ],
-        "politePrefixes": [],
-        "politeSuffixes": []
+        "politePrefixes": [
+          "Could you please",
+          "Would you mind",
+          "Can you kindly",
+          "Please"
+        ],
+        "politeSuffixes": [
+          "Thank you!",
+          "Thanks!",
+          "I appreciate it!",
+          "Much appreciated!"
+        ]
+      }
+    },
+    {
+      "request": "add piali to the AI Systems meeting this week",
+      "action": {
+        "fullActionName": "calendar.addParticipants",
+        "parameters": {
+          "eventReference": {
+            "timeRange": {
+              "startDateTime": {
+                "week": "this week"
+              },
+              "endDateTime": {
+                "week": "this week"
+              }
+            },
+            "description": "AI Systems meeting",
+            "lookup": true
+          },
+          "participants": [
+            "Piali"
+          ]
+        }
+      },
+      "explanation": {
+        "properties": [
+          {
+            "name": "fullActionName",
+            "value": "calendar.addParticipants",
+            "substrings": [
+              "add piali to the AI Systems meeting this week"
+            ]
+          },
+          {
+            "name": "parameters.eventReference.timeRange.startDateTime.week",
+            "value": "this week",
+            "substrings": [
+              "this week"
+            ]
+          },
+          {
+            "name": "parameters.eventReference.timeRange.endDateTime.week",
+            "value": "this week",
+            "substrings": [
+              "this week"
+            ]
+          },
+          {
+            "name": "parameters.eventReference.description",
+            "value": "AI Systems meeting",
+            "substrings": [
+              "AI Systems meeting"
+            ]
+          },
+          {
+            "name": "parameters.eventReference.lookup",
+            "value": true,
+            "isImplicit": true
+          },
+          {
+            "name": "parameters.participants.0",
+            "value": "Piali",
+            "substrings": [
+              "piali"
+            ]
+          }
+        ],
+        "subPhrases": [
+          {
+            "text": "add",
+            "category": "action",
+            "propertyNames": [
+              "fullActionName"
+            ]
+          },
+          {
+            "text": "piali",
+            "category": "participant",
+            "propertyNames": [
+              "parameters.participants.0"
+            ]
+          },
+          {
+            "text": "to the",
+            "category": "preposition",
+            "synonyms": [
+              "into the",
+              "towards the",
+              "for the"
+            ],
+            "isOptional": true
+          },
+          {
+            "text": "AI Systems meeting",
+            "category": "event",
+            "propertyNames": [
+              "parameters.eventReference.description"
+            ]
+          },
+          {
+            "text": "this week",
+            "category": "time",
+            "propertyNames": [
+              "parameters.eventReference.timeRange.startDateTime.week",
+              "parameters.eventReference.timeRange.endDateTime.week"
+            ]
+          }
+        ],
+        "propertyAlternatives": [
+          {
+            "propertyName": "fullActionName",
+            "propertyValue": "calendar.addParticipants",
+            "propertySubPhrases": [
+              "add"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "calendar.removeParticipants",
+                "propertySubPhrases": [
+                  "remove"
+                ]
+              },
+              {
+                "propertyValue": "calendar.updateParticipants",
+                "propertySubPhrases": [
+                  "update"
+                ]
+              },
+              {
+                "propertyValue": "calendar.listParticipants",
+                "propertySubPhrases": [
+                  "list"
+                ]
+              }
+            ]
+          },
+          {
+            "propertyName": "parameters.participants.0",
+            "propertyValue": "Piali",
+            "propertySubPhrases": [
+              "piali"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "John",
+                "propertySubPhrases": [
+                  "john"
+                ]
+              },
+              {
+                "propertyValue": "Alice",
+                "propertySubPhrases": [
+                  "alice"
+                ]
+              },
+              {
+                "propertyValue": "Michael",
+                "propertySubPhrases": [
+                  "michael"
+                ]
+              }
+            ]
+          },
+          {
+            "propertyName": "parameters.eventReference.description",
+            "propertyValue": "AI Systems meeting",
+            "propertySubPhrases": [
+              "AI Systems meeting"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "Project Planning meeting",
+                "propertySubPhrases": [
+                  "Project Planning meeting"
+                ]
+              },
+              {
+                "propertyValue": "Team Sync meeting",
+                "propertySubPhrases": [
+                  "Team Sync meeting"
+                ]
+              },
+              {
+                "propertyValue": "Client Review meeting",
+                "propertySubPhrases": [
+                  "Client Review meeting"
+                ]
+              }
+            ]
+          },
+          {
+            "propertyName": "parameters.eventReference.timeRange.startDateTime.week",
+            "propertyValue": "this week",
+            "propertySubPhrases": [
+              "this week"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "next week",
+                "propertySubPhrases": [
+                  "next week"
+                ]
+              },
+              {
+                "propertyValue": "last week",
+                "propertySubPhrases": [
+                  "last week"
+                ]
+              },
+              {
+                "propertyValue": "first week of November",
+                "propertySubPhrases": [
+                  "first week of November"
+                ]
+              }
+            ]
+          },
+          {
+            "propertyName": "parameters.eventReference.timeRange.endDateTime.week",
+            "propertyValue": "this week",
+            "propertySubPhrases": [
+              "this week"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "next week",
+                "propertySubPhrases": [
+                  "next week"
+                ]
+              },
+              {
+                "propertyValue": "last week",
+                "propertySubPhrases": [
+                  "last week"
+                ]
+              },
+              {
+                "propertyValue": "first week of November",
+                "propertySubPhrases": [
+                  "first week of November"
+                ]
+              }
+            ]
+          }
+        ],
+        "politePrefixes": [
+          "Could you please",
+          "Would you mind",
+          "Can you kindly",
+          "Please"
+        ],
+        "politeSuffixes": [
+          "Thank you",
+          "Thanks a lot",
+          "I appreciate it",
+          "Much appreciated"
+        ]
+      }
+    },
+    {
+      "request": "can you record lunch with Luis at 12pm on Friday",
+      "action": {
+        "fullActionName": "calendar.addEvent",
+        "parameters": {
+          "event": {
+            "timeRange": {
+              "startDateTime": {
+                "day": "Friday",
+                "hms": "12:00:00"
+              },
+              "endDateTime": {
+                "day": "Friday",
+                "hms": "12:00:00"
+              }
+            },
+            "description": "lunch with Luis",
+            "location": "",
+            "participants": []
+          }
+        }
+      },
+      "explanation": {
+        "properties": [
+          {
+            "name": "fullActionName",
+            "value": "calendar.addEvent",
+            "substrings": [
+              "can you record"
+            ]
+          },
+          {
+            "name": "parameters.event.timeRange.startDateTime.day",
+            "value": "Friday",
+            "substrings": [
+              "Friday"
+            ]
+          },
+          {
+            "name": "parameters.event.timeRange.startDateTime.hms",
+            "value": "12:00:00",
+            "substrings": [
+              "12pm"
+            ]
+          },
+          {
+            "name": "parameters.event.timeRange.endDateTime.day",
+            "value": "Friday",
+            "substrings": [
+              "Friday"
+            ]
+          },
+          {
+            "name": "parameters.event.timeRange.endDateTime.hms",
+            "value": "12:00:00",
+            "substrings": [
+              "12pm"
+            ]
+          },
+          {
+            "name": "parameters.event.description",
+            "value": "lunch with Luis",
+            "substrings": [
+              "lunch with Luis"
+            ]
+          },
+          {
+            "name": "parameters.event.location",
+            "value": "",
+            "isImplicit": true
+          }
+        ],
+        "subPhrases": [
+          {
+            "text": "can you record",
+            "category": "action",
+            "propertyNames": [
+              "fullActionName"
+            ]
+          },
+          {
+            "text": "lunch with Luis",
+            "category": "event description",
+            "propertyNames": [
+              "parameters.event.description"
+            ]
+          },
+          {
+            "text": "at",
+            "category": "preposition",
+            "synonyms": [
+              "on",
+              "during",
+              "by"
+            ],
+            "isOptional": true
+          },
+          {
+            "text": "12pm",
+            "category": "time",
+            "propertyNames": [
+              "parameters.event.timeRange.startDateTime.hms",
+              "parameters.event.timeRange.endDateTime.hms"
+            ]
+          },
+          {
+            "text": "on",
+            "category": "preposition",
+            "synonyms": [
+              "at",
+              "during",
+              "by"
+            ],
+            "isOptional": true
+          },
+          {
+            "text": "Friday",
+            "category": "day",
+            "propertyNames": [
+              "parameters.event.timeRange.startDateTime.day",
+              "parameters.event.timeRange.endDateTime.day"
+            ]
+          }
+        ],
+        "propertyAlternatives": [
+          {
+            "propertyName": "fullActionName",
+            "propertyValue": "calendar.addEvent",
+            "propertySubPhrases": [
+              "can you record"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "calendar.scheduleEvent",
+                "propertySubPhrases": [
+                  "can you schedule"
+                ]
+              },
+              {
+                "propertyValue": "calendar.createEvent",
+                "propertySubPhrases": [
+                  "can you create"
+                ]
+              },
+              {
+                "propertyValue": "calendar.logEvent",
+                "propertySubPhrases": [
+                  "can you log"
+                ]
+              }
+            ]
+          },
+          {
+            "propertyName": "parameters.event.description",
+            "propertyValue": "lunch with Luis",
+            "propertySubPhrases": [
+              "lunch with Luis"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "meeting with Luis",
+                "propertySubPhrases": [
+                  "meeting with Luis"
+                ]
+              },
+              {
+                "propertyValue": "dinner with Luis",
+                "propertySubPhrases": [
+                  "dinner with Luis"
+                ]
+              },
+              {
+                "propertyValue": "coffee with Luis",
+                "propertySubPhrases": [
+                  "coffee with Luis"
+                ]
+              }
+            ]
+          },
+          {
+            "propertyName": "parameters.event.timeRange.startDateTime.hms",
+            "propertyValue": "12:00:00",
+            "propertySubPhrases": [
+              "12pm"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "13:00:00",
+                "propertySubPhrases": [
+                  "1pm"
+                ]
+              },
+              {
+                "propertyValue": "14:00:00",
+                "propertySubPhrases": [
+                  "2pm"
+                ]
+              },
+              {
+                "propertyValue": "11:00:00",
+                "propertySubPhrases": [
+                  "11am"
+                ]
+              }
+            ]
+          },
+          {
+            "propertyName": "parameters.event.timeRange.endDateTime.hms",
+            "propertyValue": "12:00:00",
+            "propertySubPhrases": [
+              "12pm"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "13:00:00",
+                "propertySubPhrases": [
+                  "1pm"
+                ]
+              },
+              {
+                "propertyValue": "14:00:00",
+                "propertySubPhrases": [
+                  "2pm"
+                ]
+              },
+              {
+                "propertyValue": "11:00:00",
+                "propertySubPhrases": [
+                  "11am"
+                ]
+              }
+            ]
+          },
+          {
+            "propertyName": "parameters.event.timeRange.startDateTime.day",
+            "propertyValue": "Friday",
+            "propertySubPhrases": [
+              "Friday"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "Monday",
+                "propertySubPhrases": [
+                  "Monday"
+                ]
+              },
+              {
+                "propertyValue": "Tuesday",
+                "propertySubPhrases": [
+                  "Tuesday"
+                ]
+              },
+              {
+                "propertyValue": "Wednesday",
+                "propertySubPhrases": [
+                  "Wednesday"
+                ]
+              }
+            ]
+          },
+          {
+            "propertyName": "parameters.event.timeRange.endDateTime.day",
+            "propertyValue": "Friday",
+            "propertySubPhrases": [
+              "Friday"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "Monday",
+                "propertySubPhrases": [
+                  "Monday"
+                ]
+              },
+              {
+                "propertyValue": "Tuesday",
+                "propertySubPhrases": [
+                  "Tuesday"
+                ]
+              },
+              {
+                "propertyValue": "Wednesday",
+                "propertySubPhrases": [
+                  "Wednesday"
+                ]
+              }
+            ]
+          }
+        ],
+        "politePrefixes": [
+          "Could you please",
+          "Would you mind",
+          "May I ask you to",
+          "If it's not too much trouble, could you"
+        ],
+        "politeSuffixes": [
+          "Thank you!",
+          "I would appreciate it.",
+          "Thanks in advance!",
+          "Your help is appreciated."
+        ]
+      }
+    },
+    {
+      "request": "Please add Jennifer to the scrum next Thursday",
+      "action": {
+        "fullActionName": "calendar.addParticipants",
+        "parameters": {
+          "eventReference": {
+            "description": "scrum",
+            "timeRange": {
+              "startDateTime": {
+                "day": "Thursday"
+              },
+              "endDateTime": {
+                "day": "Thursday"
+              }
+            },
+            "lookup": true
+          },
+          "participants": [
+            "Jennifer"
+          ]
+        }
+      },
+      "explanation": {
+        "properties": [
+          {
+            "name": "fullActionName",
+            "value": "calendar.addParticipants",
+            "substrings": [
+              "add Jennifer to the scrum next Thursday"
+            ]
+          },
+          {
+            "name": "parameters.eventReference.description",
+            "value": "scrum",
+            "substrings": [
+              "scrum"
+            ]
+          },
+          {
+            "name": "parameters.eventReference.timeRange.startDateTime.day",
+            "value": "Thursday",
+            "substrings": [
+              "next Thursday"
+            ]
+          },
+          {
+            "name": "parameters.eventReference.timeRange.endDateTime.day",
+            "value": "Thursday",
+            "substrings": [
+              "next Thursday"
+            ]
+          },
+          {
+            "name": "parameters.eventReference.lookup",
+            "value": true,
+            "isImplicit": true
+          },
+          {
+            "name": "parameters.participants.0",
+            "value": "Jennifer",
+            "substrings": [
+              "Jennifer"
+            ]
+          }
+        ],
+        "subPhrases": [
+          {
+            "text": "Please",
+            "category": "politeness",
+            "synonyms": [
+              "kindly",
+              "could you",
+              "would you mind"
+            ],
+            "isOptional": true
+          },
+          {
+            "text": "add Jennifer",
+            "category": "action",
+            "propertyNames": [
+              "fullActionName"
+            ]
+          },
+          {
+            "text": "to the scrum",
+            "category": "event description",
+            "propertyNames": [
+              "parameters.eventReference.description"
+            ]
+          },
+          {
+            "text": "next Thursday",
+            "category": "time",
+            "propertyNames": [
+              "parameters.eventReference.timeRange.startDateTime.day",
+              "parameters.eventReference.timeRange.endDateTime.day"
+            ]
+          }
+        ],
+        "propertyAlternatives": [
+          {
+            "propertyName": "fullActionName",
+            "propertyValue": "calendar.addParticipants",
+            "propertySubPhrases": [
+              "add Jennifer"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "calendar.inviteParticipants",
+                "propertySubPhrases": [
+                  "invite Jennifer"
+                ]
+              },
+              {
+                "propertyValue": "calendar.includeParticipants",
+                "propertySubPhrases": [
+                  "include Jennifer"
+                ]
+              },
+              {
+                "propertyValue": "calendar.addAttendees",
+                "propertySubPhrases": [
+                  "add attendees Jennifer"
+                ]
+              }
+            ]
+          },
+          {
+            "propertyName": "parameters.eventReference.description",
+            "propertyValue": "scrum",
+            "propertySubPhrases": [
+              "to the scrum"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "meeting",
+                "propertySubPhrases": [
+                  "to the meeting"
+                ]
+              },
+              {
+                "propertyValue": "standup",
+                "propertySubPhrases": [
+                  "to the standup"
+                ]
+              },
+              {
+                "propertyValue": "discussion",
+                "propertySubPhrases": [
+                  "to the discussion"
+                ]
+              }
+            ]
+          },
+          {
+            "propertyName": "parameters.eventReference.timeRange.startDateTime.day",
+            "propertyValue": "Thursday",
+            "propertySubPhrases": [
+              "next Thursday"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "Friday",
+                "propertySubPhrases": [
+                  "next Friday"
+                ]
+              },
+              {
+                "propertyValue": "Wednesday",
+                "propertySubPhrases": [
+                  "next Wednesday"
+                ]
+              },
+              {
+                "propertyValue": "Monday",
+                "propertySubPhrases": [
+                  "next Monday"
+                ]
+              }
+            ]
+          },
+          {
+            "propertyName": "parameters.eventReference.timeRange.endDateTime.day",
+            "propertyValue": "Thursday",
+            "propertySubPhrases": [
+              "next Thursday"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "Friday",
+                "propertySubPhrases": [
+                  "next Friday"
+                ]
+              },
+              {
+                "propertyValue": "Wednesday",
+                "propertySubPhrases": [
+                  "next Wednesday"
+                ]
+              },
+              {
+                "propertyValue": "Monday",
+                "propertySubPhrases": [
+                  "next Monday"
+                ]
+              }
+            ]
+          }
+        ],
+        "politePrefixes": [
+          "Could you kindly",
+          "Would you be able to",
+          "I would appreciate it if you could",
+          "If it's not too much trouble, please"
+        ],
+        "politeSuffixes": [
+          "Thank you very much!",
+          "I appreciate your help!",
+          "Thanks a lot!",
+          "Your assistance is greatly appreciated!"
+        ]
       },
       "corrections": [
         {
@@ -1457,19 +1637,28 @@
                 "name": "fullActionName",
                 "value": "calendar.addParticipants",
                 "substrings": [
-                  "add"
+                  "add Jennifer to the scrum next Thursday"
                 ]
-              },
-              {
-                "name": "parameters.eventReference.day",
-                "value": "1/30/2025",
-                "isImplicit": true
               },
               {
                 "name": "parameters.eventReference.description",
                 "value": "scrum",
                 "substrings": [
                   "scrum"
+                ]
+              },
+              {
+                "name": "parameters.eventReference.timeRange.startDateTime.day",
+                "value": "Thursday",
+                "substrings": [
+                  "next Thursday"
+                ]
+              },
+              {
+                "name": "parameters.eventReference.timeRange.endDateTime.day",
+                "value": "Thursday",
+                "substrings": [
+                  "next Thursday"
                 ]
               },
               {
@@ -1490,14 +1679,14 @@
                 "text": "Please",
                 "category": "politeness",
                 "synonyms": [
-                  "Kindly",
-                  "Would you mind",
-                  "Could you"
+                  "kindly",
+                  "could you",
+                  "would you mind"
                 ],
                 "isOptional": true
               },
               {
-                "text": "add",
+                "text": "add Jennifer to the scrum next Thursday",
                 "category": "action",
                 "propertyNames": [
                   "fullActionName"
@@ -1511,33 +1700,114 @@
                 ]
               },
               {
-                "text": "to the",
-                "category": "preposition",
-                "synonyms": [
-                  "into the",
-                  "onto the",
-                  "towards the"
-                ],
-                "isOptional": true
-              },
-              {
                 "text": "scrum",
-                "category": "event",
+                "category": "event description",
                 "propertyNames": [
                   "parameters.eventReference.description"
                 ]
               },
               {
                 "text": "next Thursday",
-                "category": "date",
+                "category": "time",
                 "propertyNames": [
-                  "parameters.eventReference.day"
+                  "parameters.eventReference.timeRange.startDateTime.day",
+                  "parameters.eventReference.timeRange.endDateTime.day"
                 ]
               }
             ]
           },
           "correction": [
-            "Property 'parameters.eventReference.day' is expected to be implicit and should not be included as a property name in a sub-phrase"
+            "Overlapping sub-phrase: explanation has overlapping text 'Jennifer'."
+          ]
+        },
+        {
+          "data": {
+            "properties": [
+              {
+                "name": "fullActionName",
+                "value": "calendar.addParticipants",
+                "substrings": [
+                  "add Jennifer to the scrum next Thursday"
+                ]
+              },
+              {
+                "name": "parameters.eventReference.description",
+                "value": "scrum",
+                "substrings": [
+                  "scrum"
+                ]
+              },
+              {
+                "name": "parameters.eventReference.timeRange.startDateTime.day",
+                "value": "Thursday",
+                "substrings": [
+                  "next Thursday"
+                ]
+              },
+              {
+                "name": "parameters.eventReference.timeRange.endDateTime.day",
+                "value": "Thursday",
+                "substrings": [
+                  "next Thursday"
+                ]
+              },
+              {
+                "name": "parameters.eventReference.lookup",
+                "value": true,
+                "isImplicit": true
+              },
+              {
+                "name": "parameters.participants.0",
+                "value": "Jennifer",
+                "substrings": [
+                  "Jennifer"
+                ]
+              }
+            ],
+            "subPhrases": [
+              {
+                "text": "Please",
+                "category": "politeness",
+                "synonyms": [
+                  "kindly",
+                  "could you",
+                  "would you mind"
+                ],
+                "isOptional": true
+              },
+              {
+                "text": "add Jennifer",
+                "category": "action",
+                "propertyNames": [
+                  "fullActionName"
+                ]
+              },
+              {
+                "text": "Jennifer",
+                "category": "participant",
+                "propertyNames": [
+                  "parameters.participants.0"
+                ]
+              },
+              {
+                "text": "to the scrum",
+                "category": "event description",
+                "propertyNames": [
+                  "parameters.eventReference.description"
+                ]
+              },
+              {
+                "text": "next Thursday",
+                "category": "time",
+                "propertyNames": [
+                  "parameters.eventReference.timeRange.startDateTime.day",
+                  "parameters.eventReference.timeRange.endDateTime.day"
+                ]
+              }
+            ]
+          },
+          "correction": [
+            "Overlapping sub-phrase: explanation has overlapping text 'Jennifer'."
           ]
         }
       ]
@@ -1548,12 +1818,16 @@
         "fullActionName": "calendar.addEvent",
         "parameters": {
           "event": {
-            "day": "January 27",
             "timeRange": {
-              "startTime": "10:00 am",
-              "duration": "1 hour"
+              "startDateTime": {
+                "day": "Monday",
+                "hms": "10:00:00"
+              },
+              "duration": "1:00:00"
             },
-            "description": "bridge game"
+            "description": "bridge game",
+            "location": "",
+            "participants": []
           }
         }
       },
@@ -1562,23 +1836,27 @@
           {
             "name": "fullActionName",
             "value": "calendar.addEvent",
-            "substrings": []
+            "substrings": [
+              "record"
+            ]
           },
           {
-            "name": "parameters.event.day",
-            "value": "January 27",
-            "substrings": []
+            "name": "parameters.event.timeRange.startDateTime.day",
+            "value": "Monday",
+            "substrings": [
+              "Monday"
+            ]
           },
           {
-            "name": "parameters.event.timeRange.startTime",
-            "value": "10:00 am",
+            "name": "parameters.event.timeRange.startDateTime.hms",
+            "value": "10:00:00",
             "substrings": [
               "10"
             ]
           },
           {
             "name": "parameters.event.timeRange.duration",
-            "value": "1 hour",
+            "value": "1:00:00",
             "substrings": [
               "one hour"
             ]
@@ -1589,6 +1867,11 @@
             "substrings": [
               "bridge game"
             ]
+          },
+          {
+            "name": "parameters.event.location",
+            "value": "",
+            "isImplicit": true
           }
         ],
         "subPhrases": [
@@ -1601,7 +1884,7 @@
           },
           {
             "text": "bridge game",
-            "category": "event description",
+            "category": "description",
             "propertyNames": [
               "parameters.event.description"
             ]
@@ -1610,18 +1893,40 @@
             "text": "Monday",
             "category": "day",
             "propertyNames": [
-              "parameters.event.day"
+              "parameters.event.timeRange.startDateTime.day"
             ]
           },
           {
-            "text": "at 10",
-            "category": "start time",
+            "text": "at",
+            "category": "preposition",
+            "synonyms": [
+              "on",
+              "by",
+              "in",
+              "during"
+            ],
+            "isOptional": true
+          },
+          {
+            "text": "10",
+            "category": "time",
             "propertyNames": [
-              "parameters.event.timeRange.startTime"
+              "parameters.event.timeRange.startDateTime.hms"
             ]
           },
           {
-            "text": "for one hour",
+            "text": "for",
+            "category": "preposition",
+            "synonyms": [
+              "during",
+              "over",
+              "throughout",
+              "within"
+            ],
+            "isOptional": true
+          },
+          {
+            "text": "one hour",
             "category": "duration",
             "propertyNames": [
               "parameters.event.timeRange.duration"
@@ -1684,26 +1989,26 @@
             ]
           },
           {
-            "propertyName": "parameters.event.day",
-            "propertyValue": "January 27",
+            "propertyName": "parameters.event.timeRange.startDateTime.day",
+            "propertyValue": "Monday",
             "propertySubPhrases": [
               "Monday"
             ],
             "alternatives": [
               {
-                "propertyValue": "January 28",
+                "propertyValue": "Tuesday",
                 "propertySubPhrases": [
                   "Tuesday"
                 ]
               },
               {
-                "propertyValue": "January 29",
+                "propertyValue": "Wednesday",
                 "propertySubPhrases": [
                   "Wednesday"
                 ]
               },
               {
-                "propertyValue": "January 30",
+                "propertyValue": "Thursday",
                 "propertySubPhrases": [
                   "Thursday"
                 ]
@@ -1711,55 +2016,55 @@
             ]
           },
           {
-            "propertyName": "parameters.event.timeRange.startTime",
-            "propertyValue": "10:00 am",
+            "propertyName": "parameters.event.timeRange.startDateTime.hms",
+            "propertyValue": "10:00:00",
             "propertySubPhrases": [
-              "at 10"
+              "10"
             ],
             "alternatives": [
               {
-                "propertyValue": "11:00 am",
+                "propertyValue": "11:00:00",
                 "propertySubPhrases": [
-                  "at 11"
+                  "11"
                 ]
               },
               {
-                "propertyValue": "9:00 am",
+                "propertyValue": "12:00:00",
                 "propertySubPhrases": [
-                  "at 9"
+                  "12"
                 ]
               },
               {
-                "propertyValue": "8:00 am",
+                "propertyValue": "13:00:00",
                 "propertySubPhrases": [
-                  "at 8"
+                  "1 PM"
                 ]
               }
             ]
           },
           {
             "propertyName": "parameters.event.timeRange.duration",
-            "propertyValue": "1 hour",
+            "propertyValue": "1:00:00",
             "propertySubPhrases": [
-              "for one hour"
+              "one hour"
             ],
             "alternatives": [
               {
-                "propertyValue": "2 hours",
+                "propertyValue": "2:00:00",
                 "propertySubPhrases": [
-                  "for two hours"
+                  "two hours"
                 ]
               },
               {
-                "propertyValue": "30 minutes",
+                "propertyValue": "0:30:00",
                 "propertySubPhrases": [
-                  "for thirty minutes"
+                  "half an hour"
                 ]
               },
               {
-                "propertyValue": "1.5 hours",
+                "propertyValue": "3:00:00",
                 "propertySubPhrases": [
-                  "for one and a half hours"
+                  "three hours"
                 ]
               }
             ]
@@ -1768,14 +2073,14 @@
         "politePrefixes": [
           "Could you please",
           "Would you mind",
-          "If it's not too much trouble, could you",
-          "I would appreciate it if you could"
+          "I would appreciate it if you could",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "Thanks a lot!",
-          "I appreciate it!",
-          "Much appreciated!"
+          "Thank you",
+          "Thanks in advance",
+          "I appreciate it",
+          "If possible"
         ]
       },
       "corrections": [
@@ -1785,25 +2090,27 @@
               {
                 "name": "fullActionName",
                 "value": "calendar.addEvent",
-                "substrings": []
+                "substrings": [
+                  "record"
+                ]
               },
               {
-                "name": "parameters.event.day",
+                "name": "parameters.event.timeRange.startDateTime.day",
                 "value": "Monday",
                 "substrings": [
                   "Monday"
                 ]
               },
               {
-                "name": "parameters.event.timeRange.startTime",
-                "value": "10:00 am",
+                "name": "parameters.event.timeRange.startDateTime.hms",
+                "value": "10:00:00",
                 "substrings": [
                   "10"
                 ]
               },
               {
                 "name": "parameters.event.timeRange.duration",
-                "value": "1 hour",
+                "value": "1:00:00",
                 "substrings": [
                   "one hour"
                 ]
@@ -1814,11 +2121,75 @@
                 "substrings": [
                   "bridge game"
                 ]
+              },
+              {
+                "name": "parameters.event.location",
+                "value": "",
+                "isImplicit": true
+              }
+            ],
+            "subPhrases": [
+              {
+                "text": "record",
+                "category": "action",
+                "propertyNames": [
+                  "fullActionName"
+                ]
+              },
+              {
+                "text": "bridge game",
+                "category": "description",
+                "propertyNames": [
+                  "parameters.event.description"
+                ]
+              },
+              {
+                "text": "Monday",
+                "category": "day",
+                "propertyNames": [
+                  "parameters.event.timeRange.startDateTime.day"
+                ]
+              },
+              {
+                "text": "10",
+                "category": "time",
+                "propertyNames": [
+                  "parameters.event.timeRange.startDateTime.hms"
+                ]
+              },
+              {
+                "text": "one hour",
+                "category": "duration",
+                "propertyNames": [
+                  "parameters.event.timeRange.duration"
+                ]
+              },
+              {
+                "text": "at",
+                "category": "preposition",
+                "synonyms": [
+                  "on",
+                  "by",
+                  "in",
+                  "during"
+                ],
+                "isOptional": true
+              },
+              {
+                "text": "for",
+                "category": "preposition",
+                "synonyms": [
+                  "during",
+                  "over",
+                  "throughout",
+                  "within"
+                ],
+                "isOptional": true
               }
             ]
           },
           "correction": [
-            "Mismatch parameter value: 'Monday' in the explanation is not the value of the parameter 'parameters.event.day' in the action"
+            "Missing sub-phrase: explanation missing for 'at'"
           ]
         }
       ]
@@ -1829,10 +2200,18 @@
         "fullActionName": "calendar.findEvents",
         "parameters": {
           "eventReference": {
-            "dayRange": "this week",
             "participants": [
               "Gavin"
-            ]
+            ],
+            "timeRange": {
+              "startDateTime": {
+                "week": "0"
+              },
+              "endDateTime": {
+                "week": "0"
+              }
+            },
+            "lookup": true
           }
         }
       },
@@ -1846,18 +2225,30 @@
             ]
           },
           {
-            "name": "parameters.eventReference.dayRange",
-            "value": "this week",
-            "substrings": [
-              "this week"
-            ]
-          },
-          {
             "name": "parameters.eventReference.participants.0",
             "value": "Gavin",
             "substrings": [
               "Gavin"
             ]
+          },
+          {
+            "name": "parameters.eventReference.timeRange.startDateTime.week",
+            "value": "0",
+            "substrings": [
+              "this week"
+            ]
+          },
+          {
+            "name": "parameters.eventReference.timeRange.endDateTime.week",
+            "value": "0",
+            "substrings": [
+              "this week"
+            ]
+          },
+          {
+            "name": "parameters.eventReference.lookup",
+            "value": true,
+            "isImplicit": true
           }
         ],
         "subPhrases": [
@@ -1877,9 +2268,10 @@
           },
           {
             "text": "this week",
-            "category": "time",
+            "category": "timeRange",
             "propertyNames": [
-              "parameters.eventReference.dayRange"
+              "parameters.eventReference.timeRange.startDateTime.week",
+              "parameters.eventReference.timeRange.endDateTime.week"
             ]
           }
         ],
@@ -1892,21 +2284,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "calendar.searchEvents",
+                "propertyValue": "calendar.scheduleMeeting",
                 "propertySubPhrases": [
-                  "Look for any meetings"
+                  "Schedule a meeting"
                 ]
               },
               {
-                "propertyValue": "calendar.queryEvents",
+                "propertyValue": "calendar.cancelMeeting",
                 "propertySubPhrases": [
-                  "Find any meetings"
+                  "Cancel a meeting"
                 ]
               },
               {
-                "propertyValue": "calendar.locateEvents",
+                "propertyValue": "calendar.updateMeeting",
                 "propertySubPhrases": [
-                  "Locate any meetings"
+                  "Update a meeting"
                 ]
               }
             ]
@@ -1919,48 +2311,75 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "John",
+                "propertyValue": "Alice",
                 "propertySubPhrases": [
-                  "with John"
+                  "with Alice"
                 ]
               },
               {
-                "propertyValue": "Emily",
+                "propertyValue": "Bob",
                 "propertySubPhrases": [
-                  "with Emily"
+                  "with Bob"
                 ]
               },
               {
-                "propertyValue": "Sarah",
+                "propertyValue": "Charlie",
                 "propertySubPhrases": [
-                  "with Sarah"
+                  "with Charlie"
                 ]
               }
             ]
           },
           {
-            "propertyName": "parameters.eventReference.dayRange",
-            "propertyValue": "this week",
+            "propertyName": "parameters.eventReference.timeRange.startDateTime.week",
+            "propertyValue": "0",
             "propertySubPhrases": [
               "this week"
             ],
             "alternatives": [
               {
-                "propertyValue": "today",
+                "propertyValue": "-1",
                 "propertySubPhrases": [
-                  "today"
+                  "last week"
                 ]
               },
               {
-                "propertyValue": "tomorrow",
-                "propertySubPhrases": [
-                  "tomorrow"
-                ]
-              },
-              {
-                "propertyValue": "next week",
+                "propertyValue": "1",
                 "propertySubPhrases": [
                   "next week"
+                ]
+              },
+              {
+                "propertyValue": "2",
+                "propertySubPhrases": [
+                  "in two weeks"
+                ]
+              }
+            ]
+          },
+          {
+            "propertyName": "parameters.eventReference.timeRange.endDateTime.week",
+            "propertyValue": "0",
+            "propertySubPhrases": [
+              "this week"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "-1",
+                "propertySubPhrases": [
+                  "last week"
+                ]
+              },
+              {
+                "propertyValue": "1",
+                "propertySubPhrases": [
+                  "next week"
+                ]
+              },
+              {
+                "propertyValue": "2",
+                "propertySubPhrases": [
+                  "in two weeks"
                 ]
               }
             ]
@@ -1969,16 +2388,61 @@
         "politePrefixes": [
           "Could you please",
           "Would you mind",
-          "If it's not too much trouble, could you",
-          "May I kindly ask you to"
+          "Can you kindly",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it.",
-          "Thanks a lot!",
-          "Your help is appreciated."
+          "for me?",
+          "if possible?",
+          "when you get a chance?",
+          "thanks!"
         ]
-      }
+      },
+      "corrections": [
+        {
+          "data": {
+            "properties": [
+              {
+                "name": "fullActionName",
+                "value": "calendar.findEvents",
+                "substrings": [
+                  "Search for any meetings"
+                ]
+              },
+              {
+                "name": "parameters.eventReference.participants.0",
+                "value": "Gavin",
+                "substrings": [
+                  "Gavin"
+                ]
+              },
+              {
+                "name": "parameters.eventReference.timeRange.startDateTime.week",
+                "value": 0,
+                "substrings": [
+                  "this week"
+                ]
+              },
+              {
+                "name": "parameters.eventReference.timeRange.endDateTime.week",
+                "value": 0,
+                "substrings": [
+                  "this week"
+                ]
+              },
+              {
+                "name": "parameters.eventReference.lookup",
+                "value": true,
+                "isImplicit": true
+              }
+            ]
+          },
+          "correction": [
+            "Mismatch parameter value: '0' in the explanation is not the value of the parameter 'parameters.eventReference.timeRange.startDateTime.week' in the action",
+            "Mismatch parameter value: '0' in the explanation is not the value of the parameter 'parameters.eventReference.timeRange.endDateTime.week' in the action"
+          ]
+        }
+      ]
     }
   ]
 }

--- a/ts/packages/defaultAgentProvider/test/data/explanations/player/v5/changeVolume.json
+++ b/ts/packages/defaultAgentProvider/test/data/explanations/player/v5/changeVolume.json
@@ -56,20 +56,17 @@
           {
             "text": "in audio",
             "category": "context",
-            "synonyms": [
-              "in sound",
-              "in volume",
-              "in music"
-            ],
-            "isOptional": true
+            "propertyNames": [
+              "fullActionName"
+            ]
           },
           {
             "text": "would be perfect.",
-            "category": "politeness",
+            "category": "confirmation",
             "synonyms": [
-              "please",
-              "if possible",
-              "that would be great"
+              "is fine.",
+              "is good.",
+              "is okay."
             ],
             "isOptional": true
           }
@@ -105,19 +102,46 @@
                 ]
               }
             ]
+          },
+          {
+            "propertyName": "fullActionName",
+            "propertyValue": "player.changeVolume",
+            "propertySubPhrases": [
+              "in audio"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "player.mute",
+                "propertySubPhrases": [
+                  "mute audio"
+                ]
+              },
+              {
+                "propertyValue": "player.increaseVolume",
+                "propertySubPhrases": [
+                  "increase audio"
+                ]
+              },
+              {
+                "propertyValue": "player.decreaseVolume",
+                "propertySubPhrases": [
+                  "decrease audio"
+                ]
+              }
+            ]
           }
         ],
         "politePrefixes": [
           "Could you please",
           "Would you mind",
-          "If it's not too much trouble,",
+          "If possible,",
           "I would appreciate it if you could"
         ],
         "politeSuffixes": [
-          "Thank you.",
-          "Thanks a lot.",
-          "I appreciate it.",
-          "That would be great."
+          "Thank you!",
+          "Please.",
+          "Thanks in advance.",
+          "I appreciate it."
         ]
       },
       "corrections": [
@@ -172,7 +196,7 @@
         "subPhrases": [
           {
             "text": "Adjust the volume",
-            "category": "action",
+            "category": "command",
             "propertyNames": [
               "fullActionName"
             ]
@@ -189,7 +213,7 @@
           },
           {
             "text": "30%",
-            "category": "value",
+            "category": "quantity",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
@@ -253,11 +277,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If you don't mind",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it."
+          "Thank you.",
+          "Thanks.",
+          "I appreciate it.",
+          "If that's okay."
         ]
       }
     },
@@ -313,19 +341,19 @@
               {
                 "propertyValue": "player.adjustVolume",
                 "propertySubPhrases": [
-                  "Adjust the volume"
-                ]
-              },
-              {
-                "propertyValue": "player.setVolume",
-                "propertySubPhrases": [
-                  "Set the volume"
+                  "Adjust the sound level"
                 ]
               },
               {
                 "propertyValue": "player.modifyVolume",
                 "propertySubPhrases": [
-                  "Modify the volume"
+                  "Modify the sound level"
+                ]
+              },
+              {
+                "propertyValue": "player.setVolume",
+                "propertySubPhrases": [
+                  "Set the sound level"
                 ]
               }
             ]
@@ -361,42 +389,16 @@
         "politePrefixes": [
           "Could you please",
           "Would you mind",
-          "If it's not too much trouble, could you",
-          "May I kindly ask you to"
+          "If it's not too much trouble,",
+          "Please"
         ],
         "politeSuffixes": [
           "Thank you!",
-          "I would appreciate it.",
-          "Thanks a lot!",
-          "That would be great."
+          "Thanks!",
+          "I appreciate it!",
+          "If you don't mind."
         ]
-      },
-      "corrections": [
-        {
-          "data": {
-            "properties": [
-              {
-                "name": "fullActionName",
-                "value": "player.changeVolume",
-                "substrings": [
-                  "Alter the sound level"
-                ]
-              },
-              {
-                "name": "volumeChangePercentage",
-                "value": 10,
-                "substrings": [
-                  "hike it up by 10%"
-                ]
-              }
-            ]
-          },
-          "correction": [
-            "Extraneous parameter: 'volumeChangePercentage' is not a parameter in the action",
-            "Missing parameter: parameter 'parameters.volumeChangePercentage' in the action is missing from explanation"
-          ]
-        }
-      ]
+      }
     },
     {
       "request": "Amplify the sound by 30%.",
@@ -432,8 +434,18 @@
             ]
           },
           {
-            "text": "by 30%",
-            "category": "parameter",
+            "text": "by",
+            "category": "preposition",
+            "synonyms": [
+              "with",
+              "using",
+              "through"
+            ],
+            "isOptional": true
+          },
+          {
+            "text": "30%",
+            "category": "value",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
@@ -450,19 +462,19 @@
               {
                 "propertyValue": "player.increaseVolume",
                 "propertySubPhrases": [
-                  "Increase the volume"
+                  "Increase the sound"
                 ]
               },
               {
                 "propertyValue": "player.raiseVolume",
                 "propertySubPhrases": [
-                  "Raise the volume"
+                  "Raise the sound"
                 ]
               },
               {
                 "propertyValue": "player.boostVolume",
                 "propertySubPhrases": [
-                  "Boost the volume"
+                  "Boost the sound"
                 ]
               }
             ]
@@ -471,25 +483,25 @@
             "propertyName": "parameters.volumeChangePercentage",
             "propertyValue": 30,
             "propertySubPhrases": [
-              "by 30%"
+              "30%"
             ],
             "alternatives": [
               {
                 "propertyValue": 20,
                 "propertySubPhrases": [
-                  "by 20%"
+                  "20%"
+                ]
+              },
+              {
+                "propertyValue": 40,
+                "propertySubPhrases": [
+                  "40%"
                 ]
               },
               {
                 "propertyValue": 50,
                 "propertySubPhrases": [
-                  "by 50%"
-                ]
-              },
-              {
-                "propertyValue": 10,
-                "propertySubPhrases": [
-                  "by 10%"
+                  "50%"
                 ]
               }
             ]
@@ -497,11 +509,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If possible,",
+          "Kindly"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it."
+          "thank you.",
+          "please.",
+          "if you don't mind.",
+          "thanks."
         ]
       }
     },
@@ -533,24 +549,34 @@
         "subPhrases": [
           {
             "text": "Boost the volume",
-            "category": "action",
+            "category": "command",
             "propertyNames": [
               "fullActionName"
             ]
           },
           {
-            "text": "by a cool",
+            "text": "by",
+            "category": "preposition",
+            "synonyms": [
+              "to",
+              "up to",
+              "at"
+            ],
+            "isOptional": true
+          },
+          {
+            "text": "a cool",
             "category": "filler",
             "synonyms": [
-              "by",
-              "by an impressive",
-              "by a nice"
+              "exactly",
+              "precisely",
+              "just"
             ],
             "isOptional": true
           },
           {
             "text": "30%",
-            "category": "value",
+            "category": "quantity",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
@@ -598,15 +624,15 @@
                 ]
               },
               {
-                "propertyValue": 50,
+                "propertyValue": 40,
                 "propertySubPhrases": [
-                  "50%"
+                  "40%"
                 ]
               },
               {
-                "propertyValue": 10,
+                "propertyValue": 50,
                 "propertySubPhrases": [
-                  "10%"
+                  "50%"
                 ]
               }
             ]
@@ -616,13 +642,13 @@
           "Could you please",
           "Would you mind",
           "If it's not too much trouble,",
-          "Kindly"
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you.",
-          "Thanks a lot.",
-          "I appreciate it.",
-          "Much appreciated."
+          "Thank you!",
+          "Thanks!",
+          "I appreciate it!",
+          "If you don't mind."
         ]
       }
     },
@@ -640,7 +666,7 @@
             "name": "fullActionName",
             "value": "player.changeVolume",
             "substrings": [
-              "sound level up"
+              "sound level"
             ]
           },
           {
@@ -656,32 +682,32 @@
             "text": "Can we get",
             "category": "politeness",
             "synonyms": [
-              "Could we have",
-              "May we get",
-              "Would it be possible to get"
+              "Could you",
+              "Please",
+              "Would you mind"
             ],
             "isOptional": true
           },
           {
-            "text": "the sound level up",
-            "category": "action",
+            "text": "the sound level",
+            "category": "property",
             "propertyNames": [
               "fullActionName"
             ]
           },
           {
-            "text": "by a decent",
+            "text": "up by a decent",
             "category": "filler",
             "synonyms": [
-              "by a good",
-              "by a reasonable",
-              "by an adequate"
+              "increase",
+              "raise",
+              "boost"
             ],
             "isOptional": true
           },
           {
             "text": "10%",
-            "category": "value",
+            "category": "property",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
@@ -692,25 +718,25 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.changeVolume",
             "propertySubPhrases": [
-              "the sound level up"
+              "the sound level"
             ],
             "alternatives": [
               {
-                "propertyValue": "player.increaseVolume",
-                "propertySubPhrases": [
-                  "increase the volume"
-                ]
-              },
-              {
-                "propertyValue": "player.raiseVolume",
-                "propertySubPhrases": [
-                  "raise the volume"
-                ]
-              },
-              {
                 "propertyValue": "player.adjustVolume",
                 "propertySubPhrases": [
-                  "adjust the volume"
+                  "the volume"
+                ]
+              },
+              {
+                "propertyValue": "player.setVolume",
+                "propertySubPhrases": [
+                  "the audio level"
+                ]
+              },
+              {
+                "propertyValue": "player.modifyVolume",
+                "propertySubPhrases": [
+                  "the sound"
                 ]
               }
             ]
@@ -745,11 +771,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would it be possible to",
+          "May I kindly ask",
+          "If you don't mind,"
         ],
         "politeSuffixes": [
           "Thank you!",
-          "I would appreciate it."
+          "Please.",
+          "I would appreciate it.",
+          "Thanks in advance."
         ]
       }
     },
@@ -792,14 +822,14 @@
           },
           {
             "text": "the audio",
-            "category": "category",
+            "category": "object",
             "propertyNames": [
               "fullActionName"
             ]
           },
           {
             "text": "20%",
-            "category": "percentage",
+            "category": "amount",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
@@ -821,21 +851,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.mute",
+                "propertyValue": "player.adjustVolume",
                 "propertySubPhrases": [
-                  "mute the audio"
-                ]
-              },
-              {
-                "propertyValue": "player.unmute",
-                "propertySubPhrases": [
-                  "unmute the audio"
+                  "the sound"
                 ]
               },
               {
                 "propertyValue": "player.setVolume",
                 "propertySubPhrases": [
-                  "set the volume"
+                  "the volume"
+                ]
+              },
+              {
+                "propertyValue": "player.modifyVolume",
+                "propertySubPhrases": [
+                  "the audio level"
                 ]
               }
             ]
@@ -863,10 +893,10 @@
                 ]
               },
               {
-                "propertyValue": 20,
+                "propertyValue": -50,
                 "propertySubPhrases": [
-                  "20%",
-                  "up"
+                  "50%",
+                  "down"
                 ]
               }
             ]
@@ -874,11 +904,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would it be possible to",
+          "May I kindly ask",
+          "If you don't mind"
         ],
         "politeSuffixes": [
-          "Thank you.",
-          "I would appreciate it."
+          "thank you",
+          "please",
+          "if that's okay",
+          "if you could"
         ]
       },
       "corrections": [
@@ -939,17 +973,24 @@
             "category": "politeness",
             "synonyms": [
               "Could we",
-              "Would it be possible to",
-              "Shall we"
+              "Would you",
+              "Please"
             ],
             "isOptional": true
           },
           {
-            "text": "trim down the volume",
+            "text": "trim down",
             "category": "action",
             "propertyNames": [
               "fullActionName",
               "parameters.volumeChangePercentage"
+            ]
+          },
+          {
+            "text": "the volume",
+            "category": "object",
+            "propertyNames": [
+              "fullActionName"
             ]
           },
           {
@@ -964,7 +1005,7 @@
           },
           {
             "text": "5%",
-            "category": "percentage",
+            "category": "amount",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
@@ -975,25 +1016,29 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.changeVolume",
             "propertySubPhrases": [
-              "trim down the volume"
+              "trim down",
+              "the volume"
             ],
             "alternatives": [
               {
-                "propertyValue": "player.increaseVolume",
+                "propertyValue": "player.decreaseVolume",
                 "propertySubPhrases": [
-                  "increase the volume"
+                  "lower",
+                  "the volume"
                 ]
               },
               {
-                "propertyValue": "player.muteVolume",
+                "propertyValue": "player.reduceVolume",
                 "propertySubPhrases": [
-                  "mute the volume"
+                  "reduce",
+                  "the volume"
                 ]
               },
               {
-                "propertyValue": "player.setVolume",
+                "propertyValue": "player.turnDownVolume",
                 "propertySubPhrases": [
-                  "set the volume"
+                  "turn down",
+                  "the volume"
                 ]
               }
             ]
@@ -1002,28 +1047,28 @@
             "propertyName": "parameters.volumeChangePercentage",
             "propertyValue": -5,
             "propertySubPhrases": [
-              "trim down the volume",
+              "trim down",
               "5%"
             ],
             "alternatives": [
               {
                 "propertyValue": -10,
                 "propertySubPhrases": [
-                  "trim down the volume",
+                  "trim down",
                   "10%"
                 ]
               },
               {
                 "propertyValue": -15,
                 "propertySubPhrases": [
-                  "trim down the volume",
+                  "trim down",
                   "15%"
                 ]
               },
               {
                 "propertyValue": -20,
                 "propertySubPhrases": [
-                  "trim down the volume",
+                  "trim down",
                   "20%"
                 ]
               }
@@ -1032,10 +1077,14 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If it's not too much trouble,",
+          "May I kindly ask"
         ],
         "politeSuffixes": [
-          "Thank you!",
+          "thank you.",
+          "please.",
+          "if that's okay.",
           "I would appreciate it."
         ]
       },
@@ -1061,66 +1110,6 @@
           },
           "correction": [
             "Value -5 for property 'parameters.volumeChangePercentage' doesn't match the number 5 in the substring '5%'. Missing other substring to explain the value."
-          ]
-        },
-        {
-          "data": {
-            "properties": [
-              {
-                "name": "fullActionName",
-                "value": "player.changeVolume",
-                "substrings": [
-                  "trim down the volume"
-                ]
-              },
-              {
-                "name": "parameters.volumeChangePercentage",
-                "value": -5,
-                "substrings": [
-                  "trim down",
-                  "5%"
-                ]
-              }
-            ],
-            "subPhrases": [
-              {
-                "text": "Can we",
-                "category": "politeness",
-                "synonyms": [
-                  "Could we",
-                  "Would it be possible to",
-                  "Shall we"
-                ],
-                "isOptional": true
-              },
-              {
-                "text": "trim down the volume",
-                "category": "action",
-                "propertyNames": [
-                  "fullActionName"
-                ]
-              },
-              {
-                "text": "by a tiny",
-                "category": "filler",
-                "synonyms": [
-                  "by a small",
-                  "by a little",
-                  "by a slight"
-                ],
-                "isOptional": true
-              },
-              {
-                "text": "5%",
-                "category": "percentage",
-                "propertyNames": [
-                  "parameters.volumeChangePercentage"
-                ]
-              }
-            ]
-          },
-          "correction": [
-            "Explicit property 'parameters.volumeChangePercentage' must be included as property names for all subphrases that contain the substring 'trim down'"
           ]
         }
       ]
@@ -1174,7 +1163,7 @@
             "synonyms": [
               "by a solid",
               "by a good",
-              "by a hefty"
+              "by a decent"
             ],
             "isOptional": true
           },
@@ -1244,11 +1233,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If it's not too much trouble,",
+          "May I kindly ask you to"
         ],
         "politeSuffixes": [
           "Thank you!",
-          "I would appreciate it."
+          "I would appreciate it.",
+          "Thanks in advance!",
+          "If you don't mind."
         ]
       }
     },
@@ -1297,20 +1290,10 @@
           },
           {
             "text": "by 5%",
-            "category": "parameter",
+            "category": "quantity",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
-          },
-          {
-            "text": "?",
-            "category": "punctuation",
-            "synonyms": [
-              ".",
-              "!",
-              ""
-            ],
-            "isOptional": true
           }
         ],
         "propertyAlternatives": [
@@ -1371,11 +1354,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If it's not too much trouble, could you",
+          "May I ask you to"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it."
+          "thank you",
+          "please",
+          "if you don't mind",
+          "I'd appreciate it"
         ]
       }
     },
@@ -1393,7 +1380,6 @@
             "name": "fullActionName",
             "value": "player.changeVolume",
             "substrings": [
-              "shave off",
               "volume"
             ]
           },
@@ -1421,13 +1407,12 @@
             "text": "shave off",
             "category": "action",
             "propertyNames": [
-              "fullActionName",
               "parameters.volumeChangePercentage"
             ]
           },
           {
             "text": "5%",
-            "category": "percentage",
+            "category": "quantity",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
@@ -1441,37 +1426,6 @@
           }
         ],
         "propertyAlternatives": [
-          {
-            "propertyName": "fullActionName",
-            "propertyValue": "player.changeVolume",
-            "propertySubPhrases": [
-              "shave off",
-              "from the volume"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "player.decreaseVolume",
-                "propertySubPhrases": [
-                  "reduce",
-                  "from the volume"
-                ]
-              },
-              {
-                "propertyValue": "player.lowerVolume",
-                "propertySubPhrases": [
-                  "lower",
-                  "from the volume"
-                ]
-              },
-              {
-                "propertyValue": "player.dimVolume",
-                "propertySubPhrases": [
-                  "dim",
-                  "from the volume"
-                ]
-              }
-            ]
-          },
           {
             "propertyName": "parameters.volumeChangePercentage",
             "propertyValue": -5,
@@ -1502,15 +1456,46 @@
                 ]
               }
             ]
+          },
+          {
+            "propertyName": "fullActionName",
+            "propertyValue": "player.changeVolume",
+            "propertySubPhrases": [
+              "from the volume"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "player.adjustVolume",
+                "propertySubPhrases": [
+                  "from the sound level"
+                ]
+              },
+              {
+                "propertyValue": "player.modifyVolume",
+                "propertySubPhrases": [
+                  "from the audio level"
+                ]
+              },
+              {
+                "propertyValue": "player.setVolume",
+                "propertySubPhrases": [
+                  "from the volume setting"
+                ]
+              }
+            ]
           }
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If it's not too much trouble, could you",
+          "I would appreciate it if you could"
         ],
         "politeSuffixes": [
           "Thank you!",
-          "I would appreciate it."
+          "Please.",
+          "If you don't mind.",
+          "Thanks a lot!"
         ]
       },
       "corrections": [
@@ -1521,7 +1506,6 @@
                 "name": "fullActionName",
                 "value": "player.changeVolume",
                 "substrings": [
-                  "shave off",
                   "volume"
                 ]
               },
@@ -1529,13 +1513,13 @@
                 "name": "parameters.volumeChangePercentage",
                 "value": -5,
                 "substrings": [
-                  "5%"
+                  "shave off 5%"
                 ]
               }
             ]
           },
           "correction": [
-            "Value -5 for property 'parameters.volumeChangePercentage' doesn't match the number 5 in the substring '5%'. Missing other substring to explain the value."
+            "Value -5 for property 'parameters.volumeChangePercentage' doesn't match the number 5 in the substring 'shave off 5%'. Missing other substring to explain the value."
           ]
         }
       ]
@@ -1568,14 +1552,14 @@
         "subPhrases": [
           {
             "text": "Change the sound level",
-            "category": "command",
+            "category": "action",
             "propertyNames": [
               "fullActionName"
             ]
           },
           {
             "text": "bump it up by 10%",
-            "category": "command",
+            "category": "parameter",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
@@ -1590,21 +1574,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.increaseVolume",
-                "propertySubPhrases": [
-                  "Increase the volume"
-                ]
-              },
-              {
-                "propertyValue": "player.raiseVolume",
-                "propertySubPhrases": [
-                  "Raise the volume"
-                ]
-              },
-              {
                 "propertyValue": "player.adjustVolume",
                 "propertySubPhrases": [
-                  "Adjust the volume"
+                  "Adjust the sound level"
+                ]
+              },
+              {
+                "propertyValue": "player.setVolume",
+                "propertySubPhrases": [
+                  "Set the sound level"
+                ]
+              },
+              {
+                "propertyValue": "player.modifyVolume",
+                "propertySubPhrases": [
+                  "Modify the sound level"
                 ]
               }
             ]
@@ -1619,19 +1603,19 @@
               {
                 "propertyValue": 5,
                 "propertySubPhrases": [
-                  "bump it up by 5%"
+                  "increase it by 5%"
                 ]
               },
               {
                 "propertyValue": 15,
                 "propertySubPhrases": [
-                  "bump it up by 15%"
+                  "raise it by 15%"
                 ]
               },
               {
                 "propertyValue": 20,
                 "propertySubPhrases": [
-                  "bump it up by 20%"
+                  "boost it by 20%"
                 ]
               }
             ]
@@ -1639,11 +1623,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If possible,",
+          "Kindly"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it."
+          "thank you.",
+          "please.",
+          "if you don't mind.",
+          "thanks."
         ]
       }
     },
@@ -1695,14 +1683,14 @@
             "category": "filler",
             "synonyms": [
               "by a nice",
-              "by a cool",
-              "by an awesome"
+              "by a lovely",
+              "by a cool"
             ],
             "isOptional": true
           },
           {
             "text": "25%",
-            "category": "value",
+            "category": "quantity",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
@@ -1729,9 +1717,9 @@
                 ]
               },
               {
-                "propertyValue": "player.turnUpVolume",
+                "propertyValue": "player.boostVolume",
                 "propertySubPhrases": [
-                  "turn up the volume"
+                  "boost the volume"
                 ]
               }
             ]
@@ -1764,8 +1752,18 @@
             ]
           }
         ],
-        "politePrefixes": [],
-        "politeSuffixes": []
+        "politePrefixes": [
+          "If you don't mind,",
+          "When you have a moment,",
+          "If it's not too much trouble,",
+          "Whenever you get a chance,"
+        ],
+        "politeSuffixes": [
+          "Thank you!",
+          "I would really appreciate it.",
+          "Thanks a lot!",
+          "That would be great, thanks!"
+        ]
       }
     },
     {
@@ -1798,9 +1796,9 @@
             "text": "Could you",
             "category": "politeness",
             "synonyms": [
-              "Can you",
-              "Would you",
-              "Will you"
+              "please",
+              "would you mind",
+              "can you"
             ],
             "isOptional": true
           },
@@ -1823,7 +1821,7 @@
           },
           {
             "text": "10%",
-            "category": "value",
+            "category": "quantity",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
@@ -1840,19 +1838,19 @@
               {
                 "propertyValue": "player.increaseVolume",
                 "propertySubPhrases": [
-                  "increase the volume"
+                  "increase the audio level"
                 ]
               },
               {
                 "propertyValue": "player.raiseVolume",
                 "propertySubPhrases": [
-                  "raise the volume"
+                  "raise the audio level"
                 ]
               },
               {
                 "propertyValue": "player.boostVolume",
                 "propertySubPhrases": [
-                  "boost the volume"
+                  "boost the audio level"
                 ]
               }
             ]
@@ -1885,8 +1883,18 @@
             ]
           }
         ],
-        "politePrefixes": [],
-        "politeSuffixes": []
+        "politePrefixes": [
+          "Please,",
+          "If you don't mind,",
+          "Would you kindly,",
+          "I would appreciate it if you could,"
+        ],
+        "politeSuffixes": [
+          "Thank you.",
+          "Thanks a lot.",
+          "I appreciate it.",
+          "Much appreciated."
+        ]
       }
     },
     {
@@ -1920,9 +1928,9 @@
             "text": "Could you",
             "category": "politeness",
             "synonyms": [
-              "Can you",
-              "Would you",
-              "Will you"
+              "please",
+              "would you mind",
+              "can you"
             ],
             "isOptional": true
           },
@@ -1946,7 +1954,7 @@
           },
           {
             "text": "5%",
-            "category": "value",
+            "category": "quantity",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
@@ -1961,21 +1969,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.increaseVolume",
+                "propertyValue": "player.adjustVolume",
                 "propertySubPhrases": [
-                  "increase the volume"
+                  "adjust the volume"
                 ]
               },
               {
-                "propertyValue": "player.decreaseVolume",
+                "propertyValue": "player.setVolume",
                 "propertySubPhrases": [
-                  "decrease the volume"
+                  "set the volume"
                 ]
               },
               {
-                "propertyValue": "player.muteVolume",
+                "propertyValue": "player.modifyVolume",
                 "propertySubPhrases": [
-                  "mute the volume"
+                  "modify the volume"
                 ]
               }
             ]
@@ -2012,8 +2020,18 @@
             ]
           }
         ],
-        "politePrefixes": [],
-        "politeSuffixes": []
+        "politePrefixes": [
+          "Please",
+          "If you don't mind,",
+          "Would you kindly",
+          "May I ask you to"
+        ],
+        "politeSuffixes": [
+          "Thank you.",
+          "I would appreciate it.",
+          "Thanks a lot.",
+          "That would be great."
+        ]
       },
       "corrections": [
         {
@@ -2063,9 +2081,9 @@
                 "text": "Could you",
                 "category": "politeness",
                 "synonyms": [
-                  "Can you",
-                  "Would you",
-                  "Will you"
+                  "please",
+                  "would you mind",
+                  "can you"
                 ],
                 "isOptional": true
               },
@@ -2088,7 +2106,7 @@
               },
               {
                 "text": "5%",
-                "category": "value",
+                "category": "quantity",
                 "propertyNames": [
                   "parameters.volumeChangePercentage"
                 ]
@@ -2123,7 +2141,7 @@
             "value": -5,
             "substrings": [
               "down",
-              "by 5%"
+              "5%"
             ]
           }
         ],
@@ -2134,7 +2152,7 @@
             "synonyms": [
               "Can you",
               "Would you",
-              "Will you"
+              "Please"
             ],
             "isOptional": true
           },
@@ -2220,8 +2238,18 @@
             ]
           }
         ],
-        "politePrefixes": [],
-        "politeSuffixes": []
+        "politePrefixes": [
+          "Please",
+          "If you don't mind",
+          "Would you kindly",
+          "When you have a moment"
+        ],
+        "politeSuffixes": [
+          "Thank you",
+          "I'd appreciate it",
+          "Thanks a lot",
+          "Much appreciated"
+        ]
       },
       "corrections": [
         {
@@ -2279,9 +2307,9 @@
             "text": "Could you",
             "category": "politeness",
             "synonyms": [
-              "Can you",
-              "Would you",
-              "Will you"
+              "please",
+              "would you mind",
+              "can you"
             ],
             "isOptional": true
           },
@@ -2293,17 +2321,7 @@
             ]
           },
           {
-            "text": "by",
-            "category": "preposition",
-            "synonyms": [
-              "to",
-              "at",
-              "with"
-            ],
-            "isOptional": true
-          },
-          {
-            "text": "10%",
+            "text": "by 10%",
             "category": "quantity",
             "propertyNames": [
               "parameters.volumeChangePercentage"
@@ -2331,9 +2349,9 @@
                 ]
               },
               {
-                "propertyValue": "player.turnUpVolume",
+                "propertyValue": "player.adjustVolume",
                 "propertySubPhrases": [
-                  "turn up the volume"
+                  "adjust the volume"
                 ]
               }
             ]
@@ -2342,32 +2360,42 @@
             "propertyName": "parameters.volumeChangePercentage",
             "propertyValue": 10,
             "propertySubPhrases": [
-              "10%"
+              "by 10%"
             ],
             "alternatives": [
               {
                 "propertyValue": 5,
                 "propertySubPhrases": [
-                  "5%"
+                  "by 5%"
                 ]
               },
               {
                 "propertyValue": 15,
                 "propertySubPhrases": [
-                  "15%"
+                  "by 15%"
                 ]
               },
               {
                 "propertyValue": 20,
                 "propertySubPhrases": [
-                  "20%"
+                  "by 20%"
                 ]
               }
             ]
           }
         ],
-        "politePrefixes": [],
-        "politeSuffixes": []
+        "politePrefixes": [
+          "Please",
+          "Would you mind",
+          "If you could",
+          "Kindly"
+        ],
+        "politeSuffixes": [
+          "thank you",
+          "please",
+          "if that's okay",
+          "if you don't mind"
+        ]
       }
     },
     {
@@ -2399,7 +2427,7 @@
         "subPhrases": [
           {
             "text": "Cut back",
-            "category": "command",
+            "category": "action",
             "propertyNames": [
               "fullActionName",
               "parameters.volumeChangePercentage"
@@ -2407,14 +2435,14 @@
           },
           {
             "text": "on the volume",
-            "category": "context",
+            "category": "object",
             "propertyNames": [
               "fullActionName"
             ]
           },
           {
             "text": "by 10%",
-            "category": "specification",
+            "category": "quantity",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
@@ -2437,16 +2465,16 @@
                 ]
               },
               {
-                "propertyValue": "player.muteVolume",
+                "propertyValue": "player.decreaseVolume",
                 "propertySubPhrases": [
-                  "Mute",
+                  "Decrease",
                   "the volume"
                 ]
               },
               {
-                "propertyValue": "player.unmuteVolume",
+                "propertyValue": "player.muteVolume",
                 "propertySubPhrases": [
-                  "Unmute",
+                  "Mute",
                   "the volume"
                 ]
               }
@@ -2487,14 +2515,14 @@
         "politePrefixes": [
           "Could you please",
           "Would you mind",
-          "If it's not too much trouble, could you",
-          "May I kindly ask you to"
+          "If possible, could you",
+          "Please"
         ],
         "politeSuffixes": [
           "Thank you.",
-          "Thanks a lot.",
-          "I would appreciate it.",
-          "That would be great."
+          "If that's okay.",
+          "Thanks.",
+          "I appreciate it."
         ]
       },
       "corrections": [
@@ -2583,23 +2611,23 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.lowerVolume",
+                "propertyValue": "player.increaseVolume",
                 "propertySubPhrases": [
-                  "Lower",
+                  "Increase",
                   "the volume"
                 ]
               },
               {
-                "propertyValue": "player.reduceVolume",
+                "propertyValue": "player.muteVolume",
                 "propertySubPhrases": [
-                  "Reduce",
+                  "Mute",
                   "the volume"
                 ]
               },
               {
-                "propertyValue": "player.turnDownVolume",
+                "propertyValue": "player.unmuteVolume",
                 "propertySubPhrases": [
-                  "Turn down",
+                  "Unmute",
                   "the volume"
                 ]
               }
@@ -2614,6 +2642,13 @@
             ],
             "alternatives": [
               {
+                "propertyValue": -20,
+                "propertySubPhrases": [
+                  "Decrease",
+                  "by 20%"
+                ]
+              },
+              {
                 "propertyValue": -5,
                 "propertySubPhrases": [
                   "Decrease",
@@ -2626,24 +2661,21 @@
                   "Decrease",
                   "by 15%"
                 ]
-              },
-              {
-                "propertyValue": -20,
-                "propertySubPhrases": [
-                  "Decrease",
-                  "by 20%"
-                ]
               }
             ]
           }
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If possible,",
+          "Kindly"
         ],
         "politeSuffixes": [
-          "Thank you.",
-          "I would appreciate it."
+          "thank you.",
+          "please.",
+          "if you don't mind.",
+          "thanks."
         ]
       },
       "corrections": [
@@ -2693,21 +2725,17 @@
             "name": "parameters.volumeChangePercentage",
             "value": -10,
             "substrings": [
-              "down",
+              "Dial down",
               "10%"
             ]
           }
         ],
         "subPhrases": [
           {
-            "text": "Dial",
-            "category": "command",
-            "propertyNames": []
-          },
-          {
-            "text": "down",
-            "category": "direction",
+            "text": "Dial down",
+            "category": "action",
             "propertyNames": [
+              "fullActionName",
               "parameters.volumeChangePercentage"
             ]
           },
@@ -2720,7 +2748,7 @@
           },
           {
             "text": "by 10%",
-            "category": "amount",
+            "category": "modifier",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
@@ -2728,59 +2756,63 @@
         ],
         "propertyAlternatives": [
           {
+            "propertyName": "fullActionName",
+            "propertyValue": "player.changeVolume",
+            "propertySubPhrases": [
+              "Dial down",
+              "the volume"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "player.decreaseVolume",
+                "propertySubPhrases": [
+                  "Lower",
+                  "the volume"
+                ]
+              },
+              {
+                "propertyValue": "player.reduceVolume",
+                "propertySubPhrases": [
+                  "Reduce",
+                  "the volume"
+                ]
+              },
+              {
+                "propertyValue": "player.turnDownVolume",
+                "propertySubPhrases": [
+                  "Turn down",
+                  "the volume"
+                ]
+              }
+            ]
+          },
+          {
             "propertyName": "parameters.volumeChangePercentage",
             "propertyValue": -10,
             "propertySubPhrases": [
-              "down",
+              "Dial down",
               "by 10%"
             ],
             "alternatives": [
               {
-                "propertyValue": -20,
-                "propertySubPhrases": [
-                  "down",
-                  "by 20%"
-                ]
-              },
-              {
                 "propertyValue": -5,
                 "propertySubPhrases": [
-                  "down",
+                  "Dial down",
                   "by 5%"
                 ]
               },
               {
                 "propertyValue": -15,
                 "propertySubPhrases": [
-                  "down",
+                  "Dial down",
                   "by 15%"
                 ]
-              }
-            ]
-          },
-          {
-            "propertyName": "fullActionName",
-            "propertyValue": "player.changeVolume",
-            "propertySubPhrases": [
-              "the volume"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "player.increaseVolume",
-                "propertySubPhrases": [
-                  "the volume up"
-                ]
               },
               {
-                "propertyValue": "player.muteVolume",
+                "propertyValue": -20,
                 "propertySubPhrases": [
-                  "the volume to mute"
-                ]
-              },
-              {
-                "propertyValue": "player.setVolume",
-                "propertySubPhrases": [
-                  "the volume to a specific level"
+                  "Dial down",
+                  "by 20%"
                 ]
               }
             ]
@@ -2789,14 +2821,14 @@
         "politePrefixes": [
           "Could you please",
           "Would you mind",
-          "If it's not too much trouble, could you",
-          "May I kindly ask you to"
+          "If possible, could you",
+          "May I ask you to"
         ],
         "politeSuffixes": [
-          "Thank you!",
+          "Thank you.",
+          "Please.",
           "I would appreciate it.",
-          "Thanks a lot!",
-          "That would be great."
+          "Thanks."
         ]
       },
       "corrections": [
@@ -2885,23 +2917,23 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.decreaseVolume",
+                "propertyValue": "player.increaseVolume",
                 "propertySubPhrases": [
-                  "Lower",
+                  "Increase",
                   "the volume"
                 ]
               },
               {
-                "propertyValue": "player.reduceVolume",
+                "propertyValue": "player.muteVolume",
                 "propertySubPhrases": [
-                  "Reduce",
+                  "Mute",
                   "the volume"
                 ]
               },
               {
-                "propertyValue": "player.turnDownVolume",
+                "propertyValue": "player.setVolume",
                 "propertySubPhrases": [
-                  "Turn down",
+                  "Set",
                   "the volume"
                 ]
               }
@@ -2916,6 +2948,13 @@
             ],
             "alternatives": [
               {
+                "propertyValue": -20,
+                "propertySubPhrases": [
+                  "Diminish",
+                  "by 20%"
+                ]
+              },
+              {
                 "propertyValue": -5,
                 "propertySubPhrases": [
                   "Diminish",
@@ -2928,24 +2967,21 @@
                   "Diminish",
                   "by 15%"
                 ]
-              },
-              {
-                "propertyValue": -20,
-                "propertySubPhrases": [
-                  "Diminish",
-                  "by 20%"
-                ]
               }
             ]
           }
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If you don't mind",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you.",
-          "I appreciate it."
+          "thank you",
+          "please",
+          "if that's okay",
+          "if you could"
         ]
       },
       "corrections": [
@@ -2995,8 +3031,8 @@
             "name": "parameters.volumeChangePercentage",
             "value": -10,
             "substrings": [
-              "Diminish",
-              "10%"
+              "small 10%",
+              "Diminish"
             ]
           }
         ],
@@ -3017,18 +3053,8 @@
             ]
           },
           {
-            "text": "by a small",
-            "category": "filler",
-            "synonyms": [
-              "by a little",
-              "by a bit",
-              "by a tiny"
-            ],
-            "isOptional": true
-          },
-          {
-            "text": "10%",
-            "category": "value",
+            "text": "by a small 10%",
+            "category": "measurement",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
@@ -3044,23 +3070,23 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.increaseVolume",
+                "propertyValue": "player.decreaseVolume",
                 "propertySubPhrases": [
-                  "Increase",
+                  "Lower",
                   "the volume"
                 ]
               },
               {
-                "propertyValue": "player.muteVolume",
+                "propertyValue": "player.reduceVolume",
                 "propertySubPhrases": [
-                  "Mute",
+                  "Reduce",
                   "the volume"
                 ]
               },
               {
-                "propertyValue": "player.setVolume",
+                "propertyValue": "player.turnDownVolume",
                 "propertySubPhrases": [
-                  "Set",
+                  "Turn down",
                   "the volume"
                 ]
               }
@@ -3071,28 +3097,28 @@
             "propertyValue": -10,
             "propertySubPhrases": [
               "Diminish",
-              "10%"
+              "by a small 10%"
             ],
             "alternatives": [
               {
                 "propertyValue": -5,
                 "propertySubPhrases": [
                   "Diminish",
-                  "5%"
-                ]
-              },
-              {
-                "propertyValue": -20,
-                "propertySubPhrases": [
-                  "Diminish",
-                  "20%"
+                  "by a tiny 5%"
                 ]
               },
               {
                 "propertyValue": -15,
                 "propertySubPhrases": [
                   "Diminish",
-                  "15%"
+                  "by a moderate 15%"
+                ]
+              },
+              {
+                "propertyValue": -20,
+                "propertySubPhrases": [
+                  "Diminish",
+                  "by a significant 20%"
                 ]
               }
             ]
@@ -3100,11 +3126,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If you don't mind",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you.",
-          "I would appreciate it."
+          "Thank you",
+          "Thanks",
+          "If that's okay",
+          "I appreciate it"
         ]
       },
       "corrections": [
@@ -3154,18 +3184,25 @@
             "name": "parameters.volumeChangePercentage",
             "value": -10,
             "substrings": [
-              "Drop the volume",
+              "Drop",
               "10%"
             ]
           }
         ],
         "subPhrases": [
           {
-            "text": "Drop the volume",
-            "category": "command",
+            "text": "Drop",
+            "category": "action",
             "propertyNames": [
               "fullActionName",
               "parameters.volumeChangePercentage"
+            ]
+          },
+          {
+            "text": "the volume",
+            "category": "object",
+            "propertyNames": [
+              "fullActionName"
             ]
           },
           {
@@ -3180,7 +3217,7 @@
           },
           {
             "text": "10%",
-            "category": "value",
+            "category": "quantity",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
@@ -3191,25 +3228,29 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.changeVolume",
             "propertySubPhrases": [
-              "Drop the volume"
+              "Drop",
+              "the volume"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.increaseVolume",
                 "propertySubPhrases": [
-                  "Increase the volume"
+                  "Increase",
+                  "the volume"
                 ]
               },
               {
                 "propertyValue": "player.muteVolume",
                 "propertySubPhrases": [
-                  "Mute the volume"
+                  "Mute",
+                  "the volume"
                 ]
               },
               {
                 "propertyValue": "player.setVolume",
                 "propertySubPhrases": [
-                  "Set the volume"
+                  "Set",
+                  "the volume"
                 ]
               }
             ]
@@ -3218,28 +3259,28 @@
             "propertyName": "parameters.volumeChangePercentage",
             "propertyValue": -10,
             "propertySubPhrases": [
-              "Drop the volume",
+              "Drop",
               "10%"
             ],
             "alternatives": [
               {
                 "propertyValue": -20,
                 "propertySubPhrases": [
-                  "Drop the volume",
+                  "Drop",
                   "20%"
                 ]
               },
               {
                 "propertyValue": -5,
                 "propertySubPhrases": [
-                  "Drop the volume",
+                  "Drop",
                   "5%"
                 ]
               },
               {
                 "propertyValue": -15,
                 "propertySubPhrases": [
-                  "Drop the volume",
+                  "Drop",
                   "15%"
                 ]
               }
@@ -3249,14 +3290,14 @@
         "politePrefixes": [
           "Could you please",
           "Would you mind",
-          "If it's not too much trouble, could you",
-          "May I kindly ask you to"
+          "If you don't mind",
+          "Please"
         ],
         "politeSuffixes": [
           "Thank you!",
-          "I would appreciate it.",
-          "Thanks a lot!",
-          "That would be great, thanks!"
+          "Thanks!",
+          "I appreciate it!",
+          "If that's okay."
         ]
       },
       "corrections": [
@@ -3314,21 +3355,21 @@
         "subPhrases": [
           {
             "text": "Elevate the audio level",
-            "category": "command",
+            "category": "action",
             "propertyNames": [
               "fullActionName"
             ]
           },
           {
             "text": "push it up",
-            "category": "command",
+            "category": "action",
             "propertyNames": [
               "fullActionName"
             ]
           },
           {
             "text": "by 10%",
-            "category": "specification",
+            "category": "parameter",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
@@ -3346,22 +3387,22 @@
               {
                 "propertyValue": "player.increaseVolume",
                 "propertySubPhrases": [
-                  "Increase the volume",
-                  "raise it"
+                  "Increase the audio level",
+                  "raise it up"
                 ]
               },
               {
-                "propertyValue": "player.raiseVolume",
+                "propertyValue": "player.adjustVolume",
                 "propertySubPhrases": [
-                  "Raise the audio level",
-                  "boost it"
+                  "Adjust the audio level",
+                  "modify it"
                 ]
               },
               {
-                "propertyValue": "player.amplifyVolume",
+                "propertyValue": "player.setVolume",
                 "propertySubPhrases": [
-                  "Amplify the sound",
-                  "turn it up"
+                  "Set the audio level",
+                  "change it"
                 ]
               }
             ]
@@ -3374,9 +3415,9 @@
             ],
             "alternatives": [
               {
-                "propertyValue": 5,
+                "propertyValue": 20,
                 "propertySubPhrases": [
-                  "by 5%"
+                  "by 20%"
                 ]
               },
               {
@@ -3386,9 +3427,9 @@
                 ]
               },
               {
-                "propertyValue": 20,
+                "propertyValue": 5,
                 "propertySubPhrases": [
-                  "by 20%"
+                  "by 5%"
                 ]
               }
             ]
@@ -3396,11 +3437,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If possible,",
+          "Kindly"
         ],
         "politeSuffixes": [
-          "Thank you.",
-          "I would appreciate it."
+          "thank you.",
+          "please.",
+          "if you don't mind.",
+          "thanks."
         ]
       }
     },
@@ -3475,22 +3520,153 @@
               {
                 "propertyValue": "player.increaseVolume",
                 "propertySubPhrases": [
-                  "Increase the volume",
+                  "Increase the audio level",
                   "turn it up"
                 ]
               },
               {
                 "propertyValue": "player.raiseVolume",
                 "propertySubPhrases": [
-                  "Raise the volume",
+                  "Raise the audio level",
                   "boost it"
                 ]
               },
               {
                 "propertyValue": "player.amplifyVolume",
                 "propertySubPhrases": [
-                  "Amplify the sound",
+                  "Amplify the audio level",
                   "crank it up"
+                ]
+              }
+            ]
+          },
+          {
+            "propertyName": "parameters.volumeChangePercentage",
+            "propertyValue": 10,
+            "propertySubPhrases": [
+              "10%"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": 20,
+                "propertySubPhrases": [
+                  "20%"
+                ]
+              },
+              {
+                "propertyValue": 30,
+                "propertySubPhrases": [
+                  "30%"
+                ]
+              },
+              {
+                "propertyValue": 50,
+                "propertySubPhrases": [
+                  "50%"
+                ]
+              }
+            ]
+          }
+        ],
+        "politePrefixes": [
+          "Could you please",
+          "Would you mind",
+          "If possible,",
+          "Please"
+        ],
+        "politeSuffixes": [
+          "Thank you.",
+          "if you don't mind.",
+          "please.",
+          "I would appreciate it."
+        ]
+      }
+    },
+    {
+      "request": "Fancy cranking up the volume by a notable 10%?",
+      "action": {
+        "fullActionName": "player.changeVolume",
+        "parameters": {
+          "volumeChangePercentage": 10
+        }
+      },
+      "explanation": {
+        "properties": [
+          {
+            "name": "fullActionName",
+            "value": "player.changeVolume",
+            "substrings": [
+              "cranking up the volume"
+            ]
+          },
+          {
+            "name": "parameters.volumeChangePercentage",
+            "value": 10,
+            "substrings": [
+              "10%"
+            ]
+          }
+        ],
+        "subPhrases": [
+          {
+            "text": "Fancy",
+            "category": "politeness",
+            "synonyms": [
+              "Would you like",
+              "How about",
+              "Do you want"
+            ],
+            "isOptional": true
+          },
+          {
+            "text": "cranking up the volume",
+            "category": "action",
+            "propertyNames": [
+              "fullActionName"
+            ]
+          },
+          {
+            "text": "by a notable",
+            "category": "filler",
+            "synonyms": [
+              "by a significant",
+              "by an impressive",
+              "by a considerable"
+            ],
+            "isOptional": true
+          },
+          {
+            "text": "10%",
+            "category": "quantity",
+            "propertyNames": [
+              "parameters.volumeChangePercentage"
+            ]
+          }
+        ],
+        "propertyAlternatives": [
+          {
+            "propertyName": "fullActionName",
+            "propertyValue": "player.changeVolume",
+            "propertySubPhrases": [
+              "cranking up the volume"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "player.increaseVolume",
+                "propertySubPhrases": [
+                  "turning up the volume"
+                ]
+              },
+              {
+                "propertyValue": "player.raiseVolume",
+                "propertySubPhrases": [
+                  "raising the volume"
+                ]
+              },
+              {
+                "propertyValue": "player.boostVolume",
+                "propertySubPhrases": [
+                  "boosting the volume"
                 ]
               }
             ]
@@ -3526,111 +3702,14 @@
         "politePrefixes": [
           "Could you please",
           "Would you mind",
-          "If it's not too much trouble, could you",
+          "If it's not too much trouble,",
           "May I kindly ask you to"
         ],
         "politeSuffixes": [
           "Thank you!",
+          "Please.",
           "I would appreciate it.",
-          "Thanks a lot!",
-          "That would be great."
-        ]
-      }
-    },
-    {
-      "request": "Fancy cranking up the volume by a notable 10%?",
-      "action": {
-        "fullActionName": "player.changeVolume",
-        "parameters": {
-          "volumeChangePercentage": 10
-        }
-      },
-      "explanation": {
-        "properties": [
-          {
-            "name": "fullActionName",
-            "value": "player.changeVolume",
-            "isImplicit": true
-          },
-          {
-            "name": "parameters.volumeChangePercentage",
-            "value": 10,
-            "substrings": [
-              "10%"
-            ]
-          }
-        ],
-        "subPhrases": [
-          {
-            "text": "Fancy",
-            "category": "filler",
-            "synonyms": [
-              "How about",
-              "Would you like",
-              "Do you want"
-            ],
-            "isOptional": true
-          },
-          {
-            "text": "cranking up the volume by a notable",
-            "category": "filler",
-            "synonyms": [
-              "increasing the volume by",
-              "raising the volume by",
-              "turning up the volume by"
-            ],
-            "isOptional": true
-          },
-          {
-            "text": "10%",
-            "category": "parameter",
-            "propertyNames": [
-              "parameters.volumeChangePercentage"
-            ]
-          }
-        ],
-        "propertyAlternatives": [
-          {
-            "propertyName": "parameters.volumeChangePercentage",
-            "propertyValue": 10,
-            "propertySubPhrases": [
-              "10%"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": 5,
-                "propertySubPhrases": [
-                  "5%"
-                ]
-              },
-              {
-                "propertyValue": 15,
-                "propertySubPhrases": [
-                  "15%"
-                ]
-              },
-              {
-                "propertyValue": 20,
-                "propertySubPhrases": [
-                  "20%"
-                ]
-              },
-              {
-                "propertyValue": 25,
-                "propertySubPhrases": [
-                  "25%"
-                ]
-              }
-            ]
-          }
-        ],
-        "politePrefixes": [
-          "Could you please",
-          "Would you mind"
-        ],
-        "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it."
+          "Thanks a lot!"
         ]
       }
     },
@@ -3664,9 +3743,9 @@
             "text": "Fancy",
             "category": "politeness",
             "synonyms": [
-              "Would you like to",
+              "Would you like",
               "How about",
-              "Do you want to"
+              "Do you want"
             ],
             "isOptional": true
           },
@@ -3681,15 +3760,15 @@
             "text": "by a smooth",
             "category": "filler",
             "synonyms": [
-              "by exactly",
-              "by precisely",
-              "by"
+              "by a nice",
+              "by a gentle",
+              "by a steady"
             ],
             "isOptional": true
           },
           {
             "text": "10%",
-            "category": "value",
+            "category": "quantity",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
@@ -3706,19 +3785,19 @@
               {
                 "propertyValue": "player.increaseVolume",
                 "propertySubPhrases": [
-                  "increasing the volume"
+                  "increase the volume"
                 ]
               },
               {
                 "propertyValue": "player.raiseVolume",
                 "propertySubPhrases": [
-                  "raising the volume"
+                  "raise the volume"
                 ]
               },
               {
-                "propertyValue": "player.volumeUp",
+                "propertyValue": "player.boostVolume",
                 "propertySubPhrases": [
-                  "volume up"
+                  "boost the volume"
                 ]
               }
             ]
@@ -3753,11 +3832,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If it's not too much trouble,",
+          "May I ask you to"
         ],
         "politeSuffixes": [
           "Thank you!",
-          "I would appreciate it."
+          "Please.",
+          "I'd appreciate it.",
+          "Thanks a lot!"
         ]
       }
     },
@@ -3815,7 +3898,7 @@
           },
           {
             "text": "by 20%",
-            "category": "magnitude",
+            "category": "quantity",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
@@ -3831,23 +3914,23 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.decreaseVolume",
+                "propertyValue": "player.increaseVolume",
                 "propertySubPhrases": [
-                  "lower",
-                  "the sound"
+                  "increase",
+                  "the audio"
                 ]
               },
               {
-                "propertyValue": "player.reduceVolume",
+                "propertyValue": "player.muteVolume",
                 "propertySubPhrases": [
-                  "reduce",
-                  "the volume"
+                  "mute",
+                  "the audio"
                 ]
               },
               {
-                "propertyValue": "player.turnDownVolume",
+                "propertyValue": "player.restoreVolume",
                 "propertySubPhrases": [
-                  "turn down",
+                  "restore",
                   "the audio"
                 ]
               }
@@ -3887,11 +3970,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If you don't mind",
+          "Please"
         ],
         "politeSuffixes": [
           "Thank you.",
-          "I would appreciate it."
+          "Thanks.",
+          "I appreciate it.",
+          "Much appreciated."
         ]
       },
       "corrections": [
@@ -3951,14 +4038,14 @@
             "text": "Hey",
             "category": "greeting",
             "synonyms": [
-              "Hi",
               "Hello",
+              "Hi",
               "Greetings"
             ],
             "isOptional": true
           },
           {
-            "text": "slash the volume",
+            "text": "slash",
             "category": "action",
             "propertyNames": [
               "fullActionName",
@@ -3966,18 +4053,15 @@
             ]
           },
           {
-            "text": "by",
-            "category": "preposition",
-            "synonyms": [
-              "to",
-              "at",
-              "with"
-            ],
-            "isOptional": true
+            "text": "the volume",
+            "category": "action",
+            "propertyNames": [
+              "fullActionName"
+            ]
           },
           {
-            "text": "5%",
-            "category": "value",
+            "text": "by 5%",
+            "category": "quantity",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
@@ -3988,25 +4072,29 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.changeVolume",
             "propertySubPhrases": [
-              "slash the volume"
+              "slash",
+              "the volume"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.increaseVolume",
                 "propertySubPhrases": [
-                  "increase the volume"
-                ]
-              },
-              {
-                "propertyValue": "player.decreaseVolume",
-                "propertySubPhrases": [
-                  "decrease the volume"
+                  "boost",
+                  "the volume"
                 ]
               },
               {
                 "propertyValue": "player.muteVolume",
                 "propertySubPhrases": [
-                  "mute the volume"
+                  "mute",
+                  "the volume"
+                ]
+              },
+              {
+                "propertyValue": "player.unmuteVolume",
+                "propertySubPhrases": [
+                  "unmute",
+                  "the volume"
                 ]
               }
             ]
@@ -4015,36 +4103,46 @@
             "propertyName": "parameters.volumeChangePercentage",
             "propertyValue": -5,
             "propertySubPhrases": [
-              "slash the volume",
-              "5%"
+              "slash",
+              "by 5%"
             ],
             "alternatives": [
               {
                 "propertyValue": -10,
                 "propertySubPhrases": [
-                  "slash the volume",
-                  "10%"
-                ]
-              },
-              {
-                "propertyValue": -15,
-                "propertySubPhrases": [
-                  "slash the volume",
-                  "15%"
+                  "slash",
+                  "by 10%"
                 ]
               },
               {
                 "propertyValue": -20,
                 "propertySubPhrases": [
-                  "slash the volume",
-                  "20%"
+                  "slash",
+                  "by 20%"
+                ]
+              },
+              {
+                "propertyValue": -15,
+                "propertySubPhrases": [
+                  "slash",
+                  "by 15%"
                 ]
               }
             ]
           }
         ],
-        "politePrefixes": [],
-        "politeSuffixes": []
+        "politePrefixes": [
+          "Could you please",
+          "Would you mind",
+          "If you don't mind",
+          "Please"
+        ],
+        "politeSuffixes": [
+          "thank you",
+          "if that's okay",
+          "please",
+          "thanks"
+        ]
       },
       "corrections": [
         {
@@ -4094,8 +4192,8 @@
                 "text": "Hey",
                 "category": "greeting",
                 "synonyms": [
-                  "Hi",
                   "Hello",
+                  "Hi",
                   "Greetings"
                 ],
                 "isOptional": true
@@ -4108,18 +4206,65 @@
                 ]
               },
               {
-                "text": "by",
-                "category": "preposition",
+                "text": "slash",
+                "category": "action",
+                "propertyNames": [
+                  "parameters.volumeChangePercentage"
+                ]
+              },
+              {
+                "text": "5%",
+                "category": "quantity",
+                "propertyNames": [
+                  "parameters.volumeChangePercentage"
+                ]
+              }
+            ]
+          },
+          "correction": [
+            "Overlapping sub-phrase: explanation has overlapping text 'slash'."
+          ]
+        },
+        {
+          "data": {
+            "properties": [
+              {
+                "name": "fullActionName",
+                "value": "player.changeVolume",
+                "substrings": [
+                  "slash the volume"
+                ]
+              },
+              {
+                "name": "parameters.volumeChangePercentage",
+                "value": -5,
+                "substrings": [
+                  "slash",
+                  "5%"
+                ]
+              }
+            ],
+            "subPhrases": [
+              {
+                "text": "Hey",
+                "category": "greeting",
                 "synonyms": [
-                  "to",
-                  "at",
-                  "with"
+                  "Hello",
+                  "Hi",
+                  "Greetings"
                 ],
                 "isOptional": true
               },
               {
-                "text": "5%",
-                "category": "value",
+                "text": "slash the volume",
+                "category": "action",
+                "propertyNames": [
+                  "fullActionName"
+                ]
+              },
+              {
+                "text": "by 5%",
+                "category": "quantity",
                 "propertyNames": [
                   "parameters.volumeChangePercentage"
                 ]
@@ -4179,15 +4324,15 @@
             "text": "by a fair",
             "category": "filler",
             "synonyms": [
-              "by an appropriate",
               "by a reasonable",
+              "by an appropriate",
               "by a suitable"
             ],
             "isOptional": true
           },
           {
             "text": "10%",
-            "category": "value",
+            "category": "quantity",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
@@ -4251,11 +4396,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If it's not too much trouble,",
+          "May I kindly ask"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it."
+          "please?",
+          "if you don't mind.",
+          "thank you.",
+          "if that's okay."
         ]
       }
     },
@@ -4289,8 +4438,8 @@
             "text": "How about we",
             "category": "filler",
             "synonyms": [
-              "Shall we",
               "Let's",
+              "Shall we",
               "Why don't we"
             ],
             "isOptional": true
@@ -4308,16 +4457,6 @@
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
-          },
-          {
-            "text": "?",
-            "category": "punctuation",
-            "synonyms": [
-              ".",
-              "!",
-              ""
-            ],
-            "isOptional": true
           }
         ],
         "propertyAlternatives": [
@@ -4341,9 +4480,9 @@
                 ]
               },
               {
-                "propertyValue": "player.turnUpVolume",
+                "propertyValue": "player.boostVolume",
                 "propertySubPhrases": [
-                  "turn up the volume"
+                  "boost the volume"
                 ]
               }
             ]
@@ -4356,9 +4495,9 @@
             ],
             "alternatives": [
               {
-                "propertyValue": 5,
+                "propertyValue": 20,
                 "propertySubPhrases": [
-                  "by 5%"
+                  "by 20%"
                 ]
               },
               {
@@ -4368,9 +4507,9 @@
                 ]
               },
               {
-                "propertyValue": 20,
+                "propertyValue": 5,
                 "propertySubPhrases": [
-                  "by 20%"
+                  "by 5%"
                 ]
               }
             ]
@@ -4378,11 +4517,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If it's not too much trouble,",
+          "May I kindly ask"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it."
+          "please?",
+          "if you don't mind.",
+          "thank you.",
+          "if that's okay."
         ]
       }
     },
@@ -4399,9 +4542,7 @@
           {
             "name": "fullActionName",
             "value": "player.changeVolume",
-            "substrings": [
-              "decrease in audio"
-            ]
+            "substrings": []
           },
           {
             "name": "parameters.volumeChangePercentage",
@@ -4419,39 +4560,34 @@
             "synonyms": [
               "I think",
               "I believe",
-              "In my opinion"
+              "I suppose"
             ],
             "isOptional": true
           },
           {
-            "text": "a 20%",
+            "text": "a 20% decrease",
             "category": "volume change",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
           },
           {
-            "text": "decrease",
-            "category": "volume change",
-            "propertyNames": [
-              "parameters.volumeChangePercentage",
-              "fullActionName"
-            ]
-          },
-          {
             "text": "in audio",
-            "category": "audio context",
-            "propertyNames": [
-              "fullActionName"
-            ]
+            "category": "context",
+            "synonyms": [
+              "in sound",
+              "in volume",
+              "in the audio"
+            ],
+            "isOptional": true
           },
           {
             "text": "would be ideal",
-            "category": "filler",
+            "category": "confirmation",
             "synonyms": [
-              "is preferred",
-              "is best",
-              "is optimal"
+              "is perfect",
+              "is great",
+              "is good"
             ],
             "isOptional": true
           }
@@ -4461,60 +4597,31 @@
             "propertyName": "parameters.volumeChangePercentage",
             "propertyValue": -20,
             "propertySubPhrases": [
-              "a 20%",
-              "decrease"
+              "a 20% decrease"
             ],
             "alternatives": [
               {
                 "propertyValue": -10,
                 "propertySubPhrases": [
-                  "a 10%",
-                  "decrease"
+                  "a 10% decrease"
                 ]
               },
               {
                 "propertyValue": -30,
                 "propertySubPhrases": [
-                  "a 30%",
-                  "decrease"
+                  "a 30% decrease"
                 ]
               },
               {
                 "propertyValue": -50,
                 "propertySubPhrases": [
-                  "a 50%",
-                  "decrease"
-                ]
-              }
-            ]
-          },
-          {
-            "propertyName": "fullActionName",
-            "propertyValue": "player.changeVolume",
-            "propertySubPhrases": [
-              "decrease",
-              "in audio"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "player.increaseVolume",
-                "propertySubPhrases": [
-                  "increase",
-                  "in audio"
+                  "a 50% decrease"
                 ]
               },
               {
-                "propertyValue": "player.muteVolume",
+                "propertyValue": -5,
                 "propertySubPhrases": [
-                  "mute",
-                  "in audio"
-                ]
-              },
-              {
-                "propertyValue": "player.adjustVolume",
-                "propertySubPhrases": [
-                  "adjust",
-                  "in audio"
+                  "a 5% decrease"
                 ]
               }
             ]
@@ -4523,14 +4630,14 @@
         "politePrefixes": [
           "Could you please",
           "Would you mind",
-          "If it's not too much trouble, could you",
-          "May I kindly ask you to"
+          "If it's not too much trouble,",
+          "May I kindly request"
         ],
         "politeSuffixes": [
           "Thank you.",
-          "I would appreciate it.",
-          "Thanks a lot.",
-          "That would be great."
+          "I appreciate it.",
+          "Thanks in advance.",
+          "If that's okay with you."
         ]
       },
       "corrections": [
@@ -4540,9 +4647,7 @@
               {
                 "name": "fullActionName",
                 "value": "player.changeVolume",
-                "substrings": [
-                  "decrease in audio"
-                ]
+                "substrings": []
               },
               {
                 "name": "parameters.volumeChangePercentage",
@@ -4604,7 +4709,7 @@
           },
           {
             "text": "by 25%",
-            "category": "specification",
+            "category": "measurement",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
@@ -4631,9 +4736,9 @@
                 ]
               },
               {
-                "propertyValue": "player.turnUpVolume",
+                "propertyValue": "player.amplifyVolume",
                 "propertySubPhrases": [
-                  "turn up the volume"
+                  "amplify the volume"
                 ]
               }
             ]
@@ -4667,7 +4772,12 @@
           }
         ],
         "politePrefixes": [],
-        "politeSuffixes": []
+        "politeSuffixes": [
+          "Thank you.",
+          "Thanks in advance.",
+          "I hope that's okay.",
+          "If you don't mind."
+        ]
       }
     },
     {
@@ -4715,7 +4825,7 @@
           },
           {
             "text": "by 25%",
-            "category": "parameter",
+            "category": "quantity",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
@@ -4742,9 +4852,9 @@
                 ]
               },
               {
-                "propertyValue": "player.turnUpVolume",
+                "propertyValue": "player.amplifyVolume",
                 "propertySubPhrases": [
-                  "turn up the volume"
+                  "amplify the volume"
                 ]
               }
             ]
@@ -4778,7 +4888,12 @@
           }
         ],
         "politePrefixes": [],
-        "politeSuffixes": []
+        "politeSuffixes": [
+          "Thank you.",
+          "I appreciate it.",
+          "Thanks in advance.",
+          "Your help is appreciated."
+        ]
       }
     },
     {
@@ -4811,9 +4926,9 @@
             "text": "I'd be happy if you could",
             "category": "politeness",
             "synonyms": [
-              "Please",
-              "Kindly",
-              "Would you mind"
+              "please",
+              "kindly",
+              "would you mind"
             ],
             "isOptional": true
           },
@@ -4828,9 +4943,9 @@
             "text": "by a considerable",
             "category": "filler",
             "synonyms": [
-              "by",
-              "with",
-              "at"
+              "by a significant",
+              "by a notable",
+              "by a substantial"
             ],
             "isOptional": true
           },
@@ -4898,15 +5013,12 @@
             ]
           }
         ],
-        "politePrefixes": [
-          "Could you please",
-          "Would you kindly",
-          "If it's not too much trouble, could you"
-        ],
+        "politePrefixes": [],
         "politeSuffixes": [
           "Thank you!",
-          "I would appreciate it.",
-          "Thanks in advance!"
+          "I appreciate it!",
+          "Thanks in advance!",
+          "If you could do that, it would be great!"
         ]
       }
     },
@@ -4923,7 +5035,9 @@
           {
             "name": "fullActionName",
             "value": "player.changeVolume",
-            "isImplicit": true
+            "substrings": [
+              "audio"
+            ]
           },
           {
             "name": "parameters.volumeChangePercentage",
@@ -4936,24 +5050,24 @@
         ],
         "subPhrases": [
           {
-            "text": "I'd enjoy the audio",
+            "text": "I'd enjoy",
             "category": "politeness",
             "synonyms": [
-              "I would like the audio",
-              "I want the audio",
-              "Please make the audio"
+              "I would like",
+              "I would appreciate",
+              "I want"
             ],
             "isOptional": true
           },
           {
-            "text": "20%",
-            "category": "volume change",
+            "text": "the audio",
+            "category": "object",
             "propertyNames": [
-              "parameters.volumeChangePercentage"
+              "fullActionName"
             ]
           },
           {
-            "text": "softer",
+            "text": "20% softer",
             "category": "volume change",
             "propertyNames": [
               "parameters.volumeChangePercentage"
@@ -4964,40 +5078,63 @@
             "category": "politeness",
             "synonyms": [
               "if you can",
-              "if it's not too much trouble",
-              "if you don't mind"
+              "if you don't mind",
+              "if it's okay"
             ],
             "isOptional": true
           }
         ],
         "propertyAlternatives": [
           {
+            "propertyName": "fullActionName",
+            "propertyValue": "player.changeVolume",
+            "propertySubPhrases": [
+              "the audio"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "player.adjustVolume",
+                "propertySubPhrases": [
+                  "the sound"
+                ]
+              },
+              {
+                "propertyValue": "player.setVolume",
+                "propertySubPhrases": [
+                  "the volume"
+                ]
+              },
+              {
+                "propertyValue": "player.modifyVolume",
+                "propertySubPhrases": [
+                  "the audio level"
+                ]
+              }
+            ]
+          },
+          {
             "propertyName": "parameters.volumeChangePercentage",
             "propertyValue": -20,
             "propertySubPhrases": [
-              "20%",
-              "softer"
+              "20% softer"
             ],
             "alternatives": [
               {
                 "propertyValue": -10,
                 "propertySubPhrases": [
-                  "10%",
-                  "softer"
+                  "10% softer"
                 ]
               },
               {
                 "propertyValue": -30,
                 "propertySubPhrases": [
-                  "30%",
-                  "softer"
+                  "30% softer"
                 ]
               },
               {
                 "propertyValue": -50,
                 "propertySubPhrases": [
-                  "50%",
-                  "softer"
+                  "50% softer"
                 ]
               }
             ]
@@ -5005,11 +5142,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If it's not too much trouble,",
+          "May I kindly ask"
         ],
         "politeSuffixes": [
           "Thank you!",
-          "I appreciate it!"
+          "I would appreciate it.",
+          "Thanks in advance!",
+          "That would be great."
         ]
       },
       "corrections": [
@@ -5019,7 +5160,9 @@
               {
                 "name": "fullActionName",
                 "value": "player.changeVolume",
-                "isImplicit": true
+                "substrings": [
+                  "audio"
+                ]
               },
               {
                 "name": "parameters.volumeChangePercentage",
@@ -5032,132 +5175,6 @@
           },
           "correction": [
             "Value -20 for property 'parameters.volumeChangePercentage' doesn't match the number 20 in the substring '20% softer'. Missing other substring to explain the value."
-          ]
-        }
-      ]
-    },
-    {
-      "request": "I'd like the audio to be 20% more mellow.",
-      "action": {
-        "fullActionName": "player.changeVolume",
-        "parameters": {
-          "volumeChangePercentage": -20
-        }
-      },
-      "explanation": {
-        "properties": [
-          {
-            "name": "fullActionName",
-            "value": "player.changeVolume",
-            "isImplicit": true
-          },
-          {
-            "name": "parameters.volumeChangePercentage",
-            "value": -20,
-            "substrings": [
-              "20%",
-              "more mellow"
-            ]
-          }
-        ],
-        "subPhrases": [
-          {
-            "text": "I'd like",
-            "category": "politeness",
-            "synonyms": [
-              "I would like",
-              "I want",
-              "Please"
-            ],
-            "isOptional": true
-          },
-          {
-            "text": "the audio to be",
-            "category": "filler",
-            "synonyms": [
-              "the sound to be",
-              "the volume to be",
-              "the music to be"
-            ],
-            "isOptional": true
-          },
-          {
-            "text": "20%",
-            "category": "volume change",
-            "propertyNames": [
-              "parameters.volumeChangePercentage"
-            ]
-          },
-          {
-            "text": "more mellow",
-            "category": "volume change",
-            "propertyNames": [
-              "parameters.volumeChangePercentage"
-            ]
-          }
-        ],
-        "propertyAlternatives": [
-          {
-            "propertyName": "parameters.volumeChangePercentage",
-            "propertyValue": -20,
-            "propertySubPhrases": [
-              "20%",
-              "more mellow"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": -10,
-                "propertySubPhrases": [
-                  "10%",
-                  "more mellow"
-                ]
-              },
-              {
-                "propertyValue": -30,
-                "propertySubPhrases": [
-                  "30%",
-                  "more mellow"
-                ]
-              },
-              {
-                "propertyValue": -40,
-                "propertySubPhrases": [
-                  "40%",
-                  "more mellow"
-                ]
-              }
-            ]
-          }
-        ],
-        "politePrefixes": [
-          "Could you please",
-          "Would you mind"
-        ],
-        "politeSuffixes": [
-          "Thank you!",
-          "I appreciate it!"
-        ]
-      },
-      "corrections": [
-        {
-          "data": {
-            "properties": [
-              {
-                "name": "fullActionName",
-                "value": "player.changeVolume",
-                "isImplicit": true
-              },
-              {
-                "name": "parameters.volumeChangePercentage",
-                "value": -20,
-                "substrings": [
-                  "20% more mellow"
-                ]
-              }
-            ]
-          },
-          "correction": [
-            "Value -20 for property 'parameters.volumeChangePercentage' doesn't match the number 20 in the substring '20% more mellow'. Missing other substring to explain the value."
           ]
         }
       ]
@@ -5207,7 +5224,7 @@
           },
           {
             "text": "by 20%",
-            "category": "value",
+            "category": "quantity",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
@@ -5234,19 +5251,19 @@
               {
                 "propertyValue": "player.increaseVolume",
                 "propertySubPhrases": [
-                  "increase the volume"
+                  "increase the audio level"
                 ]
               },
               {
                 "propertyValue": "player.raiseVolume",
                 "propertySubPhrases": [
-                  "raise the volume"
+                  "raise the audio level"
                 ]
               },
               {
-                "propertyValue": "player.amplifySound",
+                "propertyValue": "player.amplifyVolume",
                 "propertySubPhrases": [
-                  "amplify the sound"
+                  "amplify the audio level"
                 ]
               }
             ]
@@ -5279,8 +5296,18 @@
             ]
           }
         ],
-        "politePrefixes": [],
-        "politeSuffixes": []
+        "politePrefixes": [
+          "Could you kindly",
+          "Would you be able to",
+          "If it's not too much trouble,",
+          "May I request that you"
+        ],
+        "politeSuffixes": [
+          "Thank you.",
+          "I appreciate it.",
+          "Thanks a lot.",
+          "Your help is appreciated."
+        ]
       }
     },
     {
@@ -5314,8 +5341,8 @@
             "category": "politeness",
             "synonyms": [
               "please",
-              "if you don't mind",
-              "if possible"
+              "kindly",
+              "would you mind"
             ],
             "isOptional": true
           },
@@ -5330,15 +5357,15 @@
             "text": "by a good",
             "category": "filler",
             "synonyms": [
-              "by about",
-              "by approximately",
-              "by around"
+              "about",
+              "approximately",
+              "around"
             ],
             "isOptional": true
           },
           {
             "text": "25%",
-            "category": "value",
+            "category": "quantity",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
@@ -5400,8 +5427,18 @@
             ]
           }
         ],
-        "politePrefixes": [],
-        "politeSuffixes": []
+        "politePrefixes": [
+          "Could you please",
+          "Would you mind",
+          "If it's not too much trouble",
+          "I would appreciate it if you could"
+        ],
+        "politeSuffixes": [
+          "Thank you!",
+          "Thanks a lot!",
+          "I appreciate it!",
+          "Much appreciated!"
+        ]
       }
     },
     {
@@ -5418,7 +5455,7 @@
             "name": "fullActionName",
             "value": "player.changeVolume",
             "substrings": [
-              "the audio"
+              "audio"
             ]
           },
           {
@@ -5435,9 +5472,10 @@
             "text": "I'd prefer if",
             "category": "politeness",
             "synonyms": [
+              "please",
               "I would like",
-              "I prefer",
-              "I want"
+              "I want",
+              "kindly"
             ],
             "isOptional": true
           },
@@ -5449,25 +5487,8 @@
             ]
           },
           {
-            "text": "was",
-            "category": "filler",
-            "synonyms": [
-              "is",
-              "be",
-              "to be"
-            ],
-            "isOptional": true
-          },
-          {
-            "text": "20%",
-            "category": "amount",
-            "propertyNames": [
-              "parameters.volumeChangePercentage"
-            ]
-          },
-          {
-            "text": "lower",
-            "category": "direction",
+            "text": "was 20% lower",
+            "category": "action",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
@@ -5482,21 +5503,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.mute",
+                "propertyValue": "player.adjustSound",
                 "propertySubPhrases": [
                   "the sound"
                 ]
               },
               {
-                "propertyValue": "player.increaseVolume",
+                "propertyValue": "player.modifyVolume",
                 "propertySubPhrases": [
                   "the volume"
                 ]
               },
               {
-                "propertyValue": "player.decreaseVolume",
+                "propertyValue": "player.setAudioLevel",
                 "propertySubPhrases": [
-                  "the music"
+                  "the audio level"
                 ]
               }
             ]
@@ -5505,29 +5526,25 @@
             "propertyName": "parameters.volumeChangePercentage",
             "propertyValue": -20,
             "propertySubPhrases": [
-              "20%",
-              "lower"
+              "was 20% lower"
             ],
             "alternatives": [
               {
                 "propertyValue": -10,
                 "propertySubPhrases": [
-                  "10%",
-                  "lower"
+                  "was 10% lower"
                 ]
               },
               {
                 "propertyValue": -30,
                 "propertySubPhrases": [
-                  "30%",
-                  "lower"
+                  "was 30% lower"
                 ]
               },
               {
                 "propertyValue": -50,
                 "propertySubPhrases": [
-                  "50%",
-                  "lower"
+                  "was 50% lower"
                 ]
               }
             ]
@@ -5535,11 +5552,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If it's not too much trouble,",
+          "May I request that"
         ],
         "politeSuffixes": [
           "Thank you.",
-          "I appreciate it."
+          "I appreciate it.",
+          "Thanks in advance.",
+          "If that's okay with you."
         ]
       },
       "corrections": [
@@ -5550,7 +5571,7 @@
                 "name": "fullActionName",
                 "value": "player.changeVolume",
                 "substrings": [
-                  "the audio"
+                  "audio"
                 ]
               },
               {
@@ -5582,7 +5603,7 @@
             "name": "fullActionName",
             "value": "player.changeVolume",
             "substrings": [
-              "cut in the audio"
+              "audio"
             ]
           },
           {
@@ -5614,18 +5635,18 @@
           },
           {
             "text": "in the audio",
-            "category": "context",
+            "category": "audio",
             "propertyNames": [
               "fullActionName"
             ]
           },
           {
-            "text": "would be nice.",
+            "text": "would be nice",
             "category": "politeness",
             "synonyms": [
               "please",
-              "if possible",
-              "if you don't mind"
+              "if you could",
+              "I would appreciate it"
             ],
             "isOptional": true
           }
@@ -5689,14 +5710,14 @@
         "politePrefixes": [
           "Could you please",
           "Would you mind",
-          "If it's not too much trouble, could you",
+          "If it's not too much trouble,",
           "I would appreciate it if you could"
         ],
         "politeSuffixes": [
           "Thank you!",
-          "Thanks a lot!",
-          "I appreciate it!",
-          "That would be great, thanks!"
+          "Please.",
+          "Thanks in advance.",
+          "I appreciate it."
         ]
       },
       "corrections": [
@@ -5707,7 +5728,7 @@
                 "name": "fullActionName",
                 "value": "player.changeVolume",
                 "substrings": [
-                  "cut in the audio"
+                  "audio"
                 ]
               },
               {
@@ -5763,14 +5784,14 @@
             "category": "preposition",
             "synonyms": [
               "to",
-              "at",
-              "with"
+              "up to",
+              "at"
             ],
             "isOptional": true
           },
           {
             "text": "10%",
-            "category": "value",
+            "category": "quantity",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
@@ -5791,15 +5812,15 @@
                 ]
               },
               {
-                "propertyValue": "player.turnUpVolume",
+                "propertyValue": "player.volumeUp",
                 "propertySubPhrases": [
-                  "Turn up the volume"
+                  "Volume up"
                 ]
               },
               {
-                "propertyValue": "player.boostVolume",
+                "propertyValue": "player.adjustVolume",
                 "propertySubPhrases": [
-                  "Boost the volume"
+                  "Adjust the volume"
                 ]
               }
             ]
@@ -5834,11 +5855,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If it's not too much trouble,",
+          "May I ask you to"
         ],
         "politeSuffixes": [
-          "Thank you.",
-          "I would appreciate it."
+          "thank you.",
+          "please.",
+          "if you don't mind.",
+          "I'd appreciate it."
         ]
       }
     },
@@ -5879,9 +5904,9 @@
             "text": "by",
             "category": "preposition",
             "synonyms": [
-              "to",
-              "at",
-              "with"
+              "with",
+              "using",
+              "at"
             ],
             "isOptional": true
           },
@@ -5914,9 +5939,9 @@
                 ]
               },
               {
-                "propertyValue": "player.turnUpVolume",
+                "propertyValue": "player.adjustVolume",
                 "propertySubPhrases": [
-                  "Turn up the volume"
+                  "Adjust the volume"
                 ]
               }
             ]
@@ -5935,15 +5960,15 @@
                 ]
               },
               {
-                "propertyValue": 50,
+                "propertyValue": 40,
                 "propertySubPhrases": [
-                  "50%"
+                  "40%"
                 ]
               },
               {
-                "propertyValue": 10,
+                "propertyValue": 50,
                 "propertySubPhrases": [
-                  "10%"
+                  "50%"
                 ]
               }
             ]
@@ -5951,11 +5976,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "May I ask you to",
+          "If it's not too much trouble, could you"
         ],
         "politeSuffixes": [
-          "Thank you.",
-          "I would appreciate it."
+          "thank you.",
+          "please.",
+          "if you don't mind.",
+          "thanks."
         ]
       }
     },
@@ -5992,7 +6021,9 @@
             "synonyms": [
               "please",
               "if you could",
-              "would you mind"
+              "would you mind",
+              "could you",
+              "would you kindly"
             ],
             "isOptional": true
           },
@@ -6013,7 +6044,7 @@
           },
           {
             "text": "by 20%",
-            "category": "magnitude",
+            "category": "amount",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
@@ -6043,9 +6074,9 @@
                 ]
               },
               {
-                "propertyValue": "player.setVolume",
+                "propertyValue": "player.unmuteVolume",
                 "propertySubPhrases": [
-                  "set",
+                  "unmute",
                   "the audio level"
                 ]
               }
@@ -6084,7 +6115,12 @@
           }
         ],
         "politePrefixes": [],
-        "politeSuffixes": []
+        "politeSuffixes": [
+          "Thank you.",
+          "I appreciate it.",
+          "If you could, please.",
+          "Thanks in advance."
+        ]
       },
       "corrections": [
         {
@@ -6142,9 +6178,9 @@
             "text": "Kindly",
             "category": "politeness",
             "synonyms": [
-              "Please",
-              "Would you mind",
-              "If you could"
+              "please",
+              "if you would",
+              "be so kind"
             ],
             "isOptional": true
           },
@@ -6157,7 +6193,7 @@
           },
           {
             "text": "by 25%",
-            "category": "value",
+            "category": "quantity",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
@@ -6220,7 +6256,12 @@
           }
         ],
         "politePrefixes": [],
-        "politeSuffixes": []
+        "politeSuffixes": [
+          "Thank you.",
+          "Please.",
+          "I appreciate it.",
+          "If you don't mind."
+        ]
       }
     },
     {
@@ -6251,11 +6292,11 @@
         "subPhrases": [
           {
             "text": "Let's",
-            "category": "filler",
+            "category": "politeness",
             "synonyms": [
-              "Let us",
-              "We should",
-              "How about"
+              "please",
+              "kindly",
+              "let us"
             ],
             "isOptional": true
           },
@@ -6278,7 +6319,7 @@
           },
           {
             "text": "30%",
-            "category": "value",
+            "category": "quantity",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
@@ -6295,19 +6336,19 @@
               {
                 "propertyValue": "player.increaseVolume",
                 "propertySubPhrases": [
-                  "increase the volume"
+                  "increase the sound"
                 ]
               },
               {
                 "propertyValue": "player.raiseVolume",
                 "propertySubPhrases": [
-                  "raise the volume"
+                  "raise the sound"
                 ]
               },
               {
                 "propertyValue": "player.boostVolume",
                 "propertySubPhrases": [
-                  "boost the volume"
+                  "boost the sound"
                 ]
               }
             ]
@@ -6326,27 +6367,31 @@
                 ]
               },
               {
-                "propertyValue": 50,
+                "propertyValue": 40,
                 "propertySubPhrases": [
-                  "50%"
+                  "40%"
                 ]
               },
               {
-                "propertyValue": 10,
+                "propertyValue": 50,
                 "propertySubPhrases": [
-                  "10%"
+                  "50%"
                 ]
               }
             ]
           }
         ],
         "politePrefixes": [
-          "Could we please",
-          "Would you mind if we"
+          "Could you please",
+          "Would you mind",
+          "If it's not too much trouble,",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it."
+          "thank you.",
+          "if you don't mind.",
+          "please.",
+          "thanks."
         ]
       }
     },
@@ -6364,7 +6409,7 @@
             "name": "fullActionName",
             "value": "player.changeVolume",
             "substrings": [
-              "Let's dial back the sound"
+              "dial back the sound"
             ]
           },
           {
@@ -6381,9 +6426,9 @@
             "text": "Let's",
             "category": "politeness",
             "synonyms": [
-              "Please",
-              "Kindly",
-              "Would you"
+              "please",
+              "kindly",
+              "would you mind"
             ],
             "isOptional": true
           },
@@ -6404,11 +6449,11 @@
           },
           {
             "text": "by a subtle",
-            "category": "filler",
+            "category": "modifier",
             "synonyms": [
+              "gently",
               "slightly",
-              "a bit",
-              "a little"
+              "softly"
             ],
             "isOptional": true
           },
@@ -6430,24 +6475,24 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.lowerVolume",
+                "propertyValue": "player.increaseVolume",
                 "propertySubPhrases": [
-                  "lower",
-                  "the volume"
-                ]
-              },
-              {
-                "propertyValue": "player.decreaseVolume",
-                "propertySubPhrases": [
-                  "decrease",
+                  "increase",
                   "the sound"
                 ]
               },
               {
-                "propertyValue": "player.reduceVolume",
+                "propertyValue": "player.muteVolume",
                 "propertySubPhrases": [
-                  "reduce",
-                  "the volume"
+                  "mute",
+                  "the sound"
+                ]
+              },
+              {
+                "propertyValue": "player.setVolume",
+                "propertySubPhrases": [
+                  "set",
+                  "the sound"
                 ]
               }
             ]
@@ -6487,14 +6532,14 @@
         "politePrefixes": [
           "Could you please",
           "Would you mind",
-          "If it's not too much trouble,",
-          "May I kindly ask you to"
+          "If you don't mind",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you.",
-          "I would appreciate it.",
-          "Thanks a lot.",
-          "That would be great."
+          "Thank you!",
+          "Thanks!",
+          "I appreciate it!",
+          "Much appreciated!"
         ]
       },
       "corrections": [
@@ -6505,7 +6550,7 @@
                 "name": "fullActionName",
                 "value": "player.changeVolume",
                 "substrings": [
-                  "Let's dial back the sound"
+                  "dial back the sound"
                 ]
               },
               {
@@ -6536,7 +6581,9 @@
           {
             "name": "fullActionName",
             "value": "player.changeVolume",
-            "substrings": []
+            "substrings": [
+              "sound"
+            ]
           },
           {
             "name": "parameters.volumeChangePercentage",
@@ -6549,35 +6596,32 @@
         ],
         "subPhrases": [
           {
-            "text": "Let's",
-            "category": "filler",
+            "text": "Let's have",
+            "category": "politeness",
             "synonyms": [
-              "Let us",
-              "We should",
-              "How about"
+              "please",
+              "kindly",
+              "would you mind"
             ],
             "isOptional": true
           },
           {
-            "text": "have the sound",
-            "category": "filler",
-            "synonyms": [
-              "adjust the volume",
-              "change the sound",
-              "modify the audio"
-            ],
-            "isOptional": true
+            "text": "the sound",
+            "category": "object",
+            "propertyNames": [
+              "fullActionName"
+            ]
           },
           {
             "text": "15%",
-            "category": "volume change",
+            "category": "quantity",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
           },
           {
             "text": "lower",
-            "category": "volume change",
+            "category": "direction",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
@@ -6594,6 +6638,33 @@
           }
         ],
         "propertyAlternatives": [
+          {
+            "propertyName": "fullActionName",
+            "propertyValue": "player.changeVolume",
+            "propertySubPhrases": [
+              "the sound"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "player.adjustVolume",
+                "propertySubPhrases": [
+                  "the audio"
+                ]
+              },
+              {
+                "propertyValue": "player.setVolume",
+                "propertySubPhrases": [
+                  "the volume"
+                ]
+              },
+              {
+                "propertyValue": "player.modifyVolume",
+                "propertySubPhrases": [
+                  "the sound level"
+                ]
+              }
+            ]
+          },
           {
             "propertyName": "parameters.volumeChangePercentage",
             "propertyValue": -15,
@@ -6617,17 +6688,27 @@
                 ]
               },
               {
-                "propertyValue": -25,
+                "propertyValue": -5,
                 "propertySubPhrases": [
-                  "25%",
+                  "5%",
                   "lower"
                 ]
               }
             ]
           }
         ],
-        "politePrefixes": [],
-        "politeSuffixes": []
+        "politePrefixes": [
+          "Could you please",
+          "Would you mind",
+          "If it's not too much trouble",
+          "May I kindly ask"
+        ],
+        "politeSuffixes": [
+          "Thank you!",
+          "I would appreciate it.",
+          "Thanks in advance.",
+          "If you don't mind."
+        ]
       },
       "corrections": [
         {
@@ -6636,7 +6717,9 @@
               {
                 "name": "fullActionName",
                 "value": "player.changeVolume",
-                "substrings": []
+                "substrings": [
+                  "sound"
+                ]
               },
               {
                 "name": "parameters.volumeChangePercentage",
@@ -6681,11 +6764,13 @@
         "subPhrases": [
           {
             "text": "Let's",
-            "category": "filler",
+            "category": "politeness",
             "synonyms": [
-              "Let us",
-              "We should",
-              "How about we"
+              "please",
+              "kindly",
+              "if you would",
+              "would you mind",
+              "could you"
             ],
             "isOptional": true
           },
@@ -6701,14 +6786,15 @@
             "category": "filler",
             "synonyms": [
               "by a significant",
-              "by a large",
-              "by a considerable"
+              "by a considerable",
+              "by a substantial",
+              "by a large"
             ],
             "isOptional": true
           },
           {
             "text": "30%",
-            "category": "value",
+            "category": "quantity",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
@@ -6723,21 +6809,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.decreaseVolume",
+                "propertyValue": "player.raiseVolume",
                 "propertySubPhrases": [
-                  "decrease the volume"
+                  "raise the volume"
                 ]
               },
               {
-                "propertyValue": "player.muteVolume",
+                "propertyValue": "player.boostVolume",
                 "propertySubPhrases": [
-                  "mute the volume"
+                  "boost the volume"
                 ]
               },
               {
-                "propertyValue": "player.maximizeVolume",
+                "propertyValue": "player.amplifyVolume",
                 "propertySubPhrases": [
-                  "maximize the volume"
+                  "amplify the volume"
                 ]
               }
             ]
@@ -6750,9 +6836,15 @@
             ],
             "alternatives": [
               {
-                "propertyValue": 10,
+                "propertyValue": 20,
                 "propertySubPhrases": [
-                  "10%"
+                  "20%"
+                ]
+              },
+              {
+                "propertyValue": 40,
+                "propertySubPhrases": [
+                  "40%"
                 ]
               },
               {
@@ -6760,23 +6852,21 @@
                 "propertySubPhrases": [
                   "50%"
                 ]
-              },
-              {
-                "propertyValue": 100,
-                "propertySubPhrases": [
-                  "100%"
-                ]
               }
             ]
           }
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If you don't mind",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it."
+          "thank you.",
+          "if that's okay.",
+          "please.",
+          "thanks."
         ]
       }
     },
@@ -6811,9 +6901,9 @@
             "text": "Let's",
             "category": "politeness",
             "synonyms": [
-              "Let us",
-              "We should",
-              "How about we"
+              "Please",
+              "Kindly",
+              "Would you mind"
             ],
             "isOptional": true
           },
@@ -6833,7 +6923,7 @@
           },
           {
             "text": "more chill",
-            "category": "modifier",
+            "category": "description",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
@@ -6901,11 +6991,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If you don't mind",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it."
+          "thank you",
+          "if that's okay",
+          "please",
+          "thanks"
         ]
       },
       "corrections": [
@@ -6967,16 +7061,23 @@
             "synonyms": [
               "Please",
               "Kindly",
-              "Would you"
+              "Would you mind"
             ],
             "isOptional": true
           },
           {
-            "text": "trim the volume",
+            "text": "trim",
             "category": "action",
             "propertyNames": [
               "fullActionName",
               "parameters.volumeChangePercentage"
+            ]
+          },
+          {
+            "text": "the volume",
+            "category": "action",
+            "propertyNames": [
+              "fullActionName"
             ]
           },
           {
@@ -6991,7 +7092,7 @@
           },
           {
             "text": "5%",
-            "category": "value",
+            "category": "quantity",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
@@ -7002,25 +7103,29 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.changeVolume",
             "propertySubPhrases": [
-              "trim the volume"
+              "trim",
+              "the volume"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.increaseVolume",
                 "propertySubPhrases": [
-                  "increase the volume"
+                  "increase",
+                  "the volume"
                 ]
               },
               {
                 "propertyValue": "player.decreaseVolume",
                 "propertySubPhrases": [
-                  "decrease the volume"
+                  "decrease",
+                  "the volume"
                 ]
               },
               {
                 "propertyValue": "player.adjustVolume",
                 "propertySubPhrases": [
-                  "adjust the volume"
+                  "adjust",
+                  "the volume"
                 ]
               }
             ]
@@ -7029,28 +7134,28 @@
             "propertyName": "parameters.volumeChangePercentage",
             "propertyValue": -5,
             "propertySubPhrases": [
-              "trim the volume",
+              "trim",
               "5%"
             ],
             "alternatives": [
               {
                 "propertyValue": -10,
                 "propertySubPhrases": [
-                  "trim the volume",
+                  "trim",
                   "10%"
                 ]
               },
               {
                 "propertyValue": -15,
                 "propertySubPhrases": [
-                  "trim the volume",
+                  "trim",
                   "15%"
                 ]
               },
               {
                 "propertyValue": -20,
                 "propertySubPhrases": [
-                  "trim the volume",
+                  "trim",
                   "20%"
                 ]
               }
@@ -7059,11 +7164,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If you don't mind",
+          "Please"
         ],
         "politeSuffixes": [
           "Thank you!",
-          "I would appreciate it."
+          "Thanks!",
+          "I appreciate it!",
+          "If that's okay with you."
         ]
       },
       "corrections": [
@@ -7116,7 +7225,7 @@
                 "synonyms": [
                   "Please",
                   "Kindly",
-                  "Would you"
+                  "Would you mind"
                 ],
                 "isOptional": true
               },
@@ -7139,7 +7248,7 @@
               },
               {
                 "text": "5%",
-                "category": "value",
+                "category": "quantity",
                 "propertyNames": [
                   "parameters.volumeChangePercentage"
                 ]
@@ -7180,11 +7289,11 @@
         "subPhrases": [
           {
             "text": "Let's",
-            "category": "filler",
+            "category": "politeness",
             "synonyms": [
-              "Let us",
-              "We should",
-              "How about"
+              "Please",
+              "Kindly",
+              "Would you mind"
             ],
             "isOptional": true
           },
@@ -7200,14 +7309,14 @@
             "category": "filler",
             "synonyms": [
               "by exactly",
-              "by a full",
-              "by a complete"
+              "by precisely",
+              "by"
             ],
             "isOptional": true
           },
           {
             "text": "30%",
-            "category": "value",
+            "category": "quantity",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
@@ -7273,13 +7382,13 @@
           "Could you please",
           "Would you mind",
           "If it's not too much trouble,",
-          "May I kindly ask you to"
+          "May I kindly ask"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it.",
-          "Thanks a lot!",
-          "That would be great!"
+          "thank you.",
+          "please.",
+          "if you don't mind.",
+          "I'd appreciate it."
         ]
       }
     },
@@ -7312,7 +7421,7 @@
         "subPhrases": [
           {
             "text": "Lower",
-            "category": "action",
+            "category": "command",
             "propertyNames": [
               "fullActionName",
               "parameters.volumeChangePercentage"
@@ -7399,11 +7508,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If you don't mind,",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you.",
-          "I would appreciate it."
+          "thank you.",
+          "if that's okay.",
+          "please.",
+          "thanks."
         ]
       },
       "corrections": [
@@ -7466,8 +7579,18 @@
             ]
           },
           {
-            "text": "by 30%",
-            "category": "parameter",
+            "text": "by",
+            "category": "preposition",
+            "synonyms": [
+              "with",
+              "using",
+              "through"
+            ],
+            "isOptional": true
+          },
+          {
+            "text": "30%",
+            "category": "percentage",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
@@ -7484,19 +7607,19 @@
               {
                 "propertyValue": "player.increaseVolume",
                 "propertySubPhrases": [
-                  "Increase the volume"
+                  "Increase the sound"
                 ]
               },
               {
                 "propertyValue": "player.raiseVolume",
                 "propertySubPhrases": [
-                  "Raise the volume"
+                  "Raise the sound"
                 ]
               },
               {
-                "propertyValue": "player.boostVolume",
+                "propertyValue": "player.amplifyVolume",
                 "propertySubPhrases": [
-                  "Boost the volume"
+                  "Amplify the sound"
                 ]
               }
             ]
@@ -7505,25 +7628,25 @@
             "propertyName": "parameters.volumeChangePercentage",
             "propertyValue": 30,
             "propertySubPhrases": [
-              "by 30%"
+              "30%"
             ],
             "alternatives": [
               {
                 "propertyValue": 20,
                 "propertySubPhrases": [
-                  "by 20%"
+                  "20%"
+                ]
+              },
+              {
+                "propertyValue": 40,
+                "propertySubPhrases": [
+                  "40%"
                 ]
               },
               {
                 "propertyValue": 50,
                 "propertySubPhrases": [
-                  "by 50%"
-                ]
-              },
-              {
-                "propertyValue": 10,
-                "propertySubPhrases": [
-                  "by 10%"
+                  "50%"
                 ]
               }
             ]
@@ -7531,11 +7654,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If possible, could you",
+          "I would appreciate it if you could"
         ],
         "politeSuffixes": [
           "Thank you.",
-          "I would appreciate it."
+          "Please.",
+          "If you don't mind.",
+          "Thanks in advance."
         ]
       }
     },
@@ -7568,21 +7695,21 @@
         "subPhrases": [
           {
             "text": "Make the sound",
-            "category": "action",
+            "category": "command",
             "propertyNames": [
               "fullActionName"
             ]
           },
           {
             "text": "15%",
-            "category": "volume",
+            "category": "percentage",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
           },
           {
             "text": "less loud",
-            "category": "volume",
+            "category": "description",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
@@ -7597,21 +7724,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.adjustVolume",
+                "propertyValue": "audio.adjustVolume",
                 "propertySubPhrases": [
                   "Adjust the sound"
                 ]
               },
               {
-                "propertyValue": "player.setVolume",
+                "propertyValue": "sound.modifyVolume",
                 "propertySubPhrases": [
-                  "Set the sound"
+                  "Modify the sound"
                 ]
               },
               {
-                "propertyValue": "player.modifyVolume",
+                "propertyValue": "volume.setLevel",
                 "propertySubPhrases": [
-                  "Modify the sound"
+                  "Set the volume"
                 ]
               }
             ]
@@ -7651,14 +7778,14 @@
         "politePrefixes": [
           "Could you please",
           "Would you mind",
-          "If it's not too much trouble, could you",
-          "May I kindly ask you to"
+          "If possible, could you",
+          "Please"
         ],
         "politeSuffixes": [
           "Thank you.",
+          "Thanks.",
           "I would appreciate it.",
-          "Thanks a lot.",
-          "That would be great."
+          "If you don't mind."
         ]
       },
       "corrections": [
@@ -7701,7 +7828,7 @@
             "name": "fullActionName",
             "value": "player.changeVolume",
             "substrings": [
-              "Make the volume softer"
+              "Make the volume"
             ]
           },
           {
@@ -7709,22 +7836,28 @@
             "value": -10,
             "substrings": [
               "softer",
-              "10%"
+              "by 10%"
             ]
           }
         ],
         "subPhrases": [
           {
-            "text": "Make the volume softer",
+            "text": "Make the volume",
             "category": "command",
             "propertyNames": [
-              "fullActionName",
+              "fullActionName"
+            ]
+          },
+          {
+            "text": "softer",
+            "category": "description",
+            "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
           },
           {
             "text": "by 10%",
-            "category": "volumeChange",
+            "category": "measurement",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
@@ -7735,25 +7868,25 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.changeVolume",
             "propertySubPhrases": [
-              "Make the volume softer"
+              "Make the volume"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.increaseVolume",
                 "propertySubPhrases": [
-                  "Make the volume louder"
+                  "Increase the volume"
+                ]
+              },
+              {
+                "propertyValue": "player.decreaseVolume",
+                "propertySubPhrases": [
+                  "Decrease the volume"
                 ]
               },
               {
                 "propertyValue": "player.muteVolume",
                 "propertySubPhrases": [
                   "Mute the volume"
-                ]
-              },
-              {
-                "propertyValue": "player.unmuteVolume",
-                "propertySubPhrases": [
-                  "Unmute the volume"
                 ]
               }
             ]
@@ -7762,29 +7895,29 @@
             "propertyName": "parameters.volumeChangePercentage",
             "propertyValue": -10,
             "propertySubPhrases": [
-              "Make the volume softer",
+              "softer",
               "by 10%"
             ],
             "alternatives": [
               {
                 "propertyValue": -20,
                 "propertySubPhrases": [
-                  "Make the volume softer",
+                  "much softer",
                   "by 20%"
                 ]
               },
               {
                 "propertyValue": -5,
                 "propertySubPhrases": [
-                  "Make the volume softer",
+                  "slightly softer",
                   "by 5%"
                 ]
               },
               {
-                "propertyValue": -15,
+                "propertyValue": 10,
                 "propertySubPhrases": [
-                  "Make the volume softer",
-                  "by 15%"
+                  "louder",
+                  "by 10%"
                 ]
               }
             ]
@@ -7792,11 +7925,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If possible, could you",
+          "Please"
         ],
         "politeSuffixes": [
           "Thank you.",
-          "I would appreciate it."
+          "If you don't mind.",
+          "I would appreciate it.",
+          "Thanks."
         ]
       },
       "corrections": [
@@ -7807,107 +7944,20 @@
                 "name": "fullActionName",
                 "value": "player.changeVolume",
                 "substrings": [
-                  "Make the volume softer"
+                  "Make the volume"
                 ]
               },
               {
                 "name": "parameters.volumeChangePercentage",
                 "value": -10,
                 "substrings": [
-                  "10%"
+                  "softer by 10%"
                 ]
               }
             ]
           },
           "correction": [
-            "Value -10 for property 'parameters.volumeChangePercentage' doesn't match the number 10 in the substring '10%'. Missing other substring to explain the value."
-          ]
-        },
-        {
-          "data": {
-            "properties": [
-              {
-                "name": "fullActionName",
-                "value": "player.changeVolume",
-                "substrings": [
-                  "Make the volume softer"
-                ]
-              },
-              {
-                "name": "parameters.volumeChangePercentage",
-                "value": -10,
-                "substrings": [
-                  "softer",
-                  "10%"
-                ]
-              }
-            ],
-            "subPhrases": [
-              {
-                "text": "Make the volume softer",
-                "category": "command",
-                "propertyNames": [
-                  "fullActionName"
-                ]
-              },
-              {
-                "text": "softer",
-                "category": "volumeChange",
-                "propertyNames": [
-                  "parameters.volumeChangePercentage"
-                ]
-              },
-              {
-                "text": "by 10%",
-                "category": "volumeChange",
-                "propertyNames": [
-                  "parameters.volumeChangePercentage"
-                ]
-              }
-            ]
-          },
-          "correction": [
-            "Overlapping sub-phrase: explanation has overlapping text 'softer'."
-          ]
-        },
-        {
-          "data": {
-            "properties": [
-              {
-                "name": "fullActionName",
-                "value": "player.changeVolume",
-                "substrings": [
-                  "Make the volume softer"
-                ]
-              },
-              {
-                "name": "parameters.volumeChangePercentage",
-                "value": -10,
-                "substrings": [
-                  "softer",
-                  "10%"
-                ]
-              }
-            ],
-            "subPhrases": [
-              {
-                "text": "Make the volume softer",
-                "category": "command",
-                "propertyNames": [
-                  "fullActionName"
-                ]
-              },
-              {
-                "text": "by 10%",
-                "category": "volumeChange",
-                "propertyNames": [
-                  "parameters.volumeChangePercentage"
-                ]
-              }
-            ]
-          },
-          "correction": [
-            "Explicit property 'parameters.volumeChangePercentage' must be included as property names for all subphrases that contain the substring 'softer'"
+            "Value -10 for property 'parameters.volumeChangePercentage' doesn't match the number 10 in the substring 'softer by 10%'. Missing other substring to explain the value."
           ]
         }
       ]
@@ -7942,9 +7992,9 @@
             "text": "Mind",
             "category": "politeness",
             "synonyms": [
-              "Would you",
               "Could you",
-              "Can you"
+              "Would you",
+              "Please"
             ],
             "isOptional": true
           },
@@ -7994,9 +8044,9 @@
                 ]
               },
               {
-                "propertyValue": "player.turnUpVolume",
+                "propertyValue": "player.adjustVolume",
                 "propertySubPhrases": [
-                  "turning up the volume"
+                  "adjusting the volume"
                 ]
               }
             ]
@@ -8038,36 +8088,10 @@
         "politeSuffixes": [
           "Thank you!",
           "I would appreciate it.",
-          "Thanks a lot!",
-          "Much appreciated!"
+          "Thanks in advance!",
+          "If you don't mind."
         ]
-      },
-      "corrections": [
-        {
-          "data": {
-            "properties": [
-              {
-                "name": "fullActionName",
-                "value": "player.changeVolume",
-                "substrings": [
-                  "bumping up the volume"
-                ]
-              },
-              {
-                "name": "volumeChangePercentage",
-                "value": 10,
-                "substrings": [
-                  "10%"
-                ]
-              }
-            ]
-          },
-          "correction": [
-            "Extraneous parameter: 'volumeChangePercentage' is not a parameter in the action",
-            "Missing parameter: parameter 'parameters.volumeChangePercentage' in the action is missing from explanation"
-          ]
-        }
-      ]
+      }
     },
     {
       "request": "Mind cranking up the volume by 10%?",
@@ -8099,9 +8123,9 @@
             "text": "Mind",
             "category": "politeness",
             "synonyms": [
-              "Would you mind",
               "Could you",
-              "Can you"
+              "Would you",
+              "Please"
             ],
             "isOptional": true
           },
@@ -8113,8 +8137,18 @@
             ]
           },
           {
-            "text": "by 10%",
-            "category": "parameter",
+            "text": "by",
+            "category": "preposition",
+            "synonyms": [
+              "to",
+              "at",
+              "with"
+            ],
+            "isOptional": true
+          },
+          {
+            "text": "10%",
+            "category": "quantity",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
@@ -8131,19 +8165,19 @@
               {
                 "propertyValue": "player.increaseVolume",
                 "propertySubPhrases": [
-                  "increasing the volume"
+                  "increase the volume"
                 ]
               },
               {
                 "propertyValue": "player.raiseVolume",
                 "propertySubPhrases": [
-                  "raising the volume"
+                  "raise the volume"
                 ]
               },
               {
                 "propertyValue": "player.turnUpVolume",
                 "propertySubPhrases": [
-                  "turning up the volume"
+                  "turn up the volume"
                 ]
               }
             ]
@@ -8152,25 +8186,25 @@
             "propertyName": "parameters.volumeChangePercentage",
             "propertyValue": 10,
             "propertySubPhrases": [
-              "by 10%"
+              "10%"
             ],
             "alternatives": [
               {
-                "propertyValue": 20,
+                "propertyValue": 5,
                 "propertySubPhrases": [
-                  "by 20%"
+                  "5%"
                 ]
               },
               {
                 "propertyValue": 15,
                 "propertySubPhrases": [
-                  "by 15%"
+                  "15%"
                 ]
               },
               {
-                "propertyValue": 5,
+                "propertyValue": 20,
                 "propertySubPhrases": [
-                  "by 5%"
+                  "20%"
                 ]
               }
             ]
@@ -8178,11 +8212,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If it's not too much trouble,",
+          "May I ask you to"
         ],
         "politeSuffixes": [
           "Thank you!",
-          "I would appreciate it!"
+          "Please.",
+          "If you don't mind.",
+          "I would appreciate it."
         ]
       }
     },
@@ -8238,19 +8276,19 @@
               {
                 "propertyValue": "player.adjustVolume",
                 "propertySubPhrases": [
-                  "Adjust the volume"
+                  "Adjust the sound level"
                 ]
               },
               {
                 "propertyValue": "player.setVolume",
                 "propertySubPhrases": [
-                  "Set the volume"
+                  "Set the sound level"
                 ]
               },
               {
-                "propertyValue": "player.updateVolume",
+                "propertyValue": "player.changeAudioLevel",
                 "propertySubPhrases": [
-                  "Update the sound level"
+                  "Change the audio level"
                 ]
               }
             ]
@@ -8263,21 +8301,21 @@
             ],
             "alternatives": [
               {
+                "propertyValue": 20,
+                "propertySubPhrases": [
+                  "increase it by 20%"
+                ]
+              },
+              {
                 "propertyValue": 5,
                 "propertySubPhrases": [
                   "increase it by 5%"
                 ]
               },
               {
-                "propertyValue": 15,
+                "propertyValue": -10,
                 "propertySubPhrases": [
-                  "increase it by 15%"
-                ]
-              },
-              {
-                "propertyValue": 20,
-                "propertySubPhrases": [
-                  "increase it by 20%"
+                  "decrease it by 10%"
                 ]
               }
             ]
@@ -8286,14 +8324,14 @@
         "politePrefixes": [
           "Could you please",
           "Would you mind",
-          "If it's not too much trouble, could you",
-          "May I kindly ask you to"
+          "If possible,",
+          "Kindly"
         ],
         "politeSuffixes": [
-          "Thank you.",
-          "I would appreciate it.",
-          "Thanks a lot.",
-          "That would be great."
+          "thank you.",
+          "please.",
+          "if you don't mind.",
+          "thanks."
         ]
       }
     },
@@ -8333,8 +8371,18 @@
             ]
           },
           {
-            "text": "by 15%",
-            "category": "modifier",
+            "text": "by",
+            "category": "preposition",
+            "synonyms": [
+              "at",
+              "with",
+              "to"
+            ],
+            "isOptional": true
+          },
+          {
+            "text": "15%",
+            "category": "quantity",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
@@ -8373,28 +8421,28 @@
             "propertyValue": -15,
             "propertySubPhrases": [
               "Muffle the sound",
-              "by 15%"
+              "15%"
             ],
             "alternatives": [
               {
                 "propertyValue": -10,
                 "propertySubPhrases": [
                   "Muffle the sound",
-                  "by 10%"
+                  "10%"
                 ]
               },
               {
                 "propertyValue": -20,
                 "propertySubPhrases": [
                   "Muffle the sound",
-                  "by 20%"
+                  "20%"
                 ]
               },
               {
                 "propertyValue": -25,
                 "propertySubPhrases": [
                   "Muffle the sound",
-                  "by 25%"
+                  "25%"
                 ]
               }
             ]
@@ -8402,11 +8450,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If possible, could you",
+          "I would appreciate it if you could"
         ],
         "politeSuffixes": [
           "Thank you.",
-          "I would appreciate it."
+          "Please.",
+          "If you don't mind.",
+          "Thanks in advance."
         ]
       },
       "corrections": [
@@ -8463,7 +8515,7 @@
         "subPhrases": [
           {
             "text": "Nudge the volume up",
-            "category": "action",
+            "category": "command",
             "propertyNames": [
               "fullActionName"
             ]
@@ -8472,15 +8524,15 @@
             "text": "by",
             "category": "preposition",
             "synonyms": [
-              "to",
-              "at",
-              "with"
+              "with",
+              "using",
+              "through"
             ],
             "isOptional": true
           },
           {
             "text": "30%",
-            "category": "value",
+            "category": "quantity",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
@@ -8507,9 +8559,9 @@
                 ]
               },
               {
-                "propertyValue": "player.boostVolume",
+                "propertyValue": "player.adjustVolume",
                 "propertySubPhrases": [
-                  "Boost the volume"
+                  "Adjust the volume"
                 ]
               }
             ]
@@ -8544,11 +8596,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If possible,",
+          "May I ask you to"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it."
+          "thank you.",
+          "please.",
+          "if you don't mind.",
+          "thanks."
         ]
       }
     },
@@ -8597,7 +8653,7 @@
           },
           {
             "text": "by 25%",
-            "category": "parameter",
+            "category": "quantity",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
@@ -8624,9 +8680,9 @@
                 ]
               },
               {
-                "propertyValue": "player.turnUpVolume",
+                "propertyValue": "player.amplifyVolume",
                 "propertySubPhrases": [
-                  "turn up the volume"
+                  "amplify the volume"
                 ]
               }
             ]
@@ -8659,8 +8715,18 @@
             ]
           }
         ],
-        "politePrefixes": [],
-        "politeSuffixes": []
+        "politePrefixes": [
+          "Could you kindly",
+          "Would you be so kind as to",
+          "If you don't mind,",
+          "May I request that you"
+        ],
+        "politeSuffixes": [
+          "Thank you.",
+          "I would appreciate it.",
+          "Thanks in advance.",
+          "Your assistance is appreciated."
+        ]
       }
     },
     {
@@ -8694,8 +8760,8 @@
             "category": "politeness",
             "synonyms": [
               "Kindly",
-              "Would you mind",
-              "Could you"
+              "Could you",
+              "Would you mind"
             ],
             "isOptional": true
           },
@@ -8712,7 +8778,7 @@
             "synonyms": [
               "by a considerable",
               "by a significant",
-              "by a notable"
+              "by a substantial"
             ],
             "isOptional": true
           },
@@ -8780,8 +8846,18 @@
             ]
           }
         ],
-        "politePrefixes": [],
-        "politeSuffixes": []
+        "politePrefixes": [
+          "Could you kindly",
+          "Would you be so kind as to",
+          "If you don't mind,",
+          "May I request that you"
+        ],
+        "politeSuffixes": [
+          "Thank you.",
+          "I would appreciate it.",
+          "Thanks in advance.",
+          "Your assistance is appreciated."
+        ]
       }
     },
     {
@@ -8829,7 +8905,7 @@
           },
           {
             "text": "by 25%",
-            "category": "parameter",
+            "category": "quantity",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
@@ -8856,9 +8932,9 @@
                 ]
               },
               {
-                "propertyValue": "player.amplifyVolume",
+                "propertyValue": "player.boostVolume",
                 "propertySubPhrases": [
-                  "amplify the volume"
+                  "boost the volume"
                 ]
               }
             ]
@@ -8891,8 +8967,18 @@
             ]
           }
         ],
-        "politePrefixes": [],
-        "politeSuffixes": []
+        "politePrefixes": [
+          "Could you kindly",
+          "Would you mind",
+          "If it's not too much trouble,",
+          "May I request that you"
+        ],
+        "politeSuffixes": [
+          "Thank you.",
+          "I would appreciate it.",
+          "Thanks in advance.",
+          "Your help is appreciated."
+        ]
       }
     },
     {
@@ -8908,13 +8994,15 @@
           {
             "name": "fullActionName",
             "value": "player.changeVolume",
-            "substrings": []
+            "substrings": [
+              "request the audio"
+            ]
           },
           {
             "name": "parameters.volumeChangePercentage",
             "value": -20,
             "substrings": [
-              "20%",
+              "20% softer",
               "softer"
             ]
           }
@@ -8924,41 +9012,21 @@
             "text": "Politely",
             "category": "politeness",
             "synonyms": [
-              "Please",
-              "Kindly",
-              "If you could"
+              "please",
+              "kindly",
+              "if you could"
             ],
             "isOptional": true
           },
           {
-            "text": "request",
-            "category": "politeness",
-            "synonyms": [
-              "ask",
-              "inquire",
-              "demand"
-            ],
-            "isOptional": true
-          },
-          {
-            "text": "the audio to be",
-            "category": "preposition",
-            "synonyms": [
-              "the sound to be",
-              "the volume to be",
-              "the audio level to be"
-            ],
-            "isOptional": true
-          },
-          {
-            "text": "20%",
-            "category": "percentage",
+            "text": "request the audio",
+            "category": "action",
             "propertyNames": [
-              "parameters.volumeChangePercentage"
+              "fullActionName"
             ]
           },
           {
-            "text": "softer",
+            "text": "to be 20% softer",
             "category": "volume change",
             "propertyNames": [
               "parameters.volumeChangePercentage"
@@ -8967,32 +9035,55 @@
         ],
         "propertyAlternatives": [
           {
+            "propertyName": "fullActionName",
+            "propertyValue": "player.changeVolume",
+            "propertySubPhrases": [
+              "request the audio"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "player.increaseVolume",
+                "propertySubPhrases": [
+                  "request the audio to be louder"
+                ]
+              },
+              {
+                "propertyValue": "player.muteVolume",
+                "propertySubPhrases": [
+                  "request the audio to be muted"
+                ]
+              },
+              {
+                "propertyValue": "player.unmuteVolume",
+                "propertySubPhrases": [
+                  "request the audio to be unmuted"
+                ]
+              }
+            ]
+          },
+          {
             "propertyName": "parameters.volumeChangePercentage",
             "propertyValue": -20,
             "propertySubPhrases": [
-              "20%",
-              "softer"
+              "to be 20% softer"
             ],
             "alternatives": [
               {
                 "propertyValue": -10,
                 "propertySubPhrases": [
-                  "10%",
-                  "softer"
+                  "to be 10% softer"
                 ]
               },
               {
                 "propertyValue": -30,
                 "propertySubPhrases": [
-                  "30%",
-                  "softer"
+                  "to be 30% softer"
                 ]
               },
               {
                 "propertyValue": -50,
                 "propertySubPhrases": [
-                  "50%",
-                  "softer"
+                  "to be 50% softer"
                 ]
               }
             ]
@@ -9000,10 +9091,14 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If it's not too much trouble,",
+          "May I kindly ask"
         ],
         "politeSuffixes": [
-          "Thank you.",
+          "thank you.",
+          "please.",
+          "if you don't mind.",
           "I would appreciate it."
         ]
       },
@@ -9014,7 +9109,9 @@
               {
                 "name": "fullActionName",
                 "value": "player.changeVolume",
-                "substrings": []
+                "substrings": [
+                  "request the audio"
+                ]
               },
               {
                 "name": "parameters.volumeChangePercentage",
@@ -9059,7 +9156,7 @@
         "subPhrases": [
           {
             "text": "Ramp up the sound level",
-            "category": "command",
+            "category": "action",
             "propertyNames": [
               "fullActionName"
             ]
@@ -9069,7 +9166,7 @@
             "category": "filler",
             "synonyms": [
               "by a cool",
-              "by an awesome",
+              "by an impressive",
               "by a neat"
             ],
             "isOptional": true
@@ -9093,19 +9190,19 @@
               {
                 "propertyValue": "player.increaseVolume",
                 "propertySubPhrases": [
-                  "Increase the volume"
+                  "Increase the sound level"
                 ]
               },
               {
                 "propertyValue": "player.raiseVolume",
                 "propertySubPhrases": [
-                  "Raise the volume"
+                  "Raise the sound level"
                 ]
               },
               {
                 "propertyValue": "player.boostVolume",
                 "propertySubPhrases": [
-                  "Boost the volume"
+                  "Boost the sound level"
                 ]
               }
             ]
@@ -9118,21 +9215,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": 5,
-                "propertySubPhrases": [
-                  "5%"
-                ]
-              },
-              {
-                "propertyValue": 15,
-                "propertySubPhrases": [
-                  "15%"
-                ]
-              },
-              {
                 "propertyValue": 20,
                 "propertySubPhrases": [
                   "20%"
+                ]
+              },
+              {
+                "propertyValue": 30,
+                "propertySubPhrases": [
+                  "30%"
+                ]
+              },
+              {
+                "propertyValue": 50,
+                "propertySubPhrases": [
+                  "50%"
                 ]
               }
             ]
@@ -9140,11 +9237,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If you don't mind",
+          "Please"
         ],
         "politeSuffixes": [
           "Thank you!",
-          "I would appreciate it."
+          "Thanks!",
+          "I appreciate it!",
+          "Much appreciated!"
         ]
       }
     },
@@ -9170,7 +9271,7 @@
             "value": -10,
             "substrings": [
               "down",
-              "by 10%"
+              "10%"
             ]
           }
         ],
@@ -9184,8 +9285,18 @@
             ]
           },
           {
-            "text": "by 10%",
-            "category": "amount",
+            "text": "by",
+            "category": "preposition",
+            "synonyms": [
+              "through",
+              "via",
+              "using"
+            ],
+            "isOptional": true
+          },
+          {
+            "text": "10%",
+            "category": "percentage",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
@@ -9200,21 +9311,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.increaseVolume",
+                "propertyValue": "player.decreaseVolume",
                 "propertySubPhrases": [
-                  "Increase the volume"
+                  "Decrease the volume"
                 ]
               },
               {
-                "propertyValue": "player.muteVolume",
+                "propertyValue": "player.lowerVolume",
                 "propertySubPhrases": [
-                  "Mute the volume"
+                  "Lower the volume"
                 ]
               },
               {
-                "propertyValue": "player.unmuteVolume",
+                "propertyValue": "player.reduceVolume",
                 "propertySubPhrases": [
-                  "Unmute the volume"
+                  "Reduce the volume"
                 ]
               }
             ]
@@ -9224,28 +9335,28 @@
             "propertyValue": -10,
             "propertySubPhrases": [
               "Scale down the volume",
-              "by 10%"
+              "10%"
             ],
             "alternatives": [
-              {
-                "propertyValue": -20,
-                "propertySubPhrases": [
-                  "Scale down the volume",
-                  "by 20%"
-                ]
-              },
               {
                 "propertyValue": -5,
                 "propertySubPhrases": [
                   "Scale down the volume",
-                  "by 5%"
+                  "5%"
                 ]
               },
               {
                 "propertyValue": -15,
                 "propertySubPhrases": [
                   "Scale down the volume",
-                  "by 15%"
+                  "15%"
+                ]
+              },
+              {
+                "propertyValue": -20,
+                "propertySubPhrases": [
+                  "Scale down the volume",
+                  "20%"
                 ]
               }
             ]
@@ -9253,11 +9364,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If possible, could you",
+          "Please"
         ],
         "politeSuffixes": [
           "Thank you.",
-          "I appreciate it."
+          "Thanks.",
+          "I would appreciate it.",
+          "If you don't mind."
         ]
       },
       "corrections": [
@@ -9275,13 +9390,13 @@
                 "name": "parameters.volumeChangePercentage",
                 "value": -10,
                 "substrings": [
-                  "by 10%"
+                  "10%"
                 ]
               }
             ]
           },
           "correction": [
-            "Value -10 for property 'parameters.volumeChangePercentage' doesn't match the number 10 in the substring 'by 10%'. Missing other substring to explain the value."
+            "Value -10 for property 'parameters.volumeChangePercentage' doesn't match the number 10 in the substring '10%'. Missing other substring to explain the value."
           ]
         },
         {
@@ -9299,7 +9414,7 @@
                 "value": -10,
                 "substrings": [
                   "down",
-                  "by 10%"
+                  "10%"
                 ]
               }
             ],
@@ -9319,8 +9434,8 @@
                 ]
               },
               {
-                "text": "by 10%",
-                "category": "amount",
+                "text": "10%",
+                "category": "percentage",
                 "propertyNames": [
                   "parameters.volumeChangePercentage"
                 ]
@@ -9346,7 +9461,7 @@
                 "value": -10,
                 "substrings": [
                   "down",
-                  "by 10%"
+                  "10%"
                 ]
               }
             ],
@@ -9359,8 +9474,8 @@
                 ]
               },
               {
-                "text": "by 10%",
-                "category": "amount",
+                "text": "10%",
+                "category": "percentage",
                 "propertyNames": [
                   "parameters.volumeChangePercentage"
                 ]
@@ -9368,6 +9483,7 @@
             ]
           },
           "correction": [
+            "Missing sub-phrase: explanation missing for 'by'",
             "Explicit property 'parameters.volumeChangePercentage' must be included as property names for all subphrases that contain the substring 'down'"
           ]
         }
@@ -9402,18 +9518,18 @@
         "subPhrases": [
           {
             "text": "Set the sound",
-            "category": "action",
+            "category": "command",
             "propertyNames": [
               "fullActionName"
             ]
           },
           {
             "text": "to be",
-            "category": "filler",
+            "category": "preposition",
             "synonyms": [
-              "as",
               "to",
-              "become"
+              "for",
+              "in order to"
             ],
             "isOptional": true
           },
@@ -9426,7 +9542,7 @@
           },
           {
             "text": "quieter",
-            "category": "direction",
+            "category": "volumeChange",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
@@ -9441,21 +9557,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.increaseVolume",
+                "propertyValue": "player.adjustVolume",
                 "propertySubPhrases": [
-                  "Increase the sound"
+                  "Adjust the sound"
                 ]
               },
               {
-                "propertyValue": "player.decreaseVolume",
+                "propertyValue": "player.modifyVolume",
                 "propertySubPhrases": [
-                  "Decrease the sound"
+                  "Modify the sound"
                 ]
               },
               {
-                "propertyValue": "player.mute",
+                "propertyValue": "player.setVolume",
                 "propertySubPhrases": [
-                  "Mute the sound"
+                  "Set the volume"
                 ]
               }
             ]
@@ -9483,9 +9599,9 @@
                 ]
               },
               {
-                "propertyValue": -30,
+                "propertyValue": -5,
                 "propertySubPhrases": [
-                  "30%",
+                  "5%",
                   "quieter"
                 ]
               }
@@ -9495,14 +9611,14 @@
         "politePrefixes": [
           "Could you please",
           "Would you mind",
-          "If it's not too much trouble, could you",
-          "May I ask you to"
+          "Please",
+          "If you don't mind"
         ],
         "politeSuffixes": [
-          "Thank you.",
-          "I would appreciate it.",
-          "Thanks a lot.",
-          "That would be great."
+          "thank you",
+          "please",
+          "if that's okay",
+          "if you could"
         ]
       },
       "corrections": [
@@ -9528,53 +9644,6 @@
           "correction": [
             "Value -15 for property 'parameters.volumeChangePercentage' doesn't match the number 15 in the substring '15% quieter'. Missing other substring to explain the value."
           ]
-        },
-        {
-          "data": {
-            "properties": [
-              {
-                "name": "fullActionName",
-                "value": "player.changeVolume",
-                "substrings": [
-                  "Set the sound"
-                ]
-              },
-              {
-                "name": "parameters.volumeChangePercentage",
-                "value": -15,
-                "substrings": [
-                  "15%",
-                  "quieter"
-                ]
-              }
-            ],
-            "subPhrases": [
-              {
-                "text": "Set the sound",
-                "category": "action",
-                "propertyNames": [
-                  "fullActionName"
-                ]
-              },
-              {
-                "text": "15%",
-                "category": "percentage",
-                "propertyNames": [
-                  "parameters.volumeChangePercentage"
-                ]
-              },
-              {
-                "text": "quieter",
-                "category": "direction",
-                "propertyNames": [
-                  "parameters.volumeChangePercentage"
-                ]
-              }
-            ]
-          },
-          "correction": [
-            "Missing sub-phrase: explanation missing for 'to be'"
-          ]
         }
       ]
     },
@@ -9599,39 +9668,30 @@
             "name": "parameters.volumeChangePercentage",
             "value": -10,
             "substrings": [
-              "a slight",
-              "10%"
+              "a slight 10%",
+              "Shave"
             ]
           }
         ],
         "subPhrases": [
           {
-            "text": "Shave the volume",
+            "text": "Shave",
             "category": "action",
+            "propertyNames": [
+              "fullActionName",
+              "parameters.volumeChangePercentage"
+            ]
+          },
+          {
+            "text": "the volume",
+            "category": "object",
             "propertyNames": [
               "fullActionName"
             ]
           },
           {
-            "text": "by",
-            "category": "preposition",
-            "synonyms": [
-              "to",
-              "at",
-              "with"
-            ],
-            "isOptional": true
-          },
-          {
-            "text": "a slight",
+            "text": "by a slight 10%",
             "category": "modifier",
-            "propertyNames": [
-              "parameters.volumeChangePercentage"
-            ]
-          },
-          {
-            "text": "10%",
-            "category": "value",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
@@ -9642,25 +9702,29 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.changeVolume",
             "propertySubPhrases": [
-              "Shave the volume"
+              "Shave",
+              "the volume"
             ],
             "alternatives": [
               {
-                "propertyValue": "player.decreaseVolume",
+                "propertyValue": "player.adjustVolume",
                 "propertySubPhrases": [
-                  "Lower the volume"
+                  "Adjust",
+                  "the volume"
                 ]
               },
               {
-                "propertyValue": "player.reduceVolume",
+                "propertyValue": "player.modifyVolume",
                 "propertySubPhrases": [
-                  "Reduce the volume"
+                  "Modify",
+                  "the volume"
                 ]
               },
               {
-                "propertyValue": "player.dimVolume",
+                "propertyValue": "player.setVolume",
                 "propertySubPhrases": [
-                  "Dim the volume"
+                  "Set",
+                  "the volume"
                 ]
               }
             ]
@@ -9669,29 +9733,29 @@
             "propertyName": "parameters.volumeChangePercentage",
             "propertyValue": -10,
             "propertySubPhrases": [
-              "a slight",
-              "10%"
+              "Shave",
+              "by a slight 10%"
             ],
             "alternatives": [
               {
                 "propertyValue": -5,
                 "propertySubPhrases": [
-                  "a slight",
-                  "5%"
+                  "Shave",
+                  "by a slight 5%"
                 ]
               },
               {
                 "propertyValue": -15,
                 "propertySubPhrases": [
-                  "a slight",
-                  "15%"
+                  "Shave",
+                  "by a slight 15%"
                 ]
               },
               {
                 "propertyValue": -20,
                 "propertySubPhrases": [
-                  "a slight",
-                  "20%"
+                  "Shave",
+                  "by a slight 20%"
                 ]
               }
             ]
@@ -9700,14 +9764,14 @@
         "politePrefixes": [
           "Could you please",
           "Would you mind",
-          "If it's not too much trouble, could you",
-          "May I kindly ask you to"
+          "If possible,",
+          "Kindly"
         ],
         "politeSuffixes": [
-          "Thank you.",
-          "I would appreciate it.",
-          "Thanks a lot.",
-          "That would be great."
+          "thank you.",
+          "please.",
+          "if you don't mind.",
+          "thanks."
         ]
       },
       "corrections": [
@@ -9732,6 +9796,29 @@
           },
           "correction": [
             "Value -10 for property 'parameters.volumeChangePercentage' doesn't match the number 10 in the substring '10%'. Missing other substring to explain the value."
+          ]
+        },
+        {
+          "data": {
+            "properties": [
+              {
+                "name": "fullActionName",
+                "value": "player.changeVolume",
+                "substrings": [
+                  "Shave the volume"
+                ]
+              },
+              {
+                "name": "parameters.volumeChangePercentage",
+                "value": -10,
+                "substrings": [
+                  "a slight 10%"
+                ]
+              }
+            ]
+          },
+          "correction": [
+            "Value -10 for property 'parameters.volumeChangePercentage' doesn't match the number 10 in the substring 'a slight 10%'. Missing other substring to explain the value."
           ]
         }
       ]
@@ -9765,7 +9852,7 @@
         "subPhrases": [
           {
             "text": "Subdue",
-            "category": "command",
+            "category": "action",
             "propertyNames": [
               "fullActionName",
               "parameters.volumeChangePercentage"
@@ -9852,11 +9939,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "Please",
+          "If you don't mind"
         ],
         "politeSuffixes": [
-          "Thank you.",
-          "I would appreciate it."
+          "thank you.",
+          "please.",
+          "if that's okay.",
+          "thanks."
         ]
       },
       "corrections": [
@@ -9906,29 +9997,30 @@
             "name": "parameters.volumeChangePercentage",
             "value": -15,
             "substrings": [
-              "by a reasonable",
-              "15%"
+              "by a reasonable 15%",
+              "Subdue"
             ]
           }
         ],
         "subPhrases": [
           {
-            "text": "Subdue the sound",
-            "category": "command",
+            "text": "Subdue",
+            "category": "action",
+            "propertyNames": [
+              "fullActionName",
+              "parameters.volumeChangePercentage"
+            ]
+          },
+          {
+            "text": "the sound",
+            "category": "object",
             "propertyNames": [
               "fullActionName"
             ]
           },
           {
-            "text": "by a reasonable",
+            "text": "by a reasonable 15%",
             "category": "modifier",
-            "propertyNames": [
-              "parameters.volumeChangePercentage"
-            ]
-          },
-          {
-            "text": "15%",
-            "category": "percentage",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
@@ -9939,25 +10031,29 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.changeVolume",
             "propertySubPhrases": [
-              "Subdue the sound"
+              "Subdue",
+              "the sound"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.lowerVolume",
                 "propertySubPhrases": [
-                  "Lower the sound"
+                  "Lower",
+                  "the sound"
                 ]
               },
               {
                 "propertyValue": "player.reduceVolume",
                 "propertySubPhrases": [
-                  "Reduce the sound"
+                  "Reduce",
+                  "the sound"
                 ]
               },
               {
                 "propertyValue": "player.decreaseVolume",
                 "propertySubPhrases": [
-                  "Decrease the sound"
+                  "Decrease",
+                  "the sound"
                 ]
               }
             ]
@@ -9966,29 +10062,29 @@
             "propertyName": "parameters.volumeChangePercentage",
             "propertyValue": -15,
             "propertySubPhrases": [
-              "by a reasonable",
-              "15%"
+              "Subdue",
+              "by a reasonable 15%"
             ],
             "alternatives": [
               {
                 "propertyValue": -10,
                 "propertySubPhrases": [
-                  "by a slight",
-                  "10%"
+                  "Subdue",
+                  "by a reasonable 10%"
                 ]
               },
               {
                 "propertyValue": -20,
                 "propertySubPhrases": [
-                  "by a significant",
-                  "20%"
+                  "Subdue",
+                  "by a reasonable 20%"
                 ]
               },
               {
                 "propertyValue": -25,
                 "propertySubPhrases": [
-                  "by a large",
-                  "25%"
+                  "Subdue",
+                  "by a reasonable 25%"
                 ]
               }
             ]
@@ -9996,10 +10092,14 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If possible,",
+          "Kindly"
         ],
         "politeSuffixes": [
           "Thank you.",
+          "Please.",
+          "If you don't mind.",
           "I would appreciate it."
         ]
       },
@@ -10025,6 +10125,29 @@
           },
           "correction": [
             "Value -15 for property 'parameters.volumeChangePercentage' doesn't match the number 15 in the substring '15%'. Missing other substring to explain the value."
+          ]
+        },
+        {
+          "data": {
+            "properties": [
+              {
+                "name": "fullActionName",
+                "value": "player.changeVolume",
+                "substrings": [
+                  "Subdue the sound"
+                ]
+              },
+              {
+                "name": "parameters.volumeChangePercentage",
+                "value": -15,
+                "substrings": [
+                  "by a reasonable 15%"
+                ]
+              }
+            ]
+          },
+          "correction": [
+            "Value -15 for property 'parameters.volumeChangePercentage' doesn't match the number 15 in the substring 'by a reasonable 15%'. Missing other substring to explain the value."
           ]
         }
       ]
@@ -10058,7 +10181,7 @@
         "subPhrases": [
           {
             "text": "Take down",
-            "category": "command",
+            "category": "action",
             "propertyNames": [
               "fullActionName",
               "parameters.volumeChangePercentage"
@@ -10073,11 +10196,11 @@
           },
           {
             "text": "by a modest",
-            "category": "filler",
+            "category": "modifier",
             "synonyms": [
               "by a small",
               "by a slight",
-              "by a little"
+              "by a minor"
             ],
             "isOptional": true
           },
@@ -10099,23 +10222,23 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.increaseVolume",
+                "propertyValue": "player.decreaseVolume",
                 "propertySubPhrases": [
-                  "Increase",
+                  "Lower",
                   "the volume"
                 ]
               },
               {
-                "propertyValue": "player.muteVolume",
+                "propertyValue": "player.reduceVolume",
                 "propertySubPhrases": [
-                  "Mute",
+                  "Reduce",
                   "the volume"
                 ]
               },
               {
-                "propertyValue": "player.setVolume",
+                "propertyValue": "player.turnDownVolume",
                 "propertySubPhrases": [
-                  "Set",
+                  "Turn down",
                   "the volume"
                 ]
               }
@@ -10130,13 +10253,6 @@
             ],
             "alternatives": [
               {
-                "propertyValue": -20,
-                "propertySubPhrases": [
-                  "Take down",
-                  "20%"
-                ]
-              },
-              {
                 "propertyValue": -5,
                 "propertySubPhrases": [
                   "Take down",
@@ -10149,6 +10265,13 @@
                   "Take down",
                   "15%"
                 ]
+              },
+              {
+                "propertyValue": -20,
+                "propertySubPhrases": [
+                  "Take down",
+                  "20%"
+                ]
               }
             ]
           }
@@ -10156,14 +10279,14 @@
         "politePrefixes": [
           "Could you please",
           "Would you mind",
-          "If it's not too much trouble, could you",
-          "May I kindly ask you to"
+          "If you don't mind",
+          "Please"
         ],
         "politeSuffixes": [
           "Thank you.",
-          "I would appreciate it.",
-          "Thanks a lot.",
-          "That would be great."
+          "Thanks.",
+          "I appreciate it.",
+          "If that's okay."
         ]
       },
       "corrections": [
@@ -10221,7 +10344,7 @@
         "subPhrases": [
           {
             "text": "Tone down",
-            "category": "command",
+            "category": "action",
             "propertyNames": [
               "fullActionName",
               "parameters.volumeChangePercentage"
@@ -10252,10 +10375,17 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.decreaseVolume",
+                "propertyValue": "player.lowerVolume",
                 "propertySubPhrases": [
                   "Lower",
-                  "the volume"
+                  "the sound"
+                ]
+              },
+              {
+                "propertyValue": "player.decreaseVolume",
+                "propertySubPhrases": [
+                  "Decrease",
+                  "the sound"
                 ]
               },
               {
@@ -10263,13 +10393,6 @@
                 "propertySubPhrases": [
                   "Reduce",
                   "the sound"
-                ]
-              },
-              {
-                "propertyValue": "player.turnDownVolume",
-                "propertySubPhrases": [
-                  "Turn down",
-                  "the volume"
                 ]
               }
             ]
@@ -10309,14 +10432,14 @@
         "politePrefixes": [
           "Could you please",
           "Would you mind",
-          "If it's not too much trouble,",
+          "If possible, could you",
           "Please"
         ],
         "politeSuffixes": [
           "Thank you.",
-          "Thanks.",
-          "I appreciate it.",
-          "If you don't mind."
+          "If that's okay.",
+          "I would appreciate it.",
+          "Thanks."
         ]
       },
       "corrections": [
@@ -10382,9 +10505,9 @@
             "text": "by",
             "category": "preposition",
             "synonyms": [
-              "to",
               "at",
-              "with"
+              "with",
+              "to"
             ],
             "isOptional": true
           },
@@ -10417,9 +10540,9 @@
                 ]
               },
               {
-                "propertyValue": "player.amplifySound",
+                "propertyValue": "player.volumeUp",
                 "propertySubPhrases": [
-                  "Amplify the sound"
+                  "Volume up"
                 ]
               }
             ]
@@ -10454,11 +10577,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If it's not too much trouble,",
+          "May I ask you to"
         ],
         "politeSuffixes": [
-          "Thank you.",
-          "I would appreciate it."
+          "thank you.",
+          "please.",
+          "if you don't mind.",
+          "thanks."
         ]
       }
     },
@@ -10505,18 +10632,25 @@
             ]
           },
           {
-            "text": "the volume by a neat",
+            "text": "the volume",
+            "category": "object",
+            "propertyNames": [
+              "fullActionName"
+            ]
+          },
+          {
+            "text": "by a neat",
             "category": "filler",
             "synonyms": [
-              "the volume by",
-              "the volume",
-              "by a neat"
+              "by exactly",
+              "by precisely",
+              "by"
             ],
             "isOptional": true
           },
           {
             "text": "5%",
-            "category": "percentage",
+            "category": "value",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
@@ -10553,15 +10687,46 @@
                 ]
               }
             ]
+          },
+          {
+            "propertyName": "fullActionName",
+            "propertyValue": "player.changeVolume",
+            "propertySubPhrases": [
+              "the volume"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "player.increaseVolume",
+                "propertySubPhrases": [
+                  "increase the volume"
+                ]
+              },
+              {
+                "propertyValue": "player.decreaseVolume",
+                "propertySubPhrases": [
+                  "decrease the volume"
+                ]
+              },
+              {
+                "propertyValue": "player.muteVolume",
+                "propertySubPhrases": [
+                  "mute the volume"
+                ]
+              }
+            ]
           }
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If it's not too much trouble,",
+          "May I ask you to"
         ],
         "politeSuffixes": [
           "Thank you!",
-          "I would appreciate it!"
+          "Please.",
+          "I'd appreciate it.",
+          "Thanks!"
         ]
       },
       "corrections": [
@@ -10577,13 +10742,13 @@
                 "name": "parameters.volumeChangePercentage",
                 "value": -5,
                 "substrings": [
-                  "5%"
+                  "slice the volume by a neat 5%"
                 ]
               }
             ]
           },
           "correction": [
-            "Value -5 for property 'parameters.volumeChangePercentage' doesn't match the number 5 in the substring '5%'. Missing other substring to explain the value."
+            "Value -5 for property 'parameters.volumeChangePercentage' doesn't match the number 5 in the substring 'slice the volume by a neat 5%'. Missing other substring to explain the value."
           ]
         }
       ]
@@ -10620,7 +10785,7 @@
             "synonyms": [
               "Could you",
               "Can you",
-              "Is it possible to"
+              "Please"
             ],
             "isOptional": true
           },
@@ -10632,21 +10797,21 @@
             ]
           },
           {
-            "text": "by 10%",
-            "category": "parameter",
+            "text": "by",
+            "category": "preposition",
+            "synonyms": [
+              "with",
+              "at",
+              "to"
+            ],
+            "isOptional": true
+          },
+          {
+            "text": "10%",
+            "category": "quantity",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
-          },
-          {
-            "text": "?",
-            "category": "punctuation",
-            "synonyms": [
-              ".",
-              "!",
-              ""
-            ],
-            "isOptional": true
           }
         ],
         "propertyAlternatives": [
@@ -10681,32 +10846,42 @@
             "propertyName": "parameters.volumeChangePercentage",
             "propertyValue": 10,
             "propertySubPhrases": [
-              "by 10%"
+              "10%"
             ],
             "alternatives": [
               {
                 "propertyValue": 5,
                 "propertySubPhrases": [
-                  "by 5%"
+                  "5%"
                 ]
               },
               {
                 "propertyValue": 15,
                 "propertySubPhrases": [
-                  "by 15%"
+                  "15%"
                 ]
               },
               {
                 "propertyValue": 20,
                 "propertySubPhrases": [
-                  "by 20%"
+                  "20%"
                 ]
               }
             ]
           }
         ],
-        "politePrefixes": [],
-        "politeSuffixes": []
+        "politePrefixes": [
+          "Could you please",
+          "If it's not too much trouble,",
+          "Would you kindly",
+          "May I ask you to"
+        ],
+        "politeSuffixes": [
+          "Thank you.",
+          "I would appreciate it.",
+          "If you don't mind.",
+          "Thanks in advance."
+        ]
       }
     },
     {
@@ -10740,7 +10915,7 @@
             "category": "politeness",
             "synonyms": [
               "Could you please",
-              "Do you mind",
+              "Can you",
               "Would it be possible"
             ],
             "isOptional": true
@@ -10781,9 +10956,9 @@
                 ]
               },
               {
-                "propertyValue": "player.boostVolume",
+                "propertyValue": "player.adjustVolume",
                 "propertySubPhrases": [
-                  "boosting the volume"
+                  "adjusting the volume"
                 ]
               }
             ]
@@ -10816,8 +10991,18 @@
             ]
           }
         ],
-        "politePrefixes": [],
-        "politeSuffixes": []
+        "politePrefixes": [
+          "Could you please",
+          "If it's not too much trouble,",
+          "Would it be possible to",
+          "I would appreciate it if you could"
+        ],
+        "politeSuffixes": [
+          "Thank you!",
+          "I would be grateful.",
+          "Thanks in advance!",
+          "Much appreciated."
+        ]
       }
     },
     {
@@ -10841,8 +11026,8 @@
             "name": "parameters.volumeChangePercentage",
             "value": -5,
             "substrings": [
-              "by 5%",
-              "trim"
+              "trim",
+              "5%"
             ]
           }
         ],
@@ -10876,8 +11061,18 @@
             ]
           },
           {
-            "text": "by 5%",
-            "category": "volume change",
+            "text": "by",
+            "category": "preposition",
+            "synonyms": [
+              "to",
+              "with",
+              "at"
+            ],
+            "isOptional": true
+          },
+          {
+            "text": "5%",
+            "category": "percentage",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
@@ -10916,28 +11111,28 @@
             "propertyValue": -5,
             "propertySubPhrases": [
               "trim the volume",
-              "by 5%"
+              "5%"
             ],
             "alternatives": [
               {
                 "propertyValue": -10,
                 "propertySubPhrases": [
                   "trim the volume",
-                  "by 10%"
+                  "10%"
                 ]
               },
               {
                 "propertyValue": -15,
                 "propertySubPhrases": [
                   "trim the volume",
-                  "by 15%"
+                  "15%"
                 ]
               },
               {
                 "propertyValue": -20,
                 "propertySubPhrases": [
                   "trim the volume",
-                  "by 20%"
+                  "20%"
                 ]
               }
             ]
@@ -10945,11 +11140,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If it's not too much trouble, could you",
+          "May I ask you to"
         ],
         "politeSuffixes": [
-          "Thank you",
-          "I appreciate it"
+          "Thank you!",
+          "I would appreciate it.",
+          "Thanks a lot!",
+          "That would be great."
         ]
       },
       "corrections": [
@@ -10967,13 +11166,13 @@
                 "name": "parameters.volumeChangePercentage",
                 "value": -5,
                 "substrings": [
-                  "by 5%"
+                  "5%"
                 ]
               }
             ]
           },
           "correction": [
-            "Value -5 for property 'parameters.volumeChangePercentage' doesn't match the number 5 in the substring 'by 5%'. Missing other substring to explain the value."
+            "Value -5 for property 'parameters.volumeChangePercentage' doesn't match the number 5 in the substring '5%'. Missing other substring to explain the value."
           ]
         },
         {
@@ -10990,8 +11189,8 @@
                 "name": "parameters.volumeChangePercentage",
                 "value": -5,
                 "substrings": [
-                  "by 5%",
-                  "trim"
+                  "trim",
+                  "5%"
                 ]
               }
             ],
@@ -11024,8 +11223,18 @@
                 ]
               },
               {
-                "text": "by 5%",
-                "category": "volume change",
+                "text": "by",
+                "category": "preposition",
+                "synonyms": [
+                  "to",
+                  "with",
+                  "at"
+                ],
+                "isOptional": true
+              },
+              {
+                "text": "5%",
+                "category": "percentage",
                 "propertyNames": [
                   "parameters.volumeChangePercentage"
                 ]
@@ -11059,7 +11268,7 @@
             "name": "parameters.volumeChangePercentage",
             "value": -5,
             "substrings": [
-              "drop",
+              "drop the volume",
               "5%"
             ]
           }
@@ -11084,18 +11293,8 @@
             ]
           },
           {
-            "text": "by",
-            "category": "preposition",
-            "synonyms": [
-              "to",
-              "at",
-              "with"
-            ],
-            "isOptional": true
-          },
-          {
-            "text": "5%",
-            "category": "value",
+            "text": "by 5%",
+            "category": "quantity",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
@@ -11112,7 +11311,7 @@
               {
                 "propertyValue": "player.increaseVolume",
                 "propertySubPhrases": [
-                  "raise the volume"
+                  "increase the volume"
                 ]
               },
               {
@@ -11122,9 +11321,9 @@
                 ]
               },
               {
-                "propertyValue": "player.unmuteVolume",
+                "propertyValue": "player.setVolume",
                 "propertySubPhrases": [
-                  "unmute the volume"
+                  "set the volume"
                 ]
               }
             ]
@@ -11134,28 +11333,28 @@
             "propertyValue": -5,
             "propertySubPhrases": [
               "drop the volume",
-              "5%"
+              "by 5%"
             ],
             "alternatives": [
               {
                 "propertyValue": -10,
                 "propertySubPhrases": [
                   "drop the volume",
-                  "10%"
+                  "by 10%"
                 ]
               },
               {
                 "propertyValue": -15,
                 "propertySubPhrases": [
                   "drop the volume",
-                  "15%"
+                  "by 15%"
                 ]
               },
               {
                 "propertyValue": -20,
                 "propertySubPhrases": [
                   "drop the volume",
-                  "20%"
+                  "by 20%"
                 ]
               }
             ]
@@ -11163,11 +11362,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If possible,",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you",
-          "I appreciate it"
+          "thank you.",
+          "if you don't mind.",
+          "please.",
+          "thanks."
         ]
       },
       "corrections": [
@@ -11192,66 +11395,6 @@
           },
           "correction": [
             "Value -5 for property 'parameters.volumeChangePercentage' doesn't match the number 5 in the substring '5%'. Missing other substring to explain the value."
-          ]
-        },
-        {
-          "data": {
-            "properties": [
-              {
-                "name": "fullActionName",
-                "value": "player.changeVolume",
-                "substrings": [
-                  "drop the volume"
-                ]
-              },
-              {
-                "name": "parameters.volumeChangePercentage",
-                "value": -5,
-                "substrings": [
-                  "drop",
-                  "5%"
-                ]
-              }
-            ],
-            "subPhrases": [
-              {
-                "text": "Yo",
-                "category": "greeting",
-                "synonyms": [
-                  "Hey",
-                  "Hi",
-                  "Hello"
-                ],
-                "isOptional": true
-              },
-              {
-                "text": "drop the volume",
-                "category": "action",
-                "propertyNames": [
-                  "fullActionName"
-                ]
-              },
-              {
-                "text": "by",
-                "category": "preposition",
-                "synonyms": [
-                  "to",
-                  "at",
-                  "with"
-                ],
-                "isOptional": true
-              },
-              {
-                "text": "5%",
-                "category": "value",
-                "propertyNames": [
-                  "parameters.volumeChangePercentage"
-                ]
-              }
-            ]
-          },
-          "correction": [
-            "Explicit property 'parameters.volumeChangePercentage' must be included as property names for all subphrases that contain the substring 'drop'"
           ]
         }
       ]
@@ -11295,11 +11438,11 @@
           },
           {
             "text": "let's",
-            "category": "filler",
+            "category": "confirmation",
             "synonyms": [
-              "let us",
               "we should",
-              "how about we"
+              "we will",
+              "we can"
             ],
             "isOptional": true
           },
@@ -11322,15 +11465,15 @@
             "text": "by a cool",
             "category": "filler",
             "synonyms": [
-              "by",
-              "around",
-              "approximately"
+              "by exactly",
+              "by precisely",
+              "by"
             ],
             "isOptional": true
           },
           {
             "text": "5%",
-            "category": "value",
+            "category": "amount",
             "propertyNames": [
               "parameters.volumeChangePercentage"
             ]
@@ -11402,11 +11545,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If it's not too much trouble,",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it."
+          "thank you.",
+          "if you don't mind.",
+          "please.",
+          "thanks."
         ]
       },
       "corrections": [
@@ -11434,6 +11581,12 @@
           ]
         }
       ]
+    }
+  ],
+  "failed": [
+    {
+      "request": "I'd like the audio to be 20% more mellow.",
+      "message": "Failed translation: Unknown action"
     }
   ]
 }

--- a/ts/packages/defaultAgentProvider/test/data/explanations/player/v5/full.json
+++ b/ts/packages/defaultAgentProvider/test/data/explanations/player/v5/full.json
@@ -18,7 +18,7 @@
             "name": "fullActionName",
             "value": "player.playTrack",
             "substrings": [
-              "get down to"
+              "it's time to get down to"
             ]
           },
           {
@@ -41,25 +41,25 @@
             "isOptional": true
           },
           {
-            "text": "it's time to",
-            "category": "filler",
-            "synonyms": [
-              "let's",
-              "time to",
-              "we should"
-            ],
-            "isOptional": true
-          },
-          {
-            "text": "get down to",
-            "category": "action",
+            "text": "it's time to get down to",
+            "category": "action initiation",
             "propertyNames": [
               "fullActionName"
             ]
           },
           {
-            "text": "some 'Sensual Seduction'",
-            "category": "trackName",
+            "text": "some",
+            "category": "filler",
+            "synonyms": [
+              "a bit of",
+              "a little",
+              "some"
+            ],
+            "isOptional": true
+          },
+          {
+            "text": "'Sensual Seduction'",
+            "category": "track name",
             "propertyNames": [
               "parameters.trackName"
             ]
@@ -69,8 +69,8 @@
             "category": "confirmation",
             "synonyms": [
               "you know?",
-              "right?",
-              "do you understand?"
+              "you understand?",
+              "you get it?"
             ],
             "isOptional": true
           }
@@ -80,25 +80,25 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.playTrack",
             "propertySubPhrases": [
-              "get down to"
+              "it's time to get down to"
             ],
             "alternatives": [
               {
-                "propertyValue": "player.pauseTrack",
+                "propertyValue": "player.startPlaying",
                 "propertySubPhrases": [
-                  "pause"
+                  "let's start playing"
                 ]
               },
               {
-                "propertyValue": "player.stopTrack",
+                "propertyValue": "player.beginTrack",
                 "propertySubPhrases": [
-                  "stop"
+                  "begin the track"
                 ]
               },
               {
-                "propertyValue": "player.skipTrack",
+                "propertyValue": "player.initiatePlayback",
                 "propertySubPhrases": [
-                  "skip"
+                  "initiate playback"
                 ]
               }
             ]
@@ -107,25 +107,25 @@
             "propertyName": "parameters.trackName",
             "propertyValue": "Sensual Seduction",
             "propertySubPhrases": [
-              "some 'Sensual Seduction'"
+              "'Sensual Seduction'"
             ],
             "alternatives": [
               {
-                "propertyValue": "Bohemian Rhapsody",
+                "propertyValue": "Smooth Operator",
                 "propertySubPhrases": [
-                  "some 'Bohemian Rhapsody'"
+                  "'Smooth Operator'"
                 ]
               },
               {
-                "propertyValue": "Shape of You",
+                "propertyValue": "Sexual Healing",
                 "propertySubPhrases": [
-                  "some 'Shape of You'"
+                  "'Sexual Healing'"
                 ]
               },
               {
-                "propertyValue": "Blinding Lights",
+                "propertyValue": "Let's Get It On",
                 "propertySubPhrases": [
-                  "some 'Blinding Lights'"
+                  "'Let's Get It On'"
                 ]
               }
             ]
@@ -133,46 +133,42 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If you don't mind",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you",
-          "I appreciate it"
+          "thank you",
+          "if that's okay",
+          "please",
+          "thanks"
         ]
       }
     },
     {
       "request": "Aight, it's time to pump up the volume with some fresh beats!",
       "action": {
-        "fullActionName": "player.setVolume",
-        "parameters": {
-          "newVolumeLevel": 100
-        }
+        "fullActionName": "player.playRandom"
       },
       "explanation": {
         "properties": [
           {
             "name": "fullActionName",
-            "value": "player.setVolume",
+            "value": "player.playRandom",
             "substrings": [
-              "pump up the volume"
+              "pump up the volume",
+              "fresh beats"
             ]
-          },
-          {
-            "name": "parameters.newVolumeLevel",
-            "value": 100,
-            "isImplicit": true
           }
         ],
         "subPhrases": [
           {
-            "text": "Aight,",
+            "text": "Aight",
             "category": "acknowledgement",
             "synonyms": [
-              "Alright,",
-              "Okay,",
-              "Sure,",
-              "Got it,"
+              "Alright",
+              "Okay",
+              "Sure"
             ],
             "isOptional": true
           },
@@ -181,9 +177,8 @@
             "category": "filler",
             "synonyms": [
               "let's",
-              "time to",
-              "we should",
-              "let us"
+              "time for",
+              "ready to"
             ],
             "isOptional": true
           },
@@ -195,41 +190,51 @@
             ]
           },
           {
-            "text": "with some fresh beats!",
-            "category": "filler",
+            "text": "with some",
+            "category": "preposition",
             "synonyms": [
-              "with some music!",
-              "with some tunes!",
-              "with some sound!",
-              "with some audio!"
+              "including",
+              "featuring",
+              "along with"
             ],
             "isOptional": true
+          },
+          {
+            "text": "fresh beats",
+            "category": "action",
+            "propertyNames": [
+              "fullActionName"
+            ]
           }
         ],
         "propertyAlternatives": [
           {
             "propertyName": "fullActionName",
-            "propertyValue": "player.setVolume",
+            "propertyValue": "player.playRandom",
             "propertySubPhrases": [
-              "pump up the volume"
+              "pump up the volume",
+              "fresh beats"
             ],
             "alternatives": [
               {
-                "propertyValue": "player.increaseVolume",
+                "propertyValue": "player.play",
                 "propertySubPhrases": [
-                  "turn up the volume"
+                  "turn up the music",
+                  "cool tunes"
                 ]
               },
               {
-                "propertyValue": "player.raiseVolume",
+                "propertyValue": "player.shuffle",
                 "propertySubPhrases": [
-                  "crank up the volume"
+                  "mix it up",
+                  "new tracks"
                 ]
               },
               {
-                "propertyValue": "player.boostVolume",
+                "propertyValue": "player.playFavorites",
                 "propertySubPhrases": [
-                  "boost the volume"
+                  "play my favorites",
+                  "top hits"
                 ]
               }
             ]
@@ -237,37 +242,17 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If you don't mind",
+          "Please"
         ],
         "politeSuffixes": [
           "Thank you!",
-          "I appreciate it!"
+          "Thanks!",
+          "I appreciate it!",
+          "Cheers!"
         ]
-      },
-      "corrections": [
-        {
-          "data": {
-            "properties": [
-              {
-                "name": "fullActionName",
-                "value": "player.setVolume",
-                "substrings": [
-                  "pump up the volume"
-                ]
-              },
-              {
-                "name": "newVolumeLevel",
-                "value": 100,
-                "isImplicit": true
-              }
-            ]
-          },
-          "correction": [
-            "Extraneous implicit parameter: 'newVolumeLevel' is not a parameter in the action",
-            "Missing parameter: parameter 'parameters.newVolumeLevel' in the action is missing from explanation"
-          ]
-        }
-      ]
+      }
     },
     {
       "request": "Ayo, DJ, drop that 'Gin and Juice' like it's hot, ya dig?",
@@ -296,22 +281,22 @@
         ],
         "subPhrases": [
           {
-            "text": "Ayo,",
+            "text": "Ayo",
             "category": "greeting",
             "synonyms": [
-              "Hey,",
-              "Yo,",
-              "Hi,"
+              "Hey",
+              "Hello",
+              "Hi"
             ],
             "isOptional": true
           },
           {
-            "text": "DJ,",
+            "text": "DJ",
             "category": "acknowledgement",
             "synonyms": [
-              "DJ,",
-              "DJ,",
-              "DJ,"
+              "DJ",
+              "Disc Jockey",
+              "Music Mixer"
             ],
             "isOptional": true
           },
@@ -323,19 +308,39 @@
             ]
           },
           {
-            "text": "that 'Gin and Juice'",
+            "text": "that",
+            "category": "filler",
+            "synonyms": [
+              "the",
+              "this",
+              "that"
+            ],
+            "isOptional": true
+          },
+          {
+            "text": "'Gin and Juice'",
             "category": "track",
             "propertyNames": [
               "parameters.trackName"
             ]
           },
           {
-            "text": "like it's hot, ya dig?",
+            "text": "like it's hot",
             "category": "filler",
             "synonyms": [
-              "like it's hot, you know?",
-              "like it's hot, right?",
-              "like it's hot, okay?"
+              "right now",
+              "immediately",
+              "quickly"
+            ],
+            "isOptional": true
+          },
+          {
+            "text": "ya dig?",
+            "category": "confirmation",
+            "synonyms": [
+              "you understand?",
+              "got it?",
+              "okay?"
             ],
             "isOptional": true
           }
@@ -349,12 +354,6 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.queueTrack",
-                "propertySubPhrases": [
-                  "queue"
-                ]
-              },
-              {
                 "propertyValue": "player.pauseTrack",
                 "propertySubPhrases": [
                   "pause"
@@ -365,6 +364,12 @@
                 "propertySubPhrases": [
                   "stop"
                 ]
+              },
+              {
+                "propertyValue": "player.skipTrack",
+                "propertySubPhrases": [
+                  "skip"
+                ]
               }
             ]
           },
@@ -372,25 +377,25 @@
             "propertyName": "parameters.trackName",
             "propertyValue": "Gin and Juice",
             "propertySubPhrases": [
-              "that 'Gin and Juice'"
+              "'Gin and Juice'"
             ],
             "alternatives": [
               {
                 "propertyValue": "Nuthin' but a 'G' Thang",
                 "propertySubPhrases": [
-                  "that 'Nuthin' but a 'G' Thang'"
-                ]
-              },
-              {
-                "propertyValue": "Still D.R.E.",
-                "propertySubPhrases": [
-                  "that 'Still D.R.E.'"
+                  "'Nuthin' but a 'G' Thang'"
                 ]
               },
               {
                 "propertyValue": "California Love",
                 "propertySubPhrases": [
-                  "that 'California Love'"
+                  "'California Love'"
+                ]
+              },
+              {
+                "propertyValue": "Regulate",
+                "propertySubPhrases": [
+                  "'Regulate'"
                 ]
               }
             ]
@@ -398,11 +403,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If you don't mind",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it!"
+          "thank you",
+          "if that's okay",
+          "please",
+          "thanks"
         ]
       }
     },
@@ -420,7 +429,8 @@
             "name": "fullActionName",
             "value": "player.playArtist",
             "substrings": [
-              "drop"
+              "drop",
+              "beat"
             ]
           },
           {
@@ -438,13 +448,14 @@
             "synonyms": [
               "Hey",
               "Hello",
-              "Hi"
+              "Hi",
+              "Yo"
             ],
             "isOptional": true
           },
           {
             "text": "drop",
-            "category": "command",
+            "category": "action",
             "propertyNames": [
               "fullActionName"
             ]
@@ -468,13 +479,10 @@
           },
           {
             "text": "beat",
-            "category": "filler",
-            "synonyms": [
-              "track",
-              "song",
-              "music"
-            ],
-            "isOptional": true
+            "category": "action",
+            "propertyNames": [
+              "fullActionName"
+            ]
           }
         ],
         "propertyAlternatives": [
@@ -482,25 +490,29 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.playArtist",
             "propertySubPhrases": [
-              "drop"
+              "drop",
+              "beat"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.playSong",
                 "propertySubPhrases": [
-                  "play"
+                  "drop",
+                  "song"
                 ]
               },
               {
                 "propertyValue": "player.playAlbum",
                 "propertySubPhrases": [
-                  "spin"
+                  "drop",
+                  "album"
                 ]
               },
               {
                 "propertyValue": "player.playPlaylist",
                 "propertySubPhrases": [
-                  "queue"
+                  "drop",
+                  "playlist"
                 ]
               }
             ]
@@ -534,37 +546,31 @@
           }
         ],
         "politePrefixes": [
+          "Please,",
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If you don't mind,"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it!"
+          "thank you.",
+          "please.",
+          "if that's okay.",
+          "thanks."
         ]
       }
     },
     {
       "request": "Ayo, let's bump some dope beats up in here!",
       "action": {
-        "fullActionName": "player.playGenre",
-        "parameters": {
-          "genre": "hip-hop"
-        }
+        "fullActionName": "player.playRandom"
       },
       "explanation": {
         "properties": [
           {
             "name": "fullActionName",
-            "value": "player.playGenre",
+            "value": "player.playRandom",
             "substrings": [
-              "let's bump some dope beats"
-            ]
-          },
-          {
-            "name": "parameters.genre",
-            "value": "hip-hop",
-            "substrings": [
-              "dope beats"
+              "Ayo, let's bump some dope beats up in here!"
             ]
           }
         ],
@@ -575,126 +581,66 @@
             "synonyms": [
               "Hey",
               "Hi",
-              "Yo"
+              "Hello"
             ],
             "isOptional": true
           },
           {
-            "text": "let's bump some",
+            "text": "let's bump some dope beats up in here",
             "category": "command",
             "propertyNames": [
               "fullActionName"
             ]
-          },
-          {
-            "text": "dope beats",
-            "category": "genre",
-            "propertyNames": [
-              "parameters.genre"
-            ]
-          },
-          {
-            "text": "up in here",
-            "category": "filler",
-            "synonyms": [
-              "right now",
-              "here",
-              "in this place"
-            ],
-            "isOptional": true
           }
         ],
         "propertyAlternatives": [
           {
             "propertyName": "fullActionName",
-            "propertyValue": "player.playGenre",
+            "propertyValue": "player.playRandom",
             "propertySubPhrases": [
-              "let's bump some"
+              "let's bump some dope beats up in here"
             ],
             "alternatives": [
               {
-                "propertyValue": "player.playSong",
+                "propertyValue": "player.playTopHits",
                 "propertySubPhrases": [
-                  "let's play some"
+                  "let's play the top hits up in here"
                 ]
               },
               {
-                "propertyValue": "player.playAlbum",
+                "propertyValue": "player.playFavorites",
                 "propertySubPhrases": [
-                  "let's spin some"
+                  "let's play my favorite songs up in here"
                 ]
               },
               {
-                "propertyValue": "player.playArtist",
+                "propertyValue": "player.playNewReleases",
                 "propertySubPhrases": [
-                  "let's hear some"
-                ]
-              }
-            ]
-          },
-          {
-            "propertyName": "parameters.genre",
-            "propertyValue": "hip-hop",
-            "propertySubPhrases": [
-              "dope beats"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "rock",
-                "propertySubPhrases": [
-                  "rocking tunes"
+                  "let's play the new releases up in here"
                 ]
               },
               {
-                "propertyValue": "jazz",
+                "propertyValue": "player.playChillVibes",
                 "propertySubPhrases": [
-                  "smooth jazz"
-                ]
-              },
-              {
-                "propertyValue": "pop",
-                "propertySubPhrases": [
-                  "pop hits"
+                  "let's play some chill vibes up in here"
                 ]
               }
             ]
           }
         ],
         "politePrefixes": [
-          "Could you please",
-          "Would you mind"
+          "Please",
+          "Could you",
+          "Would you mind",
+          "If you don't mind"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it!"
+          "Thank you",
+          "Thanks",
+          "Please",
+          "If that's okay"
         ]
-      },
-      "corrections": [
-        {
-          "data": {
-            "properties": [
-              {
-                "name": "fullActionName",
-                "value": "player.playGenre",
-                "substrings": [
-                  "let's bump some dope beats"
-                ]
-              },
-              {
-                "name": "genre",
-                "value": "hip-hop",
-                "substrings": [
-                  "dope beats"
-                ]
-              }
-            ]
-          },
-          "correction": [
-            "Extraneous parameter: 'genre' is not a parameter in the action",
-            "Missing parameter: parameter 'parameters.genre' in the action is missing from explanation"
-          ]
-        }
-      ]
+      }
     },
     {
       "request": "Ayo, let's bump some of that classic Snoop Dogg, ya dig?",
@@ -710,7 +656,7 @@
             "name": "fullActionName",
             "value": "player.playArtist",
             "substrings": [
-              "Ayo, let's bump some of that classic Snoop Dogg, ya dig?"
+              "let's bump"
             ]
           },
           {
@@ -728,17 +674,26 @@
             "synonyms": [
               "Hey",
               "Hi",
-              "Hello"
+              "Hello",
+              "Yo"
             ],
             "isOptional": true
           },
           {
-            "text": "let's bump some of that classic",
+            "text": "let's bump",
+            "category": "action",
+            "propertyNames": [
+              "fullActionName"
+            ]
+          },
+          {
+            "text": "some of that classic",
             "category": "filler",
             "synonyms": [
-              "let's play some",
-              "let's listen to some",
-              "how about some"
+              "some",
+              "that",
+              "classic",
+              "some classic"
             ],
             "isOptional": true
           },
@@ -751,16 +706,44 @@
           },
           {
             "text": "ya dig?",
-            "category": "filler",
+            "category": "confirmation",
             "synonyms": [
               "you know?",
               "right?",
-              "okay?"
+              "okay?",
+              "got it?"
             ],
             "isOptional": true
           }
         ],
         "propertyAlternatives": [
+          {
+            "propertyName": "fullActionName",
+            "propertyValue": "player.playArtist",
+            "propertySubPhrases": [
+              "let's bump"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "player.playSong",
+                "propertySubPhrases": [
+                  "let's play"
+                ]
+              },
+              {
+                "propertyValue": "player.playAlbum",
+                "propertySubPhrases": [
+                  "let's listen to"
+                ]
+              },
+              {
+                "propertyValue": "player.playPlaylist",
+                "propertySubPhrases": [
+                  "let's jam to"
+                ]
+              }
+            ]
+          },
           {
             "propertyName": "parameters.artist",
             "propertyValue": "Snoop Dogg",
@@ -790,16 +773,16 @@
           }
         ],
         "politePrefixes": [
-          "Could you please",
-          "Would you mind",
-          "If it's not too much trouble,",
-          "May I kindly ask"
+          "Hey, could you please",
+          "Excuse me, would you mind",
+          "Hello, can we",
+          "Hi, could you"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it.",
-          "Thanks a lot!",
-          "Much appreciated!"
+          "please?",
+          "if that's okay?",
+          "thanks!",
+          "thank you!"
         ]
       }
     },
@@ -836,7 +819,7 @@
             "synonyms": [
               "let us",
               "we should",
-              "we will"
+              "how about we"
             ],
             "isOptional": true
           },
@@ -877,34 +860,45 @@
               {
                 "propertyValue": "player.playTopHits",
                 "propertySubPhrases": [
-                  "crank up the volume",
-                  "with the top hits"
+                  "turn up the heat",
+                  "with the hottest tracks"
                 ]
               },
               {
-                "propertyValue": "player.playChill",
+                "propertyValue": "player.playFavorites",
                 "propertySubPhrases": [
-                  "set the mood",
-                  "with some chill vibes"
+                  "turn up the heat",
+                  "with my favorite tracks"
                 ]
               },
               {
-                "propertyValue": "player.playParty",
+                "propertyValue": "player.playNewReleases",
                 "propertySubPhrases": [
-                  "get the party started",
-                  "with some party anthems"
+                  "turn up the heat",
+                  "with the latest tracks"
+                ]
+              },
+              {
+                "propertyValue": "player.playGenre",
+                "propertySubPhrases": [
+                  "turn up the heat",
+                  "with some rock tracks"
                 ]
               }
             ]
           }
         ],
         "politePrefixes": [
-          "Could you please",
-          "Would you mind"
+          "Please, ",
+          "Could you kindly ",
+          "Would you mind ",
+          "If you don't mind, "
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it!"
+          " please?",
+          " if that's okay.",
+          " thank you!",
+          " I'd appreciate it."
         ]
       }
     },
@@ -921,13 +915,15 @@
           {
             "name": "fullActionName",
             "value": "player.playTrack",
-            "isImplicit": true
+            "substrings": [
+              "let's get this party poppin'"
+            ]
           },
           {
             "name": "parameters.trackName",
             "value": "Lay Low",
             "substrings": [
-              "Lay Low"
+              "'Lay Low'"
             ]
           }
         ],
@@ -944,7 +940,7 @@
           },
           {
             "text": "nephew",
-            "category": "filler",
+            "category": "acknowledgement",
             "synonyms": [
               "buddy",
               "pal",
@@ -954,13 +950,10 @@
           },
           {
             "text": "let's get this party poppin'",
-            "category": "filler",
-            "synonyms": [
-              "let's start the music",
-              "let's begin the fun",
-              "let's get going"
-            ],
-            "isOptional": true
+            "category": "action",
+            "propertyNames": [
+              "fullActionName"
+            ]
           },
           {
             "text": "with some",
@@ -968,7 +961,7 @@
             "synonyms": [
               "featuring",
               "including",
-              "playing"
+              "along with"
             ],
             "isOptional": true
           },
@@ -982,6 +975,33 @@
         ],
         "propertyAlternatives": [
           {
+            "propertyName": "fullActionName",
+            "propertyValue": "player.playTrack",
+            "propertySubPhrases": [
+              "let's get this party poppin'"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "player.startMusic",
+                "propertySubPhrases": [
+                  "let's start the music"
+                ]
+              },
+              {
+                "propertyValue": "player.beginPlayback",
+                "propertySubPhrases": [
+                  "let's begin playback"
+                ]
+              },
+              {
+                "propertyValue": "player.initiateTunes",
+                "propertySubPhrases": [
+                  "let's initiate tunes"
+                ]
+              }
+            ]
+          },
+          {
             "propertyName": "parameters.trackName",
             "propertyValue": "Lay Low",
             "propertySubPhrases": [
@@ -989,33 +1009,32 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "Still D.R.E.",
+                "propertyValue": "California Love",
                 "propertySubPhrases": [
-                  "'Still D.R.E.'"
+                  "'California Love'"
                 ]
               },
               {
-                "propertyValue": "Nuthin' but a 'G' Thang",
+                "propertyValue": "Nuthin' But a G Thang",
                 "propertySubPhrases": [
-                  "'Nuthin' but a 'G' Thang'"
+                  "'Nuthin' But a G Thang'"
                 ]
               },
               {
-                "propertyValue": "The Next Episode",
+                "propertyValue": "Gin and Juice",
                 "propertySubPhrases": [
-                  "'The Next Episode'"
+                  "'Gin and Juice'"
                 ]
               }
             ]
           }
         ],
-        "politePrefixes": [
-          "Could you please",
-          "Would you mind"
-        ],
+        "politePrefixes": [],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it!"
+          "please.",
+          "if you don't mind.",
+          "thank you.",
+          "would be appreciated."
         ]
       }
     },
@@ -1058,8 +1077,8 @@
             "category": "politeness",
             "synonyms": [
               "Could you play",
-              "Would you mind playing",
-              "Please play"
+              "Please play",
+              "I would like to hear"
             ],
             "isOptional": true
           },
@@ -1081,9 +1100,9 @@
             "text": "my main man",
             "category": "acknowledgement",
             "synonyms": [
-              "buddy",
-              "friend",
-              "pal"
+              "my friend",
+              "my buddy",
+              "my pal"
             ],
             "isOptional": true
           }
@@ -1103,15 +1122,15 @@
                 ]
               },
               {
-                "propertyValue": "Get Lucky",
+                "propertyValue": "Freedom",
                 "propertySubPhrases": [
-                  "'Get Lucky'"
+                  "'Freedom'"
                 ]
               },
               {
-                "propertyValue": "Blurred Lines",
+                "propertyValue": "Get Lucky",
                 "propertySubPhrases": [
-                  "'Blurred Lines'"
+                  "'Get Lucky'"
                 ]
               }
             ]
@@ -1124,21 +1143,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "Snoop Dogg",
+                "propertyValue": "Jay-Z",
                 "propertySubPhrases": [
-                  "featuring Snoop Dogg"
+                  "featuring Jay-Z"
                 ]
               },
               {
-                "propertyValue": "Daft Punk",
+                "propertyValue": "Beyoncé",
                 "propertySubPhrases": [
-                  "featuring Daft Punk"
+                  "featuring Beyoncé"
                 ]
               },
               {
-                "propertyValue": "Robin Thicke",
+                "propertyValue": "Kanye West",
                 "propertySubPhrases": [
-                  "featuring Robin Thicke"
+                  "featuring Kanye West"
                 ]
               }
             ]
@@ -1147,12 +1166,14 @@
         "politePrefixes": [
           "Could you please",
           "Would you mind",
-          "If it's not too much trouble, could you"
+          "May I kindly request",
+          "If it's not too much trouble"
         ],
         "politeSuffixes": [
           "Thank you!",
-          "I would really appreciate it.",
-          "Thanks a lot!"
+          "I would appreciate it.",
+          "Thanks a lot!",
+          "Much appreciated."
         ]
       }
     },
@@ -1205,7 +1226,7 @@
             "synonyms": [
               "to a few",
               "to several",
-              "to any"
+              "to"
             ],
             "isOptional": true
           },
@@ -1244,13 +1265,13 @@
               {
                 "propertyValue": "player.playAlbum",
                 "propertySubPhrases": [
-                  "play album"
+                  "put on"
                 ]
               },
               {
-                "propertyValue": "player.playPlaylist",
+                "propertyValue": "player.playGenre",
                 "propertySubPhrases": [
-                  "play playlist"
+                  "hear"
                 ]
               }
             ]
@@ -1285,11 +1306,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would it be possible to",
+          "May I kindly ask",
+          "If you don't mind"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it."
+          "please?",
+          "if that's okay?",
+          "thank you!",
+          "if you could?"
         ]
       }
     },
@@ -1314,7 +1339,7 @@
             "name": "parameters.genre",
             "value": "chill electronic",
             "substrings": [
-              "chill electronic"
+              "chill electronic music"
             ]
           }
         ],
@@ -1340,28 +1365,18 @@
             "text": "some",
             "category": "filler",
             "synonyms": [
+              "any",
               "a bit of",
-              "a little",
-              "some"
+              "a little"
             ],
             "isOptional": true
           },
           {
-            "text": "chill electronic",
+            "text": "chill electronic music",
             "category": "genre",
             "propertyNames": [
               "parameters.genre"
             ]
-          },
-          {
-            "text": "music",
-            "category": "filler",
-            "synonyms": [
-              "tunes",
-              "songs",
-              "tracks"
-            ],
-            "isOptional": true
           }
         ],
         "propertyAlternatives": [
@@ -1396,35 +1411,41 @@
             "propertyName": "parameters.genre",
             "propertyValue": "chill electronic",
             "propertySubPhrases": [
-              "chill electronic"
+              "chill electronic music"
             ],
             "alternatives": [
               {
-                "propertyValue": "jazz",
+                "propertyValue": "lo-fi",
                 "propertySubPhrases": [
-                  "jazz"
+                  "lo-fi music"
                 ]
               },
               {
-                "propertyValue": "rock",
+                "propertyValue": "ambient",
                 "propertySubPhrases": [
-                  "rock"
+                  "ambient music"
                 ]
               },
               {
-                "propertyValue": "classical",
+                "propertyValue": "house",
                 "propertySubPhrases": [
-                  "classical"
+                  "house music"
                 ]
               }
             ]
           }
         ],
         "politePrefixes": [
-          "Please"
+          "Could you please",
+          "Would it be possible to",
+          "May I kindly ask",
+          "If you don't mind"
         ],
         "politeSuffixes": [
-          "Thank you"
+          "please?",
+          "if that's okay?",
+          "thank you!",
+          "if you could?"
         ]
       }
     },
@@ -1449,7 +1470,7 @@
             "name": "parameters.genre",
             "value": "mellow acoustic guitar",
             "substrings": [
-              "mellow acoustic guitar"
+              "mellow acoustic guitar music"
             ]
           }
         ],
@@ -1460,7 +1481,7 @@
             "synonyms": [
               "Could we",
               "May we",
-              "Shall we"
+              "Would it be possible for us to"
             ],
             "isOptional": true
           },
@@ -1475,28 +1496,18 @@
             "text": "some",
             "category": "filler",
             "synonyms": [
+              "any",
               "a bit of",
-              "a little",
-              "some"
+              "a little"
             ],
             "isOptional": true
           },
           {
-            "text": "mellow acoustic guitar",
+            "text": "mellow acoustic guitar music",
             "category": "genre",
             "propertyNames": [
               "parameters.genre"
             ]
-          },
-          {
-            "text": "music",
-            "category": "filler",
-            "synonyms": [
-              "tunes",
-              "songs",
-              "melodies"
-            ],
-            "isOptional": true
           }
         ],
         "propertyAlternatives": [
@@ -1508,21 +1519,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.playSong",
+                "propertyValue": "player.startPlaying",
                 "propertySubPhrases": [
-                  "play"
+                  "start playing"
                 ]
               },
               {
-                "propertyValue": "player.playAlbum",
+                "propertyValue": "player.beginPlayback",
                 "propertySubPhrases": [
-                  "put on"
+                  "begin playback"
                 ]
               },
               {
-                "propertyValue": "player.playPlaylist",
+                "propertyValue": "player.playMusic",
                 "propertySubPhrases": [
-                  "start"
+                  "play music"
                 ]
               }
             ]
@@ -1531,40 +1542,199 @@
             "propertyName": "parameters.genre",
             "propertyValue": "mellow acoustic guitar",
             "propertySubPhrases": [
-              "mellow acoustic guitar"
+              "mellow acoustic guitar music"
             ],
             "alternatives": [
               {
-                "propertyValue": "classical",
+                "propertyValue": "soft rock",
                 "propertySubPhrases": [
-                  "classical"
+                  "soft rock music"
                 ]
               },
               {
-                "propertyValue": "jazz",
+                "propertyValue": "smooth jazz",
                 "propertySubPhrases": [
-                  "jazz"
+                  "smooth jazz music"
                 ]
               },
               {
-                "propertyValue": "rock",
+                "propertyValue": "chill electronic",
                 "propertySubPhrases": [
-                  "rock"
+                  "chill electronic music"
                 ]
               }
             ]
           }
         ],
         "politePrefixes": [
-          "Please"
+          "Would it be possible to",
+          "Could you please",
+          "I would appreciate it if we could",
+          "If it's not too much trouble, can we"
         ],
         "politeSuffixes": [
-          "Thank you"
+          "please?",
+          "if you don't mind.",
+          "thank you.",
+          "if that's okay."
         ]
       }
     },
     {
       "request": "Can you entertain me with some Bach melodies, please?",
+      "action": {
+        "fullActionName": "player.playArtist",
+        "parameters": {
+          "artist": "Bach"
+        }
+      },
+      "explanation": {
+        "properties": [
+          {
+            "name": "fullActionName",
+            "value": "player.playArtist",
+            "substrings": [
+              "entertain me",
+              "melodies"
+            ]
+          },
+          {
+            "name": "parameters.artist",
+            "value": "Bach",
+            "substrings": [
+              "Bach"
+            ]
+          }
+        ],
+        "subPhrases": [
+          {
+            "text": "Can you",
+            "category": "politeness",
+            "synonyms": [
+              "Could you",
+              "Would you",
+              "Will you"
+            ],
+            "isOptional": true
+          },
+          {
+            "text": "entertain me",
+            "category": "command",
+            "propertyNames": [
+              "fullActionName"
+            ]
+          },
+          {
+            "text": "with some",
+            "category": "preposition",
+            "synonyms": [
+              "using",
+              "featuring",
+              "including"
+            ],
+            "isOptional": true
+          },
+          {
+            "text": "Bach",
+            "category": "artist",
+            "propertyNames": [
+              "parameters.artist"
+            ]
+          },
+          {
+            "text": "melodies",
+            "category": "music",
+            "propertyNames": [
+              "fullActionName"
+            ]
+          },
+          {
+            "text": "please",
+            "category": "politeness",
+            "synonyms": [
+              "kindly",
+              "if you would",
+              "if you please"
+            ],
+            "isOptional": true
+          }
+        ],
+        "propertyAlternatives": [
+          {
+            "propertyName": "fullActionName",
+            "propertyValue": "player.playArtist",
+            "propertySubPhrases": [
+              "entertain me",
+              "melodies"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "player.playSong",
+                "propertySubPhrases": [
+                  "entertain me",
+                  "song"
+                ]
+              },
+              {
+                "propertyValue": "player.playAlbum",
+                "propertySubPhrases": [
+                  "entertain me",
+                  "album"
+                ]
+              },
+              {
+                "propertyValue": "player.playPlaylist",
+                "propertySubPhrases": [
+                  "entertain me",
+                  "playlist"
+                ]
+              }
+            ]
+          },
+          {
+            "propertyName": "parameters.artist",
+            "propertyValue": "Bach",
+            "propertySubPhrases": [
+              "Bach"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "Mozart",
+                "propertySubPhrases": [
+                  "Mozart"
+                ]
+              },
+              {
+                "propertyValue": "Beethoven",
+                "propertySubPhrases": [
+                  "Beethoven"
+                ]
+              },
+              {
+                "propertyValue": "Chopin",
+                "propertySubPhrases": [
+                  "Chopin"
+                ]
+              }
+            ]
+          }
+        ],
+        "politePrefixes": [
+          "Would you mind",
+          "Could you kindly",
+          "If it's not too much trouble,",
+          "I would appreciate it if you could"
+        ],
+        "politeSuffixes": [
+          "Thank you!",
+          "I would be grateful.",
+          "Thanks a lot!",
+          "Much appreciated."
+        ]
+      }
+    },
+    {
+      "request": "Can you entertain me with some Bach music?",
       "action": {
         "fullActionName": "player.playArtist",
         "parameters": {
@@ -1614,22 +1784,12 @@
             ]
           },
           {
-            "text": "melodies,",
+            "text": "music",
             "category": "filler",
             "synonyms": [
-              "songs,",
-              "tunes,",
-              "pieces,"
-            ],
-            "isOptional": true
-          },
-          {
-            "text": "please?",
-            "category": "politeness",
-            "synonyms": [
-              "thank you",
-              "if you don't mind",
-              "if you could"
+              "songs",
+              "tunes",
+              "melodies"
             ],
             "isOptional": true
           }
@@ -1643,21 +1803,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.playSong",
+                "propertyValue": "player.playGenre",
                 "propertySubPhrases": [
-                  "play a song by"
-                ]
-              },
-              {
-                "propertyValue": "player.playAlbum",
-                "propertySubPhrases": [
-                  "play an album by"
+                  "entertain me with some"
                 ]
               },
               {
                 "propertyValue": "player.playPlaylist",
                 "propertySubPhrases": [
-                  "play a playlist by"
+                  "entertain me with some"
+                ]
+              },
+              {
+                "propertyValue": "player.playAlbum",
+                "propertySubPhrases": [
+                  "entertain me with some"
                 ]
               }
             ]
@@ -1690,49 +1850,49 @@
             ]
           }
         ],
-        "politePrefixes": [],
-        "politeSuffixes": []
+        "politePrefixes": [
+          "Please,",
+          "Would you mind,",
+          "Could you kindly,",
+          "If you don't mind,"
+        ],
+        "politeSuffixes": [
+          "Thank you.",
+          "I would appreciate it.",
+          "Thanks a lot.",
+          "That would be great."
+        ]
       }
     },
     {
-      "request": "Can you entertain me with some Bach music?",
+      "request": "Can you play some fun 80s hits for us to enjoy?",
       "action": {
-        "fullActionName": "player.playArtist",
+        "fullActionName": "player.searchTracks",
         "parameters": {
-          "artist": "Bach"
+          "query": "fun 80s hits"
         }
       },
       "explanation": {
         "properties": [
           {
             "name": "fullActionName",
-            "value": "player.playArtist",
+            "value": "player.searchTracks",
             "substrings": [
-              "entertain me with"
+              "Can you play"
             ]
           },
           {
-            "name": "parameters.artist",
-            "value": "Bach",
+            "name": "parameters.query",
+            "value": "fun 80s hits",
             "substrings": [
-              "Bach"
+              "fun 80s hits"
             ]
           }
         ],
         "subPhrases": [
           {
-            "text": "Can you",
-            "category": "politeness",
-            "synonyms": [
-              "Could you",
-              "Would you",
-              "Will you"
-            ],
-            "isOptional": true
-          },
-          {
-            "text": "entertain me with",
-            "category": "action",
+            "text": "Can you play",
+            "category": "action request",
             "propertyNames": [
               "fullActionName"
             ]
@@ -1741,179 +1901,26 @@
             "text": "some",
             "category": "filler",
             "synonyms": [
-              "a bit of",
-              "a little",
-              "any"
-            ],
-            "isOptional": true
-          },
-          {
-            "text": "Bach",
-            "category": "artist",
-            "propertyNames": [
-              "parameters.artist"
-            ]
-          },
-          {
-            "text": "music",
-            "category": "filler",
-            "synonyms": [
-              "tunes",
-              "songs",
-              "melodies"
-            ],
-            "isOptional": true
-          }
-        ],
-        "propertyAlternatives": [
-          {
-            "propertyName": "fullActionName",
-            "propertyValue": "player.playArtist",
-            "propertySubPhrases": [
-              "entertain me with"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "player.playSong",
-                "propertySubPhrases": [
-                  "play a song by"
-                ]
-              },
-              {
-                "propertyValue": "player.playAlbum",
-                "propertySubPhrases": [
-                  "play an album by"
-                ]
-              },
-              {
-                "propertyValue": "player.playPlaylist",
-                "propertySubPhrases": [
-                  "play a playlist by"
-                ]
-              }
-            ]
-          },
-          {
-            "propertyName": "parameters.artist",
-            "propertyValue": "Bach",
-            "propertySubPhrases": [
-              "Bach"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "Mozart",
-                "propertySubPhrases": [
-                  "Mozart"
-                ]
-              },
-              {
-                "propertyValue": "Beethoven",
-                "propertySubPhrases": [
-                  "Beethoven"
-                ]
-              },
-              {
-                "propertyValue": "Chopin",
-                "propertySubPhrases": [
-                  "Chopin"
-                ]
-              }
-            ]
-          }
-        ],
-        "politePrefixes": [
-          "Could you please",
-          "Would you mind"
-        ],
-        "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it."
-        ]
-      }
-    },
-    {
-      "request": "Can you play some fun 80s hits for us to enjoy?",
-      "action": {
-        "fullActionName": "player.playGenre",
-        "parameters": {
-          "genre": "80s",
-          "quantity": 1
-        }
-      },
-      "explanation": {
-        "properties": [
-          {
-            "name": "fullActionName",
-            "value": "player.playGenre",
-            "substrings": [
-              "play"
-            ]
-          },
-          {
-            "name": "parameters.genre",
-            "value": "80s",
-            "substrings": [
-              "80s"
-            ]
-          },
-          {
-            "name": "parameters.quantity",
-            "value": 1,
-            "isImplicit": true
-          }
-        ],
-        "subPhrases": [
-          {
-            "text": "Can you",
-            "category": "politeness",
-            "synonyms": [
-              "Could you",
-              "Would you",
-              "Will you"
-            ],
-            "isOptional": true
-          },
-          {
-            "text": "play",
-            "category": "action",
-            "propertyNames": [
-              "fullActionName"
-            ]
-          },
-          {
-            "text": "some fun",
-            "category": "filler",
-            "synonyms": [
               "a few",
-              "some",
-              "a couple of"
+              "any",
+              "several"
             ],
             "isOptional": true
           },
           {
-            "text": "80s",
-            "category": "genre",
+            "text": "fun 80s hits",
+            "category": "query",
             "propertyNames": [
-              "parameters.genre"
+              "parameters.query"
             ]
-          },
-          {
-            "text": "hits",
-            "category": "filler",
-            "synonyms": [
-              "songs",
-              "tracks",
-              "tunes"
-            ],
-            "isOptional": true
           },
           {
             "text": "for us to enjoy",
             "category": "filler",
             "synonyms": [
-              "for us",
-              "to listen to",
-              "to have fun with"
+              "for our enjoyment",
+              "for us to listen to",
+              "for us to have fun with"
             ],
             "isOptional": true
           }
@@ -1921,54 +1928,54 @@
         "propertyAlternatives": [
           {
             "propertyName": "fullActionName",
-            "propertyValue": "player.playGenre",
+            "propertyValue": "player.searchTracks",
             "propertySubPhrases": [
-              "play"
+              "Can you play"
             ],
             "alternatives": [
               {
-                "propertyValue": "player.playSong",
+                "propertyValue": "player.playTracks",
                 "propertySubPhrases": [
-                  "play a song"
+                  "Play"
                 ]
               },
               {
-                "propertyValue": "player.playAlbum",
+                "propertyValue": "player.queueTracks",
                 "propertySubPhrases": [
-                  "play an album"
+                  "Add to queue"
                 ]
               },
               {
-                "propertyValue": "player.playPlaylist",
+                "propertyValue": "player.shuffleTracks",
                 "propertySubPhrases": [
-                  "play a playlist"
+                  "Shuffle"
                 ]
               }
             ]
           },
           {
-            "propertyName": "parameters.genre",
-            "propertyValue": "80s",
+            "propertyName": "parameters.query",
+            "propertyValue": "fun 80s hits",
             "propertySubPhrases": [
-              "80s"
+              "fun 80s hits"
             ],
             "alternatives": [
               {
-                "propertyValue": "90s",
+                "propertyValue": "classic rock",
                 "propertySubPhrases": [
-                  "90s"
+                  "classic rock"
                 ]
               },
               {
-                "propertyValue": "rock",
+                "propertyValue": "pop music",
                 "propertySubPhrases": [
-                  "rock"
+                  "pop music"
                 ]
               },
               {
-                "propertyValue": "pop",
+                "propertyValue": "dance tracks",
                 "propertySubPhrases": [
-                  "pop"
+                  "dance tracks"
                 ]
               }
             ]
@@ -1976,11 +1983,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If it's not too much trouble, could you",
+          "Please"
         ],
         "politeSuffixes": [
           "Thank you!",
-          "Much appreciated!"
+          "Thanks a lot!",
+          "We'd appreciate it!",
+          "That would be great!"
         ]
       }
     },
@@ -2031,9 +2042,9 @@
             "text": "some music by",
             "category": "filler",
             "synonyms": [
-              "music by",
-              "songs by",
-              "tracks by"
+              "some songs by",
+              "some tracks by",
+              "some pieces by"
             ],
             "isOptional": true
           },
@@ -2103,11 +2114,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If it's not too much trouble",
+          "I would appreciate it if you could"
         ],
         "politeSuffixes": [
           "Thank you!",
-          "I would appreciate it!"
+          "Please.",
+          "If you don't mind.",
+          "Thanks a lot!"
         ]
       }
     },
@@ -2229,10 +2244,16 @@
           }
         ],
         "politePrefixes": [
-          "Could you please"
+          "Could you please",
+          "Would you mind",
+          "If it's not too much trouble, could you",
+          "I would appreciate it if you could"
         ],
         "politeSuffixes": [
-          "Thank you!"
+          "Thank you!",
+          "Please.",
+          "If you don't mind.",
+          "Thanks a lot!"
         ]
       }
     },
@@ -2250,7 +2271,7 @@
             "name": "fullActionName",
             "value": "player.playArtist",
             "substrings": [
-              "Can you play"
+              "play"
             ]
           },
           {
@@ -2263,8 +2284,18 @@
         ],
         "subPhrases": [
           {
-            "text": "Can you play",
-            "category": "command",
+            "text": "Can you",
+            "category": "politeness",
+            "synonyms": [
+              "Could you",
+              "Would you",
+              "Will you"
+            ],
+            "isOptional": true
+          },
+          {
+            "text": "play",
+            "category": "action",
             "propertyNames": [
               "fullActionName"
             ]
@@ -2273,9 +2304,9 @@
             "text": "some pieces by",
             "category": "filler",
             "synonyms": [
-              "some tracks by",
-              "a few pieces by",
-              "some music by"
+              "some music by",
+              "some works by",
+              "some compositions by"
             ],
             "isOptional": true
           },
@@ -2292,25 +2323,25 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.playArtist",
             "propertySubPhrases": [
-              "Can you play"
+              "play"
             ],
             "alternatives": [
               {
-                "propertyValue": "player.playSong",
+                "propertyValue": "player.pauseArtist",
                 "propertySubPhrases": [
-                  "Can you play a song by"
+                  "pause"
                 ]
               },
               {
-                "propertyValue": "player.playAlbum",
+                "propertyValue": "player.stopArtist",
                 "propertySubPhrases": [
-                  "Can you play an album by"
+                  "stop"
                 ]
               },
               {
-                "propertyValue": "player.playPlaylist",
+                "propertyValue": "player.resumeArtist",
                 "propertySubPhrases": [
-                  "Can you play a playlist by"
+                  "resume"
                 ]
               }
             ]
@@ -2345,11 +2376,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If it's not too much trouble, could you",
+          "I would appreciate it if you could"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it."
+          "please?",
+          "if you don't mind.",
+          "thank you.",
+          "if that's okay."
         ]
       }
     },
@@ -2424,8 +2459,8 @@
             "category": "filler",
             "synonyms": [
               "music",
-              "for us",
-              "for me"
+              "songs",
+              "tunes"
             ],
             "isOptional": true
           }
@@ -2439,21 +2474,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.pause",
+                "propertyValue": "player.startGenre",
                 "propertySubPhrases": [
-                  "pause"
+                  "start"
                 ]
               },
               {
-                "propertyValue": "player.stop",
+                "propertyValue": "player.beginGenre",
                 "propertySubPhrases": [
-                  "stop"
+                  "begin"
                 ]
               },
               {
-                "propertyValue": "player.resume",
+                "propertyValue": "player.initiateGenre",
                 "propertySubPhrases": [
-                  "resume"
+                  "initiate"
                 ]
               }
             ]
@@ -2472,15 +2507,15 @@
                 ]
               },
               {
-                "propertyValue": "rock",
+                "propertyValue": "blues",
                 "propertySubPhrases": [
-                  "rock"
+                  "blues"
                 ]
               },
               {
-                "propertyValue": "pop",
+                "propertyValue": "ambient",
                 "propertySubPhrases": [
-                  "pop"
+                  "ambient"
                 ]
               }
             ]
@@ -2488,11 +2523,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If it's not too much trouble, could you",
+          "May I kindly ask you to"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it!"
+          "please?",
+          "if you don't mind.",
+          "thank you.",
+          "if it's convenient."
         ]
       }
     },
@@ -2512,13 +2551,15 @@
           {
             "name": "fullActionName",
             "value": "player.playTrack",
-            "isImplicit": true
+            "substrings": [
+              "play"
+            ]
           },
           {
             "name": "parameters.trackName",
             "value": "Gin and Juice",
             "substrings": [
-              "Gin and Juice"
+              "'Gin and Juice'"
             ]
           },
           {
@@ -2543,10 +2584,8 @@
           {
             "text": "play",
             "category": "action",
-            "synonyms": [
-              "start",
-              "put on",
-              "play"
+            "propertyNames": [
+              "fullActionName"
             ]
           },
           {
@@ -2560,11 +2599,21 @@
             "isOptional": true
           },
           {
-            "text": "Snoop Dogg's",
+            "text": "Snoop Dogg",
             "category": "artist",
             "propertyNames": [
               "parameters.artists.0"
             ]
+          },
+          {
+            "text": "'s",
+            "category": "preposition",
+            "synonyms": [
+              "of",
+              "by",
+              "from"
+            ],
+            "isOptional": true
           },
           {
             "text": "'Gin and Juice'",
@@ -2576,28 +2625,55 @@
         ],
         "propertyAlternatives": [
           {
+            "propertyName": "fullActionName",
+            "propertyValue": "player.playTrack",
+            "propertySubPhrases": [
+              "play"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "player.pauseTrack",
+                "propertySubPhrases": [
+                  "pause"
+                ]
+              },
+              {
+                "propertyValue": "player.stopTrack",
+                "propertySubPhrases": [
+                  "stop"
+                ]
+              },
+              {
+                "propertyValue": "player.skipTrack",
+                "propertySubPhrases": [
+                  "skip"
+                ]
+              }
+            ]
+          },
+          {
             "propertyName": "parameters.artists.0",
             "propertyValue": "Snoop Dogg",
             "propertySubPhrases": [
-              "Snoop Dogg's"
+              "Snoop Dogg"
             ],
             "alternatives": [
               {
                 "propertyValue": "Dr. Dre",
                 "propertySubPhrases": [
-                  "Dr. Dre's"
+                  "Dr. Dre"
                 ]
               },
               {
                 "propertyValue": "Eminem",
                 "propertySubPhrases": [
-                  "Eminem's"
+                  "Eminem"
                 ]
               },
               {
                 "propertyValue": "Ice Cube",
                 "propertySubPhrases": [
-                  "Ice Cube's"
+                  "Ice Cube"
                 ]
               }
             ]
@@ -2622,9 +2698,9 @@
                 ]
               },
               {
-                "propertyValue": "Still D.R.E.",
+                "propertyValue": "Beautiful",
                 "propertySubPhrases": [
-                  "'Still D.R.E.'"
+                  "'Beautiful'"
                 ]
               }
             ]
@@ -2632,11 +2708,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If it's not too much trouble, could you",
+          "I would appreciate it if you could"
         ],
         "politeSuffixes": [
           "Thank you!",
-          "I would appreciate it."
+          "Please.",
+          "If you don't mind.",
+          "Thanks a lot!"
         ]
       },
       "corrections": [
@@ -2646,13 +2726,15 @@
               {
                 "name": "fullActionName",
                 "value": "player.playTrack",
-                "isImplicit": true
+                "substrings": [
+                  "play"
+                ]
               },
               {
                 "name": "parameters.trackName",
                 "value": "Gin and Juice",
                 "substrings": [
-                  "Gin and Juice"
+                  "'Gin and Juice'"
                 ]
               },
               {
@@ -2692,7 +2774,7 @@
                 "isOptional": true
               },
               {
-                "text": "Snoop Dogg's",
+                "text": "Snoop Dogg",
                 "category": "artist",
                 "propertyNames": [
                   "parameters.artists.0"
@@ -2708,7 +2790,7 @@
             ]
           },
           "correction": [
-            "Property 'fullActionName' is expected to be implicit and should not be included as a property name in a sub-phrase"
+            "Missing sub-phrase: explanation missing for ''s'"
           ]
         }
       ]
@@ -2760,9 +2842,9 @@
             "text": "some",
             "category": "filler",
             "synonyms": [
-              "a few",
               "any",
-              "several"
+              "a few",
+              "a couple"
             ],
             "isOptional": true
           },
@@ -2793,21 +2875,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.playSong",
+                "propertyValue": "player.startArtist",
                 "propertySubPhrases": [
-                  "play"
+                  "start playing"
                 ]
               },
               {
-                "propertyValue": "player.playAlbum",
+                "propertyValue": "player.queueArtist",
                 "propertySubPhrases": [
-                  "put on the album"
+                  "queue up"
                 ]
               },
               {
-                "propertyValue": "player.playPlaylist",
+                "propertyValue": "player.beginArtist",
                 "propertySubPhrases": [
-                  "play the playlist"
+                  "begin playing"
                 ]
               }
             ]
@@ -2841,12 +2923,16 @@
           }
         ],
         "politePrefixes": [
+          "Please",
+          "Would you mind",
           "Could you please",
-          "Would you mind"
+          "If you don't mind"
         ],
         "politeSuffixes": [
           "Thank you",
-          "Please"
+          "Please",
+          "If that's okay",
+          "Thanks"
         ]
       }
     },
@@ -2878,7 +2964,7 @@
           },
           {
             "text": "put on some music",
-            "category": "command",
+            "category": "action",
             "propertyNames": [
               "fullActionName"
             ]
@@ -2893,31 +2979,43 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.play",
+                "propertyValue": "player.playSpecific",
                 "propertySubPhrases": [
-                  "play some music"
+                  "play a specific song"
                 ]
               },
               {
-                "propertyValue": "player.shuffle",
+                "propertyValue": "player.playPlaylist",
                 "propertySubPhrases": [
-                  "shuffle the music"
+                  "play a playlist"
                 ]
               },
               {
-                "propertyValue": "player.startRadio",
+                "propertyValue": "player.playGenre",
                 "propertySubPhrases": [
-                  "start the radio"
+                  "play some jazz music"
+                ]
+              },
+              {
+                "propertyValue": "player.playArtist",
+                "propertySubPhrases": [
+                  "play some music by The Beatles"
                 ]
               }
             ]
           }
         ],
         "politePrefixes": [
-          "Please"
+          "Please,",
+          "Would you mind",
+          "Could you kindly",
+          "If you don't mind,"
         ],
         "politeSuffixes": [
-          "Thank you"
+          "please?",
+          "if that's okay?",
+          "thank you.",
+          "if you could."
         ]
       }
     },
@@ -2949,7 +3047,7 @@
           },
           {
             "text": "put on some tunes",
-            "category": "action",
+            "category": "command",
             "propertyNames": [
               "fullActionName"
             ]
@@ -2970,28 +3068,38 @@
                 ]
               },
               {
-                "propertyValue": "player.playPlaylist",
+                "propertyValue": "player.shuffle",
                 "propertySubPhrases": [
-                  "play a playlist"
+                  "shuffle the playlist"
                 ]
               },
               {
-                "propertyValue": "player.playAlbum",
+                "propertyValue": "player.startRadio",
                 "propertySubPhrases": [
-                  "play an album"
+                  "start the radio"
                 ]
               },
               {
-                "propertyValue": "player.playArtist",
+                "propertyValue": "player.playGenre",
                 "propertySubPhrases": [
-                  "play some songs by"
+                  "play some jazz"
                 ]
               }
             ]
           }
         ],
-        "politePrefixes": [],
-        "politeSuffixes": []
+        "politePrefixes": [
+          "Please, ",
+          "Would you mind, ",
+          "Could you kindly, ",
+          "If you don't mind, "
+        ],
+        "politeSuffixes": [
+          " please?",
+          " if that's okay?",
+          " thank you!",
+          " would be great!"
+        ]
       }
     },
     {
@@ -3055,17 +3163,7 @@
             ]
           },
           {
-            "text": "by",
-            "category": "preposition",
-            "synonyms": [
-              "from",
-              "performed by",
-              "sung by"
-            ],
-            "isOptional": true
-          },
-          {
-            "text": "Fleetwood Mac",
+            "text": "by Fleetwood Mac",
             "category": "artist",
             "propertyNames": [
               "parameters.artists.0"
@@ -3108,21 +3206,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "The Dark Side of the Moon",
-                "propertySubPhrases": [
-                  "'The Dark Side of the Moon'"
-                ]
-              },
-              {
                 "propertyValue": "Abbey Road",
                 "propertySubPhrases": [
                   "'Abbey Road'"
                 ]
               },
               {
-                "propertyValue": "Hotel California",
+                "propertyValue": "Thriller",
                 "propertySubPhrases": [
-                  "'Hotel California'"
+                  "'Thriller'"
+                ]
+              },
+              {
+                "propertyValue": "The Dark Side of the Moon",
+                "propertySubPhrases": [
+                  "'The Dark Side of the Moon'"
                 ]
               }
             ]
@@ -3131,37 +3229,41 @@
             "propertyName": "parameters.artists.0",
             "propertyValue": "Fleetwood Mac",
             "propertySubPhrases": [
-              "Fleetwood Mac"
+              "by Fleetwood Mac"
             ],
             "alternatives": [
               {
                 "propertyValue": "The Beatles",
                 "propertySubPhrases": [
-                  "The Beatles"
+                  "by The Beatles"
+                ]
+              },
+              {
+                "propertyValue": "Michael Jackson",
+                "propertySubPhrases": [
+                  "by Michael Jackson"
                 ]
               },
               {
                 "propertyValue": "Pink Floyd",
                 "propertySubPhrases": [
-                  "Pink Floyd"
-                ]
-              },
-              {
-                "propertyValue": "Eagles",
-                "propertySubPhrases": [
-                  "Eagles"
+                  "by Pink Floyd"
                 ]
               }
             ]
           }
         ],
         "politePrefixes": [
-          "Could you please",
-          "Would you mind"
+          "Please",
+          "Would you mind",
+          "Could you kindly",
+          "If you don't mind"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it."
+          "please",
+          "if you could",
+          "thank you",
+          "thanks"
         ]
       }
     },
@@ -3254,9 +3356,9 @@
                 ]
               },
               {
-                "propertyValue": "player.playMusicAlbum",
+                "propertyValue": "player.loadAlbum",
                 "propertySubPhrases": [
-                  "play the music album"
+                  "load the album"
                 ]
               }
             ]
@@ -3320,13 +3422,13 @@
           "Could you please",
           "Would you mind",
           "If it's not too much trouble, could you",
-          "May I kindly ask you to"
+          "I would appreciate it if you could"
         ],
         "politeSuffixes": [
           "Thank you!",
-          "I would appreciate it!",
-          "Thanks a lot!",
-          "That would be great!"
+          "Please.",
+          "If you don't mind.",
+          "Thanks a lot!"
         ]
       }
     },
@@ -3344,7 +3446,8 @@
             "name": "fullActionName",
             "value": "player.playArtist",
             "substrings": [
-              "serenade"
+              "serenade me",
+              "Bach compositions"
             ]
           },
           {
@@ -3367,38 +3470,29 @@
             "isOptional": true
           },
           {
-            "text": "serenade",
+            "text": "serenade me",
             "category": "action",
             "propertyNames": [
               "fullActionName"
             ]
           },
           {
-            "text": "me with some beautiful",
+            "text": "with some beautiful",
             "category": "filler",
             "synonyms": [
-              "me with some lovely",
-              "me with some nice",
-              "me with some wonderful"
+              "with some lovely",
+              "with some nice",
+              "with some wonderful"
             ],
             "isOptional": true
           },
           {
-            "text": "Bach",
+            "text": "Bach compositions",
             "category": "artist",
             "propertyNames": [
+              "fullActionName",
               "parameters.artist"
             ]
-          },
-          {
-            "text": "compositions",
-            "category": "filler",
-            "synonyms": [
-              "pieces",
-              "works",
-              "music"
-            ],
-            "isOptional": true
           }
         ],
         "propertyAlternatives": [
@@ -3406,25 +3500,29 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.playArtist",
             "propertySubPhrases": [
-              "serenade"
+              "serenade me",
+              "Bach compositions"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.playSong",
                 "propertySubPhrases": [
-                  "play"
+                  "play me",
+                  "Bach compositions"
                 ]
               },
               {
                 "propertyValue": "player.playAlbum",
                 "propertySubPhrases": [
-                  "play album"
+                  "play an album",
+                  "Bach compositions"
                 ]
               },
               {
                 "propertyValue": "player.playPlaylist",
                 "propertySubPhrases": [
-                  "play playlist"
+                  "play a playlist",
+                  "Bach compositions"
                 ]
               }
             ]
@@ -3433,37 +3531,41 @@
             "propertyName": "parameters.artist",
             "propertyValue": "Bach",
             "propertySubPhrases": [
-              "Bach"
+              "Bach compositions"
             ],
             "alternatives": [
               {
                 "propertyValue": "Mozart",
                 "propertySubPhrases": [
-                  "Mozart"
+                  "Mozart compositions"
                 ]
               },
               {
                 "propertyValue": "Beethoven",
                 "propertySubPhrases": [
-                  "Beethoven"
+                  "Beethoven compositions"
                 ]
               },
               {
                 "propertyValue": "Chopin",
                 "propertySubPhrases": [
-                  "Chopin"
+                  "Chopin compositions"
                 ]
               }
             ]
           }
         ],
         "politePrefixes": [
-          "Could you please",
-          "Would you mind"
+          "Please, ",
+          "Would you mind, ",
+          "If you could, ",
+          "I would appreciate it if you could, "
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it!"
+          " please.",
+          " if you don't mind.",
+          " thank you.",
+          " I'd be grateful."
         ]
       }
     },
@@ -3481,7 +3583,7 @@
             "name": "fullActionName",
             "value": "player.playArtist",
             "substrings": [
-              "entertain us with"
+              "entertain us"
             ]
           },
           {
@@ -3497,26 +3599,26 @@
             "text": "Could you be so good as to",
             "category": "politeness",
             "synonyms": [
-              "Would you kindly",
               "Please",
-              "If you would be so kind"
+              "Would you mind",
+              "Kindly"
             ],
             "isOptional": true
           },
           {
-            "text": "entertain us with",
+            "text": "entertain us",
             "category": "action",
             "propertyNames": [
               "fullActionName"
             ]
           },
           {
-            "text": "a touch of",
+            "text": "with a touch of",
             "category": "filler",
             "synonyms": [
-              "some",
-              "a bit of",
-              "a piece of"
+              "featuring",
+              "including",
+              "accompanied by"
             ],
             "isOptional": true
           },
@@ -3533,25 +3635,25 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.playArtist",
             "propertySubPhrases": [
-              "entertain us with"
+              "entertain us"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.playSong",
                 "propertySubPhrases": [
-                  "play us a song by"
+                  "play us a song"
                 ]
               },
               {
                 "propertyValue": "player.playAlbum",
                 "propertySubPhrases": [
-                  "play an album by"
+                  "play an album"
                 ]
               },
               {
                 "propertyValue": "player.playPlaylist",
                 "propertySubPhrases": [
-                  "play a playlist by"
+                  "play a playlist"
                 ]
               }
             ]
@@ -3564,12 +3666,6 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "Bach",
-                "propertySubPhrases": [
-                  "Bach"
-                ]
-              },
-              {
                 "propertyValue": "Mozart",
                 "propertySubPhrases": [
                   "Mozart"
@@ -3580,12 +3676,23 @@
                 "propertySubPhrases": [
                   "Beethoven"
                 ]
+              },
+              {
+                "propertyValue": "Bach",
+                "propertySubPhrases": [
+                  "Bach"
+                ]
               }
             ]
           }
         ],
         "politePrefixes": [],
-        "politeSuffixes": []
+        "politeSuffixes": [
+          "please?",
+          "if you don't mind.",
+          "thank you.",
+          "would you?"
+        ]
       }
     },
     {
@@ -3696,7 +3803,12 @@
           }
         ],
         "politePrefixes": [],
-        "politeSuffixes": []
+        "politeSuffixes": [
+          "please?",
+          "if you would be so kind.",
+          "thank you.",
+          "we would greatly appreciate it."
+        ]
       }
     },
     {
@@ -3730,8 +3842,8 @@
             "category": "politeness",
             "synonyms": [
               "please",
-              "would you mind",
-              "if you could"
+              "if you don't mind",
+              "would you mind"
             ],
             "isOptional": true
           },
@@ -3769,21 +3881,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.playSong",
+                "propertyValue": "player.pauseArtist",
                 "propertySubPhrases": [
-                  "play a song"
+                  "pause"
                 ]
               },
               {
-                "propertyValue": "player.playAlbum",
+                "propertyValue": "player.stopArtist",
                 "propertySubPhrases": [
-                  "play an album"
+                  "stop"
                 ]
               },
               {
-                "propertyValue": "player.playPlaylist",
+                "propertyValue": "player.resumeArtist",
                 "propertySubPhrases": [
-                  "play a playlist"
+                  "resume"
                 ]
               }
             ]
@@ -3817,7 +3929,12 @@
           }
         ],
         "politePrefixes": [],
-        "politeSuffixes": []
+        "politeSuffixes": [
+          "please.",
+          "if you don't mind.",
+          "thank you.",
+          "I would appreciate it."
+        ]
       }
     },
     {
@@ -3850,9 +3967,9 @@
             "text": "Could you",
             "category": "politeness",
             "synonyms": [
-              "Can you",
-              "Would you",
-              "Will you"
+              "please",
+              "would you mind",
+              "can you"
             ],
             "isOptional": true
           },
@@ -3865,11 +3982,11 @@
           },
           {
             "text": "some compositions by",
-            "category": "filler",
+            "category": "preposition",
             "synonyms": [
-              "some pieces by",
-              "some works by",
-              "some music by"
+              "works of",
+              "pieces by",
+              "music by"
             ],
             "isOptional": true
           },
@@ -3890,21 +4007,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.pauseArtist",
+                "propertyValue": "player.playSong",
                 "propertySubPhrases": [
-                  "pause"
+                  "play some compositions"
                 ]
               },
               {
-                "propertyValue": "player.stopArtist",
+                "propertyValue": "player.playAlbum",
                 "propertySubPhrases": [
-                  "stop"
+                  "play some compositions"
                 ]
               },
               {
-                "propertyValue": "player.resumeArtist",
+                "propertyValue": "player.playPlaylist",
                 "propertySubPhrases": [
-                  "resume"
+                  "play some compositions"
                 ]
               }
             ]
@@ -3937,8 +4054,18 @@
             ]
           }
         ],
-        "politePrefixes": [],
-        "politeSuffixes": []
+        "politePrefixes": [
+          "Please,",
+          "Would you mind",
+          "If it's not too much trouble,",
+          "Kindly,"
+        ],
+        "politeSuffixes": [
+          "Thank you.",
+          "I would appreciate it.",
+          "Thanks a lot.",
+          "Much appreciated."
+        ]
       }
     },
     {
@@ -3946,10 +4073,7 @@
       "action": {
         "fullActionName": "player.playAlbum",
         "parameters": {
-          "albumName": "Hamilton",
-          "artists": [
-            "Original Broadway Cast"
-          ]
+          "albumName": "Hamilton Original Broadway Cast Recording"
         }
       },
       "explanation": {
@@ -3963,16 +4087,9 @@
           },
           {
             "name": "parameters.albumName",
-            "value": "Hamilton",
+            "value": "Hamilton Original Broadway Cast Recording",
             "substrings": [
-              "Hamilton"
-            ]
-          },
-          {
-            "name": "parameters.artists.0",
-            "value": "Original Broadway Cast",
-            "substrings": [
-              "Original Broadway Cast"
+              "'Hamilton' Original Broadway Cast Recording"
             ]
           }
         ],
@@ -3981,9 +4098,9 @@
             "text": "Could you",
             "category": "politeness",
             "synonyms": [
-              "Can you",
-              "Would you",
-              "Will you"
+              "please",
+              "would you mind",
+              "can you"
             ],
             "isOptional": true
           },
@@ -3999,34 +4116,17 @@
             "category": "filler",
             "synonyms": [
               "a",
-              "an",
+              "this",
               "that"
             ],
             "isOptional": true
           },
           {
-            "text": "'Hamilton'",
-            "category": "albumName",
+            "text": "'Hamilton' Original Broadway Cast Recording",
+            "category": "album",
             "propertyNames": [
               "parameters.albumName"
             ]
-          },
-          {
-            "text": "Original Broadway Cast",
-            "category": "artists",
-            "propertyNames": [
-              "parameters.artists.0"
-            ]
-          },
-          {
-            "text": "Recording",
-            "category": "filler",
-            "synonyms": [
-              "Album",
-              "Soundtrack",
-              "Music"
-            ],
-            "isOptional": true
           }
         ],
         "propertyAlternatives": [
@@ -4059,62 +4159,70 @@
           },
           {
             "propertyName": "parameters.albumName",
-            "propertyValue": "Hamilton",
+            "propertyValue": "Hamilton Original Broadway Cast Recording",
             "propertySubPhrases": [
-              "'Hamilton'"
+              "'Hamilton' Original Broadway Cast Recording"
             ],
             "alternatives": [
               {
-                "propertyValue": "Les Misérables",
+                "propertyValue": "The Lion King Original Broadway Cast Recording",
                 "propertySubPhrases": [
-                  "'Les Misérables'"
+                  "'The Lion King' Original Broadway Cast Recording"
                 ]
               },
               {
-                "propertyValue": "The Phantom of the Opera",
+                "propertyValue": "Wicked Original Broadway Cast Recording",
                 "propertySubPhrases": [
-                  "'The Phantom of the Opera'"
+                  "'Wicked' Original Broadway Cast Recording"
                 ]
               },
               {
-                "propertyValue": "Wicked",
+                "propertyValue": "Les Misérables Original Broadway Cast Recording",
                 "propertySubPhrases": [
-                  "'Wicked'"
-                ]
-              }
-            ]
-          },
-          {
-            "propertyName": "parameters.artists.0",
-            "propertyValue": "Original Broadway Cast",
-            "propertySubPhrases": [
-              "Original Broadway Cast"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "London Cast",
-                "propertySubPhrases": [
-                  "London Cast"
-                ]
-              },
-              {
-                "propertyValue": "Movie Cast",
-                "propertySubPhrases": [
-                  "Movie Cast"
-                ]
-              },
-              {
-                "propertyValue": "Revival Cast",
-                "propertySubPhrases": [
-                  "Revival Cast"
+                  "'Les Misérables' Original Broadway Cast Recording"
                 ]
               }
             ]
           }
         ],
-        "politePrefixes": [],
-        "politeSuffixes": []
-      }
+        "politePrefixes": [
+          "Please,",
+          "Would you mind,",
+          "If it's not too much trouble,",
+          "Kindly,"
+        ],
+        "politeSuffixes": [
+          "Thank you.",
+          "I would appreciate it.",
+          "Thanks a lot.",
+          "Much appreciated."
+        ]
+      },
+      "corrections": [
+        {
+          "data": {
+            "properties": [
+              {
+                "name": "fullActionName",
+                "value": "player.playAlbum",
+                "substrings": [
+                  "play"
+                ]
+              },
+              {
+                "name": "parameters.albumName",
+                "value": "Hamilton Original Broadway Cast Recording",
+                "substrings": [
+                  "Hamilton Original Broadway Cast Recording"
+                ]
+              }
+            ]
+          },
+          "correction": [
+            "Substring 'Hamilton Original Broadway Cast Recording' for property 'parameters.albumName' not found in the request string. Substring must be exact copy of part of the original request and is not changed by correcting misspelling or grammar."
+          ]
+        }
+      ]
     },
     {
       "request": "Could you please play some Bach music?",
@@ -4157,8 +4265,8 @@
             "category": "politeness",
             "synonyms": [
               "kindly",
-              "if you could",
-              "if you would"
+              "if you don't mind",
+              "if you could"
             ],
             "isOptional": true
           },
@@ -4170,11 +4278,31 @@
             ]
           },
           {
-            "text": "some Bach music",
+            "text": "some",
+            "category": "filler",
+            "synonyms": [
+              "any",
+              "a bit of",
+              "a little"
+            ],
+            "isOptional": true
+          },
+          {
+            "text": "Bach",
             "category": "artist",
             "propertyNames": [
               "parameters.artist"
             ]
+          },
+          {
+            "text": "music",
+            "category": "filler",
+            "synonyms": [
+              "tunes",
+              "songs",
+              "melodies"
+            ],
+            "isOptional": true
           }
         ],
         "propertyAlternatives": [
@@ -4209,32 +4337,37 @@
             "propertyName": "parameters.artist",
             "propertyValue": "Bach",
             "propertySubPhrases": [
-              "some Bach music"
+              "Bach"
             ],
             "alternatives": [
               {
                 "propertyValue": "Mozart",
                 "propertySubPhrases": [
-                  "some Mozart music"
+                  "Mozart"
                 ]
               },
               {
                 "propertyValue": "Beethoven",
                 "propertySubPhrases": [
-                  "some Beethoven music"
+                  "Beethoven"
                 ]
               },
               {
                 "propertyValue": "Chopin",
                 "propertySubPhrases": [
-                  "some Chopin music"
+                  "Chopin"
                 ]
               }
             ]
           }
         ],
         "politePrefixes": [],
-        "politeSuffixes": []
+        "politeSuffixes": [
+          "Thank you!",
+          "I would appreciate it.",
+          "If you don't mind.",
+          "Thanks in advance!"
+        ]
       }
     },
     {
@@ -4278,8 +4411,8 @@
             "category": "politeness",
             "synonyms": [
               "kindly",
-              "if you don't mind",
-              "if you could"
+              "if you could",
+              "if you would"
             ],
             "isOptional": true
           },
@@ -4295,7 +4428,7 @@
             "category": "filler",
             "synonyms": [
               "a few",
-              "a couple of",
+              "any",
               "several"
             ],
             "isOptional": true
@@ -4312,8 +4445,8 @@
             "category": "filler",
             "synonyms": [
               "tracks",
-              "tunes",
-              "music"
+              "music",
+              "tunes"
             ],
             "isOptional": true
           }
@@ -4354,15 +4487,15 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "jazz",
-                "propertySubPhrases": [
-                  "jazz"
-                ]
-              },
-              {
                 "propertyValue": "pop",
                 "propertySubPhrases": [
                   "pop"
+                ]
+              },
+              {
+                "propertyValue": "jazz",
+                "propertySubPhrases": [
+                  "jazz"
                 ]
               },
               {
@@ -4375,7 +4508,12 @@
           }
         ],
         "politePrefixes": [],
-        "politeSuffixes": []
+        "politeSuffixes": [
+          "if you don't mind.",
+          "thank you.",
+          "when you have a moment.",
+          "if it's not too much trouble."
+        ]
       }
     },
     {
@@ -4405,22 +4543,12 @@
         ],
         "subPhrases": [
           {
-            "text": "Could you",
+            "text": "Could you please",
             "category": "politeness",
             "synonyms": [
-              "Can you",
-              "Would you",
-              "Will you"
-            ],
-            "isOptional": true
-          },
-          {
-            "text": "please",
-            "category": "politeness",
-            "synonyms": [
-              "kindly",
-              "if you don't mind",
-              "if you could"
+              "Can you please",
+              "Would you mind",
+              "Please"
             ],
             "isOptional": true
           },
@@ -4462,7 +4590,7 @@
               {
                 "propertyValue": "player.playPlaylist",
                 "propertySubPhrases": [
-                  "play the playlist"
+                  "put on the playlist"
                 ]
               }
             ]
@@ -4496,7 +4624,12 @@
           }
         ],
         "politePrefixes": [],
-        "politeSuffixes": []
+        "politeSuffixes": [
+          "Thank you!",
+          "I would appreciate it.",
+          "If you don't mind.",
+          "Thanks in advance!"
+        ]
       }
     },
     {
@@ -4530,14 +4663,14 @@
             "category": "politeness",
             "synonyms": [
               "Can you please",
-              "Would you mind",
+              "Would you kindly",
               "Please"
             ],
             "isOptional": true
           },
           {
             "text": "put on",
-            "category": "command",
+            "category": "action",
             "propertyNames": [
               "fullActionName"
             ]
@@ -4546,8 +4679,8 @@
             "text": "some lively",
             "category": "filler",
             "synonyms": [
-              "a bit of",
               "some",
+              "a bit of",
               "a little"
             ],
             "isOptional": true
@@ -4579,21 +4712,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.startMusic",
+                "propertyValue": "player.startPlaying",
                 "propertySubPhrases": [
                   "start playing"
                 ]
               },
               {
-                "propertyValue": "player.playMusic",
+                "propertyValue": "player.beginPlayback",
                 "propertySubPhrases": [
-                  "play"
+                  "begin playback"
                 ]
               },
               {
-                "propertyValue": "player.beginGenre",
+                "propertyValue": "player.initiateMusic",
                 "propertySubPhrases": [
-                  "begin"
+                  "initiate music"
                 ]
               }
             ]
@@ -4606,15 +4739,15 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "jazz",
-                "propertySubPhrases": [
-                  "jazz"
-                ]
-              },
-              {
                 "propertyValue": "rock",
                 "propertySubPhrases": [
                   "rock"
+                ]
+              },
+              {
+                "propertyValue": "jazz",
+                "propertySubPhrases": [
+                  "jazz"
                 ]
               },
               {
@@ -4627,7 +4760,12 @@
           }
         ],
         "politePrefixes": [],
-        "politeSuffixes": []
+        "politeSuffixes": [
+          "Thank you!",
+          "If you don't mind.",
+          "I would appreciate it.",
+          "Thanks a lot!"
+        ]
       }
     },
     {
@@ -4680,22 +4818,12 @@
             ]
           },
           {
-            "text": "some",
+            "text": "some soothing",
             "category": "filler",
             "synonyms": [
-              "a bit of",
-              "a little",
-              "any"
-            ],
-            "isOptional": true
-          },
-          {
-            "text": "soothing",
-            "category": "filler",
-            "synonyms": [
-              "relaxing",
-              "calming",
-              "peaceful"
+              "some relaxing",
+              "some calming",
+              "some peaceful"
             ],
             "isOptional": true
           },
@@ -4732,15 +4860,15 @@
                 ]
               },
               {
-                "propertyValue": "player.playType",
+                "propertyValue": "player.playStyle",
                 "propertySubPhrases": [
                   "play"
                 ]
               },
               {
-                "propertyValue": "player.beginGenre",
+                "propertyValue": "player.activateGenre",
                 "propertySubPhrases": [
-                  "begin"
+                  "activate"
                 ]
               }
             ]
@@ -4773,8 +4901,18 @@
             ]
           }
         ],
-        "politePrefixes": [],
-        "politeSuffixes": []
+        "politePrefixes": [
+          "Would you mind",
+          "If it's not too much trouble,",
+          "Please",
+          "I would appreciate it if"
+        ],
+        "politeSuffixes": [
+          "Thank you.",
+          "if you don't mind.",
+          "please.",
+          "Thanks a lot."
+        ]
       }
     },
     {
@@ -4787,7 +4925,9 @@
           {
             "name": "fullActionName",
             "value": "player.playRandom",
-            "isImplicit": true
+            "substrings": [
+              "turn on the music"
+            ]
           }
         ],
         "subPhrases": [
@@ -4803,8 +4943,10 @@
           },
           {
             "text": "turn on the music",
-            "category": "action",
-            "propertyNames": []
+            "category": "command",
+            "propertyNames": [
+              "fullActionName"
+            ]
           },
           {
             "text": "please",
@@ -4817,155 +4959,54 @@
             "isOptional": true
           }
         ],
-        "propertyAlternatives": [],
-        "politePrefixes": [],
-        "politeSuffixes": []
-      },
-      "corrections": [
-        {
-          "data": {
-            "properties": [
-              {
-                "name": "fullActionName",
-                "value": "player.playRandom",
-                "isImplicit": true
-              }
+        "propertyAlternatives": [
+          {
+            "propertyName": "fullActionName",
+            "propertyValue": "player.playRandom",
+            "propertySubPhrases": [
+              "turn on the music"
             ],
-            "subPhrases": [
+            "alternatives": [
               {
-                "text": "Could you",
-                "category": "politeness",
-                "synonyms": [
-                  "Can you",
-                  "Would you",
-                  "Will you"
-                ],
-                "isOptional": true
-              },
-              {
-                "text": "turn on the music",
-                "category": "action",
-                "propertyNames": [
-                  "fullActionName"
+                "propertyValue": "player.play",
+                "propertySubPhrases": [
+                  "play the music"
                 ]
               },
               {
-                "text": "please",
-                "category": "politeness",
-                "synonyms": [
-                  "kindly",
-                  "if you don't mind",
-                  "if you could"
-                ],
-                "isOptional": true
-              }
-            ]
-          },
-          "correction": [
-            "Property 'fullActionName' is expected to be implicit and should not be included as a property name in a sub-phrase"
-          ]
-        },
-        {
-          "data": {
-            "properties": [
-              {
-                "name": "fullActionName",
-                "value": "player.playRandom",
-                "isImplicit": true
-              }
-            ],
-            "subPhrases": [
-              {
-                "text": "Could you",
-                "category": "politeness",
-                "synonyms": [
-                  "Can you",
-                  "Would you",
-                  "Will you"
-                ],
-                "isOptional": true
-              },
-              {
-                "text": "turn on the music",
-                "category": "action",
-                "propertyNames": []
-              },
-              {
-                "text": "please",
-                "category": "politeness",
-                "synonyms": [
-                  "kindly",
-                  "if you don't mind",
-                  "if you could"
-                ],
-                "isOptional": true
-              }
-            ],
-            "propertyAlternatives": [
-              {
-                "propertyName": "action",
-                "propertyValue": "turn on",
+                "propertyValue": "player.resume",
                 "propertySubPhrases": [
-                  "turn on the music"
-                ],
-                "alternatives": [
-                  {
-                    "propertyValue": "play",
-                    "propertySubPhrases": [
-                      "play the music"
-                    ]
-                  },
-                  {
-                    "propertyValue": "start",
-                    "propertySubPhrases": [
-                      "start the music"
-                    ]
-                  },
-                  {
-                    "propertyValue": "activate",
-                    "propertySubPhrases": [
-                      "activate the music"
-                    ]
-                  }
+                  "resume the music"
                 ]
               },
               {
-                "propertyName": "politeness",
-                "propertyValue": "please",
+                "propertyValue": "player.start",
                 "propertySubPhrases": [
-                  "please"
-                ],
-                "alternatives": [
-                  {
-                    "propertyValue": "kindly",
-                    "propertySubPhrases": [
-                      "kindly"
-                    ]
-                  },
-                  {
-                    "propertyValue": "if you don't mind",
-                    "propertySubPhrases": [
-                      "if you don't mind"
-                    ]
-                  },
-                  {
-                    "propertyValue": "would you mind",
-                    "propertySubPhrases": [
-                      "would you mind"
-                    ]
-                  }
+                  "start the music"
+                ]
+              },
+              {
+                "propertyValue": "player.activate",
+                "propertySubPhrases": [
+                  "activate the music"
                 ]
               }
             ]
-          },
-          "correction": [
-            "Extraneous parameter: 'action' is not a parameter in the action",
-            "Implicit property shouldn't have alternatives",
-            "Extraneous parameter: 'politeness' is not a parameter in the action",
-            "Implicit property shouldn't have alternatives"
-          ]
-        }
-      ]
+          }
+        ],
+        "politePrefixes": [
+          "Would you mind",
+          "If it's not too much trouble",
+          "May I ask",
+          "Could I kindly request"
+        ],
+        "politeSuffixes": [
+          "if you don't mind?",
+          "thank you!",
+          "if it's convenient for you.",
+          "I would appreciate it."
+        ]
+      }
     },
     {
       "request": "Crank up some Snoop D-O-Double-G, please!",
@@ -5006,7 +5047,7 @@
             "synonyms": [
               "a bit of",
               "a little",
-              "some of"
+              "some"
             ],
             "isOptional": true
           },
@@ -5022,7 +5063,7 @@
             "category": "politeness",
             "synonyms": [
               "kindly",
-              "if you don't mind",
+              "if you would",
               "if you please"
             ],
             "isOptional": true
@@ -5043,15 +5084,15 @@
                 ]
               },
               {
-                "propertyValue": "player.playAlbum",
+                "propertyValue": "player.shuffleArtist",
                 "propertySubPhrases": [
-                  "Play the album"
+                  "Shuffle"
                 ]
               },
               {
-                "propertyValue": "player.playPlaylist",
+                "propertyValue": "player.playAlbum",
                 "propertySubPhrases": [
-                  "Play the playlist"
+                  "Play album"
                 ]
               }
             ]
@@ -5084,8 +5125,18 @@
             ]
           }
         ],
-        "politePrefixes": [],
-        "politeSuffixes": []
+        "politePrefixes": [
+          "Could you",
+          "Would you mind",
+          "If you don't mind",
+          "May I ask you to"
+        ],
+        "politeSuffixes": [
+          "Thank you!",
+          "I would appreciate it.",
+          "Thanks a lot!",
+          "Much appreciated."
+        ]
       }
     },
     {
@@ -5115,12 +5166,22 @@
         ],
         "subPhrases": [
           {
-            "text": "Do you have any",
+            "text": "Do you",
             "category": "politeness",
             "synonyms": [
-              "Could you provide",
-              "Would you happen to have",
-              "Can you offer"
+              "Can you",
+              "Would you",
+              "Could you"
+            ],
+            "isOptional": true
+          },
+          {
+            "text": "have any",
+            "category": "confirmation",
+            "synonyms": [
+              "got any",
+              "possess any",
+              "hold any"
             ],
             "isOptional": true
           },
@@ -5197,11 +5258,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "May I ask",
+          "If it's not too much trouble"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it!"
+          "please?",
+          "if you don't mind.",
+          "thank you.",
+          "if that's okay."
         ]
       }
     },
@@ -5210,10 +5275,7 @@
       "action": {
         "fullActionName": "player.playAlbum",
         "parameters": {
-          "albumName": "Doggystyle",
-          "artists": [
-            "Snoop Dogg"
-          ]
+          "albumName": "Doggystyle"
         }
       },
       "explanation": {
@@ -5222,21 +5284,15 @@
             "name": "fullActionName",
             "value": "player.playAlbum",
             "substrings": [
-              "let's get some of that",
-              "playin' up in here"
+              "let's get some of that Doggystyle album playin' up in here."
             ]
           },
           {
             "name": "parameters.albumName",
             "value": "Doggystyle",
             "substrings": [
-              "Doggystyle album"
+              "Doggystyle"
             ]
-          },
-          {
-            "name": "parameters.artists.0",
-            "value": "Snoop Dogg",
-            "isImplicit": true
           }
         ],
         "subPhrases": [
@@ -5252,21 +5308,24 @@
           },
           {
             "text": "let's get some of that",
-            "category": "command",
-            "propertyNames": [
-              "fullActionName"
-            ]
+            "category": "politeness",
+            "synonyms": [
+              "please play",
+              "can we have",
+              "let's hear"
+            ],
+            "isOptional": true
           },
           {
-            "text": "Doggystyle album",
+            "text": "Doggystyle",
             "category": "albumName",
             "propertyNames": [
               "parameters.albumName"
             ]
           },
           {
-            "text": "playin' up in here",
-            "category": "command",
+            "text": "album playin' up in here",
+            "category": "fullActionName",
             "propertyNames": [
               "fullActionName"
             ]
@@ -5274,178 +5333,55 @@
         ],
         "propertyAlternatives": [
           {
-            "propertyName": "fullActionName",
-            "propertyValue": "player.playAlbum",
-            "propertySubPhrases": [
-              "let's get some of that",
-              "playin' up in here"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "player.queueAlbum",
-                "propertySubPhrases": [
-                  "let's queue up some of that",
-                  "playin' up in here"
-                ]
-              },
-              {
-                "propertyValue": "player.shuffleAlbum",
-                "propertySubPhrases": [
-                  "let's shuffle some of that",
-                  "playin' up in here"
-                ]
-              },
-              {
-                "propertyValue": "player.repeatAlbum",
-                "propertySubPhrases": [
-                  "let's repeat some of that",
-                  "playin' up in here"
-                ]
-              }
-            ]
-          },
-          {
             "propertyName": "parameters.albumName",
             "propertyValue": "Doggystyle",
             "propertySubPhrases": [
-              "Doggystyle album"
+              "Doggystyle"
             ],
             "alternatives": [
               {
                 "propertyValue": "The Chronic",
                 "propertySubPhrases": [
-                  "The Chronic album"
+                  "The Chronic"
                 ]
               },
               {
                 "propertyValue": "2001",
                 "propertySubPhrases": [
-                  "2001 album"
+                  "2001"
                 ]
               },
               {
-                "propertyValue": "Tha Carter III",
+                "propertyValue": "All Eyez on Me",
                 "propertySubPhrases": [
-                  "Tha Carter III album"
+                  "All Eyez on Me"
                 ]
               }
             ]
-          }
-        ],
-        "politePrefixes": [
-          "Could you please",
-          "Would you mind"
-        ],
-        "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it!"
-        ]
-      }
-    },
-    {
-      "request": "Fo' shizzle, my nizzle, let's get this party bumpin' with some 'Drop It Like It's Hot'!",
-      "action": {
-        "fullActionName": "player.playTrack",
-        "parameters": {
-          "trackName": "Drop It Like It's Hot",
-          "artists": [
-            "Snoop Dogg"
-          ]
-        }
-      },
-      "explanation": {
-        "properties": [
-          {
-            "name": "fullActionName",
-            "value": "player.playTrack",
-            "isImplicit": true
           },
           {
-            "name": "parameters.trackName",
-            "value": "Drop It Like It's Hot",
-            "substrings": [
-              "Drop It Like It's Hot"
-            ]
-          },
-          {
-            "name": "parameters.artists.0",
-            "value": "Snoop Dogg",
-            "isImplicit": true
-          }
-        ],
-        "subPhrases": [
-          {
-            "text": "Fo' shizzle, my nizzle,",
-            "category": "filler",
-            "synonyms": [
-              "Hey",
-              "Yo",
-              "Alright"
-            ],
-            "isOptional": true
-          },
-          {
-            "text": "let's get this party bumpin' with some",
-            "category": "filler",
-            "synonyms": [
-              "let's play",
-              "let's start",
-              "let's listen to"
-            ],
-            "isOptional": true
-          },
-          {
-            "text": "'",
-            "category": "punctuation",
-            "synonyms": [
-              "",
-              "",
-              ""
-            ],
-            "isOptional": true
-          },
-          {
-            "text": "Drop It Like It's Hot",
-            "category": "trackName",
-            "propertyNames": [
-              "parameters.trackName"
-            ]
-          },
-          {
-            "text": "'",
-            "category": "punctuation",
-            "synonyms": [
-              "",
-              "",
-              ""
-            ],
-            "isOptional": true
-          }
-        ],
-        "propertyAlternatives": [
-          {
-            "propertyName": "parameters.trackName",
-            "propertyValue": "Drop It Like It's Hot",
+            "propertyName": "fullActionName",
+            "propertyValue": "player.playAlbum",
             "propertySubPhrases": [
-              "Drop It Like It's Hot"
+              "album playin' up in here"
             ],
             "alternatives": [
               {
-                "propertyValue": "Gin and Juice",
+                "propertyValue": "player.playSong",
                 "propertySubPhrases": [
-                  "Gin and Juice"
+                  "song playin' up in here"
                 ]
               },
               {
-                "propertyValue": "Nuthin' but a 'G' Thang",
+                "propertyValue": "player.playPlaylist",
                 "propertySubPhrases": [
-                  "Nuthin' but a 'G' Thang"
+                  "playlist playin' up in here"
                 ]
               },
               {
-                "propertyValue": "Who Am I (What's My Name)?",
+                "propertyValue": "player.playArtist",
                 "propertySubPhrases": [
-                  "Who Am I (What's My Name)?"
+                  "artist playin' up in here"
                 ]
               }
             ]
@@ -5454,71 +5390,147 @@
         "politePrefixes": [
           "Could you please",
           "Would you mind",
-          "If it's not too much trouble, could you"
+          "If it's not too much trouble",
+          "I would appreciate it if you could"
         ],
         "politeSuffixes": [
           "Thank you!",
-          "I would really appreciate it!",
-          "Thanks a lot!"
+          "Thanks a lot!",
+          "I appreciate it!",
+          "Much appreciated!"
         ]
+      }
+    },
+    {
+      "request": "Fo' shizzle, my nizzle, let's get this party bumpin' with some 'Drop It Like It's Hot'!",
+      "action": {
+        "fullActionName": "player.playTrack",
+        "parameters": {
+          "trackName": "Drop It Like It's Hot"
+        }
       },
-      "corrections": [
-        {
-          "data": {
-            "properties": [
+      "explanation": {
+        "properties": [
+          {
+            "name": "fullActionName",
+            "value": "player.playTrack",
+            "substrings": [
+              "let's get this party bumpin'"
+            ]
+          },
+          {
+            "name": "parameters.trackName",
+            "value": "Drop It Like It's Hot",
+            "substrings": [
+              "'Drop It Like It's Hot'"
+            ]
+          }
+        ],
+        "subPhrases": [
+          {
+            "text": "Fo' shizzle, my nizzle",
+            "category": "filler",
+            "synonyms": [
+              "hey",
+              "yo",
+              "what's up"
+            ],
+            "isOptional": true
+          },
+          {
+            "text": "let's get this party bumpin'",
+            "category": "action",
+            "propertyNames": [
+              "fullActionName"
+            ]
+          },
+          {
+            "text": "with some",
+            "category": "preposition",
+            "synonyms": [
+              "featuring",
+              "including",
+              "along with"
+            ],
+            "isOptional": true
+          },
+          {
+            "text": "'Drop It Like It's Hot'",
+            "category": "trackName",
+            "propertyNames": [
+              "parameters.trackName"
+            ]
+          }
+        ],
+        "propertyAlternatives": [
+          {
+            "propertyName": "fullActionName",
+            "propertyValue": "player.playTrack",
+            "propertySubPhrases": [
+              "let's get this party bumpin'"
+            ],
+            "alternatives": [
               {
-                "name": "fullActionName",
-                "value": "player.playTrack",
-                "isImplicit": true
-              },
-              {
-                "name": "parameters.trackName",
-                "value": "Drop It Like It's Hot",
-                "substrings": [
-                  "Drop It Like It's Hot"
+                "propertyValue": "player.startMusic",
+                "propertySubPhrases": [
+                  "let's get this party started"
                 ]
               },
               {
-                "name": "parameters.artists.0",
-                "value": "Snoop Dogg",
-                "isImplicit": true
-              }
-            ],
-            "subPhrases": [
-              {
-                "text": "Fo' shizzle, my nizzle,",
-                "category": "filler",
-                "synonyms": [
-                  "Hey",
-                  "Yo",
-                  "Alright"
-                ],
-                "isOptional": true
+                "propertyValue": "player.queueTrack",
+                "propertySubPhrases": [
+                  "let's add some tunes"
+                ]
               },
               {
-                "text": "let's get this party bumpin' with some",
-                "category": "filler",
-                "synonyms": [
-                  "let's play",
-                  "let's start",
-                  "let's listen to"
-                ],
-                "isOptional": true
-              },
-              {
-                "text": "Drop It Like It's Hot",
-                "category": "trackName",
-                "propertyNames": [
-                  "parameters.trackName"
+                "propertyValue": "player.playSong",
+                "propertySubPhrases": [
+                  "let's play a song"
                 ]
               }
             ]
           },
-          "correction": [
-            "Missing sub-phrase: explanation missing for '''"
-          ]
-        }
-      ]
+          {
+            "propertyName": "parameters.trackName",
+            "propertyValue": "Drop It Like It's Hot",
+            "propertySubPhrases": [
+              "'Drop It Like It's Hot'"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "Gin and Juice",
+                "propertySubPhrases": [
+                  "'Gin and Juice'"
+                ]
+              },
+              {
+                "propertyValue": "Nuthin' But a G Thang",
+                "propertySubPhrases": [
+                  "'Nuthin' But a G Thang'"
+                ]
+              },
+              {
+                "propertyValue": "California Love",
+                "propertySubPhrases": [
+                  "'California Love'"
+                ]
+              }
+            ]
+          }
+        ],
+        "politePrefixes": [
+          "Could you please",
+          "Would you mind",
+          "If it's not too much trouble",
+          "I would appreciate it if you could"
+        ],
+        "politeSuffixes": [
+          "thank you",
+          "please",
+          "if you don't mind",
+          "thanks a lot"
+        ]
+      }
     },
     {
       "request": "Hey bot, can you please play some music by Bach for me?",
@@ -5562,7 +5574,7 @@
             "synonyms": [
               "could you please",
               "would you mind",
-              "can you"
+              "please"
             ],
             "isOptional": true
           },
@@ -5584,9 +5596,9 @@
             "text": "for me",
             "category": "filler",
             "synonyms": [
+              "for myself",
               "for us",
-              "for everyone",
-              "for all"
+              "for them"
             ],
             "isOptional": true
           }
@@ -5648,7 +5660,12 @@
           }
         ],
         "politePrefixes": [],
-        "politeSuffixes": []
+        "politeSuffixes": [
+          "Thank you!",
+          "I appreciate it!",
+          "Thanks a lot!",
+          "Much appreciated!"
+        ]
       }
     },
     {
@@ -5678,12 +5695,13 @@
         ],
         "subPhrases": [
           {
-            "text": "Hey nephew,",
+            "text": "Hey nephew",
             "category": "greeting",
             "synonyms": [
-              "Hello nephew,",
-              "Hi nephew,",
-              "Greetings nephew,"
+              "Hello",
+              "Hi there",
+              "Greetings",
+              "Hey buddy"
             ],
             "isOptional": true
           },
@@ -5693,7 +5711,8 @@
             "synonyms": [
               "could you",
               "would you",
-              "please"
+              "please",
+              "might you"
             ],
             "isOptional": true
           },
@@ -5708,9 +5727,10 @@
             "text": "some of that smooth",
             "category": "filler",
             "synonyms": [
-              "some smooth",
-              "that smooth",
-              "smooth"
+              "some",
+              "a bit of",
+              "a little",
+              "some smooth"
             ],
             "isOptional": true
           },
@@ -5722,12 +5742,13 @@
             ]
           },
           {
-            "text": "for me?",
+            "text": "for me",
             "category": "politeness",
             "synonyms": [
-              "please?",
-              "if you could?",
-              "thanks?"
+              "please",
+              "if you don't mind",
+              "if you could",
+              "thanks"
             ],
             "isOptional": true
           }
@@ -5749,13 +5770,13 @@
               {
                 "propertyValue": "player.queueGenre",
                 "propertySubPhrases": [
-                  "queue up"
+                  "add to queue"
                 ]
               },
               {
-                "propertyValue": "player.playMusic",
+                "propertyValue": "player.loadGenre",
                 "propertySubPhrases": [
-                  "play"
+                  "load up"
                 ]
               }
             ]
@@ -5790,11 +5811,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If it's not too much trouble",
+          "I would appreciate it if you could"
         ],
         "politeSuffixes": [
           "Thank you!",
-          "I would appreciate it."
+          "I appreciate it!",
+          "Thanks a lot!",
+          "Much appreciated!"
         ]
       }
     },
@@ -5825,12 +5850,13 @@
         ],
         "subPhrases": [
           {
-            "text": "Hey nephew,",
+            "text": "Hey nephew",
             "category": "greeting",
             "synonyms": [
-              "Hello there,",
-              "Hi,",
-              "Hey,"
+              "Hello",
+              "Hi there",
+              "Greetings",
+              "Hey"
             ],
             "isOptional": true
           },
@@ -5843,7 +5869,7 @@
           },
           {
             "text": "'Who Am I (What's My Name)?'",
-            "category": "trackName",
+            "category": "track",
             "propertyNames": [
               "parameters.trackName"
             ]
@@ -5852,9 +5878,10 @@
             "text": "and let's get this place groovin'!",
             "category": "filler",
             "synonyms": [
-              "and let's have some fun!",
-              "and let's enjoy the music!",
-              "and let's get the party started!"
+              "let's party",
+              "let's dance",
+              "let's have fun",
+              "let's enjoy"
             ],
             "isOptional": true
           }
@@ -5868,21 +5895,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.startTrack",
-                "propertySubPhrases": [
-                  "start that"
-                ]
-              },
-              {
                 "propertyValue": "player.queueTrack",
                 "propertySubPhrases": [
-                  "queue up"
+                  "add that to the queue"
                 ]
               },
               {
-                "propertyValue": "player.playSong",
+                "propertyValue": "player.pauseTrack",
                 "propertySubPhrases": [
-                  "play the song"
+                  "pause that"
+                ]
+              },
+              {
+                "propertyValue": "player.stopTrack",
+                "propertySubPhrases": [
+                  "stop that"
                 ]
               }
             ]
@@ -5895,15 +5922,15 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "Nuthin' But a 'G' Thang",
-                "propertySubPhrases": [
-                  "'Nuthin' But a 'G' Thang'"
-                ]
-              },
-              {
                 "propertyValue": "Gin and Juice",
                 "propertySubPhrases": [
                   "'Gin and Juice'"
+                ]
+              },
+              {
+                "propertyValue": "Nuthin' But a G Thang",
+                "propertySubPhrases": [
+                  "'Nuthin' But a G Thang'"
                 ]
               },
               {
@@ -5917,11 +5944,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If you don't mind",
+          "Please"
         ],
         "politeSuffixes": [
           "Thank you!",
-          "I would appreciate it!"
+          "Thanks!",
+          "I appreciate it!",
+          "Much appreciated!"
         ]
       }
     },
@@ -5930,7 +5961,7 @@
       "action": {
         "fullActionName": "player.playGenre",
         "parameters": {
-          "genre": "hip hop"
+          "genre": "hip-hop"
         }
       },
       "explanation": {
@@ -5946,7 +5977,7 @@
           },
           {
             "name": "parameters.genre",
-            "value": "hip hop",
+            "value": "hip-hop",
             "substrings": [
               "dope rhymes",
               "ill beats"
@@ -5970,7 +6001,7 @@
             "synonyms": [
               "could we",
               "may we",
-              "shall we"
+              "might we"
             ],
             "isOptional": true
           },
@@ -5987,7 +6018,7 @@
             "synonyms": [
               "with some",
               "for some",
-              "to a few"
+              "on some"
             ],
             "isOptional": true
           },
@@ -6003,8 +6034,8 @@
             "text": "and",
             "category": "conjunction",
             "synonyms": [
-              "&",
               "plus",
+              "along with",
               "as well as"
             ],
             "isOptional": true
@@ -6037,18 +6068,18 @@
                 ]
               },
               {
-                "propertyValue": "player.startPlaylist",
+                "propertyValue": "player.playSongs",
                 "propertySubPhrases": [
-                  "start",
-                  "awesome tracks",
+                  "jam to",
+                  "awesome lyrics",
                   "great rhythms"
                 ]
               },
               {
-                "propertyValue": "player.playSongs",
+                "propertyValue": "player.playTracks",
                 "propertySubPhrases": [
-                  "play",
-                  "amazing songs",
+                  "groove to",
+                  "amazing verses",
                   "fantastic beats"
                 ]
               }
@@ -6056,7 +6087,7 @@
           },
           {
             "propertyName": "parameters.genre",
-            "propertyValue": "hip hop",
+            "propertyValue": "hip-hop",
             "propertySubPhrases": [
               "dope rhymes",
               "ill beats"
@@ -6072,25 +6103,31 @@
               {
                 "propertyValue": "R&B",
                 "propertySubPhrases": [
-                  "smooth vocals",
+                  "smooth lyrics",
                   "groovy beats"
                 ]
               },
               {
                 "propertyValue": "trap",
                 "propertySubPhrases": [
-                  "hard-hitting lyrics",
-                  "heavy bass"
+                  "hard rhymes",
+                  "heavy beats"
                 ]
               }
             ]
           }
         ],
         "politePrefixes": [
-          "Please"
+          "Could you please",
+          "Would you mind",
+          "If it's not too much trouble",
+          "I would appreciate it if you could"
         ],
         "politeSuffixes": [
-          "Thank you"
+          "Thank you!",
+          "Please.",
+          "Thanks a lot!",
+          "I appreciate it."
         ]
       }
     },
@@ -6111,7 +6148,7 @@
             "name": "fullActionName",
             "value": "player.playTrack",
             "substrings": [
-              "vibe to"
+              "Hey, can we vibe to some of that 'Beautiful' featuring Pharrell, please?"
             ]
           },
           {
@@ -6131,31 +6168,37 @@
         ],
         "subPhrases": [
           {
-            "text": "Hey,",
+            "text": "Hey",
             "category": "greeting",
             "synonyms": [
-              "Hi,",
-              "Hello,",
-              "Hey there,"
+              "Hi",
+              "Hello",
+              "Hey there",
+              "Greetings"
             ],
             "isOptional": true
           },
           {
             "text": "can we",
-            "category": "politeness",
+            "category": "confirmation",
             "synonyms": [
               "could we",
               "may we",
-              "would we"
+              "shall we",
+              "might we"
             ],
             "isOptional": true
           },
           {
             "text": "vibe to",
-            "category": "action",
-            "propertyNames": [
-              "fullActionName"
-            ]
+            "category": "filler",
+            "synonyms": [
+              "listen to",
+              "play",
+              "hear",
+              "enjoy"
+            ],
+            "isOptional": true
           },
           {
             "text": "some of that",
@@ -6163,7 +6206,8 @@
             "synonyms": [
               "some",
               "a bit of",
-              "a little of"
+              "a little of",
+              "part of"
             ],
             "isOptional": true
           },
@@ -6176,50 +6220,24 @@
           },
           {
             "text": "featuring Pharrell",
-            "category": "artist",
+            "category": "artists",
             "propertyNames": [
               "parameters.artists.0"
             ]
           },
           {
-            "text": "please?",
+            "text": "please",
             "category": "politeness",
             "synonyms": [
-              "thanks",
-              "if you don't mind",
-              "kindly"
+              "kindly",
+              "if you please",
+              "would you mind",
+              "please do"
             ],
             "isOptional": true
           }
         ],
         "propertyAlternatives": [
-          {
-            "propertyName": "fullActionName",
-            "propertyValue": "player.playTrack",
-            "propertySubPhrases": [
-              "vibe to"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "player.playSong",
-                "propertySubPhrases": [
-                  "listen to"
-                ]
-              },
-              {
-                "propertyValue": "player.startTrack",
-                "propertySubPhrases": [
-                  "play"
-                ]
-              },
-              {
-                "propertyValue": "player.queueTrack",
-                "propertySubPhrases": [
-                  "add to queue"
-                ]
-              }
-            ]
-          },
           {
             "propertyName": "parameters.trackName",
             "propertyValue": "Beautiful",
@@ -6234,15 +6252,15 @@
                 ]
               },
               {
-                "propertyValue": "Get Lucky",
+                "propertyValue": "Freedom",
                 "propertySubPhrases": [
-                  "'Get Lucky'"
+                  "'Freedom'"
                 ]
               },
               {
-                "propertyValue": "Blurred Lines",
+                "propertyValue": "Gust of Wind",
                 "propertySubPhrases": [
-                  "'Blurred Lines'"
+                  "'Gust of Wind'"
                 ]
               }
             ]
@@ -6255,28 +6273,38 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "Daft Punk",
+                "propertyValue": "Jay-Z",
                 "propertySubPhrases": [
-                  "featuring Daft Punk"
+                  "featuring Jay-Z"
                 ]
               },
               {
-                "propertyValue": "Robin Thicke",
+                "propertyValue": "Kanye West",
                 "propertySubPhrases": [
-                  "featuring Robin Thicke"
+                  "featuring Kanye West"
                 ]
               },
               {
-                "propertyValue": "Snoop Dogg",
+                "propertyValue": "Beyoncé",
                 "propertySubPhrases": [
-                  "featuring Snoop Dogg"
+                  "featuring Beyoncé"
                 ]
               }
             ]
           }
         ],
-        "politePrefixes": [],
-        "politeSuffixes": []
+        "politePrefixes": [
+          "Excuse me,",
+          "Would you mind if",
+          "If it's not too much trouble,",
+          "Could you please"
+        ],
+        "politeSuffixes": [
+          "Thank you!",
+          "I'd appreciate it.",
+          "Thanks a lot!",
+          "Much appreciated."
+        ]
       }
     },
     {
@@ -6310,9 +6338,9 @@
             "text": "how about we",
             "category": "filler",
             "synonyms": [
-              "what if we",
               "let's",
-              "shall we"
+              "shall we",
+              "how about"
             ],
             "isOptional": true
           },
@@ -6325,7 +6353,7 @@
           },
           {
             "text": "some fly jams",
-            "category": "content",
+            "category": "object",
             "propertyNames": [
               "fullActionName"
             ]
@@ -6351,31 +6379,48 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.play",
+                "propertyValue": "player.playTopHits",
                 "propertySubPhrases": [
-                  "play",
-                  "some music"
+                  "crank up",
+                  "some top hits"
                 ]
               },
               {
-                "propertyValue": "player.shuffle",
+                "propertyValue": "player.playFavorites",
                 "propertySubPhrases": [
-                  "shuffle",
-                  "the playlist"
+                  "crank up",
+                  "some favorite songs"
                 ]
               },
               {
-                "propertyValue": "player.startRadio",
+                "propertyValue": "player.playChill",
                 "propertySubPhrases": [
-                  "start",
-                  "the radio"
+                  "crank up",
+                  "some chill tunes"
+                ]
+              },
+              {
+                "propertyValue": "player.playClassics",
+                "propertySubPhrases": [
+                  "crank up",
+                  "some classic tracks"
                 ]
               }
             ]
           }
         ],
-        "politePrefixes": [],
-        "politeSuffixes": []
+        "politePrefixes": [
+          "Could you please",
+          "Would you mind",
+          "If it's not too much trouble",
+          "I would appreciate it if you could"
+        ],
+        "politeSuffixes": [
+          "Thank you!",
+          "Please.",
+          "Thanks a lot!",
+          "Much appreciated."
+        ]
       }
     },
     {
@@ -6392,7 +6437,7 @@
             "name": "fullActionName",
             "value": "player.playArtist",
             "substrings": [
-              "Hey, let's get some Snoop Dogg vibes up in here!"
+              "let's get"
             ]
           },
           {
@@ -6410,17 +6455,25 @@
             "synonyms": [
               "Hi",
               "Hello",
-              "Hey there"
+              "Hey there",
+              "Greetings"
             ],
             "isOptional": true
           },
           {
-            "text": "let's get some",
+            "text": "let's get",
+            "category": "action initiation",
+            "propertyNames": [
+              "fullActionName"
+            ]
+          },
+          {
+            "text": "some",
             "category": "filler",
             "synonyms": [
-              "let's have some",
-              "let's play some",
-              "let's enjoy some"
+              "a bit of",
+              "some of",
+              "a little"
             ],
             "isOptional": true
           },
@@ -6432,17 +6485,44 @@
             ]
           },
           {
-            "text": "vibes up in here!",
-            "category": "filler",
+            "text": "vibes up in here",
+            "category": "context",
             "synonyms": [
-              "music here",
-              "tunes here",
-              "songs here"
+              "music playing",
+              "songs",
+              "tracks"
             ],
             "isOptional": true
           }
         ],
         "propertyAlternatives": [
+          {
+            "propertyName": "fullActionName",
+            "propertyValue": "player.playArtist",
+            "propertySubPhrases": [
+              "let's get"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "player.playAlbum",
+                "propertySubPhrases": [
+                  "let's play"
+                ]
+              },
+              {
+                "propertyValue": "player.playSong",
+                "propertySubPhrases": [
+                  "let's listen to"
+                ]
+              },
+              {
+                "propertyValue": "player.playPlaylist",
+                "propertySubPhrases": [
+                  "let's enjoy"
+                ]
+              }
+            ]
+          },
           {
             "propertyName": "parameters.artist",
             "propertyValue": "Snoop Dogg",
@@ -6463,16 +6543,26 @@
                 ]
               },
               {
-                "propertyValue": "Kendrick Lamar",
+                "propertyValue": "Ice Cube",
                 "propertySubPhrases": [
-                  "Kendrick Lamar"
+                  "Ice Cube"
                 ]
               }
             ]
           }
         ],
-        "politePrefixes": [],
-        "politeSuffixes": []
+        "politePrefixes": [
+          "Could you please",
+          "Would you mind",
+          "If it's not too much trouble,",
+          "I would appreciate it if you could"
+        ],
+        "politeSuffixes": [
+          "Thank you!",
+          "Thanks a lot!",
+          "I appreciate it!",
+          "Cheers!"
+        ]
       }
     },
     {
@@ -6480,7 +6570,8 @@
       "action": {
         "fullActionName": "player.playGenre",
         "parameters": {
-          "genre": "classic"
+          "genre": "classic",
+          "quantity": 10
         }
       },
       "explanation": {
@@ -6488,7 +6579,10 @@
           {
             "name": "fullActionName",
             "value": "player.playGenre",
-            "substrings": []
+            "substrings": [
+              "let's kick it old school",
+              "classic jams"
+            ]
           },
           {
             "name": "parameters.genre",
@@ -6496,6 +6590,11 @@
             "substrings": [
               "classic"
             ]
+          },
+          {
+            "name": "parameters.quantity",
+            "value": 10,
+            "isImplicit": true
           }
         ],
         "subPhrases": [
@@ -6503,19 +6602,26 @@
             "text": "Hey",
             "category": "greeting",
             "synonyms": [
-              "Hi",
               "Hello",
-              "Hey there"
+              "Hi",
+              "Greetings"
             ],
             "isOptional": true
           },
           {
-            "text": "let's kick it old school with some",
+            "text": "let's kick it old school",
+            "category": "action",
+            "propertyNames": [
+              "fullActionName"
+            ]
+          },
+          {
+            "text": "with some",
             "category": "filler",
             "synonyms": [
-              "let's go retro with",
-              "let's enjoy some",
-              "how about some"
+              "including",
+              "featuring",
+              "along with"
             ],
             "isOptional": true
           },
@@ -6527,17 +6633,55 @@
             ]
           },
           {
-            "text": "jams on the stereo!",
-            "category": "filler",
+            "text": "jams",
+            "category": "action",
+            "propertyNames": [
+              "fullActionName"
+            ]
+          },
+          {
+            "text": "on the stereo",
+            "category": "context",
             "synonyms": [
-              "music on the stereo",
-              "tunes on the stereo",
-              "songs on the stereo"
+              "on the speakers",
+              "on the sound system",
+              "on the audio system"
             ],
             "isOptional": true
           }
         ],
         "propertyAlternatives": [
+          {
+            "propertyName": "fullActionName",
+            "propertyValue": "player.playGenre",
+            "propertySubPhrases": [
+              "let's kick it old school",
+              "jams"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "player.playRetro",
+                "propertySubPhrases": [
+                  "let's kick it old school",
+                  "retro"
+                ]
+              },
+              {
+                "propertyValue": "player.playHits",
+                "propertySubPhrases": [
+                  "let's kick it old school",
+                  "hits"
+                ]
+              },
+              {
+                "propertyValue": "player.playClassics",
+                "propertySubPhrases": [
+                  "let's kick it old school",
+                  "classics"
+                ]
+              }
+            ]
+          },
           {
             "propertyName": "parameters.genre",
             "propertyValue": "classic",
@@ -6562,18 +6706,22 @@
                 "propertySubPhrases": [
                   "pop"
                 ]
-              },
-              {
-                "propertyValue": "hip-hop",
-                "propertySubPhrases": [
-                  "hip-hop"
-                ]
               }
             ]
           }
         ],
-        "politePrefixes": [],
-        "politeSuffixes": []
+        "politePrefixes": [
+          "Please,",
+          "Would you mind,",
+          "Could you please,",
+          "If you don't mind,"
+        ],
+        "politeSuffixes": [
+          "thank you!",
+          "please.",
+          "if that's okay.",
+          "thanks!"
+        ]
       }
     },
     {
@@ -6608,7 +6756,8 @@
             "synonyms": [
               "Hi",
               "Hello",
-              "Hey there"
+              "Hey there",
+              "Greetings"
             ],
             "isOptional": true
           },
@@ -6624,8 +6773,9 @@
             "category": "filler",
             "synonyms": [
               "a few",
-              "some",
-              "a couple"
+              "some of",
+              "a couple of",
+              "several"
             ],
             "isOptional": true
           },
@@ -6642,17 +6792,19 @@
             "synonyms": [
               "songs",
               "music",
-              "tunes"
+              "tunes",
+              "jams"
             ],
             "isOptional": true
           },
           {
             "text": "for us",
-            "category": "filler",
+            "category": "preposition",
             "synonyms": [
               "for me",
-              "for us",
-              "for everyone"
+              "for everyone",
+              "for the group",
+              "for the party"
             ],
             "isOptional": true
           },
@@ -6662,7 +6814,8 @@
             "synonyms": [
               ".",
               "?",
-              "!"
+              "...",
+              ""
             ],
             "isOptional": true
           }
@@ -6682,15 +6835,15 @@
                 ]
               },
               {
-                "propertyValue": "player.playAlbum",
+                "propertyValue": "player.shuffleArtist",
                 "propertySubPhrases": [
-                  "put on"
+                  "shuffle"
                 ]
               },
               {
-                "propertyValue": "player.playPlaylist",
+                "propertyValue": "player.queueArtist",
                 "propertySubPhrases": [
-                  "queue up"
+                  "queue"
                 ]
               }
             ]
@@ -6703,15 +6856,15 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "Dr. Dre",
-                "propertySubPhrases": [
-                  "Dr. Dre"
-                ]
-              },
-              {
                 "propertyValue": "Eminem",
                 "propertySubPhrases": [
                   "Eminem"
+                ]
+              },
+              {
+                "propertyValue": "Dr. Dre",
+                "propertySubPhrases": [
+                  "Dr. Dre"
                 ]
               },
               {
@@ -6723,8 +6876,18 @@
             ]
           }
         ],
-        "politePrefixes": [],
-        "politeSuffixes": []
+        "politePrefixes": [
+          "Could you please",
+          "Would you mind",
+          "If you don't mind",
+          "Please"
+        ],
+        "politeSuffixes": [
+          "Thank you!",
+          "Thanks!",
+          "Much appreciated!",
+          "If that's okay with you."
+        ]
       }
     },
     {
@@ -6759,7 +6922,7 @@
             "synonyms": [
               "Let's",
               "Shall we",
-              "How about"
+              "How do you feel about"
             ],
             "isOptional": true
           },
@@ -6772,18 +6935,18 @@
           },
           {
             "text": "'Murder Was the Case'",
-            "category": "album name",
+            "category": "album",
             "propertyNames": [
               "parameters.albumName"
             ]
           },
           {
-            "text": "soundtrack?",
+            "text": "soundtrack",
             "category": "filler",
             "synonyms": [
-              "album?",
-              "record?",
-              "music?"
+              "album",
+              "record",
+              "music"
             ],
             "isOptional": true
           }
@@ -6811,7 +6974,7 @@
               {
                 "propertyValue": "player.playArtist",
                 "propertySubPhrases": [
-                  "listen to some tracks by"
+                  "listen to some music by"
                 ]
               }
             ]
@@ -6845,12 +7008,16 @@
           }
         ],
         "politePrefixes": [
-          "Could you please",
-          "Would you mind"
+          "Could we please",
+          "Would you mind if we",
+          "May I suggest that we",
+          "If it's not too much trouble, could we"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it!"
+          "please?",
+          "if that's okay with you.",
+          "thank you.",
+          "if you don't mind."
         ]
       }
     },
@@ -6884,9 +7051,9 @@
             "text": "How about we",
             "category": "filler",
             "synonyms": [
-              "What if we",
+              "Let's",
               "Shall we",
-              "Let's"
+              "How about"
             ],
             "isOptional": true
           },
@@ -6902,8 +7069,8 @@
             "category": "preposition",
             "synonyms": [
               "from",
-              "of",
-              "featuring"
+              "featuring",
+              "with"
             ],
             "isOptional": true
           },
@@ -6913,16 +7080,6 @@
             "propertyNames": [
               "parameters.artist"
             ]
-          },
-          {
-            "text": "?",
-            "category": "punctuation",
-            "synonyms": [
-              ".",
-              "!",
-              ""
-            ],
-            "isOptional": true
           }
         ],
         "propertyAlternatives": [
@@ -6942,13 +7099,13 @@
               {
                 "propertyValue": "player.playAlbum",
                 "propertySubPhrases": [
-                  "play an album"
+                  "listen to an album"
                 ]
               },
               {
                 "propertyValue": "player.playPlaylist",
                 "propertySubPhrases": [
-                  "start a playlist"
+                  "listen to a playlist"
                 ]
               }
             ]
@@ -6983,11 +7140,15 @@
         ],
         "politePrefixes": [
           "Would you mind if",
-          "Could we please"
+          "Could we please",
+          "May I suggest",
+          "If it's not too much trouble,"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "If that's okay with you."
+          "please?",
+          "if you don't mind.",
+          "thank you.",
+          "if that's okay."
         ]
       }
     },
@@ -7011,9 +7172,9 @@
             "text": "How about we",
             "category": "filler",
             "synonyms": [
-              "What if we",
+              "Let's",
               "Shall we",
-              "Let's"
+              "Why don't we"
             ],
             "isOptional": true
           },
@@ -7034,27 +7195,27 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.playSong",
+                "propertyValue": "player.playSpecific",
                 "propertySubPhrases": [
-                  "play a song"
-                ]
-              },
-              {
-                "propertyValue": "player.playAlbum",
-                "propertySubPhrases": [
-                  "play an album"
+                  "listen to a specific song"
                 ]
               },
               {
                 "propertyValue": "player.playPlaylist",
                 "propertySubPhrases": [
-                  "play a playlist"
+                  "listen to a playlist"
+                ]
+              },
+              {
+                "propertyValue": "player.playGenre",
+                "propertySubPhrases": [
+                  "listen to some jazz music"
                 ]
               },
               {
                 "propertyValue": "player.playArtist",
                 "propertySubPhrases": [
-                  "play an artist"
+                  "listen to some music by The Beatles"
                 ]
               }
             ]
@@ -7062,11 +7223,15 @@
         ],
         "politePrefixes": [
           "Would you mind if",
-          "Could we please"
+          "Could we please",
+          "May I suggest",
+          "If it's not too much trouble"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "Please?"
+          "please?",
+          "if you don't mind.",
+          "thank you.",
+          "if that's okay."
         ]
       }
     },
@@ -7084,7 +7249,7 @@
             "name": "fullActionName",
             "value": "player.playArtist",
             "substrings": [
-              "could you please indulge me?"
+              "I do fancy a bit of Beethoven, could you please indulge me?"
             ]
           },
           {
@@ -7098,13 +7263,10 @@
         "subPhrases": [
           {
             "text": "I do fancy a bit of",
-            "category": "filler",
-            "synonyms": [
-              "I would like to hear",
-              "I want to listen to",
-              "I am in the mood for"
-            ],
-            "isOptional": true
+            "category": "request",
+            "propertyNames": [
+              "fullActionName"
+            ]
           },
           {
             "text": "Beethoven",
@@ -7117,14 +7279,41 @@
             "text": "could you please indulge me?",
             "category": "politeness",
             "synonyms": [
-              "would you mind playing it?",
-              "can you play it for me?",
-              "please play it for me"
+              "can you please help me?",
+              "would you mind?",
+              "could you assist me?"
             ],
             "isOptional": true
           }
         ],
         "propertyAlternatives": [
+          {
+            "propertyName": "fullActionName",
+            "propertyValue": "player.playArtist",
+            "propertySubPhrases": [
+              "I do fancy a bit of"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "player.playSong",
+                "propertySubPhrases": [
+                  "I would love to hear"
+                ]
+              },
+              {
+                "propertyValue": "player.playAlbum",
+                "propertySubPhrases": [
+                  "I am in the mood for"
+                ]
+              },
+              {
+                "propertyValue": "player.playGenre",
+                "propertySubPhrases": [
+                  "I feel like listening to some"
+                ]
+              }
+            ]
+          },
           {
             "propertyName": "parameters.artist",
             "propertyValue": "Beethoven",
@@ -7153,8 +7342,18 @@
             ]
           }
         ],
-        "politePrefixes": [],
-        "politeSuffixes": []
+        "politePrefixes": [
+          "If you don't mind,",
+          "Would you be so kind,",
+          "If it's not too much trouble,",
+          "When you have a moment,"
+        ],
+        "politeSuffixes": [
+          "Thank you!",
+          "Much appreciated!",
+          "Thanks a lot!",
+          "I would be grateful!"
+        ]
       }
     },
     {
@@ -7187,9 +7386,9 @@
             "text": "I should be most delighted if you could",
             "category": "politeness",
             "synonyms": [
-              "I would be very happy if you could",
-              "It would be wonderful if you could",
-              "I would appreciate it if you could"
+              "please",
+              "kindly",
+              "would you mind"
             ],
             "isOptional": true
           },
@@ -7204,9 +7403,9 @@
             "text": "some enchanting",
             "category": "filler",
             "synonyms": [
-              "some beautiful",
-              "some lovely",
-              "some wonderful"
+              "some",
+              "a bit of",
+              "a little"
             ],
             "isOptional": true
           },
@@ -7235,13 +7434,13 @@
               {
                 "propertyValue": "player.playAlbum",
                 "propertySubPhrases": [
-                  "give us"
+                  "provide us with"
                 ]
               },
               {
                 "propertyValue": "player.playPlaylist",
                 "propertySubPhrases": [
-                  "provide us with"
+                  "give us"
                 ]
               }
             ]
@@ -7254,15 +7453,15 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "Beethoven",
-                "propertySubPhrases": [
-                  "Beethoven"
-                ]
-              },
-              {
                 "propertyValue": "Mozart",
                 "propertySubPhrases": [
                   "Mozart"
+                ]
+              },
+              {
+                "propertyValue": "Beethoven",
+                "propertySubPhrases": [
+                  "Beethoven"
                 ]
               },
               {
@@ -7275,7 +7474,12 @@
           }
         ],
         "politePrefixes": [],
-        "politeSuffixes": []
+        "politeSuffixes": [
+          "Thank you very much.",
+          "I would greatly appreciate it.",
+          "If you could do this, it would be wonderful.",
+          "Your assistance is greatly valued."
+        ]
       }
     },
     {
@@ -7292,7 +7496,7 @@
             "name": "fullActionName",
             "value": "player.playArtist",
             "substrings": [
-              "regale us with"
+              "regale us with some splendid Vivaldi"
             ]
           },
           {
@@ -7315,21 +7519,11 @@
             "isOptional": true
           },
           {
-            "text": "regale us with",
+            "text": "regale us with some splendid",
             "category": "action",
             "propertyNames": [
               "fullActionName"
             ]
-          },
-          {
-            "text": "some splendid",
-            "category": "filler",
-            "synonyms": [
-              "some",
-              "a bit of",
-              "a little"
-            ],
-            "isOptional": true
           },
           {
             "text": "Vivaldi",
@@ -7344,25 +7538,25 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.playArtist",
             "propertySubPhrases": [
-              "regale us with"
+              "regale us with some splendid"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.playSong",
                 "propertySubPhrases": [
-                  "play us"
+                  "play a wonderful"
                 ]
               },
               {
                 "propertyValue": "player.playAlbum",
                 "propertySubPhrases": [
-                  "entertain us with"
+                  "play the amazing album"
                 ]
               },
               {
                 "propertyValue": "player.playPlaylist",
                 "propertySubPhrases": [
-                  "delight us with"
+                  "play the fantastic playlist"
                 ]
               }
             ]
@@ -7375,12 +7569,6 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "Bach",
-                "propertySubPhrases": [
-                  "Bach"
-                ]
-              },
-              {
                 "propertyValue": "Mozart",
                 "propertySubPhrases": [
                   "Mozart"
@@ -7391,12 +7579,23 @@
                 "propertySubPhrases": [
                   "Beethoven"
                 ]
+              },
+              {
+                "propertyValue": "Bach",
+                "propertySubPhrases": [
+                  "Bach"
+                ]
               }
             ]
           }
         ],
         "politePrefixes": [],
-        "politeSuffixes": []
+        "politeSuffixes": [
+          "Thank you very much.",
+          "I would appreciate it greatly.",
+          "Your assistance is much appreciated.",
+          "Kind regards."
+        ]
       }
     },
     {
@@ -7416,15 +7615,18 @@
         ],
         "subPhrases": [
           {
-            "text": "I want to hear",
-            "category": "request",
-            "propertyNames": [
-              "fullActionName"
-            ]
+            "text": "I want to",
+            "category": "politeness",
+            "synonyms": [
+              "I'd like to",
+              "I would like to",
+              "I wish to"
+            ],
+            "isOptional": true
           },
           {
-            "text": "some melodies",
-            "category": "content",
+            "text": "hear some melodies",
+            "category": "action",
             "propertyNames": [
               "fullActionName"
             ]
@@ -7435,36 +7637,25 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.playRandom",
             "propertySubPhrases": [
-              "I want to hear",
-              "some melodies"
+              "hear some melodies"
             ],
             "alternatives": [
               {
-                "propertyValue": "player.playSong",
+                "propertyValue": "player.playMusic",
                 "propertySubPhrases": [
-                  "I want to hear",
-                  "a song"
+                  "hear some music"
                 ]
               },
               {
-                "propertyValue": "player.playAlbum",
+                "propertyValue": "player.playSongs",
                 "propertySubPhrases": [
-                  "I want to hear",
-                  "an album"
+                  "hear some songs"
                 ]
               },
               {
-                "propertyValue": "player.playPlaylist",
+                "propertyValue": "player.playTunes",
                 "propertySubPhrases": [
-                  "I want to hear",
-                  "a playlist"
-                ]
-              },
-              {
-                "propertyValue": "player.playGenre",
-                "propertySubPhrases": [
-                  "I want to hear",
-                  "some jazz"
+                  "hear some tunes"
                 ]
               }
             ]
@@ -7473,12 +7664,14 @@
         "politePrefixes": [
           "Could you please",
           "Would you mind",
-          "If it's not too much trouble, could you"
+          "If it's not too much trouble,",
+          "May I kindly request"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it.",
-          "Thanks a lot!"
+          "thank you.",
+          "please.",
+          "if you don't mind.",
+          "I would appreciate it."
         ]
       }
     },
@@ -7514,7 +7707,7 @@
             "synonyms": [
               "please",
               "kindly",
-              "if you don't mind"
+              "would you mind"
             ],
             "isOptional": true
           },
@@ -7560,13 +7753,13 @@
               {
                 "propertyValue": "player.playAlbum",
                 "propertySubPhrases": [
-                  "play an album"
+                  "play album"
                 ]
               },
               {
                 "propertyValue": "player.playPlaylist",
                 "propertySubPhrases": [
-                  "play a playlist"
+                  "play playlist"
                 ]
               }
             ]
@@ -7600,7 +7793,12 @@
           }
         ],
         "politePrefixes": [],
-        "politeSuffixes": []
+        "politeSuffixes": [
+          "Thank you very much.",
+          "I appreciate your help.",
+          "Your assistance is greatly appreciated.",
+          "Thanks a lot."
+        ]
       }
     },
     {
@@ -7659,7 +7857,7 @@
             "synonyms": [
               "please",
               "if you don't mind",
-              "kindly"
+              "would you"
             ],
             "isOptional": true
           }
@@ -7721,7 +7919,12 @@
           }
         ],
         "politePrefixes": [],
-        "politeSuffixes": []
+        "politeSuffixes": [
+          "Thank you.",
+          "Please.",
+          "If you don't mind.",
+          "Whenever you have a moment."
+        ]
       }
     },
     {
@@ -7794,21 +7997,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.playSong",
+                "propertyValue": "player.pause",
                 "propertySubPhrases": [
-                  "play a song"
+                  "pause"
                 ]
               },
               {
-                "propertyValue": "player.playAlbum",
+                "propertyValue": "player.stop",
                 "propertySubPhrases": [
-                  "play an album"
+                  "stop"
                 ]
               },
               {
-                "propertyValue": "player.playPlaylist",
+                "propertyValue": "player.resume",
                 "propertySubPhrases": [
-                  "play a playlist"
+                  "resume"
                 ]
               }
             ]
@@ -7842,8 +8045,138 @@
           }
         ],
         "politePrefixes": [],
-        "politeSuffixes": []
-      }
+        "politeSuffixes": [
+          "Thank you.",
+          "Please.",
+          "If you don't mind.",
+          "Whenever you have a moment."
+        ]
+      },
+      "corrections": [
+        {
+          "data": {
+            "properties": [
+              {
+                "name": "fullActionName",
+                "value": "player.playArtist",
+                "substrings": [
+                  "play"
+                ]
+              },
+              {
+                "name": "parameters.artist",
+                "value": "Bach",
+                "substrings": [
+                  "Bach"
+                ]
+              }
+            ],
+            "subPhrases": [
+              {
+                "text": "I'd appreciate it if you could",
+                "category": "politeness",
+                "synonyms": [
+                  "please",
+                  "kindly",
+                  "would you mind"
+                ],
+                "isOptional": true
+              },
+              {
+                "text": "play",
+                "category": "action",
+                "propertyNames": [
+                  "fullActionName"
+                ]
+              },
+              {
+                "text": "some",
+                "category": "filler",
+                "synonyms": [
+                  "a bit of",
+                  "a little",
+                  "any"
+                ],
+                "isOptional": true
+              },
+              {
+                "text": "Bach",
+                "category": "artist",
+                "propertyNames": [
+                  "parameters.artist"
+                ]
+              }
+            ],
+            "propertyAlternatives": [
+              {
+                "propertyName": "fullActionName",
+                "propertyValue": "player.playArtist",
+                "propertySubPhrases": [
+                  "play"
+                ],
+                "alternatives": [
+                  {
+                    "propertyValue": "player.playSong",
+                    "propertySubPhrases": [
+                      "play",
+                      "some",
+                      "song"
+                    ]
+                  },
+                  {
+                    "propertyValue": "player.playAlbum",
+                    "propertySubPhrases": [
+                      "play",
+                      "some",
+                      "album"
+                    ]
+                  },
+                  {
+                    "propertyValue": "player.playPlaylist",
+                    "propertySubPhrases": [
+                      "play",
+                      "some",
+                      "playlist"
+                    ]
+                  }
+                ]
+              },
+              {
+                "propertyName": "parameters.artist",
+                "propertyValue": "Bach",
+                "propertySubPhrases": [
+                  "Bach"
+                ],
+                "alternatives": [
+                  {
+                    "propertyValue": "Mozart",
+                    "propertySubPhrases": [
+                      "Mozart"
+                    ]
+                  },
+                  {
+                    "propertyValue": "Beethoven",
+                    "propertySubPhrases": [
+                      "Beethoven"
+                    ]
+                  },
+                  {
+                    "propertyValue": "Chopin",
+                    "propertySubPhrases": [
+                      "Chopin"
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          "correction": [
+            "Mismatch number of sub-phrases: alternatives value 'player.playSong' for property 'fullActionName' must have 1 sub-phrases",
+            "Mismatch number of sub-phrases: alternatives value 'player.playAlbum' for property 'fullActionName' must have 1 sub-phrases",
+            "Mismatch number of sub-phrases: alternatives value 'player.playPlaylist' for property 'fullActionName' must have 1 sub-phrases"
+          ]
+        }
+      ]
     },
     {
       "request": "I'd like to hear some classical music, perhaps Beethoven's Symphony No. 9.",
@@ -7853,7 +8186,8 @@
           "trackName": "Symphony No. 9",
           "artists": [
             "Beethoven"
-          ]
+          ],
+          "albumName": "Classical Music"
         }
       },
       "explanation": {
@@ -7861,7 +8195,7 @@
           {
             "name": "fullActionName",
             "value": "player.playTrack",
-            "isImplicit": true
+            "substrings": []
           },
           {
             "name": "parameters.trackName",
@@ -7876,35 +8210,86 @@
             "substrings": [
               "Beethoven"
             ]
+          },
+          {
+            "name": "parameters.albumName",
+            "value": "Classical Music",
+            "substrings": [
+              "classical music"
+            ]
           }
         ],
         "subPhrases": [
           {
-            "text": "I'd like to hear some classical music, perhaps",
+            "text": "I'd like to hear",
+            "category": "politeness",
+            "synonyms": [
+              "I would like to listen to",
+              "I want to hear",
+              "I wish to listen to"
+            ],
+            "isOptional": true
+          },
+          {
+            "text": "some classical music",
+            "category": "input",
+            "propertyNames": [
+              "parameters.albumName"
+            ]
+          },
+          {
+            "text": "perhaps",
             "category": "filler",
             "synonyms": [
-              "I want to listen to some classical music",
-              "Can you play some classical music",
-              "Please play some classical music"
+              "maybe",
+              "possibly",
+              "potentially"
             ],
             "isOptional": true
           },
           {
             "text": "Beethoven's",
-            "category": "artist",
+            "category": "input",
             "propertyNames": [
               "parameters.artists.0"
             ]
           },
           {
             "text": "Symphony No. 9",
-            "category": "track",
+            "category": "input",
             "propertyNames": [
               "parameters.trackName"
             ]
           }
         ],
         "propertyAlternatives": [
+          {
+            "propertyName": "parameters.albumName",
+            "propertyValue": "Classical Music",
+            "propertySubPhrases": [
+              "some classical music"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "Baroque Music",
+                "propertySubPhrases": [
+                  "some baroque music"
+                ]
+              },
+              {
+                "propertyValue": "Romantic Music",
+                "propertySubPhrases": [
+                  "some romantic music"
+                ]
+              },
+              {
+                "propertyValue": "Modern Music",
+                "propertySubPhrases": [
+                  "some modern music"
+                ]
+              }
+            ]
+          },
           {
             "propertyName": "parameters.artists.0",
             "propertyValue": "Beethoven",
@@ -7946,15 +8331,15 @@
                 ]
               },
               {
-                "propertyValue": "Symphony No. 6",
+                "propertyValue": "Symphony No. 3",
                 "propertySubPhrases": [
-                  "Symphony No. 6"
+                  "Symphony No. 3"
                 ]
               },
               {
-                "propertyValue": "Symphony No. 7",
+                "propertyValue": "Symphony No. 6",
                 "propertySubPhrases": [
-                  "Symphony No. 7"
+                  "Symphony No. 6"
                 ]
               }
             ]
@@ -7962,11 +8347,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If it's not too much trouble",
+          "May I kindly request"
         ],
         "politeSuffixes": [
           "Thank you!",
-          "I would appreciate it."
+          "I would appreciate it.",
+          "Thanks in advance!",
+          "That would be wonderful."
         ]
       }
     },
@@ -7986,113 +8375,99 @@
           {
             "name": "fullActionName",
             "value": "player.playTrack",
-            "isImplicit": true
+            "substrings": [
+              "I'd like to listen to"
+            ]
           },
           {
             "name": "parameters.trackName",
             "value": "Hotel California",
             "substrings": [
-              "Hotel California"
+              "'Hotel California'"
             ]
           },
           {
             "name": "parameters.artists.0",
             "value": "Eagles",
             "substrings": [
-              "Eagles"
+              "by Eagles"
             ]
           }
         ],
         "subPhrases": [
           {
             "text": "I'd like to listen to",
-            "category": "politeness",
-            "synonyms": [
-              "I want to hear",
-              "Can you play",
-              "Please play"
-            ],
-            "isOptional": true
+            "category": "request",
+            "propertyNames": [
+              "fullActionName"
+            ]
           },
           {
-            "text": "'",
-            "category": "punctuation",
-            "synonyms": [
-              "\"",
-              "",
-              "“"
-            ],
-            "isOptional": true
-          },
-          {
-            "text": "Hotel California",
-            "category": "trackName",
+            "text": "'Hotel California'",
+            "category": "track",
             "propertyNames": [
               "parameters.trackName"
             ]
           },
           {
-            "text": "'",
-            "category": "punctuation",
-            "synonyms": [
-              "\"",
-              "",
-              "”"
-            ],
-            "isOptional": true
-          },
-          {
-            "text": "by",
-            "category": "preposition",
-            "synonyms": [
-              "from",
-              "performed by",
-              "sung by"
-            ],
-            "isOptional": true
-          },
-          {
-            "text": "Eagles",
-            "category": "artistName",
+            "text": "by Eagles",
+            "category": "artist",
             "propertyNames": [
               "parameters.artists.0"
             ]
-          },
-          {
-            "text": ".",
-            "category": "punctuation",
-            "synonyms": [
-              "",
-              "!",
-              "?"
-            ],
-            "isOptional": true
           }
         ],
         "propertyAlternatives": [
           {
+            "propertyName": "fullActionName",
+            "propertyValue": "player.playTrack",
+            "propertySubPhrases": [
+              "I'd like to listen to"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "player.queueTrack",
+                "propertySubPhrases": [
+                  "I'd like to add to the queue"
+                ]
+              },
+              {
+                "propertyValue": "player.playAlbum",
+                "propertySubPhrases": [
+                  "I'd like to listen to the album"
+                ]
+              },
+              {
+                "propertyValue": "player.playPlaylist",
+                "propertySubPhrases": [
+                  "I'd like to listen to the playlist"
+                ]
+              }
+            ]
+          },
+          {
             "propertyName": "parameters.trackName",
             "propertyValue": "Hotel California",
             "propertySubPhrases": [
-              "Hotel California"
+              "'Hotel California'"
             ],
             "alternatives": [
               {
                 "propertyValue": "Bohemian Rhapsody",
                 "propertySubPhrases": [
-                  "Bohemian Rhapsody"
+                  "'Bohemian Rhapsody'"
                 ]
               },
               {
                 "propertyValue": "Stairway to Heaven",
                 "propertySubPhrases": [
-                  "Stairway to Heaven"
+                  "'Stairway to Heaven'"
                 ]
               },
               {
                 "propertyValue": "Imagine",
                 "propertySubPhrases": [
-                  "Imagine"
+                  "'Imagine'"
                 ]
               }
             ]
@@ -8101,25 +8476,25 @@
             "propertyName": "parameters.artists.0",
             "propertyValue": "Eagles",
             "propertySubPhrases": [
-              "Eagles"
+              "by Eagles"
             ],
             "alternatives": [
               {
                 "propertyValue": "Queen",
                 "propertySubPhrases": [
-                  "Queen"
+                  "by Queen"
                 ]
               },
               {
                 "propertyValue": "Led Zeppelin",
                 "propertySubPhrases": [
-                  "Led Zeppelin"
+                  "by Led Zeppelin"
                 ]
               },
               {
                 "propertyValue": "John Lennon",
                 "propertySubPhrases": [
-                  "John Lennon"
+                  "by John Lennon"
                 ]
               }
             ]
@@ -8127,79 +8502,17 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If it's not too much trouble",
+          "May I kindly request"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it."
+          "thank you",
+          "please",
+          "if you don't mind",
+          "I'd appreciate it"
         ]
-      },
-      "corrections": [
-        {
-          "data": {
-            "properties": [
-              {
-                "name": "fullActionName",
-                "value": "player.playTrack",
-                "isImplicit": true
-              },
-              {
-                "name": "parameters.trackName",
-                "value": "Hotel California",
-                "substrings": [
-                  "Hotel California"
-                ]
-              },
-              {
-                "name": "parameters.artists.0",
-                "value": "Eagles",
-                "substrings": [
-                  "Eagles"
-                ]
-              }
-            ],
-            "subPhrases": [
-              {
-                "text": "I'd like to listen to",
-                "category": "politeness",
-                "synonyms": [
-                  "I want to hear",
-                  "Can you play",
-                  "Please play"
-                ],
-                "isOptional": true
-              },
-              {
-                "text": "Hotel California",
-                "category": "trackName",
-                "propertyNames": [
-                  "parameters.trackName"
-                ]
-              },
-              {
-                "text": "by",
-                "category": "preposition",
-                "synonyms": [
-                  "from",
-                  "performed by",
-                  "sung by"
-                ],
-                "isOptional": true
-              },
-              {
-                "text": "Eagles",
-                "category": "artistName",
-                "propertyNames": [
-                  "parameters.artists.0"
-                ]
-              }
-            ]
-          },
-          "correction": [
-            "Missing sub-phrase: explanation missing for '''"
-          ]
-        }
-      ]
+      }
     },
     {
       "request": "I'd like to listen to music now",
@@ -8211,7 +8524,9 @@
           {
             "name": "fullActionName",
             "value": "player.playRandom",
-            "isImplicit": true
+            "substrings": [
+              "listen to music"
+            ]
           }
         ],
         "subPhrases": [
@@ -8219,183 +8534,78 @@
             "text": "I'd like to",
             "category": "politeness",
             "synonyms": [
-              "I would like to",
-              "I want to",
-              "I wish to"
+              "please",
+              "could you",
+              "would you mind"
             ],
             "isOptional": true
           },
           {
             "text": "listen to music",
             "category": "action",
-            "propertyNames": []
+            "propertyNames": [
+              "fullActionName"
+            ]
           },
           {
             "text": "now",
             "category": "time",
             "synonyms": [
-              "right now",
               "immediately",
+              "right away",
               "at this moment"
             ],
             "isOptional": true
           }
         ],
-        "propertyAlternatives": [],
+        "propertyAlternatives": [
+          {
+            "propertyName": "fullActionName",
+            "propertyValue": "player.playRandom",
+            "propertySubPhrases": [
+              "listen to music"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "player.playSpecific",
+                "propertySubPhrases": [
+                  "play a specific song"
+                ]
+              },
+              {
+                "propertyValue": "player.pause",
+                "propertySubPhrases": [
+                  "pause the music"
+                ]
+              },
+              {
+                "propertyValue": "player.stop",
+                "propertySubPhrases": [
+                  "stop the music"
+                ]
+              },
+              {
+                "propertyValue": "player.next",
+                "propertySubPhrases": [
+                  "skip to the next song"
+                ]
+              }
+            ]
+          }
+        ],
         "politePrefixes": [
-          "Please",
-          "Could you"
+          "Could you please",
+          "Would you mind",
+          "If it's not too much trouble",
+          "May I kindly"
         ],
         "politeSuffixes": [
-          "Thank you",
-          "if you don't mind"
+          "if you don't mind",
+          "please",
+          "thank you",
+          "if that's okay"
         ]
-      },
-      "corrections": [
-        {
-          "data": {
-            "properties": [
-              {
-                "name": "fullActionName",
-                "value": "player.playRandom",
-                "isImplicit": true
-              }
-            ],
-            "subPhrases": [
-              {
-                "text": "I'd like to",
-                "category": "politeness",
-                "synonyms": [
-                  "I would like to",
-                  "I want to",
-                  "I wish to"
-                ],
-                "isOptional": true
-              },
-              {
-                "text": "listen to music",
-                "category": "action",
-                "propertyNames": [
-                  "fullActionName"
-                ]
-              },
-              {
-                "text": "now",
-                "category": "time",
-                "synonyms": [
-                  "right now",
-                  "immediately",
-                  "at this moment"
-                ],
-                "isOptional": true
-              }
-            ]
-          },
-          "correction": [
-            "Property 'fullActionName' is expected to be implicit and should not be included as a property name in a sub-phrase"
-          ]
-        },
-        {
-          "data": {
-            "properties": [
-              {
-                "name": "fullActionName",
-                "value": "player.playRandom",
-                "isImplicit": true
-              }
-            ],
-            "subPhrases": [
-              {
-                "text": "I'd like to",
-                "category": "politeness",
-                "synonyms": [
-                  "I would like to",
-                  "I want to",
-                  "I wish to"
-                ],
-                "isOptional": true
-              },
-              {
-                "text": "listen to music",
-                "category": "action",
-                "propertyNames": []
-              },
-              {
-                "text": "now",
-                "category": "time",
-                "synonyms": [
-                  "right now",
-                  "immediately",
-                  "at this moment"
-                ],
-                "isOptional": true
-              }
-            ],
-            "propertyAlternatives": [
-              {
-                "propertyName": "action",
-                "propertyValue": "listen to music",
-                "propertySubPhrases": [
-                  "listen to music"
-                ],
-                "alternatives": [
-                  {
-                    "propertyValue": "watch a movie",
-                    "propertySubPhrases": [
-                      "watch a movie"
-                    ]
-                  },
-                  {
-                    "propertyValue": "read a book",
-                    "propertySubPhrases": [
-                      "read a book"
-                    ]
-                  },
-                  {
-                    "propertyValue": "play a game",
-                    "propertySubPhrases": [
-                      "play a game"
-                    ]
-                  }
-                ]
-              },
-              {
-                "propertyName": "time",
-                "propertyValue": "now",
-                "propertySubPhrases": [
-                  "now"
-                ],
-                "alternatives": [
-                  {
-                    "propertyValue": "later",
-                    "propertySubPhrases": [
-                      "later"
-                    ]
-                  },
-                  {
-                    "propertyValue": "tomorrow",
-                    "propertySubPhrases": [
-                      "tomorrow"
-                    ]
-                  },
-                  {
-                    "propertyValue": "in an hour",
-                    "propertySubPhrases": [
-                      "in an hour"
-                    ]
-                  }
-                ]
-              }
-            ]
-          },
-          "correction": [
-            "Extraneous parameter: 'action' is not a parameter in the action",
-            "Implicit property shouldn't have alternatives",
-            "Extraneous parameter: 'time' is not a parameter in the action",
-            "Implicit property shouldn't have alternatives"
-          ]
-        }
-      ]
+      }
     },
     {
       "request": "I'd like to listen to some Bach, can you play his music?",
@@ -8410,7 +8620,9 @@
           {
             "name": "fullActionName",
             "value": "player.playArtist",
-            "isImplicit": true
+            "substrings": [
+              "can you play his music?"
+            ]
           },
           {
             "name": "parameters.artist",
@@ -8427,7 +8639,7 @@
             "synonyms": [
               "I would like to hear",
               "I want to listen to",
-              "Please play"
+              "I would enjoy listening to"
             ],
             "isOptional": true
           },
@@ -8440,13 +8652,10 @@
           },
           {
             "text": "can you play his music?",
-            "category": "confirmation",
-            "synonyms": [
-              "could you play his music?",
-              "will you play his music?",
-              "please play his music"
-            ],
-            "isOptional": true
+            "category": "action request",
+            "propertyNames": [
+              "fullActionName"
+            ]
           }
         ],
         "propertyAlternatives": [
@@ -8476,17 +8685,74 @@
                 ]
               }
             ]
+          },
+          {
+            "propertyName": "fullActionName",
+            "propertyValue": "player.playArtist",
+            "propertySubPhrases": [
+              "can you play his music?"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "player.playAlbum",
+                "propertySubPhrases": [
+                  "can you play his album?"
+                ]
+              },
+              {
+                "propertyValue": "player.playSong",
+                "propertySubPhrases": [
+                  "can you play his song?"
+                ]
+              },
+              {
+                "propertyValue": "player.playPlaylist",
+                "propertySubPhrases": [
+                  "can you play his playlist?"
+                ]
+              }
+            ]
           }
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If it's not too much trouble",
+          "I would appreciate it if you could"
         ],
         "politeSuffixes": [
           "Thank you!",
-          "I would appreciate it."
+          "Please.",
+          "If you don't mind.",
+          "Thanks a lot!"
         ]
-      }
+      },
+      "corrections": [
+        {
+          "data": {
+            "properties": [
+              {
+                "name": "fullActionName",
+                "value": "player.playArtist",
+                "substrings": [
+                  "can you play his music?"
+                ]
+              },
+              {
+                "name": "artist",
+                "value": "Bach",
+                "substrings": [
+                  "Bach"
+                ]
+              }
+            ]
+          },
+          "correction": [
+            "Extraneous parameter: 'artist' is not a parameter in the action",
+            "Missing parameter: parameter 'parameters.artist' in the action is missing from explanation"
+          ]
+        }
+      ]
     },
     {
       "request": "I'd like to listen to some Bach, can you play it?",
@@ -8501,7 +8767,9 @@
           {
             "name": "fullActionName",
             "value": "player.playArtist",
-            "isImplicit": true
+            "substrings": [
+              "can you play it?"
+            ]
           },
           {
             "name": "parameters.artist",
@@ -8531,13 +8799,10 @@
           },
           {
             "text": "can you play it?",
-            "category": "confirmation",
-            "synonyms": [
-              "could you play it?",
-              "would you play it?",
-              "can you start it?"
-            ],
-            "isOptional": true
+            "category": "request",
+            "propertyNames": [
+              "fullActionName"
+            ]
           }
         ],
         "propertyAlternatives": [
@@ -8567,15 +8832,46 @@
                 ]
               }
             ]
+          },
+          {
+            "propertyName": "fullActionName",
+            "propertyValue": "player.playArtist",
+            "propertySubPhrases": [
+              "can you play it?"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "player.playAlbum",
+                "propertySubPhrases": [
+                  "can you play the album?"
+                ]
+              },
+              {
+                "propertyValue": "player.playSong",
+                "propertySubPhrases": [
+                  "can you play the song?"
+                ]
+              },
+              {
+                "propertyValue": "player.playPlaylist",
+                "propertySubPhrases": [
+                  "can you play the playlist?"
+                ]
+              }
+            ]
           }
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If it's not too much trouble",
+          "May I kindly ask"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it."
+          "thank you",
+          "please",
+          "if you don't mind",
+          "I'd appreciate it"
         ]
       }
     },
@@ -8622,29 +8918,26 @@
             "isOptional": true
           },
           {
-            "text": "listen to some",
-            "category": "preposition",
-            "synonyms": [
-              "hear some",
-              "play some",
-              "enjoy some"
-            ],
-            "isOptional": true
+            "text": "listen to",
+            "category": "action",
+            "propertyNames": [
+              "fullActionName"
+            ]
           },
           {
-            "text": "jazz",
+            "text": "some jazz music",
             "category": "genre",
             "propertyNames": [
               "parameters.genre"
             ]
           },
           {
-            "text": "music, maybe something by",
-            "category": "filler",
+            "text": "maybe something by",
+            "category": "suggestion",
             "synonyms": [
-              "music, perhaps something by",
-              "music, possibly something by",
-              "music, potentially something by"
+              "perhaps something by",
+              "possibly something by",
+              "how about something by"
             ],
             "isOptional": true
           },
@@ -8658,28 +8951,55 @@
         ],
         "propertyAlternatives": [
           {
-            "propertyName": "parameters.genre",
-            "propertyValue": "jazz",
+            "propertyName": "fullActionName",
+            "propertyValue": "player.playArtist",
             "propertySubPhrases": [
-              "jazz"
+              "listen to"
             ],
             "alternatives": [
               {
-                "propertyValue": "blues",
+                "propertyValue": "player.playSong",
                 "propertySubPhrases": [
-                  "blues"
+                  "play a song"
                 ]
               },
               {
+                "propertyValue": "player.playAlbum",
+                "propertySubPhrases": [
+                  "play an album"
+                ]
+              },
+              {
+                "propertyValue": "player.playPlaylist",
+                "propertySubPhrases": [
+                  "play a playlist"
+                ]
+              }
+            ]
+          },
+          {
+            "propertyName": "parameters.genre",
+            "propertyValue": "jazz",
+            "propertySubPhrases": [
+              "some jazz music"
+            ],
+            "alternatives": [
+              {
                 "propertyValue": "rock",
                 "propertySubPhrases": [
-                  "rock"
+                  "some rock music"
                 ]
               },
               {
                 "propertyValue": "classical",
                 "propertySubPhrases": [
-                  "classical"
+                  "some classical music"
+                ]
+              },
+              {
+                "propertyValue": "pop",
+                "propertySubPhrases": [
+                  "some pop music"
                 ]
               }
             ]
@@ -8698,15 +9018,15 @@
                 ]
               },
               {
-                "propertyValue": "Duke Ellington",
-                "propertySubPhrases": [
-                  "Duke Ellington"
-                ]
-              },
-              {
                 "propertyValue": "Louis Armstrong",
                 "propertySubPhrases": [
                   "Louis Armstrong"
+                ]
+              },
+              {
+                "propertyValue": "Duke Ellington",
+                "propertySubPhrases": [
+                  "Duke Ellington"
                 ]
               }
             ]
@@ -8714,11 +9034,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If it's not too much trouble,",
+          "I would appreciate it if you could"
         ],
         "politeSuffixes": [
           "Thank you!",
-          "I would appreciate it."
+          "Thanks a lot!",
+          "I appreciate it!",
+          "If that's okay with you."
         ]
       }
     },
@@ -8750,11 +9074,11 @@
         "subPhrases": [
           {
             "text": "I'd love to hear some",
-            "category": "filler",
+            "category": "politeness",
             "synonyms": [
-              "I would like to listen to",
-              "I want to hear",
-              "I wish to listen to"
+              "I would like to hear",
+              "I want to listen to",
+              "I would enjoy hearing"
             ],
             "isOptional": true
           },
@@ -8839,8 +9163,18 @@
             ]
           }
         ],
-        "politePrefixes": [],
-        "politeSuffixes": []
+        "politePrefixes": [
+          "Could you please",
+          "Would you mind",
+          "If it's not too much trouble",
+          "I would appreciate it if you could"
+        ],
+        "politeSuffixes": [
+          "Thank you!",
+          "Please.",
+          "If you don't mind.",
+          "Thanks a lot!"
+        ]
       }
     },
     {
@@ -8871,11 +9205,11 @@
         "subPhrases": [
           {
             "text": "I'd love to hear some",
-            "category": "filler",
+            "category": "politeness",
             "synonyms": [
               "I would like to listen to",
               "I want to hear",
-              "I feel like listening to"
+              "I would enjoy hearing"
             ],
             "isOptional": true
           },
@@ -8888,7 +9222,7 @@
           },
           {
             "text": "can you play it?",
-            "category": "action request",
+            "category": "request",
             "propertyNames": [
               "fullActionName"
             ]
@@ -8952,11 +9286,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If it's not too much trouble",
+          "I would appreciate it if you could"
         ],
         "politeSuffixes": [
           "Thank you!",
-          "I appreciate it!"
+          "Please.",
+          "If you don't mind.",
+          "Thanks a lot!"
         ]
       }
     },
@@ -8974,7 +9312,7 @@
             "name": "fullActionName",
             "value": "player.playArtist",
             "substrings": [
-              "can you play"
+              "can you play some?"
             ]
           },
           {
@@ -8988,10 +9326,10 @@
         "subPhrases": [
           {
             "text": "I'd love to hear some",
-            "category": "filler",
+            "category": "politeness",
             "synonyms": [
-              "I would like to listen to",
-              "I want to hear",
+              "I would like to hear",
+              "I want to listen to",
               "I would enjoy hearing"
             ],
             "isOptional": true
@@ -9006,12 +9344,9 @@
           {
             "text": "can you play some?",
             "category": "request",
-            "synonyms": [
-              "could you play some?",
-              "would you play some?",
-              "can you put on some?"
-            ],
-            "isOptional": false
+            "propertyNames": [
+              "fullActionName"
+            ]
           }
         ],
         "propertyAlternatives": [
@@ -9041,10 +9376,47 @@
                 ]
               }
             ]
+          },
+          {
+            "propertyName": "fullActionName",
+            "propertyValue": "player.playArtist",
+            "propertySubPhrases": [
+              "can you play some?"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "player.playAlbum",
+                "propertySubPhrases": [
+                  "can you play an album?"
+                ]
+              },
+              {
+                "propertyValue": "player.playSong",
+                "propertySubPhrases": [
+                  "can you play a song?"
+                ]
+              },
+              {
+                "propertyValue": "player.playPlaylist",
+                "propertySubPhrases": [
+                  "can you play a playlist?"
+                ]
+              }
+            ]
           }
         ],
-        "politePrefixes": [],
-        "politeSuffixes": []
+        "politePrefixes": [
+          "Could you please",
+          "Would you mind",
+          "If it's not too much trouble",
+          "I would appreciate it if you could"
+        ],
+        "politeSuffixes": [
+          "Thank you!",
+          "Please.",
+          "If you don't mind.",
+          "Thanks a lot!"
+        ]
       }
     },
     {
@@ -9058,7 +9430,7 @@
             "name": "fullActionName",
             "value": "player.playRandom",
             "substrings": [
-              "hear some music"
+              "I'd love to hear some music"
             ]
           }
         ],
@@ -9096,15 +9468,15 @@
                 ]
               },
               {
-                "propertyValue": "player.pause",
+                "propertyValue": "player.playPlaylist",
                 "propertySubPhrases": [
-                  "pause the music"
+                  "play a playlist"
                 ]
               },
               {
-                "propertyValue": "player.stop",
+                "propertyValue": "player.playGenre",
                 "propertySubPhrases": [
-                  "stop the music"
+                  "play some jazz"
                 ]
               }
             ]
@@ -9112,11 +9484,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If it's not too much trouble",
+          "I would appreciate it if you could"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it."
+          "thank you",
+          "please",
+          "if you don't mind",
+          "thanks a lot"
         ]
       }
     },
@@ -9165,7 +9541,7 @@
           },
           {
             "text": "can you play that for me?",
-            "category": "action request",
+            "category": "request",
             "propertyNames": [
               "fullActionName"
             ]
@@ -9180,9 +9556,9 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "Bohemian Rhapsody",
+                "propertyValue": "Love Me Like You Do",
                 "propertySubPhrases": [
-                  "'Bohemian Rhapsody'"
+                  "'Love Me Like You Do'"
                 ]
               },
               {
@@ -9207,21 +9583,21 @@
             ],
             "alternatives": [
               {
+                "propertyValue": "player.queueTrack",
+                "propertySubPhrases": [
+                  "can you add that to the queue?"
+                ]
+              },
+              {
                 "propertyValue": "player.pauseTrack",
                 "propertySubPhrases": [
-                  "can you pause that for me?"
+                  "can you pause the music?"
                 ]
               },
               {
                 "propertyValue": "player.stopTrack",
                 "propertySubPhrases": [
-                  "can you stop that for me?"
-                ]
-              },
-              {
-                "propertyValue": "player.skipTrack",
-                "propertySubPhrases": [
-                  "can you skip that for me?"
+                  "can you stop the music?"
                 ]
               }
             ]
@@ -9229,11 +9605,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If it's not too much trouble",
+          "I would appreciate it if you could"
         ],
         "politeSuffixes": [
           "Thank you!",
-          "I would appreciate it!"
+          "Please.",
+          "If you don't mind.",
+          "Thanks a lot!"
         ]
       }
     },
@@ -9251,7 +9631,7 @@
             "name": "fullActionName",
             "value": "player.playArtist",
             "substrings": [
-              "can you play"
+              "can you play some?"
             ]
           },
           {
@@ -9283,12 +9663,9 @@
           {
             "text": "can you play some?",
             "category": "request",
-            "synonyms": [
-              "could you play some?",
-              "would you play some?",
-              "please play some?"
-            ],
-            "isOptional": false
+            "propertyNames": [
+              "fullActionName"
+            ]
           }
         ],
         "propertyAlternatives": [
@@ -9318,15 +9695,46 @@
                 ]
               }
             ]
+          },
+          {
+            "propertyName": "fullActionName",
+            "propertyValue": "player.playArtist",
+            "propertySubPhrases": [
+              "can you play some?"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "player.playAlbum",
+                "propertySubPhrases": [
+                  "can you play an album?"
+                ]
+              },
+              {
+                "propertyValue": "player.playSong",
+                "propertySubPhrases": [
+                  "can you play a song?"
+                ]
+              },
+              {
+                "propertyValue": "player.playPlaylist",
+                "propertySubPhrases": [
+                  "can you play a playlist?"
+                ]
+              }
+            ]
           }
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If it's not too much trouble",
+          "May I request"
         ],
         "politeSuffixes": [
           "Thank you!",
-          "I would appreciate it!"
+          "I would appreciate it.",
+          "If you don't mind.",
+          "Thanks a lot!"
         ]
       }
     },
@@ -9393,8 +9801,8 @@
             "category": "filler",
             "synonyms": [
               "a bit of",
-              "a little",
-              "any"
+              "any",
+              "a little"
             ],
             "isOptional": true
           },
@@ -9491,11 +9899,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If it's not too much trouble",
+          "I would appreciate it if you could"
         ],
         "politeSuffixes": [
           "Thank you!",
-          "I would appreciate it!"
+          "Please.",
+          "If you don't mind.",
+          "Thanks a lot!"
         ]
       }
     },
@@ -9529,9 +9941,9 @@
             "text": "It ain't a party without some",
             "category": "filler",
             "synonyms": [
-              "It's not a celebration without",
               "No party is complete without",
-              "We can't have a party without"
+              "A party isn't the same without",
+              "We need"
             ],
             "isOptional": true
           },
@@ -9543,7 +9955,17 @@
             ]
           },
           {
-            "text": "so let's get it started!",
+            "text": "so",
+            "category": "preposition",
+            "synonyms": [
+              "therefore",
+              "thus",
+              "hence"
+            ],
+            "isOptional": true
+          },
+          {
+            "text": "let's get it started",
             "category": "fullActionName",
             "propertyNames": [
               "fullActionName"
@@ -9565,9 +9987,9 @@
                 ]
               },
               {
-                "propertyValue": "Nuthin' but a 'G' Thang",
+                "propertyValue": "Nuthin' But a 'G' Thang",
                 "propertySubPhrases": [
-                  "'Nuthin' but a 'G' Thang'"
+                  "'Nuthin' But a 'G' Thang'"
                 ]
               },
               {
@@ -9582,25 +10004,25 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.playTrack",
             "propertySubPhrases": [
-              "so let's get it started!"
+              "let's get it started"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.queueTrack",
                 "propertySubPhrases": [
-                  "so let's queue it up!"
-                ]
-              },
-              {
-                "propertyValue": "player.addTrackToPlaylist",
-                "propertySubPhrases": [
-                  "so let's add it to the playlist!"
+                  "add it to the queue"
                 ]
               },
               {
                 "propertyValue": "player.shufflePlay",
                 "propertySubPhrases": [
-                  "so let's shuffle things up!"
+                  "shuffle the playlist"
+                ]
+              },
+              {
+                "propertyValue": "player.repeatTrack",
+                "propertySubPhrases": [
+                  "put it on repeat"
                 ]
               }
             ]
@@ -9608,11 +10030,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If you don't mind",
+          "Please"
         ],
         "politeSuffixes": [
           "Thank you!",
-          "I would appreciate it!"
+          "Thanks!",
+          "I appreciate it!",
+          "Much appreciated!"
         ]
       }
     },
@@ -9655,8 +10081,8 @@
             "category": "punctuation",
             "synonyms": [
               "\"",
-              "",
-              "“"
+              "“",
+              "‘"
             ],
             "isOptional": true
           },
@@ -9672,18 +10098,18 @@
             "category": "punctuation",
             "synonyms": [
               "\"",
-              "",
-              "”"
+              "”",
+              "’"
             ],
             "isOptional": true
           },
           {
             "text": "ya feel me?",
-            "category": "filler",
+            "category": "confirmation",
             "synonyms": [
               "you know?",
               "right?",
-              "do you understand?"
+              "you get me?"
             ],
             "isOptional": true
           }
@@ -9713,6 +10139,12 @@
                 "propertySubPhrases": [
                   "Blinding Lights"
                 ]
+              },
+              {
+                "propertyValue": "Rolling in the Deep",
+                "propertySubPhrases": [
+                  "Rolling in the Deep"
+                ]
               }
             ]
           }
@@ -9720,14 +10152,14 @@
         "politePrefixes": [
           "Could you please",
           "Would you mind",
-          "If it's not too much trouble,",
-          "May I kindly ask"
+          "If you don't mind",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it.",
-          "Thanks a lot!",
-          "Much appreciated!"
+          "thank you",
+          "if that's okay",
+          "please",
+          "thanks"
         ]
       },
       "corrections": [
@@ -9767,11 +10199,11 @@
               },
               {
                 "text": "ya feel me?",
-                "category": "filler",
+                "category": "confirmation",
                 "synonyms": [
                   "you know?",
                   "right?",
-                  "do you understand?"
+                  "you get me?"
                 ],
                 "isOptional": true
               }
@@ -9810,58 +10242,54 @@
         ],
         "subPhrases": [
           {
-            "text": "Let's get this place smokin' with some",
-            "category": "action",
-            "propertyNames": [
-              "fullActionName"
-            ]
+            "text": "Let's",
+            "category": "politeness",
+            "synonyms": [
+              "Please",
+              "Kindly",
+              "Would you"
+            ],
+            "isOptional": true
+          },
+          {
+            "text": "get this place smokin'",
+            "category": "filler",
+            "synonyms": [
+              "make it lively",
+              "energize the atmosphere",
+              "get the party started"
+            ],
+            "isOptional": true
+          },
+          {
+            "text": "with some",
+            "category": "preposition",
+            "synonyms": [
+              "using",
+              "featuring",
+              "including"
+            ],
+            "isOptional": true
           },
           {
             "text": "'Vato'",
-            "category": "track name",
+            "category": "trackName",
             "propertyNames": [
               "parameters.trackName"
             ]
           },
           {
             "text": "ya dig?",
-            "category": "filler",
+            "category": "confirmation",
             "synonyms": [
-              "you know?",
-              "right?",
-              "got it?"
+              "you understand?",
+              "got it?",
+              "okay?"
             ],
             "isOptional": true
           }
         ],
         "propertyAlternatives": [
-          {
-            "propertyName": "fullActionName",
-            "propertyValue": "player.playTrack",
-            "propertySubPhrases": [
-              "Let's get this place smokin' with some"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "player.startMusic",
-                "propertySubPhrases": [
-                  "Let's start the party with some"
-                ]
-              },
-              {
-                "propertyValue": "player.queueTrack",
-                "propertySubPhrases": [
-                  "Let's queue up some"
-                ]
-              },
-              {
-                "propertyValue": "player.playSong",
-                "propertySubPhrases": [
-                  "Let's play some"
-                ]
-              }
-            ]
-          },
           {
             "propertyName": "parameters.trackName",
             "propertyValue": "Vato",
@@ -9891,40 +10319,18 @@
           }
         ],
         "politePrefixes": [
-          "Please",
-          "Kindly"
+          "Could you please",
+          "Would you mind",
+          "If you don't mind",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you",
-          "Much appreciated"
+          "thank you",
+          "if that's okay",
+          "please",
+          "thanks"
         ]
-      },
-      "corrections": [
-        {
-          "data": {
-            "properties": [
-              {
-                "name": "fullActionName",
-                "value": "player.playTrack",
-                "substrings": [
-                  "Let's get this place smokin' with some 'Vato', ya dig?"
-                ]
-              },
-              {
-                "name": "trackName",
-                "value": "Vato",
-                "substrings": [
-                  "'Vato'"
-                ]
-              }
-            ]
-          },
-          "correction": [
-            "Extraneous parameter: 'trackName' is not a parameter in the action",
-            "Missing parameter: parameter 'parameters.trackName' in the action is missing from explanation"
-          ]
-        }
-      ]
+      }
     },
     {
       "request": "Let's groove to some Snoop Dogg tunes!",
@@ -9940,7 +10346,7 @@
             "name": "fullActionName",
             "value": "player.playArtist",
             "substrings": [
-              "Let's groove to"
+              "Let's groove to some Snoop Dogg tunes!"
             ]
           },
           {
@@ -9953,19 +10359,22 @@
         ],
         "subPhrases": [
           {
-            "text": "Let's groove to",
-            "category": "command",
-            "propertyNames": [
-              "fullActionName"
-            ]
+            "text": "Let's",
+            "category": "politeness",
+            "synonyms": [
+              "Please",
+              "Kindly",
+              "Would you mind"
+            ],
+            "isOptional": true
           },
           {
-            "text": "some",
+            "text": "groove to some",
             "category": "filler",
             "synonyms": [
-              "a few",
-              "several",
-              "a couple"
+              "listen to",
+              "play",
+              "enjoy"
             ],
             "isOptional": true
           },
@@ -9981,40 +10390,13 @@
             "category": "filler",
             "synonyms": [
               "songs",
-              "tracks",
-              "music"
+              "music",
+              "tracks"
             ],
             "isOptional": true
           }
         ],
         "propertyAlternatives": [
-          {
-            "propertyName": "fullActionName",
-            "propertyValue": "player.playArtist",
-            "propertySubPhrases": [
-              "Let's groove to"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "player.playSong",
-                "propertySubPhrases": [
-                  "Let's listen to"
-                ]
-              },
-              {
-                "propertyValue": "player.playAlbum",
-                "propertySubPhrases": [
-                  "Let's enjoy"
-                ]
-              },
-              {
-                "propertyValue": "player.playPlaylist",
-                "propertySubPhrases": [
-                  "Let's vibe to"
-                ]
-              }
-            ]
-          },
           {
             "propertyName": "parameters.artist",
             "propertyValue": "Snoop Dogg",
@@ -10035,6 +10417,12 @@
                 ]
               },
               {
+                "propertyValue": "Ice Cube",
+                "propertySubPhrases": [
+                  "Ice Cube"
+                ]
+              },
+              {
                 "propertyValue": "Kendrick Lamar",
                 "propertySubPhrases": [
                   "Kendrick Lamar"
@@ -10044,12 +10432,16 @@
           }
         ],
         "politePrefixes": [
-          "Could you please",
-          "Would you mind"
+          "Please",
+          "Could you",
+          "Would you mind",
+          "Kindly"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it!"
+          "thank you",
+          "please",
+          "if you don't mind",
+          "if that's okay"
         ]
       }
     },
@@ -10070,7 +10462,7 @@
             "name": "fullActionName",
             "value": "player.playTrack",
             "substrings": [
-              "Let's hear"
+              "Let's hear some Snoop Dogg's 'Drop It Like It's Hot'!"
             ]
           },
           {
@@ -10090,19 +10482,12 @@
         ],
         "subPhrases": [
           {
-            "text": "Let's hear",
-            "category": "command",
-            "propertyNames": [
-              "fullActionName"
-            ]
-          },
-          {
-            "text": "some",
-            "category": "filler",
+            "text": "Let's hear some",
+            "category": "politeness",
             "synonyms": [
-              "a bit of",
-              "a little",
-              "some of"
+              "Please play",
+              "Can you play",
+              "I would like to hear"
             ],
             "isOptional": true
           },
@@ -10115,50 +10500,23 @@
           },
           {
             "text": "'s",
-            "category": "possessive",
+            "category": "preposition",
             "synonyms": [
-              "of",
               "by",
-              "from"
+              "from",
+              "featuring"
             ],
             "isOptional": true
           },
           {
             "text": "'Drop It Like It's Hot'",
-            "category": "track",
+            "category": "trackName",
             "propertyNames": [
               "parameters.trackName"
             ]
           }
         ],
         "propertyAlternatives": [
-          {
-            "propertyName": "fullActionName",
-            "propertyValue": "player.playTrack",
-            "propertySubPhrases": [
-              "Let's hear"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "player.queueTrack",
-                "propertySubPhrases": [
-                  "Queue up"
-                ]
-              },
-              {
-                "propertyValue": "player.addTrackToPlaylist",
-                "propertySubPhrases": [
-                  "Add"
-                ]
-              },
-              {
-                "propertyValue": "player.shufflePlay",
-                "propertySubPhrases": [
-                  "Shuffle"
-                ]
-              }
-            ]
-          },
           {
             "propertyName": "parameters.artists.0",
             "propertyValue": "Snoop Dogg",
@@ -10179,9 +10537,9 @@
                 ]
               },
               {
-                "propertyValue": "Kendrick Lamar",
+                "propertyValue": "Ice Cube",
                 "propertySubPhrases": [
-                  "Kendrick Lamar"
+                  "Ice Cube"
                 ]
               }
             ]
@@ -10200,9 +10558,9 @@
                 ]
               },
               {
-                "propertyValue": "Nuthin' but a 'G' Thang",
+                "propertyValue": "Nuthin' But a 'G' Thang",
                 "propertySubPhrases": [
-                  "'Nuthin' but a 'G' Thang'"
+                  "'Nuthin' But a 'G' Thang'"
                 ]
               },
               {
@@ -10217,12 +10575,14 @@
         "politePrefixes": [
           "Could you please",
           "Would you mind",
-          "If it's not too much trouble, could you"
+          "If it's not too much trouble,",
+          "May I request"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it!",
-          "Thanks a lot!"
+          "thank you!",
+          "please.",
+          "if you don't mind.",
+          "thanks!"
         ]
       },
       "corrections": [
@@ -10233,7 +10593,7 @@
                 "name": "fullActionName",
                 "value": "player.playTrack",
                 "substrings": [
-                  "Let's hear"
+                  "Let's hear some Snoop Dogg's 'Drop It Like It's Hot'!"
                 ]
               },
               {
@@ -10253,19 +10613,12 @@
             ],
             "subPhrases": [
               {
-                "text": "Let's hear",
-                "category": "command",
-                "propertyNames": [
-                  "fullActionName"
-                ]
-              },
-              {
-                "text": "some",
-                "category": "filler",
+                "text": "Let's hear some",
+                "category": "politeness",
                 "synonyms": [
-                  "a bit of",
-                  "a little",
-                  "some of"
+                  "Please play",
+                  "Can you play",
+                  "I would like to hear"
                 ],
                 "isOptional": true
               },
@@ -10278,7 +10631,7 @@
               },
               {
                 "text": "'Drop It Like It's Hot'",
-                "category": "track",
+                "category": "trackName",
                 "propertyNames": [
                   "parameters.trackName"
                 ]
@@ -10305,7 +10658,7 @@
             "name": "fullActionName",
             "value": "player.playArtist",
             "substrings": [
-              "Let's listen to"
+              "Let's listen to some Bach, shall we?"
             ]
           },
           {
@@ -10318,21 +10671,21 @@
         ],
         "subPhrases": [
           {
-            "text": "Let's listen to",
-            "category": "command",
+            "text": "Let's",
+            "category": "politeness",
+            "synonyms": [
+              "Please",
+              "Kindly",
+              "Would you mind"
+            ],
+            "isOptional": true
+          },
+          {
+            "text": "listen to some",
+            "category": "action",
             "propertyNames": [
               "fullActionName"
             ]
-          },
-          {
-            "text": "some",
-            "category": "filler",
-            "synonyms": [
-              "a bit of",
-              "a little",
-              "some"
-            ],
-            "isOptional": true
           },
           {
             "text": "Bach",
@@ -10347,7 +10700,7 @@
             "synonyms": [
               "okay?",
               "alright?",
-              "right?"
+              "if you don't mind"
             ],
             "isOptional": true
           }
@@ -10357,25 +10710,25 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.playArtist",
             "propertySubPhrases": [
-              "Let's listen to"
+              "listen to some"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.playSong",
                 "propertySubPhrases": [
-                  "Let's listen to a song by"
+                  "listen to a song by"
                 ]
               },
               {
                 "propertyValue": "player.playAlbum",
                 "propertySubPhrases": [
-                  "Let's listen to an album by"
+                  "listen to an album by"
                 ]
               },
               {
                 "propertyValue": "player.playPlaylist",
                 "propertySubPhrases": [
-                  "Let's listen to a playlist by"
+                  "listen to a playlist by"
                 ]
               }
             ]
@@ -10408,8 +10761,18 @@
             ]
           }
         ],
-        "politePrefixes": [],
-        "politeSuffixes": []
+        "politePrefixes": [
+          "Would you mind if",
+          "Could we please",
+          "If it's not too much trouble,",
+          "I would appreciate it if"
+        ],
+        "politeSuffixes": [
+          "please?",
+          "thank you.",
+          "if you don't mind.",
+          "thanks!"
+        ]
       }
     },
     {
@@ -10433,8 +10796,8 @@
             "category": "politeness",
             "synonyms": [
               "Let us",
-              "We should",
-              "How about we"
+              "Please",
+              "Would you mind"
             ],
             "isOptional": true
           },
@@ -10451,7 +10814,7 @@
             "synonyms": [
               "okay?",
               "alright?",
-              "right?"
+              "if you agree"
             ],
             "isOptional": true
           }
@@ -10465,21 +10828,9 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.play",
+                "propertyValue": "player.playSpecific",
                 "propertySubPhrases": [
-                  "play some music"
-                ]
-              },
-              {
-                "propertyValue": "player.shuffle",
-                "propertySubPhrases": [
-                  "shuffle the music"
-                ]
-              },
-              {
-                "propertyValue": "player.startRadio",
-                "propertySubPhrases": [
-                  "start the radio"
+                  "play a specific song"
                 ]
               },
               {
@@ -10487,12 +10838,34 @@
                 "propertySubPhrases": [
                   "play a playlist"
                 ]
+              },
+              {
+                "propertyValue": "player.playGenre",
+                "propertySubPhrases": [
+                  "play some jazz"
+                ]
+              },
+              {
+                "propertyValue": "player.playArtist",
+                "propertySubPhrases": [
+                  "play some Beatles"
+                ]
               }
             ]
           }
         ],
-        "politePrefixes": [],
-        "politeSuffixes": []
+        "politePrefixes": [
+          "Would you mind if",
+          "Could we please",
+          "If it's not too much trouble,",
+          "May I suggest"
+        ],
+        "politeSuffixes": [
+          "please?",
+          "if you don't mind?",
+          "thank you.",
+          "if that's okay with you."
+        ]
       }
     },
     {
@@ -10506,7 +10879,8 @@
             "name": "fullActionName",
             "value": "player.playRandom",
             "substrings": [
-              "Let's listen to some tunes"
+              "listen",
+              "tunes"
             ]
           }
         ],
@@ -10515,15 +10889,33 @@
             "text": "Let's",
             "category": "politeness",
             "synonyms": [
-              "Let us",
-              "Let's go",
-              "How about we"
+              "please",
+              "let us",
+              "kindly",
+              "would you mind"
             ],
             "isOptional": true
           },
           {
-            "text": "listen to some tunes",
+            "text": "listen",
             "category": "action",
+            "propertyNames": [
+              "fullActionName"
+            ]
+          },
+          {
+            "text": "to some",
+            "category": "preposition",
+            "synonyms": [
+              "to a few",
+              "to several",
+              "to"
+            ],
+            "isOptional": true
+          },
+          {
+            "text": "tunes",
+            "category": "object",
             "propertyNames": [
               "fullActionName"
             ]
@@ -10534,35 +10926,45 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.playRandom",
             "propertySubPhrases": [
-              "listen to some tunes"
+              "listen",
+              "tunes"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.playMusic",
                 "propertySubPhrases": [
-                  "play some music"
-                ]
-              },
-              {
-                "propertyValue": "player.shuffle",
-                "propertySubPhrases": [
-                  "shuffle the playlist"
+                  "listen",
+                  "music"
                 ]
               },
               {
                 "propertyValue": "player.playSongs",
                 "propertySubPhrases": [
-                  "play some songs"
+                  "listen",
+                  "songs"
+                ]
+              },
+              {
+                "propertyValue": "player.playTracks",
+                "propertySubPhrases": [
+                  "listen",
+                  "tracks"
                 ]
               }
             ]
           }
         ],
         "politePrefixes": [
-          "Please"
+          "Could we please",
+          "Would you mind if we",
+          "May we",
+          "I would appreciate if we could"
         ],
         "politeSuffixes": [
-          "Thank you"
+          "if that's okay with you.",
+          "please.",
+          "if you don't mind.",
+          "thank you."
         ]
       }
     },
@@ -10579,57 +10981,59 @@
           {
             "name": "fullActionName",
             "value": "player.playTrack",
-            "isImplicit": true
+            "substrings": [
+              "Let's take it back to the old school with some 'Murder Was the Case', homie."
+            ]
           },
           {
             "name": "parameters.trackName",
             "value": "Murder Was the Case",
             "substrings": [
-              "Murder Was the Case"
+              "'Murder Was the Case'"
             ]
           }
         ],
         "subPhrases": [
           {
-            "text": "Let's take it back to the old school with some",
+            "text": "Let's",
+            "category": "politeness",
+            "synonyms": [
+              "Please",
+              "Kindly",
+              "Would you mind"
+            ],
+            "isOptional": true
+          },
+          {
+            "text": "take it back to the old school",
             "category": "filler",
             "synonyms": [
-              "Let's go back to the classics with",
-              "How about we play some",
-              "Let's rewind to the old days with"
+              "reminisce",
+              "go back in time",
+              "remember the past"
             ],
             "isOptional": true
           },
           {
-            "text": "'",
-            "category": "punctuation",
+            "text": "with some",
+            "category": "preposition",
             "synonyms": [
-              "\"",
-              "",
-              "“"
+              "featuring",
+              "including",
+              "along with"
             ],
             "isOptional": true
           },
           {
-            "text": "Murder Was the Case",
+            "text": "'Murder Was the Case'",
             "category": "trackName",
             "propertyNames": [
               "parameters.trackName"
             ]
           },
           {
-            "text": "'",
-            "category": "punctuation",
-            "synonyms": [
-              "\"",
-              "",
-              "”"
-            ],
-            "isOptional": true
-          },
-          {
             "text": "homie",
-            "category": "filler",
+            "category": "acknowledgement",
             "synonyms": [
               "buddy",
               "friend",
@@ -10643,25 +11047,31 @@
             "propertyName": "parameters.trackName",
             "propertyValue": "Murder Was the Case",
             "propertySubPhrases": [
-              "Murder Was the Case"
+              "'Murder Was the Case'"
             ],
             "alternatives": [
               {
-                "propertyValue": "Nuthin' but a 'G' Thang",
-                "propertySubPhrases": [
-                  "Nuthin' but a 'G' Thang"
-                ]
-              },
-              {
                 "propertyValue": "Gin and Juice",
                 "propertySubPhrases": [
-                  "Gin and Juice"
+                  "'Gin and Juice'"
                 ]
               },
               {
-                "propertyValue": "Who Am I (What's My Name)?",
+                "propertyValue": "Nuthin' But a 'G' Thang",
                 "propertySubPhrases": [
-                  "Who Am I (What's My Name)?"
+                  "'Nuthin' But a 'G' Thang'"
+                ]
+              },
+              {
+                "propertyValue": "California Love",
+                "propertySubPhrases": [
+                  "'California Love'"
+                ]
+              },
+              {
+                "propertyValue": "Regulate",
+                "propertySubPhrases": [
+                  "'Regulate'"
                 ]
               }
             ]
@@ -10670,90 +11080,16 @@
         "politePrefixes": [
           "Could you please",
           "Would you mind",
-          "If it's not too much trouble,",
-          "Kindly"
+          "If you don't mind",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you.",
-          "I would appreciate it.",
-          "Thanks a lot.",
-          "Much appreciated."
+          "thank you",
+          "if that's okay",
+          "please",
+          "thanks"
         ]
-      },
-      "corrections": [
-        {
-          "data": {
-            "properties": [
-              {
-                "name": "fullActionName",
-                "value": "player.playTrack",
-                "isImplicit": true
-              },
-              {
-                "name": "trackName",
-                "value": "Murder Was the Case",
-                "substrings": [
-                  "Murder Was the Case"
-                ]
-              }
-            ]
-          },
-          "correction": [
-            "Extraneous parameter: 'trackName' is not a parameter in the action",
-            "Missing parameter: parameter 'parameters.trackName' in the action is missing from explanation"
-          ]
-        },
-        {
-          "data": {
-            "properties": [
-              {
-                "name": "fullActionName",
-                "value": "player.playTrack",
-                "isImplicit": true
-              },
-              {
-                "name": "parameters.trackName",
-                "value": "Murder Was the Case",
-                "substrings": [
-                  "Murder Was the Case"
-                ]
-              }
-            ],
-            "subPhrases": [
-              {
-                "text": "Let's take it back to the old school with some",
-                "category": "filler",
-                "synonyms": [
-                  "Let's go back to the classics with",
-                  "How about we play some",
-                  "Let's rewind to the old days with"
-                ],
-                "isOptional": true
-              },
-              {
-                "text": "Murder Was the Case",
-                "category": "trackName",
-                "propertyNames": [
-                  "parameters.trackName"
-                ]
-              },
-              {
-                "text": "homie",
-                "category": "filler",
-                "synonyms": [
-                  "buddy",
-                  "friend",
-                  "pal"
-                ],
-                "isOptional": true
-              }
-            ]
-          },
-          "correction": [
-            "Missing sub-phrase: explanation missing for '''"
-          ]
-        }
-      ]
+      }
     },
     {
       "request": "Let's take it back to the old school with some 'Who Am I (What's My Name)?'",
@@ -10769,7 +11105,7 @@
             "name": "fullActionName",
             "value": "player.playTrack",
             "substrings": [
-              "Let's take it back to the old school with some 'Who Am I (What's My Name)?'"
+              "Let's take it back to the old school with some"
             ]
           },
           {
@@ -10783,14 +11119,14 @@
         "subPhrases": [
           {
             "text": "Let's take it back to the old school with some",
-            "category": "context",
+            "category": "action",
             "propertyNames": [
               "fullActionName"
             ]
           },
           {
             "text": "'Who Am I (What's My Name)?'",
-            "category": "trackName",
+            "category": "track",
             "propertyNames": [
               "parameters.trackName"
             ]
@@ -10805,21 +11141,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.queueTrack",
-                "propertySubPhrases": [
-                  "Add to the queue some"
-                ]
-              },
-              {
                 "propertyValue": "player.pauseTrack",
                 "propertySubPhrases": [
-                  "Pause the track"
+                  "Let's take a break from the old school with some"
                 ]
               },
               {
                 "propertyValue": "player.stopTrack",
                 "propertySubPhrases": [
-                  "Stop playing"
+                  "Let's stop the old school vibes with some"
+                ]
+              },
+              {
+                "propertyValue": "player.skipTrack",
+                "propertySubPhrases": [
+                  "Let's skip the old school with some"
                 ]
               }
             ]
@@ -10832,15 +11168,15 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "Nuthin' But a 'G' Thang",
-                "propertySubPhrases": [
-                  "'Nuthin' But a 'G' Thang'"
-                ]
-              },
-              {
                 "propertyValue": "Gin and Juice",
                 "propertySubPhrases": [
                   "'Gin and Juice'"
+                ]
+              },
+              {
+                "propertyValue": "Nuthin' But a 'G' Thang",
+                "propertySubPhrases": [
+                  "'Nuthin' But a 'G' Thang'"
                 ]
               },
               {
@@ -10854,39 +11190,17 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If it's not too much trouble,",
+          "I would appreciate it if you could"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it!"
+          "thank you.",
+          "please.",
+          "if you don't mind.",
+          "thanks a lot."
         ]
-      },
-      "corrections": [
-        {
-          "data": {
-            "properties": [
-              {
-                "name": "fullActionName",
-                "value": "player.playTrack",
-                "substrings": [
-                  "Let's take it back to the old school with some 'Who Am I (What's My Name)?'"
-                ]
-              },
-              {
-                "name": "trackName",
-                "value": "Who Am I (What's My Name)?",
-                "substrings": [
-                  "'Who Am I (What's My Name)?'"
-                ]
-              }
-            ]
-          },
-          "correction": [
-            "Extraneous parameter: 'trackName' is not a parameter in the action",
-            "Missing parameter: parameter 'parameters.trackName' in the action is missing from explanation"
-          ]
-        }
-      ]
+      }
     },
     {
       "request": "Might I request the pleasure of listening to some exquisite Bach?",
@@ -10902,7 +11216,7 @@
             "name": "fullActionName",
             "value": "player.playArtist",
             "substrings": [
-              "Might I request the pleasure of listening to"
+              "request the pleasure of listening"
             ]
           },
           {
@@ -10915,22 +11229,29 @@
         ],
         "subPhrases": [
           {
-            "text": "Might I request the pleasure of listening to",
+            "text": "Might I",
             "category": "politeness",
             "synonyms": [
-              "Could I please listen to",
-              "I would like to hear",
-              "Please play"
+              "Could I",
+              "May I",
+              "Would I"
             ],
             "isOptional": true
           },
           {
-            "text": "some exquisite",
+            "text": "request the pleasure of listening",
+            "category": "action",
+            "propertyNames": [
+              "fullActionName"
+            ]
+          },
+          {
+            "text": "to some exquisite",
             "category": "filler",
             "synonyms": [
-              "some",
-              "a bit of",
-              "a little"
+              "to some",
+              "to",
+              "some"
             ],
             "isOptional": true
           },
@@ -10943,6 +11264,33 @@
           }
         ],
         "propertyAlternatives": [
+          {
+            "propertyName": "fullActionName",
+            "propertyValue": "player.playArtist",
+            "propertySubPhrases": [
+              "request the pleasure of listening"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "player.playSong",
+                "propertySubPhrases": [
+                  "request the pleasure of hearing"
+                ]
+              },
+              {
+                "propertyValue": "player.playAlbum",
+                "propertySubPhrases": [
+                  "request the pleasure of enjoying"
+                ]
+              },
+              {
+                "propertyValue": "player.playPlaylist",
+                "propertySubPhrases": [
+                  "request the pleasure of experiencing"
+                ]
+              }
+            ]
+          },
           {
             "propertyName": "parameters.artist",
             "propertyValue": "Bach",
@@ -10972,7 +11320,12 @@
           }
         ],
         "politePrefixes": [],
-        "politeSuffixes": []
+        "politeSuffixes": [
+          "if it pleases you.",
+          "if you would be so kind.",
+          "if it is not too much trouble.",
+          "if you don't mind."
+        ]
       }
     },
     {
@@ -10980,7 +11333,8 @@
       "action": {
         "fullActionName": "player.playGenre",
         "parameters": {
-          "genre": "jazz"
+          "genre": "jazz",
+          "quantity": 1
         }
       },
       "explanation": {
@@ -10998,6 +11352,11 @@
             "substrings": [
               "jazz"
             ]
+          },
+          {
+            "name": "parameters.quantity",
+            "value": 1,
+            "isImplicit": true
           }
         ],
         "subPhrases": [
@@ -11009,12 +11368,22 @@
             ]
           },
           {
-            "text": "some relaxing",
+            "text": "some",
             "category": "filler",
             "synonyms": [
               "a bit of",
-              "some",
-              "a little"
+              "a little",
+              "some amount of"
+            ],
+            "isOptional": true
+          },
+          {
+            "text": "relaxing",
+            "category": "filler",
+            "synonyms": [
+              "calming",
+              "soothing",
+              "peaceful"
             ],
             "isOptional": true
           },
@@ -11045,19 +11414,19 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.pause",
+                "propertyValue": "player.pauseGenre",
                 "propertySubPhrases": [
                   "Pause"
                 ]
               },
               {
-                "propertyValue": "player.stop",
+                "propertyValue": "player.stopGenre",
                 "propertySubPhrases": [
                   "Stop"
                 ]
               },
               {
-                "propertyValue": "player.resume",
+                "propertyValue": "player.resumeGenre",
                 "propertySubPhrases": [
                   "Resume"
                 ]
@@ -11072,15 +11441,15 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "classical",
-                "propertySubPhrases": [
-                  "classical"
-                ]
-              },
-              {
                 "propertyValue": "rock",
                 "propertySubPhrases": [
                   "rock"
+                ]
+              },
+              {
+                "propertyValue": "classical",
+                "propertySubPhrases": [
+                  "classical"
                 ]
               },
               {
@@ -11094,11 +11463,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If it's not too much trouble,",
+          "I would appreciate it if you could"
         ],
         "politeSuffixes": [
-          "Thank you",
-          "I would appreciate it"
+          "thank you.",
+          "please.",
+          "if you don't mind.",
+          "thanks a lot."
         ]
       }
     },
@@ -11148,7 +11521,7 @@
             "synonyms": [
               "kindly",
               "if you don't mind",
-              "if you please"
+              "would you mind"
             ],
             "isOptional": true
           }
@@ -11164,19 +11537,19 @@
               {
                 "propertyValue": "player.playAlbum",
                 "propertySubPhrases": [
-                  "Play the album by"
+                  "Play an album by"
                 ]
               },
               {
                 "propertyValue": "player.playPlaylist",
                 "propertySubPhrases": [
-                  "Play the playlist by"
+                  "Play a playlist by"
                 ]
               },
               {
                 "propertyValue": "player.playTrack",
                 "propertySubPhrases": [
-                  "Play the track by"
+                  "Play a track by"
                 ]
               }
             ]
@@ -11209,8 +11582,18 @@
             ]
           }
         ],
-        "politePrefixes": [],
-        "politeSuffixes": []
+        "politePrefixes": [
+          "Could you",
+          "Would you mind",
+          "May I ask you to",
+          "If you don't mind"
+        ],
+        "politeSuffixes": [
+          "thank you",
+          "if that's okay",
+          "if you could",
+          "I would appreciate it"
+        ]
       }
     },
     {
@@ -11258,16 +11641,16 @@
             "synonyms": [
               "a few",
               "several",
-              "a couple of"
+              "a number of"
             ],
             "isOptional": true
           },
           {
             "text": "soothing",
-            "category": "filler",
+            "category": "adjective",
             "synonyms": [
-              "relaxing",
               "calming",
+              "relaxing",
               "peaceful"
             ],
             "isOptional": true
@@ -11281,13 +11664,135 @@
           },
           {
             "text": "songs",
-            "category": "filler",
+            "category": "noun",
             "synonyms": [
               "tracks",
               "tunes",
               "melodies"
             ],
             "isOptional": true
+          }
+        ],
+        "propertyAlternatives": [
+          {
+            "propertyName": "fullActionName",
+            "propertyValue": "player.playGenre",
+            "propertySubPhrases": [
+              "Play"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "player.playArtist",
+                "propertySubPhrases": [
+                  "Play"
+                ]
+              },
+              {
+                "propertyValue": "player.playAlbum",
+                "propertySubPhrases": [
+                  "Play"
+                ]
+              },
+              {
+                "propertyValue": "player.playPlaylist",
+                "propertySubPhrases": [
+                  "Play"
+                ]
+              }
+            ]
+          },
+          {
+            "propertyName": "parameters.genre",
+            "propertyValue": "acoustic guitar",
+            "propertySubPhrases": [
+              "acoustic guitar"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "classical",
+                "propertySubPhrases": [
+                  "classical"
+                ]
+              },
+              {
+                "propertyValue": "jazz",
+                "propertySubPhrases": [
+                  "jazz"
+                ]
+              },
+              {
+                "propertyValue": "blues",
+                "propertySubPhrases": [
+                  "blues"
+                ]
+              }
+            ]
+          }
+        ],
+        "politePrefixes": [
+          "Could you please",
+          "Would you mind",
+          "I would appreciate it if you could",
+          "Please"
+        ],
+        "politeSuffixes": [
+          "if possible.",
+          "thank you.",
+          "please.",
+          "when you have a moment."
+        ]
+      }
+    },
+    {
+      "request": "Play the best of 90s alternative rock",
+      "action": {
+        "fullActionName": "player.playGenre",
+        "parameters": {
+          "genre": "90s alternative rock"
+        }
+      },
+      "explanation": {
+        "properties": [
+          {
+            "name": "fullActionName",
+            "value": "player.playGenre",
+            "substrings": [
+              "Play"
+            ]
+          },
+          {
+            "name": "parameters.genre",
+            "value": "90s alternative rock",
+            "substrings": [
+              "90s alternative rock"
+            ]
+          }
+        ],
+        "subPhrases": [
+          {
+            "text": "Play",
+            "category": "action",
+            "propertyNames": [
+              "fullActionName"
+            ]
+          },
+          {
+            "text": "the best of",
+            "category": "filler",
+            "synonyms": [
+              "top",
+              "greatest",
+              "most popular",
+              "best"
+            ],
+            "isOptional": true
+          },
+          {
+            "text": "90s alternative rock",
+            "category": "genre",
+            "propertyNames": [
+              "parameters.genre"
+            ]
           }
         ],
         "propertyAlternatives": [
@@ -11320,123 +11825,6 @@
           },
           {
             "propertyName": "parameters.genre",
-            "propertyValue": "acoustic guitar",
-            "propertySubPhrases": [
-              "acoustic guitar"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "classical",
-                "propertySubPhrases": [
-                  "classical"
-                ]
-              },
-              {
-                "propertyValue": "jazz",
-                "propertySubPhrases": [
-                  "jazz"
-                ]
-              },
-              {
-                "propertyValue": "rock",
-                "propertySubPhrases": [
-                  "rock"
-                ]
-              }
-            ]
-          }
-        ],
-        "politePrefixes": [
-          "Could you please",
-          "Would you mind"
-        ],
-        "politeSuffixes": [
-          "Thank you",
-          "I would appreciate it"
-        ]
-      }
-    },
-    {
-      "request": "Play the best of 90s alternative rock",
-      "action": {
-        "fullActionName": "player.playGenre",
-        "parameters": {
-          "genre": "90s alternative rock"
-        }
-      },
-      "explanation": {
-        "properties": [
-          {
-            "name": "fullActionName",
-            "value": "player.playGenre",
-            "substrings": [
-              "Play"
-            ]
-          },
-          {
-            "name": "parameters.genre",
-            "value": "90s alternative rock",
-            "substrings": [
-              "90s alternative rock"
-            ]
-          }
-        ],
-        "subPhrases": [
-          {
-            "text": "Play",
-            "category": "command",
-            "propertyNames": [
-              "fullActionName"
-            ]
-          },
-          {
-            "text": "the best of",
-            "category": "filler",
-            "synonyms": [
-              "some",
-              "a selection of",
-              "a mix of"
-            ],
-            "isOptional": true
-          },
-          {
-            "text": "90s alternative rock",
-            "category": "genre",
-            "propertyNames": [
-              "parameters.genre"
-            ]
-          }
-        ],
-        "propertyAlternatives": [
-          {
-            "propertyName": "fullActionName",
-            "propertyValue": "player.playGenre",
-            "propertySubPhrases": [
-              "Play"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "player.playSong",
-                "propertySubPhrases": [
-                  "Play a song"
-                ]
-              },
-              {
-                "propertyValue": "player.playAlbum",
-                "propertySubPhrases": [
-                  "Play an album"
-                ]
-              },
-              {
-                "propertyValue": "player.playPlaylist",
-                "propertySubPhrases": [
-                  "Play a playlist"
-                ]
-              }
-            ]
-          },
-          {
-            "propertyName": "parameters.genre",
             "propertyValue": "90s alternative rock",
             "propertySubPhrases": [
               "90s alternative rock"
@@ -11455,9 +11843,9 @@
                 ]
               },
               {
-                "propertyValue": "modern indie",
+                "propertyValue": "jazz",
                 "propertySubPhrases": [
-                  "modern indie"
+                  "jazz"
                 ]
               }
             ]
@@ -11466,14 +11854,14 @@
         "politePrefixes": [
           "Could you please",
           "Would you mind",
-          "If it's not too much trouble,",
+          "If you don't mind",
           "I would appreciate it if you could"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "Thanks a lot!",
-          "I appreciate it!",
-          "That would be great!"
+          "thank you",
+          "please",
+          "if that's okay",
+          "if you could"
         ]
       }
     },
@@ -11508,7 +11896,7 @@
             "name": "parameters.artists.0",
             "value": "Queen",
             "substrings": [
-              "by Queen"
+              "Queen"
             ]
           }
         ],
@@ -11522,14 +11910,14 @@
           },
           {
             "text": "'Bohemian Rhapsody'",
-            "category": "trackName",
+            "category": "track name",
             "propertyNames": [
               "parameters.trackName"
             ]
           },
           {
             "text": "by Queen",
-            "category": "artist",
+            "category": "artist name",
             "propertyNames": [
               "parameters.artists.0"
             ]
@@ -11544,21 +11932,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.pauseTrack",
+                "propertyValue": "player.startTrack",
                 "propertySubPhrases": [
-                  "Pause the song"
+                  "Start the song"
                 ]
               },
               {
-                "propertyValue": "player.stopTrack",
+                "propertyValue": "player.queueTrack",
                 "propertySubPhrases": [
-                  "Stop the song"
+                  "Queue the song"
                 ]
               },
               {
-                "propertyValue": "player.resumeTrack",
+                "propertyValue": "player.playMusic",
                 "propertySubPhrases": [
-                  "Resume the song"
+                  "Play the music"
                 ]
               }
             ]
@@ -11571,21 +11959,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "Stairway to Heaven",
+                "propertyValue": "We Will Rock You",
                 "propertySubPhrases": [
-                  "'Stairway to Heaven'"
+                  "'We Will Rock You'"
                 ]
               },
               {
-                "propertyValue": "Hotel California",
+                "propertyValue": "Another One Bites the Dust",
                 "propertySubPhrases": [
-                  "'Hotel California'"
+                  "'Another One Bites the Dust'"
                 ]
               },
               {
-                "propertyValue": "Imagine",
+                "propertyValue": "Radio Ga Ga",
                 "propertySubPhrases": [
-                  "'Imagine'"
+                  "'Radio Ga Ga'"
                 ]
               }
             ]
@@ -11598,21 +11986,21 @@
             ],
             "alternatives": [
               {
+                "propertyValue": "The Beatles",
+                "propertySubPhrases": [
+                  "by The Beatles"
+                ]
+              },
+              {
                 "propertyValue": "Led Zeppelin",
                 "propertySubPhrases": [
                   "by Led Zeppelin"
                 ]
               },
               {
-                "propertyValue": "The Eagles",
+                "propertyValue": "Pink Floyd",
                 "propertySubPhrases": [
-                  "by The Eagles"
-                ]
-              },
-              {
-                "propertyValue": "John Lennon",
-                "propertySubPhrases": [
-                  "by John Lennon"
+                  "by Pink Floyd"
                 ]
               }
             ]
@@ -11621,14 +12009,14 @@
         "politePrefixes": [
           "Could you please",
           "Would you mind",
-          "If it's not too much trouble, could you",
-          "May I kindly ask you to"
+          "I would appreciate it if you could",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it!",
-          "Thanks a lot!",
-          "That would be great!"
+          "thank you",
+          "if that's okay",
+          "please",
+          "thanks"
         ]
       }
     },
@@ -11675,7 +12063,7 @@
           },
           {
             "text": "the",
-            "category": "filler",
+            "category": "preposition",
             "synonyms": [
               "a",
               "an",
@@ -11699,11 +12087,11 @@
           },
           {
             "text": "tracks",
-            "category": "filler",
+            "category": "object",
             "synonyms": [
               "songs",
-              "tunes",
-              "music"
+              "music",
+              "tunes"
             ],
             "isOptional": true
           }
@@ -11717,21 +12105,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.pause",
+                "propertyValue": "player.pauseGenre",
                 "propertySubPhrases": [
                   "Pause"
                 ]
               },
               {
-                "propertyValue": "player.stop",
+                "propertyValue": "player.stopGenre",
                 "propertySubPhrases": [
                   "Stop"
                 ]
               },
               {
-                "propertyValue": "player.skip",
+                "propertyValue": "player.resumeGenre",
                 "propertySubPhrases": [
-                  "Skip"
+                  "Resume"
                 ]
               }
             ]
@@ -11793,11 +12181,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "I would appreciate it if you could",
+          "If it's not too much trouble, could you"
         ],
         "politeSuffixes": [
-          "Thank you",
-          "I appreciate it"
+          "thank you",
+          "please",
+          "if you don't mind",
+          "thanks a lot"
         ]
       }
     },
@@ -11817,22 +12209,20 @@
           {
             "name": "fullActionName",
             "value": "player.playTrack",
-            "substrings": [
-              "Please play"
-            ]
+            "isImplicit": true
           },
           {
             "name": "parameters.trackName",
             "value": "Imagine",
             "substrings": [
-              "'Imagine'"
+              "Imagine"
             ]
           },
           {
             "name": "parameters.artists.0",
             "value": "John Lennon",
             "substrings": [
-              "by John Lennon"
+              "John Lennon"
             ]
           }
         ],
@@ -11842,17 +12232,15 @@
             "category": "politeness",
             "synonyms": [
               "Kindly",
-              "Could you",
-              "Would you"
+              "Would you mind",
+              "Could you"
             ],
             "isOptional": true
           },
           {
             "text": "play",
             "category": "action",
-            "propertyNames": [
-              "fullActionName"
-            ]
+            "propertyNames": []
           },
           {
             "text": "'Imagine'",
@@ -11862,7 +12250,17 @@
             ]
           },
           {
-            "text": "by John Lennon",
+            "text": "by",
+            "category": "preposition",
+            "synonyms": [
+              "from",
+              "performed by",
+              "sung by"
+            ],
+            "isOptional": true
+          },
+          {
+            "text": "John Lennon",
             "category": "artist",
             "propertyNames": [
               "parameters.artists.0"
@@ -11870,33 +12268,6 @@
           }
         ],
         "propertyAlternatives": [
-          {
-            "propertyName": "fullActionName",
-            "propertyValue": "player.playTrack",
-            "propertySubPhrases": [
-              "play"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "player.pauseTrack",
-                "propertySubPhrases": [
-                  "pause"
-                ]
-              },
-              {
-                "propertyValue": "player.stopTrack",
-                "propertySubPhrases": [
-                  "stop"
-                ]
-              },
-              {
-                "propertyValue": "player.resumeTrack",
-                "propertySubPhrases": [
-                  "resume"
-                ]
-              }
-            ]
-          },
           {
             "propertyName": "parameters.trackName",
             "propertyValue": "Imagine",
@@ -11928,33 +12299,116 @@
             "propertyName": "parameters.artists.0",
             "propertyValue": "John Lennon",
             "propertySubPhrases": [
-              "by John Lennon"
+              "John Lennon"
             ],
             "alternatives": [
               {
-                "propertyValue": "The Beatles",
+                "propertyValue": "Paul McCartney",
                 "propertySubPhrases": [
-                  "by The Beatles"
+                  "Paul McCartney"
                 ]
               },
               {
-                "propertyValue": "Queen",
+                "propertyValue": "Freddie Mercury",
                 "propertySubPhrases": [
-                  "by Queen"
+                  "Freddie Mercury"
                 ]
               },
               {
-                "propertyValue": "Eagles",
+                "propertyValue": "Elton John",
                 "propertySubPhrases": [
-                  "by Eagles"
+                  "Elton John"
                 ]
               }
             ]
           }
         ],
-        "politePrefixes": [],
-        "politeSuffixes": []
-      }
+        "politePrefixes": [
+          "Could you kindly",
+          "Would you mind",
+          "If it's not too much trouble",
+          "I would appreciate it if you could"
+        ],
+        "politeSuffixes": [
+          "Thank you!",
+          "Thanks a lot!",
+          "I appreciate it!",
+          "Much appreciated!"
+        ]
+      },
+      "corrections": [
+        {
+          "data": {
+            "properties": [
+              {
+                "name": "fullActionName",
+                "value": "player.playTrack",
+                "isImplicit": true
+              },
+              {
+                "name": "parameters.trackName",
+                "value": "Imagine",
+                "substrings": [
+                  "Imagine"
+                ]
+              },
+              {
+                "name": "parameters.artists.0",
+                "value": "John Lennon",
+                "substrings": [
+                  "John Lennon"
+                ]
+              }
+            ],
+            "subPhrases": [
+              {
+                "text": "Please",
+                "category": "politeness",
+                "synonyms": [
+                  "Kindly",
+                  "Would you mind",
+                  "Could you"
+                ],
+                "isOptional": true
+              },
+              {
+                "text": "play",
+                "category": "action",
+                "propertyNames": [
+                  "fullActionName"
+                ]
+              },
+              {
+                "text": "'Imagine'",
+                "category": "trackName",
+                "propertyNames": [
+                  "parameters.trackName"
+                ]
+              },
+              {
+                "text": "by",
+                "category": "preposition",
+                "synonyms": [
+                  "from",
+                  "performed by",
+                  "sung by"
+                ],
+                "isOptional": true
+              },
+              {
+                "text": "John Lennon",
+                "category": "artist",
+                "propertyNames": [
+                  "parameters.artists.0"
+                ]
+              }
+            ]
+          },
+          "correction": [
+            "Property 'fullActionName' is expected to be implicit and should not be included as a property name in a sub-phrase"
+          ]
+        }
+      ]
     },
     {
       "request": "Please play a few tracks",
@@ -11976,7 +12430,9 @@
           {
             "name": "parameters.quantity",
             "value": 3,
-            "isImplicit": true
+            "substrings": [
+              "a few"
+            ]
           }
         ],
         "subPhrases": [
@@ -11986,7 +12442,7 @@
             "synonyms": [
               "Kindly",
               "Would you mind",
-              "Could you please"
+              "Could you"
             ],
             "isOptional": true
           },
@@ -11998,9 +12454,20 @@
             ]
           },
           {
-            "text": "a few tracks",
+            "text": "a few",
             "category": "quantity",
-            "synonyms": [],
+            "propertyNames": [
+              "parameters.quantity"
+            ]
+          },
+          {
+            "text": "tracks",
+            "category": "object",
+            "synonyms": [
+              "songs",
+              "music",
+              "tunes"
+            ],
             "isOptional": false
           }
         ],
@@ -12031,60 +12498,48 @@
                 ]
               }
             ]
-          }
-        ],
-        "politePrefixes": [],
-        "politeSuffixes": []
-      },
-      "corrections": [
-        {
-          "data": {
-            "properties": [
-              {
-                "name": "fullActionName",
-                "value": "player.playRandom",
-                "substrings": [
-                  "play"
-                ]
-              },
-              {
-                "name": "parameters.quantity",
-                "value": 3,
-                "isImplicit": true
-              }
+          },
+          {
+            "propertyName": "parameters.quantity",
+            "propertyValue": 3,
+            "propertySubPhrases": [
+              "a few"
             ],
-            "subPhrases": [
+            "alternatives": [
               {
-                "text": "Please",
-                "category": "politeness",
-                "synonyms": [
-                  "Kindly",
-                  "Would you mind",
-                  "Could you please"
-                ],
-                "isOptional": true
-              },
-              {
-                "text": "play",
-                "category": "action",
-                "propertyNames": [
-                  "fullActionName"
+                "propertyValue": 1,
+                "propertySubPhrases": [
+                  "one"
                 ]
               },
               {
-                "text": "a few tracks",
-                "category": "quantity",
-                "propertyNames": [
-                  "parameters.quantity"
+                "propertyValue": 5,
+                "propertySubPhrases": [
+                  "several"
+                ]
+              },
+              {
+                "propertyValue": 10,
+                "propertySubPhrases": [
+                  "many"
                 ]
               }
             ]
-          },
-          "correction": [
-            "Property 'parameters.quantity' is expected to be implicit and should not be included as a property name in a sub-phrase"
-          ]
-        }
-      ]
+          }
+        ],
+        "politePrefixes": [
+          "Could you kindly",
+          "Would you mind",
+          "If it's not too much trouble",
+          "I would appreciate it if you could"
+        ],
+        "politeSuffixes": [
+          "Thank you!",
+          "Thanks a lot!",
+          "Much appreciated!",
+          "Cheers!"
+        ]
+      }
     },
     {
       "request": "Please play some Bach masterpieces for me, bot.",
@@ -12117,8 +12572,8 @@
             "category": "politeness",
             "synonyms": [
               "Kindly",
-              "Would you",
-              "Could you"
+              "Would you mind",
+              "Could you please"
             ],
             "isOptional": true
           },
@@ -12131,18 +12586,19 @@
           },
           {
             "text": "some Bach masterpieces",
-            "category": "content",
+            "category": "object",
             "propertyNames": [
               "parameters.artist"
             ]
           },
           {
             "text": "for me, bot.",
-            "category": "acknowledgement",
+            "category": "filler",
             "synonyms": [
-              "for me, assistant.",
-              "for me, AI.",
-              "for me, please."
+              "for me",
+              "bot",
+              "please",
+              "if you can"
             ],
             "isOptional": true
           }
@@ -12203,8 +12659,18 @@
             ]
           }
         ],
-        "politePrefixes": [],
-        "politeSuffixes": []
+        "politePrefixes": [
+          "Could you kindly",
+          "Would you mind",
+          "If you don't mind",
+          "I would appreciate it if you could"
+        ],
+        "politeSuffixes": [
+          "Thank you!",
+          "I appreciate it!",
+          "Thanks a lot!",
+          "Much appreciated!"
+        ]
       }
     },
     {
@@ -12238,8 +12704,8 @@
             "category": "politeness",
             "synonyms": [
               "Kindly",
-              "Would you",
-              "Could you"
+              "Could you",
+              "Would you mind"
             ],
             "isOptional": true
           },
@@ -12314,8 +12780,18 @@
             ]
           }
         ],
-        "politePrefixes": [],
-        "politeSuffixes": []
+        "politePrefixes": [
+          "Could you kindly",
+          "Would you mind",
+          "If it's not too much trouble",
+          "I would appreciate it if you could"
+        ],
+        "politeSuffixes": [
+          "Thank you!",
+          "Thanks a lot!",
+          "I appreciate it!",
+          "Much appreciated!"
+        ]
       }
     },
     {
@@ -12349,8 +12825,8 @@
             "category": "politeness",
             "synonyms": [
               "Kindly",
-              "Would you mind",
-              "Could you please"
+              "Could you",
+              "Would you mind"
             ],
             "isOptional": true
           },
@@ -12367,20 +12843,20 @@
             "synonyms": [
               "of the",
               "out of the",
-              "from"
+              "off the"
             ],
             "isOptional": true
           },
           {
             "text": "'Guardians of the Galaxy'",
-            "category": "albumName",
+            "category": "album",
             "propertyNames": [
               "parameters.albumName"
             ]
           },
           {
             "text": "soundtrack",
-            "category": "filler",
+            "category": "context",
             "synonyms": [
               "album",
               "record",
@@ -12425,28 +12901,38 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "The Beatles",
+                "propertyValue": "The Greatest Showman",
                 "propertySubPhrases": [
-                  "'The Beatles'"
+                  "'The Greatest Showman'"
                 ]
               },
               {
-                "propertyValue": "Thriller",
+                "propertyValue": "Frozen",
                 "propertySubPhrases": [
-                  "'Thriller'"
+                  "'Frozen'"
                 ]
               },
               {
-                "propertyValue": "Back in Black",
+                "propertyValue": "Hamilton",
                 "propertySubPhrases": [
-                  "'Back in Black'"
+                  "'Hamilton'"
                 ]
               }
             ]
           }
         ],
-        "politePrefixes": [],
-        "politeSuffixes": []
+        "politePrefixes": [
+          "Could you kindly",
+          "Would you mind",
+          "If it's not too much trouble",
+          "I would appreciate it if you could"
+        ],
+        "politeSuffixes": [
+          "Thank you!",
+          "Thanks a lot!",
+          "I appreciate it!",
+          "Much appreciated!"
+        ]
       }
     },
     {
@@ -12454,7 +12940,8 @@
       "action": {
         "fullActionName": "player.playGenre",
         "parameters": {
-          "genre": "rock"
+          "genre": "rock",
+          "quantity": 10
         }
       },
       "explanation": {
@@ -12472,6 +12959,11 @@
             "substrings": [
               "rock"
             ]
+          },
+          {
+            "name": "parameters.quantity",
+            "value": 10,
+            "isImplicit": true
           }
         ],
         "subPhrases": [
@@ -12483,12 +12975,22 @@
             ]
           },
           {
-            "text": "some energetic",
+            "text": "some",
             "category": "filler",
             "synonyms": [
+              "a few",
               "a bit of",
-              "some lively",
-              "a few"
+              "any"
+            ],
+            "isOptional": true
+          },
+          {
+            "text": "energetic",
+            "category": "descriptor",
+            "synonyms": [
+              "lively",
+              "dynamic",
+              "vigorous"
             ],
             "isOptional": true
           },
@@ -12519,21 +13021,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.playSong",
+                "propertyValue": "player.playMood",
                 "propertySubPhrases": [
                   "Play"
                 ]
               },
               {
-                "propertyValue": "player.playAlbum",
+                "propertyValue": "player.playArtist",
                 "propertySubPhrases": [
-                  "Put on the album"
+                  "Play some"
                 ]
               },
               {
                 "propertyValue": "player.playPlaylist",
                 "propertySubPhrases": [
-                  "Start the playlist"
+                  "Put on a"
                 ]
               }
             ]
@@ -12568,11 +13070,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "I would appreciate it if you could",
+          "Please"
         ],
         "politeSuffixes": [
           "Thank you",
-          "Thanks a lot"
+          "Thanks",
+          "If you don't mind",
+          "I appreciate it"
         ]
       }
     },
@@ -12615,7 +13121,7 @@
             "synonyms": [
               "a bit of",
               "a little",
-              "any"
+              "some of"
             ],
             "isOptional": true
           },
@@ -12630,9 +13136,9 @@
             "text": "and let's get this party started!",
             "category": "filler",
             "synonyms": [
-              "and let's have fun!",
-              "and let's enjoy!",
-              "and let's begin the fun!"
+              "and let's begin the party!",
+              "and let's start the party!",
+              "and let's kick off the party!"
             ],
             "isOptional": true
           }
@@ -12660,7 +13166,7 @@
               {
                 "propertyValue": "player.playPlaylist",
                 "propertySubPhrases": [
-                  "Play the playlist"
+                  "Put on the playlist"
                 ]
               }
             ]
@@ -12695,11 +13201,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If it's not too much trouble,",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it!"
+          "thank you!",
+          "if you don't mind.",
+          "please.",
+          "thanks!"
         ]
       }
     },
@@ -12813,37 +13323,36 @@
         "politePrefixes": [
           "Could you please",
           "Would you mind",
-          "If it's not too much trouble, could you",
-          "May I kindly ask you to"
+          "If it's not too much trouble,",
+          "Please"
         ],
         "politeSuffixes": [
-          "thank you",
-          "please",
-          "if you don't mind",
-          "thanks a lot"
+          "thank you.",
+          "if you don't mind.",
+          "please.",
+          "thanks."
         ]
       }
     },
     {
       "request": "Start the classical symphony playlist",
       "action": {
-        "fullActionName": "player.getPlaylist",
+        "fullActionName": "player.playTrack",
         "parameters": {
-          "name": "classical symphony"
+          "trackName": "classical symphony"
         }
       },
       "explanation": {
         "properties": [
           {
             "name": "fullActionName",
-            "value": "player.getPlaylist",
+            "value": "player.playTrack",
             "substrings": [
-              "Start",
-              "playlist"
+              "Start"
             ]
           },
           {
-            "name": "parameters.name",
+            "name": "parameters.trackName",
             "value": "classical symphony",
             "substrings": [
               "classical symphony"
@@ -12860,16 +13369,147 @@
           },
           {
             "text": "the",
-            "category": "filler",
+            "category": "preposition",
             "synonyms": [
               "a",
-              "an",
-              "this"
+              "this",
+              "that"
             ],
             "isOptional": true
           },
           {
             "text": "classical symphony",
+            "category": "track",
+            "propertyNames": [
+              "parameters.trackName"
+            ]
+          },
+          {
+            "text": "playlist",
+            "category": "object",
+            "synonyms": [
+              "album",
+              "track list",
+              "collection"
+            ],
+            "isOptional": true
+          }
+        ],
+        "propertyAlternatives": [
+          {
+            "propertyName": "fullActionName",
+            "propertyValue": "player.playTrack",
+            "propertySubPhrases": [
+              "Start"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "player.pauseTrack",
+                "propertySubPhrases": [
+                  "Pause"
+                ]
+              },
+              {
+                "propertyValue": "player.stopTrack",
+                "propertySubPhrases": [
+                  "Stop"
+                ]
+              },
+              {
+                "propertyValue": "player.resumeTrack",
+                "propertySubPhrases": [
+                  "Resume"
+                ]
+              }
+            ]
+          },
+          {
+            "propertyName": "parameters.trackName",
+            "propertyValue": "classical symphony",
+            "propertySubPhrases": [
+              "classical symphony"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "jazz collection",
+                "propertySubPhrases": [
+                  "jazz collection"
+                ]
+              },
+              {
+                "propertyValue": "rock hits",
+                "propertySubPhrases": [
+                  "rock hits"
+                ]
+              },
+              {
+                "propertyValue": "pop favorites",
+                "propertySubPhrases": [
+                  "pop favorites"
+                ]
+              }
+            ]
+          }
+        ],
+        "politePrefixes": [
+          "Could you please",
+          "Would you mind",
+          "If it's not too much trouble,",
+          "I would appreciate it if you could"
+        ],
+        "politeSuffixes": [
+          "thank you.",
+          "please.",
+          "if you don't mind.",
+          "thanks a lot."
+        ]
+      }
+    },
+    {
+      "request": "Start the smooth R&B playlist",
+      "action": {
+        "fullActionName": "player.getPlaylist",
+        "parameters": {
+          "name": "smooth R&B"
+        }
+      },
+      "explanation": {
+        "properties": [
+          {
+            "name": "fullActionName",
+            "value": "player.getPlaylist",
+            "substrings": [
+              "Start the smooth R&B playlist"
+            ]
+          },
+          {
+            "name": "parameters.name",
+            "value": "smooth R&B",
+            "substrings": [
+              "smooth R&B"
+            ]
+          }
+        ],
+        "subPhrases": [
+          {
+            "text": "Start",
+            "category": "action",
+            "propertyNames": [
+              "fullActionName"
+            ]
+          },
+          {
+            "text": "the",
+            "category": "preposition",
+            "synonyms": [
+              "a",
+              "this",
+              "that"
+            ],
+            "isOptional": true
+          },
+          {
+            "text": "smooth R&B",
             "category": "playlist name",
             "propertyNames": [
               "parameters.name"
@@ -12917,123 +13557,6 @@
           },
           {
             "propertyName": "parameters.name",
-            "propertyValue": "classical symphony",
-            "propertySubPhrases": [
-              "classical symphony"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "jazz classics",
-                "propertySubPhrases": [
-                  "jazz classics"
-                ]
-              },
-              {
-                "propertyValue": "rock anthems",
-                "propertySubPhrases": [
-                  "rock anthems"
-                ]
-              },
-              {
-                "propertyValue": "pop hits",
-                "propertySubPhrases": [
-                  "pop hits"
-                ]
-              }
-            ]
-          }
-        ],
-        "politePrefixes": [
-          "Could you please",
-          "Would you mind"
-        ],
-        "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it."
-        ]
-      }
-    },
-    {
-      "request": "Start the smooth R&B playlist",
-      "action": {
-        "fullActionName": "player.getPlaylist",
-        "parameters": {
-          "name": "smooth R&B"
-        }
-      },
-      "explanation": {
-        "properties": [
-          {
-            "name": "fullActionName",
-            "value": "player.getPlaylist",
-            "substrings": [
-              "Start the"
-            ]
-          },
-          {
-            "name": "parameters.name",
-            "value": "smooth R&B",
-            "substrings": [
-              "smooth R&B"
-            ]
-          }
-        ],
-        "subPhrases": [
-          {
-            "text": "Start the",
-            "category": "command",
-            "propertyNames": [
-              "fullActionName"
-            ]
-          },
-          {
-            "text": "smooth R&B",
-            "category": "playlist name",
-            "propertyNames": [
-              "parameters.name"
-            ]
-          },
-          {
-            "text": "playlist",
-            "category": "object",
-            "synonyms": [
-              "tracklist",
-              "music list",
-              "song collection"
-            ],
-            "isOptional": true
-          }
-        ],
-        "propertyAlternatives": [
-          {
-            "propertyName": "fullActionName",
-            "propertyValue": "player.getPlaylist",
-            "propertySubPhrases": [
-              "Start the"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "player.playPlaylist",
-                "propertySubPhrases": [
-                  "Play the"
-                ]
-              },
-              {
-                "propertyValue": "player.resumePlaylist",
-                "propertySubPhrases": [
-                  "Resume the"
-                ]
-              },
-              {
-                "propertyValue": "player.beginPlaylist",
-                "propertySubPhrases": [
-                  "Begin the"
-                ]
-              }
-            ]
-          },
-          {
-            "propertyName": "parameters.name",
             "propertyValue": "smooth R&B",
             "propertySubPhrases": [
               "smooth R&B"
@@ -13062,11 +13585,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If you don't mind",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you",
-          "I would appreciate it"
+          "when you get a chance?",
+          "if that's okay.",
+          "please.",
+          "thank you."
         ]
       }
     },
@@ -13084,7 +13611,7 @@
             "name": "fullActionName",
             "value": "player.playArtist",
             "substrings": [
-              "bump"
+              "Time to bump some Snoop Dogg, homie!"
             ]
           },
           {
@@ -13097,29 +13624,12 @@
         ],
         "subPhrases": [
           {
-            "text": "Time to",
+            "text": "Time to bump some",
             "category": "filler",
             "synonyms": [
-              "Let's",
-              "How about",
-              "It's time to"
-            ],
-            "isOptional": true
-          },
-          {
-            "text": "bump",
-            "category": "action",
-            "propertyNames": [
-              "fullActionName"
-            ]
-          },
-          {
-            "text": "some",
-            "category": "filler",
-            "synonyms": [
-              "a bit of",
-              "a little",
-              "some of"
+              "Let's play",
+              "Let's listen to",
+              "How about we play"
             ],
             "isOptional": true
           },
@@ -13135,40 +13645,13 @@
             "category": "filler",
             "synonyms": [
               "buddy",
-              "friend",
-              "pal"
+              "pal",
+              "friend"
             ],
             "isOptional": true
           }
         ],
         "propertyAlternatives": [
-          {
-            "propertyName": "fullActionName",
-            "propertyValue": "player.playArtist",
-            "propertySubPhrases": [
-              "bump"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "player.playSong",
-                "propertySubPhrases": [
-                  "play"
-                ]
-              },
-              {
-                "propertyValue": "player.playAlbum",
-                "propertySubPhrases": [
-                  "spin"
-                ]
-              },
-              {
-                "propertyValue": "player.playPlaylist",
-                "propertySubPhrases": [
-                  "queue up"
-                ]
-              }
-            ]
-          },
           {
             "propertyName": "parameters.artist",
             "propertyValue": "Snoop Dogg",
@@ -13189,9 +13672,9 @@
                 ]
               },
               {
-                "propertyValue": "Kendrick Lamar",
+                "propertyValue": "Ice Cube",
                 "propertySubPhrases": [
-                  "Kendrick Lamar"
+                  "Ice Cube"
                 ]
               }
             ]
@@ -13199,11 +13682,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If you don't mind",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it!"
+          "thank you",
+          "if that's okay",
+          "please",
+          "thanks"
         ]
       }
     },
@@ -13250,8 +13737,8 @@
             "text": "the latest",
             "category": "filler",
             "synonyms": [
+              "recent",
               "newest",
-              "most recent",
               "current"
             ],
             "isOptional": true
@@ -13283,19 +13770,19 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.playSong",
+                "propertyValue": "player.playArtist",
                 "propertySubPhrases": [
                   "Play"
                 ]
               },
               {
-                "propertyValue": "player.startGenre",
+                "propertyValue": "player.playAlbum",
                 "propertySubPhrases": [
                   "Start"
                 ]
               },
               {
-                "propertyValue": "player.activateGenre",
+                "propertyValue": "player.playPlaylist",
                 "propertySubPhrases": [
                   "Activate"
                 ]
@@ -13332,11 +13819,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "Please",
+          "If you don't mind"
         ],
         "politeSuffixes": [
-          "Thank you",
-          "Thanks a lot"
+          "for me?",
+          "please?",
+          "if that's okay?",
+          "thank you!"
         ]
       }
     },
@@ -13376,9 +13867,9 @@
             "text": "Would it be possible to",
             "category": "politeness",
             "synonyms": [
-              "Could you",
               "Can you",
-              "Is it possible to"
+              "Could you",
+              "Please"
             ],
             "isOptional": true
           },
@@ -13411,8 +13902,8 @@
             "category": "filler",
             "synonyms": [
               "songs",
-              "tunes",
-              "music"
+              "music",
+              "tunes"
             ],
             "isOptional": true
           }
@@ -13459,22 +13950,32 @@
                 ]
               },
               {
-                "propertyValue": "jazz",
-                "propertySubPhrases": [
-                  "jazz"
-                ]
-              },
-              {
                 "propertyValue": "pop",
                 "propertySubPhrases": [
                   "pop"
+                ]
+              },
+              {
+                "propertyValue": "jazz",
+                "propertySubPhrases": [
+                  "jazz"
                 ]
               }
             ]
           }
         ],
-        "politePrefixes": [],
-        "politeSuffixes": []
+        "politePrefixes": [
+          "Could you please",
+          "If it's not too much trouble,",
+          "Would you mind",
+          "I would appreciate it if you could"
+        ],
+        "politeSuffixes": [
+          "Thank you!",
+          "I would be grateful.",
+          "Thanks in advance!",
+          "Much appreciated."
+        ]
       }
     },
     {
@@ -13509,7 +14010,7 @@
             "synonyms": [
               "Could you please",
               "Would you mind",
-              "Can you"
+              "If you don't mind"
             ],
             "isOptional": true
           },
@@ -13547,21 +14048,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.pause",
+                "propertyValue": "player.pauseArtist",
                 "propertySubPhrases": [
                   "pause"
                 ]
               },
               {
-                "propertyValue": "player.stop",
+                "propertyValue": "player.stopArtist",
                 "propertySubPhrases": [
                   "stop"
                 ]
               },
               {
-                "propertyValue": "player.skip",
+                "propertyValue": "player.resumeArtist",
                 "propertySubPhrases": [
-                  "skip"
+                  "resume"
                 ]
               }
             ]
@@ -13595,7 +14096,12 @@
           }
         ],
         "politePrefixes": [],
-        "politeSuffixes": []
+        "politeSuffixes": [
+          "please.",
+          "if you don't mind.",
+          "thank you.",
+          "I would appreciate it."
+        ]
       }
     },
     {
@@ -13645,9 +14151,9 @@
             "text": "some delightful",
             "category": "filler",
             "synonyms": [
-              "a bit of",
-              "some",
-              "a little"
+              "some wonderful",
+              "some lovely",
+              "some beautiful"
             ],
             "isOptional": true
           },
@@ -13660,11 +14166,11 @@
           },
           {
             "text": "for us",
-            "category": "filler",
+            "category": "preposition",
             "synonyms": [
               "for me",
-              "for everyone",
-              "for the group"
+              "for them",
+              "for everyone"
             ],
             "isOptional": true
           }
@@ -13678,21 +14184,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.pause",
+                "propertyValue": "player.pauseArtist",
                 "propertySubPhrases": [
                   "pause"
                 ]
               },
               {
-                "propertyValue": "player.stop",
+                "propertyValue": "player.stopArtist",
                 "propertySubPhrases": [
                   "stop"
                 ]
               },
               {
-                "propertyValue": "player.skip",
+                "propertyValue": "player.resumeArtist",
                 "propertySubPhrases": [
-                  "skip"
+                  "resume"
                 ]
               }
             ]
@@ -13726,7 +14232,12 @@
           }
         ],
         "politePrefixes": [],
-        "politeSuffixes": []
+        "politeSuffixes": [
+          "please?",
+          "if you don't mind.",
+          "thank you.",
+          "would be appreciated."
+        ]
       }
     },
     {
@@ -13799,21 +14310,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.playSong",
+                "propertyValue": "player.playAlbum",
                 "propertySubPhrases": [
-                  "playing a song by"
+                  "playing an album"
                 ]
               },
               {
-                "propertyValue": "player.playAlbum",
+                "propertyValue": "player.playSong",
                 "propertySubPhrases": [
-                  "playing an album by"
+                  "playing a song"
                 ]
               },
               {
                 "propertyValue": "player.playPlaylist",
                 "propertySubPhrases": [
-                  "playing a playlist of"
+                  "playing a playlist"
                 ]
               }
             ]
@@ -13828,26 +14339,31 @@
               {
                 "propertyValue": "Beethoven",
                 "propertySubPhrases": [
-                  "Beethoven's masterpieces"
+                  "Beethoven's finest"
                 ]
               },
               {
                 "propertyValue": "Mozart",
                 "propertySubPhrases": [
-                  "Mozart's greatest hits"
+                  "Mozart's finest"
                 ]
               },
               {
                 "propertyValue": "Bach",
                 "propertySubPhrases": [
-                  "Bach's best works"
+                  "Bach's finest"
                 ]
               }
             ]
           }
         ],
         "politePrefixes": [],
-        "politeSuffixes": []
+        "politeSuffixes": [
+          "please?",
+          "if you don't mind.",
+          "thank you.",
+          "I would appreciate it."
+        ]
       }
     },
     {
@@ -13881,8 +14397,8 @@
             "category": "politeness",
             "synonyms": [
               "Could you please",
-              "Would it be possible",
-              "Can you"
+              "Would you kindly",
+              "Do you mind"
             ],
             "isOptional": true
           },
@@ -13894,11 +14410,31 @@
             ]
           },
           {
-            "text": "some Bach music",
+            "text": "some",
+            "category": "filler",
+            "synonyms": [
+              "any",
+              "a bit of",
+              "a little"
+            ],
+            "isOptional": true
+          },
+          {
+            "text": "Bach",
             "category": "artist",
             "propertyNames": [
               "parameters.artist"
             ]
+          },
+          {
+            "text": "music",
+            "category": "filler",
+            "synonyms": [
+              "songs",
+              "tunes",
+              "melodies"
+            ],
+            "isOptional": true
           }
         ],
         "propertyAlternatives": [
@@ -13912,19 +14448,19 @@
               {
                 "propertyValue": "player.playSong",
                 "propertySubPhrases": [
-                  "playing a song"
+                  "playing"
                 ]
               },
               {
                 "propertyValue": "player.playAlbum",
                 "propertySubPhrases": [
-                  "playing an album"
+                  "playing"
                 ]
               },
               {
                 "propertyValue": "player.playPlaylist",
                 "propertySubPhrases": [
-                  "playing a playlist"
+                  "playing"
                 ]
               }
             ]
@@ -13933,33 +14469,173 @@
             "propertyName": "parameters.artist",
             "propertyValue": "Bach",
             "propertySubPhrases": [
-              "some Bach music"
+              "Bach"
             ],
             "alternatives": [
               {
                 "propertyValue": "Mozart",
                 "propertySubPhrases": [
-                  "some Mozart music"
+                  "Mozart"
                 ]
               },
               {
                 "propertyValue": "Beethoven",
                 "propertySubPhrases": [
-                  "some Beethoven music"
+                  "Beethoven"
                 ]
               },
               {
                 "propertyValue": "Chopin",
                 "propertySubPhrases": [
-                  "some Chopin music"
+                  "Chopin"
                 ]
               }
             ]
           }
         ],
         "politePrefixes": [],
-        "politeSuffixes": []
-      }
+        "politeSuffixes": [
+          "please?",
+          "if you don't mind.",
+          "thank you.",
+          "if it's not too much trouble."
+        ]
+      },
+      "corrections": [
+        {
+          "data": {
+            "properties": [
+              {
+                "name": "fullActionName",
+                "value": "player.playArtist",
+                "substrings": [
+                  "playing"
+                ]
+              },
+              {
+                "name": "parameters.artist",
+                "value": "Bach",
+                "substrings": [
+                  "Bach"
+                ]
+              }
+            ],
+            "subPhrases": [
+              {
+                "text": "Would you mind",
+                "category": "politeness",
+                "synonyms": [
+                  "Could you please",
+                  "Would you kindly",
+                  "Do you mind"
+                ],
+                "isOptional": true
+              },
+              {
+                "text": "playing",
+                "category": "action",
+                "propertyNames": [
+                  "fullActionName"
+                ]
+              },
+              {
+                "text": "some",
+                "category": "filler",
+                "synonyms": [
+                  "any",
+                  "a bit of",
+                  "a little"
+                ],
+                "isOptional": true
+              },
+              {
+                "text": "Bach",
+                "category": "artist",
+                "propertyNames": [
+                  "parameters.artist"
+                ]
+              },
+              {
+                "text": "music",
+                "category": "filler",
+                "synonyms": [
+                  "songs",
+                  "tunes",
+                  "melodies"
+                ],
+                "isOptional": true
+              }
+            ],
+            "propertyAlternatives": [
+              {
+                "propertyName": "fullActionName",
+                "propertyValue": "player.playArtist",
+                "propertySubPhrases": [
+                  "playing"
+                ],
+                "alternatives": [
+                  {
+                    "propertyValue": "player.playSong",
+                    "propertySubPhrases": [
+                      "playing",
+                      "some",
+                      "song"
+                    ]
+                  },
+                  {
+                    "propertyValue": "player.playAlbum",
+                    "propertySubPhrases": [
+                      "playing",
+                      "some",
+                      "album"
+                    ]
+                  },
+                  {
+                    "propertyValue": "player.playPlaylist",
+                    "propertySubPhrases": [
+                      "playing",
+                      "some",
+                      "playlist"
+                    ]
+                  }
+                ]
+              },
+              {
+                "propertyName": "parameters.artist",
+                "propertyValue": "Bach",
+                "propertySubPhrases": [
+                  "Bach"
+                ],
+                "alternatives": [
+                  {
+                    "propertyValue": "Mozart",
+                    "propertySubPhrases": [
+                      "Mozart"
+                    ]
+                  },
+                  {
+                    "propertyValue": "Beethoven",
+                    "propertySubPhrases": [
+                      "Beethoven"
+                    ]
+                  },
+                  {
+                    "propertyValue": "Chopin",
+                    "propertySubPhrases": [
+                      "Chopin"
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          "correction": [
+            "Mismatch number of sub-phrases: alternatives value 'player.playSong' for property 'fullActionName' must have 1 sub-phrases",
+            "Mismatch number of sub-phrases: alternatives value 'player.playAlbum' for property 'fullActionName' must have 1 sub-phrases",
+            "Mismatch number of sub-phrases: alternatives value 'player.playPlaylist' for property 'fullActionName' must have 1 sub-phrases"
+          ]
+        }
+      ]
     },
     {
       "request": "Would you mind playing some music by Bach?",
@@ -13975,7 +14651,7 @@
             "name": "fullActionName",
             "value": "player.playArtist",
             "substrings": [
-              "playing"
+              "playing some music"
             ]
           },
           {
@@ -13991,26 +14667,26 @@
             "text": "Would you mind",
             "category": "politeness",
             "synonyms": [
-              "Could you please",
-              "Would it be possible",
-              "Can you"
+              "Could you",
+              "Can you",
+              "Please"
             ],
             "isOptional": true
           },
           {
-            "text": "playing",
+            "text": "playing some music",
             "category": "action",
             "propertyNames": [
               "fullActionName"
             ]
           },
           {
-            "text": "some music by",
-            "category": "filler",
+            "text": "by",
+            "category": "preposition",
             "synonyms": [
-              "a few tracks by",
-              "songs from",
-              "music from"
+              "from",
+              "of",
+              "featuring"
             ],
             "isOptional": true
           },
@@ -14027,7 +14703,7 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.playArtist",
             "propertySubPhrases": [
-              "playing"
+              "playing some music"
             ],
             "alternatives": [
               {
@@ -14078,8 +14754,18 @@
             ]
           }
         ],
-        "politePrefixes": [],
-        "politeSuffixes": []
+        "politePrefixes": [
+          "Could you please",
+          "If it's not too much trouble,",
+          "Would it be possible to",
+          "I would appreciate it if you could"
+        ],
+        "politeSuffixes": [
+          "Thank you!",
+          "If you don't mind.",
+          "Please.",
+          "Thanks a lot!"
+        ]
       }
     },
     {
@@ -14113,8 +14799,8 @@
             "category": "politeness",
             "synonyms": [
               "Could you please",
-              "Would it be possible",
-              "Can you"
+              "Do you mind",
+              "Would it be possible"
             ],
             "isOptional": true
           },
@@ -14130,8 +14816,8 @@
             "category": "preposition",
             "synonyms": [
               "from",
-              "of",
-              "featuring"
+              "featuring",
+              "including"
             ],
             "isOptional": true
           },
@@ -14200,7 +14886,12 @@
           }
         ],
         "politePrefixes": [],
-        "politeSuffixes": []
+        "politeSuffixes": [
+          "please.",
+          "if you don't mind.",
+          "thank you.",
+          "if it's not too much trouble."
+        ]
       }
     },
     {
@@ -14283,21 +14974,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.playSong",
+                "propertyValue": "player.pause",
                 "propertySubPhrases": [
-                  "playing a song"
+                  "pausing"
                 ]
               },
               {
-                "propertyValue": "player.playAlbum",
+                "propertyValue": "player.stop",
                 "propertySubPhrases": [
-                  "playing an album"
+                  "stopping"
                 ]
               },
               {
-                "propertyValue": "player.playPlaylist",
+                "propertyValue": "player.skip",
                 "propertySubPhrases": [
-                  "playing a playlist"
+                  "skipping"
                 ]
               }
             ]
@@ -14331,7 +15022,12 @@
           }
         ],
         "politePrefixes": [],
-        "politeSuffixes": []
+        "politeSuffixes": [
+          "please?",
+          "if you don't mind.",
+          "thank you.",
+          "I'd appreciate it."
+        ]
       }
     },
     {
@@ -14339,7 +15035,8 @@
       "action": {
         "fullActionName": "player.playGenre",
         "parameters": {
-          "genre": "pop"
+          "genre": "pop",
+          "quantity": 10
         }
       },
       "explanation": {
@@ -14357,6 +15054,11 @@
             "substrings": [
               "pop"
             ]
+          },
+          {
+            "name": "parameters.quantity",
+            "value": 10,
+            "isImplicit": true
           }
         ],
         "subPhrases": [
@@ -14365,8 +15067,8 @@
             "category": "politeness",
             "synonyms": [
               "Could you please",
-              "Do you mind",
-              "Would it be possible"
+              "Would it be possible",
+              "Can you"
             ],
             "isOptional": true
           },
@@ -14381,9 +15083,9 @@
             "text": "some upbeat",
             "category": "filler",
             "synonyms": [
-              "a few",
               "some lively",
-              "some energetic"
+              "some energetic",
+              "some vibrant"
             ],
             "isOptional": true
           },
@@ -14399,8 +15101,8 @@
             "category": "filler",
             "synonyms": [
               "songs",
-              "tracks",
-              "music"
+              "music",
+              "tracks"
             ],
             "isOptional": true
           }
@@ -14414,21 +15116,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.playSong",
+                "propertyValue": "player.playMood",
                 "propertySubPhrases": [
-                  "playing"
-                ]
-              },
-              {
-                "propertyValue": "player.playAlbum",
-                "propertySubPhrases": [
-                  "putting on the album"
+                  "setting the mood with"
                 ]
               },
               {
                 "propertyValue": "player.playPlaylist",
                 "propertySubPhrases": [
-                  "putting on the playlist"
+                  "playing the playlist"
+                ]
+              },
+              {
+                "propertyValue": "player.playArtist",
+                "propertySubPhrases": [
+                  "playing songs by"
                 ]
               }
             ]
@@ -14461,8 +15163,18 @@
             ]
           }
         ],
-        "politePrefixes": [],
-        "politeSuffixes": []
+        "politePrefixes": [
+          "Could you please",
+          "If it's not too much trouble,",
+          "Would it be possible for you to",
+          "I would appreciate it if you could"
+        ],
+        "politeSuffixes": [
+          "Thank you!",
+          "I would be very grateful.",
+          "Thanks a lot!",
+          "I appreciate it!"
+        ]
       }
     },
     {
@@ -14479,7 +15191,7 @@
             "name": "fullActionName",
             "value": "player.playArtist",
             "substrings": [
-              "Would you play"
+              "play"
             ]
           },
           {
@@ -14492,8 +15204,18 @@
         ],
         "subPhrases": [
           {
-            "text": "Would you play",
-            "category": "command",
+            "text": "Would you",
+            "category": "politeness",
+            "synonyms": [
+              "Could you",
+              "Can you",
+              "Will you"
+            ],
+            "isOptional": true
+          },
+          {
+            "text": "play",
+            "category": "action",
             "propertyNames": [
               "fullActionName"
             ]
@@ -14502,9 +15224,9 @@
             "text": "some",
             "category": "filler",
             "synonyms": [
+              "any",
               "a bit of",
-              "a little",
-              "any"
+              "a little"
             ],
             "isOptional": true
           },
@@ -14520,18 +15242,8 @@
             "category": "politeness",
             "synonyms": [
               "please",
-              "if you could",
-              "kindly"
-            ],
-            "isOptional": true
-          },
-          {
-            "text": "?",
-            "category": "punctuation",
-            "synonyms": [
-              ".",
-              "!",
-              ""
+              "if you don't mind",
+              "if you could"
             ],
             "isOptional": true
           }
@@ -14541,25 +15253,25 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.playArtist",
             "propertySubPhrases": [
-              "Would you play"
+              "play"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.playSong",
                 "propertySubPhrases": [
-                  "Would you play a song"
+                  "play a song"
                 ]
               },
               {
                 "propertyValue": "player.playAlbum",
                 "propertySubPhrases": [
-                  "Would you play an album"
+                  "play an album"
                 ]
               },
               {
                 "propertyValue": "player.playPlaylist",
                 "propertySubPhrases": [
-                  "Would you play a playlist"
+                  "play a playlist"
                 ]
               }
             ]
@@ -14592,8 +15304,18 @@
             ]
           }
         ],
-        "politePrefixes": [],
-        "politeSuffixes": []
+        "politePrefixes": [
+          "Could you please",
+          "Would you kindly",
+          "If you don't mind,",
+          "May I ask you to"
+        ],
+        "politeSuffixes": [
+          "if it's not too much trouble?",
+          "please?",
+          "thank you.",
+          "if you could."
+        ]
       }
     },
     {
@@ -14638,19 +15360,29 @@
             "synonyms": [
               "DJ",
               "Disc Jockey",
-              "Music Master"
+              "Music Mixer"
             ],
             "isOptional": true
           },
           {
-            "text": "let's get this place jumpin' with some",
-            "category": "command",
+            "text": "let's get this place jumpin'",
+            "category": "filler",
             "synonyms": [
-              "let's start the party with",
-              "let's play",
-              "let's hear"
+              "let's get this party started",
+              "let's make some noise",
+              "let's get everyone dancing"
             ],
-            "isOptional": false
+            "isOptional": true
+          },
+          {
+            "text": "with some",
+            "category": "preposition",
+            "synonyms": [
+              "featuring",
+              "including",
+              "playing"
+            ],
+            "isOptional": true
           },
           {
             "text": "'Young, Wild & Free'",
@@ -14685,17 +15417,27 @@
                 "propertySubPhrases": [
                   "'Blinding Lights'"
                 ]
+              },
+              {
+                "propertyValue": "Despacito",
+                "propertySubPhrases": [
+                  "'Despacito'"
+                ]
               }
             ]
           }
         ],
         "politePrefixes": [
-          "Could you please",
-          "Would you mind"
+          "Hey there,",
+          "Excuse me,",
+          "Could you please,",
+          "Would you mind,"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it!"
+          "thanks!",
+          "please?",
+          "if you don't mind.",
+          "thank you!"
         ]
       }
     },
@@ -14726,12 +15468,12 @@
         ],
         "subPhrases": [
           {
-            "text": "Yo,",
+            "text": "Yo",
             "category": "greeting",
             "synonyms": [
-              "Hey,",
-              "Hi,",
-              "Hello,"
+              "Hey",
+              "Hi",
+              "Hello"
             ],
             "isOptional": true
           },
@@ -14740,8 +15482,8 @@
             "category": "filler",
             "synonyms": [
               "let's",
-              "why don't we",
-              "shall we"
+              "shall we",
+              "why don't we"
             ],
             "isOptional": true
           },
@@ -14756,26 +15498,26 @@
             "text": "some of that",
             "category": "filler",
             "synonyms": [
-              "a bit of",
               "some",
+              "a bit of",
               "a little of"
             ],
             "isOptional": true
           },
           {
             "text": "'Gin and Juice'",
-            "category": "trackName",
+            "category": "track",
             "propertyNames": [
               "parameters.trackName"
             ]
           },
           {
-            "text": "right now?",
-            "category": "confirmation",
+            "text": "right now",
+            "category": "time",
             "synonyms": [
-              "immediately?",
-              "at this moment?",
-              "right away?"
+              "immediately",
+              "at once",
+              "straight away"
             ],
             "isOptional": true
           }
@@ -14789,21 +15531,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.startSong",
+                "propertyValue": "player.startMusic",
                 "propertySubPhrases": [
                   "jam to"
                 ]
               },
               {
-                "propertyValue": "player.playMusic",
+                "propertyValue": "player.beginPlayback",
                 "propertySubPhrases": [
                   "listen to"
                 ]
               },
               {
-                "propertyValue": "player.playTune",
+                "propertyValue": "player.activateTrack",
                 "propertySubPhrases": [
-                  "vibe to"
+                  "play"
                 ]
               }
             ]
@@ -14822,9 +15564,9 @@
                 ]
               },
               {
-                "propertyValue": "Nuthin' but a 'G' Thang",
+                "propertyValue": "Nuthin' But a G Thang",
                 "propertySubPhrases": [
-                  "'Nuthin' but a 'G' Thang'"
+                  "'Nuthin' But a G Thang'"
                 ]
               },
               {
@@ -14838,11 +15580,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If it's not too much trouble",
+          "May I request"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it!"
+          "thank you",
+          "please",
+          "if you don't mind",
+          "I'd appreciate it"
         ]
       }
     },
@@ -14862,7 +15608,7 @@
           {
             "name": "fullActionName",
             "value": "player.playTrack",
-            "isImplicit": true
+            "substrings": []
           },
           {
             "name": "parameters.trackName",
@@ -14884,8 +15630,8 @@
             "text": "Yo",
             "category": "greeting",
             "synonyms": [
-              "Hey",
               "Hi",
+              "Hey",
               "Hello"
             ],
             "isOptional": true
@@ -14895,17 +15641,37 @@
             "category": "filler",
             "synonyms": [
               "let's play",
-              "how about",
-              "let's listen to"
+              "let's listen to",
+              "how about"
             ],
             "isOptional": true
           },
           {
-            "text": "'Young, Wild & Free'",
+            "text": "'",
+            "category": "punctuation",
+            "synonyms": [
+              "\"",
+              "“",
+              "‘"
+            ],
+            "isOptional": true
+          },
+          {
+            "text": "Young, Wild & Free",
             "category": "trackName",
             "propertyNames": [
               "parameters.trackName"
             ]
+          },
+          {
+            "text": "'",
+            "category": "punctuation",
+            "synonyms": [
+              "\"",
+              "”",
+              "’"
+            ],
+            "isOptional": true
           },
           {
             "text": "with",
@@ -14913,13 +15679,13 @@
             "synonyms": [
               "featuring",
               "by",
-              "along with"
+              "including"
             ],
             "isOptional": true
           },
           {
             "text": "Wiz Khalifa",
-            "category": "artist",
+            "category": "artistName",
             "propertyNames": [
               "parameters.artists.0"
             ]
@@ -14930,25 +15696,25 @@
             "propertyName": "parameters.trackName",
             "propertyValue": "Young, Wild & Free",
             "propertySubPhrases": [
-              "'Young, Wild & Free'"
+              "Young, Wild & Free"
             ],
             "alternatives": [
               {
                 "propertyValue": "See You Again",
                 "propertySubPhrases": [
-                  "'See You Again'"
+                  "See You Again"
                 ]
               },
               {
                 "propertyValue": "Black and Yellow",
                 "propertySubPhrases": [
-                  "'Black and Yellow'"
+                  "Black and Yellow"
                 ]
               },
               {
-                "propertyValue": "We Dem Boyz",
+                "propertyValue": "Roll Up",
                 "propertySubPhrases": [
-                  "'We Dem Boyz'"
+                  "Roll Up"
                 ]
               }
             ]
@@ -14982,14 +15748,94 @@
           }
         ],
         "politePrefixes": [
+          "Hey,",
+          "Excuse me,",
           "Could you please",
           "Would you mind"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it!"
+          "please?",
+          "if you don't mind.",
+          "thanks!",
+          "thank you."
         ]
-      }
+      },
+      "corrections": [
+        {
+          "data": {
+            "properties": [
+              {
+                "name": "fullActionName",
+                "value": "player.playTrack",
+                "substrings": []
+              },
+              {
+                "name": "parameters.trackName",
+                "value": "Young, Wild & Free",
+                "substrings": [
+                  "Young, Wild & Free"
+                ]
+              },
+              {
+                "name": "parameters.artists.0",
+                "value": "Wiz Khalifa",
+                "substrings": [
+                  "Wiz Khalifa"
+                ]
+              }
+            ],
+            "subPhrases": [
+              {
+                "text": "Yo",
+                "category": "greeting",
+                "synonyms": [
+                  "Hi",
+                  "Hey",
+                  "Hello"
+                ],
+                "isOptional": true
+              },
+              {
+                "text": "let's get down to some of that",
+                "category": "filler",
+                "synonyms": [
+                  "let's play",
+                  "let's listen to",
+                  "how about"
+                ],
+                "isOptional": true
+              },
+              {
+                "text": "Young, Wild & Free",
+                "category": "trackName",
+                "propertyNames": [
+                  "parameters.trackName"
+                ]
+              },
+              {
+                "text": "with",
+                "category": "preposition",
+                "synonyms": [
+                  "featuring",
+                  "by",
+                  "including"
+                ],
+                "isOptional": true
+              },
+              {
+                "text": "Wiz Khalifa",
+                "category": "artistName",
+                "propertyNames": [
+                  "parameters.artists.0"
+                ]
+              }
+            ]
+          },
+          "correction": [
+            "Missing sub-phrase: explanation missing for '''"
+          ]
+        }
+      ]
     },
     {
       "request": "Yo, let's get lit with some bangin' tunes on the speakers!",
@@ -15002,7 +15848,8 @@
             "name": "fullActionName",
             "value": "player.playRandom",
             "substrings": [
-              "Yo, let's get lit with some bangin' tunes on the speakers!"
+              "let's get lit",
+              "bangin' tunes"
             ]
           }
         ],
@@ -15018,8 +15865,22 @@
             "isOptional": true
           },
           {
-            "text": "let's get lit with some bangin' tunes on the speakers",
-            "category": "command",
+            "text": "let's get lit",
+            "category": "action",
+            "propertyNames": [
+              "fullActionName"
+            ]
+          },
+          {
+            "text": "with some bangin' tunes",
+            "category": "action",
+            "propertyNames": [
+              "fullActionName"
+            ]
+          },
+          {
+            "text": "on the speakers",
+            "category": "context",
             "propertyNames": [
               "fullActionName"
             ]
@@ -15030,37 +15891,57 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.playRandom",
             "propertySubPhrases": [
-              "let's get lit with some bangin' tunes on the speakers"
+              "let's get lit",
+              "with some bangin' tunes",
+              "on the speakers"
             ],
             "alternatives": [
               {
-                "propertyValue": "player.play",
+                "propertyValue": "player.playSpecific",
                 "propertySubPhrases": [
-                  "let's play some music on the speakers"
-                ]
-              },
-              {
-                "propertyValue": "player.shuffle",
-                "propertySubPhrases": [
-                  "let's shuffle some tracks on the speakers"
+                  "let's get lit",
+                  "with some specific tunes",
+                  "on the speakers"
                 ]
               },
               {
                 "propertyValue": "player.playPlaylist",
                 "propertySubPhrases": [
-                  "let's play a playlist on the speakers"
+                  "let's get lit",
+                  "with a playlist",
+                  "on the speakers"
+                ]
+              },
+              {
+                "propertyValue": "player.playAlbum",
+                "propertySubPhrases": [
+                  "let's get lit",
+                  "with an album",
+                  "on the speakers"
+                ]
+              },
+              {
+                "propertyValue": "player.playArtist",
+                "propertySubPhrases": [
+                  "let's get lit",
+                  "with some tunes from an artist",
+                  "on the speakers"
                 ]
               }
             ]
           }
         ],
         "politePrefixes": [
-          "Could you please",
-          "Would you mind"
+          "Hey there,",
+          "Excuse me,",
+          "If you don't mind,",
+          "Could you please"
         ],
         "politeSuffixes": [
           "Thank you!",
-          "I would appreciate it!"
+          "Please.",
+          "Thanks a lot!",
+          "I appreciate it."
         ]
       }
     },
@@ -15075,7 +15956,8 @@
             "name": "fullActionName",
             "value": "player.playRandom",
             "substrings": [
-              "Yo, let's get this party started with some phat tracks!"
+              "let's get this party started",
+              "phat tracks"
             ]
           }
         ],
@@ -15091,8 +15973,25 @@
             "isOptional": true
           },
           {
-            "text": "let's get this party started with some phat tracks!",
+            "text": "let's get this party started",
             "category": "command",
+            "propertyNames": [
+              "fullActionName"
+            ]
+          },
+          {
+            "text": "with some",
+            "category": "preposition",
+            "synonyms": [
+              "including",
+              "featuring",
+              "along with"
+            ],
+            "isOptional": true
+          },
+          {
+            "text": "phat tracks",
+            "category": "music",
             "propertyNames": [
               "fullActionName"
             ]
@@ -15103,37 +16002,52 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.playRandom",
             "propertySubPhrases": [
-              "let's get this party started with some phat tracks!"
+              "let's get this party started",
+              "phat tracks"
             ],
             "alternatives": [
               {
-                "propertyValue": "player.play",
+                "propertyValue": "player.playTopHits",
                 "propertySubPhrases": [
-                  "let's play some music!"
-                ]
-              },
-              {
-                "propertyValue": "player.shuffle",
-                "propertySubPhrases": [
-                  "shuffle the playlist!"
+                  "let's get this party started",
+                  "top hits"
                 ]
               },
               {
                 "propertyValue": "player.playFavorites",
                 "propertySubPhrases": [
-                  "play my favorite songs!"
+                  "let's get this party started",
+                  "favorite songs"
+                ]
+              },
+              {
+                "propertyValue": "player.playNewReleases",
+                "propertySubPhrases": [
+                  "let's get this party started",
+                  "new releases"
+                ]
+              },
+              {
+                "propertyValue": "player.playChillVibes",
+                "propertySubPhrases": [
+                  "let's get this party started",
+                  "chill vibes"
                 ]
               }
             ]
           }
         ],
         "politePrefixes": [
-          "Could you please",
-          "Would you mind"
+          "Please, ",
+          "Could you kindly ",
+          "Would you mind ",
+          "If you don't mind, "
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it!"
+          " please?",
+          " if that's okay.",
+          " thank you!",
+          " if you could."
         ]
       }
     },
@@ -15169,7 +16083,8 @@
             "synonyms": [
               "Hey",
               "Hi",
-              "Hello"
+              "Hello",
+              "What's up"
             ],
             "isOptional": true
           },
@@ -15198,12 +16113,12 @@
             ]
           },
           {
-            "text": "beats!",
+            "text": "beats",
             "category": "filler",
             "synonyms": [
-              "music!",
-              "tracks!",
-              "songs!"
+              "music",
+              "tracks",
+              "songs"
             ],
             "isOptional": true
           }
@@ -15219,19 +16134,19 @@
               {
                 "propertyValue": "player.startParty",
                 "propertySubPhrases": [
-                  "let's start the party"
+                  "let's get this party started"
+                ]
+              },
+              {
+                "propertyValue": "player.playMusic",
+                "propertySubPhrases": [
+                  "let's play some music"
                 ]
               },
               {
                 "propertyValue": "player.activateDanceMode",
                 "propertySubPhrases": [
                   "let's activate dance mode"
-                ]
-              },
-              {
-                "propertyValue": "player.beginMusicSession",
-                "propertySubPhrases": [
-                  "let's begin the music session"
                 ]
               }
             ]
@@ -15250,27 +16165,31 @@
                 ]
               },
               {
-                "propertyValue": "jazz",
+                "propertyValue": "pop",
                 "propertySubPhrases": [
-                  "jazz"
+                  "pop"
                 ]
               },
               {
-                "propertyValue": "electronic",
+                "propertyValue": "jazz",
                 "propertySubPhrases": [
-                  "electronic"
+                  "jazz"
                 ]
               }
             ]
           }
         ],
         "politePrefixes": [
-          "Could you please",
-          "Would you mind"
+          "Please, ",
+          "Could you please, ",
+          "Would you mind, ",
+          "If you don't mind, "
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it."
+          " Thank you!",
+          " Please!",
+          " If that's okay.",
+          " I'd appreciate it."
         ]
       }
     },
@@ -15306,7 +16225,8 @@
             "synonyms": [
               "Hey",
               "Hi",
-              "Hello"
+              "Hello",
+              "What's up"
             ],
             "isOptional": true
           },
@@ -15322,8 +16242,9 @@
             "category": "filler",
             "synonyms": [
               "some",
-              "a bit of",
-              "a little of"
+              "that",
+              "classic",
+              "some classic"
             ],
             "isOptional": true
           },
@@ -15344,19 +16265,19 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.pause",
+                "propertyValue": "player.pauseArtist",
                 "propertySubPhrases": [
                   "pause"
                 ]
               },
               {
-                "propertyValue": "player.stop",
+                "propertyValue": "player.stopArtist",
                 "propertySubPhrases": [
                   "stop"
                 ]
               },
               {
-                "propertyValue": "player.skip",
+                "propertyValue": "player.skipArtist",
                 "propertySubPhrases": [
                   "skip"
                 ]
@@ -15393,11 +16314,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If you don't mind",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it!"
+          "thank you",
+          "please",
+          "if that's okay",
+          "if you could"
         ]
       }
     }

--- a/ts/packages/defaultAgentProvider/test/data/explanations/player/v5/nextAction.json
+++ b/ts/packages/defaultAgentProvider/test/data/explanations/player/v5/nextAction.json
@@ -53,17 +53,27 @@
                 "propertySubPhrases": [
                   "Play the current item."
                 ]
+              },
+              {
+                "propertyValue": "player.stop",
+                "propertySubPhrases": [
+                  "Stop the current item."
+                ]
               }
             ]
           }
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If you don't mind",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you.",
-          "I appreciate it."
+          "thank you",
+          "if that's okay",
+          "please",
+          "thanks"
         ]
       }
     },
@@ -86,23 +96,21 @@
           {
             "text": "Bounce",
             "category": "command",
-            "propertyNames": [
-              "fullActionName"
-            ]
+            "propertyNames": []
           },
           {
             "text": "to the",
             "category": "preposition",
             "synonyms": [
-              "towards the",
-              "in the direction of the",
-              "heading to the"
+              "towards",
+              "into",
+              "onto"
             ],
             "isOptional": true
           },
           {
             "text": "next track",
-            "category": "command",
+            "category": "action",
             "propertyNames": [
               "fullActionName"
             ]
@@ -113,29 +121,25 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.next",
             "propertySubPhrases": [
-              "Bounce",
               "next track"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.previous",
                 "propertySubPhrases": [
-                  "Bounce",
                   "previous track"
                 ]
               },
               {
                 "propertyValue": "player.pause",
                 "propertySubPhrases": [
-                  "Bounce",
-                  "pause"
+                  "pause track"
                 ]
               },
               {
                 "propertyValue": "player.play",
                 "propertySubPhrases": [
-                  "Bounce",
-                  "play"
+                  "play track"
                 ]
               }
             ]
@@ -143,11 +147,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "Please",
+          "If you don't mind"
         ],
         "politeSuffixes": [
-          "Thank you.",
-          "I would appreciate it."
+          "thank you",
+          "please",
+          "if that's okay",
+          "thanks"
         ]
       }
     },
@@ -173,7 +181,7 @@
             "synonyms": [
               "Could we",
               "May we",
-              "Shall we"
+              "Would we"
             ],
             "isOptional": true
           },
@@ -220,17 +228,27 @@
                 "propertySubPhrases": [
                   "play track"
                 ]
+              },
+              {
+                "propertyValue": "player.stop",
+                "propertySubPhrases": [
+                  "stop track"
+                ]
               }
             ]
           }
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If it's not too much trouble",
+          "May I kindly ask"
         ],
         "politeSuffixes": [
-          "Thank you",
-          "I would appreciate it"
+          "if you don't mind?",
+          "please?",
+          "thank you.",
+          "if that's okay?"
         ]
       }
     },
@@ -256,22 +274,22 @@
             "synonyms": [
               "Could we",
               "May we",
-              "Shall we"
+              "Would we"
             ],
             "isOptional": true
           },
           {
-            "text": "hop to the",
-            "category": "filler",
+            "text": "hop to",
+            "category": "confirmation",
             "synonyms": [
-              "jump to the",
-              "move to the",
-              "skip to the"
+              "skip to",
+              "move to",
+              "jump to"
             ],
             "isOptional": true
           },
           {
-            "text": "next track",
+            "text": "the next track",
             "category": "action",
             "propertyNames": [
               "fullActionName"
@@ -283,38 +301,48 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.next",
             "propertySubPhrases": [
-              "next track"
+              "the next track"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.previous",
                 "propertySubPhrases": [
-                  "previous track"
+                  "the previous track"
                 ]
               },
               {
                 "propertyValue": "player.pause",
                 "propertySubPhrases": [
-                  "pause track"
+                  "pause the track"
                 ]
               },
               {
                 "propertyValue": "player.play",
                 "propertySubPhrases": [
-                  "play track"
+                  "play the track"
                 ]
               },
               {
                 "propertyValue": "player.stop",
                 "propertySubPhrases": [
-                  "stop track"
+                  "stop the track"
                 ]
               }
             ]
           }
         ],
-        "politePrefixes": [],
-        "politeSuffixes": []
+        "politePrefixes": [
+          "Could you please",
+          "Would you mind",
+          "If it's not too much trouble",
+          "May I kindly ask"
+        ],
+        "politeSuffixes": [
+          "if you don't mind?",
+          "please?",
+          "thank you.",
+          "if that's okay?"
+        ]
       }
     },
     {
@@ -376,15 +404,27 @@
                 "propertySubPhrases": [
                   "play the song"
                 ]
+              },
+              {
+                "propertyValue": "player.stop",
+                "propertySubPhrases": [
+                  "stop the song"
+                ]
               }
             ]
           }
         ],
         "politePrefixes": [
-          "Please"
+          "Please",
+          "Would you mind",
+          "Could you please",
+          "If you don't mind"
         ],
         "politeSuffixes": [
-          "Thank you"
+          "please",
+          "if you could",
+          "thank you",
+          "if that's okay"
         ]
       }
     },
@@ -416,11 +456,11 @@
           },
           {
             "text": "go to the",
-            "category": "filler",
+            "category": "preposition",
             "synonyms": [
-              "move to the",
-              "skip to the",
-              "advance to the"
+              "move to",
+              "switch to",
+              "change to"
             ],
             "isOptional": true
           },
@@ -457,12 +497,28 @@
                 "propertySubPhrases": [
                   "play track"
                 ]
+              },
+              {
+                "propertyValue": "player.stop",
+                "propertySubPhrases": [
+                  "stop track"
+                ]
               }
             ]
           }
         ],
-        "politePrefixes": [],
-        "politeSuffixes": []
+        "politePrefixes": [
+          "Could you please",
+          "Would you mind",
+          "If you don't mind",
+          "May I ask you to"
+        ],
+        "politeSuffixes": [
+          "please?",
+          "if that's okay?",
+          "thank you.",
+          "if you could."
+        ]
       }
     },
     {
@@ -476,7 +532,7 @@
             "name": "fullActionName",
             "value": "player.next",
             "substrings": [
-              "hit the next button"
+              "next"
             ]
           }
         ],
@@ -492,11 +548,31 @@
             "isOptional": true
           },
           {
-            "text": "hit the next button",
+            "text": "hit the",
+            "category": "filler",
+            "synonyms": [
+              "press the",
+              "tap the",
+              "click the"
+            ],
+            "isOptional": true
+          },
+          {
+            "text": "next",
             "category": "action",
             "propertyNames": [
               "fullActionName"
             ]
+          },
+          {
+            "text": "button",
+            "category": "filler",
+            "synonyms": [
+              "key",
+              "control",
+              "switch"
+            ],
+            "isOptional": true
           }
         ],
         "propertyAlternatives": [
@@ -504,35 +580,41 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.next",
             "propertySubPhrases": [
-              "hit the next button"
+              "next"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.previous",
                 "propertySubPhrases": [
-                  "hit the previous button"
+                  "previous"
                 ]
               },
               {
                 "propertyValue": "player.pause",
                 "propertySubPhrases": [
-                  "hit the pause button"
+                  "pause"
                 ]
               },
               {
                 "propertyValue": "player.play",
                 "propertySubPhrases": [
-                  "hit the play button"
+                  "play"
                 ]
               }
             ]
           }
         ],
         "politePrefixes": [
-          "Please"
+          "Please",
+          "Would you mind",
+          "Could you kindly",
+          "If you don't mind"
         ],
         "politeSuffixes": [
-          "Thank you"
+          "please?",
+          "if that's okay?",
+          "thank you!",
+          "if you could?"
         ]
       }
     },
@@ -557,8 +639,8 @@
             "category": "politeness",
             "synonyms": [
               "Can we",
-              "Would we",
-              "Shall we"
+              "May we",
+              "Would we"
             ],
             "isOptional": true
           },
@@ -587,20 +669,36 @@
               {
                 "propertyValue": "player.pause",
                 "propertySubPhrases": [
-                  "pause the track"
+                  "pause the current track"
                 ]
               },
               {
                 "propertyValue": "player.play",
                 "propertySubPhrases": [
-                  "play the track"
+                  "play the current track"
+                ]
+              },
+              {
+                "propertyValue": "player.stop",
+                "propertySubPhrases": [
+                  "stop the current track"
                 ]
               }
             ]
           }
         ],
-        "politePrefixes": [],
-        "politeSuffixes": []
+        "politePrefixes": [
+          "Please",
+          "Would you mind",
+          "If it's not too much trouble",
+          "May I kindly ask"
+        ],
+        "politeSuffixes": [
+          "Thank you",
+          "If you don't mind",
+          "Please",
+          "Thanks"
+        ]
       }
     },
     {
@@ -614,7 +712,7 @@
             "name": "fullActionName",
             "value": "player.next",
             "substrings": [
-              "move to the next track"
+              "next track"
             ]
           }
         ],
@@ -630,7 +728,17 @@
             "isOptional": true
           },
           {
-            "text": "move to the next track",
+            "text": "move to the",
+            "category": "preposition",
+            "synonyms": [
+              "skip to",
+              "go to",
+              "switch to"
+            ],
+            "isOptional": true
+          },
+          {
+            "text": "next track",
             "category": "action",
             "propertyNames": [
               "fullActionName"
@@ -642,38 +750,48 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.next",
             "propertySubPhrases": [
-              "move to the next track"
+              "next track"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.previous",
                 "propertySubPhrases": [
-                  "move to the previous track"
+                  "previous track"
                 ]
               },
               {
                 "propertyValue": "player.pause",
                 "propertySubPhrases": [
-                  "pause the track"
+                  "pause track"
                 ]
               },
               {
                 "propertyValue": "player.play",
                 "propertySubPhrases": [
-                  "play the track"
+                  "play track"
                 ]
               },
               {
                 "propertyValue": "player.stop",
                 "propertySubPhrases": [
-                  "stop the track"
+                  "stop track"
                 ]
               }
             ]
           }
         ],
-        "politePrefixes": [],
-        "politeSuffixes": []
+        "politePrefixes": [
+          "Please",
+          "Would you mind",
+          "If you could",
+          "Kindly"
+        ],
+        "politeSuffixes": [
+          "please",
+          "if you don't mind",
+          "thank you",
+          "would be appreciated"
+        ]
       }
     },
     {
@@ -696,9 +814,9 @@
             "text": "Flick to the",
             "category": "filler",
             "synonyms": [
-              "Switch to the",
               "Move to the",
-              "Change to the"
+              "Skip to the",
+              "Jump to the"
             ],
             "isOptional": true
           },
@@ -711,7 +829,7 @@
           },
           {
             "text": "tune",
-            "category": "filler",
+            "category": "object",
             "synonyms": [
               "song",
               "track",
@@ -751,11 +869,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "May I ask you to",
+          "If you don't mind"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it."
+          "thank you",
+          "please",
+          "if that's okay",
+          "if you could"
         ]
       }
     },
@@ -777,13 +899,8 @@
         "subPhrases": [
           {
             "text": "Flip to the",
-            "category": "filler",
-            "synonyms": [
-              "Switch to the",
-              "Change to the",
-              "Move to the"
-            ],
-            "isOptional": true
+            "category": "command",
+            "propertyNames": []
           },
           {
             "text": "next",
@@ -793,14 +910,9 @@
             ]
           },
           {
-            "text": "song",
+            "text": "song.",
             "category": "object",
-            "synonyms": [
-              "track",
-              "tune",
-              "music"
-            ],
-            "isOptional": true
+            "propertyNames": []
           }
         ],
         "propertyAlternatives": [
@@ -834,11 +946,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If you don't mind",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you.",
-          "I would appreciate it."
+          "for me?",
+          "if that's okay.",
+          "please.",
+          "thank you."
         ]
       }
     },
@@ -865,7 +981,7 @@
           },
           {
             "text": "next",
-            "category": "command",
+            "category": "action",
             "propertyNames": [
               "fullActionName"
             ]
@@ -896,23 +1012,21 @@
                 "propertySubPhrases": [
                   "play"
                 ]
-              },
-              {
-                "propertyValue": "player.stop",
-                "propertySubPhrases": [
-                  "stop"
-                ]
               }
             ]
           }
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "Can you kindly",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you.",
-          "I would appreciate it."
+          "thank you",
+          "if you don't mind",
+          "please",
+          "thanks"
         ]
       }
     },
@@ -927,24 +1041,31 @@
             "name": "fullActionName",
             "value": "player.next",
             "substrings": [
-              "listen to the next song"
+              "next"
             ]
           }
         ],
         "subPhrases": [
           {
             "text": "I want to",
-            "category": "filler",
+            "category": "politeness",
             "synonyms": [
-              "I'd like to",
-              "I would like to",
-              "I wish to"
+              "please",
+              "could you",
+              "would you mind"
             ],
             "isOptional": true
           },
           {
-            "text": "listen to the next song",
+            "text": "listen to",
             "category": "action",
+            "propertyNames": [
+              "fullActionName"
+            ]
+          },
+          {
+            "text": "the next song",
+            "category": "object",
             "propertyNames": [
               "fullActionName"
             ]
@@ -955,31 +1076,36 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.next",
             "propertySubPhrases": [
-              "listen to the next song"
+              "listen to",
+              "the next song"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.previous",
                 "propertySubPhrases": [
-                  "listen to the previous song"
+                  "listen to",
+                  "the previous song"
                 ]
               },
               {
                 "propertyValue": "player.pause",
                 "propertySubPhrases": [
-                  "pause the song"
+                  "pause",
+                  "the song"
                 ]
               },
               {
                 "propertyValue": "player.play",
                 "propertySubPhrases": [
-                  "play the song"
+                  "play",
+                  "the song"
                 ]
               },
               {
-                "propertyValue": "player.stop",
+                "propertyValue": "player.shuffle",
                 "propertySubPhrases": [
-                  "stop the song"
+                  "shuffle",
+                  "the songs"
                 ]
               }
             ]
@@ -987,11 +1113,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If possible,",
+          "May I kindly"
         ],
         "politeSuffixes": [
-          "Thank you.",
-          "I would appreciate it."
+          "thank you.",
+          "please.",
+          "if you don't mind.",
+          "if that's okay."
         ]
       }
     },
@@ -1006,7 +1136,7 @@
             "name": "fullActionName",
             "value": "player.next",
             "substrings": [
-              "the next song"
+              "next"
             ]
           }
         ],
@@ -1015,22 +1145,44 @@
             "text": "I'd appreciate",
             "category": "politeness",
             "synonyms": [
-              "I would like",
-              "I would appreciate",
-              "I want"
+              "please",
+              "kindly",
+              "if you could",
+              "would you mind"
             ],
             "isOptional": true
           },
           {
-            "text": "the next song",
+            "text": "the",
+            "category": "filler",
+            "synonyms": [
+              "a",
+              "an",
+              "this",
+              "that"
+            ],
+            "isOptional": true
+          },
+          {
+            "text": "next",
             "category": "action",
             "propertyNames": [
               "fullActionName"
             ]
           },
           {
+            "text": "song",
+            "category": "object",
+            "synonyms": [
+              "track",
+              "music",
+              "tune"
+            ],
+            "isOptional": true
+          },
+          {
             "text": "now",
-            "category": "confirmation",
+            "category": "time",
             "synonyms": [
               "immediately",
               "right away",
@@ -1044,32 +1196,42 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.next",
             "propertySubPhrases": [
-              "the next song"
+              "next"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.previous",
                 "propertySubPhrases": [
-                  "the previous song"
+                  "previous"
                 ]
               },
               {
                 "propertyValue": "player.pause",
                 "propertySubPhrases": [
-                  "pause the song"
+                  "pause"
                 ]
               },
               {
                 "propertyValue": "player.play",
                 "propertySubPhrases": [
-                  "play the song"
+                  "play"
                 ]
               }
             ]
           }
         ],
-        "politePrefixes": [],
-        "politeSuffixes": []
+        "politePrefixes": [
+          "Could you please",
+          "Would you mind",
+          "If it's not too much trouble",
+          "May I kindly ask"
+        ],
+        "politeSuffixes": [
+          "thank you",
+          "if you don't mind",
+          "please",
+          "thanks a lot"
+        ]
       }
     },
     {
@@ -1089,17 +1251,27 @@
         ],
         "subPhrases": [
           {
-            "text": "I'd like to hear",
+            "text": "I'd like to",
             "category": "politeness",
             "synonyms": [
-              "I want to listen to",
-              "I would like to play",
-              "Can you play"
+              "I would like to",
+              "I want to",
+              "I wish to"
             ],
             "isOptional": true
           },
           {
-            "text": "the next track",
+            "text": "hear the",
+            "category": "filler",
+            "synonyms": [
+              "listen to",
+              "play",
+              "put on"
+            ],
+            "isOptional": true
+          },
+          {
+            "text": "next track",
             "category": "action",
             "propertyNames": [
               "fullActionName"
@@ -1111,31 +1283,31 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.next",
             "propertySubPhrases": [
-              "the next track"
+              "next track"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.previous",
                 "propertySubPhrases": [
-                  "the previous track"
+                  "previous track"
                 ]
               },
               {
                 "propertyValue": "player.pause",
                 "propertySubPhrases": [
-                  "pause the track"
+                  "pause track"
                 ]
               },
               {
                 "propertyValue": "player.play",
                 "propertySubPhrases": [
-                  "play the track"
+                  "play track"
                 ]
               },
               {
                 "propertyValue": "player.stop",
                 "propertySubPhrases": [
-                  "stop the track"
+                  "stop track"
                 ]
               }
             ]
@@ -1143,11 +1315,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If it's not too much trouble",
+          "May I kindly request"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I appreciate it!"
+          "thank you",
+          "please",
+          "if you don't mind",
+          "I'd appreciate it"
         ]
       }
     },
@@ -1171,9 +1347,9 @@
             "text": "I'd like to",
             "category": "politeness",
             "synonyms": [
-              "I would like to",
-              "I want to",
-              "I wish to"
+              "please",
+              "can you",
+              "could you"
             ],
             "isOptional": true
           },
@@ -1202,13 +1378,19 @@
               {
                 "propertyValue": "player.pause",
                 "propertySubPhrases": [
-                  "pause the playback"
+                  "pause the current"
                 ]
               },
               {
                 "propertyValue": "player.play",
                 "propertySubPhrases": [
-                  "start playing"
+                  "play the current"
+                ]
+              },
+              {
+                "propertyValue": "player.stop",
+                "propertySubPhrases": [
+                  "stop the current"
                 ]
               }
             ]
@@ -1217,14 +1399,14 @@
         "politePrefixes": [
           "Could you please",
           "Would you mind",
-          "If it's not too much trouble,",
-          "May I kindly ask"
+          "If it's not too much trouble",
+          "May I kindly request"
         ],
         "politeSuffixes": [
-          "Thank you.",
-          "I appreciate it.",
-          "Thanks a lot.",
-          "Much appreciated."
+          "thank you",
+          "please",
+          "if you don't mind",
+          "I'd appreciate it"
         ]
       }
     },
@@ -1239,7 +1421,7 @@
             "name": "fullActionName",
             "value": "player.next",
             "substrings": [
-              "next"
+              "next track"
             ]
           }
         ],
@@ -1250,26 +1432,16 @@
             "synonyms": [
               "I would like",
               "I want",
-              "I prefer"
+              "I wish"
             ],
             "isOptional": true
           },
           {
             "text": "the next track",
-            "category": "property",
+            "category": "action",
             "propertyNames": [
               "fullActionName"
             ]
-          },
-          {
-            "text": ".",
-            "category": "punctuation",
-            "synonyms": [
-              ".",
-              "!",
-              ""
-            ],
-            "isOptional": true
           }
         ],
         "propertyAlternatives": [
@@ -1309,11 +1481,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If it's not too much trouble",
+          "May I kindly ask"
         ],
         "politeSuffixes": [
-          "Thank you",
-          "If that's okay"
+          "thank you",
+          "please",
+          "if you don't mind",
+          "I'd appreciate it"
         ]
       }
     },
@@ -1334,29 +1510,29 @@
         ],
         "subPhrases": [
           {
-            "text": "I'm ready for the",
+            "text": "I'm ready for",
             "category": "filler",
             "synonyms": [
-              "I am prepared for the",
-              "I am set for the",
-              "I am ready for the"
+              "I am prepared for",
+              "I am set for",
+              "I am ready to"
             ],
             "isOptional": true
           },
           {
-            "text": "next",
-            "category": "action",
+            "text": "the next",
+            "category": "property",
             "propertyNames": [
               "fullActionName"
             ]
           },
           {
-            "text": "song.",
-            "category": "object",
+            "text": "song",
+            "category": "filler",
             "synonyms": [
-              "track.",
-              "tune.",
-              "music."
+              "track",
+              "tune",
+              "music"
             ],
             "isOptional": true
           }
@@ -1366,13 +1542,13 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.next",
             "propertySubPhrases": [
-              "next"
+              "the next"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.previous",
                 "propertySubPhrases": [
-                  "previous"
+                  "the previous"
                 ]
               },
               {
@@ -1386,17 +1562,27 @@
                 "propertySubPhrases": [
                   "play"
                 ]
+              },
+              {
+                "propertyValue": "player.stop",
+                "propertySubPhrases": [
+                  "stop"
+                ]
               }
             ]
           }
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If it's not too much trouble",
+          "May I kindly request"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I appreciate it!"
+          "thank you",
+          "please",
+          "if you don't mind",
+          "I'd appreciate it"
         ]
       }
     },
@@ -1411,27 +1597,24 @@
             "name": "fullActionName",
             "value": "player.next",
             "substrings": [
-              "next"
+              "Jump to the next track."
             ]
           }
         ],
         "subPhrases": [
           {
-            "text": "Jump to the",
+            "text": "Jump to",
             "category": "command",
-            "propertyNames": []
-          },
-          {
-            "text": "next",
-            "category": "property",
             "propertyNames": [
               "fullActionName"
             ]
           },
           {
-            "text": "track.",
+            "text": "the next track",
             "category": "object",
-            "propertyNames": []
+            "propertyNames": [
+              "fullActionName"
+            ]
           }
         ],
         "propertyAlternatives": [
@@ -1439,25 +1622,36 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.next",
             "propertySubPhrases": [
-              "next"
+              "Jump to",
+              "the next track"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.previous",
                 "propertySubPhrases": [
-                  "previous"
+                  "Jump to",
+                  "the previous track"
                 ]
               },
               {
                 "propertyValue": "player.pause",
                 "propertySubPhrases": [
-                  "pause"
+                  "Pause",
+                  "the track"
                 ]
               },
               {
                 "propertyValue": "player.play",
                 "propertySubPhrases": [
-                  "play"
+                  "Play",
+                  "the track"
+                ]
+              },
+              {
+                "propertyValue": "player.stop",
+                "propertySubPhrases": [
+                  "Stop",
+                  "the track"
                 ]
               }
             ]
@@ -1466,14 +1660,14 @@
         "politePrefixes": [
           "Could you please",
           "Would you mind",
-          "If it's not too much trouble, could you",
-          "May I kindly ask you to"
+          "If you don't mind",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you.",
-          "I would appreciate it.",
-          "Thanks a lot.",
-          "That would be great."
+          "if that's okay.",
+          "please.",
+          "if you could.",
+          "thank you."
         ]
       }
     },
@@ -1497,21 +1691,21 @@
             "text": "Kindly",
             "category": "politeness",
             "synonyms": [
-              "Please",
-              "Would you",
-              "Could you"
+              "please",
+              "if you would",
+              "be so kind"
             ],
             "isOptional": true
           },
           {
             "text": "take us to the",
-            "category": "filler",
+            "category": "preposition",
             "synonyms": [
               "move to",
               "go to",
               "switch to"
             ],
-            "isOptional": true
+            "isOptional": false
           },
           {
             "text": "next track",
@@ -1550,8 +1744,18 @@
             ]
           }
         ],
-        "politePrefixes": [],
-        "politeSuffixes": []
+        "politePrefixes": [
+          "Please",
+          "Would you mind",
+          "Could you kindly",
+          "If you don't mind"
+        ],
+        "politeSuffixes": [
+          "please",
+          "if you could",
+          "thank you",
+          "if that's okay"
+        ]
       }
     },
     {
@@ -1574,9 +1778,9 @@
             "text": "Let's go to the",
             "category": "filler",
             "synonyms": [
-              "Let's move to the",
-              "Proceed to the",
-              "Advance to the"
+              "let's proceed to the",
+              "let's move to the",
+              "let's advance to the"
             ],
             "isOptional": true
           },
@@ -1618,12 +1822,16 @@
           }
         ],
         "politePrefixes": [
-          "Could we please",
-          "Would you mind if we"
+          "Could you please",
+          "Would you mind",
+          "If you don't mind",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you.",
-          "I would appreciate it."
+          "if that's okay.",
+          "thank you.",
+          "please.",
+          "if you could."
         ]
       }
     },
@@ -1649,14 +1857,16 @@
             "synonyms": [
               "Let us",
               "We should",
-              "How about we"
+              "Let's go"
             ],
             "isOptional": true
           },
           {
             "text": "hear",
             "category": "action",
-            "propertyNames": []
+            "propertyNames": [
+              "fullActionName"
+            ]
           },
           {
             "text": "the next one",
@@ -1671,200 +1881,57 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.next",
             "propertySubPhrases": [
+              "hear",
               "the next one"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.previous",
                 "propertySubPhrases": [
+                  "hear",
                   "the previous one"
                 ]
               },
               {
                 "propertyValue": "player.pause",
                 "propertySubPhrases": [
-                  "pause the music"
+                  "pause",
+                  "the current one"
                 ]
               },
               {
                 "propertyValue": "player.play",
                 "propertySubPhrases": [
-                  "play the music"
+                  "play",
+                  "the current one"
                 ]
               },
               {
                 "propertyValue": "player.stop",
                 "propertySubPhrases": [
-                  "stop the music"
+                  "stop",
+                  "the current one"
                 ]
               }
             ]
           }
         ],
         "politePrefixes": [
-          "Please",
-          "Kindly"
+          "Could you please",
+          "Would you mind",
+          "If you don't mind",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you",
-          "if you don't mind"
+          "thank you",
+          "if that's okay",
+          "please",
+          "thanks"
         ]
       }
     },
     {
       "request": "Let's jump to the next tune.",
-      "action": {
-        "fullActionName": "player.next"
-      },
-      "explanation": {
-        "properties": [
-          {
-            "name": "fullActionName",
-            "value": "player.next",
-            "substrings": [
-              "jump to the next tune"
-            ]
-          }
-        ],
-        "subPhrases": [
-          {
-            "text": "Let's",
-            "category": "filler",
-            "synonyms": [
-              "Let us",
-              "We should",
-              "How about we"
-            ],
-            "isOptional": true
-          },
-          {
-            "text": "jump to the next tune",
-            "category": "action",
-            "propertyNames": [
-              "fullActionName"
-            ]
-          }
-        ],
-        "propertyAlternatives": [
-          {
-            "propertyName": "fullActionName",
-            "propertyValue": "player.next",
-            "propertySubPhrases": [
-              "jump to the next tune"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "player.previous",
-                "propertySubPhrases": [
-                  "go back to the previous tune"
-                ]
-              },
-              {
-                "propertyValue": "player.pause",
-                "propertySubPhrases": [
-                  "pause the tune"
-                ]
-              },
-              {
-                "propertyValue": "player.play",
-                "propertySubPhrases": [
-                  "play the tune"
-                ]
-              },
-              {
-                "propertyValue": "player.stop",
-                "propertySubPhrases": [
-                  "stop the tune"
-                ]
-              }
-            ]
-          }
-        ],
-        "politePrefixes": [
-          "Please",
-          "Kindly"
-        ],
-        "politeSuffixes": [
-          "Thank you",
-          "if you don't mind"
-        ]
-      }
-    },
-    {
-      "request": "Let's proceed to the next song.",
-      "action": {
-        "fullActionName": "player.next"
-      },
-      "explanation": {
-        "properties": [
-          {
-            "name": "fullActionName",
-            "value": "player.next",
-            "substrings": [
-              "proceed to the next song"
-            ]
-          }
-        ],
-        "subPhrases": [
-          {
-            "text": "Let's",
-            "category": "filler",
-            "synonyms": [
-              "Let us",
-              "We should",
-              "How about we"
-            ],
-            "isOptional": true
-          },
-          {
-            "text": "proceed to the next song",
-            "category": "action",
-            "propertyNames": [
-              "fullActionName"
-            ]
-          }
-        ],
-        "propertyAlternatives": [
-          {
-            "propertyName": "fullActionName",
-            "propertyValue": "player.next",
-            "propertySubPhrases": [
-              "proceed to the next song"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "player.previous",
-                "propertySubPhrases": [
-                  "go back to the previous song"
-                ]
-              },
-              {
-                "propertyValue": "player.pause",
-                "propertySubPhrases": [
-                  "pause the song"
-                ]
-              },
-              {
-                "propertyValue": "player.play",
-                "propertySubPhrases": [
-                  "play the song"
-                ]
-              }
-            ]
-          }
-        ],
-        "politePrefixes": [
-          "Please",
-          "Kindly"
-        ],
-        "politeSuffixes": [
-          "Thank you",
-          "if you don't mind"
-        ]
-      }
-    },
-    {
-      "request": "Let's roll to the next song.",
       "action": {
         "fullActionName": "player.next"
       },
@@ -1885,22 +1952,110 @@
             "synonyms": [
               "Let us",
               "We should",
-              "How about we"
+              "Let's go"
             ],
             "isOptional": true
           },
           {
-            "text": "roll to the",
+            "text": "jump to",
+            "category": "action",
+            "propertyNames": [
+              "fullActionName"
+            ]
+          },
+          {
+            "text": "the next tune",
+            "category": "object",
+            "propertyNames": [
+              "fullActionName"
+            ]
+          }
+        ],
+        "propertyAlternatives": [
+          {
+            "propertyName": "fullActionName",
+            "propertyValue": "player.next",
+            "propertySubPhrases": [
+              "jump to",
+              "the next tune"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "player.skip",
+                "propertySubPhrases": [
+                  "skip to",
+                  "the next track"
+                ]
+              },
+              {
+                "propertyValue": "player.advance",
+                "propertySubPhrases": [
+                  "advance to",
+                  "the next song"
+                ]
+              },
+              {
+                "propertyValue": "player.forward",
+                "propertySubPhrases": [
+                  "move forward to",
+                  "the next melody"
+                ]
+              }
+            ]
+          }
+        ],
+        "politePrefixes": [
+          "Could you please",
+          "Would you mind",
+          "If you don't mind",
+          "Please"
+        ],
+        "politeSuffixes": [
+          "if that's okay.",
+          "please.",
+          "if you could.",
+          "thank you."
+        ]
+      }
+    },
+    {
+      "request": "Let's proceed to the next song.",
+      "action": {
+        "fullActionName": "player.next"
+      },
+      "explanation": {
+        "properties": [
+          {
+            "name": "fullActionName",
+            "value": "player.next",
+            "substrings": [
+              "next song"
+            ]
+          }
+        ],
+        "subPhrases": [
+          {
+            "text": "Let's",
             "category": "filler",
             "synonyms": [
-              "move to the",
-              "go to the",
-              "proceed to the"
+              "Let us",
+              "We should",
+              "We can"
             ],
             "isOptional": true
           },
           {
-            "text": "next song",
+            "text": "proceed to",
+            "category": "filler",
+            "synonyms": [
+              "move to",
+              "go to",
+              "advance to"
+            ],
+            "isOptional": true
+          },
+          {
+            "text": "the next song",
             "category": "action",
             "propertyNames": [
               "fullActionName"
@@ -1912,25 +2067,31 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.next",
             "propertySubPhrases": [
-              "next song"
+              "the next song"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.previous",
                 "propertySubPhrases": [
-                  "previous song"
+                  "the previous song"
                 ]
               },
               {
                 "propertyValue": "player.pause",
                 "propertySubPhrases": [
-                  "pause song"
+                  "pause the song"
                 ]
               },
               {
                 "propertyValue": "player.play",
                 "propertySubPhrases": [
-                  "play song"
+                  "play the song"
+                ]
+              },
+              {
+                "propertyValue": "player.stop",
+                "propertySubPhrases": [
+                  "stop the song"
                 ]
               }
             ]
@@ -1938,11 +2099,102 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If you don't mind",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it."
+          "thank you",
+          "if that's okay",
+          "please",
+          "thanks"
+        ]
+      }
+    },
+    {
+      "request": "Let's roll to the next song.",
+      "action": {
+        "fullActionName": "player.next"
+      },
+      "explanation": {
+        "properties": [
+          {
+            "name": "fullActionName",
+            "value": "player.next",
+            "substrings": [
+              "next"
+            ]
+          }
+        ],
+        "subPhrases": [
+          {
+            "text": "Let's roll to the",
+            "category": "filler",
+            "synonyms": [
+              "Let's move to the",
+              "Let's go to the",
+              "Let's switch to the"
+            ],
+            "isOptional": true
+          },
+          {
+            "text": "next",
+            "category": "action",
+            "propertyNames": [
+              "fullActionName"
+            ]
+          },
+          {
+            "text": "song",
+            "category": "object",
+            "synonyms": [
+              "track",
+              "music",
+              "tune"
+            ],
+            "isOptional": true
+          }
+        ],
+        "propertyAlternatives": [
+          {
+            "propertyName": "fullActionName",
+            "propertyValue": "player.next",
+            "propertySubPhrases": [
+              "next"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "player.previous",
+                "propertySubPhrases": [
+                  "previous"
+                ]
+              },
+              {
+                "propertyValue": "player.pause",
+                "propertySubPhrases": [
+                  "pause"
+                ]
+              },
+              {
+                "propertyValue": "player.play",
+                "propertySubPhrases": [
+                  "play"
+                ]
+              }
+            ]
+          }
+        ],
+        "politePrefixes": [
+          "Could you please",
+          "Would you mind",
+          "If you don't mind",
+          "May I ask you to"
+        ],
+        "politeSuffixes": [
+          "please?",
+          "if that's okay?",
+          "thank you!",
+          "if you could?"
         ]
       }
     },
@@ -1997,31 +2249,35 @@
               {
                 "propertyValue": "player.pause",
                 "propertySubPhrases": [
-                  "pause the music"
+                  "pause the track"
                 ]
               },
               {
                 "propertyValue": "player.play",
                 "propertySubPhrases": [
-                  "play the music"
+                  "play the track"
                 ]
               },
               {
                 "propertyValue": "player.stop",
                 "propertySubPhrases": [
-                  "stop the music"
+                  "stop the track"
                 ]
               }
             ]
           }
         ],
         "politePrefixes": [
-          "Could we please",
-          "Would you mind if we"
+          "Could you please",
+          "Would you mind",
+          "If you don't mind",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "Thanks!"
+          "if that's okay.",
+          "please.",
+          "if you could.",
+          "thank you."
         ]
       }
     },
@@ -2036,14 +2292,34 @@
             "name": "fullActionName",
             "value": "player.next",
             "substrings": [
-              "Move on to the next song."
+              "next song"
             ]
           }
         ],
         "subPhrases": [
           {
-            "text": "Move on to the next song.",
-            "category": "command",
+            "text": "Move on to",
+            "category": "filler",
+            "synonyms": [
+              "proceed to",
+              "go to",
+              "advance to"
+            ],
+            "isOptional": true
+          },
+          {
+            "text": "the",
+            "category": "preposition",
+            "synonyms": [
+              "a",
+              "this",
+              "that"
+            ],
+            "isOptional": true
+          },
+          {
+            "text": "next song",
+            "category": "action",
             "propertyNames": [
               "fullActionName"
             ]
@@ -2054,25 +2330,31 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.next",
             "propertySubPhrases": [
-              "Move on to the next song."
+              "next song"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.previous",
                 "propertySubPhrases": [
-                  "Go back to the previous song."
+                  "previous song"
                 ]
               },
               {
                 "propertyValue": "player.pause",
                 "propertySubPhrases": [
-                  "Pause the music."
+                  "pause song"
                 ]
               },
               {
                 "propertyValue": "player.play",
                 "propertySubPhrases": [
-                  "Play the music."
+                  "play song"
+                ]
+              },
+              {
+                "propertyValue": "player.stop",
+                "propertySubPhrases": [
+                  "stop song"
                 ]
               }
             ]
@@ -2080,11 +2362,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If you don't mind",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you.",
-          "I would appreciate it."
+          "thank you",
+          "if that's okay",
+          "please",
+          "thanks"
         ]
       }
     },
@@ -2106,7 +2392,7 @@
         "subPhrases": [
           {
             "text": "Next",
-            "category": "action",
+            "category": "command",
             "propertyNames": [
               "fullActionName"
             ]
@@ -2115,158 +2401,9 @@
             "text": "hit",
             "category": "filler",
             "synonyms": [
-              "track",
-              "song",
-              "item"
-            ],
-            "isOptional": true
-          },
-          {
-            "text": "please",
-            "category": "politeness",
-            "synonyms": [
-              "kindly",
-              "if you could",
-              "would you mind"
-            ],
-            "isOptional": true
-          }
-        ],
-        "propertyAlternatives": [
-          {
-            "propertyName": "fullActionName",
-            "propertyValue": "player.next",
-            "propertySubPhrases": [
-              "Next"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "player.previous",
-                "propertySubPhrases": [
-                  "Previous"
-                ]
-              },
-              {
-                "propertyValue": "player.pause",
-                "propertySubPhrases": [
-                  "Pause"
-                ]
-              },
-              {
-                "propertyValue": "player.play",
-                "propertySubPhrases": [
-                  "Play"
-                ]
-              }
-            ]
-          }
-        ],
-        "politePrefixes": [],
-        "politeSuffixes": []
-      }
-    },
-    {
-      "request": "Next melody, please.",
-      "action": {
-        "fullActionName": "player.next"
-      },
-      "explanation": {
-        "properties": [
-          {
-            "name": "fullActionName",
-            "value": "player.next",
-            "substrings": [
-              "Next"
-            ]
-          }
-        ],
-        "subPhrases": [
-          {
-            "text": "Next",
-            "category": "command",
-            "propertyNames": [
-              "fullActionName"
-            ]
-          },
-          {
-            "text": "melody",
-            "category": "object",
-            "propertyNames": []
-          },
-          {
-            "text": "please",
-            "category": "politeness",
-            "synonyms": [
-              "kindly",
-              "if you would",
-              "if you please"
-            ],
-            "isOptional": true
-          }
-        ],
-        "propertyAlternatives": [
-          {
-            "propertyName": "fullActionName",
-            "propertyValue": "player.next",
-            "propertySubPhrases": [
-              "Next"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "player.previous",
-                "propertySubPhrases": [
-                  "Previous"
-                ]
-              },
-              {
-                "propertyValue": "player.pause",
-                "propertySubPhrases": [
-                  "Pause"
-                ]
-              },
-              {
-                "propertyValue": "player.play",
-                "propertySubPhrases": [
-                  "Play"
-                ]
-              }
-            ]
-          }
-        ],
-        "politePrefixes": [],
-        "politeSuffixes": []
-      }
-    },
-    {
-      "request": "Next number, please.",
-      "action": {
-        "fullActionName": "player.next"
-      },
-      "explanation": {
-        "properties": [
-          {
-            "name": "fullActionName",
-            "value": "player.next",
-            "substrings": [
-              "Next"
-            ]
-          }
-        ],
-        "subPhrases": [
-          {
-            "text": "Next",
-            "category": "action",
-            "propertyNames": [
-              "fullActionName"
-            ]
-          },
-          {
-            "text": "number",
-            "category": "filler",
-            "synonyms": [
-              "item",
-              "track",
-              "song"
+              "strike",
+              "blow",
+              "shot"
             ],
             "isOptional": true
           },
@@ -2312,16 +2449,20 @@
         ],
         "politePrefixes": [
           "Could you",
-          "Would you mind"
+          "Would you mind",
+          "May I ask",
+          "If you don't mind"
         ],
         "politeSuffixes": [
-          "Thank you.",
-          "Please."
+          "thank you",
+          "if that's okay",
+          "please and thank you",
+          "if you could"
         ]
       }
     },
     {
-      "request": "Next on the queue.",
+      "request": "Next melody, please.",
       "action": {
         "fullActionName": "player.next"
       },
@@ -2338,18 +2479,23 @@
         "subPhrases": [
           {
             "text": "Next",
-            "category": "action",
+            "category": "command",
             "propertyNames": [
               "fullActionName"
             ]
           },
           {
-            "text": "on the queue.",
-            "category": "context",
+            "text": "melody",
+            "category": "object",
+            "propertyNames": []
+          },
+          {
+            "text": "please",
+            "category": "politeness",
             "synonyms": [
-              "in the queue.",
-              "from the queue.",
-              "within the queue."
+              "kindly",
+              "if you would",
+              "if you could"
             ],
             "isOptional": true
           }
@@ -2384,12 +2530,170 @@
           }
         ],
         "politePrefixes": [
-          "Could you please",
-          "Would you mind"
+          "Could you",
+          "Would you mind",
+          "May I ask",
+          "If you don't mind"
         ],
         "politeSuffixes": [
-          "Thank you.",
-          "I appreciate it."
+          "thank you",
+          "if that's okay",
+          "please",
+          "thanks"
+        ]
+      }
+    },
+    {
+      "request": "Next number, please.",
+      "action": {
+        "fullActionName": "player.next"
+      },
+      "explanation": {
+        "properties": [
+          {
+            "name": "fullActionName",
+            "value": "player.next",
+            "substrings": [
+              "Next"
+            ]
+          }
+        ],
+        "subPhrases": [
+          {
+            "text": "Next",
+            "category": "command",
+            "propertyNames": [
+              "fullActionName"
+            ]
+          },
+          {
+            "text": "number",
+            "category": "object",
+            "propertyNames": []
+          },
+          {
+            "text": "please",
+            "category": "politeness",
+            "synonyms": [
+              "kindly",
+              "if you would",
+              "if you please"
+            ],
+            "isOptional": true
+          }
+        ],
+        "propertyAlternatives": [
+          {
+            "propertyName": "fullActionName",
+            "propertyValue": "player.next",
+            "propertySubPhrases": [
+              "Next"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "player.previous",
+                "propertySubPhrases": [
+                  "Previous"
+                ]
+              },
+              {
+                "propertyValue": "player.pause",
+                "propertySubPhrases": [
+                  "Pause"
+                ]
+              },
+              {
+                "propertyValue": "player.play",
+                "propertySubPhrases": [
+                  "Play"
+                ]
+              }
+            ]
+          }
+        ],
+        "politePrefixes": [
+          "Could you kindly",
+          "Would you mind",
+          "If you don't mind",
+          "May I request"
+        ],
+        "politeSuffixes": [
+          "thank you",
+          "if that's okay",
+          "please and thank you",
+          "if you could"
+        ]
+      }
+    },
+    {
+      "request": "Next on the queue.",
+      "action": {
+        "fullActionName": "player.next"
+      },
+      "explanation": {
+        "properties": [
+          {
+            "name": "fullActionName",
+            "value": "player.next",
+            "substrings": [
+              "Next"
+            ]
+          }
+        ],
+        "subPhrases": [
+          {
+            "text": "Next",
+            "category": "command",
+            "propertyNames": [
+              "fullActionName"
+            ]
+          },
+          {
+            "text": "on the queue.",
+            "category": "context",
+            "propertyNames": []
+          }
+        ],
+        "propertyAlternatives": [
+          {
+            "propertyName": "fullActionName",
+            "propertyValue": "player.next",
+            "propertySubPhrases": [
+              "Next"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "player.previous",
+                "propertySubPhrases": [
+                  "Previous"
+                ]
+              },
+              {
+                "propertyValue": "player.pause",
+                "propertySubPhrases": [
+                  "Pause"
+                ]
+              },
+              {
+                "propertyValue": "player.play",
+                "propertySubPhrases": [
+                  "Play"
+                ]
+              }
+            ]
+          }
+        ],
+        "politePrefixes": [
+          "Could you please",
+          "Would you mind",
+          "May I ask you to",
+          "If you don't mind"
+        ],
+        "politeSuffixes": [
+          "thank you",
+          "please",
+          "if that's okay",
+          "if you could"
         ]
       }
     },
@@ -2421,8 +2725,9 @@
             "category": "politeness",
             "synonyms": [
               "please",
-              "if it's not too much trouble",
-              "if you could"
+              "if it's okay",
+              "if you could",
+              "if possible"
             ],
             "isOptional": true
           }
@@ -2444,20 +2749,30 @@
               {
                 "propertyValue": "player.pause",
                 "propertySubPhrases": [
-                  "Pause the music"
+                  "Pause song"
                 ]
               },
               {
                 "propertyValue": "player.play",
                 "propertySubPhrases": [
-                  "Play the music"
+                  "Play song"
                 ]
               }
             ]
           }
         ],
-        "politePrefixes": [],
-        "politeSuffixes": []
+        "politePrefixes": [
+          "Could you please",
+          "Would you kindly",
+          "May I ask you to",
+          "If it's not too much trouble"
+        ],
+        "politeSuffixes": [
+          "thank you",
+          "please",
+          "if you could",
+          "I'd appreciate it"
+        ]
       }
     },
     {
@@ -2523,8 +2838,18 @@
             ]
           }
         ],
-        "politePrefixes": [],
-        "politeSuffixes": []
+        "politePrefixes": [
+          "Could you",
+          "Would you mind",
+          "May I ask",
+          "If you don't mind"
+        ],
+        "politeSuffixes": [
+          "thank you",
+          "if that's okay",
+          "please and thank you",
+          "if you could"
+        ]
       }
     },
     {
@@ -2538,14 +2863,14 @@
             "name": "fullActionName",
             "value": "player.next",
             "substrings": [
-              "Next"
+              "Next tune"
             ]
           }
         ],
         "subPhrases": [
           {
             "text": "Next tune",
-            "category": "action",
+            "category": "command",
             "propertyNames": [
               "fullActionName"
             ]
@@ -2555,7 +2880,7 @@
             "category": "politeness",
             "synonyms": [
               "please",
-              "if you don't mind",
+              "if you would",
               "be so kind"
             ],
             "isOptional": true
@@ -2586,12 +2911,23 @@
                 "propertySubPhrases": [
                   "Play tune"
                 ]
+              },
+              {
+                "propertyValue": "player.stop",
+                "propertySubPhrases": [
+                  "Stop tune"
+                ]
               }
             ]
           }
         ],
         "politePrefixes": [],
-        "politeSuffixes": []
+        "politeSuffixes": [
+          "please.",
+          "if you don't mind.",
+          "thank you.",
+          "would you kindly?"
+        ]
       }
     },
     {
@@ -2605,22 +2941,27 @@
             "name": "fullActionName",
             "value": "player.next",
             "substrings": [
-              "Next up"
+              "Next"
             ]
           }
         ],
         "subPhrases": [
           {
-            "text": "Next up",
-            "category": "action",
+            "text": "Next",
+            "category": "command",
             "propertyNames": [
               "fullActionName"
             ]
           },
           {
-            "text": "on the playlist",
+            "text": "up on the playlist.",
             "category": "context",
-            "propertyNames": []
+            "synonyms": [
+              "in the playlist",
+              "on the list",
+              "in the queue"
+            ],
+            "isOptional": true
           }
         ],
         "propertyAlternatives": [
@@ -2628,25 +2969,25 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.next",
             "propertySubPhrases": [
-              "Next up"
+              "Next"
             ],
             "alternatives": [
               {
-                "propertyValue": "player.skip",
+                "propertyValue": "player.previous",
                 "propertySubPhrases": [
-                  "Skip to the next"
+                  "Previous"
                 ]
               },
               {
-                "propertyValue": "player.forward",
+                "propertyValue": "player.pause",
                 "propertySubPhrases": [
-                  "Forward to the next"
+                  "Pause"
                 ]
               },
               {
-                "propertyValue": "player.advance",
+                "propertyValue": "player.play",
                 "propertySubPhrases": [
-                  "Advance to the next"
+                  "Play"
                 ]
               }
             ]
@@ -2654,11 +2995,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "May I ask you to",
+          "If you don't mind"
         ],
         "politeSuffixes": [
-          "Thank you.",
-          "I appreciate it."
+          "thank you",
+          "please",
+          "if that's okay",
+          "if you could"
         ]
       }
     },
@@ -2727,11 +3072,15 @@
         ],
         "politePrefixes": [
           "Could you",
-          "Would you mind"
+          "Would you mind",
+          "If you don't mind",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "Please"
+          "Thank you",
+          "Thanks",
+          "If that's okay",
+          "I appreciate it"
         ]
       }
     },
@@ -2746,17 +3095,37 @@
             "name": "fullActionName",
             "value": "player.next",
             "substrings": [
-              "On to the next one."
+              "next"
             ]
           }
         ],
         "subPhrases": [
           {
-            "text": "On to the next one.",
-            "category": "command",
+            "text": "On to the",
+            "category": "filler",
+            "synonyms": [
+              "moving to",
+              "proceeding to",
+              "advancing to"
+            ],
+            "isOptional": true
+          },
+          {
+            "text": "next",
+            "category": "action",
             "propertyNames": [
               "fullActionName"
             ]
+          },
+          {
+            "text": "one.",
+            "category": "filler",
+            "synonyms": [
+              "item",
+              "track",
+              "song"
+            ],
+            "isOptional": true
           }
         ],
         "propertyAlternatives": [
@@ -2764,37 +3133,41 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.next",
             "propertySubPhrases": [
-              "On to the next one."
+              "next"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.previous",
                 "propertySubPhrases": [
-                  "Go back to the previous one."
+                  "previous"
                 ]
               },
               {
                 "propertyValue": "player.pause",
                 "propertySubPhrases": [
-                  "Pause the current one."
+                  "pause"
                 ]
               },
               {
-                "propertyValue": "player.stop",
+                "propertyValue": "player.play",
                 "propertySubPhrases": [
-                  "Stop the current one."
+                  "play"
                 ]
               }
             ]
           }
         ],
         "politePrefixes": [
-          "Please",
-          "Kindly"
+          "Could you please",
+          "Would you mind",
+          "If you don't mind",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you",
-          "if you don't mind"
+          "thank you",
+          "if that's okay",
+          "please",
+          "thanks"
         ]
       }
     },
@@ -2809,7 +3182,7 @@
             "name": "fullActionName",
             "value": "player.next",
             "substrings": [
-              "cue the next track"
+              "next"
             ]
           }
         ],
@@ -2818,18 +3191,28 @@
             "text": "Please",
             "category": "politeness",
             "synonyms": [
-              "Kindly",
-              "Would you mind",
-              "Could you"
+              "kindly",
+              "would you mind",
+              "could you"
             ],
             "isOptional": true
           },
           {
-            "text": "cue the next track",
-            "category": "action",
+            "text": "cue the",
+            "category": "command",
+            "propertyNames": []
+          },
+          {
+            "text": "next",
+            "category": "descriptor",
             "propertyNames": [
               "fullActionName"
             ]
+          },
+          {
+            "text": "track",
+            "category": "object",
+            "propertyNames": []
           }
         ],
         "propertyAlternatives": [
@@ -2837,38 +3220,42 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.next",
             "propertySubPhrases": [
-              "cue the next track"
+              "next"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.previous",
                 "propertySubPhrases": [
-                  "cue the previous track"
+                  "previous"
                 ]
               },
               {
                 "propertyValue": "player.pause",
                 "propertySubPhrases": [
-                  "pause the track"
+                  "pause"
                 ]
               },
               {
                 "propertyValue": "player.play",
                 "propertySubPhrases": [
-                  "play the track"
-                ]
-              },
-              {
-                "propertyValue": "player.stop",
-                "propertySubPhrases": [
-                  "stop the track"
+                  "play"
                 ]
               }
             ]
           }
         ],
-        "politePrefixes": [],
-        "politeSuffixes": []
+        "politePrefixes": [
+          "Could you kindly",
+          "Would you mind",
+          "If it's not too much trouble",
+          "May I ask you to"
+        ],
+        "politeSuffixes": [
+          "when you have a moment?",
+          "if you don't mind.",
+          "please.",
+          "thank you."
+        ]
       }
     },
     {
@@ -2893,7 +3280,7 @@
             "synonyms": [
               "Kindly",
               "Would you mind",
-              "Could you please"
+              "Could you"
             ],
             "isOptional": true
           },
@@ -2922,26 +3309,36 @@
               {
                 "propertyValue": "player.pause",
                 "propertySubPhrases": [
-                  "pause the track"
+                  "pause the current track"
                 ]
               },
               {
                 "propertyValue": "player.play",
                 "propertySubPhrases": [
-                  "play the track"
+                  "play the current track"
                 ]
               },
               {
                 "propertyValue": "player.stop",
                 "propertySubPhrases": [
-                  "stop the track"
+                  "stop the current track"
                 ]
               }
             ]
           }
         ],
-        "politePrefixes": [],
-        "politeSuffixes": []
+        "politePrefixes": [
+          "Could you kindly",
+          "Would you mind",
+          "If it's not too much trouble",
+          "May I ask you to"
+        ],
+        "politeSuffixes": [
+          "Thank you.",
+          "I appreciate it.",
+          "Thanks a lot.",
+          "Much appreciated."
+        ]
       }
     },
     {
@@ -2955,7 +3352,7 @@
             "name": "fullActionName",
             "value": "player.next",
             "substrings": [
-              "play the next one"
+              "next"
             ]
           }
         ],
@@ -2971,8 +3368,15 @@
             "isOptional": true
           },
           {
-            "text": "play the next one",
+            "text": "play",
             "category": "action",
+            "propertyNames": [
+              "fullActionName"
+            ]
+          },
+          {
+            "text": "the next one",
+            "category": "object",
             "propertyNames": [
               "fullActionName"
             ]
@@ -2983,32 +3387,53 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.next",
             "propertySubPhrases": [
-              "play the next one"
+              "play",
+              "the next one"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.previous",
                 "propertySubPhrases": [
-                  "play the previous one"
+                  "play",
+                  "the previous one"
                 ]
               },
               {
                 "propertyValue": "player.pause",
                 "propertySubPhrases": [
-                  "pause the playback"
+                  "pause",
+                  "the current one"
                 ]
               },
               {
                 "propertyValue": "player.stop",
                 "propertySubPhrases": [
-                  "stop the playback"
+                  "stop",
+                  "the current one"
+                ]
+              },
+              {
+                "propertyValue": "player.shuffle",
+                "propertySubPhrases": [
+                  "shuffle",
+                  "the playlist"
                 ]
               }
             ]
           }
         ],
-        "politePrefixes": [],
-        "politeSuffixes": []
+        "politePrefixes": [
+          "Could you kindly",
+          "Would you mind",
+          "If you don't mind",
+          "May I ask you to"
+        ],
+        "politeSuffixes": [
+          "if it's not too much trouble?",
+          "please?",
+          "thank you.",
+          "if you could."
+        ]
       }
     },
     {
@@ -3032,8 +3457,8 @@
             "category": "politeness",
             "synonyms": [
               "Kindly",
-              "Would you mind",
-              "Could you"
+              "Could you",
+              "Would you mind"
             ],
             "isOptional": true
           },
@@ -3079,8 +3504,18 @@
             ]
           }
         ],
-        "politePrefixes": [],
-        "politeSuffixes": []
+        "politePrefixes": [
+          "Could you kindly",
+          "Would you mind",
+          "If it's not too much trouble",
+          "May I ask you to"
+        ],
+        "politeSuffixes": [
+          "if you don't mind?",
+          "please?",
+          "thank you.",
+          "if that's okay."
+        ]
       }
     },
     {
@@ -3094,17 +3529,37 @@
             "name": "fullActionName",
             "value": "player.next",
             "substrings": [
-              "Proceed to the next song."
+              "next"
             ]
           }
         ],
         "subPhrases": [
           {
-            "text": "Proceed to the next song.",
-            "category": "command",
+            "text": "Proceed to the",
+            "category": "filler",
+            "synonyms": [
+              "Go to the",
+              "Move to the",
+              "Advance to the"
+            ],
+            "isOptional": true
+          },
+          {
+            "text": "next",
+            "category": "action",
             "propertyNames": [
               "fullActionName"
             ]
+          },
+          {
+            "text": "song",
+            "category": "object",
+            "synonyms": [
+              "track",
+              "music",
+              "tune"
+            ],
+            "isOptional": true
           }
         ],
         "propertyAlternatives": [
@@ -3112,31 +3567,25 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.next",
             "propertySubPhrases": [
-              "Proceed to the next song."
+              "next"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.previous",
                 "propertySubPhrases": [
-                  "Go back to the previous song."
+                  "previous"
                 ]
               },
               {
                 "propertyValue": "player.pause",
                 "propertySubPhrases": [
-                  "Pause the song."
+                  "pause"
                 ]
               },
               {
                 "propertyValue": "player.play",
                 "propertySubPhrases": [
-                  "Play the song."
-                ]
-              },
-              {
-                "propertyValue": "player.stop",
-                "propertySubPhrases": [
-                  "Stop the song."
+                  "play"
                 ]
               }
             ]
@@ -3144,11 +3593,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If you don't mind",
+          "May I ask you to"
         ],
         "politeSuffixes": [
-          "Thank you.",
-          "I would appreciate it."
+          "thank you",
+          "please",
+          "if that's okay",
+          "if you could"
         ]
       }
     },
@@ -3176,8 +3629,8 @@
             ]
           },
           {
-            "text": "next.",
-            "category": "command",
+            "text": "next",
+            "category": "object",
             "propertyNames": [
               "fullActionName"
             ]
@@ -3189,28 +3642,28 @@
             "propertyValue": "player.next",
             "propertySubPhrases": [
               "Push",
-              "next."
+              "next"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.previous",
                 "propertySubPhrases": [
                   "Push",
-                  "previous."
+                  "previous"
                 ]
               },
               {
                 "propertyValue": "player.pause",
                 "propertySubPhrases": [
                   "Push",
-                  "pause."
+                  "pause"
                 ]
               },
               {
                 "propertyValue": "player.play",
                 "propertySubPhrases": [
                   "Push",
-                  "play."
+                  "play"
                 ]
               }
             ]
@@ -3218,11 +3671,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If you don't mind",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you.",
-          "I appreciate it."
+          "thank you",
+          "if that's okay",
+          "please",
+          "thanks"
         ]
       }
     },
@@ -3237,17 +3694,37 @@
             "name": "fullActionName",
             "value": "player.next",
             "substrings": [
-              "Queue up the next song."
+              "next"
             ]
           }
         ],
         "subPhrases": [
           {
-            "text": "Queue up the next song.",
+            "text": "Queue up",
             "category": "command",
+            "propertyNames": []
+          },
+          {
+            "text": "the",
+            "category": "preposition",
+            "synonyms": [
+              "a",
+              "an",
+              "this"
+            ],
+            "isOptional": true
+          },
+          {
+            "text": "next",
+            "category": "descriptor",
             "propertyNames": [
               "fullActionName"
             ]
+          },
+          {
+            "text": "song",
+            "category": "object",
+            "propertyNames": []
           }
         ],
         "propertyAlternatives": [
@@ -3255,25 +3732,25 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.next",
             "propertySubPhrases": [
-              "Queue up the next song."
+              "next"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.previous",
                 "propertySubPhrases": [
-                  "Queue up the previous song."
+                  "previous"
                 ]
               },
               {
                 "propertyValue": "player.pause",
                 "propertySubPhrases": [
-                  "Pause the song."
+                  "pause"
                 ]
               },
               {
                 "propertyValue": "player.play",
                 "propertySubPhrases": [
-                  "Play the song."
+                  "play"
                 ]
               }
             ]
@@ -3282,12 +3759,14 @@
         "politePrefixes": [
           "Could you please",
           "Would you mind",
-          "If it's not too much trouble, could you"
+          "If you don't mind",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it.",
-          "Thanks a lot!"
+          "thank you",
+          "if that's okay",
+          "please",
+          "thanks"
         ]
       }
     },
@@ -3302,14 +3781,24 @@
             "name": "fullActionName",
             "value": "player.next",
             "substrings": [
-              "Shift to the next track."
+              "next track"
             ]
           }
         ],
         "subPhrases": [
           {
-            "text": "Shift to the next track.",
-            "category": "command",
+            "text": "Shift to the",
+            "category": "filler",
+            "synonyms": [
+              "move to",
+              "go to",
+              "switch to"
+            ],
+            "isOptional": true
+          },
+          {
+            "text": "next track",
+            "category": "action",
             "propertyNames": [
               "fullActionName"
             ]
@@ -3320,31 +3809,25 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.next",
             "propertySubPhrases": [
-              "Shift to the next track."
+              "next track"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.previous",
                 "propertySubPhrases": [
-                  "Shift to the previous track."
+                  "previous track"
                 ]
               },
               {
                 "propertyValue": "player.pause",
                 "propertySubPhrases": [
-                  "Pause the track."
+                  "pause track"
                 ]
               },
               {
                 "propertyValue": "player.play",
                 "propertySubPhrases": [
-                  "Play the track."
-                ]
-              },
-              {
-                "propertyValue": "player.stop",
-                "propertySubPhrases": [
-                  "Stop the track."
+                  "play track"
                 ]
               }
             ]
@@ -3352,11 +3835,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If you don't mind",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you.",
-          "I would appreciate it."
+          "thank you",
+          "if that's okay",
+          "please",
+          "thanks"
         ]
       }
     },
@@ -3409,17 +3896,27 @@
                 "propertySubPhrases": [
                   "Play the song."
                 ]
+              },
+              {
+                "propertyValue": "player.stop",
+                "propertySubPhrases": [
+                  "Stop the song."
+                ]
               }
             ]
           }
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If you don't mind",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it."
+          "thank you",
+          "if that's okay",
+          "please",
+          "thanks"
         ]
       }
     },
@@ -3440,12 +3937,22 @@
         ],
         "subPhrases": [
           {
-            "text": "Slide over to the",
+            "text": "Slide over to",
             "category": "filler",
             "synonyms": [
-              "Move to the",
-              "Go to the",
-              "Switch to the"
+              "move to",
+              "go to",
+              "switch to"
+            ],
+            "isOptional": true
+          },
+          {
+            "text": "the",
+            "category": "preposition",
+            "synonyms": [
+              "a",
+              "this",
+              "that"
             ],
             "isOptional": true
           },
@@ -3482,17 +3989,27 @@
                 "propertySubPhrases": [
                   "play song"
                 ]
+              },
+              {
+                "propertyValue": "player.stop",
+                "propertySubPhrases": [
+                  "stop song"
+                ]
               }
             ]
           }
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If you don't mind",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it."
+          "thank you",
+          "if that's okay",
+          "please",
+          "thanks"
         ]
       }
     },
@@ -3513,12 +4030,17 @@
         ],
         "subPhrases": [
           {
-            "text": "Swipe to the",
-            "category": "filler",
+            "text": "Swipe",
+            "category": "action",
+            "propertyNames": []
+          },
+          {
+            "text": "to the",
+            "category": "preposition",
             "synonyms": [
-              "Move to the",
-              "Go to the",
-              "Switch to the"
+              "towards",
+              "for",
+              "in direction of"
             ],
             "isOptional": true
           },
@@ -3555,17 +4077,27 @@
                 "propertySubPhrases": [
                   "play track"
                 ]
+              },
+              {
+                "propertyValue": "player.stop",
+                "propertySubPhrases": [
+                  "stop track"
+                ]
               }
             ]
           }
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "Please",
+          "Kindly"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it."
+          "if you don't mind.",
+          "please.",
+          "thank you.",
+          "if possible."
         ]
       }
     },
@@ -3590,8 +4122,8 @@
             "category": "politeness",
             "synonyms": [
               "Could you please",
-              "Do you mind",
-              "Would it be possible"
+              "Can you",
+              "Would you kindly"
             ],
             "isOptional": true
           },
@@ -3628,12 +4160,28 @@
                 "propertySubPhrases": [
                   "play the track"
                 ]
+              },
+              {
+                "propertyValue": "player.stop",
+                "propertySubPhrases": [
+                  "stop the track"
+                ]
               }
             ]
           }
         ],
-        "politePrefixes": [],
-        "politeSuffixes": []
+        "politePrefixes": [
+          "Could you please",
+          "If it's not too much trouble,",
+          "Would it be possible to",
+          "May I kindly ask you to"
+        ],
+        "politeSuffixes": [
+          "please?",
+          "if you don't mind.",
+          "thank you.",
+          "if that's okay."
+        ]
       }
     },
     {
@@ -3656,9 +4204,9 @@
             "text": "Yo",
             "category": "greeting",
             "synonyms": [
-              "Hey",
               "Hi",
-              "Hello"
+              "Hello",
+              "Hey"
             ],
             "isOptional": true
           },
@@ -3700,12 +4248,16 @@
           }
         ],
         "politePrefixes": [
-          "Could you please",
-          "Would you mind"
+          "Please",
+          "Could you",
+          "Would you mind",
+          "Kindly"
         ],
         "politeSuffixes": [
-          "Thank you",
-          "Please"
+          "please",
+          "if you don't mind",
+          "thank you",
+          "thanks"
         ]
       }
     }

--- a/ts/packages/defaultAgentProvider/test/data/explanations/player/v5/param.json
+++ b/ts/packages/defaultAgentProvider/test/data/explanations/player/v5/param.json
@@ -32,7 +32,7 @@
           },
           {
             "text": "start the music",
-            "category": "action",
+            "category": "command",
             "propertyNames": [
               "fullActionName"
             ]
@@ -57,34 +57,38 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.pause",
+                "propertyValue": "player.play",
                 "propertySubPhrases": [
-                  "pause the music"
+                  "play the music"
                 ]
               },
               {
-                "propertyValue": "player.stop",
+                "propertyValue": "player.resume",
                 "propertySubPhrases": [
-                  "stop the music"
+                  "resume the music"
                 ]
               },
               {
-                "propertyValue": "player.next",
+                "propertyValue": "player.shuffle",
                 "propertySubPhrases": [
-                  "skip the song"
-                ]
-              },
-              {
-                "propertyValue": "player.previous",
-                "propertySubPhrases": [
-                  "play the previous song"
+                  "shuffle the music"
                 ]
               }
             ]
           }
         ],
-        "politePrefixes": [],
-        "politeSuffixes": []
+        "politePrefixes": [
+          "Would you mind",
+          "Could you kindly",
+          "If it's not too much trouble",
+          "May I ask you to"
+        ],
+        "politeSuffixes": [
+          "if you don't mind?",
+          "when you have a moment.",
+          "if it's convenient for you.",
+          "at your earliest convenience."
+        ]
       }
     },
     {
@@ -107,15 +111,15 @@
             "text": "How about",
             "category": "filler",
             "synonyms": [
-              "What about",
-              "Why don't you",
-              "How's this"
+              "What if",
+              "Maybe",
+              "Suppose"
             ],
             "isOptional": true
           },
           {
             "text": "you choose a song to play",
-            "category": "action",
+            "category": "command",
             "propertyNames": [
               "fullActionName"
             ]
@@ -132,25 +136,25 @@
               {
                 "propertyValue": "player.playNext",
                 "propertySubPhrases": [
-                  "you play the next song"
+                  "play the next song"
                 ]
               },
               {
                 "propertyValue": "player.playPrevious",
                 "propertySubPhrases": [
-                  "you play the previous song"
+                  "play the previous song"
                 ]
               },
               {
-                "propertyValue": "player.playFavorite",
+                "propertyValue": "player.playSpecific",
                 "propertySubPhrases": [
-                  "you play a favorite song"
+                  "play a specific song"
                 ]
               },
               {
-                "propertyValue": "player.playTop",
+                "propertyValue": "player.shufflePlay",
                 "propertySubPhrases": [
-                  "you play a top song"
+                  "shuffle and play songs"
                 ]
               }
             ]
@@ -158,11 +162,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If it's not too much trouble",
+          "May I kindly ask"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it."
+          "if you don't mind?",
+          "please?",
+          "thank you.",
+          "if that's okay with you."
         ]
       }
     },
@@ -195,7 +203,7 @@
             "synonyms": [
               "please",
               "if you could",
-              "kindly"
+              "would you mind"
             ],
             "isOptional": true
           }
@@ -211,7 +219,7 @@
               {
                 "propertyValue": "player.playSpecific",
                 "propertySubPhrases": [
-                  "Play the song"
+                  "Play a specific song"
                 ]
               },
               {
@@ -232,12 +240,14 @@
         "politePrefixes": [
           "Could you please",
           "Would you mind",
-          "If it's not too much trouble, could you"
+          "If you don't mind",
+          "I would appreciate it if you could"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it.",
-          "Thanks a lot!"
+          "thank you",
+          "please",
+          "if that's okay",
+          "if you could"
         ]
       }
     },
@@ -266,8 +276,18 @@
             ]
           },
           {
-            "text": "some tunes",
-            "category": "content",
+            "text": "some",
+            "category": "filler",
+            "synonyms": [
+              "a few",
+              "any",
+              "several"
+            ],
+            "isOptional": true
+          },
+          {
+            "text": "tunes",
+            "category": "object",
             "propertyNames": [
               "fullActionName"
             ]
@@ -289,28 +309,28 @@
             "propertyValue": "player.playRandom",
             "propertySubPhrases": [
               "Play",
-              "some tunes"
+              "tunes"
             ],
             "alternatives": [
               {
-                "propertyValue": "player.playPlaylist",
+                "propertyValue": "player.playSpecific",
                 "propertySubPhrases": [
                   "Play",
-                  "a playlist"
+                  "specific tunes"
                 ]
               },
               {
-                "propertyValue": "player.playAlbum",
+                "propertyValue": "player.playGenre",
                 "propertySubPhrases": [
                   "Play",
-                  "an album"
+                  "genre tunes"
                 ]
               },
               {
-                "propertyValue": "player.playSong",
+                "propertyValue": "player.playFavorites",
                 "propertySubPhrases": [
                   "Play",
-                  "a song"
+                  "favorite tunes"
                 ]
               }
             ]
@@ -318,11 +338,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If you don't mind",
+          "I would appreciate it if you could"
         ],
         "politeSuffixes": [
-          "Thank you",
-          "if that's okay"
+          "thank you",
+          "please",
+          "if that's okay",
+          "if you could"
         ]
       }
     },
@@ -348,7 +372,7 @@
             "synonyms": [
               "Can we",
               "Should we",
-              "Do we want to"
+              "Will we"
             ],
             "isOptional": true
           },
@@ -395,12 +419,28 @@
                 "propertySubPhrases": [
                   "stop the music"
                 ]
+              },
+              {
+                "propertyValue": "player.skip",
+                "propertySubPhrases": [
+                  "skip this song"
+                ]
               }
             ]
           }
         ],
-        "politePrefixes": [],
-        "politeSuffixes": []
+        "politePrefixes": [
+          "Would you mind if",
+          "Could we please",
+          "May I suggest that",
+          "How about"
+        ],
+        "politeSuffixes": [
+          "if that's okay with you?",
+          "please?",
+          "if you don't mind?",
+          "if that works for you?"
+        ]
       }
     },
     {
@@ -426,7 +466,7 @@
           },
           {
             "text": "my favorite songs",
-            "category": "content",
+            "category": "object",
             "propertyNames": [
               "fullActionName"
             ]
@@ -463,11 +503,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If it's not too much trouble,",
+          "I would appreciate it if you could"
         ],
         "politeSuffixes": [
-          "Thank you",
-          "I would appreciate it"
+          "thank you.",
+          "please.",
+          "if you don't mind.",
+          "thanks a lot."
         ]
       }
     },
@@ -481,14 +525,18 @@
           {
             "name": "fullActionName",
             "value": "player.playRandom",
-            "isImplicit": true
+            "substrings": [
+              "Start the music"
+            ]
           }
         ],
         "subPhrases": [
           {
             "text": "Start the music",
             "category": "command",
-            "propertyNames": []
+            "propertyNames": [
+              "fullActionName"
+            ]
           },
           {
             "text": "please",
@@ -496,50 +544,59 @@
             "synonyms": [
               "kindly",
               "if you would",
-              "if you please"
+              "if you could"
             ],
             "isOptional": true
           }
         ],
-        "propertyAlternatives": [],
-        "politePrefixes": [],
-        "politeSuffixes": []
-      },
-      "corrections": [
-        {
-          "data": {
-            "properties": [
-              {
-                "name": "fullActionName",
-                "value": "player.playRandom",
-                "isImplicit": true
-              }
+        "propertyAlternatives": [
+          {
+            "propertyName": "fullActionName",
+            "propertyValue": "player.playRandom",
+            "propertySubPhrases": [
+              "Start the music"
             ],
-            "subPhrases": [
+            "alternatives": [
               {
-                "text": "Start the music",
-                "category": "command",
-                "propertyNames": [
-                  "fullActionName"
+                "propertyValue": "player.play",
+                "propertySubPhrases": [
+                  "Play the music"
                 ]
               },
               {
-                "text": "please",
-                "category": "politeness",
-                "synonyms": [
-                  "kindly",
-                  "if you would",
-                  "if you please"
-                ],
-                "isOptional": true
+                "propertyValue": "player.resume",
+                "propertySubPhrases": [
+                  "Resume the music"
+                ]
+              },
+              {
+                "propertyValue": "player.shuffle",
+                "propertySubPhrases": [
+                  "Shuffle the music"
+                ]
+              },
+              {
+                "propertyValue": "player.start",
+                "propertySubPhrases": [
+                  "Begin the music"
+                ]
               }
             ]
-          },
-          "correction": [
-            "Property 'fullActionName' is expected to be implicit and should not be included as a property name in a sub-phrase"
-          ]
-        }
-      ]
+          }
+        ],
+        "politePrefixes": [
+          "Could you kindly",
+          "Would you be so kind as to",
+          "If you don't mind,",
+          "May I ask you to"
+        ],
+        "politeSuffixes": [
+          "if you would be so kind.",
+          "thank you.",
+          "please.",
+          "if it's not too much trouble."
+        ]
+      }
     },
     {
       "request": "Turn up the volume on the electronic dance music",
@@ -609,37 +666,17 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If you don't mind",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you",
-          "I appreciate it"
+          "thank you",
+          "please",
+          "if that's okay",
+          "if you could"
         ]
-      },
-      "corrections": [
-        {
-          "data": {
-            "properties": [
-              {
-                "name": "fullActionName",
-                "value": "player.changeVolume",
-                "substrings": [
-                  "Turn up the volume"
-                ]
-              },
-              {
-                "name": "volumeChangePercentage",
-                "value": 10,
-                "isImplicit": true
-              }
-            ]
-          },
-          "correction": [
-            "Extraneous implicit parameter: 'volumeChangePercentage' is not a parameter in the action",
-            "Missing parameter: parameter 'parameters.volumeChangePercentage' in the action is missing from explanation"
-          ]
-        }
-      ]
+      }
     },
     {
       "request": "Would you mind playing some music?",
@@ -684,28 +721,38 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.playJazz",
+                "propertyValue": "player.playSpecific",
                 "propertySubPhrases": [
-                  "playing some jazz"
+                  "playing a specific song"
                 ]
               },
               {
-                "propertyValue": "player.playRock",
+                "propertyValue": "player.playPlaylist",
                 "propertySubPhrases": [
-                  "playing some rock"
+                  "playing a playlist"
                 ]
               },
               {
-                "propertyValue": "player.playClassical",
+                "propertyValue": "player.playGenre",
                 "propertySubPhrases": [
-                  "playing some classical music"
+                  "playing some genre music"
                 ]
               }
             ]
           }
         ],
-        "politePrefixes": [],
-        "politeSuffixes": []
+        "politePrefixes": [
+          "If it's not too much trouble, ",
+          "Could you please, ",
+          "If you don't mind, ",
+          "Would it be possible for you to, "
+        ],
+        "politeSuffixes": [
+          " please?",
+          " if you could?",
+          " thank you!",
+          " I'd appreciate it!"
+        ]
       }
     },
     {
@@ -719,7 +766,8 @@
             "name": "fullActionName",
             "value": "player.playRandom",
             "substrings": [
-              "some sick tunes"
+              "sick tunes",
+              "blastin'"
             ]
           }
         ],
@@ -752,12 +800,19 @@
             ]
           },
           {
-            "text": "blastin' on these streets",
-            "category": "context",
+            "text": "blastin'",
+            "category": "music",
+            "propertyNames": [
+              "fullActionName"
+            ]
+          },
+          {
+            "text": "on these streets",
+            "category": "location",
             "synonyms": [
-              "playing loudly here",
-              "blaring around",
-              "booming in this area"
+              "around here",
+              "in this area",
+              "in the neighborhood"
             ],
             "isOptional": true
           }
@@ -767,31 +822,36 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.playRandom",
             "propertySubPhrases": [
-              "some sick tunes"
+              "some sick tunes",
+              "blastin'"
             ],
             "alternatives": [
               {
-                "propertyValue": "player.playRock",
+                "propertyValue": "player.play",
                 "propertySubPhrases": [
-                  "some rock tunes"
+                  "some music",
+                  "playing"
                 ]
               },
               {
-                "propertyValue": "player.playJazz",
+                "propertyValue": "player.shuffle",
                 "propertySubPhrases": [
-                  "some jazz tunes"
+                  "some tracks",
+                  "shuffling"
                 ]
               },
               {
-                "propertyValue": "player.playClassical",
+                "propertyValue": "player.playFavorites",
                 "propertySubPhrases": [
-                  "some classical tunes"
+                  "favorite songs",
+                  "playing"
                 ]
               },
               {
-                "propertyValue": "player.playHipHop",
+                "propertyValue": "player.playGenre",
                 "propertySubPhrases": [
-                  "some hip-hop tunes"
+                  "some jazz",
+                  "playing"
                 ]
               }
             ]
@@ -799,11 +859,15 @@
         ],
         "politePrefixes": [
           "Excuse me,",
-          "Could you please"
+          "Could you please",
+          "Would you mind",
+          "If it's not too much trouble,"
         ],
         "politeSuffixes": [
-          "Thank you.",
-          "I would appreciate it."
+          "please?",
+          "if you don't mind.",
+          "thank you.",
+          "thanks!"
         ]
       }
     }

--- a/ts/packages/defaultAgentProvider/test/data/explanations/player/v5/pauseAction.json
+++ b/ts/packages/defaultAgentProvider/test/data/explanations/player/v5/pauseAction.json
@@ -26,7 +26,7 @@
             "synonyms": [
               "Could we have a quiet moment?",
               "May we have a quiet moment?",
-              "Let's have a quiet moment."
+              "Would you mind giving us a quiet moment?"
             ],
             "isOptional": true
           },
@@ -69,11 +69,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If it's not too much trouble,",
+          "May I kindly ask"
         ],
         "politeSuffixes": [
           "Thank you.",
-          "I would appreciate it."
+          "I would appreciate it.",
+          "If you don't mind.",
+          "Thanks in advance."
         ]
       }
     },
@@ -99,7 +103,7 @@
             "synonyms": [
               "Could we stop the sound?",
               "Would you stop the sound?",
-              "Please stop the sound?"
+              "Please stop the sound"
             ],
             "isOptional": true
           },
@@ -128,13 +132,13 @@
               {
                 "propertyValue": "player.mute",
                 "propertySubPhrases": [
-                  "Mute it."
+                  "Mute the sound."
                 ]
               },
               {
                 "propertyValue": "player.resume",
                 "propertySubPhrases": [
-                  "Resume it."
+                  "Resume the sound."
                 ]
               }
             ]
@@ -142,11 +146,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If it's not too much trouble,",
+          "May I kindly ask"
         ],
         "politeSuffixes": [
-          "Thank you.",
-          "I would appreciate it."
+          "thank you.",
+          "please.",
+          "if you don't mind.",
+          "I'd appreciate it."
         ]
       }
     },
@@ -170,9 +178,9 @@
             "text": "Can we take a brief intermission?",
             "category": "politeness",
             "synonyms": [
-              "Could we have a short break?",
-              "May we take a quick pause?",
-              "Is it possible to have a brief pause?"
+              "Could we take a short break?",
+              "May we have a brief pause?",
+              "Would it be possible to have a short intermission?"
             ],
             "isOptional": true
           },
@@ -199,21 +207,15 @@
                 ]
               },
               {
-                "propertyValue": "player.resume",
+                "propertyValue": "player.halt",
                 "propertySubPhrases": [
-                  "Resume the song."
+                  "Halt the song."
                 ]
               },
               {
-                "propertyValue": "player.rewind",
+                "propertyValue": "player.interrupt",
                 "propertySubPhrases": [
-                  "Rewind the song."
-                ]
-              },
-              {
-                "propertyValue": "player.fastForward",
-                "propertySubPhrases": [
-                  "Fast forward the song."
+                  "Interrupt the song."
                 ]
               }
             ]
@@ -221,11 +223,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If it's not too much trouble",
+          "May I kindly ask"
         ],
         "politeSuffixes": [
           "Thank you.",
-          "I would appreciate it."
+          "I would appreciate it.",
+          "Thanks in advance.",
+          "If you don't mind."
         ]
       }
     },
@@ -246,12 +252,22 @@
         ],
         "subPhrases": [
           {
-            "text": "Can you give the play button a rest?",
+            "text": "Can you",
             "category": "politeness",
             "synonyms": [
-              "Could you stop the play button?",
-              "Would you mind pausing the play button?",
-              "Please pause the play button."
+              "Could you",
+              "Would you",
+              "Will you"
+            ],
+            "isOptional": true
+          },
+          {
+            "text": "give the play button a rest?",
+            "category": "filler",
+            "synonyms": [
+              "stop the play button",
+              "halt the play button",
+              "pause the play button"
             ],
             "isOptional": true
           },
@@ -284,27 +300,25 @@
                 ]
               },
               {
-                "propertyValue": "player.rewind",
+                "propertyValue": "player.resume",
                 "propertySubPhrases": [
-                  "Rewind it."
-                ]
-              },
-              {
-                "propertyValue": "player.fastForward",
-                "propertySubPhrases": [
-                  "Fast forward it."
+                  "Resume it."
                 ]
               }
             ]
           }
         ],
         "politePrefixes": [
-          "Could you please",
-          "Would you mind"
+          "Please,",
+          "Would you mind,",
+          "Could you kindly,",
+          "If you don't mind,"
         ],
         "politeSuffixes": [
           "Thank you.",
-          "I would appreciate it."
+          "I would appreciate it.",
+          "Thanks a lot.",
+          "Much appreciated."
         ]
       }
     },
@@ -344,7 +358,12 @@
           {
             "text": "the playback",
             "category": "object",
-            "propertyNames": []
+            "synonyms": [
+              "the video",
+              "the audio",
+              "the media"
+            ],
+            "isOptional": true
           },
           {
             "text": "there",
@@ -352,7 +371,7 @@
             "synonyms": [
               "here",
               "at this point",
-              "at that point"
+              "now"
             ],
             "isOptional": true
           }
@@ -378,9 +397,9 @@
                 ]
               },
               {
-                "propertyValue": "player.rewind",
+                "propertyValue": "player.resume",
                 "propertySubPhrases": [
-                  "rewind"
+                  "resume"
                 ]
               }
             ]
@@ -388,11 +407,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If you don't mind",
+          "May I ask you to"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it."
+          "please?",
+          "if that's okay?",
+          "thank you.",
+          "if you could."
         ]
       }
     },
@@ -461,16 +484,26 @@
                 ]
               },
               {
-                "propertyValue": "player.skip",
+                "propertyValue": "player.resume",
                 "propertySubPhrases": [
-                  "skip"
+                  "resume"
                 ]
               }
             ]
           }
         ],
-        "politePrefixes": [],
-        "politeSuffixes": []
+        "politePrefixes": [
+          "Please",
+          "Would you mind",
+          "Could you kindly",
+          "If you don't mind"
+        ],
+        "politeSuffixes": [
+          "please?",
+          "if that's okay?",
+          "thank you.",
+          "if you could."
+        ]
       }
     },
     {
@@ -500,15 +533,15 @@
             "isOptional": true
           },
           {
-            "text": "put the music on hold",
-            "category": "action",
+            "text": "put the music on hold?",
+            "category": "request",
             "propertyNames": [
               "fullActionName"
             ]
           },
           {
             "text": "Pause it.",
-            "category": "action",
+            "category": "request",
             "propertyNames": [
               "fullActionName"
             ]
@@ -519,41 +552,45 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.pause",
             "propertySubPhrases": [
-              "put the music on hold",
+              "put the music on hold?",
               "Pause it."
             ],
             "alternatives": [
               {
                 "propertyValue": "player.stop",
                 "propertySubPhrases": [
-                  "stop the music",
+                  "stop the music?",
                   "Stop it."
                 ]
               },
               {
                 "propertyValue": "player.resume",
                 "propertySubPhrases": [
-                  "resume the music",
+                  "resume the music?",
                   "Resume it."
                 ]
               },
               {
-                "propertyValue": "player.mute",
+                "propertyValue": "player.play",
                 "propertySubPhrases": [
-                  "mute the music",
-                  "Mute it."
+                  "play the music?",
+                  "Play it."
                 ]
               }
             ]
           }
         ],
         "politePrefixes": [
-          "Could you please",
-          "Would you mind"
+          "Please,",
+          "Would you mind,",
+          "Could you kindly,",
+          "If you don't mind,"
         ],
         "politeSuffixes": [
-          "Thank you.",
-          "I would appreciate it."
+          "thank you.",
+          "please.",
+          "if that's okay.",
+          "if you could."
         ]
       }
     },
@@ -576,14 +613,16 @@
           {
             "text": "Cease the sound",
             "category": "command",
-            "propertyNames": []
+            "propertyNames": [
+              "fullActionName"
+            ]
           },
           {
             "text": "please",
             "category": "politeness",
             "synonyms": [
               "kindly",
-              "if you could",
+              "if you would",
               "would you mind"
             ],
             "isOptional": true
@@ -601,32 +640,46 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.pause",
             "propertySubPhrases": [
+              "Cease the sound",
               "pause"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.stop",
                 "propertySubPhrases": [
-                  "Cease the sound"
+                  "Stop the sound",
+                  "halt"
                 ]
               },
               {
                 "propertyValue": "player.mute",
                 "propertySubPhrases": [
-                  "Cease the sound"
+                  "Mute the sound",
+                  "silence"
                 ]
               },
               {
-                "propertyValue": "player.silence",
+                "propertyValue": "player.resume",
                 "propertySubPhrases": [
-                  "Cease the sound"
+                  "Resume the sound",
+                  "continue"
                 ]
               }
             ]
           }
         ],
-        "politePrefixes": [],
-        "politeSuffixes": []
+        "politePrefixes": [
+          "Could you kindly",
+          "Would you mind",
+          "If you don't mind",
+          "May I ask you to"
+        ],
+        "politeSuffixes": [
+          "if it's not too much trouble.",
+          "thank you.",
+          "please.",
+          "I would appreciate it."
+        ]
       }
     },
     {
@@ -649,22 +702,25 @@
             "text": "Could you",
             "category": "politeness",
             "synonyms": [
-              "Can you",
               "Would you",
+              "Can you",
               "Will you"
             ],
             "isOptional": true
           },
           {
-            "text": "give the song a break?",
-            "category": "request",
-            "propertyNames": [
-              "fullActionName"
-            ]
+            "text": "give the song a break",
+            "category": "politeness",
+            "synonyms": [
+              "stop the song",
+              "pause the song",
+              "halt the song"
+            ],
+            "isOptional": true
           },
           {
             "text": "Pause it.",
-            "category": "request",
+            "category": "command",
             "propertyNames": [
               "fullActionName"
             ]
@@ -675,36 +731,42 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.pause",
             "propertySubPhrases": [
-              "give the song a break?",
               "Pause it."
             ],
             "alternatives": [
               {
                 "propertyValue": "player.stop",
                 "propertySubPhrases": [
-                  "stop the song?",
                   "Stop it."
                 ]
               },
               {
-                "propertyValue": "player.resume",
+                "propertyValue": "player.halt",
                 "propertySubPhrases": [
-                  "resume the song?",
-                  "Resume it."
+                  "Halt it."
                 ]
               },
               {
-                "propertyValue": "player.rewind",
+                "propertyValue": "player.interrupt",
                 "propertySubPhrases": [
-                  "rewind the song?",
-                  "Rewind it."
+                  "Interrupt it."
                 ]
               }
             ]
           }
         ],
-        "politePrefixes": [],
-        "politeSuffixes": []
+        "politePrefixes": [
+          "Please,",
+          "If you don't mind,",
+          "Would you kindly,",
+          "I would appreciate it if you could,"
+        ],
+        "politeSuffixes": [
+          "Thank you.",
+          "Thanks.",
+          "I appreciate it.",
+          "If that's okay."
+        ]
       }
     },
     {
@@ -728,15 +790,15 @@
             "text": "Could you",
             "category": "politeness",
             "synonyms": [
-              "Can you",
-              "Would you",
-              "Will you"
+              "please",
+              "would you mind",
+              "can you"
             ],
             "isOptional": true
           },
           {
             "text": "hit",
-            "category": "filler",
+            "category": "confirmation",
             "synonyms": [
               "press",
               "tap",
@@ -752,17 +814,7 @@
             ]
           },
           {
-            "text": "on the",
-            "category": "preposition",
-            "synonyms": [
-              "at the",
-              "to the",
-              "onto the"
-            ],
-            "isOptional": true
-          },
-          {
-            "text": "player",
+            "text": "on the player",
             "category": "object",
             "propertyNames": [
               "fullActionName"
@@ -775,42 +827,45 @@
             "propertyValue": "player.pause",
             "propertySubPhrases": [
               "pause",
-              "player"
+              "on the player"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.play",
                 "propertySubPhrases": [
                   "play",
-                  "player"
+                  "on the player"
                 ]
               },
               {
                 "propertyValue": "player.stop",
                 "propertySubPhrases": [
                   "stop",
-                  "player"
+                  "on the player"
                 ]
               },
               {
                 "propertyValue": "player.rewind",
                 "propertySubPhrases": [
                   "rewind",
-                  "player"
-                ]
-              },
-              {
-                "propertyValue": "player.fastForward",
-                "propertySubPhrases": [
-                  "fast forward",
-                  "player"
+                  "on the player"
                 ]
               }
             ]
           }
         ],
-        "politePrefixes": [],
-        "politeSuffixes": []
+        "politePrefixes": [
+          "Please",
+          "Would you mind",
+          "If you could",
+          "Kindly"
+        ],
+        "politeSuffixes": [
+          "please",
+          "if you don't mind",
+          "thank you",
+          "would be appreciated"
+        ]
       }
     },
     {
@@ -885,7 +940,7 @@
                 "propertyValue": "player.mute",
                 "propertySubPhrases": [
                   "mute the music",
-                  "silence the audio"
+                  "silence playback"
                 ]
               },
               {
@@ -896,17 +951,27 @@
                 ]
               },
               {
-                "propertyValue": "player.play",
+                "propertyValue": "player.skip",
                 "propertySubPhrases": [
-                  "play the music",
-                  "start playback"
+                  "skip the music",
+                  "next track"
                 ]
               }
             ]
           }
         ],
-        "politePrefixes": [],
-        "politeSuffixes": []
+        "politePrefixes": [
+          "Please",
+          "Would you mind",
+          "If you could",
+          "Kindly"
+        ],
+        "politeSuffixes": [
+          "Thank you",
+          "Please",
+          "If you don't mind",
+          "I would appreciate it"
+        ]
       }
     },
     {
@@ -931,13 +996,13 @@
             "synonyms": [
               "Stop the rhythm",
               "Halt the tunes",
-              "Cease the sound"
+              "Cease the beats"
             ],
             "isOptional": true
           },
           {
             "text": "pause the music",
-            "category": "action",
+            "category": "command",
             "propertyNames": [
               "fullActionName"
             ]
@@ -964,9 +1029,9 @@
                 ]
               },
               {
-                "propertyValue": "player.resume",
+                "propertyValue": "player.silence",
                 "propertySubPhrases": [
-                  "resume the music"
+                  "silence the music"
                 ]
               }
             ]
@@ -974,11 +1039,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If you don't mind",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you.",
-          "I would appreciate it."
+          "thank you",
+          "please",
+          "if that's okay",
+          "thanks"
         ]
       }
     },
@@ -1000,8 +1069,13 @@
         "subPhrases": [
           {
             "text": "Give the music a break,",
-            "category": "command",
-            "propertyNames": []
+            "category": "filler",
+            "synonyms": [
+              "Stop the music for a moment,",
+              "Take a break from the music,",
+              "Pause the music for a bit,"
+            ],
+            "isOptional": true
           },
           {
             "text": "pause",
@@ -1014,9 +1088,9 @@
             "text": "it.",
             "category": "filler",
             "synonyms": [
-              "this",
-              "that",
-              "the music"
+              "the music.",
+              "the track.",
+              "the song."
             ],
             "isOptional": true
           }
@@ -1036,15 +1110,21 @@
                 ]
               },
               {
-                "propertyValue": "player.resume",
+                "propertyValue": "player.halt",
                 "propertySubPhrases": [
-                  "resume"
+                  "halt"
                 ]
               },
               {
-                "propertyValue": "player.play",
+                "propertyValue": "player.interrupt",
                 "propertySubPhrases": [
-                  "play"
+                  "interrupt"
+                ]
+              },
+              {
+                "propertyValue": "player.freeze",
+                "propertySubPhrases": [
+                  "freeze"
                 ]
               }
             ]
@@ -1052,11 +1132,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If you don't mind",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you.",
-          "I would appreciate it."
+          "Thank you",
+          "Thanks",
+          "If that's okay",
+          "I appreciate it"
         ]
       }
     },
@@ -1094,22 +1178,12 @@
             ]
           },
           {
-            "text": "button,",
-            "category": "filler",
-            "synonyms": [
-              "control,",
-              "key,",
-              "switch,"
-            ],
-            "isOptional": true
-          },
-          {
-            "text": "will you?",
+            "text": "button, will you?",
             "category": "politeness",
             "synonyms": [
-              "please?",
-              "could you?",
-              "would you?"
+              "button, please?",
+              "button, could you?",
+              "button, would you?"
             ],
             "isOptional": true
           }
@@ -1139,23 +1213,21 @@
                 "propertySubPhrases": [
                   "rewind"
                 ]
-              },
-              {
-                "propertyValue": "player.fastForward",
-                "propertySubPhrases": [
-                  "fast forward"
-                ]
               }
             ]
           }
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If you don't mind",
+          "Please"
         ],
         "politeSuffixes": [
           "thank you",
-          "please"
+          "if that's okay",
+          "please",
+          "thanks"
         ]
       }
     },
@@ -1187,11 +1259,11 @@
           },
           {
             "text": "let's",
-            "category": "filler",
+            "category": "politeness",
             "synonyms": [
-              "we should",
-              "we will",
-              "we are going to"
+              "please",
+              "kindly",
+              "would you mind"
             ],
             "isOptional": true
           },
@@ -1205,7 +1277,12 @@
           {
             "text": "the tunes",
             "category": "object",
-            "propertyNames": []
+            "synonyms": [
+              "the music",
+              "the song",
+              "the audio"
+            ],
+            "isOptional": true
           }
         ],
         "propertyAlternatives": [
@@ -1223,27 +1300,31 @@
                 ]
               },
               {
-                "propertyValue": "player.play",
+                "propertyValue": "player.mute",
                 "propertySubPhrases": [
-                  "play"
+                  "mute"
                 ]
               },
               {
-                "propertyValue": "player.resume",
+                "propertyValue": "player.silence",
                 "propertySubPhrases": [
-                  "resume"
+                  "silence"
                 ]
               }
             ]
           }
         ],
         "politePrefixes": [
-          "Could you please",
-          "Would you mind"
+          "Please",
+          "Could you",
+          "Would you mind",
+          "If you don't mind"
         ],
         "politeSuffixes": [
-          "Thank you",
-          "I appreciate it"
+          "thank you",
+          "please",
+          "if that's okay",
+          "if you could"
         ]
       }
     },
@@ -1265,10 +1346,13 @@
         "subPhrases": [
           {
             "text": "Hold the tunes",
-            "category": "command",
-            "propertyNames": [
-              "fullActionName"
-            ]
+            "category": "filler",
+            "synonyms": [
+              "stop the tunes",
+              "halt the tunes",
+              "cease the tunes"
+            ],
+            "isOptional": true
           },
           {
             "text": "pause the music",
@@ -1283,29 +1367,25 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.pause",
             "propertySubPhrases": [
-              "Hold the tunes",
               "pause the music"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.stop",
                 "propertySubPhrases": [
-                  "Stop the tunes",
                   "stop the music"
-                ]
-              },
-              {
-                "propertyValue": "player.resume",
-                "propertySubPhrases": [
-                  "Resume the tunes",
-                  "resume the music"
                 ]
               },
               {
                 "propertyValue": "player.mute",
                 "propertySubPhrases": [
-                  "Mute the tunes",
                   "mute the music"
+                ]
+              },
+              {
+                "propertyValue": "player.resume",
+                "propertySubPhrases": [
+                  "resume the music"
                 ]
               }
             ]
@@ -1313,11 +1393,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If you don't mind",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I appreciate it!"
+          "thank you",
+          "if that's okay",
+          "please",
+          "thanks"
         ]
       }
     },
@@ -1356,11 +1440,11 @@
           },
           {
             "text": "that",
-            "category": "filler",
+            "category": "object",
             "synonyms": [
               "it",
               "this",
-              "the thing"
+              "the video"
             ],
             "isOptional": true
           }
@@ -1396,11 +1480,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If you don't mind",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you",
-          "I appreciate it"
+          "for me?",
+          "if you could?",
+          "please?",
+          "thank you."
         ]
       }
     },
@@ -1435,14 +1523,14 @@
             "category": "politeness",
             "synonyms": [
               "kindly",
-              "if you could",
+              "could you",
               "would you mind"
             ],
             "isOptional": true
           },
           {
             "text": "pause the music",
-            "category": "action",
+            "category": "command",
             "propertyNames": [
               "fullActionName"
             ]
@@ -1469,16 +1557,26 @@
                 ]
               },
               {
-                "propertyValue": "player.resume",
+                "propertyValue": "player.silence",
                 "propertySubPhrases": [
-                  "resume the music"
+                  "silence the music"
                 ]
               }
             ]
           }
         ],
-        "politePrefixes": [],
-        "politeSuffixes": []
+        "politePrefixes": [
+          "Could you kindly",
+          "Would you mind",
+          "If it's not too much trouble",
+          "May I request"
+        ],
+        "politeSuffixes": [
+          "Thank you.",
+          "I would appreciate it.",
+          "Thanks in advance.",
+          "Your help is appreciated."
+        ]
       }
     },
     {
@@ -1503,7 +1601,7 @@
             "synonyms": [
               "please",
               "kindly",
-              "if you don't mind"
+              "would you mind"
             ],
             "isOptional": true
           },
@@ -1529,12 +1627,6 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.play",
-                "propertySubPhrases": [
-                  "played"
-                ]
-              },
-              {
                 "propertyValue": "player.stop",
                 "propertySubPhrases": [
                   "stopped"
@@ -1545,12 +1637,28 @@
                 "propertySubPhrases": [
                   "resumed"
                 ]
+              },
+              {
+                "propertyValue": "player.rewind",
+                "propertySubPhrases": [
+                  "rewound"
+                ]
               }
             ]
           }
         ],
-        "politePrefixes": [],
-        "politeSuffixes": []
+        "politePrefixes": [
+          "Could you please",
+          "Would you mind",
+          "If it's not too much trouble",
+          "May I kindly ask"
+        ],
+        "politeSuffixes": [
+          "Thank you.",
+          "I would be grateful.",
+          "Thanks a lot.",
+          "Much appreciated."
+        ]
       }
     },
     {
@@ -1571,8 +1679,13 @@
         "subPhrases": [
           {
             "text": "Interrupt the rhythm",
-            "category": "command",
-            "propertyNames": []
+            "category": "filler",
+            "synonyms": [
+              "stop the music",
+              "halt the beat",
+              "break the flow"
+            ],
+            "isOptional": true
           },
           {
             "text": "pause the track",
@@ -1603,9 +1716,9 @@
                 ]
               },
               {
-                "propertyValue": "player.skip",
+                "propertyValue": "player.rewind",
                 "propertySubPhrases": [
-                  "skip the track"
+                  "rewind the track"
                 ]
               }
             ]
@@ -1613,11 +1726,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If you don't mind",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you.",
-          "I would appreciate it."
+          "if that's okay.",
+          "thank you.",
+          "please.",
+          "if you could."
         ]
       }
     },
@@ -1639,23 +1756,18 @@
         "subPhrases": [
           {
             "text": "Let's",
-            "category": "filler",
+            "category": "politeness",
             "synonyms": [
-              "Let us",
-              "We should",
-              "How about"
+              "please",
+              "kindly",
+              "let us"
             ],
             "isOptional": true
           },
           {
             "text": "freeze the playlist",
-            "category": "filler",
-            "synonyms": [
-              "stop the playlist",
-              "halt the playlist",
-              "pause the playlist"
-            ],
-            "isOptional": true
+            "category": "action",
+            "propertyNames": []
           },
           {
             "text": "pause the song",
@@ -1690,17 +1802,27 @@
                 "propertySubPhrases": [
                   "rewind the song"
                 ]
+              },
+              {
+                "propertyValue": "player.fastForward",
+                "propertySubPhrases": [
+                  "fast forward the song"
+                ]
               }
             ]
           }
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If you don't mind",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you.",
-          "I would appreciate it."
+          "thank you",
+          "if that's okay",
+          "please",
+          "thanks"
         ]
       }
     },
@@ -1724,9 +1846,9 @@
             "text": "Let's have a",
             "category": "filler",
             "synonyms": [
-              "Let's take a",
-              "Let's do a",
-              "Let's make a"
+              "let us",
+              "we should",
+              "how about"
             ],
             "isOptional": true
           },
@@ -1738,115 +1860,12 @@
             ]
           },
           {
-            "text": "in the music.",
+            "text": "in the music",
             "category": "context",
             "synonyms": [
-              "in the song.",
-              "in the audio.",
-              "in the playback."
-            ],
-            "isOptional": true
-          }
-        ],
-        "propertyAlternatives": [
-          {
-            "propertyName": "fullActionName",
-            "propertyValue": "player.pause",
-            "propertySubPhrases": [
-              "pause"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "player.play",
-                "propertySubPhrases": [
-                  "play"
-                ]
-              },
-              {
-                "propertyValue": "player.stop",
-                "propertySubPhrases": [
-                  "stop"
-                ]
-              },
-              {
-                "propertyValue": "player.resume",
-                "propertySubPhrases": [
-                  "resume"
-                ]
-              }
-            ]
-          }
-        ],
-        "politePrefixes": [
-          "Could we please",
-          "Would you mind if we"
-        ],
-        "politeSuffixes": [
-          "Thank you.",
-          "I would appreciate it."
-        ]
-      }
-    },
-    {
-      "request": "Let's hold off on the music, pause it.",
-      "action": {
-        "fullActionName": "player.pause"
-      },
-      "explanation": {
-        "properties": [
-          {
-            "name": "fullActionName",
-            "value": "player.pause",
-            "substrings": [
-              "pause"
-            ]
-          }
-        ],
-        "subPhrases": [
-          {
-            "text": "Let's",
-            "category": "filler",
-            "synonyms": [
-              "Let us",
-              "We should",
-              "How about"
-            ],
-            "isOptional": true
-          },
-          {
-            "text": "hold off on",
-            "category": "filler",
-            "synonyms": [
-              "stop",
-              "pause",
-              "halt"
-            ],
-            "isOptional": true
-          },
-          {
-            "text": "the music,",
-            "category": "filler",
-            "synonyms": [
-              "the song,",
-              "the audio,",
-              "the track,"
-            ],
-            "isOptional": true
-          },
-          {
-            "text": "pause",
-            "category": "action",
-            "propertyNames": [
-              "fullActionName"
-            ]
-          },
-          {
-            "text": "it.",
-            "category": "filler",
-            "synonyms": [
-              "this.",
-              "that.",
-              "the music."
+              "in the song",
+              "in the audio",
+              "in the playback"
             ],
             "isOptional": true
           }
@@ -1872,9 +1891,92 @@
                 ]
               },
               {
+                "propertyValue": "player.silence",
+                "propertySubPhrases": [
+                  "silence"
+                ]
+              }
+            ]
+          }
+        ],
+        "politePrefixes": [
+          "Could we please",
+          "Would you mind if we",
+          "May I kindly request that we",
+          "If it's not too much trouble, let's"
+        ],
+        "politeSuffixes": [
+          "for a moment?",
+          "if that's okay?",
+          "please?",
+          "thank you."
+        ]
+      }
+    },
+    {
+      "request": "Let's hold off on the music, pause it.",
+      "action": {
+        "fullActionName": "player.pause"
+      },
+      "explanation": {
+        "properties": [
+          {
+            "name": "fullActionName",
+            "value": "player.pause",
+            "substrings": [
+              "pause"
+            ]
+          }
+        ],
+        "subPhrases": [
+          {
+            "text": "Let's hold off on the music,",
+            "category": "filler",
+            "synonyms": [
+              "Let's stop the music,",
+              "Let's take a break from the music,",
+              "Let's pause the music,"
+            ],
+            "isOptional": true
+          },
+          {
+            "text": "pause it.",
+            "category": "command",
+            "propertyNames": [
+              "fullActionName"
+            ]
+          }
+        ],
+        "propertyAlternatives": [
+          {
+            "propertyName": "fullActionName",
+            "propertyValue": "player.pause",
+            "propertySubPhrases": [
+              "pause it."
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "player.stop",
+                "propertySubPhrases": [
+                  "stop it."
+                ]
+              },
+              {
+                "propertyValue": "player.mute",
+                "propertySubPhrases": [
+                  "mute it."
+                ]
+              },
+              {
                 "propertyValue": "player.resume",
                 "propertySubPhrases": [
-                  "resume"
+                  "resume it."
+                ]
+              },
+              {
+                "propertyValue": "player.play",
+                "propertySubPhrases": [
+                  "play it."
                 ]
               }
             ]
@@ -1882,11 +1984,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If you don't mind",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you.",
-          "I would appreciate it."
+          "for a moment?",
+          "if that's okay.",
+          "thank you.",
+          "please."
         ]
       }
     },
@@ -1907,18 +2013,18 @@
         ],
         "subPhrases": [
           {
-            "text": "Let's interrupt the flow,",
+            "text": "Let's interrupt the flow",
             "category": "filler",
             "synonyms": [
-              "Let's take a break,",
-              "Let's stop for a moment,",
-              "Let's halt the flow,"
+              "Let's stop for a moment",
+              "Let's take a break",
+              "Let's halt the process"
             ],
             "isOptional": true
           },
           {
-            "text": "pause the track.",
-            "category": "action",
+            "text": "pause the track",
+            "category": "command",
             "propertyNames": [
               "fullActionName"
             ]
@@ -1929,41 +2035,47 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.pause",
             "propertySubPhrases": [
-              "pause the track."
+              "pause the track"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.stop",
                 "propertySubPhrases": [
-                  "stop the track."
+                  "stop the track"
                 ]
               },
               {
                 "propertyValue": "player.resume",
                 "propertySubPhrases": [
-                  "resume the track."
+                  "resume the track"
                 ]
               },
               {
                 "propertyValue": "player.rewind",
                 "propertySubPhrases": [
-                  "rewind the track."
+                  "rewind the track"
+                ]
+              },
+              {
+                "propertyValue": "player.fastForward",
+                "propertySubPhrases": [
+                  "fast forward the track"
                 ]
               }
             ]
           }
         ],
         "politePrefixes": [
-          "Could you please",
+          "Please,",
+          "Could you kindly",
           "Would you mind",
-          "If it's not too much trouble, could you",
-          "May I kindly ask you to"
+          "If you don't mind,"
         ],
         "politeSuffixes": [
-          "Thank you.",
-          "I would appreciate it.",
-          "Thanks a lot.",
-          "Much appreciated."
+          "thank you.",
+          "please.",
+          "if that's okay.",
+          "thanks."
         ]
       }
     },
@@ -1978,23 +2090,23 @@
             "name": "fullActionName",
             "value": "player.pause",
             "substrings": [
-              "pause the music"
+              "pause the music."
             ]
           }
         ],
         "subPhrases": [
           {
-            "text": "Let's put a pin in it",
+            "text": "Let's put a pin in it,",
             "category": "filler",
             "synonyms": [
               "hold on",
               "wait a moment",
-              "pause for now"
+              "pause for a second"
             ],
             "isOptional": true
           },
           {
-            "text": "pause the music",
+            "text": "pause the music.",
             "category": "command",
             "propertyNames": [
               "fullActionName"
@@ -2006,25 +2118,31 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.pause",
             "propertySubPhrases": [
-              "pause the music"
+              "pause the music."
             ],
             "alternatives": [
               {
                 "propertyValue": "player.stop",
                 "propertySubPhrases": [
-                  "stop the music"
+                  "stop the music."
                 ]
               },
               {
                 "propertyValue": "player.mute",
                 "propertySubPhrases": [
-                  "mute the music"
+                  "mute the music."
                 ]
               },
               {
                 "propertyValue": "player.resume",
                 "propertySubPhrases": [
-                  "resume the music"
+                  "resume the music."
+                ]
+              },
+              {
+                "propertyValue": "player.play",
+                "propertySubPhrases": [
+                  "play the music."
                 ]
               }
             ]
@@ -2033,12 +2151,14 @@
         "politePrefixes": [
           "Could you please",
           "Would you mind",
-          "If it's not too much trouble, could you"
+          "If you don't mind",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it.",
-          "Thanks a lot!"
+          "Thank you",
+          "Thanks",
+          "If that's okay",
+          "I appreciate it"
         ]
       }
     },
@@ -2060,23 +2180,18 @@
         "subPhrases": [
           {
             "text": "Let's",
-            "category": "filler",
+            "category": "politeness",
             "synonyms": [
-              "Let us",
-              "We should",
-              "How about we"
+              "please",
+              "kindly",
+              "would you mind"
             ],
             "isOptional": true
           },
           {
             "text": "silence the sound for a sec",
-            "category": "filler",
-            "synonyms": [
-              "mute the audio for a moment",
-              "turn off the sound briefly",
-              "stop the sound for a bit"
-            ],
-            "isOptional": true
+            "category": "action",
+            "propertyNames": []
           },
           {
             "text": "hit pause",
@@ -2097,7 +2212,7 @@
               {
                 "propertyValue": "player.stop",
                 "propertySubPhrases": [
-                  "stop the player"
+                  "hit stop"
                 ]
               },
               {
@@ -2117,11 +2232,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If you don't mind",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it."
+          "thank you",
+          "if that's okay",
+          "please",
+          "thanks"
         ]
       }
     },
@@ -2153,7 +2272,7 @@
           },
           {
             "text": "pause the song",
-            "category": "action",
+            "category": "command",
             "propertyNames": [
               "fullActionName"
             ]
@@ -2184,17 +2303,27 @@
                 "propertySubPhrases": [
                   "rewind the song"
                 ]
+              },
+              {
+                "propertyValue": "player.fastForward",
+                "propertySubPhrases": [
+                  "fast forward the song"
+                ]
               }
             ]
           }
         ],
         "politePrefixes": [
-          "Could we please",
-          "Would you mind if we"
+          "Could you please",
+          "Would you mind",
+          "If you don't mind",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you.",
-          "I appreciate it."
+          "if that's okay.",
+          "thank you.",
+          "please.",
+          "if you could."
         ]
       }
     },
@@ -2215,12 +2344,12 @@
         ],
         "subPhrases": [
           {
-            "text": "Let's take a music break,",
+            "text": "Let's take a music break",
             "category": "filler",
             "synonyms": [
-              "Let's have a music break,",
-              "Let's take a break with music,",
-              "Let's pause for some music,"
+              "Let's have a music break",
+              "Let's enjoy a music break",
+              "Let's take a break with music"
             ],
             "isOptional": true
           },
@@ -2262,12 +2391,16 @@
           }
         ],
         "politePrefixes": [
-          "Please",
-          "Kindly"
+          "Could you please",
+          "Would you mind",
+          "If you don't mind",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you",
-          "if you don't mind"
+          "thank you",
+          "if that's okay",
+          "please",
+          "thanks"
         ]
       }
     },
@@ -2288,22 +2421,12 @@
         ],
         "subPhrases": [
           {
-            "text": "Let's",
+            "text": "Let's take a",
             "category": "filler",
             "synonyms": [
-              "Let us",
-              "We should",
-              "How about"
-            ],
-            "isOptional": true
-          },
-          {
-            "text": "take a",
-            "category": "filler",
-            "synonyms": [
-              "have a",
-              "make a",
-              "do a"
+              "let us take a",
+              "we should take a",
+              "how about we take a"
             ],
             "isOptional": true
           },
@@ -2318,9 +2441,9 @@
             "text": "from the music",
             "category": "context",
             "synonyms": [
-              "from playing",
               "from the song",
-              "from the audio"
+              "from the audio",
+              "from the track"
             ],
             "isOptional": true
           }
@@ -2340,15 +2463,15 @@
                 ]
               },
               {
-                "propertyValue": "player.resume",
-                "propertySubPhrases": [
-                  "resume"
-                ]
-              },
-              {
                 "propertyValue": "player.mute",
                 "propertySubPhrases": [
                   "mute"
+                ]
+              },
+              {
+                "propertyValue": "player.silence",
+                "propertySubPhrases": [
+                  "silence"
                 ]
               }
             ]
@@ -2356,11 +2479,15 @@
         ],
         "politePrefixes": [
           "Could we please",
-          "Would you mind if we"
+          "Would you mind if we",
+          "May I kindly request that we",
+          "If it's not too much trouble, let's"
         ],
         "politeSuffixes": [
-          "Thank you.",
-          "I would appreciate it."
+          "for a moment?",
+          "if that's okay?",
+          "please?",
+          "thank you."
         ]
       }
     },
@@ -2385,7 +2512,7 @@
             "category": "politeness",
             "synonyms": [
               "Could you stop the music?",
-              "Would you mind pausing the music?",
+              "Would you mind pausing the songs?",
               "Can you halt the tunes?"
             ],
             "isOptional": true
@@ -2429,11 +2556,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If it's not too much trouble,",
+          "May I ask you to"
         ],
         "politeSuffixes": [
-          "Thank you.",
-          "I would appreciate it."
+          "Thank you!",
+          "I appreciate it.",
+          "Thanks a lot!",
+          "Much appreciated."
         ]
       }
     },
@@ -2491,22 +2622,32 @@
                 ]
               },
               {
-                "propertyValue": "player.resume",
-                "propertySubPhrases": [
-                  "Resume"
-                ]
-              },
-              {
                 "propertyValue": "player.mute",
                 "propertySubPhrases": [
                   "Mute"
+                ]
+              },
+              {
+                "propertyValue": "player.resume",
+                "propertySubPhrases": [
+                  "Resume"
                 ]
               }
             ]
           }
         ],
-        "politePrefixes": [],
-        "politeSuffixes": []
+        "politePrefixes": [
+          "Could you please",
+          "Would you mind",
+          "If you don't mind",
+          "May I ask you to"
+        ],
+        "politeSuffixes": [
+          "please?",
+          "if that's okay.",
+          "if you could.",
+          "thank you."
+        ]
       }
     },
     {
@@ -2541,9 +2682,9 @@
             "text": "for me",
             "category": "politeness",
             "synonyms": [
-              "for us",
-              "for them",
-              "for you"
+              "please",
+              "if you could",
+              "kindly"
             ],
             "isOptional": true
           },
@@ -2552,8 +2693,8 @@
             "category": "politeness",
             "synonyms": [
               "kindly",
-              "if you would",
-              "if you please"
+              "if you could",
+              "would you mind"
             ],
             "isOptional": true
           }
@@ -2573,22 +2714,32 @@
                 ]
               },
               {
-                "propertyValue": "player.resume",
+                "propertyValue": "player.halt",
                 "propertySubPhrases": [
-                  "Resume"
+                  "Halt"
                 ]
               },
               {
-                "propertyValue": "player.mute",
+                "propertyValue": "player.freeze",
                 "propertySubPhrases": [
-                  "Mute"
+                  "Freeze"
                 ]
               }
             ]
           }
         ],
-        "politePrefixes": [],
-        "politeSuffixes": []
+        "politePrefixes": [
+          "Could you",
+          "Would you mind",
+          "If you don't mind",
+          "May I ask you to"
+        ],
+        "politeSuffixes": [
+          "if that's okay?",
+          "if you could?",
+          "thank you.",
+          "I would appreciate it."
+        ]
       }
     },
     {
@@ -2625,7 +2776,7 @@
             "propertyNames": []
           },
           {
-            "text": "will you?",
+            "text": "will you",
             "category": "politeness",
             "synonyms": [
               "please",
@@ -2650,22 +2801,32 @@
                 ]
               },
               {
-                "propertyValue": "player.resume",
+                "propertyValue": "player.halt",
                 "propertySubPhrases": [
-                  "Resume"
+                  "Halt"
                 ]
               },
               {
-                "propertyValue": "player.start",
+                "propertyValue": "player.suspend",
                 "propertySubPhrases": [
-                  "Start"
+                  "Suspend"
                 ]
               }
             ]
           }
         ],
-        "politePrefixes": [],
-        "politeSuffixes": []
+        "politePrefixes": [
+          "Could you please",
+          "Would you mind",
+          "If you don't mind",
+          "May I ask you to"
+        ],
+        "politeSuffixes": [
+          "please?",
+          "if that's okay?",
+          "if you could?",
+          "thank you!"
+        ]
       }
     },
     {
@@ -2697,13 +2858,13 @@
             "synonyms": [
               "for a moment",
               "for a bit",
-              "for a second"
+              "for a short while"
             ],
             "isOptional": true
           },
           {
             "text": "I need to think",
-            "category": "explanation",
+            "category": "reason",
             "synonyms": [
               "I need to concentrate",
               "I need to focus",
@@ -2743,11 +2904,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If you don't mind",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it."
+          "Thank you",
+          "Thanks",
+          "I appreciate it",
+          "If that's okay"
         ]
       }
     },
@@ -2775,12 +2940,12 @@
             ]
           },
           {
-            "text": ", I have an announcement.",
-            "category": "filler",
+            "text": "I have an announcement",
+            "category": "statement",
             "synonyms": [
-              ", I need to say something.",
-              ", I have something to announce.",
-              ", I need to make an announcement."
+              "I need to say something",
+              "I have something to share",
+              "I need to make an announcement"
             ],
             "isOptional": true
           }
@@ -2816,11 +2981,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If you don't mind",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you.",
-          "I would appreciate it."
+          "Thank you",
+          "Thanks",
+          "I appreciate it",
+          "If that's okay"
         ]
       }
     },
@@ -2835,27 +3004,27 @@
             "name": "fullActionName",
             "value": "player.pause",
             "substrings": [
-              "Pause the music"
+              "Pause"
             ]
           }
         ],
         "subPhrases": [
           {
-            "text": "Pause the music",
+            "text": "Pause",
             "category": "command",
             "propertyNames": [
               "fullActionName"
             ]
           },
           {
+            "text": "the music",
+            "category": "object",
+            "propertyNames": []
+          },
+          {
             "text": "it's too loud",
-            "category": "explanation",
-            "synonyms": [
-              "the volume is high",
-              "it's very noisy",
-              "the sound is too much"
-            ],
-            "isOptional": true
+            "category": "reason",
+            "propertyNames": []
           }
         ],
         "propertyAlternatives": [
@@ -2863,25 +3032,25 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.pause",
             "propertySubPhrases": [
-              "Pause the music"
+              "Pause"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.stop",
                 "propertySubPhrases": [
-                  "Stop the music"
+                  "Stop"
                 ]
               },
               {
                 "propertyValue": "player.mute",
                 "propertySubPhrases": [
-                  "Mute the music"
+                  "Mute"
                 ]
               },
               {
-                "propertyValue": "player.lowerVolume",
+                "propertyValue": "player.silence",
                 "propertySubPhrases": [
-                  "Lower the volume"
+                  "Silence"
                 ]
               }
             ]
@@ -2889,11 +3058,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "Please",
+          "If you don't mind"
         ],
         "politeSuffixes": [
           "Thank you.",
-          "I would appreciate it."
+          "Thanks.",
+          "I appreciate it.",
+          "If that's okay."
         ]
       }
     },
@@ -2908,27 +3081,27 @@
             "name": "fullActionName",
             "value": "player.pause",
             "substrings": [
-              "Pause the playback"
+              "Pause"
             ]
           }
         ],
         "subPhrases": [
           {
-            "text": "Pause the playback",
+            "text": "Pause",
             "category": "command",
             "propertyNames": [
               "fullActionName"
             ]
           },
           {
+            "text": "the playback",
+            "category": "object",
+            "propertyNames": []
+          },
+          {
             "text": "for a moment",
-            "category": "filler",
-            "synonyms": [
-              "briefly",
-              "for a short while",
-              "temporarily"
-            ],
-            "isOptional": true
+            "category": "time",
+            "propertyNames": []
           }
         ],
         "propertyAlternatives": [
@@ -2936,25 +3109,25 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.pause",
             "propertySubPhrases": [
-              "Pause the playback"
+              "Pause"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.stop",
                 "propertySubPhrases": [
-                  "Stop the playback"
+                  "Stop"
                 ]
               },
               {
                 "propertyValue": "player.resume",
                 "propertySubPhrases": [
-                  "Resume the playback"
+                  "Resume"
                 ]
               },
               {
                 "propertyValue": "player.rewind",
                 "propertySubPhrases": [
-                  "Rewind the playback"
+                  "Rewind"
                 ]
               }
             ]
@@ -2962,11 +3135,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If you don't mind",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you.",
-          "I would appreciate it."
+          "for me?",
+          "if that's okay.",
+          "thank you.",
+          "please."
         ]
       }
     },
@@ -3002,9 +3179,9 @@
             "text": "if you don't mind",
             "category": "politeness",
             "synonyms": [
-              "if it's not too much trouble",
+              "please",
               "if you could",
-              "if you would be so kind"
+              "if it's not too much trouble"
             ],
             "isOptional": true
           }
@@ -3038,8 +3215,18 @@
             ]
           }
         ],
-        "politePrefixes": [],
-        "politeSuffixes": []
+        "politePrefixes": [
+          "Could you please",
+          "Would you kindly",
+          "May I ask you to",
+          "If it's not too much trouble"
+        ],
+        "politeSuffixes": [
+          "Thank you.",
+          "I would appreciate it.",
+          "Thanks a lot.",
+          "Much appreciated."
+        ]
       }
     },
     {
@@ -3096,15 +3283,15 @@
                 ]
               },
               {
-                "propertyValue": "player.play",
-                "propertySubPhrases": [
-                  "Play"
-                ]
-              },
-              {
                 "propertyValue": "player.resume",
                 "propertySubPhrases": [
                   "Resume"
+                ]
+              },
+              {
+                "propertyValue": "player.play",
+                "propertySubPhrases": [
+                  "Play"
                 ]
               }
             ]
@@ -3113,14 +3300,14 @@
         "politePrefixes": [
           "Could you please",
           "Would you mind",
-          "If it's not too much trouble, could you",
-          "May I ask you to"
+          "If you don't mind",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it.",
-          "Thanks a lot!",
-          "That would be great."
+          "for a moment?",
+          "if that's okay.",
+          "please.",
+          "thank you."
         ]
       }
     },
@@ -3135,27 +3322,27 @@
             "name": "fullActionName",
             "value": "player.pause",
             "substrings": [
-              "Pause the sound"
+              "Pause"
             ]
           }
         ],
         "subPhrases": [
           {
-            "text": "Pause the sound",
+            "text": "Pause",
             "category": "command",
             "propertyNames": [
               "fullActionName"
             ]
           },
           {
-            "text": ", I need to talk.",
-            "category": "explanation",
-            "synonyms": [
-              ", I have to speak.",
-              ", I need to say something.",
-              ", I need to speak."
-            ],
-            "isOptional": true
+            "text": "the sound",
+            "category": "object",
+            "propertyNames": []
+          },
+          {
+            "text": "I need to talk",
+            "category": "reason",
+            "propertyNames": []
           }
         ],
         "propertyAlternatives": [
@@ -3163,25 +3350,25 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.pause",
             "propertySubPhrases": [
-              "Pause the sound"
+              "Pause"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.stop",
                 "propertySubPhrases": [
-                  "Stop the sound"
+                  "Stop"
                 ]
               },
               {
                 "propertyValue": "player.mute",
                 "propertySubPhrases": [
-                  "Mute the sound"
+                  "Mute"
                 ]
               },
               {
-                "propertyValue": "player.resume",
+                "propertyValue": "player.silence",
                 "propertySubPhrases": [
-                  "Resume the sound"
+                  "Silence"
                 ]
               }
             ]
@@ -3189,11 +3376,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If you don't mind",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you.",
-          "I would appreciate it."
+          "Thank you",
+          "Thanks",
+          "I appreciate it",
+          "If that's okay"
         ]
       }
     },
@@ -3230,8 +3421,8 @@
             "category": "politeness",
             "synonyms": [
               "kindly",
-              "if you could",
-              "would you mind"
+              "if you would",
+              "if you could"
             ],
             "isOptional": true
           }
@@ -3251,22 +3442,32 @@
                 ]
               },
               {
-                "propertyValue": "player.play",
-                "propertySubPhrases": [
-                  "Play"
-                ]
-              },
-              {
                 "propertyValue": "player.resume",
                 "propertySubPhrases": [
                   "Resume"
+                ]
+              },
+              {
+                "propertyValue": "player.mute",
+                "propertySubPhrases": [
+                  "Mute"
                 ]
               }
             ]
           }
         ],
-        "politePrefixes": [],
-        "politeSuffixes": []
+        "politePrefixes": [
+          "Could you",
+          "Would you mind",
+          "If you don't mind",
+          "May I ask you to"
+        ],
+        "politeSuffixes": [
+          "thank you",
+          "if that's okay",
+          "if you could",
+          "I would appreciate it"
+        ]
       }
     },
     {
@@ -3293,14 +3494,14 @@
             ]
           },
           {
-            "text": "the tunes for a moment.",
-            "category": "filler",
-            "synonyms": [
-              "the music for a bit",
-              "the song for a while",
-              "the audio for a second"
-            ],
-            "isOptional": true
+            "text": "the tunes",
+            "category": "object",
+            "propertyNames": []
+          },
+          {
+            "text": "for a moment",
+            "category": "duration",
+            "propertyNames": []
           }
         ],
         "propertyAlternatives": [
@@ -3318,9 +3519,9 @@
                 ]
               },
               {
-                "propertyValue": "player.play",
+                "propertyValue": "player.mute",
                 "propertySubPhrases": [
-                  "Play"
+                  "Mute"
                 ]
               },
               {
@@ -3334,11 +3535,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If you don't mind",
+          "May I ask you to"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "if that's okay."
+          "for me?",
+          "please?",
+          "if that's okay?",
+          "thank you."
         ]
       }
     },
@@ -3366,32 +3571,12 @@
             ]
           },
           {
-            "text": "the",
+            "text": "the vibes for a second.",
             "category": "filler",
             "synonyms": [
-              "a",
-              "an",
-              "some"
-            ],
-            "isOptional": true
-          },
-          {
-            "text": "vibes",
-            "category": "object",
-            "synonyms": [
-              "music",
-              "sound",
-              "audio"
-            ],
-            "isOptional": true
-          },
-          {
-            "text": "for a second",
-            "category": "duration",
-            "synonyms": [
-              "for a moment",
-              "for a bit",
-              "temporarily"
+              "the music for a moment",
+              "the track for a bit",
+              "the song for a while"
             ],
             "isOptional": true
           }
@@ -3428,14 +3613,14 @@
         "politePrefixes": [
           "Could you please",
           "Would you mind",
-          "If it's not too much trouble, could you",
-          "May I kindly ask you to"
+          "If you don't mind",
+          "May I ask you to"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it.",
-          "Thanks a lot!",
-          "That would be great, thanks!"
+          "for me?",
+          "please?",
+          "if that's okay?",
+          "thank you."
         ]
       }
     },
@@ -3459,9 +3644,9 @@
             "text": "Please",
             "category": "politeness",
             "synonyms": [
-              "Kindly",
-              "Would you mind",
-              "Could you"
+              "kindly",
+              "could you",
+              "would you mind"
             ],
             "isOptional": true
           },
@@ -3475,7 +3660,12 @@
           {
             "text": "the music",
             "category": "object",
-            "propertyNames": []
+            "synonyms": [
+              "the song",
+              "the audio",
+              "the track"
+            ],
+            "isOptional": false
           }
         ],
         "propertyAlternatives": [
@@ -3507,8 +3697,18 @@
             ]
           }
         ],
-        "politePrefixes": [],
-        "politeSuffixes": []
+        "politePrefixes": [
+          "Could you kindly",
+          "Would you mind",
+          "If it's not too much trouble",
+          "May I ask you to"
+        ],
+        "politeSuffixes": [
+          "if you don't mind?",
+          "please?",
+          "thank you.",
+          "if that's okay."
+        ]
       }
     },
     {
@@ -3535,11 +3735,21 @@
             ]
           },
           {
-            "text": "on that, would you?",
+            "text": "on that",
+            "category": "preposition",
+            "synonyms": [
+              "on it",
+              "on this",
+              "on the item"
+            ],
+            "isOptional": true
+          },
+          {
+            "text": "would you?",
             "category": "politeness",
             "synonyms": [
               "please",
-              "if you don't mind",
+              "if you could",
               "kindly"
             ],
             "isOptional": true
@@ -3580,8 +3790,18 @@
             ]
           }
         ],
-        "politePrefixes": [],
-        "politeSuffixes": []
+        "politePrefixes": [
+          "Could you please",
+          "Would you mind",
+          "If you don't mind",
+          "May I ask you to"
+        ],
+        "politeSuffixes": [
+          "please?",
+          "if you could?",
+          "thank you.",
+          "if that's okay."
+        ]
       }
     },
     {
@@ -3628,95 +3848,12 @@
             "isOptional": true
           },
           {
-            "text": "okay?",
-            "category": "confirmation",
+            "text": "okay",
+            "category": "acknowledgement",
             "synonyms": [
-              "alright?",
-              "right?",
-              "is that okay?"
-            ],
-            "isOptional": true
-          }
-        ],
-        "propertyAlternatives": [
-          {
-            "propertyName": "fullActionName",
-            "propertyValue": "player.pause",
-            "propertySubPhrases": [
-              "pause"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "player.play",
-                "propertySubPhrases": [
-                  "play"
-                ]
-              },
-              {
-                "propertyValue": "player.stop",
-                "propertySubPhrases": [
-                  "stop"
-                ]
-              },
-              {
-                "propertyValue": "player.resume",
-                "propertySubPhrases": [
-                  "resume"
-                ]
-              }
-            ]
-          }
-        ],
-        "politePrefixes": [
-          "Could you please",
-          "Would you mind"
-        ],
-        "politeSuffixes": [
-          "Thank you!",
-          "I appreciate it!"
-        ]
-      }
-    },
-    {
-      "request": "Time out on the tunes, pause them.",
-      "action": {
-        "fullActionName": "player.pause"
-      },
-      "explanation": {
-        "properties": [
-          {
-            "name": "fullActionName",
-            "value": "player.pause",
-            "substrings": [
-              "pause"
-            ]
-          }
-        ],
-        "subPhrases": [
-          {
-            "text": "Time out on the tunes,",
-            "category": "filler",
-            "synonyms": [
-              "Stop the music,",
-              "Hold the tunes,",
-              "Pause the music,"
-            ],
-            "isOptional": true
-          },
-          {
-            "text": "pause",
-            "category": "command",
-            "propertyNames": [
-              "fullActionName"
-            ]
-          },
-          {
-            "text": "them.",
-            "category": "filler",
-            "synonyms": [
-              "it.",
-              "the music.",
-              "the tunes."
+              "alright",
+              "sure",
+              "got it"
             ],
             "isOptional": true
           }
@@ -3753,14 +3890,101 @@
         "politePrefixes": [
           "Could you please",
           "Would you mind",
-          "If it's not too much trouble, could you",
-          "May I kindly ask you to"
+          "If you don't mind",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it.",
-          "Thanks a lot!",
-          "Much appreciated."
+          "Thank you",
+          "Thanks",
+          "I appreciate it",
+          "If that's alright"
+        ]
+      }
+    },
+    {
+      "request": "Time out on the tunes, pause them.",
+      "action": {
+        "fullActionName": "player.pause"
+      },
+      "explanation": {
+        "properties": [
+          {
+            "name": "fullActionName",
+            "value": "player.pause",
+            "substrings": [
+              "pause"
+            ]
+          }
+        ],
+        "subPhrases": [
+          {
+            "text": "Time out on the tunes,",
+            "category": "filler",
+            "synonyms": [
+              "Stop the music,",
+              "Hold the songs,",
+              "Pause the tracks,"
+            ],
+            "isOptional": true
+          },
+          {
+            "text": "pause",
+            "category": "command",
+            "propertyNames": [
+              "fullActionName"
+            ]
+          },
+          {
+            "text": "them.",
+            "category": "filler",
+            "synonyms": [
+              "it.",
+              "the music.",
+              "the songs."
+            ],
+            "isOptional": true
+          }
+        ],
+        "propertyAlternatives": [
+          {
+            "propertyName": "fullActionName",
+            "propertyValue": "player.pause",
+            "propertySubPhrases": [
+              "pause"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "player.stop",
+                "propertySubPhrases": [
+                  "stop"
+                ]
+              },
+              {
+                "propertyValue": "player.mute",
+                "propertySubPhrases": [
+                  "mute"
+                ]
+              },
+              {
+                "propertyValue": "player.silence",
+                "propertySubPhrases": [
+                  "silence"
+                ]
+              }
+            ]
+          }
+        ],
+        "politePrefixes": [
+          "Could you please",
+          "Would you mind",
+          "If you don't mind",
+          "Please"
+        ],
+        "politeSuffixes": [
+          "thank you",
+          "please",
+          "if that's okay",
+          "thanks"
         ]
       }
     },
@@ -3785,8 +4009,8 @@
             "category": "politeness",
             "synonyms": [
               "Could you please",
-              "Do you mind",
-              "Would it be possible"
+              "Do you think you could",
+              "Would it be possible for you to"
             ],
             "isOptional": true
           },
@@ -3800,7 +4024,9 @@
           {
             "text": "the music",
             "category": "object",
-            "propertyNames": []
+            "propertyNames": [
+              "fullActionName"
+            ]
           }
         ],
         "propertyAlternatives": [
@@ -3808,32 +4034,46 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.pause",
             "propertySubPhrases": [
-              "pausing"
+              "pausing",
+              "the music"
             ],
             "alternatives": [
               {
-                "propertyValue": "player.play",
+                "propertyValue": "player.stop",
                 "propertySubPhrases": [
-                  "playing"
+                  "stopping",
+                  "the music"
                 ]
               },
               {
-                "propertyValue": "player.stop",
+                "propertyValue": "player.mute",
                 "propertySubPhrases": [
-                  "stopping"
+                  "muting",
+                  "the music"
                 ]
               },
               {
                 "propertyValue": "player.resume",
                 "propertySubPhrases": [
-                  "resuming"
+                  "resuming",
+                  "the music"
                 ]
               }
             ]
           }
         ],
-        "politePrefixes": [],
-        "politeSuffixes": []
+        "politePrefixes": [
+          "Could you please",
+          "If it's not too much trouble,",
+          "Would it be possible to",
+          "May I kindly ask you to"
+        ],
+        "politeSuffixes": [
+          "if you don't mind?",
+          "please?",
+          "if it's okay with you?",
+          "thank you."
+        ]
       }
     },
     {
@@ -3856,15 +4096,15 @@
             "text": "Yo",
             "category": "greeting",
             "synonyms": [
-              "Hey",
               "Hi",
-              "Hello"
+              "Hello",
+              "Hey"
             ],
             "isOptional": true
           },
           {
             "text": "pause",
-            "category": "action",
+            "category": "command",
             "propertyNames": [
               "fullActionName"
             ]
@@ -3905,12 +4145,16 @@
           }
         ],
         "politePrefixes": [
-          "Could you please",
-          "Would you mind"
+          "Please",
+          "Could you",
+          "Would you mind",
+          "Kindly"
         ],
         "politeSuffixes": [
-          "Thank you.",
-          "I would appreciate it."
+          "please",
+          "if you don't mind",
+          "thank you",
+          "if you could"
         ]
       }
     }

--- a/ts/packages/defaultAgentProvider/test/data/explanations/player/v5/previousAction.json
+++ b/ts/packages/defaultAgentProvider/test/data/explanations/player/v5/previousAction.json
@@ -15,7 +15,7 @@
             "name": "fullActionName",
             "value": "player.previous",
             "substrings": [
-              "go back"
+              "go back one song"
             ]
           }
         ],
@@ -26,21 +26,16 @@
             "synonyms": [
               "Could we",
               "May we",
-              "Shall we"
+              "Would we"
             ],
             "isOptional": true
           },
           {
-            "text": "go back",
+            "text": "go back one song",
             "category": "action",
             "propertyNames": [
               "fullActionName"
             ]
-          },
-          {
-            "text": "one song",
-            "category": "specification",
-            "propertyNames": []
           }
         ],
         "propertyAlternatives": [
@@ -48,37 +43,41 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.previous",
             "propertySubPhrases": [
-              "go back"
+              "go back one song"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.next",
                 "propertySubPhrases": [
-                  "go forward"
+                  "skip to the next song"
                 ]
               },
               {
                 "propertyValue": "player.pause",
                 "propertySubPhrases": [
-                  "pause"
+                  "pause the song"
                 ]
               },
               {
                 "propertyValue": "player.play",
                 "propertySubPhrases": [
-                  "play"
+                  "play the song"
                 ]
               }
             ]
           }
         ],
         "politePrefixes": [
-          "Please",
-          "Would you mind"
+          "Could you please",
+          "Would you mind",
+          "If it's not too much trouble",
+          "May I kindly ask"
         ],
         "politeSuffixes": [
-          "Thank you",
-          "if that's okay"
+          "please?",
+          "if you don't mind.",
+          "thank you.",
+          "if that's okay."
         ]
       }
     },
@@ -128,7 +127,7 @@
             "synonyms": [
               "once more",
               "one more time",
-              "another time"
+              "repeat"
             ],
             "isOptional": true
           }
@@ -150,6 +149,13 @@
                 ]
               },
               {
+                "propertyValue": "player.play",
+                "propertySubPhrases": [
+                  "hear the song",
+                  "right now"
+                ]
+              },
+              {
                 "propertyValue": "player.pause",
                 "propertySubPhrases": [
                   "pause the song",
@@ -157,17 +163,27 @@
                 ]
               },
               {
-                "propertyValue": "player.play",
+                "propertyValue": "player.stop",
                 "propertySubPhrases": [
-                  "play the song",
-                  "from the beginning"
+                  "stop the song",
+                  "right now"
                 ]
               }
             ]
           }
         ],
-        "politePrefixes": [],
-        "politeSuffixes": []
+        "politePrefixes": [
+          "Could you please",
+          "Would it be possible to",
+          "May I kindly ask",
+          "If you don't mind"
+        ],
+        "politeSuffixes": [
+          "please?",
+          "if that's okay?",
+          "thank you!",
+          "if you could?"
+        ]
       }
     },
     {
@@ -181,37 +197,45 @@
             "name": "fullActionName",
             "value": "player.previous",
             "substrings": [
-              "revisit the last song"
+              "revisit",
+              "last song"
             ]
           }
         ],
         "subPhrases": [
           {
-            "text": "Can we",
+            "text": "Can",
             "category": "politeness",
             "synonyms": [
-              "Could we",
-              "May we",
-              "Shall we"
+              "Could",
+              "Would",
+              "May"
             ],
             "isOptional": true
           },
           {
-            "text": "revisit the last song",
+            "text": "we",
+            "category": "politeness",
+            "synonyms": [
+              "us",
+              "I",
+              "you"
+            ],
+            "isOptional": true
+          },
+          {
+            "text": "revisit",
             "category": "action",
             "propertyNames": [
               "fullActionName"
             ]
           },
           {
-            "text": "?",
-            "category": "punctuation",
-            "synonyms": [
-              "",
-              ".",
-              "!"
-            ],
-            "isOptional": true
+            "text": "the last song",
+            "category": "object",
+            "propertyNames": [
+              "fullActionName"
+            ]
           }
         ],
         "propertyAlternatives": [
@@ -219,37 +243,52 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.previous",
             "propertySubPhrases": [
-              "revisit the last song"
+              "revisit",
+              "the last song"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.next",
                 "propertySubPhrases": [
-                  "skip to the next song"
+                  "skip",
+                  "to the next song"
                 ]
               },
               {
                 "propertyValue": "player.pause",
                 "propertySubPhrases": [
-                  "pause the music"
+                  "pause",
+                  "the song"
                 ]
               },
               {
                 "propertyValue": "player.play",
                 "propertySubPhrases": [
-                  "play the music"
+                  "play",
+                  "the song"
+                ]
+              },
+              {
+                "propertyValue": "player.stop",
+                "propertySubPhrases": [
+                  "stop",
+                  "the song"
                 ]
               }
             ]
           }
         ],
         "politePrefixes": [
-          "Please",
-          "Kindly"
+          "Could you please",
+          "Would you mind",
+          "If it's not too much trouble",
+          "May I kindly ask"
         ],
         "politeSuffixes": [
-          "Thank you",
-          "If you don't mind"
+          "if you don't mind?",
+          "please?",
+          "thank you.",
+          "if that's okay?"
         ]
       }
     },
@@ -338,11 +377,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If it's not too much trouble",
+          "May I ask you to"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it."
+          "please?",
+          "if you don't mind.",
+          "thank you.",
+          "if that's okay."
         ]
       }
     },
@@ -389,21 +432,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.next",
+                "propertyValue": "player.replay",
                 "propertySubPhrases": [
-                  "play the next track"
+                  "replay the last track"
                 ]
               },
               {
-                "propertyValue": "player.pause",
+                "propertyValue": "player.restart",
                 "propertySubPhrases": [
-                  "pause the track"
+                  "restart the last track"
                 ]
               },
               {
-                "propertyValue": "player.stop",
+                "propertyValue": "player.repeat",
                 "propertySubPhrases": [
-                  "stop the track"
+                  "repeat the last track"
                 ]
               }
             ]
@@ -411,11 +454,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If it's not too much trouble",
+          "May I kindly ask"
         ],
         "politeSuffixes": [
-          "Thank you",
-          "I would appreciate it"
+          "thank you",
+          "please",
+          "if you don't mind",
+          "I'd appreciate it"
         ]
       }
     },
@@ -430,8 +477,7 @@
             "name": "fullActionName",
             "value": "player.previous",
             "substrings": [
-              "rewind",
-              "before this one"
+              "rewind to the song before this one"
             ]
           }
         ],
@@ -447,25 +493,8 @@
             "isOptional": true
           },
           {
-            "text": "rewind",
+            "text": "rewind to the song before this one",
             "category": "action",
-            "propertyNames": [
-              "fullActionName"
-            ]
-          },
-          {
-            "text": "to the song",
-            "category": "preposition",
-            "synonyms": [
-              "to the track",
-              "to the music",
-              "to the tune"
-            ],
-            "isOptional": true
-          },
-          {
-            "text": "before this one",
-            "category": "specification",
             "propertyNames": [
               "fullActionName"
             ]
@@ -476,29 +505,25 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.previous",
             "propertySubPhrases": [
-              "rewind",
-              "before this one"
+              "rewind to the song before this one"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.next",
                 "propertySubPhrases": [
-                  "skip",
-                  "to the next one"
+                  "skip to the next song"
                 ]
               },
               {
                 "propertyValue": "player.pause",
                 "propertySubPhrases": [
-                  "pause",
-                  "the song"
+                  "pause the song"
                 ]
               },
               {
                 "propertyValue": "player.play",
                 "propertySubPhrases": [
-                  "play",
-                  "the song"
+                  "play the song"
                 ]
               }
             ]
@@ -506,11 +531,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If it's not too much trouble",
+          "May I kindly ask"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it."
+          "please?",
+          "if you don't mind.",
+          "thank you.",
+          "please and thank you."
         ]
       }
     },
@@ -525,7 +554,7 @@
             "name": "fullActionName",
             "value": "player.previous",
             "substrings": [
-              "previous"
+              "previous song"
             ]
           }
         ],
@@ -544,28 +573,18 @@
             "text": "take it to the",
             "category": "filler",
             "synonyms": [
-              "move to the",
-              "switch to the",
-              "change to the"
+              "move it to",
+              "switch to",
+              "change to"
             ],
             "isOptional": true
           },
           {
-            "text": "previous",
+            "text": "previous song",
             "category": "action",
             "propertyNames": [
               "fullActionName"
             ]
-          },
-          {
-            "text": "song",
-            "category": "object",
-            "synonyms": [
-              "track",
-              "tune",
-              "music"
-            ],
-            "isOptional": true
           }
         ],
         "propertyAlternatives": [
@@ -573,31 +592,31 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.previous",
             "propertySubPhrases": [
-              "previous"
+              "previous song"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.next",
                 "propertySubPhrases": [
-                  "next"
+                  "next song"
                 ]
               },
               {
                 "propertyValue": "player.pause",
                 "propertySubPhrases": [
-                  "pause"
+                  "pause the song"
                 ]
               },
               {
                 "propertyValue": "player.play",
                 "propertySubPhrases": [
-                  "play"
+                  "play the song"
                 ]
               },
               {
                 "propertyValue": "player.stop",
                 "propertySubPhrases": [
-                  "stop"
+                  "stop the song"
                 ]
               }
             ]
@@ -605,11 +624,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If it's not too much trouble",
+          "May I kindly ask"
         ],
         "politeSuffixes": [
-          "Thank you",
-          "I would appreciate it"
+          "please?",
+          "if you don't mind?",
+          "thank you.",
+          "if that's okay?"
         ]
       }
     },
@@ -635,30 +658,27 @@
             "synonyms": [
               "Can we",
               "May we",
-              "Shall we"
+              "Would we"
             ],
             "isOptional": true
           },
           {
-            "text": "listen to the",
-            "category": "preposition",
-            "synonyms": [
-              "play the",
-              "hear the",
-              "put on the"
-            ],
-            "isOptional": true
-          },
-          {
-            "text": "previous track",
+            "text": "listen to",
             "category": "action",
             "propertyNames": [
               "fullActionName"
             ]
           },
           {
+            "text": "the previous track",
+            "category": "object",
+            "propertyNames": [
+              "fullActionName"
+            ]
+          },
+          {
             "text": "once more",
-            "category": "confirmation",
+            "category": "repetition",
             "synonyms": [
               "again",
               "one more time",
@@ -672,38 +692,53 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.previous",
             "propertySubPhrases": [
-              "previous track"
+              "listen to",
+              "the previous track"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.next",
                 "propertySubPhrases": [
-                  "next track"
+                  "listen to",
+                  "the next track"
                 ]
               },
               {
                 "propertyValue": "player.pause",
                 "propertySubPhrases": [
-                  "pause the track"
+                  "pause",
+                  "the track"
                 ]
               },
               {
                 "propertyValue": "player.play",
                 "propertySubPhrases": [
-                  "play the track"
+                  "play",
+                  "the track"
                 ]
               },
               {
                 "propertyValue": "player.stop",
                 "propertySubPhrases": [
-                  "stop the track"
+                  "stop",
+                  "the track"
                 ]
               }
             ]
           }
         ],
-        "politePrefixes": [],
-        "politeSuffixes": []
+        "politePrefixes": [
+          "Please, ",
+          "Would you mind if ",
+          "If it's not too much trouble, ",
+          "May I kindly ask that "
+        ],
+        "politeSuffixes": [
+          " please?",
+          " if you don't mind.",
+          " thank you.",
+          " would be appreciated."
+        ]
       }
     },
     {
@@ -727,14 +762,14 @@
             "category": "politeness",
             "synonyms": [
               "Can you please",
-              "Would you mind",
+              "Would you kindly",
               "Please"
             ],
             "isOptional": true
           },
           {
             "text": "go back to the last song",
-            "category": "action",
+            "category": "command",
             "propertyNames": [
               "fullActionName"
             ]
@@ -769,14 +804,24 @@
               {
                 "propertyValue": "player.stop",
                 "propertySubPhrases": [
-                  "stop the music"
+                  "stop the song"
                 ]
               }
             ]
           }
         ],
-        "politePrefixes": [],
-        "politeSuffixes": []
+        "politePrefixes": [
+          "Would you mind",
+          "If it's not too much trouble",
+          "May I kindly ask",
+          "I would appreciate it if"
+        ],
+        "politeSuffixes": [
+          "Thank you so much",
+          "I appreciate it",
+          "Thanks a lot",
+          "Your help is appreciated"
+        ]
       }
     },
     {
@@ -806,29 +851,24 @@
             "isOptional": true
           },
           {
-            "text": "put the",
-            "category": "filler",
-            "synonyms": [
-              "play the",
-              "start the",
-              "turn on the"
-            ],
-            "isOptional": true
+            "text": "put",
+            "category": "action",
+            "propertyNames": []
           },
           {
-            "text": "previous track",
-            "category": "action",
+            "text": "the previous track",
+            "category": "object",
             "propertyNames": [
               "fullActionName"
             ]
           },
           {
-            "text": "on?",
-            "category": "filler",
+            "text": "on",
+            "category": "preposition",
             "synonyms": [
-              "now?",
-              "please?",
-              "right now?"
+              "play",
+              "start",
+              "begin"
             ],
             "isOptional": true
           }
@@ -838,32 +878,48 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.previous",
             "propertySubPhrases": [
-              "previous track"
+              "the previous track"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.next",
                 "propertySubPhrases": [
-                  "next track"
+                  "the next track"
                 ]
               },
               {
                 "propertyValue": "player.pause",
                 "propertySubPhrases": [
-                  "pause track"
+                  "pause the track"
                 ]
               },
               {
                 "propertyValue": "player.play",
                 "propertySubPhrases": [
-                  "play track"
+                  "play the track"
+                ]
+              },
+              {
+                "propertyValue": "player.stop",
+                "propertySubPhrases": [
+                  "stop the track"
                 ]
               }
             ]
           }
         ],
-        "politePrefixes": [],
-        "politeSuffixes": []
+        "politePrefixes": [
+          "Please, ",
+          "Would you mind, ",
+          "If you could, ",
+          "Kindly, "
+        ],
+        "politeSuffixes": [
+          " please.",
+          " if you don't mind.",
+          " thank you.",
+          " would be appreciated."
+        ]
       }
     },
     {
@@ -878,7 +934,7 @@
             "value": "player.previous",
             "substrings": [
               "skip back",
-              "the song before"
+              "song before"
             ]
           }
         ],
@@ -889,7 +945,7 @@
             "synonyms": [
               "Can you",
               "Would you",
-              "Will you"
+              "Please"
             ],
             "isOptional": true
           },
@@ -918,31 +974,41 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.next",
+                "propertyValue": "player.rewind",
                 "propertySubPhrases": [
-                  "skip forward",
-                  "to the next song"
+                  "rewind",
+                  "to the previous track"
                 ]
               },
               {
-                "propertyValue": "player.pause",
+                "propertyValue": "player.restart",
                 "propertySubPhrases": [
-                  "pause",
-                  "the song"
+                  "restart",
+                  "the current song"
                 ]
               },
               {
-                "propertyValue": "player.play",
+                "propertyValue": "player.replay",
                 "propertySubPhrases": [
-                  "play",
-                  "the song"
+                  "replay",
+                  "the last song"
                 ]
               }
             ]
           }
         ],
-        "politePrefixes": [],
-        "politeSuffixes": []
+        "politePrefixes": [
+          "Please",
+          "If you don't mind",
+          "Would you kindly",
+          "May I ask"
+        ],
+        "politeSuffixes": [
+          "please",
+          "if that's okay",
+          "thank you",
+          "if you could"
+        ]
       }
     },
     {
@@ -956,7 +1022,7 @@
             "name": "fullActionName",
             "value": "player.previous",
             "substrings": [
-              "back a track"
+              "back"
             ]
           }
         ],
@@ -982,11 +1048,21 @@
             "isOptional": true
           },
           {
-            "text": "back a track",
-            "category": "action",
+            "text": "back",
+            "category": "direction",
             "propertyNames": [
               "fullActionName"
             ]
+          },
+          {
+            "text": "a track",
+            "category": "filler",
+            "synonyms": [
+              "one track",
+              "a song",
+              "one song"
+            ],
+            "isOptional": true
           }
         ],
         "propertyAlternatives": [
@@ -994,32 +1070,42 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.previous",
             "propertySubPhrases": [
-              "back a track"
+              "back"
             ],
             "alternatives": [
               {
-                "propertyValue": "player.next",
+                "propertyValue": "player.rewind",
                 "propertySubPhrases": [
-                  "forward a track"
+                  "rewind"
                 ]
               },
               {
-                "propertyValue": "player.pause",
+                "propertyValue": "player.restart",
                 "propertySubPhrases": [
-                  "pause the track"
+                  "restart"
                 ]
               },
               {
-                "propertyValue": "player.play",
+                "propertyValue": "player.replay",
                 "propertySubPhrases": [
-                  "play the track"
+                  "replay"
                 ]
               }
             ]
           }
         ],
-        "politePrefixes": [],
-        "politeSuffixes": []
+        "politePrefixes": [
+          "Please",
+          "Would you mind",
+          "If you could",
+          "Kindly"
+        ],
+        "politeSuffixes": [
+          "please",
+          "if you don't mind",
+          "thank you",
+          "thanks"
+        ]
       }
     },
     {
@@ -1057,19 +1143,25 @@
               {
                 "propertyValue": "player.next",
                 "propertySubPhrases": [
-                  "Skip to the next track."
+                  "Go to the next track."
                 ]
               },
               {
                 "propertyValue": "player.pause",
                 "propertySubPhrases": [
-                  "Pause the music."
+                  "Pause the track."
                 ]
               },
               {
                 "propertyValue": "player.play",
                 "propertySubPhrases": [
-                  "Play the music."
+                  "Play the track."
+                ]
+              },
+              {
+                "propertyValue": "player.stop",
+                "propertySubPhrases": [
+                  "Stop the track."
                 ]
               }
             ]
@@ -1078,14 +1170,14 @@
         "politePrefixes": [
           "Could you please",
           "Would you mind",
-          "If it's not too much trouble, could you",
-          "May I kindly ask you to"
+          "If you don't mind",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "Thanks a lot!",
-          "I would appreciate it!",
-          "That would be great!"
+          "thank you",
+          "if that's okay",
+          "please",
+          "thanks"
         ]
       }
     },
@@ -1100,7 +1192,7 @@
             "name": "fullActionName",
             "value": "player.previous",
             "substrings": [
-              "back button",
+              "back",
               "player"
             ]
           }
@@ -1108,19 +1200,34 @@
         "subPhrases": [
           {
             "text": "Hit the",
-            "category": "command",
-            "propertyNames": []
+            "category": "filler",
+            "synonyms": [
+              "Press the",
+              "Tap the",
+              "Click the"
+            ],
+            "isOptional": true
           },
           {
-            "text": "back button",
+            "text": "back",
             "category": "action",
             "propertyNames": [
               "fullActionName"
             ]
           },
           {
-            "text": "on the player",
-            "category": "context",
+            "text": "button on the",
+            "category": "filler",
+            "synonyms": [
+              "control on the",
+              "key on the",
+              "switch on the"
+            ],
+            "isOptional": true
+          },
+          {
+            "text": "player",
+            "category": "object",
             "propertyNames": [
               "fullActionName"
             ]
@@ -1131,36 +1238,29 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.previous",
             "propertySubPhrases": [
-              "back button",
-              "on the player"
+              "back",
+              "player"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.next",
                 "propertySubPhrases": [
-                  "next button",
-                  "on the player"
+                  "next",
+                  "player"
                 ]
               },
               {
                 "propertyValue": "player.pause",
                 "propertySubPhrases": [
-                  "pause button",
-                  "on the player"
+                  "pause",
+                  "player"
                 ]
               },
               {
                 "propertyValue": "player.play",
                 "propertySubPhrases": [
-                  "play button",
-                  "on the player"
-                ]
-              },
-              {
-                "propertyValue": "player.stop",
-                "propertySubPhrases": [
-                  "stop button",
-                  "on the player"
+                  "play",
+                  "player"
                 ]
               }
             ]
@@ -1169,14 +1269,14 @@
         "politePrefixes": [
           "Could you please",
           "Would you mind",
-          "If it's not too much trouble, could you",
-          "May I kindly ask you to"
+          "Please",
+          "If you don't mind"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it.",
-          "Thanks a lot!",
-          "That would be great."
+          "for me?",
+          "please?",
+          "if that's okay?",
+          "thank you."
         ]
       }
     },
@@ -1218,8 +1318,8 @@
             "category": "politeness",
             "synonyms": [
               "kindly",
-              "if you would",
-              "if you please"
+              "if you could",
+              "would you mind"
             ],
             "isOptional": true
           }
@@ -1253,8 +1353,18 @@
             ]
           }
         ],
-        "politePrefixes": [],
-        "politeSuffixes": []
+        "politePrefixes": [
+          "Could you",
+          "Would you mind",
+          "If you don't mind",
+          "May I ask you to"
+        ],
+        "politeSuffixes": [
+          "if that's okay",
+          "if you could",
+          "thank you",
+          "if possible"
+        ]
       }
     },
     {
@@ -1274,14 +1384,14 @@
         ],
         "subPhrases": [
           {
-            "text": "Hit the",
-            "category": "filler",
-            "synonyms": [
-              "Press the",
-              "Tap the",
-              "Click the"
-            ],
-            "isOptional": true
+            "text": "Hit",
+            "category": "command",
+            "propertyNames": []
+          },
+          {
+            "text": "the",
+            "category": "article",
+            "propertyNames": []
           },
           {
             "text": "previous track",
@@ -1291,14 +1401,9 @@
             ]
           },
           {
-            "text": "button.",
-            "category": "filler",
-            "synonyms": [
-              "control",
-              "key",
-              "icon"
-            ],
-            "isOptional": true
+            "text": "button",
+            "category": "object",
+            "propertyNames": []
           }
         ],
         "propertyAlternatives": [
@@ -1326,6 +1431,12 @@
                 "propertySubPhrases": [
                   "play"
                 ]
+              },
+              {
+                "propertyValue": "player.stop",
+                "propertySubPhrases": [
+                  "stop"
+                ]
               }
             ]
           }
@@ -1333,14 +1444,14 @@
         "politePrefixes": [
           "Could you please",
           "Would you mind",
-          "If it's not too much trouble, could you",
-          "May I kindly ask you to"
+          "Please",
+          "If you don't mind"
         ],
         "politeSuffixes": [
-          "Thank you.",
-          "I would appreciate it.",
-          "Thanks a lot.",
-          "That would be great."
+          "thank you",
+          "please",
+          "if that's okay",
+          "thanks"
         ]
       }
     },
@@ -1387,21 +1498,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.next",
+                "propertyValue": "player.replay",
                 "propertySubPhrases": [
-                  "listen to the next track"
+                  "replay the last track"
                 ]
               },
               {
-                "propertyValue": "player.pause",
+                "propertyValue": "player.repeat",
                 "propertySubPhrases": [
-                  "pause the track"
+                  "repeat the last track"
                 ]
               },
               {
-                "propertyValue": "player.play",
+                "propertyValue": "player.restart",
                 "propertySubPhrases": [
-                  "play the track"
+                  "restart the last track"
                 ]
               }
             ]
@@ -1409,11 +1520,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If it's not too much trouble,",
+          "May I kindly ask"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it."
+          "thank you.",
+          "please.",
+          "if you don't mind.",
+          "I'd appreciate it."
         ]
       }
     },
@@ -1437,9 +1552,9 @@
             "text": "I want to",
             "category": "politeness",
             "synonyms": [
-              "I'd like to",
-              "I would like to",
-              "Can you"
+              "please",
+              "could you",
+              "would you mind"
             ],
             "isOptional": true
           },
@@ -1476,6 +1591,12 @@
                 "propertySubPhrases": [
                   "stop the song"
                 ]
+              },
+              {
+                "propertyValue": "player.shuffle",
+                "propertySubPhrases": [
+                  "shuffle the playlist"
+                ]
               }
             ]
           }
@@ -1483,14 +1604,14 @@
         "politePrefixes": [
           "Could you please",
           "Would you mind",
-          "If it's not too much trouble,",
+          "If possible, could you",
           "May I kindly ask you to"
         ],
         "politeSuffixes": [
-          "Thank you.",
-          "I would appreciate it.",
-          "Thanks a lot.",
-          "That would be great."
+          "if you don't mind?",
+          "please?",
+          "thank you.",
+          "if that's okay."
         ]
       }
     },
@@ -1516,26 +1637,16 @@
             "synonyms": [
               "please",
               "kindly",
-              "it would be great if"
+              "would you mind"
             ],
             "isOptional": true
           },
           {
-            "text": "listen to the previous track",
+            "text": "listen to the previous track again",
             "category": "action",
             "propertyNames": [
               "fullActionName"
             ]
-          },
-          {
-            "text": "again",
-            "category": "confirmation",
-            "synonyms": [
-              "once more",
-              "one more time",
-              "replay"
-            ],
-            "isOptional": true
           }
         ],
         "propertyAlternatives": [
@@ -1543,7 +1654,7 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.previous",
             "propertySubPhrases": [
-              "listen to the previous track"
+              "listen to the previous track again"
             ],
             "alternatives": [
               {
@@ -1573,8 +1684,18 @@
             ]
           }
         ],
-        "politePrefixes": [],
-        "politeSuffixes": []
+        "politePrefixes": [
+          "Could you please",
+          "Would you mind",
+          "If it's not too much trouble",
+          "I would be grateful if"
+        ],
+        "politeSuffixes": [
+          "Thank you.",
+          "If you don't mind.",
+          "Please.",
+          "Thanks a lot."
+        ]
       }
     },
     {
@@ -1588,7 +1709,8 @@
             "name": "fullActionName",
             "value": "player.previous",
             "substrings": [
-              "go back to the last track"
+              "go back",
+              "last track"
             ]
           }
         ],
@@ -1604,8 +1726,15 @@
             "isOptional": true
           },
           {
-            "text": "go back to the last track",
+            "text": "go back",
             "category": "action",
+            "propertyNames": [
+              "fullActionName"
+            ]
+          },
+          {
+            "text": "to the last track",
+            "category": "target",
             "propertyNames": [
               "fullActionName"
             ]
@@ -1615,8 +1744,8 @@
             "category": "politeness",
             "synonyms": [
               "kindly",
-              "if you don't mind",
-              "if you please"
+              "if you please",
+              "would you mind"
             ],
             "isOptional": true
           }
@@ -1626,32 +1755,46 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.previous",
             "propertySubPhrases": [
-              "go back to the last track"
+              "go back",
+              "to the last track"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.next",
                 "propertySubPhrases": [
-                  "skip to the next track"
+                  "skip forward",
+                  "to the next track"
                 ]
               },
               {
                 "propertyValue": "player.pause",
                 "propertySubPhrases": [
-                  "pause the music"
+                  "pause",
+                  "the current track"
                 ]
               },
               {
                 "propertyValue": "player.play",
                 "propertySubPhrases": [
-                  "play the music"
+                  "play",
+                  "the current track"
                 ]
               }
             ]
           }
         ],
-        "politePrefixes": [],
-        "politeSuffixes": []
+        "politePrefixes": [
+          "Could you",
+          "Would you mind",
+          "May I kindly ask",
+          "If it's not too much trouble"
+        ],
+        "politeSuffixes": [
+          "thank you",
+          "if you don't mind",
+          "I'd appreciate it",
+          "when you have a moment"
+        ]
       }
     },
     {
@@ -1665,7 +1808,7 @@
             "name": "fullActionName",
             "value": "player.previous",
             "substrings": [
-              "the previous song"
+              "previous"
             ]
           }
         ],
@@ -1674,15 +1817,15 @@
             "text": "I'd like to hear",
             "category": "politeness",
             "synonyms": [
-              "I want to hear",
               "I would like to hear",
+              "I want to hear",
               "Can I hear"
             ],
             "isOptional": true
           },
           {
             "text": "the previous song",
-            "category": "action",
+            "category": "property",
             "propertyNames": [
               "fullActionName"
             ]
@@ -1723,17 +1866,27 @@
                 "propertySubPhrases": [
                   "play the song"
                 ]
+              },
+              {
+                "propertyValue": "player.stop",
+                "propertySubPhrases": [
+                  "stop the song"
+                ]
               }
             ]
           }
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If it's not too much trouble",
+          "May I kindly request"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I appreciate it!"
+          "Thank you.",
+          "Please.",
+          "If you don't mind.",
+          "I would appreciate it."
         ]
       }
     },
@@ -1802,10 +1955,14 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If it's not too much trouble",
+          "May I kindly request"
         ],
         "politeSuffixes": [
           "Thank you!",
+          "Please.",
+          "If you don't mind.",
           "I would appreciate it."
         ]
       }
@@ -1833,7 +1990,7 @@
             "synonyms": [
               "Let us",
               "We should",
-              "How about"
+              "How about we"
             ],
             "isOptional": true
           },
@@ -1849,14 +2006,14 @@
             "category": "preposition",
             "synonyms": [
               "towards the",
-              "back to the",
-              "return to the"
+              "up to the",
+              "until the"
             ],
             "isOptional": true
           },
           {
             "text": "previous",
-            "category": "descriptor",
+            "category": "action",
             "propertyNames": [
               "fullActionName"
             ]
@@ -1866,8 +2023,8 @@
             "category": "object",
             "synonyms": [
               "track",
-              "tune",
-              "music"
+              "music",
+              "tune"
             ],
             "isOptional": true
           }
@@ -1882,24 +2039,31 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.next",
+                "propertyValue": "player.rewind",
                 "propertySubPhrases": [
-                  "skip",
-                  "next"
+                  "rewind",
+                  "previous"
                 ]
               },
               {
-                "propertyValue": "player.pause",
+                "propertyValue": "player.goBack",
                 "propertySubPhrases": [
-                  "pause",
-                  "current"
+                  "go back",
+                  "previous"
                 ]
               },
               {
-                "propertyValue": "player.play",
+                "propertyValue": "player.reverse",
                 "propertySubPhrases": [
-                  "play",
-                  "current"
+                  "reverse",
+                  "previous"
+                ]
+              },
+              {
+                "propertyValue": "player.skipBack",
+                "propertySubPhrases": [
+                  "skip back",
+                  "previous"
                 ]
               }
             ]
@@ -1907,11 +2071,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If you don't mind",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you.",
-          "I appreciate it."
+          "if that's okay.",
+          "please.",
+          "if you could.",
+          "thank you."
         ]
       }
     },
@@ -1936,9 +2104,9 @@
             "text": "Let's do a quick",
             "category": "filler",
             "synonyms": [
-              "Let's quickly",
-              "Let's just",
-              "Let's"
+              "let's proceed with",
+              "let's go ahead with",
+              "let's start with"
             ],
             "isOptional": true
           },
@@ -1967,47 +2135,40 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.next",
+                "propertyValue": "player.rewind",
                 "propertySubPhrases": [
-                  "skip",
-                  "to the next song"
+                  "rewind",
+                  "to the last song"
                 ]
               },
               {
-                "propertyValue": "player.pause",
+                "propertyValue": "player.skipBack",
                 "propertySubPhrases": [
-                  "pause",
-                  "the music"
+                  "skip back",
+                  "to the last song"
                 ]
               },
               {
-                "propertyValue": "player.play",
+                "propertyValue": "player.goBack",
                 "propertySubPhrases": [
-                  "play",
-                  "the music"
-                ]
-              },
-              {
-                "propertyValue": "player.stop",
-                "propertySubPhrases": [
-                  "stop",
-                  "the music"
+                  "go back",
+                  "to the last song"
                 ]
               }
             ]
           }
         ],
         "politePrefixes": [
-          "Could we please",
-          "Would you mind if we",
-          "If it's not too much trouble, let's",
-          "May I kindly ask you to"
+          "Could you please",
+          "Would you mind",
+          "If you don't mind",
+          "May I ask you to"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "Thanks a lot!",
-          "I appreciate it!",
-          "Much appreciated!"
+          "if that's okay?",
+          "please?",
+          "if you could?",
+          "thank you!"
         ]
       }
     },
@@ -2023,7 +2184,7 @@
             "value": "player.previous",
             "substrings": [
               "go back",
-              "before"
+              "played before"
             ]
           }
         ],
@@ -2046,13 +2207,8 @@
             ]
           },
           {
-            "text": "to the song that played",
-            "category": "context",
-            "propertyNames": []
-          },
-          {
-            "text": "before",
-            "category": "time",
+            "text": "to the song that played before",
+            "category": "description",
             "propertyNames": [
               "fullActionName"
             ]
@@ -2064,44 +2220,44 @@
             "propertyValue": "player.previous",
             "propertySubPhrases": [
               "go back",
-              "before"
+              "to the song that played before"
             ],
             "alternatives": [
               {
-                "propertyValue": "player.next",
+                "propertyValue": "player.rewind",
                 "propertySubPhrases": [
-                  "skip ahead",
-                  "next"
+                  "rewind",
+                  "to the song that played before"
                 ]
               },
               {
-                "propertyValue": "player.pause",
+                "propertyValue": "player.restart",
                 "propertySubPhrases": [
-                  "pause",
-                  "stop"
+                  "restart",
+                  "to the song that played before"
                 ]
               },
               {
-                "propertyValue": "player.play",
+                "propertyValue": "player.replay",
                 "propertySubPhrases": [
-                  "play",
-                  "start"
+                  "replay",
+                  "to the song that played before"
                 ]
               }
             ]
           }
         ],
         "politePrefixes": [
-          "Could we please",
-          "Would you mind if we",
-          "May we kindly",
-          "If it's not too much trouble, could we"
+          "Could you please",
+          "Would you mind",
+          "If it's not too much trouble",
+          "May I kindly ask"
         ],
         "politeSuffixes": [
-          "thank you.",
-          "please.",
-          "if you don't mind.",
-          "thanks a lot."
+          "Thank you!",
+          "Please.",
+          "If you don't mind.",
+          "I would appreciate it."
         ]
       }
     },
@@ -2125,9 +2281,9 @@
             "text": "Let's go",
             "category": "filler",
             "synonyms": [
-              "Let's move",
-              "Let's proceed",
-              "Let's continue"
+              "let us proceed",
+              "let's move",
+              "let's continue"
             ],
             "isOptional": true
           },
@@ -2169,12 +2325,16 @@
           }
         ],
         "politePrefixes": [
-          "Could we please",
-          "Would you mind if we"
+          "Could you please",
+          "Would you mind",
+          "If you don't mind",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it."
+          "thank you",
+          "please",
+          "if that's okay",
+          "if you could"
         ]
       }
     },
@@ -2189,18 +2349,18 @@
             "name": "fullActionName",
             "value": "player.previous",
             "substrings": [
-              "the preceding song"
+              "preceding"
             ]
           }
         ],
         "subPhrases": [
           {
             "text": "Let's",
-            "category": "politeness",
+            "category": "filler",
             "synonyms": [
               "Let us",
-              "Allow us to",
-              "We should"
+              "We should",
+              "How about"
             ],
             "isOptional": true
           },
@@ -2212,21 +2372,18 @@
             ]
           },
           {
-            "text": "the preceding song",
-            "category": "object",
+            "text": "the preceding",
+            "category": "description",
             "propertyNames": [
               "fullActionName"
             ]
           },
           {
-            "text": "again",
-            "category": "repetition",
-            "synonyms": [
-              "once more",
-              "one more time",
-              "another time"
-            ],
-            "isOptional": true
+            "text": "song again",
+            "category": "object",
+            "propertyNames": [
+              "fullActionName"
+            ]
           }
         ],
         "propertyAlternatives": [
@@ -2235,28 +2392,40 @@
             "propertyValue": "player.previous",
             "propertySubPhrases": [
               "hear",
-              "the preceding song"
+              "the preceding",
+              "song again"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.next",
                 "propertySubPhrases": [
                   "hear",
-                  "the next song"
+                  "the next",
+                  "song again"
                 ]
               },
               {
                 "propertyValue": "player.pause",
                 "propertySubPhrases": [
                   "pause",
-                  "the song"
+                  "the current",
+                  "song"
                 ]
               },
               {
                 "propertyValue": "player.play",
                 "propertySubPhrases": [
                   "play",
-                  "the song"
+                  "the current",
+                  "song"
+                ]
+              },
+              {
+                "propertyValue": "player.stop",
+                "propertySubPhrases": [
+                  "stop",
+                  "the current",
+                  "song"
                 ]
               }
             ]
@@ -2264,11 +2433,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If it's not too much trouble",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you.",
-          "I would appreciate it."
+          "Thank you!",
+          "if you don't mind.",
+          "please.",
+          "Thanks!"
         ]
       }
     },
@@ -2290,11 +2463,11 @@
         "subPhrases": [
           {
             "text": "Let's",
-            "category": "filler",
+            "category": "politeness",
             "synonyms": [
               "Let us",
               "We should",
-              "How about"
+              "We could"
             ],
             "isOptional": true
           },
@@ -2323,24 +2496,24 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.next",
+                "propertyValue": "player.rewind",
                 "propertySubPhrases": [
-                  "skip forward",
+                  "rewind",
                   "one track"
                 ]
               },
               {
-                "propertyValue": "player.pause",
+                "propertyValue": "player.skipBack",
                 "propertySubPhrases": [
-                  "pause",
-                  "the track"
+                  "skip back",
+                  "one track"
                 ]
               },
               {
-                "propertyValue": "player.play",
+                "propertyValue": "player.goBack",
                 "propertySubPhrases": [
-                  "play",
-                  "the track"
+                  "go back",
+                  "one track"
                 ]
               }
             ]
@@ -2348,11 +2521,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If you don't mind",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it."
+          "thank you",
+          "if that's okay",
+          "please",
+          "thanks"
         ]
       }
     },
@@ -2367,7 +2544,6 @@
             "name": "fullActionName",
             "value": "player.previous",
             "substrings": [
-              "replay",
               "before this one"
             ]
           }
@@ -2375,24 +2551,24 @@
         "subPhrases": [
           {
             "text": "Let's",
-            "category": "filler",
+            "category": "politeness",
             "synonyms": [
-              "Let us",
-              "We should",
-              "How about"
+              "Please",
+              "Kindly",
+              "Would you mind"
             ],
             "isOptional": true
           },
           {
-            "text": "replay",
-            "category": "action",
+            "text": "replay the song",
+            "category": "command",
             "propertyNames": [
               "fullActionName"
             ]
           },
           {
-            "text": "the song that was on",
-            "category": "object",
+            "text": "that was on",
+            "category": "description",
             "propertyNames": [
               "fullActionName"
             ]
@@ -2410,33 +2586,33 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.previous",
             "propertySubPhrases": [
-              "replay",
-              "the song that was on",
+              "replay the song",
+              "that was on",
               "before this one"
             ],
             "alternatives": [
               {
-                "propertyValue": "player.replay",
+                "propertyValue": "player.rewind",
                 "propertySubPhrases": [
-                  "replay",
-                  "the song that was on",
-                  "again"
+                  "rewind the song",
+                  "that was playing",
+                  "earlier"
                 ]
               },
               {
                 "propertyValue": "player.restart",
                 "propertySubPhrases": [
-                  "restart",
-                  "the song that was on",
-                  "from the beginning"
+                  "restart the song",
+                  "that was playing",
+                  "previously"
                 ]
               },
               {
-                "propertyValue": "player.repeat",
+                "propertyValue": "player.replay",
                 "propertySubPhrases": [
-                  "repeat",
-                  "the song that was on",
-                  "once more"
+                  "replay the track",
+                  "that was playing",
+                  "before this"
                 ]
               }
             ]
@@ -2445,104 +2621,16 @@
         "politePrefixes": [
           "Could you please",
           "Would you mind",
-          "If it's not too much trouble,",
-          "May I kindly ask you to"
+          "If you don't mind",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you.",
-          "I would appreciate it.",
-          "Thanks a lot.",
-          "Much appreciated."
+          "Thank you",
+          "Thanks",
+          "If that's okay",
+          "I appreciate it"
         ]
-      },
-      "corrections": [
-        {
-          "data": {
-            "properties": [
-              {
-                "name": "fullActionName",
-                "value": "player.previous",
-                "substrings": [
-                  "replay",
-                  "before this one"
-                ]
-              }
-            ],
-            "subPhrases": [
-              {
-                "text": "Let's",
-                "category": "filler",
-                "synonyms": [
-                  "Let us",
-                  "We should",
-                  "How about"
-                ],
-                "isOptional": true
-              },
-              {
-                "text": "replay",
-                "category": "action",
-                "propertyNames": [
-                  "fullActionName"
-                ]
-              },
-              {
-                "text": "the song that was on",
-                "category": "object",
-                "propertyNames": [
-                  "fullActionName"
-                ]
-              },
-              {
-                "text": "before this one",
-                "category": "time",
-                "propertyNames": [
-                  "fullActionName"
-                ]
-              }
-            ],
-            "propertyAlternatives": [
-              {
-                "propertyName": "fullActionName",
-                "propertyValue": "player.previous",
-                "propertySubPhrases": [
-                  "replay",
-                  "the song that was on",
-                  "before this one"
-                ],
-                "alternatives": [
-                  {
-                    "propertyValue": "player.replay",
-                    "propertySubPhrases": [
-                      "replay",
-                      "the song"
-                    ]
-                  },
-                  {
-                    "propertyValue": "player.restart",
-                    "propertySubPhrases": [
-                      "restart",
-                      "the song"
-                    ]
-                  },
-                  {
-                    "propertyValue": "player.repeat",
-                    "propertySubPhrases": [
-                      "repeat",
-                      "the song"
-                    ]
-                  }
-                ]
-              }
-            ]
-          },
-          "correction": [
-            "Mismatch number of sub-phrases: alternatives value 'player.replay' for property 'fullActionName' must have 3 sub-phrases",
-            "Mismatch number of sub-phrases: alternatives value 'player.restart' for property 'fullActionName' must have 3 sub-phrases",
-            "Mismatch number of sub-phrases: alternatives value 'player.repeat' for property 'fullActionName' must have 3 sub-phrases"
-          ]
-        }
-      ]
+      }
     },
     {
       "request": "Let's return to the last track.",
@@ -2564,9 +2652,9 @@
             "text": "Let's",
             "category": "politeness",
             "synonyms": [
-              "Let us",
-              "We should",
-              "How about we"
+              "please",
+              "kindly",
+              "let us"
             ],
             "isOptional": true
           },
@@ -2614,16 +2702,16 @@
           }
         ],
         "politePrefixes": [
-          "Could we please",
-          "Would you mind if we",
-          "May we kindly",
-          "If it's not too much trouble, let's"
+          "Could you please",
+          "Would you mind",
+          "If possible,",
+          "Kindly"
         ],
         "politeSuffixes": [
-          "Thank you.",
-          "Please.",
-          "Thanks a lot.",
-          "I would appreciate it."
+          "thank you.",
+          "please.",
+          "if you don't mind.",
+          "if that's okay."
         ]
       }
     },
@@ -2638,7 +2726,8 @@
             "name": "fullActionName",
             "value": "player.previous",
             "substrings": [
-              "reverse to the previous track"
+              "reverse",
+              "previous track"
             ]
           }
         ],
@@ -2647,15 +2736,32 @@
             "text": "Let's",
             "category": "politeness",
             "synonyms": [
-              "Let us",
-              "We should",
-              "How about we"
+              "please",
+              "kindly",
+              "let us"
             ],
             "isOptional": true
           },
           {
-            "text": "reverse to the previous track",
+            "text": "reverse",
             "category": "action",
+            "propertyNames": [
+              "fullActionName"
+            ]
+          },
+          {
+            "text": "to the",
+            "category": "preposition",
+            "synonyms": [
+              "towards",
+              "into",
+              "onto"
+            ],
+            "isOptional": true
+          },
+          {
+            "text": "previous track",
+            "category": "object",
             "propertyNames": [
               "fullActionName"
             ]
@@ -2666,25 +2772,29 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.previous",
             "propertySubPhrases": [
-              "reverse to the previous track"
+              "reverse",
+              "previous track"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.next",
                 "propertySubPhrases": [
-                  "skip to the next track"
+                  "advance",
+                  "next track"
                 ]
               },
               {
                 "propertyValue": "player.pause",
                 "propertySubPhrases": [
-                  "pause the track"
+                  "halt",
+                  "current track"
                 ]
               },
               {
                 "propertyValue": "player.play",
                 "propertySubPhrases": [
-                  "play the track"
+                  "start",
+                  "current track"
                 ]
               }
             ]
@@ -2692,11 +2802,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If you don't mind",
+          "May I ask you to"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it."
+          "thank you",
+          "please",
+          "if that's okay",
+          "if you could"
         ]
       }
     },
@@ -2719,11 +2833,11 @@
         "subPhrases": [
           {
             "text": "Let's",
-            "category": "filler",
+            "category": "politeness",
             "synonyms": [
-              "Let us",
-              "We should",
-              "How about"
+              "please",
+              "kindly",
+              "would you mind"
             ],
             "isOptional": true
           },
@@ -2764,7 +2878,7 @@
                 "propertySubPhrases": [
                   "skip",
                   "the track",
-                  "to the next one"
+                  "after this one"
                 ]
               },
               {
@@ -2795,12 +2909,16 @@
           }
         ],
         "politePrefixes": [
-          "Could we please",
-          "Would you mind if we"
+          "Could you please",
+          "Would you mind",
+          "If you don't mind",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it."
+          "if that's okay.",
+          "please.",
+          "if you could.",
+          "thank you."
         ]
       }
     },
@@ -2815,32 +2933,24 @@
             "name": "fullActionName",
             "value": "player.previous",
             "substrings": [
-              "rewind",
-              "the song we just heard"
+              "rewind to the song we just heard"
             ]
           }
         ],
         "subPhrases": [
           {
             "text": "Let's",
-            "category": "filler",
+            "category": "politeness",
             "synonyms": [
-              "Let us",
-              "We should",
-              "How about"
+              "please",
+              "kindly",
+              "would you mind"
             ],
             "isOptional": true
           },
           {
-            "text": "rewind",
+            "text": "rewind to the song we just heard",
             "category": "action",
-            "propertyNames": [
-              "fullActionName"
-            ]
-          },
-          {
-            "text": "to the song we just heard",
-            "category": "context",
             "propertyNames": [
               "fullActionName"
             ]
@@ -2851,29 +2961,25 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.previous",
             "propertySubPhrases": [
-              "rewind",
-              "to the song we just heard"
+              "rewind to the song we just heard"
             ],
             "alternatives": [
               {
-                "propertyValue": "player.replay",
+                "propertyValue": "player.rewind",
                 "propertySubPhrases": [
-                  "replay",
-                  "the song we just heard"
+                  "rewind the song"
                 ]
               },
               {
-                "propertyValue": "player.restart",
+                "propertyValue": "player.skipBack",
                 "propertySubPhrases": [
-                  "restart",
-                  "the song we just heard"
+                  "skip back to the previous song"
                 ]
               },
               {
-                "propertyValue": "player.back",
+                "propertyValue": "player.goBack",
                 "propertySubPhrases": [
-                  "go back",
-                  "to the song we just heard"
+                  "go back to the last song"
                 ]
               }
             ]
@@ -2881,11 +2987,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If you don't mind",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it."
+          "if that's okay.",
+          "thank you.",
+          "please.",
+          "if you could."
         ]
       }
     },
@@ -2906,31 +3016,41 @@
         ],
         "subPhrases": [
           {
-            "text": "Mind",
+            "text": "Mind hitting",
             "category": "politeness",
             "synonyms": [
-              "Would you mind",
               "Could you",
+              "Would you mind",
               "Can you"
             ],
             "isOptional": true
           },
           {
-            "text": "hitting the",
-            "category": "filler",
+            "text": "the",
+            "category": "preposition",
             "synonyms": [
-              "playing the",
-              "skipping to the",
-              "going to the"
+              "a",
+              "this",
+              "that"
             ],
             "isOptional": true
           },
           {
-            "text": "previous song",
+            "text": "previous",
             "category": "action",
             "propertyNames": [
               "fullActionName"
             ]
+          },
+          {
+            "text": "song",
+            "category": "object",
+            "synonyms": [
+              "track",
+              "music",
+              "tune"
+            ],
+            "isOptional": true
           }
         ],
         "propertyAlternatives": [
@@ -2938,25 +3058,25 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.previous",
             "propertySubPhrases": [
-              "previous song"
+              "previous"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.next",
                 "propertySubPhrases": [
-                  "next song"
+                  "next"
                 ]
               },
               {
                 "propertyValue": "player.pause",
                 "propertySubPhrases": [
-                  "pause the song"
+                  "pause"
                 ]
               },
               {
                 "propertyValue": "player.play",
                 "propertySubPhrases": [
-                  "play the song"
+                  "play"
                 ]
               }
             ]
@@ -2964,11 +3084,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If you don't mind",
+          "May I ask you to"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it."
+          "please?",
+          "if that's okay?",
+          "if you could?",
+          "thank you!"
         ]
       }
     },
@@ -2993,9 +3117,9 @@
             "text": "Mind",
             "category": "politeness",
             "synonyms": [
-              "Would you",
               "Could you",
-              "Can you"
+              "Would you",
+              "Please"
             ],
             "isOptional": true
           },
@@ -3049,11 +3173,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you kindly",
+          "If you don't mind",
+          "May I ask you to"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it."
+          "if that's okay?",
+          "please?",
+          "if you could?",
+          "thank you!"
         ]
       }
     },
@@ -3081,8 +3209,15 @@
             ]
           },
           {
-            "text": "the last song again.",
+            "text": "the last song",
             "category": "object",
+            "propertyNames": [
+              "fullActionName"
+            ]
+          },
+          {
+            "text": "again",
+            "category": "modifier",
             "propertyNames": [
               "fullActionName"
             ]
@@ -3094,35 +3229,32 @@
             "propertyValue": "player.previous",
             "propertySubPhrases": [
               "Play",
-              "the last song again."
+              "the last song",
+              "again"
             ],
             "alternatives": [
               {
-                "propertyValue": "player.next",
+                "propertyValue": "player.repeat",
                 "propertySubPhrases": [
                   "Play",
-                  "the next song."
+                  "the last song",
+                  "again"
                 ]
               },
               {
-                "propertyValue": "player.pause",
+                "propertyValue": "player.replay",
                 "propertySubPhrases": [
-                  "Pause",
-                  "the song."
+                  "Play",
+                  "the last song",
+                  "again"
                 ]
               },
               {
-                "propertyValue": "player.stop",
+                "propertyValue": "player.restart",
                 "propertySubPhrases": [
-                  "Stop",
-                  "the song."
-                ]
-              },
-              {
-                "propertyValue": "player.shuffle",
-                "propertySubPhrases": [
-                  "Shuffle",
-                  "the playlist."
+                  "Play",
+                  "the last song",
+                  "again"
                 ]
               }
             ]
@@ -3131,12 +3263,14 @@
         "politePrefixes": [
           "Could you please",
           "Would you mind",
-          "If it's not too much trouble, could you"
+          "If you don't mind",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "Thanks a lot!",
-          "I would appreciate it!"
+          "thank you",
+          "please",
+          "if that's okay",
+          "if you could"
         ]
       }
     },
@@ -3162,18 +3296,8 @@
             "propertyNames": []
           },
           {
-            "text": "the",
-            "category": "preposition",
-            "synonyms": [
-              "a",
-              "this",
-              "that"
-            ],
-            "isOptional": true
-          },
-          {
-            "text": "preceding track",
-            "category": "content",
+            "text": "the preceding track",
+            "category": "object",
             "propertyNames": [
               "fullActionName"
             ]
@@ -3181,12 +3305,7 @@
           {
             "text": "once more",
             "category": "repetition",
-            "synonyms": [
-              "again",
-              "one more time",
-              "another time"
-            ],
-            "isOptional": true
+            "propertyNames": []
           }
         ],
         "propertyAlternatives": [
@@ -3194,31 +3313,31 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.previous",
             "propertySubPhrases": [
-              "preceding track"
+              "the preceding track"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.next",
                 "propertySubPhrases": [
-                  "next track"
+                  "the next track"
                 ]
               },
               {
                 "propertyValue": "player.pause",
                 "propertySubPhrases": [
-                  "pause"
+                  "pause the track"
                 ]
               },
               {
                 "propertyValue": "player.stop",
                 "propertySubPhrases": [
-                  "stop"
+                  "stop the track"
                 ]
               },
               {
                 "propertyValue": "player.play",
                 "propertySubPhrases": [
-                  "play"
+                  "play the track"
                 ]
               }
             ]
@@ -3227,14 +3346,14 @@
         "politePrefixes": [
           "Could you please",
           "Would you mind",
-          "If it's not too much trouble, could you",
-          "May I kindly ask you to"
+          "If it's not too much trouble,",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it.",
-          "Thanks a lot!",
-          "That would be great, thanks!"
+          "thank you.",
+          "if you don't mind.",
+          "please.",
+          "thanks."
         ]
       }
     },
@@ -3249,15 +3368,31 @@
             "name": "fullActionName",
             "value": "player.previous",
             "substrings": [
-              "prev"
+              "Press",
+              "the",
+              "prev",
+              "button",
+              "on",
+              "the",
+              "music",
+              "player"
             ]
           }
         ],
         "subPhrases": [
           {
-            "text": "Press the",
+            "text": "Press",
             "category": "command",
-            "propertyNames": []
+            "propertyNames": [
+              "fullActionName"
+            ]
+          },
+          {
+            "text": "the",
+            "category": "article",
+            "propertyNames": [
+              "fullActionName"
+            ]
           },
           {
             "text": "prev",
@@ -3267,9 +3402,39 @@
             ]
           },
           {
-            "text": "button on the music player.",
-            "category": "context",
-            "propertyNames": []
+            "text": "button",
+            "category": "object",
+            "propertyNames": [
+              "fullActionName"
+            ]
+          },
+          {
+            "text": "on",
+            "category": "preposition",
+            "propertyNames": [
+              "fullActionName"
+            ]
+          },
+          {
+            "text": "the",
+            "category": "article",
+            "propertyNames": [
+              "fullActionName"
+            ]
+          },
+          {
+            "text": "music",
+            "category": "object",
+            "propertyNames": [
+              "fullActionName"
+            ]
+          },
+          {
+            "text": "player",
+            "category": "object",
+            "propertyNames": [
+              "fullActionName"
+            ]
           }
         ],
         "propertyAlternatives": [
@@ -3277,25 +3442,53 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.previous",
             "propertySubPhrases": [
-              "prev"
+              "Press",
+              "the",
+              "prev",
+              "button",
+              "on",
+              "the",
+              "music",
+              "player"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.next",
                 "propertySubPhrases": [
-                  "next"
+                  "Press",
+                  "the",
+                  "next",
+                  "button",
+                  "on",
+                  "the",
+                  "music",
+                  "player"
                 ]
               },
               {
                 "propertyValue": "player.pause",
                 "propertySubPhrases": [
-                  "pause"
+                  "Press",
+                  "the",
+                  "pause",
+                  "button",
+                  "on",
+                  "the",
+                  "music",
+                  "player"
                 ]
               },
               {
                 "propertyValue": "player.play",
                 "propertySubPhrases": [
-                  "play"
+                  "Press",
+                  "the",
+                  "play",
+                  "button",
+                  "on",
+                  "the",
+                  "music",
+                  "player"
                 ]
               }
             ]
@@ -3304,14 +3497,14 @@
         "politePrefixes": [
           "Could you please",
           "Would you mind",
-          "If it's not too much trouble, could you",
-          "May I kindly ask you to"
+          "If you don't mind",
+          "May I ask you to"
         ],
         "politeSuffixes": [
-          "Thank you.",
-          "I would appreciate it.",
-          "Thanks a lot.",
-          "That would be great."
+          "thank you",
+          "please",
+          "if that's okay",
+          "if you could"
         ]
       }
     },
@@ -3366,20 +3559,30 @@
               {
                 "propertyValue": "player.pause",
                 "propertySubPhrases": [
-                  "Pause the music"
+                  "Pause song"
                 ]
               },
               {
                 "propertyValue": "player.play",
                 "propertySubPhrases": [
-                  "Play the music"
+                  "Play song"
                 ]
               }
             ]
           }
         ],
-        "politePrefixes": [],
-        "politeSuffixes": []
+        "politePrefixes": [
+          "Could you please",
+          "Would you kindly",
+          "May I ask you to",
+          "If it's not too much trouble"
+        ],
+        "politeSuffixes": [
+          "thank you",
+          "please",
+          "if you could",
+          "I'd appreciate it"
+        ]
       }
     },
     {
@@ -3410,8 +3613,8 @@
             "category": "politeness",
             "synonyms": [
               "kindly",
-              "if you don't mind",
-              "would you mind"
+              "if you would",
+              "if you could"
             ],
             "isOptional": true
           }
@@ -3445,8 +3648,18 @@
             ]
           }
         ],
-        "politePrefixes": [],
-        "politeSuffixes": []
+        "politePrefixes": [
+          "Could you",
+          "Would you mind",
+          "May I ask",
+          "If you don't mind"
+        ],
+        "politeSuffixes": [
+          "thank you",
+          "if that's okay",
+          "please and thank you",
+          "if you could"
+        ]
       }
     },
     {
@@ -3467,7 +3680,7 @@
         "subPhrases": [
           {
             "text": "Previous track",
-            "category": "action",
+            "category": "command",
             "propertyNames": [
               "fullActionName"
             ]
@@ -3477,8 +3690,8 @@
             "category": "politeness",
             "synonyms": [
               "if you don't mind",
-              "if that's alright",
-              "if that's acceptable"
+              "if it's alright",
+              "if it's okay"
             ],
             "isOptional": true
           }
@@ -3508,12 +3721,28 @@
                 "propertySubPhrases": [
                   "Play track"
                 ]
+              },
+              {
+                "propertyValue": "player.stop",
+                "propertySubPhrases": [
+                  "Stop track"
+                ]
               }
             ]
           }
         ],
-        "politePrefixes": [],
-        "politeSuffixes": []
+        "politePrefixes": [
+          "Could you please",
+          "Would you mind",
+          "If you don't mind",
+          "May I ask you to"
+        ],
+        "politeSuffixes": [
+          "please?",
+          "if you could?",
+          "thank you.",
+          "if that's alright."
+        ]
       }
     },
     {
@@ -3544,8 +3773,8 @@
             "category": "politeness",
             "synonyms": [
               "kindly",
-              "if you don't mind",
-              "would you mind"
+              "if you would",
+              "if you could"
             ],
             "isOptional": true
           }
@@ -3579,8 +3808,18 @@
             ]
           }
         ],
-        "politePrefixes": [],
-        "politeSuffixes": []
+        "politePrefixes": [
+          "Could you",
+          "Would you mind",
+          "May I ask you to",
+          "If you don't mind"
+        ],
+        "politeSuffixes": [
+          "thank you",
+          "if that's okay",
+          "please",
+          "thanks"
+        ]
       }
     },
     {
@@ -3609,17 +3848,22 @@
             "category": "preposition",
             "synonyms": [
               "a",
-              "this",
-              "that"
+              "an",
+              "this"
             ],
             "isOptional": true
           },
           {
-            "text": "previous track",
-            "category": "property",
+            "text": "previous",
+            "category": "descriptor",
             "propertyNames": [
               "fullActionName"
             ]
+          },
+          {
+            "text": "track",
+            "category": "object",
+            "propertyNames": []
           },
           {
             "text": "again",
@@ -3627,7 +3871,7 @@
             "synonyms": [
               "once more",
               "another time",
-              "one more time"
+              "repeatedly"
             ],
             "isOptional": true
           }
@@ -3637,25 +3881,25 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.previous",
             "propertySubPhrases": [
-              "previous track"
+              "previous"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.next",
                 "propertySubPhrases": [
-                  "next track"
+                  "next"
                 ]
               },
               {
                 "propertyValue": "player.pause",
                 "propertySubPhrases": [
-                  "pause track"
+                  "pause"
                 ]
               },
               {
                 "propertyValue": "player.play",
                 "propertySubPhrases": [
-                  "play track"
+                  "play"
                 ]
               }
             ]
@@ -3664,14 +3908,14 @@
         "politePrefixes": [
           "Could you please",
           "Would you mind",
-          "If it's not too much trouble,",
-          "May I kindly ask you to"
+          "If possible, can you",
+          "I would appreciate it if you could"
         ],
         "politeSuffixes": [
           "thank you.",
           "please.",
           "if you don't mind.",
-          "thanks a lot."
+          "thanks."
         ]
       }
     },
@@ -3692,8 +3936,15 @@
         ],
         "subPhrases": [
           {
-            "text": "Rewind to the last track.",
-            "category": "command",
+            "text": "Rewind",
+            "category": "action",
+            "propertyNames": [
+              "fullActionName"
+            ]
+          },
+          {
+            "text": "to the last track.",
+            "category": "target",
             "propertyNames": [
               "fullActionName"
             ]
@@ -3704,25 +3955,36 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.previous",
             "propertySubPhrases": [
-              "Rewind to the last track."
+              "Rewind",
+              "to the last track."
             ],
             "alternatives": [
               {
                 "propertyValue": "player.next",
                 "propertySubPhrases": [
-                  "Skip to the next track."
+                  "Skip",
+                  "to the next track."
                 ]
               },
               {
                 "propertyValue": "player.pause",
                 "propertySubPhrases": [
-                  "Pause the track."
+                  "Pause",
+                  "the current track."
                 ]
               },
               {
                 "propertyValue": "player.play",
                 "propertySubPhrases": [
-                  "Play the track."
+                  "Play",
+                  "the current track."
+                ]
+              },
+              {
+                "propertyValue": "player.stop",
+                "propertySubPhrases": [
+                  "Stop",
+                  "the current track."
                 ]
               }
             ]
@@ -3730,11 +3992,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If you don't mind",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you.",
-          "I appreciate it."
+          "thank you",
+          "if that's okay",
+          "please",
+          "thanks"
         ]
       }
     },
@@ -3749,32 +4015,14 @@
             "name": "fullActionName",
             "value": "player.previous",
             "substrings": [
-              "Skip back",
-              "former track"
+              "Skip back to the former track"
             ]
           }
         ],
         "subPhrases": [
           {
-            "text": "Skip back",
-            "category": "command",
-            "propertyNames": [
-              "fullActionName"
-            ]
-          },
-          {
-            "text": "to the",
-            "category": "preposition",
-            "synonyms": [
-              "towards the",
-              "in the direction of the",
-              "heading to the"
-            ],
-            "isOptional": true
-          },
-          {
-            "text": "former track",
-            "category": "object",
+            "text": "Skip back to the former track",
+            "category": "action",
             "propertyNames": [
               "fullActionName"
             ]
@@ -3784,8 +4032,10 @@
             "category": "politeness",
             "synonyms": [
               "kindly",
-              "if you don't mind",
-              "would you mind"
+              "if you would",
+              "if you could",
+              "would you mind",
+              "could you"
             ],
             "isOptional": true
           }
@@ -3795,36 +4045,42 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.previous",
             "propertySubPhrases": [
-              "Skip back",
-              "former track"
+              "Skip back to the former track"
             ],
             "alternatives": [
               {
-                "propertyValue": "player.rewind",
+                "propertyValue": "player.next",
                 "propertySubPhrases": [
-                  "Rewind",
-                  "to the previous track"
+                  "Skip forward to the next track"
                 ]
               },
               {
-                "propertyValue": "player.restart",
+                "propertyValue": "player.pause",
                 "propertySubPhrases": [
-                  "Restart",
-                  "the current track"
+                  "Pause the track"
                 ]
               },
               {
-                "propertyValue": "player.back",
+                "propertyValue": "player.play",
                 "propertySubPhrases": [
-                  "Go back",
-                  "to the last track"
+                  "Play the track"
                 ]
               }
             ]
           }
         ],
-        "politePrefixes": [],
-        "politeSuffixes": []
+        "politePrefixes": [
+          "Could you",
+          "Would you mind",
+          "May I ask you to",
+          "If you don't mind"
+        ],
+        "politeSuffixes": [
+          "thank you",
+          "if that's okay",
+          "if you could",
+          "I'd appreciate it"
+        ]
       }
     },
     {
@@ -3838,7 +4094,8 @@
             "name": "fullActionName",
             "value": "player.previous",
             "substrings": [
-              "Take it back"
+              "Take it back",
+              "the song that just played"
             ]
           }
         ],
@@ -3851,9 +4108,21 @@
             ]
           },
           {
-            "text": "to the song that just played",
-            "category": "context",
-            "propertyNames": []
+            "text": "to",
+            "category": "preposition",
+            "synonyms": [
+              "towards",
+              "into",
+              "onto"
+            ],
+            "isOptional": true
+          },
+          {
+            "text": "the song that just played",
+            "category": "description",
+            "propertyNames": [
+              "fullActionName"
+            ]
           }
         ],
         "propertyAlternatives": [
@@ -3861,25 +4130,29 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.previous",
             "propertySubPhrases": [
-              "Take it back"
+              "Take it back",
+              "the song that just played"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.rewind",
                 "propertySubPhrases": [
-                  "Rewind it"
+                  "Rewind",
+                  "the song that just played"
                 ]
               },
               {
                 "propertyValue": "player.restart",
                 "propertySubPhrases": [
-                  "Restart the song"
+                  "Restart",
+                  "the song that just played"
                 ]
               },
               {
                 "propertyValue": "player.replay",
                 "propertySubPhrases": [
-                  "Play it again"
+                  "Replay",
+                  "the song that just played"
                 ]
               }
             ]
@@ -3887,11 +4160,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If you don't mind",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you.",
-          "I would appreciate it."
+          "thank you",
+          "please",
+          "if that's okay",
+          "thanks"
         ]
       }
     },
@@ -3906,27 +4183,27 @@
             "name": "fullActionName",
             "value": "player.previous",
             "substrings": [
-              "previous song"
+              "previous"
             ]
           }
         ],
         "subPhrases": [
           {
             "text": "Take us to the",
-            "category": "filler",
-            "synonyms": [
-              "Bring us to the",
-              "Move us to the",
-              "Navigate to the"
-            ],
-            "isOptional": true
+            "category": "command",
+            "propertyNames": []
           },
           {
-            "text": "previous song",
-            "category": "action",
+            "text": "previous",
+            "category": "descriptor",
             "propertyNames": [
               "fullActionName"
             ]
+          },
+          {
+            "text": "song",
+            "category": "object",
+            "propertyNames": []
           },
           {
             "text": "would you?",
@@ -3934,7 +4211,7 @@
             "synonyms": [
               "please",
               "if you don't mind",
-              "could you?"
+              "could you"
             ],
             "isOptional": true
           }
@@ -3944,32 +4221,37 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.previous",
             "propertySubPhrases": [
-              "previous song"
+              "previous"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.next",
                 "propertySubPhrases": [
-                  "next song"
+                  "next"
                 ]
               },
               {
                 "propertyValue": "player.pause",
                 "propertySubPhrases": [
-                  "pause the song"
+                  "pause"
                 ]
               },
               {
                 "propertyValue": "player.play",
                 "propertySubPhrases": [
-                  "play the song"
+                  "play"
                 ]
               }
             ]
           }
         ],
         "politePrefixes": [],
-        "politeSuffixes": []
+        "politeSuffixes": [
+          "please.",
+          "if you don't mind.",
+          "thank you.",
+          "kindly."
+        ]
       }
     },
     {
@@ -3994,7 +4276,7 @@
             "synonyms": [
               "Could you please",
               "Do you mind",
-              "Would it be possible"
+              "Can you"
             ],
             "isOptional": true
           },
@@ -4031,12 +4313,23 @@
                 "propertySubPhrases": [
                   "stopping the track"
                 ]
+              },
+              {
+                "propertyValue": "player.play",
+                "propertySubPhrases": [
+                  "playing the track"
+                ]
               }
             ]
           }
         ],
         "politePrefixes": [],
-        "politeSuffixes": []
+        "politeSuffixes": [
+          "please?",
+          "if you don't mind.",
+          "thank you.",
+          "I'd appreciate it."
+        ]
       }
     },
     {
@@ -4082,33 +4375,37 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.rewind",
-                "propertySubPhrases": [
-                  "rewind that last one"
-                ]
-              },
-              {
                 "propertyValue": "player.replay",
                 "propertySubPhrases": [
-                  "replay that last one"
+                  "play that again"
                 ]
               },
               {
                 "propertyValue": "player.restart",
                 "propertySubPhrases": [
-                  "restart that last one"
+                  "start that over"
+                ]
+              },
+              {
+                "propertyValue": "player.repeat",
+                "propertySubPhrases": [
+                  "repeat that"
                 ]
               }
             ]
           }
         ],
         "politePrefixes": [
-          "Could you please",
-          "Would you mind"
+          "Please",
+          "Could you",
+          "Would you mind",
+          "If you don't mind"
         ],
         "politeSuffixes": [
-          "Thank you",
-          "I appreciate it"
+          "please",
+          "if you could",
+          "thank you",
+          "thanks"
         ]
       }
     },
@@ -4169,19 +4466,23 @@
               {
                 "propertyValue": "player.play",
                 "propertySubPhrases": [
-                  "start playing music"
+                  "start playing the music"
                 ]
               }
             ]
           }
         ],
         "politePrefixes": [
-          "Could you please",
-          "Would you mind"
+          "Please, ",
+          "Could you please, ",
+          "Would you mind, ",
+          "If you don't mind, "
         ],
         "politeSuffixes": [
-          "Thank you",
-          "I would appreciate it"
+          " please.",
+          " if you could.",
+          " thank you.",
+          " would be great."
         ]
       }
     }

--- a/ts/packages/defaultAgentProvider/test/data/explanations/player/v5/resumeAction.json
+++ b/ts/packages/defaultAgentProvider/test/data/explanations/player/v5/resumeAction.json
@@ -24,7 +24,7 @@
         "subPhrases": [
           {
             "text": "Activate",
-            "category": "action",
+            "category": "command",
             "propertyNames": [
               "fullActionName"
             ]
@@ -63,19 +63,19 @@
                 ]
               },
               {
-                "propertyValue": "player.unpause",
+                "propertyValue": "player.restart",
                 "propertySubPhrases": [
-                  "Unpause",
-                  "the audio",
-                  "again"
+                  "Restart",
+                  "the sound",
+                  "from the beginning"
                 ]
               },
               {
-                "propertyValue": "player.continue",
+                "propertyValue": "player.unpause",
                 "propertySubPhrases": [
-                  "Continue",
-                  "the music",
-                  "once more"
+                  "Unpause",
+                  "the sound",
+                  "now"
                 ]
               }
             ]
@@ -83,62 +83,71 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If it's not too much trouble,",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you.",
-          "I would appreciate it."
+          "thank you.",
+          "if you don't mind.",
+          "please.",
+          "thanks."
         ]
       }
     },
     {
       "request": "Bring back the beats.",
       "action": {
-        "fullActionName": "player.playRandom"
+        "fullActionName": "player.resume"
       },
       "explanation": {
         "properties": [
           {
             "name": "fullActionName",
-            "value": "player.playRandom",
+            "value": "player.resume",
             "substrings": [
-              "Bring back the beats."
+              "Bring back"
             ]
           }
         ],
         "subPhrases": [
           {
-            "text": "Bring back the beats.",
+            "text": "Bring back",
             "category": "command",
             "propertyNames": [
               "fullActionName"
             ]
+          },
+          {
+            "text": "the beats",
+            "category": "object",
+            "propertyNames": []
           }
         ],
         "propertyAlternatives": [
           {
             "propertyName": "fullActionName",
-            "propertyValue": "player.playRandom",
+            "propertyValue": "player.resume",
             "propertySubPhrases": [
-              "Bring back the beats."
+              "Bring back"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.play",
                 "propertySubPhrases": [
-                  "Play the music."
+                  "Start playing"
                 ]
               },
               {
-                "propertyValue": "player.resume",
+                "propertyValue": "player.unpause",
                 "propertySubPhrases": [
-                  "Resume the music."
+                  "Unpause"
                 ]
               },
               {
-                "propertyValue": "player.shuffle",
+                "propertyValue": "player.continue",
                 "propertySubPhrases": [
-                  "Shuffle the tracks."
+                  "Continue playing"
                 ]
               }
             ]
@@ -146,11 +155,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If you don't mind",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you.",
-          "I would appreciate it."
+          "thank you",
+          "please",
+          "if you could",
+          "I'd appreciate it"
         ]
       }
     },
@@ -171,22 +184,12 @@
         ],
         "subPhrases": [
           {
-            "text": "Can",
+            "text": "Can we",
             "category": "confirmation",
             "synonyms": [
-              "Could",
-              "Would",
-              "Will"
-            ],
-            "isOptional": true
-          },
-          {
-            "text": "we",
-            "category": "filler",
-            "synonyms": [
-              "us",
-              "I",
-              "you"
+              "Could we",
+              "Shall we",
+              "May we"
             ],
             "isOptional": true
           },
@@ -199,13 +202,8 @@
           },
           {
             "text": "with the songs",
-            "category": "context",
-            "synonyms": [
-              "with the music",
-              "with the playlist",
-              "with the tracks"
-            ],
-            "isOptional": true
+            "category": "object",
+            "propertyNames": []
           }
         ],
         "propertyAlternatives": [
@@ -219,29 +217,41 @@
               {
                 "propertyValue": "player.play",
                 "propertySubPhrases": [
-                  "play"
-                ]
-              },
-              {
-                "propertyValue": "player.start",
-                "propertySubPhrases": [
                   "start"
                 ]
               },
               {
-                "propertyValue": "player.begin",
+                "propertyValue": "player.pause",
                 "propertySubPhrases": [
-                  "begin"
+                  "pause"
+                ]
+              },
+              {
+                "propertyValue": "player.stop",
+                "propertySubPhrases": [
+                  "stop"
+                ]
+              },
+              {
+                "propertyValue": "player.skip",
+                "propertySubPhrases": [
+                  "skip"
                 ]
               }
             ]
           }
         ],
         "politePrefixes": [
-          "Please"
+          "Please, ",
+          "Would you mind if ",
+          "Could you please ",
+          "If it's not too much trouble, "
         ],
         "politeSuffixes": [
-          "Thank you"
+          " please?",
+          " if you don't mind.",
+          " thank you.",
+          " would be appreciated."
         ]
       }
     },
@@ -267,12 +277,22 @@
             "synonyms": [
               "Could",
               "Would",
-              "Will"
+              "May"
             ],
             "isOptional": true
           },
           {
-            "text": "we get the sound back?",
+            "text": "we",
+            "category": "acknowledgement",
+            "synonyms": [
+              "I",
+              "you",
+              "they"
+            ],
+            "isOptional": true
+          },
+          {
+            "text": "get the sound back",
             "category": "action",
             "propertyNames": [
               "fullActionName"
@@ -284,35 +304,41 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.resume",
             "propertySubPhrases": [
-              "we get the sound back?"
+              "get the sound back"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.play",
                 "propertySubPhrases": [
-                  "we start the sound?"
+                  "play the sound"
                 ]
               },
               {
                 "propertyValue": "player.unmute",
                 "propertySubPhrases": [
-                  "we unmute the sound?"
+                  "unmute the sound"
                 ]
               },
               {
-                "propertyValue": "player.replay",
+                "propertyValue": "player.start",
                 "propertySubPhrases": [
-                  "we replay the sound?"
+                  "start the sound"
                 ]
               }
             ]
           }
         ],
         "politePrefixes": [
-          "Please"
+          "Please,",
+          "Would you mind if",
+          "Could you please",
+          "If possible,"
         ],
         "politeSuffixes": [
-          "Thank you"
+          "Thank you.",
+          "if you don't mind.",
+          "please.",
+          "Thanks."
         ]
       }
     },
@@ -328,7 +354,8 @@
             "value": "player.resume",
             "substrings": [
               "kickstart",
-              "tunes"
+              "tunes",
+              "again"
             ]
           }
         ],
@@ -339,7 +366,7 @@
             "synonyms": [
               "Could you",
               "Would you",
-              "Will you"
+              "Please"
             ],
             "isOptional": true
           },
@@ -359,13 +386,10 @@
           },
           {
             "text": "again",
-            "category": "repetition",
-            "synonyms": [
-              "once more",
-              "one more time",
-              "another time"
-            ],
-            "isOptional": true
+            "category": "frequency",
+            "propertyNames": [
+              "fullActionName"
+            ]
           }
         ],
         "propertyAlternatives": [
@@ -374,40 +398,48 @@
             "propertyValue": "player.resume",
             "propertySubPhrases": [
               "kickstart",
-              "the tunes"
+              "the tunes",
+              "again"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.play",
                 "propertySubPhrases": [
                   "start",
-                  "the music"
+                  "the music",
+                  "now"
                 ]
               },
               {
                 "propertyValue": "player.restart",
                 "propertySubPhrases": [
                   "restart",
-                  "the songs"
+                  "the songs",
+                  "from the beginning"
                 ]
               },
               {
                 "propertyValue": "player.unpause",
                 "propertySubPhrases": [
                   "unpause",
-                  "the tracks"
+                  "the tracks",
+                  "please"
                 ]
               }
             ]
           }
         ],
         "politePrefixes": [
-          "Could you please",
-          "Would you mind"
+          "Please,",
+          "Would you mind,",
+          "Could you kindly,",
+          "If you don't mind,"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it."
+          "please?",
+          "if that's okay?",
+          "thank you.",
+          "if you could."
         ]
       }
     },
@@ -470,15 +502,27 @@
                 "propertySubPhrases": [
                   "continue the music"
                 ]
+              },
+              {
+                "propertyValue": "player.unpause",
+                "propertySubPhrases": [
+                  "unpause the music"
+                ]
               }
             ]
           }
         ],
         "politePrefixes": [
-          "Please"
+          "Could you please",
+          "Would you mind",
+          "If it's not too much trouble, could you",
+          "May I kindly ask you to"
         ],
         "politeSuffixes": [
-          "Thank you"
+          "please?",
+          "if you don't mind.",
+          "thank you.",
+          "if that's okay."
         ]
       }
     },
@@ -493,7 +537,7 @@
             "name": "fullActionName",
             "value": "player.resume",
             "substrings": [
-              "restart the music"
+              "restart"
             ]
           }
         ],
@@ -504,16 +548,21 @@
             "synonyms": [
               "Could you",
               "Would you",
-              "Will you"
+              "Please"
             ],
             "isOptional": true
           },
           {
-            "text": "restart the music",
+            "text": "restart",
             "category": "action",
             "propertyNames": [
               "fullActionName"
             ]
+          },
+          {
+            "text": "the music",
+            "category": "object",
+            "propertyNames": []
           }
         ],
         "propertyAlternatives": [
@@ -521,32 +570,48 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.resume",
             "propertySubPhrases": [
-              "restart the music"
+              "restart"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.play",
                 "propertySubPhrases": [
-                  "play the music"
+                  "play"
                 ]
               },
               {
-                "propertyValue": "player.stop",
+                "propertyValue": "player.start",
                 "propertySubPhrases": [
-                  "stop the music"
+                  "start"
                 ]
               },
               {
-                "propertyValue": "player.pause",
+                "propertyValue": "player.begin",
                 "propertySubPhrases": [
-                  "pause the music"
+                  "begin"
+                ]
+              },
+              {
+                "propertyValue": "player.continue",
+                "propertySubPhrases": [
+                  "continue"
                 ]
               }
             ]
           }
         ],
-        "politePrefixes": [],
-        "politeSuffixes": []
+        "politePrefixes": [
+          "Please",
+          "Would you mind",
+          "Could you kindly",
+          "If you don't mind"
+        ],
+        "politeSuffixes": [
+          "please?",
+          "if that's okay?",
+          "thank you.",
+          "if you could."
+        ]
       }
     },
     {
@@ -612,8 +677,18 @@
             ]
           }
         ],
-        "politePrefixes": [],
-        "politeSuffixes": []
+        "politePrefixes": [
+          "Please",
+          "Would you mind",
+          "Could you kindly",
+          "If you don't mind"
+        ],
+        "politeSuffixes": [
+          "please?",
+          "if that's okay.",
+          "thank you.",
+          "if you could."
+        ]
       }
     },
     {
@@ -634,23 +709,13 @@
         "subPhrases": [
           {
             "text": "Continue playing",
-            "category": "action",
+            "category": "command",
             "propertyNames": [
               "fullActionName"
             ]
           },
           {
-            "text": "the",
-            "category": "filler",
-            "synonyms": [
-              "a",
-              "an",
-              "that"
-            ],
-            "isOptional": true
-          },
-          {
-            "text": "tunes",
+            "text": "the tunes",
             "category": "object",
             "propertyNames": []
           }
@@ -670,15 +735,15 @@
                 ]
               },
               {
-                "propertyValue": "player.replay",
+                "propertyValue": "player.restart",
                 "propertySubPhrases": [
-                  "Replay"
+                  "Restart playing"
                 ]
               },
               {
-                "propertyValue": "player.continue",
+                "propertyValue": "player.unpause",
                 "propertySubPhrases": [
-                  "Keep playing"
+                  "Unpause playing"
                 ]
               }
             ]
@@ -686,11 +751,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If you don't mind",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you.",
-          "I appreciate it."
+          "thank you",
+          "if that's okay",
+          "please",
+          "thanks"
         ]
       }
     },
@@ -754,16 +823,26 @@
                 ]
               },
               {
-                "propertyValue": "player.unpause",
+                "propertyValue": "player.begin",
                 "propertySubPhrases": [
-                  "Unpause"
+                  "Begin"
                 ]
               }
             ]
           }
         ],
-        "politePrefixes": [],
-        "politeSuffixes": []
+        "politePrefixes": [
+          "Could you kindly",
+          "Would you mind",
+          "If you don't mind",
+          "May I ask you to"
+        ],
+        "politeSuffixes": [
+          "if that's okay with you.",
+          "if you please.",
+          "thank you.",
+          "I would appreciate it."
+        ]
       }
     },
     {
@@ -834,8 +913,18 @@
             ]
           }
         ],
-        "politePrefixes": [],
-        "politeSuffixes": []
+        "politePrefixes": [
+          "Please",
+          "If you don't mind",
+          "Would you kindly",
+          "May I ask"
+        ],
+        "politeSuffixes": [
+          "please?",
+          "if that's okay?",
+          "thank you.",
+          "if you could."
+        ]
       }
     },
     {
@@ -860,7 +949,7 @@
             "synonyms": [
               "Can you",
               "Would you",
-              "Will you"
+              "Please"
             ],
             "isOptional": true
           },
@@ -887,9 +976,9 @@
                 ]
               },
               {
-                "propertyValue": "player.unpause",
+                "propertyValue": "player.restart",
                 "propertySubPhrases": [
-                  "unpause the music"
+                  "restart the music"
                 ]
               },
               {
@@ -901,8 +990,18 @@
             ]
           }
         ],
-        "politePrefixes": [],
-        "politeSuffixes": []
+        "politePrefixes": [
+          "Please,",
+          "If you don't mind,",
+          "Would you kindly,",
+          "May I ask you to,"
+        ],
+        "politeSuffixes": [
+          "please?",
+          "if that's okay?",
+          "if you could?",
+          "thank you."
+        ]
       }
     },
     {
@@ -973,8 +1072,18 @@
             ]
           }
         ],
-        "politePrefixes": [],
-        "politeSuffixes": []
+        "politePrefixes": [
+          "Please",
+          "Would you mind",
+          "If you could",
+          "Kindly"
+        ],
+        "politeSuffixes": [
+          "thank you",
+          "please",
+          "if possible",
+          "I'd appreciate it"
+        ]
       }
     },
     {
@@ -1023,13 +1132,13 @@
               {
                 "propertyValue": "player.pause",
                 "propertySubPhrases": [
-                  "pause the music"
+                  "pause playing"
                 ]
               },
               {
                 "propertyValue": "player.stop",
                 "propertySubPhrases": [
-                  "stop the music"
+                  "stop playing"
                 ]
               }
             ]
@@ -1038,14 +1147,14 @@
         "politePrefixes": [
           "Could you please",
           "Would you mind",
-          "If it's not too much trouble, could you",
-          "May I kindly ask you to"
+          "If you don't mind",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "Thanks a lot!",
-          "I would appreciate it!",
-          "That would be great!"
+          "thank you.",
+          "if that's okay.",
+          "please.",
+          "thanks."
         ]
       }
     },
@@ -1088,15 +1197,15 @@
                 ]
               },
               {
-                "propertyValue": "player.continue",
-                "propertySubPhrases": [
-                  "Continue the tracks."
-                ]
-              },
-              {
                 "propertyValue": "player.unpause",
                 "propertySubPhrases": [
                   "Unpause the tracks."
+                ]
+              },
+              {
+                "propertyValue": "player.continue",
+                "propertySubPhrases": [
+                  "Continue the tracks."
                 ]
               }
             ]
@@ -1105,14 +1214,14 @@
         "politePrefixes": [
           "Could you please",
           "Would you mind",
-          "If it's not too much trouble, could you",
-          "May I kindly ask you to"
+          "If possible, could you",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you.",
-          "I would appreciate it.",
-          "Thanks a lot.",
-          "That would be great."
+          "when you have a moment?",
+          "if you don't mind.",
+          "please.",
+          "thank you."
         ]
       }
     },
@@ -1137,18 +1246,18 @@
             "category": "filler",
             "synonyms": [
               "proceed",
-              "carry on",
-              "continue"
+              "continue",
+              "carry on"
             ],
             "isOptional": true
           },
           {
             "text": "and",
-            "category": "preposition",
+            "category": "conjunction",
             "synonyms": [
               "plus",
-              "along with",
-              "together with"
+              "also",
+              "along with"
             ],
             "isOptional": true
           },
@@ -1195,14 +1304,60 @@
           }
         ],
         "politePrefixes": [
-          "Could you please",
+          "Please",
+          "Kindly",
+          "If you don't mind,",
           "Would you mind"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it."
+          "thank you.",
+          "please.",
+          "if that's okay.",
+          "if you could."
         ]
-      }
+      },
+      "corrections": [
+        {
+          "data": {
+            "properties": [
+              {
+                "name": "fullActionName",
+                "value": "player.resume",
+                "substrings": [
+                  "resume"
+                ]
+              }
+            ],
+            "subPhrases": [
+              {
+                "text": "Go ahead",
+                "category": "filler",
+                "synonyms": [
+                  "proceed",
+                  "continue",
+                  "carry on"
+                ],
+                "isOptional": true
+              },
+              {
+                "text": "resume",
+                "category": "action",
+                "propertyNames": [
+                  "fullActionName"
+                ]
+              },
+              {
+                "text": "the playlist",
+                "category": "object",
+                "propertyNames": []
+              }
+            ]
+          },
+          "correction": [
+            "Missing sub-phrase: explanation missing for 'and'"
+          ]
+        }
+      ]
     },
     {
       "request": "Hey, could you hit play?",
@@ -1226,7 +1381,8 @@
             "synonyms": [
               "Hi",
               "Hello",
-              "Hey there"
+              "Hey there",
+              "Greetings"
             ],
             "isOptional": true
           },
@@ -1236,7 +1392,8 @@
             "synonyms": [
               "please",
               "would you mind",
-              "can you"
+              "can you",
+              "would you kindly"
             ],
             "isOptional": true
           },
@@ -1283,8 +1440,18 @@
             ]
           }
         ],
-        "politePrefixes": [],
-        "politeSuffixes": []
+        "politePrefixes": [
+          "Please",
+          "Would you mind",
+          "If you don't mind",
+          "Could you kindly"
+        ],
+        "politeSuffixes": [
+          "please",
+          "if you could",
+          "thank you",
+          "thanks"
+        ]
       }
     },
     {
@@ -1305,8 +1472,13 @@
         "subPhrases": [
           {
             "text": "Hit",
-            "category": "command",
-            "propertyNames": []
+            "category": "filler",
+            "synonyms": [
+              "Press",
+              "Tap",
+              "Click"
+            ],
+            "isOptional": true
           },
           {
             "text": "play again",
@@ -1325,9 +1497,9 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.start",
+                "propertyValue": "player.restart",
                 "propertySubPhrases": [
-                  "start playing"
+                  "restart"
                 ]
               },
               {
@@ -1339,7 +1511,7 @@
               {
                 "propertyValue": "player.continue",
                 "propertySubPhrases": [
-                  "continue playing"
+                  "continue"
                 ]
               }
             ]
@@ -1347,11 +1519,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If you don't mind",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you.",
-          "I would appreciate it."
+          "if that's okay.",
+          "thank you.",
+          "please.",
+          "if you could."
         ]
       }
     },
@@ -1366,42 +1542,28 @@
             "name": "fullActionName",
             "value": "player.resume",
             "substrings": [
-              "play",
-              "again"
+              "Hit the play button again."
             ]
           }
         ],
         "subPhrases": [
           {
-            "text": "Hit the",
-            "category": "filler",
-            "synonyms": [
-              "Press the",
-              "Tap the",
-              "Click the"
-            ],
-            "isOptional": true
-          },
-          {
-            "text": "play",
-            "category": "action",
+            "text": "Hit",
+            "category": "command",
             "propertyNames": [
               "fullActionName"
             ]
           },
           {
-            "text": "button",
+            "text": "the play button",
             "category": "object",
-            "synonyms": [
-              "key",
-              "control",
-              "switch"
-            ],
-            "isOptional": true
+            "propertyNames": [
+              "fullActionName"
+            ]
           },
           {
             "text": "again",
-            "category": "repetition",
+            "category": "frequency",
             "propertyNames": [
               "fullActionName"
             ]
@@ -1412,28 +1574,32 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.resume",
             "propertySubPhrases": [
-              "play",
+              "Hit",
+              "the play button",
               "again"
             ],
             "alternatives": [
               {
-                "propertyValue": "player.replay",
+                "propertyValue": "player.play",
                 "propertySubPhrases": [
-                  "play",
-                  "again"
+                  "Press",
+                  "the play button",
+                  "now"
                 ]
               },
               {
-                "propertyValue": "player.restart",
+                "propertyValue": "player.start",
                 "propertySubPhrases": [
-                  "play",
-                  "again"
+                  "Start",
+                  "the play button",
+                  "now"
                 ]
               },
               {
                 "propertyValue": "player.continue",
                 "propertySubPhrases": [
-                  "play",
+                  "Continue",
+                  "the play button",
                   "again"
                 ]
               }
@@ -1443,103 +1609,16 @@
         "politePrefixes": [
           "Could you please",
           "Would you mind",
-          "If it's not too much trouble, could you",
-          "May I kindly ask you to"
+          "If you don't mind",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you.",
-          "Thanks a lot.",
-          "I would appreciate it.",
-          "That would be great."
+          "thank you",
+          "if that's okay",
+          "please",
+          "thanks"
         ]
-      },
-      "corrections": [
-        {
-          "data": {
-            "properties": [
-              {
-                "name": "fullActionName",
-                "value": "player.resume",
-                "substrings": [
-                  "play",
-                  "again"
-                ]
-              }
-            ],
-            "subPhrases": [
-              {
-                "text": "Hit the",
-                "category": "filler",
-                "synonyms": [
-                  "Press the",
-                  "Tap the",
-                  "Click the"
-                ],
-                "isOptional": true
-              },
-              {
-                "text": "play",
-                "category": "action",
-                "propertyNames": [
-                  "fullActionName"
-                ]
-              },
-              {
-                "text": "button",
-                "category": "object",
-                "synonyms": [
-                  "key",
-                  "control",
-                  "switch"
-                ],
-                "isOptional": true
-              },
-              {
-                "text": "again",
-                "category": "repetition",
-                "propertyNames": [
-                  "fullActionName"
-                ]
-              }
-            ],
-            "propertyAlternatives": [
-              {
-                "propertyName": "fullActionName",
-                "propertyValue": "player.resume",
-                "propertySubPhrases": [
-                  "play",
-                  "again"
-                ],
-                "alternatives": [
-                  {
-                    "propertyValue": "player.play",
-                    "propertySubPhrases": [
-                      "play"
-                    ]
-                  },
-                  {
-                    "propertyValue": "player.start",
-                    "propertySubPhrases": [
-                      "start"
-                    ]
-                  },
-                  {
-                    "propertyValue": "player.replay",
-                    "propertySubPhrases": [
-                      "replay"
-                    ]
-                  }
-                ]
-              }
-            ]
-          },
-          "correction": [
-            "Mismatch number of sub-phrases: alternatives value 'player.play' for property 'fullActionName' must have 2 sub-phrases",
-            "Mismatch number of sub-phrases: alternatives value 'player.start' for property 'fullActionName' must have 2 sub-phrases",
-            "Mismatch number of sub-phrases: alternatives value 'player.replay' for property 'fullActionName' must have 2 sub-phrases"
-          ]
-        }
-      ]
+      }
     },
     {
       "request": "I'd appreciate it if you could play the music again.",
@@ -1590,9 +1669,9 @@
                 ]
               },
               {
-                "propertyValue": "player.start",
+                "propertyValue": "player.restart",
                 "propertySubPhrases": [
-                  "start the music"
+                  "restart the music"
                 ]
               },
               {
@@ -1600,33 +1679,45 @@
                 "propertySubPhrases": [
                   "replay the music"
                 ]
-              },
-              {
-                "propertyValue": "player.continue",
-                "propertySubPhrases": [
-                  "continue the music"
-                ]
               }
             ]
           }
         ],
-        "politePrefixes": [],
-        "politeSuffixes": []
+        "politePrefixes": [
+          "If it's not too much trouble, ",
+          "When you have a moment, ",
+          "If you don't mind, ",
+          "Whenever you're ready, "
+        ],
+        "politeSuffixes": [
+          " Thank you!",
+          " Please.",
+          " I'd be grateful.",
+          " Thanks a lot!"
+        ]
       }
     },
     {
       "request": "I'd like to hear the rest of that song.",
       "action": {
-        "fullActionName": "player.resume"
+        "fullActionName": "player.playFromCurrentTrackList",
+        "parameters": {
+          "trackNumber": 1
+        }
       },
       "explanation": {
         "properties": [
           {
             "name": "fullActionName",
-            "value": "player.resume",
+            "value": "player.playFromCurrentTrackList",
             "substrings": [
-              "hear the rest of that song"
+              "I'd like to hear the rest of that song."
             ]
+          },
+          {
+            "name": "parameters.trackNumber",
+            "value": 1,
+            "isImplicit": true
           }
         ],
         "subPhrases": [
@@ -1646,38 +1737,42 @@
             "propertyNames": [
               "fullActionName"
             ]
+          },
+          {
+            "text": ".",
+            "category": "punctuation",
+            "synonyms": [
+              ".",
+              "!",
+              "?"
+            ],
+            "isOptional": true
           }
         ],
         "propertyAlternatives": [
           {
             "propertyName": "fullActionName",
-            "propertyValue": "player.resume",
+            "propertyValue": "player.playFromCurrentTrackList",
             "propertySubPhrases": [
               "hear the rest of that song"
             ],
             "alternatives": [
               {
-                "propertyValue": "player.play",
+                "propertyValue": "player.playNextTrack",
                 "propertySubPhrases": [
-                  "play that song"
+                  "play the next song"
                 ]
               },
               {
-                "propertyValue": "player.pause",
+                "propertyValue": "player.playPreviousTrack",
                 "propertySubPhrases": [
-                  "pause that song"
+                  "play the previous song"
                 ]
               },
               {
-                "propertyValue": "player.stop",
+                "propertyValue": "player.playSpecificTrack",
                 "propertySubPhrases": [
-                  "stop that song"
-                ]
-              },
-              {
-                "propertyValue": "player.rewind",
-                "propertySubPhrases": [
-                  "rewind that song"
+                  "play a specific song"
                 ]
               }
             ]
@@ -1685,13 +1780,41 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If it's not too much trouble,",
+          "May I kindly request"
         ],
         "politeSuffixes": [
           "Thank you.",
-          "I appreciate it."
+          "Please.",
+          "I would appreciate it.",
+          "Thanks a lot."
         ]
-      }
+      },
+      "corrections": [
+        {
+          "data": {
+            "properties": [
+              {
+                "name": "fullActionName",
+                "value": "player.playFromCurrentTrackList",
+                "substrings": [
+                  "I'd like to hear the rest of that song."
+                ]
+              },
+              {
+                "name": "trackNumber",
+                "value": 1,
+                "isImplicit": true
+              }
+            ]
+          },
+          "correction": [
+            "Extraneous implicit parameter: 'trackNumber' is not a parameter in the action",
+            "Missing parameter: parameter 'parameters.trackNumber' in the action is missing from explanation"
+          ]
+        }
+      ]
     },
     {
       "request": "I'd love it if you could continue the music.",
@@ -1714,8 +1837,8 @@
             "category": "politeness",
             "synonyms": [
               "please",
-              "kindly",
-              "would you mind"
+              "would you kindly",
+              "it would be great if"
             ],
             "isOptional": true
           },
@@ -1742,22 +1865,32 @@
                 ]
               },
               {
-                "propertyValue": "player.unpause",
+                "propertyValue": "player.restart",
                 "propertySubPhrases": [
-                  "unpause the music"
+                  "restart the music"
                 ]
               },
               {
-                "propertyValue": "player.replay",
+                "propertyValue": "player.unpause",
                 "propertySubPhrases": [
-                  "replay the music"
+                  "unpause the music"
                 ]
               }
             ]
           }
         ],
-        "politePrefixes": [],
-        "politeSuffixes": []
+        "politePrefixes": [
+          "Could you please",
+          "Would you mind",
+          "If it's not too much trouble",
+          "I would appreciate it if"
+        ],
+        "politeSuffixes": [
+          "Thank you!",
+          "Please.",
+          "If you don't mind.",
+          "Thanks a lot!"
+        ]
       }
     },
     {
@@ -1799,27 +1932,31 @@
                 ]
               },
               {
-                "propertyValue": "player.continue",
+                "propertyValue": "player.pause",
                 "propertySubPhrases": [
-                  "Continue the music."
+                  "Pause the music."
                 ]
               },
               {
-                "propertyValue": "player.unpause",
+                "propertyValue": "player.stop",
                 "propertySubPhrases": [
-                  "Unpause the music."
+                  "Stop the music."
                 ]
               }
             ]
           }
         ],
         "politePrefixes": [
-          "Could you please",
-          "Would you mind"
+          "Please",
+          "Could you",
+          "Would you mind",
+          "Kindly"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it."
+          "please",
+          "if you don't mind",
+          "thank you",
+          "thanks"
         ]
       }
     },
@@ -1847,7 +1984,7 @@
             ]
           },
           {
-            "text": "with the music.",
+            "text": "with the music",
             "category": "context",
             "propertyNames": [
               "fullActionName"
@@ -1860,40 +1997,51 @@
             "propertyValue": "player.playRandom",
             "propertySubPhrases": [
               "Keep the party going",
-              "with the music."
+              "with the music"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.playNext",
                 "propertySubPhrases": [
-                  "Play the next song",
-                  "to keep the party going."
+                  "Keep the party going",
+                  "with the next song"
                 ]
               },
               {
-                "propertyValue": "player.playFavorite",
+                "propertyValue": "player.playFavorites",
                 "propertySubPhrases": [
-                  "Play my favorite tracks",
-                  "to keep the party alive."
+                  "Keep the party going",
+                  "with the favorite tracks"
+                ]
+              },
+              {
+                "propertyValue": "player.playPlaylist",
+                "propertySubPhrases": [
+                  "Keep the party going",
+                  "with the party playlist"
                 ]
               },
               {
                 "propertyValue": "player.playGenre",
                 "propertySubPhrases": [
-                  "Play some jazz",
-                  "to keep the mood."
+                  "Keep the party going",
+                  "with the genre music"
                 ]
               }
             ]
           }
         ],
         "politePrefixes": [
-          "Could you please",
-          "Would you mind"
+          "Please",
+          "Kindly",
+          "Would you mind",
+          "Could you"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it."
+          "Thank you",
+          "If you don't mind",
+          "Please",
+          "Thanks"
         ]
       }
     },
@@ -1938,13 +2086,13 @@
               {
                 "propertyValue": "player.continue",
                 "propertySubPhrases": [
-                  "Continue the music."
+                  "Continue the song."
                 ]
               },
               {
                 "propertyValue": "player.unpause",
                 "propertySubPhrases": [
-                  "Unpause the music."
+                  "Unpause the track."
                 ]
               }
             ]
@@ -1952,11 +2100,15 @@
         ],
         "politePrefixes": [
           "Please",
+          "Could you",
+          "Would you mind",
           "Kindly"
         ],
         "politeSuffixes": [
-          "Thank you",
-          "Much appreciated"
+          "please",
+          "if you don't mind",
+          "thank you",
+          "if that's okay"
         ]
       }
     },
@@ -1971,7 +2123,7 @@
             "name": "fullActionName",
             "value": "player.resume",
             "substrings": [
-              "Kindly continue with the playlist."
+              "Kindly continue"
             ]
           }
         ],
@@ -1987,11 +2139,16 @@
             "isOptional": true
           },
           {
-            "text": "continue with the playlist",
+            "text": "continue",
             "category": "action",
             "propertyNames": [
               "fullActionName"
             ]
+          },
+          {
+            "text": "with the playlist",
+            "category": "context",
+            "propertyNames": []
           }
         ],
         "propertyAlternatives": [
@@ -1999,38 +2156,48 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.resume",
             "propertySubPhrases": [
-              "continue with the playlist"
+              "continue"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.play",
                 "propertySubPhrases": [
-                  "start the playlist"
+                  "start"
                 ]
               },
               {
                 "propertyValue": "player.pause",
                 "propertySubPhrases": [
-                  "pause the playlist"
+                  "pause"
                 ]
               },
               {
                 "propertyValue": "player.stop",
                 "propertySubPhrases": [
-                  "stop the playlist"
+                  "stop"
                 ]
               },
               {
                 "propertyValue": "player.next",
                 "propertySubPhrases": [
-                  "skip to the next song"
+                  "skip"
                 ]
               }
             ]
           }
         ],
-        "politePrefixes": [],
-        "politeSuffixes": []
+        "politePrefixes": [
+          "Please",
+          "Would you mind",
+          "Could you please",
+          "If you don't mind"
+        ],
+        "politeSuffixes": [
+          "Thank you",
+          "Thanks",
+          "I appreciate it",
+          "Much appreciated"
+        ]
       }
     },
     {
@@ -2050,8 +2217,18 @@
         ],
         "subPhrases": [
           {
-            "text": "Let the music flow again.",
-            "category": "command",
+            "text": "Let",
+            "category": "confirmation",
+            "synonyms": [
+              "allow",
+              "permit",
+              "enable"
+            ],
+            "isOptional": true
+          },
+          {
+            "text": "the music flow again",
+            "category": "action",
             "propertyNames": [
               "fullActionName"
             ]
@@ -2062,37 +2239,41 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.resume",
             "propertySubPhrases": [
-              "Let the music flow again."
+              "the music flow again"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.play",
                 "propertySubPhrases": [
-                  "Start the music."
+                  "start the music"
                 ]
               },
               {
                 "propertyValue": "player.unpause",
                 "propertySubPhrases": [
-                  "Unpause the music."
+                  "continue the music"
                 ]
               },
               {
-                "propertyValue": "player.continue",
+                "propertyValue": "player.restart",
                 "propertySubPhrases": [
-                  "Continue the music."
+                  "restart the music"
                 ]
               }
             ]
           }
         ],
         "politePrefixes": [
-          "Could you please",
-          "Would you mind"
+          "Please",
+          "Kindly",
+          "Would you mind",
+          "If you could"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it."
+          "please",
+          "thank you",
+          "if you don't mind",
+          "would be appreciated"
         ]
       }
     },
@@ -2107,7 +2288,7 @@
             "name": "fullActionName",
             "value": "player.resume",
             "substrings": [
-              "Let's get back to the beats."
+              "get back"
             ]
           }
         ],
@@ -2123,11 +2304,16 @@
             "isOptional": true
           },
           {
-            "text": "get back to the beats.",
-            "category": "command",
+            "text": "get back",
+            "category": "action",
             "propertyNames": [
               "fullActionName"
             ]
+          },
+          {
+            "text": "to the beats",
+            "category": "object",
+            "propertyNames": []
           }
         ],
         "propertyAlternatives": [
@@ -2135,37 +2321,41 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.resume",
             "propertySubPhrases": [
-              "get back to the beats."
+              "get back"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.play",
                 "propertySubPhrases": [
-                  "start the music."
+                  "start playing"
                 ]
               },
               {
-                "propertyValue": "player.pause",
+                "propertyValue": "player.restart",
                 "propertySubPhrases": [
-                  "pause the beats."
+                  "restart"
                 ]
               },
               {
-                "propertyValue": "player.stop",
+                "propertyValue": "player.continue",
                 "propertySubPhrases": [
-                  "stop the music."
+                  "continue"
                 ]
               }
             ]
           }
         ],
         "politePrefixes": [
-          "Please",
-          "Kindly"
+          "Please,",
+          "Kindly,",
+          "If you don't mind,",
+          "Would you be so kind,"
         ],
         "politeSuffixes": [
-          "Thank you",
-          "if you don't mind"
+          "thank you.",
+          "please.",
+          "if that's okay.",
+          "if you could."
         ]
       }
     },
@@ -2187,7 +2377,7 @@
         "subPhrases": [
           {
             "text": "Let's",
-            "category": "filler",
+            "category": "politeness",
             "synonyms": [
               "Let us",
               "We should",
@@ -2218,6 +2408,12 @@
                 ]
               },
               {
+                "propertyValue": "player.restart",
+                "propertySubPhrases": [
+                  "restart the music"
+                ]
+              },
+              {
                 "propertyValue": "player.unpause",
                 "propertySubPhrases": [
                   "unpause the music"
@@ -2233,12 +2429,16 @@
           }
         ],
         "politePrefixes": [
+          "Please,",
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If you don't mind,"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it."
+          "thank you.",
+          "please.",
+          "if that's okay.",
+          "if you could."
         ]
       }
     },
@@ -2260,11 +2460,11 @@
         "subPhrases": [
           {
             "text": "Let's",
-            "category": "filler",
+            "category": "politeness",
             "synonyms": [
               "Let us",
-              "We should",
-              "How about"
+              "Allow us",
+              "Please"
             ],
             "isOptional": true
           },
@@ -2312,12 +2512,16 @@
           }
         ],
         "politePrefixes": [
-          "Please",
-          "Kindly"
+          "Could you please",
+          "Would you mind",
+          "If you don't mind",
+          "I would appreciate it if you could"
         ],
         "politeSuffixes": [
-          "Thank you",
-          "if you don't mind"
+          "Thank you!",
+          "Please.",
+          "If that's okay.",
+          "Thanks a lot!"
         ]
       }
     },
@@ -2332,18 +2536,19 @@
             "name": "fullActionName",
             "value": "player.resume",
             "substrings": [
-              "pick up where we left off"
+              "pick up where we left off",
+              "with the music"
             ]
           }
         ],
         "subPhrases": [
           {
             "text": "Let's",
-            "category": "filler",
+            "category": "politeness",
             "synonyms": [
-              "Let us",
-              "We should",
-              "How about we"
+              "please",
+              "kindly",
+              "would you mind"
             ],
             "isOptional": true
           },
@@ -2357,7 +2562,9 @@
           {
             "text": "with the music",
             "category": "context",
-            "propertyNames": []
+            "propertyNames": [
+              "fullActionName"
+            ]
           }
         ],
         "propertyAlternatives": [
@@ -2365,37 +2572,45 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.resume",
             "propertySubPhrases": [
-              "pick up where we left off"
+              "pick up where we left off",
+              "with the music"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.play",
                 "propertySubPhrases": [
-                  "start the music"
+                  "start playing",
+                  "the music"
                 ]
               },
               {
-                "propertyValue": "player.continue",
+                "propertyValue": "player.pause",
                 "propertySubPhrases": [
-                  "continue the music"
+                  "pause",
+                  "the music"
                 ]
               },
               {
-                "propertyValue": "player.replay",
+                "propertyValue": "player.stop",
                 "propertySubPhrases": [
-                  "replay the music"
+                  "stop",
+                  "the music"
                 ]
               }
             ]
           }
         ],
         "politePrefixes": [
-          "Please",
-          "Kindly"
+          "Please,",
+          "Would you mind",
+          "Could you kindly",
+          "If you don't mind,"
         ],
         "politeSuffixes": [
-          "Thank you",
-          "Much appreciated"
+          "thank you.",
+          "please.",
+          "if that's okay.",
+          "if you could."
         ]
       }
     },
@@ -2421,7 +2636,7 @@
             "synonyms": [
               "Let us",
               "We should",
-              "How about we"
+              "Let's go ahead"
             ],
             "isOptional": true
           },
@@ -2469,11 +2684,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If you don't mind",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you.",
-          "I would appreciate it."
+          "thank you",
+          "if that's okay",
+          "please",
+          "thanks"
         ]
       }
     },
@@ -2506,7 +2725,7 @@
             "synonyms": [
               "kindly",
               "if you would",
-              "if you please"
+              "if you could"
             ],
             "isOptional": true
           }
@@ -2520,34 +2739,38 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.pause",
+                "propertyValue": "player.start",
                 "propertySubPhrases": [
-                  "Pause"
+                  "Start playing"
                 ]
               },
               {
-                "propertyValue": "player.stop",
+                "propertyValue": "player.continue",
                 "propertySubPhrases": [
-                  "Stop"
+                  "Continue playing"
                 ]
               },
               {
-                "propertyValue": "player.next",
+                "propertyValue": "player.play",
                 "propertySubPhrases": [
-                  "Next"
-                ]
-              },
-              {
-                "propertyValue": "player.previous",
-                "propertySubPhrases": [
-                  "Previous"
+                  "Play"
                 ]
               }
             ]
           }
         ],
-        "politePrefixes": [],
-        "politeSuffixes": []
+        "politePrefixes": [
+          "Could you",
+          "Would you mind",
+          "If you don't mind",
+          "May I ask you to"
+        ],
+        "politeSuffixes": [
+          "if you could",
+          "if it's not too much trouble",
+          "if you don't mind",
+          "thank you"
+        ]
       }
     },
     {
@@ -2567,8 +2790,15 @@
         ],
         "subPhrases": [
           {
-            "text": "Play the music",
+            "text": "Play",
             "category": "command",
+            "propertyNames": [
+              "fullActionName"
+            ]
+          },
+          {
+            "text": "the music",
+            "category": "object",
             "propertyNames": [
               "fullActionName"
             ]
@@ -2586,29 +2816,33 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.resume",
             "propertySubPhrases": [
-              "Play the music",
+              "Play",
+              "the music",
               "once more"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.play",
                 "propertySubPhrases": [
-                  "Start the music",
+                  "Start",
+                  "the music",
                   "again"
-                ]
-              },
-              {
-                "propertyValue": "player.replay",
-                "propertySubPhrases": [
-                  "Replay the song",
-                  "one more time"
                 ]
               },
               {
                 "propertyValue": "player.restart",
                 "propertySubPhrases": [
-                  "Restart the track",
+                  "Restart",
+                  "the song",
                   "from the beginning"
+                ]
+              },
+              {
+                "propertyValue": "player.replay",
+                "propertySubPhrases": [
+                  "Replay",
+                  "the track",
+                  "one more time"
                 ]
               }
             ]
@@ -2616,11 +2850,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If you don't mind",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it."
+          "thank you",
+          "if that's okay",
+          "please",
+          "thanks"
         ]
       }
     },
@@ -2645,8 +2883,8 @@
             "category": "politeness",
             "synonyms": [
               "Kindly",
-              "Would you mind",
-              "Could you"
+              "Could you",
+              "Would you mind"
             ],
             "isOptional": true
           },
@@ -2669,12 +2907,6 @@
               {
                 "propertyValue": "player.play",
                 "propertySubPhrases": [
-                  "play the music"
-                ]
-              },
-              {
-                "propertyValue": "player.start",
-                "propertySubPhrases": [
                   "start the music"
                 ]
               },
@@ -2683,12 +2915,28 @@
                 "propertySubPhrases": [
                   "unpause the music"
                 ]
+              },
+              {
+                "propertyValue": "player.restart",
+                "propertySubPhrases": [
+                  "restart the music"
+                ]
               }
             ]
           }
         ],
-        "politePrefixes": [],
-        "politeSuffixes": []
+        "politePrefixes": [
+          "Could you kindly",
+          "Would you mind",
+          "If you don't mind",
+          "May I ask you to"
+        ],
+        "politeSuffixes": [
+          "if that's okay with you.",
+          "please.",
+          "if you could.",
+          "thank you."
+        ]
       }
     },
     {
@@ -2702,7 +2950,8 @@
             "name": "fullActionName",
             "value": "player.playRandom",
             "substrings": [
-              "hit play"
+              "hit play",
+              "music"
             ]
           }
         ],
@@ -2713,26 +2962,33 @@
             "synonyms": [
               "Kindly",
               "Would you mind",
-              "Could you please"
+              "Could you"
             ],
             "isOptional": true
           },
           {
             "text": "hit play",
-            "category": "command",
+            "category": "action",
             "propertyNames": [
               "fullActionName"
             ]
           },
           {
-            "text": "on the music",
-            "category": "context",
+            "text": "on the",
+            "category": "preposition",
             "synonyms": [
-              "with the music",
-              "to the music",
-              "for the music"
+              "to the",
+              "onto the",
+              "upon the"
             ],
             "isOptional": true
+          },
+          {
+            "text": "music",
+            "category": "object",
+            "propertyNames": [
+              "fullActionName"
+            ]
           }
         ],
         "propertyAlternatives": [
@@ -2740,38 +2996,53 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.playRandom",
             "propertySubPhrases": [
-              "hit play"
+              "hit play",
+              "music"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.pause",
                 "propertySubPhrases": [
-                  "pause"
+                  "hit pause",
+                  "music"
                 ]
               },
               {
                 "propertyValue": "player.stop",
                 "propertySubPhrases": [
-                  "stop"
+                  "hit stop",
+                  "music"
                 ]
               },
               {
-                "propertyValue": "player.next",
+                "propertyValue": "player.nextTrack",
                 "propertySubPhrases": [
-                  "skip"
+                  "skip",
+                  "music"
                 ]
               },
               {
-                "propertyValue": "player.previous",
+                "propertyValue": "player.previousTrack",
                 "propertySubPhrases": [
-                  "go back"
+                  "go back",
+                  "music"
                 ]
               }
             ]
           }
         ],
-        "politePrefixes": [],
-        "politeSuffixes": []
+        "politePrefixes": [
+          "Could you kindly",
+          "Would you mind",
+          "If you don't mind",
+          "May I ask you to"
+        ],
+        "politeSuffixes": [
+          "if that's okay with you.",
+          "please.",
+          "if you could.",
+          "thank you."
+        ]
       }
     },
     {
@@ -2795,8 +3066,8 @@
             "category": "politeness",
             "synonyms": [
               "Kindly",
-              "Would you mind",
-              "Could you"
+              "Could you",
+              "Would you mind"
             ],
             "isOptional": true
           },
@@ -2828,22 +3099,32 @@
                 ]
               },
               {
-                "propertyValue": "player.start",
+                "propertyValue": "player.pause",
                 "propertySubPhrases": [
-                  "start"
+                  "pause"
                 ]
               },
               {
-                "propertyValue": "player.continue",
+                "propertyValue": "player.stop",
                 "propertySubPhrases": [
-                  "continue"
+                  "stop"
                 ]
               }
             ]
           }
         ],
-        "politePrefixes": [],
-        "politeSuffixes": []
+        "politePrefixes": [
+          "Could you kindly",
+          "Would you mind",
+          "If you don't mind",
+          "May I ask you to"
+        ],
+        "politeSuffixes": [
+          "if that's okay with you.",
+          "please.",
+          "if you could.",
+          "thank you."
+        ]
       }
     },
     {
@@ -2857,22 +3138,21 @@
             "name": "fullActionName",
             "value": "player.resume",
             "substrings": [
-              "Proceed",
-              "with the audio playback"
+              "Proceed with the audio playback."
             ]
           }
         ],
         "subPhrases": [
           {
-            "text": "Proceed",
+            "text": "Proceed with",
             "category": "command",
             "propertyNames": [
               "fullActionName"
             ]
           },
           {
-            "text": "with the audio playback",
-            "category": "command detail",
+            "text": "the audio playback.",
+            "category": "object",
             "propertyNames": [
               "fullActionName"
             ]
@@ -2883,29 +3163,36 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.resume",
             "propertySubPhrases": [
-              "Proceed",
-              "with the audio playback"
+              "Proceed with",
+              "the audio playback."
             ],
             "alternatives": [
               {
                 "propertyValue": "player.play",
                 "propertySubPhrases": [
                   "Start",
-                  "the audio playback"
+                  "the audio playback."
                 ]
               },
               {
-                "propertyValue": "player.continue",
+                "propertyValue": "player.pause",
                 "propertySubPhrases": [
-                  "Continue",
-                  "the audio playback"
+                  "Pause",
+                  "the audio playback."
                 ]
               },
               {
-                "propertyValue": "player.begin",
+                "propertyValue": "player.stop",
                 "propertySubPhrases": [
-                  "Begin",
-                  "the audio playback"
+                  "Stop",
+                  "the audio playback."
+                ]
+              },
+              {
+                "propertyValue": "player.rewind",
+                "propertySubPhrases": [
+                  "Rewind",
+                  "the audio playback."
                 ]
               }
             ]
@@ -2913,11 +3200,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If you don't mind",
+          "Kindly"
         ],
         "politeSuffixes": [
-          "Thank you.",
-          "I would appreciate it."
+          "thank you",
+          "please",
+          "if that's okay",
+          "if you could"
         ]
       }
     },
@@ -2947,15 +3238,17 @@
           {
             "text": "the jam",
             "category": "object",
-            "propertyNames": []
+            "propertyNames": [
+              "fullActionName"
+            ]
           },
           {
             "text": "please",
             "category": "politeness",
             "synonyms": [
               "kindly",
-              "if you could",
-              "would you mind"
+              "if you would",
+              "if you could"
             ],
             "isOptional": true
           }
@@ -2965,38 +3258,46 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.resume",
             "propertySubPhrases": [
-              "Restart"
+              "Restart",
+              "the jam"
             ],
             "alternatives": [
               {
+                "propertyValue": "player.play",
+                "propertySubPhrases": [
+                  "Play",
+                  "the jam"
+                ]
+              },
+              {
                 "propertyValue": "player.start",
                 "propertySubPhrases": [
-                  "Start"
+                  "Start",
+                  "the jam"
                 ]
               },
               {
                 "propertyValue": "player.replay",
                 "propertySubPhrases": [
-                  "Replay"
-                ]
-              },
-              {
-                "propertyValue": "player.restart",
-                "propertySubPhrases": [
-                  "Restart"
-                ]
-              },
-              {
-                "propertyValue": "player.continue",
-                "propertySubPhrases": [
-                  "Continue"
+                  "Replay",
+                  "the jam"
                 ]
               }
             ]
           }
         ],
-        "politePrefixes": [],
-        "politeSuffixes": []
+        "politePrefixes": [
+          "Could you kindly",
+          "Would you mind",
+          "If you don't mind",
+          "May I ask you to"
+        ],
+        "politeSuffixes": [
+          "if it's not too much trouble.",
+          "when you have a moment.",
+          "if you could.",
+          "thank you."
+        ]
       }
     },
     {
@@ -3017,7 +3318,7 @@
         "subPhrases": [
           {
             "text": "Resume",
-            "category": "command",
+            "category": "action",
             "propertyNames": [
               "fullActionName"
             ]
@@ -3032,8 +3333,8 @@
             "category": "politeness",
             "synonyms": [
               "kindly",
-              "if you would",
-              "if you please"
+              "if you could",
+              "would you mind"
             ],
             "isOptional": true
           }
@@ -3067,8 +3368,18 @@
             ]
           }
         ],
-        "politePrefixes": [],
-        "politeSuffixes": []
+        "politePrefixes": [
+          "Could you kindly",
+          "Would you mind",
+          "If you don't mind",
+          "May I ask you to"
+        ],
+        "politeSuffixes": [
+          "Thank you.",
+          "I would appreciate it.",
+          "Thanks a lot.",
+          "Much appreciated."
+        ]
       }
     },
     {
@@ -3104,8 +3415,8 @@
             "category": "politeness",
             "synonyms": [
               "please",
-              "if it's not too much trouble",
-              "if you could"
+              "if you could",
+              "if it's not too much trouble"
             ],
             "isOptional": true
           }
@@ -3125,22 +3436,32 @@
                 ]
               },
               {
-                "propertyValue": "player.start",
+                "propertyValue": "player.pause",
                 "propertySubPhrases": [
-                  "Start"
+                  "Pause"
                 ]
               },
               {
-                "propertyValue": "player.continue",
+                "propertyValue": "player.stop",
                 "propertySubPhrases": [
-                  "Continue"
+                  "Stop"
                 ]
               }
             ]
           }
         ],
-        "politePrefixes": [],
-        "politeSuffixes": []
+        "politePrefixes": [
+          "Could you please",
+          "Would you kindly",
+          "If it's not too much trouble,",
+          "May I ask you to"
+        ],
+        "politeSuffixes": [
+          "thank you.",
+          "please.",
+          "if you would be so kind.",
+          "I would appreciate it."
+        ]
       }
     },
     {
@@ -3211,8 +3532,18 @@
             ]
           }
         ],
-        "politePrefixes": [],
-        "politeSuffixes": []
+        "politePrefixes": [
+          "Could you please",
+          "Would you mind",
+          "If it's not too much trouble",
+          "May I ask you to"
+        ],
+        "politeSuffixes": [
+          "Thank you.",
+          "I would appreciate it.",
+          "Thanks in advance.",
+          "If you don't mind."
+        ]
       }
     },
     {
@@ -3248,8 +3579,8 @@
             "category": "politeness",
             "synonyms": [
               "kindly",
-              "if you could",
-              "would you mind"
+              "if you would",
+              "if you could"
             ],
             "isOptional": true
           }
@@ -3283,8 +3614,18 @@
             ]
           }
         ],
-        "politePrefixes": [],
-        "politeSuffixes": []
+        "politePrefixes": [
+          "Could you",
+          "Would you mind",
+          "If you don't mind",
+          "May I ask you to"
+        ],
+        "politeSuffixes": [
+          "Thank you",
+          "if that's okay",
+          "if you could",
+          "I would appreciate it"
+        ]
       }
     },
     {
@@ -3304,8 +3645,22 @@
         ],
         "subPhrases": [
           {
-            "text": "Start the music up again.",
+            "text": "Start",
             "category": "command",
+            "propertyNames": [
+              "fullActionName"
+            ]
+          },
+          {
+            "text": "the music",
+            "category": "object",
+            "propertyNames": [
+              "fullActionName"
+            ]
+          },
+          {
+            "text": "up again",
+            "category": "continuation",
             "propertyNames": [
               "fullActionName"
             ]
@@ -3316,25 +3671,33 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.resume",
             "propertySubPhrases": [
-              "Start the music up again."
+              "Start",
+              "the music",
+              "up again"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.play",
                 "propertySubPhrases": [
-                  "Play the music."
+                  "Play",
+                  "the music",
+                  "now"
                 ]
               },
               {
                 "propertyValue": "player.restart",
                 "propertySubPhrases": [
-                  "Restart the music."
+                  "Restart",
+                  "the music",
+                  "from the beginning"
                 ]
               },
               {
                 "propertyValue": "player.continue",
                 "propertySubPhrases": [
-                  "Continue the music."
+                  "Continue",
+                  "the music",
+                  "playing"
                 ]
               }
             ]
@@ -3342,11 +3705,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If you don't mind",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you.",
-          "I would appreciate it."
+          "if that's okay.",
+          "thank you.",
+          "please.",
+          "if you could."
         ]
       }
     },
@@ -3384,7 +3751,7 @@
             "synonyms": [
               "please",
               "if you don't mind",
-              "kindly"
+              "could you"
             ],
             "isOptional": true
           }
@@ -3414,17 +3781,27 @@
                 "propertySubPhrases": [
                   "Continue"
                 ]
+              },
+              {
+                "propertyValue": "player.unpause",
+                "propertySubPhrases": [
+                  "Unpause"
+                ]
               }
             ]
           }
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If you don't mind",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "Thanks a lot!"
+          "Thank you",
+          "If that's okay",
+          "I'd appreciate it",
+          "Thanks"
         ]
       }
     },
@@ -3448,9 +3825,9 @@
             "text": "Would you mind",
             "category": "politeness",
             "synonyms": [
-              "Could you please",
-              "Do you mind",
-              "Would it be possible"
+              "Could you",
+              "Can you",
+              "Please"
             ],
             "isOptional": true
           },
@@ -3496,8 +3873,18 @@
             ]
           }
         ],
-        "politePrefixes": [],
-        "politeSuffixes": []
+        "politePrefixes": [
+          "If it's not too much trouble, ",
+          "Could you please, ",
+          "When you have a moment, ",
+          "If you don't mind, "
+        ],
+        "politeSuffixes": [
+          " please?",
+          " if you could.",
+          " thank you.",
+          " I'd appreciate it."
+        ]
       }
     },
     {
@@ -3522,7 +3909,7 @@
             "synonyms": [
               "Could you",
               "Can you",
-              "Will you"
+              "Please"
             ],
             "isOptional": true
           },
@@ -3536,12 +3923,7 @@
           {
             "text": "the audio",
             "category": "object",
-            "synonyms": [
-              "the sound",
-              "the playback",
-              "the recording"
-            ],
-            "isOptional": true
+            "propertyNames": []
           }
         ],
         "propertyAlternatives": [
@@ -3569,12 +3951,28 @@
                 "propertySubPhrases": [
                   "stop"
                 ]
+              },
+              {
+                "propertyValue": "player.rewind",
+                "propertySubPhrases": [
+                  "rewind"
+                ]
               }
             ]
           }
         ],
-        "politePrefixes": [],
-        "politeSuffixes": []
+        "politePrefixes": [
+          "Could you please",
+          "Would you kindly",
+          "If you don't mind,",
+          "May I ask you to"
+        ],
+        "politeSuffixes": [
+          "please?",
+          "if that's okay?",
+          "thank you.",
+          "if you could."
+        ]
       }
     },
     {
@@ -3626,25 +4024,31 @@
                 ]
               },
               {
-                "propertyValue": "player.continue",
+                "propertyValue": "player.pause",
                 "propertySubPhrases": [
-                  "continue the tracks"
+                  "pause the beats"
                 ]
               },
               {
-                "propertyValue": "player.unpause",
+                "propertyValue": "player.stop",
                 "propertySubPhrases": [
-                  "unpause the tunes"
+                  "stop the music"
                 ]
               }
             ]
           }
         ],
         "politePrefixes": [
-          "Please"
+          "Please",
+          "Could you",
+          "Would you mind",
+          "Kindly"
         ],
         "politeSuffixes": [
-          "Thank you"
+          "thank you",
+          "please",
+          "if you don't mind",
+          "thanks"
         ]
       }
     },
@@ -3688,13 +4092,13 @@
             "synonyms": [
               "on it",
               "on this",
-              "on the thing"
+              "on"
             ],
             "isOptional": true
           },
           {
             "text": "again",
-            "category": "command",
+            "category": "repetition",
             "propertyNames": [
               "fullActionName"
             ]
@@ -3720,7 +4124,7 @@
                 "propertyValue": "player.replay",
                 "propertySubPhrases": [
                   "press play",
-                  "on that again"
+                  "again"
                 ]
               },
               {
@@ -3729,19 +4133,126 @@
                   "press play",
                   "on that"
                 ]
+              },
+              {
+                "propertyValue": "player.restart",
+                "propertySubPhrases": [
+                  "press play",
+                  "again"
+                ]
               }
             ]
           }
         ],
         "politePrefixes": [
-          "Could you please",
-          "Would you mind"
+          "Please",
+          "Could you",
+          "Would you mind",
+          "If you don't mind"
         ],
         "politeSuffixes": [
-          "Thank you",
-          "I appreciate it"
+          "please",
+          "if you could",
+          "thank you",
+          "if that's okay"
         ]
-      }
+      },
+      "corrections": [
+        {
+          "data": {
+            "properties": [
+              {
+                "name": "fullActionName",
+                "value": "player.resume",
+                "substrings": [
+                  "press play",
+                  "again"
+                ]
+              }
+            ],
+            "subPhrases": [
+              {
+                "text": "Yo",
+                "category": "greeting",
+                "synonyms": [
+                  "Hey",
+                  "Hi",
+                  "Hello"
+                ],
+                "isOptional": true
+              },
+              {
+                "text": "press play",
+                "category": "command",
+                "propertyNames": [
+                  "fullActionName"
+                ]
+              },
+              {
+                "text": "on that",
+                "category": "filler",
+                "synonyms": [
+                  "on it",
+                  "on this",
+                  "on"
+                ],
+                "isOptional": true
+              },
+              {
+                "text": "again",
+                "category": "repetition",
+                "propertyNames": [
+                  "fullActionName"
+                ]
+              }
+            ],
+            "propertyAlternatives": [
+              {
+                "propertyName": "fullActionName",
+                "propertyValue": "player.resume",
+                "propertySubPhrases": [
+                  "press play",
+                  "again"
+                ],
+                "alternatives": [
+                  {
+                    "propertyValue": "player.start",
+                    "propertySubPhrases": [
+                      "press play",
+                      "on that"
+                    ]
+                  },
+                  {
+                    "propertyValue": "player.replay",
+                    "propertySubPhrases": [
+                      "press play",
+                      "again"
+                    ]
+                  },
+                  {
+                    "propertyValue": "player.restart",
+                    "propertySubPhrases": [
+                      "press play",
+                      "on that",
+                      "again"
+                    ]
+                  },
+                  {
+                    "propertyValue": "player.continue",
+                    "propertySubPhrases": [
+                      "press play",
+                      "on that"
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          "correction": [
+            "Mismatch number of sub-phrases: alternatives value 'player.restart' for property 'fullActionName' must have 2 sub-phrases"
+          ]
+        }
+      ]
     }
   ]
 }

--- a/ts/packages/defaultAgentProvider/test/data/explanations/player/v5/searchTracks.json
+++ b/ts/packages/defaultAgentProvider/test/data/explanations/player/v5/searchTracks.json
@@ -18,7 +18,7 @@
             "name": "fullActionName",
             "value": "player.searchTracks",
             "substrings": [
-              "Find acoustic versions of popular songs"
+              "Find"
             ]
           },
           {
@@ -32,7 +32,7 @@
         "subPhrases": [
           {
             "text": "Find",
-            "category": "action",
+            "category": "command",
             "propertyNames": [
               "fullActionName"
             ]
@@ -54,21 +54,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.findTracks",
+                "propertyValue": "player.findSongs",
                 "propertySubPhrases": [
-                  "Search"
+                  "Find"
                 ]
               },
               {
                 "propertyValue": "player.lookupTracks",
                 "propertySubPhrases": [
-                  "Look up"
+                  "Find"
                 ]
               },
               {
-                "propertyValue": "player.browseTracks",
+                "propertyValue": "player.searchMusic",
                 "propertySubPhrases": [
-                  "Browse"
+                  "Find"
                 ]
               }
             ]
@@ -87,15 +87,15 @@
                 ]
               },
               {
-                "propertyValue": "unplugged versions of famous tracks",
+                "propertyValue": "unplugged versions of famous songs",
                 "propertySubPhrases": [
-                  "unplugged versions of famous tracks"
+                  "unplugged versions of famous songs"
                 ]
               },
               {
-                "propertyValue": "acoustic renditions of top songs",
+                "propertyValue": "acoustic renditions of popular tracks",
                 "propertySubPhrases": [
-                  "acoustic renditions of top songs"
+                  "acoustic renditions of popular tracks"
                 ]
               }
             ]
@@ -104,12 +104,14 @@
         "politePrefixes": [
           "Could you please",
           "Would you mind",
-          "If it's not too much trouble, could you"
+          "I would appreciate it if you could",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it.",
-          "Thanks in advance!"
+          "Thank you",
+          "Thanks",
+          "If possible",
+          "I appreciate it"
         ]
       }
     },
@@ -127,8 +129,7 @@
             "name": "fullActionName",
             "value": "player.playGenre",
             "substrings": [
-              "Find",
-              "music"
+              "Find chillout music for relaxation"
             ]
           },
           {
@@ -155,31 +156,11 @@
             ]
           },
           {
-            "text": "music",
-            "category": "command",
+            "text": "music for relaxation",
+            "category": "context",
             "propertyNames": [
               "fullActionName"
             ]
-          },
-          {
-            "text": "for",
-            "category": "preposition",
-            "synonyms": [
-              "to",
-              "in order to",
-              "so as to"
-            ],
-            "isOptional": true
-          },
-          {
-            "text": "relaxation",
-            "category": "purpose",
-            "synonyms": [
-              "calm",
-              "unwind",
-              "chill"
-            ],
-            "isOptional": true
           }
         ],
         "propertyAlternatives": [
@@ -188,28 +169,28 @@
             "propertyValue": "player.playGenre",
             "propertySubPhrases": [
               "Find",
-              "music"
+              "music for relaxation"
             ],
             "alternatives": [
               {
-                "propertyValue": "player.playSong",
+                "propertyValue": "player.playMood",
                 "propertySubPhrases": [
-                  "Play",
-                  "song"
-                ]
-              },
-              {
-                "propertyValue": "player.playAlbum",
-                "propertySubPhrases": [
-                  "Play",
-                  "album"
+                  "Find",
+                  "music for relaxation"
                 ]
               },
               {
                 "propertyValue": "player.playPlaylist",
                 "propertySubPhrases": [
-                  "Play",
-                  "playlist"
+                  "Find",
+                  "music for relaxation"
+                ]
+              },
+              {
+                "propertyValue": "player.playArtist",
+                "propertySubPhrases": [
+                  "Find",
+                  "music for relaxation"
                 ]
               }
             ]
@@ -222,21 +203,27 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "jazz",
-                "propertySubPhrases": [
-                  "jazz"
-                ]
-              },
-              {
-                "propertyValue": "classical",
-                "propertySubPhrases": [
-                  "classical"
-                ]
-              },
-              {
                 "propertyValue": "ambient",
                 "propertySubPhrases": [
                   "ambient"
+                ]
+              },
+              {
+                "propertyValue": "lo-fi",
+                "propertySubPhrases": [
+                  "lo-fi"
+                ]
+              },
+              {
+                "propertyValue": "downtempo",
+                "propertySubPhrases": [
+                  "downtempo"
+                ]
+              },
+              {
+                "propertyValue": "meditation",
+                "propertySubPhrases": [
+                  "meditation"
                 ]
               }
             ]
@@ -244,37 +231,40 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "I would appreciate it if you could",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you",
-          "I would appreciate it"
+          "if possible.",
+          "thank you.",
+          "please.",
+          "thanks."
         ]
       }
     },
     {
       "request": "Find chillwave tracks for a laid-back evening",
       "action": {
-        "fullActionName": "player.playGenre",
+        "fullActionName": "player.searchTracks",
         "parameters": {
-          "genre": "chillwave"
+          "query": "chillwave tracks for a laid-back evening"
         }
       },
       "explanation": {
         "properties": [
           {
             "name": "fullActionName",
-            "value": "player.playGenre",
+            "value": "player.searchTracks",
             "substrings": [
-              "Find",
-              "tracks"
+              "Find chillwave tracks for a laid-back evening"
             ]
           },
           {
-            "name": "parameters.genre",
-            "value": "chillwave",
+            "name": "parameters.query",
+            "value": "chillwave tracks for a laid-back evening",
             "substrings": [
-              "chillwave"
+              "chillwave tracks for a laid-back evening"
             ]
           }
         ],
@@ -287,85 +277,64 @@
             ]
           },
           {
-            "text": "chillwave",
-            "category": "genre",
+            "text": "chillwave tracks for a laid-back evening",
+            "category": "query",
             "propertyNames": [
-              "parameters.genre"
+              "parameters.query"
             ]
-          },
-          {
-            "text": "tracks",
-            "category": "object",
-            "propertyNames": [
-              "fullActionName"
-            ]
-          },
-          {
-            "text": "for a laid-back evening",
-            "category": "context",
-            "synonyms": [
-              "for a relaxing evening",
-              "for a calm night",
-              "for a peaceful evening"
-            ],
-            "isOptional": true
           }
         ],
         "propertyAlternatives": [
           {
             "propertyName": "fullActionName",
-            "propertyValue": "player.playGenre",
+            "propertyValue": "player.searchTracks",
             "propertySubPhrases": [
-              "Find",
-              "tracks"
+              "Find"
             ],
             "alternatives": [
               {
-                "propertyValue": "player.playPlaylist",
+                "propertyValue": "player.findSongs",
                 "propertySubPhrases": [
-                  "Play",
-                  "playlist"
+                  "Find"
                 ]
               },
               {
-                "propertyValue": "player.playAlbum",
+                "propertyValue": "player.lookupMusic",
                 "propertySubPhrases": [
-                  "Play",
-                  "album"
+                  "Find"
                 ]
               },
               {
-                "propertyValue": "player.playArtist",
+                "propertyValue": "player.searchMusic",
                 "propertySubPhrases": [
-                  "Play",
-                  "artist"
+                  "Find"
                 ]
               }
             ]
           },
           {
-            "propertyName": "parameters.genre",
-            "propertyValue": "chillwave",
+            "propertyName": "parameters.query",
+            "propertyValue": "chillwave tracks for a laid-back evening",
             "propertySubPhrases": [
-              "chillwave"
+              "chillwave tracks for a laid-back evening"
             ],
             "alternatives": [
               {
-                "propertyValue": "lofi",
+                "propertyValue": "chillwave songs for a relaxing night",
                 "propertySubPhrases": [
-                  "lofi"
+                  "chillwave songs for a relaxing night"
                 ]
               },
               {
-                "propertyValue": "ambient",
+                "propertyValue": "chillwave music for a calm evening",
                 "propertySubPhrases": [
-                  "ambient"
+                  "chillwave music for a calm evening"
                 ]
               },
               {
-                "propertyValue": "jazz",
+                "propertyValue": "chillwave tunes for a peaceful evening",
                 "propertySubPhrases": [
-                  "jazz"
+                  "chillwave tunes for a peaceful evening"
                 ]
               }
             ]
@@ -374,14 +343,14 @@
         "politePrefixes": [
           "Could you please",
           "Would you mind",
-          "If it's not too much trouble,",
-          "May I kindly ask you to"
+          "I would appreciate it if you could",
+          "Please"
         ],
         "politeSuffixes": [
           "Thank you!",
-          "I would appreciate it.",
-          "Thanks a lot!",
-          "That would be great."
+          "if that's okay.",
+          "Thanks!",
+          "if you don't mind."
         ]
       }
     },
@@ -441,13 +410,13 @@
                 ]
               },
               {
-                "propertyValue": "music.searchTracks",
+                "propertyValue": "player.lookupTracks",
                 "propertySubPhrases": [
                   "Find"
                 ]
               },
               {
-                "propertyValue": "audio.searchTracks",
+                "propertyValue": "player.searchMusic",
                 "propertySubPhrases": [
                   "Find"
                 ]
@@ -484,11 +453,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "I would appreciate it if you could",
+          "Please"
         ],
         "politeSuffixes": [
           "Thank you",
-          "I would appreciate it"
+          "Thanks",
+          "If you don't mind",
+          "I appreciate it"
         ]
       }
     },
@@ -542,21 +515,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.playTracks",
+                "propertyValue": "player.findSongs",
                 "propertySubPhrases": [
-                  "Play"
+                  "Find"
                 ]
               },
               {
-                "propertyValue": "player.addTracksToQueue",
+                "propertyValue": "player.lookupMusic",
                 "propertySubPhrases": [
-                  "Queue"
+                  "Find"
                 ]
               },
               {
-                "propertyValue": "player.shuffleTracks",
+                "propertyValue": "player.searchMusic",
                 "propertySubPhrases": [
-                  "Shuffle"
+                  "Find"
                 ]
               }
             ]
@@ -569,156 +542,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "pop music hits",
+                "propertyValue": "EDM hits",
                 "propertySubPhrases": [
-                  "pop music hits"
+                  "EDM hits"
                 ]
               },
               {
-                "propertyValue": "rock music hits",
+                "propertyValue": "electronic dance hits",
                 "propertySubPhrases": [
-                  "rock music hits"
+                  "electronic dance hits"
                 ]
               },
               {
-                "propertyValue": "hip hop music hits",
+                "propertyValue": "top electronic dance tracks",
                 "propertySubPhrases": [
-                  "hip hop music hits"
-                ]
-              }
-            ]
-          }
-        ],
-        "politePrefixes": [
-          "Could you please",
-          "Would you mind"
-        ],
-        "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it."
-        ]
-      }
-    },
-    {
-      "request": "Find Hotel California by The Eagles",
-      "action": {
-        "fullActionName": "player.playTrack",
-        "parameters": {
-          "trackName": "Hotel California",
-          "artists": [
-            "The Eagles"
-          ]
-        }
-      },
-      "explanation": {
-        "properties": [
-          {
-            "name": "fullActionName",
-            "value": "player.playTrack",
-            "isImplicit": true
-          },
-          {
-            "name": "parameters.trackName",
-            "value": "Hotel California",
-            "substrings": [
-              "Hotel California"
-            ]
-          },
-          {
-            "name": "parameters.artists.0",
-            "value": "The Eagles",
-            "substrings": [
-              "The Eagles"
-            ]
-          }
-        ],
-        "subPhrases": [
-          {
-            "text": "Find",
-            "category": "command",
-            "synonyms": [
-              "Search",
-              "Look for",
-              "Locate"
-            ],
-            "isOptional": true
-          },
-          {
-            "text": "Hotel California",
-            "category": "trackName",
-            "propertyNames": [
-              "parameters.trackName"
-            ]
-          },
-          {
-            "text": "by",
-            "category": "preposition",
-            "synonyms": [
-              "from",
-              "performed by",
-              "sung by"
-            ],
-            "isOptional": true
-          },
-          {
-            "text": "The Eagles",
-            "category": "artistName",
-            "propertyNames": [
-              "parameters.artists.0"
-            ]
-          }
-        ],
-        "propertyAlternatives": [
-          {
-            "propertyName": "parameters.trackName",
-            "propertyValue": "Hotel California",
-            "propertySubPhrases": [
-              "Hotel California"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "Bohemian Rhapsody",
-                "propertySubPhrases": [
-                  "Bohemian Rhapsody"
-                ]
-              },
-              {
-                "propertyValue": "Stairway to Heaven",
-                "propertySubPhrases": [
-                  "Stairway to Heaven"
-                ]
-              },
-              {
-                "propertyValue": "Imagine",
-                "propertySubPhrases": [
-                  "Imagine"
-                ]
-              }
-            ]
-          },
-          {
-            "propertyName": "parameters.artists.0",
-            "propertyValue": "The Eagles",
-            "propertySubPhrases": [
-              "The Eagles"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "Queen",
-                "propertySubPhrases": [
-                  "Queen"
-                ]
-              },
-              {
-                "propertyValue": "Led Zeppelin",
-                "propertySubPhrases": [
-                  "Led Zeppelin"
-                ]
-              },
-              {
-                "propertyValue": "John Lennon",
-                "propertySubPhrases": [
-                  "John Lennon"
+                  "top electronic dance tracks"
                 ]
               }
             ]
@@ -727,77 +565,127 @@
         "politePrefixes": [
           "Could you please",
           "Would you mind",
-          "If it's not too much trouble, could you"
+          "I would appreciate it if you could",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it.",
-          "Thanks a lot!"
+          "for me",
+          "if possible",
+          "thank you",
+          "when you have a moment"
         ]
+      }
+    },
+    {
+      "request": "Find Hotel California by The Eagles",
+      "action": {
+        "fullActionName": "player.searchTracks",
+        "parameters": {
+          "query": "Hotel California by The Eagles"
+        }
       },
-      "corrections": [
-        {
-          "data": {
-            "properties": [
-              {
-                "name": "fullActionName",
-                "value": "player.playTrack",
-                "isImplicit": true
-              },
-              {
-                "name": "parameters.trackName",
-                "value": "Hotel California",
-                "substrings": [
-                  "Hotel California"
-                ]
-              },
-              {
-                "name": "parameters.artists.0",
-                "value": "The Eagles",
-                "substrings": [
-                  "The Eagles"
-                ]
-              }
+      "explanation": {
+        "properties": [
+          {
+            "name": "fullActionName",
+            "value": "player.searchTracks",
+            "substrings": [
+              "Find"
+            ]
+          },
+          {
+            "name": "parameters.query",
+            "value": "Hotel California by The Eagles",
+            "substrings": [
+              "Hotel California by The Eagles"
+            ]
+          }
+        ],
+        "subPhrases": [
+          {
+            "text": "Find",
+            "category": "action",
+            "propertyNames": [
+              "fullActionName"
+            ]
+          },
+          {
+            "text": "Hotel California by The Eagles",
+            "category": "query",
+            "propertyNames": [
+              "parameters.query"
+            ]
+          }
+        ],
+        "propertyAlternatives": [
+          {
+            "propertyName": "fullActionName",
+            "propertyValue": "player.searchTracks",
+            "propertySubPhrases": [
+              "Find"
             ],
-            "subPhrases": [
+            "alternatives": [
               {
-                "text": "Find",
-                "category": "command",
-                "propertyNames": [
-                  "fullActionName"
+                "propertyValue": "player.findSongs",
+                "propertySubPhrases": [
+                  "Find"
                 ]
               },
               {
-                "text": "Hotel California",
-                "category": "trackName",
-                "propertyNames": [
-                  "parameters.trackName"
+                "propertyValue": "player.lookupTracks",
+                "propertySubPhrases": [
+                  "Find"
                 ]
               },
               {
-                "text": "by",
-                "category": "preposition",
-                "synonyms": [
-                  "from",
-                  "performed by",
-                  "sung by"
-                ],
-                "isOptional": true
-              },
-              {
-                "text": "The Eagles",
-                "category": "artistName",
-                "propertyNames": [
-                  "parameters.artists.0"
+                "propertyValue": "player.searchMusic",
+                "propertySubPhrases": [
+                  "Find"
                 ]
               }
             ]
           },
-          "correction": [
-            "Property 'fullActionName' is expected to be implicit and should not be included as a property name in a sub-phrase"
-          ]
-        }
-      ]
+          {
+            "propertyName": "parameters.query",
+            "propertyValue": "Hotel California by The Eagles",
+            "propertySubPhrases": [
+              "Hotel California by The Eagles"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "Bohemian Rhapsody by Queen",
+                "propertySubPhrases": [
+                  "Bohemian Rhapsody by Queen"
+                ]
+              },
+              {
+                "propertyValue": "Stairway to Heaven by Led Zeppelin",
+                "propertySubPhrases": [
+                  "Stairway to Heaven by Led Zeppelin"
+                ]
+              },
+              {
+                "propertyValue": "Imagine by John Lennon",
+                "propertySubPhrases": [
+                  "Imagine by John Lennon"
+                ]
+              }
+            ]
+          }
+        ],
+        "politePrefixes": [
+          "Could you please",
+          "Would you mind",
+          "Can you kindly",
+          "Please"
+        ],
+        "politeSuffixes": [
+          "for me?",
+          "if you don't mind.",
+          "thank you.",
+          "please."
+        ]
+      }
     },
     {
       "request": "Find K-pop hits like Dynamite by BTS",
@@ -813,7 +701,7 @@
             "name": "fullActionName",
             "value": "player.searchTracks",
             "substrings": [
-              "Find"
+              "Find K-pop hits like Dynamite by BTS"
             ]
           },
           {
@@ -851,19 +739,19 @@
               {
                 "propertyValue": "player.findSongs",
                 "propertySubPhrases": [
-                  "Find"
+                  "Search"
                 ]
               },
               {
                 "propertyValue": "player.lookupTracks",
                 "propertySubPhrases": [
-                  "Find"
+                  "Look up"
                 ]
               },
               {
-                "propertyValue": "player.searchMusic",
+                "propertyValue": "player.discoverMusic",
                 "propertySubPhrases": [
-                  "Find"
+                  "Discover"
                 ]
               }
             ]
@@ -899,14 +787,14 @@
         "politePrefixes": [
           "Could you please",
           "Would you mind",
-          "If it's not too much trouble,",
-          "May I kindly ask you to"
+          "I would appreciate it if you could",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it.",
-          "Thanks a lot!",
-          "Your help is much appreciated."
+          "Thank you",
+          "Thanks",
+          "I appreciate it",
+          "If you don't mind"
         ]
       }
     },
@@ -962,19 +850,19 @@
               {
                 "propertyValue": "player.findSongs",
                 "propertySubPhrases": [
-                  "Search"
+                  "Find"
                 ]
               },
               {
                 "propertyValue": "player.lookupMusic",
                 "propertySubPhrases": [
-                  "Look up"
+                  "Find"
                 ]
               },
               {
-                "propertyValue": "player.discoverTracks",
+                "propertyValue": "player.searchMusic",
                 "propertySubPhrases": [
-                  "Discover"
+                  "Find"
                 ]
               }
             ]
@@ -987,21 +875,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "chill music for focus",
+                "propertyValue": "chill study music",
                 "propertySubPhrases": [
-                  "chill music for focus"
+                  "chill study music"
                 ]
               },
               {
-                "propertyValue": "ambient sounds for concentration",
+                "propertyValue": "relaxing study tunes",
                 "propertySubPhrases": [
-                  "ambient sounds for concentration"
+                  "relaxing study tunes"
                 ]
               },
               {
-                "propertyValue": "study music playlist",
+                "propertyValue": "ambient study sounds",
                 "propertySubPhrases": [
-                  "study music playlist"
+                  "ambient study sounds"
                 ]
               }
             ]
@@ -1009,142 +897,120 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "Can you kindly",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it."
+          "for me?",
+          "if you don't mind.",
+          "when you get a chance.",
+          "thank you."
         ]
       }
     },
     {
       "request": "Find me some jazz tunes from the 60s",
       "action": {
-        "fullActionName": "player.playGenre",
+        "fullActionName": "player.searchTracks",
         "parameters": {
-          "genre": "jazz",
-          "quantity": 60
+          "query": "jazz tunes from the 60s"
         }
       },
       "explanation": {
         "properties": [
           {
             "name": "fullActionName",
-            "value": "player.playGenre",
-            "substrings": []
-          },
-          {
-            "name": "parameters.genre",
-            "value": "jazz",
+            "value": "player.searchTracks",
             "substrings": [
-              "jazz"
+              "Find me some jazz tunes from the 60s"
             ]
           },
           {
-            "name": "parameters.quantity",
-            "value": 60,
+            "name": "parameters.query",
+            "value": "jazz tunes from the 60s",
             "substrings": [
-              "60s"
+              "jazz tunes from the 60s"
             ]
           }
         ],
         "subPhrases": [
           {
             "text": "Find me",
-            "category": "politeness",
-            "synonyms": [
-              "Get me",
-              "Fetch me",
-              "Bring me"
-            ],
-            "isOptional": true
+            "category": "command",
+            "propertyNames": [
+              "fullActionName"
+            ]
           },
           {
             "text": "some",
             "category": "filler",
             "synonyms": [
               "a few",
-              "a couple of",
-              "several"
+              "several",
+              "a number of"
             ],
             "isOptional": true
           },
           {
-            "text": "jazz",
-            "category": "genre",
+            "text": "jazz tunes from the 60s",
+            "category": "query",
             "propertyNames": [
-              "parameters.genre"
-            ]
-          },
-          {
-            "text": "tunes",
-            "category": "filler",
-            "synonyms": [
-              "songs",
-              "tracks",
-              "melodies"
-            ],
-            "isOptional": true
-          },
-          {
-            "text": "from the 60s",
-            "category": "quantity",
-            "propertyNames": [
-              "parameters.quantity"
+              "parameters.query"
             ]
           }
         ],
         "propertyAlternatives": [
           {
-            "propertyName": "parameters.genre",
-            "propertyValue": "jazz",
+            "propertyName": "fullActionName",
+            "propertyValue": "player.searchTracks",
             "propertySubPhrases": [
-              "jazz"
+              "Find me"
             ],
             "alternatives": [
               {
-                "propertyValue": "blues",
+                "propertyValue": "player.findSongs",
                 "propertySubPhrases": [
-                  "blues"
+                  "Find me"
                 ]
               },
               {
-                "propertyValue": "rock",
+                "propertyValue": "player.lookupMusic",
                 "propertySubPhrases": [
-                  "rock"
+                  "Find me"
                 ]
               },
               {
-                "propertyValue": "classical",
+                "propertyValue": "player.searchMusic",
                 "propertySubPhrases": [
-                  "classical"
+                  "Find me"
                 ]
               }
             ]
           },
           {
-            "propertyName": "parameters.quantity",
-            "propertyValue": 60,
+            "propertyName": "parameters.query",
+            "propertyValue": "jazz tunes from the 60s",
             "propertySubPhrases": [
-              "from the 60s"
+              "jazz tunes from the 60s"
             ],
             "alternatives": [
               {
-                "propertyValue": 70,
+                "propertyValue": "jazz music from the 60s",
                 "propertySubPhrases": [
-                  "from the 70s"
+                  "jazz tunes from the 60s"
                 ]
               },
               {
-                "propertyValue": 80,
+                "propertyValue": "60s jazz songs",
                 "propertySubPhrases": [
-                  "from the 80s"
+                  "jazz tunes from the 60s"
                 ]
               },
               {
-                "propertyValue": 90,
+                "propertyValue": "jazz tracks from the 1960s",
                 "propertySubPhrases": [
-                  "from the 90s"
+                  "jazz tunes from the 60s"
                 ]
               }
             ]
@@ -1152,11 +1018,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "I would appreciate it if you could",
+          "Please"
         ],
         "politeSuffixes": [
           "Thank you!",
-          "I would appreciate it."
+          "if that's okay.",
+          "Thanks!",
+          "if you don't mind."
         ]
       }
     },
@@ -1188,28 +1058,18 @@
         "subPhrases": [
           {
             "text": "Find music",
-            "category": "action",
+            "category": "command",
             "propertyNames": [
               "fullActionName"
             ]
           },
           {
-            "text": "by",
-            "category": "preposition",
-            "synonyms": [
-              "from",
-              "of",
-              "featuring"
-            ],
-            "isOptional": true
-          },
-          {
-            "text": "legendary guitarist",
+            "text": "by legendary guitarist",
             "category": "description",
             "synonyms": [
-              "famous guitarist",
-              "renowned guitarist",
-              "iconic guitarist"
+              "by famous guitarist",
+              "by renowned guitarist",
+              "by iconic guitarist"
             ],
             "isOptional": true
           },
@@ -1230,21 +1090,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.playSong",
+                "propertyValue": "player.searchArtist",
                 "propertySubPhrases": [
-                  "Play song"
+                  "Search for music"
                 ]
               },
               {
-                "propertyValue": "player.playAlbum",
+                "propertyValue": "player.browseArtist",
                 "propertySubPhrases": [
-                  "Play album"
+                  "Browse music"
                 ]
               },
               {
-                "propertyValue": "player.playPlaylist",
+                "propertyValue": "player.discoverArtist",
                 "propertySubPhrases": [
-                  "Play playlist"
+                  "Discover music"
                 ]
               }
             ]
@@ -1280,12 +1140,14 @@
         "politePrefixes": [
           "Could you please",
           "Would you mind",
-          "If it's not too much trouble, could you"
+          "Please",
+          "I would appreciate it if you could"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it.",
-          "Thanks a lot!"
+          "for me?",
+          "thank you.",
+          "if that's okay.",
+          "please."
         ]
       }
     },
@@ -1328,7 +1190,7 @@
             "synonyms": [
               "from",
               "with",
-              "featuring"
+              "via"
             ],
             "isOptional": true
           },
@@ -1382,15 +1244,15 @@
                 ]
               },
               {
-                "propertyValue": "classic artists",
-                "propertySubPhrases": [
-                  "classic artists"
-                ]
-              },
-              {
                 "propertyValue": "new releases",
                 "propertySubPhrases": [
                   "new releases"
+                ]
+              },
+              {
+                "propertyValue": "top charts",
+                "propertySubPhrases": [
+                  "top charts"
                 ]
               }
             ]
@@ -1399,36 +1261,36 @@
         "politePrefixes": [
           "Could you please",
           "Would you mind",
-          "If it's not too much trouble, could you",
-          "May I kindly ask you to"
+          "I would appreciate it if you could",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it!",
-          "Thanks a lot!",
-          "Much appreciated!"
+          "Thank you",
+          "Thanks",
+          "If you don't mind",
+          "I appreciate it"
         ]
       }
     },
     {
       "request": "Find music for a beach party",
       "action": {
-        "fullActionName": "player.playGenre",
+        "fullActionName": "player.searchTracks",
         "parameters": {
-          "genre": "beach party"
+          "query": "beach party"
         }
       },
       "explanation": {
         "properties": [
           {
             "name": "fullActionName",
-            "value": "player.playGenre",
+            "value": "player.searchTracks",
             "substrings": [
               "Find music"
             ]
           },
           {
-            "name": "parameters.genre",
+            "name": "parameters.query",
             "value": "beach party",
             "substrings": [
               "beach party"
@@ -1449,69 +1311,69 @@
             "synonyms": [
               "for the",
               "for an",
-              "for"
+              "for some"
             ],
             "isOptional": true
           },
           {
             "text": "beach party",
-            "category": "genre",
+            "category": "query",
             "propertyNames": [
-              "parameters.genre"
+              "parameters.query"
             ]
           }
         ],
         "propertyAlternatives": [
           {
             "propertyName": "fullActionName",
-            "propertyValue": "player.playGenre",
+            "propertyValue": "player.searchTracks",
             "propertySubPhrases": [
               "Find music"
             ],
             "alternatives": [
               {
-                "propertyValue": "player.playSong",
+                "propertyValue": "player.playTracks",
                 "propertySubPhrases": [
-                  "Play a song"
+                  "Play music"
                 ]
               },
               {
-                "propertyValue": "player.playAlbum",
+                "propertyValue": "player.recommendTracks",
                 "propertySubPhrases": [
-                  "Play an album"
+                  "Recommend music"
                 ]
               },
               {
-                "propertyValue": "player.playPlaylist",
+                "propertyValue": "player.shuffleTracks",
                 "propertySubPhrases": [
-                  "Play a playlist"
+                  "Shuffle music"
                 ]
               }
             ]
           },
           {
-            "propertyName": "parameters.genre",
+            "propertyName": "parameters.query",
             "propertyValue": "beach party",
             "propertySubPhrases": [
               "beach party"
             ],
             "alternatives": [
               {
-                "propertyValue": "rock",
+                "propertyValue": "pool party",
                 "propertySubPhrases": [
-                  "rock"
+                  "pool party"
                 ]
               },
               {
-                "propertyValue": "jazz",
+                "propertyValue": "house party",
                 "propertySubPhrases": [
-                  "jazz"
+                  "house party"
                 ]
               },
               {
-                "propertyValue": "classical",
+                "propertyValue": "birthday party",
                 "propertySubPhrases": [
-                  "classical"
+                  "birthday party"
                 ]
               }
             ]
@@ -1519,43 +1381,47 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "I would appreciate it if you could",
+          "Please"
         ],
         "politeSuffixes": [
           "Thank you!",
-          "I would appreciate it."
+          "Thanks!",
+          "If you don't mind.",
+          "I appreciate it."
         ]
       }
     },
     {
       "request": "Find music from the Baroque period",
       "action": {
-        "fullActionName": "player.playGenre",
+        "fullActionName": "player.searchTracks",
         "parameters": {
-          "genre": "Baroque"
+          "query": "Baroque period"
         }
       },
       "explanation": {
         "properties": [
           {
             "name": "fullActionName",
-            "value": "player.playGenre",
+            "value": "player.searchTracks",
             "substrings": [
               "Find music"
             ]
           },
           {
-            "name": "parameters.genre",
-            "value": "Baroque",
+            "name": "parameters.query",
+            "value": "Baroque period",
             "substrings": [
-              "Baroque"
+              "Baroque period"
             ]
           }
         ],
         "subPhrases": [
           {
             "text": "Find music",
-            "category": "command",
+            "category": "action",
             "propertyNames": [
               "fullActionName"
             ]
@@ -1572,63 +1438,63 @@
           },
           {
             "text": "Baroque period",
-            "category": "genre",
+            "category": "query",
             "propertyNames": [
-              "parameters.genre"
+              "parameters.query"
             ]
           }
         ],
         "propertyAlternatives": [
           {
             "propertyName": "fullActionName",
-            "propertyValue": "player.playGenre",
+            "propertyValue": "player.searchTracks",
             "propertySubPhrases": [
               "Find music"
             ],
             "alternatives": [
               {
-                "propertyValue": "player.playSong",
+                "propertyValue": "player.playTracks",
                 "propertySubPhrases": [
-                  "Play a song"
+                  "Play music"
                 ]
               },
               {
-                "propertyValue": "player.playAlbum",
+                "propertyValue": "player.pauseTracks",
                 "propertySubPhrases": [
-                  "Play an album"
+                  "Pause music"
                 ]
               },
               {
-                "propertyValue": "player.playPlaylist",
+                "propertyValue": "player.stopTracks",
                 "propertySubPhrases": [
-                  "Play a playlist"
+                  "Stop music"
                 ]
               }
             ]
           },
           {
-            "propertyName": "parameters.genre",
-            "propertyValue": "Baroque",
+            "propertyName": "parameters.query",
+            "propertyValue": "Baroque period",
             "propertySubPhrases": [
               "Baroque period"
             ],
             "alternatives": [
               {
-                "propertyValue": "Classical",
+                "propertyValue": "Classical period",
                 "propertySubPhrases": [
                   "Classical period"
                 ]
               },
               {
-                "propertyValue": "Romantic",
+                "propertyValue": "Romantic period",
                 "propertySubPhrases": [
                   "Romantic period"
                 ]
               },
               {
-                "propertyValue": "Jazz",
+                "propertyValue": "Modern period",
                 "propertySubPhrases": [
-                  "Jazz era"
+                  "Modern period"
                 ]
               }
             ]
@@ -1636,10 +1502,14 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "I would appreciate it if you could",
+          "Please"
         ],
         "politeSuffixes": [
           "Thank you",
+          "Thanks in advance",
+          "If you don't mind",
           "I appreciate it"
         ]
       }
@@ -1649,7 +1519,7 @@
       "action": {
         "fullActionName": "player.playGenre",
         "parameters": {
-          "genre": "wedding"
+          "genre": "wedding reception"
         }
       },
       "explanation": {
@@ -1663,23 +1533,33 @@
           },
           {
             "name": "parameters.genre",
-            "value": "wedding",
+            "value": "wedding reception",
             "substrings": [
-              "wedding"
+              "wedding reception"
             ]
           }
         ],
         "subPhrases": [
           {
             "text": "Find music to play",
-            "category": "action",
+            "category": "command",
             "propertyNames": [
               "fullActionName"
             ]
           },
           {
-            "text": "at a wedding reception",
-            "category": "genre",
+            "text": "at a",
+            "category": "preposition",
+            "synonyms": [
+              "for a",
+              "during a",
+              "in a"
+            ],
+            "isOptional": true
+          },
+          {
+            "text": "wedding reception",
+            "category": "event",
             "propertyNames": [
               "parameters.genre"
             ]
@@ -1700,42 +1580,42 @@
                 ]
               },
               {
-                "propertyValue": "player.playPlaylist",
-                "propertySubPhrases": [
-                  "Play a playlist"
-                ]
-              },
-              {
                 "propertyValue": "player.playAlbum",
                 "propertySubPhrases": [
                   "Play an album"
+                ]
+              },
+              {
+                "propertyValue": "player.playPlaylist",
+                "propertySubPhrases": [
+                  "Play a playlist"
                 ]
               }
             ]
           },
           {
             "propertyName": "parameters.genre",
-            "propertyValue": "wedding",
+            "propertyValue": "wedding reception",
             "propertySubPhrases": [
-              "at a wedding reception"
+              "wedding reception"
             ],
             "alternatives": [
               {
                 "propertyValue": "party",
                 "propertySubPhrases": [
-                  "at a party"
+                  "party"
                 ]
               },
               {
                 "propertyValue": "birthday",
                 "propertySubPhrases": [
-                  "at a birthday party"
+                  "birthday"
                 ]
               },
               {
-                "propertyValue": "corporate",
+                "propertyValue": "anniversary",
                 "propertySubPhrases": [
-                  "at a corporate event"
+                  "anniversary"
                 ]
               }
             ]
@@ -1744,12 +1624,14 @@
         "politePrefixes": [
           "Could you please",
           "Would you mind",
-          "If it's not too much trouble, could you"
+          "I would appreciate it if you could",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it.",
-          "Thanks in advance!"
+          "Thank you",
+          "Thanks in advance",
+          "I appreciate your help",
+          "If you don't mind"
         ]
       }
     },
@@ -1789,17 +1671,27 @@
           },
           {
             "text": "punk rock",
-            "category": "music genre",
+            "category": "genre",
             "propertyNames": [
               "parameters.query"
             ]
           },
           {
-            "text": "songs by",
-            "category": "music search",
+            "text": "songs",
+            "category": "object",
             "propertyNames": [
               "fullActionName"
             ]
+          },
+          {
+            "text": "by",
+            "category": "preposition",
+            "synonyms": [
+              "from",
+              "of",
+              "with"
+            ],
+            "isOptional": true
           },
           {
             "text": "The Ramones",
@@ -1815,28 +1707,28 @@
             "propertyValue": "player.searchTracks",
             "propertySubPhrases": [
               "Find",
-              "songs by"
+              "songs"
             ],
             "alternatives": [
               {
-                "propertyValue": "player.findSongs",
+                "propertyValue": "player.searchAlbums",
                 "propertySubPhrases": [
                   "Find",
-                  "songs by"
+                  "albums"
                 ]
               },
               {
-                "propertyValue": "music.searchTracks",
+                "propertyValue": "player.searchArtists",
                 "propertySubPhrases": [
                   "Find",
-                  "songs by"
+                  "artists"
                 ]
               },
               {
-                "propertyValue": "audio.searchTracks",
+                "propertyValue": "player.searchPlaylists",
                 "propertySubPhrases": [
                   "Find",
-                  "songs by"
+                  "playlists"
                 ]
               }
             ]
@@ -1850,23 +1742,23 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "rock The Ramones",
+                "propertyValue": "classic rock The Ramones",
                 "propertySubPhrases": [
-                  "rock",
+                  "classic rock",
                   "The Ramones"
                 ]
               },
               {
-                "propertyValue": "punk rock The Clash",
+                "propertyValue": "punk rock Green Day",
                 "propertySubPhrases": [
                   "punk rock",
-                  "The Clash"
+                  "Green Day"
                 ]
               },
               {
-                "propertyValue": "punk The Ramones",
+                "propertyValue": "alternative rock The Ramones",
                 "propertySubPhrases": [
-                  "punk",
+                  "alternative rock",
                   "The Ramones"
                 ]
               }
@@ -1875,11 +1767,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "I would appreciate it if you could",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it."
+          "for me?",
+          "if possible.",
+          "thank you.",
+          "when you have a moment."
         ]
       }
     },
@@ -1888,7 +1784,7 @@
       "action": {
         "fullActionName": "player.searchTracks",
         "parameters": {
-          "query": "road trip"
+          "query": "road trip playlist"
         }
       },
       "explanation": {
@@ -1902,9 +1798,9 @@
           },
           {
             "name": "parameters.query",
-            "value": "road trip",
+            "value": "road trip playlist",
             "substrings": [
-              "road trip"
+              "road trip playlist"
             ]
           }
         ],
@@ -1922,26 +1818,16 @@
             "synonyms": [
               "for the",
               "for an",
-              "for any"
+              "for my"
             ],
             "isOptional": true
           },
           {
-            "text": "road trip",
+            "text": "road trip playlist",
             "category": "query",
             "propertyNames": [
               "parameters.query"
             ]
-          },
-          {
-            "text": "playlist",
-            "category": "filler",
-            "synonyms": [
-              "list",
-              "collection",
-              "set"
-            ],
-            "isOptional": true
           }
         ],
         "propertyAlternatives": [
@@ -1953,48 +1839,48 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.searchAlbums",
+                "propertyValue": "player.findSongs",
                 "propertySubPhrases": [
-                  "Find albums"
+                  "Find songs"
                 ]
               },
               {
-                "propertyValue": "player.searchArtists",
+                "propertyValue": "player.lookupTracks",
                 "propertySubPhrases": [
-                  "Find artists"
+                  "Find songs"
                 ]
               },
               {
-                "propertyValue": "player.searchPlaylists",
+                "propertyValue": "player.searchMusic",
                 "propertySubPhrases": [
-                  "Find playlists"
+                  "Find songs"
                 ]
               }
             ]
           },
           {
             "propertyName": "parameters.query",
-            "propertyValue": "road trip",
+            "propertyValue": "road trip playlist",
             "propertySubPhrases": [
-              "road trip"
+              "road trip playlist"
             ],
             "alternatives": [
               {
-                "propertyValue": "workout",
+                "propertyValue": "driving songs",
                 "propertySubPhrases": [
-                  "workout"
+                  "driving songs"
                 ]
               },
               {
-                "propertyValue": "relaxation",
+                "propertyValue": "travel tunes",
                 "propertySubPhrases": [
-                  "relaxation"
+                  "travel tunes"
                 ]
               },
               {
-                "propertyValue": "party",
+                "propertyValue": "journey playlist",
                 "propertySubPhrases": [
-                  "party"
+                  "journey playlist"
                 ]
               }
             ]
@@ -2003,14 +1889,14 @@
         "politePrefixes": [
           "Could you please",
           "Would you mind",
-          "If it's not too much trouble,",
-          "I would appreciate it if you could"
+          "I would appreciate it if you could",
+          "Please"
         ],
         "politeSuffixes": [
           "Thank you!",
-          "Thanks a lot!",
-          "I appreciate it!",
-          "Much appreciated!"
+          "Thanks!",
+          "If you could, that would be great.",
+          "I appreciate it!"
         ]
       }
     },
@@ -2074,21 +1960,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.playTracks",
+                "propertyValue": "player.findMusic",
                 "propertySubPhrases": [
-                  "Play songs"
+                  "Find music"
                 ]
               },
               {
-                "propertyValue": "player.queueTracks",
+                "propertyValue": "player.lookupSongs",
                 "propertySubPhrases": [
-                  "Queue songs"
+                  "Look up songs"
                 ]
               },
               {
-                "propertyValue": "player.recommendTracks",
+                "propertyValue": "player.searchTunes",
                 "propertySubPhrases": [
-                  "Recommend songs"
+                  "Search tunes"
                 ]
               }
             ]
@@ -2101,21 +1987,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "party",
+                "propertyValue": "candlelight dinner",
                 "propertySubPhrases": [
-                  "party"
+                  "candlelight dinner"
                 ]
               },
               {
-                "propertyValue": "workout",
+                "propertyValue": "date night",
                 "propertySubPhrases": [
-                  "workout"
+                  "date night"
                 ]
               },
               {
-                "propertyValue": "study session",
+                "propertyValue": "intimate evening",
                 "propertySubPhrases": [
-                  "study session"
+                  "intimate evening"
                 ]
               }
             ]
@@ -2123,11 +2009,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "I would appreciate it if you could",
+          "Please"
         ],
         "politeSuffixes": [
           "Thank you",
-          "I would appreciate it"
+          "if possible",
+          "please",
+          "when you have a moment"
         ]
       }
     },
@@ -2145,7 +2035,7 @@
             "name": "fullActionName",
             "value": "player.searchTracks",
             "substrings": [
-              "Find songs from the soundtrack of The Greatest Showman"
+              "Find songs"
             ]
           },
           {
@@ -2165,128 +2055,17 @@
             ]
           },
           {
-            "text": "from the soundtrack of The Greatest Showman",
-            "category": "query",
-            "propertyNames": [
-              "parameters.query"
-            ]
-          }
-        ],
-        "propertyAlternatives": [
-          {
-            "propertyName": "fullActionName",
-            "propertyValue": "player.searchTracks",
-            "propertySubPhrases": [
-              "Find songs"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "player.playTracks",
-                "propertySubPhrases": [
-                  "Play songs"
-                ]
-              },
-              {
-                "propertyValue": "player.addTracksToQueue",
-                "propertySubPhrases": [
-                  "Add songs to queue"
-                ]
-              },
-              {
-                "propertyValue": "player.downloadTracks",
-                "propertySubPhrases": [
-                  "Download songs"
-                ]
-              }
-            ]
-          },
-          {
-            "propertyName": "parameters.query",
-            "propertyValue": "soundtrack of The Greatest Showman",
-            "propertySubPhrases": [
-              "from the soundtrack of The Greatest Showman"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "soundtrack of La La Land",
-                "propertySubPhrases": [
-                  "from the soundtrack of La La Land"
-                ]
-              },
-              {
-                "propertyValue": "soundtrack of Hamilton",
-                "propertySubPhrases": [
-                  "from the soundtrack of Hamilton"
-                ]
-              },
-              {
-                "propertyValue": "soundtrack of Moana",
-                "propertySubPhrases": [
-                  "from the soundtrack of Moana"
-                ]
-              }
-            ]
-          }
-        ],
-        "politePrefixes": [
-          "Could you please",
-          "Would you mind",
-          "If it's not too much trouble, could you",
-          "May I kindly ask you to"
-        ],
-        "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it!",
-          "Thanks a lot!",
-          "Much appreciated!"
-        ]
-      }
-    },
-    {
-      "request": "Find songs that feature a saxophone",
-      "action": {
-        "fullActionName": "player.searchTracks",
-        "parameters": {
-          "query": "saxophone"
-        }
-      },
-      "explanation": {
-        "properties": [
-          {
-            "name": "fullActionName",
-            "value": "player.searchTracks",
-            "substrings": [
-              "Find songs"
-            ]
-          },
-          {
-            "name": "parameters.query",
-            "value": "saxophone",
-            "substrings": [
-              "saxophone"
-            ]
-          }
-        ],
-        "subPhrases": [
-          {
-            "text": "Find songs",
-            "category": "action",
-            "propertyNames": [
-              "fullActionName"
-            ]
-          },
-          {
-            "text": "that feature a",
-            "category": "filler",
+            "text": "from the",
+            "category": "preposition",
             "synonyms": [
-              "including",
-              "with",
-              "featuring"
+              "of the",
+              "in the",
+              "by the"
             ],
             "isOptional": true
           },
           {
-            "text": "saxophone",
+            "text": "soundtrack of The Greatest Showman",
             "category": "query",
             "propertyNames": [
               "parameters.query"
@@ -2323,27 +2102,27 @@
           },
           {
             "propertyName": "parameters.query",
-            "propertyValue": "saxophone",
+            "propertyValue": "soundtrack of The Greatest Showman",
             "propertySubPhrases": [
-              "saxophone"
+              "soundtrack of The Greatest Showman"
             ],
             "alternatives": [
               {
-                "propertyValue": "guitar",
+                "propertyValue": "soundtrack of La La Land",
                 "propertySubPhrases": [
-                  "guitar"
+                  "soundtrack of La La Land"
                 ]
               },
               {
-                "propertyValue": "piano",
+                "propertyValue": "soundtrack of Hamilton",
                 "propertySubPhrases": [
-                  "piano"
+                  "soundtrack of Hamilton"
                 ]
               },
               {
-                "propertyValue": "drums",
+                "propertyValue": "soundtrack of Moana",
                 "propertySubPhrases": [
-                  "drums"
+                  "soundtrack of Moana"
                 ]
               }
             ]
@@ -2352,12 +2131,125 @@
         "politePrefixes": [
           "Could you please",
           "Would you mind",
-          "If it's not too much trouble, could you"
+          "I would appreciate it if you could",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it.",
-          "Thanks a lot!"
+          "Thank you",
+          "Thanks in advance",
+          "If you don't mind",
+          "I appreciate it"
+        ]
+      }
+    },
+    {
+      "request": "Find songs that feature a saxophone",
+      "action": {
+        "fullActionName": "player.searchTracks",
+        "parameters": {
+          "query": "songs that feature a saxophone"
+        }
+      },
+      "explanation": {
+        "properties": [
+          {
+            "name": "fullActionName",
+            "value": "player.searchTracks",
+            "substrings": [
+              "Find songs that feature a saxophone"
+            ]
+          },
+          {
+            "name": "parameters.query",
+            "value": "songs that feature a saxophone",
+            "substrings": [
+              "songs that feature a saxophone"
+            ]
+          }
+        ],
+        "subPhrases": [
+          {
+            "text": "Find",
+            "category": "command",
+            "propertyNames": [
+              "fullActionName"
+            ]
+          },
+          {
+            "text": "songs that feature a saxophone",
+            "category": "query",
+            "propertyNames": [
+              "parameters.query"
+            ]
+          }
+        ],
+        "propertyAlternatives": [
+          {
+            "propertyName": "fullActionName",
+            "propertyValue": "player.searchTracks",
+            "propertySubPhrases": [
+              "Find"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "player.findSongs",
+                "propertySubPhrases": [
+                  "Find"
+                ]
+              },
+              {
+                "propertyValue": "player.lookupTracks",
+                "propertySubPhrases": [
+                  "Find"
+                ]
+              },
+              {
+                "propertyValue": "player.searchMusic",
+                "propertySubPhrases": [
+                  "Find"
+                ]
+              }
+            ]
+          },
+          {
+            "propertyName": "parameters.query",
+            "propertyValue": "songs that feature a saxophone",
+            "propertySubPhrases": [
+              "songs that feature a saxophone"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "tracks with saxophone",
+                "propertySubPhrases": [
+                  "songs that feature a saxophone"
+                ]
+              },
+              {
+                "propertyValue": "music featuring saxophone",
+                "propertySubPhrases": [
+                  "songs that feature a saxophone"
+                ]
+              },
+              {
+                "propertyValue": "saxophone songs",
+                "propertySubPhrases": [
+                  "songs that feature a saxophone"
+                ]
+              }
+            ]
+          }
+        ],
+        "politePrefixes": [
+          "Could you please",
+          "Would you mind",
+          "Please",
+          "I would appreciate it if you could"
+        ],
+        "politeSuffixes": [
+          "for me?",
+          "when you have a moment.",
+          "if that's okay.",
+          "thank you."
         ]
       }
     },
@@ -2389,7 +2281,7 @@
         "subPhrases": [
           {
             "text": "Find",
-            "category": "action",
+            "category": "command",
             "propertyNames": [
               "fullActionName"
             ]
@@ -2438,21 +2330,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "songs to sing along to in the car",
+                "propertyValue": "songs to sing along in the car",
                 "propertySubPhrases": [
-                  "songs to sing along to in the car"
+                  "songs to belt out in the car"
                 ]
               },
               {
                 "propertyValue": "car karaoke songs",
                 "propertySubPhrases": [
-                  "car karaoke songs"
+                  "songs to belt out in the car"
                 ]
               },
               {
-                "propertyValue": "road trip anthems",
+                "propertyValue": "road trip sing-along songs",
                 "propertySubPhrases": [
-                  "road trip anthems"
+                  "songs to belt out in the car"
                 ]
               }
             ]
@@ -2460,11 +2352,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "I would appreciate it if you could",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it!"
+          "for me?",
+          "if possible.",
+          "thank you.",
+          "when you have a moment."
         ]
       }
     },
@@ -2481,7 +2377,9 @@
           {
             "name": "fullActionName",
             "value": "player.searchTracks",
-            "substrings": []
+            "substrings": [
+              "Find"
+            ]
           },
           {
             "name": "parameters.query",
@@ -2494,8 +2392,10 @@
         "subPhrases": [
           {
             "text": "Find",
-            "category": "command",
-            "propertyNames": []
+            "category": "action",
+            "propertyNames": [
+              "fullActionName"
+            ]
           },
           {
             "text": "songs to boost your mood",
@@ -2507,6 +2407,33 @@
         ],
         "propertyAlternatives": [
           {
+            "propertyName": "fullActionName",
+            "propertyValue": "player.searchTracks",
+            "propertySubPhrases": [
+              "Find"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "player.playTracks",
+                "propertySubPhrases": [
+                  "Play"
+                ]
+              },
+              {
+                "propertyValue": "player.queueTracks",
+                "propertySubPhrases": [
+                  "Queue"
+                ]
+              },
+              {
+                "propertyValue": "player.shuffleTracks",
+                "propertySubPhrases": [
+                  "Shuffle"
+                ]
+              }
+            ]
+          },
+          {
             "propertyName": "parameters.query",
             "propertyValue": "songs to boost your mood",
             "propertySubPhrases": [
@@ -2514,27 +2441,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "songs to relax",
+                "propertyValue": "happy songs",
                 "propertySubPhrases": [
-                  "songs to relax"
+                  "happy songs"
                 ]
               },
               {
-                "propertyValue": "songs to energize",
+                "propertyValue": "upbeat tracks",
                 "propertySubPhrases": [
-                  "songs to energize"
+                  "upbeat tracks"
                 ]
               },
               {
-                "propertyValue": "songs to focus",
+                "propertyValue": "feel-good music",
                 "propertySubPhrases": [
-                  "songs to focus"
-                ]
-              },
-              {
-                "propertyValue": "songs to sleep",
-                "propertySubPhrases": [
-                  "songs to sleep"
+                  "feel-good music"
                 ]
               }
             ]
@@ -2543,14 +2464,14 @@
         "politePrefixes": [
           "Could you please",
           "Would you mind",
-          "Kindly",
+          "I would appreciate it if you could",
           "Please"
         ],
         "politeSuffixes": [
-          "Thank you",
-          "Thanks",
-          "I appreciate it",
-          "If you don't mind"
+          "for me",
+          "if possible",
+          "thank you",
+          "when you have a moment"
         ]
       }
     },
@@ -2582,7 +2503,7 @@
         "subPhrases": [
           {
             "text": "Find",
-            "category": "command",
+            "category": "action",
             "propertyNames": [
               "fullActionName"
             ]
@@ -2631,21 +2552,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "shower songs",
-                "propertySubPhrases": [
-                  "shower songs"
-                ]
-              },
-              {
-                "propertyValue": "singing in the shower",
-                "propertySubPhrases": [
-                  "singing in the shower"
-                ]
-              },
-              {
                 "propertyValue": "songs for shower time",
                 "propertySubPhrases": [
-                  "songs for shower time"
+                  "songs to sing in the shower"
+                ]
+              },
+              {
+                "propertyValue": "shower singing playlist",
+                "propertySubPhrases": [
+                  "songs to sing in the shower"
+                ]
+              },
+              {
+                "propertyValue": "music for shower",
+                "propertySubPhrases": [
+                  "songs to sing in the shower"
                 ]
               }
             ]
@@ -2654,12 +2575,14 @@
         "politePrefixes": [
           "Could you please",
           "Would you mind",
-          "If it's not too much trouble, could you"
+          "I would appreciate it if you could",
+          "Please"
         ],
         "politeSuffixes": [
           "Thank you!",
-          "I would appreciate it.",
-          "Thanks a lot!"
+          "if that's okay.",
+          "Thanks!",
+          "if you don't mind."
         ]
       }
     },
@@ -2698,11 +2621,11 @@
           },
           {
             "text": "with the word",
-            "category": "filler",
+            "category": "preposition",
             "synonyms": [
-              "containing the word",
-              "that includes the word",
-              "featuring the word"
+              "containing",
+              "including",
+              "featuring"
             ],
             "isOptional": true
           },
@@ -2715,11 +2638,11 @@
           },
           {
             "text": "in the title",
-            "category": "filler",
+            "category": "preposition",
             "synonyms": [
               "in the name",
-              "in the song title",
-              "in the track title"
+              "in the heading",
+              "in the caption"
             ],
             "isOptional": true
           }
@@ -2760,21 +2683,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "happy",
+                "propertyValue": "heart",
                 "propertySubPhrases": [
-                  "happy"
+                  "heart"
                 ]
               },
               {
-                "propertyValue": "sad",
+                "propertyValue": "romance",
                 "propertySubPhrases": [
-                  "sad"
+                  "romance"
                 ]
               },
               {
-                "propertyValue": "dance",
+                "propertyValue": "affection",
                 "propertySubPhrases": [
-                  "dance"
+                  "affection"
                 ]
               }
             ]
@@ -2783,14 +2706,14 @@
         "politePrefixes": [
           "Could you please",
           "Would you mind",
-          "If it's not too much trouble, could you",
-          "May I kindly ask you to"
+          "I would appreciate it if you could",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it!",
-          "Thanks a lot!",
-          "Much appreciated!"
+          "Thank you",
+          "Thanks",
+          "If you don't mind",
+          "I appreciate it"
         ]
       }
     },
@@ -2822,23 +2745,13 @@
         "subPhrases": [
           {
             "text": "Find",
-            "category": "action",
+            "category": "command",
             "propertyNames": [
               "fullActionName"
             ]
           },
           {
-            "text": "the",
-            "category": "filler",
-            "synonyms": [
-              "a",
-              "an",
-              "that"
-            ],
-            "isOptional": true
-          },
-          {
-            "text": "best of 90s R&B",
+            "text": "the best of 90s R&B",
             "category": "query",
             "propertyNames": [
               "parameters.query"
@@ -2854,7 +2767,7 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.findTracks",
+                "propertyValue": "player.findSongs",
                 "propertySubPhrases": [
                   "Search"
                 ]
@@ -2866,9 +2779,9 @@
                 ]
               },
               {
-                "propertyValue": "player.discoverTracks",
+                "propertyValue": "player.browseMusic",
                 "propertySubPhrases": [
-                  "Discover"
+                  "Browse"
                 ]
               }
             ]
@@ -2877,25 +2790,25 @@
             "propertyName": "parameters.query",
             "propertyValue": "best of 90s R&B",
             "propertySubPhrases": [
-              "best of 90s R&B"
+              "the best of 90s R&B"
             ],
             "alternatives": [
               {
-                "propertyValue": "top 90s R&B",
+                "propertyValue": "top 90s R&B hits",
                 "propertySubPhrases": [
-                  "top 90s R&B"
+                  "the top 90s R&B hits"
                 ]
               },
               {
-                "propertyValue": "greatest 90s R&B",
+                "propertyValue": "90s R&B classics",
                 "propertySubPhrases": [
-                  "greatest 90s R&B"
+                  "the 90s R&B classics"
                 ]
               },
               {
-                "propertyValue": "90s R&B hits",
+                "propertyValue": "greatest 90s R&B songs",
                 "propertySubPhrases": [
-                  "90s R&B hits"
+                  "the greatest 90s R&B songs"
                 ]
               }
             ]
@@ -2903,11 +2816,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "I would appreciate it if you could",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it."
+          "for me?",
+          "when you have a moment.",
+          "if that's okay.",
+          "thank you."
         ]
       }
     },
@@ -2971,21 +2888,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.playTracks",
+                "propertyValue": "player.findSongs",
                 "propertySubPhrases": [
-                  "Play"
+                  "Find"
                 ]
               },
               {
-                "propertyValue": "player.addTracksToQueue",
+                "propertyValue": "player.lookupTracks",
                 "propertySubPhrases": [
-                  "Queue"
+                  "Find"
                 ]
               },
               {
-                "propertyValue": "player.shuffleTracks",
+                "propertyValue": "player.searchMusic",
                 "propertySubPhrases": [
-                  "Shuffle"
+                  "Find"
                 ]
               }
             ]
@@ -2998,21 +2915,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "top country rock",
+                "propertyValue": "top country rock hits",
                 "propertySubPhrases": [
-                  "top country rock"
+                  "top country rock hits"
                 ]
               },
               {
-                "propertyValue": "greatest country rock",
+                "propertyValue": "greatest country rock songs",
                 "propertySubPhrases": [
-                  "greatest country rock"
+                  "greatest country rock songs"
                 ]
               },
               {
-                "propertyValue": "country rock hits",
+                "propertyValue": "country rock classics",
                 "propertySubPhrases": [
-                  "country rock hits"
+                  "country rock classics"
                 ]
               }
             ]
@@ -3020,11 +2937,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "I would appreciate it if you could",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it."
+          "for me",
+          "if possible",
+          "thank you",
+          "when you have a moment"
         ]
       }
     },
@@ -3056,7 +2977,7 @@
         "subPhrases": [
           {
             "text": "Find",
-            "category": "action",
+            "category": "command",
             "propertyNames": [
               "fullActionName"
             ]
@@ -3078,21 +2999,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.findTracks",
+                "propertyValue": "player.playTracks",
                 "propertySubPhrases": [
-                  "Locate"
+                  "Play"
                 ]
               },
               {
-                "propertyValue": "player.lookupTracks",
+                "propertyValue": "player.queueTracks",
                 "propertySubPhrases": [
-                  "Search for"
+                  "Queue"
                 ]
               },
               {
-                "propertyValue": "player.browseTracks",
+                "propertyValue": "player.shuffleTracks",
                 "propertySubPhrases": [
-                  "Browse"
+                  "Shuffle"
                 ]
               }
             ]
@@ -3107,19 +3028,19 @@
               {
                 "propertyValue": "top electronic trance music",
                 "propertySubPhrases": [
-                  "the top electronic trance music"
-                ]
-              },
-              {
-                "propertyValue": "greatest electronic trance music",
-                "propertySubPhrases": [
-                  "the greatest electronic trance music"
+                  "top electronic trance music"
                 ]
               },
               {
                 "propertyValue": "popular electronic trance music",
                 "propertySubPhrases": [
-                  "the popular electronic trance music"
+                  "popular electronic trance music"
+                ]
+              },
+              {
+                "propertyValue": "electronic trance music hits",
+                "propertySubPhrases": [
+                  "electronic trance music hits"
                 ]
               }
             ]
@@ -3127,11 +3048,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "I would appreciate it if you could",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you",
-          "I appreciate it"
+          "for me?",
+          "thanks!",
+          "if possible.",
+          "when you have a moment."
         ]
       }
     },
@@ -3148,7 +3073,9 @@
           {
             "name": "fullActionName",
             "value": "player.searchTracks",
-            "substrings": []
+            "substrings": [
+              "Find"
+            ]
           },
           {
             "name": "parameters.query",
@@ -3162,10 +3089,22 @@
           {
             "text": "Find",
             "category": "command",
-            "propertyNames": []
+            "propertyNames": [
+              "fullActionName"
+            ]
           },
           {
-            "text": "the best of reggaeton",
+            "text": "the",
+            "category": "filler",
+            "synonyms": [
+              "a",
+              "an",
+              "some"
+            ],
+            "isOptional": true
+          },
+          {
+            "text": "best of reggaeton",
             "category": "query",
             "propertyNames": [
               "parameters.query"
@@ -3174,28 +3113,55 @@
         ],
         "propertyAlternatives": [
           {
+            "propertyName": "fullActionName",
+            "propertyValue": "player.searchTracks",
+            "propertySubPhrases": [
+              "Find"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "player.findSongs",
+                "propertySubPhrases": [
+                  "Find"
+                ]
+              },
+              {
+                "propertyValue": "player.lookupMusic",
+                "propertySubPhrases": [
+                  "Find"
+                ]
+              },
+              {
+                "propertyValue": "player.searchMusic",
+                "propertySubPhrases": [
+                  "Find"
+                ]
+              }
+            ]
+          },
+          {
             "propertyName": "parameters.query",
             "propertyValue": "best of reggaeton",
             "propertySubPhrases": [
-              "the best of reggaeton"
+              "best of reggaeton"
             ],
             "alternatives": [
               {
                 "propertyValue": "top reggaeton hits",
                 "propertySubPhrases": [
-                  "the top reggaeton hits"
+                  "top reggaeton hits"
+                ]
+              },
+              {
+                "propertyValue": "reggaeton favorites",
+                "propertySubPhrases": [
+                  "reggaeton favorites"
                 ]
               },
               {
                 "propertyValue": "popular reggaeton songs",
                 "propertySubPhrases": [
-                  "the popular reggaeton songs"
-                ]
-              },
-              {
-                "propertyValue": "greatest reggaeton tracks",
-                "propertySubPhrases": [
-                  "the greatest reggaeton tracks"
+                  "popular reggaeton songs"
                 ]
               }
             ]
@@ -3204,12 +3170,14 @@
         "politePrefixes": [
           "Could you please",
           "Would you mind",
-          "If it's not too much trouble, could you"
+          "Please",
+          "I would appreciate it if you could"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it.",
-          "Thanks in advance!"
+          "thank you",
+          "please",
+          "if you don't mind",
+          "thanks"
         ]
       }
     },
@@ -3234,7 +3202,7 @@
             "name": "parameters.query",
             "value": "best of synth-pop",
             "substrings": [
-              "the best of synth-pop"
+              "best of synth-pop"
             ]
           }
         ],
@@ -3247,7 +3215,17 @@
             ]
           },
           {
-            "text": "the best of synth-pop",
+            "text": "the",
+            "category": "filler",
+            "synonyms": [
+              "a",
+              "an",
+              "some"
+            ],
+            "isOptional": true
+          },
+          {
+            "text": "best of synth-pop",
             "category": "query",
             "propertyNames": [
               "parameters.query"
@@ -3263,19 +3241,19 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.findTracks",
+                "propertyValue": "player.findSongs",
                 "propertySubPhrases": [
                   "Find"
                 ]
               },
               {
-                "propertyValue": "music.searchTracks",
+                "propertyValue": "player.lookupTracks",
                 "propertySubPhrases": [
                   "Find"
                 ]
               },
               {
-                "propertyValue": "audio.searchTracks",
+                "propertyValue": "player.searchMusic",
                 "propertySubPhrases": [
                   "Find"
                 ]
@@ -3286,25 +3264,25 @@
             "propertyName": "parameters.query",
             "propertyValue": "best of synth-pop",
             "propertySubPhrases": [
-              "the best of synth-pop"
+              "best of synth-pop"
             ],
             "alternatives": [
               {
                 "propertyValue": "top synth-pop hits",
                 "propertySubPhrases": [
-                  "the best of synth-pop"
-                ]
-              },
-              {
-                "propertyValue": "synth-pop classics",
-                "propertySubPhrases": [
-                  "the best of synth-pop"
+                  "best of synth-pop"
                 ]
               },
               {
                 "propertyValue": "greatest synth-pop songs",
                 "propertySubPhrases": [
-                  "the best of synth-pop"
+                  "best of synth-pop"
+                ]
+              },
+              {
+                "propertyValue": "synth-pop classics",
+                "propertySubPhrases": [
+                  "best of synth-pop"
                 ]
               }
             ]
@@ -3313,12 +3291,14 @@
         "politePrefixes": [
           "Could you please",
           "Would you mind",
-          "If it's not too much trouble, could you"
+          "Please",
+          "Kindly"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it.",
-          "Thanks in advance!"
+          "for me?",
+          "if you don't mind.",
+          "please.",
+          "thank you."
         ]
       }
     },
@@ -3335,7 +3315,9 @@
           {
             "name": "fullActionName",
             "value": "player.searchTracks",
-            "isImplicit": true
+            "substrings": [
+              "Find"
+            ]
           },
           {
             "name": "parameters.query",
@@ -3348,105 +3330,13 @@
         "subPhrases": [
           {
             "text": "Find",
-            "category": "command",
-            "propertyNames": []
-          },
-          {
-            "text": "the greatest hits of the 80s",
-            "category": "query",
-            "propertyNames": [
-              "parameters.query"
-            ]
-          }
-        ],
-        "propertyAlternatives": [
-          {
-            "propertyName": "parameters.query",
-            "propertyValue": "greatest hits of the 80s",
-            "propertySubPhrases": [
-              "the greatest hits of the 80s"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "greatest hits of the 90s",
-                "propertySubPhrases": [
-                  "the greatest hits of the 90s"
-                ]
-              },
-              {
-                "propertyValue": "top songs of the 80s",
-                "propertySubPhrases": [
-                  "the top songs of the 80s"
-                ]
-              },
-              {
-                "propertyValue": "best of the 80s",
-                "propertySubPhrases": [
-                  "the best of the 80s"
-                ]
-              }
-            ]
-          }
-        ],
-        "politePrefixes": [
-          "Could you please",
-          "Would you mind",
-          "If it's not too much trouble,",
-          "May I kindly ask you to"
-        ],
-        "politeSuffixes": [
-          "Thank you.",
-          "I would appreciate it.",
-          "Thanks a lot.",
-          "Much appreciated."
-        ]
-      }
-    },
-    {
-      "request": "Find the most iconic guitar solos",
-      "action": {
-        "fullActionName": "player.searchTracks",
-        "parameters": {
-          "query": "iconic guitar solos"
-        }
-      },
-      "explanation": {
-        "properties": [
-          {
-            "name": "fullActionName",
-            "value": "player.searchTracks",
-            "substrings": [
-              "Find"
-            ]
-          },
-          {
-            "name": "parameters.query",
-            "value": "iconic guitar solos",
-            "substrings": [
-              "iconic guitar solos"
-            ]
-          }
-        ],
-        "subPhrases": [
-          {
-            "text": "Find",
             "category": "action",
             "propertyNames": [
               "fullActionName"
             ]
           },
           {
-            "text": "the most",
-            "category": "filler",
-            "synonyms": [
-              "the best",
-              "the greatest",
-              "the top"
-            ],
-            "isOptional": true
-          },
-          {
-            "text": "iconic guitar solos",
+            "text": "the greatest hits of the 80s",
             "category": "query",
             "propertyNames": [
               "parameters.query"
@@ -3462,48 +3352,48 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.findTracks",
+                "propertyValue": "player.findSongs",
                 "propertySubPhrases": [
-                  "Find"
+                  "Locate"
                 ]
               },
               {
                 "propertyValue": "player.lookupTracks",
                 "propertySubPhrases": [
-                  "Find"
+                  "Search"
                 ]
               },
               {
-                "propertyValue": "player.searchSongs",
+                "propertyValue": "player.browseMusic",
                 "propertySubPhrases": [
-                  "Find"
+                  "Browse"
                 ]
               }
             ]
           },
           {
             "propertyName": "parameters.query",
-            "propertyValue": "iconic guitar solos",
+            "propertyValue": "greatest hits of the 80s",
             "propertySubPhrases": [
-              "iconic guitar solos"
+              "the greatest hits of the 80s"
             ],
             "alternatives": [
               {
-                "propertyValue": "famous guitar solos",
+                "propertyValue": "top songs of the 80s",
                 "propertySubPhrases": [
-                  "famous guitar solos"
+                  "the top songs of the 80s"
                 ]
               },
               {
-                "propertyValue": "legendary guitar solos",
+                "propertyValue": "best tracks of the 80s",
                 "propertySubPhrases": [
-                  "legendary guitar solos"
+                  "the best tracks of the 80s"
                 ]
               },
               {
-                "propertyValue": "classic guitar solos",
+                "propertyValue": "popular hits of the 80s",
                 "propertySubPhrases": [
-                  "classic guitar solos"
+                  "the popular hits of the 80s"
                 ]
               }
             ]
@@ -3512,12 +3402,136 @@
         "politePrefixes": [
           "Could you please",
           "Would you mind",
-          "If it's not too much trouble, could you"
+          "Please",
+          "I would appreciate it if you could"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it.",
-          "Thanks in advance!"
+          "Thank you",
+          "Thanks",
+          "If you don't mind",
+          "I appreciate it"
+        ]
+      }
+    },
+    {
+      "request": "Find the most iconic guitar solos",
+      "action": {
+        "fullActionName": "player.searchTracks",
+        "parameters": {
+          "query": "most iconic guitar solos"
+        }
+      },
+      "explanation": {
+        "properties": [
+          {
+            "name": "fullActionName",
+            "value": "player.searchTracks",
+            "substrings": [
+              "Find"
+            ]
+          },
+          {
+            "name": "parameters.query",
+            "value": "most iconic guitar solos",
+            "substrings": [
+              "most iconic guitar solos"
+            ]
+          }
+        ],
+        "subPhrases": [
+          {
+            "text": "Find",
+            "category": "command",
+            "propertyNames": [
+              "fullActionName"
+            ]
+          },
+          {
+            "text": "the",
+            "category": "preposition",
+            "synonyms": [
+              "a",
+              "an",
+              "this",
+              "that"
+            ],
+            "isOptional": true
+          },
+          {
+            "text": "most iconic guitar solos",
+            "category": "query",
+            "propertyNames": [
+              "parameters.query"
+            ]
+          }
+        ],
+        "propertyAlternatives": [
+          {
+            "propertyName": "fullActionName",
+            "propertyValue": "player.searchTracks",
+            "propertySubPhrases": [
+              "Find"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "player.searchAlbums",
+                "propertySubPhrases": [
+                  "Find albums"
+                ]
+              },
+              {
+                "propertyValue": "player.searchArtists",
+                "propertySubPhrases": [
+                  "Find artists"
+                ]
+              },
+              {
+                "propertyValue": "player.searchPlaylists",
+                "propertySubPhrases": [
+                  "Find playlists"
+                ]
+              }
+            ]
+          },
+          {
+            "propertyName": "parameters.query",
+            "propertyValue": "most iconic guitar solos",
+            "propertySubPhrases": [
+              "most iconic guitar solos"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "best guitar solos",
+                "propertySubPhrases": [
+                  "best guitar solos"
+                ]
+              },
+              {
+                "propertyValue": "top guitar solos",
+                "propertySubPhrases": [
+                  "top guitar solos"
+                ]
+              },
+              {
+                "propertyValue": "greatest guitar solos",
+                "propertySubPhrases": [
+                  "greatest guitar solos"
+                ]
+              }
+            ]
+          }
+        ],
+        "politePrefixes": [
+          "Could you please",
+          "Would you mind",
+          "I would appreciate it if you could",
+          "Please"
+        ],
+        "politeSuffixes": [
+          "Thank you",
+          "Thanks a lot",
+          "I appreciate it",
+          "If you don't mind"
         ]
       }
     },
@@ -3549,13 +3563,23 @@
         "subPhrases": [
           {
             "text": "Find",
-            "category": "action",
+            "category": "command",
             "propertyNames": [
               "fullActionName"
             ]
           },
           {
-            "text": "the most relaxing songs ever",
+            "text": "the",
+            "category": "preposition",
+            "synonyms": [
+              "a",
+              "an",
+              "some"
+            ],
+            "isOptional": true
+          },
+          {
+            "text": "most relaxing songs ever",
             "category": "query",
             "propertyNames": [
               "parameters.query"
@@ -3571,21 +3595,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.findTracks",
+                "propertyValue": "player.findSongs",
                 "propertySubPhrases": [
-                  "Locate"
+                  "Find"
                 ]
               },
               {
                 "propertyValue": "player.lookupTracks",
                 "propertySubPhrases": [
-                  "Search for"
+                  "Find"
                 ]
               },
               {
-                "propertyValue": "player.browseTracks",
+                "propertyValue": "player.searchMusic",
                 "propertySubPhrases": [
-                  "Browse"
+                  "Find"
                 ]
               }
             ]
@@ -3594,25 +3618,25 @@
             "propertyName": "parameters.query",
             "propertyValue": "most relaxing songs ever",
             "propertySubPhrases": [
-              "the most relaxing songs ever"
+              "most relaxing songs ever"
             ],
             "alternatives": [
               {
-                "propertyValue": "most calming music ever",
+                "propertyValue": "most calming songs ever",
                 "propertySubPhrases": [
-                  "the most calming music ever"
+                  "most calming songs ever"
                 ]
               },
               {
-                "propertyValue": "most soothing tracks ever",
+                "propertyValue": "most soothing songs ever",
                 "propertySubPhrases": [
-                  "the most soothing tracks ever"
+                  "most soothing songs ever"
                 ]
               },
               {
-                "propertyValue": "most peaceful melodies ever",
+                "propertyValue": "most peaceful songs ever",
                 "propertySubPhrases": [
-                  "the most peaceful melodies ever"
+                  "most peaceful songs ever"
                 ]
               }
             ]
@@ -3621,12 +3645,14 @@
         "politePrefixes": [
           "Could you please",
           "Would you mind",
-          "If it's not too much trouble, could you"
+          "Please",
+          "I would appreciate it if you could"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would really appreciate it.",
-          "Thanks a lot!"
+          "Thank you",
+          "Thanks",
+          "If you don't mind",
+          "I would be grateful"
         ]
       }
     },
@@ -3680,21 +3706,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.findTracks",
+                "propertyValue": "player.findSongs",
                 "propertySubPhrases": [
-                  "Find"
+                  "Locate"
+                ]
+              },
+              {
+                "propertyValue": "player.getTopTracks",
+                "propertySubPhrases": [
+                  "Get"
                 ]
               },
               {
                 "propertyValue": "player.lookupTracks",
                 "propertySubPhrases": [
-                  "Find"
-                ]
-              },
-              {
-                "propertyValue": "player.getTracks",
-                "propertySubPhrases": [
-                  "Find"
+                  "Search"
                 ]
               }
             ]
@@ -3729,11 +3755,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "I would appreciate it if you could",
+          "Please"
         ],
         "politeSuffixes": [
           "Thank you!",
-          "I appreciate it!"
+          "Thanks in advance!",
+          "If possible, please.",
+          "I appreciate your help!"
         ]
       }
     },
@@ -3750,7 +3780,9 @@
           {
             "name": "fullActionName",
             "value": "player.searchTracks",
-            "substrings": []
+            "substrings": [
+              "Find top hits from the 2000s"
+            ]
           },
           {
             "name": "parameters.query",
@@ -3791,13 +3823,13 @@
                 ]
               },
               {
-                "propertyValue": "music.searchTracks",
+                "propertyValue": "player.lookupTracks",
                 "propertySubPhrases": [
                   "Find"
                 ]
               },
               {
-                "propertyValue": "audio.searchTracks",
+                "propertyValue": "player.searchMusic",
                 "propertySubPhrases": [
                   "Find"
                 ]
@@ -3812,21 +3844,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "top songs from the 2000s",
+                "propertyValue": "popular songs from the 2000s",
                 "propertySubPhrases": [
-                  "top songs from the 2000s"
+                  "popular songs from the 2000s"
                 ]
               },
               {
-                "propertyValue": "best hits from the 2000s",
+                "propertyValue": "best tracks from the 2000s",
                 "propertySubPhrases": [
-                  "best hits from the 2000s"
+                  "best tracks from the 2000s"
                 ]
               },
               {
-                "propertyValue": "popular tracks from the 2000s",
+                "propertyValue": "hit songs from the 2000s",
                 "propertySubPhrases": [
-                  "popular tracks from the 2000s"
+                  "hit songs from the 2000s"
                 ]
               }
             ]
@@ -3834,11 +3866,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "Please",
+          "I would appreciate it if you could"
         ],
         "politeSuffixes": [
           "Thank you!",
-          "I would appreciate it."
+          "Thanks!",
+          "If you don't mind.",
+          "I appreciate it."
         ]
       }
     },
@@ -3902,21 +3938,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.findSongs",
+                "propertyValue": "player.searchAlbums",
                 "propertySubPhrases": [
-                  "Find songs"
+                  "Find albums"
                 ]
               },
               {
-                "propertyValue": "player.lookupTracks",
+                "propertyValue": "player.searchArtists",
                 "propertySubPhrases": [
-                  "Look up tracks"
+                  "Find artists"
                 ]
               },
               {
-                "propertyValue": "player.searchMusic",
+                "propertyValue": "player.searchPlaylists",
                 "propertySubPhrases": [
-                  "Search music"
+                  "Find playlists"
                 ]
               }
             ]
@@ -3941,9 +3977,9 @@
                 ]
               },
               {
-                "propertyValue": "Beyoncé",
+                "propertyValue": "Billie Eilish",
                 "propertySubPhrases": [
-                  "Beyoncé"
+                  "Billie Eilish"
                 ]
               }
             ]
@@ -3951,20 +3987,24 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "I would appreciate it if you could",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it!"
+          "Thank you",
+          "Thanks",
+          "If you don't mind",
+          "I appreciate it"
         ]
       }
     },
     {
       "request": "Find tracks from the album Rumours by Fleetwood Mac",
       "action": {
-        "fullActionName": "player.playAlbum",
+        "fullActionName": "player.playTrack",
         "parameters": {
-          "albumName": "Rumours",
+          "trackName": "Rumours",
           "artists": [
             "Fleetwood Mac"
           ]
@@ -3974,13 +4014,11 @@
         "properties": [
           {
             "name": "fullActionName",
-            "value": "player.playAlbum",
-            "substrings": [
-              "Find tracks from the album"
-            ]
+            "value": "player.playTrack",
+            "substrings": []
           },
           {
-            "name": "parameters.albumName",
+            "name": "parameters.trackName",
             "value": "Rumours",
             "substrings": [
               "Rumours"
@@ -4004,24 +4042,14 @@
           },
           {
             "text": "Rumours",
-            "category": "album name",
+            "category": "trackName",
             "propertyNames": [
-              "parameters.albumName"
+              "parameters.trackName"
             ]
           },
           {
-            "text": "by",
-            "category": "preposition",
-            "synonyms": [
-              "from",
-              "featuring",
-              "with"
-            ],
-            "isOptional": true
-          },
-          {
-            "text": "Fleetwood Mac",
-            "category": "artist name",
+            "text": "by Fleetwood Mac",
+            "category": "artist",
             "propertyNames": [
               "parameters.artists.0"
             ]
@@ -4030,25 +4058,25 @@
         "propertyAlternatives": [
           {
             "propertyName": "fullActionName",
-            "propertyValue": "player.playAlbum",
+            "propertyValue": "player.playTrack",
             "propertySubPhrases": [
               "Find tracks from the album"
             ],
             "alternatives": [
               {
-                "propertyValue": "player.queueAlbum",
+                "propertyValue": "player.queueTrack",
                 "propertySubPhrases": [
                   "Queue tracks from the album"
                 ]
               },
               {
-                "propertyValue": "player.addAlbumToPlaylist",
+                "propertyValue": "player.addTrackToPlaylist",
                 "propertySubPhrases": [
-                  "Add tracks from the album to playlist"
+                  "Add tracks from the album"
                 ]
               },
               {
-                "propertyValue": "player.shuffleAlbum",
+                "propertyValue": "player.shuffleTrack",
                 "propertySubPhrases": [
                   "Shuffle tracks from the album"
                 ]
@@ -4056,18 +4084,12 @@
             ]
           },
           {
-            "propertyName": "parameters.albumName",
+            "propertyName": "parameters.trackName",
             "propertyValue": "Rumours",
             "propertySubPhrases": [
               "Rumours"
             ],
             "alternatives": [
-              {
-                "propertyValue": "The Dark Side of the Moon",
-                "propertySubPhrases": [
-                  "The Dark Side of the Moon"
-                ]
-              },
               {
                 "propertyValue": "Abbey Road",
                 "propertySubPhrases": [
@@ -4079,6 +4101,12 @@
                 "propertySubPhrases": [
                   "Thriller"
                 ]
+              },
+              {
+                "propertyValue": "The Dark Side of the Moon",
+                "propertySubPhrases": [
+                  "The Dark Side of the Moon"
+                ]
               }
             ]
           },
@@ -4086,25 +4114,25 @@
             "propertyName": "parameters.artists.0",
             "propertyValue": "Fleetwood Mac",
             "propertySubPhrases": [
-              "Fleetwood Mac"
+              "by Fleetwood Mac"
             ],
             "alternatives": [
               {
-                "propertyValue": "Pink Floyd",
-                "propertySubPhrases": [
-                  "Pink Floyd"
-                ]
-              },
-              {
                 "propertyValue": "The Beatles",
                 "propertySubPhrases": [
-                  "The Beatles"
+                  "by The Beatles"
                 ]
               },
               {
                 "propertyValue": "Michael Jackson",
                 "propertySubPhrases": [
-                  "Michael Jackson"
+                  "by Michael Jackson"
+                ]
+              },
+              {
+                "propertyValue": "Pink Floyd",
+                "propertySubPhrases": [
+                  "by Pink Floyd"
                 ]
               }
             ]
@@ -4113,14 +4141,14 @@
         "politePrefixes": [
           "Could you please",
           "Would you mind",
-          "If it's not too much trouble, could you",
-          "I would appreciate it if you could"
+          "I would appreciate it if you could",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "Thanks a lot!",
-          "I appreciate it!",
-          "Much appreciated!"
+          "Thank you",
+          "Thanks",
+          "If you don't mind",
+          "I appreciate it"
         ]
       }
     },
@@ -4137,7 +4165,9 @@
           {
             "name": "fullActionName",
             "value": "player.searchTracks",
-            "substrings": []
+            "substrings": [
+              "Look for"
+            ]
           },
           {
             "name": "parameters.query",
@@ -4151,22 +4181,46 @@
           {
             "text": "Look for",
             "category": "command",
-            "synonyms": [
-              "Search for",
-              "Find",
-              "Locate"
-            ],
-            "isOptional": true
+            "propertyNames": [
+              "fullActionName"
+            ]
           },
           {
             "text": "90s grunge bands like Nirvana",
-            "category": "search query",
+            "category": "query",
             "propertyNames": [
               "parameters.query"
             ]
           }
         ],
         "propertyAlternatives": [
+          {
+            "propertyName": "fullActionName",
+            "propertyValue": "player.searchTracks",
+            "propertySubPhrases": [
+              "Look for"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "player.findSongs",
+                "propertySubPhrases": [
+                  "Find"
+                ]
+              },
+              {
+                "propertyValue": "player.locateMusic",
+                "propertySubPhrases": [
+                  "Locate"
+                ]
+              },
+              {
+                "propertyValue": "player.seekTunes",
+                "propertySubPhrases": [
+                  "Seek"
+                ]
+              }
+            ]
+          },
           {
             "propertyName": "parameters.query",
             "propertyValue": "90s grunge bands like Nirvana",
@@ -4175,21 +4229,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "90s grunge bands like Pearl Jam",
+                "propertyValue": "90s alternative rock bands like Pearl Jam",
                 "propertySubPhrases": [
-                  "90s grunge bands like Pearl Jam"
+                  "90s alternative rock bands like Pearl Jam"
                 ]
               },
               {
-                "propertyValue": "90s grunge bands like Soundgarden",
+                "propertyValue": "90s punk rock bands like Green Day",
                 "propertySubPhrases": [
-                  "90s grunge bands like Soundgarden"
+                  "90s punk rock bands like Green Day"
                 ]
               },
               {
-                "propertyValue": "90s grunge bands like Alice in Chains",
+                "propertyValue": "90s metal bands like Metallica",
                 "propertySubPhrases": [
-                  "90s grunge bands like Alice in Chains"
+                  "90s metal bands like Metallica"
                 ]
               }
             ]
@@ -4197,11 +4251,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "I would appreciate it if you could",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I appreciate it!"
+          "Thank you",
+          "If that's okay",
+          "Thanks",
+          "I appreciate it"
         ]
       }
     },
@@ -4233,7 +4291,7 @@
         "subPhrases": [
           {
             "text": "Look for",
-            "category": "action",
+            "category": "command",
             "propertyNames": [
               "fullActionName"
             ]
@@ -4255,21 +4313,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.playTrack",
+                "propertyValue": "player.findSongs",
                 "propertySubPhrases": [
-                  "Play"
+                  "Find"
                 ]
               },
               {
-                "propertyValue": "player.addTrackToQueue",
+                "propertyValue": "player.lookupTracks",
                 "propertySubPhrases": [
-                  "Add to queue"
+                  "Search for"
                 ]
               },
               {
-                "propertyValue": "player.likeTrack",
+                "propertyValue": "player.seekMusic",
                 "propertySubPhrases": [
-                  "Like"
+                  "Seek"
                 ]
               }
             ]
@@ -4305,14 +4363,42 @@
         "politePrefixes": [
           "Could you please",
           "Would you mind",
-          "If it's not too much trouble, could you"
+          "Please",
+          "I would appreciate it if you could"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it.",
-          "Thanks a lot!"
+          "thank you",
+          "please",
+          "if you don't mind",
+          "thanks"
         ]
-      }
+      },
+      "corrections": [
+        {
+          "data": {
+            "properties": [
+              {
+                "name": "fullActionName",
+                "value": "player.searchTracks",
+                "substrings": [
+                  "Look for"
+                ]
+              },
+              {
+                "name": "query",
+                "value": "Africa by Toto",
+                "substrings": [
+                  "Africa by Toto"
+                ]
+              }
+            ]
+          },
+          "correction": [
+            "Extraneous parameter: 'query' is not a parameter in the action",
+            "Missing parameter: parameter 'parameters.query' in the action is missing from explanation"
+          ]
+        }
+      ]
     },
     {
       "request": "Look for All I Want for Christmas Is You by Mariah Carey",
@@ -4342,7 +4428,7 @@
         "subPhrases": [
           {
             "text": "Look for",
-            "category": "action",
+            "category": "command",
             "propertyNames": [
               "fullActionName"
             ]
@@ -4413,11 +4499,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "Please",
+          "I would appreciate it if you could"
         ],
         "politeSuffixes": [
           "Thank you",
-          "I would appreciate it"
+          "Please",
+          "If you don't mind",
+          "Thanks"
         ]
       }
     },
@@ -4483,7 +4573,7 @@
                 ]
               },
               {
-                "propertyValue": "player.seekTracks",
+                "propertyValue": "player.seekSongs",
                 "propertySubPhrases": [
                   "Seek"
                 ]
@@ -4520,11 +4610,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "Please",
+          "Kindly"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it."
+          "if you don't mind",
+          "please",
+          "thank you",
+          "if that's okay"
         ]
       }
     },
@@ -4584,15 +4678,15 @@
                 ]
               },
               {
-                "propertyValue": "player.lookupTracks",
+                "propertyValue": "player.lookupMusic",
                 "propertySubPhrases": [
                   "Search for"
                 ]
               },
               {
-                "propertyValue": "player.browseTracks",
+                "propertyValue": "player.discoverTracks",
                 "propertySubPhrases": [
-                  "Browse"
+                  "Discover"
                 ]
               }
             ]
@@ -4627,10 +4721,14 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "I would appreciate it if you could",
+          "Please"
         ],
         "politeSuffixes": [
           "Thank you",
+          "Thanks",
+          "If you don't mind",
           "I appreciate it"
         ]
       }
@@ -4640,7 +4738,7 @@
       "action": {
         "fullActionName": "player.searchTracks",
         "parameters": {
-          "query": "Can't Help Falling in Love by Elvis Presley"
+          "query": "Cant Help Falling in Love by Elvis Presley"
         }
       },
       "explanation": {
@@ -4654,7 +4752,7 @@
           },
           {
             "name": "parameters.query",
-            "value": "Can't Help Falling in Love by Elvis Presley",
+            "value": "Cant Help Falling in Love by Elvis Presley",
             "substrings": [
               "Cant Help Falling in Love by Elvis Presley"
             ]
@@ -4663,7 +4761,7 @@
         "subPhrases": [
           {
             "text": "Look for",
-            "category": "action",
+            "category": "command",
             "propertyNames": [
               "fullActionName"
             ]
@@ -4693,20 +4791,20 @@
               {
                 "propertyValue": "player.lookupTracks",
                 "propertySubPhrases": [
-                  "Lookup"
+                  "Search for"
                 ]
               },
               {
-                "propertyValue": "player.searchMusic",
+                "propertyValue": "player.seekMusic",
                 "propertySubPhrases": [
-                  "Search for"
+                  "Seek"
                 ]
               }
             ]
           },
           {
             "propertyName": "parameters.query",
-            "propertyValue": "Can't Help Falling in Love by Elvis Presley",
+            "propertyValue": "Cant Help Falling in Love by Elvis Presley",
             "propertySubPhrases": [
               "Cant Help Falling in Love by Elvis Presley"
             ],
@@ -4724,9 +4822,9 @@
                 ]
               },
               {
-                "propertyValue": "Hound Dog by Elvis Presley",
+                "propertyValue": "Love Me Tender by Elvis Presley",
                 "propertySubPhrases": [
-                  "Hound Dog by Elvis Presley"
+                  "Love Me Tender by Elvis Presley"
                 ]
               }
             ]
@@ -4734,11 +4832,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "Please",
+          "Kindly"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it."
+          "for me?",
+          "if you don't mind.",
+          "please.",
+          "thank you."
         ]
       }
     },
@@ -4770,7 +4872,7 @@
         "subPhrases": [
           {
             "text": "Look for",
-            "category": "action",
+            "category": "command",
             "propertyNames": [
               "fullActionName"
             ]
@@ -4798,15 +4900,15 @@
                 ]
               },
               {
-                "propertyValue": "player.lookupTracks",
+                "propertyValue": "player.locateTracks",
                 "propertySubPhrases": [
-                  "Lookup"
+                  "Locate"
                 ]
               },
               {
-                "propertyValue": "player.browseTracks",
+                "propertyValue": "player.seekMusic",
                 "propertySubPhrases": [
-                  "Browse"
+                  "Seek"
                 ]
               }
             ]
@@ -4819,21 +4921,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "rock hits by Elvis Presley",
+                "propertyValue": "rock songs by Elvis Presley",
                 "propertySubPhrases": [
-                  "rock hits by Elvis Presley"
+                  "rock songs by Elvis Presley"
                 ]
               },
               {
-                "propertyValue": "pop songs by Michael Jackson",
+                "propertyValue": "pop tracks by Michael Jackson",
                 "propertySubPhrases": [
-                  "pop songs by Michael Jackson"
+                  "pop tracks by Michael Jackson"
                 ]
               },
               {
-                "propertyValue": "jazz classics by Miles Davis",
+                "propertyValue": "jazz tunes by Miles Davis",
                 "propertySubPhrases": [
-                  "jazz classics by Miles Davis"
+                  "jazz tunes by Miles Davis"
                 ]
               }
             ]
@@ -4841,11 +4943,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "Please",
+          "If you don't mind"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it."
+          "thank you",
+          "please",
+          "if possible",
+          "thanks"
         ]
       }
     },
@@ -4862,7 +4968,9 @@
           {
             "name": "fullActionName",
             "value": "player.searchTracks",
-            "substrings": []
+            "substrings": [
+              "Look for"
+            ]
           },
           {
             "name": "parameters.query",
@@ -4876,12 +4984,9 @@
           {
             "text": "Look for",
             "category": "command",
-            "synonyms": [
-              "Search for",
-              "Find",
-              "Seek"
-            ],
-            "isOptional": true
+            "propertyNames": [
+              "fullActionName"
+            ]
           },
           {
             "text": "energetic workout playlists",
@@ -4893,6 +4998,33 @@
         ],
         "propertyAlternatives": [
           {
+            "propertyName": "fullActionName",
+            "propertyValue": "player.searchTracks",
+            "propertySubPhrases": [
+              "Look for"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "player.findTracks",
+                "propertySubPhrases": [
+                  "Find"
+                ]
+              },
+              {
+                "propertyValue": "player.locateTracks",
+                "propertySubPhrases": [
+                  "Locate"
+                ]
+              },
+              {
+                "propertyValue": "player.seekTracks",
+                "propertySubPhrases": [
+                  "Seek"
+                ]
+              }
+            ]
+          },
+          {
             "propertyName": "parameters.query",
             "propertyValue": "energetic workout playlists",
             "propertySubPhrases": [
@@ -4900,21 +5032,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "calm workout playlists",
+                "propertyValue": "high-energy exercise playlists",
                 "propertySubPhrases": [
-                  "calm workout playlists"
+                  "high-energy exercise playlists"
                 ]
               },
               {
-                "propertyValue": "intense workout playlists",
+                "propertyValue": "intense workout music",
                 "propertySubPhrases": [
-                  "intense workout playlists"
+                  "intense workout music"
                 ]
               },
               {
-                "propertyValue": "relaxing workout playlists",
+                "propertyValue": "upbeat fitness playlists",
                 "propertySubPhrases": [
-                  "relaxing workout playlists"
+                  "upbeat fitness playlists"
                 ]
               }
             ]
@@ -4922,11 +5054,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "I would appreciate it if you could",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you",
-          "I appreciate it"
+          "for me?",
+          "when you have a moment.",
+          "if that's okay.",
+          "thank you."
         ]
       }
     },
@@ -5007,21 +5143,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "Grammy Award winners",
+                "propertyValue": "Eurovision winners",
                 "propertySubPhrases": [
-                  "Grammy Award winners"
+                  "Eurovision winners"
                 ]
               },
               {
-                "propertyValue": "Billboard Hot 100",
+                "propertyValue": "Eurovision Song Contest champions",
                 "propertySubPhrases": [
-                  "Billboard Hot 100"
+                  "Eurovision Song Contest champions"
                 ]
               },
               {
-                "propertyValue": "MTV Music Award winners",
+                "propertyValue": "Eurovision Song Contest top performers",
                 "propertySubPhrases": [
-                  "MTV Music Award winners"
+                  "Eurovision Song Contest top performers"
                 ]
               }
             ]
@@ -5029,11 +5165,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "Please",
+          "I would appreciate it if you could"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it."
+          "Thank you",
+          "Thanks",
+          "If you don't mind",
+          "Please and thank you"
         ]
       }
     },
@@ -5065,7 +5205,7 @@
         "subPhrases": [
           {
             "text": "Look for",
-            "category": "action",
+            "category": "command",
             "propertyNames": [
               "fullActionName"
             ]
@@ -5093,15 +5233,15 @@
                 ]
               },
               {
-                "propertyValue": "player.lookupMusic",
+                "propertyValue": "player.locateMusic",
                 "propertySubPhrases": [
-                  "Look up"
+                  "Locate"
                 ]
               },
               {
-                "propertyValue": "player.browseTracks",
+                "propertyValue": "player.seekTunes",
                 "propertySubPhrases": [
-                  "Browse"
+                  "Seek"
                 ]
               }
             ]
@@ -5136,11 +5276,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "Please",
+          "Kindly"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it."
+          "for me?",
+          "if you don't mind.",
+          "thank you.",
+          "please."
         ]
       }
     },
@@ -5172,7 +5316,7 @@
         "subPhrases": [
           {
             "text": "Look for",
-            "category": "action",
+            "category": "command",
             "propertyNames": [
               "fullActionName"
             ]
@@ -5200,15 +5344,15 @@
                 ]
               },
               {
-                "propertyValue": "player.lookupTracks",
+                "propertyValue": "player.locateTracks",
                 "propertySubPhrases": [
-                  "Lookup"
+                  "Locate"
                 ]
               },
               {
-                "propertyValue": "player.browseTracks",
+                "propertyValue": "player.seekMusic",
                 "propertySubPhrases": [
-                  "Browse"
+                  "Seek"
                 ]
               }
             ]
@@ -5227,15 +5371,15 @@
                 ]
               },
               {
-                "propertyValue": "Billboard top songs",
+                "propertyValue": "Grammy winners",
                 "propertySubPhrases": [
-                  "Billboard top songs"
+                  "Grammy winners"
                 ]
               },
               {
-                "propertyValue": "Top 40 hits",
+                "propertyValue": "Grammy award songs",
                 "propertySubPhrases": [
-                  "Top 40 hits"
+                  "Grammy award songs"
                 ]
               }
             ]
@@ -5243,11 +5387,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "Please",
+          "I would appreciate it if you could"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it."
+          "for me?",
+          "when you have a moment.",
+          "if that's okay.",
+          "thank you."
         ]
       }
     },
@@ -5313,7 +5461,7 @@
                 ]
               },
               {
-                "propertyValue": "player.browseTracks",
+                "propertyValue": "player.browseSongs",
                 "propertySubPhrases": [
                   "Browse"
                 ]
@@ -5328,21 +5476,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "Shape of You by Ed Sheeran",
+                "propertyValue": "Happy by Pharrell",
                 "propertySubPhrases": [
-                  "Shape of You by Ed Sheeran"
+                  "Happy by Pharrell"
                 ]
               },
               {
-                "propertyValue": "Blinding Lights by The Weeknd",
+                "propertyValue": "Happy by P. Williams",
                 "propertySubPhrases": [
-                  "Blinding Lights by The Weeknd"
+                  "Happy by P. Williams"
                 ]
               },
               {
-                "propertyValue": "Rolling in the Deep by Adele",
+                "propertyValue": "Happy by Pharrell W.",
                 "propertySubPhrases": [
-                  "Rolling in the Deep by Adele"
+                  "Happy by Pharrell W."
                 ]
               }
             ]
@@ -5350,11 +5498,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "Can you kindly",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you",
-          "I would appreciate it"
+          "if you don't mind",
+          "thank you",
+          "please",
+          "if it's not too much trouble"
         ]
       }
     },
@@ -5371,7 +5523,9 @@
           {
             "name": "fullActionName",
             "value": "player.searchTracks",
-            "substrings": []
+            "substrings": [
+              "Look for"
+            ]
           },
           {
             "name": "parameters.query",
@@ -5385,12 +5539,9 @@
           {
             "text": "Look for",
             "category": "command",
-            "synonyms": [
-              "Search for",
-              "Find",
-              "Seek out"
-            ],
-            "isOptional": true
+            "propertyNames": [
+              "fullActionName"
+            ]
           },
           {
             "text": "heavy metal bands like Metallica",
@@ -5402,6 +5553,33 @@
         ],
         "propertyAlternatives": [
           {
+            "propertyName": "fullActionName",
+            "propertyValue": "player.searchTracks",
+            "propertySubPhrases": [
+              "Look for"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "player.findSongs",
+                "propertySubPhrases": [
+                  "Find"
+                ]
+              },
+              {
+                "propertyValue": "player.locateMusic",
+                "propertySubPhrases": [
+                  "Locate"
+                ]
+              },
+              {
+                "propertyValue": "player.searchMusic",
+                "propertySubPhrases": [
+                  "Search for"
+                ]
+              }
+            ]
+          },
+          {
             "propertyName": "parameters.query",
             "propertyValue": "heavy metal bands like Metallica",
             "propertySubPhrases": [
@@ -5409,21 +5587,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "heavy metal bands like Iron Maiden",
+                "propertyValue": "rock bands like Led Zeppelin",
                 "propertySubPhrases": [
-                  "heavy metal bands like Iron Maiden"
+                  "rock bands like Led Zeppelin"
                 ]
               },
               {
-                "propertyValue": "heavy metal bands like Black Sabbath",
+                "propertyValue": "punk bands like The Ramones",
                 "propertySubPhrases": [
-                  "heavy metal bands like Black Sabbath"
+                  "punk bands like The Ramones"
                 ]
               },
               {
-                "propertyValue": "heavy metal bands like Slayer",
+                "propertyValue": "alternative bands like Radiohead",
                 "propertySubPhrases": [
-                  "heavy metal bands like Slayer"
+                  "alternative bands like Radiohead"
                 ]
               }
             ]
@@ -5431,11 +5609,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "Please",
+          "I would appreciate it if you could"
         ],
         "politeSuffixes": [
           "Thank you",
-          "I appreciate it"
+          "Thanks",
+          "If you don't mind",
+          "Please and thank you"
         ]
       }
     },
@@ -5474,113 +5656,6 @@
           },
           {
             "text": "iconic 70s disco tracks",
-            "category": "searchQuery",
-            "propertyNames": [
-              "parameters.query"
-            ]
-          }
-        ],
-        "propertyAlternatives": [
-          {
-            "propertyName": "fullActionName",
-            "propertyValue": "player.searchTracks",
-            "propertySubPhrases": [
-              "Look for"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "player.findSongs",
-                "propertySubPhrases": [
-                  "Search for"
-                ]
-              },
-              {
-                "propertyValue": "player.lookupMusic",
-                "propertySubPhrases": [
-                  "Find"
-                ]
-              },
-              {
-                "propertyValue": "player.browseTracks",
-                "propertySubPhrases": [
-                  "Browse"
-                ]
-              }
-            ]
-          },
-          {
-            "propertyName": "parameters.query",
-            "propertyValue": "iconic 70s disco tracks",
-            "propertySubPhrases": [
-              "iconic 70s disco tracks"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "classic 80s rock songs",
-                "propertySubPhrases": [
-                  "classic 80s rock songs"
-                ]
-              },
-              {
-                "propertyValue": "famous 90s pop hits",
-                "propertySubPhrases": [
-                  "famous 90s pop hits"
-                ]
-              },
-              {
-                "propertyValue": "popular 2000s hip hop tracks",
-                "propertySubPhrases": [
-                  "popular 2000s hip hop tracks"
-                ]
-              }
-            ]
-          }
-        ],
-        "politePrefixes": [
-          "Could you please",
-          "Would you mind"
-        ],
-        "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it."
-        ]
-      }
-    },
-    {
-      "request": "Look for instrumental jazz music",
-      "action": {
-        "fullActionName": "player.searchTracks",
-        "parameters": {
-          "query": "instrumental jazz music"
-        }
-      },
-      "explanation": {
-        "properties": [
-          {
-            "name": "fullActionName",
-            "value": "player.searchTracks",
-            "substrings": [
-              "Look for"
-            ]
-          },
-          {
-            "name": "parameters.query",
-            "value": "instrumental jazz music",
-            "substrings": [
-              "instrumental jazz music"
-            ]
-          }
-        ],
-        "subPhrases": [
-          {
-            "text": "Look for",
-            "category": "action",
-            "propertyNames": [
-              "fullActionName"
-            ]
-          },
-          {
-            "text": "instrumental jazz music",
             "category": "query",
             "propertyNames": [
               "parameters.query"
@@ -5602,42 +5677,42 @@
                 ]
               },
               {
-                "propertyValue": "player.locateTracks",
+                "propertyValue": "player.locateMusic",
                 "propertySubPhrases": [
                   "Locate"
                 ]
               },
               {
-                "propertyValue": "player.searchMusic",
+                "propertyValue": "player.seekTunes",
                 "propertySubPhrases": [
-                  "Search for"
+                  "Seek"
                 ]
               }
             ]
           },
           {
             "propertyName": "parameters.query",
-            "propertyValue": "instrumental jazz music",
+            "propertyValue": "iconic 70s disco tracks",
             "propertySubPhrases": [
-              "instrumental jazz music"
+              "iconic 70s disco tracks"
             ],
             "alternatives": [
               {
-                "propertyValue": "classical music",
+                "propertyValue": "classic 70s disco songs",
                 "propertySubPhrases": [
-                  "classical music"
+                  "classic 70s disco songs"
                 ]
               },
               {
-                "propertyValue": "rock music",
+                "propertyValue": "famous 70s disco hits",
                 "propertySubPhrases": [
-                  "rock music"
+                  "famous 70s disco hits"
                 ]
               },
               {
-                "propertyValue": "pop music",
+                "propertyValue": "popular 70s disco tunes",
                 "propertySubPhrases": [
-                  "pop music"
+                  "popular 70s disco tunes"
                 ]
               }
             ]
@@ -5646,12 +5721,100 @@
         "politePrefixes": [
           "Could you please",
           "Would you mind",
-          "If it's not too much trouble, could you"
+          "Please",
+          "I would appreciate it if you could"
         ],
         "politeSuffixes": [
           "Thank you!",
-          "I would appreciate it.",
-          "Thanks a lot!"
+          "if possible.",
+          "Thanks!",
+          "when you have a moment."
+        ]
+      }
+    },
+    {
+      "request": "Look for instrumental jazz music",
+      "action": {
+        "fullActionName": "player.searchTracks",
+        "parameters": {
+          "query": "instrumental jazz music"
+        }
+      },
+      "explanation": {
+        "properties": [
+          {
+            "name": "fullActionName",
+            "value": "player.searchTracks",
+            "isImplicit": true
+          },
+          {
+            "name": "parameters.query",
+            "value": "instrumental jazz music",
+            "substrings": [
+              "instrumental jazz music"
+            ]
+          }
+        ],
+        "subPhrases": [
+          {
+            "text": "Look for",
+            "category": "command",
+            "propertyNames": []
+          },
+          {
+            "text": "instrumental jazz music",
+            "category": "query",
+            "propertyNames": [
+              "parameters.query"
+            ]
+          }
+        ],
+        "propertyAlternatives": [
+          {
+            "propertyName": "parameters.query",
+            "propertyValue": "instrumental jazz music",
+            "propertySubPhrases": [
+              "instrumental jazz music"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "smooth jazz music",
+                "propertySubPhrases": [
+                  "smooth jazz music"
+                ]
+              },
+              {
+                "propertyValue": "classic jazz music",
+                "propertySubPhrases": [
+                  "classic jazz music"
+                ]
+              },
+              {
+                "propertyValue": "modern jazz music",
+                "propertySubPhrases": [
+                  "modern jazz music"
+                ]
+              },
+              {
+                "propertyValue": "jazz fusion music",
+                "propertySubPhrases": [
+                  "jazz fusion music"
+                ]
+              }
+            ]
+          }
+        ],
+        "politePrefixes": [
+          "Could you please",
+          "Would you mind",
+          "I would appreciate it if you could",
+          "Please"
+        ],
+        "politeSuffixes": [
+          "for me?",
+          "if possible.",
+          "thank you.",
+          "when you have a moment."
         ]
       }
     },
@@ -5690,7 +5853,7 @@
           },
           {
             "text": "live performances by Queen",
-            "category": "search query",
+            "category": "query",
             "propertyNames": [
               "parameters.query"
             ]
@@ -5713,7 +5876,7 @@
               {
                 "propertyValue": "player.lookupTracks",
                 "propertySubPhrases": [
-                  "Look up"
+                  "Search for"
                 ]
               },
               {
@@ -5754,11 +5917,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "Please",
+          "I would appreciate it if you could"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it."
+          "thank you",
+          "please",
+          "if you don't mind",
+          "thanks"
         ]
       }
     },
@@ -5824,9 +5991,9 @@
                 ]
               },
               {
-                "propertyValue": "player.searchMusic",
+                "propertyValue": "player.browseTracks",
                 "propertySubPhrases": [
-                  "Search for"
+                  "Browse"
                 ]
               }
             ]
@@ -5845,15 +6012,15 @@
                 ]
               },
               {
-                "propertyValue": "Without Me by Eminem",
-                "propertySubPhrases": [
-                  "Without Me by Eminem"
-                ]
-              },
-              {
                 "propertyValue": "Not Afraid by Eminem",
                 "propertySubPhrases": [
                   "Not Afraid by Eminem"
+                ]
+              },
+              {
+                "propertyValue": "The Real Slim Shady by Eminem",
+                "propertySubPhrases": [
+                  "The Real Slim Shady by Eminem"
                 ]
               }
             ]
@@ -5861,11 +6028,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "Can you kindly",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you",
-          "I would appreciate it"
+          "for me?",
+          "if you don't mind.",
+          "please.",
+          "thanks."
         ]
       }
     },
@@ -5952,15 +6123,15 @@
                 ]
               },
               {
-                "propertyValue": "Bohemian Rhapsody by Queen",
+                "propertyValue": "Rolling in the Deep by Adele",
                 "propertySubPhrases": [
-                  "Bohemian Rhapsody by Queen"
+                  "Rolling in the Deep by Adele"
                 ]
               },
               {
-                "propertyValue": "Thriller by Michael Jackson",
+                "propertyValue": "Blinding Lights by The Weeknd",
                 "propertySubPhrases": [
-                  "Thriller by Michael Jackson"
+                  "Blinding Lights by The Weeknd"
                 ]
               }
             ]
@@ -5969,14 +6140,14 @@
         "politePrefixes": [
           "Could you please",
           "Would you mind",
-          "Kindly",
-          "Please"
+          "Please",
+          "I would appreciate it if you could"
         ],
         "politeSuffixes": [
           "Thank you",
           "Thanks",
-          "I would appreciate it",
-          "If you don't mind"
+          "If you don't mind",
+          "Please and thank you"
         ]
       }
     },
@@ -6042,7 +6213,7 @@
                 ]
               },
               {
-                "propertyValue": "player.browseTracks",
+                "propertyValue": "player.browseTunes",
                 "propertySubPhrases": [
                   "Browse"
                 ]
@@ -6063,15 +6234,15 @@
                 ]
               },
               {
-                "propertyValue": "club bangers for a night out",
+                "propertyValue": "club songs for a night out",
                 "propertySubPhrases": [
-                  "club bangers for a night out"
+                  "club songs for a night out"
                 ]
               },
               {
-                "propertyValue": "night out party songs",
+                "propertyValue": "night out music",
                 "propertySubPhrases": [
-                  "night out party songs"
+                  "night out music"
                 ]
               }
             ]
@@ -6079,11 +6250,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "Please",
+          "I would appreciate it if you could"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it!"
+          "Thank you",
+          "Thanks",
+          "If you don't mind",
+          "Please and thank you"
         ]
       }
     },
@@ -6115,7 +6290,7 @@
         "subPhrases": [
           {
             "text": "Look for",
-            "category": "action",
+            "category": "command",
             "propertyNames": [
               "fullActionName"
             ]
@@ -6143,15 +6318,15 @@
                 ]
               },
               {
-                "propertyValue": "player.lookupTracks",
+                "propertyValue": "player.locateTracks",
                 "propertySubPhrases": [
-                  "Search for"
+                  "Locate"
                 ]
               },
               {
-                "propertyValue": "player.browseTracks",
+                "propertyValue": "player.searchMusic",
                 "propertySubPhrases": [
-                  "Browse"
+                  "Search for"
                 ]
               }
             ]
@@ -6170,15 +6345,15 @@
                 ]
               },
               {
-                "propertyValue": "jazz music by Miles Davis",
-                "propertySubPhrases": [
-                  "jazz music by Miles Davis"
-                ]
-              },
-              {
                 "propertyValue": "pop music by Michael Jackson",
                 "propertySubPhrases": [
                   "pop music by Michael Jackson"
+                ]
+              },
+              {
+                "propertyValue": "jazz music by Miles Davis",
+                "propertySubPhrases": [
+                  "jazz music by Miles Davis"
                 ]
               }
             ]
@@ -6187,14 +6362,14 @@
         "politePrefixes": [
           "Could you please",
           "Would you mind",
-          "Kindly",
+          "I would appreciate it if you could",
           "Please"
         ],
         "politeSuffixes": [
           "Thank you",
           "Thanks a lot",
-          "I appreciate it",
-          "Much appreciated"
+          "If you don't mind",
+          "I appreciate it"
         ]
       }
     },
@@ -6226,7 +6401,7 @@
         "subPhrases": [
           {
             "text": "Look for",
-            "category": "action",
+            "category": "command",
             "propertyNames": [
               "fullActionName"
             ]
@@ -6275,9 +6450,9 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "calm piano tunes",
+                "propertyValue": "calming piano tunes",
                 "propertySubPhrases": [
-                  "calm piano tunes"
+                  "calming piano tunes"
                 ]
               },
               {
@@ -6287,9 +6462,9 @@
                 ]
               },
               {
-                "propertyValue": "peaceful piano pieces",
+                "propertyValue": "peaceful piano songs",
                 "propertySubPhrases": [
-                  "peaceful piano pieces"
+                  "peaceful piano songs"
                 ]
               }
             ]
@@ -6297,11 +6472,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "Please",
+          "I would appreciate it if you could"
         ],
         "politeSuffixes": [
-          "Thank you",
-          "I would appreciate it"
+          "for me",
+          "if possible",
+          "thank you",
+          "please"
         ]
       }
     },
@@ -6319,7 +6498,7 @@
             "name": "fullActionName",
             "value": "player.searchTracks",
             "substrings": [
-              "Look for"
+              "Look for rock anthems from the 90s"
             ]
           },
           {
@@ -6361,15 +6540,15 @@
                 ]
               },
               {
-                "propertyValue": "player.lookupTracks",
+                "propertyValue": "player.locateMusic",
                 "propertySubPhrases": [
-                  "Search for"
+                  "Locate"
                 ]
               },
               {
-                "propertyValue": "player.browseTracks",
+                "propertyValue": "player.seekTunes",
                 "propertySubPhrases": [
-                  "Browse"
+                  "Seek"
                 ]
               }
             ]
@@ -6382,21 +6561,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "90s rock hits",
+                "propertyValue": "rock hits from the 90s",
                 "propertySubPhrases": [
-                  "90s rock hits"
+                  "rock hits from the 90s"
                 ]
               },
               {
-                "propertyValue": "rock classics from the 90s",
+                "propertyValue": "90s rock classics",
                 "propertySubPhrases": [
-                  "rock classics from the 90s"
+                  "90s rock classics"
                 ]
               },
               {
-                "propertyValue": "90s rock anthems",
+                "propertyValue": "90s rock songs",
                 "propertySubPhrases": [
-                  "90s rock anthems"
+                  "90s rock songs"
                 ]
               }
             ]
@@ -6404,11 +6583,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "I would appreciate it if you could",
+          "Please"
         ],
         "politeSuffixes": [
           "Thank you",
-          "I would appreciate it"
+          "If you don't mind",
+          "Thanks",
+          "I appreciate it"
         ]
       }
     },
@@ -6440,7 +6623,7 @@
         "subPhrases": [
           {
             "text": "Look for",
-            "category": "action",
+            "category": "command",
             "propertyNames": [
               "fullActionName"
             ]
@@ -6470,13 +6653,13 @@
               {
                 "propertyValue": "player.lookupTracks",
                 "propertySubPhrases": [
-                  "Search for"
+                  "Lookup"
                 ]
               },
               {
-                "propertyValue": "player.browseTracks",
+                "propertyValue": "player.searchMusic",
                 "propertySubPhrases": [
-                  "Browse"
+                  "Search for"
                 ]
               }
             ]
@@ -6511,11 +6694,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "Can you kindly",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it."
+          "if you don't mind",
+          "thank you",
+          "please",
+          "when you have a moment"
         ]
       }
     },
@@ -6532,7 +6719,9 @@
           {
             "name": "fullActionName",
             "value": "player.searchTracks",
-            "isImplicit": true
+            "substrings": [
+              "Look for"
+            ]
           },
           {
             "name": "parameters.query",
@@ -6546,12 +6735,9 @@
           {
             "text": "Look for",
             "category": "command",
-            "synonyms": [
-              "Find",
-              "Search for",
-              "Seek"
-            ],
-            "isOptional": true
+            "propertyNames": [
+              "fullActionName"
+            ]
           },
           {
             "text": "salsa music to dance to",
@@ -6563,6 +6749,33 @@
         ],
         "propertyAlternatives": [
           {
+            "propertyName": "fullActionName",
+            "propertyValue": "player.searchTracks",
+            "propertySubPhrases": [
+              "Look for"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "player.findSongs",
+                "propertySubPhrases": [
+                  "Find"
+                ]
+              },
+              {
+                "propertyValue": "player.locateMusic",
+                "propertySubPhrases": [
+                  "Locate"
+                ]
+              },
+              {
+                "propertyValue": "player.seekTunes",
+                "propertySubPhrases": [
+                  "Seek"
+                ]
+              }
+            ]
+          },
+          {
             "propertyName": "parameters.query",
             "propertyValue": "salsa music to dance to",
             "propertySubPhrases": [
@@ -6570,21 +6783,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "bachata music to dance to",
+                "propertyValue": "salsa dance tracks",
                 "propertySubPhrases": [
-                  "bachata music to dance to"
+                  "salsa dance tracks"
                 ]
               },
               {
-                "propertyValue": "merengue music to dance to",
+                "propertyValue": "salsa dancing songs",
                 "propertySubPhrases": [
-                  "merengue music to dance to"
+                  "salsa dancing songs"
                 ]
               },
               {
-                "propertyValue": "reggaeton music to dance to",
+                "propertyValue": "salsa danceable music",
                 "propertySubPhrases": [
-                  "reggaeton music to dance to"
+                  "salsa danceable music"
                 ]
               }
             ]
@@ -6593,14 +6806,14 @@
         "politePrefixes": [
           "Could you please",
           "Would you mind",
-          "If it's not too much trouble, could you",
-          "May I kindly ask you to"
+          "Please",
+          "I would appreciate it if you could"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it.",
-          "Thanks a lot!",
-          "Your help is appreciated."
+          "thank you",
+          "please",
+          "if you don't mind",
+          "thanks"
         ]
       }
     },
@@ -6662,13 +6875,13 @@
               {
                 "propertyValue": "player.lookupTracks",
                 "propertySubPhrases": [
-                  "Lookup"
+                  "Search for"
                 ]
               },
               {
-                "propertyValue": "player.searchMusic",
+                "propertyValue": "player.browseTracks",
                 "propertySubPhrases": [
-                  "Search for"
+                  "Browse"
                 ]
               }
             ]
@@ -6693,9 +6906,9 @@
                 ]
               },
               {
-                "propertyValue": "Imagine by John Lennon",
+                "propertyValue": "Stairway to Heaven by Led Zeppelin",
                 "propertySubPhrases": [
-                  "Imagine by John Lennon"
+                  "Stairway to Heaven by Led Zeppelin"
                 ]
               }
             ]
@@ -6703,11 +6916,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "Please",
+          "I would appreciate it if you could"
         ],
         "politeSuffixes": [
           "Thank you",
-          "I appreciate it"
+          "Please",
+          "If you don't mind",
+          "Thanks"
         ]
       }
     },
@@ -6739,7 +6956,7 @@
         "subPhrases": [
           {
             "text": "Look for",
-            "category": "action",
+            "category": "command",
             "propertyNames": [
               "fullActionName"
             ]
@@ -6773,9 +6990,9 @@
                 ]
               },
               {
-                "propertyValue": "player.browseTracks",
+                "propertyValue": "player.seekTracks",
                 "propertySubPhrases": [
-                  "Browse"
+                  "Seek"
                 ]
               }
             ]
@@ -6810,11 +7027,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "Can you kindly",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you",
-          "Please"
+          "if you don't mind",
+          "thank you",
+          "please",
+          "if possible"
         ]
       }
     },
@@ -6846,7 +7067,7 @@
         "subPhrases": [
           {
             "text": "Look for",
-            "category": "action",
+            "category": "command",
             "propertyNames": [
               "fullActionName"
             ]
@@ -6876,13 +7097,13 @@
               {
                 "propertyValue": "player.lookupTracks",
                 "propertySubPhrases": [
-                  "Lookup"
+                  "Search for"
                 ]
               },
               {
-                "propertyValue": "player.searchMusic",
+                "propertyValue": "player.seekMusic",
                 "propertySubPhrases": [
-                  "Search for"
+                  "Seek"
                 ]
               }
             ]
@@ -6917,11 +7138,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "Please",
+          "I would appreciate it if you could"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I appreciate it!"
+          "Thank you",
+          "Thanks",
+          "If you don't mind",
+          "Please and thank you"
         ]
       }
     },
@@ -6983,13 +7208,13 @@
               {
                 "propertyValue": "player.lookupTracks",
                 "propertySubPhrases": [
-                  "Search for"
+                  "Lookup"
                 ]
               },
               {
-                "propertyValue": "player.browseTracks",
+                "propertyValue": "player.searchMusic",
                 "propertySubPhrases": [
-                  "Browse"
+                  "Search for"
                 ]
               }
             ]
@@ -7024,11 +7249,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "Can you kindly",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it!"
+          "for me?",
+          "if you don't mind.",
+          "please.",
+          "thanks!"
         ]
       }
     },
@@ -7090,13 +7319,13 @@
               {
                 "propertyValue": "player.lookupTracks",
                 "propertySubPhrases": [
-                  "Search for"
+                  "Lookup"
                 ]
               },
               {
-                "propertyValue": "player.browseTracks",
+                "propertyValue": "player.searchMusic",
                 "propertySubPhrases": [
-                  "Browse"
+                  "Search for"
                 ]
               }
             ]
@@ -7131,11 +7360,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "Can you kindly",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you",
-          "I appreciate it"
+          "if you don't mind",
+          "thank you",
+          "please",
+          "when you have a moment"
         ]
       }
     },
@@ -7160,7 +7393,7 @@
             "name": "parameters.query",
             "value": "latest hip-hop releases",
             "substrings": [
-              "the latest hip-hop releases"
+              "latest hip-hop releases"
             ]
           }
         ],
@@ -7173,7 +7406,17 @@
             ]
           },
           {
-            "text": "the latest hip-hop releases",
+            "text": "the",
+            "category": "preposition",
+            "synonyms": [
+              "a",
+              "an",
+              "some"
+            ],
+            "isOptional": true
+          },
+          {
+            "text": "latest hip-hop releases",
             "category": "query",
             "propertyNames": [
               "parameters.query"
@@ -7195,15 +7438,15 @@
                 ]
               },
               {
-                "propertyValue": "player.browseMusic",
+                "propertyValue": "player.locateMusic",
                 "propertySubPhrases": [
-                  "Browse"
+                  "Locate"
                 ]
               },
               {
-                "propertyValue": "player.discoverTracks",
+                "propertyValue": "player.seekTunes",
                 "propertySubPhrases": [
-                  "Discover"
+                  "Seek"
                 ]
               }
             ]
@@ -7212,19 +7455,19 @@
             "propertyName": "parameters.query",
             "propertyValue": "latest hip-hop releases",
             "propertySubPhrases": [
-              "the latest hip-hop releases"
+              "latest hip-hop releases"
             ],
             "alternatives": [
               {
-                "propertyValue": "new rap songs",
+                "propertyValue": "new hip-hop tracks",
                 "propertySubPhrases": [
-                  "new rap songs"
+                  "new hip-hop tracks"
                 ]
               },
               {
-                "propertyValue": "recent hip-hop tracks",
+                "propertyValue": "recent hip-hop songs",
                 "propertySubPhrases": [
-                  "recent hip-hop tracks"
+                  "recent hip-hop songs"
                 ]
               },
               {
@@ -7238,11 +7481,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "Please",
+          "If you could"
         ],
         "politeSuffixes": [
-          "Thank you",
-          "I appreciate it"
+          "for me?",
+          "please?",
+          "if possible.",
+          "thank you."
         ]
       }
     },
@@ -7280,7 +7527,17 @@
             ]
           },
           {
-            "text": "the most streamed songs this week",
+            "text": "the",
+            "category": "filler",
+            "synonyms": [
+              "a",
+              "any",
+              "some"
+            ],
+            "isOptional": true
+          },
+          {
+            "text": "most streamed songs this week",
             "category": "query",
             "propertyNames": [
               "parameters.query"
@@ -7296,21 +7553,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.findTracks",
-                "propertySubPhrases": [
-                  "Search for"
-                ]
-              },
-              {
-                "propertyValue": "player.lookupTracks",
+                "propertyValue": "player.findSongs",
                 "propertySubPhrases": [
                   "Find"
                 ]
               },
               {
-                "propertyValue": "player.browseTracks",
+                "propertyValue": "player.locateTracks",
                 "propertySubPhrases": [
-                  "Browse"
+                  "Locate"
+                ]
+              },
+              {
+                "propertyValue": "player.searchMusic",
+                "propertySubPhrases": [
+                  "Search for"
                 ]
               }
             ]
@@ -7319,25 +7576,25 @@
             "propertyName": "parameters.query",
             "propertyValue": "most streamed songs this week",
             "propertySubPhrases": [
-              "the most streamed songs this week"
+              "most streamed songs this week"
             ],
             "alternatives": [
               {
                 "propertyValue": "top songs this week",
                 "propertySubPhrases": [
-                  "the top songs this week"
+                  "top songs this week"
                 ]
               },
               {
-                "propertyValue": "popular songs this week",
+                "propertyValue": "popular tracks this week",
                 "propertySubPhrases": [
-                  "the popular songs this week"
+                  "popular tracks this week"
                 ]
               },
               {
                 "propertyValue": "trending songs this week",
                 "propertySubPhrases": [
-                  "the trending songs this week"
+                  "trending songs this week"
                 ]
               }
             ]
@@ -7345,11 +7602,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "Please",
+          "I would appreciate it if you could"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it."
+          "Thank you",
+          "Thanks",
+          "If you don't mind",
+          "Please and thank you"
         ]
       }
     },
@@ -7367,7 +7628,7 @@
             "name": "fullActionName",
             "value": "player.searchTracks",
             "substrings": [
-              "Look for the song"
+              "Look for"
             ]
           },
           {
@@ -7380,11 +7641,21 @@
         ],
         "subPhrases": [
           {
-            "text": "Look for the song",
-            "category": "action",
+            "text": "Look for",
+            "category": "command",
             "propertyNames": [
               "fullActionName"
             ]
+          },
+          {
+            "text": "the song",
+            "category": "filler",
+            "synonyms": [
+              "the track",
+              "the music",
+              "the tune"
+            ],
+            "isOptional": true
           },
           {
             "text": "Bohemian Rhapsody",
@@ -7399,25 +7670,25 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.searchTracks",
             "propertySubPhrases": [
-              "Look for the song"
+              "Look for"
             ],
             "alternatives": [
               {
                 "propertyValue": "player.findSongs",
                 "propertySubPhrases": [
-                  "Find the song"
+                  "Find"
                 ]
               },
               {
-                "propertyValue": "player.lookupTracks",
+                "propertyValue": "player.locateTracks",
                 "propertySubPhrases": [
-                  "Lookup the song"
+                  "Locate"
                 ]
               },
               {
-                "propertyValue": "player.searchMusic",
+                "propertyValue": "player.seekMusic",
                 "propertySubPhrases": [
-                  "Search for the song"
+                  "Seek"
                 ]
               }
             ]
@@ -7452,11 +7723,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "Please",
+          "If you don't mind"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it."
+          "for me?",
+          "please?",
+          "if possible?",
+          "thank you."
         ]
       }
     },
@@ -7473,7 +7748,9 @@
           {
             "name": "fullActionName",
             "value": "player.searchTracks",
-            "isImplicit": true
+            "substrings": [
+              "Look for"
+            ]
           },
           {
             "name": "parameters.query",
@@ -7487,10 +7764,22 @@
           {
             "text": "Look for",
             "category": "command",
-            "propertyNames": []
+            "propertyNames": [
+              "fullActionName"
+            ]
           },
           {
-            "text": "the ultimate workout mix",
+            "text": "the",
+            "category": "preposition",
+            "synonyms": [
+              "a",
+              "an",
+              "any"
+            ],
+            "isOptional": true
+          },
+          {
+            "text": "ultimate workout mix",
             "category": "query",
             "propertyNames": [
               "parameters.query"
@@ -7499,28 +7788,55 @@
         ],
         "propertyAlternatives": [
           {
-            "propertyName": "parameters.query",
-            "propertyValue": "ultimate workout mix",
+            "propertyName": "fullActionName",
+            "propertyValue": "player.searchTracks",
             "propertySubPhrases": [
-              "the ultimate workout mix"
+              "Look for"
             ],
             "alternatives": [
               {
-                "propertyValue": "best workout playlist",
+                "propertyValue": "player.findSongs",
                 "propertySubPhrases": [
-                  "the best workout playlist"
+                  "Find"
                 ]
               },
               {
-                "propertyValue": "top gym songs",
+                "propertyValue": "player.locateTracks",
                 "propertySubPhrases": [
-                  "the top gym songs"
+                  "Locate"
                 ]
               },
               {
-                "propertyValue": "high energy exercise music",
+                "propertyValue": "player.seekMusic",
                 "propertySubPhrases": [
-                  "the high energy exercise music"
+                  "Seek"
+                ]
+              }
+            ]
+          },
+          {
+            "propertyName": "parameters.query",
+            "propertyValue": "ultimate workout mix",
+            "propertySubPhrases": [
+              "ultimate workout mix"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "best exercise playlist",
+                "propertySubPhrases": [
+                  "best exercise playlist"
+                ]
+              },
+              {
+                "propertyValue": "top fitness tracks",
+                "propertySubPhrases": [
+                  "top fitness tracks"
+                ]
+              },
+              {
+                "propertyValue": "greatest gym songs",
+                "propertySubPhrases": [
+                  "greatest gym songs"
                 ]
               }
             ]
@@ -7528,11 +7844,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "Please",
+          "If you don't mind"
         ],
         "politeSuffixes": [
-          "Thank you",
-          "I would appreciate it"
+          "for me?",
+          "please?",
+          "if possible?",
+          "thank you!"
         ]
       }
     },
@@ -7564,7 +7884,7 @@
         "subPhrases": [
           {
             "text": "Look for",
-            "category": "action",
+            "category": "command",
             "propertyNames": [
               "fullActionName"
             ]
@@ -7594,13 +7914,13 @@
               {
                 "propertyValue": "player.lookupTracks",
                 "propertySubPhrases": [
-                  "Lookup"
+                  "Search for"
                 ]
               },
               {
-                "propertyValue": "player.searchMusic",
+                "propertyValue": "player.seekMusic",
                 "propertySubPhrases": [
-                  "Search for"
+                  "Seek"
                 ]
               }
             ]
@@ -7635,11 +7955,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "I would appreciate it if you could",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you",
-          "I appreciate it"
+          "for me",
+          "if possible",
+          "thank you",
+          "when you have a moment"
         ]
       }
     },
@@ -7720,21 +8044,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "relaxing music for yoga",
+                "propertyValue": "relaxing music for meditation",
                 "propertySubPhrases": [
-                  "relaxing music for yoga"
+                  "relaxing music for meditation"
                 ]
               },
               {
-                "propertyValue": "calm sounds for sleep",
+                "propertyValue": "calming sounds for meditation",
                 "propertySubPhrases": [
-                  "calm sounds for sleep"
+                  "calming sounds for meditation"
                 ]
               },
               {
-                "propertyValue": "nature sounds for relaxation",
+                "propertyValue": "meditation background music",
                 "propertySubPhrases": [
-                  "nature sounds for relaxation"
+                  "meditation background music"
                 ]
               }
             ]
@@ -7742,11 +8066,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "I would appreciate it if you could",
+          "Please"
         ],
         "politeSuffixes": [
           "Thank you",
-          "I would appreciate it"
+          "if you don't mind",
+          "please",
+          "thanks"
         ]
       }
     },
@@ -7808,7 +8136,7 @@
               {
                 "propertyValue": "player.searchArtists",
                 "propertySubPhrases": [
-                  "Look up"
+                  "Look for"
                 ]
               },
               {
@@ -7827,21 +8155,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "rock albums from The Beatles",
+                "propertyValue": "rock albums from B.B. King",
                 "propertySubPhrases": [
-                  "rock albums from The Beatles"
+                  "rock albums from B.B. King"
                 ]
               },
               {
-                "propertyValue": "jazz albums from Miles Davis",
+                "propertyValue": "jazz albums from B.B. King",
                 "propertySubPhrases": [
-                  "jazz albums from Miles Davis"
+                  "jazz albums from B.B. King"
                 ]
               },
               {
-                "propertyValue": "pop albums from Michael Jackson",
+                "propertyValue": "blues songs from B.B. King",
                 "propertySubPhrases": [
-                  "pop albums from Michael Jackson"
+                  "blues songs from B.B. King"
                 ]
               }
             ]
@@ -7850,14 +8178,14 @@
         "politePrefixes": [
           "Could you please",
           "Would you mind",
-          "Kindly",
+          "I would appreciate it if you could",
           "Please"
         ],
         "politeSuffixes": [
-          "Thank you.",
-          "Thanks a lot.",
-          "I appreciate it.",
-          "Much appreciated."
+          "Thank you",
+          "If you don't mind",
+          "Thanks a lot",
+          "I appreciate it"
         ]
       }
     },
@@ -7917,7 +8245,7 @@
                 ]
               },
               {
-                "propertyValue": "player.lookupTracks",
+                "propertyValue": "player.lookupMusic",
                 "propertySubPhrases": [
                   "Look up"
                 ]
@@ -7938,21 +8266,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "classical music",
+                "propertyValue": "Broadway songs",
                 "propertySubPhrases": [
-                  "classical music"
+                  "Broadway songs"
                 ]
               },
               {
-                "propertyValue": "jazz standards",
+                "propertyValue": "musical theater tracks",
                 "propertySubPhrases": [
-                  "jazz standards"
+                  "musical theater tracks"
                 ]
               },
               {
-                "propertyValue": "pop hits",
+                "propertyValue": "Broadway show tunes",
                 "propertySubPhrases": [
-                  "pop hits"
+                  "Broadway show tunes"
                 ]
               }
             ]
@@ -7961,12 +8289,14 @@
         "politePrefixes": [
           "Could you please",
           "Would you mind",
-          "If it's not too much trouble, could you"
+          "I would appreciate it if you could",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it.",
-          "Thanks a lot!"
+          "Thank you",
+          "If you don't mind",
+          "Thanks a lot",
+          "I appreciate it"
         ]
       }
     },
@@ -8020,13 +8350,13 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.findTracks",
+                "propertyValue": "player.findSongs",
                 "propertySubPhrases": [
                   "Find"
                 ]
               },
               {
-                "propertyValue": "player.lookupTracks",
+                "propertyValue": "player.lookupMusic",
                 "propertySubPhrases": [
                   "Look up"
                 ]
@@ -8059,9 +8389,9 @@
                 ]
               },
               {
-                "propertyValue": "Beethoven's string quartets",
+                "propertyValue": "Beethoven's orchestral works",
                 "propertySubPhrases": [
-                  "Beethoven's string quartets"
+                  "Beethoven's orchestral works"
                 ]
               }
             ]
@@ -8069,10 +8399,14 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "I would appreciate it if you could",
+          "Please"
         ],
         "politeSuffixes": [
           "Thank you",
+          "Thanks a lot",
+          "If you don't mind",
           "I appreciate it"
         ]
       }
@@ -8154,21 +8488,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "cover songs by popular YouTubers",
+                "propertyValue": "popular cover songs",
                 "propertySubPhrases": [
-                  "cover songs by popular YouTubers"
+                  "popular cover songs"
                 ]
               },
               {
-                "propertyValue": "cover songs by well-known YouTubers",
+                "propertyValue": "YouTube cover songs",
                 "propertySubPhrases": [
-                  "cover songs by well-known YouTubers"
+                  "YouTube cover songs"
                 ]
               },
               {
-                "propertyValue": "cover songs by top YouTubers",
+                "propertyValue": "cover songs by trending YouTubers",
                 "propertySubPhrases": [
-                  "cover songs by top YouTubers"
+                  "cover songs by trending YouTubers"
                 ]
               }
             ]
@@ -8176,11 +8510,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "I would appreciate it if you could",
+          "Please"
         ],
         "politeSuffixes": [
           "Thank you!",
-          "I would appreciate it."
+          "if that's okay.",
+          "Thanks!",
+          "I appreciate it."
         ]
       }
     },
@@ -8234,7 +8572,7 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.findTracks",
+                "propertyValue": "player.findSongs",
                 "propertySubPhrases": [
                   "Find"
                 ]
@@ -8267,15 +8605,15 @@
                 ]
               },
               {
-                "propertyValue": "Marvel movie soundtracks",
+                "propertyValue": "Disney animated movie songs",
                 "propertySubPhrases": [
-                  "Marvel movie soundtracks"
+                  "Disney animated movie songs"
                 ]
               },
               {
-                "propertyValue": "Disney animated movie soundtracks",
+                "propertyValue": "Disney classics soundtracks",
                 "propertySubPhrases": [
-                  "Disney animated movie soundtracks"
+                  "Disney classics soundtracks"
                 ]
               }
             ]
@@ -8284,14 +8622,14 @@
         "politePrefixes": [
           "Could you please",
           "Would you mind",
-          "If it's not too much trouble, could you",
-          "May I kindly ask you to"
+          "I would appreciate it if you could",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it!",
-          "Thanks a lot!",
-          "Much appreciated!"
+          "for me?",
+          "when you have a moment.",
+          "if that's okay.",
+          "thank you."
         ]
       }
     },
@@ -8300,7 +8638,7 @@
       "action": {
         "fullActionName": "player.searchTracks",
         "parameters": {
-          "query": "Don't Stop Believin by Journey"
+          "query": "Dont Stop Believin by Journey"
         }
       },
       "explanation": {
@@ -8314,7 +8652,7 @@
           },
           {
             "name": "parameters.query",
-            "value": "Don't Stop Believin by Journey",
+            "value": "Dont Stop Believin by Journey",
             "substrings": [
               "Dont Stop Believin by Journey"
             ]
@@ -8366,7 +8704,7 @@
           },
           {
             "propertyName": "parameters.query",
-            "propertyValue": "Don't Stop Believin by Journey",
+            "propertyValue": "Dont Stop Believin by Journey",
             "propertySubPhrases": [
               "Dont Stop Believin by Journey"
             ],
@@ -8395,14 +8733,14 @@
         "politePrefixes": [
           "Could you please",
           "Would you mind",
-          "Kindly",
+          "Can you kindly",
           "Please"
         ],
         "politeSuffixes": [
-          "Thank you",
-          "Thanks",
-          "I appreciate it",
-          "Much appreciated"
+          "if you don't mind",
+          "thank you",
+          "please",
+          "when you have a moment"
         ]
       }
     },
@@ -8505,10 +8843,14 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "I would appreciate it if you could",
+          "Please"
         ],
         "politeSuffixes": [
           "Thank you",
+          "Thanks",
+          "If you don't mind",
           "I appreciate it"
         ]
       }
@@ -8569,13 +8911,13 @@
                 ]
               },
               {
-                "propertyValue": "player.lookupTracks",
+                "propertyValue": "player.lookupMusic",
                 "propertySubPhrases": [
                   "Look up"
                 ]
               },
               {
-                "propertyValue": "player.browseTracks",
+                "propertyValue": "player.browseTunes",
                 "propertySubPhrases": [
                   "Browse"
                 ]
@@ -8590,21 +8932,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "classical music",
+                "propertyValue": "popular opera songs",
                 "propertySubPhrases": [
-                  "classical music"
+                  "popular opera songs"
                 ]
               },
               {
-                "propertyValue": "popular rock songs",
+                "propertyValue": "well-known opera pieces",
                 "propertySubPhrases": [
-                  "popular rock songs"
+                  "well-known opera pieces"
                 ]
               },
               {
-                "propertyValue": "jazz standards",
+                "propertyValue": "renowned opera melodies",
                 "propertySubPhrases": [
-                  "jazz standards"
+                  "renowned opera melodies"
                 ]
               }
             ]
@@ -8613,14 +8955,14 @@
         "politePrefixes": [
           "Could you please",
           "Would you mind",
-          "If it's not too much trouble,",
-          "May I kindly ask you to"
+          "I would appreciate it if you could",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you.",
-          "I would appreciate it.",
-          "Thanks a lot.",
-          "Much appreciated."
+          "for me?",
+          "when you have a moment.",
+          "if that's okay.",
+          "thank you."
         ]
       }
     },
@@ -8676,19 +9018,19 @@
               {
                 "propertyValue": "player.findSongs",
                 "propertySubPhrases": [
-                  "Find songs"
+                  "Find"
                 ]
               },
               {
                 "propertyValue": "player.lookupMusic",
                 "propertySubPhrases": [
-                  "Look up music"
+                  "Look up"
                 ]
               },
               {
                 "propertyValue": "player.browseTracks",
                 "propertySubPhrases": [
-                  "Browse tracks"
+                  "Browse"
                 ]
               }
             ]
@@ -8713,9 +9055,9 @@
                 ]
               },
               {
-                "propertyValue": "international folk tunes",
+                "propertyValue": "global folk tunes",
                 "propertySubPhrases": [
-                  "international folk tunes"
+                  "global folk tunes"
                 ]
               }
             ]
@@ -8723,11 +9065,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "I would appreciate it if you could",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it."
+          "Thank you",
+          "if you don't mind",
+          "please",
+          "Thanks"
         ]
       }
     },
@@ -8793,9 +9139,9 @@
                 ]
               },
               {
-                "propertyValue": "player.discoverTracks",
+                "propertyValue": "player.querySongs",
                 "propertySubPhrases": [
-                  "Discover"
+                  "Query"
                 ]
               }
             ]
@@ -8830,11 +9176,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "I would appreciate it if you could",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it."
+          "Thank you",
+          "if that's okay",
+          "please",
+          "if you don't mind"
         ]
       }
     },
@@ -8927,9 +9277,9 @@
                 ]
               },
               {
-                "propertyValue": "Formation by Beyoncé",
+                "propertyValue": "Irreplaceable by Beyoncé",
                 "propertySubPhrases": [
-                  "Formation by Beyoncé"
+                  "Irreplaceable by Beyoncé"
                 ]
               }
             ]
@@ -8938,14 +9288,14 @@
         "politePrefixes": [
           "Could you please",
           "Would you mind",
-          "If it's not too much trouble,",
-          "May I kindly ask you to"
+          "Can you kindly",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it.",
-          "Thanks a lot!",
-          "Much appreciated!"
+          "for me?",
+          "if you don't mind.",
+          "please.",
+          "thanks!"
         ]
       }
     },
@@ -9049,14 +9399,14 @@
         "politePrefixes": [
           "Could you please",
           "Would you mind",
-          "Kindly",
+          "I would appreciate it if you could",
           "Please"
         ],
         "politeSuffixes": [
           "Thank you",
           "Thanks",
-          "I appreciate it",
-          "Much appreciated"
+          "If you don't mind",
+          "I appreciate it"
         ]
       }
     },
@@ -9088,7 +9438,7 @@
         "subPhrases": [
           {
             "text": "Search for",
-            "category": "command",
+            "category": "action",
             "propertyNames": [
               "fullActionName"
             ]
@@ -9122,9 +9472,9 @@
                 ]
               },
               {
-                "propertyValue": "player.browseTracks",
+                "propertyValue": "player.seekMusic",
                 "propertySubPhrases": [
-                  "Browse"
+                  "Seek"
                 ]
               }
             ]
@@ -9137,21 +9487,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "Shape of You by Ed Sheeran",
+                "propertyValue": "I Will Always Love You by Dolly Parton",
                 "propertySubPhrases": [
-                  "Shape of You by Ed Sheeran"
+                  "I Will Always Love You by Dolly Parton"
                 ]
               },
               {
-                "propertyValue": "Bohemian Rhapsody by Queen",
+                "propertyValue": "I Will Always Love You by John Doe",
                 "propertySubPhrases": [
-                  "Bohemian Rhapsody by Queen"
+                  "I Will Always Love You by John Doe"
                 ]
               },
               {
-                "propertyValue": "Thriller by Michael Jackson",
+                "propertyValue": "I Will Always Love You by Jane Smith",
                 "propertySubPhrases": [
-                  "Thriller by Michael Jackson"
+                  "I Will Always Love You by Jane Smith"
                 ]
               }
             ]
@@ -9159,11 +9509,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "I would appreciate it if you could",
+          "Please"
         ],
         "politeSuffixes": [
           "Thank you",
-          "I appreciate it"
+          "if that's okay",
+          "please",
+          "thanks"
         ]
       }
     },
@@ -9172,7 +9526,7 @@
       "action": {
         "fullActionName": "player.searchTracks",
         "parameters": {
-          "query": "Imagine John Lennon"
+          "query": "Imagine by John Lennon"
         }
       },
       "explanation": {
@@ -9186,7 +9540,7 @@
           },
           {
             "name": "parameters.query",
-            "value": "Imagine John Lennon",
+            "value": "Imagine by John Lennon",
             "substrings": [
               "Imagine by John Lennon"
             ]
@@ -9229,34 +9583,34 @@
                 ]
               },
               {
-                "propertyValue": "player.locateTracks",
+                "propertyValue": "player.browseTracks",
                 "propertySubPhrases": [
-                  "Locate"
+                  "Browse"
                 ]
               }
             ]
           },
           {
             "propertyName": "parameters.query",
-            "propertyValue": "Imagine John Lennon",
+            "propertyValue": "Imagine by John Lennon",
             "propertySubPhrases": [
               "Imagine by John Lennon"
             ],
             "alternatives": [
               {
-                "propertyValue": "Hey Jude The Beatles",
+                "propertyValue": "Hey Jude by The Beatles",
                 "propertySubPhrases": [
                   "Hey Jude by The Beatles"
                 ]
               },
               {
-                "propertyValue": "Bohemian Rhapsody Queen",
+                "propertyValue": "Bohemian Rhapsody by Queen",
                 "propertySubPhrases": [
                   "Bohemian Rhapsody by Queen"
                 ]
               },
               {
-                "propertyValue": "Hotel California Eagles",
+                "propertyValue": "Hotel California by Eagles",
                 "propertySubPhrases": [
                   "Hotel California by Eagles"
                 ]
@@ -9266,10 +9620,14 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "I would appreciate it if you could",
+          "Please"
         ],
         "politeSuffixes": [
           "Thank you",
+          "If you don't mind",
+          "Thanks in advance",
           "I appreciate it"
         ]
       }
@@ -9330,15 +9688,15 @@
                 ]
               },
               {
-                "propertyValue": "player.lookupTracks",
+                "propertyValue": "player.lookupMusic",
                 "propertySubPhrases": [
-                  "Look up tracks"
+                  "Look up music"
                 ]
               },
               {
-                "propertyValue": "player.browseMusic",
+                "propertyValue": "player.discoverTracks",
                 "propertySubPhrases": [
-                  "Browse music"
+                  "Discover tracks"
                 ]
               }
             ]
@@ -9351,21 +9709,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "alternative bands like The Strokes",
+                "propertyValue": "indie bands similar to Arctic Monkeys",
                 "propertySubPhrases": [
-                  "alternative bands like The Strokes"
+                  "indie bands similar to Arctic Monkeys"
                 ]
               },
               {
-                "propertyValue": "rock bands like The Black Keys",
+                "propertyValue": "indie artists like Arctic Monkeys",
                 "propertySubPhrases": [
-                  "rock bands like The Black Keys"
+                  "indie artists like Arctic Monkeys"
                 ]
               },
               {
-                "propertyValue": "indie artists like Tame Impala",
+                "propertyValue": "indie groups like Arctic Monkeys",
                 "propertySubPhrases": [
-                  "indie artists like Tame Impala"
+                  "indie groups like Arctic Monkeys"
                 ]
               }
             ]
@@ -9374,14 +9732,14 @@
         "politePrefixes": [
           "Could you please",
           "Would you mind",
-          "If it's not too much trouble,",
-          "May I kindly ask you to"
+          "I would appreciate it if you could",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it.",
-          "Thanks a lot!",
-          "That would be great!"
+          "Thank you",
+          "Thanks",
+          "If you don't mind",
+          "I appreciate it"
         ]
       }
     },
@@ -9399,7 +9757,7 @@
             "name": "fullActionName",
             "value": "player.searchTracks",
             "substrings": [
-              "Search for"
+              "Search"
             ]
           },
           {
@@ -9412,11 +9770,21 @@
         ],
         "subPhrases": [
           {
-            "text": "Search for",
+            "text": "Search",
             "category": "action",
             "propertyNames": [
               "fullActionName"
             ]
+          },
+          {
+            "text": "for",
+            "category": "preposition",
+            "synonyms": [
+              "about",
+              "regarding",
+              "concerning"
+            ],
+            "isOptional": true
           },
           {
             "text": "Italian opera classics",
@@ -9431,7 +9799,7 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.searchTracks",
             "propertySubPhrases": [
-              "Search for"
+              "Search"
             ],
             "alternatives": [
               {
@@ -9447,7 +9815,7 @@
                 ]
               },
               {
-                "propertyValue": "player.browseTracks",
+                "propertyValue": "player.browseTunes",
                 "propertySubPhrases": [
                   "Browse"
                 ]
@@ -9462,21 +9830,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "Italian classical music",
-                "propertySubPhrases": [
-                  "Italian classical music"
-                ]
-              },
-              {
                 "propertyValue": "Italian opera hits",
                 "propertySubPhrases": [
                   "Italian opera hits"
                 ]
               },
               {
-                "propertyValue": "Italian opera arias",
+                "propertyValue": "Italian opera songs",
                 "propertySubPhrases": [
-                  "Italian opera arias"
+                  "Italian opera songs"
+                ]
+              },
+              {
+                "propertyValue": "Italian opera music",
+                "propertySubPhrases": [
+                  "Italian opera music"
                 ]
               }
             ]
@@ -9484,11 +9852,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "I would appreciate it if you could",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you",
-          "I appreciate it"
+          "for me?",
+          "if possible.",
+          "when you have a moment.",
+          "thank you."
         ]
       }
     },
@@ -9554,9 +9926,9 @@
                 ]
               },
               {
-                "propertyValue": "player.browseTracks",
+                "propertyValue": "player.querySongs",
                 "propertySubPhrases": [
-                  "Browse"
+                  "Query"
                 ]
               }
             ]
@@ -9591,10 +9963,14 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "I would appreciate it if you could",
+          "Please"
         ],
         "politeSuffixes": [
           "Thank you",
+          "Thanks",
+          "If you don't mind",
           "I appreciate it"
         ]
       }
@@ -9613,7 +9989,7 @@
             "name": "fullActionName",
             "value": "player.searchTracks",
             "substrings": [
-              "Search for"
+              "Search"
             ]
           },
           {
@@ -9626,11 +10002,21 @@
         ],
         "subPhrases": [
           {
-            "text": "Search for",
+            "text": "Search",
             "category": "action",
             "propertyNames": [
               "fullActionName"
             ]
+          },
+          {
+            "text": "for",
+            "category": "preposition",
+            "synonyms": [
+              "about",
+              "regarding",
+              "concerning"
+            ],
+            "isOptional": true
           },
           {
             "text": "love ballads by Adele",
@@ -9645,7 +10031,7 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.searchTracks",
             "propertySubPhrases": [
-              "Search for"
+              "Search"
             ],
             "alternatives": [
               {
@@ -9661,7 +10047,7 @@
                 ]
               },
               {
-                "propertyValue": "player.browseTracks",
+                "propertyValue": "player.browseSongs",
                 "propertySubPhrases": [
                   "Browse"
                 ]
@@ -9698,11 +10084,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "I would appreciate it if you could",
+          "Please"
         ],
         "politeSuffixes": [
           "Thank you",
-          "I appreciate it"
+          "Thanks",
+          "If you don't mind",
+          "Please and thank you"
         ]
       }
     },
@@ -9805,10 +10195,14 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "I would appreciate it if you could",
+          "Please"
         ],
         "politeSuffixes": [
           "Thank you",
+          "Thanks",
+          "If you don't mind",
           "I appreciate it"
         ]
       }
@@ -9875,9 +10269,9 @@
                 ]
               },
               {
-                "propertyValue": "player.discoverTracks",
+                "propertyValue": "player.querySongs",
                 "propertySubPhrases": [
-                  "Discover"
+                  "Query"
                 ]
               }
             ]
@@ -9912,10 +10306,14 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "I would appreciate it if you could",
+          "Please"
         ],
         "politeSuffixes": [
           "Thank you",
+          "If you don't mind",
+          "Thanks a lot",
           "I appreciate it"
         ]
       }
@@ -9982,7 +10380,7 @@
                 ]
               },
               {
-                "propertyValue": "player.browseSongs",
+                "propertyValue": "player.browseMusic",
                 "propertySubPhrases": [
                   "Browse"
                 ]
@@ -10019,11 +10417,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "I would appreciate it if you could",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it."
+          "for me",
+          "if possible",
+          "thank you",
+          "when you have a moment"
         ]
       }
     },
@@ -10127,14 +10529,14 @@
         "politePrefixes": [
           "Could you please",
           "Would you mind",
-          "Kindly",
-          "If it's not too much trouble"
+          "I would appreciate it if you could",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it.",
-          "Thanks a lot!",
-          "Much appreciated!"
+          "Thank you",
+          "Thanks",
+          "If you don't mind",
+          "I appreciate it"
         ]
       }
     },
@@ -10166,7 +10568,7 @@
         "subPhrases": [
           {
             "text": "Search for",
-            "category": "action",
+            "category": "command",
             "propertyNames": [
               "fullActionName"
             ]
@@ -10237,11 +10639,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "Can you kindly",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you",
-          "I appreciate it"
+          "if you don't mind",
+          "thank you",
+          "please",
+          "when you have a moment"
         ]
       }
     },
@@ -10317,9 +10723,9 @@
                 ]
               },
               {
-                "propertyValue": "player.discoverTracks",
+                "propertyValue": "player.browseTracks",
                 "propertySubPhrases": [
-                  "Discover songs"
+                  "Browse songs"
                 ]
               }
             ]
@@ -10354,11 +10760,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "Please",
+          "I would appreciate it if you could"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it."
+          "Thank you",
+          "Thanks",
+          "If you don't mind",
+          "Please and thank you"
         ]
       }
     },
@@ -10439,21 +10849,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "Aretha Franklin's greatest hits",
+                "propertyValue": "Aretha Franklin's soulful songs",
                 "propertySubPhrases": [
-                  "Aretha Franklin's greatest hits"
+                  "Aretha Franklin's soulful songs"
                 ]
               },
               {
-                "propertyValue": "Aretha Franklin's top songs",
+                "propertyValue": "soul music by Aretha Franklin",
                 "propertySubPhrases": [
-                  "Aretha Franklin's top songs"
+                  "soul music by Aretha Franklin"
                 ]
               },
               {
-                "propertyValue": "Aretha Franklin's best tracks",
+                "propertyValue": "Aretha Franklin's soul hits",
                 "propertySubPhrases": [
-                  "Aretha Franklin's best tracks"
+                  "Aretha Franklin's soul hits"
                 ]
               }
             ]
@@ -10461,11 +10871,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "I would appreciate it if you could",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it."
+          "Thank you",
+          "Thanks",
+          "If you don't mind",
+          "I appreciate it"
         ]
       }
     },
@@ -10483,7 +10897,7 @@
             "name": "fullActionName",
             "value": "player.searchTracks",
             "substrings": [
-              "Search for"
+              "Search"
             ]
           },
           {
@@ -10496,11 +10910,21 @@
         ],
         "subPhrases": [
           {
-            "text": "Search for",
+            "text": "Search",
             "category": "action",
             "propertyNames": [
               "fullActionName"
             ]
+          },
+          {
+            "text": "for",
+            "category": "preposition",
+            "synonyms": [
+              "about",
+              "regarding",
+              "concerning"
+            ],
+            "isOptional": true
           },
           {
             "text": "Spanish guitar music",
@@ -10515,7 +10939,7 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.searchTracks",
             "propertySubPhrases": [
-              "Search for"
+              "Search"
             ],
             "alternatives": [
               {
@@ -10546,21 +10970,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "classical guitar music",
+                "propertyValue": "Flamenco guitar music",
                 "propertySubPhrases": [
-                  "classical guitar music"
+                  "Flamenco guitar music"
                 ]
               },
               {
-                "propertyValue": "flamenco guitar music",
+                "propertyValue": "Latin guitar music",
                 "propertySubPhrases": [
-                  "flamenco guitar music"
+                  "Latin guitar music"
                 ]
               },
               {
-                "propertyValue": "acoustic guitar music",
+                "propertyValue": "Classical guitar music",
                 "propertySubPhrases": [
-                  "acoustic guitar music"
+                  "Classical guitar music"
                 ]
               }
             ]
@@ -10569,14 +10993,14 @@
         "politePrefixes": [
           "Could you please",
           "Would you mind",
-          "If it's not too much trouble, could you",
-          "May I kindly ask you to"
+          "I would appreciate it if you could",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it!",
-          "Thanks a lot!",
-          "Much appreciated!"
+          "Thank you",
+          "Thanks",
+          "If you don't mind",
+          "I appreciate it"
         ]
       }
     },
@@ -10642,9 +11066,9 @@
                 ]
               },
               {
-                "propertyValue": "player.searchMusic",
+                "propertyValue": "player.querySongs",
                 "propertySubPhrases": [
-                  "Search music for"
+                  "Query"
                 ]
               }
             ]
@@ -10657,21 +11081,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "Bohemian Rhapsody by Queen",
+                "propertyValue": "November Rain by Guns N Roses",
                 "propertySubPhrases": [
-                  "Bohemian Rhapsody by Queen"
+                  "November Rain by Guns N Roses"
                 ]
               },
               {
-                "propertyValue": "Hotel California by Eagles",
+                "propertyValue": "Paradise City by Guns N Roses",
                 "propertySubPhrases": [
-                  "Hotel California by Eagles"
+                  "Paradise City by Guns N Roses"
                 ]
               },
               {
-                "propertyValue": "Stairway to Heaven by Led Zeppelin",
+                "propertyValue": "Welcome to the Jungle by Guns N Roses",
                 "propertySubPhrases": [
-                  "Stairway to Heaven by Led Zeppelin"
+                  "Welcome to the Jungle by Guns N Roses"
                 ]
               }
             ]
@@ -10679,10 +11103,14 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "I would appreciate it if you could",
+          "Please"
         ],
         "politeSuffixes": [
           "Thank you",
+          "Thanks",
+          "If you don't mind",
           "I appreciate it"
         ]
       }
@@ -10692,114 +11120,7 @@
       "action": {
         "fullActionName": "player.searchTracks",
         "parameters": {
-          "query": "Thriller by Michael Jackson"
-        }
-      },
-      "explanation": {
-        "properties": [
-          {
-            "name": "fullActionName",
-            "value": "player.searchTracks",
-            "substrings": [
-              "Search for the album"
-            ]
-          },
-          {
-            "name": "parameters.query",
-            "value": "Thriller by Michael Jackson",
-            "substrings": [
-              "Thriller by Michael Jackson"
-            ]
-          }
-        ],
-        "subPhrases": [
-          {
-            "text": "Search for the album",
-            "category": "action",
-            "propertyNames": [
-              "fullActionName"
-            ]
-          },
-          {
-            "text": "Thriller by Michael Jackson",
-            "category": "query",
-            "propertyNames": [
-              "parameters.query"
-            ]
-          }
-        ],
-        "propertyAlternatives": [
-          {
-            "propertyName": "fullActionName",
-            "propertyValue": "player.searchTracks",
-            "propertySubPhrases": [
-              "Search for the album"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "player.searchAlbums",
-                "propertySubPhrases": [
-                  "Find the album"
-                ]
-              },
-              {
-                "propertyValue": "player.searchSongs",
-                "propertySubPhrases": [
-                  "Search for the song"
-                ]
-              },
-              {
-                "propertyValue": "player.searchArtists",
-                "propertySubPhrases": [
-                  "Look for the artist"
-                ]
-              }
-            ]
-          },
-          {
-            "propertyName": "parameters.query",
-            "propertyValue": "Thriller by Michael Jackson",
-            "propertySubPhrases": [
-              "Thriller by Michael Jackson"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "Bad by Michael Jackson",
-                "propertySubPhrases": [
-                  "Bad by Michael Jackson"
-                ]
-              },
-              {
-                "propertyValue": "Dangerous by Michael Jackson",
-                "propertySubPhrases": [
-                  "Dangerous by Michael Jackson"
-                ]
-              },
-              {
-                "propertyValue": "Off the Wall by Michael Jackson",
-                "propertySubPhrases": [
-                  "Off the Wall by Michael Jackson"
-                ]
-              }
-            ]
-          }
-        ],
-        "politePrefixes": [
-          "Could you please",
-          "Would you mind"
-        ],
-        "politeSuffixes": [
-          "Thank you",
-          "I would appreciate it"
-        ]
-      }
-    },
-    {
-      "request": "Search for the best of British rock",
-      "action": {
-        "fullActionName": "player.searchTracks",
-        "parameters": {
-          "query": "best of British rock"
+          "query": "Thriller Michael Jackson"
         }
       },
       "explanation": {
@@ -10813,9 +11134,10 @@
           },
           {
             "name": "parameters.query",
-            "value": "best of British rock",
+            "value": "Thriller Michael Jackson",
             "substrings": [
-              "best of British rock"
+              "Thriller",
+              "Michael Jackson"
             ]
           }
         ],
@@ -10828,7 +11150,34 @@
             ]
           },
           {
-            "text": "the best of British rock",
+            "text": "the album",
+            "category": "filler",
+            "synonyms": [
+              "the record",
+              "the collection",
+              "the compilation"
+            ],
+            "isOptional": true
+          },
+          {
+            "text": "Thriller",
+            "category": "query",
+            "propertyNames": [
+              "parameters.query"
+            ]
+          },
+          {
+            "text": "by",
+            "category": "preposition",
+            "synonyms": [
+              "from",
+              "created by",
+              "performed by"
+            ],
+            "isOptional": true
+          },
+          {
+            "text": "Michael Jackson",
             "category": "query",
             "propertyNames": [
               "parameters.query"
@@ -10856,6 +11205,131 @@
                 ]
               },
               {
+                "propertyValue": "player.locateMusic",
+                "propertySubPhrases": [
+                  "Locate"
+                ]
+              }
+            ]
+          },
+          {
+            "propertyName": "parameters.query",
+            "propertyValue": "Thriller Michael Jackson",
+            "propertySubPhrases": [
+              "Thriller",
+              "Michael Jackson"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "Bad Michael Jackson",
+                "propertySubPhrases": [
+                  "Bad",
+                  "Michael Jackson"
+                ]
+              },
+              {
+                "propertyValue": "Dangerous Michael Jackson",
+                "propertySubPhrases": [
+                  "Dangerous",
+                  "Michael Jackson"
+                ]
+              },
+              {
+                "propertyValue": "Off the Wall Michael Jackson",
+                "propertySubPhrases": [
+                  "Off the Wall",
+                  "Michael Jackson"
+                ]
+              }
+            ]
+          }
+        ],
+        "politePrefixes": [
+          "Could you please",
+          "Would you mind",
+          "Please",
+          "Kindly"
+        ],
+        "politeSuffixes": [
+          "if you don't mind",
+          "thank you",
+          "please",
+          "if possible"
+        ]
+      }
+    },
+    {
+      "request": "Search for the best of British rock",
+      "action": {
+        "fullActionName": "player.searchTracks",
+        "parameters": {
+          "query": "best of British rock"
+        }
+      },
+      "explanation": {
+        "properties": [
+          {
+            "name": "fullActionName",
+            "value": "player.searchTracks",
+            "substrings": [
+              "Search"
+            ]
+          },
+          {
+            "name": "parameters.query",
+            "value": "best of British rock",
+            "substrings": [
+              "best of British rock"
+            ]
+          }
+        ],
+        "subPhrases": [
+          {
+            "text": "Search",
+            "category": "action",
+            "propertyNames": [
+              "fullActionName"
+            ]
+          },
+          {
+            "text": "for",
+            "category": "preposition",
+            "synonyms": [
+              "to",
+              "about",
+              "regarding"
+            ],
+            "isOptional": true
+          },
+          {
+            "text": "the best of British rock",
+            "category": "query",
+            "propertyNames": [
+              "parameters.query"
+            ]
+          }
+        ],
+        "propertyAlternatives": [
+          {
+            "propertyName": "fullActionName",
+            "propertyValue": "player.searchTracks",
+            "propertySubPhrases": [
+              "Search"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "player.findSongs",
+                "propertySubPhrases": [
+                  "Find"
+                ]
+              },
+              {
+                "propertyValue": "player.lookupMusic",
+                "propertySubPhrases": [
+                  "Look up"
+                ]
+              },
+              {
                 "propertyValue": "player.browseTracks",
                 "propertySubPhrases": [
                   "Browse"
@@ -10873,19 +11347,19 @@
               {
                 "propertyValue": "top British rock",
                 "propertySubPhrases": [
-                  "the top British rock"
+                  "top British rock"
                 ]
               },
               {
                 "propertyValue": "greatest British rock",
                 "propertySubPhrases": [
-                  "the greatest British rock"
+                  "greatest British rock"
                 ]
               },
               {
-                "propertyValue": "classic British rock",
+                "propertyValue": "British rock hits",
                 "propertySubPhrases": [
-                  "the classic British rock"
+                  "British rock hits"
                 ]
               }
             ]
@@ -10894,14 +11368,14 @@
         "politePrefixes": [
           "Could you please",
           "Would you mind",
-          "Kindly",
+          "I would appreciate it if you could",
           "Please"
         ],
         "politeSuffixes": [
           "Thank you",
           "Thanks a lot",
-          "I appreciate it",
-          "Much appreciated"
+          "If you don't mind",
+          "I appreciate it"
         ]
       }
     },
@@ -10919,7 +11393,7 @@
             "name": "fullActionName",
             "value": "player.searchTracks",
             "substrings": [
-              "Search for"
+              "Search"
             ]
           },
           {
@@ -10932,11 +11406,21 @@
         ],
         "subPhrases": [
           {
-            "text": "Search for",
+            "text": "Search",
             "category": "action",
             "propertyNames": [
               "fullActionName"
             ]
+          },
+          {
+            "text": "for",
+            "category": "preposition",
+            "synonyms": [
+              "about",
+              "regarding",
+              "concerning"
+            ],
+            "isOptional": true
           },
           {
             "text": "top charting pop songs",
@@ -10951,7 +11435,7 @@
             "propertyName": "fullActionName",
             "propertyValue": "player.searchTracks",
             "propertySubPhrases": [
-              "Search for"
+              "Search"
             ],
             "alternatives": [
               {
@@ -10982,21 +11466,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "latest pop hits",
+                "propertyValue": "popular pop songs",
                 "propertySubPhrases": [
-                  "latest pop hits"
+                  "popular pop songs"
                 ]
               },
               {
-                "propertyValue": "popular pop tracks",
+                "propertyValue": "hit pop songs",
                 "propertySubPhrases": [
-                  "popular pop tracks"
+                  "hit pop songs"
                 ]
               },
               {
-                "propertyValue": "current pop chart-toppers",
+                "propertyValue": "trending pop songs",
                 "propertySubPhrases": [
-                  "current pop chart-toppers"
+                  "trending pop songs"
                 ]
               }
             ]
@@ -11005,12 +11489,14 @@
         "politePrefixes": [
           "Could you please",
           "Would you mind",
-          "If it's not too much trouble, could you"
+          "I would appreciate it if you could",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it.",
-          "Thanks a lot!"
+          "for me?",
+          "when you get a chance.",
+          "if possible.",
+          "thank you."
         ]
       }
     },
@@ -11042,7 +11528,7 @@
         "subPhrases": [
           {
             "text": "Search for",
-            "category": "action",
+            "category": "command",
             "propertyNames": [
               "fullActionName"
             ]
@@ -11076,9 +11562,9 @@
                 ]
               },
               {
-                "propertyValue": "player.browseTracks",
+                "propertyValue": "player.seekMusic",
                 "propertySubPhrases": [
-                  "Browse"
+                  "Seek"
                 ]
               }
             ]
@@ -11113,11 +11599,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "Please",
+          "I would appreciate it if you could"
         ],
         "politeSuffixes": [
-          "Thank you",
-          "I appreciate it"
+          "thank you",
+          "please",
+          "if you don't mind",
+          "thanks"
         ]
       }
     },
@@ -11177,13 +11667,13 @@
                 ]
               },
               {
-                "propertyValue": "player.lookupTracks",
+                "propertyValue": "player.lookupMusic",
                 "propertySubPhrases": [
                   "Look up"
                 ]
               },
               {
-                "propertyValue": "player.browseTracks",
+                "propertyValue": "player.browseTunes",
                 "propertySubPhrases": [
                   "Browse"
                 ]
@@ -11198,21 +11688,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "classic rock records",
+                "propertyValue": "classic rock albums",
                 "propertySubPhrases": [
-                  "classic rock records"
+                  "classic rock albums"
                 ]
               },
               {
-                "propertyValue": "old school hip hop records",
+                "propertyValue": "old jazz records",
                 "propertySubPhrases": [
-                  "old school hip hop records"
+                  "old jazz records"
                 ]
               },
               {
-                "propertyValue": "retro pop records",
+                "propertyValue": "retro pop singles",
                 "propertySubPhrases": [
-                  "retro pop records"
+                  "retro pop singles"
                 ]
               }
             ]
@@ -11220,11 +11710,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "I would appreciate it if you could",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you",
-          "I would appreciate it"
+          "for me?",
+          "when you have a moment.",
+          "if that's okay.",
+          "thank you."
         ]
       }
     },
@@ -11256,7 +11750,7 @@
         "subPhrases": [
           {
             "text": "Search for",
-            "category": "action",
+            "category": "command",
             "propertyNames": [
               "fullActionName"
             ]
@@ -11290,9 +11784,9 @@
                 ]
               },
               {
-                "propertyValue": "player.searchMusic",
+                "propertyValue": "player.browseTracks",
                 "propertySubPhrases": [
-                  "Search music for"
+                  "Browse"
                 ]
               }
             ]
@@ -11317,9 +11811,9 @@
                 ]
               },
               {
-                "propertyValue": "Billie Jean by Michael Jackson",
+                "propertyValue": "Rolling in the Deep by Adele",
                 "propertySubPhrases": [
-                  "Billie Jean by Michael Jackson"
+                  "Rolling in the Deep by Adele"
                 ]
               }
             ]
@@ -11327,11 +11821,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "I would appreciate it if you could",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it."
+          "for me",
+          "if possible",
+          "thank you",
+          "when you have a moment"
         ]
       }
     },
@@ -11363,7 +11861,7 @@
         "subPhrases": [
           {
             "text": "Search for",
-            "category": "action",
+            "category": "command",
             "propertyNames": [
               "fullActionName"
             ]
@@ -11435,14 +11933,14 @@
         "politePrefixes": [
           "Could you please",
           "Would you mind",
-          "If it's not too much trouble,",
-          "May I kindly ask you to"
+          "I would appreciate it if you could",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you.",
-          "I would appreciate it.",
-          "Thanks a lot.",
-          "Much appreciated."
+          "Thank you",
+          "If you don't mind",
+          "Thanks a lot",
+          "I appreciate it"
         ]
       }
     }

--- a/ts/packages/defaultAgentProvider/test/data/explanations/player/v5/simple.json
+++ b/ts/packages/defaultAgentProvider/test/data/explanations/player/v5/simple.json
@@ -17,7 +17,9 @@
           {
             "name": "fullActionName",
             "value": "player.playArtist",
-            "isImplicit": true
+            "substrings": [
+              "could you play"
+            ]
           },
           {
             "name": "parameters.artist",
@@ -34,7 +36,7 @@
             "synonyms": [
               "um",
               "uh",
-              "er"
+              "well"
             ],
             "isOptional": true
           },
@@ -42,16 +44,18 @@
             "text": "yes",
             "category": "confirmation",
             "synonyms": [
-              "yeah",
-              "yep",
-              "sure"
+              "sure",
+              "okay",
+              "alright"
             ],
             "isOptional": true
           },
           {
             "text": "could you play",
             "category": "request",
-            "propertyNames": []
+            "propertyNames": [
+              "fullActionName"
+            ]
           },
           {
             "text": "um",
@@ -59,7 +63,7 @@
             "synonyms": [
               "ah",
               "uh",
-              "er"
+              "well"
             ],
             "isOptional": true
           },
@@ -74,9 +78,9 @@
             "text": "aa...like songs",
             "category": "filler",
             "synonyms": [
-              "like",
-              "such as",
-              "for example"
+              "um...like songs",
+              "uh...like songs",
+              "well...like songs"
             ],
             "isOptional": true
           },
@@ -92,6 +96,33 @@
           }
         ],
         "propertyAlternatives": [
+          {
+            "propertyName": "fullActionName",
+            "propertyValue": "player.playArtist",
+            "propertySubPhrases": [
+              "could you play"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "player.playSong",
+                "propertySubPhrases": [
+                  "could you play a song by"
+                ]
+              },
+              {
+                "propertyValue": "player.playAlbum",
+                "propertySubPhrases": [
+                  "could you play an album by"
+                ]
+              },
+              {
+                "propertyValue": "player.playPlaylist",
+                "propertySubPhrases": [
+                  "could you play a playlist by"
+                ]
+              }
+            ]
+          },
           {
             "propertyName": "parameters.artist",
             "propertyValue": "Paul Simon",
@@ -121,97 +152,13 @@
           }
         ],
         "politePrefixes": [],
-        "politeSuffixes": []
-      },
-      "corrections": [
-        {
-          "data": {
-            "properties": [
-              {
-                "name": "fullActionName",
-                "value": "player.playArtist",
-                "isImplicit": true
-              },
-              {
-                "name": "parameters.artist",
-                "value": "Paul Simon",
-                "substrings": [
-                  "Paul Simon"
-                ]
-              }
-            ],
-            "subPhrases": [
-              {
-                "text": "ah",
-                "category": "filler",
-                "synonyms": [
-                  "um",
-                  "uh",
-                  "er"
-                ],
-                "isOptional": true
-              },
-              {
-                "text": "yes",
-                "category": "confirmation",
-                "synonyms": [
-                  "yeah",
-                  "yep",
-                  "sure"
-                ],
-                "isOptional": true
-              },
-              {
-                "text": "could you play",
-                "category": "request",
-                "propertyNames": [
-                  "fullActionName"
-                ]
-              },
-              {
-                "text": "um",
-                "category": "filler",
-                "synonyms": [
-                  "ah",
-                  "uh",
-                  "er"
-                ],
-                "isOptional": true
-              },
-              {
-                "text": "Paul Simon",
-                "category": "artist",
-                "propertyNames": [
-                  "parameters.artist"
-                ]
-              },
-              {
-                "text": "aa...like songs",
-                "category": "filler",
-                "synonyms": [
-                  "like",
-                  "such as",
-                  "for example"
-                ],
-                "isOptional": true
-              },
-              {
-                "text": "please",
-                "category": "politeness",
-                "synonyms": [
-                  "kindly",
-                  "if you could",
-                  "would you mind"
-                ],
-                "isOptional": true
-              }
-            ]
-          },
-          "correction": [
-            "Property 'fullActionName' is expected to be implicit and should not be included as a property name in a sub-phrase"
-          ]
-        }
-      ]
+        "politeSuffixes": [
+          "if you don't mind.",
+          "thank you.",
+          "when you get a chance.",
+          "if it's not too much trouble."
+        ]
+      }
     },
     {
       "request": "all right buddy, lets hear some, ahh, I guess Debussy Preludes",
@@ -229,7 +176,9 @@
           {
             "name": "fullActionName",
             "value": "player.playTrack",
-            "isImplicit": true
+            "substrings": [
+              "lets hear"
+            ]
           },
           {
             "name": "parameters.trackName",
@@ -251,39 +200,26 @@
             "text": "all right buddy",
             "category": "acknowledgement",
             "synonyms": [
-              "okay",
-              "sure thing",
-              "alright"
+              "okay friend",
+              "sure pal",
+              "alright mate"
             ],
             "isOptional": true
           },
           {
-            "text": "lets hear some",
+            "text": "lets hear",
             "category": "command",
-            "synonyms": [
-              "play",
-              "put on",
-              "start"
-            ],
-            "isOptional": true
+            "propertyNames": [
+              "fullActionName"
+            ]
           },
           {
-            "text": "ahh",
+            "text": "some, ahh, I guess",
             "category": "filler",
             "synonyms": [
-              "um",
-              "uh",
-              "hmm"
-            ],
-            "isOptional": true
-          },
-          {
-            "text": "I guess",
-            "category": "filler",
-            "synonyms": [
-              "maybe",
-              "perhaps",
-              "I think"
+              "um, maybe",
+              "well, I think",
+              "perhaps"
             ],
             "isOptional": true
           },
@@ -304,6 +240,33 @@
         ],
         "propertyAlternatives": [
           {
+            "propertyName": "fullActionName",
+            "propertyValue": "player.playTrack",
+            "propertySubPhrases": [
+              "lets hear"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "player.queueTrack",
+                "propertySubPhrases": [
+                  "queue up"
+                ]
+              },
+              {
+                "propertyValue": "player.addTrackToPlaylist",
+                "propertySubPhrases": [
+                  "add to playlist"
+                ]
+              },
+              {
+                "propertyValue": "player.shufflePlay",
+                "propertySubPhrases": [
+                  "shuffle play"
+                ]
+              }
+            ]
+          },
+          {
             "propertyName": "parameters.artists.0",
             "propertyValue": "Debussy",
             "propertySubPhrases": [
@@ -311,15 +274,15 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "Beethoven",
-                "propertySubPhrases": [
-                  "Beethoven"
-                ]
-              },
-              {
                 "propertyValue": "Mozart",
                 "propertySubPhrases": [
                   "Mozart"
+                ]
+              },
+              {
+                "propertyValue": "Beethoven",
+                "propertySubPhrases": [
+                  "Beethoven"
                 ]
               },
               {
@@ -344,15 +307,15 @@
                 ]
               },
               {
-                "propertyValue": "Moonlight Sonata",
+                "propertyValue": "Arabesque",
                 "propertySubPhrases": [
-                  "Moonlight Sonata"
+                  "Arabesque"
                 ]
               },
               {
-                "propertyValue": "Nocturnes",
+                "propertyValue": "La Mer",
                 "propertySubPhrases": [
-                  "Nocturnes"
+                  "La Mer"
                 ]
               }
             ]
@@ -360,11 +323,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If it's not too much trouble",
+          "I would appreciate it if you could"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it."
+          "thank you",
+          "please",
+          "if you don't mind",
+          "thanks a lot"
         ]
       }
     },
@@ -382,7 +349,9 @@
           {
             "name": "fullActionName",
             "value": "player.playArtist",
-            "isImplicit": true
+            "substrings": [
+              "can I hear"
+            ]
           },
           {
             "name": "parameters.artist",
@@ -395,20 +364,17 @@
             "name": "parameters.quantity",
             "value": 2,
             "substrings": [
-              "a couple of"
+              "a couple of songs"
             ]
           }
         ],
         "subPhrases": [
           {
             "text": "can I hear",
-            "category": "politeness",
-            "synonyms": [
-              "could I listen to",
-              "may I hear",
-              "would I be able to hear"
-            ],
-            "isOptional": true
+            "category": "request",
+            "propertyNames": [
+              "fullActionName"
+            ]
           },
           {
             "text": "katie perry",
@@ -423,29 +389,47 @@
             "synonyms": [
               "um",
               "ah",
-              "well"
+              "well",
+              "like"
             ],
             "isOptional": true
           },
           {
-            "text": "like a couple of",
+            "text": "like a couple of songs",
             "category": "quantity",
             "propertyNames": [
               "parameters.quantity"
             ]
-          },
-          {
-            "text": "songs",
-            "category": "confirmation",
-            "synonyms": [
-              "tracks",
-              "tunes",
-              "pieces"
-            ],
-            "isOptional": true
           }
         ],
         "propertyAlternatives": [
+          {
+            "propertyName": "fullActionName",
+            "propertyValue": "player.playArtist",
+            "propertySubPhrases": [
+              "can I hear"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "player.playSong",
+                "propertySubPhrases": [
+                  "can I listen to"
+                ]
+              },
+              {
+                "propertyValue": "player.playAlbum",
+                "propertySubPhrases": [
+                  "can I play"
+                ]
+              },
+              {
+                "propertyValue": "player.playPlaylist",
+                "propertySubPhrases": [
+                  "can I put on"
+                ]
+              }
+            ]
+          },
           {
             "propertyName": "parameters.artist",
             "propertyValue": "Katy Perry",
@@ -477,25 +461,25 @@
             "propertyName": "parameters.quantity",
             "propertyValue": 2,
             "propertySubPhrases": [
-              "like a couple of"
+              "like a couple of songs"
             ],
             "alternatives": [
               {
                 "propertyValue": 1,
                 "propertySubPhrases": [
-                  "one"
+                  "one song"
                 ]
               },
               {
                 "propertyValue": 3,
                 "propertySubPhrases": [
-                  "three"
+                  "a few songs"
                 ]
               },
               {
                 "propertyValue": 5,
                 "propertySubPhrases": [
-                  "five"
+                  "five songs"
                 ]
               }
             ]
@@ -503,10 +487,14 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would it be possible to",
+          "May I kindly",
+          "If you don't mind,"
         ],
         "politeSuffixes": [
-          "Thank you!",
+          "thank you.",
+          "please.",
+          "if that's okay.",
           "I would appreciate it."
         ]
       }
@@ -516,7 +504,7 @@
       "action": {
         "fullActionName": "player.playArtist",
         "parameters": {
-          "artist": "Katy Perry"
+          "artist": "Katie Perry"
         }
       },
       "explanation": {
@@ -530,7 +518,7 @@
           },
           {
             "name": "parameters.artist",
-            "value": "Katy Perry",
+            "value": "Katie Perry",
             "substrings": [
               "katie perry"
             ]
@@ -539,11 +527,11 @@
         "subPhrases": [
           {
             "text": "can I",
-            "category": "filler",
+            "category": "politeness",
             "synonyms": [
               "could I",
               "may I",
-              "would I"
+              "would I be able to"
             ],
             "isOptional": true
           },
@@ -595,14 +583,14 @@
               {
                 "propertyValue": "player.playPlaylist",
                 "propertySubPhrases": [
-                  "queue up"
+                  "stream"
                 ]
               }
             ]
           },
           {
             "propertyName": "parameters.artist",
-            "propertyValue": "Katy Perry",
+            "propertyValue": "Katie Perry",
             "propertySubPhrases": [
               "katie perry"
             ],
@@ -629,12 +617,16 @@
           }
         ],
         "politePrefixes": [
-          "Could you please",
-          "Would you mind"
+          "Please, ",
+          "Could you please, ",
+          "Would you mind, ",
+          "If it's not too much trouble, "
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it!"
+          ", thank you.",
+          ", please.",
+          ", if you don't mind.",
+          ", I'd appreciate it."
         ]
       }
     },
@@ -651,7 +643,9 @@
           {
             "name": "fullActionName",
             "value": "player.playArtist",
-            "isImplicit": true
+            "substrings": [
+              "cue up"
+            ]
           },
           {
             "name": "parameters.artist",
@@ -663,14 +657,21 @@
         ],
         "subPhrases": [
           {
-            "text": "cue up some",
-            "category": "command",
+            "text": "cue up",
+            "category": "action",
+            "propertyNames": [
+              "fullActionName"
+            ]
+          },
+          {
+            "text": "some",
+            "category": "filler",
             "synonyms": [
-              "play",
-              "start",
-              "put on"
+              "a bit of",
+              "any",
+              "a little"
             ],
-            "isOptional": false
+            "isOptional": true
           },
           {
             "text": "Taylor Swift",
@@ -681,6 +682,33 @@
           }
         ],
         "propertyAlternatives": [
+          {
+            "propertyName": "fullActionName",
+            "propertyValue": "player.playArtist",
+            "propertySubPhrases": [
+              "cue up"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "player.queueArtist",
+                "propertySubPhrases": [
+                  "queue up"
+                ]
+              },
+              {
+                "propertyValue": "player.addArtistToPlaylist",
+                "propertySubPhrases": [
+                  "add to playlist"
+                ]
+              },
+              {
+                "propertyValue": "player.startArtistRadio",
+                "propertySubPhrases": [
+                  "start radio"
+                ]
+              }
+            ]
+          },
           {
             "propertyName": "parameters.artist",
             "propertyValue": "Taylor Swift",
@@ -701,9 +729,9 @@
                 ]
               },
               {
-                "propertyValue": "Beyoncé",
+                "propertyValue": "Billie Eilish",
                 "propertySubPhrases": [
-                  "Beyoncé"
+                  "Billie Eilish"
                 ]
               }
             ]
@@ -711,11 +739,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If it's not too much trouble,",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "Thanks a lot!"
+          "thank you.",
+          "if you don't mind.",
+          "please.",
+          "thanks."
         ]
       }
     },
@@ -763,19 +795,29 @@
             ]
           },
           {
-            "text": "the Bach vibes",
+            "text": "the",
+            "category": "preposition",
+            "synonyms": [
+              "a",
+              "some",
+              "those"
+            ],
+            "isOptional": true
+          },
+          {
+            "text": "Bach",
             "category": "artist",
             "propertyNames": [
               "parameters.artist"
             ]
           },
           {
-            "text": "?",
-            "category": "punctuation",
+            "text": "vibes",
+            "category": "filler",
             "synonyms": [
-              "",
-              ".",
-              "!"
+              "music",
+              "tunes",
+              "sounds"
             ],
             "isOptional": true
           }
@@ -789,21 +831,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.startMusic",
+                "propertyValue": "player.playSong",
                 "propertySubPhrases": [
-                  "start the music"
+                  "play"
                 ]
               },
               {
-                "propertyValue": "player.beginPlayback",
+                "propertyValue": "player.playAlbum",
                 "propertySubPhrases": [
-                  "begin playback"
+                  "put on"
                 ]
               },
               {
-                "propertyValue": "player.initiateTunes",
+                "propertyValue": "player.playPlaylist",
                 "propertySubPhrases": [
-                  "initiate the tunes"
+                  "start"
                 ]
               }
             ]
@@ -812,25 +854,25 @@
             "propertyName": "parameters.artist",
             "propertyValue": "Bach",
             "propertySubPhrases": [
-              "the Bach vibes"
+              "Bach"
             ],
             "alternatives": [
               {
                 "propertyValue": "Mozart",
                 "propertySubPhrases": [
-                  "the Mozart vibes"
+                  "Mozart"
                 ]
               },
               {
                 "propertyValue": "Beethoven",
                 "propertySubPhrases": [
-                  "the Beethoven vibes"
+                  "Beethoven"
                 ]
               },
               {
                 "propertyValue": "Chopin",
                 "propertySubPhrases": [
-                  "the Chopin vibes"
+                  "Chopin"
                 ]
               }
             ]
@@ -838,11 +880,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If it's not too much trouble,",
+          "May I kindly ask"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it."
+          "please?",
+          "if you don't mind.",
+          "thank you.",
+          "if that's okay."
         ]
       }
     },
@@ -891,7 +937,7 @@
           },
           {
             "text": "Pretzel Logic",
-            "category": "album name",
+            "category": "album",
             "propertyNames": [
               "parameters.albumName"
             ]
@@ -902,13 +948,13 @@
             "synonyms": [
               "from",
               "of",
-              "featuring"
+              "with"
             ],
             "isOptional": true
           },
           {
             "text": "Steely Dan",
-            "category": "artist name",
+            "category": "artist",
             "propertyNames": [
               "parameters.artists.0"
             ]
@@ -999,11 +1045,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If it's not too much trouble,",
+          "I would appreciate it if you could"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it."
+          "thank you.",
+          "please.",
+          "if you don't mind.",
+          "thanks a lot."
         ]
       }
     },
@@ -1023,9 +1073,7 @@
           {
             "name": "fullActionName",
             "value": "player.playAlbum",
-            "substrings": [
-              "lets listen to"
-            ]
+            "isImplicit": true
           },
           {
             "name": "parameters.albumName",
@@ -1045,14 +1093,12 @@
         "subPhrases": [
           {
             "text": "lets listen to",
-            "category": "action",
-            "propertyNames": [
-              "fullActionName"
-            ]
+            "category": "command",
+            "propertyNames": []
           },
           {
             "text": "Pretzel Logic",
-            "category": "albumName",
+            "category": "album",
             "propertyNames": [
               "parameters.albumName"
             ]
@@ -1063,7 +1109,7 @@
             "synonyms": [
               "from",
               "performed by",
-              "sung by"
+              "created by"
             ],
             "isOptional": true
           },
@@ -1076,33 +1122,6 @@
           }
         ],
         "propertyAlternatives": [
-          {
-            "propertyName": "fullActionName",
-            "propertyValue": "player.playAlbum",
-            "propertySubPhrases": [
-              "lets listen to"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "player.playSong",
-                "propertySubPhrases": [
-                  "lets play the song"
-                ]
-              },
-              {
-                "propertyValue": "player.playPlaylist",
-                "propertySubPhrases": [
-                  "lets play the playlist"
-                ]
-              },
-              {
-                "propertyValue": "player.playPodcast",
-                "propertySubPhrases": [
-                  "lets listen to the podcast"
-                ]
-              }
-            ]
-          },
           {
             "propertyName": "parameters.albumName",
             "propertyValue": "Pretzel Logic",
@@ -1117,15 +1136,15 @@
                 ]
               },
               {
-                "propertyValue": "Gaucho",
+                "propertyValue": "Countdown to Ecstasy",
                 "propertySubPhrases": [
-                  "Gaucho"
+                  "Countdown to Ecstasy"
                 ]
               },
               {
-                "propertyValue": "The Royal Scam",
+                "propertyValue": "Katy Lied",
                 "propertySubPhrases": [
-                  "The Royal Scam"
+                  "Katy Lied"
                 ]
               }
             ]
@@ -1159,12 +1178,16 @@
           }
         ],
         "politePrefixes": [
-          "Could you please",
-          "Would you mind"
+          "Could we please",
+          "Would you mind if we",
+          "May I kindly ask to",
+          "If it's not too much trouble, let's"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it."
+          "thank you",
+          "please",
+          "if you don't mind",
+          "if that's okay"
         ]
       }
     },
@@ -1195,12 +1218,22 @@
         ],
         "subPhrases": [
           {
-            "text": "ok computer",
+            "text": "ok",
             "category": "acknowledgement",
             "synonyms": [
-              "okay computer",
-              "alright computer",
-              "hey computer"
+              "alright",
+              "sure",
+              "fine"
+            ],
+            "isOptional": true
+          },
+          {
+            "text": "computer",
+            "category": "filler",
+            "synonyms": [
+              "device",
+              "machine",
+              "system"
             ],
             "isOptional": true
           },
@@ -1213,11 +1246,11 @@
           },
           {
             "text": "some pieces by",
-            "category": "filler",
+            "category": "preposition",
             "synonyms": [
-              "some music by",
-              "songs by",
-              "tracks by"
+              "works by",
+              "compositions by",
+              "music by"
             ],
             "isOptional": true
           },
@@ -1250,9 +1283,9 @@
                 ]
               },
               {
-                "propertyValue": "player.skip",
+                "propertyValue": "player.resume",
                 "propertySubPhrases": [
-                  "skip"
+                  "resume"
                 ]
               }
             ]
@@ -1271,15 +1304,15 @@
                 ]
               },
               {
-                "propertyValue": "Beethoven",
-                "propertySubPhrases": [
-                  "Beethoven"
-                ]
-              },
-              {
                 "propertyValue": "Mozart",
                 "propertySubPhrases": [
                   "Mozart"
+                ]
+              },
+              {
+                "propertyValue": "Beethoven",
+                "propertySubPhrases": [
+                  "Beethoven"
                 ]
               }
             ]
@@ -1287,11 +1320,15 @@
         ],
         "politePrefixes": [
           "Please",
-          "Could you"
+          "Could you",
+          "Would you mind",
+          "If you don't mind"
         ],
         "politeSuffixes": [
-          "Thank you",
-          "Thanks"
+          "thank you",
+          "please",
+          "if that's okay",
+          "if you could"
         ]
       }
     },
@@ -1330,45 +1367,75 @@
         ],
         "subPhrases": [
           {
-            "text": "Ok,",
+            "text": "Ok",
             "category": "acknowledgement",
             "synonyms": [
-              "Alright,",
-              "Okay,",
-              "Sure,"
+              "alright",
+              "okay",
+              "sure"
             ],
             "isOptional": true
           },
           {
-            "text": "next I wanna hear,",
+            "text": "next",
             "category": "filler",
             "synonyms": [
-              "next I want to hear,",
-              "next I would like to hear,",
-              "next I wanna listen to,"
+              "then",
+              "after that",
+              "following"
             ],
             "isOptional": true
           },
           {
-            "text": "aa, um... yeah,",
+            "text": "I wanna hear",
+            "category": "confirmation",
+            "synonyms": [
+              "I want to listen to",
+              "I would like to hear",
+              "I want to play"
+            ],
+            "isOptional": true
+          },
+          {
+            "text": "aa",
             "category": "filler",
             "synonyms": [
-              "uh, um... yeah,",
-              "uh, um... sure,",
-              "uh, um... okay,"
+              "um",
+              "uh",
+              "ah"
             ],
             "isOptional": true
           },
           {
-            "text": "some Def Leppard.",
-            "category": "property",
+            "text": "um",
+            "category": "filler",
+            "synonyms": [
+              "uh",
+              "ah",
+              "aa"
+            ],
+            "isOptional": true
+          },
+          {
+            "text": "yeah",
+            "category": "acknowledgement",
+            "synonyms": [
+              "yes",
+              "yep",
+              "sure"
+            ],
+            "isOptional": true
+          },
+          {
+            "text": "some Def Leppard",
+            "category": "confirmation",
             "propertyNames": [
               "parameters.artists.0"
             ]
           },
           {
-            "text": "Armageddon It.",
-            "category": "property",
+            "text": "Armageddon It",
+            "category": "confirmation",
             "propertyNames": [
               "parameters.trackName"
             ]
@@ -1379,25 +1446,25 @@
             "propertyName": "parameters.artists.0",
             "propertyValue": "Def Leppard",
             "propertySubPhrases": [
-              "some Def Leppard."
+              "some Def Leppard"
             ],
             "alternatives": [
               {
                 "propertyValue": "AC/DC",
                 "propertySubPhrases": [
-                  "some AC/DC."
+                  "some AC/DC"
                 ]
               },
               {
                 "propertyValue": "Queen",
                 "propertySubPhrases": [
-                  "some Queen."
+                  "some Queen"
                 ]
               },
               {
                 "propertyValue": "Led Zeppelin",
                 "propertySubPhrases": [
-                  "some Led Zeppelin."
+                  "some Led Zeppelin"
                 ]
               }
             ]
@@ -1406,25 +1473,25 @@
             "propertyName": "parameters.trackName",
             "propertyValue": "Armageddon It",
             "propertySubPhrases": [
-              "Armageddon It."
+              "Armageddon It"
             ],
             "alternatives": [
               {
                 "propertyValue": "Pour Some Sugar On Me",
                 "propertySubPhrases": [
-                  "Pour Some Sugar On Me."
-                ]
-              },
-              {
-                "propertyValue": "Hysteria",
-                "propertySubPhrases": [
-                  "Hysteria."
+                  "Pour Some Sugar On Me"
                 ]
               },
               {
                 "propertyValue": "Love Bites",
                 "propertySubPhrases": [
-                  "Love Bites."
+                  "Love Bites"
+                ]
+              },
+              {
+                "propertyValue": "Hysteria",
+                "propertySubPhrases": [
+                  "Hysteria"
                 ]
               }
             ]
@@ -1433,14 +1500,14 @@
         "politePrefixes": [
           "Could you please",
           "Would you mind",
-          "If it's not too much trouble, could you",
+          "If it's not too much trouble",
           "I would appreciate it if you could"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "Thanks a lot!",
-          "I appreciate it!",
-          "Much appreciated!"
+          "thank you",
+          "please",
+          "if you don't mind",
+          "thanks a lot"
         ]
       }
     },
@@ -1494,7 +1561,7 @@
           },
           {
             "text": "songs by",
-            "category": "filler",
+            "category": "preposition",
             "synonyms": [
               "tracks by",
               "music by",
@@ -1519,21 +1586,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.pause",
+                "propertyValue": "player.pauseArtist",
                 "propertySubPhrases": [
                   "pause"
                 ]
               },
               {
-                "propertyValue": "player.stop",
+                "propertyValue": "player.stopArtist",
                 "propertySubPhrases": [
                   "stop"
                 ]
               },
               {
-                "propertyValue": "player.skip",
+                "propertyValue": "player.resumeArtist",
                 "propertySubPhrases": [
-                  "skip"
+                  "resume"
                 ]
               }
             ]
@@ -1595,11 +1662,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If it's not too much trouble,",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you",
-          "I would appreciate it"
+          "thank you.",
+          "if you don't mind.",
+          "please.",
+          "thanks."
         ]
       }
     },
@@ -1609,7 +1680,6 @@
         "fullActionName": "player.playArtist",
         "parameters": {
           "artist": "Bach",
-          "genre": "fugue",
           "quantity": 2
         }
       },
@@ -1630,17 +1700,10 @@
             ]
           },
           {
-            "name": "parameters.genre",
-            "value": "fugue",
-            "substrings": [
-              "fugues"
-            ]
-          },
-          {
             "name": "parameters.quantity",
             "value": 2,
             "substrings": [
-              "a couple of"
+              "a couple"
             ]
           }
         ],
@@ -1663,26 +1726,19 @@
             ]
           },
           {
-            "text": "a couple of",
+            "text": "a couple",
             "category": "quantity",
             "propertyNames": [
               "parameters.quantity"
             ]
           },
           {
-            "text": "fugues",
-            "category": "genre",
-            "propertyNames": [
-              "parameters.genre"
-            ]
-          },
-          {
-            "text": "by",
-            "category": "preposition",
+            "text": "of fugues by",
+            "category": "filler",
             "synonyms": [
-              "from",
-              "of",
-              "composed by"
+              "some pieces by",
+              "a few compositions by",
+              "several works by"
             ],
             "isOptional": true
           },
@@ -1715,9 +1771,9 @@
                 ]
               },
               {
-                "propertyValue": "player.skipArtist",
+                "propertyValue": "player.resumeArtist",
                 "propertySubPhrases": [
-                  "skip"
+                  "resume"
                 ]
               }
             ]
@@ -1726,7 +1782,7 @@
             "propertyName": "parameters.quantity",
             "propertyValue": 2,
             "propertySubPhrases": [
-              "a couple of"
+              "a couple"
             ],
             "alternatives": [
               {
@@ -1745,33 +1801,6 @@
                 "propertyValue": 5,
                 "propertySubPhrases": [
                   "several"
-                ]
-              }
-            ]
-          },
-          {
-            "propertyName": "parameters.genre",
-            "propertyValue": "fugue",
-            "propertySubPhrases": [
-              "fugues"
-            ],
-            "alternatives": [
-              {
-                "propertyValue": "symphony",
-                "propertySubPhrases": [
-                  "symphonies"
-                ]
-              },
-              {
-                "propertyValue": "concerto",
-                "propertySubPhrases": [
-                  "concertos"
-                ]
-              },
-              {
-                "propertyValue": "sonata",
-                "propertySubPhrases": [
-                  "sonatas"
                 ]
               }
             ]
@@ -1804,8 +1833,18 @@
             ]
           }
         ],
-        "politePrefixes": [],
-        "politeSuffixes": []
+        "politePrefixes": [
+          "Could you kindly",
+          "Would you be so kind as to",
+          "If you don't mind,",
+          "I would appreciate it if you could"
+        ],
+        "politeSuffixes": [
+          "Thank you.",
+          "I appreciate it.",
+          "Thanks a lot.",
+          "Much appreciated."
+        ]
       }
     },
     {
@@ -1911,22 +1950,32 @@
                 ]
               },
               {
-                "propertyValue": "Bob Dylan",
+                "propertyValue": "Billy Joel",
                 "propertySubPhrases": [
-                  "Bob Dylan"
+                  "Billy Joel"
                 ]
               },
               {
-                "propertyValue": "Stevie Wonder",
+                "propertyValue": "Bob Dylan",
                 "propertySubPhrases": [
-                  "Stevie Wonder"
+                  "Bob Dylan"
                 ]
               }
             ]
           }
         ],
-        "politePrefixes": [],
-        "politeSuffixes": []
+        "politePrefixes": [
+          "Could you",
+          "Would you mind",
+          "I would appreciate it if you",
+          "If you don't mind"
+        ],
+        "politeSuffixes": [
+          "thank you",
+          "please",
+          "if that's okay",
+          "if you could"
+        ]
       }
     },
     {
@@ -1970,8 +2019,8 @@
             "category": "politeness",
             "synonyms": [
               "kindly",
-              "would you",
-              "could you"
+              "could you",
+              "would you mind"
             ],
             "isOptional": true
           },
@@ -2043,21 +2092,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "Elton John",
-                "propertySubPhrases": [
-                  "Elton John"
-                ]
-              },
-              {
                 "propertyValue": "Bob Dylan",
                 "propertySubPhrases": [
                   "Bob Dylan"
                 ]
               },
               {
-                "propertyValue": "Stevie Wonder",
+                "propertyValue": "Elton John",
                 "propertySubPhrases": [
-                  "Stevie Wonder"
+                  "Elton John"
+                ]
+              },
+              {
+                "propertyValue": "David Bowie",
+                "propertySubPhrases": [
+                  "David Bowie"
                 ]
               }
             ]
@@ -2070,49 +2119,54 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "The Stranger",
+                "propertyValue": "The Freewheelin' Bob Dylan",
                 "propertySubPhrases": [
-                  "The Stranger"
+                  "The Freewheelin' Bob Dylan"
                 ]
               },
               {
-                "propertyValue": "Thriller",
+                "propertyValue": "Goodbye Yellow Brick Road",
                 "propertySubPhrases": [
-                  "Thriller"
+                  "Goodbye Yellow Brick Road"
                 ]
               },
               {
-                "propertyValue": "Rumours",
+                "propertyValue": "The Rise and Fall of Ziggy Stardust and the Spiders from Mars",
                 "propertySubPhrases": [
-                  "Rumours"
+                  "The Rise and Fall of Ziggy Stardust and the Spiders from Mars"
                 ]
               }
             ]
           }
         ],
         "politePrefixes": [],
-        "politeSuffixes": []
+        "politeSuffixes": [
+          "if you don't mind.",
+          "thank you.",
+          "when you have a moment.",
+          "I would appreciate it."
+        ]
       }
     },
     {
       "request": "que up some Taylor Swift",
       "action": {
-        "fullActionName": "player.playArtist",
+        "fullActionName": "player.searchTracks",
         "parameters": {
-          "artist": "Taylor Swift"
+          "query": "Taylor Swift"
         }
       },
       "explanation": {
         "properties": [
           {
             "name": "fullActionName",
-            "value": "player.playArtist",
+            "value": "player.searchTracks",
             "substrings": [
               "que up"
             ]
           },
           {
-            "name": "parameters.artist",
+            "name": "parameters.query",
             "value": "Taylor Swift",
             "substrings": [
               "Taylor Swift"
@@ -2131,30 +2185,30 @@
             "text": "some",
             "category": "filler",
             "synonyms": [
-              "a bit of",
-              "a little",
-              "some of"
+              "a few",
+              "several",
+              "a couple"
             ],
             "isOptional": true
           },
           {
             "text": "Taylor Swift",
-            "category": "artist",
+            "category": "query",
             "propertyNames": [
-              "parameters.artist"
+              "parameters.query"
             ]
           }
         ],
         "propertyAlternatives": [
           {
             "propertyName": "fullActionName",
-            "propertyValue": "player.playArtist",
+            "propertyValue": "player.searchTracks",
             "propertySubPhrases": [
               "que up"
             ],
             "alternatives": [
               {
-                "propertyValue": "player.playSong",
+                "propertyValue": "player.playTracks",
                 "propertySubPhrases": [
                   "play"
                 ]
@@ -2166,7 +2220,7 @@
                 ]
               },
               {
-                "propertyValue": "player.shuffleArtist",
+                "propertyValue": "player.shuffleTracks",
                 "propertySubPhrases": [
                   "shuffle"
                 ]
@@ -2174,7 +2228,7 @@
             ]
           },
           {
-            "propertyName": "parameters.artist",
+            "propertyName": "parameters.query",
             "propertyValue": "Taylor Swift",
             "propertySubPhrases": [
               "Taylor Swift"
@@ -2193,9 +2247,9 @@
                 ]
               },
               {
-                "propertyValue": "Drake",
+                "propertyValue": "Billie Eilish",
                 "propertySubPhrases": [
-                  "Drake"
+                  "Billie Eilish"
                 ]
               }
             ]
@@ -2204,14 +2258,14 @@
         "politePrefixes": [
           "Could you please",
           "Would you mind",
-          "If it's not too much trouble, could you",
-          "May I kindly ask you to"
+          "Can you kindly",
+          "If possible, could you"
         ],
         "politeSuffixes": [
           "thank you",
           "please",
           "if you don't mind",
-          "thanks a lot"
+          "thanks"
         ]
       }
     },
@@ -2254,7 +2308,7 @@
             "synonyms": [
               "a bit of",
               "a little",
-              "some of"
+              "some tunes"
             ],
             "isOptional": true
           },
@@ -2287,9 +2341,9 @@
                 ]
               },
               {
-                "propertyValue": "player.playMusic",
+                "propertyValue": "player.playMusicByArtist",
                 "propertySubPhrases": [
-                  "play"
+                  "play some"
                 ]
               }
             ]
@@ -2325,14 +2379,14 @@
         "politePrefixes": [
           "Could you please",
           "Would you mind",
-          "If it's not too much trouble, could you",
-          "May I kindly ask you to"
+          "Can you kindly",
+          "Please"
         ],
         "politeSuffixes": [
-          "thank you",
-          "please",
-          "if you don't mind",
-          "thanks a lot"
+          "for me?",
+          "if you don't mind.",
+          "thank you.",
+          "please."
         ]
       }
     },
@@ -2364,14 +2418,14 @@
         "subPhrases": [
           {
             "text": "start playing",
-            "category": "command",
+            "category": "action",
             "propertyNames": [
               "fullActionName"
             ]
           },
           {
             "text": "Highway to Hell",
-            "category": "trackName",
+            "category": "track",
             "propertyNames": [
               "parameters.trackName"
             ]
@@ -2392,15 +2446,15 @@
                 ]
               },
               {
-                "propertyValue": "player.resumeTrack",
+                "propertyValue": "player.playSong",
                 "propertySubPhrases": [
-                  "resume playing"
+                  "play"
                 ]
               },
               {
-                "propertyValue": "player.initiateTrack",
+                "propertyValue": "player.activateTrack",
                 "propertySubPhrases": [
-                  "initiate playing"
+                  "activate playing"
                 ]
               }
             ]
@@ -2435,11 +2489,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "I would appreciate it if you could",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you",
-          "I would appreciate it"
+          "thank you",
+          "if that's okay",
+          "please",
+          "thanks"
         ]
       }
     },
@@ -2481,8 +2539,8 @@
             "category": "preposition",
             "synonyms": [
               "from",
-              "featuring",
-              "with"
+              "with",
+              "featuring"
             ],
             "isOptional": true
           },
@@ -2503,15 +2561,15 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.playSong",
-                "propertySubPhrases": [
-                  "play a song"
-                ]
-              },
-              {
                 "propertyValue": "player.playAlbum",
                 "propertySubPhrases": [
                   "play an album"
+                ]
+              },
+              {
+                "propertyValue": "player.playSong",
+                "propertySubPhrases": [
+                  "play a song"
                 ]
               },
               {
@@ -2536,15 +2594,15 @@
                 ]
               },
               {
-                "propertyValue": "Beethoven",
-                "propertySubPhrases": [
-                  "Beethoven"
-                ]
-              },
-              {
                 "propertyValue": "Mozart",
                 "propertySubPhrases": [
                   "Mozart"
+                ]
+              },
+              {
+                "propertyValue": "Beethoven",
+                "propertySubPhrases": [
+                  "Beethoven"
                 ]
               }
             ]
@@ -2553,36 +2611,36 @@
         "politePrefixes": [
           "Could you please",
           "Would you mind",
-          "If it's not too much trouble, could you",
-          "May I kindly ask you to"
+          "If you don't mind",
+          "Please"
         ],
         "politeSuffixes": [
           "thank you",
           "please",
-          "if you don't mind",
-          "I would appreciate it"
+          "if that's okay",
+          "if you could"
         ]
       }
     },
     {
       "request": "thanks, and also queue up some Chemical Brothers",
       "action": {
-        "fullActionName": "player.playArtist",
+        "fullActionName": "player.searchTracks",
         "parameters": {
-          "artist": "Chemical Brothers"
+          "query": "Chemical Brothers"
         }
       },
       "explanation": {
         "properties": [
           {
             "name": "fullActionName",
-            "value": "player.playArtist",
+            "value": "player.searchTracks",
             "substrings": [
               "queue up"
             ]
           },
           {
-            "name": "parameters.artist",
+            "name": "parameters.query",
             "value": "Chemical Brothers",
             "substrings": [
               "Chemical Brothers"
@@ -2591,12 +2649,12 @@
         ],
         "subPhrases": [
           {
-            "text": "thanks,",
+            "text": "thanks",
             "category": "acknowledgement",
             "synonyms": [
               "thank you",
-              "thanks a lot",
-              "thank you very much"
+              "cheers",
+              "much appreciated"
             ],
             "isOptional": true
           },
@@ -2605,8 +2663,8 @@
             "category": "filler",
             "synonyms": [
               "as well",
-              "additionally",
-              "plus"
+              "plus",
+              "in addition"
             ],
             "isOptional": true
           },
@@ -2621,50 +2679,50 @@
             "text": "some",
             "category": "filler",
             "synonyms": [
+              "a few",
               "a bit of",
-              "a little",
               "some of"
             ],
             "isOptional": true
           },
           {
             "text": "Chemical Brothers",
-            "category": "artist",
+            "category": "query",
             "propertyNames": [
-              "parameters.artist"
+              "parameters.query"
             ]
           }
         ],
         "propertyAlternatives": [
           {
             "propertyName": "fullActionName",
-            "propertyValue": "player.playArtist",
+            "propertyValue": "player.searchTracks",
             "propertySubPhrases": [
               "queue up"
             ],
             "alternatives": [
               {
-                "propertyValue": "player.addToQueue",
+                "propertyValue": "player.playTracks",
                 "propertySubPhrases": [
-                  "add to queue"
+                  "play"
                 ]
               },
               {
-                "propertyValue": "player.playNext",
+                "propertyValue": "player.addToPlaylist",
                 "propertySubPhrases": [
-                  "play next"
+                  "add to playlist"
                 ]
               },
               {
-                "propertyValue": "player.shufflePlay",
+                "propertyValue": "player.shuffleTracks",
                 "propertySubPhrases": [
-                  "shuffle play"
+                  "shuffle"
                 ]
               }
             ]
           },
           {
-            "propertyName": "parameters.artist",
+            "propertyName": "parameters.query",
             "propertyValue": "Chemical Brothers",
             "propertySubPhrases": [
               "Chemical Brothers"
@@ -2692,7 +2750,12 @@
           }
         ],
         "politePrefixes": [],
-        "politeSuffixes": []
+        "politeSuffixes": [
+          "please.",
+          "if you don't mind.",
+          "thank you.",
+          "thanks!"
+        ]
       }
     },
     {
@@ -2735,7 +2798,7 @@
             "synonyms": [
               "could you please",
               "can you please",
-              "would you mind"
+              "would you kindly"
             ],
             "isOptional": true
           },
@@ -2780,12 +2843,6 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "player.playSong",
-                "propertySubPhrases": [
-                  "play a song"
-                ]
-              },
-              {
                 "propertyValue": "player.playAlbum",
                 "propertySubPhrases": [
                   "play an album"
@@ -2795,6 +2852,12 @@
                 "propertyValue": "player.playPlaylist",
                 "propertySubPhrases": [
                   "play a playlist"
+                ]
+              },
+              {
+                "propertyValue": "player.playSong",
+                "propertySubPhrases": [
+                  "play a song"
                 ]
               }
             ]
@@ -2809,7 +2872,7 @@
               {
                 "propertyValue": 1,
                 "propertySubPhrases": [
-                  "a single"
+                  "one"
                 ]
               },
               {
@@ -2840,22 +2903,27 @@
                 ]
               },
               {
-                "propertyValue": "Queen",
-                "propertySubPhrases": [
-                  "of Queen"
-                ]
-              },
-              {
                 "propertyValue": "Madonna",
                 "propertySubPhrases": [
                   "of Madonna"
+                ]
+              },
+              {
+                "propertyValue": "Queen",
+                "propertySubPhrases": [
+                  "of Queen"
                 ]
               }
             ]
           }
         ],
         "politePrefixes": [],
-        "politeSuffixes": []
+        "politeSuffixes": [
+          "if you don't mind.",
+          "thank you.",
+          "if it's not too much trouble.",
+          "I would appreciate it."
+        ]
       }
     },
     {
@@ -2874,7 +2942,9 @@
           {
             "name": "fullActionName",
             "value": "player.playAlbum",
-            "isImplicit": true
+            "substrings": [
+              "play"
+            ]
           },
           {
             "name": "parameters.albumName",
@@ -2893,23 +2963,35 @@
         ],
         "subPhrases": [
           {
-            "text": "would you please",
+            "text": "would you",
             "category": "politeness",
             "synonyms": [
-              "could you please",
-              "can you please",
-              "would you mind"
+              "could you",
+              "can you",
+              "will you"
+            ],
+            "isOptional": true
+          },
+          {
+            "text": "please",
+            "category": "politeness",
+            "synonyms": [
+              "kindly",
+              "if you don't mind",
+              "if you could"
             ],
             "isOptional": true
           },
           {
             "text": "play",
             "category": "action",
-            "propertyNames": []
+            "propertyNames": [
+              "fullActionName"
+            ]
           },
           {
             "text": "Aja",
-            "category": "albumName",
+            "category": "album",
             "propertyNames": [
               "parameters.albumName"
             ]
@@ -2920,7 +3002,7 @@
             "synonyms": [
               "from",
               "performed by",
-              "sung by"
+              "created by"
             ],
             "isOptional": true
           },
@@ -2933,6 +3015,33 @@
           }
         ],
         "propertyAlternatives": [
+          {
+            "propertyName": "fullActionName",
+            "propertyValue": "player.playAlbum",
+            "propertySubPhrases": [
+              "play"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "player.pauseAlbum",
+                "propertySubPhrases": [
+                  "pause"
+                ]
+              },
+              {
+                "propertyValue": "player.stopAlbum",
+                "propertySubPhrases": [
+                  "stop"
+                ]
+              },
+              {
+                "propertyValue": "player.resumeAlbum",
+                "propertySubPhrases": [
+                  "resume"
+                ]
+              }
+            ]
+          },
           {
             "propertyName": "parameters.albumName",
             "propertyValue": "Aja",
@@ -2974,96 +3083,28 @@
                 ]
               },
               {
-                "propertyValue": "Fleetwood Mac",
-                "propertySubPhrases": [
-                  "Fleetwood Mac"
-                ]
-              },
-              {
                 "propertyValue": "Pink Floyd",
                 "propertySubPhrases": [
                   "Pink Floyd"
+                ]
+              },
+              {
+                "propertyValue": "Led Zeppelin",
+                "propertySubPhrases": [
+                  "Led Zeppelin"
                 ]
               }
             ]
           }
         ],
         "politePrefixes": [],
-        "politeSuffixes": []
-      },
-      "corrections": [
-        {
-          "data": {
-            "properties": [
-              {
-                "name": "fullActionName",
-                "value": "player.playAlbum",
-                "isImplicit": true
-              },
-              {
-                "name": "parameters.albumName",
-                "value": "Aja",
-                "substrings": [
-                  "Aja"
-                ]
-              },
-              {
-                "name": "parameters.artists.0",
-                "value": "Steely Dan",
-                "substrings": [
-                  "Steely Dan"
-                ]
-              }
-            ],
-            "subPhrases": [
-              {
-                "text": "would you please",
-                "category": "politeness",
-                "synonyms": [
-                  "could you please",
-                  "can you please",
-                  "would you mind"
-                ],
-                "isOptional": true
-              },
-              {
-                "text": "play",
-                "category": "action",
-                "propertyNames": [
-                  "fullActionName"
-                ]
-              },
-              {
-                "text": "Aja",
-                "category": "albumName",
-                "propertyNames": [
-                  "parameters.albumName"
-                ]
-              },
-              {
-                "text": "by",
-                "category": "preposition",
-                "synonyms": [
-                  "from",
-                  "performed by",
-                  "sung by"
-                ],
-                "isOptional": true
-              },
-              {
-                "text": "Steely Dan",
-                "category": "artist",
-                "propertyNames": [
-                  "parameters.artists.0"
-                ]
-              }
-            ]
-          },
-          "correction": [
-            "Property 'fullActionName' is expected to be implicit and should not be included as a property name in a sub-phrase"
-          ]
-        }
-      ]
+        "politeSuffixes": [
+          "if you don't mind.",
+          "thank you.",
+          "when you have a moment.",
+          "please."
+        ]
+      }
     },
     {
       "request": "would you please play Graceland by Paul Simon",
@@ -3102,12 +3143,22 @@
         ],
         "subPhrases": [
           {
-            "text": "would you please",
+            "text": "would you",
             "category": "politeness",
             "synonyms": [
-              "could you please",
-              "can you please",
-              "would you mind"
+              "could you",
+              "can you",
+              "will you"
+            ],
+            "isOptional": true
+          },
+          {
+            "text": "please",
+            "category": "politeness",
+            "synonyms": [
+              "kindly",
+              "if you don't mind",
+              "if you could"
             ],
             "isOptional": true
           },
@@ -3164,9 +3215,9 @@
                 ]
               },
               {
-                "propertyValue": "player.resumeTrack",
+                "propertyValue": "player.skipTrack",
                 "propertySubPhrases": [
-                  "resume"
+                  "skip"
                 ]
               }
             ]
@@ -3206,15 +3257,15 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "Simon & Garfunkel",
-                "propertySubPhrases": [
-                  "Simon & Garfunkel"
-                ]
-              },
-              {
                 "propertyValue": "Art Garfunkel",
                 "propertySubPhrases": [
                   "Art Garfunkel"
+                ]
+              },
+              {
+                "propertyValue": "Simon & Garfunkel",
+                "propertySubPhrases": [
+                  "Simon & Garfunkel"
                 ]
               },
               {
@@ -3226,8 +3277,18 @@
             ]
           }
         ],
-        "politePrefixes": [],
-        "politeSuffixes": []
+        "politePrefixes": [
+          "Could you kindly",
+          "If you don't mind,",
+          "Would it be possible to",
+          "May I request that you"
+        ],
+        "politeSuffixes": [
+          "Thank you.",
+          "I would appreciate it.",
+          "If that's alright.",
+          "Thanks in advance."
+        ]
       }
     },
     {
@@ -3257,12 +3318,22 @@
         ],
         "subPhrases": [
           {
-            "text": "would you please",
+            "text": "would you",
             "category": "politeness",
             "synonyms": [
-              "could you please",
-              "can you please",
-              "would you mind"
+              "could you",
+              "can you",
+              "will you"
+            ],
+            "isOptional": true
+          },
+          {
+            "text": "please",
+            "category": "politeness",
+            "synonyms": [
+              "kindly",
+              "if you don't mind",
+              "if you could"
             ],
             "isOptional": true
           },
@@ -3277,9 +3348,9 @@
             "text": "some",
             "category": "filler",
             "synonyms": [
+              "any",
               "a bit of",
-              "a little",
-              "any"
+              "a little"
             ],
             "isOptional": true
           },
@@ -3302,19 +3373,19 @@
               {
                 "propertyValue": "player.playSong",
                 "propertySubPhrases": [
-                  "play a song"
+                  "play a song by"
                 ]
               },
               {
                 "propertyValue": "player.playAlbum",
                 "propertySubPhrases": [
-                  "play an album"
+                  "play an album by"
                 ]
               },
               {
                 "propertyValue": "player.playPlaylist",
                 "propertySubPhrases": [
-                  "play a playlist"
+                  "play a playlist by"
                 ]
               }
             ]
@@ -3333,30 +3404,35 @@
                 ]
               },
               {
-                "propertyValue": "Queen",
-                "propertySubPhrases": [
-                  "Queen"
-                ]
-              },
-              {
                 "propertyValue": "Madonna",
                 "propertySubPhrases": [
                   "Madonna"
+                ]
+              },
+              {
+                "propertyValue": "Michael Jackson",
+                "propertySubPhrases": [
+                  "Michael Jackson"
                 ]
               }
             ]
           }
         ],
         "politePrefixes": [],
-        "politeSuffixes": []
+        "politeSuffixes": [
+          "if you don't mind.",
+          "thank you.",
+          "please.",
+          "if it's not too much trouble."
+        ]
       }
     },
     {
       "request": "yo, play some Metallica And Justice for All",
       "action": {
-        "fullActionName": "player.playAlbum",
+        "fullActionName": "player.playTrack",
         "parameters": {
-          "albumName": "And Justice for All",
+          "trackName": "And Justice for All",
           "artists": [
             "Metallica"
           ]
@@ -3366,11 +3442,11 @@
         "properties": [
           {
             "name": "fullActionName",
-            "value": "player.playAlbum",
+            "value": "player.playTrack",
             "isImplicit": true
           },
           {
-            "name": "parameters.albumName",
+            "name": "parameters.trackName",
             "value": "And Justice for All",
             "substrings": [
               "And Justice for All"
@@ -3390,8 +3466,8 @@
             "category": "greeting",
             "synonyms": [
               "hi",
-              "hey",
-              "hello"
+              "hello",
+              "hey"
             ],
             "isOptional": true
           },
@@ -3419,9 +3495,9 @@
           },
           {
             "text": "And Justice for All",
-            "category": "album",
+            "category": "track",
             "propertyNames": [
-              "parameters.albumName"
+              "parameters.trackName"
             ]
           }
         ],
@@ -3434,48 +3510,48 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "Nirvana",
+                "propertyValue": "Iron Maiden",
                 "propertySubPhrases": [
-                  "Nirvana"
+                  "Iron Maiden"
                 ]
               },
               {
-                "propertyValue": "AC/DC",
+                "propertyValue": "Megadeth",
                 "propertySubPhrases": [
-                  "AC/DC"
+                  "Megadeth"
                 ]
               },
               {
-                "propertyValue": "Led Zeppelin",
+                "propertyValue": "Slayer",
                 "propertySubPhrases": [
-                  "Led Zeppelin"
+                  "Slayer"
                 ]
               }
             ]
           },
           {
-            "propertyName": "parameters.albumName",
+            "propertyName": "parameters.trackName",
             "propertyValue": "And Justice for All",
             "propertySubPhrases": [
               "And Justice for All"
             ],
             "alternatives": [
               {
-                "propertyValue": "Nevermind",
+                "propertyValue": "Master of Puppets",
                 "propertySubPhrases": [
-                  "Nevermind"
+                  "Master of Puppets"
                 ]
               },
               {
-                "propertyValue": "Back in Black",
+                "propertyValue": "Enter Sandman",
                 "propertySubPhrases": [
-                  "Back in Black"
+                  "Enter Sandman"
                 ]
               },
               {
-                "propertyValue": "Led Zeppelin IV",
+                "propertyValue": "One",
                 "propertySubPhrases": [
-                  "Led Zeppelin IV"
+                  "One"
                 ]
               }
             ]
@@ -3483,11 +3559,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If you don't mind",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you",
-          "Thanks a lot"
+          "thank you",
+          "please",
+          "if that's okay",
+          "thanks"
         ]
       },
       "corrections": [
@@ -3496,11 +3576,11 @@
             "properties": [
               {
                 "name": "fullActionName",
-                "value": "player.playAlbum",
+                "value": "player.playTrack",
                 "isImplicit": true
               },
               {
-                "name": "parameters.albumName",
+                "name": "parameters.trackName",
                 "value": "And Justice for All",
                 "substrings": [
                   "And Justice for All"
@@ -3520,8 +3600,8 @@
                 "category": "greeting",
                 "synonyms": [
                   "hi",
-                  "hey",
-                  "hello"
+                  "hello",
+                  "hey"
                 ],
                 "isOptional": true
               },
@@ -3551,9 +3631,9 @@
               },
               {
                 "text": "And Justice for All",
-                "category": "album",
+                "category": "track",
                 "propertyNames": [
-                  "parameters.albumName"
+                  "parameters.trackName"
                 ]
               }
             ]
@@ -3604,9 +3684,11 @@
             "text": "yo, yo",
             "category": "greeting",
             "synonyms": [
-              "hey",
               "hi",
-              "hello"
+              "hello",
+              "hey",
+              "hi there",
+              "hey there"
             ],
             "isOptional": true
           },
@@ -3695,21 +3777,21 @@
             ],
             "alternatives": [
               {
-                "propertyValue": "Abbey Road",
+                "propertyValue": "In Utero",
                 "propertySubPhrases": [
-                  "on Abbey Road"
+                  "on In Utero"
                 ]
               },
               {
-                "propertyValue": "The Wall",
+                "propertyValue": "Bleach",
                 "propertySubPhrases": [
-                  "on The Wall"
+                  "on Bleach"
                 ]
               },
               {
-                "propertyValue": "Thriller",
+                "propertyValue": "MTV Unplugged in New York",
                 "propertySubPhrases": [
-                  "on Thriller"
+                  "on MTV Unplugged in New York"
                 ]
               }
             ]
@@ -3717,11 +3799,15 @@
         ],
         "politePrefixes": [
           "Could you please",
-          "Would you mind"
+          "Would you mind",
+          "If you don't mind",
+          "Please"
         ],
         "politeSuffixes": [
-          "Thank you!",
-          "I would appreciate it."
+          "for me?",
+          "if that's okay?",
+          "please?",
+          "thanks!"
         ]
       }
     },
@@ -3738,7 +3824,9 @@
           {
             "name": "fullActionName",
             "value": "player.playArtist",
-            "isImplicit": true
+            "substrings": [
+              "spin me some"
+            ]
           },
           {
             "name": "parameters.artist",
@@ -3755,14 +3843,17 @@
             "synonyms": [
               "hey",
               "hi",
-              "hello"
+              "hello",
+              "what's up"
             ],
             "isOptional": true
           },
           {
             "text": "spin me some",
             "category": "command",
-            "propertyNames": []
+            "propertyNames": [
+              "fullActionName"
+            ]
           },
           {
             "text": "Snoop Dogg",
@@ -3776,13 +3867,41 @@
             "category": "filler",
             "synonyms": [
               "you get me?",
+              "you understand?",
               "you feel me?",
-              "you understand?"
+              "you know?"
             ],
             "isOptional": true
           }
         ],
         "propertyAlternatives": [
+          {
+            "propertyName": "fullActionName",
+            "propertyValue": "player.playArtist",
+            "propertySubPhrases": [
+              "spin me some"
+            ],
+            "alternatives": [
+              {
+                "propertyValue": "player.playAlbum",
+                "propertySubPhrases": [
+                  "play me the album"
+                ]
+              },
+              {
+                "propertyValue": "player.playSong",
+                "propertySubPhrases": [
+                  "play me the song"
+                ]
+              },
+              {
+                "propertyValue": "player.playPlaylist",
+                "propertySubPhrases": [
+                  "play me the playlist"
+                ]
+              }
+            ]
+          },
           {
             "propertyName": "parameters.artist",
             "propertyValue": "Snoop Dogg",
@@ -3803,76 +3922,27 @@
                 ]
               },
               {
-                "propertyValue": "Kendrick Lamar",
+                "propertyValue": "Ice Cube",
                 "propertySubPhrases": [
-                  "Kendrick Lamar"
+                  "Ice Cube"
                 ]
               }
             ]
           }
         ],
-        "politePrefixes": [],
-        "politeSuffixes": []
-      },
-      "corrections": [
-        {
-          "data": {
-            "properties": [
-              {
-                "name": "fullActionName",
-                "value": "player.playArtist",
-                "isImplicit": true
-              },
-              {
-                "name": "parameters.artist",
-                "value": "Snoop Dogg",
-                "substrings": [
-                  "Snoop Dogg"
-                ]
-              }
-            ],
-            "subPhrases": [
-              {
-                "text": "yo, yo,",
-                "category": "greeting",
-                "synonyms": [
-                  "hey",
-                  "hi",
-                  "hello"
-                ],
-                "isOptional": true
-              },
-              {
-                "text": "spin me some",
-                "category": "command",
-                "propertyNames": [
-                  "fullActionName"
-                ]
-              },
-              {
-                "text": "Snoop Dogg",
-                "category": "artist",
-                "propertyNames": [
-                  "parameters.artist"
-                ]
-              },
-              {
-                "text": "you know what I am sayin?",
-                "category": "filler",
-                "synonyms": [
-                  "you get me?",
-                  "you feel me?",
-                  "you understand?"
-                ],
-                "isOptional": true
-              }
-            ]
-          },
-          "correction": [
-            "Property 'fullActionName' is expected to be implicit and should not be included as a property name in a sub-phrase"
-          ]
-        }
-      ]
+        "politePrefixes": [
+          "Could you please",
+          "Would you mind",
+          "If you don't mind",
+          "I would appreciate it if you could"
+        ],
+        "politeSuffixes": [
+          "thank you",
+          "please",
+          "if that's okay",
+          "if you could"
+        ]
+      }
     }
   ]
 }

--- a/ts/packages/dispatcher/src/agentProvider/agentProviderUtils.ts
+++ b/ts/packages/dispatcher/src/agentProvider/agentProviderUtils.ts
@@ -35,9 +35,14 @@ function getActionConfigs(
 
 export async function createActionConfigProvider(
     providers: AppAgentProvider[],
+    additionalManifests?: Record<string, AppAgentManifest>,
 ): Promise<ActionConfigProvider> {
-    const appAgentManifests = await getAppAgentManifests(providers);
-    const actionConfigs = await getActionConfigs(appAgentManifests);
+    const appAgentManifests = {
+        ...(await getAppAgentManifests(providers)),
+        ...additionalManifests,
+    };
+
+    const actionConfigs = getActionConfigs(appAgentManifests);
     const actionSchemaFileCache = new ActionSchemaFileCache();
     const actionConfigProvider: ActionConfigProvider = {
         tryGetActionConfig(schemaName: string) {

--- a/ts/packages/dispatcher/src/context/inlineAgentProvider.ts
+++ b/ts/packages/dispatcher/src/context/inlineAgentProvider.ts
@@ -9,7 +9,10 @@ import {
 } from "./dispatcher/dispatcherAgent.js";
 import { AppAgentProvider } from "../agentProvider/agentProvider.js";
 import { systemAgent, systemManifest } from "./system/systemAgent.js";
-import { getSchemaNamesForAppAgentManifests } from "../agentProvider/agentProviderUtils.js";
+import {
+    createActionConfigProvider,
+    getSchemaNamesForAppAgentManifests,
+} from "../agentProvider/agentProviderUtils.js";
 import { ActionConfigProvider } from "../translation/actionConfigProvider.js";
 
 const builtinAgents: Record<string, AppAgent> = {
@@ -65,4 +68,8 @@ export function getAllSchemaNames(provider: ActionConfigProvider): string[] {
             .getActionConfigs()
             .map((actionConfig) => actionConfig.schemaName),
     ];
+}
+
+export function getAllActionConfigProvider(providers: AppAgentProvider[]) {
+    return createActionConfigProvider(providers, builtinAgentManifest);
 }

--- a/ts/packages/dispatcher/src/execute/actionHandlers.ts
+++ b/ts/packages/dispatcher/src/execute/actionHandlers.ts
@@ -748,12 +748,17 @@ export async function validateWildcardMatch(
             continue;
         }
         const appAgentName = getAppAgentName(translatorName);
+        if (!context.agents.isActionActive(appAgentName)) {
+            // Assume validateWildcardMatch is true.
+            continue;
+        }
         const appAgent = context.agents.getAppAgent(appAgentName);
         const sessionContext = context.agents.getSessionContext(appAgentName);
-        if (
-            (await appAgent.validateWildcardMatch?.(action, sessionContext)) ===
-            false
-        ) {
+        const validate = await appAgent.validateWildcardMatch?.(
+            action,
+            sessionContext,
+        );
+        if (validate === false) {
             return false;
         }
     }

--- a/ts/packages/dispatcher/src/internal.ts
+++ b/ts/packages/dispatcher/src/internal.ts
@@ -25,6 +25,9 @@ export { getFullSchemaText } from "./translation/agentTranslators.js";
 export { getAppAgentName } from "./translation/agentTranslators.js";
 export { createSchemaInfoProvider } from "./translation/actionSchemaFileCache.js";
 export { createActionConfigProvider } from "./agentProvider/agentProviderUtils.js";
-export { getAllSchemaNames } from "./context/inlineAgentProvider.js";
+export {
+    getAllSchemaNames,
+    getAllActionConfigProvider,
+} from "./context/inlineAgentProvider.js";
 
 export type { ChatHistoryInput } from "./context/system/handlers/historyCommandHandler.js";


### PR DESCRIPTION
- Fix the regression from request+action format in the explanation prompt, which should have `fullActionName` instead of  `translatorName+actionName`.
- Construction support rehydrating empty array value for schema that required array (instead of leaving it optional)
- Properly implement normalization for construction round trip test results for comparison (lower case for example).   The normalization should only do that for values, not property names.
- Add `--cache` for the `cli test translate` command to enable using  imported the constructions for the translation tests.
- Update the explanation test files based on current schema.