### PR TITLE
Browser RPC: follow link

### DIFF
--- a/ts/packages/agentSdk/src/helpers/actionHelpers.ts
+++ b/ts/packages/agentSdk/src/helpers/actionHelpers.ts
@@ -87,13 +87,16 @@ export function createActionResultFromHtmlDisplayWithScript(
  */
 export function createActionResultFromMarkdownDisplay(
     markdownText: string | string[],
+    literalText?: string,
     entities: Entity[] = [],
     resultEntity?: Entity,
 ): ActionResultSuccess {
     return {
-        literalText: Array.isArray(markdownText)
-            ? markdownText.join("\n")
-            : markdownText,
+        literalText:
+            literalText ??
+            (Array.isArray(markdownText)
+                ? markdownText.join("\n")
+                : markdownText),
         entities,
         resultEntity,
         displayContent: { type: "markdown", content: markdownText },

--- a/ts/packages/agents/browser/src/agent/actionHandler.mts
+++ b/ts/packages/agents/browser/src/agent/actionHandler.mts
@@ -14,7 +14,10 @@ import {
     SessionContext,
     TypeAgentAction,
 } from "@typeagent/agent-sdk";
-import { createActionResult } from "@typeagent/agent-sdk/helpers/action";
+import {
+    createActionResult,
+    createActionResultFromMarkdownDisplay,
+} from "@typeagent/agent-sdk/helpers/action";
 import {
     displayError,
     displayStatus,
@@ -634,6 +637,37 @@ async function executeBrowserAction(
             case "scrollDown":
                 await getActionBrowserControl(context).scrollDown();
                 return;
+            case "followLinkByText": {
+                const control = getActionBrowserControl(context);
+                const { keywords, openInNewTab } = action.parameters;
+                const url = await control.followLinkByText(
+                    keywords,
+                    openInNewTab,
+                );
+                if (!url) {
+                    throw new Error(`No link found for '${keywords}'`);
+                }
+
+                return createActionResultFromMarkdownDisplay(
+                    `Navigated to link for [${keywords}](${url})`,
+                    `Navigated to link for '${keywords}'`,
+                );
+            }
+            case "followLinkByPosition":
+                const control = getActionBrowserControl(context);
+                const url = await control.followLinkByPosition(
+                    action.parameters.position,
+                    action.parameters.openInNewTab,
+                );
+                if (!url) {
+                    throw new Error(
+                        `No link found at position ${action.parameters.position}`,
+                    );
+                }
+                return createActionResultFromMarkdownDisplay(
+                    `Navigated to [link](${url}) at position ${action.parameters.position}`,
+                    `Navigated to link at position ${action.parameters.position}`,
+                );
         }
     }
     const webSocketEndpoint = context.sessionContext.agentContext.webSocket;

--- a/ts/packages/agents/browser/src/agent/browserControl.mts
+++ b/ts/packages/agents/browser/src/agent/browserControl.mts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-export interface BrowserControl {
+export type BrowserControlInvokeFunctions = {
     /**
      * open a new browser view with the specified URL.
      * @param url The URL to open in the browser.
@@ -12,29 +12,27 @@ export interface BrowserControl {
      * close the browser view.
      */
     closeWebPage(): Promise<void>;
-
-    goForward(): Promise<void>;
-    goBack(): Promise<void>;
-    reload(): Promise<void>;
-
-    getPageUrl(): Promise<string>;
-
-    setAgentStatus(isBusy: boolean, message: string): void;
-    scrollUp(): Promise<void>;
-    scrollDown(): Promise<void>;
-}
-
-export type BrowserControlInvokeFunctions = {
-    openWebPage(url: string): Promise<void>;
-    closeWebPage(): Promise<void>;
     goForward(): Promise<void>;
     goBack(): Promise<void>;
     reload(): Promise<void>;
     getPageUrl(): Promise<string>;
     scrollUp(): Promise<void>;
     scrollDown(): Promise<void>;
+    // returns the URL, or undefined if not found
+    followLinkByText(
+        keywords: string,
+        openInNewTab?: boolean,
+    ): Promise<string | undefined>;
+    // returns the URL, or undefined if not found
+    followLinkByPosition(
+        position: number,
+        openInNewTab?: boolean,
+    ): Promise<string | undefined>;
 };
 
 export type BrowserControlCallFunctions = {
     setAgentStatus(isBusy: boolean, message: string): void;
 };
+
+export type BrowserControl = BrowserControlInvokeFunctions &
+    BrowserControlCallFunctions;

--- a/ts/packages/agents/browser/src/agent/rpc/externalBrowserControlClient.mts
+++ b/ts/packages/agents/browser/src/agent/rpc/externalBrowserControlClient.mts
@@ -47,8 +47,8 @@ export function createExternalBrowserClient(
     >("browser:extension", browserControlChannel.channel);
 
     return {
-        openWebPage: async (url: string) => {
-            return rpc.invoke("openWebPage", url);
+        openWebPage: async (...args) => {
+            return rpc.invoke("openWebPage", ...args);
         },
         closeWebPage: async () => {
             return rpc.invoke("closeWebPage");
@@ -73,6 +73,12 @@ export function createExternalBrowserClient(
         },
         scrollDown: async () => {
             return rpc.invoke("scrollDown");
+        },
+        followLinkByText: (...args) => {
+            return rpc.invoke("followLinkByText", ...args);
+        },
+        followLinkByPosition: (...args) => {
+            return rpc.invoke("followLinkByPosition", ...args);
         },
     };
 }

--- a/ts/packages/agents/browser/src/common/contentScriptRpc/client.mts
+++ b/ts/packages/agents/browser/src/common/contentScriptRpc/client.mts
@@ -5,7 +5,9 @@ import type { ContentScriptRpc } from "./types.mjs";
 import type { RpcChannel } from "agent-rpc/channel";
 import { createRpc } from "agent-rpc/rpc";
 
-export function createContentScriptRpcClient(channel: RpcChannel) {
+export function createContentScriptRpcClient(
+    channel: RpcChannel,
+): ContentScriptRpc {
     const contentScriptRpcClient = createRpc<ContentScriptRpc>(
         "browser:content",
         channel,
@@ -14,5 +16,9 @@ export function createContentScriptRpcClient(channel: RpcChannel) {
     return {
         scrollUp: () => contentScriptRpcClient.invoke("scrollUp"),
         scrollDown: () => contentScriptRpcClient.invoke("scrollDown"),
+        getPageLinksByQuery: (keywords: string) =>
+            contentScriptRpcClient.invoke("getPageLinksByQuery", keywords),
+        getPageLinksByPosition: (position: number) =>
+            contentScriptRpcClient.invoke("getPageLinksByPosition", position),
     };
 }

--- a/ts/packages/agents/browser/src/common/contentScriptRpc/types.mts
+++ b/ts/packages/agents/browser/src/common/contentScriptRpc/types.mts
@@ -4,4 +4,6 @@
 export type ContentScriptRpc = {
     scrollUp(): Promise<void>;
     scrollDown(): Promise<void>;
+    getPageLinksByQuery(query: string): Promise<string | undefined>;
+    getPageLinksByPosition(position: number): Promise<string | undefined>;
 };

--- a/ts/packages/agents/browser/src/extension/contentScript/eventHandlers.ts
+++ b/ts/packages/agents/browser/src/extension/contentScript/eventHandlers.ts
@@ -144,6 +144,14 @@ function setupMessageListeners(): void {
         scrollDown: async () => {
             scrollPageDown();
         },
+        getPageLinksByQuery: async (query: string) => {
+            const link = matchLinks(query) as HTMLAnchorElement;
+            return link?.href;
+        },
+        getPageLinksByPosition: async (position: number) => {
+            const link = matchLinksByPosition(position) as HTMLAnchorElement;
+            return link?.href;
+        },
     };
 
     createRpc(
@@ -189,28 +197,6 @@ export async function handleMessage(
 ): Promise<void> {
     try {
         switch (message.type) {
-            case "get_page_links_by_query": {
-                const link = matchLinks(message.query) as HTMLAnchorElement;
-                if (link && link.href) {
-                    sendResponse({ url: link.href });
-                } else {
-                    sendResponse({});
-                }
-                break;
-            }
-
-            case "get_page_links_by_position": {
-                const link = matchLinksByPosition(
-                    message.position,
-                ) as HTMLAnchorElement;
-                if (link && link.href) {
-                    sendResponse({ url: link.href });
-                } else {
-                    sendResponse({});
-                }
-                break;
-            }
-
             case "read_page_content": {
                 const article = getReadablePageContent();
                 sendResponse(article);

--- a/ts/packages/agents/browser/src/extension/serviceWorker/browserActions.ts
+++ b/ts/packages/agents/browser/src/extension/serviceWorker/browserActions.ts
@@ -94,52 +94,6 @@ export async function runBrowserAction(action: AppAction): Promise<any> {
             confirmationMessage = `Opened new tab with query ${action.parameters.query}`;
             break;
         }
-        case "followLinkByText": {
-            const targetTab = await getActiveTab();
-            const response = await chrome.tabs.sendMessage(targetTab?.id!, {
-                type: "get_page_links_by_query",
-                query: action.parameters.keywords,
-            });
-
-            if (response && response.url) {
-                if (action.parameters.openInNewTab) {
-                    await chrome.tabs.create({
-                        url: response.url,
-                    });
-                } else {
-                    await chrome.tabs.update(targetTab?.id!, {
-                        url: response.url,
-                    });
-                }
-
-                confirmationMessage = `Navigated to the ${action.parameters.keywords} link`;
-            }
-
-            break;
-        }
-        case "followLinkByPosition": {
-            const targetTab = await getActiveTab();
-            const response = await chrome.tabs.sendMessage(targetTab?.id!, {
-                type: "get_page_links_by_position",
-                position: action.parameters.position,
-            });
-
-            if (response && response.url) {
-                if (action.parameters.openInNewTab) {
-                    await chrome.tabs.create({
-                        url: response.url,
-                    });
-                } else {
-                    await chrome.tabs.update(targetTab?.id!, {
-                        url: response.url,
-                    });
-                }
-
-                confirmationMessage = `Navigated to the ${action.parameters.position} link`;
-            }
-
-            break;
-        }
 
         case "openFromHistory": {
             const targetTab = await getActiveTab();

--- a/ts/packages/agents/browser/src/extension/serviceWorker/externalBrowserControlServer.ts
+++ b/ts/packages/agents/browser/src/extension/serviceWorker/externalBrowserControlServer.ts
@@ -92,6 +92,38 @@ export function createExternalBrowserServer(channel: RpcChannel) {
         scrollDown: async () => {
             return contentScriptRpc.scrollDown();
         },
+        followLinkByText: async (keywords: string, openInNewTab?: boolean) => {
+            const url = await contentScriptRpc.getPageLinksByQuery(keywords);
+
+            if (url) {
+                if (openInNewTab) {
+                    await chrome.tabs.create({ url });
+                } else {
+                    // REVIEW: the active tab might have changed from getPageLinksByQuery call
+                    const targetTab = await getActiveTab();
+                    await chrome.tabs.update(targetTab?.id!, { url });
+                }
+            }
+
+            return url;
+        },
+        followLinkByPosition: async (position, openInNewTab) => {
+            const url = await contentScriptRpc.getPageLinksByPosition(position);
+
+            if (url) {
+                if (openInNewTab) {
+                    await chrome.tabs.create({
+                        url,
+                    });
+                } else {
+                    // REVIEW: the active tab might have changed from getPageLinksByPosition call
+                    const targetTab = await getActiveTab();
+                    await chrome.tabs.update(targetTab?.id!, { url });
+                }
+            }
+
+            return url;
+        },
     };
     const callFunctions: BrowserControlCallFunctions = {
         setAgentStatus: (isBusy: boolean, message: string) => {

--- a/ts/packages/agents/list/src/listActionHandler.ts
+++ b/ts/packages/agents/list/src/listActionHandler.ts
@@ -286,6 +286,7 @@ function getListDisplay(
     // set displayText to markdown list of the items
     return createActionResultFromMarkdownDisplay(
         `List '${listName}' has items:\n\n${plainList.map((item) => `- ${item}`).join("\n")}${suffix ? `\n\n${suffix}` : ""}`,
+        undefined,
         getEntities(listName, plainList),
     );
 }

--- a/ts/packages/agents/montage/src/agent/montageActionHandler.ts
+++ b/ts/packages/agents/montage/src/agent/montageActionHandler.ts
@@ -652,6 +652,7 @@ async function handleMontageAction(
 
                 result = createActionResultFromMarkdownDisplay(
                     names.join("\n"),
+                    undefined,
                     agentContext.montages.map((m) => entityFromMontage(m)),
                 );
             } else {

--- a/ts/packages/agents/spelunker/src/searchCode.ts
+++ b/ts/packages/agents/spelunker/src/searchCode.ts
@@ -97,6 +97,7 @@ export async function searchCode(
 
     return createActionResultFromMarkdownDisplay(
         answer,
+        undefined,
         outputEntities,
         resultEntity,
     );

--- a/ts/packages/dispatcher/src/context/dispatcher/dispatcherAgent.ts
+++ b/ts/packages/dispatcher/src/context/dispatcher/dispatcherAgent.ts
@@ -237,7 +237,11 @@ function clarifyEntityAction(
         `Please clarify which one you meant.`,
     ];
 
-    return createActionResultFromMarkdownDisplay(question, result.entities);
+    return createActionResultFromMarkdownDisplay(
+        question,
+        undefined,
+        result.entities,
+    );
 }
 
 export const dispatcherManifest: AppAgentManifest = {

--- a/ts/packages/dispatcher/src/execute/actionHandlers.ts
+++ b/ts/packages/dispatcher/src/execute/actionHandlers.ts
@@ -437,24 +437,6 @@ export async function executeActions(
             );
         }
 
-        if (result.additionalActions !== undefined) {
-            try {
-                const actions = getAdditionalExecutableActions(
-                    result.additionalActions,
-                    action.schemaName,
-                    systemContext,
-                );
-                // REVIEW: assume that the agent will fill the entities already?  Also, current format doesn't support resultEntityIds.
-                actionQueue.unshift(
-                    ...(await toPendingActions(context, actions, undefined)),
-                );
-            } catch (e) {
-                throw new Error(
-                    `${action.schemaName}.${action.actionName} returned an invalid action: ${e}`,
-                );
-            }
-        }
-
         if (result.activityContext !== undefined) {
             if (actionQueue.length > 0) {
                 throw new Error(
@@ -484,6 +466,24 @@ export async function executeActions(
                 if (port !== undefined) {
                     await systemContext.clientIO.openLocalView(port);
                 }
+            }
+        }
+
+        if (result.additionalActions !== undefined) {
+            try {
+                const actions = getAdditionalExecutableActions(
+                    result.additionalActions,
+                    action.schemaName,
+                    systemContext,
+                );
+                // REVIEW: assume that the agent will fill the entities already?  Also, current format doesn't support resultEntityIds.
+                actionQueue.unshift(
+                    ...(await toPendingActions(context, actions, undefined)),
+                );
+            } catch (e) {
+                throw new Error(
+                    `${action.schemaName}.${action.actionName} returned an invalid action: ${e}`,
+                );
             }
         }
         actionIndex++;

--- a/ts/packages/shell/src/main/inlineBrowserControl.ts
+++ b/ts/packages/shell/src/main/inlineBrowserControl.ts
@@ -63,5 +63,33 @@ export function createInlineBrowserControl(
         async scrollDown() {
             return contentScriptControl.scrollDown();
         },
+        async followLinkByPosition(position: number, openInNewTab?: boolean) {
+            if (openInNewTab) {
+                // TODO: Support opening in new browser view.
+                throw new Error(
+                    "New tab opening is not supported in inline browser.",
+                );
+            }
+            const url =
+                await contentScriptControl.getPageLinksByPosition(position);
+            if (url) {
+                await shellWindow.openInlineBrowser(new URL(url));
+            }
+            return url;
+        },
+        async followLinkByText(keywords: string, openInNewTab?: boolean) {
+            if (openInNewTab) {
+                // TODO: Support opening in new browser view.
+                throw new Error(
+                    "New tab opening is not supported in inline browser.",
+                );
+            }
+            const url =
+                await contentScriptControl.getPageLinksByQuery(keywords);
+            if (url) {
+                await shellWindow.openInlineBrowser(new URL(url));
+            }
+            return url;
+        },
     };
 }

--- a/ts/packages/shell/src/preload/webView.ts
+++ b/ts/packages/shell/src/preload/webView.ts
@@ -4,7 +4,6 @@
 const { contextBridge } = require("electron/renderer");
 const { webFrame } = require("electron");
 
-import DOMPurify from "dompurify";
 import { ipcRenderer } from "electron";
 import registerDebug from "debug";
 import {
@@ -164,24 +163,6 @@ async function runBrowserAction(action: any) {
     const actionName =
         action.actionName ?? action.fullActionName.split(".").at(-1);
     switch (actionName) {
-        case "followLinkByText": {
-            const response = await sendScriptAction(
-                {
-                    type: "get_page_links_by_query",
-                    query: action.parameters.keywords,
-                },
-                5000,
-            );
-            console.log("We should navigate to " + JSON.stringify(response));
-
-            if (response && response.url) {
-                const sanitizedUrl = DOMPurify.sanitize(response.url);
-                window.location.href = sanitizedUrl;
-                confirmationMessage = `Navigated to the  ${action.parameters.keywords} link`;
-            }
-
-            break;
-        }
         case "zoomIn": {
             if (window.location.href.startsWith("https://paleobiodb.org/")) {
                 sendScriptAction({

--- a/ts/packages/shell/src/renderer/src/setContent.ts
+++ b/ts/packages/shell/src/renderer/src/setContent.ts
@@ -50,6 +50,16 @@ function processContent(
             });
         case "markdown":
             const md = new MarkdownIt();
+            // Links in the chat windows should open in a new tab.
+            const defaultRender =
+                md.renderer.rules.link_open ||
+                function (tokens, idx, options, _env, self) {
+                    return self.renderToken(tokens, idx, options);
+                };
+            md.renderer.rules.link_open = (tokens, idx, ...args) => {
+                tokens[idx].attrSet("target", "_blank");
+                return defaultRender(tokens, idx, ...args);
+            };
             return inline ? md.renderInline(content) : md.render(content);
         case "text":
             return enableText2Html


### PR DESCRIPTION
- Implement follow link actions using RPC.  
- Show result to the user, including link not found.
- Fix `exitActivity`, clear the activity context before queueing `additionalAction`
- Add `literalString` parameter to `createActionResultFromMarkdownDisplay`
- Links in markdown for display should open in a new browser, in the chat display context.