### PR TITLE
Browser extension build fix

### DIFF
--- a/ts/packages/agents/browser/scripts/buildExtension.mjs
+++ b/ts/packages/agents/browser/scripts/buildExtension.mjs
@@ -21,6 +21,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 // Helper function to create Vite build options that avoid TypeScript plugin conflicts
 function createBuildOptions(outDir, options = {}) {
     return {
+        configFile: false,
         logLevel: "error",
         plugins: [
             // Explicitly disable TypeScript plugin to avoid outDir conflicts


### PR DESCRIPTION
Set `configFile: false`  in the vite config for building extension to not load the config file (which only applies to the view.