### PR TITLE
Fixes

### DIFF
--- a/ts/packages/commonUtils/test/objectProperties.spec.ts
+++ b/ts/packages/commonUtils/test/objectProperties.spec.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { getObjectProperty } from "../src/objectProperty.js";
+import { getObjectProperty, setObjectProperty } from "../src/objectProperty.js";
 describe("getObjectProperty", () => {
     it("should return obj itself for empty string", () => {
         const obj = { a: 1, b: 2 };
@@ -72,5 +72,95 @@ describe("getObjectProperty", () => {
         expect(() => getObjectProperty(obj, "prototype")).toThrow(
             "Invalid property name: prototype",
         );
+    });
+    it("should return undefined for index on an object", () => {
+        const obj = { a: { b: 1 } };
+        expect(getObjectProperty(obj, "a.0")).toBeUndefined();
+    });
+    it("should return undefined for property on array", () => {
+        const obj = { a: [0] };
+        expect(getObjectProperty(obj, "a.b")).toBeUndefined();
+    });
+});
+
+describe("setObjectProperty", () => {
+    it("should set a property on an object", () => {
+        const obj: any = {};
+        setObjectProperty({ obj }, "obj", "a", 1);
+        expect(obj.a).toBe(1);
+    });
+    it("should set a property on a nested object", () => {
+        const obj: any = { a: {} };
+        setObjectProperty({ obj }, "obj", "a.b", 2);
+        expect(obj.a.b).toBe(2);
+    });
+    it("should set a property on an array", () => {
+        const obj: any = { a: [] };
+        setObjectProperty({ obj }, "obj", "a.0", 3);
+        expect(obj.a[0]).toBe(3);
+    });
+    it("should set a property on a nested array", () => {
+        const obj: any = { a: [[], []] };
+        setObjectProperty({ obj }, "obj", "a.0.0", 4);
+        expect(obj.a[0][0]).toBe(4);
+    });
+    it("should set a property on an empty object", () => {
+        const obj: any = {};
+        setObjectProperty({ obj }, "obj", "a", 5);
+        expect(obj.a).toBe(5);
+    });
+    it("should set a property on an empty array", () => {
+        const obj: any = [];
+        setObjectProperty({ obj }, "obj", "0", 6);
+        expect(obj[0]).toBe(6);
+    });
+    it("should throw a property on a null value", () => {
+        const obj: any = { a: null };
+        expect(() => setObjectProperty({ obj }, "obj", "a.b", 7)).toThrow(
+            "Cannot set property 'b' on null property 'a'",
+        );
+    });
+    it("should set a property on an undefined value", () => {
+        const obj: any = { a: undefined };
+        setObjectProperty({ obj }, "obj", "a.b", 8);
+        expect(obj.a).toEqual({ b: 8 });
+    });
+    it("should throw on invalid property names", () => {
+        const obj: any = { a: 1, b: 2 };
+        expect(() => setObjectProperty({ obj }, "obj", "__proto__", 9)).toThrow(
+            "Invalid property name: __proto__",
+        );
+        expect(() =>
+            setObjectProperty({ obj }, "obj", "constructor", 10),
+        ).toThrow("Invalid property name: constructor");
+        expect(() =>
+            setObjectProperty({ obj }, "obj", "prototype", 11),
+        ).toThrow("Invalid property name: prototype");
+    });
+    it("should throw setting index on root object", () => {
+        const obj: any = { a: 1, b: 2 };
+        expect(() => setObjectProperty({ obj }, "obj", "0", 12)).toThrow(
+            "Cannot set index '0' on object property 'obj'",
+        );
+    });
+    it("should throw setting property on root array", () => {
+        const obj: any = [1, 2];
+        expect(() => setObjectProperty({ obj }, "obj", "a", 13)).toThrow(
+            "Cannot set property 'a' on array property 'obj'",
+        );
+    });
+    it("should override setting index on object", () => {
+        const obj: any = { a: 1, b: 2 };
+        const data = { obj };
+        setObjectProperty(data, "obj", "0", 12, true);
+        expect(Array.isArray(data.obj)).toBe(true);
+        expect(data.obj[0]).toBe(12);
+    });
+    it("should override setting property on array", () => {
+        const obj: any = [1, 2];
+        const data = { obj };
+        setObjectProperty(data, "obj", "a", 13, true);
+        expect(Array.isArray(data.obj)).toBe(false);
+        expect(data.obj.a).toBe(13);
     });
 });

--- a/ts/packages/defaultAgentProvider/test/data/translate-e2e.json
+++ b/ts/packages/defaultAgentProvider/test/data/translate-e2e.json
@@ -75,5 +75,29 @@
       "dispatcher.lookup.lookupAndAnswer",
       "dispatcher.pendingRequestAction"
     ]
-  }
+  },
+  [
+    {
+      "request": "add ham to the list",
+      "action": "dispatcher.clarify.clarifyMissingParameter",
+      "history": {
+        "text": "Which list would you like to add ham to?",
+        "source": "list",
+        "additionalInstructions": [
+          "Asked the user to clarify the request 'add ham to the list'"
+        ]
+      }
+    },
+    {
+      "request": "grocery",
+      "action": {
+        "translatorName": "list",
+        "actionName": "addItems",
+        "parameters": {
+          "items": ["ham"],
+          "listName": "grocery"
+        }
+      }
+    }
+  ]
 ]

