### PR TITLE
Agent process inherit trace settings

### DIFF
--- a/ts/packages/agentRpc/src/client.ts
+++ b/ts/packages/agentRpc/src/client.ts
@@ -77,7 +77,7 @@ export async function createAgentRpcClient(
     name: string,
     channelProvider: ChannelProvider,
 ) {
-    const channel = channelProvider.createChannel(name);
+    const channel = channelProvider.createChannel(`agent:${name}`);
     const agentInterface = await new Promise<(keyof AgentInvokeFunctions)[]>(
         (resolve, reject) => {
             channel.once("message", (message: any) => {

--- a/ts/packages/agentRpc/src/common.ts
+++ b/ts/packages/agentRpc/src/common.ts
@@ -34,7 +34,7 @@ type ChannelData = {
 };
 
 export type ChannelProvider = {
-    createChannel(name: string): RpcChannel;
+    createChannel<T = any>(name: string): RpcChannel<T>;
     deleteChannel(name: string): void;
 };
 export type GenericChannelProvider = ChannelProvider & {

--- a/ts/packages/agentRpc/src/server.ts
+++ b/ts/packages/agentRpc/src/server.ts
@@ -39,7 +39,7 @@ export function createAgentRpcServer(
     agent: AppAgent,
     channelProvider: ChannelProvider,
 ) {
-    const channel = channelProvider.createChannel(name);
+    const channel = channelProvider.createChannel(`agent:${name}`);
     const agentInvokeHandlers: AgentInvokeFunctions = {
         async initializeAgentContext(): Promise<unknown> {
             if (agent.initializeAgentContext === undefined) {

--- a/ts/packages/agents/desktop/src/actionHandler.ts
+++ b/ts/packages/agents/desktop/src/actionHandler.ts
@@ -1,7 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { ActionContext, AppAction, SessionContext } from "@typeagent/agent-sdk";
+import {
+    ActionContext,
+    AppAction,
+    AppAgent,
+    SessionContext,
+} from "@typeagent/agent-sdk";
 import { createActionResult } from "@typeagent/agent-sdk/helpers/action";
 import {
     disableDesktopActionContext,
@@ -10,7 +15,7 @@ import {
     setupDesktopActionContext,
 } from "./connector.js";
 import { DesktopActions } from "./actionsSchema.js";
-export function instantiate() {
+export function instantiate(): AppAgent {
     return {
         initializeAgentContext: initializeDesktopContext,
         updateAgentContext: updateDesktopContext,
@@ -18,7 +23,7 @@ export function instantiate() {
     };
 }
 
-function initializeDesktopContext(): DesktopActionContext {
+async function initializeDesktopContext(): Promise<DesktopActionContext> {
     return {
         desktopProcess: undefined,
         programNameIndex: undefined,

--- a/ts/packages/dispatcher/src/agentProvider/agentProvider.ts
+++ b/ts/packages/dispatcher/src/agentProvider/agentProvider.ts
@@ -8,6 +8,7 @@ export interface AppAgentProvider {
     getAppAgentManifest(appAgentName: string): Promise<AppAgentManifest>;
     loadAppAgent(appAgentName: string): Promise<AppAgent>;
     unloadAppAgent(appAgentName: string): Promise<void>;
+    setTraceNamespaces?(namespaces: string): void;
 }
 
 export interface AppAgentInstaller {

--- a/ts/packages/dispatcher/src/agentProvider/npmAgentProvider.ts
+++ b/ts/packages/dispatcher/src/agentProvider/npmAgentProvider.ts
@@ -75,7 +75,6 @@ async function loadModuleAgent(
     }
     return {
         appAgent: module.instantiate(),
-        process: undefined,
         count: 1,
     };
 }
@@ -130,6 +129,11 @@ export function createNpmAppAgentProvider(
             if (--agent.count === 0) {
                 agent.process?.kill();
                 moduleAgents.delete(appAgentName);
+            }
+        },
+        setTraceNamespaces(namespaces: string) {
+            for (const agent of moduleAgents.values()) {
+                agent.trace?.(namespaces);
             }
         },
     };

--- a/ts/packages/dispatcher/src/agentProvider/process/agentProcess.ts
+++ b/ts/packages/dispatcher/src/agentProvider/process/agentProcess.ts
@@ -1,16 +1,44 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { AppAgent } from "@typeagent/agent-sdk";
-
 import registerDebug from "debug";
+import { AppAgent } from "@typeagent/agent-sdk";
 import { createAgentRpcServer } from "agent-rpc/server";
 import { createChannelProvider } from "agent-rpc/channel";
+import { createRequire } from "node:module";
 
-const debug = registerDebug("typeagent:dispatcher:agentProcess");
-
+//=================================================================
+// Get arguments from command line
+//=================================================================
 const agentName = process.argv[2];
 const modulePath = process.argv[3];
+
+//=================================================================
+// Create debug trace object
+//=================================================================
+const debug = registerDebug(`typeagent:dispatcher:agentProcess:${agentName}`);
+
+//=================================================================
+// Check and setup process
+//=================================================================
+function isIPCProcess(
+    process: NodeJS.Process,
+): process is NodeJS.Process & { send: (message: any) => void } {
+    return typeof process.send === "function";
+}
+
+if (!isIPCProcess(process)) {
+    throw new Error("No IPC channel to parent process");
+}
+
+process.on("disconnect", () => {
+    debug(`Parent process disconnected, exiting '${agentName}': ${modulePath}`);
+    process.exit(-1);
+});
+
+//=================================================================
+// Load the module.
+//=================================================================
 const module = await import(modulePath);
 if (typeof module.instantiate !== "function") {
     throw new Error(
@@ -18,20 +46,41 @@ if (typeof module.instantiate !== "function") {
     );
 }
 
+//=================================================================
+// Instantiate agent and  Create agent RPC server
+//=================================================================
 const agent: AppAgent = module.instantiate();
+const channelProvider = createChannelProvider(process);
+createAgentRpcServer(agentName, agent, channelProvider);
 
-if (process.send === undefined) {
-    throw new Error("No IPC channel to parent process");
+//=================================================================
+// Set up debug trace coordination
+//=================================================================
+async function getAgentDebug(): Promise<typeof registerDebug | undefined> {
+    try {
+        // get the "debug" package from the module.
+        const require = createRequire(modulePath);
+        const debugPath = require.resolve("debug");
+        const agentDebug = (await import(debugPath)).default;
+        if (agentDebug === registerDebug) {
+            return undefined;
+        }
+        debug(`'${agentName}': Agent debug trace loaded. ${debugPath}`);
+        return agentDebug;
+    } catch {
+        return undefined;
+    }
 }
 
-const checkedProcess = process as NodeJS.Process & {
-    send: (message: any) => void;
-};
-
-createAgentRpcServer(agentName, agent, createChannelProvider(checkedProcess));
-
-debug(`${agentName} agent process started: ${modulePath}`);
-process.on("disconnect", () => {
-    debug(`Parent process disconnected, exiting '${agentName}': ${modulePath}`);
-    process.exit(-1);
+const agentDebug = await getAgentDebug();
+const traceChannel = channelProvider.createChannel<string>("trace");
+traceChannel.on("message", (message) => {
+    registerDebug.enable(message);
+    agentDebug?.enable(message);
+    debug(`'${agentName}': Trace settings:  ${message}`);
 });
+
+//=================================================================
+// Done
+//=================================================================
+debug(`${agentName} agent process started: ${modulePath}`);

--- a/ts/packages/dispatcher/src/context/appAgentManager.ts
+++ b/ts/packages/dispatcher/src/context/appAgentManager.ts
@@ -667,6 +667,17 @@ export class AppAgentManager implements ActionConfigProvider {
     ): ActionSchemaFile {
         return this.actionSchemaFileCache.getActionSchemaFile(config);
     }
+
+    public setTraceNamespaces(namespaces: string) {
+        const providers = new Set<AppAgentProvider>();
+        for (const { provider } of this.agents.values()) {
+            if (provider === undefined || providers.has(provider)) {
+                continue;
+            }
+            provider.setTraceNamespaces?.(namespaces);
+            providers.add(provider);
+        }
+    }
 }
 
 export type AppAgentStateInitSettings =

--- a/ts/packages/dispatcher/src/context/system/handlers/traceCommandHandler.ts
+++ b/ts/packages/dispatcher/src/context/system/handlers/traceCommandHandler.ts
@@ -52,19 +52,30 @@ export class TraceCommandHandler implements CommandHandler {
         context: ActionContext<CommandHandlerContext>,
         params: ParsedCommandParams<typeof this.parameters>,
     ) {
+        // Disable the trace namespaces to get the current settings
         let settings = registerDebug.disable();
         if (params.flags.clear) {
             settings = "";
             displaySuccess("All trace namespaces cleared", context);
         }
         if (params.args.namespaces !== undefined) {
+            // Modify the trace namespaces
             settings = (
                 settings
                     ? [settings, ...params.args.namespaces]
                     : params.args.namespaces
             ).join(",");
-            registerDebug.enable(settings);
+
+            // For new processes, set the DEBUG environment variable
+            process.env.DEBUG = settings;
+
+            context.sessionContext.agentContext.agents.setTraceNamespaces(
+                settings,
+            );
         }
+
+        // Reenable the trace namespaces
+        registerDebug.enable(settings);
 
         displaySuccess(`Current trace settings: ${settings}`, context);
     }


### PR DESCRIPTION
When trace settings are modified using `@trace` command, make sure the agent processes are updated as well.