### PR TITLE
fix test port

### DIFF
--- a/ts/packages/defaultAgentProvider/test/basic.spec.ts
+++ b/ts/packages/defaultAgentProvider/test/basic.spec.ts
@@ -4,6 +4,8 @@
 import { createDispatcher } from "agent-dispatcher";
 import { getDefaultAppAgentProviders } from "../src/defaultAgentProviders.js";
 
+// Use 3001 as the base for test port
+process.env["PORT"] = "3001";
 describe("AppAgentProvider", () => {
     describe("Built-in Provider", () => {
         it("startup and shutdown", async () => {

--- a/ts/packages/shell/test/testHelper.ts
+++ b/ts/packages/shell/test/testHelper.ts
@@ -29,9 +29,9 @@ export async function startShell(
         `test_${process.env["TEST_WORKER_INDEX"]}_${process.env["TEST_PARALLEL_INDEX"]}`;
 
     // other related multi-instance variables that need to be modified to ensure we can run multiple shell instances
-    // Assuming less then 50 port is needed.
+    // Use 3001 as test port and assuming less then 50 port is needed per worker instance
     process.env["PORT"] = (
-        9001 +
+        3001 +
         parseInt(process.env["TEST_WORKER_INDEX"]!) * 50
     ).toString();
     process.env["WEBSOCKET_HOST"] =


### PR DESCRIPTION
Use 3001 as the base to avoid conflict with running instance of TypeAgent shell.