### PR TITLE
Refactor Client API and others

### DIFF
--- a/ts/packages/agents/greeting/src/greetingCommandHandler.ts
+++ b/ts/packages/agents/greeting/src/greetingCommandHandler.ts
@@ -68,10 +68,12 @@ async function initializeGreetingAgentContext(): Promise<GreetingAgentContext> {
 
                 context.user.givenName = user.givenName;
                 context.user.surName = user.surname;
-                if (context.getUserNameResolve) {
-                    context.getUserNameResolve(user);
-                }
             } catch {}
+
+            // Make sure we resolve the promise whether we succeeded or not
+            if (context.getUserNameResolve) {
+                context.getUserNameResolve(context.user);
+            }
         },
     );
 

--- a/ts/packages/api/src/webDispatcher.ts
+++ b/ts/packages/api/src/webDispatcher.ts
@@ -51,7 +51,6 @@ export async function createWebDispatcher(): Promise<WebDispatcher> {
                 JSON.stringify({
                     message: "setting-summary-changed",
                     data: {
-                        summary: newSettingSummary,
                         registeredAgents: [
                             ...dispatcher.getTranslatorNameToEmojiMap(),
                         ],

--- a/ts/packages/shell/electron.vite.config.mts
+++ b/ts/packages/shell/electron.vite.config.mts
@@ -18,6 +18,7 @@ export default defineConfig({
             rollupOptions: {
                 input: {
                     index: resolve(__dirname, "src/preload/index.ts"),
+                    main: resolve(__dirname, "./src/preload/main.ts"),
                 },
             },
         },

--- a/ts/packages/shell/src/main/demo.ts
+++ b/ts/packages/shell/src/main/demo.ts
@@ -31,7 +31,7 @@ function getActionCompleteEvent(awaitKeyboardInput: boolean) {
             if (awaitKeyboardInput) {
                 targetName = "Alt+Right";
             }
-            if (name == targetName) {
+            if (name === targetName) {
                 ipcMain.removeListener("send-demo-event", callback);
                 resolve(undefined);
             }

--- a/ts/packages/shell/src/main/index.ts
+++ b/ts/packages/shell/src/main/index.ts
@@ -5,7 +5,6 @@ import dotenv from "dotenv";
 import {
     ipcMain,
     app,
-    BrowserWindow,
     globalShortcut,
     dialog,
     session,
@@ -64,11 +63,10 @@ export function runningTests(): boolean {
 const time = performance.now();
 debugShell("Starting...");
 
-async function createWindow() {
+async function createWindow(settings: ShellSettings) {
     debugShell("Creating window", performance.now() - time);
 
     // Create the browser window.
-    const settings = ShellSettings.getinstance();
     const shellWindow = new ShellWindow(settings);
     const mainWindow = shellWindow.mainWindow;
     const chatView = shellWindow.chatView;
@@ -272,23 +270,8 @@ async function initializeDispatcher(
     }
 }
 
-// This method will be called when Electron has finished
-// initialization and is ready to create browser windows.
-// Some APIs can only be used after this event occurs.
-async function initialize() {
-    debugShell("Ready", performance.now() - time);
-    // Set app user model id for windows
-    electronApp.setAppUserModelId("com.electron");
-
-    const browserExtensionPath = join(
-        app.getAppPath(),
-        "../agents/browser/dist/electron",
-    );
-    await session.defaultSession.loadExtension(browserExtensionPath, {
-        allowFileAccess: true,
-    });
-
-    const shellWindow = await createWindow();
+async function initializeInstance(settings: ShellSettings) {
+    const shellWindow = await createWindow(settings);
     const { mainWindow, chatView } = shellWindow;
     let title: string = "";
     function updateTitle(dispatcher: Dispatcher) {
@@ -302,7 +285,6 @@ async function initialize() {
             title = newTitle;
             chatView.webContents.send(
                 "setting-summary-changed",
-                newTitle,
                 dispatcher.getTranslatorNameToEmojiMap(),
             );
 
@@ -314,27 +296,9 @@ async function initialize() {
     const dispatcherP = initializeDispatcher(shellWindow, updateTitle);
     ipcMain.on("dom ready", async () => {
         debugShell("Showing window", performance.now() - time);
-        mainWindow.show();
-        // Main window shouldn't zoom, otherwise the divider position won't be correct.  Setting it here just to make sure.
-        mainWindow.webContents.zoomFactor = 1;
 
         // Send settings asap
         shellWindow.settings.onSettingsChanged!();
-
-        // Load chat history if enabled
-        const chatHistory: string = path.join(
-            getInstanceDir(),
-            "chat_history.html",
-        );
-        if (shellWindow.settings.chatHistory && existsSync(chatHistory)) {
-            chatView.webContents.send(
-                "chat-history",
-                readFileSync(
-                    path.join(getInstanceDir(), "chat_history.html"),
-                    "utf-8",
-                ),
-            );
-        }
 
         // The dispatcher can be use now that dom is ready and the client is ready to receive messages
         const dispatcher = await dispatcherP;
@@ -343,39 +307,11 @@ async function initialize() {
             return;
         }
         updateTitle(dispatcher);
-        // open the canvas if it was previously open
-        if (shellWindow.settings.canvas !== undefined) {
-            shellWindow.openInlineBrowser(
-                new URL(ShellSettings.getinstance().canvas!),
-            );
-        }
 
         // send the agent greeting if it's turned on
         if (shellWindow.settings.agentGreeting) {
             dispatcher.processCommand("@greeting", "agent-0", []);
         }
-    });
-
-    // Store the chat history whenever the DOM changes
-    // this let's us rehydrate the chat when reopening the shell
-    ipcMain.on("dom changed", async (_event, html) => {
-        // store the modified DOM contents
-        const file: string = path.join(getInstanceDir(), "chat_history.html");
-
-        debugShell(`Saving chat history to '${file}'.`, performance.now());
-
-        try {
-            writeFileSync(file, html);
-        } catch (e) {
-            debugShell(
-                `Unable to save history to '${file}'. Error: ${e}`,
-                performance.now(),
-            );
-        }
-    });
-
-    ipcMain.handle("get-localWhisper-status", async () => {
-        return isLocalWhisperEnabled();
     });
 
     ipcMain.on("save-settings", (_event, settings: ShellSettings) => {
@@ -401,15 +337,65 @@ async function initialize() {
         }
     });
 
-    ipcMain.on(
-        "send-to-browser-ipc",
-        async (_event, data: WebSocketMessageV2) => {
-            await BrowserAgentIpc.getinstance().send(data);
-        },
-    );
+    return shellWindow.waitForContentLoaded();
+}
 
-    globalShortcut.register("Alt+Right", () => {
-        chatView.webContents.send("send-demo-event", "Alt+Right");
+// This method will be called when Electron has finished
+// initialization and is ready to create browser windows.
+// Some APIs can only be used after this event occurs.
+async function initialize() {
+    debugShell("Ready", performance.now() - time);
+    // Set app user model id for windows
+    electronApp.setAppUserModelId("com.electron");
+
+    const browserExtensionPath = join(
+        app.getAppPath(),
+        "../agents/browser/dist/electron",
+    );
+    await session.defaultSession.loadExtension(browserExtensionPath, {
+        allowFileAccess: true,
+    });
+
+    const settings = ShellSettings.getinstance();
+    ipcMain.handle("get-chat-history", async () => {
+        // Load chat history if enabled
+        const chatHistory: string = path.join(
+            getInstanceDir(),
+            "chat_history.html",
+        );
+        if (settings.chatHistory && existsSync(chatHistory)) {
+            return readFileSync(
+                path.join(getInstanceDir(), "chat_history.html"),
+                "utf-8",
+            );
+        }
+        return undefined;
+    });
+
+    // Store the chat history whenever the DOM changes
+    // this let's us rehydrate the chat when reopening the shell
+    ipcMain.on("save-chat-history", async (_, html) => {
+        // store the modified DOM contents
+        const file: string = path.join(getInstanceDir(), "chat_history.html");
+
+        debugShell(`Saving chat history to '${file}'.`, performance.now());
+
+        try {
+            writeFileSync(file, html);
+        } catch (e) {
+            debugShell(
+                `Unable to save history to '${file}'. Error: ${e}`,
+                performance.now(),
+            );
+        }
+    });
+
+    ipcMain.handle("get-localWhisper-status", async () => {
+        return isLocalWhisperEnabled();
+    });
+
+    ipcMain.on("send-to-browser-ipc", async (_, data: WebSocketMessageV2) => {
+        await BrowserAgentIpc.getinstance().send(data);
     });
 
     // Default open or close DevTools by F12 in development
@@ -422,7 +408,8 @@ async function initialize() {
     app.on("activate", async function () {
         // On macOS it's common to re-create a window in the app when the
         // dock icon is clicked and there are no other windows open.
-        if (BrowserWindow.getAllWindows().length === 0) await createWindow();
+        if (ShellWindow.getInstance() === undefined)
+            await initializeInstance(settings);
     });
 
     // On windows, we will spin up a local end point that listens
@@ -432,9 +419,14 @@ async function initialize() {
         const pipePath = path.join("\\\\.\\pipe\\TypeAgent", "speech");
         const server = net.createServer((stream) => {
             stream.on("data", (c) => {
+                const shellWindow = ShellWindow.getInstance();
+                if (shellWindow === undefined) {
+                    // Ignore if there is no shell window
+                    return;
+                }
                 if (c.toString() == "triggerRecognitionOnce") {
                     console.log("Pen click note button click received!");
-                    triggerRecognitionOnce(chatView);
+                    triggerRecognitionOnce(shellWindow.chatView);
                 }
             });
             stream.on("error", (e) => {
@@ -448,7 +440,7 @@ async function initialize() {
             debugShellError(`Error creating pipe at ${pipePath}`);
         }
     }
-    return shellWindow.waitForContentLoaded();
+    return initializeInstance(settings);
 }
 
 app.whenReady()

--- a/ts/packages/shell/src/main/shellSettings.ts
+++ b/ts/packages/shell/src/main/shellSettings.ts
@@ -97,7 +97,7 @@ export class ShellSettings
     };
 
     public getSerializable(): ShellSettings {
-        return new ShellSettings(ShellSettings.getinstance());
+        return new ShellSettings(this);
     }
 
     private static load(): Partial<ShellSettingsType> | null {
@@ -120,36 +120,31 @@ export class ShellSettings
     }
 
     public set(name: string, value: any) {
-        const t = typeof ShellSettings.getinstance()[name];
-        const oldValue = ShellSettings.getinstance()[name];
+        const t = typeof this[name];
+        const oldValue = this[name];
         if (t === typeof value) {
-            ShellSettings.getinstance()[name] = value;
+            this[name] = value;
         } else {
             switch (t) {
                 case "string":
-                    ShellSettings.getinstance()[name] = value;
+                    this[name] = value;
                     break;
                 case "number":
-                    ShellSettings.getinstance()[name] = Number(value);
+                    this[name] = Number(value);
                     break;
                 case "boolean":
-                    if (typeof value === t) {
-                    }
-                    ShellSettings.getinstance()[name] =
+                    this[name] =
                         value.toLowerCase() === "true" || value === "1";
                     break;
                 case "object":
                 case "undefined":
-                    ShellSettings.getinstance()[name] = JSON.parse(value);
+                    this[name] = JSON.parse(value);
                     break;
             }
         }
 
-        if (
-            ShellSettings.getinstance().onSettingsChanged != null &&
-            oldValue != value
-        ) {
-            ShellSettings.getinstance().onSettingsChanged!(name);
+        if (this.onSettingsChanged != null && oldValue != value) {
+            this.onSettingsChanged!(name);
         }
     }
 

--- a/ts/packages/shell/src/main/shellSettings.ts
+++ b/ts/packages/shell/src/main/shellSettings.ts
@@ -63,10 +63,14 @@ export class ShellSettings
             };
         }
 
+        // Window state
         this.size = settings.size;
         this.position = settings.position;
         this.zoomLevel = settings.zoomLevel;
         this.devTools = settings.devTools;
+        this.canvas = settings.canvas;
+
+        // Settings
         this.microphoneId = settings.microphoneId;
         this.microphoneName = settings.microphoneName;
         this.notifyFilter = settings.notifyFilter;
@@ -77,11 +81,10 @@ export class ShellSettings
         this.devUI = settings.devUI;
         this.partialCompletion = settings.partialCompletion;
         this.disallowedDisplayType = settings.disallowedDisplayType;
-
-        this.onSettingsChanged = null;
         this.darkMode = settings.darkMode;
         this.chatHistory = settings.chatHistory;
-        this.canvas = settings.canvas;
+
+        this.onSettingsChanged = null;
     }
 
     public static get filePath(): string {
@@ -146,15 +149,5 @@ export class ShellSettings
         if (this.onSettingsChanged != null && oldValue != value) {
             this.onSettingsChanged!(name);
         }
-    }
-
-    public isDisplayTypeAllowed(displayType: DisplayType): boolean {
-        for (let i = 0; i < this.disallowedDisplayType.length; i++) {
-            if (this.disallowedDisplayType[i] === displayType) {
-                return true;
-            }
-        }
-
-        return false;
     }
 }

--- a/ts/packages/shell/src/main/shellWindow.ts
+++ b/ts/packages/shell/src/main/shellWindow.ts
@@ -4,6 +4,8 @@
 import {
     BrowserWindow,
     DevicePermissionHandlerHandlerDetails,
+    globalShortcut,
+    ipcMain,
     shell,
     WebContents,
     WebContentsView,
@@ -20,12 +22,21 @@ const userAgent =
 const isMac = process.platform === "darwin";
 const isLinux = process.platform === "linux";
 export class ShellWindow {
+    public static getInstance(): ShellWindow | undefined {
+        return this.instance;
+    }
+    private static instance: ShellWindow | undefined;
+
     public readonly mainWindow: BrowserWindow;
     public readonly chatView: WebContentsView;
     private inlineWebContentView: WebContentsView | undefined;
     private readonly contentLoadP: Promise<void>[];
+    private readonly handlers = new Map<string, (event: any) => void>();
 
     constructor(public readonly settings: ShellSettings) {
+        if (ShellWindow.instance !== undefined) {
+            throw new Error("ShellWindow already created");
+        }
         const mainWindow = createMainWindow(settings);
         const chatView = createChatView(settings);
 
@@ -33,15 +44,9 @@ export class ShellWindow {
         this.setupWebContents(mainWindow.webContents);
         this.setupWebContents(chatView.webContents);
 
-        mainWindow.on("ready-to-show", () => {
-            mainWindow.show();
-
-            if (settings.devTools) {
-                chatView.webContents.openDevTools();
-            }
-        });
-
         mainWindow.on("close", () => {
+            this.cleanup();
+
             mainWindow.hide();
             mainWindow.removeAllListeners("move");
             mainWindow.removeAllListeners("moved");
@@ -58,6 +63,7 @@ export class ShellWindow {
 
         mainWindow.on("closed", () => {
             settings.save();
+            ShellWindow.instance = undefined;
         });
 
         if (isLinux) {
@@ -80,6 +86,10 @@ export class ShellWindow {
 
         this.mainWindow = mainWindow;
         this.chatView = chatView;
+
+        this.installHandler("dom ready", () => {
+            this.ready();
+        });
 
         const contentLoadP: Promise<void>[] = [];
         // HMR for renderer base on electron-vite cli.
@@ -107,6 +117,41 @@ export class ShellWindow {
         this.contentLoadP = contentLoadP;
 
         this.updateContentSize();
+        ShellWindow.instance = this;
+    }
+
+    private installHandler(name: string, handler: (event: any) => void) {
+        this.handlers.set(name, handler);
+        ipcMain.on(name, handler);
+    }
+
+    private cleanup() {
+        for (const [key, handler] of this.handlers) {
+            ipcMain.removeListener(key, handler);
+        }
+        this.handlers.clear();
+
+        globalShortcut.unregister("Alt+Right");
+    }
+
+    private ready() {
+        const mainWindow = this.mainWindow;
+        mainWindow.show();
+        // Main window shouldn't zoom, otherwise the divider position won't be correct.  Setting it here just to make sure.
+        mainWindow.webContents.zoomFactor = 1;
+
+        if (this.settings.devTools) {
+            this.chatView.webContents.openDevTools();
+        }
+
+        // open the canvas if it was previously open
+        if (this.settings.canvas !== undefined) {
+            this.openInlineBrowser(new URL(this.settings.canvas));
+        }
+
+        globalShortcut.register("Alt+Right", () => {
+            this.chatView.webContents.send("send-demo-event", "Alt+Right");
+        });
     }
 
     public async waitForContentLoaded() {
@@ -344,7 +389,7 @@ function createMainWindow(settings: ShellSettings) {
         show: false,
         autoHideMenuBar: true,
         webPreferences: {
-            preload: path.join(__dirname, "../preload/index.mjs"),
+            preload: path.join(__dirname, "../preload/main.mjs"),
             sandbox: false,
             zoomFactor: 1,
         },
@@ -352,7 +397,6 @@ function createMainWindow(settings: ShellSettings) {
         y: settings.y,
     });
 
-    console.log(settings.x, settings.y);
     // This (seemingly redundant) call is needed when we use a BrowserView.
     // Without this call, the mainWindow opens using default width/height, not the
     // values saved in ShellSettings

--- a/ts/packages/shell/src/main/shellWindow.ts
+++ b/ts/packages/shell/src/main/shellWindow.ts
@@ -25,7 +25,7 @@ export class ShellWindow {
     private inlineWebContentView: WebContentsView | undefined;
     private readonly contentLoadP: Promise<void>[];
 
-    constructor(private readonly settings: ShellSettings) {
+    constructor(public readonly settings: ShellSettings) {
         const mainWindow = createMainWindow(settings);
         const chatView = createChatView(settings);
 
@@ -212,6 +212,20 @@ export class ShellWindow {
         this.settings.save();
     }
 
+    public updateSettings(settings: ShellSettings) {
+        // Save the shell configurable settings
+        this.settings.microphoneId = settings.microphoneId;
+        this.settings.microphoneName = settings.microphoneName;
+        this.settings.tts = settings.tts;
+        this.settings.ttsSettings = settings.ttsSettings;
+        this.settings.agentGreeting = settings.agentGreeting;
+        this.settings.partialCompletion = settings.partialCompletion;
+        this.settings.darkMode = settings.darkMode;
+        this.settings.chatHistory = settings.chatHistory;
+
+        // write the settings to disk
+        this.settings.save();
+    }
     public toggleTopMost() {
         this.mainWindow.setAlwaysOnTop(!this.mainWindow.isAlwaysOnTop());
     }

--- a/ts/packages/shell/src/preload/electronTypes.ts
+++ b/ts/packages/shell/src/preload/electronTypes.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { ElectronAPI } from "@electron-toolkit/preload";
 import type { ShellSettingsType } from "./shellSettingsType.js";
 import type { Dispatcher, ClientIO } from "agent-dispatcher";
 
@@ -35,60 +34,31 @@ export type ClientActions =
 
 // end duplicate type section
 
+// Functions that are called from the renderer process to the main process.
 export interface ClientAPI {
-    onListenEvent: (
-        callback: (
-            e: Electron.IpcRendererEvent,
-            name: string,
-            token?: SpeechToken,
-            useLocalWhisper?: boolean,
-        ) => void,
-    ) => void;
-    onSettingSummaryChanged(
-        callback: (
-            e: Electron.IpcRendererEvent,
-            summary: string,
-            agents: Map<string, string>,
-        ) => void,
-    ): void;
-
+    registerClient: (client: Client) => void;
     getSpeechToken: () => Promise<SpeechToken | undefined>;
     getLocalWhisperStatus: () => Promise<boolean | undefined>;
-    onSendInputText(
-        callback: (e: Electron.IpcRendererEvent, message: string) => void,
-    ): void;
-    onSendDemoEvent(
-        callback: (e: Electron.IpcRendererEvent, name: string) => void,
-    ): void;
-    onHelpRequested(
-        callback: (e: Electron.IpcRendererEvent, key: string) => void,
-    ): void;
-    onShowDialog(
-        callback: (e: Electron.IpcRendererEvent, key: string) => void,
-    ): void;
-    onSettingsChanged(
-        callback: (
-            e: Electron.IpcRendererEvent,
-            settings: ShellSettingsType,
-        ) => void,
-    ): void;
-    onChatHistory(
-        callback: (e: Electron.IpcRendererEvent, chatHistory: string) => void,
-    ): void;
-    onFileSelected(
-        callback: (
-            e: Electron.IpcRendererEvent,
-            fileName: string,
-            fileContent: string,
-        ) => void,
-    ): void;
-    registerClientIO(clientIO: ClientIO);
+    getChatHistory: () => Promise<string | undefined>;
+    saveChatHistory: (history: string) => void;
+    saveSettings: (settings: ShellSettingsType) => void;
+    openImageFile: () => void;
+}
+
+// Functions that are called from the main process to the renderer process.
+export interface Client {
+    clientIO: ClientIO;
+    updateRegisterAgents(agents: Map<string, string>): void;
+    showInputText(message: string): Promise<void>;
+    showDialog(key: string): void;
+    updateSettings(settings: ShellSettingsType): void;
+    fileSelected(fileName: string, fileContent: string): void;
+    listen(name: string, token?: SpeechToken, useLocalWhisper?: boolean): void;
 }
 
 export interface ElectronWindowFields {
     api: ClientAPI;
     dispatcher: Dispatcher;
-    electron: ElectronAPI;
 }
 
 export type ElectronWindow = typeof globalThis & ElectronWindowFields;

--- a/ts/packages/shell/src/preload/index.ts
+++ b/ts/packages/shell/src/preload/index.ts
@@ -2,65 +2,79 @@
 // Licensed under the MIT License.
 
 import { contextBridge, ipcRenderer } from "electron";
-import { electronAPI } from "@electron-toolkit/preload";
-import { ClientAPI, SpeechToken } from "./electronTypes.js"; // Custom APIs for renderer
-import { ClientIO, Dispatcher } from "agent-dispatcher";
+import { Client, ClientAPI, ShellSettingsType } from "./electronTypes.js"; // Custom APIs for renderer
+import { Dispatcher } from "agent-dispatcher";
 import { createGenericChannel } from "agent-rpc/channel";
 import { createDispatcherRpcClient } from "agent-dispatcher/rpc/dispatcher/client";
 import { createClientIORpcServer } from "agent-dispatcher/rpc/clientio/server";
 
-let clientIORegistered = false;
+ipcRenderer.on("send-demo-event", (_, name) => {
+    // bounce back to the main process
+    ipcRenderer.send("send-demo-event", name);
+});
+
+let clientRegistered = false;
+function registerClient(client: Client) {
+    if (clientRegistered) {
+        throw new Error("Client already registered");
+    }
+
+    // Establish the clientIO RPC
+    clientRegistered = true;
+    const clientIOChannel = createGenericChannel((message: any) =>
+        ipcRenderer.send("clientio-rpc-reply", message),
+    );
+    ipcRenderer.on("clientio-rpc-call", (_event, message) => {
+        clientIOChannel.message(message);
+    });
+    createClientIORpcServer(client.clientIO, clientIOChannel.channel);
+
+    ipcRenderer.on("listen-event", (_, name, token, useLocalWhisper) => {
+        client.listen(name, token, useLocalWhisper);
+    });
+    ipcRenderer.on("setting-summary-changed", (_, updatedAgents) => {
+        client.updateRegisterAgents(updatedAgents);
+    });
+    ipcRenderer.on("send-input-text", async (_, message) => {
+        await client.showInputText(message);
+        ipcRenderer.send("send-input-text-complete");
+    });
+    ipcRenderer.on("show-dialog", (_, key) => {
+        client.showDialog(key);
+    });
+    ipcRenderer.on("settings-changed", (_, value: ShellSettingsType) => {
+        client.updateSettings(value);
+    });
+    ipcRenderer.on(
+        "file-selected",
+        (_, fileName: string, fileContent: string) => {
+            client.fileSelected(fileName, fileContent);
+        },
+    );
+
+    // Signal the main process that the client has been registered
+    ipcRenderer.send("dom ready");
+}
+
 const api: ClientAPI = {
-    onListenEvent: (
-        callback: (
-            e: Electron.IpcRendererEvent,
-            name: string,
-            token?: SpeechToken,
-            useLocalWhisper?: boolean,
-        ) => void,
-    ) => ipcRenderer.on("listen-event", callback),
-    onSettingSummaryChanged(callback) {
-        ipcRenderer.on("setting-summary-changed", callback);
-    },
+    registerClient,
     getSpeechToken: () => {
         return ipcRenderer.invoke("get-speech-token");
     },
     getLocalWhisperStatus: () => {
         return ipcRenderer.invoke("get-localWhisper-status");
     },
-    onSendInputText(callback) {
-        ipcRenderer.on("send-input-text", callback);
+    openImageFile: () => {
+        ipcRenderer.send("open-image-file");
     },
-    onSendDemoEvent(callback) {
-        ipcRenderer.on("send-demo-event", callback);
+    getChatHistory: () => {
+        return ipcRenderer.invoke("get-chat-history");
     },
-    onHelpRequested(callback) {
-        ipcRenderer.on("help-requested", callback);
+    saveChatHistory: (html: string) => {
+        ipcRenderer.send("save-chat-history", html);
     },
-    onShowDialog(callback) {
-        ipcRenderer.on("show-dialog", callback);
-    },
-    onSettingsChanged(callback) {
-        ipcRenderer.on("settings-changed", callback);
-    },
-    onChatHistory(callback) {
-        ipcRenderer.on("chat-history", callback);
-    },
-    onFileSelected(callback) {
-        ipcRenderer.on("file-selected", callback);
-    },
-    registerClientIO: (clientIO: ClientIO) => {
-        if (clientIORegistered) {
-            throw new Error("ClientIO already registered");
-        }
-        clientIORegistered = true;
-        const clientIOChannel = createGenericChannel((message: any) =>
-            ipcRenderer.send("clientio-rpc-reply", message),
-        );
-        ipcRenderer.on("clientio-rpc-call", (_event, message) => {
-            clientIOChannel.message(message);
-        });
-        createClientIORpcServer(clientIO, clientIOChannel.channel);
+    saveSettings: (settings: ShellSettingsType) => {
+        ipcRenderer.send("save-settings", settings);
     },
 };
 
@@ -81,15 +95,12 @@ const dispatcher: Dispatcher = createDispatcherRpcClient(
 // just add to the DOM global.
 if (process.contextIsolated) {
     try {
-        contextBridge.exposeInMainWorld("electron", electronAPI);
         contextBridge.exposeInMainWorld("api", api);
         contextBridge.exposeInMainWorld("dispatcher", dispatcher);
     } catch (error) {
         console.error(error);
     }
 } else {
-    // @ts-ignore (define in dts)
-    window.electron = electronAPI;
     // @ts-ignore (define in dts)
     window.api = api;
     // @ts-ignore (define in dts)

--- a/ts/packages/shell/src/preload/main.ts
+++ b/ts/packages/shell/src/preload/main.ts
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { exposeElectronAPI } from "@electron-toolkit/preload";
+
+exposeElectronAPI();

--- a/ts/packages/shell/src/renderer/src/chatView.ts
+++ b/ts/packages/shell/src/renderer/src/chatView.ts
@@ -586,8 +586,6 @@ export class ChatView {
         });
 
         input.dispatchEvent(keyboardEvent);
-
-        (window as any).electron.ipcRenderer.send("send-input-text-complete");
     }
 
     public setMetricsVisible(visible: boolean) {

--- a/ts/packages/shell/src/renderer/src/main.ts
+++ b/ts/packages/shell/src/renderer/src/main.ts
@@ -8,6 +8,7 @@ import {
     NotifyCommands,
     SpeechToken,
     ShellSettingsType,
+    Client,
 } from "../../preload/electronTypes.js";
 import { ChatView } from "./chatView";
 import { TabView } from "./tabView";
@@ -55,6 +56,79 @@ export function getWebDispatcher(): Dispatcher {
     }
 
     return globalThis.webDispatcher;
+}
+
+async function initializeChatHistory(chatView: ChatView) {
+    const history = await getClientAPI().getChatHistory();
+    if (history === undefined) {
+        return;
+    }
+    // load the history
+    chatView.getScrollContainer().innerHTML = history;
+
+    // add the separator
+    if (history.length > 0) {
+        // don't add a separator if there's already one there
+        if (
+            !chatView
+                .getScrollContainer()
+                .children[0].classList.contains("chat-separator")
+        ) {
+            let separator: HTMLDivElement = document.createElement("div");
+            separator.classList.add("chat-separator");
+            separator.innerHTML =
+                '<div class="chat-separator-line"></div><div class="chat-separator-text">previously</div><div class="chat-separator-line"></div>';
+
+            chatView.getScrollContainer().prepend(separator);
+        }
+
+        // make all old messages "inactive" and set the context for each separator
+        let lastSeparatorText: HTMLDivElement | null;
+        for (
+            let i = 0;
+            i < chatView.getScrollContainer().children.length;
+            i++
+        ) {
+            // gray out this item
+            const div = chatView.getScrollContainer().children[i];
+            div.classList.add("history");
+
+            // is this a separator?
+            const separator = div.querySelector(".chat-separator-text");
+            if (separator != null) {
+                lastSeparatorText = div.querySelector(".chat-separator-text");
+            }
+
+            // get the timestamp for this chat bubble (if applicable)
+            const span: HTMLSpanElement | null =
+                div.querySelector(".timestring");
+
+            if (span !== null) {
+                const timeStamp: Date = new Date(span.attributes["data"].value);
+                lastSeparatorText!.innerText = getDateDifferenceDescription(
+                    new Date(),
+                    timeStamp,
+                );
+            }
+
+            // rewire up action-data click handler
+            const nameDiv = div.querySelector(".agent-name.clickable");
+            if (nameDiv != null) {
+                const messageDiv = div.querySelector(".chat-message-content");
+
+                if (messageDiv) {
+                    nameDiv.addEventListener("click", () => {
+                        swapContent(
+                            nameDiv as HTMLSpanElement,
+                            messageDiv as HTMLDivElement,
+                        );
+                    });
+                }
+            }
+
+            // TODO: wire up any other functionality (player agent?)
+        }
+    }
 }
 
 function addEvents(
@@ -196,144 +270,68 @@ function addEvents(
         },
     };
 
-    const api = getClientAPI();
-    api.registerClientIO(clientIO);
-
-    api.onListenEvent((_, name, token, useLocalWhisper) => {
-        console.log(`listen event: ${name}`);
-        if (useLocalWhisper) {
-            recognizeOnce(
-                undefined,
-                "phraseDiv",
-                "reco",
-                (message: string) => {
-                    chatView.addUserMessage(message);
-                },
-                useLocalWhisper,
-            );
-        } else {
-            if (token) {
-                setSpeechToken(token);
-                if (name === "Alt+M") {
-                    recognizeOnce(
-                        token,
-                        "phraseDiv",
-                        "reco",
-                        (message: string) => {
-                            chatView.addUserMessage(message);
-                        },
-                        useLocalWhisper,
-                    );
-                }
-            } else {
-                console.log("no token");
+    const client: Client = {
+        clientIO,
+        updateRegisterAgents(updatedAgents: Map<string, string>): void {
+            agents.clear();
+            for (const [key, value] of updatedAgents.entries()) {
+                agents.set(key, value);
             }
-        }
-    });
-    api.onSettingSummaryChanged((_, __, registeredAgents) => {
-        agents.clear();
-        for (let key of registeredAgents.keys()) {
-            agents.set(key, registeredAgents.get(key) as string);
-        }
-    });
-    api.onSendInputText((_, message) => {
-        chatView.showInputText(message);
-    });
-    api.onSendDemoEvent((_, name) => {
-        (window as any).electron.ipcRenderer.send("send-demo-event", name);
-    });
-    api.onHelpRequested((_, key) => {
-        console.log(`User asked for help via ${key}`);
-        chatView.addUserMessage(`@help`);
-    });
-    api.onShowDialog((_, key) => {
-        if (key.toLocaleLowerCase() == "settings") {
+        },
+        async showInputText(message: string): Promise<void> {
+            return chatView.showInputText(message);
+        },
+        showDialog(key: string): void {
+            if (key.toLocaleLowerCase() == "settings") {
+                tabsView.showTab(key);
+            }
+
             tabsView.showTab(key);
-        }
-
-        tabsView.showTab(key);
-    });
-    api.onSettingsChanged((_, value: ShellSettingsType) => {
-        settingsView.shellSettings = value;
-    });
-    api.onChatHistory((_, history: string) => {
-        if (settingsView.shellSettings.chatHistory) {
-            // load the history
-            chatView.getScrollContainer().innerHTML = history;
-
-            // add the separator
-            if (history.length > 0) {
-                // don't add a separator if there's already one there
-                if (
-                    !chatView
-                        .getScrollContainer()
-                        .children[0].classList.contains("chat-separator")
-                ) {
-                    let separator: HTMLDivElement =
-                        document.createElement("div");
-                    separator.classList.add("chat-separator");
-                    separator.innerHTML =
-                        '<div class="chat-separator-line"></div><div class="chat-separator-text">previously</div><div class="chat-separator-line"></div>';
-
-                    chatView.getScrollContainer().prepend(separator);
-                }
-
-                // make all old messages "inactive" and set the context for each separator
-                let lastSeparatorText: HTMLDivElement | null;
-                for (
-                    let i = 0;
-                    i < chatView.getScrollContainer().children.length;
-                    i++
-                ) {
-                    // gray out this item
-                    const div = chatView.getScrollContainer().children[i];
-                    div.classList.add("history");
-
-                    // is this a separator?
-                    const separator = div.querySelector(".chat-separator-text");
-                    if (separator != null) {
-                        lastSeparatorText = div.querySelector(
-                            ".chat-separator-text",
+        },
+        updateSettings(settings: ShellSettingsType): void {
+            settingsView.shellSettings = settings;
+        },
+        fileSelected(fileName: string, fileContent: string): void {
+            chatView.chatInput.loadImageContent(fileName, fileContent);
+        },
+        listen(
+            name: string,
+            token?: SpeechToken,
+            useLocalWhisper?: boolean,
+        ): void {
+            console.log(`listen event: ${name}`);
+            if (useLocalWhisper) {
+                recognizeOnce(
+                    undefined,
+                    "phraseDiv",
+                    "reco",
+                    (message: string) => {
+                        chatView.addUserMessage(message);
+                    },
+                    useLocalWhisper,
+                );
+            } else {
+                if (token) {
+                    setSpeechToken(token);
+                    if (name === "Alt+M") {
+                        recognizeOnce(
+                            token,
+                            "phraseDiv",
+                            "reco",
+                            (message: string) => {
+                                chatView.addUserMessage(message);
+                            },
+                            useLocalWhisper,
                         );
                     }
-
-                    // get the timestamp for this chat bubble (if applicable)
-                    const span: HTMLSpanElement | null =
-                        div.querySelector(".timestring");
-
-                    if (span !== null) {
-                        const timeStamp: Date = new Date(
-                            span.attributes["data"].value,
-                        );
-                        lastSeparatorText!.innerText =
-                            getDateDifferenceDescription(new Date(), timeStamp);
-                    }
-
-                    // rewire up action-data click handler
-                    const nameDiv = div.querySelector(".agent-name.clickable");
-                    if (nameDiv != null) {
-                        const messageDiv = div.querySelector(
-                            ".chat-message-content",
-                        );
-
-                        if (messageDiv) {
-                            nameDiv.addEventListener("click", () => {
-                                swapContent(
-                                    nameDiv as HTMLSpanElement,
-                                    messageDiv as HTMLDivElement,
-                                );
-                            });
-                        }
-                    }
-
-                    // TODO: wire up any other functionality (player agent?)
+                } else {
+                    console.log("no token");
                 }
             }
-        }
-    });
-    api.onFileSelected((_, fileName: string, fileContent: string) => {
-        chatView.chatInput.loadImageContent(fileName, fileContent);
-    });
+        },
+    };
+
+    getClientAPI().registerClient(client);
 }
 
 function showNotifications(
@@ -433,6 +431,8 @@ document.addEventListener("DOMContentLoaded", async function () {
     };
 
     const chatView = new ChatView(idGenerator, agents);
+    initializeChatHistory(chatView);
+
     const cameraView = new CameraView((image: HTMLImageElement) => {
         // copy image
         const newImage: HTMLImageElement = document.createElement("img");
@@ -456,9 +456,7 @@ document.addEventListener("DOMContentLoaded", async function () {
     };
 
     chatView.chatInput.attachButton.onclick = () => {
-        if ((window as any).electron) {
-            (window as any).electron.ipcRenderer.send("open-image-file");
-        }
+        getClientAPI().openImageFile();
     };
 
     const settingsView = new SettingsView(chatView);
@@ -497,10 +495,6 @@ document.addEventListener("DOMContentLoaded", async function () {
     }
 
     watchForDOMChanges(chatView.getScrollContainer());
-
-    if ((window as any).electron) {
-        (window as any).electron.ipcRenderer.send("dom ready");
-    }
 });
 
 function watchForDOMChanges(element: HTMLDivElement) {
@@ -519,12 +513,7 @@ function watchForDOMChanges(element: HTMLDivElement) {
         setTimeout(() => {
             if (--idleCounter == 0) {
                 // last one notifies main process
-                if ((window as any).electron) {
-                    (window as any).electron.ipcRenderer.send(
-                        "dom changed",
-                        element.innerHTML,
-                    );
-                }
+                getClientAPI().saveChatHistory(element.innerHTML);
             }
         }, 3000);
     });

--- a/ts/packages/shell/src/renderer/src/settingsView.ts
+++ b/ts/packages/shell/src/renderer/src/settingsView.ts
@@ -10,6 +10,7 @@ import { ChatView } from "./chatView.js";
 import { getTTS, getTTSProviders, getTTSVoices } from "./tts/tts.js";
 import { iconMoon, iconSun } from "./icon.js";
 import { DisplayType } from "@typeagent/agent-sdk";
+import { getClientAPI } from "./main";
 
 function addOption(
     select: HTMLSelectElement,
@@ -377,10 +378,7 @@ export class SettingsView {
     }
 
     private saveSettings() {
-        (window as any).electron.ipcRenderer.send(
-            "save-settings",
-            this.shellSettings,
-        );
+        getClientAPI().saveSettings(this.shellSettings);
     }
 
     public isDisplayTypeAllowed(displayType: DisplayType): boolean {


### PR DESCRIPTION
- Instead of register handler for each main->renderer call individually, set it up with one "register call" in the reload script.
- Refer to settings in the shellWindow instead of getting it thru ShellSettings.getinstance() when possible.
- Fix greeting agent that if the call the Azure CLI failed to get the current user name, it should still resolve the promise.
- Change the chat history from pushing from main to render, to instead have the render call the main process to get the history.
- The full electronAPI is no longer exposed in the chat view.
