### PR TITLE
[python/knowpro] Fix VectorBase.add_key(); improve demo.py output; misc improvements

### DIFF
--- a/python/ta/TODO.md
+++ b/python/ta/TODO.md
@@ -31,19 +31,10 @@ STARTING THIS NOW.
 
 For robustness -- TypeChat already retries, but my embeddings don't.
 
-## Small functionality
-
-- Implement Podcast._build_caches(), by implementing TermEmbeddingCache?
-  - Umesh wants to redo this anyway, so low priority
-
 ## Refactoring implementations
 
 - Change some inconsistent module names
 - Rewrite podcast parsing without regexes
-
-## Main/demo/test program support
-
-- Unify various dotenv calls and make them search harder (relative to repo)
 
 ## Type checking stuff
 
@@ -61,6 +52,6 @@ For robustness -- TypeChat already retries, but my embeddings don't.
 ## Questions
 
 - Do the serialization data formats (which are TypedDicts, not Protocols):
-  - Really belong in interfaces.py?
-  - Need to have names starting with 'I'?
+  - Really belong in interfaces.py? [UMES: No] [me: TODO]
+  - Need to have names starting with 'I'? [UMESH: No] [me: DONE]
   My answers for both are no, unless Steve explains why.

--- a/python/ta/demo.py
+++ b/python/ta/demo.py
@@ -4,6 +4,7 @@
 import argparse
 import asyncio
 import os
+import textwrap
 import time
 
 from typeagent.aitools import auth
@@ -44,9 +45,20 @@ async def main():
             assert 0 <= ord < len(pod.semantic_refs)
             sref = pod.semantic_refs[ord]
             assert sref.semantic_ref_ordinal == ord
-            print(
-                f"{ord}: Term {term!r} has nowledge of type {sref.knowledge_type!r}: {sref.knowledge}"
-            )
+            print(f"\n{ord}: Term {term!r} has knowledge", end=" ")
+            print(f"of type {sref.knowledge_type!r} at {sref.range}:")
+            print("    ", sref.knowledge)
+            # Now dig up the messages
+            start_msg_ord = sref.range.start.message_ordinal
+            end_msg_ord = sref.range.end.message_ordinal if sref.range.end else None
+            messages = pod.messages[start_msg_ord:end_msg_ord]
+            for message, msg_ord in zip(
+                messages, range(start_msg_ord, (end_msg_ord or start_msg_ord) + 1)
+            ):
+                text = " ".join(message.text_chunks).strip()
+                wrapped = textwrap.wrap(text)
+                for line in wrapped:
+                    print(f"  {line}")
 
     print(f"\nChecking that serialize -> deserialize -> serialize is 'idempotent' ...")
     ser1 = pod.serialize()

--- a/python/ta/typeagent/aitools/auth.py
+++ b/python/ta/typeagent/aitools/auth.py
@@ -56,6 +56,24 @@ def get_shared_token_provider() -> AzureTokenProvider:
     return _shared_token_provider
 
 
+def load_dotenv() -> None:
+    import os
+    import dotenv
+
+    dirname = os.path.dirname
+    here = dirname(__file__)
+    typeagent = dirname(here)
+    package = dirname(typeagent)
+    python = dirname(package)
+    repo_top = dirname(python)
+    env_path = os.path.join(repo_top, "ts", ".env")
+    dotenv.load_dotenv(env_path)
+    # for k, v in os.environ.items():
+    #     if "KEY" in k:
+    #         print(f"{k}={v!r}")
+    # print(f"Loaded {env_path}")
+
+
 if __name__ == "__main__":
     # Usage: eval `./typeagent/aitools/aith.py`
     print(f"export AZURE_OPENAI_API_KEY={AzureTokenProvider().get_token()}")

--- a/python/ta/typeagent/aitools/embeddings.py
+++ b/python/ta/typeagent/aitools/embeddings.py
@@ -140,9 +140,9 @@ class AsyncEmbeddingModel:
 
 
 async def main():
-    import dotenv
+    from . import auth
 
