### PR TITLE
Reinstate special handler better-sqlite3 to load native module for node

### DIFF
--- a/ts/examples/agentExamples/measure/src/database.ts
+++ b/ts/examples/agentExamples/measure/src/database.ts
@@ -2,7 +2,22 @@
 // Licensed under the MIT License.
 
 import Database, * as sqlite from "better-sqlite3";
+import { createRequire } from "node:module";
+import path from "node:path";
 import { removeFile } from "typeagent";
+
+function getDbOptions() {
+    if (process?.versions?.electron !== undefined) {
+        return undefined;
+    }
+    const r = createRequire(import.meta.url);
+    const betterSqlitePath = r.resolve("better-sqlite3/package.json");
+    const nativeBinding = path.join(
+        betterSqlitePath,
+        "../build/Release-Node/better_sqlite3.node",
+    );
+    return { nativeBinding };
+}
 
 export async function createDatabase(
     filePath: string,
@@ -11,7 +26,7 @@ export async function createDatabase(
     if (createNew) {
         await deleteDatabase(filePath);
     }
-    const db = new Database(filePath);
+    const db = new Database(filePath, getDbOptions());
     db.pragma("journal_mode = WAL");
     return db;
 }

--- a/ts/examples/memoryProviders/src/sqlite/common.ts
+++ b/ts/examples/memoryProviders/src/sqlite/common.ts
@@ -3,6 +3,8 @@
 
 import Database, * as sqlite from "better-sqlite3";
 import { ValueDataType, ValueType } from "knowledge-processor";
+import { createRequire } from "node:module";
+import path from "node:path";
 import { removeFile } from "typeagent";
 export type AssignedId<T> = {
     id: T;
@@ -11,6 +13,19 @@ export type AssignedId<T> = {
 
 export type BooleanRow = {};
 
+function getDbOptions() {
+    if (process?.versions?.electron !== undefined) {
+        return undefined;
+    }
+    const r = createRequire(import.meta.url);
+    const betterSqlitePath = r.resolve("better-sqlite3/package.json");
+    const nativeBinding = path.join(
+        betterSqlitePath,
+        "../build/Release-Node/better_sqlite3.node",
+    );
+    return { nativeBinding };
+}
+
 export async function createDatabase(
     filePath: string,
     createNew: boolean,
@@ -18,7 +33,7 @@ export async function createDatabase(
     if (createNew) {
         await deleteDatabase(filePath);
     }
-    const db = new Database(filePath);
+    const db = new Database(filePath, getDbOptions());
     db.pragma("journal_mode = WAL");
     return db;
 }

--- a/ts/package.json
+++ b/ts/package.json
@@ -25,7 +25,7 @@
     "elevate": "node tools/scripts/elevate.js",
     "getKeys": "node tools/scripts/getKeys.mjs",
     "getKeys:build": "node tools/scripts/getKeys.mjs --vault build-pipeline-kv",
-    "postinstall": "cd node_modules/.pnpm/node_modules/better-sqlite3 && shx rm -rf ./build && pnpm exec prebuild-install && shx cp build/Release/better_sqlite3.node build/better_sqlite3.node",
+    "postinstall": "cd node_modules/.pnpm/node_modules/better-sqlite3 && shx rm -rf ./build && pnpm exec prebuild-install && shx mkdir build/Release-Node && shx cp build/Release/better_sqlite3.node build/Release-Node/better_sqlite3.node",
     "knowledgeVisualizer": "pnpm -C packages/knowledgeVisualizer exec npm run start",
     "kv": "pnpm -C packages/knowledgeVisualizer exec npm run start",
     "lint": "fluid-build . -t prettier",

--- a/ts/packages/memory/storage/src/sqlite/sqliteCommon.ts
+++ b/ts/packages/memory/storage/src/sqlite/sqliteCommon.ts
@@ -4,6 +4,20 @@
 import Database, * as sqlite from "better-sqlite3";
 import path from "node:path";
 import { removeFile, ensureDir } from "../fileSystem.js";
+import { createRequire } from "node:module";
+
+function getDbOptions() {
+    if (process?.versions?.electron !== undefined) {
+        return undefined;
+    }
+    const r = createRequire(import.meta.url);
+    const betterSqlitePath = r.resolve("better-sqlite3/package.json");
+    const nativeBinding = path.join(
+        betterSqlitePath,
+        "../build/Release-Node/better_sqlite3.node",
+    );
+    return { nativeBinding };
+}
 
 export function createDatabase(
     filePath: string,
@@ -13,7 +27,7 @@ export function createDatabase(
         deleteDatabase(filePath);
     }
     ensureDir(path.dirname(filePath));
-    const db = new Database(filePath);
+    const db = new Database(filePath, getDbOptions());
     db.pragma("journal_mode = WAL");
     return db;
 }


### PR DESCRIPTION
Revert part to #1101.  `binding` package only retry different path if the load error is "not found"