### PR TITLE
knowpro: Refactored test apps for clarity

### DIFF
--- a/ts/examples/chat/README.md
+++ b/ts/examples/chat/README.md
@@ -1,19 +1,20 @@
-## Chat test app
+## Chat and Memory example
 
-**Frequent changes**
-
-- This **test app is sample code** that is used to interactively test and explore several **conversation** and **memory** related packages as they are being developed.
+- **Sample code** used to interactively experiment with several **conversation** and **memory** related packages as they are being developed.
 - Requires file system access. The app creates test directories under **/data/testChat**
+- **Frequent changes**
 
 Interaction is via a set of commands.
 
 - Enter @**help** for a list of commands
-- Command names must be prefixed with @ to run. E.g. @kpCmRemember
-- Get help for any command like this: @kpEmailsLoad --?
+- All command names must be prefixed with **@**
+  - E.g: @kpCmRemember
+- Get help for any command using --?
+  - E.g: @kpCmRemember --?
 
 ## knowpro and memory
 
-Packages targeted:
+Packages explored:
 
 - [knowpro](../../packages/knowPro/)
 - [memory](../../packages/memory/)
@@ -24,19 +25,18 @@ You can list all commands matching a prefix by typing the prefix: e.g. @kpSearch
 
 | Feature Area                                               | Command Prefix             |
 | ---------------------------------------------------------- | -------------------------- |
-| [Podcast Memory](./src/memory/knowproMemory.ts)            | @kpPodcast...              |
-| [Image Memory](./src/memory/knowproMemory.ts)              | @kpImage...                |
 | [knowpro Search/Answer](./src/memory/knowproMemory.ts)     | @kpSearch..., @kpAnswer... |
+| [Podcast Memory](./src/memory/knowproPodcast.ts)           | @kpPodcast...              |
+| [Image Memory](./src/memory/knowproImage.ts)               | @kpImage...                |
 | [Email](./src/memory/knowproEmail.ts)                      | @kpEmail...                |
 | [Conversation Memory](./src/memory/knowproConversation.ts) | @kpCm...                   |
 
 ## knowledge-processor
 
-Packages targeted:
+Any command that does not have the prefix "@kp".
+Experiments with older packages:
 
 - [knowledge-processor](../../packages/knowledgeProcessor/)
-
-Any command that does not have the prefix "@kp".
 
 ## code-processor
 

--- a/ts/examples/chat/src/memory/knowproConversation.ts
+++ b/ts/examples/chat/src/memory/knowproConversation.ts
@@ -16,11 +16,11 @@ import * as kp from "knowpro";
 import * as cm from "conversation-memory";
 import path from "path";
 
-import { KnowProContext } from "./knowproMemory.js";
+import { KnowproContext } from "./knowproMemory.js";
 import { ensureDir } from "typeagent";
 import chalk from "chalk";
 