-    dotenv.load_dotenv(os.path.expanduser("~/TypeAgent/ts/.env"))
+    auth.load_dotenv()
 
     async_model = AsyncEmbeddingModel()
     e = await async_model.get_embeddings([])

--- a/python/ta/typeagent/aitools/vectorbase.py
+++ b/python/ta/typeagent/aitools/vectorbase.py
@@ -76,7 +76,7 @@ class VectorBase:
             self._model.add_embedding(key, embedding)
 
     async def add_key(self, key: str, cache: bool = True) -> None:
-        embedding = (await self.get_embedding(key)).reshape((self._embedding_size,))
+        embedding = (await self.get_embedding(key)).reshape(1, -1)  # Make it 2D
         self._vectors = np.append(self._vectors, embedding, axis=0)
 
     async def add_keys(self, keys: list[str], cache: bool = True) -> None:
@@ -93,7 +93,7 @@ class VectorBase:
         embedding = await self.get_embedding(key)
         scores = np.dot(self._vectors, embedding)  # This does most of the work
         scored_ordinals = [
-            ScoredOrdinal(i, score)
+            ScoredOrdinal(i, float(score))
             for i, score in enumerate(scores)
             if score >= min_score
         ]
@@ -120,7 +120,8 @@ class VectorBase:
 
 
 async def main():
-    import dotenv, os, time
+    import time
+    from . import auth
 
     epoch = time.time()
 
@@ -135,7 +136,7 @@ async def main():
     def debugv(heading):
         log(f"{heading}: bool={bool(v)}, len={len(v)}")
 
-    dotenv.load_dotenv(os.path.expanduser("~/TypeAgent/ts/.env"))
+    auth.load_dotenv()
     v = VectorBase()
     debugv("\nEmpty vector base")
 

--- a/python/ta/typeagent/knowpro/serialization.py
+++ b/python/ta/typeagent/knowpro/serialization.py
@@ -190,7 +190,7 @@ def to_camel(name: str) -> str:
 
 
 # No exceptions are caught; they just bubble out.
-async def read_conversation_data_from_file(
+def read_conversation_data_from_file(
     filename: str, embedding_size: int
 ) -> ConversationDataWithIndexes | None:
     with open(filename + DATA_FILE_SUFFIX) as f:

--- a/python/ta/typeagent/podcasts/__main__.py
+++ b/python/ta/typeagent/podcasts/__main__.py
@@ -5,8 +5,6 @@
 # Check Python version before importing anything else.
 import sys
 
-from typeagent.knowpro import importing, serialization
-
 minver = (3, 12)
 if sys.version_info < minver:
     sys.exit(
@@ -17,22 +15,21 @@ if sys.version_info < minver:
 import argparse
 import os
 
-import dotenv
-
-from ..knowpro.interfaces import (
+# Use absolute imports so you can run this as a script file.
+from typeagent.aitools import auth
+from typeagent.knowpro import importing, serialization
+from typeagent.knowpro.interfaces import (
     Datetime,
     IndexingEventHandlers,
     MessageOrdinal,
     TextLocation,
 )
-from .podcast import Podcast
-from .podcast_import import import_podcast
+from typeagent.podcasts.podcast import Podcast
+from typeagent.podcasts.podcast_import import import_podcast
 
 
 async def main():
-    dotenv.load_dotenv(
-        os.path.expanduser("~/TypeAgent/ts/.env")
-    )  # TODO: Only works in dev tree
+    auth.load_dotenv()
     parser = argparse.ArgumentParser(description="Import a podcast")
     parser.add_argument("filename", nargs="?", help="The filename to import")
     # TODO: Add more arguments for the import_podcast function.


### PR DESCRIPTION
Also:
- Centralize dotenv call (now auth.load_dotenv())
- Make sure np.float32 values are converted to Python float.
- read_conversation_data_from_file() has no reason (yet) to be async, and neiter does read_from_file()
- Use all absolute imports in podcasts/__main__.py (so you can run it as a script)
- Add PodcastMessage.deserialize() and use it
- Remove commented-out Podcast._build_caches(), it has vanished from the TS version too
