### PR TITLE
Azure package pipeline improvements

### DIFF
--- a/pipelines/azure-build-package-shell.yml
+++ b/pipelines/azure-build-package-shell.yml
@@ -26,15 +26,19 @@ variables:
     value: ts/packages/shell
   - name: nodeVersion
     value: 22
+  - name: platforms
+    value: win,linux,mac
+  - name: ELECTRON_CACHE_DIR
+    value: $(Pipeline.Workspace)/cache/
+  - name: ELECTRON_CACHE
+    value: $(ELECTRON_CACHE_DIR)electron
   - name: ELECTRON_BUILDER_CACHE
-    value: $(Pipeline.Workspace)/electron-builder-cache
+    value: $(ELECTRON_CACHE_DIR)electron-builder-cache
   - name: channel
     ${{ if eq(variables['Build.Reason'], 'Manual') }}:
       value: ${{ parameters.channel }}
     ${{ if ne(variables['Build.Reason'], 'Manual') }}:
       value: ci
-  - name: platform
-    value: windows,linux,mac
 
 jobs:
   - job: build_package_shell
@@ -94,7 +98,17 @@ jobs:
         displayName: Build Shell
         workingDirectory: $(workingDirectory)
 
-      - script: |
+      - task: Cache@2
+        displayName: Cache Electron Builder
+        inputs:
+          key: electron | $(Agent.OS) | $(Agent.OSArchitecture) | $(Build.SourcesDirectory)/ts/pnpm-lock.yaml
+          path: $(ELECTRON_CACHE_DIR)
+          restoreKeys: |
+            electron | $(Agent.OS) | $(Agent.OSArchitecture)
+
+      - bash: |
+          echo $ELECTRON_BUILDER_CACHE
+          echo $ELECTRON_CACHE
           pnpm run shell:package:$(platform)
         displayName: Package - shell
         workingDirectory: $(workingDirectory)
@@ -114,7 +128,7 @@ jobs:
       runOnce:
         deploy:
           steps:
-            - ${{ each platform in split(variables.platform, ',') }}:
+            - ${{ each platform in split(variables.platforms, ',') }}:
                 - download: current
                   artifact: shell-${{ platform }}
                   displayName: Download shell package - ${{ platform }}

--- a/pipelines/azure-build-package-shell.yml
+++ b/pipelines/azure-build-package-shell.yml
@@ -12,21 +12,29 @@ pr:
       - "*"
 
 parameters:
-  - name: platforms
-    type: object
-    default: [win, linux, mac]
   - name: channel
     type: string
-    default: ci
+    default: test
     values:
-      - ci
-      - lkg
       - test
+      - lkg
 
 variables:
-  workingDirectory: ts
-  shell_folder: ts/packages/shell
-  nodeVersion: 22
+  - name: workingDirectory
+    value: ts
+  - name: shell_folder
+    value: ts/packages/shell
+  - name: nodeVersion
+    value: 22
+  - name: ELECTRON_BUILDER_CACHE
+    value: $(Pipeline.Workspace)/electron-builder-cache
+  - name: channel
+    ${{ if eq(variables['Build.Reason'], 'Manual') }}:
+      value: ${{ parameters.channel }}
+    ${{ if ne(variables['Build.Reason'], 'Manual') }}:
+      value: ci
+  - name: platform
+    value: windows,linux,mac
 
 jobs:
   - job: build_package_shell
@@ -49,6 +57,18 @@ jobs:
         displayName: Checkout TypeAgent Repository
         path: "typeagent"
 
+      - bash: |
+          echo "registry=$(REGISTRY)" > .npmrc
+          echo "always-auth=true" >> .npmrc
+          cat .npmrc
+        displayName: Set npm registry
+        workingDirectory: $(Build.SourcesDirectory)/ts
+
+      - task: npmAuthenticate@0
+        displayName: Authenticate to npm registry
+        inputs:
+          workingFile: $(Build.SourcesDirectory)/ts/.npmrc
+
       - task: UseNode@1
         displayName: Setup Node.js
         inputs:
@@ -67,7 +87,7 @@ jobs:
       - template: include-update-package-version.yml
         parameters:
           packageFolder: $(shell_folder)
-          prerelease: ${{ parameters.channel }}.$(Build.BuildNumber)
+          prerelease: $(channel).$(Build.BuildNumber)
 
       - script: |
           pnpm run build:shell
@@ -85,7 +105,7 @@ jobs:
 
   - deployment: publish
     displayName: Publish TypeAgent Shell
-    environment: typeagent-shell-${{ parameters.channel }}
+    environment: typeagent-shell-$(channel)
     dependsOn: build_package_shell
     pool:
       # AzureFileCopy requires windows
@@ -94,14 +114,14 @@ jobs:
       runOnce:
         deploy:
           steps:
-            - ${{ each platform in parameters.platforms }}:
+            - ${{ each platform in split(variables.platform, ',') }}:
                 - download: current
                   artifact: shell-${{ platform }}
                   displayName: Download shell package - ${{ platform }}
                   patterns: |
                     TypeAgent Shell[-_]*
                     typeagentshell-*
-                    ${{ parameters.channel }}*.yml
+                    $(channel)*.yml
                   condition: succeeded()
 
                 - task: AzureFileCopy@6

--- a/pipelines/include-install-pnpm.yml
+++ b/pipelines/include-install-pnpm.yml
@@ -20,10 +20,6 @@ parameters:
     type: string
     default: $(Pipeline.Workspace)/.pnpm-store
 
-  - name: pnpmCacheKey
-    type: string
-    default: $(System.DefinitionId)
-
 steps:
   - ${{ if eq(parameters.enableCache, true) }}:
       - task: Cache@2
@@ -33,10 +29,10 @@ steps:
         inputs:
           # Caches are already scoped to individual pipelines, so no need to include the release group name or tag
           # in the cache key
-          key: '${{ parameters.pnpmCacheKey }} | pnpm-store | "$(Agent.OS)" | ${{ parameters.buildDirectory }}/pnpm-lock.yaml'
+          key: pnpm-store | $(Agent.OS) | $(Agent.OSArchitecture) | ${{ parameters.buildDirectory }}/pnpm-lock.yaml
           path: ${{ parameters.pnpmStorePath }}
           restoreKeys: |
-            ${{ parameters.pnpmCacheKey }} | pnpm-store | "$(Agent.OS)"
+            pnpm-store | $(Agent.OS) | $(Agent.OSArchitecture)
 
   # workspace-concurrency 0 means use use the CPU core count. This is better than the default (4) for larger agents.
   - bash: |


### PR DESCRIPTION
- Cache electron-builder downloads
- Use internal feed for npm packages.
- Pnpm cache should be separate based on arch as well
- Disable manually building 'ci' channel