### PR TITLE
Parsed Action Schema

### DIFF
--- a/ts/packages/actionSchema/src/index.ts
+++ b/ts/packages/actionSchema/src/index.ts
@@ -8,7 +8,7 @@ export {
     ActionSchemaTypeDefinition,
     ActionSchemaEntryTypeDefinition,
     ActionSchemaGroup,
-    ActionSchemaFile,
+    ParsedActionSchema,
     ActionSchemaObject,
     ActionSchemaUnion,
 } from "./type.js";
@@ -31,11 +31,9 @@ export { getParameterType, getParameterNames } from "./utils.js";
 export * as ActionSchemaCreator from "./creator.js";
 
 export {
-    ActionSchemaFileJSON,
-    toJSONActionSchemaFile,
-    fromJSONActionSchemaFile,
-    loadParsedActionSchema,
-    saveParsedActionSchema,
+    ParsedActionSchemaJSON,
+    toJSONParsedActionSchema,
+    fromJSONParsedActionSchema,
 } from "./serialize.js";
 
 // Generic (non-action) Schema

--- a/ts/packages/actionSchema/src/type.ts
+++ b/ts/packages/actionSchema/src/type.ts
@@ -149,11 +149,3 @@ export type ParsedActionSchema = ActionSchemaGroup & {
     // separate the cache by action name
     actionNamespace?: boolean; // default to false
 };
-
-export type ActionSchemaFile = ParsedActionSchema & {
-    // Schema name
-    schemaName: string;
-
-    // original file source hash
-    sourceHash: string;
-};