-export type KnowProChatContext = {
+export type KnowproConversationContext = {
     printer: KnowProPrinter;
     conversationMemory?: cm.ConversationMemory | undefined;
     basePath: string;
@@ -28,10 +28,10 @@ export type KnowProChatContext = {
 };
 
 export async function createKnowproConversationCommands(
-    kpContext: KnowProContext,
+    kpContext: KnowproContext,
     commands: Record<string, CommandHandler>,
 ) {
-    const context: KnowProChatContext = {
+    const context: KnowproConversationContext = {
         printer: kpContext.printer,
         basePath: path.join(kpContext.basePath, "chat"),
         defaultName: "default",

--- a/ts/examples/chat/src/memory/knowproDataFrame.ts
+++ b/ts/examples/chat/src/memory/knowproDataFrame.ts
@@ -12,7 +12,7 @@ import {
     ProgressBar,
     StopWatch,
 } from "interactive-app";
-import { KnowProContext } from "./knowproMemory.js";
+import { KnowproContext } from "./knowproMemory.js";
 import { Result, success } from "typechat";
 import { ensureDir, getFileName, readAllText } from "typeagent";
 import * as kp from "knowpro";
@@ -24,7 +24,7 @@ import { argDestFile, argSourceFile } from "./common.js";
 import path from "path";
 
 export async function createKnowproDataFrameCommands(
-    context: KnowProContext,
+    context: KnowproContext,
     commands: Record<string, CommandHandler>,
 ): Promise<void> {
     //commands.kpGetSchema = getSchema;

--- a/ts/examples/chat/src/memory/knowproDataFrame.ts
+++ b/ts/examples/chat/src/memory/knowproDataFrame.ts
@@ -252,7 +252,6 @@ export async function createKnowproDataFrameCommands(
         }
 
         context.conversation = restaurantCollection.conversation;
-        context.printer.conversation = restaurantCollection.conversation;
     }
 
     async function buildIndex(restaurantCollection: RestaurantIndex) {

--- a/ts/examples/chat/src/memory/knowproEmail.ts
+++ b/ts/examples/chat/src/memory/knowproEmail.ts
@@ -11,7 +11,7 @@ import {
     ProgressBar,
     StopWatch,
 } from "interactive-app";
-import { KnowProContext } from "./knowproMemory.js";
+import { KnowproContext } from "./knowproMemory.js";
 import { KnowProPrinter } from "./knowproPrinter.js";
 import * as cm from "conversation-memory";
 import path from "path";
@@ -30,7 +30,7 @@ export type KnowProEmailContext = {
 };
 
 export async function createKnowproEmailCommands(
-    kpContext: KnowProContext,
+    kpContext: KnowproContext,
     commands: Record<string, CommandHandler>,
 ): Promise<void> {
     const context: KnowProEmailContext = {

--- a/ts/examples/chat/src/memory/knowproImage.ts
+++ b/ts/examples/chat/src/memory/knowproImage.ts
@@ -1,0 +1,234 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import {
+    arg,
+    argBool,
+    argNum,
+    CommandHandler,
+    CommandMetadata,
+    NamedArgs,
+    parseNamedArguments,
+    ProgressBar,
+} from "interactive-app";
+import { KnowproContext } from "./knowproMemory.js";
+import { KnowProPrinter } from "./knowproPrinter.js";
+import * as kp from "knowpro";
+import * as im from "image-memory";
+import fs from "fs";
+import path from "path";
+import {
+    createIndexingEventHandler,
+    memoryNameToIndexPath,
+    sourcePathToMemoryIndexPath,
+} from "./knowproCommon.js";
+import { argDestFile, argSourceFile } from "./common.js";
+import { ensureDir, getFileName } from "typeagent";
+
+export type KnowproImageContext = {
+    printer: KnowProPrinter;
+    images?: im.ImageCollection | undefined;
+    basePath: string;
+};
+
+export async function createKnowproImageCommands(
+    kpContext: KnowproContext,
+    commands: Record<string, CommandHandler>,
+) {
+    const context: KnowproImageContext = {
+        printer: kpContext.printer,
+        basePath: kpContext.basePath,
+    };
+
+    commands.kpImages = showImages;
+    commands.kpImagesImport = imagesImport;
+    commands.kpImagesSave = imagesSave;
+    commands.kpImagesLoad = imagesLoad;
+    commands.kpImagesBuildIndex = imagesBuildIndex;
+
+    function showImagesDef(): CommandMetadata {
+        return {
+            description: "Show all images",
+            options: {
+                maxMessages: argNum("Maximum images to display"),
+            },
+        };
+    }
+    commands.kpImages.metadata = "Show all images";
+    async function showImages(args: string[]) {
+        const conversation = ensureConversationLoaded();
+        if (!conversation) {
+            return;
+        }
+        const namedArgs = parseNamedArguments(args, showImagesDef());
+        const messages =
+            namedArgs.maxMessages > 0
+                ? conversation.messages.getSlice(0, namedArgs.maxMessages)
+                : conversation.messages;
+        context.printer.writeMessages(messages);
+    }
+
+    function imageImportDef(): CommandMetadata {
+        return {
+            description: "Create knowPro image index",
+            args: {
+                filePath: arg("File path to an image file or folder"),
+            },
+            options: {
+                knowledge: argBool("Index knowledge", true),
+                related: argBool("Index related terms", true),
+                indexFilePath: arg("Output path for index file"),
+                maxMessages: argNum("Maximum images to index"),
+                cachePath: arg("Path to image knowledge response cache."),
+            },
+        };
+    }
+    commands.kpImagesImport.metadata = imageImportDef();
+    async function imagesImport(args: string[]): Promise<void> {
+        const namedArgs = parseNamedArguments(args, imageImportDef());
+        if (!fs.existsSync(namedArgs.filePath)) {
+            context.printer.writeError(`${namedArgs.filePath} not found`);
+            return;
+        }
+
+        let progress = new ProgressBar(context.printer, 165);
+        context.images = await im.importImages(
+            namedArgs.filePath,
+            namedArgs.cachePath,
+            true,
+            (text, _index, max) => {
+                progress.total = max;
+                progress.advance();
+                return progress.count < max;
+            },
+        );
+        kpContext.conversation = context.images;
+        progress.complete();
+
+        context.printer.writeLine("Imported images:");
+        context.printer.writeImageCollectionInfo(context.images!);
+
+        if (!namedArgs.index) {
+            return;
+        }
+
+        // Build the image collection index
+        await imagesBuildIndex(namedArgs);
+
+        // Save the image collection index
+        namedArgs.filePath = sourcePathToMemoryIndexPath(
+            namedArgs.filePath,
+            namedArgs.indexFilePath,
+        );
+        await imagesSave(namedArgs);
+    }
+
+    function imagesSaveDef(): CommandMetadata {
+        return {
+            description: "Save Image Collection",
+            args: {
+                filePath: argDestFile(),
+            },
+        };
+    }
+
+    commands.kpImagesSave.metadata = imagesSaveDef();
+    async function imagesSave(args: string[] | NamedArgs): Promise<void> {
+        const namedArgs = parseNamedArguments(args, imagesSaveDef());
+        if (!context.images) {
+            context.printer.writeError("No image collection loaded");
+            return;
+        }
+        context.printer.writeLine("Saving index");
+        context.printer.writeLine(namedArgs.filePath);
+        if (context.images) {
+            const dirName = path.dirname(namedArgs.filePath);
+            await ensureDir(dirName);
+            await context.images.writeToFile(
+                dirName,
+                getFileName(namedArgs.filePath),
+            );
+        }
+    }
+
+    function imagesLoadDef(): CommandMetadata {
+        return {
+            description: "Load knowPro image collection",
+            options: {
+                filePath: argSourceFile(),
+                name: arg("Image Collection Name"),
+            },
+        };
+    }
+
+    commands.kpImagesLoad.metadata = imagesLoadDef();
+    async function imagesLoad(args: string[]): Promise<void> {
+        const namedArgs = parseNamedArguments(args, imagesLoadDef());
+        let imagesFilePath = namedArgs.filePath;
+        imagesFilePath ??= namedArgs.name
+            ? memoryNameToIndexPath(context.basePath, namedArgs.name)
+            : undefined;
+        if (!imagesFilePath) {
+            context.printer.writeError("No filepath or name provided");
+            return;
+        }
+        context.images = await im.ImageCollection.readFromFile(
+            path.dirname(imagesFilePath),
+            getFileName(imagesFilePath),
+        );
+        if (!context.images) {
+            context.printer.writeLine("ImageCollection not found");
+            return;
+        }
+        kpContext.conversation = context.images;
+        context.printer.writeImageCollectionInfo(context.images);
+    }
+
+    function imageCollectionBuildIndexDef(): CommandMetadata {
+        return {
+            description: "Build image collection index",
+            options: {
+                knowledge: argBool("Index knowledge", false),
+                related: argBool("Index related terms", false),
+                maxMessages: argNum("Maximum messages to index"),
+            },
+        };
+    }
+
+    commands.kpImagesBuildIndex.metadata = imageCollectionBuildIndexDef();
+    async function imagesBuildIndex(args: string[] | NamedArgs): Promise<void> {
+        if (!context.images) {
+            context.printer.writeError("No image collection loaded");
+            return;
+        }
+        const messageCount = context.images.messages.length;
+        if (messageCount === 0) {
+            return;
+        }
+
+        const namedArgs = parseNamedArguments(
+            args,
+            imageCollectionBuildIndexDef(),
+        );
+        // Build index
+        context.printer.writeLine();
+        context.printer.writeLine("Building index");
+        const maxMessages = namedArgs.maxMessages ?? messageCount;
+        let progress = new ProgressBar(context.printer, maxMessages);
+        const indexResult = await context.images?.buildIndex(
+            createIndexingEventHandler(context.printer, progress, maxMessages),
+        );
+        progress.complete();
+        context.printer.writeIndexingResults(indexResult);
+    }
+
+    function ensureConversationLoaded(): kp.IConversation | undefined {
+        if (context.images) {
+            return context.images;
+        }
+        context.printer.writeError("No conversation loaded");
+        return undefined;
+    }
+
+    return;
+}

--- a/ts/examples/chat/src/memory/knowproPodcast.ts
+++ b/ts/examples/chat/src/memory/knowproPodcast.ts
@@ -1,0 +1,277 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import {
+    arg,
+    argBool,
+    argNum,
+    CommandHandler,
+    CommandMetadata,
+    NamedArgs,
+    parseNamedArguments,
+    ProgressBar,
+    StopWatch,
+} from "interactive-app";
+import { KnowproContext } from "./knowproMemory.js";
+import { KnowProPrinter } from "./knowproPrinter.js";
+import * as kp from "knowpro";
+import * as cm from "conversation-memory";
+import fs from "fs";
+import path from "path";
+import {
+    createIndexingEventHandler,
+    memoryNameToIndexPath,
+    sourcePathToMemoryIndexPath,
+} from "./knowproCommon.js";
+import { argDestFile, argSourceFile, argToDate } from "./common.js";
+import { ensureDir, getFileName } from "typeagent";
+import chalk from "chalk";
+
+export type KnowproPodcastContext = {
+    printer: KnowProPrinter;
+    podcast?: cm.Podcast | undefined;
+    basePath: string;
+};
+
+export async function createKnowproPodcastCommands(
+    kpContext: KnowproContext,
+    commands: Record<string, CommandHandler>,
+) {
+    const context: KnowproPodcastContext = {
+        printer: kpContext.printer,
+        basePath: kpContext.basePath,
+    };
+
+    commands.kpPodcastImport = podcastImport;
+    commands.kpPodcastSave = podcastSave;
+    commands.kpPodcastLoad = podcastLoad;
+    commands.kpPodcastBuildIndex = podcastBuildIndex;
+    commands.kpPodcastBuildMessageIndex = podcastBuildMessageIndex;
+
+    function podcastImportDef(): CommandMetadata {
+        return {
+            description: "Create knowPro index",
+            args: {
+                filePath: arg("File path to transcript file"),
+                startAt: arg("Start date and time"),
+            },
+            options: {
+                indexFilePath: arg("Output path for index file"),
+                maxMessages: argNum("Maximum messages to index"),
+                batchSize: argNum("Indexing batch size", 4),
+                length: argNum("Length of the podcast in minutes", 60),
+                buildIndex: argBool("Index the imported podcast", true),
+            },
+        };
+    }
+    commands.kpPodcastImport.metadata = podcastImportDef();
+    async function podcastImport(args: string[]): Promise<void> {
+        const namedArgs = parseNamedArguments(args, podcastImportDef());
+        if (!fs.existsSync(namedArgs.filePath)) {
+            context.printer.writeError(`${namedArgs.filePath} not found`);
+            return;
+        }
+        const startAt = argToDate(namedArgs.startAt)!;
+
+        context.podcast = await cm.importPodcast(
+            namedArgs.filePath,
+            getFileName(namedArgs.filePath),
+            startAt,
+            namedArgs.length,
+        );
+
+        kpContext.conversation = context.podcast;
+        context.printer.writeLine("Imported podcast:");
+        context.printer.writePodcastInfo(context.podcast);
+        if (!namedArgs.buildIndex) {
+            return;
+        }
+        // Build index
+        await podcastBuildIndex(namedArgs);
+
+        // Save the index
+        namedArgs.filePath = sourcePathToMemoryIndexPath(
+            namedArgs.filePath,
+            namedArgs.indexFilePath,
+        );
+        await podcastSave(namedArgs);
+    }
+
+    function podcastSaveDef(): CommandMetadata {
+        return {
+            description: "Save Podcast",
+            args: {
+                filePath: argDestFile(),
+            },
+        };
+    }
+    commands.kpPodcastSave.metadata = podcastSaveDef();
+    async function podcastSave(args: string[] | NamedArgs): Promise<void> {
+        const namedArgs = parseNamedArguments(args, podcastSaveDef());
+        if (!context.podcast) {
+            context.printer.writeError("No podcast loaded");
+            return;
+        }
+        context.printer.writeLine("Saving index");
+        context.printer.writeLine(namedArgs.filePath);
+        const dirName = path.dirname(namedArgs.filePath);
+        await ensureDir(dirName);
+
+        const clock = new StopWatch();
+        clock.start();
+        await context.podcast.writeToFile(
+            dirName,
+            getFileName(namedArgs.filePath),
+        );
+        clock.stop();
+        context.printer.writeTiming(chalk.gray, clock, "Write to file");
+    }
+
+    function podcastLoadDef(): CommandMetadata {
+        return {
+            description: "Load knowPro podcast",
+            options: {
+                filePath: argSourceFile(),
+                name: arg("Podcast name"),
+            },
+        };
+    }
+    commands.kpPodcastLoad.metadata = podcastLoadDef();
+    async function podcastLoad(args: string[]): Promise<void> {
+        const namedArgs = parseNamedArguments(args, podcastLoadDef());
+        let podcastFilePath = namedArgs.filePath;
+        podcastFilePath ??= namedArgs.name
+            ? memoryNameToIndexPath(context.basePath, namedArgs.name)
+            : undefined;
+        if (!podcastFilePath) {
+            context.printer.writeError("No filepath or name provided");
+            return;
+        }
+        const clock = new StopWatch();
+        clock.start();
+        const podcast = await cm.Podcast.readFromFile(
+            path.dirname(podcastFilePath),
+            getFileName(podcastFilePath),
+        );
+        clock.stop();
+        context.printer.writeTiming(chalk.gray, clock, "Read file");
+        if (!podcast) {
+            context.printer.writeLine("Podcast file not found");
+            return;
+        }
+        context.podcast = podcast;
+        kpContext.conversation = context.podcast;
+        context.printer.writePodcastInfo(context.podcast);
+    }
+
+    function podcastBuildIndexDef(): CommandMetadata {
+        return {
+            description: "Build index",
+            options: {
+                maxMessages: argNum("Maximum messages to index"),
+                batchSize: argNum("Indexing batch size", 8),
+            },
+        };
+    }
+    commands.kpPodcastBuildIndex.metadata = podcastBuildIndexDef();
+    async function podcastBuildIndex(
+        args: string[] | NamedArgs,
+    ): Promise<void> {
+        if (!context.podcast) {
+            context.printer.writeError("No podcast loaded");
+            return;
+        }
+        const messageCount = context.podcast.messages.length;
+        if (messageCount === 0) {
+            return;
+        }
+
+        const namedArgs = parseNamedArguments(args, podcastBuildIndexDef());
+        // Build index
+        context.printer.writeLine();
+        const maxMessages = namedArgs.maxMessages ?? messageCount;
+        let originalMessages = context.podcast.messages;
+        try {
+            if (maxMessages < messageCount) {
+                context.podcast.messages =
+                    new kp.MessageCollection<cm.PodcastMessage>(
+                        context.podcast.messages.getSlice(0, maxMessages),
+                    );
+            }
+            context.printer.writeLine(`Building Index`);
+            let progress = new ProgressBar(context.printer, maxMessages);
+            const eventHandler = createIndexingEventHandler(
+                context.printer,
+                progress,
+                maxMessages,
+            );
+            // Build full index?
+            const clock = new StopWatch();
+            clock.start();
+
+            context.podcast.settings.semanticRefIndexSettings.batchSize =
+                namedArgs.batchSize;
+            const indexResult = await context.podcast.buildIndex(eventHandler);
+
+            clock.stop();
+            progress.complete();
+            context.printer.writeTiming(chalk.gray, clock);
+            context.printer.writeIndexingResults(indexResult);
+        } finally {
+            context.podcast.messages = originalMessages;
+        }
+    }
+
+    function podcastBuildMessageIndexDef(): CommandMetadata {
+        return {
+            description: "Build fuzzy message index for the podcast",
+            options: {
+                maxMessages: argNum("Maximum messages to index"),
+                batchSize: argNum("Batch size", 4),
+            },
+        };
+    }
+    commands.kpPodcastBuildMessageIndex.metadata =
+        podcastBuildMessageIndexDef();
+    async function podcastBuildMessageIndex(args: string[]): Promise<void> {
+        if (!ensureConversationLoaded()) {
+            return;
+        }
+        const namedArgs = parseNamedArguments(
+            args,
+            podcastBuildMessageIndexDef(),
+        );
+        context.printer.writeLine(`Indexing messages`);
+
+        const podcast = context.podcast!;
+        const settings: kp.MessageTextIndexSettings = {
+            ...context.podcast!.settings.messageTextIndexSettings,
+        };
+        settings.embeddingIndexSettings.batchSize = namedArgs.batchSize;
+        let progress = new ProgressBar(context.printer, namedArgs.maxMessages);
+        podcast.secondaryIndexes.messageIndex = new kp.MessageTextIndex(
+            settings,
+        );
+        const result = await kp.buildMessageIndex(
+            podcast,
+            settings,
+            createIndexingEventHandler(
+                context.printer,
+                progress,
+                namedArgs.maxMessages,
+            ),
+        );
+        progress.complete();
+        context.printer.writeListIndexingResult(result);
+    }
+
+    function ensureConversationLoaded(): kp.IConversation | undefined {
+        if (context.podcast) {
+            return context.podcast;
+        }
+        context.printer.writeError("No podcast loaded");
+        return undefined;
+    }
+
+    return;
+}

--- a/ts/examples/chat/src/memory/knowproPrinter.ts
+++ b/ts/examples/chat/src/memory/knowproPrinter.ts
@@ -11,7 +11,7 @@ import * as im from "image-memory";
 
 export class KnowProPrinter extends MemoryConsoleWriter {
     public sortAsc: boolean = true;
-    constructor(public conversation: kp.IConversation | undefined = undefined) {
+    constructor() {
         super();
     }
 


### PR DESCRIPTION
Knowpro example:
* Refactored podcast and image into their own files. Just like email, conversation & dataframe
* knowproMemory now contains standard commands that apply to any conversation
* Updated README