### PR TITLE
Move crossword schema cache storage locally

### DIFF
--- a/ts/packages/agents/browser/src/agent/actionHandler.mts
+++ b/ts/packages/agents/browser/src/agent/actionHandler.mts
@@ -72,6 +72,8 @@ import * as website from "website-memory";
 import { openai, TextEmbeddingModel } from "aiclient";
 import { urlResolver, bingWithGrounding } from "azure-ai-foundry";
 import { createExternalBrowserClient } from "./rpc/externalBrowserControlClient.mjs";
+import { deleteCachedSchema } from "./crossword/cachedSchema.mjs";
+import { getCrosswordCommandHandlerTable } from "./crossword/commandHandler.mjs";
 
 const debug = registerDebug("typeagent:browser:action");
 const debugWebSocket = registerDebug("typeagent:browser:ws");
@@ -92,6 +94,7 @@ export type BrowserActionContext = {
     useExternalBrowserControl: boolean;
     webSocket?: WebSocket | undefined;
     webAgentChannels?: WebAgentChannels | undefined;
+    crosswordCachedSchemas?: Map<string, Crossword> | undefined;
     crossWordState?: Crossword | undefined;
     browserConnector?: BrowserConnector | undefined;
     browserProcess?: ChildProcess | undefined;
@@ -264,6 +267,10 @@ async function updateBrowserContext(
                                 targetTranslator,
                                 false,
                             );
+                            break;
+                        }
+                        case "removeCrosswordPageCache": {
+                            await deleteCachedSchema(context, data.params.url);
                             break;
                         }
                         case "addTabIdToIndex":
@@ -889,7 +896,7 @@ export const handlers: CommandHandlerTable = {
                 close: new CloseBrowserHandler(),
             },
         },
