### PR TITLE
better-sqlite3 dual node/electron setup for native modules

### DIFF
--- a/ts/examples/agentExamples/measure/src/database.ts
+++ b/ts/examples/agentExamples/measure/src/database.ts
@@ -2,22 +2,7 @@
 // Licensed under the MIT License.
 
 import Database, * as sqlite from "better-sqlite3";
-import { createRequire } from "node:module";
-import path from "node:path";
 import { removeFile } from "typeagent";
-
-function getDbOptions() {
-    if (process?.versions?.electron !== undefined) {
-        return undefined;
-    }
-    const r = createRequire(import.meta.url);
-    const betterSqlitePath = r.resolve("better-sqlite3/package.json");
-    const nativeBinding = path.join(
-        betterSqlitePath,
-        "../build/Release-Node/better_sqlite3.node",
-    );
-    return { nativeBinding };
-}
 
 export async function createDatabase(
     filePath: string,
@@ -26,7 +11,7 @@ export async function createDatabase(
     if (createNew) {
         await deleteDatabase(filePath);
     }
-    const db = new Database(filePath, getDbOptions());
+    const db = new Database(filePath);
     db.pragma("journal_mode = WAL");
     return db;
 }

--- a/ts/examples/memoryProviders/src/sqlite/common.ts
+++ b/ts/examples/memoryProviders/src/sqlite/common.ts
@@ -4,27 +4,12 @@
 import Database, * as sqlite from "better-sqlite3";
 import { ValueDataType, ValueType } from "knowledge-processor";
 import { removeFile } from "typeagent";
-import { createRequire } from "node:module";
-import path from "node:path";
 export type AssignedId<T> = {
     id: T;
     isNew: boolean;
 };
 
 export type BooleanRow = {};
-
-function getDbOptions() {
-    if (process?.versions?.electron !== undefined) {
-        return undefined;
-    }
-    const r = createRequire(import.meta.url);
-    const betterSqlitePath = r.resolve("better-sqlite3/package.json");
-    const nativeBinding = path.join(
-        betterSqlitePath,
-        "../build/Release-Node/better_sqlite3.node",
-    );
-    return { nativeBinding };
-}
 
 export async function createDatabase(
     filePath: string,
@@ -33,7 +18,7 @@ export async function createDatabase(
     if (createNew) {
         await deleteDatabase(filePath);
     }
-    const db = new Database(filePath, getDbOptions());
+    const db = new Database(filePath);
     db.pragma("journal_mode = WAL");
     return db;
 }

--- a/ts/package.json
+++ b/ts/package.json
@@ -25,7 +25,7 @@
     "elevate": "node tools/scripts/elevate.js",
     "getKeys": "node tools/scripts/getKeys.mjs",
     "getKeys:build": "node tools/scripts/getKeys.mjs --vault build-pipeline-kv",
-    "postinstall": "cd node_modules/.pnpm/node_modules/better-sqlite3 && pnpm exec prebuild-install && shx mkdir -p build/Release-Node && shx cp build/Release/better_sqlite3.node build/Release-Node",
+    "postinstall": "cd node_modules/.pnpm/node_modules/better-sqlite3 && shx rm -rf ./build && pnpm exec prebuild-install && shx cp build/Release/better_sqlite3.node build/better_sqlite3.node",
     "knowledgeVisualizer": "pnpm -C packages/knowledgeVisualizer exec npm run start",
     "kv": "pnpm -C packages/knowledgeVisualizer exec npm run start",
     "lint": "fluid-build . -t prettier",

--- a/ts/packages/agents/spelunker/src/databaseUtils.ts
+++ b/ts/packages/agents/spelunker/src/databaseUtils.ts
@@ -2,8 +2,6 @@
 // Licensed under the MIT License.
 
 import * as fs from "fs";
-import * as path from "path";
-import { createRequire } from "module";
 
 import Database, * as sqlite from "better-sqlite3";
 
@@ -43,19 +41,6 @@ CREATE TABLE IF NOT EXISTS ChunkEmbeddings (
 );
 `;
 
-function getDbOptions() {
-    if (process?.versions?.electron !== undefined) {
-        return undefined;
-    }
-    const r = createRequire(import.meta.url);
-    const betterSqlitePath = r.resolve("better-sqlite3/package.json");
-    const nativeBinding = path.join(
-        betterSqlitePath,
-        "../build/Release-Node/better_sqlite3.node",
-    );
-    return { nativeBinding };
-}
-
 export function createDatabase(context: SpelunkerContext): void {
     if (!context.queryContext) {
         throw new Error(
@@ -72,7 +57,7 @@ export function createDatabase(context: SpelunkerContext): void {
     } else {
         console_log(`[Creating database at ${loc}]`);
     }
-    const db = new Database(loc, getDbOptions());
+    const db = new Database(loc);
     // Write-Ahead Logging, improving concurrency and performance
     db.pragma("journal_mode = WAL");
     // Fix permissions to be read/write only by the owner

--- a/ts/packages/defaultAgentProvider/package.json
+++ b/ts/packages/defaultAgentProvider/package.json
@@ -27,7 +27,6 @@
     "tsc": "tsc -b"
   },
   "dependencies": {
-    "@azure/msal-node-extensions": "^1.5.0",
     "@modelcontextprotocol/sdk": "^1.8.0",
     "@modelcontextprotocol/server-filesystem": "2025.1.14",
     "@typeagent/agent-sdk": "workspace:*",

--- a/ts/packages/memory/storage/src/sqlite/sqliteCommon.ts
+++ b/ts/packages/memory/storage/src/sqlite/sqliteCommon.ts
@@ -2,22 +2,8 @@
 // Licensed under the MIT License.
 
 import Database, * as sqlite from "better-sqlite3";
-import { createRequire } from "node:module";
 import path from "node:path";
 import { removeFile, ensureDir } from "../fileSystem.js";
-
-function getDbOptions() {
-    if (process?.versions?.electron !== undefined) {
-        return undefined;
-    }
-    const r = createRequire(import.meta.url);
-    const betterSqlitePath = r.resolve("better-sqlite3/package.json");
-    const nativeBinding = path.join(
-        betterSqlitePath,
-        "../build/Release-Node/better_sqlite3.node",
-    );
-    return { nativeBinding };
-}
 
 export function createDatabase(
     filePath: string,
@@ -27,7 +13,7 @@ export function createDatabase(
         deleteDatabase(filePath);
     }
     ensureDir(path.dirname(filePath));
-    const db = new Database(filePath, getDbOptions());
+    const db = new Database(filePath);
     db.pragma("journal_mode = WAL");
     return db;
 }

--- a/ts/packages/shell/electron-builder.config.js
+++ b/ts/packages/shell/electron-builder.config.js
@@ -27,6 +27,22 @@ export default {
         buildResources: "build",
         output: "dist",
     },
+    files: [
+        // Filter native module for platform and arch.
+        // For some reason, electron-builder only process "!" and FileSet for node modules.
+        {
+            filter: [
+                "**/*",
+                "!node_modules/koffi/build/koffi",
+                "node_modules/koffi/build/koffi/${platform}_${arch}",
+                `!node_modules/@azure/msal-node-runtime/dist/${arch === "ia32" ? "x64" : "x86"}`,
+                "!node_modules/@azure/msal-node-extensions/bin",
+                "node_modules/@azure/msal-node-extensions/bin/${arch}",
+                "!node_modules/@img",
+                "node_modules/@img/sharp*-${platform}*-${arch}/**/*",
+            ],
+        },
+    ],
     asarUnpack: [
         // electron can't load the browser extension from the ASAR
         "node_modules/browser-typeagent/dist/electron/**/*",

--- a/ts/pnpm-lock.yaml
+++ b/ts/pnpm-lock.yaml
@@ -2162,9 +2162,6 @@ importers:
 
   packages/defaultAgentProvider:
     dependencies:
-      '@azure/msal-node-extensions':
-        specifier: ^1.5.0
-        version: 1.5.0
       '@modelcontextprotocol/sdk':
         specifier: ^1.8.0
         version: 1.8.0
@@ -2321,7 +2318,7 @@ importers:
     dependencies:
       '@azure/msal-node-extensions':
         specifier: ^1.5.0
-        version: 1.5.0
+        version: 1.5.13
       '@typeagent/agent-sdk':
         specifier: workspace:*
         version: link:../agentSdk
@@ -2794,7 +2791,7 @@ importers:
         version: 4.2.1
       '@azure/msal-node-extensions':
         specifier: ^1.5.0
-        version: 1.5.0
+        version: 1.5.13
       '@electron-toolkit/preload':
         specifier: ^3.0.2
         version: 3.0.2(electron@35.2.1)
@@ -3309,35 +3306,27 @@ packages:
     resolution: {integrity: sha512-PB9GlnfojcQ4nf9WXdQvWeAk7gm8P74o+Z5IHz5YLK/W+3vrNrmVVVuFpGOvCPrLjag50UinaZsMBtPtxoiobg==}
     engines: {node: '>=14.0.0'}
 
-  '@azure/msal-browser@3.26.1':
-    resolution: {integrity: sha512-y78sr9g61aCAH9fcLO1um+oHFXc1/5Ap88RIsUSuzkm0BHzFnN+PXGaQeuM1h5Qf5dTnWNOd6JqkskkMPAhh7Q==}
-    engines: {node: '>=0.8.0'}
-
-  '@azure/msal-common@14.12.0':
-    resolution: {integrity: sha512-IDDXmzfdwmDkv4SSmMEyAniJf6fDu3FJ7ncOjlxkDuT85uSnLEhZi3fGZpoR7T4XZpOMx9teM9GXBgrfJgyeBw==}
-    engines: {node: '>=0.8.0'}
-
-  '@azure/msal-common@14.15.0':
-    resolution: {integrity: sha512-ImAQHxmpMneJ/4S8BRFhjt1MZ3bppmpRPYYNyzeQPeFN288YKbb8TmmISQEbtfkQ1BPASvYZU5doIZOPBAqENQ==}
+  '@azure/msal-browser@3.28.1':
+    resolution: {integrity: sha512-OHHEWMB5+Zrix8yKvLVzU3rKDFvh7SOzAzXfICD7YgUXLxfHpTPX2pzOotrri1kskwhHqIj4a5LvhZlIqE7C7g==}
     engines: {node: '>=0.8.0'}
 
   '@azure/msal-common@14.16.0':
     resolution: {integrity: sha512-1KOZj9IpcDSwpNiQNjt0jDYZpQvNZay7QAEi/5DLubay40iGYtLzya/jbjRPLyOTZhEKyL1MzPuw2HqBCjceYA==}
     engines: {node: '>=0.8.0'}
 
-  '@azure/msal-node-extensions@1.5.0':
-    resolution: {integrity: sha512-UfEyh2xmJHKH64zPS/SbN1bd9adV4ZWGp1j2OSwIuhVraqpUXyXZ1LpDpiUqg/peTgLLtx20qrHOzYT0kKzmxQ==}
+  '@azure/msal-common@15.6.0':
+    resolution: {integrity: sha512-EotmBz42apYGjqiIV9rDUdptaMptpTn4TdGf3JfjLvFvinSe9BJ6ywU92K9ky+t/b0ghbeTSe9RfqlgLh8f2jA==}
+    engines: {node: '>=0.8.0'}
+
+  '@azure/msal-node-extensions@1.5.13':
+    resolution: {integrity: sha512-5JQaPS/hGN5iL1rNBr+t17eVrpIjp8oXnCIrkj8WX4a8YbhlHaw+GhQthetdkMMvJE5RwbdzEN4Vm6zKX9ArGQ==}
     engines: {node: '>=16'}
 
-  '@azure/msal-node-runtime@0.17.1':
-    resolution: {integrity: sha512-qAfTg+iGJsg+XvD9nmknI63+XuoX32oT+SX4wJdFz7CS6ETVpSHoroHVaUmsTU1H7H0+q1/ZkP988gzPRMYRsg==}
+  '@azure/msal-node-runtime@0.18.2':
+    resolution: {integrity: sha512-v45fyBQp80BrjZAeGJXl+qggHcbylQiFBihr0ijO2eniDCW9tz5TZBKYsqzH06VuiRaVG/Sa0Hcn4pjhJqFSTw==}
 
   '@azure/msal-node@2.16.2':
     resolution: {integrity: sha512-An7l1hEr0w1HMMh1LU+rtDtqL7/jw74ORlc9Wnh06v7TU/xpG39/Zdr1ZJu3QpjUfKJ+E0/OXMW8DRSWTlh7qQ==}
-    engines: {node: '>=16'}
-
-  '@azure/msal-node@2.9.2':
-    resolution: {integrity: sha512-8tvi6Cos3m+0KmRbPjgkySXi+UQU/QiuVRFnrxIwt5xZlEEFa69O04RTaNESGgImyBBlYbo2mfE8/U8Bbdk1WQ==}
     engines: {node: '>=16'}
 
   '@azure/storage-blob@12.26.0':
@@ -10986,8 +10975,8 @@ snapshots:
     dependencies:
       '@azure/core-auth': 1.7.1
       '@azure/identity': 4.2.1
-      '@azure/msal-node': 2.9.2
-      '@azure/msal-node-extensions': 1.5.0
+      '@azure/msal-node': 2.16.2
+      '@azure/msal-node-extensions': 1.5.13
       keytar: 7.9.0
       tslib: 2.8.1
     transitivePeerDependencies:
@@ -11002,7 +10991,7 @@ snapshots:
       '@azure/core-tracing': 1.2.0
       '@azure/core-util': 1.11.0
       '@azure/logger': 1.1.1
-      '@azure/msal-browser': 3.26.1
+      '@azure/msal-browser': 3.28.1
       '@azure/msal-node': 2.16.2
       events: 3.3.0
       jws: 4.0.0
@@ -11033,33 +11022,25 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@azure/msal-browser@3.26.1':
+  '@azure/msal-browser@3.28.1':
     dependencies:
-      '@azure/msal-common': 14.15.0
-
-  '@azure/msal-common@14.12.0': {}
-
-  '@azure/msal-common@14.15.0': {}
+      '@azure/msal-common': 14.16.0
 
   '@azure/msal-common@14.16.0': {}
 
-  '@azure/msal-node-extensions@1.5.0':
+  '@azure/msal-common@15.6.0': {}
+
+  '@azure/msal-node-extensions@1.5.13':
     dependencies:
-      '@azure/msal-common': 14.16.0
-      '@azure/msal-node-runtime': 0.17.1
+      '@azure/msal-common': 15.6.0
+      '@azure/msal-node-runtime': 0.18.2
       keytar: 7.9.0
 
-  '@azure/msal-node-runtime@0.17.1': {}
+  '@azure/msal-node-runtime@0.18.2': {}
 
   '@azure/msal-node@2.16.2':
     dependencies:
       '@azure/msal-common': 14.16.0
-      jsonwebtoken: 9.0.2
-      uuid: 8.3.2
-
-  '@azure/msal-node@2.9.2':
-    dependencies:
-      '@azure/msal-common': 14.12.0
       jsonwebtoken: 9.0.2
       uuid: 8.3.2
 


### PR DESCRIPTION
- Repeat `pnpm i` was leaving the node version for electron to use because of .forge-meta indicate that it is set up already.  Delete the build directory everytime to force it to be refresh again.
- Change the location of the node version of the binary for `binding` package to find as well so that an explicit native path is no longer necesary.
- Filter out binaries that doesn't match with packaged installer.