### PR TITLE
Resolve Entity before execute

### DIFF
--- a/ts/packages/actionSchema/src/parser.ts
+++ b/ts/packages/actionSchema/src/parser.ts
@@ -194,6 +194,7 @@ export function createParsedActionSchema(
         pending.push(entry.activity);
     }
     const actionSchemas = new Map<string, ActionSchemaTypeDefinition>();
+    const entitySchemas = new Map<string, ActionSchemaTypeDefinition>();
     while (pending.length > 0) {
         const current = pending.shift()!;
         switch (current.type.type) {
@@ -255,6 +256,7 @@ export function createParsedActionSchema(
     const parsedActionSchema: ParsedActionSchema = {
         entry: entry as ActionSchemaEntryTypeDefinitions,
         actionSchemas,
+        entitySchemas,
     };
     if (schemaConfig?.actionNamespace === true) {
         parsedActionSchema.actionNamespace = true;

--- a/ts/packages/actionSchema/src/parser.ts
+++ b/ts/packages/actionSchema/src/parser.ts
@@ -316,6 +316,7 @@ export function createParsedActionSchema(
 type SchemaTypeNames = {
     action?: string;
     activity?: string;
+    entity?: string;
 };
 
 export function parseActionSchemaSource(
@@ -407,6 +408,16 @@ class ActionParser {
                 );
             }
         }
+
+        const entityTypeName =
+            typeof typeName === "string" ? undefined : typeName.entity;
+        if (entityTypeName) {
+            definitions.entity = this.typeMap.get(entityTypeName);
+            if (definitions.entity === undefined) {
+                throw new Error(`Entity type '${entityTypeName}' not found`);
+            }
+        }
+
         return definitions;
     }
 

--- a/ts/packages/actionSchema/src/parser.ts
+++ b/ts/packages/actionSchema/src/parser.ts
@@ -14,8 +14,8 @@ import {
     ActionSchemaTypeDefinition,
     SchemaObjectField,
     ParsedActionSchema,
-    SchemaEntryTypeDefinitions,
     ActionSchemaEntryTypeDefinitions,
+    ActionSchemaEntityTypeDefinition,
 } from "./type.js";
 import ts from "typescript";
 import { ActionParamSpecs, SchemaConfig } from "./schemaConfig.js";
@@ -171,7 +171,7 @@ function checkActionSchema(
 }
 
 export function createParsedActionSchema(
-    entry: SchemaEntryTypeDefinitions,
+    entry: ParsedSchemaEntryTypeDefinitions,
     order: Map<string, number> | undefined,
     strict: boolean,
     schemaConfig?: SchemaConfig,
@@ -194,7 +194,7 @@ export function createParsedActionSchema(
         pending.push(entry.activity);
     }
     const actionSchemas = new Map<string, ActionSchemaTypeDefinition>();
-    const entitySchemas = new Map<string, ActionSchemaTypeDefinition>();
+
     while (pending.length > 0) {
         const current = pending.shift()!;
         switch (current.type.type) {
@@ -253,6 +253,52 @@ export function createParsedActionSchema(
     if (actionSchemas.size === 0) {
         throw new Error("No action schema found");
     }
+
+    let entitySchemas:
+        | Map<string, ActionSchemaEntityTypeDefinition>
+        | undefined;
+    if (entry.entity) {
+        entitySchemas = new Map<string, ActionSchemaEntityTypeDefinition>();
+        if (strict && !entry.entity.exported) {
+            throw new Error(
+                `Schema Error: Entity entry type '${entry.entity.name}' must be exported`,
+            );
+        }
+        const addEntityType = (type: SchemaTypeReference) => {
+            const definition = type.definition;
+            if (definition === undefined) {
+                throw new Error(
+                    `Schema Error: unresolved type reference '${type.name}' in the entity type`,
+                );
+            }
+            if (!definition.alias || definition.type.type !== "string") {
+                throw new Error(
+                    `Schema Error: entity type must be a type alias to string`,
+                );
+            }
+            entitySchemas!.set(
+                definition.name,
+                definition as ActionSchemaEntityTypeDefinition,
+            );
+        };
+        const entityEntityTypeType = entry.entity.type.type;
+        if (entityEntityTypeType === "type-reference") {
+            addEntityType(entry.entity.type);
+        } else if (entityEntityTypeType === "type-union") {
+            for (const type of entry.entity.type.types) {
+                if (type.type !== "type-reference") {
+                    throw new Error(
+                        `Schema Error: entity type in the entity entry union must be type reference`,
+                    );
+                }
+                addEntityType(type);
+            }
+        } else {
+            throw new Error(
+                `Schema Error: entity entry type ${entry.entity.name} must be a reference or union of of entity type`,
+            );
+        }
+    }
     const parsedActionSchema: ParsedActionSchema = {
         entry: entry as ActionSchemaEntryTypeDefinitions,
         actionSchemas,
@@ -300,6 +346,12 @@ export function parseActionSchemaSource(
     }
 }
 
+export type ParsedSchemaEntryTypeDefinitions = {
+    action?: SchemaTypeDefinition | undefined;
+    activity?: SchemaTypeDefinition | undefined;
+    entity?: SchemaTypeDefinition | undefined;
+};
+
 class ActionParser {
     static parseSourceFile(
         sourceFile: ts.SourceFile,
@@ -321,7 +373,7 @@ class ActionParser {
     private parseSchema(
         sourceFile: ts.SourceFile,
         typeName: string | SchemaTypeNames,
-    ): SchemaEntryTypeDefinitions {
+    ): ParsedSchemaEntryTypeDefinitions {
         this.fullText = sourceFile.getFullText();
         ts.forEachChild(sourceFile, (node: ts.Node) => {
             this.parseAST(node);
@@ -335,7 +387,7 @@ class ActionParser {
             pending.definition = resolvedType;
         }
 
-        const definitions: SchemaEntryTypeDefinitions = {};
+        const definitions: ParsedSchemaEntryTypeDefinitions = {};
         const actionTypeName =
             typeof typeName === "string" ? typeName : typeName.action;
         if (actionTypeName) {

--- a/ts/packages/actionSchema/src/serialize.ts
+++ b/ts/packages/actionSchema/src/serialize.ts
@@ -14,6 +14,7 @@ export type ParsedActionSchemaJSON = {
     entry: {
         action?: string | undefined;
         activity?: string | undefined;
+        entity?: string | undefined;
     };
     types: Record<string, SchemaTypeDefinition>;
     actionNamespace?: boolean; // default to false
@@ -84,11 +85,18 @@ export function toJSONParsedActionSchema(
         definitions[activityEntryName] = entry.activity;
         collectTypes(definitions, entry.activity.type);
     }
+    let entityEntryName = undefined;
+    if (entry.entity) {
+        entityEntryName = entry.entity.name;
+        definitions[entityEntryName] = entry.entity;
+        collectTypes(definitions, entry.entity.type);
+    }
     const result: ParsedActionSchemaJSON = {
         version: parsedActionSchemaVersion,
         entry: {
             action: actionEntryName,
             activity: activityEntryName,
+            entity: entityEntryName,
         },
         types: definitions,
     };
@@ -158,6 +166,7 @@ export function fromJSONParsedActionSchema(
         activity: json.entry.activity
             ? json.types[json.entry.activity]
             : undefined,
+        entity: json.entry.entity ? json.types[json.entry.entity] : undefined,
     };
     const order = json.order ? new Map(Object.entries(json.order)) : undefined;
     // paramSpecs are already stored in each action definition.

--- a/ts/packages/actionSchema/src/type.ts
+++ b/ts/packages/actionSchema/src/type.ts
@@ -140,6 +140,8 @@ export type ActionSchemaGroup<T = ActionSchemaEntryTypeDefinition> = {
     entry: T;
     // Map action name to action type definition
     actionSchemas: Map<string, ActionSchemaTypeDefinition>;
+    // Map of entity type name to type definition
+    entitySchemas?: Map<string, ActionSchemaTypeDefinition>;
     // Order for the type definitions
     order?: Map<string, number>; // for exact regen
 };

--- a/ts/packages/actionSchema/src/type.ts
+++ b/ts/packages/actionSchema/src/type.ts
@@ -141,18 +141,25 @@ export type ActionSchemaGroup<T = ActionSchemaEntryTypeDefinition> = {
     // Map action name to action type definition
     actionSchemas: Map<string, ActionSchemaTypeDefinition>;
     // Map of entity type name to type definition
-    entitySchemas?: Map<string, ActionSchemaTypeDefinition>;
+    entitySchemas?: Map<string, ActionSchemaEntityTypeDefinition> | undefined;
     // Order for the type definitions
     order?: Map<string, number>; // for exact regen
 };
 
-export type SchemaEntryTypeDefinitions<T = SchemaTypeDefinition> = {
-    action?: T | undefined;
-    activity?: T | undefined;
-};
+// Only support string for now.
+export type ActionSchemaEntityTypeDefinition =
+    SchemaTypeAliasDefinition<SchemaTypeString>;
 
-export type ActionSchemaEntryTypeDefinitions =
-    SchemaEntryTypeDefinitions<ActionSchemaEntryTypeDefinition>;
+export type ActionSchemaEntityEntryTypeDefinition = SchemaTypeAliasDefinition<
+    | SchemaTypeReference<ActionSchemaEntityTypeDefinition>
+    | SchemaTypeUnion<SchemaTypeReference<ActionSchemaEntityTypeDefinition>>
+>;
+
+export type ActionSchemaEntryTypeDefinitions = {
+    action?: ActionSchemaEntryTypeDefinition | undefined;
+    activity?: ActionSchemaEntryTypeDefinition | undefined;
+    entity?: ActionSchemaEntityEntryTypeDefinition | undefined;
+};
 
 // Action schema that is parsed from a file.
 export type ParsedActionSchema =

--- a/ts/packages/actionSchema/test/regen.spec.ts
+++ b/ts/packages/actionSchema/test/regen.spec.ts
@@ -14,7 +14,7 @@ import { generateSchemaTypeDefinition } from "../src/generator.js";
 
 import prettier from "prettier";
 import { SchemaConfig } from "../src/schemaConfig.js";
-import { ParsedActionSchema } from "../src/type.js";
+import { ParsedActionSchema, SchemaTypeDefinition } from "../src/type.js";
 
 const defaultAgentProviderPath = fileURLToPath(
     new URL("../../../defaultAgentProvider", import.meta.url),
@@ -110,15 +110,15 @@ function generateParsedActionSchema(
     parsedActionSchema: ParsedActionSchema,
     exact?: boolean,
 ) {
-    const entry = [];
-    if (parsedActionSchema.entry.action) {
-        entry.push(parsedActionSchema.entry.action);
+    const entries: SchemaTypeDefinition[] = [];
+    for (const entry of Object.values(parsedActionSchema.entry)) {
+        if (entry !== undefined) {
+            entries.push(entry);
+        }
     }
-    if (parsedActionSchema.entry.activity) {
-        entry.push(parsedActionSchema.entry.activity);
-    }
+
     return generateSchemaTypeDefinition(
-        entry,
+        entries,
         exact
             ? {
                   exact: true,

--- a/ts/packages/agentRpc/src/client.ts
+++ b/ts/packages/agentRpc/src/client.ts
@@ -430,6 +430,17 @@ export async function createAgentRpcClient(
                 }),
             );
         },
+        resolveEntity(
+            type: string,
+            name: string,
+            context: SessionContext<ShimContext>,
+        ) {
+            return rpc.invoke("resolveEntity", {
+                ...getContextParam(context),
+                type,
+                name,
+            });
+        },
         getTemplateSchema(
             templateName,
             data,

--- a/ts/packages/agentRpc/src/server.ts
+++ b/ts/packages/agentRpc/src/server.ts
@@ -135,6 +135,16 @@ export function createAgentRpcServer(
                 getActionContextShim(param),
             );
         },
+        async resolveEntity(param) {
+            if (agent.resolveEntity === undefined) {
+                throw new Error("Invalid invocation of resolveEntity");
+            }
+            return agent.resolveEntity(
+                param.type,
+                param.name,
+                getSessionContextShim(param),
+            );
+        },
         async getTemplateSchema(param) {
             if (agent.getTemplateSchema === undefined) {
                 throw new Error("Invalid invocation of getTemplateSchema");

--- a/ts/packages/agentRpc/src/types.ts
+++ b/ts/packages/agentRpc/src/types.ts
@@ -21,6 +21,7 @@ import {
     TemplateSchema,
     TypeAgentAction,
 } from "@typeagent/agent-sdk";
+import { ResolveEntityResult } from "../../agentSdk/dist/agentInterface.js";
 
 export type AgentContextCallFunctions = {
     notify(param: {
@@ -162,6 +163,12 @@ export type AgentInvokeFunctions = {
             params: ParsedCommandParams<ParameterDefinitions> | undefined;
         },
     ): Promise<void>;
+    resolveEntity(
+        param: Partial<ContextParams> & {
+            type: string;
+            name: string;
+        },
+    ): Promise<ResolveEntityResult | undefined>;
     getTemplateSchema(
         param: Partial<ContextParams> & {
             templateName: string;

--- a/ts/packages/agentSdk/src/agentInterface.ts
+++ b/ts/packages/agentSdk/src/agentInterface.ts
@@ -4,6 +4,7 @@
 import { AppAction, ActionResult, TypeAgentAction } from "./action.js";
 import { AppAgentCommandInterface } from "./command.js";
 import { ActionIO, DisplayType, DynamicDisplay } from "./display.js";
+import { Entity } from "./memory.js";
 import { Profiler } from "./profiler.js";
 import { TemplateSchema } from "./templateInput.js";
 
@@ -50,6 +51,10 @@ export type ActionManifest = {
 export type AppAgentInitSettings = {
     localHostPort?: number; // the assigned port to use to serve the view if localHostPort is true in the manifest
 };
+
+export type ResolveEntityResult = {
+    entity: Entity;
+};
 export interface AppAgent extends Partial<AppAgentCommandInterface> {
     // Setup
     initializeAgentContext?(settings?: AppAgentInitSettings): Promise<unknown>;
@@ -80,6 +85,11 @@ export interface AppAgent extends Partial<AppAgentCommandInterface> {
     ): Promise<boolean>;
 
     // Input
+    resolveEntity?(
+        type: string,
+        name: string,
+        context: SessionContext,
+    ): Promise<ResolveEntityResult | undefined>;
     getTemplateSchema?(
         templateName: string,
         data: unknown,

--- a/ts/packages/agentSdk/src/agentInterface.ts
+++ b/ts/packages/agentSdk/src/agentInterface.ts
@@ -16,12 +16,13 @@ export type AppAgentManifest = {
     description: string;
     commandDefaultEnabled?: boolean;
     localView?: boolean; // whether the agent serve a local view, default is false
-    sharedLocalView?: string[]; // the agent to share the local view with, default is none
+    sharedLocalView?: string[]; // list of agents to share the local view with, default is none
 } & ActionManifest;
 
 export type SchemaTypeNames = {
     action?: string;
     activity?: string;
+    entities?: string;
 };
 
 export type SchemaFormat = "ts" | "pas";

--- a/ts/packages/agents/montage/src/agent/montageActionSchema.ts
+++ b/ts/packages/agents/montage/src/agent/montageActionSchema.ts
@@ -16,12 +16,13 @@ export type MontageAction =
     | MergeMontageAction;
 
 export type MontageActivity = StartEditMontageAction | CreateMontageAction;
-
+export type MontageEntity = Montage;
+export type Montage = string;
 export type StartEditMontageAction = {
     actionName: "startEditMontage";
     parameters: {
         // title of the montage
-        title: string;
+        title: Montage;
     };
 };
 
@@ -30,7 +31,7 @@ export type SelectPhotosAction = {
     actionName: "selectPhotos";
     parameters: {
         // title of the montage
-        title: string;
+        title: Montage;
         // any search terms to use indicating the photos to remove
         search_filters?: string[];
         // any indices provided indicating the photos to remove from the set of available images
@@ -45,7 +46,7 @@ export type AddPhotosAction = {
     actionName: "addPhotos";
     parameters: {
         // title of the montage
-        title: string;
+        title: Montage;
         // placeholder for images to be populated later
         files?: string[];
         // always empty
@@ -58,7 +59,7 @@ export type ChangeTitleAction = {
     actionName: "changeTitle";
     parameters: {
         // current title of the montage to change
-        title: string;
+        title: Montage;
         newTitle: string;
     };
 };
@@ -68,7 +69,7 @@ export type RemovePhotosAction = {
     actionName: "removePhotos";
     parameters: {
         // title of the montage
-        title: string;
+        title: Montage;
         // any search terms to use indicating the photos to remove
         search_filters?: string[];
         // any indices provided indicating the photos to remove from the set of available images
@@ -85,7 +86,7 @@ export type ClearSelectionAction = {
     actionName: "clearSelectedPhotos";
     parameters: {
         // title of the montage
-        title: string;
+        title: Montage;
     };
 };
 
@@ -110,7 +111,7 @@ export type SetSearchParametersAction = {
 export type StartSlideShowAction = {
     actionName: "startSlideShow";
     parameters: {
-        title: string;
+        title: Montage;
     };
 };
 
@@ -119,7 +120,7 @@ export type CreateMontageAction = {
     actionName: "createNewMontage";
     parameters: {
         // Montage title, defaults to "Untitled"
-        title: string;
+        title: Montage;
         // any search terms to use to seed the montage based off of the title
         search_filters?: string[];
         // a flag indicating if the UI should immediately switch to this montage, defaults to true
@@ -134,7 +135,7 @@ export type DeleteMontageAction = {
     actionName: "deleteMontage";
     parameters: {
         // The title of the montage to delete
-        title: string;
+        title: Montage;
     };
 };
 
@@ -155,7 +156,7 @@ export type MergeMontageAction = {
         // The title of the merged montage
         mergedMontageTitle: string;
         // The titles of the montages to merge
-        titles?: string[];
+        titles?: Montage[];
         // THe ids of the montages to merge
         ids?: number[];
     };

--- a/ts/packages/agents/montage/src/agent/montageManifest.json
+++ b/ts/packages/agents/montage/src/agent/montageManifest.json
@@ -7,7 +7,8 @@
     "schemaFile": "./montageActionSchema.ts",
     "schemaType": {
       "action": "MontageAction",
-      "activity": "MontageActivity"
+      "activity": "MontageActivity",
+      "entity": "MontageEntity"
     }
   }
 }

--- a/ts/packages/dispatcher/src/translation/actionSchemaFileCache.ts
+++ b/ts/packages/dispatcher/src/translation/actionSchemaFileCache.ts
@@ -25,7 +25,6 @@ import { SchemaInfoProvider } from "agent-cache";
 import {
     getActionSchemaTypeName,
     getActivitySchemaTypeName,
-    getCombinedSchemaTypeName,
 } from "./agentTranslators.js";
 
 const debug = registerDebug("typeagent:dispatcher:schema:cache");
@@ -80,6 +79,7 @@ function loadParsedActionSchema(
                 `Schema type mismatch: actual: ${parsedActionSchema.entry.action?.name}, expected:${activityTypeName}`,
             );
         }
+        
         return {
             schemaName,
             sourceHash,
@@ -190,9 +190,7 @@ export class ActionSchemaFileCache {
             this.getSchemaSource(actionConfig);
 
         const hash = config ? hashStrings(source, config) : hashStrings(source);
-        const typeKey = getCombinedSchemaTypeName(actionConfig.schemaType);
-
-        const cacheKey = `${format}|${actionConfig.schemaName}|${typeKey}|${fullPath ?? ""}`;
+        const cacheKey = `${format}|${actionConfig.schemaName}|${JSON.stringify(actionConfig.schemaType)}|${fullPath ?? ""}`;
 
         const lastCached = this.prevSaved.get(cacheKey);
         if (lastCached !== undefined) {

--- a/ts/packages/dispatcher/src/translation/actionSchemaFileCache.ts
+++ b/ts/packages/dispatcher/src/translation/actionSchemaFileCache.ts
@@ -79,7 +79,7 @@ function loadParsedActionSchema(
                 `Schema type mismatch: actual: ${parsedActionSchema.entry.action?.name}, expected:${activityTypeName}`,
             );
         }
-        
+
         return {
             schemaName,
             sourceHash,

--- a/ts/packages/dispatcher/src/translation/actionSchemaJsonTranslator.ts
+++ b/ts/packages/dispatcher/src/translation/actionSchemaJsonTranslator.ts
@@ -170,6 +170,7 @@ class ActionSchemaBuilder {
         }
 
         const actionSchemas = new Map<string, ActionSchemaTypeDefinition>();
+        const entitySchemas = new Map<string, ActionSchemaTypeDefinition>();
         const pending = [...this.definitions];
         while (pending.length > 0) {
             const current = pending.shift()!;
@@ -212,7 +213,7 @@ class ActionSchemaBuilder {
             }
         }
 
-        return { entry, actionSchemas, order };
+        return { entry, actionSchemas, entitySchemas, order };
     }
 }
 

--- a/ts/packages/dispatcher/src/translation/actionSchemaJsonTranslator.ts
+++ b/ts/packages/dispatcher/src/translation/actionSchemaJsonTranslator.ts
@@ -23,7 +23,7 @@ import {
 } from "common-utils";
 import {
     createChangeAssistantActionSchema,
-    getCombinedSchemaTypeName,
+    getCombinedActionSchemaTypeName,
     TranslatedAction,
 } from "./agentTranslators.js";
 import {
@@ -170,7 +170,6 @@ class ActionSchemaBuilder {
         }
 
         const actionSchemas = new Map<string, ActionSchemaTypeDefinition>();
-        const entitySchemas = new Map<string, ActionSchemaTypeDefinition>();
         const pending = [...this.definitions];
         while (pending.length > 0) {
             const current = pending.shift()!;
@@ -213,7 +212,7 @@ class ActionSchemaBuilder {
             }
         }
 
-        return { entry, actionSchemas, entitySchemas, order };
+        return { entry, actionSchemas, entitySchemas: undefined, order };
     }
 }
 
@@ -246,7 +245,7 @@ export function composeSelectedActionSchema(
 ) {
     const builder = new ActionSchemaBuilder(provider, options?.activity);
     const union = sc.union(definitions.map((definition) => sc.ref(definition)));
-    const typeName = `Partial${getCombinedSchemaTypeName(actionConfig.schemaType)}`;
+    const typeName = `Partial${getCombinedActionSchemaTypeName(actionConfig)}`;
     const comments = `${typeName} is a partial list of actions available in schema group '${actionConfig.schemaName}'.`;
 
     const entry = sc.type(typeName, union, comments);

--- a/ts/packages/dispatcher/src/translation/agentTranslators.ts
+++ b/ts/packages/dispatcher/src/translation/agentTranslators.ts
@@ -125,12 +125,33 @@ export function getActivitySchemaTypeName(
     return typeof schemaType === "string" ? undefined : schemaType.activity;
 }
 
-export function getCombinedSchemaTypeName(
-    schemaType: string | SchemaTypeNames,
-) {
-    return typeof schemaType === "string"
-        ? schemaType
-        : Object.values(schemaType).join("");
+export function getEntitySchemaTypeName(schemaType: string | SchemaTypeNames) {
+    return typeof schemaType === "string" ? undefined : schemaType.entities;
+}
+
+/**
+ * Combine all action schema type names into a single type name
+ * @param schemaType
+ * @returns
+ */
+export function getCombinedActionSchemaTypeName(
+    actionConfig: ActionConfig,
+): string | undefined {
+    const schemaType = actionConfig.schemaType;
+    if (typeof schemaType === "string") {
+        return schemaType;
+    }
+    if (schemaType.action !== undefined) {
+        return schemaType.activity !== undefined
+            ? `${schemaType.action}${schemaType.activity}`
+            : schemaType.action;
+    }
+    if (schemaType.activity !== undefined) {
+        return schemaType.activity;
+    }
+    throw new Error(
+        `Action config ${actionConfig.schemaName} does not have any action or activity schema type`,
+    );
 }
 
 function getTranslatorSchemaDef(

--- a/ts/packages/dispatcher/src/translation/unknownSwitcher.ts
+++ b/ts/packages/dispatcher/src/translation/unknownSwitcher.ts
@@ -12,7 +12,7 @@ import {
     generateSchemaTypeDefinition,
     ActionSchemaCreator as sc,
 } from "action-schema";
-import { getCombinedSchemaTypeName } from "./agentTranslators.js";
+import { getCombinedActionSchemaTypeName } from "./agentTranslators.js";
 const debugSwitchSearch = registerDebug("typeagent:switch:search");
 
 function createSelectionActionTypeDefinition(
@@ -44,7 +44,7 @@ function createSelectionActionTypeDefinition(
         return undefined;
     }
 
-    const typeName = `${getCombinedSchemaTypeName(actionConfig.schemaType)}Assistant`;
+    const typeName = `${getCombinedActionSchemaTypeName(actionConfig)}Assistant`;
 
     const schema = sc.type(
         typeName,


### PR DESCRIPTION
Add the infrastructure to resolve entity before execution.  Setting up for future implementation of clarification flow if the name is not an exact match.