### PR TITLE
Fix RPC param typing

### DIFF
--- a/ts/packages/agentRpc/src/rpc.ts
+++ b/ts/packages/agentRpc/src/rpc.ts
@@ -7,16 +7,16 @@ import { RpcChannel } from "./common.js";
 
 type RpcFuncTypes<
     N extends string,
-    T extends Record<string, (...args: any) => any>,
+    T extends Record<string, (...args: any[]) => any>,
 > = {
     [K in keyof T as `${N}`]: <K extends string>(
         name: K,
-        param: Parameters<T[K]>[0],
+        ...args: Parameters<T[K]>
     ) => ReturnType<T[K]>;
 };
 
-type RpcInvokeFunction = (param: any) => Promise<unknown>;
-type RpcCallFunction = (param: any) => void;
+type RpcInvokeFunction = (...args: any[]) => Promise<unknown>;
+type RpcCallFunction = (...args: any[]) => void;
 type RpcInvokeFunctions = Record<string, RpcInvokeFunction>;
 type RpcCallFunctions = Record<string, RpcCallFunction>;
 type RpcReturn<
@@ -59,7 +59,7 @@ export function createRpc<
             if (f === undefined) {
                 debugError("No call handler", message);
             } else {
-                f(message.param);
+                f(...message.args);
             }
             return;
         }
