### PR TITLE
Resolve entity

### DIFF
--- a/ts/packages/actionSchema/src/utils.ts
+++ b/ts/packages/actionSchema/src/utils.ts
@@ -8,19 +8,23 @@ import {
 } from "./type.js";
 import { validateSchema } from "./validate.js";
 
-export function resolveUnionType(type: ResolvedSchemaType, actual: unknown) {
-    if (type.type !== "type-union") {
-        return type;
+export function resolveUnionType(
+    fieldType: SchemaType,
+    actualType: ResolvedSchemaType,
+    value: unknown,
+) {
+    if (actualType.type !== "type-union") {
+        return { fieldType, actualType };
     }
-    for (const t of type.types) {
+    for (const t of actualType.types) {
         const actualType = resolveTypeReference(t);
         if (actualType === undefined) {
             throw new Error("Unresolved type reference");
         }
         try {
-            validateSchema("", actualType, actual, false);
+            validateSchema("", actualType, value, false);
             // REVIEW: just pick the first match?
-            return actualType;
+            return { fieldType: t, actualType };
         } catch {}
     }
     return undefined;

--- a/ts/packages/agentSdk/src/agentInterface.ts
+++ b/ts/packages/agentSdk/src/agentInterface.ts
@@ -54,8 +54,10 @@ export type AppAgentInitSettings = {
 };
 
 export type ResolveEntityResult = {
-    entity: Entity;
+    match: "exact" | "fuzzy";
+    entities: Entity[];
 };
+
 export interface AppAgent extends Partial<AppAgentCommandInterface> {
     // Setup
     initializeAgentContext?(settings?: AppAgentInitSettings): Promise<unknown>;

--- a/ts/packages/agents/montage/src/route/route.ts
+++ b/ts/packages/agents/montage/src/route/route.ts
@@ -144,7 +144,7 @@ function sendThumbnailorOriginalImage(
  * Gets the knowledge reponse file for the supplied image (if available)
  * Used for debugging purposes only.
  */
-app.get("/knowlegeResponse", (req: Request, res: Response) => {
+app.get("/knowledgeResponse", (req: Request, res: Response) => {
     const imageFile = `${req.query.path}`;
 
     // replace the image path root with the index cache root since KR files are stored in the index cache

--- a/ts/packages/agents/montage/src/site/photo.ts
+++ b/ts/packages/agents/montage/src/site/photo.ts
@@ -19,7 +19,7 @@ export class Photo {
         this.img.src = "/thumbnail?path=" + imgPath;
 
         // get the image caption
-        fetch(`/knowlegeResponse?path=${imgPath}`).then(async (response) => {
+        fetch(`/knowledgeResponse?path=${imgPath}`).then(async (response) => {
             const ii = await response.json();
             this.img.title = ii.fileName + " - " + ii.altText;
         });


### PR DESCRIPTION
- Make sure we track the original type before `resolveReference`, when resolving entity so that we can trigger the `resolveEntity` call to the agent
- Agent will now return possible matches to allow dispatcher to build heuristic in resolving which entity to resolve to (not in this PR)