### PR TITLE
Fix inline browser extension message round trip for WebAgent 

### DIFF
--- a/ts/packages/dispatcher/src/context/system/handlers/serviceHost/service.ts
+++ b/ts/packages/dispatcher/src/context/system/handlers/serviceHost/service.ts
@@ -128,7 +128,7 @@ try {
                     const errorMessage =
                         client.role === "client"
                             ? `The ${channelName} agent is not connected. The message cannot be processed.`
-                            : `No ${channelName} clients are listening for messaages on this channel`;
+                            : `No ${channelName} clients are listening for messages on this channel`;
                     ws.send(JSON.stringify({ error: errorMessage }));
                 }
             } catch {

--- a/ts/packages/shell/src/main/agent.ts
+++ b/ts/packages/shell/src/main/agent.ts
@@ -225,6 +225,10 @@ class ShellOpenWebContentView implements CommandHandler {
                 targetUrl = new URL("https://www.target.com/");
                 break;
 
+            case "turtlegraphics":
+                targetUrl = new URL("http://localhost:9000/");
+                break;
+
             default:
                 try {
                     const port =

--- a/ts/packages/shell/src/main/browserIpc.ts
+++ b/ts/packages/shell/src/main/browserIpc.ts
@@ -54,7 +54,10 @@ export class BrowserAgentIpc {
             keepWebSocketAlive(this.webSocket, "browser");
 
             this.webSocket.onmessage = async (event: any) => {
-                const text = event.data.toString();
+                const text =
+                    typeof event.data === "string"
+                        ? event.data
+                        : await (event.data as Blob).text();
                 try {
                     const data = JSON.parse(text) as WebSocketMessageV2;
                     if (data.method) {

--- a/ts/packages/shell/src/main/shellActionSchema.ts
+++ b/ts/packages/shell/src/main/shellActionSchema.ts
@@ -15,6 +15,7 @@ export type OpenCanvasAction = {
             | "montage"
             | "markdown"
             | "planViewer"
+            | "turtleGraphics"
             | string;
     };
 };

--- a/ts/packages/shell/src/main/shellWindow.ts
+++ b/ts/packages/shell/src/main/shellWindow.ts
@@ -189,7 +189,10 @@ export class ShellWindow {
     }
 
     public sendMessageToInlineWebContent(message: WebSocketMessageV2) {
-        this.inlineWebContentView?.webContents.send("webview-message", message);
+        this.inlineWebContentView?.webContents.send(
+            "received-from-browser-ipc",
+            message,
+        );
     }
 
     public runDemo(interactive: boolean = false) {


### PR DESCRIPTION
- Fix two issues with the message with the result from the dispatcher to the browser doesn't get thru because
  - The data sometimes are blobs.
  - The Electron IPC channel name is `"received-from-browser-ipc` instead of webView
- Add turtle graphics as one of the sites for shell open action.
- Fix spelling. 