@@ -72,7 +72,7 @@ export function createRpc<
                     error: "No invoke handler",
                 });
             } else {
-                f(message.param).then(
+                f(...message.args).then(
                     (result) => {
                         out({
                             type: "invokeResult",
@@ -123,18 +123,18 @@ export function createRpc<
 
     let nextCallId = 0;
     const rpc = {
-        invoke: async function <P, T>(
+        invoke: async function (
             name: keyof InvokeTargetFunctions,
-            param: P,
-        ): Promise<T> {
+            ...args: any[]
+        ): Promise<any> {
             const message = {
                 type: "invoke",
                 callId: nextCallId++,
                 name,
-                param,
+                args,
             };
 
-            return new Promise<T>((resolve, reject) => {
+            return new Promise<any>((resolve, reject) => {
                 out(message, (err) => {
                     if (err !== null) {
                         reject(err);
@@ -143,12 +143,12 @@ export function createRpc<
                 pending.set(message.callId, { resolve, reject });
             });
         },
-        send: <P>(name: keyof CallTargetFunctions, param?: P) => {
+        send: (name: keyof CallTargetFunctions, ...args: any[]) => {
             out({
                 type: "call",
                 callId: nextCallId++,
                 name,
-                param,
+                args,
             });
         },
     } as RpcReturn<InvokeTargetFunctions, CallTargetFunctions>;
@@ -173,16 +173,16 @@ function isInvokeError(message: any): message is InvokeError {
 
 type CallMessage = {
     type: "call";
-    callId: number;
+    callId: number; // Not necessary for call messages. included for tracing.
     name: string;
-    param: any;
+    args: any[];
 };
 
 type InvokeMessage = {
     type: "invoke";
     callId: number;
     name: string;
-    param: any;
+    args: any[];
 };
 
 type InvokeResult<T = void> = {

--- a/ts/packages/agents/browser/package.json
+++ b/ts/packages/agents/browser/package.json
@@ -19,8 +19,8 @@
   },
   "main": "index.js",
   "scripts": {
-    "build": "npm run tsc:common && concurrently npm:tsc:agent npm:tsc:puppeteer npm:vite",
-    "build:dev": "npm run tsc:common && concurrently npm:tsc:agent npm:tsc:puppeteer npm:vite:dev",
+    "build": "npm run tsc:common && concurrently npm:tsc:agent npm:tsc:puppeteer npm:vite npm:tsc:typecheck",
+    "build:dev": "npm run tsc:common && concurrently npm:tsc:agent npm:tsc:puppeteer npm:vite:dev npm:tsc:typecheck",
     "clean": "rimraf dist deploy",
     "package": "node scripts/packExtension.mjs",
     "prettier": "prettier --check . --ignore-path ../../../.prettierignore",
@@ -29,6 +29,7 @@
     "tsc:agent": "tsc -p src/agent/tsconfig.json",
     "tsc:common": "tsc -p src/common/tsconfig.json",
     "tsc:puppeteer": "tsc -p src/puppeteer/tsconfig.json",
+    "tsc:typecheck": "tsc --noEmit -p tsconfig.json",
     "vite": "node scripts/buildExtension.mjs",
     "vite:dev": "node scripts/buildExtension.mjs --dev"
   },

--- a/ts/packages/agents/browser/src/agent/interface.mts
+++ b/ts/packages/agents/browser/src/agent/interface.mts
@@ -32,5 +32,5 @@ export type BrowserControlInvokeFunctions = {
 };
 
 export type BrowserControlCallFunctions = {
-    setAgentStatus(params: { isBusy: boolean; message: string }): void;
+    setAgentStatus(isBusy: boolean, message: string): void;
 };

--- a/ts/packages/agents/browser/src/agent/rpc/externalBrowserControlClient.mts
+++ b/ts/packages/agents/browser/src/agent/rpc/externalBrowserControlClient.mts
@@ -51,25 +51,22 @@ export function createExternalBrowserClient(
             return rpc.invoke("openWebPage", url);
         },
         closeWebPage: async () => {
-            return rpc.invoke("closeWebPage", undefined);
+            return rpc.invoke("closeWebPage");
         },
         goForward: async () => {
-            return rpc.invoke("goForward", undefined);
+            return rpc.invoke("goForward");
         },
         goBack: async () => {
-            return rpc.invoke("goBack", undefined);
+            return rpc.invoke("goBack");
         },
         reload: async () => {
-            return rpc.invoke("reload", undefined);
+            return rpc.invoke("reload");
         },
         getPageUrl: async () => {
-            return rpc.invoke("getPageUrl", undefined);
+            return rpc.invoke("getPageUrl");
         },
-        setAgentStatus: (isBusy: boolean, message: string) => {
-            rpc.send("setAgentStatus", {
-                isBusy,
-                message,
-            });
+        setAgentStatus: (...args) => {
+            rpc.send("setAgentStatus", ...args);
         },
     };
 }

--- a/ts/packages/agents/browser/src/extension/serviceWorker/externalBrowserControlServer.ts
+++ b/ts/packages/agents/browser/src/extension/serviceWorker/externalBrowserControlServer.ts
@@ -56,7 +56,7 @@ export function createExternalBrowserServer(channel: RpcChannel) {
         },
     };
     const callFunctions: BrowserControlCallFunctions = {
-        setAgentStatus: ({ isBusy, message }) => {
+        setAgentStatus: (isBusy: boolean, message: string) => {
             if (isBusy) {
                 showBadgeBusy();
             } else {
@@ -65,5 +65,10 @@ export function createExternalBrowserServer(channel: RpcChannel) {
             console.log(`${message} (isBusy: ${isBusy})`);
         },
     };
-    return createRpc(channel, invokeFunctions, callFunctions);
+    return createRpc(
+        "browser:extension",
+        channel,
+        invokeFunctions,
+        callFunctions,
+    );
 }

--- a/ts/packages/agents/browser/src/extension/webTypeAgentMain.ts
+++ b/ts/packages/agents/browser/src/extension/webTypeAgentMain.ts
@@ -72,6 +72,7 @@ function ensureDynamicTypeAgentManager(): DynamicTypeAgentManager {
     });
 
     const rpc = createRpc<DynamicTypeAgentManagerInvokeFunctions>(
+        "webAgent",
         registerChannel.channel,
     );
     manager = {

--- a/ts/packages/dispatcher/src/rpc/clientIOClient.ts
+++ b/ts/packages/dispatcher/src/rpc/clientIOClient.ts
@@ -22,10 +22,10 @@ export function createClientIORpcClient(channel: RpcChannel): ClientIO {
     );
     return {
         clear(): void {
-            return rpc.send("clear", undefined);
+            return rpc.send("clear");
         },
         exit(): void {
-            return rpc.send("exit", undefined);
+            return rpc.send("exit");
         },
         setDisplayInfo(
             source: string,

--- a/ts/packages/dispatcher/src/rpc/dispatcherClient.ts
+++ b/ts/packages/dispatcher/src/rpc/dispatcherClient.ts
@@ -48,7 +48,7 @@ export function createDispatcherRpcClient(channel: RpcChannel): Dispatcher {
             return rpc.invoke("getCommandCompletion", { prefix });
         },
         async close() {
-            return rpc.invoke("close", undefined);
+            return rpc.invoke("close");
         },
         getPrompt: remoteCallNotSupported,
         getSettingSummary: remoteCallNotSupported,


### PR DESCRIPTION
- Allow RPC functions after marshalling to pass multiple params (and not force them to always be passed in a single object)
- Add back type checking to browser agent extension and electron content scripts.
- Mix missing name parameter when creating RPC discover from adding back type checking.