### PR TITLE
Browser RPC: Move zoom functionalities

### DIFF
--- a/ts/packages/agentRpc/src/client.ts
+++ b/ts/packages/agentRpc/src/client.ts
@@ -119,10 +119,24 @@ function createOptionsRpc(channelProvider: ChannelProvider, name: string) {
                 name: string;
                 args: any[];
             }) => {
-                const options = optionsMap.get(param.id);
-                const fn = getObjectProperty(options, param.name);
-                // TODO: provide "this" object
-                return fn(...param.args);
+                const options: any = optionsMap.get(param.id);
+                let thisObject: any = undefined;
+                let fn: (...args: any[]) => any;
+                const name = param.name;
+                if (name === "") {
+                    fn = options;
+                } else {
+                    const names = param.name.split(".");
+                    if (names.length === 1) {
+                        thisObject = options;
+                        fn = options[name];
+                    } else {
+                        const funcName = names.pop();
+                        thisObject = getObjectProperty(options, name);
+                        fn = thisObject[funcName!];
+                    }
+                }
+                return fn.call(thisObject, ...param.args);
             },
         }),
     };

--- a/ts/packages/agents/browser/src/agent/actionHandler.mts
+++ b/ts/packages/agents/browser/src/agent/actionHandler.mts
@@ -666,6 +666,15 @@ async function executeBrowserAction(
             case "scrollDown":
                 await getActionBrowserControl(context).scrollDown();
                 return;
+            case "zoomIn":
+                await getActionBrowserControl(context).zoomIn();
+                return;
+            case "zoomOut":
+                await getActionBrowserControl(context).zoomOut();
+                return;
+            case "zoomReset":
+                await getActionBrowserControl(context).zoomReset();
+                return;
             case "followLinkByText": {
                 const control = getActionBrowserControl(context);
                 const { keywords, openInNewTab } = action.parameters;

--- a/ts/packages/agents/browser/src/agent/actionsSchema.mts
+++ b/ts/packages/agents/browser/src/agent/actionsSchema.mts
@@ -32,7 +32,7 @@ export type OpenWebPage = {
         // Name or description of the site to search for and open
         // Do NOT put URL here unless the user request specified the URL.
         site:
-            | "paelobiodb"
+            | "paleobiodb"
             | "crossword"
             | "commerce"
             | "montage"

--- a/ts/packages/agents/browser/src/agent/browserControl.mts
+++ b/ts/packages/agents/browser/src/agent/browserControl.mts
@@ -18,6 +18,9 @@ export type BrowserControlInvokeFunctions = {
     getPageUrl(): Promise<string>;
     scrollUp(): Promise<void>;
     scrollDown(): Promise<void>;
+    zoomIn(): Promise<void>;
+    zoomOut(): Promise<void>;
+    zoomReset(): Promise<void>;
     // returns the URL, or undefined if not found
     followLinkByText(
         keywords: string,

--- a/ts/packages/agents/browser/src/agent/rpc/externalBrowserControlClient.mts
+++ b/ts/packages/agents/browser/src/agent/rpc/externalBrowserControlClient.mts
@@ -74,6 +74,15 @@ export function createExternalBrowserClient(
         scrollDown: async () => {
             return rpc.invoke("scrollDown");
         },
+        zoomIn: async () => {
+            return rpc.invoke("zoomIn");
+        },
+        zoomOut: async () => {
+            return rpc.invoke("zoomOut");
+        },
+        zoomReset: async () => {
+            return rpc.invoke("zoomReset");
+        },
         followLinkByText: (...args) => {
             return rpc.invoke("followLinkByText", ...args);
         },

--- a/ts/packages/agents/browser/src/common/contentScriptRpc/client.mts
+++ b/ts/packages/agents/browser/src/common/contentScriptRpc/client.mts
@@ -20,5 +20,7 @@ export function createContentScriptRpcClient(
             contentScriptRpcClient.invoke("getPageLinksByQuery", keywords),
         getPageLinksByPosition: (position: number) =>
             contentScriptRpcClient.invoke("getPageLinksByPosition", position),
+        runPaleoBioDbAction: (action: any) =>
+            contentScriptRpcClient.invoke("runPaleoBioDbAction", action),
     };
 }

--- a/ts/packages/agents/browser/src/common/contentScriptRpc/types.mts
+++ b/ts/packages/agents/browser/src/common/contentScriptRpc/types.mts
@@ -6,4 +6,6 @@ export type ContentScriptRpc = {
     scrollDown(): Promise<void>;
     getPageLinksByQuery(query: string): Promise<string | undefined>;
     getPageLinksByPosition(position: number): Promise<string | undefined>;
+
+    runPaleoBioDbAction(action: any): Promise<void>;
 };

--- a/ts/packages/agents/browser/src/extension/contentScript/eventHandlers.ts
+++ b/ts/packages/agents/browser/src/extension/contentScript/eventHandlers.ts
@@ -152,6 +152,9 @@ function setupMessageListeners(): void {
             const link = matchLinksByPosition(position) as HTMLAnchorElement;
             return link?.href;
         },
+        runPaleoBioDbAction: async (action: any) => {
+            sendPaleoDbRequest(action);
+        },
     };
 
     createRpc(
@@ -255,12 +258,6 @@ export async function handleMessage(
 
             case "run_ui_event": {
                 await sendUIEventsRequest(message.action);
-                sendResponse({});
-                break;
-            }
-
-            case "run_paleoBioDb_action": {
-                sendPaleoDbRequest(message.action);
                 sendResponse({});
                 break;
             }

--- a/ts/packages/agents/browser/src/extension/serviceWorker/browserActions.ts
+++ b/ts/packages/agents/browser/src/extension/serviceWorker/browserActions.ts
@@ -166,51 +166,7 @@ export async function runBrowserAction(action: AppAction): Promise<any> {
             chrome.tts.stop();
             break;
         }
-        case "zoomIn": {
-            const targetTab = await getActiveTab();
-            if (targetTab?.url?.startsWith("https://paleobiodb.org/")) {
-                const result = await chrome.tabs.sendMessage(targetTab.id!, {
-                    type: "run_paleoBioDb_action",
-                    action: action,
-                });
-            } else {
-                const currentZoom = await chrome.tabs.getZoom();
-                if (currentZoom < 5) {
-                    var stepValue = 1;
-                    if (currentZoom < 2) {
-                        stepValue = 0.25;
-                    }
 
-                    await chrome.tabs.setZoom(currentZoom + stepValue);
-                }
-            }
-
-            break;
-        }
-        case "zoomOut": {
-            const targetTab = await getActiveTab();
-            if (targetTab?.url?.startsWith("https://paleobiodb.org/")) {
-                const result = await chrome.tabs.sendMessage(targetTab.id!, {
-                    type: "run_paleoBioDb_action",
-                    action: action,
-                });
-            } else {
-                const currentZoom = await chrome.tabs.getZoom();
-                if (currentZoom > 0) {
-                    var stepValue = 1;
-                    if (currentZoom < 2) {
-                        stepValue = 0.25;
-                    }
-
-                    await chrome.tabs.setZoom(currentZoom - stepValue);
-                }
-            }
-            break;
-        }
-        case "zoomReset": {
-            await chrome.tabs.setZoom(0);
-            break;
-        }
         case "captureScreenshot": {
             responseObject = await getTabScreenshot(
                 action.parameters?.downloadAsFile,

--- a/ts/packages/agents/browser/src/extension/serviceWorker/websocket.ts
+++ b/ts/packages/agents/browser/src/extension/serviceWorker/websocket.ts
@@ -74,19 +74,17 @@ export async function ensureWebsocketConnected(): Promise<
 
         const browserControlChannel = createGenericChannel((message: any) => {
             if (webSocket && webSocket.readyState === WebSocket.OPEN) {
-                webSocket.send(
-                    JSON.stringify({
-                        source: "browserExtension",
-                        method: "browserControl/message",
-                        params: message,
-                    }),
-                );
+                const text = JSON.stringify({
+                    source: "browserExtension",
+                    method: "browserControl/message",
+                    params: message,
+                });
+                webSocket.send(text);
             }
         });
         createExternalBrowserServer(browserControlChannel.channel);
         webSocket.onmessage = async (event: MessageEvent) => {
             const text = await (event.data as Blob).text();
-            console.log(`Browser websocket client received message: ${text}`);
 
             const data = JSON.parse(text) as WebSocketMessageV2;
             if (data.error) {

--- a/ts/packages/agents/browser/src/extension/sites/paleobiodb.ts
+++ b/ts/packages/agents/browser/src/extension/sites/paleobiodb.ts
@@ -243,8 +243,7 @@ export function createPaleoBioDbAgent(): AppAgent {
 document.addEventListener("toPaleoDbAutomation", function (e: any) {
     var message = e.detail;
     console.log("received", message);
-    const actionName =
-        message.actionName ?? message.fullActionName.split(".").at(-1);
+    const actionName = message.actionName;
     switch (actionName) {
         case "zoomIn": {
             zoomInOnPaleoBioDb();

--- a/ts/packages/shell/src/main/inlineBrowserControl.ts
+++ b/ts/packages/shell/src/main/inlineBrowserControl.ts
@@ -63,6 +63,30 @@ export function createInlineBrowserControl(
         async scrollDown() {
             return contentScriptControl.scrollDown();
         },
+        async zoomIn() {
+            const url = await this.getPageUrl();
+            if (url.startsWith("https://paleobiodb.org/")) {
+                return contentScriptControl.runPaleoBioDbAction({
+                    actionName: "zoomIn",
+                });
+            }
+            const webContents = shellWindow.inlineBrowser.webContents;
+            webContents.setZoomFactor(webContents.getZoomFactor() + 0.1);
+        },
+        async zoomOut() {
+            const url = await this.getPageUrl();
+            if (url.startsWith("https://paleobiodb.org/")) {
+                return contentScriptControl.runPaleoBioDbAction({
+                    actionName: "zoomOut",
+                });
+            }
+            const webContents = shellWindow.inlineBrowser.webContents;
+            webContents.setZoomFactor(webContents.getZoomFactor() - 0.1);
+        },
+        async zoomReset() {
+            const webContents = shellWindow.inlineBrowser.webContents;
+            webContents.setZoomFactor(1.0);
+        },
         async followLinkByPosition(position: number, openInNewTab?: boolean) {
             if (openInNewTab) {
                 // TODO: Support opening in new browser view.

--- a/ts/packages/shell/src/preload/inlineBrowserRendererRpcServer.ts
+++ b/ts/packages/shell/src/preload/inlineBrowserRendererRpcServer.ts
@@ -16,9 +16,9 @@ export function setupInlineBrowserRendererProxy() {
 
     window.addEventListener("message", (event) => {
         if (
-            event.data.target == "preload" &&
-            event.data.source == "contentScript" &&
-            event.data.messageType == "rpc" &&
+            event.data.target === "preload" &&
+            event.data.source === "contentScript" &&
+            event.data.messageType === "rpc" &&
             event.data.body
         ) {
             ipcRenderer.send("inline-browser-rpc-reply", event.data.body);

--- a/ts/packages/shell/src/preload/webView.ts
+++ b/ts/packages/shell/src/preload/webView.ts
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 const { contextBridge } = require("electron/renderer");
-const { webFrame } = require("electron");
 
 import { ipcRenderer } from "electron";
 import registerDebug from "debug";
@@ -163,36 +162,6 @@ async function runBrowserAction(action: any) {
     const actionName =
         action.actionName ?? action.fullActionName.split(".").at(-1);
     switch (actionName) {
-        case "zoomIn": {
-            if (window.location.href.startsWith("https://paleobiodb.org/")) {
-                sendScriptAction({
-                    type: "run_paleoBioDb_action",
-                    action: action,
-                });
-            } else {
-                const currZoom = webFrame.getZoomFactor();
-                webFrame.setZoomFactor(currZoom + 0.2);
-            }
-
-            break;
-        }
-        case "zoomOut": {
-            if (window.location.href.startsWith("https://paleobiodb.org/")) {
-                sendScriptAction({
-                    type: "run_paleoBioDb_action",
-                    action: action,
-                });
-            } else {
-                const currZoom = webFrame.getZoomFactor();
-                webFrame.setZoomFactor(currZoom - 0.2);
-            }
-            break;
-        }
-        case "zoomReset": {
-            webFrame.setZoomFactor(1.0);
-            break;
-        }
-
         case "getHTML": {
             responseObject = await getTabHTMLFragments(
                 action.parameters.fullHTML,


### PR DESCRIPTION
- Move `zoomIn`, `zoomOut`, `zoomReset` to use browser RPC.
- Fix the problem with changing active tab while a browser control is being run, by create a different RPC object per tab. Enable detection of disconnection error when tab get closed during a call.
- Change all external browser control to throw error if there is no active tab or active tab doesn't have id.
- Provide the "this" object when invoking a remote RPC call on the initialization option object provided by the client.
- Fix the spelling of `paleobiodb` in the open action schema
