### PR TITLE
Avoid starting lookup activity if the user specify what to lookup

### DIFF
--- a/ts/packages/defaultAgentProvider/test/data/translate-e2e.json
+++ b/ts/packages/defaultAgentProvider/test/data/translate-e2e.json
@@ -3,26 +3,6 @@
     "request": "why do birds suddenly appear every time you are near",
     "action": "chat.generateResponse"
   },
-  {
-    "request": "I am planning a trip to Spain. can you look up some of the cities I should visit.",
-    "action": "dispatcher.lookup.lookupAndAnswer"
-  },
-  {
-    "request": "Look up the ingredients for lemon meringue pie",
-    "action": "dispatcher.lookup.lookupAndAnswer"
-  },
-  {
-    "request": "Did duke win its bball game",
-    "action": "dispatcher.lookup.lookupAndAnswer"
-  },
-  {
-    "request": "Lookup duke result on the web",
-    "action": "dispatcher.lookup.lookupAndAnswer"
-  },
-  {
-    "request": "lookup snowdrop flowers",
-    "action": "dispatcher.lookup.lookupAndAnswer"
-  },
   { "request": "add play to the To do list", "action": "list.addItems" },
   { "request": "add homework to To do list", "action": "list.addItems" },
   { "request": "add plan holiday to To do list.", "action": "list.addItems" },

--- a/ts/packages/defaultAgentProvider/test/data/translate-lookup-e2e.json
+++ b/ts/packages/defaultAgentProvider/test/data/translate-lookup-e2e.json
@@ -1,5 +1,54 @@
 [
   {
+    "request": "I am planning a trip to Spain. can you look up some of the cities I should visit.",
+    "action": "dispatcher.lookup.lookupAndAnswer"
+  },
+  {
+    "request": "Look up the ingredients for lemon meringue pie",
+    "action": "dispatcher.lookup.lookupAndAnswer"
+  },
+  {
+    "request": "Did duke win its bball game",
+    "action": "dispatcher.lookup.lookupAndAnswer"
+  },
+  {
+    "request": "Lookup duke result on the web",
+    "action": "dispatcher.lookup.lookupAndAnswer"
+  },
+  {
+    "request": "lookup snowdrop flowers",
+    "action": "dispatcher.lookup.lookupAndAnswer"
+  },
+  {
+    "request": "lookup snowdrops on the web",
+    "action": "dispatcher.lookup.lookupAndAnswer"
+  },
+  {
+    "request": "I'd like to look up something on the web",
+    "action": {
+      "translatorName": "dispatcher.lookup",
+      "actionName": "startLookup",
+      "parameters": {
+        "lookup":{
+          "source": "internet"
+        } 
+      }
+    }
+  },
+  {
+    "request": "I'd like to look up something on https://wikipedia.com",
+    "action": {
+      "translatorName": "dispatcher.lookup",
+      "actionName": "startLookup",
+      "parameters": {
+        "lookup": {
+          "source": "internet",
+          "site": ["https://wikipedia.com"]
+        }
+      }
+    }
+  },
+  {
     "request": "play the song by Bach we talked about yesterday",
     "action": "dispatcher.clarify.clarifyUnresolvedReference"
   },

--- a/ts/packages/dispatcher/src/context/dispatcher/schema/lookupActionSchema.ts
+++ b/ts/packages/dispatcher/src/context/dispatcher/schema/lookupActionSchema.ts
@@ -83,7 +83,8 @@ export type StartLookupInternet = {
     site?: string[]; // specific sites to look up in.
 };
 
-// The user want to start looking information for a specific source.
+// The user want to start looking information for a specific source without specifying what to look for.
+// Don't use this action if the request includes what to look for.
 export interface StartLookupAction {
     actionName: "startLookup";
     parameters: {

--- a/ts/packages/dispatcher/src/helpers/userData.ts
+++ b/ts/packages/dispatcher/src/helpers/userData.ts
@@ -123,25 +123,18 @@ function getInstanceDirName(instanceName: string) {
         return ensureInstanceDirName(instanceName);
     });
 }
-function getInstanceName(prod: boolean) {
-    return (
-        process.env.INSTANCE_NAME ??
-        (prod ? "prod" : `dev:${getPackageFilePath(".")}`)
-    );
+
+function getInstanceName() {
+    return process.env.INSTANCE_NAME ?? `dev:${getPackageFilePath(".")}`;
 }
 
 let instanceDir: string | undefined;
-let instanceMode: boolean | undefined;
-export function getInstanceDir(prod: boolean = false) {
+export function getInstanceDir() {
     if (instanceDir === undefined) {
-        instanceMode = prod;
         instanceDir = path.join(
             getInstancesDir(),
-            getInstanceDirName(getInstanceName(prod)),
+            getInstanceDirName(getInstanceName()),
         );
-    }
-    if (instanceMode !== prod) {
-        throw new Error("Instance mode cannot be changed");
     }
     return instanceDir;
 }

--- a/ts/packages/shell/src/main/keys.ts
+++ b/ts/packages/shell/src/main/keys.ts
@@ -31,8 +31,14 @@ async function createPersistence(dir: string) {
 
 async function loadKeysFromPersistence(dir: string) {
     debugShell("Loading keys persistence from directory", dir);
-    const persistence = await createPersistence(dir);
-    return persistence.load();
+    try {
+        const persistence = await createPersistence(dir);
+        return await persistence.load();
+    } catch (e) {
+        // Ignore load error and return null as if we don't have the keys.
+        debugShellError("Failed to load keys persistence", e);
+        return null;
+    }
 }
 
 async function saveKeysToPersistence(dir: string, keys: string) {


### PR DESCRIPTION
`on the web` sometimes trigger startLookup action. Add comments to avoid that

Also:
- Clean up unused prod mode for getInstanceDir()
- Silently ignore error when loading from keyvault, and just assume we don't have any data.  This is needed when running against repro zip from other machine on windows (thes ecret is in a file encrypted a per machine key.