### PR TITLE
Adjust clarifyMissingParameter to only clarify if the user is asking for actions.

### DIFF
--- a/ts/packages/defaultAgentProvider/test/data/translate-e2e.json
+++ b/ts/packages/defaultAgentProvider/test/data/translate-e2e.json
@@ -19,6 +19,10 @@
     "request": "Lookup duke result on the web",
     "action": "dispatcher.lookup.lookupAndAnswer"
   },
+  {
+    "request": "lookup snowdrop flowers",
+    "action": "dispatcher.lookup.lookupAndAnswer"
+  },
   { "request": "add play to the To do list", "action": "list.addItems" },
   { "request": "add homework to To do list", "action": "list.addItems" },
   { "request": "add plan holiday to To do list.", "action": "list.addItems" },

--- a/ts/packages/dispatcher/src/context/dispatcher/schema/clarifyActionSchema.ts
+++ b/ts/packages/dispatcher/src/context/dispatcher/schema/clarifyActionSchema.ts
@@ -19,7 +19,8 @@ export interface ClarifyMultiplePossibleActionName {
     };
 }
 
-// Ask the user for clarification for request is missing parameter of an known action. Don't clarify unknown action.
+// The user request is for an action, but some of the parameter is not specified or cannot be infer from the context.
+// Ask the user for clarification for the missing parameter of an known action. Don't clarify unknown action.
 export interface ClarifyMissingParameter {
     actionName: "clarifyMissingParameter";
     parameters: {

--- a/ts/packages/dispatcher/src/translation/translateRequest.ts
+++ b/ts/packages/dispatcher/src/translation/translateRequest.ts
@@ -123,6 +123,7 @@ export function getTranslatorForSchema(
         ? undefined
         : context.translatorCache.get(schemaName);
     if (translator !== undefined) {
+        debugTranslate(`Using cached translator for '${translatorName}'`);
         return translator;
     }
     const config = context.session.getConfig().translation;
@@ -134,6 +135,13 @@ export function getTranslatorForSchema(
         context.activityContext,
     );
 
+    debugTranslate(
+        `Creating translator for '${translatorName}':\n  schemas: ${actionConfigs
+            .map((actionConfig) => actionConfig.schemaName)
+            .join(",")}\n  switch: ${switchActionConfigs
+            .map((actionConfig) => actionConfig.schemaName)
+            .join(",")}`,
+    );
     const newTranslator = loadAgentJsonTranslator(
         actionConfigs,
         switchActionConfigs,
@@ -151,6 +159,7 @@ export function getTranslatorForSchema(
     );
     if (!activityContext) {
         context.translatorCache.set(translatorName, newTranslator);
+        debugTranslate(`Cached translator for '${translatorName}'`);
     }
     return newTranslator;
 }


### PR DESCRIPTION
Avoid clarification with the test case `lookup snowdrop flowers`.

Also add trace on translator creation/caching.