### PR TITLE
[python/knowpro] Flesh out collections.py and interfaces.py, add more tests

### DIFF
--- a/python/ta/Makefile
+++ b/python/ta/Makefile
@@ -16,7 +16,7 @@ check: venv
 
 .PHONY: test
 test: venv
-	venv/bin/python -m pytest
+	venv/bin/python -m pytest test
 
 .PHONY: build
 build: venv

--- a/python/ta/TODO.md
+++ b/python/ta/TODO.md
@@ -19,11 +19,11 @@ So we can finally do some end-to-end testing.
 
 STARTING THIS NOW.
 
-> UMESH:
+UMESH:
 > - query.ts
 >   - MatchSearchTermExpr
 >   - MatchPropertySearchTermExpr
-> - SemanticRefAccumulator is in collection.ts
+> - SemanticRefAccumulator is in collections.ts
 > 
 > Ignore code path "without indexes"
 
@@ -40,6 +40,16 @@ For robustness -- TypeChat already retries, but my embeddings don't.
 
 - fuzzy_index type mismatch (could VectorBase be made to match the type?)
 - Fix need for `# type: ignore` comments (usually need to make some I-interface generic in actual message/index/etc.)
+
+## Projct layout
+
+- Move typeagent into src and associated changes everywhere
+- Move test to tests
+- Configure testpaths in pyproject.toml
+
+## Testing
+
+- Review Copilot-generated tests for sanity and minimal mocking
 
 ## Low priority
 

--- a/python/ta/make.bat
+++ b/python/ta/make.bat
@@ -36,7 +36,7 @@ goto end
 :test
 if not exist "venv\" call make.bat venv
 echo Running tests...
-venv\Scripts\python -m pytest
+venv\Scripts\python -m pytest test
 goto end
 
 :build

