### PR TITLE
Refactor shell's windowing code.

### DIFF
--- a/ts/packages/shell/src/main/agent.ts
+++ b/ts/packages/shell/src/main/agent.ts
@@ -22,11 +22,13 @@ import {
 } from "@typeagent/agent-sdk/helpers/display";
 import { getLocalWhisperCommandHandlers } from "./localWhisperCommandHandler.js";
 import { ShellAction } from "./shellActionSchema.js";
+import { ShellWindow } from "./shellWindow.js";
 
 const port = process.env.PORT || 9001;
 
 type ShellContext = {
     settings: ShellSettings;
+    shellWindow: ShellWindow;
 };
 
 const config: AppAgentManifest = {
@@ -43,7 +45,7 @@ class ShellShowSettingsCommandHandler implements CommandHandlerNoParams {
     public readonly description = "Show shell settings";
     public async run(context: ActionContext<ShellContext>) {
         const agentContext = context.sessionContext.agentContext;
-        agentContext.settings.show("settings");
+        agentContext.shellWindow.showDialog("settings");
     }
 }
 
@@ -51,7 +53,7 @@ class ShellShowHelpCommandHandler implements CommandHandlerNoParams {
     public readonly description = "Show shell help";
     public async run(context: ActionContext<ShellContext>) {
         const agentContext = context.sessionContext.agentContext;
-        agentContext.settings.show("help");
+        agentContext.shellWindow.showDialog("help");
     }
 }
 
@@ -59,7 +61,7 @@ class ShellShowMetricsCommandHandler implements CommandHandlerNoParams {
     public readonly description = "Show shell metrics";
     public async run(context: ActionContext<ShellContext>) {
         const agentContext = context.sessionContext.agentContext;
-        agentContext.settings.show("Metrics");
+        agentContext.shellWindow.showDialog("Metrics");
     }
 }
 
@@ -142,14 +144,14 @@ class ShellSetSettingCommandHandler implements CommandHandler {
 class ShellRunDemoCommandHandler implements CommandHandlerNoParams {
     public readonly description = "Run Demo";
     public async run(context: ActionContext<ShellContext>) {
-        context.sessionContext.agentContext.settings.runDemo();
+        context.sessionContext.agentContext.shellWindow.runDemo();
     }
 }
 
 class ShellRunDemoInteractiveCommandHandler implements CommandHandlerNoParams {
     public readonly description = "Run Demo Interactive";
     public async run(context: ActionContext<ShellContext>) {
-        context.sessionContext.agentContext.settings.runDemo(true);
+        context.sessionContext.agentContext.shellWindow.runDemo(true);
     }
 }
 
@@ -157,7 +159,7 @@ class ShellSetTopMostCommandHandler implements CommandHandlerNoParams {
     public readonly description =
         "Always keep the shell window on top of other windows";
     public async run(context: ActionContext<ShellContext>) {
-        context.sessionContext.agentContext.settings.toggleTopMost();
+        context.sessionContext.agentContext.shellWindow.toggleTopMost();
     }
 }
 
@@ -230,7 +232,7 @@ class ShellOpenWebContentView implements CommandHandler {
 
                 break;
         }
-        context.sessionContext.agentContext.settings.openInlineBrowser(
+        context.sessionContext.agentContext.shellWindow.openInlineBrowser(
             targetUrl,
         );
     }
@@ -239,7 +241,7 @@ class ShellOpenWebContentView implements CommandHandler {
 class ShellCloseWebContentView implements CommandHandlerNoParams {
     public readonly description = "Close the new Web Content view";
     public async run(context: ActionContext<ShellContext>) {
-        context.sessionContext.agentContext.settings.closeInlineBrowser();
+        context.sessionContext.agentContext.shellWindow.closeInlineBrowser();
     }
 }
 
@@ -272,57 +274,61 @@ const handlers: CommandHandlerTable = {
     },
 };
 
-const agent: AppAgent = {
-    async initializeAgentContext(): Promise<ShellContext> {
-        return {
-            settings: ShellSettings.getinstance(),
-        };
-    },
-    async executeAction(
-        action: AppAction,
-        context: ActionContext<ShellContext>,
-    ) {
-        const shellAction = action as ShellAction;
-        switch (shellAction.actionName) {
-            case "openCanvas":
-                const openCmd = new ShellOpenWebContentView();
-                const parameters = {
-                    args: {
-                        site: shellAction.parameters.site,
-                    },
-                };
-                openCmd.run(context, parameters as any);
-                break;
-            case "closeCanvas":
-                const closeCmd = new ShellCloseWebContentView();
-                closeCmd.run(context);
-                break;
-        }
+export function createShellAgentProvider(shellWindow: ShellWindow) {
+    const agent: AppAgent = {
+        async initializeAgentContext(): Promise<ShellContext> {
+            return {
+                settings: ShellSettings.getinstance(),
+                shellWindow,
+            };
+        },
+        async executeAction(
+            action: AppAction,
+            context: ActionContext<ShellContext>,
+        ) {
+            const shellAction = action as ShellAction;
+            switch (shellAction.actionName) {
+                case "openCanvas":
+                    const openCmd = new ShellOpenWebContentView();
+                    const parameters = {
+                        args: {
+                            site: shellAction.parameters.site,
+                        },
+                    };
+                    openCmd.run(context, parameters as any);
+                    break;
+                case "closeCanvas":
+                    const closeCmd = new ShellCloseWebContentView();
+                    closeCmd.run(context);
+                    break;
+            }
 
-        return undefined;
-    },
-    ...getCommandInterface(handlers),
-};
+            return undefined;
+        },
+        ...getCommandInterface(handlers),
+    };
 
-export const shellAgentProvider: AppAgentProvider = {
-    getAppAgentNames: () => {
-        return ["shell"];
-    },
-    getAppAgentManifest: async (appAgentName: string) => {
-        if (appAgentName !== "shell") {
-            throw new Error(`Unknown app agent: ${appAgentName}`);
-        }
-        return config;
-    },
-    loadAppAgent: async (appAgentName: string) => {
-        if (appAgentName !== "shell") {
-            throw new Error(`Unknown app agent: ${appAgentName}`);
-        }
-        return agent;
-    },
-    unloadAppAgent: async (appAgentName: string) => {
-        if (appAgentName !== "shell") {
-            throw new Error(`Unknown app agent: ${appAgentName}`);
-        }
-    },
-};
+    const shellAgentProvider: AppAgentProvider = {
+        getAppAgentNames: () => {
+            return ["shell"];
+        },
+        getAppAgentManifest: async (appAgentName: string) => {
+            if (appAgentName !== "shell") {
+                throw new Error(`Unknown app agent: ${appAgentName}`);
+            }
+            return config;
+        },
+        loadAppAgent: async (appAgentName: string) => {
+            if (appAgentName !== "shell") {
+                throw new Error(`Unknown app agent: ${appAgentName}`);
+            }
+            return agent;
+        },
+        unloadAppAgent: async (appAgentName: string) => {
+            if (appAgentName !== "shell") {
+                throw new Error(`Unknown app agent: ${appAgentName}`);
+            }
+        },
+    };
+    return shellAgentProvider;
+}

--- a/ts/packages/shell/src/main/shellSettings.ts
+++ b/ts/packages/shell/src/main/shellSettings.ts
@@ -8,10 +8,7 @@ import {
     ShellSettingsType,
     TTSSettings,
 } from "../preload/shellSettingsType.js";
-import {
-    ClientSettingsProvider,
-    EmptyFunction,
-} from "../preload/electronTypes.js";
+import { ClientSettingsProvider } from "../preload/electronTypes.js";
 import { getInstanceDir } from "agent-dispatcher/helpers/data";
 import path from "path";
 import { DisplayType } from "@typeagent/agent-sdk";
@@ -38,11 +35,6 @@ export class ShellSettings
     public partialCompletion: boolean;
     public disallowedDisplayType: DisplayType[];
     public onSettingsChanged: ((name?: string | undefined) => void) | null;
-    public onShowSettingsDialog: ((dialogName: string) => void) | null;
-    public onRunDemo: ((interactive: boolean) => void) | null;
-    public onToggleTopMost: EmptyFunction | null;
-    public onOpenInlineBrowser: ((targetUrl: URL) => void) | null;
-    public onCloseInlineBrowser: ((save: boolean) => void) | null;
     public darkMode: boolean;
     public chatHistory: boolean;
     public canvas?: string;
@@ -87,11 +79,6 @@ export class ShellSettings
         this.disallowedDisplayType = settings.disallowedDisplayType;
 
         this.onSettingsChanged = null;
-        this.onShowSettingsDialog = null;
-        this.onRunDemo = null;
-        this.onToggleTopMost = null;
-        this.onOpenInlineBrowser = null;
-        this.onCloseInlineBrowser = null;
         this.darkMode = settings.darkMode;
         this.chatHistory = settings.chatHistory;
         this.canvas = settings.canvas;
@@ -166,24 +153,6 @@ export class ShellSettings
         }
     }
 