--- a/ts/packages/dispatcher/src/context/commandHandlerContext.ts
+++ b/ts/packages/dispatcher/src/context/commandHandlerContext.ts
@@ -358,15 +358,6 @@ export async function initializeCommandHandlerContext(
         }
         const sessionDirPath = session.getSessionDirPath();
         debug(`Session directory: ${sessionDirPath}`);
-        const conversationManager = sessionDirPath
-            ? await Conversation.createConversationManager(
-                  {},
-                  "conversation",
-                  sessionDirPath,
-                  false,
-              )
-            : undefined;
-
         const clientIO = options?.clientIO ?? nullClientIO;
         const loggerSink = getLoggerSink(() => context.dblogging, clientIO);
         const logger = new ChildLogger(loggerSink, DispatcherName, {
@@ -398,7 +389,8 @@ export async function initializeCommandHandlerContext(
             persistDir,
             cacheDir,
             embeddingCacheDir,
-            conversationManager,
+            conversationManager:
+                await createConversationManager(sessionDirPath),
             explanationAsynchronousMode,
             dblogging: options?.dblogging ?? false,
             clientIO,
@@ -535,12 +527,28 @@ export async function closeCommandHandlerContext(
     }
 }
 
+async function createConversationManager(
+    sessionDirPath: string | undefined,
+): Promise<Conversation.ConversationManager | undefined> {
+    return sessionDirPath
+        ? await Conversation.createConversationManager(
+              {},
+              "conversation",
+              sessionDirPath,
+              false,
+          )
+        : undefined;
+}
 export async function setSessionOnCommandHandlerContext(
     context: CommandHandlerContext,
     session: Session,
 ) {
     context.session = session;
     await context.agents.close();
+
+    context.conversationManager = await createConversationManager(
+        session.getSessionDirPath(),
+    );
     context.agentCache = await getAgentCache(
         context.session,
         context.agents,

--- a/ts/packages/dispatcher/src/context/dispatcher/dispatcherAgent.ts
+++ b/ts/packages/dispatcher/src/context/dispatcher/dispatcherAgent.ts
@@ -151,7 +151,6 @@ async function clarifyWithLookup(
 
     const actionConfigs = [
         agents.getActionConfig("dispatcher.lookup"),
-        agents.getActionConfig("dispatcher.clarify"),
         agents.getActionConfig("dispatcher"),
     ];
     // TODO: cache this?

--- a/ts/packages/dispatcher/src/context/system/handlers/historyCommandHandler.ts
+++ b/ts/packages/dispatcher/src/context/system/handlers/historyCommandHandler.ts
@@ -85,6 +85,7 @@ type ChatHistoryInputAssistant = {
     text: string;
     source: string;
     entities?: Entity[];
+    additionalInstructions?: string[];
 };
 export type ChatHistoryInput = {
     user: string;
@@ -100,6 +101,7 @@ function convertAssistantMessage(
         text: message.text,
         sourceAppAgentName: message.source,
         entities: message.entities,
+        additionalInstructions: message.additionalInstructions,
     });
 }
 
@@ -143,6 +145,7 @@ const assistantInputSchema = sc.obj({
             }),
         ),
     ),
+    additionalInstructions: sc.optional(sc.array(sc.string())),
 });
 
 const messageInputSchema = sc.obj({

--- a/ts/packages/dispatcher/src/search/search.ts
+++ b/ts/packages/dispatcher/src/search/search.ts
@@ -1,18 +1,26 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { createActionResult } from "@typeagent/agent-sdk/helpers/action";
+import {
+    createActionResult,
+    createActionResultFromError,
+} from "@typeagent/agent-sdk/helpers/action";
 import { CommandHandlerContext } from "../context/commandHandlerContext.js";
 import { LookupAndAnswerAction } from "../context/dispatcher/schema/lookupActionSchema.js";
 import { ActionContext, ActionResult, Entity } from "@typeagent/agent-sdk";
 import { conversation } from "knowledge-processor";
 import { getLookupSettings, handleLookup } from "./internet.js";
+import registerDebug from "debug";
+
+const debug = registerDebug("typeagent:dispatcher:lookup");
+const debugError = registerDebug("typeagent:dispatcher:lookup:error");
 
 export async function lookupAndAnswer(
     lookupAction: LookupAndAnswerAction,
     context: ActionContext<CommandHandlerContext>,
 ): Promise<ActionResult> {
-    switch (lookupAction.parameters.lookup.source) {
+    const source = lookupAction.parameters.lookup.source;
+    switch (source) {
         case "internet":
             const { question, lookup } = lookupAction.parameters;
             return handleLookup(
@@ -26,70 +34,61 @@ export async function lookupAndAnswer(
             const conversationManager: conversation.ConversationManager = (
                 context.sessionContext as any
             ).conversationManager;
-            if (conversationManager !== undefined) {
-                let searchResponse =
-                    await conversationManager.getSearchResponse(
-                        lookupAction.parameters.question,
-                        lookupAction.parameters.lookup
-                            .conversationLookupFilters,
-                    );
-                if (searchResponse) {
-                    searchResponse.response?.hasHits()
-                        ? console.log(
-                              `Search response has ${searchResponse.response?.messages?.length} hits`,
-                          )
-                        : console.log("No search hits");
-
-                    const matches =
-                        await conversationManager.generateAnswerForSearchResponse(
-                            lookupAction.parameters.question,
-                            searchResponse,
-                        );
-                    if (
-                        matches &&
-                        matches.response &&
-                        matches.response.answer
-                    ) {
-                        console.log("CONVERSATION MEMORY MATCHES:");
-                        conversation.log.logSearchResponse(matches.response);
-
-                        if (matches.response.answer.whyNoAnswer) {
-                            console.log(
-                                "No Answer: " +
-                                    matches.response.answer.whyNoAnswer,
-                            );
-                            return createActionResult(
-                                "Not Answered - " +
-                                    matches.response.answer.whyNoAnswer,
-                                undefined,
-                                matchedEntities(matches.response),
-                            );
-                        } else {
-                            console.log(
-                                "Answer: " +
-                                    matches.response.answer.answer
-                                        ?.replace("\n", "")
-                                        .substring(0, 100) +
-                                    "...",
-                            );
-                            return createActionResult(
-                                matches.response.answer.answer!,
-                                undefined,
-                                matchedEntities(matches.response),
-                            );
-                        }
-                    } else {
-                        console.log("bug bug");
-                        return createActionResult(
-                            "I don't know anything about that.",
-                        );
-                    }
-                }
-            } else {
-                console.log("Conversation manager is undefined!");
+            if (conversationManager === undefined) {
+                throw new Error("Conversation manager is undefined!");
             }
+            let searchResponse = await conversationManager.getSearchResponse(
+                lookupAction.parameters.question,
+                lookupAction.parameters.lookup.conversationLookupFilters,
+            );
+            if (searchResponse === undefined) {
+                throw new Error("Search response is undefined!");
+            }
+
+            if (debug.enabled) {
+                searchResponse.response?.hasHits()
+                    ? debug(
+                          `Search response has ${searchResponse.response?.messages?.length} hits`,
+                      )
+                    : debug("No search hits");
+            }
+            const matches =
+                await conversationManager.generateAnswerForSearchResponse(
+                    lookupAction.parameters.question,
+                    searchResponse,
+                );
+            if (matches && matches.response && matches.response.answer) {
+                console.log("CONVERSATION MEMORY MATCHES:");
+                conversation.log.logSearchResponse(matches.response);
+
+                const whyNoAnswer = matches.response.answer.whyNoAnswer;
+                if (whyNoAnswer) {
+                    debugError(`No Answer: ${whyNoAnswer}`);
+                    return createActionResultFromError(
+                        `Not Answered - ${whyNoAnswer}`,
+                    );
+                } else {
+                    debug(
+                        "Answer: " +
+                            matches.response.answer.answer
+                                ?.replace("\n", "")
+                                .substring(0, 100) +
+                            "...",
+                    );
+                    return createActionResult(
+                        matches.response.answer.answer!,
+                        undefined,
+                        matchedEntities(matches.response),
+                    );
+                }
+            }
+            debugError("bug bug");
+            return createActionResultFromError(
+                "I don't know anything about that.",
+            );
+        default:
+            throw new Error(`Unknown lookup source: ${source}`);
     }
-    return createActionResult("No information found");
 }
 
 function matchedEntities(response: conversation.SearchResponse): Entity[] {

--- a/ts/packages/dispatcher/src/translation/actionSchemaJsonTranslator.ts
+++ b/ts/packages/dispatcher/src/translation/actionSchemaJsonTranslator.ts
@@ -61,7 +61,9 @@ export function createActionSchemaJsonValidator<T extends TranslatedAction>(
         : generateJsonSchema
           ? generateActionJsonSchema(actionSchemaGroup)
           : undefined;
-    const jsonSchemaValidate = generateOptions?.jsonSchemaValidate ?? false;
+    const schemaValidate =
+        jsonSchema === undefined ||
+        (generateOptions?.jsonSchemaValidate ?? false);
     return {
         getSchemaText: () => schema,
         getTypeName: () => actionSchemaGroup.entry.name,
@@ -84,7 +86,7 @@ export function createActionSchemaJsonValidator<T extends TranslatedAction>(
                     return error(`Unknown action name: ${value.actionName}`);
                 }
 
-                if (jsonSchemaValidate) {
+                if (schemaValidate) {
                     validateAction(actionSchema, value);
                 }
                 // Return the unwrapped value with generateJsonSchema as the translated result


### PR DESCRIPTION
- Make sure conversation manager is recreated when we change the session.
- If implicit look up on missing parameter clarification failed to find the answer, just directly ask the user instead of retranslation (and get into infinite loop)
- Make sure we validate when generationOptions is not passed intn for the implicit look up on missing parameter clarification

Testing:
- Add clarification test case
- Allow `additionalInstruction` in `@history insert` command
- Add testing for `setObjectProperty` and fix some corner cases.