### PR TITLE
Browser RPC: Move external browser window close to use RPC

### DIFF
--- a/ts/packages/agentRpc/src/client.ts
+++ b/ts/packages/agentRpc/src/client.ts
@@ -362,6 +362,14 @@ export async function createAgentRpcClient(
                 param.defaultId,
             );
         },
+        queueToggleTransientAgent: async (
+            contextId: number,
+            agentName: string,
+            active: boolean,
+        ) => {
+            const context = actionContextMap.get(contextId);
+            return context.queueToggleTransientAgent(agentName, active);
+        },
     };
 
     const agentContextCallHandlers: AgentContextCallFunctions = {

--- a/ts/packages/agentRpc/src/server.ts
+++ b/ts/packages/agentRpc/src/server.ts
@@ -581,6 +581,14 @@ export function createAgentRpcServer(
             get actionIO() {
                 return actionIO;
             },
+            queueToggleTransientAgent(agentName: string, active: boolean) {
+                return rpc.invoke(
+                    "queueToggleTransientAgent",
+                    actionContextId,
+                    agentName,
+                    active,
+                );
+            },
         };
     }
 

--- a/ts/packages/agentRpc/src/types.ts
+++ b/ts/packages/agentRpc/src/types.ts
@@ -119,6 +119,12 @@ export type AgentContextInvokeFunctions = {
         choices?: string[] | undefined;
         defaultId?: number | undefined;
     }) => Promise<number>;
