### PR TITLE
Enable crossword interactions while schema initialization is running

### DIFF
--- a/ts/packages/agents/browser/src/agent/actionHandler.mts
+++ b/ts/packages/agents/browser/src/agent/actionHandler.mts
@@ -128,6 +128,7 @@ async function updateBrowserContext(
                                 );
                                 context.agentContext.crossWordState =
                                     await getBoardSchema(context);
+
                                 sendSiteTranslatorStatus(
                                     targetTranslator,
                                     "initialized",

--- a/ts/packages/agents/browser/src/agent/crossword/schema/pageComponents.mts
+++ b/ts/packages/agents/browser/src/agent/crossword/schema/pageComponents.mts
@@ -1,0 +1,10 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+export type CrosswordClue = {
+    number: number;
+    text: string;
+    // The CSS Selector for the HTML element that holds the clue
+    // Construct the selector based on the element's Id attribute if the id is present.
+    cssSelector?: string;
+};


### PR DESCRIPTION
- If schema initialization is still running, run user actions using a slow path, where we pass the HTML to LLM and ask for the relevant clue element.