### PR TITLE
Improve unknown page open experience.

### DIFF
--- a/ts/packages/agents/browser/src/agent/actionsSchema.mts
+++ b/ts/packages/agents/browser/src/agent/actionsSchema.mts
@@ -26,7 +26,8 @@ export type BrowserEntities = WebPage;
 export type OpenWebPage = {
     actionName: "openWebPage";
     parameters: {
-        // Alias or URL for the site of the open.
+        // Name or description of the site to search for and open
+        // Do NOT put URL here unless the user request specified the URL.
         site:
             | "paelobiodb"
             | "crossword"

--- a/ts/packages/agents/browser/src/agent/manifest.json
+++ b/ts/packages/agents/browser/src/agent/manifest.json
@@ -1,6 +1,6 @@
 {
   "emojiChar": "🌐",
-  "defaultEnabled": false,
+  "defaultEnabled": true,
   "description": "Agent that allows you control an existing browser window",
   "schema": {
     "description": "Browser agent that allows you control an existing browser window and perform actions such as opening a new tab, closing a tab, scrolling, zooming and navigating to a specific URL.",

--- a/ts/packages/defaultAgentProvider/test/data/translate-browser-e2e.json
+++ b/ts/packages/defaultAgentProvider/test/data/translate-browser-e2e.json
@@ -1,0 +1,12 @@
+[
+    {
+        "request": "Open the portugal consulate website",
+        "action": {
+            "schemaName": "browser",
+            "actionName": "openWebPage",
+            "parameters": {
+                "site": "portugal consulate"
+            }
+        }
+    }
+]

--- a/ts/packages/defaultAgentProvider/test/translate_browser.test.ts
+++ b/ts/packages/defaultAgentProvider/test/translate_browser.test.ts
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+/*
+ * NOTE: This test has the extension .test.ts and not .spec.ts.
+ * *.test.ts files are run under test:live && test:live:debug
+ * project settings (see ../package.json).  The assumption is
+ * test:live has API endpoints where as test:local tests run
+ * wholly locally.
+ */
+
+import { defineTranslateTest } from "./translateTestCommon.js";
+const dataFiles = ["test/data/translate-browser-e2e.json"];
+
+await defineTranslateTest("translate browser (w/history)", dataFiles);

--- a/ts/packages/dispatcher/src/context/appAgentManager.ts
+++ b/ts/packages/dispatcher/src/context/appAgentManager.ts
@@ -393,7 +393,7 @@ export class AppAgentManager implements ActionConfigProvider {
     public getAppAgent(appAgentName: string): AppAgent {
         const record = this.getRecord(appAgentName);
         if (record.appAgent === undefined) {
-            throw new Error(`App agent' ${appAgentName}' is not initialized`);
+            throw new Error(`App agent '${appAgentName}' is not initialized`);
         }
         return record.appAgent;
     }

--- a/ts/packages/dispatcher/src/execute/actionHandlers.ts
+++ b/ts/packages/dispatcher/src/execute/actionHandlers.ts
@@ -308,7 +308,7 @@ export async function executeActions(
 
     // Even if the action is not executed, resolve the entities for the commandResult.
     const actionQueue: PendingAction[] = await toPendingActions(
-        systemContext,
+        context,
         actions,
         entities,
     );
@@ -335,7 +335,7 @@ export async function executeActions(
             const requestAction = translationResult.requestAction;
             actionQueue.unshift(
                 ...(await toPendingActions(
-                    systemContext,
+                    context,
                     requestAction.actions,
                     requestAction.history?.entities,
                 )),
@@ -391,11 +391,7 @@ export async function executeActions(
                 );
                 // REVIEW: assume that the agent will fill the entities already?  Also, current format doesn't support resultEntityIds.
                 actionQueue.unshift(
-                    ...(await toPendingActions(
-                        systemContext,
-                        actions,
-                        undefined,
-                    )),
+                    ...(await toPendingActions(context, actions, undefined)),
                 );
             } catch (e) {
                 throw new Error(


### PR DESCRIPTION
- Add comment in the action schema to push the model to not translate the URL based on trained data, which could be outdated, and allow the agent to resolve the URL based on current grounded information instead  (also added test)
- Test if the input for site is already an URL and directly return it.
- Restore the try/catch around the local port resolution so that it doesn't throw if the input is not an agent name
- Add status message when resolving entities (which can take a while for web pages)