+
+    queueToggleTransientAgent: (
+        contextId: number,
+        agentName: string,
+        active: boolean,
+    ) => Promise<void>;
 };
 
 export type AgentCallFunctions = {

--- a/ts/packages/agentSdk/src/agentInterface.ts
+++ b/ts/packages/agentSdk/src/agentInterface.ts
@@ -207,4 +207,10 @@ export interface ActionContext<T = void> {
     readonly activityContext: ActivityContext | undefined;
     readonly actionIO: ActionIO;
     readonly sessionContext: SessionContext<T>;
+
+    // queue up toggle transient agent to be executed at the end of the commands
+    queueToggleTransientAgent(
+        agentName: string,
+        active: boolean,
+    ): Promise<void>;
 }

--- a/ts/packages/agents/browser/src/agent/manifest.json
+++ b/ts/packages/agents/browser/src/agent/manifest.json
@@ -12,7 +12,7 @@
     }
   },
   "subActionManifests": {
-    "externalBrowser": {
+    "external": {
       "defaultEnabled": false,
       "transient": true,
       "schema": {

--- a/ts/packages/agents/browser/src/agent/rpc/externalBrowserControlClient.mts
+++ b/ts/packages/agents/browser/src/agent/rpc/externalBrowserControlClient.mts
@@ -89,5 +89,8 @@ export function createExternalBrowserClient(
         followLinkByPosition: (...args) => {
             return rpc.invoke("followLinkByPosition", ...args);
         },
+        closeWindow: async () => {
+            return rpc.invoke("closeWindow");
+        },
     };
 }

--- a/ts/packages/agents/browser/src/common/browserControl.mts
+++ b/ts/packages/agents/browser/src/common/browserControl.mts
@@ -31,6 +31,8 @@ export type BrowserControlInvokeFunctions = {
         position: number,
         openInNewTab?: boolean,
     ): Promise<string | undefined>;
+
+    closeWindow(): Promise<void>;
 };
 
 export type BrowserControlCallFunctions = {

--- a/ts/packages/agents/browser/src/extension/serviceWorker/externalBrowserControlServer.ts
+++ b/ts/packages/agents/browser/src/extension/serviceWorker/externalBrowserControlServer.ts
@@ -192,6 +192,15 @@ export function createExternalBrowserServer(channel: RpcChannel) {
 
             return url;
         },
+
+        closeWindow: async () => {
+            const current = await chrome.windows.getCurrent();
+            if (current.id) {
+                await chrome.windows.remove(current.id);
+            } else {
+                throw new Error("No current window found to close.");
+            }
+        },
     };
     const callFunctions: BrowserControlCallFunctions = {
         setAgentStatus: (isBusy: boolean, message: string) => {

--- a/ts/packages/dispatcher/src/context/commandHandlerContext.ts
+++ b/ts/packages/dispatcher/src/context/commandHandlerContext.ts
@@ -120,6 +120,7 @@ export type CommandHandlerContext = {
     // Runtime context
     commandLock: Limiter; // Make sure we process one command at a time.
     lastActionSchemaName: string;
+    pendingToggleTransientAgents: [string, boolean][];
     translatorCache: Map<string, TypeAgentTranslator>;
     agentCache: AgentCache;
     currentScriptDir: string;
@@ -437,6 +438,7 @@ export async function initializeCommandHandlerContext(
 
             // Runtime context
             commandLock: createLimiter(1), // Make sure we process one command at a time.
+            pendingToggleTransientAgents: [],
             agentCache: await getAgentCache(
                 session,
                 agents,

--- a/ts/packages/dispatcher/src/execute/actionContext.ts
+++ b/ts/packages/dispatcher/src/execute/actionContext.ts
@@ -79,6 +79,18 @@ export function getActionContext(
         get actionIO() {
             return actionIO;
         },
+        async queueToggleTransientAgent(subAgentName: string, active: boolean) {
+            if (!subAgentName.startsWith(`${appAgentName}.`)) {
+                throw new Error(`Invalid sub agent name: ${subAgentName}`);
+            }
+            const state = context.agents.getTransientState(subAgentName);
+            if (state === undefined) {
+                throw new Error(
+                    `Transient sub agent not found: ${subAgentName}`,
+                );
+            }
+            context.pendingToggleTransientAgents.push([subAgentName, active]);
+        },
     };
     return {
         actionContext,

--- a/ts/packages/shell/src/main/inlineBrowserControl.ts
+++ b/ts/packages/shell/src/main/inlineBrowserControl.ts
@@ -29,9 +29,10 @@ export function createInlineBrowserControl(
             return shellWindow.openInlineBrowser(new URL(url));
         },
         async closeWebPage() {
-            shellWindow.closeInlineBrowser();
+            if (!shellWindow.closeInlineBrowser()) {
+                throw new Error("No inline browser is currently open.");
+            }
         },
-
         async goForward() {
             const navigateHistory =
                 shellWindow.inlineBrowser.webContents.navigationHistory;
@@ -114,6 +115,11 @@ export function createInlineBrowserControl(
                 await shellWindow.openInlineBrowser(new URL(url));
             }
             return url;
+        },
+        async closeWindow() {
+            throw new Error(
+                "Closing the inline browser window is not supported.",
+            );
         },
     };
 }

--- a/ts/packages/shell/src/main/shellWindow.ts
+++ b/ts/packages/shell/src/main/shellWindow.ts
@@ -356,7 +356,7 @@ export class ShellWindow {
     public closeInlineBrowser(save: boolean = true) {
         const inlineWebContentView = this.inlineWebContentView;
         if (inlineWebContentView === undefined) {
-            return;
+            return false;
         }
         const browserBounds = inlineWebContentView.getBounds();
         inlineWebContentView.webContents.close();
@@ -375,6 +375,7 @@ export class ShellWindow {
             this.targetUrl = undefined;
             this.setUserSettingValue("canvas", undefined);
         }
+        return true;
     }
 
     // ================================================================

--- a/ts/packages/shell/src/preload/webView.ts
+++ b/ts/packages/shell/src/preload/webView.ts
@@ -180,12 +180,6 @@ async function runBrowserAction(action: any) {
             });
             break;
         }
-        case "closeWindow": {
-            window.close();
-            // todo: call method on IPC process to close the window/view
-
-            break;
-        }
 
         default:
             throw new Error(`Invalid action: ${actionName}`);


### PR DESCRIPTION
Also add API so that we can queue toggle transient agent at the end of the command (instead of using `toggleTransientAgent` which is for background call, and cannot be call "in command"