--- a/python/ta/test/test_collections.py
+++ b/python/ta/test/test_collections.py
@@ -1,0 +1,185 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+from typeagent.knowpro.kplib import Action, ConcreteEntity
+from typeagent.knowpro.collections import (
+    MatchAccumulator,
+    SemanticRefAccumulator,
+    TextRangeCollection,
+    TextRangesInScope,
+)
+from typeagent.knowpro.interfaces import (
+    Knowledge,
+    TextRange,
+    ScoredSemanticRefOrdinal,
+    SemanticRef,
+    KnowledgeType,
+    TextLocation,
+    Term,
+    ISemanticRefCollection,
+)
+
+
+def test_match_accumulator_add_and_get():
+    """Test adding and retrieving matches in MatchAccumulator."""
+    accumulator = MatchAccumulator[str]()
+    accumulator.add("example", score=1.0)
+    accumulator.add("example", score=0.5)
+
+    match = accumulator.get_match("example")
+    assert match is not None
+    assert match.value == "example"
+    assert match.score == 1.5
+    assert match.hit_count == 2
+
+
+def test_match_accumulator_get_sorted_by_score():
+    """Test sorting matches by score in MatchAccumulator."""
+    accumulator = MatchAccumulator[str]()
+    accumulator.add("low", score=0.5)
+    accumulator.add("high", score=2.0)
+    accumulator.add("medium", score=1.0)
+
+    sorted_matches = accumulator.get_sorted_by_score()
+    assert len(sorted_matches) == 3
+    assert sorted_matches[0].value == "high"
+    assert sorted_matches[1].value == "medium"
+    assert sorted_matches[2].value == "low"
+
+
+def test_match_accumulator_get_matches_with_min_hit_count():
+    """Test filtering matches by minimum hit count."""
+    accumulator = MatchAccumulator[str]()
+    accumulator.add("example1", score=1.0)
+    accumulator.add("example1", score=0.5)
+    accumulator.add("example2", score=2.0)
+
+    matches = list(accumulator._matches_with_min_hit_count(min_hit_count=2))
+    assert len(matches) == 1
+    assert matches[0].value == "example1"
+
+
+def test_semantic_ref_accumulator_add_term_matches():
+    """Test adding term matches to SemanticRefAccumulator."""
+    accumulator = SemanticRefAccumulator()
+    search_term: Term = Term("example term")
+    scored_refs = [
+        ScoredSemanticRefOrdinal(semantic_ref_ordinal=1, score=0.8),
+        ScoredSemanticRefOrdinal(semantic_ref_ordinal=2, score=0.6),
+    ]
+
+    accumulator.add_term_matches(
+        search_term, scored_refs, is_exact_match=True, weight=1.0
+    )
+
+    match1 = accumulator.get_match(1)
+    match2 = accumulator.get_match(2)
+
+    assert match1 is not None
+    assert match1.score == 0.8
+    assert match1.hit_count == 1
+
+    assert match2 is not None
+    assert match2.score == 0.6
+    assert match2.hit_count == 1
+
+    # Convert Term to string for comparison
+    assert search_term.text in accumulator.search_term_matches
+
+
+def test_text_range_collection_add_and_check():
+    """Test adding ranges to TextRangeCollection and checking containment."""
+    range1 = TextRange(start=TextLocation(0), end=TextLocation(10))
+    range2 = TextRange(start=TextLocation(20), end=TextLocation(30))
+    range3 = TextRange(start=TextLocation(5), end=TextLocation(10))
+    range4 = TextRange(start=TextLocation(5), end=TextLocation(25))
+    range5 = TextRange(start=TextLocation(50), end=TextLocation(60))
+
+    collection = TextRangeCollection()
+    collection.add_range(range1)
+    collection.add_range(range2)
+
+    assert len(collection) == 2
+
+    assert collection.is_in_range(range1) is True
+    assert collection.is_in_range(range2) is True
+    assert collection.is_in_range(range3) is False
+    assert collection.is_in_range(range4) is False
+    assert (
+        collection.is_in_range(range5)
+        is False
+    )
+
+
+def test_text_ranges_in_scope():
+    """Test adding ranges to TextRangesInScope and checking scope."""
+    range1 = TextRange(start=TextLocation(0), end=TextLocation(10))
+    range2 = TextRange(start=TextLocation(0), end=TextLocation(20))
+    range3 = TextRange(start=TextLocation(0), end=TextLocation(10))
+    range4 = TextRange(start=TextLocation(5), end=TextLocation(15))
+
+    collection1 = TextRangeCollection([range1])
+    collection2 = TextRangeCollection([range2])
+
+    ranges_in_scope = TextRangesInScope()
+    ranges_in_scope.add_text_ranges(collection1)
+    ranges_in_scope.add_text_ranges(collection2)
+
+    assert ranges_in_scope.is_range_in_scope(range3)
+    assert not ranges_in_scope.is_range_in_scope(range4)
+
+
+class MockSemanticRefCollection(ISemanticRefCollection):
+    """Mock implementation of ISemanticRefCollection."""
+
+    def __init__(self):
+        self.refs = {
+            1: SemanticRef(
+                1,
+                range=TextRange(TextLocation(0)),
+                knowledge_type="entity",
+                knowledge=ConcreteEntity("ref1", ["ref"]),
+            ),
+            2: SemanticRef(
+                1,
+                range=TextRange(TextLocation(2)),
+                knowledge_type="action",
+                knowledge=Action(["go"], "past"),
+            ),
+        }
+
+    def get(self, ordinal: int) -> SemanticRef:
+        return self.refs[ordinal]
+
+    def get_multiple(self, ordinals: list[int]) -> list[SemanticRef]:
+        return [self.refs[o] for o in ordinals if o in self.refs]
+
+    def get_slice(self, start: int, end: int) -> list[SemanticRef]:
+        return [v for k, v in self.refs.items() if start <= k < end]
+
+    def __len__(self):
+        return len(self.refs)
+
+    def __iter__(self):
+        return iter(self.refs.values())
+
+    @property
+    def is_persistent(self) -> bool:
+        return False
+
+    def append(self, *items: SemanticRef) -> None:
+        raise NotImplementedError
+
+
+def test_semantic_ref_accumulator_group_matches_by_type():
+    """Test grouping matches by knowledge type in SemanticRefAccumulator."""
+    accumulator = SemanticRefAccumulator()
+    accumulator.add(1, score=0.8)
+    accumulator.add(2, score=0.6)
+
+    groups = accumulator.group_matches_by_type(MockSemanticRefCollection())
+    assert len(groups) == 2
+    assert "entity" in groups
+    assert "action" in groups
+    assert groups["entity"].get_match(1) is not None
+    assert groups["action"].get_match(2) is not None

--- a/python/ta/test/test_interfaces.py
+++ b/python/ta/test/test_interfaces.py
@@ -47,6 +47,63 @@ def test_text_range_serialization():
     }
 
 
