### PR TITLE
Reduce dependency of session

### DIFF
--- a/ts/packages/dispatcher/src/context/appAgentManager.ts
+++ b/ts/packages/dispatcher/src/context/appAgentManager.ts
@@ -30,6 +30,7 @@ import {
 import { ActionSchemaFileCache } from "../translation/actionSchemaFileCache.js";
 import path from "path";
 import { callEnsureError } from "../utils/exceptions.js";
+import { AppAgentStateConfig, appAgentStateKeys } from "./appAgentStateConfig.js";
 
 const debug = registerDebug("typeagent:dispatcher:agents");
 const debugError = registerDebug("typeagent:dispatcher:agents:error");
@@ -47,14 +48,6 @@ type AppAgentRecord = {
     sessionContextP?: Promise<SessionContext> | undefined;
     schemaErrors: Map<string, Error>;
 };
-
-export type AppAgentStateConfig = {
-    schemas: Record<string, boolean>;
-    actions: Record<string, boolean>;
-    commands: Record<string, boolean>;
-};
-
-export const appAgentStateKeys = ["schemas", "actions", "commands"] as const;
 
 export type AppAgentStateSettings = Partial<AppAgentStateConfig>;
 

--- a/ts/packages/dispatcher/src/context/appAgentManager.ts
+++ b/ts/packages/dispatcher/src/context/appAgentManager.ts
@@ -30,7 +30,10 @@ import {
 import { ActionSchemaFileCache } from "../translation/actionSchemaFileCache.js";
 import path from "path";
 import { callEnsureError } from "../utils/exceptions.js";
-import { AppAgentStateConfig, appAgentStateKeys } from "./appAgentStateConfig.js";
+import {
+    AppAgentStateConfig,
+    appAgentStateKeys,
+} from "./appAgentStateConfig.js";
 
 const debug = registerDebug("typeagent:dispatcher:agents");
 const debugError = registerDebug("typeagent:dispatcher:agents:error");

--- a/ts/packages/dispatcher/src/context/appAgentStateConfig.ts
+++ b/ts/packages/dispatcher/src/context/appAgentStateConfig.ts
@@ -1,0 +1,10 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+export type AppAgentStateConfig = {
+    schemas: Record<string, boolean>;
+    actions: Record<string, boolean>;
+    commands: Record<string, boolean>;
+};
+
+export const appAgentStateKeys = ["schemas", "actions", "commands"] as const;

--- a/ts/packages/dispatcher/src/context/session.ts
+++ b/ts/packages/dispatcher/src/context/session.ts
@@ -11,7 +11,10 @@ import fs from "node:fs";
 import path from "node:path";
 import { getUniqueFileName, getYMDPrefix } from "../utils/fsUtils.js";
 import ExifReader from "exifreader";
-import { AppAgentStateConfig, appAgentStateKeys } from "./appAgentManager.js";
+import {
+    AppAgentStateConfig,
+    appAgentStateKeys,
+} from "./appAgentStateConfig.js";
 import {
     cloneConfig,
     isEmptySettings,

--- a/ts/packages/dispatcher/src/context/system/handlers/sessionCommandHandlers.ts
+++ b/ts/packages/dispatcher/src/context/system/handlers/sessionCommandHandlers.ts
@@ -28,7 +28,7 @@ import {
     displayWarn,
 } from "@typeagent/agent-sdk/helpers/display";
 import { askYesNoWithContext } from "../../interactiveIO.js";
-import { appAgentStateKeys } from "../../appAgentManager.js";
+import { appAgentStateKeys } from "../../appAgentStateConfig.js";
 
 class SessionNewCommandHandler implements CommandHandler {
     public readonly description = "Create a new empty session";


### PR DESCRIPTION
Avoid session.ts depending on the full appAgentManager.ts (which pulls in @azure/msal-node-extensions which require libsecret).