-
+        crossword: getCrosswordCommandHandlerTable(),
         open: new OpenWebPageHandler(),
         close: new CloseWebPageHandler(),
         external: {

--- a/ts/packages/agents/browser/src/agent/browserConnector.mts
+++ b/ts/packages/agents/browser/src/agent/browserConnector.mts
@@ -155,31 +155,6 @@ export class BrowserConnector {
         return screenshot;
     }
 
-    async getCurrentPageSchema(url: string | undefined) {
-        const timeoutPromise = new Promise((f) => setTimeout(f, 3000));
-        const action = {
-            actionName: "getPageSchema",
-            parameters: {
-                url: url,
-            },
-        };
-
-        const actionPromise = this.getPageDataFromBrowser(action);
-        return Promise.race([actionPromise, timeoutPromise]);
-    }
-
-    async setCurrentPageSchema(url: string, data: any) {
-        const schemaAction = {
-            actionName: "setPageSchema",
-            parameters: {
-                url: url,
-                schema: data,
-            },
-        };
-
-        return this.sendActionToBrowser(schemaAction, "browser");
-    }
-
     async getCurrentPageStoredProperty(url: string, key: string) {
         const timeoutPromise = new Promise((f) => setTimeout(f, 3000));
         const action = {

--- a/ts/packages/agents/browser/src/agent/crossword/cachedSchema.mts
+++ b/ts/packages/agents/browser/src/agent/crossword/cachedSchema.mts
@@ -1,0 +1,98 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { SessionContext, Storage } from "@typeagent/agent-sdk";
+import registerDebug from "debug";
+import { Crossword } from "./schema/pageSchema.mjs";
+import { BrowserActionContext } from "../actionHandler.mjs";
+const debugError = registerDebug("typeagent:browser:crossword:schema:error");
+const cacheSchemaFile = `crosswordSchema.json`;
+
+async function readCachedSchemas(
+    storage?: Storage,
+): Promise<Map<string, Crossword> | undefined> {
+    if (!storage) {
+        return undefined;
+    }
+    if (!(await storage.exists(cacheSchemaFile))) {
+        return undefined;
+    }
+
+    try {
+        const cachedSchema = await storage.read(cacheSchemaFile, "utf8");
+        return new Map(JSON.parse(cachedSchema) as [string, Crossword][]);
+    } catch {
+        return undefined;
+    }
+}
+async function ensureCachedSchemas(
+    context: SessionContext<BrowserActionContext>,
+) {
+    const agentContext = context.agentContext;
+    if (agentContext.crosswordCachedSchemas === undefined) {
+        agentContext.crosswordCachedSchemas =
+            (await readCachedSchemas(context.sessionStorage)) ??
+            new Map<string, Crossword>();
+    }
+
+    return agentContext.crosswordCachedSchemas;
+}
+
+export async function getCachedSchema(
+    context: SessionContext<BrowserActionContext>,
+    url: string,
+): Promise<Crossword | undefined> {
+    const cachedSchemas = await ensureCachedSchemas(context);
+    return cachedSchemas.get(url);
+}
+
+async function writeCachedSchemas(
+    context: SessionContext<BrowserActionContext>,
+): Promise<void> {
+    const cachedSchemas = context.agentContext.crosswordCachedSchemas;
+    if (cachedSchemas === undefined) {
+        return;
+    }
+    const storage = context.sessionStorage;
+    if (storage === undefined) {
+        return;
+    }
+
+    try {
+        await storage.write(
+            cacheSchemaFile,
+            JSON.stringify([...cachedSchemas.entries()]),
+        );
+    } catch (e) {
+        debugError("Failed to write cached crossword schema.", e);
+    }
+}
+export async function setCachedSchema(
+    context: SessionContext<BrowserActionContext>,
+    url: string,
+    schema: Crossword,
+): Promise<void> {
+    const cachedSchemas = await ensureCachedSchemas(context);
+    cachedSchemas.set(url, schema);
+    await writeCachedSchemas(context);
+}
+
+export async function deleteCachedSchema(
+    context: SessionContext<BrowserActionContext>,
+    url: string,
+): Promise<void> {
+    const cachedSchemas = await ensureCachedSchemas(context);
+    cachedSchemas.delete(url);
+    await writeCachedSchemas(context);
+}
+
+export async function clearCachedSchemas(
+    context: SessionContext<BrowserActionContext>,
+): Promise<void> {
+    const storage = context.sessionStorage;
+    if (storage === undefined) {
+        return;
+    }
+    await storage.delete(cacheSchemaFile);
+    context.agentContext.crosswordCachedSchemas = undefined;
+}

--- a/ts/packages/agents/browser/src/agent/crossword/commandHandler.mts
+++ b/ts/packages/agents/browser/src/agent/crossword/commandHandler.mts
@@ -1,0 +1,112 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { ActionContext, ParsedCommandParams } from "@typeagent/agent-sdk";
+import { BrowserActionContext } from "../actionHandler.mjs";
+import { getBoardSchema } from "./actionHandler.mjs";
+import { CommandHandlerTable } from "@typeagent/agent-sdk/helpers/command";
+import { clearCachedSchemas, deleteCachedSchema } from "./cachedSchema.mjs";
+
+const schemaClearCommandParameters = {
+    args: {
+        url: {
+            type: "string",
+            description:
+                "The URL of the crossword page to clear the schema for. If not provided, all cached schemas will be cleared.",
+            multiple: false,
+            optional: true,
+        },
+    },
+} as const;
+export const getCrosswordCommandHandlerTable = (): CommandHandlerTable => {
+    return {
+        description: "Crossword commands",
+        commands: {
+            schema: {
+                description: "Crossword schema commands",
+                commands: {
+                    clear: {
+                        description: "Clear the crossword schema",
+                        parameters: schemaClearCommandParameters,
+                        run: async (
+                            context: ActionContext<BrowserActionContext>,
+                            parameters: ParsedCommandParams<
+                                typeof schemaClearCommandParameters
+                            >,
+                        ) => {
+                            const urls = parameters.args.url;
+                            if (urls !== undefined) {
+                                for (const url of urls) {
+                                    await deleteCachedSchema(
+                                        context.sessionContext,
+                                        url,
+                                    );
+                                }
+                                context.actionIO.setDisplay(
+                                    `Cleared cached crossword schema for ${urls.length} urls.`,
+                                );
+                                return;
+                            }
+                            clearCachedSchemas(context.sessionContext);
+                            context.actionIO.setDisplay(
+                                `Cleared all cached crossword schema`,
+                            );
+                        },
+                    },
+                },
+            },
+            state: {
+                description: "Crossword state commands",
+                commands: {
+                    init: {
+                        description: "Initialize the crossword state",
+                        run: async (
+                            context: ActionContext<BrowserActionContext>,
+                        ) => {
+                            const state = await getBoardSchema(
+                                context.sessionContext,
+                            );
+                            context.sessionContext.agentContext.crossWordState =
+                                state;
+
+                            context.actionIO.setDisplay(
+                                state
+                                    ? "Crossword state initialized."
+                                    : "Failed to initialize crossword state.",
+                            );
+                        },
+                    },
+                    show: {
+                        description: "Show the crossword state",
+                        run: async (
+                            context: ActionContext<BrowserActionContext>,
+                        ) => {
+                            const crosswordState =
+                                context.sessionContext.agentContext
+                                    .crossWordState;
+                            if (crosswordState === undefined) {
+                                throw new Error("No crossword state.");
+                            }
+                            context.actionIO.setDisplay(
+                                JSON.stringify(crosswordState, null, 2),
+                            );
+                        },
+                    },
+                    clear: {
+                        description: "Clear the crossword state",
+                        run: async (
+                            context: ActionContext<BrowserActionContext>,
+                        ) => {
+                            context.sessionContext.agentContext.crossWordState =
+                                undefined;
+
+                            context.actionIO.setDisplay(
+                                "Crossword state cleared.",
+                            );
+                        },
+                    },
+                },
+            },
+        },
+    };
+};

--- a/ts/packages/agents/browser/src/extension/contentScript/eventHandlers.ts
+++ b/ts/packages/agents/browser/src/extension/contentScript/eventHandlers.ts
@@ -262,44 +262,6 @@ export async function handleMessage(
                 break;
             }
 
-            case "clearCrosswordPageCache": {
-                const value = await localStorage.getItem("pageSchema");
-                if (value) {
-                    localStorage.removeItem("pageSchema");
-                }
-                sendResponse({});
-                break;
-            }
-
-            case "get_page_schema": {
-                const value = localStorage.getItem("pageSchema");
-                if (value) {
-                    sendResponse(JSON.parse(value));
-                } else {
-                    sendResponse(null);
-                }
-                break;
-            }
-
-            case "set_page_schema": {
-                let updatedSchema = message.action.parameters.schema;
-                localStorage.setItem(
-                    "pageSchema",
-                    JSON.stringify(updatedSchema),
-                );
-                sendResponse({});
-                break;
-            }
-
-            case "clear_page_schema": {
-                const value = localStorage.getItem("pageSchema");
-                if (value) {
-                    localStorage.removeItem("pageSchema");
-                }
-                sendResponse({});
-                break;
-            }
-
             case "startRecording": {
                 await startRecording();
                 sendResponse({});

--- a/ts/packages/agents/browser/src/extension/serviceWorker/browserActions.ts
+++ b/ts/packages/agents/browser/src/extension/serviceWorker/browserActions.ts
@@ -14,13 +14,7 @@ import {
     getTabHTMLFragments,
     getFilteredHTMLFragments,
 } from "./capture";
-import {
-    getPageSchema,
-    setPageSchema,
-    getStoredPageProperty,
-    setStoredPageProperty,
-} from "./storage";
-import { showBadgeHealthy } from "./ui";
+import { getStoredPageProperty, setStoredPageProperty } from "./storage";
 
 /**
  * Executes a browser action
@@ -238,24 +232,6 @@ export async function runBrowserAction(action: AppAction): Promise<any> {
                 type: "run_ui_event",
                 action: action,
             });
-            break;
-        }
-        case "getPageSchema": {
-            const targetTab = await getActiveTab();
-            const key = action.parameters.url ?? targetTab?.url;
-            if (key) {
-                responseObject = await getPageSchema(key);
-                if (responseObject) {
-                    showBadgeHealthy();
-                }
-            }
-            break;
-        }
-        case "setPageSchema": {
-            const key = action.parameters.url;
-            if (key) {
-                await setPageSchema(key, action.parameters.schema);
-            }
             break;
         }
         case "getPageStoredProperty": {

--- a/ts/packages/agents/browser/src/extension/serviceWorker/contextMenu.ts
+++ b/ts/packages/agents/browser/src/extension/serviceWorker/contextMenu.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { removePageSchema } from "./storage";
 import { sendActionToAgent } from "./websocket";
 import { getWebSocket } from "./websocket";
 
@@ -95,8 +94,19 @@ export async function handleContextMenuClick(
         }
         case "clearCrosswordPageCache": {
             // remove cached schema for current tab
-            if (tab.url) {
-                await removePageSchema(tab.url);
+            // trigger translator
+            const webSocket = getWebSocket();
+            if (
+                tab.url &&
+                webSocket &&
+                webSocket.readyState === WebSocket.OPEN
+            ) {
+                webSocket.send(
+                    JSON.stringify({
+                        method: "removeCrosswordPageCache",
+                        params: { url: tab.url },
+                    }),
+                );
             }
             break;
         }

--- a/ts/packages/agents/browser/src/extension/serviceWorker/storage.ts
+++ b/ts/packages/agents/browser/src/extension/serviceWorker/storage.ts
@@ -84,66 +84,6 @@ export async function deleteStoredPageProperty(
 }
 
 /**
- * Stores schema for a page
- * @param url The URL of the page
- * @param schema The schema to store
- */
-export async function setPageSchema(url: string, schema: any): Promise<void> {
-    let value = await chrome.storage.session.get(["pageSchema"]);
-    let updatedSchema = value.pageSchema;
-
-    if (value && Array.isArray(value.pageSchema)) {
-        updatedSchema = value.pageSchema.filter(
-            (c: { url: string }) => c.url !== url,
-        );
-    } else {
-        updatedSchema = [];
-    }
-
-    updatedSchema.push({
-        url: url,
-        body: schema,
-    });
-
-    await chrome.storage.session.set({ pageSchema: updatedSchema });
-}
-
-/**
- * Gets schema for a page
- * @param url The URL of the page
- * @returns The stored schema or undefined
- */
-export async function getPageSchema(url: string): Promise<any> {
-    const value = await chrome.storage.session.get(["pageSchema"]);
-    if (value && Array.isArray(value.pageSchema)) {
-        const targetSchema = value.pageSchema.filter(
-            (c: { url: string }) => c.url === url,
-        );
-
-        if (targetSchema && targetSchema.length > 0) {
-            return targetSchema[0].body;
-        }
-    }
-
-    return undefined;
-}
-
-/**
- * Removes schema for a page
- * @param url The URL of the page
- */
-export async function removePageSchema(url: string): Promise<void> {
-    const value = await chrome.storage.session.get(["pageSchema"]);
-    if (value && Array.isArray(value.pageSchema)) {
-        const updatedSchema = value.pageSchema.filter(
-            (c: { url: string }) => c.url !== url,
-        );
-
-        await chrome.storage.session.set({ pageSchema: updatedSchema });
-    }
-}
-
-/**
  * Saves recorded actions to storage
  * @param recordedActions The recorded actions
  * @param recordedActionPageHTML The HTML of the page during recording

--- a/ts/packages/agents/browser/test/serviceWorker/contextMenu.test.ts
+++ b/ts/packages/agents/browser/test/serviceWorker/contextMenu.test.ts
@@ -3,10 +3,6 @@
 
 /// <reference path="../types/jest-chrome-extensions.d.ts" />
 
-jest.mock("../../src/extension/serviceWorker/storage", () => ({
-    removePageSchema: jest.fn().mockImplementation(() => Promise.resolve()),
-}));
-
 jest.mock("../../src/extension/serviceWorker/websocket", () => ({
     sendActionToAgent: jest
         .fn()

--- a/ts/packages/shell/src/preload/webView.ts
+++ b/ts/packages/shell/src/preload/webView.ts
@@ -180,29 +180,6 @@ async function runBrowserAction(action: any) {
             });
             break;
         }
-        case "getPageSchema": {
-            responseObject = await sendScriptAction(
-                {
-                    type: "get_page_schema",
-                },
-                1000,
-            );
-
-            break;
-        }
-        case "setPageSchema": {
-            sendScriptAction({
-                type: "set_page_schema",
-                action: action,
-            });
-            break;
-        }
-        case "clearPageSchema": {
-            sendScriptAction({
-                type: "clear_page_schema",
-            });
-            break;
-        }
         case "closeWindow": {
             window.close();
             // todo: call method on IPC process to close the window/view


### PR DESCRIPTION
- Save the crossword schema cache storage with the agent instead of browser's session/local storage.
- Add `@browser crossword` commands `state init`, `state show`and `state clear` for the schema state, and `schema clear` for schema cache.