### PR TITLE
Action Schema Compiler

### DIFF
--- a/ts/packages/actionSchema/package.json
+++ b/ts/packages/actionSchema/package.json
@@ -30,7 +30,6 @@
   },
   "dependencies": {
     "debug": "^4.4.0",
-    "typechat": "^0.1.1",
     "typescript": "^5.4.2"
   },
   "devDependencies": {

--- a/ts/packages/actionSchema/src/index.ts
+++ b/ts/packages/actionSchema/src/index.ts
@@ -28,14 +28,14 @@ export {
 export { validateAction } from "./validate.js";
 export { getParameterType, getParameterNames } from "./utils.js";
 
-export { NodeType, SchemaParser, ISymbol, SymbolNode } from "./schemaParser.js";
-
 export * as ActionSchemaCreator from "./creator.js";
 
 export {
     ActionSchemaFileJSON,
     toJSONActionSchemaFile,
     fromJSONActionSchemaFile,
+    loadParsedActionSchema,
+    saveParsedActionSchema,
 } from "./serialize.js";
 
 // Generic (non-action) Schema
@@ -43,3 +43,6 @@ export { validateType } from "./validate.js";
 
 // Schema Config
 export { SchemaConfig, ParamSpec, ActionParamSpecs } from "./schemaConfig.js";
+
+// Legacy (to be deprecated)
+export { NodeType, SchemaParser, ISymbol, SymbolNode } from "./schemaParser.js";

--- a/ts/packages/actionSchema/src/type.ts
+++ b/ts/packages/actionSchema/src/type.ts
@@ -144,13 +144,16 @@ export type ActionSchemaGroup = {
     order?: Map<string, number>; // for exact regen
 };
 
-export type ActionSchemaFile = ActionSchemaGroup & {
+// Action schema that is parsed from a file.
+export type ParsedActionSchema = ActionSchemaGroup & {
+    // separate the cache by action name
+    actionNamespace?: boolean; // default to false
+};
+
+export type ActionSchemaFile = ParsedActionSchema & {
     // Schema name
     schemaName: string;
 
     // original file source hash
     sourceHash: string;
-
-    // separate the cache by action name
-    actionNamespace?: boolean; // default to false
 };

--- a/ts/packages/actionSchema/test/regen.spec.ts
+++ b/ts/packages/actionSchema/test/regen.spec.ts
@@ -32,6 +32,7 @@ const tests: {
 type Config = {
     schema?: {
         schemaFile: string;
+        originalSchemaFile?: string;
         schemaType: string;
     };
     subActionManifests?: Record<string, Config>;
@@ -57,7 +58,8 @@ function loadSchemaConfig(fileName: string) {
 function addTest(schemaName: string, config: Config, dir: string) {
     const schema = config.schema;
     if (schema) {
-        const fileName = path.resolve(dir, schema.schemaFile);
+        const schemaFile = schema.originalSchemaFile ?? schema.schemaFile;
+        const fileName = path.resolve(dir, schemaFile);
         const schemaConfig = loadSchemaConfig(fileName);
         tests.push({
             source: fs.readFileSync(fileName, "utf-8"),

--- a/ts/packages/actionSchemaCompiler/LICENSE
+++ b/ts/packages/actionSchemaCompiler/LICENSE
@@ -1,0 +1,21 @@
+    MIT License
+
+    Copyright (c) Microsoft Corporation.
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE

--- a/ts/packages/actionSchemaCompiler/README.md
+++ b/ts/packages/actionSchemaCompiler/README.md
@@ -1,0 +1,12 @@
+# action-schema-compiler
+
+A command line tool to preprocess action schema authored in TypeScript, save the result in ParsedActionSchemaGroup JSON format.
+Dispatcher can load the result instead of having the typescript compiler parse the TypeScript schema at runtime.
+
+## Trademarks
+
+This project may contain trademarks or logos for projects, products, or services. Authorized use of Microsoft
+trademarks or logos is subject to and must follow
+[Microsoft's Trademark & Brand Guidelines](https://www.microsoft.com/en-us/legal/intellectualproperty/trademarks/usage/general).
+Use of Microsoft trademarks or logos in modified versions of this project must not cause confusion or imply Microsoft sponsorship.
+Any use of third-party trademarks or logos are subject to those third-party's policies.

--- a/ts/packages/actionSchemaCompiler/bin/dev.cmd
+++ b/ts/packages/actionSchemaCompiler/bin/dev.cmd
@@ -1,0 +1,6 @@
+:: Copyright (c) Microsoft Corporation.
+:: Licensed under the MIT License.
+
+@echo off
+
+node --loader ts-node/esm --no-warnings=ExperimentalWarning "%~dp0\dev" %*

--- a/ts/packages/actionSchemaCompiler/bin/dev.js
+++ b/ts/packages/actionSchemaCompiler/bin/dev.js
@@ -1,0 +1,10 @@
+#!/usr/bin/env -S node --loader ts-node/esm --no-warnings=ExperimentalWarning
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+async function main() {
+    const { execute } = await import("@oclif/core");
+    await execute({ development: true, dir: import.meta.url });
+}
+
+await main();

--- a/ts/packages/actionSchemaCompiler/bin/run.cmd
+++ b/ts/packages/actionSchemaCompiler/bin/run.cmd
@@ -1,0 +1,6 @@
+:: Copyright (c) Microsoft Corporation.
+:: Licensed under the MIT License.
+
+@echo off
+
+node "%~dp0\run" %*

--- a/ts/packages/actionSchemaCompiler/bin/run.js
+++ b/ts/packages/actionSchemaCompiler/bin/run.js
@@ -1,0 +1,10 @@
+#!/usr/bin/env node
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+async function main() {
+    const { execute } = await import("@oclif/core");
+    await execute({ dir: import.meta.url });
+}
+
+await main();

--- a/ts/packages/actionSchemaCompiler/package.json
+++ b/ts/packages/actionSchemaCompiler/package.json
@@ -1,0 +1,49 @@
+{
+  "name": "action-schema-compiler",
+  "version": "0.0.1",
+  "description": "Action schema compiler",
+  "homepage": "https://github.com/microsoft/TypeAgent#readme",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/microsoft/TypeAgent.git",
+    "directory": "ts/packages/actionSchemaCompiler"
+  },
+  "license": "MIT",
+  "author": "Microsoft",
+  "type": "module",
+  "main": "",
+  "bin": {
+    "asc": "./bin/run.js",
+    "asc-dev": "./bin/dev.js"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "npm run tsc",
+    "clean": "rimraf --glob dist *.tsbuildinfo *.done.build.log",
+    "prettier": "prettier --check . --ignore-path ../../.prettierignore",
+    "prettier:fix": "prettier --write . --ignore-path ../../prettierignore",
+    "tsc": "tsc -b"
+  },
+  "dependencies": {
+    "@oclif/core": "^4",
+    "@oclif/plugin-help": "^5",
+    "action-schema": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^18.18.7",
+    "rimraf": "^5.0.5"
+  },
+  "oclif": {
+    "bin": "asc",
+    "commands": {
+      "strategy": "single",
+      "target": "./dist/index.js"
+    },
+    "dirname": "asc",
+    "plugins": [
+      "@oclif/plugin-help"
+    ]
+  }
+}

--- a/ts/packages/actionSchemaCompiler/package.json
+++ b/ts/packages/actionSchemaCompiler/package.json
@@ -33,7 +33,8 @@
   },
   "devDependencies": {
     "@types/node": "^18.18.7",
-    "rimraf": "^5.0.5"
+    "rimraf": "^5.0.5",
+    "typescript": "^5.4.2"
   },
   "oclif": {
     "bin": "asc",

--- a/ts/packages/actionSchemaCompiler/package.json
+++ b/ts/packages/actionSchemaCompiler/package.json
@@ -26,16 +26,6 @@
     "prettier:fix": "prettier --write . --ignore-path ../../prettierignore",
     "tsc": "tsc -b"
   },
-  "dependencies": {
-    "@oclif/core": "^4",
-    "@oclif/plugin-help": "^5",
-    "action-schema": "workspace:*"
-  },
-  "devDependencies": {
-    "@types/node": "^18.18.7",
-    "rimraf": "^5.0.5",
-    "typescript": "^5.4.2"
-  },
   "oclif": {
     "bin": "asc",
     "commands": {
@@ -46,5 +36,15 @@
     "plugins": [
       "@oclif/plugin-help"
     ]
+  },
+  "dependencies": {
+    "@oclif/core": "^4",
+    "@oclif/plugin-help": "^5",
+    "action-schema": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^18.18.7",
+    "rimraf": "^5.0.5",
+    "typescript": "^5.4.2"
   }
 }

--- a/ts/packages/actionSchemaCompiler/src/index.ts
+++ b/ts/packages/actionSchemaCompiler/src/index.ts
@@ -61,6 +61,10 @@ export default class Compile extends Command {
         console.log(
             `Parse completed: ${actionSchemaFile.actionSchemas.size} actions found`,
         );
+        const outputDir = path.dirname(flags.output);
+        if (!fs.existsSync(outputDir)) {
+            fs.mkdirSync(outputDir, { recursive: true });
+        }
         fs.writeFileSync(
             flags.output,
             saveParsedActionSchema(actionSchemaFile),

--- a/ts/packages/actionSchemaCompiler/src/index.ts
+++ b/ts/packages/actionSchemaCompiler/src/index.ts
@@ -1,0 +1,70 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { Command, Flags } from "@oclif/core";
+import {
+    parseActionSchemaSource,
+    SchemaConfig,
+    saveParsedActionSchema,
+} from "action-schema";
+import path from "node:path";
+import fs from "node:fs";
+
+function getSchemaConfig(schemaFile: string): SchemaConfig | undefined {
+    const parts = path.parse(schemaFile);
+    const schemaConfigFile = path.join(parts.dir, parts.name + ".json");
+    if (!fs.existsSync(schemaConfigFile)) {
+        console.log(`Schema config not found`);
+        return undefined;
+    }
+
+    console.log(`Schema config loaded: ${schemaConfigFile}`);
+    return JSON.parse(fs.readFileSync(schemaConfigFile, "utf-8"));
+}
+export default class Compile extends Command {
+    static description = "Compile action schema files";
+
+    static flags = {
+        input: Flags.file({
+            description: "Input action schema definition in typescript",
+            required: true,
+            exists: true,
+            char: "i",
+        }),
+        output: Flags.string({
+            description: "Output file for parsed action schema group",
+            required: true,
+            char: "o",
+        }),
+        schemaType: Flags.string({
+            description: "Entry type name for the schema",
+            required: true,
+            char: "t",
+        }),
+    };
+
+    async run(): Promise<void> {
+        const { flags } = await this.parse(Compile);
+
+        const name = path.basename(flags.input);
+
+        const actionSchemaFile = parseActionSchemaSource(
+            fs.readFileSync(flags.input, "utf-8"),
+            name,
+            "",
+            flags.schemaType,
+            flags.input,
+            getSchemaConfig(flags.input),
+            true,
+        );
+
+        console.log(
+            `Parse completed: ${actionSchemaFile.actionSchemas.size} actions found`,
+        );
+        fs.writeFileSync(
+            flags.output,
+            saveParsedActionSchema(actionSchemaFile),
+        );
+        console.log(`Parsed action schema written: ${flags.output}`);
+    }
+}

--- a/ts/packages/actionSchemaCompiler/src/tsconfig.json
+++ b/ts/packages/actionSchemaCompiler/src/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "rootDir": ".",
+    "outDir": "../dist",
+  },
+  "include": ["./**/*"],
+  "ts-node": {
+    "esm": true
+  }
+}

--- a/ts/packages/actionSchemaCompiler/tsconfig.json
+++ b/ts/packages/actionSchemaCompiler/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true
+  },
+  "include": [],
+  "references": [{ "path": "./src" }],
+  "ts-node": {
+    "esm": true
+  }
+}

--- a/ts/packages/agentSdk/src/agentInterface.ts
+++ b/ts/packages/agentSdk/src/agentInterface.ts
@@ -19,7 +19,7 @@ export type AppAgentManifest = {
 export type SchemaManifest = {
     description: string;
     schemaType: string;
-    schemaFile: string | { type: "ts"; content: string };
+    schemaFile: string | { type: "ts" | "json"; content: string };
     injected?: boolean; // whether the translator is injected into other domains, default is false
     cached?: boolean; // whether the translator's action should be cached, default is true
     streamingActions?: string[];

--- a/ts/packages/agents/player/package.json
+++ b/ts/packages/agents/player/package.json
@@ -18,7 +18,8 @@
     "./agent/handlers": "./dist/agent/playerHandlers.js"
   },
   "scripts": {
-    "build": "npm run tsc",
+    "asc": "asc -i ./src/agent/playerSchema.ts -o ./dist/agent/playerSchema.json -t PlayerAction",
+    "build": "concurrently npm:tsc npm:asc",
     "clean": "rimraf --glob dist *.tsbuildinfo *.done.build.log",
     "tsc": "tsc -p src"
   },
@@ -38,6 +39,7 @@
     "@types/express": "^4.17.17",
     "@types/node": "^20.3.1",
     "@types/spotify-api": "^0.0.22",
+    "action-schema-compiler": "workspace:*",
     "rimraf": "^5.0.5",
     "typescript": "^5.4.2"
   }

--- a/ts/packages/agents/player/package.json
+++ b/ts/packages/agents/player/package.json
@@ -42,5 +42,18 @@
     "action-schema-compiler": "workspace:*",
     "rimraf": "^5.0.5",
     "typescript": "^5.4.2"
+  },
+  "fluidBuild": {
+    "declarativeTasks": {
+      "asc": {
+        "inputGlobs": [
+          "src/agent/playerSchema.ts",
+          "src/agent/playerSchema.json"
+        ],
+        "outputGlobs": [
+          "dist/agent/playerSchema.json"
+        ]
+      }
+    }
   }
 }

--- a/ts/packages/agents/player/src/agent/playerManifest.json
+++ b/ts/packages/agents/player/src/agent/playerManifest.json
@@ -3,7 +3,7 @@
   "description": "Agent to play music",
   "schema": {
     "description": "Music Player agent that lets you search for, play and control music.",
-    "schemaFile": "./playerSchema.ts",
+    "schemaFile": "../../dist/agent/playerSchema.json",
     "schemaType": "PlayerAction"
   }
 }

--- a/ts/packages/agents/player/src/agent/playerManifest.json
+++ b/ts/packages/agents/player/src/agent/playerManifest.json
@@ -4,6 +4,7 @@
   "schema": {
     "description": "Music Player agent that lets you search for, play and control music.",
     "schemaFile": "../../dist/agent/playerSchema.json",
+    "originalSchemaFile": "playerSchema.ts",
     "schemaType": "PlayerAction"
   }
 }

--- a/ts/packages/cli/package.json
+++ b/ts/packages/cli/package.json
@@ -43,7 +43,7 @@
     }
   },
   "dependencies": {
-    "@oclif/core": "^3",
+    "@oclif/core": "^4",
     "@oclif/plugin-help": "^5",
     "@typeagent/agent-sdk": "workspace:*",
     "action-schema": "workspace:*",

--- a/ts/packages/cli/src/commands/test/translate.ts
+++ b/ts/packages/cli/src/commands/test/translate.ts
@@ -289,7 +289,7 @@ export default class TestTranslateCommand extends Command {
             const files =
                 argv.length > 0
                     ? (argv as string[])
-                    : await getDefaultConstructionProvider().getImportTranslationFiles();
+                    : await defaultConstructionProvider.getImportTranslationFiles();
 
             const inputs = await Promise.all(
                 files.map(async (file) => {

--- a/ts/packages/defaultAgentProvider/test/data/explanations/player/v5/changeVolume.json
+++ b/ts/packages/defaultAgentProvider/test/data/explanations/player/v5/changeVolume.json
@@ -1,7 +1,7 @@
 {
   "version": 2,
   "schemaName": "player",
-  "sourceHash": "HrhZPog7XXm93zb5xwYtzWspziPTFgFnvgb4UUJ85a8=",
+  "sourceHash": "e0+5x42s99DZanPOfvIRaWpITnqeTzNTgZdO5O19oko=",
   "explainerName": "v5",
   "entries": [
     {

--- a/ts/packages/defaultAgentProvider/test/data/explanations/player/v5/full.json
+++ b/ts/packages/defaultAgentProvider/test/data/explanations/player/v5/full.json
@@ -1,7 +1,7 @@
 {
   "version": 2,
   "schemaName": "player",
-  "sourceHash": "HrhZPog7XXm93zb5xwYtzWspziPTFgFnvgb4UUJ85a8=",
+  "sourceHash": "e0+5x42s99DZanPOfvIRaWpITnqeTzNTgZdO5O19oko=",
   "explainerName": "v5",
   "entries": [
     {

--- a/ts/packages/defaultAgentProvider/test/data/explanations/player/v5/nextAction.json
+++ b/ts/packages/defaultAgentProvider/test/data/explanations/player/v5/nextAction.json
@@ -1,7 +1,7 @@
 {
   "version": 2,
   "schemaName": "player",
-  "sourceHash": "HrhZPog7XXm93zb5xwYtzWspziPTFgFnvgb4UUJ85a8=",
+  "sourceHash": "e0+5x42s99DZanPOfvIRaWpITnqeTzNTgZdO5O19oko=",
   "explainerName": "v5",
   "entries": [
     {

--- a/ts/packages/defaultAgentProvider/test/data/explanations/player/v5/param.json
+++ b/ts/packages/defaultAgentProvider/test/data/explanations/player/v5/param.json
@@ -1,7 +1,7 @@
 {
   "version": 2,
   "schemaName": "player",
-  "sourceHash": "HrhZPog7XXm93zb5xwYtzWspziPTFgFnvgb4UUJ85a8=",
+  "sourceHash": "e0+5x42s99DZanPOfvIRaWpITnqeTzNTgZdO5O19oko=",
   "explainerName": "v5",
   "entries": [
     {

--- a/ts/packages/defaultAgentProvider/test/data/explanations/player/v5/pauseAction.json
+++ b/ts/packages/defaultAgentProvider/test/data/explanations/player/v5/pauseAction.json
@@ -1,7 +1,7 @@
 {
   "version": 2,
   "schemaName": "player",
-  "sourceHash": "HrhZPog7XXm93zb5xwYtzWspziPTFgFnvgb4UUJ85a8=",
+  "sourceHash": "e0+5x42s99DZanPOfvIRaWpITnqeTzNTgZdO5O19oko=",
   "explainerName": "v5",
   "entries": [
     {

--- a/ts/packages/defaultAgentProvider/test/data/explanations/player/v5/previousAction.json
+++ b/ts/packages/defaultAgentProvider/test/data/explanations/player/v5/previousAction.json
@@ -1,7 +1,7 @@
 {
   "version": 2,
   "schemaName": "player",
-  "sourceHash": "HrhZPog7XXm93zb5xwYtzWspziPTFgFnvgb4UUJ85a8=",
+  "sourceHash": "e0+5x42s99DZanPOfvIRaWpITnqeTzNTgZdO5O19oko=",
   "explainerName": "v5",
   "entries": [
     {

--- a/ts/packages/defaultAgentProvider/test/data/explanations/player/v5/resumeAction.json
+++ b/ts/packages/defaultAgentProvider/test/data/explanations/player/v5/resumeAction.json
@@ -1,7 +1,7 @@
 {
   "version": 2,
   "schemaName": "player",
-  "sourceHash": "HrhZPog7XXm93zb5xwYtzWspziPTFgFnvgb4UUJ85a8=",
+  "sourceHash": "e0+5x42s99DZanPOfvIRaWpITnqeTzNTgZdO5O19oko=",
   "explainerName": "v5",
   "entries": [
     {

--- a/ts/packages/defaultAgentProvider/test/data/explanations/player/v5/searchTracks.json
+++ b/ts/packages/defaultAgentProvider/test/data/explanations/player/v5/searchTracks.json
@@ -1,7 +1,7 @@
 {
   "version": 2,
   "schemaName": "player",
-  "sourceHash": "HrhZPog7XXm93zb5xwYtzWspziPTFgFnvgb4UUJ85a8=",
+  "sourceHash": "e0+5x42s99DZanPOfvIRaWpITnqeTzNTgZdO5O19oko=",
   "explainerName": "v5",
   "entries": [
     {

--- a/ts/packages/defaultAgentProvider/test/data/explanations/player/v5/simple.json
+++ b/ts/packages/defaultAgentProvider/test/data/explanations/player/v5/simple.json
@@ -1,7 +1,7 @@
 {
   "version": 2,
   "schemaName": "player",
-  "sourceHash": "HrhZPog7XXm93zb5xwYtzWspziPTFgFnvgb4UUJ85a8=",
+  "sourceHash": "e0+5x42s99DZanPOfvIRaWpITnqeTzNTgZdO5O19oko=",
   "explainerName": "v5",
   "entries": [
     {

--- a/ts/pnpm-lock.yaml
+++ b/ts/pnpm-lock.yaml
@@ -538,6 +538,9 @@ importers:
       rimraf:
         specifier: ^5.0.5
         version: 5.0.5
+      typescript:
+        specifier: ^5.4.2
+        version: 5.4.5
 
   packages/agentRpc:
     dependencies:
@@ -1237,7 +1240,7 @@ importers:
         version: 7.4.2
       typechat:
         specifier: ^0.1.1
-        version: 0.1.1(typescript@5.4.3)(zod@3.23.8)
+        version: 0.1.1(typescript@5.4.5)(zod@3.23.8)
     devDependencies:
       '@types/debug':
         specifier: ^4.1.12
@@ -1259,7 +1262,7 @@ importers:
         version: 5.0.5
       typescript:
         specifier: ^5.4.2
-        version: 5.4.3
+        version: 5.4.5
 
   packages/agents/spelunker:
     dependencies:

--- a/ts/pnpm-lock.yaml
+++ b/ts/pnpm-lock.yaml
@@ -500,9 +500,6 @@ importers:
       debug:
         specifier: ^4.4.0
         version: 4.4.0(supports-color@8.1.1)
-      typechat:
-        specifier: ^0.1.1
-        version: 0.1.1(typescript@5.4.3)(zod@3.23.8)
       typescript:
         specifier: ^5.4.2
         version: 5.4.3
@@ -519,6 +516,25 @@ importers:
       jest:
         specifier: ^29.7.0
         version: 29.7.0(@types/node@18.18.7)(ts-node@10.9.2(@types/node@18.18.7)(typescript@5.4.3))
+      rimraf:
+        specifier: ^5.0.5
+        version: 5.0.5
+
+  packages/actionSchemaCompiler:
+    dependencies:
+      '@oclif/core':
+        specifier: ^4
+        version: 4.2.8
+      '@oclif/plugin-help':
+        specifier: ^5
+        version: 5.2.20(@types/node@18.18.7)(typescript@5.4.5)
+      action-schema:
+        specifier: workspace:*
+        version: link:../actionSchema
+    devDependencies:
+      '@types/node':
+        specifier: ^18.18.7
+        version: 18.18.7
       rimraf:
         specifier: ^5.0.5
         version: 5.0.5
@@ -1235,6 +1251,9 @@ importers:
       '@types/spotify-api':
         specifier: ^0.0.22
         version: 0.0.22
+      action-schema-compiler:
+        specifier: workspace:*
+        version: link:../../actionSchemaCompiler
       rimraf:
         specifier: ^5.0.5
         version: 5.0.5
@@ -1597,8 +1616,8 @@ importers:
   packages/cli:
     dependencies:
       '@oclif/core':
-        specifier: ^3
-        version: 3.9.0
+        specifier: ^4
+        version: 4.2.8
       '@oclif/plugin-help':
         specifier: ^5
         version: 5.2.20(@types/node@18.18.7)(typescript@5.4.3)
@@ -3865,10 +3884,6 @@ packages:
   '@oclif/core@2.15.0':
     resolution: {integrity: sha512-fNEMG5DzJHhYmI3MgpByTvltBOMyFcnRIUMxbiz2ai8rhaYgaTHMG3Q38HcosfIvtw9nCjxpcQtC8MN8QtVCcA==}
     engines: {node: '>=14.0.0'}
-
-  '@oclif/core@3.9.0':
-    resolution: {integrity: sha512-9UT0ySJgaUvERUQwDFh0u9Q5cfoBttfyaJ1sorSms6H5AELIjQ2Yvu2QfzPmnAit2rod+hdcDZ+O1Hia5Zcz+Q==}
-    engines: {node: '>=18.0.0'}
 
   '@oclif/core@4.2.8':
     resolution: {integrity: sha512-OWv4Va6bERxIhrYcnUGzyhGRqktc64lJO6cZ3UwkzJDpfR8ZrbCxRfKRBBah1i8kzUlOAeAXnpbMBMah3skKwA==}
@@ -11149,7 +11164,7 @@ snapshots:
       supports-color: 8.1.1
       supports-hyperlinks: 2.3.0
       ts-node: 10.9.2(@types/node@18.18.7)(typescript@5.4.3)
-      tslib: 2.6.2
+      tslib: 2.8.1
       widest-line: 3.1.0
       wordwrap: 1.0.0
       wrap-ansi: 7.0.0
@@ -11159,8 +11174,9 @@ snapshots:
       - '@types/node'
       - typescript
 
-  '@oclif/core@3.9.0':
+  '@oclif/core@2.15.0(@types/node@18.18.7)(typescript@5.4.5)':
     dependencies:
+      '@types/cli-progress': 3.11.5
       ansi-escapes: 4.3.2
       ansi-styles: 4.3.0
       cardinal: 2.1.1
@@ -11183,9 +11199,16 @@ snapshots:
       strip-ansi: 6.0.1
       supports-color: 8.1.1
       supports-hyperlinks: 2.3.0
+      ts-node: 10.9.2(@types/node@18.18.7)(typescript@5.4.5)
+      tslib: 2.8.1
       widest-line: 3.1.0
       wordwrap: 1.0.0
       wrap-ansi: 7.0.0
+    transitivePeerDependencies:
+      - '@swc/core'
+      - '@swc/wasm'
+      - '@types/node'
+      - typescript
 
   '@oclif/core@4.2.8':
     dependencies:
@@ -11231,6 +11254,15 @@ snapshots:
   '@oclif/plugin-help@5.2.20(@types/node@18.18.7)(typescript@5.4.3)':
     dependencies:
       '@oclif/core': 2.15.0(@types/node@18.18.7)(typescript@5.4.3)
+    transitivePeerDependencies:
+      - '@swc/core'
+      - '@swc/wasm'
+      - '@types/node'
+      - typescript
+
+  '@oclif/plugin-help@5.2.20(@types/node@18.18.7)(typescript@5.4.5)':
+    dependencies:
+      '@oclif/core': 2.15.0(@types/node@18.18.7)(typescript@5.4.5)
     transitivePeerDependencies:
       - '@swc/core'
       - '@swc/wasm'
@@ -14912,7 +14944,7 @@ snapshots:
 
   jake@10.8.7:
     dependencies:
-      async: 3.2.5
+      async: 3.2.6
       chalk: 4.1.2
       filelist: 1.0.4
       minimatch: 3.1.2
@@ -17216,6 +17248,24 @@ snapshots:
       diff: 4.0.2
       make-error: 1.3.6
       typescript: 5.4.3
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+
+  ts-node@10.9.2(@types/node@18.18.7)(typescript@5.4.5):
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.9
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 18.18.7
+      acorn: 8.11.1
+      acorn-walk: 8.3.0
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.2
+      make-error: 1.3.6
+      typescript: 5.4.5
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
 


### PR DESCRIPTION
Add action schema compiler CLI for parsing action schema authored in TypeScript into the native `ParsedActionSchemaGroup` format used by the dispatcher.  The tool can be activated in the build step.

Converted player to use the compiler.