### PR TITLE
Fix test instability

### DIFF
--- a/ts/packages/memory/storage/src/fileSystem.ts
+++ b/ts/packages/memory/storage/src/fileSystem.ts
@@ -12,7 +12,7 @@ export function removeFile(filePath: string): boolean {
 
 export function ensureDir(folderPath: string): string {
     if (!fs.existsSync(folderPath)) {
-        fs.promises.mkdir(folderPath, { recursive: true });
+        fs.mkdirSync(folderPath, { recursive: true });
     }
     return folderPath;
 }


### PR DESCRIPTION
Get occasional failure in `sqliteCommon.ts` createDatabase function in test complaining unable to create database because the path doesn't exist.  That's because in `ensureDir`, it calls the promise version of `mkdir` without await.  So it doesn't guarantee that the directory is actually created before it returns.   Switch to the `sync` version