### PR TITLE
Enable activites to open view.

### DIFF
--- a/ts/packages/agentRpc/src/client.ts
+++ b/ts/packages/agentRpc/src/client.ts
@@ -17,6 +17,7 @@ import {
     AppAction,
     TypeAgentAction,
     StorageEncoding,
+    AppAgentInitSettings,
 } from "@typeagent/agent-sdk";
 import {
     ActionContextParams,
@@ -184,6 +185,13 @@ export async function createAgentRpcClient(
             await context.removeDynamicAgent(param.name);
             channelProvider.deleteChannel(param.name);
         },
+        getSharedLocalHostPort: async (param: {
+            contextId: number;
+            agentName: string;
+        }) => {
+            const context = contextMap.get(param.contextId);
+            return context.getSharedLocalHostPort(param.agentName);
+        },
         indexes: async (param: { contextId: number; type: string }) => {
             const context = contextMap.get(param.contextId);
             return context.indexes(param.type as any);
@@ -325,8 +333,8 @@ export async function createAgentRpcClient(
     // The shim needs to implement all the APIs regardless whether the actual agent
     // has that API.  We remove remove it the one that is not necessary below.
     const agent: Required<AppAgent> = {
-        initializeAgentContext() {
-            return rpc.invoke("initializeAgentContext", undefined);
+        initializeAgentContext(settings?: AppAgentInitSettings) {
+            return rpc.invoke("initializeAgentContext", settings);
         },
         updateAgentContext(
             enable,

--- a/ts/packages/agentRpc/src/server.ts
+++ b/ts/packages/agentRpc/src/server.ts
@@ -16,6 +16,7 @@ import {
     ClientAction,
     AppAgentManifest,
     TypeAgentAction,
+    AppAgentInitSettings,
 } from "@typeagent/agent-sdk";
 
 import {
@@ -41,11 +42,13 @@ export function createAgentRpcServer(
 ) {
     const channel = channelProvider.createChannel(`agent:${name}`);
     const agentInvokeHandlers: AgentInvokeFunctions = {
-        async initializeAgentContext(): Promise<unknown> {
+        async initializeAgentContext(
+            settings?: AppAgentInitSettings,
+        ): Promise<unknown> {
             if (agent.initializeAgentContext === undefined) {
                 throw new Error("Invalid invocation of initializeAgentContext");
             }
-            const agentContext = await agent.initializeAgentContext?.();
+            const agentContext = await agent.initializeAgentContext?.(settings);
             return {
                 contextId: registerAgentContext(agentContext),
             };
@@ -331,6 +334,12 @@ export function createAgentRpcServer(
                     contextId,
                     name,
                     enable,
+                });
+            },
+            getSharedLocalHostPort: async (agentName: string) => {
+                return rpc.invoke("getSharedLocalHostPort", {
+                    contextId,
+                    agentName,
                 });
             },
             addDynamicAgent: async (

--- a/ts/packages/agentRpc/src/types.ts
+++ b/ts/packages/agentRpc/src/types.ts
@@ -6,6 +6,7 @@ import {
     ActivityContext,
     AppAction,
     AppAgentEvent,
+    AppAgentInitSettings,
     AppAgentManifest,
     ClientAction,
     CommandDescriptors,
@@ -104,6 +105,10 @@ export type AgentContextInvokeFunctions = {
         contextId: number;
         name: string;
     }) => Promise<void>;
+    getSharedLocalHostPort: (param: {
+        contextId: number;
+        agentName: string;
+    }) => Promise<number>;
     indexes: (param: { contextId: number; type: string }) => Promise<any>;
 };
 
@@ -119,7 +124,9 @@ export type AgentCallFunctions = {
 };
 
 export type AgentInvokeFunctions = {
-    initializeAgentContext: () => Promise<unknown>;
+    initializeAgentContext: (
+        settings?: AppAgentInitSettings,
+    ) => Promise<unknown>;
     updateAgentContext: (
         param: Partial<ContextParams> & {
             enable: boolean;

--- a/ts/packages/agentSdk/src/action.ts
+++ b/ts/packages/agentSdk/src/action.ts
@@ -30,6 +30,7 @@ export type ActionResultSuccess = {
         activityName: string;
         description: string;
         state: Record<string, unknown>;
+        openLocalView?: boolean;
     } | null; // Null to clear the activity context
 };
 

--- a/ts/packages/agentSdk/src/agentInterface.ts
+++ b/ts/packages/agentSdk/src/agentInterface.ts
@@ -14,6 +14,7 @@ export type AppAgentManifest = {
     emojiChar: string;
     description: string;
     commandDefaultEnabled?: boolean;
+    localView?: boolean; // whether the agent serve a local view, default is false
 } & ActionManifest;
 
 export type SchemaTypeNames = {

--- a/ts/packages/agentSdk/src/agentInterface.ts
+++ b/ts/packages/agentSdk/src/agentInterface.ts
@@ -15,6 +15,7 @@ export type AppAgentManifest = {
     description: string;
     commandDefaultEnabled?: boolean;
     localView?: boolean; // whether the agent serve a local view, default is false
+    sharedLocalView?: string[]; // the agent to share the local view with, default is none
 } & ActionManifest;
 
 export type SchemaTypeNames = {
@@ -46,9 +47,12 @@ export type ActionManifest = {
 // App Agent
 //==============================================================================
 
+export type AppAgentInitSettings = {
+    localHostPort?: number; // the assigned port to use to serve the view if localHostPort is true in the manifest
+};
 export interface AppAgent extends Partial<AppAgentCommandInterface> {
     // Setup
-    initializeAgentContext?(): Promise<unknown>;
+    initializeAgentContext?(settings?: AppAgentInitSettings): Promise<unknown>;
     updateAgentContext?(
         enable: boolean,
         context: SessionContext,
@@ -129,6 +133,9 @@ export interface SessionContext<T = unknown> {
     ): Promise<void>;
 
     removeDynamicAgent(agentName: string): Promise<void>;
+
+    // Experimental: get the shared local host port
+    getSharedLocalHostPort(agentName: string): Promise<number>;
 
     // Experimental: get the available indexes
     indexes(type: "image" | "email" | "all"): Promise<any[]>;

--- a/ts/packages/agentSdk/src/index.ts
+++ b/ts/packages/agentSdk/src/index.ts
@@ -16,6 +16,7 @@ export {
     ActionContext,
     SchemaTypeNames,
     ActivityContext,
+    AppAgentInitSettings,
 } from "./agentInterface.js";
 
 export {

--- a/ts/packages/agents/browser/src/agent/actionHandler.mts
+++ b/ts/packages/agents/browser/src/agent/actionHandler.mts
@@ -53,30 +53,17 @@ export function instantiate(): AppAgent {
 }
 
 export type BrowserActionContext = {
-    webSocket: WebSocket | undefined;
-    webAgentChannels: WebAgentChannels | undefined;
-    crossWordState: Crossword | undefined;
-    browserConnector: BrowserConnector | undefined;
-    browserProcess: ChildProcess | undefined;
-    tabTitleIndex: TabTitleIndex | undefined;
-    planVisualizationEndpoint: string | undefined;
+    webSocket?: WebSocket | undefined;
+    webAgentChannels?: WebAgentChannels | undefined;
+    crossWordState?: Crossword | undefined;
+    browserConnector?: BrowserConnector | undefined;
+    browserProcess?: ChildProcess | undefined;
+    tabTitleIndex?: TabTitleIndex | undefined;
 };
 
 async function initializeBrowserContext(): Promise<BrowserActionContext> {
-    return {
-        webSocket: undefined,
-        webAgentChannels: undefined,
-        crossWordState: undefined,
-        browserConnector: undefined,
-        browserProcess: undefined,
-        tabTitleIndex: undefined,
-        planVisualizationEndpoint: undefined,
-    };
+    return {};
 }
-
-const portBase = process.env.PORT ? parseInt(process.env.PORT) : 9001;
-const planViewerPortIndex = 2;
-const port = portBase + planViewerPortIndex;
 
 async function updateBrowserContext(
     enable: boolean,
@@ -90,10 +77,6 @@ async function updateBrowserContext(
     if (enable) {
         if (!context.agentContext.tabTitleIndex) {
             context.agentContext.tabTitleIndex = createTabTitleIndex();
-        }
-
-        if (!context.agentContext.planVisualizationEndpoint) {
-            context.agentContext.planVisualizationEndpoint = `http://localhost:${port}`;
         }
 
         if (context.agentContext.webSocket?.readyState === WebSocket.OPEN) {

--- a/ts/packages/agents/browser/src/agent/commerce/actionHandler.mts
+++ b/ts/packages/agents/browser/src/agent/commerce/actionHandler.mts
@@ -45,7 +45,6 @@ export async function handleCommerceAction(
             break;
         case "buyProduct":
             return await handleShoppingRequest(action);
-            break;
     }
 
     async function getComponentFromPage(
@@ -207,13 +206,17 @@ export async function handleCommerceAction(
         let executionHistory: any[] = [];
         let lastAction: any;
 
-        console.log(
-            "Plan visualizer: " +
-                context.sessionContext.agentContext.planVisualizationEndpoint,
-        );
+        const planVisualizationEndpoint = `http://localhost:${context.sessionContext.getSharedLocalHostPort("planVisualizer")}`;
+
+        if (!planVisualizationEndpoint) {
+            throw new Error(
+                "Plan visualization endpoint not assigned. Please check your configuration.",
+            );
+        }
+        console.log("Plan visualizer: " + planVisualizationEndpoint);
 
         const { trackState, reset } = createExecutionTracker(
-            context.sessionContext.agentContext.planVisualizationEndpoint!,
+            planVisualizationEndpoint,
             action.parameters.userRequest,
         );
 

--- a/ts/packages/agents/browser/src/extension/serviceWorker/browserActions.ts
+++ b/ts/packages/agents/browser/src/extension/serviceWorker/browserActions.ts
@@ -7,8 +7,6 @@ import {
     getTabByTitle,
     awaitPageLoad,
     awaitPageIncrementalUpdates,
-    downloadStringAsFile,
-    downloadImageAsFile,
 } from "./tabManager";
 import {
     getTabScreenshot,

--- a/ts/packages/agents/markdown/src/agent/markdownManifest.json
+++ b/ts/packages/agents/markdown/src/agent/markdownManifest.json
@@ -1,6 +1,7 @@
 {
   "emojiChar": "🗎",
   "description": "Agent to create and update markdown files",
+  "localView": true,
   "schema": {
     "description": "Markdown editing agent that updates documents using Github markdown flavor.",
     "schemaFile": "./markdownActionSchema.ts",

--- a/ts/packages/agents/markdown/src/view/route/service.ts
+++ b/ts/packages/agents/markdown/src/view/route/service.ts
@@ -12,9 +12,10 @@ import path from "path";
 import fs from "fs";
 
 const app: Express = express();
-const portBase = process.env.PORT ? parseInt(process.env.PORT) : 9001;
-const markDownPortIndex = 0;
-const port = portBase + markDownPortIndex;
+const port = parseInt(process.argv[2]);
+if (isNaN(port)) {
+    throw new Error("Port must be a number");
+}
 const limiter = rateLimit({
     windowMs: 60000,
     max: 100, // limit each IP to 100 requests per windowMs

--- a/ts/packages/agents/montage/src/agent/montageActionHandler.ts
+++ b/ts/packages/agents/montage/src/agent/montageActionHandler.ts
@@ -7,6 +7,7 @@ import {
     SessionContext,
     ActionResult,
     TypeAgentAction,
+    AppAgentInitSettings,
 } from "@typeagent/agent-sdk";
 import { ChildProcess, fork, spawn } from "child_process";
 import { fileURLToPath } from "node:url";
@@ -57,8 +58,9 @@ type MontageActionContext = {
     montageIdSeed: number;
     montages: PhotoMontage[];
     activeMontageId: number;
-    imageCollection: im.ImageCollection | undefined;
-    viewProcess: ChildProcess | undefined;
+    imageCollection?: im.ImageCollection | undefined;
+    viewProcess?: ChildProcess | undefined;
+    localHostPort: number;
     searchSettings: {
         minScore: number;
         exactMatch: boolean;
@@ -80,9 +82,10 @@ async function executeMontageAction(
     context: ActionContext<MontageActionContext>,
 ) {
     const agentContext = context.sessionContext.agentContext;
-    const activeMontage = getActiveMontage(agentContext);
+    const lastActiveMontage = getActiveMontage(agentContext);
     const result = await handleMontageAction(action, context);
-    if (activeMontage !== getActiveMontage(agentContext)) {
+    const currentActiveMontage = getActiveMontage(agentContext);
+    if (lastActiveMontage !== currentActiveMontage) {
         // if the active montage has changed, update the viewer
         updateMontageViewerState(agentContext);
     }
@@ -91,16 +94,18 @@ async function executeMontageAction(
         if (
             action.actionName === "startEditMontage" ||
             (context.activityContext !== undefined &&
-                context.activityContext.state.title !== activeMontage?.title)
+                context.activityContext.state.title !==
+                    currentActiveMontage?.title)
         ) {
             result.activityContext =
-                activeMontage !== undefined
+                currentActiveMontage !== undefined
                     ? {
                           activityName: "edit",
-                          description: `Editing montage ${activeMontage.title}`,
+                          description: `Editing montage ${currentActiveMontage.title}`,
                           state: {
-                              title: activeMontage.title,
+                              title: currentActiveMontage.title,
                           },
+                          openLocalView: true,
                       }
                     : null;
         }
@@ -142,15 +147,25 @@ const CryptBinaryToStringW = crypt32?.func(
     "bool CryptBinaryToStringW(ITEMIDLIST* pbBinary, uint cbBinary, uint dwFlags, _Inout_ str16 pszString, _Inout_ uint* pcchString)",
 );
 
-async function initializeMontageContext() {
+async function initializeMontageContext(
+    settings?: AppAgentInitSettings,
+): Promise<MontageActionContext> {
+    const localHostPort = settings?.localHostPort;
+    if (localHostPort === undefined) {
+        throw new Error("Local view port not assigned.");
+    }
     return {
         // default search settings
         searchSettings: {
             minScore: 0.5, // TODO tune?
             exactMatch: false,
         },
-
-        getActiveMontage,
+        localHostPort,
+        montageIdSeed: NaN,
+        montages: [],
+        activeMontageId: -1,
+        fuzzyMatchingModel: undefined,
+        indexes: [],
     };
 }
 
@@ -252,6 +267,7 @@ async function updateMontageContext(
                         agentContext.montages.push(montage);
                     }
                 },
+                agentContext.localHostPort,
             );
 
             const folders: string[] = [];
@@ -899,6 +915,7 @@ async function ensureActiveMontage(
 
 export async function createViewServiceHost(
     montageUpdatedCallback: (montage: PhotoMontage) => void,
+    port: number,
 ) {
     let timeoutHandle: NodeJS.Timeout;
 
@@ -919,7 +936,7 @@ export async function createViewServiceHost(
                     ),
                 );
 
-                const childProcess = fork(expressService);
+                const childProcess = fork(expressService, [port.toString()]);
 
                 childProcess.on("message", function (message) {
                     if (message === "Success") {

--- a/ts/packages/agents/montage/src/agent/montageManifest.json
+++ b/ts/packages/agents/montage/src/agent/montageManifest.json
@@ -1,6 +1,7 @@
 {
   "emojiChar": "🎞",
   "description": "Agent to create photo montages.",
+  "localView": true,
   "schema": {
     "description": "Photo montage agent to help the user with image management.",
     "schemaFile": "./montageActionSchema.ts",

--- a/ts/packages/agents/montage/src/route/route.ts
+++ b/ts/packages/agents/montage/src/route/route.ts
@@ -13,9 +13,11 @@ import registerDebug from "debug";
 
 const debug = registerDebug("typeagent:agent:montage:route");
 const app: Express = express();
-const portBase = process.env.PORT ? parseInt(process.env.PORT) : 9001;
-const montagePortIndex = 1;
-const port = portBase + montagePortIndex;
+
+const port = parseInt(process.argv[2]);
+if (isNaN(port)) {
+    throw new Error("Port must be a number");
+}
 
 // configurable folders for securing folder access. Is populated based on available indexes
 // but can be customized further here

--- a/ts/packages/agents/planVisualizer/src/agent/planViewManifest.json
+++ b/ts/packages/agents/planVisualizer/src/agent/planViewManifest.json
@@ -1,6 +1,8 @@
 {
   "emojiChar": "🕸",
   "description": "Agent to visualize static and dynamic Plans",
+  "localView": true,
+  "sharedLocalView": "browser",
   "schema": {
     "description": "A webPlan visualization agent, that handles static and dynamic plans.",
     "schemaFile": "./planViewActionSchema.ts",

--- a/ts/packages/agents/planVisualizer/src/view/server/server.ts
+++ b/ts/packages/agents/planVisualizer/src/view/server/server.ts
@@ -16,17 +16,11 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 const app = express();
-const isDev =
-    process.argv.includes("--dev") ||
-    process.argv.includes("--mode=development");
 
-const portBase = process.env.PORT
-    ? parseInt(process.env.PORT)
-    : isDev
-      ? 9050
-      : 9001;
-const planViewerPortIndex = 2;
-const port = portBase + planViewerPortIndex;
+const port = parseInt(process.argv[2]);
+if (isNaN(port)) {
+    throw new Error("Port must be a number");
+}
 
 // Type definitions for the server
 interface Client extends Response {}

--- a/ts/packages/dispatcher/src/context/commandHandlerContext.ts
+++ b/ts/packages/dispatcher/src/context/commandHandlerContext.ts
@@ -183,6 +183,9 @@ export type DispatcherOptions = DeepPartialUndefined<DispatcherConfig> & {
     explanationAsynchronousMode?: boolean; // default to false
     collectCommandResult?: boolean; // default to false
 
+    allowSharedLocalView?: string[]; // agents that can access any shared local views, default to undefined
+    portBase?: number; // default to 9001
+
     // Use for tests so that embedding can be cached without 'persistDir'
     embeddingCacheDir?: string | undefined; // default to 'cache' under 'persistDir' if specified
 };
@@ -385,7 +388,12 @@ export async function initializeCommandHandlerContext(
         if (embeddingCacheDir) {
             ensureDirectory(embeddingCacheDir);
         }
-        const agents = new AppAgentManager(cacheDir);
+        const portBase = options?.portBase ?? 9001;
+        const agents = new AppAgentManager(
+            cacheDir,
+            portBase,
+            options?.allowSharedLocalView,
+        );
         const constructionProvider = options?.constructionProvider;
         const context: CommandHandlerContext = {
             agents,

--- a/ts/packages/dispatcher/src/context/interactiveIO.ts
+++ b/ts/packages/dispatcher/src/context/interactiveIO.ts
@@ -86,6 +86,7 @@ export interface ClientIO {
         source: string,
     ): void;
 
+    openLocalView(port: number): void;
     // Host specific (TODO: Formalize the API)
     takeAction(action: string, data: unknown): void;
 }
@@ -145,6 +146,7 @@ export const nullClientIO: ClientIO = {
     ) => defaultValue,
     proposeAction: async () => undefined,
     notify: () => {},
+    openLocalView: () => {},
     takeAction: (action: string) => {
         throw new Error(`Action ${action} not supported`);
     },

--- a/ts/packages/dispatcher/src/helpers/console.ts
+++ b/ts/packages/dispatcher/src/helpers/console.ts
@@ -183,6 +183,9 @@ function createConsoleClientIO(rl?: readline.promises.Interface): ClientIO {
                 // ignored.
             }
         },
+        async openLocalView(port: number): Promise<void> {
+            await open(`http://localhost:${port}`);
+        },
         // Host specific (TODO: Formalize the API)
         takeAction(action: string, data: unknown): void {
             if (action === "open-folder") {

--- a/ts/packages/dispatcher/src/rpc/clientIOClient.ts
+++ b/ts/packages/dispatcher/src/rpc/clientIOClient.ts
@@ -91,7 +91,9 @@ export function createClientIORpcClient(channel: RpcChannel): ClientIO {
         ): void {
             return rpc.send("notify", { event, requestId, data, source });
         },
-
+        openLocalView(port: number): Promise<void> {
+            return rpc.invoke("openLocalView", { port });
+        },
         takeAction(action: string, data: unknown): void {
             return rpc.send("takeAction", { action, data });
         },

--- a/ts/packages/dispatcher/src/rpc/clientIOServer.ts
+++ b/ts/packages/dispatcher/src/rpc/clientIOServer.ts
@@ -28,6 +28,9 @@ export function createClientIORpcServer(
                 params.source,
             );
         },
+        openLocalView: async (params) => {
+            return clientIO.openLocalView(params.port);
+        },
     };
 
     const clientIOCallFunctions: ClientIOCallFunctions = {

--- a/ts/packages/dispatcher/src/rpc/clientIOTypes.ts
+++ b/ts/packages/dispatcher/src/rpc/clientIOTypes.ts
@@ -16,6 +16,7 @@ export type ClientIOInvokeFunctions = {
         requestId: RequestId;
         source: string;
     }): Promise<unknown>;
+    openLocalView(params: { port: number }): Promise<void>;
 };
 
 export type ClientIOCallFunctions = {

--- a/ts/packages/shell/src/main/agent.ts
+++ b/ts/packages/shell/src/main/agent.ts
@@ -26,11 +26,7 @@ import { ShellAction } from "./shellActionSchema.js";
 import { ShellWindow } from "./shellWindow.js";
 import { getObjectProperty, getObjectPropertyNames } from "common-utils";
 import { installAndRestart, updateHandlerTable } from "./commands/update.js";
-import { isProd, portBase } from "./index.js";
-
-const markdownPortIndex = 0;
-const montagePortIndex = 1;
-const planViewerPortIndex = 2;
+import { isProd } from "./index.js";
 
 export type ShellContext = {
     shellWindow: ShellWindow;
@@ -209,8 +205,9 @@ class ShellOpenWebContentView implements CommandHandler {
         context: ActionContext<ShellContext>,
         params: ParsedCommandParams<typeof this.parameters>,
     ) {
+        const agentContext = context.sessionContext.agentContext;
         let targetUrl: URL;
-        switch (params.args.site.toString().toLowerCase()) {
+        switch (params.args.site.toLowerCase()) {
             case "paleobiodb":
                 targetUrl = new URL("https://paleobiodb.org/navigator/");
 
@@ -223,49 +220,27 @@ class ShellOpenWebContentView implements CommandHandler {
                 break;
             case "commerce":
                 targetUrl = new URL("https://www.target.com/");
-
                 break;
-            case "markdown":
-                targetUrl = new URL(
-                    `http://localhost:${portBase + markdownPortIndex}/`,
-                );
 
-                break;
-            case "montage":
-                // TODO: agents should publish their port #s in manifests
-                targetUrl = new URL(
-                    `http://localhost:${portBase + montagePortIndex}/`,
-                );
-
-                break;
-            case "planviewer":
-                targetUrl = new URL(
-                    `http://localhost:${portBase + planViewerPortIndex}/`,
-                );
-
-                break;
             default:
                 try {
-                    targetUrl = new URL(params.args.site);
-                } catch (e) {
-                    // if the URL is invalid let's try to open the last used canvas item if we have one
-                    // if we don't, then we've tried our best
-                    return this.run(context, {
-                        args: {
-                            site: {
-                                description: "",
-                                value: context.sessionContext.agentContext.shellWindow.getUserSettings()
-                                    .canvas,
-                            },
-                        },
-                    } as any);
+                    const port =
+                        await context.sessionContext.getSharedLocalHostPort(
+                            params.args.site,
+                        );
+                    targetUrl = new URL(`http://localhost:${port}`);
+                } catch {
+                    try {
+                        targetUrl = new URL(params.args.site);
+                    } catch (e) {
+                        throw new Error(
+                            `Unable to open '${params.args.site}': ${e}`,
+                        );
+                    }
                 }
-
                 break;
         }
-        context.sessionContext.agentContext.shellWindow.openInlineBrowser(
-            targetUrl,
-        );
+        agentContext.shellWindow.openInlineBrowser(targetUrl);
     }
 }
 

--- a/ts/packages/shell/src/main/agent.ts
+++ b/ts/packages/shell/src/main/agent.ts
@@ -25,8 +25,7 @@ import { getLocalWhisperCommandHandlers } from "./localWhisperCommandHandler.js"
 import { ShellAction } from "./shellActionSchema.js";
 import { ShellWindow } from "./shellWindow.js";
 import { getObjectProperty, getObjectPropertyNames } from "common-utils";
-import { updateHandlerTable } from "./commands/update.js";
-import { app } from "electron";
+import { installAndRestart, updateHandlerTable } from "./commands/update.js";
 import { isProd, portBase } from "./index.js";
 
 const markdownPortIndex = 0;
@@ -312,8 +311,7 @@ const handlers: CommandHandlerTable = {
                         "Unable to restart running under vite with HMR.",
                     );
                 }
-                app.relaunch();
-                app.exit(0);
+                installAndRestart();
             },
         },
     },

--- a/ts/packages/shell/src/main/commands/update.ts
+++ b/ts/packages/shell/src/main/commands/update.ts
@@ -59,6 +59,15 @@ export function hasPendingUpdate() {
     return state.updateInfo !== undefined;
 }
 
+export function installAndRestart() {
+    if (state.updateInfo) {
+        autoUpdater.quitAndInstall(false, true);
+    } else {
+        app.relaunch();
+        app.exit(0);
+    }
+}
+
 let pendingUpdateCallback:
     | ((version: electronUpdater.UpdateInfo, background: boolean) => void)
     | undefined;

--- a/ts/packages/shell/src/main/index.ts
+++ b/ts/packages/shell/src/main/index.ts
@@ -75,14 +75,7 @@ if (isProd) {
         debugShellError("Another instance is running");
         process.exit(0);
     }
-} else {
-    // dev mode
-    if (process.env.PORT === undefined) {
-        process.env.PORT = "9050";
-    }
 }
-
-export const portBase = process.env.PORT ? parseInt(process.env.PORT) : 9001;
 
 // Set app user model id for windows
 if (process.platform === "win32") {
@@ -247,6 +240,11 @@ async function initializeDispatcher(
         const newClientIO = createClientIORpcClient(clientIOChannel.channel);
         const clientIO = {
             ...newClientIO,
+            openLocalView: (port: number) => {
+                return shellWindow.openInlineBrowser(
+                    new URL(`http://localhost:${port}`),
+                );
+            },
             exit: () => {
                 app.quit();
             },
@@ -268,6 +266,8 @@ async function initializeDispatcher(
             clientId: getClientId(),
             clientIO,
             constructionProvider: getDefaultConstructionProvider(),
+            allowSharedLocalView: ["shell"],
+            portBase: isProd ? 9001 : 9050,
         });
 
         async function processShellRequest(

--- a/ts/packages/shell/src/renderer/src/main.ts
+++ b/ts/packages/shell/src/renderer/src/main.ts
@@ -237,6 +237,9 @@ function addEvents(
                 // ignore
             }
         },
+        openLocalView: () => {
+            throw new Error("Main process should have handled openLocalView");
+        },
         takeAction: (action, data) => {
             // Android object gets injected on Android devices, otherwise unavailable
             try {


### PR DESCRIPTION
- Activity can indicate whether to open the view for the agent or not.  (used in `startEditMontage` action )
- Manifest declares whether the agent has a localhost view and dispatcher will centralize port assignment for them.
- Experimental API to allow other agent to get the port based on permissions set during dispatcher initialization (e.g. 'shell' can access any local host view), or the agent's manifest can declare who can access it (`browser` can connect to `planVisualizer`