### PR TITLE
Install python dependencies in prerun step instead of build

### DIFF
--- a/ts/examples/docuProc/package.json
+++ b/ts/examples/docuProc/package.json
@@ -14,12 +14,13 @@
   "type": "module",
   "scripts": {
     "build": "npm run tsc",
-    "postbuild": "pnpm run copy-data && copyfiles -u 1 \"src/**/*Schema.ts\" \"src/**/*.txt\" \"src/*.py\" \"data/**/*\" dist && rimraf --glob 'copyfiles-*.done.build.log' && npm run install-python-deps",
+    "postbuild": "pnpm run copy-data && copyfiles -u 1 \"src/**/*Schema.ts\" \"src/**/*.txt\" \"src/*.py\" \"data/**/*\" dist && rimraf --glob 'copyfiles-*.done.build.log'",
     "clean": "rimraf --glob dist *.tsbuildinfo *.done.build.log dist/data",
     "copy-data": "copyfiles \"data/**/*\" dist",
     "install-python-deps": "node -e \"const { execSync } = require('child_process'); try { execSync('python3 --version', { stdio: 'ignore' }); execSync('python3 -m pip install --user -qq -r requirements.txt', { stdio: 'inherit' }); } catch { try { execSync('python --version', { stdio: 'ignore' }); execSync('python -m pip install --user -qq -r requirements.txt', { stdio: 'inherit' }); } catch { console.log('Python not found, skipping...'); } }\"",
     "prettier": "prettier --check . --ignore-path ../../.prettierignore",
     "prettier:fix": "prettier --write . --ignore-path ../../.prettierignore",
+    "prerun": "npm run install-python-deps",
     "run": "node dist/main.js",
     "tsc": "tsc -p src"
   },


### PR DESCRIPTION
- Running this as part of build was causing:
```
PEP 668, which prevents system-wide Python package installations to protect the integrity of system-managed environments
 ```

- [ ] Need to investigate running chunker python script in venv.