### PR TITLE
Sidepanel: Enable users to add new actions schema using descriptions in natural language

### DIFF
--- a/ts/packages/agents/browser/src/agent/discovery/schema/discoveryActions.mts
+++ b/ts/packages/agents/browser/src/agent/discovery/schema/discoveryActions.mts
@@ -62,6 +62,7 @@ export type GetIntentFromRecording = {
         recordedActionName: string;
         recordedActionDescription: string;
         recordedActionSteps?: string;
+        existingActionNames: string[];
         fragments?: HtmlFragments[];
         screenshot?: string;
     };

--- a/ts/packages/agents/browser/src/agent/discovery/schema/expandDescription.mts
+++ b/ts/packages/agents/browser/src/agent/discovery/schema/expandDescription.mts
@@ -1,0 +1,76 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+export type SelectElementByText = {
+    actionName: "selectElementByText";
+    parameters: {
+        cssSelector: string;
+        text: string;
+        elementType?: string;
+    };
+};
+
+export type EnterText = {
+    actionName: "enterText";
+    parameters: {
+        cssSelector: string;
+        text: string;
+    };
+};
+
+// This is used on pages where the user can type anywhere in the document body
+// and the page captures input
+export type EnterTextAtPageScope = {
+    actionName: "EnterTextAtPageScope";
+    parameters: {
+        text: string;
+    };
+};
+
+export type SelectValueFromDropdown = {
+    actionName: "selectValueFromDropdown";
+    parameters: {
+        cssSelector: string;
+        valueText: string;
+    };
+};
+
+export type ClickOnButton = {
+    actionName: "clickOnButton";
+    parameters: {
+        cssSelector: string;
+        // the displayed text of the button to click on
+        buttonText: string;
+    };
+};
+
+export type ClickOnElement = {
+    actionName: "clickOnElement";
+    parameters: {
+        cssSelector: string;
+        // the displayed text of the element to click on
+        elementText: string;
+    };
+};
+
+export type ClickOnLink = {
+    actionName: "ClickOnLink";
+    parameters: {
+        cssSelector: string;
+        linkText: string;
+    };
+};
+
+export type PageActions =
+    | SelectElementByText
+    | EnterText
+    | SelectValueFromDropdown
+    | ClickOnButton
+    | ClickOnElement
+    | ClickOnLink;
+
+export type PageActionsList = {
+    planName: string;
+    description: string;
+    actions: PageActions[];
+};