--- a/ts/packages/actionSchema/test/parse.spec.ts
+++ b/ts/packages/actionSchema/test/parse.spec.ts
@@ -9,7 +9,6 @@ describe("Action Schema Strict Checks", () => {
             parseActionSchemaSource(
                 `type SomeAction = { actionName: "someAction" }`,
                 "test",
-                "",
                 "SomeAction",
                 "",
                 undefined,
@@ -24,7 +23,6 @@ describe("Action Schema Strict Checks", () => {
             parseActionSchemaSource(
                 `// comments\nexport type AllActions = SomeAction;\ntype SomeAction = { actionName: "someAction" }`,
                 "test",
-                "",
                 "AllActions",
                 "",
                 undefined,
@@ -39,7 +37,6 @@ describe("Action Schema Strict Checks", () => {
             parseActionSchemaSource(
                 `export type AllActions = SomeAction | SomeAction2;\ntype SomeAction = { actionName: "someAction" }\ntype SomeAction2 = { actionName: "someAction" }`,
                 "test",
-                "",
                 "AllActions",
                 "",
                 undefined,
@@ -54,7 +51,6 @@ describe("Action Schema Strict Checks", () => {
             parseActionSchemaSource(
                 `export type AllActions = SomeAction | { actionName: "someAction2" };\ntype SomeAction = { actionName: "someAction" }`,
                 "test",
-                "",
                 "AllActions",
                 "",
                 undefined,

--- a/ts/packages/actionSchema/test/regen.spec.ts
+++ b/ts/packages/actionSchema/test/regen.spec.ts
@@ -6,8 +6,8 @@ import fs from "node:fs";
 import path from "node:path";
 import { parseActionSchemaSource } from "../src/parser.js";
 import {
-    toJSONActionSchemaFile,
-    fromJSONActionSchemaFile,
+    toJSONParsedActionSchema,
+    fromJSONParsedActionSchema,
 } from "../src/serialize.js";
 import { fileURLToPath } from "node:url";
 import { generateActionSchema } from "../src/generator.js";
@@ -119,7 +119,6 @@ describe("Action Schema Regeneration", () => {
             const actionSchemaFile = parseActionSchemaSource(
                 source,
                 schemaName,
-                "testHash", // Don't care about source hash in tests
                 typeName,
                 fileName,
                 schemaConfig,
@@ -138,7 +137,6 @@ describe("Action Schema Regeneration", () => {
             const actionSchemaFile = parseActionSchemaSource(
                 source,
                 schemaName,
-                "testHash", // Don't care about source hash in tests
                 typeName,
                 fileName,
             );
@@ -147,7 +145,6 @@ describe("Action Schema Regeneration", () => {
             const roundtrip = parseActionSchemaSource(
                 regenerated,
                 schemaName,
-                "testHash", // Don't care about source hash in tests
                 typeName,
             );
             const schema2 = await generateActionSchema(roundtrip);
@@ -163,22 +160,23 @@ describe("Action Schema Serialization", () => {
             const actionSchemaFile = parseActionSchemaSource(
                 source,
                 schemaName,
-                "testHash", // Don't care about source hash in tests
                 typeName,
                 fileName,
             );
-            const serialized = toJSONActionSchemaFile(actionSchemaFile);
-            const deserialized = fromJSONActionSchemaFile(
+            const serialized = toJSONParsedActionSchema(actionSchemaFile);
+            const deserialized = fromJSONParsedActionSchema(
                 structuredClone(serialized),
+                schemaName,
             );
 
             expect(deserialized).toEqual(actionSchemaFile);
 
-            const serialized2 = toJSONActionSchemaFile(actionSchemaFile);
+            const serialized2 = toJSONParsedActionSchema(actionSchemaFile);
             expect(serialized2).toEqual(serialized);
 
-            const deserialized2 = fromJSONActionSchemaFile(
+            const deserialized2 = fromJSONParsedActionSchema(
                 structuredClone(serialized),
+                schemaName,
             );
             expect(deserialized2).toEqual(deserialized);
         },

--- a/ts/packages/actionSchemaCompiler/src/index.ts
+++ b/ts/packages/actionSchemaCompiler/src/index.ts
@@ -5,7 +5,7 @@ import { Command, Flags } from "@oclif/core";
 import {
     parseActionSchemaSource,
     SchemaConfig,
-    saveParsedActionSchema,
+    toJSONParsedActionSchema,
 } from "action-schema";
 import path from "node:path";
 import fs from "node:fs";
@@ -51,7 +51,6 @@ export default class Compile extends Command {
         const actionSchemaFile = parseActionSchemaSource(
             fs.readFileSync(flags.input, "utf-8"),
             name,
-            "",
             flags.schemaType,
             flags.input,
             getSchemaConfig(flags.input),
@@ -67,7 +66,7 @@ export default class Compile extends Command {
         }
         fs.writeFileSync(
             flags.output,
-            saveParsedActionSchema(actionSchemaFile),
+            JSON.stringify(toJSONParsedActionSchema(actionSchemaFile)),
         );
         console.log(`Parsed action schema written: ${flags.output}`);
     }

--- a/ts/packages/agentSdk/src/agentInterface.ts
+++ b/ts/packages/agentSdk/src/agentInterface.ts
@@ -16,10 +16,11 @@ export type AppAgentManifest = {
     commandDefaultEnabled?: boolean;
 } & ActionManifest;
 
+export type SchemaFormat = "ts" | "pas";
 export type SchemaManifest = {
     description: string;
     schemaType: string;
-    schemaFile: string | { type: "ts" | "json"; content: string };
+    schemaFile: string | { format: SchemaFormat; content: string };
     injected?: boolean; // whether the translator is injected into other domains, default is false
     cached?: boolean; // whether the translator's action should be cached, default is true
     streamingActions?: string[];

--- a/ts/packages/agentSdk/src/index.ts
+++ b/ts/packages/agentSdk/src/index.ts
@@ -4,7 +4,8 @@
 export {
     AppAgentManifest,
     ActionManifest,
-    SchemaManifest as SchemaDefinition,
+    SchemaFormat,
+    SchemaManifest,
     AppAgent,
     AppAgentEvent,
     SessionContext,

--- a/ts/packages/agents/browser/src/agent/discovery/actionHandler.mts
+++ b/ts/packages/agents/browser/src/agent/discovery/actionHandler.mts
@@ -135,7 +135,7 @@ export async function handleSchemaDiscoveryAction(
                 schema: {
                     description: schemaDescription,
                     schemaType: "DynamicUserPageActions",
-                    schemaFile: { content: schema, type: "ts" },
+                    schemaFile: { content: schema, format: "ts" },
                 },
             };
 
@@ -249,7 +249,7 @@ export async function handleSchemaDiscoveryAction(
             schema: {
                 description: schemaDescription,
                 schemaType: "DynamicUserPageActions",
-                schemaFile: { content: schema, type: "ts" },
+                schemaFile: { content: schema, format: "ts" },
             },
         };
 

--- a/ts/packages/agents/browser/src/extension/sites/paleobiodb.ts
+++ b/ts/packages/agents/browser/src/extension/sites/paleobiodb.ts
@@ -284,7 +284,7 @@ document.addEventListener("DOMContentLoaded", async () => {
             description:
                 "This enables users to explore paleological data. Users can filter fossil data by location, by geological time and by taxon.",
             schemaType: "PaleoBioDbActions",
-            schemaFile: { content: schemaTs, type: "ts" },
+            schemaFile: { content: schemaTs, format: "ts" },
         },
     };
 

--- a/ts/packages/agents/player/package.json
+++ b/ts/packages/agents/player/package.json
@@ -18,7 +18,7 @@
     "./agent/handlers": "./dist/agent/playerHandlers.js"
   },
   "scripts": {
-    "asc": "asc -i ./src/agent/playerSchema.ts -o ./dist/agent/playerSchema.json -t PlayerAction",
+    "asc": "asc -i ./src/agent/playerSchema.ts -o ./dist/agent/playerSchema.pas.json -t PlayerAction",
     "build": "concurrently npm:tsc npm:asc",
     "clean": "rimraf --glob dist *.tsbuildinfo *.done.build.log",
     "tsc": "tsc -p src"

--- a/ts/packages/agents/player/src/agent/playerManifest.json
+++ b/ts/packages/agents/player/src/agent/playerManifest.json
@@ -3,7 +3,7 @@
   "description": "Agent to play music",
   "schema": {
     "description": "Music Player agent that lets you search for, play and control music.",
-    "schemaFile": "../../dist/agent/playerSchema.json",
+    "schemaFile": "../../dist/agent/playerSchema.pas.json",
     "originalSchemaFile": "playerSchema.ts",
     "schemaType": "PlayerAction"
   }

--- a/ts/packages/agents/turtle/src/site/index.ts
+++ b/ts/packages/agents/turtle/src/site/index.ts
@@ -51,7 +51,7 @@ const manifest: AppAgentManifest = {
     schema: {
         description: "Action to control the turtle to draw on a canvas",
         schemaType: "TurtleAction",
-        schemaFile: { content: schemaTs, type: "ts" },
+        schemaFile: { content: schemaTs, format: "ts" },
     },
 };
 

--- a/ts/packages/dispatcher/src/context/appAgentManager.ts
+++ b/ts/packages/dispatcher/src/context/appAgentManager.ts
@@ -11,7 +11,10 @@ import {
     convertToActionConfig,
     ActionConfig,
 } from "../translation/actionConfig.js";
-import { ActionConfigProvider } from "../translation/actionConfigProvider.js";
+import {
+    ActionConfigProvider,
+    ActionSchemaFile,
+} from "../translation/actionConfigProvider.js";
 import { getAppAgentName } from "../translation/agentTranslators.js";
 import { createSessionContext } from "../execute/actionHandlers.js";
 import { AppAgentProvider } from "../agentProvider/agentProvider.js";
@@ -22,7 +25,6 @@ import {
     EmbeddingCache,
 } from "../translation/actionSchemaSemanticMap.js";
 import { ActionSchemaFileCache } from "../translation/actionSchemaFileCache.js";
-import { ActionSchemaFile } from "action-schema";
 import path from "path";
 import { callEnsureError } from "../utils/exceptions.js";
 
@@ -254,7 +256,7 @@ export class AppAgentManager implements ActionConfigProvider {
                     this.transientAgents[schemaName] = false;
                 }
                 if (config.injected) {
-                    for (const actionName of actionSchemaFile.actionSchemas.keys()) {
+                    for (const actionName of actionSchemaFile.parsedActionSchema.actionSchemas.keys()) {
                         this.injectedSchemaForActionName.set(
                             actionName,
                             schemaName,

--- a/ts/packages/dispatcher/src/context/system/handlers/actionCommandHandler.ts
+++ b/ts/packages/dispatcher/src/context/system/handlers/actionCommandHandler.ts
@@ -52,7 +52,8 @@ export class ActionCommandHandler implements CommandHandler {
             throw new Error(`Invalid schema name ${schemaName}`);
         }
 
-        const actionSchema = actionSchemaFile.actionSchemas.get(actionName);
+        const actionSchema =
+            actionSchemaFile.parsedActionSchema.actionSchemas.get(actionName);
         if (actionSchema === undefined) {
             throw new Error(
                 `Invalid action name ${actionName} for schema ${schemaName}`,
@@ -100,7 +101,9 @@ export class ActionCommandHandler implements CommandHandler {
                 if (actionSchemaFile === undefined) {
                     continue;
                 }
-                completions.push(...actionSchemaFile.actionSchemas.keys());
+                completions.push(
+                    ...actionSchemaFile.parsedActionSchema.actionSchemas.keys(),
+                );
                 continue;
             }
 

--- a/ts/packages/dispatcher/src/translation/actionConfig.ts
+++ b/ts/packages/dispatcher/src/translation/actionConfig.ts
@@ -4,7 +4,7 @@
 import {
     ActionManifest,
     AppAgentManifest,
-    SchemaDefinition,
+    SchemaManifest,
 } from "@typeagent/agent-sdk";
 import registerDebug from "debug";
 const debugConfig = registerDebug("typeagent:dispatcher:schema:config");
@@ -17,7 +17,7 @@ export type ActionConfig = {
     actionDefaultEnabled: boolean;
     transient: boolean;
     schemaName: string;
-} & SchemaDefinition;
+} & SchemaManifest;
 
 function collectActionConfigs(
     actionConfigs: { [key: string]: ActionConfig },

--- a/ts/packages/dispatcher/src/translation/actionConfigProvider.ts
+++ b/ts/packages/dispatcher/src/translation/actionConfigProvider.ts
@@ -1,8 +1,19 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { ActionSchemaFile } from "action-schema";
+import { ParsedActionSchema } from "action-schema";
 import { ActionConfig } from "./actionConfig.js";
+
+export type ActionSchemaFile = {
+    // Schema name
+    schemaName: string;
+
+    // original file source hash
+    sourceHash: string;
+
+    // Parsed action schema
+    parsedActionSchema: ParsedActionSchema;
+};
 
 export interface ActionConfigProvider {
     tryGetActionConfig(schemaName: string): ActionConfig | undefined;

--- a/ts/packages/dispatcher/src/translation/actionSchemaJsonTranslator.ts
+++ b/ts/packages/dispatcher/src/translation/actionSchemaJsonTranslator.ts
@@ -3,7 +3,6 @@
 
 import { error, Result, success } from "typechat";
 import {
-    ActionSchemaFile,
     generateActionSchema,
     validateAction,
     ActionSchemaCreator as sc,
@@ -31,7 +30,10 @@ import {
     MultipleActionOptions,
 } from "./multipleActionSchema.js";
 import { ActionConfig } from "./actionConfig.js";
-import { ActionConfigProvider } from "./actionConfigProvider.js";
+import {
+    ActionConfigProvider,
+    ActionSchemaFile,
+} from "./actionConfigProvider.js";
 
 function convertJsonSchemaOutput(
     jsonObject: unknown,
@@ -124,7 +126,7 @@ class ActionSchemaBuilder {
             const actionSchemaFile =
                 this.provider.getActionSchemaFileForConfig(config);
             this.files.push(actionSchemaFile);
-            this.definitions.push(actionSchemaFile.entry);
+            this.definitions.push(actionSchemaFile.parsedActionSchema.entry);
         }
     }
 
@@ -142,9 +144,9 @@ class ActionSchemaBuilder {
         const entry = sc.type(typeName, this.getTypeUnion(), undefined, true);
         const order = new Map<string, number>();
         for (const file of this.files) {
-            if (file.order) {
+            if (file.parsedActionSchema.order) {
                 const base = order.size;
-                for (const [name, num] of file.order) {
+                for (const [name, num] of file.parsedActionSchema.order) {
                     if (order.has(name)) {
                         throw new Error(
                             `Schema Builder Error: duplicate type definition '${name}'`,

--- a/ts/packages/dispatcher/src/translation/actionSchemaSemanticMap.ts
+++ b/ts/packages/dispatcher/src/translation/actionSchemaSemanticMap.ts
@@ -2,8 +2,9 @@
 // Licensed under the MIT License.
 
 import fs from "node:fs";
-import { ActionSchemaFile, ActionSchemaTypeDefinition } from "action-schema";
+import { ActionSchemaTypeDefinition } from "action-schema";
 import { ActionConfig } from "./actionConfig.js";
+import { ActionSchemaFile } from "./actionConfigProvider.js";
 import {
     generateEmbeddingWithRetry,
     generateTextEmbeddingsWithRetry,
@@ -49,7 +50,8 @@ export class ActionSchemaSemanticMap {
         const actionSemanticMap = new Map<string, Entry>();
         this.actionSemanticMaps.set(config.schemaName, actionSemanticMap);
         let reuseCount = 0;
-        for (const [name, definition] of actionSchemaFile.actionSchemas) {
+        for (const [name, definition] of actionSchemaFile.parsedActionSchema
+            .actionSchemas) {
             const key = `${config.schemaName} ${name} ${definition.comments?.[0] ?? ""}`;
             const embedding = cache?.get(key);
             if (embedding) {
@@ -66,7 +68,7 @@ export class ActionSchemaSemanticMap {
         }
 
         debug(
-            `Reused ${reuseCount}/${actionSchemaFile.actionSchemas.size} embeddings for ${config.schemaName} ${cache === undefined}`,
+            `Reused ${reuseCount}/${actionSchemaFile.parsedActionSchema.actionSchemas.size} embeddings for ${config.schemaName} ${cache === undefined}`,
         );
         const embeddings = await generateTextEmbeddingsWithRetry(
             this.model,

--- a/ts/packages/dispatcher/src/translation/actionTemplate.ts
+++ b/ts/packages/dispatcher/src/translation/actionTemplate.ts
@@ -126,7 +126,7 @@ function toTemplate(
         schemas,
         action.action.translatorName,
     );
-    const actionSchemas = actionSchemaFile.actionSchemas;
+    const actionSchemas = actionSchemaFile.parsedActionSchema.actionSchemas;
     const actionName: TemplateFieldStringUnion = {
         type: "string-union",
         typeEnum: Array.from(actionSchemas.keys()),

--- a/ts/packages/dispatcher/src/translation/agentTranslators.ts
+++ b/ts/packages/dispatcher/src/translation/agentTranslators.ts
@@ -224,7 +224,7 @@ function collectSchemaName(
     const schemaNameMap = new Map<string, string>();
     for (const actionConfig of actionConfigs) {
         const schemaFile = provider.getActionSchemaFileForConfig(actionConfig);
-        for (const actionName of schemaFile.actionSchemas.keys()) {
+        for (const actionName of schemaFile.parsedActionSchema.actionSchemas.keys()) {
             const existing = schemaNameMap.get(actionName);
             if (existing) {
                 throw new Error(

--- a/ts/packages/dispatcher/src/translation/agentTranslators.ts
+++ b/ts/packages/dispatcher/src/translation/agentTranslators.ts
@@ -122,7 +122,7 @@ function getTranslatorSchemaDef(
         };
     }
 
-    if (actionConfig.schemaFile.type === "ts") {
+    if (actionConfig.schemaFile.format === "ts") {
         return {
             kind: "inline",
             typeName: actionConfig.schemaType,
@@ -131,7 +131,7 @@ function getTranslatorSchemaDef(
     }
 
     throw new Error(
-        `Unsupported schema source type: ${actionConfig.schemaFile.type}"`,
+        `Unsupported schema source type: ${actionConfig.schemaFile.format}"`,
     );
 }
 

--- a/ts/packages/dispatcher/src/translation/translateRequest.ts
+++ b/ts/packages/dispatcher/src/translation/translateRequest.ts
@@ -153,7 +153,7 @@ async function getTranslatorForSelectedActions(
     const actionSchemaFile = context.agents.tryGetActionSchemaFile(schemaName);
     if (
         actionSchemaFile === undefined ||
-        actionSchemaFile.actionSchemas.size <= numActions
+        actionSchemaFile.parsedActionSchema.actionSchemas.size <= numActions
     ) {
         return undefined;
     }

--- a/ts/packages/dispatcher/src/translation/unknownSwitcher.ts
+++ b/ts/packages/dispatcher/src/translation/unknownSwitcher.ts
@@ -30,7 +30,10 @@ function createSelectionActionTypeDefinition(
 
     const actionNames: string[] = [];
     const actionComments: string[] = [];
-    for (const [name, info] of actionSchemaFile.actionSchemas.entries()) {
+    for (const [
+        name,
+        info,
+    ] of actionSchemaFile.parsedActionSchema.actionSchemas.entries()) {
         actionNames.push(name);
         actionComments.push(
             ` "${name}"${info.comments ? ` - ${info.comments[0].trim()}` : ""}`,


### PR DESCRIPTION
- Establish "Parsed Action Schema" as the name of the native action schema format that TypeAgent uses.
  - Format type change from `json` to `pas`
  - File extension change from `.json` to  `.pas.json`
- Move the hash, which is only needed for cache, out of the `action-schema` package.