### PR TITLE
Shell remove duplicate dev tool handler

### DIFF
--- a/ts/packages/shell/package.json
+++ b/ts/packages/shell/package.json
@@ -1,6 +1,5 @@
 {
   "name": "agent-shell",
-  "productName": "TypeAgent Shell",
   "version": "0.0.1",
   "description": "TypeAgent Shell",
   "homepage": "https://github.com/microsoft/TypeAgent#readme",

--- a/ts/packages/shell/package.json
+++ b/ts/packages/shell/package.json
@@ -44,7 +44,6 @@
     "@azure/identity": "^4.2.1",
     "@azure/msal-node-extensions": "^1.5.0",
     "@electron-toolkit/preload": "^3.0.2",
-    "@electron-toolkit/utils": "^4.0.0",
     "@fontsource/lato": "^5.2.5",
     "@typeagent/agent-sdk": "workspace:*",
     "agent-dispatcher": "workspace:*",

--- a/ts/packages/shell/package.json
+++ b/ts/packages/shell/package.json
@@ -1,5 +1,6 @@
 {
   "name": "agent-shell",
+  "productName": "TypeAgent Shell",
   "version": "0.0.1",
   "description": "TypeAgent Shell",
   "homepage": "https://github.com/microsoft/TypeAgent#readme",

--- a/ts/packages/shell/src/main/args.ts
+++ b/ts/packages/shell/src/main/args.ts
@@ -5,19 +5,28 @@ import { debugShell } from "./debug.js";
 
 type ShellCommandLineArgs = {
     reset: boolean;
+    clean: boolean;
+    prod?: boolean;
     update?: string;
+    data?: string;
     env?: string;
 };
 
 export function parseShellCommandLine() {
     const result: ShellCommandLineArgs = {
         reset: false,
+        clean: false,
     };
     for (let i = 0; i < process.argv.length; i++) {
         const arg = process.argv[i];
         if (arg.startsWith("--")) {
             if (arg === "--reset") {
                 result.reset = true;
+                continue;
+            }
+
+            if (arg === "--clean") {
+                result.clean = true;
                 continue;
             }
 
@@ -38,6 +47,26 @@ export function parseShellCommandLine() {
                 } else {
                     debugShell("Missing value for --update argument");
                 }
+                continue;
+            }
+
+            if (arg === "--data") {
+                i++;
+                if (i < process.argv.length) {
+                    result.data = process.argv[i];
+                } else {
+                    debugShell("Missing value for --dir argument");
+                }
+                continue;
+            }
+
+            if (arg === "--prod") {
+                result.prod = true;
+                continue;
+            }
+
+            if (arg === "--dev") {
+                result.prod = false;
                 continue;
             }
         }

--- a/ts/packages/shell/src/main/commands/update.ts
+++ b/ts/packages/shell/src/main/commands/update.ts
@@ -19,6 +19,7 @@ import {
 } from "@typeagent/agent-sdk/helpers/display";
 import registerDebug from "debug";
 import { getElapsedString } from "common-utils";
+import { isProd } from "../index.js";
 
 const { autoUpdater } = electronUpdater;
 
@@ -150,7 +151,7 @@ export function startBackgroundUpdateCheck(
     };
 
     const schedule = (intervalMs: number) => {
-        if (app.isPackaged && intervalMs < minIntervalMs) {
+        if (isProd && intervalMs < minIntervalMs) {
             // Guard against too small intervals unless we are in dev build.
             debugBackgroundUpdateError(
                 `Interval too small.  Minimum is ${getElapsedString(minIntervalMs)}`,

--- a/ts/packages/shell/src/main/shellWindow.ts
+++ b/ts/packages/shell/src/main/shellWindow.ts
@@ -11,7 +11,6 @@ import {
     WebContentsView,
 } from "electron";
 import path from "node:path";
-import { is } from "@electron-toolkit/utils";
 import { WebSocketMessageV2 } from "common-utils";
 import { runDemo } from "./demo.js";
 import {
@@ -21,6 +20,7 @@ import {
     ShellSettingManager,
 } from "./shellSettings.js";
 import { debugShellError } from "./debug.js";
+import { isProd } from "./index.js";
 
 const userAgent =
     "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36 Edg/124.0.0.0";
@@ -90,7 +90,7 @@ export class ShellWindow {
         const contentLoadP: Promise<void>[] = [];
         // HMR for renderer base on electron-vite cli.
         // Load the remote URL for development or the local html file for production.
-        if (is.dev && process.env["ELECTRON_RENDERER_URL"]) {
+        if (!isProd && process.env["ELECTRON_RENDERER_URL"]) {
             contentLoadP.push(
                 chatView.webContents.loadURL(
                     process.env["ELECTRON_RENDERER_URL"],
@@ -170,7 +170,6 @@ export class ShellWindow {
 
     private setupWebContents(webContents: WebContents) {
         this.setupZoomHandlers(webContents);
-        setupDevToolsHandlers(webContents);
         webContents.setUserAgent(userAgent);
     }
 
@@ -606,25 +605,4 @@ function setupDevicePermissions(mainWindow: BrowserWindow) {
             return false;
         },
     );
-}
-
-function setupDevToolsHandlers(webContents: WebContents) {
-    webContents.on("before-input-event", (_event, input) => {
-        if (input.type === "keyDown") {
-            if (!is.dev) {
-                // Ignore CommandOrControl + R
-                if (input.code === "KeyR" && (input.control || input.meta))
-                    _event.preventDefault();
-            } else {
-                // Toggle devtool(F12)
-                if (input.code === "F12") {
-                    if (webContents.isDevToolsOpened()) {
-                        webContents.closeDevTools();
-                    } else {
-                        webContents.openDevTools({ mode: "undocked" });
-                    }
-                }
-            }
-        }
-    });
 }

--- a/ts/pnpm-lock.yaml
+++ b/ts/pnpm-lock.yaml
@@ -2719,9 +2719,6 @@ importers:
       '@electron-toolkit/preload':
         specifier: ^3.0.2
         version: 3.0.2(electron@35.2.2)
-      '@electron-toolkit/utils':
-        specifier: ^4.0.0
-        version: 4.0.0(electron@35.2.2)
       '@fontsource/lato':
         specifier: ^5.2.5
         version: 5.2.5
@@ -3451,11 +3448,6 @@ packages:
     resolution: {integrity: sha512-M0Mol3odspvtCuheyujLNAW7bXq7KFNYVMRtpjFa4ZfES4MuklXBC7Nli/omvc+PRKlrklgAGx3l4VakjNo8jg==}
     peerDependencies:
       '@types/node': '*'
-
-  '@electron-toolkit/utils@4.0.0':
-    resolution: {integrity: sha512-qXSntwEzluSzKl4z5yFNBknmPGjPa3zFhE4mp9+h0cgokY5ornAeP+CJQDBhKsL1S58aOQfcwkD3NwLZCl+64g==}
-    peerDependencies:
-      electron: '>=13.0.0'
 
   '@electron/asar@3.2.18':
     resolution: {integrity: sha512-2XyvMe3N3Nrs8cV39IKELRHTYUWFKrmqqSY1U+GMlc0jvqjIVnoxhNd2H4JolWQncbJi1DCvb5TNxZuI2fEjWg==}
@@ -11039,10 +11031,6 @@ snapshots:
   '@electron-toolkit/tsconfig@1.0.1(@types/node@22.15.3)':
     dependencies:
       '@types/node': 22.15.3
-
-  '@electron-toolkit/utils@4.0.0(electron@35.2.2)':
-    dependencies:
-      electron: 35.2.2
 
   '@electron/asar@3.2.18':
     dependencies:

--- a/ts/tools/scripts/install-shell.cmd
+++ b/ts/tools/scripts/install-shell.cmd
@@ -59,6 +59,7 @@ IF ERRORLEVEL 1 (
     exit /B 1
 )
 
+
 call :ExecutePackage %PACKAGE%
 IF ERRORLEVEL 1 (
     call :Cleanup    


### PR DESCRIPTION
- Don't need to use @electron-toolkit/utils to watch for shortcut, which only works on the main browser window anyways.  
- Move the F12 handler for web content to be global.
- Clean up usage of @electron-toolkit/utils
- Add more flags to able to debug packaged builds.
- Switch data directory to the electron user data directory.
- Add `--clean` flag to clear all data.