### PR TITLE
Browser RPC

### DIFF
--- a/ts/packages/agents/browser/src/agent/actionHandler.mts
+++ b/ts/packages/agents/browser/src/agent/actionHandler.mts
@@ -18,6 +18,7 @@ import { createActionResult } from "@typeagent/agent-sdk/helpers/action";
 import {
     displayError,
     displayStatus,
+    displaySuccess,
 } from "@typeagent/agent-sdk/helpers/display";
 import { Crossword } from "./crossword/schema/pageSchema.mjs";
 import {
@@ -75,6 +76,7 @@ import {
 } from "@azure/ai-agents";
 import * as website from "website-memory";
 import { openai, TextEmbeddingModel } from "aiclient";
+import { createExternalBrowserClient } from "./rpc/externalBrowserControlClient.mjs";
 
 const debug = registerDebug("typeagent:browser:action");
 
@@ -89,7 +91,9 @@ export function instantiate(): AppAgent {
 }
 
 export type BrowserActionContext = {
-    browserControl?: BrowserControl | undefined;
+    clientBrowserControl?: BrowserControl | undefined;
+    externalBrowserControl?: BrowserControl | undefined;
+    useExternalBrowserControl: boolean;
     webSocket?: WebSocket | undefined;
     webAgentChannels?: WebAgentChannels | undefined;
     crossWordState?: Crossword | undefined;
@@ -113,9 +117,12 @@ export interface urlResolutionAction {
 async function initializeBrowserContext(
     settings?: AppAgentInitSettings,
 ): Promise<BrowserActionContext> {
-    const browserControl = settings?.options as BrowserControl | undefined;
+    const clientBrowserControl = settings?.options as
+        | BrowserControl
+        | undefined;
     return {
-        browserControl,
+        clientBrowserControl,
+        useExternalBrowserControl: clientBrowserControl === undefined,
         index: undefined,
     };
 }
@@ -172,6 +179,8 @@ async function updateBrowserContext(
         const webSocket = await createWebSocket("browser", "dispatcher");
         if (webSocket) {
             context.agentContext.webSocket = webSocket;
+            context.agentContext.externalBrowserControl =
+                createExternalBrowserClient(webSocket);
             context.agentContext.browserConnector = new BrowserConnector(
                 context,
             );
@@ -509,63 +518,64 @@ interface Response {
     }
 }
 
+function getBrowserControl(context: ActionContext<BrowserActionContext>) {
+    const agentContext = context.sessionContext.agentContext;
+    const browserControl = agentContext.useExternalBrowserControl
+        ? agentContext.externalBrowserControl
+        : agentContext.clientBrowserControl;
+    if (!browserControl) {
+        throw new Error(
+            `${agentContext.externalBrowserControl ? "External" : "Client"} browser control is not available.`,
+        );
+    }
+    return browserControl;
+}
+
 async function openWebPage(
     context: ActionContext<BrowserActionContext>,
     action: TypeAgentAction<OpenWebPage>,
 ) {
-    if (context.sessionContext.agentContext.browserControl) {
+    const browserControl = getBrowserControl(context);
+
+    displayStatus(`Opening web page for ${action.parameters.site}.`, context);
+    const siteEntity = action.entities?.site;
+    const url =
+        siteEntity?.type[0] === "WebPage"
+            ? siteEntity.uniqueId!
+            : await resolveWebPage(
+                  context.sessionContext,
+                  action.parameters.site,
+              );
+
+    if (url !== action.parameters.site) {
         displayStatus(
-            `Opening web page for ${action.parameters.site}.`,
+            `Opening web page for ${action.parameters.site} at ${url}.`,
             context,
         );
-        const siteEntity = action.entities?.site;
-        const url =
-            siteEntity?.type[0] === "WebPage"
-                ? siteEntity.uniqueId!
-                : await resolveWebPage(
-                      context.sessionContext,
-                      action.parameters.site,
-                  );
-
-        if (url !== action.parameters.site) {
-            displayStatus(
-                `Opening web page for ${action.parameters.site} at ${url}.`,
-                context,
-            );
-        }
-        await context.sessionContext.agentContext.browserControl.openWebPage(
-            url,
-        );
-        const result = createActionResult("Web page opened successfully.");
-
-        result.activityContext = {
-            activityName: "browsingWebPage",
-            description: "Browsing a web page",
-            state: {
-                site: siteEntity?.name,
-            },
-            activityEndAction: {
-                actionName: "closeWebPage",
-            },
-        };
-        return result;
     }
-    throw new Error(
-        "Browser control is not available. Please launch a browser first.",
-    );
+    await browserControl.openWebPage(url);
+    const result = createActionResult("Web page opened successfully.");
+
+    result.activityContext = {
+        activityName: "browsingWebPage",
+        description: "Browsing a web page",
+        state: {
+            site: siteEntity?.name,
+        },
+        activityEndAction: {
+            actionName: "closeWebPage",
+        },
+    };
+    return result;
 }
 
 async function closeWebPage(context: ActionContext<BrowserActionContext>) {
-    if (context.sessionContext.agentContext.browserControl) {
-        context.actionIO.setDisplay("Closing web page.");
-        await context.sessionContext.agentContext.browserControl.closeWebPage();
-        const result = createActionResult("Web page closed successfully.");
-        result.activityContext = null; // clear the activity context.
-        return result;
-    }
-    throw new Error(
-        "Browser control is not available. Please launch a browser first.",
-    );
+    const browserControl = getBrowserControl(context);
+    context.actionIO.setDisplay("Closing web page.");
+    await browserControl.closeWebPage();
+    const result = createActionResult("Web page closed successfully.");
+    result.activityContext = null; // clear the activity context.
+    return result;
 }
 
 async function executeBrowserAction(
@@ -591,6 +601,16 @@ async function executeBrowserAction(
                 return searchWebsites(context, action);
             case "getWebsiteStats":
                 return getWebsiteStats(context, action);
+            case "goForward":
+                await getBrowserControl(context).goForward();
+                return;
+            case "goBack":
+                await getBrowserControl(context).goBack();
+                return;
+            case "reloadPage":
+                // REVIEW: do we need to clear page schema?
+                await getBrowserControl(context).reload();
+                return;
         }
     }
     const webSocketEndpoint = context.sessionContext.agentContext.webSocket;
@@ -891,5 +911,46 @@ export const handlers: CommandHandlerTable = {
 
         open: new OpenWebPageHandler(),
         close: new CloseWebPageHandler(),
+        external: {
+            description: "Toggle external browser control",
+            defaultSubCommand: "on",
+            commands: {
+                on: {
+                    description: "Enable external browser control",
+                    run: async (
+                        context: ActionContext<BrowserActionContext>,
+                    ) => {
+                        const agentContext =
+                            context.sessionContext.agentContext;
+                        if (agentContext.externalBrowserControl === undefined) {
+                            throw new Error(
+                                "External browser control is not available.",
+                            );
+                        }
+                        agentContext.useExternalBrowserControl = true;
+                        displaySuccess(
+                            "Using external browser control.",
+                            context,
+                        );
+                    },
+                },
+                off: {
+                    description: "Disable external browser control",
+                    run: async (
+                        context: ActionContext<BrowserActionContext>,
+                    ) => {
+                        const agentContext =
+                            context.sessionContext.agentContext;
+                        if (agentContext.clientBrowserControl === undefined) {
+                            throw new Error(
+                                "Client browser control is not available.",
+                            );
+                        }
+                        agentContext.useExternalBrowserControl = false;
+                        displaySuccess("Use client browser control.", context);
+                    },
+                },
+            },
+        },
     },
 };

--- a/ts/packages/agents/browser/src/agent/interface.mts
+++ b/ts/packages/agents/browser/src/agent/interface.mts
@@ -12,4 +12,8 @@ export interface BrowserControl {
      * close the browser view.
      */
     closeWebPage(): Promise<void>;
+
+    goForward(): Promise<void>;
+    goBack(): Promise<void>;
+    reload(): Promise<void>;
 }

--- a/ts/packages/agents/browser/src/agent/rpc/externalBrowserControlClient.mts
+++ b/ts/packages/agents/browser/src/agent/rpc/externalBrowserControlClient.mts
@@ -1,0 +1,70 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { WebSocket } from "ws";
+import { BrowserControl } from "../interface.mjs";
+import { createGenericChannel } from "agent-rpc/channel";
+import { createRpc } from "agent-rpc/rpc";
+import { WebSocketMessageV2 } from "common-utils";
+
+type BrowserControlInvokeFunctions = {
+    goForward: () => Promise<void>;
+    goBack: () => Promise<void>;
+    reload: () => Promise<void>;
+};
+
+export function createExternalBrowserClient(
+    webSocket: WebSocket,
+): BrowserControl {
+    const browserControlChannel = createGenericChannel((message) => {
+        // Message to the browser extension
+        webSocket.send(
+            JSON.stringify({
+                source: "browserAgent",
+                method: "browserControl/message",
+                params: message,
+            }),
+        );
+    });
+
+    webSocket.on("message", (message) => {
+        // Message from the browser extension
+        const text = message.toString();
+        const data: WebSocketMessageV2 = JSON.parse(text);
+        if (
+            data.source === "browserExtension" &&
+            data.method === "browserControl/message"
+        ) {
+            browserControlChannel.message(data.params);
+        }
+    });
+
+    webSocket.on("close", () => {
+        browserControlChannel.disconnect();
+    });
+
+    const rpc = createRpc<BrowserControlInvokeFunctions>(
+        browserControlChannel.channel,
+    );
+    return {
+        openWebPage: async (url: string) => {
+            throw new Error(
+                "openWebPage not implement in external browser control",
+            );
+        },
+        closeWebPage: async () => {
+            throw new Error(
+                "closeWebPage not implement in external browser control",
+            );
+        },
+        goForward: async () => {
+            return rpc.invoke("goForward");
+        },
+        goBack: async () => {
+            return rpc.invoke("goBack");
+        },
+        reload: async () => {
+            return rpc.invoke("reload");
+        },
+    };
+}

--- a/ts/packages/agents/browser/src/extension/contentScript/eventHandlers.ts
+++ b/ts/packages/agents/browser/src/extension/contentScript/eventHandlers.ts
@@ -171,18 +171,6 @@ export async function handleMessage(
                 break;
             }
 
-            case "history_go_back": {
-                window.history.back();
-                sendResponse({});
-                break;
-            }
-
-            case "history_go_forward": {
-                window.history.forward();
-                sendResponse({});
-                break;
-            }
-
             case "read_page_content": {
                 const article = getReadablePageContent();
                 sendResponse(article);

--- a/ts/packages/agents/browser/src/extension/serviceWorker/browserActions.ts
+++ b/ts/packages/agents/browser/src/extension/serviceWorker/browserActions.ts
@@ -154,16 +154,7 @@ export async function runBrowserAction(action: AppAction): Promise<any> {
             });
             break;
         }
-        case "goBack": {
-            const targetTab = await getActiveTab();
-            await chrome.tabs.goBack(targetTab?.id!);
-            break;
-        }
-        case "goForward": {
-            const targetTab = await getActiveTab();
-            await chrome.tabs.goForward(targetTab?.id!);
-            break;
-        }
+
         case "openFromHistory": {
             const targetTab = await getActiveTab();
             const historyItems = await chrome.history.search({
@@ -391,6 +382,8 @@ export async function runBrowserAction(action: AppAction): Promise<any> {
             );
             break;
         }
+        default:
+            throw new Error(`Unknown action: ${actionName}. `);
     }
 
     return {

--- a/ts/packages/agents/browser/src/extension/serviceWorker/externalBrowserControlServer.ts
+++ b/ts/packages/agents/browser/src/extension/serviceWorker/externalBrowserControlServer.ts
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { RpcChannel } from "agent-rpc/channel";
+import { getActiveTab } from "./tabManager";
+import { createRpc } from "agent-rpc/rpc";
+export function createExternalBrowserServer(channel: RpcChannel) {
+    const browserControlInvokeFunctions = {
+        goForward: async () => {
+            const targetTab = await getActiveTab();
+            await chrome.tabs.goForward(targetTab?.id!);
+        },
+        goBack: async () => {
+            const targetTab = await getActiveTab();
+            await chrome.tabs.goBack(targetTab?.id!);
+        },
+        reload: async () => {
+            const targetTab = await getActiveTab();
+            await chrome.tabs.reload(targetTab?.id!);
+        },
+    };
+    return createRpc(channel, browserControlInvokeFunctions);
+}

--- a/ts/packages/agents/browser/src/extension/serviceWorker/websocket.ts
+++ b/ts/packages/agents/browser/src/extension/serviceWorker/websocket.ts
@@ -5,6 +5,8 @@ import { AppAction, isWebAgentMessageFromDispatcher } from "./types";
 import { getSettings } from "./storage";
 import { showBadgeError, showBadgeHealthy, showBadgeBusy } from "./ui";
 import { runBrowserAction } from "./browserActions";
+import { createGenericChannel } from "agent-rpc/channel";
+import { createExternalBrowserServer } from "./externalBrowserControlServer";
 
 let webSocket: WebSocket | undefined;
 let settings: Record<string, any>;
@@ -70,12 +72,31 @@ export async function ensureWebsocketConnected(): Promise<
         webSocket.binaryType = "blob";
         keepWebSocketAlive(webSocket);
 
+        const browserControlChannel = createGenericChannel((message: any) => {
+            if (webSocket && webSocket.readyState === WebSocket.OPEN) {
+                webSocket.send(
+                    JSON.stringify({
+                        source: "browserExtension",
+                        method: "browserControl/message",
+                        params: message,
+                    }),
+                );
+            }
+        });
+        createExternalBrowserServer(browserControlChannel.channel);
         webSocket.onmessage = async (event: MessageEvent) => {
             const text = await (event.data as Blob).text();
-            const data = JSON.parse(text) as WebSocketMessageV2;
+            console.log(`Browser websocket client received message: ${text}`);
 
+            const data = JSON.parse(text) as WebSocketMessageV2;
             if (data.error) {
                 console.error(data.error);
+                return;
+            }
+            if (data.method === "browserControl/message") {
+                if (data.source === "browserAgent") {
+                    browserControlChannel.message(data.params);
+                }
                 return;
             }
 
@@ -110,7 +131,6 @@ export async function ensureWebsocketConnected(): Promise<
                     }
                 }
             }
-            console.log(`Browser websocket client received message: ${text}`);
         };
 
         webSocket.onclose = (event: CloseEvent) => {

--- a/ts/packages/shell/src/main/index.ts
+++ b/ts/packages/shell/src/main/index.ts
@@ -287,6 +287,26 @@ async function initializeDispatcher(
             async closeWebPage() {
                 shellWindow.closeInlineBrowser();
             },
+
+            async goForward() {
+                const navigateHistory =
+                    shellWindow.inlineBrowser.webContents.navigationHistory;
+                if (!navigateHistory.canGoForward()) {
+                    throw new Error("Cannot go forward in history");
+                }
+                navigateHistory.goForward();
+            },
+            async goBack() {
+                const navigateHistory =
+                    shellWindow.inlineBrowser.webContents.navigationHistory;
+                if (!navigateHistory.canGoBack()) {
+                    throw new Error("Cannot go back in history");
+                }
+                navigateHistory.goBack();
+            },
+            async reload() {
+                shellWindow.inlineBrowser.webContents.reload();
+            },
         };
 
         // Set up dispatcher

--- a/ts/packages/shell/src/main/shellWindow.ts
+++ b/ts/packages/shell/src/main/shellWindow.ts
@@ -41,6 +41,13 @@ export class ShellWindow {
     private readonly handlers = new Map<string, (event: any) => void>();
     private readonly settings: ShellSettingManager;
     private closing: boolean = false;
+
+    public get inlineBrowser(): WebContentsView {
+        if (this.inlineWebContentView === undefined) {
+            throw new Error("Inline browser is not open");
+        }
+        return this.inlineWebContentView;
+    }
     constructor(shellSettings: ShellSettings, instanceDir: string) {
         if (ShellWindow.instance !== undefined) {
             throw new Error("ShellWindow already created");

--- a/ts/packages/shell/src/preload/webView.ts
+++ b/ts/packages/shell/src/preload/webView.ts
@@ -252,18 +252,6 @@ async function runBrowserAction(action: any) {
             });
             break;
         }
-        case "goBack": {
-            sendScriptAction({
-                type: "history_go_back",
-            });
-            break;
-        }
-        case "goForward": {
-            sendScriptAction({
-                type: "history_go_forward",
-            });
-            break;
-        }
 
         case "zoomIn": {
             if (window.location.href.startsWith("https://paleobiodb.org/")) {
@@ -340,19 +328,15 @@ async function runBrowserAction(action: any) {
             });
             break;
         }
-        case "reloadPage": {
-            sendScriptAction({
-                type: "clear_page_schema",
-            });
-            location.reload();
-            break;
-        }
         case "closeWindow": {
             window.close();
             // todo: call method on IPC process to close the window/view
 
             break;
         }
+
+        default:
+            throw new Error(`Invalid action: ${actionName}`);
     }
 
     return {


### PR DESCRIPTION
- Add RPC to control external browser as well using `BrowserControl` interface.  
- Add `goForward`, `goBack` and `reload` to `BrowserControl`. (So now reload will work on external browser as well. More action will be move to the `BrowserControl` in the future.
- Add command `@browser external on/off` to control whether the agent using a inline browser or an external browser.
- RPC types allow `param` object to be skipped in remote call signature if it is there are no parameters.
