### PR TITLE
Allow activity to be disabled.

### DIFF
--- a/ts/packages/actionSchema/src/generator.ts
+++ b/ts/packages/actionSchema/src/generator.ts
@@ -133,7 +133,7 @@ function isJsonSchemaEnabled(options?: GenerateSchemaOptions): boolean {
     return options?.jsonSchema === true || options?.jsonSchemaFunction === true;
 }
 export function generateSchemaTypeDefinition(
-    definition: SchemaTypeDefinition,
+    definition: SchemaTypeDefinition | SchemaTypeDefinition[],
     options?: GenerateSchemaOptions,
     order?: Map<string, number>,
 ): string {
@@ -151,7 +151,7 @@ export function generateSchemaTypeDefinition(
         SchemaTypeDefinition,
         { lines: string[]; order: number | undefined; emitOrder: number }
     >();
-    const pending = [definition];
+    const pending = Array.isArray(definition) ? [...definition] : [definition];
 
     while (pending.length > 0) {
         const definition = pending.shift()!;

--- a/ts/packages/actionSchema/src/jsonSchemaParser.ts
+++ b/ts/packages/actionSchema/src/jsonSchemaParser.ts
@@ -119,7 +119,7 @@ export function parseToolsJsonSchema(
     }
 
     const entry = sc.type(entryTypeName, sc.union(refs), undefined, true);
-    return createParsedActionSchema(entry, undefined, true);
+    return createParsedActionSchema({ action: entry }, undefined, true);
 }
 
 function validateToolsJsonSchema(schema: unknown): schema is ToolsJsonSchema {

--- a/ts/packages/actionSchema/src/type.ts
+++ b/ts/packages/actionSchema/src/type.ts
@@ -135,17 +135,26 @@ type ActionSchemaTypeReference =
 // A union of action schema type definitions.
 export type ActionSchemaUnion = SchemaTypeUnion<ActionSchemaTypeReference>;
 
-export type ActionSchemaGroup = {
+export type ActionSchemaGroup<T = ActionSchemaEntryTypeDefinition> = {
     // The entry type definition for the action schema.
-    entry: ActionSchemaEntryTypeDefinition;
+    entry: T;
     // Map action name to action type definition
     actionSchemas: Map<string, ActionSchemaTypeDefinition>;
     // Order for the type definitions
     order?: Map<string, number>; // for exact regen
 };
 
-// Action schema that is parsed from a file.
-export type ParsedActionSchema = ActionSchemaGroup & {
-    // separate the cache by action name
-    actionNamespace?: boolean; // default to false
+export type SchemaEntryTypeDefinitions<T = SchemaTypeDefinition> = {
+    action?: T | undefined;
+    activity?: T | undefined;
 };
+
+export type ActionSchemaEntryTypeDefinitions =
+    SchemaEntryTypeDefinitions<ActionSchemaEntryTypeDefinition>;
+
+// Action schema that is parsed from a file.
+export type ParsedActionSchema =
+    ActionSchemaGroup<ActionSchemaEntryTypeDefinitions> & {
+        // separate the cache by action name
+        actionNamespace?: boolean; // default to false
+    };

--- a/ts/packages/actionSchema/test/parse.spec.ts
+++ b/ts/packages/actionSchema/test/parse.spec.ts
@@ -4,7 +4,36 @@
 import { parseActionSchemaSource } from "../src/parser.js";
 
 describe("Action Schema Strict Checks", () => {
-    it("Error on entry type not exported", async () =>
+    it("Error on action entry type not found", async () =>
+        expect(async () =>
+            parseActionSchemaSource(
+                `type SomeAction = { actionName: "someAction" }`,
+                "test",
+                "SomeOtherAction",
+                "",
+                undefined,
+                true,
+            ),
+        ).rejects.toThrow(
+            "Error parsing schema 'test': Action type 'SomeOtherAction' not found",
+        ));
+    it("Error on activity entry type not found", async () =>
+        expect(async () =>
+            parseActionSchemaSource(
+                `type SomeAction = { actionName: "someAction" }`,
+                "test",
+                {
+                    action: "SomeAction",
+                    activity: "SomeOtherAction",
+                },
+                "",
+                undefined,
+                true,
+            ),
+        ).rejects.toThrow(
+            "Error parsing schema 'test': Activity type 'SomeOtherAction' not found",
+        ));
+    it("Error on action entry type not exported", async () =>
         expect(async () =>
             parseActionSchemaSource(
                 `type SomeAction = { actionName: "someAction" }`,
@@ -15,10 +44,10 @@ describe("Action Schema Strict Checks", () => {
                 true,
             ),
         ).rejects.toThrow(
-            "Error parsing schema 'test': Schema Error: Type 'SomeAction' must be exported",
+            "Error parsing schema 'test': Schema Error: Action entry type 'SomeAction' must be exported",
         ));
 
-    it("Error on entry type comment", async () =>
+    it("Error on action entry type comment", async () =>
         expect(async () =>
             parseActionSchemaSource(
                 `// comments\nexport type AllActions = SomeAction;\ntype SomeAction = { actionName: "someAction" }`,

--- a/ts/packages/agentSdk/src/agentInterface.ts
+++ b/ts/packages/agentSdk/src/agentInterface.ts
@@ -16,10 +16,15 @@ export type AppAgentManifest = {
     commandDefaultEnabled?: boolean;
 } & ActionManifest;
 
+export type SchemaTypeNames = {
+    action?: string;
+    activity?: string;
+};
+
 export type SchemaFormat = "ts" | "pas";
 export type SchemaManifest = {
     description: string;
-    schemaType: string;
+    schemaType: string | SchemaTypeNames; // string if there are only action schemas
     schemaFile: string | { format: SchemaFormat; content: string };
     injected?: boolean; // whether the translator is injected into other domains, default is false
     cached?: boolean; // whether the translator's action should be cached, default is true

--- a/ts/packages/agentSdk/src/index.ts
+++ b/ts/packages/agentSdk/src/index.ts
@@ -14,6 +14,7 @@ export {
     StorageEncoding,
     TokenCachePersistence,
     ActionContext,
+    SchemaTypeNames,
 } from "./agentInterface.js";
 
 export {

--- a/ts/packages/agents/list/src/listActionHandler.ts
+++ b/ts/packages/agents/list/src/listActionHandler.ts
@@ -14,7 +14,7 @@ import {
     createActionResultFromMarkdownDisplay,
     createActionResult,
 } from "@typeagent/agent-sdk/helpers/action";
-import { ListAction } from "./listSchema.js";
+import { ListAction, ListActivity } from "./listSchema.js";
 
 export function instantiate(): AppAgent {
     return {
@@ -30,7 +30,7 @@ type ListActionContext = {
 };
 
 async function executeListAction(
-    action: TypeAgentAction<ListAction>,
+    action: TypeAgentAction<ListAction | ListActivity>,
     context: ActionContext<ListActionContext>,
 ) {
     let result = await handleListAction(
@@ -101,7 +101,7 @@ function validateWildcardItems(
 }
 
 async function listValidateWildcardMatch(
-    action: ListAction,
+    action: ListAction | ListActivity,
     context: SessionContext<ListActionContext>,
 ) {
     if (action.actionName === "addItems") {
@@ -290,7 +290,7 @@ function getListDisplay(
     );
 }
 async function handleListAction(
-    action: ListAction,
+    action: TypeAgentAction<ListAction | ListActivity>,
     listContext: ListActionContext,
 ) {
     let result: ActionResult | undefined = undefined;

--- a/ts/packages/agents/list/src/listManifest.json
+++ b/ts/packages/agents/list/src/listManifest.json
@@ -4,6 +4,9 @@
   "schema": {
     "description": "List agent with actions to create lists, show list items, add and remove list items",
     "schemaFile": "./listSchema.ts",
-    "schemaType": "ListAction"
+    "schemaType": {
+      "action": "ListAction",
+      "activity": "ListActivity"
+    }
   }
 }

--- a/ts/packages/agents/list/src/listSchema.ts
+++ b/ts/packages/agents/list/src/listSchema.ts
@@ -6,8 +6,9 @@ export type ListAction =
     | RemoveItemsAction
     | CreateListAction
     | GetListAction
-    | ClearListAction
-    | StartEditList;
+    | ClearListAction;
+
+export type ListActivity = StartEditList;
 
 // add one or more items to a list; if the list does not exist, create it
 export type AddItemsAction = {

--- a/ts/packages/cli/src/commands/schema.ts
+++ b/ts/packages/cli/src/commands/schema.ts
@@ -45,10 +45,15 @@ export default class Schema extends Command {
             allowNo: true,
             default: true,
         }),
+        activity: Flags.boolean({
+            description: "Show activity schema",
+            allowNo: true,
+            default: true,
+        }),
     };
     static args = {
-        translator: Args.string({
-            description: "Translator name",
+        schemaName: Args.string({
+            description: "Schema name",
             required: true,
             options: schemaNames,
         }),
@@ -64,7 +69,7 @@ export default class Schema extends Command {
             if (args.actionName) {
                 const actionSchema = getActionSchema(
                     {
-                        translatorName: args.translator,
+                        translatorName: args.schemaName,
                         actionName: args.actionName,
                     },
                     provider,
@@ -73,7 +78,7 @@ export default class Schema extends Command {
                     console.log(generateSchemaTypeDefinition(actionSchema));
                 } else {
                     console.error(
-                        `Action ${args.actionName} not found in translator ${args.translator}`,
+                        `Action ${args.actionName} not found in translator ${args.schemaName}`,
                     );
                 }
 
@@ -81,12 +86,15 @@ export default class Schema extends Command {
             }
             console.log(
                 getFullSchemaText(
-                    args.translator,
+                    args.schemaName,
                     provider,
                     flags.active,
                     flags.change,
-                    flags.multiple,
-                    flags.generated,
+                    {
+                        activity: flags.activity,
+                        multiple: flags.multiple,
+                    },
+                    flags.generated ? { exact: true } : undefined,
                 ),
             );
         } else {

--- a/ts/packages/dispatcher/src/context/appAgentManager.ts
+++ b/ts/packages/dispatcher/src/context/appAgentManager.ts
@@ -19,10 +19,7 @@ import { getAppAgentName } from "../translation/agentTranslators.js";
 import { createSessionContext } from "../execute/actionHandlers.js";
 import { AppAgentProvider } from "../agentProvider/agentProvider.js";
 import registerDebug from "debug";
-import {
-    DispatcherActivityName,
-    DispatcherName,
-} from "./dispatcher/dispatcherUtils.js";
+import { DispatcherName } from "./dispatcher/dispatcherUtils.js";
 import {
     ActionSchemaSemanticMap,
     EmbeddingCache,
@@ -87,8 +84,8 @@ export type SetStateResult = {
 };
 
 export const alwaysEnabledAgents = {
-    schemas: [DispatcherName, DispatcherActivityName],
-    actions: [DispatcherName, DispatcherActivityName],
+    schemas: [DispatcherName],
+    actions: [DispatcherName],
     commands: ["system"],
 };
 

--- a/ts/packages/dispatcher/src/context/dispatcher/dispatcherAgent.ts
+++ b/ts/packages/dispatcher/src/context/dispatcher/dispatcherAgent.ts
@@ -29,6 +29,7 @@ import { loadAgentJsonTranslator } from "../../translation/agentTranslators.js";
 import { lookupAndAnswer } from "../../search/search.js";
 import {
     LookupAction,
+    LookupActivity,
     LookupAndAnswerAction,
 } from "./schema/lookupActionSchema.js";
 import {
@@ -52,6 +53,7 @@ async function executeDispatcherAction(
         | DispatcherActions
         | ClarifyRequestAction
         | LookupAction
+        | LookupActivity
         | ActivityActions
     >,
     context: ActionContext<CommandHandlerContext>,
@@ -154,12 +156,7 @@ async function clarifyWithLookup(
         agents.getActionConfig("dispatcher"),
     ];
     // TODO: cache this?
-    const translator = loadAgentJsonTranslator(
-        actionConfigs,
-        [],
-        agents,
-        false, // no multiple
-    );
+    const translator = loadAgentJsonTranslator(actionConfigs, [], agents);
 
     const question = `What is ${action.parameters.reference}?`;
     const result = await translator.translate(question);
@@ -241,7 +238,10 @@ export const dispatcherManifest: AppAgentManifest = {
                     "Action that helps you look up information to answer user questions.",
                 schemaFile:
                     "./src/context/dispatcher/schema/lookupActionSchema.ts",
-                schemaType: "LookupAction",
+                schemaType: {
+                    action: "LookupAction",
+                    activity: "LookupActivity",
+                },
                 injected: true,
                 cached: false,
             },

--- a/ts/packages/dispatcher/src/context/dispatcher/schema/lookupActionSchema.ts
+++ b/ts/packages/dispatcher/src/context/dispatcher/schema/lookupActionSchema.ts
@@ -1,7 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-export type LookupAction = LookupAndAnswerAction | StartLookupAction;
+export type LookupAction = LookupAndAnswerAction;
+export type LookupActivity = StartLookupAction;
 export type DateVal = {
     day: number;
     month: number;

--- a/ts/packages/dispatcher/src/translation/actionSchemaFileCache.ts
+++ b/ts/packages/dispatcher/src/translation/actionSchemaFileCache.ts
@@ -15,13 +15,17 @@ import {
     ActionSchemaFile,
 } from "./actionConfigProvider.js";
 import { getPackageFilePath } from "../utils/getPackageFilePath.js";
-import { AppAction, SchemaFormat } from "@typeagent/agent-sdk";
+import { AppAction, SchemaFormat, SchemaTypeNames } from "@typeagent/agent-sdk";
 import { DeepPartialUndefined, simpleStarRegex } from "common-utils";
 import fs from "node:fs";
 import crypto from "node:crypto";
 import registerDebug from "debug";
 import { readSchemaConfig } from "../utils/loadSchemaConfig.js";
 import { SchemaInfoProvider } from "agent-cache";
+import {
+    getActionSchemaTypeName,
+    getActivitySchemaTypeName,
+} from "./agentTranslators.js";
 
 const debug = registerDebug("typeagent:dispatcher:schema:cache");
 const debugError = registerDebug("typeagent:dispatcher:schema:cache:error");
@@ -48,7 +52,7 @@ type ActionSchemaFileCacheJSON = {
 
 function loadParsedActionSchema(
     schemaName: string,
-    schemaType: string,
+    schemaType: string | SchemaTypeNames,
     sourceHash: string,
     source: string,
 ): ActionSchemaFile {
@@ -63,9 +67,16 @@ function loadParsedActionSchema(
         const parsedActionSchema = fromJSONParsedActionSchema(
             parsedActionSchemaJSON,
         );
-        if (parsedActionSchema.entry.name !== schemaType) {
+        const actionTypeName = getActionSchemaTypeName(schemaType);
+        if (parsedActionSchema.entry.action?.name !== actionTypeName) {
             throw new Error(
-                `Schema type mismatch: actual: ${parsedActionSchema.entry.name}, expected:${schemaType}`,
+                `Schema type mismatch: actual: ${parsedActionSchema.entry.action?.name}, expected:${actionTypeName}`,
+            );
+        }
+        const activityTypeName = getActivitySchemaTypeName(schemaType);
+        if (parsedActionSchema.entry.activity?.name !== activityTypeName) {
+            throw new Error(
+                `Schema type mismatch: actual: ${parsedActionSchema.entry.action?.name}, expected:${activityTypeName}`,
             );
         }
         return {
@@ -80,14 +91,23 @@ function loadParsedActionSchema(
     }
 }
 
-function loadActionSchemaFile(record: ActionSchemaFileJSON): ActionSchemaFile {
-    return {
-        schemaName: record.schemaName,
-        sourceHash: record.sourceHash,
-        parsedActionSchema: fromJSONParsedActionSchema(
-            record.parsedActionSchema,
-        ),
-    };
+function loadCachedActionSchemaFile(
+    record: ActionSchemaFileJSON,
+): ActionSchemaFile | undefined {
+    try {
+        return {
+            schemaName: record.schemaName,
+            sourceHash: record.sourceHash,
+            parsedActionSchema: fromJSONParsedActionSchema(
+                record.parsedActionSchema,
+            ),
+        };
+    } catch (e: any) {
+        debugError(
+            `Failed to load cached action schema '${record.schemaName}': ${e.message}`,
+        );
+        return undefined;
+    }
 }
 
 function saveActionSchemaFile(
@@ -176,15 +196,18 @@ export class ActionSchemaFileCache {
             this.prevSaved.delete(cacheKey);
             if (lastCached.sourceHash === hash) {
                 debug(`Cached action schema used: ${actionConfig.schemaName}`);
-                // Add and save the cache first before convert it back (which will modify the data)
-                this.addToCache(cacheKey, lastCached);
-                const cached = loadActionSchemaFile(lastCached);
-                this.actionSchemaFiles.set(actionConfig.schemaName, cached);
-                return cached;
+                const cached = loadCachedActionSchemaFile(lastCached);
+                if (cached !== undefined) {
+                    // Add and save the cache first before convert it back (which will modify the data)
+                    this.addToCache(cacheKey, lastCached);
+                    this.actionSchemaFiles.set(actionConfig.schemaName, cached);
+                    return cached;
+                }
+            } else {
+                debugError(
+                    `Cached action schema hash mismatch: ${actionConfig.schemaName}`,
+                );
             }
-            debugError(
-                `Cached action schema hash mismatch: ${actionConfig.schemaName}`,
-            );
         }
 
         const schemaConfig: SchemaConfig | undefined = config

--- a/ts/packages/dispatcher/src/translation/actionSchemaJsonTranslator.ts
+++ b/ts/packages/dispatcher/src/translation/actionSchemaJsonTranslator.ts
@@ -215,18 +215,22 @@ class ActionSchemaBuilder {
     }
 }
 
+export type ComposeSchemaOptions = {
+    activity?: boolean; // default true
+    multiple?: MultipleActionOptions; // default false
+};
 export function composeActionSchema(
     actionConfigs: ActionConfig[],
     switchActionConfigs: ActionConfig[],
     provider: ActionConfigProvider,
-    multipleActionOptions: MultipleActionOptions,
+    options?: ComposeSchemaOptions,
 ) {
-    const builder = new ActionSchemaBuilder(provider);
+    const builder = new ActionSchemaBuilder(provider, options?.activity);
     builder.addActionConfig(...actionConfigs);
     return finalizeActionSchemaBuilder(
         builder,
         switchActionConfigs,
-        multipleActionOptions,
+        options?.multiple,
     );
 }
 
@@ -236,9 +240,9 @@ export function composeSelectedActionSchema(
     additionalActionConfigs: ActionConfig[],
     switchActionConfigs: ActionConfig[],
     provider: ActionConfigProvider,
-    multipleActionOptions: MultipleActionOptions,
+    options?: ComposeSchemaOptions,
 ) {
-    const builder = new ActionSchemaBuilder(provider);
+    const builder = new ActionSchemaBuilder(provider, options?.activity);
     const union = sc.union(definitions.map((definition) => sc.ref(definition)));
     const typeName = `Partial${actionConfig.schemaType}`;
     const comments = `${typeName} is a partial list of actions available in schema group '${actionConfig.schemaName}'.`;
@@ -249,14 +253,14 @@ export function composeSelectedActionSchema(
     return finalizeActionSchemaBuilder(
         builder,
         switchActionConfigs,
-        multipleActionOptions,
+        options?.multiple,
     );
 }
 
 function finalizeActionSchemaBuilder(
     builder: ActionSchemaBuilder,
     switchActionConfigs: ActionConfig[],
-    multipleActionOptions: MultipleActionOptions,
+    multipleActionOptions: MultipleActionOptions = false,
 ) {
     if (switchActionConfigs.length > 0) {
         builder.addTypeDefinition(

--- a/ts/packages/dispatcher/src/translation/actionSchemaJsonTranslator.ts
+++ b/ts/packages/dispatcher/src/translation/actionSchemaJsonTranslator.ts
@@ -122,13 +122,22 @@ class ActionSchemaBuilder {
     private readonly files: ActionSchemaFile[] = [];
     private readonly definitions: ActionSchemaEntryTypeDefinition[] = [];
 
-    constructor(private readonly provider: ActionConfigProvider) {}
+    constructor(
+        private readonly provider: ActionConfigProvider,
+        private readonly activity: boolean = true,
+    ) {}
     addActionConfig(...configs: ActionConfig[]) {
         for (const config of configs) {
             const actionSchemaFile =
                 this.provider.getActionSchemaFileForConfig(config);
             this.files.push(actionSchemaFile);
-            this.definitions.push(actionSchemaFile.parsedActionSchema.entry);
+            const entry = actionSchemaFile.parsedActionSchema.entry;
+            if (entry.action) {
+                this.definitions.push(entry.action);
+            }
+            if (this.activity && entry.activity) {
+                this.definitions.push(entry.activity);
+            }
         }
     }
 

--- a/ts/packages/dispatcher/src/translation/translateRequest.ts
+++ b/ts/packages/dispatcher/src/translation/translateRequest.ts
@@ -142,20 +142,25 @@ export function getTranslatorForSchema(
             .map((actionConfig) => actionConfig.schemaName)
             .join(",")}`,
     );
+    const generateOptions = config.schema.generation.enabled
+        ? {
+              exact: !config.schema.optimize.enabled,
+              jsonSchema: config.schema.generation.jsonSchema,
+              jsonSchemaFunction: config.schema.generation.jsonSchemaFunction,
+              jsonSchemaWithTs: config.schema.generation.jsonSchemaWithTs,
+              jsonSchemaValidate: config.schema.generation.jsonSchemaValidate,
+          }
+        : null;
     const newTranslator = loadAgentJsonTranslator(
         actionConfigs,
         switchActionConfigs,
         context.agents,
-        config.multiple,
-        config.schema.generation.enabled,
-        config.model,
         {
-            exact: !config.schema.optimize.enabled,
-            jsonSchema: config.schema.generation.jsonSchema,
-            jsonSchemaFunction: config.schema.generation.jsonSchemaFunction,
-            jsonSchemaWithTs: config.schema.generation.jsonSchemaWithTs,
-            jsonSchemaValidate: config.schema.generation.jsonSchemaValidate,
+            activity: context.agents.isSchemaEnabled(DispatcherActivityName),
+            multiple: config.multiple,
         },
+        generateOptions,
+        config.model,
     );
     if (!activityContext) {
         context.translatorCache.set(translatorName, newTranslator);
@@ -201,7 +206,10 @@ async function getTranslatorForSelectedActions(
         actionConfigs,
         switchActionConfigs,
         context.agents,
-        config.multiple,
+        {
+            activity: context.agents.isSchemaEnabled(DispatcherActivityName),
+            multiple: config.multiple,
+        },
         config.model,
     );
 }

--- a/ts/packages/dispatcher/src/utils/test/explanationTestData.ts
+++ b/ts/packages/dispatcher/src/utils/test/explanationTestData.ts
@@ -287,8 +287,8 @@ function getSafeTranslateFn(
         ],
         [],
         provider,
-        false, // multiple
-        true, // generated
+        undefined, // activity/no multiple
+        undefined, // generated
         model,
     );
     return async (request: string): Promise<Result<TranslatedAction>> => {

--- a/ts/packages/shell/test/testHelper.ts
+++ b/ts/packages/shell/test/testHelper.ts
@@ -29,8 +29,10 @@ export async function startShell(
         `test_${process.env["TEST_WORKER_INDEX"]}_${process.env["TEST_PARALLEL_INDEX"]}`;
 
     // other related multi-instance variables that need to be modified to ensure we can run multiple shell instances
+    // Assuming less then 50 port is needed.
     process.env["PORT"] = (
-        9001 + parseInt(process.env["TEST_WORKER_INDEX"]!)
+        9001 +
+        parseInt(process.env["TEST_WORKER_INDEX"]!) * 50
     ).toString();
     process.env["WEBSOCKET_HOST"] =
         `ws://localhost:${8080 + parseInt(process.env["TEST_WORKER_INDEX"]!)}`;


### PR DESCRIPTION
- Separate the union type for activities and actions.
- If the schema `dispatcher.activity` is disabled, then we disable all activity actions.