-    public show(dialogName: string = "settings") {
-        if (ShellSettings.getinstance().onShowSettingsDialog != null) {
-            ShellSettings.getinstance().onShowSettingsDialog!(dialogName);
-        }
-    }
-
-    public runDemo(interactive: boolean = false) {
-        if (ShellSettings.getinstance().onRunDemo != null) {
-            ShellSettings.getinstance().onRunDemo!(interactive);
-        }
-    }
-
-    public toggleTopMost() {
-        if (ShellSettings.getinstance().onToggleTopMost != null) {
-            ShellSettings.getinstance().onToggleTopMost!();
-        }
-    }
-
     public isDisplayTypeAllowed(displayType: DisplayType): boolean {
         for (let i = 0; i < this.disallowedDisplayType.length; i++) {
             if (this.disallowedDisplayType[i] === displayType) {
@@ -192,17 +161,5 @@ export class ShellSettings
         }
 
         return false;
-    }
-
-    public async openInlineBrowser(targetUrl: URL) {
-        if (ShellSettings.getinstance().onOpenInlineBrowser != null) {
-            ShellSettings.getinstance().onOpenInlineBrowser!(targetUrl);
-        }
-    }
-
-    public closeInlineBrowser(save: boolean = true) {
-        if (ShellSettings.getinstance().onCloseInlineBrowser != null) {
-            ShellSettings.getinstance().onCloseInlineBrowser!(save);
-        }
     }
 }

