### PR TITLE
Incremental build markdown

### DIFF
--- a/ts/examples/docuProc/package.json
+++ b/ts/examples/docuProc/package.json
@@ -14,7 +14,7 @@
   "type": "module",
   "scripts": {
     "build": "npm run tsc",
-    "postbuild": "pnpm run copy-data && copyfiles -u 1 \"src/**/*Schema.ts\" \"src/**/*.txt\" \"src/*.py\" \"src/srag/*.py\" \"data/**/*\" dist && rimraf --glob 'copyfiles-*.done.build.log'",
+    "postbuild": "pnpm run copy-data && copyfiles -u 1 \"src/**/*Schema.ts\" \"src/**/*.txt\" \"src/*.py\" \"src/srag/*.py\" \"data/**/*\" dist",
     "clean": "rimraf --glob dist *.tsbuildinfo *.done.build.log dist/data",
     "copy-data": "copyfiles \"data/**/*\" dist",
     "install-python-deps": "node -e \"const { execSync } = require('child_process'); try { execSync('python3 --version', { stdio: 'ignore' }); execSync('python3 -m pip install --user -qq -r requirements.txt', { stdio: 'inherit' }); } catch { try { execSync('python --version', { stdio: 'ignore' }); execSync('python -m pip install --user -qq -r requirements.txt', { stdio: 'inherit' }); } catch { console.log('Python not found, skipping...'); } }\"",

--- a/ts/packages/agents/browser/package.json
+++ b/ts/packages/agents/browser/package.json
@@ -152,6 +152,16 @@
       "build:views:client": [
         "build:views:shared"
       ]
+    },
+    "declarativeTasks": {
+      "vite": {
+        "inputGlobs": [
+          "src/views/client/**/*"
+        ],
+        "outputGlobs": [
+          "dist/views/public/**/*"
+        ]
+      }
     }
   }
 }

--- a/ts/packages/agents/markdown/package.json
+++ b/ts/packages/agents/markdown/package.json
@@ -16,10 +16,8 @@
     "./agent/handlers": "./dist/agent/markdownActionHandler.js"
   },
   "scripts": {
-    "build": "npm run tsc && npm run build:frontend",
-    "postbuild": "copyfiles -u 1 \"src/**/config.json\" dist",
+    "build": "concurrently npm:tsc npm:build:frontend",
     "build:frontend": "vite build",
-    "build:frontend:force": "vite build",
     "clean": "rimraf --glob dist *.tsbuildinfo *.done.build.log .frontend-build-cache.json .tsc-cache-*.json && rimraf .tsbuildinfo .build.cache",
     "dev": "npm run tsc && node scripts/dev-viewer.js --hmr",
     "dev:frontend": "vite  --watch",
@@ -69,6 +67,7 @@
     "@types/katex": "^0.16.7",
     "@types/markdown-it": "^14.1.2",
     "@types/ws": "^8.5.8",
+    "concurrently": "^9.1.2",
     "copyfiles": "^2.4.1",
     "jest": "^29.7.0",
     "prettier": "^3.5.3",
@@ -76,5 +75,17 @@
     "sanitize-filename": "^1.6.3",
     "typescript": "~5.4.5",
     "vite": "^4.5.14"
+  },
+  "fluidBuild": {
+    "declarativeTasks": {
+      "vite": {
+        "inputGlobs": [
+          "src/view/site/**/*"
+        ],
+        "outputGlobs": [
+          "dist/view/site/**/*"
+        ]
+      }
+    }
   }
 }

--- a/ts/pnpm-lock.yaml
+++ b/ts/pnpm-lock.yaml
@@ -1532,6 +1532,9 @@ importers:
       '@types/ws':
         specifier: ^8.5.8
         version: 8.18.1
+      concurrently:
+        specifier: ^9.1.2
+        version: 9.1.2
       copyfiles:
         specifier: ^2.4.1
         version: 2.4.1


### PR DESCRIPTION
- Declare input/output for the `vite` task for markdown package.
- Make the build steps in markdown package parallelizable. 
- Remove extraneous copyfiles in markdown package.
- Remove deletion of incremental data for `document-processor` package.
