### PR TITLE
Example MCP integration.

### DIFF
--- a/ts/packages/actionSchema/src/index.ts
+++ b/ts/packages/actionSchema/src/index.ts
@@ -19,6 +19,7 @@ export {
     generateActionSchema,
     generateSchemaTypeDefinition,
 } from "./generator.js";
+export { parseToolsJsonSchema } from "./jsonSchemaParser.js";
 export {
     generateActionJsonSchema,
     generateActionActionFunctionJsonSchemas,

--- a/ts/packages/actionSchema/src/jsonSchemaGenerator.ts
+++ b/ts/packages/actionSchema/src/jsonSchemaGenerator.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 import * as sc from "./creator.js";
+import { JsonSchema } from "./jsonSchemaTypes.js";
 import {
     ActionSchemaEntryTypeDefinition,
     ActionSchemaGroup,
@@ -17,50 +18,6 @@ export function wrapTypeWithJsonSchema(
     return sc.type(type.name, sc.obj({ response: type.type }), undefined, true);
 }
 
-type JsonSchemaObject = {
-    type: "object";
-    description?: string;
-    properties: Record<string, JsonSchema>;
-    required: string[];
-    additionalProperties: false;
-};
-type JsonSchemaArray = {
-    type: "array";
-    description?: string;
-    items: JsonSchema;
-};
-
-type JsonSchemaString = {
-    type: "string";
-    description?: string;
-    enum?: string[];
-};
-
-type JsonSchemaNumber = {
-    type: "number";
-    description?: string;
-};
-
-type JsonSchemaBoolean = {
-    type: "boolean";
-    description?: string;
-};
-
-type JsonSchemaNull = {
-    type: "null";
-    description?: string;
-};
-
-type JsonSchemaUnion = {
-    anyOf: JsonSchema[];
-    description?: string;
-};
-
-type JsonSchemaReference = {
-    $ref: string;
-    description?: string;
-};
-
 export type ActionObjectJsonSchema = {
     name: string;
     description?: string;
@@ -69,16 +26,6 @@ export type ActionObjectJsonSchema = {
 };
 
 type JsonSchemaRoot = JsonSchema & { $defs?: Record<string, JsonSchema> }; // REVIEW should be JsonSchemaObject;
-
-type JsonSchema =
-    | JsonSchemaObject
-    | JsonSchemaArray
-    | JsonSchemaString
-    | JsonSchemaNumber
-    | JsonSchemaBoolean
-    | JsonSchemaNull
-    | JsonSchemaUnion
-    | JsonSchemaReference;
 
 function fieldComments(field: SchemaObjectField): string | undefined {
     const combined = [
@@ -115,7 +62,7 @@ function generateJsonSchemaType(
                         return [key, fieldType];
                     }),
                 ),
-                required: Object.keys(type.fields),
+                required: Object.keys(type.fields), // OpenAI JSON schema requires all fields to be required
                 additionalProperties: false,
             };
         case "array":

--- a/ts/packages/actionSchema/src/jsonSchemaParser.ts
+++ b/ts/packages/actionSchema/src/jsonSchemaParser.ts
@@ -1,0 +1,239 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import {
+    JsonSchema,
+    JsonSchemaArray,
+    JsonSchemaBoolean,
+    JsonSchemaNumber,
+    JsonSchemaObject,
+    JsonSchemaReference,
+    JsonSchemaString,
+    JsonSchemaUnion,
+} from "./jsonSchemaTypes.js";
+import * as sc from "./creator.js";
+import { SchemaObjectField, SchemaType, SchemaTypeReference } from "./type.js";
+import { createParsedActionSchema } from "./parser.js";
+
+function parseJsonSchemaObject(schema: JsonSchemaObject) {
+    const fields: Record<string, SchemaObjectField> = {};
+    for (const [key, value] of Object.entries(schema.properties)) {
+        const type = parseJsonSchema(value);
+        fields[key] = schema.required?.includes(key)
+            ? sc.field(type, value.description)
+            : sc.optional(type, value.description);
+    }
+    return sc.obj(fields);
+}
+
+function parseJsonSchemaArray(schema: JsonSchemaArray) {
+    const type = parseJsonSchema(schema.items);
+    return sc.array(type);
+}
+
+function parseJsonSchemaString(schema: JsonSchemaString) {
+    return sc.string(...(schema.enum ?? []));
+}
+function parseJsonSchemaNumber(schema: JsonSchemaNumber) {
+    return sc.number();
+}
+function parseJsonSchemaBoolean(schema: JsonSchemaBoolean) {
+    return sc.boolean();
+}
+
+function parseJsonSchemaUnion(schema: JsonSchemaUnion) {
+    const types = schema.anyOf.map(parseJsonSchema);
+    return sc.union(types);
+}
+function parseJsonSchemaReference(
+    schema: JsonSchemaReference,
+): SchemaTypeReference {
+    // TODO: resolve?
+    // return sc.ref(schema.$ref);
+    throw new Error("Not implemented");
+}
+
+function isJsonSchemaUnion(schema: JsonSchema): schema is JsonSchemaUnion {
+    return (schema as JsonSchemaUnion).anyOf !== undefined;
+}
+
+function isJsonSchemaReference(
+    schema: JsonSchema,
+): schema is JsonSchemaReference {
+    return (schema as JsonSchemaReference).$ref !== undefined;
+}
+
+function parseJsonSchema(schema: JsonSchema): SchemaType {
+    if (isJsonSchemaUnion(schema)) {
+        return parseJsonSchemaUnion(schema);
+    }
+    if (isJsonSchemaReference(schema)) {
+        return parseJsonSchemaReference(schema);
+    }
+
+    switch (schema.type) {
+        case "object":
+            return parseJsonSchemaObject(schema);
+        case "array":
+            return parseJsonSchemaArray(schema);
+        case "string":
+            return parseJsonSchemaString(schema);
+        case "number":
+            return parseJsonSchemaNumber(schema);
+        case "boolean":
+            return parseJsonSchemaBoolean(schema);
+        case "null":
+            throw new Error("Null type is not supported");
+    }
+
+    throw new Error(`Invalid schema type: ${JSON.stringify(schema)}`);
+}
+
+type ToolsJsonSchema = {
+    name: string;
+    description?: string;
+    inputSchema: JsonSchemaObject;
+};
+export function parseToolsJsonSchema(
+    tools: unknown[],
+    entryTypeName: string = "AgentActions",
+) {
+    const refs: SchemaTypeReference[] = [];
+    for (const tool of tools) {
+        if (!validateToolsJsonSchema(tool)) {
+            throw new Error(`Invalid tool schema: ${JSON.stringify(tool)}`);
+        }
+
+        const actionName = tool.name;
+        const inputSchema = tool.inputSchema;
+        const type = sc.obj({
+            actionName: sc.string(actionName),
+            parameters: parseJsonSchemaObject(inputSchema),
+        });
+        const def = sc.type(
+            `${tool.name[0].toUpperCase()}${tool.name.slice(1)}`,
+            type,
+            tool.description,
+        );
+        refs.push(sc.ref(def));
+    }
+
+    const entry = sc.type(entryTypeName, sc.union(refs), undefined, true);
+    return createParsedActionSchema(entry, undefined, true);
+}
+
+function validateToolsJsonSchema(schema: unknown): schema is ToolsJsonSchema {
+    if (!isObject(schema)) {
+        return false;
+    }
+    const tool = schema as Record<string, unknown>;
+    const actionName = tool.name;
+    if (!isString(actionName)) {
+        throw new Error(`Invalid tool name: ${actionName}`);
+    }
+    if (tool.description !== undefined && !isString(tool.description)) {
+        throw new Error(
+            `Invalid tool description for ${actionName}: ${tool.description}`,
+        );
+    }
+    const inputSchema = tool.inputSchema;
+    if (!validateJsonSchemaObject(inputSchema)) {
+        throw new Error(`Invalid tool input schema ${actionName}`);
+    }
+
+    // REVIEW: extra properties are ignored?
+    return true;
+}
+function validateJsonSchemaObject(schema: unknown): schema is JsonSchema {
+    if (!isObject(schema) || schema.type !== "object") {
+        return false;
+    }
+    return validateJsonSchemaObjectFields(schema);
+}
+
+function validateJsonSchemaObjectFields(
+    schema: Record<string, unknown>,
+): schema is JsonSchemaObject {
+    if (schema.properties === undefined) {
+        return schema.required === undefined;
+    }
+    if (!isObject(schema.properties)) {
+        return false;
+    }
+    if (schema.required !== undefined) {
+        if (!Array.isArray(schema.required)) {
+            return false;
+        }
+        const keys = Object.keys(schema.properties);
+        for (const required of schema.required) {
+            if (!isString(required)) {
+                return false;
+            }
+            if (!keys.includes(required)) {
+                return false;
+            }
+        }
+    }
+
+    for (const value of Object.values(schema.properties)) {
+        if (!validateJsonSchema(value)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+function validateJsonSchema(schema: unknown): schema is JsonSchema {
+    if (!isObject(schema)) {
+        return false;
+    }
+    if (schema.description !== undefined && !isString(schema.description)) {
+        return false;
+    }
+
+    switch (schema.type) {
+        case "object":
+            return validateJsonSchemaObjectFields(schema);
+        case "array":
+            return (
+                (schema.description === undefined ||
+                    isString(schema.description)) &&
+                (schema.items === undefined || validateJsonSchema(schema.items))
+            );
+        case "string":
+            return schema.enum === undefined || isStringArray(schema.enum);
+        case "number":
+        case "boolean":
+        case "null":
+            return true;
+        case undefined:
+            if (schema.anyOf !== undefined) {
+                // JsonSchemaUnion
+                if (!Array.isArray(schema.anyOf)) {
+                    return false;
+                }
+                for (const value of schema.anyOf) {
+                    if (!validateJsonSchema(value)) {
+                        return false;
+                    }
+                }
+                return true;
+            }
+            // JsonSchemaReference
+            return isString(schema.$ref);
+        default:
+            return false;
+    }
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+    return typeof value === "object" && value !== null;
+}
+
+function isString(value: unknown): value is string {
+    return typeof value === "string";
+}
+
+function isStringArray(value: unknown): value is string[] {
+    return Array.isArray(value) && value.every(isString);
+}

--- a/ts/packages/actionSchema/src/jsonSchemaTypes.ts
+++ b/ts/packages/actionSchema/src/jsonSchemaTypes.ts
@@ -1,0 +1,56 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+export type JsonSchema =
+    | JsonSchemaObject
+    | JsonSchemaArray
+    | JsonSchemaString
+    | JsonSchemaNumber
+    | JsonSchemaBoolean
+    | JsonSchemaNull
+    | JsonSchemaUnion
+    | JsonSchemaReference;
+
+export type JsonSchemaObject = {
+    type: "object";
+    description?: string;
+    properties: Record<string, JsonSchema>;
+    required?: string[];
+    additionalProperties: false;
+};
+export type JsonSchemaArray = {
+    type: "array";
+    description?: string;
+    items: JsonSchema;
+};
+
+export type JsonSchemaString = {
+    type: "string";
+    description?: string;
+    enum?: string[];
+};
+
+export type JsonSchemaNumber = {
+    type: "number";
+    description?: string;
+};
+
+export type JsonSchemaBoolean = {
+    type: "boolean";
+    description?: string;
+};
+
+export type JsonSchemaNull = {
+    type: "null";
+    description?: string;
+};
+
+export type JsonSchemaUnion = {
+    anyOf: JsonSchema[];
+    description?: string;
+};
+
+export type JsonSchemaReference = {
+    $ref: string;
+    description?: string;
+};

--- a/ts/packages/agentSdk/src/index.ts
+++ b/ts/packages/agentSdk/src/index.ts
@@ -29,6 +29,7 @@ export {
     ParameterDefinitions,
     ParsedCommandParams,
     PartialParsedCommandParams,
+    ArgDefinitions,
     FlagDefinitions,
 } from "./parameters.js";
 export {

--- a/ts/packages/defaultAgentProvider/data/config.json
+++ b/ts/packages/defaultAgentProvider/data/config.json
@@ -55,9 +55,15 @@
     "mcpfilesystem": {
       "emojiChar": "📁",
       "description": "File system agent",
-      "defaultEnabled": true,
+      "defaultEnabled": false,
       "serverScript": "./node_modules/@modelcontextprotocol/server-filesystem/dist/index.js",
-      "serverScriptArgs": true
+      "serverScriptArgs": {
+        "allowedDirectories": {
+          "description": "Allowed directories for the file system agent to access",
+          "type": "string",
+          "multiple": true
+        }
+      }
     }
   },
   "explainers": {

--- a/ts/packages/defaultAgentProvider/data/config.json
+++ b/ts/packages/defaultAgentProvider/data/config.json
@@ -51,12 +51,19 @@
       "name": "spelunker-agent"
     }
   },
+  "mcpServers": {
+    "mcpfilesystem": {
+      "emojiChar": "📁",
+      "description": "File system agent",
+      "defaultEnabled": true,
+      "serverScript": "./node_modules/@modelcontextprotocol/server-filesystem/dist/index.js",
+      "serverScriptArgs": true
+    }
+  },
   "explainers": {
     "v5": {
       "constructions": {
-        "data": [
-          "./data/explainer/v5/data/player/basic.json"
-        ],
+        "data": ["./data/explainer/v5/data/player/basic.json"],
         "file": "./data/explainer/v5/constructions.json"
       }
     }

--- a/ts/packages/defaultAgentProvider/package.json
+++ b/ts/packages/defaultAgentProvider/package.json
@@ -28,8 +28,8 @@
   },
   "dependencies": {
     "@azure/msal-node-extensions": "^1.5.0",
-    "@modelcontextprotocol/server-filesystem": "2025.1.14",
     "@modelcontextprotocol/sdk": "^1.8.0",
+    "@modelcontextprotocol/server-filesystem": "2025.1.14",
     "@typeagent/agent-sdk": "workspace:*",
     "action-schema": "workspace:*",
     "agent-cache": "workspace:*",

--- a/ts/packages/defaultAgentProvider/package.json
+++ b/ts/packages/defaultAgentProvider/package.json
@@ -28,6 +28,8 @@
   },
   "dependencies": {
     "@azure/msal-node-extensions": "^1.5.0",
+    "@modelcontextprotocol/server-filesystem": "2025.1.14",
+    "@modelcontextprotocol/sdk": "^1.8.0",
     "@typeagent/agent-sdk": "workspace:*",
     "action-schema": "workspace:*",
     "agent-cache": "workspace:*",
@@ -61,7 +63,8 @@
     "telemetry": "workspace:*",
     "typeagent": "workspace:*",
     "typechat": "^0.1.1",
-    "ws": "^8.17.1"
+    "ws": "^8.17.1",
+    "zod": "^3.24.1"
   },
   "devDependencies": {
     "@types/debug": "^4.1.12",

--- a/ts/packages/defaultAgentProvider/src/defaultAgentProviders.ts
+++ b/ts/packages/defaultAgentProvider/src/defaultAgentProviders.ts
@@ -6,13 +6,14 @@ import { createNpmAppAgentProvider } from "agent-dispatcher/helpers/npmAgentProv
 
 import path from "node:path";
 import fs from "node:fs";
-import { getConfig, AppAgentConfig } from "./utils/config.js";
+import { getProviderConfig, AppAgentConfig } from "./utils/config.js";
+import { getDefaultMcpAppAgentProvider } from "./mcpDefaultAgentProvider.js";
 
 let defaultAppAgentProvider: AppAgentProvider | undefined;
-export function getDefaultAppAgentProvider(): AppAgentProvider {
+function getDefaultNpmAppAgentProvider(): AppAgentProvider {
     if (defaultAppAgentProvider === undefined) {
         defaultAppAgentProvider = createNpmAppAgentProvider(
-            getConfig().agents,
+            getProviderConfig().agents,
             import.meta.url,
         );
     }
@@ -40,7 +41,11 @@ function getExternalAppAgentProvider(instanceDir: string): AppAgentProvider {
 export function getDefaultAppAgentProviders(
     instanceDir: string | undefined,
 ): AppAgentProvider[] {
-    const providers = [getDefaultAppAgentProvider()];
+    const providers = [getDefaultNpmAppAgentProvider()];
+    const mcpProvider = getDefaultMcpAppAgentProvider(instanceDir);
+    if (mcpProvider !== undefined) {
+        providers.push(mcpProvider);
+    }
     if (instanceDir !== undefined) {
         providers.push(getExternalAppAgentProvider(instanceDir));
     }

--- a/ts/packages/defaultAgentProvider/src/mcpAgentProvider.ts
+++ b/ts/packages/defaultAgentProvider/src/mcpAgentProvider.ts
@@ -99,7 +99,7 @@ function getMcpCommandHandlerTable(
     return {
         description: "MCP Command Handler Server Arguments",
         commands: {
-            serverArgs: {
+            server: {
                 description: "Set the server arguments",
                 parameters: {
                     args,

--- a/ts/packages/defaultAgentProvider/src/mcpAgentProvider.ts
+++ b/ts/packages/defaultAgentProvider/src/mcpAgentProvider.ts
@@ -1,0 +1,229 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { AppAgent, AppAgentManifest } from "@typeagent/agent-sdk";
+import { createActionResult } from "@typeagent/agent-sdk/helpers/action";
+import { parseToolsJsonSchema, toJSONParsedActionSchema } from "action-schema";
+import { AppAgentProvider } from "agent-dispatcher";
+
+export type McpAppAgentInfo = {
+    emojiChar: string;
+    description: string;
+    defaultEnabled?: boolean;
+    schemaDefaultEnabled?: boolean;
+    actionDefaultEnabled?: boolean;
+    serverScript?: string;
+    serverScriptArgs?: string[] | boolean;
+};
+
+export type McpAppAgent = {
+    manifest: AppAgentManifest;
+    agent: AppAgent;
+    transport: StdioClientTransport | undefined;
+};
+export type McpAppAgentRecord = {
+    agentP: Promise<McpAppAgent>;
+    count: number;
+};
+
+export type McpAppAgentConfig = {
+    serverScriptArgs?: string[];
+};
+
+const entryTypeName = "AgentActions";
+function convertSchema(tools: any) {
+    const pas = parseToolsJsonSchema(tools, entryTypeName);
+    return JSON.stringify(toJSONParsedActionSchema(pas));
+}
+
+function createMcpAppAgentTransport(
+    appAgentName: string,
+    info: McpAppAgentInfo,
+    instanceConfig?: McpAppAgentConfig,
+) {
+    const serverScriptPath = info.serverScript;
+    if (serverScriptPath === undefined) {
+        throw new Error(`Invalid app agent: ${appAgentName}`);
+    }
+
+    const instanceServerScriptArgs = instanceConfig?.serverScriptArgs;
+    const serverScriptArgs =
+        info.serverScriptArgs === true
+            ? instanceConfig?.serverScriptArgs
+            : Array.isArray(info.serverScriptArgs)
+              ? instanceServerScriptArgs
+                  ? info.serverScriptArgs.concat(instanceServerScriptArgs)
+                  : info.serverScriptArgs
+              : []; //  info.serverScriptArgs is false or undefined;
+    if (serverScriptArgs === undefined) {
+        throw new Error(
+            `Invalid app agent config ${appAgentName}: Missing required server script args in instance config`,
+        );
+    }
+    const isJs = serverScriptPath.endsWith(".js");
+    const isPy = serverScriptPath.endsWith(".py");
+    if (!isJs && !isPy) {
+        throw new Error(
+            `Invalid app agent config ${appAgentName}: Server script must be a .js or .py file`,
+        );
+    }
+    const command = isPy
+        ? process.platform === "win32"
+            ? "python"
+            : "python3"
+        : "node";
+    return new StdioClientTransport({
+        command,
+        args: [serverScriptPath, ...serverScriptArgs],
+        stderr: "pipe",
+    });
+}
+
+function createMcpAppAgentRecord(
+    clientName: string,
+    version: string,
+    appAgentName: string,
+    info: McpAppAgentInfo,
+    instanceConfig?: McpAppAgentConfig,
+): McpAppAgentRecord {
+    const manifest: AppAgentManifest = {
+        emojiChar: info.emojiChar,
+        description: info.description,
+    };
+    if (info.defaultEnabled) {
+        manifest.defaultEnabled = info.defaultEnabled;
+    }
+    if (info.schemaDefaultEnabled) {
+        manifest.schemaDefaultEnabled = info.schemaDefaultEnabled;
+    }
+    if (info.actionDefaultEnabled) {
+        manifest.actionDefaultEnabled = info.actionDefaultEnabled;
+    }
+
+    const createMcpAppAgent = async (): Promise<McpAppAgent> => {
+        try {
+            const transport = createMcpAppAgentTransport(
+                appAgentName,
+                info,
+                instanceConfig,
+            );
+            const client = new Client({ name: clientName, version });
+            await client.connect(transport);
+            const tools = (await client.listTools()).tools;
+            if (tools.length === 0) {
+                throw new Error(
+                    `Invalid app agent config ${appAgentName}: No tools found`,
+                );
+            }
+
+            manifest.schema = {
+                description: info.description,
+                schemaType: entryTypeName,
+                schemaFile: { format: "pas", content: convertSchema(tools) },
+            };
+
+            const agent: AppAgent = {
+                executeAction: async (action, context) => {
+                    const result = await client.callTool({
+                        name: action.actionName,
+                        arguments: action.parameters,
+                    });
+
+                    const content: any = result.content;
+                    const text: string[] = [];
+                    for (const item of content) {
+                        switch (item.type) {
+                            case "text":
+                                text.push(item.text);
+                                break;
+                            default:
+                                throw new Error(
+                                    `Action ${action.actionName} return an unsupported content type ${item.type}`,
+                                );
+                        }
+                    }
+                    return createActionResult(text.join("\n"));
+                },
+            };
+            return {
+                manifest,
+                transport,
+                agent,
+            };
+        } catch (error: any) {
+            return {
+                manifest,
+                transport: undefined,
+                agent: {
+                    initializeAgentContext() {
+                        // Delay throwing error until the agent is used.
+                        throw error;
+                    },
+                    executeCommand() {
+                        // Since we don't have any schema, use a fake command handler to have it show up in the list of agents.
+                        throw error;
+                    },
+                },
+            };
+        }
+    };
+    return {
+        agentP: createMcpAppAgent(),
+        count: 1,
+    };
+}
+
+export function createMcpAppAgentProvider(
+    name: string,
+    version: string,
+    infos: Record<string, McpAppAgentInfo>,
+    instanceConfig?: Record<string, McpAppAgentConfig>,
+): AppAgentProvider {
+    const mcpAppAgents = new Map<string, McpAppAgentRecord>();
+    function getMpcAppAgentRecord(appAgentName: string) {
+        const existing = mcpAppAgents.get(appAgentName);
+        if (existing !== undefined) {
+            existing.count++;
+            return existing;
+        }
+        const info = infos[appAgentName];
+        if (info === undefined) {
+            throw new Error(`Invalid app agent: ${appAgentName}`);
+        }
+        const record = createMcpAppAgentRecord(
+            name,
+            version,
+            appAgentName,
+            info,
+            instanceConfig?.[appAgentName],
+        );
+        mcpAppAgents.set(appAgentName, record);
+        return record;
+    }
+    return {
+        getAppAgentNames() {
+            return Object.keys(infos);
+        },
+        async getAppAgentManifest(appAgentName: string) {
+            const record = getMpcAppAgentRecord(appAgentName);
+            const manifest = (await record.agentP).manifest;
+            await this.unloadAppAgent(appAgentName);
+            return manifest;
+        },
+        async loadAppAgent(appAgentName: string) {
+            return (await getMpcAppAgentRecord(appAgentName).agentP).agent;
+        },
+        async unloadAppAgent(appAgentName: string) {
+            const record = mcpAppAgents.get(appAgentName);
+            if (!record || record.count === 0) {
+                throw new Error(`Invalid app agent: ${appAgentName}`);
+            }
+            if (--record.count === 0) {
+                mcpAppAgents.delete(appAgentName);
+                (await record.agentP).transport?.close();
+            }
+        },
+    };
+}

--- a/ts/packages/defaultAgentProvider/src/mcpDefaultAgentProvider.ts
+++ b/ts/packages/defaultAgentProvider/src/mcpDefaultAgentProvider.ts
@@ -3,7 +3,7 @@
 
 import { AppAgentProvider } from "agent-dispatcher";
 import { getPackageFilePath } from "./utils/getPackageFilePath.js";
-import { getInstanceConfig, getProviderConfig } from "./utils/config.js";
+import { readInstanceConfig, getProviderConfig } from "./utils/config.js";
 import { createMcpAppAgentProvider } from "./mcpAgentProvider.js";
 
 let mcpAppAgentProvider: AppAgentProvider | undefined;
@@ -25,7 +25,8 @@ export function getDefaultMcpAppAgentProvider(
             "typeagent",
             "0.0.1",
             servers,
-            getInstanceConfig(instanceDir)?.mcpServers,
+            readInstanceConfig(instanceDir)?.mcpServers,
+            instanceDir,
         );
     }
     return mcpAppAgentProvider;

--- a/ts/packages/defaultAgentProvider/src/mcpDefaultAgentProvider.ts
+++ b/ts/packages/defaultAgentProvider/src/mcpDefaultAgentProvider.ts
@@ -1,0 +1,32 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { AppAgentProvider } from "agent-dispatcher";
+import { getPackageFilePath } from "./utils/getPackageFilePath.js";
+import { getInstanceConfig, getProviderConfig } from "./utils/config.js";
+import { createMcpAppAgentProvider } from "./mcpAgentProvider.js";
+
+let mcpAppAgentProvider: AppAgentProvider | undefined;
+export function getDefaultMcpAppAgentProvider(
+    instanceDir: string | undefined,
+): AppAgentProvider | undefined {
+    if (mcpAppAgentProvider === undefined) {
+        const servers = structuredClone(getProviderConfig().mcpServers);
+        if (servers === undefined) {
+            return undefined;
+        }
+
+        for (const entry of Object.values(servers)) {
+            if (entry.serverScript !== undefined) {
+                entry.serverScript = getPackageFilePath(entry.serverScript);
+            }
+        }
+        mcpAppAgentProvider = createMcpAppAgentProvider(
+            "typeagent",
+            "0.0.1",
+            servers,
+            getInstanceConfig(instanceDir)?.mcpServers,
+        );
+    }
+    return mcpAppAgentProvider;
+}

--- a/ts/packages/defaultAgentProvider/src/utils/config.ts
+++ b/ts/packages/defaultAgentProvider/src/utils/config.ts
@@ -43,7 +43,7 @@ export function getProviderConfig(): Config {
     return config;
 }
 
-export function getInstanceConfig(
+export function readInstanceConfig(
     instanceDir: string | undefined,
 ): InstanceConfig | undefined {
     if (instanceDir === undefined) {
@@ -54,6 +54,14 @@ export function getInstanceConfig(
         return JSON.parse(fs.readFileSync(instanceConfigPath, "utf8"));
     }
     return undefined;
+}
+
+export function writeInstanceConfig(
+    instanceDir: string,
+    config: InstanceConfig,
+): void {
+    const instanceConfigPath = path.join(instanceDir, "config.json");
+    fs.writeFileSync(instanceConfigPath, JSON.stringify(config, null, 4));
 }
 
 export function getBuiltinConstructionConfig(explainerName: string) {

--- a/ts/packages/defaultAgentProvider/test/basic.spec.ts
+++ b/ts/packages/defaultAgentProvider/test/basic.spec.ts
@@ -2,13 +2,13 @@
 // Licensed under the MIT License.
 
 import { createDispatcher } from "agent-dispatcher";
-import { getDefaultAppAgentProvider } from "../src/defaultAgentProviders.js";
+import { getDefaultAppAgentProviders } from "../src/defaultAgentProviders.js";
 
 describe("AppAgentProvider", () => {
     describe("Built-in Provider", () => {
         it("startup and shutdown", async () => {
             const dispatcher = await createDispatcher("test", {
-                appAgentProviders: [getDefaultAppAgentProvider()],
+                appAgentProviders: getDefaultAppAgentProviders(undefined),
             });
             await dispatcher.close();
         }, 60000); // take longer time to start up on CI's small machines.

--- a/ts/packages/dispatcher/src/agentProvider/agentProvider.ts
+++ b/ts/packages/dispatcher/src/agentProvider/agentProvider.ts
@@ -7,7 +7,7 @@ export interface AppAgentProvider {
     getAppAgentNames(): string[];
     getAppAgentManifest(appAgentName: string): Promise<AppAgentManifest>;
     loadAppAgent(appAgentName: string): Promise<AppAgent>;
-    unloadAppAgent(appAgentName: string): void;
+    unloadAppAgent(appAgentName: string): Promise<void>;
 }
 
 export interface AppAgentInstaller {

--- a/ts/packages/dispatcher/src/agentProvider/npmAgentProvider.ts
+++ b/ts/packages/dispatcher/src/agentProvider/npmAgentProvider.ts
@@ -15,7 +15,7 @@ const enum ExecutionMode {
     DispatcherProcess = "dispatcher",
 }
 
-export type AppAgentInfo = {
+export type NpmAppAgentInfo = {
     name: string;
     path?: string;
     execMode?: ExecutionMode;
@@ -35,14 +35,14 @@ function patchPaths(manifest: ActionManifest, dir: string) {
     }
 }
 
-function getRequire(info: AppAgentInfo, requirePath: string) {
+function getRequire(info: NpmAppAgentInfo, requirePath: string) {
     // path.sep at the at is necessary for it to work.
     // REVIEW: adding package.json is necessary for jest-resolve to work in tests for some reason.
     const loadPath = `${info.path ? `${path.resolve(info.path)}${path.sep}package.json` : requirePath}`;
     return createRequire(loadPath);
 }
 
-async function loadManifest(info: AppAgentInfo, requirePath: string) {
+async function loadManifest(info: NpmAppAgentInfo, requirePath: string) {
     const require = getRequire(info, requirePath);
     const manifestPath = require.resolve(`${info.name}/agent/manifest`);
     const config = require(manifestPath) as AppAgentManifest;
@@ -55,7 +55,7 @@ function enableExecutionMode() {
 }
 
 async function loadModuleAgent(
-    info: AppAgentInfo,
+    info: NpmAppAgentInfo,
     appAgentName: string,
     requirePath: string,
 ): Promise<AgentProcess> {
@@ -81,7 +81,7 @@ async function loadModuleAgent(
 }
 
 export function createNpmAppAgentProvider(
-    configs: Record<string, AppAgentInfo>,
+    configs: Record<string, NpmAppAgentInfo>,
     requirePath: string,
 ): AppAgentProvider {
     const moduleAgents = new Map<string, AgentProcess>();
@@ -122,7 +122,7 @@ export function createNpmAppAgentProvider(
             moduleAgents.set(appAgentName, agent);
             return agent.appAgent;
         },
-        unloadAppAgent(appAgentName: string) {
+        async unloadAppAgent(appAgentName: string) {
             const agent = moduleAgents.get(appAgentName);
             if (!agent) {
                 throw new Error(`Invalid app agent: ${appAgentName}`);

--- a/ts/packages/dispatcher/src/context/appAgentManager.ts
+++ b/ts/packages/dispatcher/src/context/appAgentManager.ts
@@ -341,7 +341,7 @@ export class AppAgentManager implements ActionConfigProvider {
 
         await this.closeSessionContext(record);
         if (record.appAgent !== undefined) {
-            record.provider?.unloadAppAgent(record.name);
+            await record.provider?.unloadAppAgent(record.name);
         }
     }
 
@@ -525,7 +525,7 @@ export class AppAgentManager implements ActionConfigProvider {
                     record.commands = false;
                     await this.closeSessionContext(record);
                     if (record.appAgent !== undefined) {
-                        record.provider?.unloadAppAgent(record.name);
+                        await record.provider?.unloadAppAgent(record.name);
                     }
                     record.appAgent = undefined;
                 })(),

--- a/ts/packages/dispatcher/src/context/inlineAgentProvider.ts
+++ b/ts/packages/dispatcher/src/context/inlineAgentProvider.ts
@@ -49,7 +49,7 @@ export function createBuiltinAppAgentProvider(
             }
             return { ...agent, initializeAgentContext: async () => context };
         },
-        unloadAppAgent(appAgentName: string) {
+        async unloadAppAgent(appAgentName: string) {
             // Inline agents are always loaded
             if (builtinAgentManifest[appAgentName] === undefined) {
                 throw new Error(`Invalid app agent: ${appAgentName}`);

--- a/ts/packages/dispatcher/src/context/system/handlers/installCommandHandlers.ts
+++ b/ts/packages/dispatcher/src/context/system/handlers/installCommandHandlers.ts
@@ -9,13 +9,8 @@ import {
     installAppProvider,
 } from "../../commandHandlerContext.js";
 import path from "node:path";
-import os from "node:os";
 import { displayResult } from "@typeagent/agent-sdk/helpers/display";
-
-function expandHome(pathname: string): string {
-    if (pathname[0] != "~") return pathname;
-    return path.join(os.homedir() + pathname.substring(1));
-}
+import { expandHome } from "../../../utils/fsUtils.js";
 
 export class InstallCommandHandler implements CommandHandler {
     public readonly description = "Install an agent";

--- a/ts/packages/dispatcher/src/context/system/handlers/runScriptCommandHandler.ts
+++ b/ts/packages/dispatcher/src/context/system/handlers/runScriptCommandHandler.ts
@@ -8,6 +8,7 @@ import { processCommands } from "../../../helpers/console.js";
 import { getPrompt, processCommandNoLock } from "../../../command/command.js";
 import fs from "node:fs";
 import path from "node:path";
+import { expandHome } from "../../../utils/fsUtils.js";
 
 export class RunCommandScriptHandler implements CommandHandler {
     public readonly description = "Run a command script file";
@@ -24,7 +25,10 @@ export class RunCommandScriptHandler implements CommandHandler {
     ) {
         const systemContext = context.sessionContext.agentContext;
         const prevScriptDir = systemContext.currentScriptDir;
-        const inputFile = path.resolve(prevScriptDir, params.args.input);
+        const inputFile = path.resolve(
+            prevScriptDir,
+            expandHome(params.args.input),
+        );
         const content = await fs.promises.readFile(inputFile, "utf8");
         const inputs = content.split(/\r?\n/);
         const prevBatchMode = systemContext.batchMode;

--- a/ts/packages/dispatcher/src/npmAgentProvider.ts
+++ b/ts/packages/dispatcher/src/npmAgentProvider.ts
@@ -2,6 +2,6 @@
 // Licensed under the MIT License.
 
 export {
-    AppAgentInfo,
+    NpmAppAgentInfo,
     createNpmAppAgentProvider,
 } from "./agentProvider/npmAgentProvider.js";

--- a/ts/packages/dispatcher/src/translation/actionSchemaFileCache.ts
+++ b/ts/packages/dispatcher/src/translation/actionSchemaFileCache.ts
@@ -53,6 +53,9 @@ function loadParsedActionSchema(
     source: string,
 ): ActionSchemaFile {
     try {
+        if (!source) {
+            throw new Error("No data");
+        }
         const parsedActionSchemaJSON = JSON.parse(
             source,
         ) as ParsedActionSchemaJSON;

--- a/ts/packages/dispatcher/src/utils/fsUtils.ts
+++ b/ts/packages/dispatcher/src/utils/fsUtils.ts
@@ -4,6 +4,12 @@
 import fs from "node:fs";
 import path from "node:path";
 import lockfile from "proper-lockfile";
+import os from "node:os";
+
+export function expandHome(pathname: string): string {
+    if (!pathname.startsWith(`~${path.sep}`)) return pathname;
+    return path.join(os.homedir(), pathname.substring(2));
+}
 
 export function getYMDPrefix() {
     const date = new Date();

--- a/ts/packages/dispatcher/test/command.spec.ts
+++ b/ts/packages/dispatcher/test/command.spec.ts
@@ -57,7 +57,7 @@ export const testCommandAgentProvider: AppAgentProvider = {
         }
         return agent;
     },
-    unloadAppAgent: (appAgentName: string) => {
+    unloadAppAgent: async (appAgentName: string) => {
         if (appAgentName !== "test") {
             throw new Error(`Unknown app agent: ${appAgentName}`);
         }

--- a/ts/packages/shell/src/main/agent.ts
+++ b/ts/packages/shell/src/main/agent.ts
@@ -283,7 +283,7 @@ export const shellAgentProvider: AppAgentProvider = {
         }
         return agent;
     },
-    unloadAppAgent: (appAgentName: string) => {
+    unloadAppAgent: async (appAgentName: string) => {
         if (appAgentName !== "shell") {
             throw new Error(`Unknown app agent: ${appAgentName}`);
         }

--- a/ts/packages/shell/src/main/index.ts
+++ b/ts/packages/shell/src/main/index.ts
@@ -31,7 +31,6 @@ import { shellAgentProvider } from "./agent.js";
 import { BrowserAgentIpc } from "./browserIpc.js";
 import { WebSocketMessageV2 } from "common-utils";
 import { AzureSpeech } from "./azureSpeech.js";
-import { auth } from "aiclient";
 import {
     closeLocalWhisper,
     isLocalWhisperEnabled,
@@ -41,8 +40,6 @@ import { createGenericChannel } from "agent-rpc/channel";
 import net from "node:net";
 import { createClientIORpcClient } from "agent-dispatcher/rpc/clientio/client";
 import { getClientId, getInstanceDir } from "agent-dispatcher/helpers/data";
-
-console.log(auth.AzureTokenScopes.CogServices);
 
 const debugShell = registerDebug("typeagent:shell");
 const debugShellError = registerDebug("typeagent:shell:error");
@@ -291,7 +288,7 @@ async function createWindow() {
     };
 
     ShellSettings.getinstance().onRunDemo = (interactive: boolean): void => {
-        runDemo(mainWindow!, interactive);
+        runDemo(mainWindow!, chatView!, interactive);
     };
 
     ShellSettings.getinstance().onToggleTopMost = () => {
@@ -514,78 +511,90 @@ async function initializeDispatcher(
     chatView: WebContentsView,
     updateSummary: (dispatcher: Dispatcher) => void,
 ) {
-    const clientIOChannel = createGenericChannel((message: any) => {
-        chatView.webContents.send("clientio-rpc-call", message);
-    });
-    ipcMain.on("clientio-rpc-reply", (_event, message) => {
-        clientIOChannel.message(message);
-    });
+    try {
+        const clientIOChannel = createGenericChannel((message: any) => {
+            chatView.webContents.send("clientio-rpc-call", message);
+        });
+        ipcMain.on("clientio-rpc-reply", (_event, message) => {
+            clientIOChannel.message(message);
+        });
 
-    const newClientIO = createClientIORpcClient(clientIOChannel.channel);
-    const clientIO = {
-        ...newClientIO,
-        exit: () => {
-            app.quit();
-        },
-    };
+        const newClientIO = createClientIORpcClient(clientIOChannel.channel);
+        const clientIO = {
+            ...newClientIO,
+            exit: () => {
+                app.quit();
+            },
+        };
 
-    const instanceDir = getInstanceDir();
+        const instanceDir = getInstanceDir();
 
-    // Set up dispatcher
-    const newDispatcher = await createDispatcher("shell", {
-        appAgentProviders: [
-            shellAgentProvider,
-            ...getDefaultAppAgentProviders(instanceDir),
-        ],
-        agentInstaller: getDefaultAppAgentInstaller(instanceDir),
-        explanationAsynchronousMode: true,
-        persistSession: true,
-        persistDir: instanceDir,
-        enableServiceHost: true,
-        metrics: true,
-        dblogging: true,
-        clientId: getClientId(),
-        clientIO,
-        constructionProvider: getDefaultConstructionProvider(),
-    });
+        // Set up dispatcher
+        const newDispatcher = await createDispatcher("shell", {
+            appAgentProviders: [
+                shellAgentProvider,
+                ...getDefaultAppAgentProviders(instanceDir),
+            ],
+            agentInstaller: getDefaultAppAgentInstaller(instanceDir),
+            explanationAsynchronousMode: true,
+            persistSession: true,
+            persistDir: instanceDir,
+            enableServiceHost: true,
+            metrics: true,
+            dblogging: true,
+            clientId: getClientId(),
+            clientIO,
+            constructionProvider: getDefaultConstructionProvider(),
+        });
 
-    async function processShellRequest(
-        text: string,
-        id: string,
-        images: string[],
-    ) {
-        if (typeof text !== "string" || typeof id !== "string") {
-            throw new Error("Invalid request");
+        async function processShellRequest(
+            text: string,
+            id: string,
+            images: string[],
+        ) {
+            if (typeof text !== "string" || typeof id !== "string") {
+                throw new Error("Invalid request");
+            }
+            debugShell(newDispatcher.getPrompt(), text);
+
+            const metrics = await newDispatcher.processCommand(
+                text,
+                id,
+                images,
+            );
+            chatView.webContents.send("send-demo-event", "CommandProcessed");
+            updateSummary(dispatcher);
+            return metrics;
         }
-        debugShell(newDispatcher.getPrompt(), text);
 
-        const metrics = await newDispatcher.processCommand(text, id, images);
-        chatView.webContents.send("send-demo-event", "CommandProcessed");
-        updateSummary(dispatcher);
-        return metrics;
+        const dispatcher = {
+            ...newDispatcher,
+            processCommand: processShellRequest,
+        };
+
+        // Set up the RPC
+        const dispatcherChannel = createGenericChannel((message: any) => {
+            chatView.webContents.send("dispatcher-rpc-reply", message);
+        });
+        ipcMain.on("dispatcher-rpc-call", (_event, message) => {
+            dispatcherChannel.message(message);
+        });
+        createDispatcherRpcServer(dispatcher, dispatcherChannel.channel);
+
+        setupQuit(dispatcher);
+
+        // Dispatcher is ready to be called from the client, but we need to wait for the dom to be ready to start
+        // using it to process command, so that the client can receive messages.
+        debugShell("Dispatcher initialized", performance.now() - time);
+
+        return dispatcher;
+    } catch (e: any) {
+        dialog.showErrorBox(
+            "Exception initializing dispatcher",
+            `${e.message}\n${e.stack}`,
+        );
+        return undefined;
     }
-
-    const dispatcher = {
-        ...newDispatcher,
-        processCommand: processShellRequest,
-    };
-
-    // Set up the RPC
-    const dispatcherChannel = createGenericChannel((message: any) => {
-        chatView.webContents.send("dispatcher-rpc-reply", message);
-    });
-    ipcMain.on("dispatcher-rpc-call", (_event, message) => {
-        dispatcherChannel.message(message);
-    });
-    createDispatcherRpcServer(dispatcher, dispatcherChannel.channel);
-
-    setupQuit(dispatcher);
-
-    // Dispatcher is ready to be called from the client, but we need to wait for the dom to be ready to start
-    // using it to process command, so that the client can receive messages.
-    debugShell("Dispatcher initialized", performance.now() - time);
-
-    return dispatcher;
 }
 
 // This method will be called when Electron has finished
@@ -619,7 +628,6 @@ async function initialize() {
 
     // Note: Make sure dom ready before using dispatcher.
     const dispatcherP = initializeDispatcher(chatView, updateSummary);
-
     ipcMain.on("dom ready", async () => {
         debugShell("Showing window", performance.now() - time);
         mainWindow.show();
@@ -653,6 +661,10 @@ async function initialize() {
 
         // The dispatcher can be use now that dom is ready and the client is ready to receive messages
         const dispatcher = await dispatcherP;
+        if (dispatcher === undefined) {
+            app.quit();
+            return;
+        }
         updateSummary(dispatcher);
 
         // send the agent greeting if it's turned on

--- a/ts/pnpm-lock.yaml
+++ b/ts/pnpm-lock.yaml
@@ -114,7 +114,7 @@ importers:
         version: link:../../packages/typeagent
       typechat:
         specifier: ^0.1.1
-        version: 0.1.1(typescript@5.4.5)(zod@3.23.8)
+        version: 0.1.1(typescript@5.4.5)(zod@3.24.2)
       typescript:
         specifier: ^5.4.2
         version: 5.4.5
@@ -142,7 +142,7 @@ importers:
         version: link:../../packages/typeagent
       typechat:
         specifier: ^0.1.1
-        version: 0.1.1(typescript@5.4.5)(zod@3.23.8)
+        version: 0.1.1(typescript@5.4.5)(zod@3.24.2)
     devDependencies:
       rimraf:
         specifier: ^6.0.1
@@ -185,7 +185,7 @@ importers:
         version: link:../../packages/typeagent
       typechat:
         specifier: ^0.1.1
-        version: 0.1.1(typescript@5.4.5)(zod@3.23.8)
+        version: 0.1.1(typescript@5.4.5)(zod@3.24.2)
       typescript:
         specifier: ^5.4.2
         version: 5.4.5
@@ -219,7 +219,7 @@ importers:
         version: link:../../packages/typeagent
       typechat:
         specifier: ^0.1.1
-        version: 0.1.1(typescript@5.4.5)(zod@3.23.8)
+        version: 0.1.1(typescript@5.4.5)(zod@3.24.2)
     devDependencies:
       '@types/better-sqlite3':
         specifier: 7.6.11
@@ -268,7 +268,7 @@ importers:
         version: link:../../packages/typeagent
       typechat:
         specifier: ^0.1.1
-        version: 0.1.1(typescript@5.4.5)(zod@3.23.8)
+        version: 0.1.1(typescript@5.4.5)(zod@3.24.2)
       typescript:
         specifier: ^5.4.2
         version: 5.4.5
@@ -299,7 +299,7 @@ importers:
         version: link:../../packages/typeagent
       typechat:
         specifier: ^0.1.1
-        version: 0.1.1(typescript@5.4.5)(zod@3.23.8)
+        version: 0.1.1(typescript@5.4.5)(zod@3.24.2)
       typescript:
         specifier: ^5.4.2
         version: 5.4.5
@@ -333,7 +333,7 @@ importers:
         version: link:../../packages/typeagent
       typechat:
         specifier: ^0.1.1
-        version: 0.1.1(typescript@5.4.5)(zod@3.23.8)
+        version: 0.1.1(typescript@5.4.5)(zod@3.24.2)
       typescript:
         specifier: ^5.4.2
         version: 5.4.5
@@ -367,7 +367,7 @@ importers:
         version: link:../../packages/typeagent
       typechat:
         specifier: ^0.1.1
-        version: 0.1.1(typescript@5.4.5)(zod@3.23.8)
+        version: 0.1.1(typescript@5.4.5)(zod@3.24.2)
       typescript:
         specifier: ^5.4.2
         version: 5.4.5
@@ -402,7 +402,7 @@ importers:
         version: 29.5.7
       copy-webpack-plugin:
         specifier: ^12.0.1
-        version: 12.0.2(webpack@5.94.0(webpack-cli@5.1.4))
+        version: 12.0.2(webpack@5.94.0)
       jest:
         specifier: ^29.7.0
         version: 29.7.0(@types/node@20.17.28)(ts-node@10.9.2(@types/node@20.17.28)(typescript@5.4.5))
@@ -414,7 +414,7 @@ importers:
         version: 6.0.1
       ts-loader:
         specifier: ^9.5.1
-        version: 9.5.1(typescript@5.4.5)(webpack@5.94.0(webpack-cli@5.1.4))
+        version: 9.5.1(typescript@5.4.5)(webpack@5.94.0)
       typescript:
         specifier: ^5.4.2
         version: 5.4.5
@@ -456,7 +456,7 @@ importers:
         version: link:../../packages/typeagent
       typechat:
         specifier: ^0.1.1
-        version: 0.1.1(typescript@5.4.5)(zod@3.23.8)
+        version: 0.1.1(typescript@5.4.5)(zod@3.24.2)
     devDependencies:
       rimraf:
         specifier: ^6.0.1
@@ -482,7 +482,7 @@ importers:
         version: 29.5.7
       copy-webpack-plugin:
         specifier: ^12.0.1
-        version: 12.0.2(webpack@5.94.0(webpack-cli@5.1.4))
+        version: 12.0.2(webpack@5.94.0)
       jest:
         specifier: ^29.7.0
         version: 29.7.0(@types/node@20.17.28)(ts-node@10.9.2(@types/node@20.17.28)(typescript@5.4.5))
@@ -494,7 +494,7 @@ importers:
         version: 6.0.1
       ts-loader:
         specifier: ^9.5.1
-        version: 9.5.1(typescript@5.4.5)(webpack@5.94.0(webpack-cli@5.1.4))
+        version: 9.5.1(typescript@5.4.5)(webpack@5.94.0)
       typescript:
         specifier: ^5.4.2
         version: 5.4.5
@@ -737,7 +737,7 @@ importers:
         version: 1.1.1
       node-polyfill-webpack-plugin:
         specifier: ^3.0.0
-        version: 3.0.0(webpack@5.94.0(webpack-cli@5.1.4))
+        version: 3.0.0(webpack@5.94.0)
       prismjs:
         specifier: ^1.30.0
         version: 1.30.0
@@ -761,7 +761,7 @@ importers:
         version: link:../../typeagent
       typechat:
         specifier: ^0.1.1
-        version: 0.1.1(typescript@5.4.5)(zod@3.23.8)
+        version: 0.1.1(typescript@5.4.5)(zod@3.24.2)
       ws:
         specifier: ^8.17.1
         version: 8.17.1
@@ -792,13 +792,13 @@ importers:
         version: 9.1.2
       copy-webpack-plugin:
         specifier: ^12.0.1
-        version: 12.0.2(webpack@5.94.0(webpack-cli@5.1.4))
+        version: 12.0.2(webpack@5.94.0)
       rimraf:
         specifier: ^6.0.1
         version: 6.0.1
       ts-loader:
         specifier: ^9.5.1
-        version: 9.5.1(typescript@5.4.5)(webpack@5.94.0(webpack-cli@5.1.4))
+        version: 9.5.1(typescript@5.4.5)(webpack@5.94.0)
       typescript:
         specifier: ^5.4.2
         version: 5.4.5
@@ -868,7 +868,7 @@ importers:
         version: link:../../typeagent
       typechat:
         specifier: ^0.1.1
-        version: 0.1.1(typescript@5.4.5)(zod@3.23.8)
+        version: 0.1.1(typescript@5.4.5)(zod@3.24.2)
     devDependencies:
       copyfiles:
         specifier: ^2.4.1
@@ -948,7 +948,7 @@ importers:
         version: link:../../typeagent
       typechat:
         specifier: ^0.1.1
-        version: 0.1.1(typescript@5.4.5)(zod@3.23.8)
+        version: 0.1.1(typescript@5.4.5)(zod@3.24.2)
       ws:
         specifier: ^8.17.1
         version: 8.17.1
@@ -1046,7 +1046,7 @@ importers:
         version: link:../../typeagent
       typechat:
         specifier: ^0.1.1
-        version: 0.1.1(typescript@5.4.5)(zod@3.23.8)
+        version: 0.1.1(typescript@5.4.5)(zod@3.24.2)
     devDependencies:
       copyfiles:
         specifier: ^2.4.1
@@ -1133,7 +1133,7 @@ importers:
         version: link:../../typeagent
       typechat:
         specifier: ^0.1.1
-        version: 0.1.1(typescript@5.4.5)(zod@3.23.8)
+        version: 0.1.1(typescript@5.4.5)(zod@3.24.2)
     devDependencies:
       '@types/debug':
         specifier: ^4.1.12
@@ -1152,7 +1152,7 @@ importers:
         version: 14.1.2
       copy-webpack-plugin:
         specifier: ^12.0.1
-        version: 12.0.2(webpack@5.94.0(webpack-cli@5.1.4))
+        version: 12.0.2(webpack@5.94.0)
       copyfiles:
         specifier: ^2.4.1
         version: 2.4.1
@@ -1167,7 +1167,7 @@ importers:
         version: 6.0.1
       ts-loader:
         specifier: ^9.5.1
-        version: 9.5.1(typescript@5.4.5)(webpack@5.94.0(webpack-cli@5.1.4))
+        version: 9.5.1(typescript@5.4.5)(webpack@5.94.0)
       typescript:
         specifier: ^5.4.2
         version: 5.4.5
@@ -1241,7 +1241,7 @@ importers:
         version: 7.4.2
       typechat:
         specifier: ^0.1.1
-        version: 0.1.1(typescript@5.4.5)(zod@3.23.8)
+        version: 0.1.1(typescript@5.4.5)(zod@3.24.2)
     devDependencies:
       '@types/debug':
         specifier: ^4.1.12
@@ -1290,7 +1290,7 @@ importers:
         version: link:../../typeagent
       typechat:
         specifier: ^0.1.1
-        version: 0.1.1(typescript@5.4.5)(zod@3.23.8)
+        version: 0.1.1(typescript@5.4.5)(zod@3.24.2)
       typescript:
         specifier: ^5.4.2
         version: 5.4.5
@@ -1344,7 +1344,7 @@ importers:
         version: 29.5.7
       copy-webpack-plugin:
         specifier: ^12.0.1
-        version: 12.0.2(webpack@5.94.0(webpack-cli@5.1.4))
+        version: 12.0.2(webpack@5.94.0)
       jest:
         specifier: ^29.7.0
         version: 29.7.0(@types/node@20.17.28)(ts-node@10.9.2(@types/node@20.17.28)(typescript@5.4.5))
@@ -1356,7 +1356,7 @@ importers:
         version: 6.0.1
       ts-loader:
         specifier: ^9.5.1
-        version: 9.5.1(typescript@5.4.5)(webpack@5.94.0(webpack-cli@5.1.4))
+        version: 9.5.1(typescript@5.4.5)(webpack@5.94.0)
       typescript:
         specifier: ^5.4.2
         version: 5.4.5
@@ -1386,7 +1386,7 @@ importers:
         version: link:../telemetry
       typechat:
         specifier: ^0.1.1
-        version: 0.1.1(typescript@5.4.5)(zod@3.23.8)
+        version: 0.1.1(typescript@5.4.5)(zod@3.24.2)
     devDependencies:
       '@types/async':
         specifier: ^3.2.24
@@ -1517,7 +1517,7 @@ importers:
         version: link:../telemetry
       typechat:
         specifier: ^0.1.1
-        version: 0.1.1(typescript@5.4.5)(zod@3.23.8)
+        version: 0.1.1(typescript@5.4.5)(zod@3.24.2)
     devDependencies:
       '@types/async':
         specifier: ^3.2.24
@@ -1564,7 +1564,7 @@ importers:
         version: 29.5.7
       html-webpack-plugin:
         specifier: ^5.6.0
-        version: 5.6.0(webpack@5.94.0(webpack-cli@5.1.4))
+        version: 5.6.0(webpack@5.94.0)
       jest:
         specifier: ^29.7.0
         version: 29.7.0(@types/node@20.17.28)(ts-node@10.9.2(@types/node@20.17.28)(typescript@5.4.5))
@@ -1576,7 +1576,7 @@ importers:
         version: 6.0.1
       ts-loader:
         specifier: ^9.5.1
-        version: 9.5.1(typescript@5.4.5)(webpack@5.94.0(webpack-cli@5.1.4))
+        version: 9.5.1(typescript@5.4.5)(webpack@5.94.0)
       typescript:
         specifier: ^5.4.2
         version: 5.4.5
@@ -1633,7 +1633,7 @@ importers:
         version: 10.9.2(@types/node@20.17.28)(typescript@5.4.5)
       typechat:
         specifier: ^0.1.1
-        version: 0.1.1(typescript@5.4.5)(zod@3.23.8)
+        version: 0.1.1(typescript@5.4.5)(zod@3.24.2)
     devDependencies:
       '@types/debug':
         specifier: ^4.1.12
@@ -1737,7 +1737,7 @@ importers:
         version: link:../typeagent
       typechat:
         specifier: ^0.1.1
-        version: 0.1.1(typescript@5.4.5)(zod@3.23.8)
+        version: 0.1.1(typescript@5.4.5)(zod@3.24.2)
       typescript:
         specifier: ^5.4.2
         version: 5.4.5
@@ -1786,7 +1786,7 @@ importers:
         version: 5.0.0(ws@8.17.1)
       typechat:
         specifier: ^0.1.1
-        version: 0.1.1(typescript@5.4.5)(zod@3.23.8)
+        version: 0.1.1(typescript@5.4.5)(zod@3.24.2)
       ws:
         specifier: ^8.17.1
         version: 8.17.1
@@ -1821,6 +1821,12 @@ importers:
       '@azure/msal-node-extensions':
         specifier: ^1.5.0
         version: 1.5.0
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.8.0
+        version: 1.8.0
+      '@modelcontextprotocol/server-filesystem':
+        specifier: 2025.1.14
+        version: 2025.1.14(zod@3.24.2)
       '@typeagent/agent-sdk':
         specifier: workspace:*
         version: link:../agentSdk
@@ -1919,10 +1925,13 @@ importers:
         version: link:../typeagent
       typechat:
         specifier: ^0.1.1
-        version: 0.1.1(typescript@5.4.5)(zod@3.23.8)
+        version: 0.1.1(typescript@5.4.5)(zod@3.24.2)
       ws:
         specifier: ^8.17.1
         version: 8.18.0
+      zod:
+        specifier: ^3.24.1
+        version: 3.24.2
     devDependencies:
       '@types/debug':
         specifier: ^4.1.12
@@ -2013,7 +2022,7 @@ importers:
         version: link:../typeagent
       typechat:
         specifier: ^0.1.1
-        version: 0.1.1(typescript@5.4.5)(zod@3.23.8)
+        version: 0.1.1(typescript@5.4.5)(zod@3.24.2)
       ws:
         specifier: ^8.17.1
         version: 8.17.1
@@ -2080,7 +2089,7 @@ importers:
         version: link:../typeagent
       typechat:
         specifier: ^0.1.1
-        version: 0.1.1(typescript@5.4.5)(zod@3.23.8)
+        version: 0.1.1(typescript@5.4.5)(zod@3.24.2)
     devDependencies:
       '@types/debug':
         specifier: ^4.1.12
@@ -2132,7 +2141,7 @@ importers:
         version: link:../typeagent
       typechat:
         specifier: ^0.1.1
-        version: 0.1.1(typescript@5.4.5)(zod@3.23.8)
+        version: 0.1.1(typescript@5.4.5)(zod@3.24.2)
     devDependencies:
       '@types/debug':
         specifier: ^4.1.12
@@ -2185,7 +2194,7 @@ importers:
         version: 29.5.7
       copy-webpack-plugin:
         specifier: ^12.0.1
-        version: 12.0.2(webpack@5.94.0(webpack-cli@5.1.4))
+        version: 12.0.2(webpack@5.94.0)
       jest:
         specifier: ^29.7.0
         version: 29.7.0(@types/node@20.17.28)(ts-node@10.9.2(@types/node@20.17.28)(typescript@5.4.5))
@@ -2197,7 +2206,7 @@ importers:
         version: 6.0.1
       ts-loader:
         specifier: ^9.5.1
-        version: 9.5.1(typescript@5.4.5)(webpack@5.94.0(webpack-cli@5.1.4))
+        version: 9.5.1(typescript@5.4.5)(webpack@5.94.0)
       typescript:
         specifier: ^5.4.2
         version: 5.4.5
@@ -2227,7 +2236,7 @@ importers:
         version: link:../../typeagent
       typechat:
         specifier: ^0.1.1
-        version: 0.1.1(typescript@5.4.5)(zod@3.23.8)
+        version: 0.1.1(typescript@5.4.5)(zod@3.24.2)
     devDependencies:
       '@types/debug':
         specifier: ^4.1.12
@@ -2273,7 +2282,7 @@ importers:
         version: link:../../typeagent
       typechat:
         specifier: ^0.1.1
-        version: 0.1.1(typescript@5.4.5)(zod@3.23.8)
+        version: 0.1.1(typescript@5.4.5)(zod@3.24.2)
     devDependencies:
       '@types/debug':
         specifier: ^4.1.12
@@ -2356,7 +2365,7 @@ importers:
         version: link:../typeagent
       typechat:
         specifier: ^0.1.1
-        version: 0.1.1(typescript@5.4.5)(zod@3.23.8)
+        version: 0.1.1(typescript@5.4.5)(zod@3.24.2)
     devDependencies:
       copyfiles:
         specifier: ^2.4.1
@@ -2426,7 +2435,7 @@ importers:
         version: 1.38.0
       typechat:
         specifier: ^0.1.1
-        version: 0.1.1(typescript@5.4.5)(zod@3.23.8)
+        version: 0.1.1(typescript@5.4.5)(zod@3.24.2)
       ws:
         specifier: ^8.17.1
         version: 8.17.1
@@ -2454,7 +2463,7 @@ importers:
         version: 30.0.1
       electron-builder:
         specifier: ^24.13.2
-        version: 24.13.3(electron-builder-squirrel-windows@24.13.3(dmg-builder@24.13.3))
+        version: 24.13.3(electron-builder-squirrel-windows@24.13.3)
       electron-vite:
         specifier: ^3.1.0
         version: 3.1.0(vite@6.2.3(@types/node@20.17.28)(less@4.2.0)(terser@5.27.0)(yaml@2.7.0))
@@ -2533,7 +2542,7 @@ importers:
         version: 16.3.1
       typechat:
         specifier: ^0.1.1
-        version: 0.1.1(typescript@5.4.5)(zod@3.23.8)
+        version: 0.1.1(typescript@5.4.5)(zod@3.24.2)
       typescript:
         specifier: ^5.4.2
         version: 5.4.5
@@ -3564,6 +3573,17 @@ packages:
   '@microsoft/microsoft-graph-types@2.40.0':
     resolution: {integrity: sha512-1fcPVrB/NkbNcGNfCy+Cgnvwxt6/sbIEEFgZHFBJ670zYLegENYJF8qMo7x3LqBjWX2/Eneq5BVVRCLTmlJN+g==}
 
+  '@modelcontextprotocol/sdk@0.5.0':
+    resolution: {integrity: sha512-RXgulUX6ewvxjAG0kOpLMEdXXWkzWgaoCGaA2CwNW7cQCIphjpJhjpHSiaPdVCnisjRF/0Cm9KWHUuIoeiAblQ==}
+
+  '@modelcontextprotocol/sdk@1.8.0':
+    resolution: {integrity: sha512-e06W7SwrontJDHwCawNO5SGxG+nU9AAx+jpHHZqGl/WrDBdWOpvirC+s58VpJTB5QemI4jTRcjWT4Pt3Q1NPQQ==}
+    engines: {node: '>=18'}
+
+  '@modelcontextprotocol/server-filesystem@2025.1.14':
+    resolution: {integrity: sha512-WjJYa2OAAf0fpslyxjzJK3JUeEk10IaDukLOc4NSoJtNptvJONd4NMC6U3Xr04VOb++2iNfM7Vp6Ac7o94Pv6g==}
+    hasBin: true
+
   '@mongodb-js/saslprep@1.1.4':
     resolution: {integrity: sha512-8zJ8N1x51xo9hwPh6AWnKdLGEC5N3lDa6kms1YHmFBoRhTpJR6HG8wWk0td1MVCu9cD4YBrvjZEtd5Obw0Fbnw==}
 
@@ -4503,6 +4523,10 @@ packages:
     resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
     engines: {node: '>= 0.6'}
 
+  accepts@2.0.0:
+    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
+    engines: {node: '>= 0.6'}
+
   acorn-import-attributes@1.9.5:
     resolution: {integrity: sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==}
     peerDependencies:
@@ -4811,6 +4835,10 @@ packages:
     resolution: {integrity: sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
 
+  body-parser@2.2.0:
+    resolution: {integrity: sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==}
+    engines: {node: '>=18'}
+
   bonjour-service@1.2.1:
     resolution: {integrity: sha512-oSzCS2zV14bh2kji6vNe7vrpJYCHGvcZnlffFQ1MEoX/WOeQ/teD8SYWKR942OI3INjq8OMNJlbPK5LLLUxFDw==}
 
@@ -4958,6 +4986,10 @@ packages:
 
   call-bind@1.0.7:
     resolution: {integrity: sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==}
+    engines: {node: '>= 0.4'}
+
+  call-bound@1.0.4:
+    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
     engines: {node: '>= 0.4'}
 
   callsites@3.1.0:
@@ -5230,6 +5262,10 @@ packages:
     resolution: {integrity: sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==}
     engines: {node: '>= 0.6'}
 
+  content-disposition@1.0.0:
+    resolution: {integrity: sha512-Au9nRL8VNUut/XSzbQA38+M78dzP4D+eqg3gfJHMIHHYa3bg067xj1KxMUWj+VULbiZMowKngFFbKczUrNJ1mg==}
+    engines: {node: '>= 0.6'}
+
   content-type@1.0.5:
     resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
     engines: {node: '>= 0.6'}
@@ -5243,6 +5279,10 @@ packages:
 
   cookie-signature@1.0.6:
     resolution: {integrity: sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==}
+
+  cookie-signature@1.2.2:
+    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
+    engines: {node: '>=6.6.0'}
 
   cookie@0.7.1:
     resolution: {integrity: sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==}
@@ -5493,6 +5533,15 @@ packages:
 
   debug@2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  debug@4.3.6:
+    resolution: {integrity: sha512-O/09Bd4Z1fBrU4VzkhFqVgpPzaGbw6Sm9FEkBT1A/YBXQFGuuSxa1dN2nxgxS34JmKXqYx8CZAwEVoJFImUXIg==}
+    engines: {node: '>=6.0'}
     peerDependencies:
       supports-color: '*'
     peerDependenciesMeta:
@@ -5925,6 +5974,14 @@ packages:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
 
+  eventsource-parser@3.0.1:
+    resolution: {integrity: sha512-VARTJ9CYeuQYb0pZEPbzi740OWFgpHe7AYJ2WFZVnUDUQp5Dk2yJUgF36YsZ81cOyxT0QxmXD2EQpapAouzWVA==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource@3.0.6:
+    resolution: {integrity: sha512-l19WpE2m9hSuyP06+FbuUUf1G+R0SFLrtQfbRb9PRr+oimOfxQhgGCbVaXg5IvZyyTThJsxh6L/srkMiCeBPDA==}
+    engines: {node: '>=18.0.0'}
+
   evp_bytestokey@1.0.3:
     resolution: {integrity: sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==}
 
@@ -5960,6 +6017,10 @@ packages:
   express@4.21.2:
     resolution: {integrity: sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==}
     engines: {node: '>= 0.10.0'}
+
+  express@5.0.1:
+    resolution: {integrity: sha512-ORF7g6qGnD+YtUG9yx4DFoqCShNMmUKiXuT5oWMHiOvt/4WFbHC6yCwQMTSBMno7AqntNCAzzcnnjowRkTL9eQ==}
+    engines: {node: '>= 18'}
 
   external-editor@3.1.0:
     resolution: {integrity: sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==}
@@ -6043,6 +6104,10 @@ packages:
     resolution: {integrity: sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==}
     engines: {node: '>= 0.8'}
 
+  finalhandler@2.1.0:
+    resolution: {integrity: sha512-/t88Ty3d5JWQbWYgaOGCCYfXRwV1+be02WqYYlL6h0lEiUAMPM8o8qKGO01YIkOHzka2up08wvgYD0mDiI+q3Q==}
+    engines: {node: '>= 0.8'}
+
   find-config@1.0.0:
     resolution: {integrity: sha512-Z+suHH+7LSE40WfUeZPIxSxypCWvrzdVc60xAjUShZeT5eMWM0/FQUduq3HjluyfAHWvC/aOBkT1pTZktyF/jg==}
     engines: {node: '>= 0.12'}
@@ -6117,6 +6182,10 @@ packages:
   fresh@0.5.2:
     resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
     engines: {node: '>= 0.6'}
+
+  fresh@2.0.0:
+    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
+    engines: {node: '>= 0.8'}
 
   fs-constants@1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
@@ -6676,6 +6745,9 @@ packages:
     resolution: {integrity: sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==}
     engines: {node: '>=0.10.0'}
 
+  is-promise@4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
+
   is-relative-url@4.0.0:
     resolution: {integrity: sha512-PkzoL1qKAYXNFct5IKdKRH/iBQou/oCC85QhXj6WKtUQBliZ4Yfd3Zk27RHu9KQG8r6zgvAA2AQKC9p+rqTszg==}
     engines: {node: '>=14.16'}
@@ -7216,6 +7288,10 @@ packages:
     resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
     engines: {node: '>= 0.6'}
 
+  media-typer@1.1.0:
+    resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
+    engines: {node: '>= 0.8'}
+
   memfs@4.9.3:
     resolution: {integrity: sha512-bsYSSnirtYTWi1+OPMFb0M048evMKyUYe0EbtuGQgq6BVQM1g1W8/KIUJCCvjgI/El0j6Q4WsmMiBwLUBSw8LA==}
     engines: {node: '>= 4.0.0'}
@@ -7229,6 +7305,10 @@ packages:
 
   merge-descriptors@1.0.3:
     resolution: {integrity: sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==}
+
+  merge-descriptors@2.0.0:
+    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
+    engines: {node: '>=18'}
 
   merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
@@ -7256,8 +7336,16 @@ packages:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
     engines: {node: '>= 0.6'}
 
+  mime-db@1.54.0:
+    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
   mime-types@2.1.35:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@3.0.1:
+    resolution: {integrity: sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==}
     engines: {node: '>= 0.6'}
 
   mime@1.6.0:
@@ -7396,6 +7484,9 @@ packages:
   ms@2.0.0:
     resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
 
+  ms@2.1.2:
+    resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
+
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
@@ -7439,6 +7530,10 @@ packages:
 
   negotiator@0.6.3:
     resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
+    engines: {node: '>= 0.6'}
+
+  negotiator@1.0.0:
+    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
 
   neo-async@2.6.2:
@@ -7531,6 +7626,10 @@ packages:
 
   object-inspect@1.13.1:
     resolution: {integrity: sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ==}
+
+  object-inspect@1.13.4:
+    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
+    engines: {node: '>= 0.4'}
 
   object-is@1.1.6:
     resolution: {integrity: sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==}
@@ -7733,6 +7832,10 @@ packages:
   path-to-regexp@0.1.12:
     resolution: {integrity: sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==}
 
+  path-to-regexp@8.2.0:
+    resolution: {integrity: sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==}
+    engines: {node: '>=16'}
+
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
@@ -7777,6 +7880,10 @@ packages:
   pirates@4.0.6:
     resolution: {integrity: sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==}
     engines: {node: '>= 6'}
+
+  pkce-challenge@4.1.0:
+    resolution: {integrity: sha512-ZBmhE1C9LcPoH9XZSdwiPtbPHZROwAnMy+kIFQVrnMCxY4Cudlz3gBOpzilgc0jOgRaiT3sIWfpMomW2ar2orQ==}
+    engines: {node: '>=16.20.0'}
 
   pkg-dir@4.2.0:
     resolution: {integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==}
@@ -7976,6 +8083,10 @@ packages:
     resolution: {integrity: sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==}
     engines: {node: '>=0.6'}
 
+  qs@6.14.0:
+    resolution: {integrity: sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==}
+    engines: {node: '>=0.6'}
+
   querystring-es3@0.2.1:
     resolution: {integrity: sha512-773xhDQnZBMFobEiztv8LIl70ch5MSF/jUQVlhwFyBILqq96anmoctVIYz+ZRp0qbCKATTn6ev02M3r7Ga5vqA==}
     engines: {node: '>=0.4.x'}
@@ -8002,6 +8113,10 @@ packages:
 
   raw-body@2.5.2:
     resolution: {integrity: sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==}
+    engines: {node: '>= 0.8'}
+
+  raw-body@3.0.0:
+    resolution: {integrity: sha512-RmkhL8CAyCRPXCE28MMH0z2PNWQBNk2Q09ZdxM9IOOXwxwZbN+qbWaatPkdkWIKL2ZVDImrN/pK5HTRz2PcS4g==}
     engines: {node: '>= 0.8'}
 
   rc@1.2.8:
@@ -8161,6 +8276,10 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  router@2.2.0:
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
+    engines: {node: '>= 18'}
+
   run-applescript@7.0.0:
     resolution: {integrity: sha512-9by4Ij99JUr/MCFBUkDKLWK3G9HVXmabKz9U5MlIAIuvuzkiOicRYs8XJLxX+xahD+mLiiCYDqF9dKAgtzKP1A==}
     engines: {node: '>=18'}
@@ -8243,6 +8362,10 @@ packages:
     resolution: {integrity: sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==}
     engines: {node: '>= 0.8.0'}
 
+  send@1.2.0:
+    resolution: {integrity: sha512-uaW0WwXKpL9blXE2o0bRhoL2EGXIrZxQ2ZQ4mgcfoBxdFmQold+qWsD2jLrfZ0trjKL6vOw0j//eAwcALFjKSw==}
+    engines: {node: '>= 18'}
+
   serialize-error@7.0.1:
     resolution: {integrity: sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==}
     engines: {node: '>=10'}
@@ -8257,6 +8380,10 @@ packages:
   serve-static@1.16.2:
     resolution: {integrity: sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==}
     engines: {node: '>= 0.8.0'}
+
+  serve-static@2.1.0:
+    resolution: {integrity: sha512-A3We5UfEjG8Z7VkDv6uItWw6HY2bBSBJT1KtVESn6EOoOr2jAxNhxWCLY3jDE2WcuHXByWju74ck3ZgLwL8xmA==}
+    engines: {node: '>= 18'}
 
   set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
@@ -8312,8 +8439,24 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  side-channel-list@1.0.0:
+    resolution: {integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-map@1.0.1:
+    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-weakmap@1.0.2:
+    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
+    engines: {node: '>= 0.4'}
+
   side-channel@1.0.6:
     resolution: {integrity: sha512-fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.0:
+    resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
   signal-exit@3.0.7:
@@ -8753,6 +8896,10 @@ packages:
 
   type-is@1.6.18:
     resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
+    engines: {node: '>= 0.6'}
+
+  type-is@2.0.1:
+    resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
     engines: {node: '>= 0.6'}
 
   typechat@0.1.1:
@@ -9210,8 +9357,16 @@ packages:
     resolution: {integrity: sha512-9qv4rlDiopXg4E69k+vMHjNN63YFMe9sZMrdlvKnCjlCRWeCBswPPMPUfx+ipsAWq1LXHe70RcbaHdJJpS6hyQ==}
     engines: {node: '>= 10'}
 
+  zod-to-json-schema@3.24.5:
+    resolution: {integrity: sha512-/AuWwMP+YqiPbsJx5D6TfgRTc4kTLjsh5SOcd4bLsfUg2RcEXrFMJl1DGgdHy2aCfsIA/cr/1JM0xcB2GZji8g==}
+    peerDependencies:
+      zod: ^3.24.1
+
   zod@3.23.8:
     resolution: {integrity: sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==}
+
+  zod@3.24.2:
+    resolution: {integrity: sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==}
 
 snapshots:
 
@@ -10828,6 +10983,37 @@ snapshots:
 
   '@microsoft/microsoft-graph-types@2.40.0': {}
 
+  '@modelcontextprotocol/sdk@0.5.0':
+    dependencies:
+      content-type: 1.0.5
+      raw-body: 3.0.0
+      zod: 3.24.2
+
+  '@modelcontextprotocol/sdk@1.8.0':
+    dependencies:
+      content-type: 1.0.5
+      cors: 2.8.5
+      cross-spawn: 7.0.6
+      eventsource: 3.0.6
+      express: 5.0.1
+      express-rate-limit: 7.5.0(express@5.0.1)
+      pkce-challenge: 4.1.0
+      raw-body: 3.0.0
+      zod: 3.24.2
+      zod-to-json-schema: 3.24.5(zod@3.24.2)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@modelcontextprotocol/server-filesystem@2025.1.14(zod@3.24.2)':
+    dependencies:
+      '@modelcontextprotocol/sdk': 0.5.0
+      diff: 5.2.0
+      glob: 10.3.12
+      minimatch: 10.0.1
+      zod-to-json-schema: 3.24.5(zod@3.24.2)
+    transitivePeerDependencies:
+      - zod
+
   '@mongodb-js/saslprep@1.1.4':
     dependencies:
       sparse-bitfield: 3.0.3
@@ -11959,34 +12145,24 @@ snapshots:
       '@webassemblyjs/ast': 1.12.1
       '@xtuc/long': 4.2.2
 
-  '@webpack-cli/configtest@2.1.1(webpack-cli@5.1.4(webpack-dev-server@5.2.0)(webpack@5.94.0))(webpack@5.94.0(webpack-cli@5.1.4))':
+  '@webpack-cli/configtest@2.1.1(webpack-cli@5.1.4)(webpack@5.94.0)':
     dependencies:
       webpack: 5.94.0(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack-dev-server@5.2.0)(webpack@5.94.0)
 
-  '@webpack-cli/configtest@2.1.1(webpack-cli@5.1.4(webpack@5.94.0))(webpack@5.94.0(webpack-cli@5.1.4))':
-    dependencies:
-      webpack: 5.94.0(webpack-cli@5.1.4)
-      webpack-cli: 5.1.4(webpack@5.94.0)
-
-  '@webpack-cli/info@2.0.2(webpack-cli@5.1.4(webpack-dev-server@5.2.0)(webpack@5.94.0))(webpack@5.94.0(webpack-cli@5.1.4))':
+  '@webpack-cli/info@2.0.2(webpack-cli@5.1.4)(webpack@5.94.0)':
     dependencies:
       webpack: 5.94.0(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack-dev-server@5.2.0)(webpack@5.94.0)
 
-  '@webpack-cli/info@2.0.2(webpack-cli@5.1.4(webpack@5.94.0))(webpack@5.94.0(webpack-cli@5.1.4))':
-    dependencies:
-      webpack: 5.94.0(webpack-cli@5.1.4)
-      webpack-cli: 5.1.4(webpack@5.94.0)
-
-  '@webpack-cli/serve@2.0.5(webpack-cli@5.1.4(webpack-dev-server@5.2.0)(webpack@5.94.0))(webpack-dev-server@5.2.0(debug@4.4.0)(webpack-cli@5.1.4)(webpack@5.94.0))(webpack@5.94.0(webpack-cli@5.1.4))':
+  '@webpack-cli/serve@2.0.5(webpack-cli@5.1.4)(webpack-dev-server@5.2.0)(webpack@5.94.0)':
     dependencies:
       webpack: 5.94.0(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack-dev-server@5.2.0)(webpack@5.94.0)
     optionalDependencies:
       webpack-dev-server: 5.2.0(debug@4.4.0)(webpack-cli@5.1.4)(webpack@5.94.0)
 
-  '@webpack-cli/serve@2.0.5(webpack-cli@5.1.4(webpack@5.94.0))(webpack@5.94.0(webpack-cli@5.1.4))':
+  '@webpack-cli/serve@2.0.5(webpack-cli@5.1.4)(webpack@5.94.0)':
     dependencies:
       webpack: 5.94.0(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack@5.94.0)
@@ -12005,6 +12181,11 @@ snapshots:
     dependencies:
       mime-types: 2.1.35
       negotiator: 0.6.3
+
+  accepts@2.0.0:
+    dependencies:
+      mime-types: 3.0.1
+      negotiator: 1.0.0
 
   acorn-import-attributes@1.9.5(acorn@8.11.1):
     dependencies:
@@ -12114,7 +12295,7 @@ snapshots:
 
   app-builder-bin@4.0.0: {}
 
-  app-builder-lib@24.13.3(dmg-builder@24.13.3(electron-builder-squirrel-windows@24.13.3))(electron-builder-squirrel-windows@24.13.3(dmg-builder@24.13.3)):
+  app-builder-lib@24.13.3(dmg-builder@24.13.3)(electron-builder-squirrel-windows@24.13.3):
     dependencies:
       '@develar/schema-utils': 2.6.5
       '@electron/notarize': 2.2.1
@@ -12393,6 +12574,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  body-parser@2.2.0:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 1.0.5
+      debug: 4.4.0(supports-color@8.1.1)
+      http-errors: 2.0.0
+      iconv-lite: 0.6.3
+      on-finished: 2.4.1
+      qs: 6.14.0
+      raw-body: 3.0.0
+      type-is: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
   bonjour-service@1.2.1:
     dependencies:
       fast-deep-equal: 3.1.3
@@ -12602,6 +12797,11 @@ snapshots:
       function-bind: 1.1.2
       get-intrinsic: 1.2.4
       set-function-length: 1.2.2
+
+  call-bound@1.0.4:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      get-intrinsic: 1.3.0
 
   callsites@3.1.0: {}
 
@@ -12883,6 +13083,10 @@ snapshots:
     dependencies:
       safe-buffer: 5.2.1
 
+  content-disposition@1.0.0:
+    dependencies:
+      safe-buffer: 5.2.1
+
   content-type@1.0.5: {}
 
   convert-source-map@2.0.0: {}
@@ -12891,13 +13095,15 @@ snapshots:
 
   cookie-signature@1.0.6: {}
 
+  cookie-signature@1.2.2: {}
+
   cookie@0.7.1: {}
 
   copy-anything@2.0.6:
     dependencies:
       is-what: 3.14.1
 
-  copy-webpack-plugin@12.0.2(webpack@5.94.0(webpack-cli@5.1.4)):
+  copy-webpack-plugin@12.0.2(webpack@5.94.0):
     dependencies:
       fast-glob: 3.3.2
       glob-parent: 6.0.2
@@ -13233,6 +13439,10 @@ snapshots:
     dependencies:
       ms: 2.0.0
 
+  debug@4.3.6:
+    dependencies:
+      ms: 2.1.2
+
   debug@4.4.0(supports-color@8.1.1):
     dependencies:
       ms: 2.1.3
@@ -13338,7 +13548,7 @@ snapshots:
 
   dmg-builder@24.13.3(electron-builder-squirrel-windows@24.13.3):
     dependencies:
-      app-builder-lib: 24.13.3(dmg-builder@24.13.3(electron-builder-squirrel-windows@24.13.3))(electron-builder-squirrel-windows@24.13.3(dmg-builder@24.13.3))
+      app-builder-lib: 24.13.3(dmg-builder@24.13.3)(electron-builder-squirrel-windows@24.13.3)
       builder-util: 24.13.1
       builder-util-runtime: 9.2.4
       fs-extra: 10.1.0
@@ -13441,7 +13651,7 @@ snapshots:
 
   electron-builder-squirrel-windows@24.13.3(dmg-builder@24.13.3):
     dependencies:
-      app-builder-lib: 24.13.3(dmg-builder@24.13.3(electron-builder-squirrel-windows@24.13.3))(electron-builder-squirrel-windows@24.13.3(dmg-builder@24.13.3))
+      app-builder-lib: 24.13.3(dmg-builder@24.13.3)(electron-builder-squirrel-windows@24.13.3)
       archiver: 5.3.2
       builder-util: 24.13.1
       fs-extra: 10.1.0
@@ -13449,9 +13659,9 @@ snapshots:
       - dmg-builder
       - supports-color
 
-  electron-builder@24.13.3(electron-builder-squirrel-windows@24.13.3(dmg-builder@24.13.3)):
+  electron-builder@24.13.3(electron-builder-squirrel-windows@24.13.3):
     dependencies:
-      app-builder-lib: 24.13.3(dmg-builder@24.13.3(electron-builder-squirrel-windows@24.13.3))(electron-builder-squirrel-windows@24.13.3(dmg-builder@24.13.3))
+      app-builder-lib: 24.13.3(dmg-builder@24.13.3)(electron-builder-squirrel-windows@24.13.3)
       builder-util: 24.13.1
       builder-util-runtime: 9.2.4
       chalk: 4.1.2
@@ -13680,6 +13890,12 @@ snapshots:
 
   events@3.3.0: {}
 
+  eventsource-parser@3.0.1: {}
+
+  eventsource@3.0.6:
+    dependencies:
+      eventsource-parser: 3.0.1
+
   evp_bytestokey@1.0.3:
     dependencies:
       md5.js: 1.3.5
@@ -13727,6 +13943,10 @@ snapshots:
     dependencies:
       express: 4.21.2
 
+  express-rate-limit@7.5.0(express@5.0.1):
+    dependencies:
+      express: 5.0.1
+
   express@4.21.2:
     dependencies:
       accepts: 1.3.8
@@ -13758,6 +13978,43 @@ snapshots:
       setprototypeof: 1.2.0
       statuses: 2.0.1
       type-is: 1.6.18
+      utils-merge: 1.0.1
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  express@5.0.1:
+    dependencies:
+      accepts: 2.0.0
+      body-parser: 2.2.0
+      content-disposition: 1.0.0
+      content-type: 1.0.5
+      cookie: 0.7.1
+      cookie-signature: 1.2.2
+      debug: 4.3.6
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 2.1.0
+      fresh: 2.0.0
+      http-errors: 2.0.0
+      merge-descriptors: 2.0.0
+      methods: 1.1.2
+      mime-types: 3.0.1
+      on-finished: 2.4.1
+      once: 1.4.0
+      parseurl: 1.3.3
+      proxy-addr: 2.0.7
+      qs: 6.13.0
+      range-parser: 1.2.1
+      router: 2.2.0
+      safe-buffer: 5.2.1
+      send: 1.2.0
+      serve-static: 2.1.0
+      setprototypeof: 1.2.0
+      statuses: 2.0.1
+      type-is: 2.0.1
       utils-merge: 1.0.1
       vary: 1.1.2
     transitivePeerDependencies:
@@ -13856,6 +14113,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  finalhandler@2.1.0:
+    dependencies:
+      debug: 4.4.0(supports-color@8.1.1)
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
   find-config@1.0.0:
     dependencies:
       user-home: 2.0.0
@@ -13926,6 +14194,8 @@ snapshots:
   forwarded@0.2.0: {}
 
   fresh@0.5.2: {}
+
+  fresh@2.0.0: {}
 
   fs-constants@1.0.0: {}
 
@@ -14246,7 +14516,7 @@ snapshots:
       htmlparser2: 8.0.2
       selderee: 0.11.0
 
-  html-webpack-plugin@5.6.0(webpack@5.94.0(webpack-cli@5.1.4)):
+  html-webpack-plugin@5.6.0(webpack@5.94.0):
     dependencies:
       '@types/html-minifier-terser': 6.1.0
       html-minifier-terser: 6.1.0
@@ -14543,6 +14813,8 @@ snapshots:
   is-plain-object@2.0.4:
     dependencies:
       isobject: 3.0.1
+
+  is-promise@4.0.0: {}
 
   is-relative-url@4.0.0:
     dependencies:
@@ -15377,6 +15649,8 @@ snapshots:
 
   media-typer@0.3.0: {}
 
+  media-typer@1.1.0: {}
+
   memfs@4.9.3:
     dependencies:
       '@jsonjoy.com/json-pack': 1.0.4(tslib@2.8.1)
@@ -15393,6 +15667,8 @@ snapshots:
       kind-of: 3.2.2
 
   merge-descriptors@1.0.3: {}
+
+  merge-descriptors@2.0.0: {}
 
   merge-stream@2.0.0: {}
 
@@ -15425,9 +15701,15 @@ snapshots:
 
   mime-db@1.52.0: {}
 
+  mime-db@1.54.0: {}
+
   mime-types@2.1.35:
     dependencies:
       mime-db: 1.52.0
+
+  mime-types@3.0.1:
+    dependencies:
+      mime-db: 1.54.0
 
   mime@1.6.0: {}
 
@@ -15537,6 +15819,8 @@ snapshots:
 
   ms@2.0.0: {}
 
+  ms@2.1.2: {}
+
   ms@2.1.3: {}
 
   multicast-dns@7.2.5:
@@ -15573,6 +15857,8 @@ snapshots:
 
   negotiator@0.6.3: {}
 
+  negotiator@1.0.0: {}
+
   neo-async@2.6.2: {}
 
   netmask@2.0.2: {}
@@ -15608,7 +15894,7 @@ snapshots:
 
   node-int64@0.4.0: {}
 
-  node-polyfill-webpack-plugin@3.0.0(webpack@5.94.0(webpack-cli@5.1.4)):
+  node-polyfill-webpack-plugin@3.0.0(webpack@5.94.0):
     dependencies:
       assert: 2.1.0
       browserify-zlib: 0.2.0
@@ -15666,6 +15952,8 @@ snapshots:
   object-hash@3.0.0: {}
 
   object-inspect@1.13.1: {}
+
+  object-inspect@1.13.4: {}
 
   object-is@1.1.6:
     dependencies:
@@ -15877,6 +16165,8 @@ snapshots:
 
   path-to-regexp@0.1.12: {}
 
+  path-to-regexp@8.2.0: {}
+
   path-type@4.0.0: {}
 
   path-type@5.0.0: {}
@@ -15909,6 +16199,8 @@ snapshots:
     optional: true
 
   pirates@4.0.6: {}
+
+  pkce-challenge@4.1.0: {}
 
   pkg-dir@4.2.0:
     dependencies:
@@ -16134,6 +16426,10 @@ snapshots:
     dependencies:
       side-channel: 1.0.6
 
+  qs@6.14.0:
+    dependencies:
+      side-channel: 1.1.0
+
   querystring-es3@0.2.1: {}
 
   queue-microtask@1.2.3: {}
@@ -16158,6 +16454,13 @@ snapshots:
       bytes: 3.1.2
       http-errors: 2.0.0
       iconv-lite: 0.4.24
+      unpipe: 1.0.0
+
+  raw-body@3.0.0:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.0
+      iconv-lite: 0.6.3
       unpipe: 1.0.0
 
   rc@1.2.8:
@@ -16356,6 +16659,16 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.37.0
       fsevents: 2.3.3
 
+  router@2.2.0:
+    dependencies:
+      debug: 4.4.0(supports-color@8.1.1)
+      depd: 2.0.0
+      is-promise: 4.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 8.2.0
+    transitivePeerDependencies:
+      - supports-color
+
   run-applescript@7.0.0: {}
 
   run-parallel@1.2.0:
@@ -16443,6 +16756,22 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  send@1.2.0:
+    dependencies:
+      debug: 4.4.0(supports-color@8.1.1)
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 2.0.0
+      http-errors: 2.0.0
+      mime-types: 3.0.1
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      statuses: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
   serialize-error@7.0.1:
     dependencies:
       type-fest: 0.13.1
@@ -16470,6 +16799,15 @@ snapshots:
       escape-html: 1.0.3
       parseurl: 1.3.3
       send: 0.19.0
+    transitivePeerDependencies:
+      - supports-color
+
+  serve-static@2.1.0:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 1.2.0
     transitivePeerDependencies:
       - supports-color
 
@@ -16530,12 +16868,40 @@ snapshots:
       minimist: 1.2.8
       shelljs: 0.9.2
 
+  side-channel-list@1.0.0:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-map@1.0.1:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-weakmap@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-map: 1.0.1
+
   side-channel@1.0.6:
     dependencies:
       call-bind: 1.0.7
       es-errors: 1.3.0
       get-intrinsic: 1.2.4
       object-inspect: 1.13.1
+
+  side-channel@1.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.0
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
 
   signal-exit@3.0.7: {}
 
@@ -16848,7 +17214,7 @@ snapshots:
       async-exit-hook: 2.0.1
       fs-extra: 10.1.0
 
-  terser-webpack-plugin@5.3.10(webpack@5.94.0(webpack-cli@5.1.4)):
+  terser-webpack-plugin@5.3.10(webpack@5.94.0):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
       jest-worker: 27.5.1
@@ -16948,7 +17314,7 @@ snapshots:
 
   ts-deepmerge@7.0.2: {}
 
-  ts-loader@9.5.1(typescript@5.4.5)(webpack@5.94.0(webpack-cli@5.1.4)):
+  ts-loader@9.5.1(typescript@5.4.5)(webpack@5.94.0):
     dependencies:
       chalk: 4.1.2
       enhanced-resolve: 5.15.0
@@ -17032,10 +17398,16 @@ snapshots:
       media-typer: 0.3.0
       mime-types: 2.1.35
 
-  typechat@0.1.1(typescript@5.4.5)(zod@3.23.8):
+  type-is@2.0.1:
+    dependencies:
+      content-type: 1.0.5
+      media-typer: 1.1.0
+      mime-types: 3.0.1
+
+  typechat@0.1.1(typescript@5.4.5)(zod@3.24.2):
     optionalDependencies:
       typescript: 5.4.5
-      zod: 3.23.8
+      zod: 3.24.2
 
   typed-query-selector@2.12.0: {}
 
@@ -17182,9 +17554,9 @@ snapshots:
   webpack-cli@5.1.4(webpack-dev-server@5.2.0)(webpack@5.94.0):
     dependencies:
       '@discoveryjs/json-ext': 0.5.7
-      '@webpack-cli/configtest': 2.1.1(webpack-cli@5.1.4(webpack-dev-server@5.2.0)(webpack@5.94.0))(webpack@5.94.0(webpack-cli@5.1.4))
-      '@webpack-cli/info': 2.0.2(webpack-cli@5.1.4(webpack-dev-server@5.2.0)(webpack@5.94.0))(webpack@5.94.0(webpack-cli@5.1.4))
-      '@webpack-cli/serve': 2.0.5(webpack-cli@5.1.4(webpack-dev-server@5.2.0)(webpack@5.94.0))(webpack-dev-server@5.2.0(debug@4.4.0)(webpack-cli@5.1.4)(webpack@5.94.0))(webpack@5.94.0(webpack-cli@5.1.4))
+      '@webpack-cli/configtest': 2.1.1(webpack-cli@5.1.4)(webpack@5.94.0)
+      '@webpack-cli/info': 2.0.2(webpack-cli@5.1.4)(webpack@5.94.0)
+      '@webpack-cli/serve': 2.0.5(webpack-cli@5.1.4)(webpack-dev-server@5.2.0)(webpack@5.94.0)
       colorette: 2.0.20
       commander: 10.0.1
       cross-spawn: 7.0.6
@@ -17201,9 +17573,9 @@ snapshots:
   webpack-cli@5.1.4(webpack@5.94.0):
     dependencies:
       '@discoveryjs/json-ext': 0.5.7
-      '@webpack-cli/configtest': 2.1.1(webpack-cli@5.1.4(webpack@5.94.0))(webpack@5.94.0(webpack-cli@5.1.4))
-      '@webpack-cli/info': 2.0.2(webpack-cli@5.1.4(webpack@5.94.0))(webpack@5.94.0(webpack-cli@5.1.4))
-      '@webpack-cli/serve': 2.0.5(webpack-cli@5.1.4(webpack@5.94.0))(webpack@5.94.0(webpack-cli@5.1.4))
+      '@webpack-cli/configtest': 2.1.1(webpack-cli@5.1.4)(webpack@5.94.0)
+      '@webpack-cli/info': 2.0.2(webpack-cli@5.1.4)(webpack@5.94.0)
+      '@webpack-cli/serve': 2.0.5(webpack-cli@5.1.4)(webpack@5.94.0)
       colorette: 2.0.20
       commander: 10.0.1
       cross-spawn: 7.0.6
@@ -17215,7 +17587,7 @@ snapshots:
       webpack: 5.94.0(webpack-cli@5.1.4)
       webpack-merge: 5.10.0
 
-  webpack-dev-middleware@7.4.2(webpack@5.94.0(webpack-cli@5.1.4)):
+  webpack-dev-middleware@7.4.2(webpack@5.94.0):
     dependencies:
       colorette: 2.0.20
       memfs: 4.9.3
@@ -17253,7 +17625,7 @@ snapshots:
       serve-index: 1.9.1
       sockjs: 0.3.24
       spdy: 4.0.2
-      webpack-dev-middleware: 7.4.2(webpack@5.94.0(webpack-cli@5.1.4))
+      webpack-dev-middleware: 7.4.2(webpack@5.94.0)
       ws: 8.18.0
     optionalDependencies:
       webpack: 5.94.0(webpack-cli@5.1.4)
@@ -17294,7 +17666,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 3.3.0
       tapable: 2.2.1
-      terser-webpack-plugin: 5.3.10(webpack@5.94.0(webpack-cli@5.1.4))
+      terser-webpack-plugin: 5.3.10(webpack@5.94.0)
       watchpack: 2.4.2
       webpack-sources: 3.2.3
     optionalDependencies:
@@ -17475,4 +17847,10 @@ snapshots:
       compress-commons: 4.1.2
       readable-stream: 3.6.2
 
+  zod-to-json-schema@3.24.5(zod@3.24.2):
+    dependencies:
+      zod: 3.24.2
+
   zod@3.23.8: {}
+
+  zod@3.24.2: {}


### PR DESCRIPTION
Added MCP file system agent (`mcpfilesystem`) as an example of auto MCP integration to TypeAgent.
  - The agent `mcpfilesystem` is not enabled by default.  Use `@config agent mcpfilesystem` to enable
  - On first run, enabling schema and action will show an error because the allowed directories need to be provided.  Use the command `@mcpfilesystem server <directory>...` to configure.   A restart is needed afterwards.

Details:
- Implement Tools JSON schema converter to our parsed action schema format, which can generate TS or back to JSON schema for prompts.
- Implemented MCP agent provider to automatically wrap a stdio MCP server. (can be extend to other transport in the future.

Other changes: 
- Allow schema parse error to be non-fatal at start up (but disable the schema)
- Shell will catch and display dispatcher initialization error and exit (instead of silently hang).
- Fix Shell's demo command `@shell run`.  Need to send the send-input-text to the chatView instead of mainWindow.
- Clean up unused tracking of injected action names.