### PR TITLE
Refactor lookupAndResponse with different information sources.

### DIFF
--- a/ts/packages/agents/chat/src/chatResponseActionSchema.ts
+++ b/ts/packages/agents/chat/src/chatResponseActionSchema.ts
@@ -11,8 +11,9 @@ export type Entity = {
 };
 
 export type ChatResponseAction =
-    | LookupAndGenerateResponseAction
-    | GenerateResponseAction;
+    | LookupAndAnswerAction
+    | GenerateResponseAction
+    | ShowImageFileAction;
 
 export type DateVal = {
     day: number;
@@ -54,24 +55,40 @@ export type TermFilter = {
     timeRange?: DateTimeRange | undefined; // in this time range
 };
 
-// this action is used to lookup information images the user has previously shared from past conversations or the internet and generate a response based on the lookup results, for example "what did we say about the project last week?" or "what is the current price of Microsoft stock?"
-export interface LookupAndGenerateResponseAction {
-    actionName: "lookupAndGenerateResponse";
+// look up for private information from past conversations (i.e. chat history) including private events, plans, projects in progress, attachments, files, file names, and other items from discussions with team members or the assistant, use the conversation lookup filters
+type LookupConversation = {
+    source: "conversation";
+    conversationLookupFilters: TermFilter[];
+};
+
+// look up for contemporary internet information including sports scores, news events, or current commerce offerings, use the lookups parameter to request a lookup of the information on the user's behalf; the assistant will generate a response based on the lookup results
+// Lookup *facts* you don't know or if your facts are out of date.
+// E.g. stock prices, time sensitive data, etc
+// the search strings to look up on the user's behalf should be specific enough to return the correct information
+// it is recommended to include the same entities as in the user request
+type LookupInternet = {
+    source: "internet";
+    internetLookups: string[];
+};
+
+// Use this action to look up answers based on information from previous conversations or the internet,
+// for user request that is a questions (for example "what did we say about the project last week?" or "what is the current price of Microsoft stock?")
+export interface LookupAndAnswerAction {
+    actionName: "lookupAndAnswer";
     parameters: {
         // the original request from the user
         originalRequest: string;
-        // if the request is for private information from past conversations including private events, plans, projects in progress, attachments, files, file names, and other items from discussions with team members or the assistant, use the conversation lookup filters
-        conversationLookupFilters?: TermFilter[];
-        // if the request is for contemporary internet information including sports scores, news events, or current commerce offerings, use the lookups parameter to request a lookup of the information on the user's behalf; the assistant will generate a response based on the lookup results
-        // Lookup *facts* you don't know or if your facts are out of date.
-        // E.g. stock prices, time sensitive data, etc
-        // the search strings to look up on the user's behalf should be specific enough to return the correct information
-        // it is recommended to include the same entities as in the user request
-        internetLookups?: string[];
-        // Any file references to images referred to by the message
-        relatedFiles?: string[];
-        // Are the contents of the files needed at this time? (i.e. does the user want to see an image or picture)
-        retrieveRelatedFilesFromStorage?: boolean;
+        // The question to get answer for.
+        question: string;
+        lookup: LookupConversation | LookupInternet;
+    };
+}
+
+export interface ShowImageFileAction {
+    actionName: "showImageFile";
+    parameters: {
+        // file entities.
+        files: string[];
     };
 }
 

--- a/ts/packages/defaultAgentProvider/test/data/translate-e2e.json
+++ b/ts/packages/defaultAgentProvider/test/data/translate-e2e.json
@@ -1,22 +1,65 @@
-[   
-    {"request": "why do birds suddenly appear every time you are near", "action": "chat.generateResponse"},
-    {"request": "I am planning a trip to Spain. can you look up some of the cities I should visit.", "action": "chat.lookupAndGenerateResponse"},
-    {"request": "Look up the ingredients for lemon meringue pie", "action": "chat.lookupAndGenerateResponse"},
-    {"request": "Did duke win its bball game", "action": "chat.lookupAndGenerateResponse"},
-    {"request": "Lookup duke result on the web", "action": "chat.lookupAndGenerateResponse"},
-    {"request": "add play to the To do list", "action": "list.addItems"},
-    {"request": "add homework to To do list", "action": "list.addItems"},    
-    {"request": "add plan holiday to To do list.", "action": "list.addItems"},
-    {
-        "request": "get my top 50 favorite songs, filter the current list to Bach pieces, and create a playlist call test",
-        "action": ["player.getFavorites", "player.filterTracks", "player.createPlaylist"]
-    },
-    {
-        "request": "look up information about Oregon and write a poem using what you found",
-        "action": ["chat.lookupAndGenerateResponse", "dispatcher.pendingRequestAction"]
-    },
-    {
-        "request": "look up the recipe for tarte a l'oignan and add the ingredients to my grocery list",
-        "action": ["chat.lookupAndGenerateResponse", "dispatcher.pendingRequestAction"]
+[
+  {
+    "request": "why do birds suddenly appear every time you are near",
+    "action": "chat.generateResponse"
+  },
+  {
+    "request": "I am planning a trip to Spain. can you look up some of the cities I should visit.",
+    "action": "chat.lookupAndAnswer"
+  },
+  {
+    "request": "Look up the ingredients for lemon meringue pie",
+    "action": "chat.lookupAndAnswer"
+  },
+  {
+    "request": "Did duke win its bball game",
+    "action": "chat.lookupAndAnswer"
+  },
+  {
+    "request": "Lookup duke result on the web",
+    "action": "chat.lookupAndAnswer"
+  },
+  { "request": "add play to the To do list", "action": "list.addItems" },
+  { "request": "add homework to To do list", "action": "list.addItems" },
+  { "request": "add plan holiday to To do list.", "action": "list.addItems" },
+  {
+    "request": "play some EDM please",
+    "action": {
+      "translatorName": "player",
+      "actionName": "playGenre",
+      "parameters": {
+        "genre": "EDM"
+      }
     }
+  },
+  {
+    "request": "play some Symphony by Beethoven please",
+    "action": {
+      "translatorName": "player",
+      "actionName": "playTrack",
+      "parameters": {
+        "trackName": "Symphony",
+        "artists": ["Beethoven"]
+      }
+    }
+  },
+  {
+    "request": "play Hello by Adele",
+    "action": {
+      "translatorName": "player",
+      "actionName": "playTrack",
+      "parameters": {
+        "trackName": "Hello",
+        "artists": ["Adele"]
+      }
+    }
+  },
+  {
+    "request": "get my top 50 favorite songs, filter the current list to Bach pieces, and create a playlist call test",
+    "action": [
+      "player.getFavorites",
+      "player.filterTracks",
+      "player.createPlaylist"
+    ]
+  }
 ]

--- a/ts/packages/defaultAgentProvider/test/data/translate-history-e2e.json
+++ b/ts/packages/defaultAgentProvider/test/data/translate-history-e2e.json
@@ -73,10 +73,14 @@
       "request": "look up the ingredient for shepherd's pie for me please",
       "action": {
         "translatorName": "chat",
-        "actionName": "lookupAndGenerateResponse",
+        "actionName": "lookupAndAnswer",
         "parameters": {
           "originalRequest": "look up the ingredient for shepherd's pie for me please",
-          "internetLookups": ["shepherd's pie ingredients"]
+          "question": "What are the ingredients for shepherd's pie?",
+          "lookup": {
+            "source": "internet",
+            "internetLookups": ["shepherd's pie ingredients"]
+          }
         }
       },
       "history": {

--- a/ts/packages/defaultAgentProvider/test/data/translate-image-history-e2e.json
+++ b/ts/packages/defaultAgentProvider/test/data/translate-image-history-e2e.json
@@ -1,89 +1,57 @@
 [
-    [
-        {
-            "request": "Tell me about the image in the chat history.",            
-            "action": {
-                "translatorName": "chat",
-                "actionName": "lookupAndGenerateResponse",
-                "parameters": {
-                    "originalRequest": "Tell me about the image in the chat history.",
-                    "conversationLookupFilters": [
-                      {
-                        "terms": [
-                          "image"
-                        ]
-                      }
-                    ]
-                }
-            },
-            "history": {
-              "text": "It's an image!",
-              "source": "chat",
-              "entities": [
-                {
-                  "name": "image",
-                  "type": [
-                    "object"
-                  ]
-                },
-                {
-                  "name": "non-existent image",
-                  "type": [
-                    "object"
-                  ]
-                },
-                {
-                  "name": "attachment__0.png",
-                  "type": [
-                    "file",
-                    "image",
-                    "data"
-                  ]
-                }
-              ]
-            },
-            "attachments": [ "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAABhSURBVDhPY6AdqJ9vwFA/5wAEA9kkAbDmuR8YGub+B2MQm2hD0DWTZAiyZnQXEGUIyL/ICuEGIBsMVIMT1M+dgBJoMANAAGwISA6ohmiAbABZYNSAwWBA/dwFYEw7wMAAAAOtdVt9DPxQAAAAAElFTkSuQmCC" ]
-        },
-        {
-          "request": "show me attachment__0.png",
-          "action" : {
-            "translatorName": "chat",
-            "actionName": "lookupAndGenerateResponse",
-            "parameters": {
-              "originalRequest": "show me attachment__0.png",
-              "relatedFiles": [
-                "attachment__0.png"
-              ],
-              "retrieveRelatedFilesFromStorage": true            
-            },
-            "entities": {
-              "relatedFiles": [
-                {
-                  "name": "attachment__0.png",
-                  "type": [
-                    "file",
-                    "image",
-                    "data"
-                  ],
-                  "sourceAppAgentName": "chat"
-                }
-              ]
-            }
-          },
-          "history": {
-            "text":"Action chat.lookupAndGenerateResponse completed.",
-            "source": "chat",
-            "entities": [
-                {
-                  "name": "attachment__0.png",
-                  "type": [
-                    "file",
-                    "image",
-                    "data"
-                  ]
-                }
-            ]
+  [
+    {
+      "request": "Tell me what images are in our chat history.",
+      "match": "partial",
+      "action": {
+        "translatorName": "chat",
+        "actionName": "lookupAndAnswer",
+        "parameters": {
+          "originalRequest": "Tell me what images are in our chat history.",
+          "question": "What images are in our chat history?",
+          "lookup": {
+            "source": "conversation"
           }
         }
-    ]
+      },
+      "history": {
+        "text": "There is a list of images in the chat history:\n - image\n - non-existent image\n - attachment__0.png",
+        "source": "chat",
+        "entities": [
+          {
+            "name": "image",
+            "type": ["object"]
+          },
+          {
+            "name": "non-existent image",
+            "type": ["object"]
+          },
+          {
+            "name": "attachment__0.png",
+            "type": ["file", "image", "data"]
+          }
+        ]
+      }
+    },
+    {
+      "request": "show me attachment__0.png",
+      "question": "show me attachment__0.png",
+      "action": {
+        "translatorName": "chat",
+        "actionName": "showImageFile",
+        "parameters": {
+          "files": ["attachment__0.png"]
+        },
+        "entities": {
+          "files": [
+            {
+              "name": "attachment__0.png",
+              "type": ["file", "image", "data"],
+              "sourceAppAgentName": "chat"
+            }
+          ]
+        }
+      }
+    }
+  ]
 ]

--- a/ts/packages/dispatcher/src/context/chatHistoryPrompt.ts
+++ b/ts/packages/dispatcher/src/context/chatHistoryPrompt.ts
@@ -37,7 +37,9 @@ export function createTypeAgentRequestPrompt(
         if (history !== undefined) {
             const promptSections: PromptSection[] = history.promptSections;
             if (promptSections.length > 1) {
-                prompts.push("The following is a summary of the chat history:");
+                prompts.push(
+                    "The following is a summary of the recent chat history:",
+                );
 
                 const promptEntities = history.entities;
                 if (promptEntities.length > 0) {
@@ -88,6 +90,9 @@ export function createTypeAgentRequestPrompt(
     prompts.push(`"""\n${request}\n"""`);
 
     prompts.push("###");
+    prompts.push(
+        "Parameter values should only use information in the user request or the recent chat history, unless the parameter is explicitly for generating new content.",
+    );
     if (context && history !== undefined) {
         prompts.push(
             "Resolve pronouns and references in the current user request with the recent entities in the chat history.",


### PR DESCRIPTION
- Break up `lookupAndResponse` with different information sources (conversation and internet search) to move in the direction that this becomes an extension point.
- Rename to `lookupAndAnswer`
- manually ran tested with `cli test translate` stability test with no regression.