+def test_text_range_equality():
+    """Test equality of TextRange objects."""
+    start1 = TextLocation(message_ordinal=1, chunk_ordinal=2, char_ordinal=3)
+    end1 = TextLocation(message_ordinal=4, chunk_ordinal=5, char_ordinal=6)
+    range1 = TextRange(start=start1, end=end1)
+    range2 = TextRange(start=start1, end=end1)
+    end3 = TextLocation(message_ordinal=4, chunk_ordinal=5, char_ordinal=7)
+
+    assert range1 == range2
+    assert range1 != TextRange(start=start1, end=end3)
+    assert range1 != "not a TextRange"
+
+
+def test_text_range_equality_end_none():
+    """Test equality of TextRange objects with None end."""
+    start1 = TextLocation(message_ordinal=1, chunk_ordinal=2, char_ordinal=3)
+    range1 = TextRange(start=start1, end=None)
+
+    start2 = TextLocation(message_ordinal=1, chunk_ordinal=2, char_ordinal=3)
+    range2 = TextRange(start=start2, end=None)
+
+    assert range1 == range2
+    assert range1 != TextRange(start=start1, end=TextLocation(message_ordinal=4))
+    assert range1 != "not a TextRange"
+
+
+def test_text_range_ordering():
+    """Test ordering of TextRange objects."""
+    start1 = TextLocation(message_ordinal=1, chunk_ordinal=2, char_ordinal=3)
+    end1 = TextLocation(message_ordinal=4, chunk_ordinal=5, char_ordinal=6)
+    range1 = TextRange(start=start1, end=end1)
+
+    start2 = TextLocation(message_ordinal=2, chunk_ordinal=3, char_ordinal=4)
+    end2 = TextLocation(message_ordinal=5, chunk_ordinal=6, char_ordinal=7)
+    range2 = TextRange(start=start2, end=end2)
+
+    assert range1 < range2
+    assert range2 > range1
+    assert range1 <= range1
+    assert range2 >= range2
+
+
+def test_text_range_ordering_end_none():
+    """Test ordering of TextRange objects with None end."""
+    start1 = TextLocation(message_ordinal=1, chunk_ordinal=2, char_ordinal=3)
+    start2 = TextLocation(message_ordinal=1, chunk_ordinal=2, char_ordinal=3)
+    end1 = TextLocation(message_ordinal=4, chunk_ordinal=5, char_ordinal=6)
+
+    range1 = TextRange(start=start1, end=None)
+    range2 = TextRange(start=start2, end=end1)
+
+    assert range1 < range2
+    assert range2 > range1
+    assert range1 <= range1
+    assert range2 >= range2
+
+
 def test_text_range_contains():
     """Test the __contains__ method of TextRange."""
     start = TextLocation(message_ordinal=1, chunk_ordinal=0, char_ordinal=0)

--- a/python/ta/typeagent/knowpro/collections.py
+++ b/python/ta/typeagent/knowpro/collections.py
@@ -260,7 +260,7 @@ class TextRangeCollection(Iterable[TextRange]):
         self._ranges.insert(pos, text_range)
         return True
 
-    def add_ranges(self, text_ranges: list[TextRange] | "TextRangeCollection") -> None:
+    def add_ranges(self, text_ranges: "list[TextRange] | TextRangeCollection") -> None:
         if isinstance(text_ranges, list):
             for text_range in text_ranges:
                 self.add_range(text_range)
@@ -269,15 +269,14 @@ class TextRangeCollection(Iterable[TextRange]):
             for text_range in text_ranges._ranges:
                 self.add_range(text_range)
 
-    def is_in_range(self, range_to_match: TextRange) -> bool:
+    def is_in_range(self, inner_range: TextRange) -> bool:
         if len(self._ranges) == 0:
             return False
-        i = bisect.bisect_left(self._ranges, range_to_match)
-        for i in range(i, len(self._ranges)):
-            r = self._ranges[i]
-            if r.start > range_to_match.start:
+        i = bisect.bisect_left(self._ranges, inner_range)
+        for outer_range in self._ranges[i:]:
+            if outer_range.start > inner_range.start:
                 break
-            if r in range_to_match:
+            if inner_range in outer_range:
                 return True
         return False
 
@@ -297,10 +296,10 @@ class TextRangesInScope:
 
     def is_range_in_scope(self, inner_range: TextRange) -> bool:
         if self.text_ranges is not None:
-            # Since outerRanges come from a set of range selectors, they may overlap, or may not agree.
+            # Since outer ranges come from a set of range selectors, they may overlap, or may not agree.
             # Outer ranges allowed by say a date range selector... may not be allowed by a tag selector.
             # We have a very simple impl: we don't intersect/union ranges yet.
-            # Instead, we ensure that the innerRange is not rejected by any outerRanges.
+            # Instead, we ensure that the inner range is not rejected by any outer ranges.
             for outer_ranges in self.text_ranges:
                 if not outer_ranges.is_in_range(inner_range):
                     return False