--- a/ts/packages/agents/browser/src/agent/discovery/schema/recordedActions.mts
+++ b/ts/packages/agents/browser/src/agent/discovery/schema/recordedActions.mts
@@ -31,7 +31,7 @@ export type UserIntentParameter = {
 };
 
 export type UserIntent = {
-    // a concise name for the action, in camelCase
+    // a concise name for the action, in camelCase. This should be based on the goal of the task the user is running.
     actionName: string;
     // a consise list of the parameters that should be captured from the user in order to implenent this action
     parameters: UserIntentParameter[];
@@ -107,6 +107,7 @@ export type PageManipulationActions =
 export type PageActionsPlan = {
     planName: string;
     description: string;
+    // The actionName of the UserIntent associated with this plan
     intentSchemaName: string;
     steps: PageManipulationActions[];
 };

--- a/ts/packages/agents/browser/src/agent/discovery/translator.mts
+++ b/ts/packages/agents/browser/src/agent/discovery/translator.mts
@@ -665,6 +665,7 @@ export class SchemaDiscoveryAgent<T extends object> {
 
     async getIntentSchemaFromRecording(
         recordedActionName: string,
+        existingActionNames: string[],
         recordedActionDescription: string,
         recordedActionSteps?: string,
         fragments?: HtmlFragments[],
@@ -716,6 +717,22 @@ export class SchemaDiscoveryAgent<T extends object> {
             Here are the recorded steps that the user went through on the webpage to complete the action.
             '''
             ${recordedActionSteps}
+            '''
+            `,
+            });
+        }
+
+        if (
+            existingActionNames !== undefined &&
+            existingActionNames.length > 0
+        ) {
+            requestSection.push({
+                type: "text",
+                text: `
+               
+            Here are existing intent names. When picking a name for the new user intent, make sure you use a unique value that is not similar to the values on this list.
+            '''
+            ${JSON.stringify(existingActionNames)}
             '''
             `,
             });
@@ -825,6 +842,81 @@ export class SchemaDiscoveryAgent<T extends object> {
                 type: "text",
                 text: `
         Examine the layout information provided as well as the user action information. Based on this
+        generate a SINGLE "${bootstrapTranslator.validator.getTypeName()}" response using the typescript schema below.
+                
+        '''
+        ${bootstrapTranslator.validator.getSchemaText()}
+        '''
+        `,
+            },
+            ...requestSection,
+            {
+                type: "text",
+                text: `
+        The following is the COMPLETE JSON response object with 2 spaces of indentation and no properties with the value undefined:            
+        `,
+            },
+        ];
+
+        const response = await bootstrapTranslator.translate("", [
+            { role: "user", content: JSON.stringify(promptSections) },
+        ]);
+        return response;
+    }
+
+    async getDetailedStepsFromDescription(
+        recordedActionName: string,
+        recordedActionDescription: string,
+        fragments?: HtmlFragments[],
+        screenshot?: string,
+    ) {
+        const packageRoot = path.join("..", "..", "..");
+        const resultsSchema = await fs.promises.readFile(
+            fileURLToPath(
+                new URL(
+                    path.join(
+                        packageRoot,
+                        "./src/agent/discovery/schema/expandDescription.mts",
+                    ),
+                    import.meta.url,
+                ),
+            ),
+            "utf8",
+        );
+
+        const bootstrapTranslator = this.getBootstrapTranslator(
+            "PageActionsList",
+            resultsSchema,
+        );
+
+        const screenshotSection = getScreenshotPromptSection(
+            screenshot,
+            fragments,
+        );
+        const htmlSection = getHtmlPromptSection(fragments);
+        const prefixSection = getBootstrapPrefixPromptSection();
+        let requestSection = [];
+        requestSection.push({
+            type: "text",
+            text: `
+               
+            The user provided an example of how they would complete the ${recordedActionName} action on the webpage. 
+            They provided a description of the task below:
+            '''
+            ${recordedActionDescription}
+            '''
+            `,
+        });
+
+        const promptSections = [
+            ...prefixSection,
+            ...screenshotSection,
+            ...htmlSection,
+            {
+                type: "text",
+                text: `
+        Examine the layout information provided as well as the user action description. Use this information to create a detailed set of steps, including
+        the HTML elements that the user would need to interact with. Based on this
         generate a SINGLE "${bootstrapTranslator.validator.getTypeName()}" response using the typescript schema below.
                 
         '''

--- a/ts/packages/agents/browser/src/extension/serviceWorker.ts
+++ b/ts/packages/agents/browser/src/extension/serviceWorker.ts
@@ -1551,8 +1551,10 @@ chrome.runtime.onMessage.addListener(
                         actionName: "getIntentFromRecording",
                         parameters: {
                             recordedActionName: message.actionName,
-                            recordedActionDescription: message.description,
+                            recordedActionDescription:
+                                message.actionDescription,
                             recordedActionSteps: message.steps,
+                            existingActionNames: message.existingActionNames,
                             fragments: message.html,
                             screenshot: message.screenshot,
                         },

--- a/ts/packages/agents/browser/src/extension/sidepanel.html
+++ b/ts/packages/agents/browser/src/extension/sidepanel.html
@@ -222,31 +222,25 @@
       <div class="card">
         <div class="card-body">
           <div class="mb-3">
-            <label class="form-label">Action Name:</label>
-            <input
-              type="text"
-              id="actionName"
-              class="form-control"
-              placeholder="Enter action name"
-              required
-            />
+            <label class="form-label">Name:</label>
+            <input type="text" id="actionName" class="form-control" required />
           </div>
           <div class="mb-3">
-            <label class="form-label">Description:</label>
+            <label class="form-label hidden">Description:</label>
             <textarea
               id="actionDescription"
-              class="form-control"
+              class="form-control hidden"
               rows="5"
               placeholder="What does this action do?"
             ></textarea>
           </div>
           <div class="mb-3">
-            <label class="form-label">Steps:</label>
+            <label class="form-label">Details:</label>
             <textarea
               id="actionStepsDescription"
               class="form-control"
               rows="5"
-              placeholder="Give the steps to perform this action"
+              placeholder="Describe how you would complete this action on the website."
             ></textarea>
             <div
               id="stepsTimelineContainer"

--- a/ts/packages/agents/browser/src/extension/sidepanel.ts
+++ b/ts/packages/agents/browser/src/extension/sidepanel.ts
@@ -182,7 +182,7 @@ async function saveUserAction() {
     const screenshot = JSON.parse(stepsContainer.dataset?.screenshot || '""');
     let html = JSON.parse(stepsContainer.dataset?.html || '""');
 
-    if (html === undefined || html == -"") {
+    if (html === undefined || html === "") {
         const htmlFragments = await chrome.runtime.sendMessage({
             type: "captureHtmlFragments",
         });
@@ -217,6 +217,28 @@ async function saveUserAction() {
     button.innerHTML = `<span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span> Saving...`;
     button.disabled = true;
 
+    const detectedActions = new Map(
+        Object.entries(
+            (await getStoredPageProperty(
+                launchUrl!,
+                "detectedActionDefinitions",
+            )) ?? {},
+        ),
+    );
+    const authoredActions = new Map(
+        Object.entries(
+            (await getStoredPageProperty(
+                launchUrl!,
+                "authoredActionDefinitions",
+            )) ?? {},
+        ),
+    );
+
+    const existingActionNames: string[] = [
+        ...detectedActions.keys(),
+        ...authoredActions.keys(),
+    ];
+
     // Get schema based on the recorded action info
     const response = await chrome.runtime.sendMessage({
         type: "getIntentFromRecording",
@@ -224,6 +246,7 @@ async function saveUserAction() {
         screenshot,
         actionName,
         actionDescription,
+        existingActionNames,
         steps: JSON.stringify(steps),
     });
     if (chrome.runtime.lastError) {

--- a/ts/packages/agents/browser/src/extension/uiEventsDispatcher.ts
+++ b/ts/packages/agents/browser/src/extension/uiEventsDispatcher.ts
@@ -82,9 +82,10 @@ function enterTextInElement(
                 !(inputElement instanceof HTMLTextAreaElement) &&
                 !inputElement.isContentEditable
             ) {
-                throw new Error(
-                    "Element must be an input, textarea, or contenteditable element",
-                );
+                // fall back to page-level scope
+                inputElement =
+                    (document.activeElement as HTMLElement) || document.body;
+                config.enterAtPageScope = true;
             }
 
             inputElement.focus();


### PR DESCRIPTION
- add logic to have model expand the user-provided description into a more detailed list of UI actions.
- add dedupe logic to the prompt so that the model generates unique action names