### PR TITLE
Reduce size and fix install packages

### DIFF
--- a/azure/README.MD
+++ b/azure/README.MD
@@ -4,13 +4,13 @@ The templates in this folder allow you to quickly create all of the necessary Az
 
 ## Quickstart
 
-To deploy these resources in your Azure subscription into a resource group called *typeagent_demo* run the following command either in the cloud shell or from an AzureCLI: 
+To deploy these resources in your Azure subscription into a resource group called _typeagent_demo_ run the following command either in the cloud shell or from an AzureCLI:
 
 `az deployment group create --resource-group typeagent_demo --template-file template.json`
 
 ## Features Not Covered
 
-The following TypeAgent features/components are not automatically created or configured by these ARM tempates:
+The following TypeAgent features/components are not automatically created or configured by these ARM templates:
 
 - Demo Tenant for [Calendar](../ts/packages/agents/calendar) & [Email](../ts/packages/agents/email/) agents
 - Permissions Assignment

--- a/ts/packages/dispatcher/package.json
+++ b/ts/packages/dispatcher/package.json
@@ -26,7 +26,8 @@
   },
   "files": [
     "dist",
-    "!dist/test"
+    "!dist/test",
+    "src/**/*ActionSchema*"
   ],
   "scripts": {
     "build": "npm run tsc",

--- a/ts/packages/shell/electron-builder.config.js
+++ b/ts/packages/shell/electron-builder.config.js
@@ -28,13 +28,18 @@ export default {
         output: "dist",
     },
     files: [
-        // Filter native module for platform and arch.
         // For some reason, electron-builder only process "!" and FileSet for node modules.
         {
             filter: [
                 "**/*",
+                // Ignore all build artifacts
                 "!**/*.tsbuildinfo",
                 "!**/*.done.build.log",
+                // source map doesn't work in asar anyways
+                "!**/*.?(c|m)@(t|j)s.map",
+                // type definitions files is not needed, but keep the .ts files for schemas for now
+                "!**/*.d.?(c|m)ts",
+                // Filter native module for platform and arch.
                 "!node_modules/koffi/build/koffi",
                 "node_modules/koffi/build/koffi/${platform}_${arch}",
                 `!node_modules/@azure/msal-node-runtime/dist/${arch === "ia32" ? "x64" : "x86"}`,

--- a/ts/packages/shell/package.json
+++ b/ts/packages/shell/package.json
@@ -14,7 +14,8 @@
   "main": "./out/main/index.js",
   "files": [
     "out",
-    "package.json"
+    "package.json",
+    "src/**/*ActionSchema*"
   ],
   "scripts": {
     "build": "concurrently npm:prepare-vite npm:build:electron:esm",
@@ -52,7 +53,6 @@
     "@azure/identity": "^4.9.1",
     "@azure/msal-node-extensions": "^1.5.0",
     "@electron-toolkit/preload": "^3.0.2",
-    "@fontsource/lato": "^5.2.5",
     "@typeagent/agent-sdk": "workspace:*",
     "agent-dispatcher": "workspace:*",
     "agent-rpc": "workspace:*",
@@ -73,6 +73,7 @@
   },
   "devDependencies": {
     "@electron-toolkit/tsconfig": "^1.0.1",
+    "@fontsource/lato": "^5.2.5",
     "@playwright/test": "^1.52.0",
     "@types/debug": "^4.1.12",
     "concurrently": "^9.1.2",

--- a/ts/packages/shell/src/main/agent.ts
+++ b/ts/packages/shell/src/main/agent.ts
@@ -27,6 +27,7 @@ import { ShellWindow } from "./shellWindow.js";
 import { getObjectProperty, getObjectPropertyNames } from "common-utils";
 import { installAndRestart, updateHandlerTable } from "./commands/update.js";
 import { isProd } from "./index.js";
+import { fileURLToPath } from "node:url";
 
 export type ShellContext = {
     shellWindow: ShellWindow;
@@ -37,7 +38,9 @@ const config: AppAgentManifest = {
     description: "Shell",
     schema: {
         description: "Graphical user interface (shell) for the user.",
-        schemaFile: "../shell/src/main/shellActionSchema.ts",
+        schemaFile: fileURLToPath(
+            new URL("../../src/main/shellActionSchema.ts", import.meta.url),
+        ),
         schemaType: "ShellAction",
     },
 };

--- a/ts/pnpm-lock.yaml
+++ b/ts/pnpm-lock.yaml
@@ -2795,9 +2795,6 @@ importers:
       '@electron-toolkit/preload':
         specifier: ^3.0.2
         version: 3.0.2(electron@35.2.1)
-      '@fontsource/lato':
-        specifier: ^5.2.5
-        version: 5.2.5
       '@typeagent/agent-sdk':
         specifier: workspace:*
         version: link:../agentSdk
@@ -2853,6 +2850,9 @@ importers:
       '@electron-toolkit/tsconfig':
         specifier: ^1.0.1
         version: 1.0.1(@types/node@22.15.2)
+      '@fontsource/lato':
+        specifier: ^5.2.5
+        version: 5.2.5
       '@playwright/test':
         specifier: ^1.52.0
         version: 1.52.0


### PR DESCRIPTION
- Make sure the action schema ts file are included in the installed package.  (Fixes dispatcher and shell actions)
- Make sure we specify the right path for the shell action schema (no matter where it is installed)
- Exclude source map and TS type files from the installed package.
- Don't include the font package in the ASAR.  (it is already in the assets directory)