### PR TITLE
Fix processing param spec for type reference in array 

### DIFF
--- a/ts/packages/actionSchema/src/serialize.ts
+++ b/ts/packages/actionSchema/src/serialize.ts
@@ -121,12 +121,10 @@ function resolveTypes(
  * Clone the data before passing into this function if you want to keep the original.
  *
  * @param json JSON data to convert
- * @param schemaName Name of the schema (for error messages)
  * @returns
  */
 export function fromJSONParsedActionSchema(
     json: ParsedActionSchemaJSON,
-    schemaName: string,
 ): ParsedActionSchema {
     for (const type of Object.values(json.types)) {
         resolveTypes(json.types, type.type);
@@ -139,11 +137,5 @@ export function fromJSONParsedActionSchema(
               actionNamespace: json.actionNamespace,
           }
         : undefined;
-    return createParsedActionSchema(
-        schemaName,
-        entry,
-        order,
-        true,
-        schemaConfig,
-    );
+    return createParsedActionSchema(entry, order, true, schemaConfig);
 }

--- a/ts/packages/actionSchema/test/paramSpec.spec.ts
+++ b/ts/packages/actionSchema/test/paramSpec.spec.ts
@@ -1,0 +1,215 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { parseActionSchemaSource } from "../src/parser.js";
+
+describe("Action Schema with param specs", () => {
+    it("basic", async () => {
+        const schemaConfig = {
+            paramSpec: {
+                someAction: {
+                    foo: "wildcard",
+                },
+            },
+        } as const;
+
+        const result = await parseActionSchemaSource(
+            `export type AllActions = SomeAction;\ntype SomeAction = { actionName: "someAction", parameters: { foo: string } }`,
+            "test",
+            "AllActions",
+            "",
+            schemaConfig,
+            false,
+        );
+        const def = result.actionSchemas.get("someAction");
+        expect(def).toBeDefined();
+        expect(def?.paramSpecs).toMatchObject(
+            schemaConfig.paramSpec.someAction,
+        );
+    });
+    it("array", async () => {
+        const schemaConfig = {
+            paramSpec: {
+                someAction: {
+                    "foo.*": "percentage",
+                },
+            },
+        } as const;
+
+        const result = await parseActionSchemaSource(
+            `export type AllActions = SomeAction;\ntype SomeAction = { actionName: "someAction", parameters: { foo: number[] } }`,
+            "test",
+            "AllActions",
+            "",
+            schemaConfig,
+            false,
+        );
+        const def = result.actionSchemas.get("someAction");
+        expect(def).toBeDefined();
+        expect(def?.paramSpecs).toMatchObject(
+            schemaConfig.paramSpec.someAction,
+        );
+    });
+    it("object", async () => {
+        const schemaConfig = {
+            paramSpec: {
+                someAction: {
+                    "foo.bar": "ordinal",
+                },
+            },
+        } as const;
+
+        const result = await parseActionSchemaSource(
+            `export type AllActions = SomeAction;\ntype SomeAction = { actionName: "someAction", parameters: { foo: { bar: number } } }`,
+            "test",
+            "AllActions",
+            "",
+            schemaConfig,
+            false,
+        );
+        const def = result.actionSchemas.get("someAction");
+        expect(def).toBeDefined();
+        expect(def?.paramSpecs).toMatchObject(
+            schemaConfig.paramSpec.someAction,
+        );
+    });
+    it("object reference", async () => {
+        const schemaConfig = {
+            paramSpec: {
+                someAction: {
+                    "foo.bar": "checked_wildcard",
+                },
+            },
+        } as const;
+
+        const result = await parseActionSchemaSource(
+            `export type AllActions = SomeAction;\ntype T = { bar: string };\ntype SomeAction = { actionName: "someAction", parameters: { foo: T } }`,
+            "test",
+            "AllActions",
+            "",
+            schemaConfig,
+            false,
+        );
+        const def = result.actionSchemas.get("someAction");
+        expect(def).toBeDefined();
+        expect(def?.paramSpecs).toMatchObject(
+            schemaConfig.paramSpec.someAction,
+        );
+    });
+    it("array reference", async () => {
+        const schemaConfig = {
+            paramSpec: {
+                someAction: {
+                    "foo.*.bar": "time",
+                },
+            },
+        } as const;
+
+        const result = await parseActionSchemaSource(
+            `export type AllActions = SomeAction;\ntype T = { bar: string };\ntype SomeAction = { actionName: "someAction", parameters: { foo: T[] } }`,
+            "test",
+            "AllActions",
+            "",
+            schemaConfig,
+            false,
+        );
+        const def = result.actionSchemas.get("someAction");
+        expect(def).toBeDefined();
+        expect(def?.paramSpecs).toMatchObject(
+            schemaConfig.paramSpec.someAction,
+        );
+    });
+    it.each(["__proto__", "constructor", "prototype"])(
+        "Reject - illegal property %s",
+        async (name) => {
+            const schemaConfig = {
+                paramSpec: {
+                    someAction: {
+                        [`foo.${name}`]: "wildcard",
+                    },
+                },
+            } as const;
+
+            expect(async () =>
+                parseActionSchemaSource(
+                    `export type AllActions = SomeAction;\ntype T = { bar: string };\ntype SomeAction = { actionName: "someAction", parameters: { foo: T } }`,
+                    "test",
+                    "AllActions",
+                    "",
+                    schemaConfig,
+                    false,
+                ),
+            ).rejects.toThrow(
+                `Error parsing schema 'test': Schema Config Error: Invalid parameter name 'foo.${name}' for action 'someAction': Illegal parameter property name '${name}'`,
+            );
+        },
+    );
+    it("Reject - index", async () => {
+        const schemaConfig = {
+            paramSpec: {
+                someAction: {
+                    "foo.0": "wildcard",
+                },
+            },
+        } as const;
+
+        expect(async () =>
+            parseActionSchemaSource(
+                `export type AllActions = SomeAction;\ntype SomeAction = { actionName: "someAction", parameters: { foo: string[] } }`,
+                "test",
+                "AllActions",
+                "",
+                schemaConfig,
+                false,
+            ),
+        ).rejects.toThrow(
+            "Error parsing schema 'test': Schema Config Error: Invalid parameter name 'foo.0' for action 'someAction': paramSpec cannot be applied to specific array index 0",
+        );
+    });
+
+    it("Reject - field of non-object", async () => {
+        const schemaConfig = {
+            paramSpec: {
+                someAction: {
+                    "foo.other": "wildcard",
+                },
+            },
+        } as const;
+
+        expect(async () =>
+            parseActionSchemaSource(
+                `export type AllActions = SomeAction;\ntype SomeAction = { actionName: "someAction", parameters: { foo: string } }`,
+                "test",
+                "AllActions",
+                "",
+                schemaConfig,
+                false,
+            ),
+        ).rejects.toThrow(
+            "Error parsing schema 'test': Schema Config Error: Invalid parameter name 'foo.other' for action 'someAction': Access property 'other' of non-object",
+        );
+    });
+
+    it("Reject - non-exist field", async () => {
+        const schemaConfig = {
+            paramSpec: {
+                someAction: {
+                    "foo.other": "wildcard",
+                },
+            },
+        } as const;
+
+        expect(async () =>
+            parseActionSchemaSource(
+                `export type AllActions = SomeAction;\ntype SomeAction = { actionName: "someAction", parameters: { foo: { bar: string } } }`,
+                "test",
+                "AllActions",
+                "",
+                schemaConfig,
+                false,
+            ),
+        ).rejects.toThrow(
+            "Error parsing schema 'test': Schema Config Error: Invalid parameter name 'foo.other' for action 'someAction': property 'other' does not exist",
+        );
+    });
+});

--- a/ts/packages/actionSchema/test/parse.spec.ts
+++ b/ts/packages/actionSchema/test/parse.spec.ts
@@ -15,7 +15,7 @@ describe("Action Schema Strict Checks", () => {
                 true,
             ),
         ).rejects.toThrow(
-            "Error parsing test: Schema Error: test: Type 'SomeAction' must be exported",
+            "Error parsing schema 'test': Schema Error: Type 'SomeAction' must be exported",
         ));
 
     it("Error on entry type comment", async () =>
@@ -29,7 +29,7 @@ describe("Action Schema Strict Checks", () => {
                 true,
             ),
         ).rejects.toThrow(
-            "Error parsing test: Schema Error: test: entry type comments for 'AllActions' are not used for prompts. Remove from the action schema file.",
+            "Error parsing schema 'test': Schema Error: entry type comments for 'AllActions' are not used for prompts. Remove from the action schema file.",
         ));
 
     it("Error on duplicate action name", async () =>
@@ -43,7 +43,7 @@ describe("Action Schema Strict Checks", () => {
                 true,
             ),
         ).rejects.toThrow(
-            "Error parsing test: Schema Error: test: Duplicate action name 'someAction'",
+            "Error parsing schema 'test': Schema Error: Duplicate action name 'someAction'",
         ));
 
     it("Error on anonymous types", async () =>
@@ -57,6 +57,6 @@ describe("Action Schema Strict Checks", () => {
                 true,
             ),
         ).rejects.toThrow(
-            "Error parsing test: Schema Error: test: expected type reference in the entry type union",
+            "Error parsing schema 'test': Schema Error: expected type reference in the entry type union",
         ));
 });

