### PR TITLE
Fix build warning on debian

### DIFF
--- a/ts/examples/docuProc/package.json
+++ b/ts/examples/docuProc/package.json
@@ -17,7 +17,7 @@
     "postbuild": "pnpm run copy-data && copyfiles -u 1 \"src/**/*Schema.ts\" \"src/**/*.txt\" \"src/*.py\" \"data/**/*\" dist && rimraf --glob 'copyfiles-*.done.build.log' && npm run install-python-deps",
     "clean": "rimraf --glob dist *.tsbuildinfo *.done.build.log dist/data",
     "copy-data": "copyfiles \"data/**/*\" dist",
-    "install-python-deps": "node -e \"const { execSync } = require('child_process'); try { execSync('python3 --version', { stdio: 'ignore' }); execSync('python3 -m pip install -qq -r requirements.txt', { stdio: 'inherit' }); } catch { try { execSync('python --version', { stdio: 'ignore' }); execSync('python -m pip install -qq -r requirements.txt', { stdio: 'inherit' }); } catch { console.log('Python not found, skipping...'); } }\"",
+    "install-python-deps": "node -e \"const { execSync } = require('child_process'); try { execSync('python3 --version', { stdio: 'ignore' }); execSync('python3 -m pip install --user -qq -r requirements.txt', { stdio: 'inherit' }); } catch { try { execSync('python --version', { stdio: 'ignore' }); execSync('python -m pip install --user -qq -r requirements.txt', { stdio: 'inherit' }); } catch { console.log('Python not found, skipping...'); } }\"",
     "prettier": "prettier --check . --ignore-path ../../.prettierignore",
     "prettier:fix": "prettier --write . --ignore-path ../../.prettierignore",
     "run": "node dist/main.js",


### PR DESCRIPTION
**Solution**: Run pip in user mode.

```
warning during command 'node -e "const { execSync } = require('child_process'); try { execSync('python3 --version', { stdio: 'ignore' }); execSync('python3 -m pip install -qq -r requirements.txt', { stdio: 'inherit' }); } catch { try { execSync('python --version', { stdio: 'ignore' }); execSync('python -m pip install -qq -r requirements.txt', { stdio: 'inherit' }); } catch { console.log('Python not found, skipping...'); } }"'
Python not found, skipping...

error: externally-managed-environment

× This environment is externally managed
╰─> To install Python packages system-wide, try apt install
    python3-xyz, where xyz is the package you are trying to
    install.

    If you wish to install a non-Debian-packaged Python package,
    create a virtual environment using python3 -m venv path/to/venv.
    Then use path/to/venv/bin/python and path/to/venv/bin/pip. Make
    sure you have python3-full installed.

    If you wish to install a non-Debian packaged Python application,
    it may be easiest to use pipx install xyz, which will manage a
    virtual environment for you. Make sure you have pipx installed.

    See /usr/share/doc/python3.12/README.venv for more information.

note: If you believe this is a mistake, please contact your Python installation or OS distribution provider. You can override this, at the risk of breaking your Python installation or OS, by passing --break-system-packages.
hint: See PEP 668 for the detailed specification.
```