### PR TITLE
Fix `tsc` incremental build in browser and markdown agent

### DIFF
--- a/ts/packages/agents/browser/src/agent/tsconfig.json
+++ b/ts/packages/agents/browser/src/agent/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
       "composite": true,
       "incremental": true,
-      "tsBuildInfoFile": "../../.tsbuildinfo/agent.tsbuildinfo",
       "rootDir": ".",
       "outDir": "../../dist/agent",
       "types": ["node"],

--- a/ts/packages/agents/browser/src/common/tsconfig.json
+++ b/ts/packages/agents/browser/src/common/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
       "composite": true,
       "incremental": true,
-      "tsBuildInfoFile": "../../.tsbuildinfo/common.tsbuildinfo",
       "rootDir": ".",
       "outDir": "../../dist/common",
       "types": ["node"],

--- a/ts/packages/agents/browser/src/puppeteer/tsconfig.json
+++ b/ts/packages/agents/browser/src/puppeteer/tsconfig.json
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "composite": true,
     "incremental": true,
-    "tsBuildInfoFile": "../../.tsbuildinfo/puppeteer.tsbuildinfo",
     "rootDir": ".",
     "outDir": "../../dist/puppeteer", 
     "lib": ["DOM"],

--- a/ts/packages/agents/browser/src/views/server/tsconfig.json
+++ b/ts/packages/agents/browser/src/views/server/tsconfig.json
@@ -4,9 +4,8 @@
     "outDir": "../../../dist/views/server",
     "rootDir": ".",
     "incremental": true,
-    "tsBuildInfoFile": "../../../.tsbuildinfo/server.tsbuildinfo",
     "lib": ["ES2020", "DOM"]
   },
-  "include": ["./**/*.ts", "../shared/**/*.ts"],
+  "include": ["./**/*.ts"],
   "references": [{ "path": "../shared" }]
 }

--- a/ts/packages/agents/browser/src/views/shared/tsconfig.json
+++ b/ts/packages/agents/browser/src/views/shared/tsconfig.json
@@ -5,7 +5,6 @@
     "rootDir": ".",
     "composite": true,
     "incremental": true,
-    "tsBuildInfoFile": "../../../.tsbuildinfo/shared.tsbuildinfo",
     "declaration": true,
     "declarationMap": true
   },

--- a/ts/packages/agents/browser/tsconfig.json
+++ b/ts/packages/agents/browser/tsconfig.json
@@ -10,7 +10,6 @@
        "outDir": "dist/js",
        "noEmitOnError": true,
        "incremental": true,
-       "tsBuildInfoFile": ".tsbuildinfo/main.tsbuildinfo",
        "typeRoots": [ "node_modules/@types" ]
     },
     "exclude": ["dist/**/*", "src/agent/*.ts", "test/*"],

--- a/ts/packages/agents/markdown/package.json
+++ b/ts/packages/agents/markdown/package.json
@@ -62,6 +62,7 @@
     "yjs": "^13.6.8"
   },
   "devDependencies": {
+    "@milkdown/ctx": "~7.13.0",
     "@types/debug": "^4.1.12",
     "@types/express": "^4.17.17",
     "@types/jest": "^29.5.7",

--- a/ts/packages/agents/markdown/src/agent/tsconfig.json
+++ b/ts/packages/agents/markdown/src/agent/tsconfig.json
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "composite": true,
     "incremental": true,
-    "tsBuildInfoFile": "../../.tsbuildinfo/agent.tsbuildinfo",
     "rootDir": ".",
     "outDir": "../../dist/agent",
     

--- a/ts/packages/agents/markdown/src/view/route/tsconfig.json
+++ b/ts/packages/agents/markdown/src/view/route/tsconfig.json
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "composite": true,
     "incremental": true,
-    "tsBuildInfoFile": "../../../.tsbuildinfo/route.tsbuildinfo",
     "rootDir": ".",
     "outDir": "../../../dist/view/route"
   },

--- a/ts/packages/agents/markdown/src/view/site/mermaid-plugin.ts
+++ b/ts/packages/agents/markdown/src/view/site/mermaid-plugin.ts
@@ -7,6 +7,7 @@ import { InputRule } from "prosemirror-inputrules";
 import { visit } from "unist-util-visit";
 import mermaid from "mermaid";
 import DOMPurify from "dompurify";
+import type { MilkdownPlugin } from "@milkdown/ctx";
 
 // Configure DOMPurify for SVG with foreignObject support
 export const createSVGSafePurifyConfig = () => {
@@ -508,7 +509,7 @@ const mermaidRenderer = $prose(() => {
 });
 
 // Export the complete mermaid plugin
-export const mermaidPlugin = [
+export const mermaidPlugin: MilkdownPlugin[] = [
     remarkMermaid,
     mermaidNode,
     mermaidLiveParser,

--- a/ts/packages/agents/markdown/src/view/site/tsconfig.json
+++ b/ts/packages/agents/markdown/src/view/site/tsconfig.json
@@ -1,13 +1,11 @@
 {
   "extends": "../../../../../../tsconfig.base.json",
   "compilerOptions": {
-    "composite": false,
+    "noEmit": true,
+    "composite": true,
     "incremental": true,
-    "tsBuildInfoFile": "../../../.tsbuildinfo/site.tsbuildinfo",
     "rootDir": ".",
-    "outDir": "../../../dist/view/site",
-    "declaration": false,
-    "declarationMap": false,
+    "outDir": "../../../dist/view/site-typecheck",
     "moduleResolution": "bundler",
     "module": "ESNext",
     "lib": ["DOM"],
@@ -15,7 +13,7 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
   },
-  "include": ["./*"],
+  "include": ["./**/*"],
   "ts-node": {
     "esm": true
   }

--- a/ts/pnpm-lock.yaml
+++ b/ts/pnpm-lock.yaml
@@ -1508,6 +1508,9 @@ importers:
         specifier: ^13.6.8
         version: 13.6.27
     devDependencies:
+      '@milkdown/ctx':
+        specifier: ~7.13.0
+        version: 7.13.1
       '@types/debug':
         specifier: ^4.1.12
         version: 4.1.12


### PR DESCRIPTION
- Remove the unnecessary `tsBuildInfoFile` location. Currently `fluid-build` doesn't support specifying custom `tsBuildInfoFile`. location.  Fluid repro [PR pending](https://github.com/microsoft/FluidFramework/pull/24911)
  - Also, this fix a problem where two `tsc` command output to the same `tsBuildInfo` location.
- Remove duplicate `src/view/shared` files in browser agents `tsconfig.json` in `src/view/server`, resulting mismatch of `tsc` thinking those files as input, but not included in the `tsBuildInfo`. `fluid-build` detected that and trigger the build, as those could be "new" files for the build that needs to be process.
- Markdown agent's `src/view/site` 
   - must be `composite` for `incremental` to be enabled in `tsc` (which `fuild-build` relies on).  
     - Fix typing errro after `composite` is enabled.
   - Also the `vite` steps afterward for that directory overwrite the result, and thus the `tsBuildInfo` is deleted, causing `fluid-build` to always rebuild.  Change it to `noEmit` and change the output directory different then the `vite` step.