--- a/ts/packages/actionSchema/test/regen.spec.ts
+++ b/ts/packages/actionSchema/test/regen.spec.ts
@@ -166,7 +166,6 @@ describe("Action Schema Serialization", () => {
             const serialized = toJSONParsedActionSchema(actionSchemaFile);
             const deserialized = fromJSONParsedActionSchema(
                 structuredClone(serialized),
-                schemaName,
             );
 
             expect(deserialized).toEqual(actionSchemaFile);
@@ -176,7 +175,6 @@ describe("Action Schema Serialization", () => {
 
             const deserialized2 = fromJSONParsedActionSchema(
                 structuredClone(serialized),
-                schemaName,
             );
             expect(deserialized2).toEqual(deserialized);
         },

--- a/ts/packages/dispatcher/src/translation/actionSchemaFileCache.ts
+++ b/ts/packages/dispatcher/src/translation/actionSchemaFileCache.ts
@@ -52,22 +52,29 @@ function loadParsedActionSchema(
     sourceHash: string,
     source: string,
 ): ActionSchemaFile {
-    // TODO: validate the json
-    const parsedActionSchemaJSON = JSON.parse(source) as ParsedActionSchemaJSON;
-    const parsedActionSchema = fromJSONParsedActionSchema(
-        parsedActionSchemaJSON,
-        schemaName,
-    );
-    if (parsedActionSchema.entry.name !== schemaType) {
+    try {
+        const parsedActionSchemaJSON = JSON.parse(
+            source,
+        ) as ParsedActionSchemaJSON;
+        // TODO: validate the json
+        const parsedActionSchema = fromJSONParsedActionSchema(
+            parsedActionSchemaJSON,
+        );
+        if (parsedActionSchema.entry.name !== schemaType) {
+            throw new Error(
+                `Schema type mismatch: actual: ${parsedActionSchema.entry.name}, expected:${schemaType}`,
+            );
+        }
+        return {
+            schemaName,
+            sourceHash,
+            parsedActionSchema,
+        };
+    } catch (e: any) {
         throw new Error(
-            `Unable to load parsed action schema: Schema type mismatch: actual: ${parsedActionSchema.entry.name}, expected:${schemaType}`,
+            `Failed to load parsed action schema '${schemaName}': ${e.message}`,
         );
     }
-    return {
-        schemaName,
-        sourceHash,
-        parsedActionSchema,
-    };
 }
 
 function loadActionSchemaFile(record: ActionSchemaFileJSON): ActionSchemaFile {
@@ -76,7 +83,6 @@ function loadActionSchemaFile(record: ActionSchemaFileJSON): ActionSchemaFile {
         sourceHash: record.sourceHash,
         parsedActionSchema: fromJSONParsedActionSchema(
             record.parsedActionSchema,
-            record.schemaName,
         ),
     };
 }


### PR DESCRIPTION
- When processing param spec, type reference needs to be resolved for arrays as well.
- Add tests for paramSpec checks.
- Remove need to pass in schema name to the `action-schema` library.  Caller will add to the error message if exception happens.