--- a/ts/packages/shell/src/main/shellWindow.ts
+++ b/ts/packages/shell/src/main/shellWindow.ts
@@ -1,0 +1,461 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import {
+    BrowserWindow,
+    DevicePermissionHandlerHandlerDetails,
+    shell,
+    WebContents,
+    WebContentsView,
+} from "electron";
+import path from "node:path";
+import { ShellSettings } from "./shellSettings.js";
+import { is } from "@electron-toolkit/utils";
+import { WebSocketMessageV2 } from "common-utils";
+import { runDemo } from "./demo.js";
+
+const inlineBrowserSize = 1000;
+const userAgent =
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36 Edg/124.0.0.0";
+const isMac = process.platform === "darwin";
+const isLinux = process.platform === "linux";
+export class ShellWindow {
+    public readonly mainWindow: BrowserWindow;
+    public readonly chatView: WebContentsView;
+    private inlineWebContentView: WebContentsView | undefined;
+    private readonly contentLoadP: Promise<void>[];
+
+    constructor(private readonly settings: ShellSettings) {
+        const mainWindow = createMainWindow(settings);
+        const chatView = createChatView(settings);
+
+        setupDevicePermissions(mainWindow);
+        this.setupWebContents(mainWindow.webContents);
+        this.setupWebContents(chatView.webContents);
+
+        mainWindow.on("ready-to-show", () => {
+            mainWindow.show();
+
+            if (settings.devTools) {
+                chatView.webContents.openDevTools();
+            }
+        });
+
+        mainWindow.on("close", () => {
+            mainWindow.hide();
+            mainWindow.removeAllListeners("move");
+            mainWindow.removeAllListeners("moved");
+            mainWindow.removeAllListeners("resize");
+            mainWindow.removeAllListeners("resized");
+
+            this.closeInlineBrowser(false);
+
+            settings.zoomLevel = chatView.webContents.zoomFactor;
+            settings.devTools = chatView.webContents.isDevToolsOpened();
+            settings.size = mainWindow.getSize();
+            settings.position = mainWindow.getPosition();
+        });
+
+        mainWindow.on("closed", () => {
+            settings.save();
+        });
+
+        if (isLinux) {
+            mainWindow.on("move", () => {
+                settings.position = mainWindow.getPosition();
+            });
+        } else {
+            mainWindow.on("moved", () => {
+                settings.position = mainWindow.getPosition();
+            });
+        }
+
+        mainWindow.on("resized", () => {
+            settings.size = mainWindow.getSize();
+        });
+
+        mainWindow.on("resize", () => this.updateContentSize());
+
+        mainWindow.contentView.addChildView(chatView);
+
+        this.mainWindow = mainWindow;
+        this.chatView = chatView;
+
+        const contentLoadP: Promise<void>[] = [];
+        // HMR for renderer base on electron-vite cli.
+        // Load the remote URL for development or the local html file for production.
+        if (is.dev && process.env["ELECTRON_RENDERER_URL"]) {
+            contentLoadP.push(
+                chatView.webContents.loadURL(
+                    process.env["ELECTRON_RENDERER_URL"],
+                ),
+            );
+        } else {
+            contentLoadP.push(
+                chatView.webContents.loadFile(
+                    path.join(__dirname, "../renderer/index.html"),
+                ),
+            );
+        }
+
+        contentLoadP.push(
+            mainWindow.webContents.loadFile(
+                path.join(__dirname, "../renderer/viewHost.html"),
+            ),
+        );
+
+        this.contentLoadP = contentLoadP;
+
+        this.updateContentSize();
+    }
+
+    public async waitForContentLoaded() {
+        return Promise.all(this.contentLoadP);
+    }
+
+    public updateContentSize(newChatWidth?: number) {
+        const bounds = this.mainWindow.getContentBounds();
+        const { width, height } = bounds;
+        let chatWidth = width;
+        if (this.inlineWebContentView) {
+            chatWidth = newChatWidth ?? this.chatView.getBounds().width;
+            if (chatWidth < 0) {
+                chatWidth = 0;
+            } else if (chatWidth > width - 4) {
+                chatWidth = width - 4;
+            }
+            const inlineWidth = width - chatWidth;
+            this.inlineWebContentView.setBounds({
+                x: chatWidth + 4,
+                y: 0,
+                width: inlineWidth,
+                height: height,
+            });
+        }
+
+        this.chatView.setBounds({
+            x: 0,
+            y: 0,
+            width: chatWidth,
+            height: height,
+        });
+
+        // Set the divider position
+        this.mainWindow.webContents.send(
+            "set-divider-left",
+            this.inlineWebContentView ? chatWidth : -1,
+        );
+    }
+
+    public openInlineBrowser(targetUrl: URL) {
+        const mainWindow = this.mainWindow;
+        const mainWindowSize = mainWindow.getBounds();
+        let newWindow: boolean = false;
+        let inlineWebContentView = this.inlineWebContentView;
+        if (!inlineWebContentView) {
+            newWindow = true;
+
+            inlineWebContentView = new WebContentsView({
+                webPreferences: {
+                    preload: path.join(__dirname, "../preload-cjs/webview.cjs"),
+                    sandbox: false,
+                    zoomFactor: this.chatView.webContents.zoomFactor,
+                },
+            });
+
+            this.setupWebContents(inlineWebContentView.webContents);
+
+            mainWindow.contentView.addChildView(inlineWebContentView);
+            this.inlineWebContentView = inlineWebContentView;
+
+            mainWindow.setBounds({
+                width: mainWindowSize.width + inlineBrowserSize,
+            });
+            this.updateContentSize();
+        }
+
+        // only open the requested canvas if it isn't already opened
+        if (this.settings.canvas !== targetUrl.toString() || newWindow) {
+            inlineWebContentView.webContents.loadURL(targetUrl.toString());
+
+            // indicate in the settings which canvas is open
+            this.settings.canvas = targetUrl.toString().toLocaleLowerCase();
+
+            // write the settings to disk
+            this.settings.save();
+        }
+    }
+
+    public closeInlineBrowser(save: boolean = true) {
+        const inlineWebContentView = this.inlineWebContentView;
+        if (inlineWebContentView === undefined) {
+            return;
+        }
+        const browserBounds = inlineWebContentView.getBounds();
+        inlineWebContentView.webContents.close();
+        this.mainWindow.contentView.removeChildView(inlineWebContentView);
+        this.inlineWebContentView = undefined;
+
+        const mainWindowSize = this.mainWindow.getBounds();
+        this.mainWindow.setBounds({
+            width: mainWindowSize.width - browserBounds.width,
+        });
+
+        this.updateContentSize();
+
+        // clear the canvas settings
+        if (save) {
+            this.settings.canvas = undefined;
+        }
+
+        // write the settings to disk
+        this.settings.save();
+    }
+
+    public toggleTopMost() {
+        this.mainWindow.setAlwaysOnTop(!this.mainWindow.isAlwaysOnTop());
+    }
+
+    public showDialog(dialogName: string) {
+        this.chatView.webContents.send("show-dialog", dialogName);
+    }
+
+    public sendMessageToInlineWebContent(message: WebSocketMessageV2) {
+        this.inlineWebContentView?.webContents.send("webview-message", message);
+    }
+
+    public runDemo(interactive: boolean = false) {
+        runDemo(this.mainWindow, this.chatView, interactive);
+    }
+    private setupWebContents(webContents: WebContents) {
+        this.setupZoomHandlers(webContents);
+        this.setupDevToolsHandlers(webContents);
+        webContents.setUserAgent(userAgent);
+    }
+
+    private setupDevToolsHandlers(webContents: WebContents) {
+        webContents.on("before-input-event", (_event, input) => {
+            if (input.type === "keyDown") {
+                if (!is.dev) {
+                    // Ignore CommandOrControl + R
+                    if (input.code === "KeyR" && (input.control || input.meta))
+                        _event.preventDefault();
+                } else {
+                    // Toggle devtool(F12)
+                    if (input.code === "F12") {
+                        if (webContents.isDevToolsOpened()) {
+                            webContents.closeDevTools();
+                        } else {
+                            webContents.openDevTools({ mode: "undocked" });
+                        }
+                    }
+                }
+            }
+        });
+    }
+
+    // Zoom handlers
+    private setupZoomHandlers(webContents: WebContents) {
+        webContents.on("before-input-event", (_event, input) => {
+            if (
+                (isMac ? input.meta : input.control) &&
+                input.type === "keyDown"
+            ) {
+                if (
+                    input.key === "NumpadAdd" ||
+                    input.key === "+" ||
+                    input.key === "="
+                ) {
+                    this.zoomIn();
+                } else if (input.key === "-" || input.key === "NumpadMinus") {
+                    this.zoomOut();
+                } else if (input.key === "0") {
+                    this.setZoomLevel(1);
+                }
+            }
+        });
+
+        // Register mouse wheel as well.
+        webContents.on("zoom-changed", (_event, zoomDirection) => {
+            if (zoomDirection === "in") {
+                this.zoomIn();
+            } else {
+                this.zoomOut();
+            }
+        });
+    }
+
+    private zoomIn() {
+        this.setZoomLevel(this.chatView.webContents.zoomFactor + 0.1);
+    }
+
+    private zoomOut() {
+        this.setZoomLevel(this.chatView.webContents.zoomFactor - 0.1);
+    }
+
+    public setZoomLevel(zoomFactor: number) {
+        if (zoomFactor < 0.1) {
+            zoomFactor = 0.1;
+        } else if (zoomFactor > 10) {
+            zoomFactor = 10;
+        }
+
+        for (const view of this.mainWindow.contentView.children) {
+            if (view instanceof WebContentsView) {
+                view.webContents.zoomFactor = zoomFactor;
+            }
+        }
+        this.settings.zoomLevel = zoomFactor;
+
+        this.updateZoomInTitle(zoomFactor);
+    }
+
+    private updateZoomInTitle(zoomFactor: number) {
+        const prevTitle = this.mainWindow.getTitle();
+        const prevZoomIndex = prevTitle.indexOf(" Zoom: ");
+        const summary =
+            prevZoomIndex !== -1
+                ? prevTitle.substring(0, prevZoomIndex)
+                : prevTitle;
+        const zoomTitle =
+            zoomFactor === 1 ? "" : ` Zoom: ${Math.round(zoomFactor * 100)}%`;
+        this.mainWindow.setTitle(`${summary}${zoomTitle}`);
+    }
+}
+
+function createMainWindow(settings: ShellSettings) {
+    const mainWindow = new BrowserWindow({
+        width: settings.width,
+        height: settings.height,
+        show: false,
+        autoHideMenuBar: true,
+        webPreferences: {
+            preload: path.join(__dirname, "../preload/index.mjs"),
+            sandbox: false,
+            zoomFactor: 1,
+        },
+        x: settings.x,
+        y: settings.y,
+    });
+
+    console.log(settings.x, settings.y);
+    // This (seemingly redundant) call is needed when we use a BrowserView.
+    // Without this call, the mainWindow opens using default width/height, not the
+    // values saved in ShellSettings
+    mainWindow.setBounds({
+        width: settings.width,
+        height: settings.height,
+    });
+
+    mainWindow.removeMenu();
+
+    // make sure links are opened in the external browser
+    mainWindow.webContents.setWindowOpenHandler((details) => {
+        shell.openExternal(details.url);
+        return { action: "deny" };
+    });
+
+    return mainWindow;
+}
+
+function createChatView(settings: ShellSettings) {
+    const chatView = new WebContentsView({
+        webPreferences: {
+            preload: path.join(__dirname, "../preload/index.mjs"),
+            sandbox: false,
+            zoomFactor: settings.zoomLevel,
+        },
+    });
+
+    // ensure links are opened in a new browser window
+    chatView.webContents.setWindowOpenHandler((details) => {
+        // TODO: add logic for keeping things in the browser window
+        shell.openExternal(details.url);
+        return { action: "deny" };
+    });
+    return chatView;
+}
+
+/**
+ * Allows the application to gain access to camera devices
+ * @param mainWindow the main browser window
+ */
+function setupDevicePermissions(mainWindow: BrowserWindow) {
+    let grantedDeviceThroughPermHandler;
+
+    mainWindow.webContents.session.on(
+        "select-usb-device",
+        (event, details, callback) => {
+            // Add events to handle devices being added or removed before the callback on
+            // `select-usb-device` is called.
+            mainWindow.webContents.session.on(
+                "usb-device-added",
+                (_event, device) => {
+                    console.log("usb-device-added FIRED WITH", device);
+                    // Optionally update details.deviceList
+                },
+            );
+
+            mainWindow.webContents.session.on(
+                "usb-device-removed",
+                (_event, device) => {
+                    console.log("usb-device-removed FIRED WITH", device);
+                    // Optionally update details.deviceList
+                },
+            );
+
+            event.preventDefault();
+            if (details.deviceList && details.deviceList.length > 0) {
+                const deviceToReturn = details.deviceList.find((device) => {
+                    return (
+                        !grantedDeviceThroughPermHandler ||
+                        device.deviceId !==
+                            grantedDeviceThroughPermHandler.deviceId
+                    );
+                });
+                if (deviceToReturn) {
+                    callback(deviceToReturn.deviceId);
+                } else {
+                    callback();
+                }
+            }
+        },
+    );
+
+    mainWindow.webContents.session.setPermissionCheckHandler(
+        (
+            _webContents: WebContents | null,
+            permission,
+            _requestingOrigin,
+            details,
+        ): boolean => {
+            if (
+                (permission === "usb" &&
+                    details.securityOrigin === "file:///") ||
+                (permission === "media" &&
+                    (details.securityOrigin?.startsWith("http://localhost") ||
+                        details.securityOrigin?.startsWith(
+                            "https://localhost",
+                        )))
+            ) {
+                return true;
+            }
+
+            return false;
+        },
+    );
+
+    mainWindow.webContents.session.setDevicePermissionHandler(
+        (details: DevicePermissionHandlerHandlerDetails): boolean => {
+            if (details.deviceType === "usb" && details.origin === "file://") {
+                if (!grantedDeviceThroughPermHandler) {
+                    grantedDeviceThroughPermHandler = details.device;
+                    return true;
+                } else {
+                    return false;
+                }
+            }
+            return false;
+        },
+    );
+}


### PR DESCRIPTION
- Create `ShellWindow` class to manage the main window and the views.
- ShellAgent have access to the ShellWindow, instead of going thru late bound functions thru ShellSettings (this will allow window to be recreated in the future.

Other fixes:
- Make sure position is saved on linux by listen to "move" instead "moved" event.
- Remove move/resize event on close so it doesn't get updated with wrong value while closing.