--- a/python/ta/typeagent/knowpro/interfaces.py
+++ b/python/ta/typeagent/knowpro/interfaces.py
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-from collections.abc import Sequence
+from collections.abc import Iterable, Sequence
 from dataclasses import dataclass, field
 from datetime import datetime as Datetime, timedelta as Timedelta
 from typing import (
@@ -163,6 +163,7 @@ class TextRange:
     def __contains__(self, other: Self) -> bool:
         otherend = other.end or other.start
         selfend = self.end or self.start
+        # TODO: In TS, isInTextRange requires other.end < self.end
         return self.start <= other.start and otherend <= selfend
 
     def serialize(self) -> TextRangeData:
@@ -605,3 +606,46 @@ class SecondaryIndexingResults:
 class IndexingResults:
     semantic_refs: TextIndexingResult | None = None
     secondary_index_results: SecondaryIndexingResults | None = None
+
+
+# --------
+# Storage
+# --------
+
+
+class IReadonlyCollection[T, TOrdinal](Iterable, Protocol):
+    def __len__(self) -> int:
+        raise NotImplementedError
+
+    def __bool__(self) -> bool:
+        return True
+
+    def get(self, index: TOrdinal) -> T:
+        raise NotImplementedError
+
+    def get_multiple(self, ordinals: list[TOrdinal]) -> list[T]:
+        raise NotImplementedError
+
+    def get_slice(self, start: TOrdinal, end: TOrdinal) -> list[T]:
+        raise NotImplementedError
+
+
+class ICollection[T, TOrdinal](IReadonlyCollection[T, TOrdinal], Protocol):
+    """An append-only collection."""
+
+    @property
+    def is_persistent(self) -> bool:
+        raise NotImplementedError
+
+    def append(self, *items: T) -> None:
+        raise NotImplementedError
+
+
+class IMessageCollection[TMessage: IMessage](
+    ICollection[TMessage, MessageOrdinal], Protocol
+):
+    """A collection of Messages."""
+
+
+class ISemanticRefCollection(ICollection[SemanticRef, SemanticRefOrdinal], Protocol):
+    """A collection of SemanticRefs."""

--- a/python/ta/typeagent/knowpro/interfaces.py
+++ b/python/ta/typeagent/knowpro/interfaces.py
@@ -147,7 +147,7 @@ class TextRangeData(TypedDict):
 
 
 # A text range within a session.
-@dataclass(order=True)
+@dataclass
 class TextRange:
     # The start of the range.
     start: TextLocation
@@ -159,6 +159,22 @@ class TextRange:
             return f"{self.__class__.__name__}({self.start})"
         else:
             return f"{self.__class__.__name__}({self.start}, {self.end})"
+
+    def __lt__(self, other: Self) -> bool:
+        if self.start != other.start:
+            return self.start < other.start
+        self_end = self.end or self.start
+        other_end = other.end or other.start
+        return self_end < other_end
+
+    def __gt__(self, other: Self) -> bool:
+        return other.__lt__(self)
+
+    def __ge__(self, other: Self) -> bool:
+        return not self.__lt__(other)
+
+    def __le__(self, other: Self) -> bool:
+        return not other.__lt__(self)
 
     def __contains__(self, other: Self) -> bool:
         otherend = other.end or other.start
@@ -620,7 +636,7 @@ class IReadonlyCollection[T, TOrdinal](Iterable, Protocol):
     def __bool__(self) -> bool:
         return True
 
-    def get(self, index: TOrdinal) -> T:
+    def get(self, ordinal: TOrdinal) -> T:
         raise NotImplementedError
 
     def get_multiple(self, ordinals: list[TOrdinal]) -> list[T]:


### PR DESCRIPTION
**In collections.py:**
- In `MatchAccumulator`, implement `get_sorted_by_score`, `_matches_with_min_hit_count`
- In `SemanticRefAccumulator`, implement many methods, from `add_term_matches_if_new` to `get_matches_in_scope`
- Add new classes `TextRangeCollection` and `TextRangesInScope`. (@Umesh: I have some questions about `is_range_in_scope` and `is_in_range`.)

**In interfaces.py:**
- Add correct `__lt__` etc. to `TextRange` (previously, ranges with `end=None` were ordered incorrectly when compared to ranges with `end=TextLocation(...)`.
- Add new definitions in the "Storage" section (`IReadonlyCollection`, `ICollection`, and derived collection types.

**Other:**
- Added `test_collections.py`.
- Updated `test_interfaces.py`.
- Updated `Makefile` and `make.bat` to restrict test collection to the `test` folder.
- Updated `TODO.md`.