### PR TITLE
Fix schema cache

### DIFF
--- a/ts/packages/actionSchema/src/serialize.ts
+++ b/ts/packages/actionSchema/src/serialize.ts
@@ -130,7 +130,7 @@ function resolveTypes(
         case "type-reference":
             if (type.definition !== undefined) {
                 throw new Error(
-                    "Internal error: type reference already have a definition",
+                    `Internal error: type reference already have a definition ${type.name}`,
                 );
             }
             const definition = definitions[type.name];

--- a/ts/packages/dispatcher/src/translation/actionSchemaFileCache.ts
+++ b/ts/packages/dispatcher/src/translation/actionSchemaFileCache.ts
@@ -100,7 +100,7 @@ function loadCachedActionSchemaFile(
             schemaName: record.schemaName,
             sourceHash: record.sourceHash,
             parsedActionSchema: fromJSONParsedActionSchema(
-                record.parsedActionSchema,
+                structuredClone(record.parsedActionSchema), // Clone to avoid modifying the original data
             ),
         };
     } catch (e: any) {


### PR DESCRIPTION
When loading from cache file, we need to clone the data before modifying it, so that the change doesn't get persist back into the cache.