### PR TITLE
Save and replay from chat history

### DIFF
--- a/ts/packages/cli/src/commands/test/translate.ts
+++ b/ts/packages/cli/src/commands/test/translate.ts
@@ -103,10 +103,8 @@ function getTokenUsageStr(usage: ai.CompletionUsageStats, count: number = 1) {
 export default class TestTranslateCommand extends Command {
     static args = {
         files: Args.string({
-            files: Args.string({
-                description:
-                    "List of test data files. Default to all test files in the config.json.",
-            }),
+            description:
+                "List of test data files. Default to all test files in the config.json.",
         }),
     };
     static flags = {

--- a/ts/packages/dispatcher/src/context/system/handlers/constructionCommandHandlers.ts
+++ b/ts/packages/dispatcher/src/context/system/handlers/constructionCommandHandlers.ts
@@ -30,6 +30,7 @@ import {
 } from "@typeagent/agent-sdk/helpers/command";
 import { ActionContext, ParsedCommandParams } from "@typeagent/agent-sdk";
 import fileSize from "file-size";
+import { checkOverwriteFile } from "../../../utils/commandHandlerUtils.js";
 
 async function checkRecreateStore(
     constructionStore: ConstructionStore,
@@ -40,19 +41,6 @@ async function checkRecreateStore(
     }
     const message =
         "Construction store has been modified.  All data will be lost!!! Continue?";
-    if (!(await askYesNoWithContext(context, message, true))) {
-        throw new Error("Aborted!");
-    }
-}
-
-async function checkOverwriteFile(
-    filePath: string | undefined,
-    context: CommandHandlerContext,
-) {
-    if (filePath === undefined || !fs.existsSync(filePath)) {
-        return;
-    }
-    const message = `File '${filePath}' exists.  Overwrite?`;
     if (!(await askYesNoWithContext(context, message, true))) {
         throw new Error("Aborted!");
     }

--- a/ts/packages/dispatcher/src/execute/pendingActions.ts
+++ b/ts/packages/dispatcher/src/execute/pendingActions.ts
@@ -84,7 +84,7 @@ async function getParameterArrayEntities(
     if (elementActualType === undefined) {
         throw new Error("Unresolved reference");
     }
-    return Promise.all(
+    const result = await Promise.all(
         value.map((v, i) =>
             getParameterEntities(
                 action,
@@ -98,6 +98,11 @@ async function getParameterArrayEntities(
             ),
         ),
     );
+    if (result.every((r) => r === undefined)) {
+        // Don't return empty array if no entities are found.
+        return undefined;
+    }
+    return result;
 }
 
 function resolvePromptEntity(

--- a/ts/packages/dispatcher/src/utils/commandHandlerUtils.ts
+++ b/ts/packages/dispatcher/src/utils/commandHandlerUtils.ts
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import fs from "node:fs";
+import { CommandHandlerContext } from "../context/commandHandlerContext.js";
+import { askYesNoWithContext } from "../context/interactiveIO.js";
+
+export async function checkOverwriteFile(
+    filePath: string | undefined,
+    context: CommandHandlerContext,
+) {
+    if (filePath === undefined || !fs.existsSync(filePath)) {
+        return;
+    }
+    const message = `File '${filePath}' exists.  Overwrite?`;
+    if (!(await askYesNoWithContext(context, message, true))) {
+        throw new Error("Aborted!");
+    }
+}


### PR DESCRIPTION
- Add command `@history save` to save chat history.
- Add CLI command `cli replay` to replay from the chat history.

Also,
- Fix entity array resolution to not add array of undefined values.
- Fix CLI command argument description for `cli test translate`
- Fix `@history insert` output message when only one assistant entry object it provided instead of an array.