### PR TITLE
Implement silent login flow on initialize

### DIFF
--- a/ts/packages/agentRpc/src/client.ts
+++ b/ts/packages/agentRpc/src/client.ts
@@ -249,6 +249,14 @@ export async function createAgentRpcClient(
             const storage = getStorage(param, context);
             return (await storage.getTokenCachePersistence()).save(param.token);
         },
+        tokenCacheDelete: async (param: {
+            contextId: number;
+            session: boolean;
+        }) => {
+            const context = contextMap.get(param.contextId);
+            const storage = getStorage(param, context);
+            return (await storage.getTokenCachePersistence()).delete();
+        },
     };
 
     const agentContextCallHandlers: AgentContextCallFunctions = {

--- a/ts/packages/agentRpc/src/server.ts
+++ b/ts/packages/agentRpc/src/server.ts
@@ -205,6 +205,12 @@ export function createAgentRpcServer(
                     token,
                 });
             },
+            delete: async (): Promise<boolean> => {
+                return rpc.invoke("tokenCacheDelete", {
+                    contextId,
+                    session,
+                });
+            },
         };
         return {
             read: (

--- a/ts/packages/agentRpc/src/types.ts
+++ b/ts/packages/agentRpc/src/types.ts
@@ -83,6 +83,10 @@ export type AgentContextInvokeFunctions = {
         session: boolean;
         token: string;
     }) => Promise<any>;
+    tokenCacheDelete: (param: {
+        contextId: number;
+        session: boolean;
+    }) => Promise<any>;
     toggleTransientAgent: (param: {
         contextId: number;
         name: string;

--- a/ts/packages/agentSdk/src/agentInterface.ts
+++ b/ts/packages/agentSdk/src/agentInterface.ts
@@ -136,6 +136,7 @@ export type StorageListOptions = {
 export interface TokenCachePersistence {
     load(): Promise<string | null>;
     save(token: string): Promise<void>;
+    delete(): Promise<boolean>;
 }
 
 export interface Storage {

--- a/ts/packages/agents/player/package.json
+++ b/ts/packages/agents/player/package.json
@@ -13,7 +13,6 @@
   "author": "Microsoft",
   "type": "module",
   "exports": {
-    ".": "./dist/index.js",
     "./agent/manifest": "./src/agent/playerManifest.json",
     "./agent/handlers": "./dist/agent/playerHandlers.js"
   },

--- a/ts/packages/agents/player/src/agent/playerCommands.ts
+++ b/ts/packages/agents/player/src/agent/playerCommands.ts
@@ -98,7 +98,8 @@ const handlers: CommandHandlerTable = {
                             displayWarn("Not logged in to Spotify.", context);
                             return;
                         }
-                        disableSpotify(sessionContext);
+                        
+                        disableSpotify(sessionContext, true);
                         displaySuccess("Logged out from Spotify.", context);
                     },
                 },

--- a/ts/packages/agents/player/src/agent/playerCommands.ts
+++ b/ts/packages/agents/player/src/agent/playerCommands.ts
@@ -11,8 +11,16 @@ import {
     CommandHandlerTable,
     CommandHandler,
 } from "@typeagent/agent-sdk/helpers/command";
-import { PlayerActionContext } from "./playerHandlers.js";
+import {
+    disableSpotify,
+    enableSpotify,
+    PlayerActionContext,
+} from "./playerHandlers.js";
 import { loadHistoryFile } from "../client.js";
+import {
+    displaySuccess,
+    displayWarn,
+} from "@typeagent/agent-sdk/helpers/display";
 
 const loadHandlerParameters = {
     args: {
@@ -55,6 +63,45 @@ const handlers: CommandHandlerTable = {
             description: "Configure spotify integration",
             commands: {
                 load: loadHandler,
+                login: {
+                    description: "Login to Spotify",
+                    run: async (
+                        context: ActionContext<PlayerActionContext>,
+                    ) => {
+                        const sessionContext = context.sessionContext;
+                        const agentContext = sessionContext.agentContext;
+                        const clientContext = agentContext.spotify;
+                        if (clientContext !== undefined) {
+                            const user =
+                                clientContext.service.retrieveUser().username;
+                            displayWarn(
+                                `Already logged in to Spotify as ${user}`,
+                                context,
+                            );
+                            return;
+                        }
+                        const user = await enableSpotify(sessionContext);
+                        displaySuccess(
+                            `Logged in to Spotify as ${user}`,
+                            context,
+                        );
+                    },
+                },
+                logout: {
+                    description: "Logout from Spotify",
+                    run: async (
+                        context: ActionContext<PlayerActionContext>,
+                    ) => {
+                        const sessionContext = context.sessionContext;
+                        const agentContext = sessionContext.agentContext;
+                        if (agentContext.spotify === undefined) {
+                            displayWarn("Not logged in to Spotify.", context);
+                            return;
+                        }
+                        disableSpotify(sessionContext);
+                        displaySuccess("Logged out from Spotify.", context);
+                    },
+                },
             },
         },
     },

--- a/ts/packages/agents/player/src/agent/playerHandlers.ts
+++ b/ts/packages/agents/player/src/agent/playerHandlers.ts
@@ -1,12 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import {
-    IClientContext,
-    getClientContext,
-    PlayerAction,
-    handleCall,
-} from "music";
+import { IClientContext, getClientContext, handleCall } from "../client.js";
 import chalk from "chalk";
 import {
     AppAgent,
@@ -28,6 +23,10 @@ import {
     SpotifyQuery,
     toQueryString,
 } from "../search.js";
+import { PlayerAction } from "./playerSchema.js";
+import registerDebug from "debug";
+
+const debugSpotify = registerDebug("typeagent:spotify");
 
 export function instantiate(): AppAgent {
     return {
@@ -64,7 +63,7 @@ async function executePlayerAction(
     }
 
     return createActionResultFromError(
-        "Action translated but not performed. Spotify integration is not enabled.",
+        "Not logged in to Spotify.  Use the command '@player spotify login' to log in.",
     );
 }
 
@@ -73,25 +72,44 @@ async function updatePlayerContext(
     context: SessionContext<PlayerActionContext>,
 ) {
     if (enable) {
-        const user = await enableSpotify(context);
-        context.notify(
-            AppAgentEvent.Info,
-            chalk.blue(`Spotify integration enabled. Logged in as ${user}.`),
-        );
-    } else {
-        const timeoutId = context.agentContext.spotify?.userData?.timeoutId;
-        if (timeoutId !== undefined) {
-            clearTimeout(timeoutId);
+        if (context.agentContext.spotify) {
+            return;
         }
-        context.agentContext.spotify = undefined;
+        try {
+            const user = await enableSpotify(context, true);
+            const message = `Spotify logged in as ${user}.`;
+            debugSpotify(message);
+            context.notify(AppAgentEvent.Info, chalk.green(message));
+        } catch (e) {
+            const message = `Spotify not logged in.  Error: ${e}`;
+            debugSpotify(message);
+            context.notify(AppAgentEvent.Error, chalk.red(message));
+        }
+    } else {
+        disableSpotify(context);
     }
 }
 
-async function enableSpotify(context: SessionContext<PlayerActionContext>) {
-    const clientContext = await getClientContext(context.instanceStorage);
+export async function enableSpotify(
+    context: SessionContext<PlayerActionContext>,
+    silent: boolean = false,
+) {
+    const clientContext = await getClientContext(
+        context.instanceStorage,
+        silent,
+    );
     context.agentContext.spotify = clientContext;
-
     return clientContext.service.retrieveUser().username;
+}
+
+export async function disableSpotify(
+    context: SessionContext<PlayerActionContext>,
+) {
+    const timeoutId = context.agentContext.spotify?.userData?.timeoutId;
+    if (timeoutId !== undefined) {
+        clearTimeout(timeoutId);
+    }
+    context.agentContext.spotify = undefined;
 }
 
 async function validatePlayerWildcardMatch(
@@ -100,7 +118,7 @@ async function validatePlayerWildcardMatch(
 ) {
     const clientContext = context.agentContext.spotify;
     if (clientContext === undefined) {
-        // Can't validate without context, assume true
+        // REVIEW: Can't validate without context, assume true
         return true;
     }
     switch (action.actionName) {

--- a/ts/packages/agents/player/src/agent/playerHandlers.ts
+++ b/ts/packages/agents/player/src/agent/playerHandlers.ts
@@ -104,12 +104,19 @@ export async function enableSpotify(
 
 export async function disableSpotify(
     context: SessionContext<PlayerActionContext>,
+    clearToken: boolean = false,
 ) {
-    const timeoutId = context.agentContext.spotify?.userData?.timeoutId;
-    if (timeoutId !== undefined) {
-        clearTimeout(timeoutId);
+    const clientContext = context.agentContext.spotify;
+    if (clientContext !== undefined) {
+        const timeoutId = clientContext.userData?.timeoutId;
+        if (timeoutId !== undefined) {
+            clearTimeout(timeoutId);
+        }
+        if (clearToken) {
+            await clientContext.service.tokenProvider.clearRefreshToken();
+        }
+        context.agentContext.spotify = undefined;
     }
-    context.agentContext.spotify = undefined;
 }
 
 async function validatePlayerWildcardMatch(

--- a/ts/packages/agents/player/src/client.ts
+++ b/ts/packages/agents/player/src/client.ts
@@ -352,9 +352,7 @@ export async function getClientContext(
     // Make sure we can get an access token, silently.
     await tokenProvider.getAccessToken(silent);
 
-    const service = new SpotifyService(
-        await createTokenProvider(instanceStorage),
-    );
+    const service = new SpotifyService(tokenProvider);
     await service.init();
     debugSpotify("Service initialized");
     const userdata = await getUserProfile(service);

--- a/ts/packages/agents/player/src/client.ts
+++ b/ts/packages/agents/player/src/client.ts
@@ -91,7 +91,6 @@ import {
 import { toTrackObjectFull } from "./spotifyUtils.js";
 
 const debugSpotify = registerDebug("typeagent:spotify");
-
 const debugSpotifyError = registerDebug("typeagent:spotify:error");
 
 function createWarningActionResult(message: string) {
@@ -346,7 +345,13 @@ async function updateTrackListAndPrint(
 
 export async function getClientContext(
     instanceStorage?: Storage,
+    silent: boolean = false,
 ): Promise<IClientContext> {
+    const tokenProvider = await createTokenProvider(instanceStorage);
+
+    // Make sure we can get an access token, silently.
+    await tokenProvider.getAccessToken(silent);
+
     const service = new SpotifyService(
         await createTokenProvider(instanceStorage),
     );

--- a/ts/packages/agents/player/src/index.ts
+++ b/ts/packages/agents/player/src/index.ts
@@ -1,5 +1,0 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
-
-export * from "./agent/playerSchema.js";
-export { IClientContext, getClientContext, handleCall } from "./client.js";

--- a/ts/packages/agents/player/src/tokenProvider.ts
+++ b/ts/packages/agents/player/src/tokenProvider.ts
@@ -32,9 +32,7 @@ export class TokenProvider {
         private readonly tokenCachePersistence?: TokenCachePersistence,
     ) {}
 
-    private getAxiosRequestConfig(
-        authorization: boolean = false,
-    ): AxiosRequestConfig {
+    private getAxiosRequestConfig(): AxiosRequestConfig {
         const config: AxiosRequestConfig = {
             headers: {
                 "Content-Type": "application/x-www-form-urlencoded",
@@ -46,7 +44,7 @@ export class TokenProvider {
         return config;
     }
 
-    public async getAccessToken(): Promise<string> {
+    public async getAccessToken(silent: boolean = false): Promise<string> {
         if (
             this.userAccessToken !== undefined &&
             this.userAccessTokenExpiration > Date.now()
@@ -55,6 +53,9 @@ export class TokenProvider {
         }
         const refreshToken = await this.loadRefreshToken();
         if (refreshToken === undefined) {
+            if (silent) {
+                throw new Error("No refresh token");
+            }
             // request both the refresh token and the access token
             return this.requestTokens();
         }
@@ -78,6 +79,9 @@ export class TokenProvider {
                 result.data.scope.split(" ").sort().join(" ") !==
                 this.scopes.sort().join(" ")
             ) {
+                if (silent) {
+                    throw new Error("No refresh token");
+                }
                 // request both the refresh token and the access token to update the scope
                 return this.requestTokens();
             }

--- a/ts/packages/agents/player/src/tokenProvider.ts
+++ b/ts/packages/agents/player/src/tokenProvider.ts
@@ -222,6 +222,13 @@ export class TokenProvider {
             await this.tokenCachePersistence.save(JSON.stringify(tokenCache));
         }
     }
+
+    public async clearRefreshToken() {
+        this.userRefreshToken = undefined;
+        if (this.tokenCachePersistence !== undefined) {
+            await this.tokenCachePersistence.delete();
+        }
+    }
 }
 
 interface TokenCache {

--- a/ts/packages/dispatcher/src/execute/storageImpl.ts
+++ b/ts/packages/dispatcher/src/execute/storageImpl.ts
@@ -79,6 +79,7 @@ export function getStorage(name: string, baseDir: string): Storage {
                 return {
                     load: async () => null,
                     save: async () => {},
+                    delete: async () => false,
                 };
             }
         },


### PR DESCRIPTION
If we don't have a refresh token to log into spotify, avoid asking the user to log in (popup window) on load.
Implemented command `@player spotify login` to start the log in flow, and `@player spotify logout` to log out and clear the token cache.

