### PR TITLE
Dispatcher knowpro initial integration

### DIFF
--- a/ts/packages/dispatcher/package.json
+++ b/ts/packages/dispatcher/package.json
@@ -52,6 +52,7 @@
     "azure-ai-foundry": "workspace:*",
     "chalk": "^5.4.1",
     "common-utils": "workspace:*",
+    "conversation-memory": "workspace:*",
     "debug": "^4.4.0",
     "exifreader": "^4.30.1",
     "file-size": "^1.0.0",

--- a/ts/packages/dispatcher/src/context/memory.ts
+++ b/ts/packages/dispatcher/src/context/memory.ts
@@ -1,0 +1,177 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { conversation } from "knowledge-processor";
+import {
+    ConversationMessage,
+    ConversationMessageMeta,
+    createConversationMemory,
+} from "conversation-memory";
+
+import type { CommandHandlerContext } from "./commandHandlerContext.js";
+import type {
+    ActionResult,
+    ActionResultActivityContext,
+    Entity,
+} from "@typeagent/agent-sdk";
+import { ExecutableAction, getFullActionName } from "agent-cache";
+import { CachedImageWithDetails } from "common-utils";
+import { getAppAgentName } from "../internal.js";
+
+export async function initializeMemory(
+    context: CommandHandlerContext,
+    sessionDirPath: string | undefined,
+) {
+    if (sessionDirPath === undefined) {
+        context.conversationManager = undefined;
+        context.conversationMemory = undefined;
+        return;
+    }
+    context.conversationManager = await conversation.createConversationManager(
+        {},
+        "conversation",
+        sessionDirPath,
+        false,
+    );
+    context.conversationMemory = await createConversationMemory(
+        {
+            dirPath: sessionDirPath,
+            baseFileName: "conversationMemory",
+        },
+        false,
+    );
+}
+
+function toConcreteEntity(
+    appAgentName: string,
+    entities: Entity[],
+): conversation.ConcreteEntity[] {
+    return entities.map((e) => {
+        const concreteEntity: conversation.ConcreteEntity = {
+            name: e.name,
+            type: e.type,
+        };
+        if (e.uniqueId) {
+            concreteEntity.facets = [
+                {
+                    name: `agent:${appAgentName}.uniqueId`,
+                    value: e.uniqueId,
+                },
+            ];
+        }
+        return concreteEntity;
+    });
+}
+
+export function addRequestToMemory(
+    context: CommandHandlerContext,
+    request: string,
+    cachedAttachments?: CachedImageWithDetails[],
+): void {
+    context.chatHistory.addUserEntry(
+        request,
+        context.requestId,
+        cachedAttachments,
+    );
+
+    if (context.conversationManager) {
+        context.conversationManager.queueAddMessage({
+            text: request,
+            timestamp: new Date(),
+        });
+    }
+    if (context.conversationMemory) {
+        context.conversationMemory.queueAddMessage(
+            new ConversationMessage(
+                request,
+                new ConversationMessageMeta("user", ["assistant"]),
+            ),
+        );
+    }
+}
+
+export function addResultToMemory(
+    context: CommandHandlerContext,
+    message: string,
+    schemaName: string,
+    entities?: Entity[],
+    additionalInstructions?: string[],
+    activityContext?: ActionResultActivityContext,
+) {
+    context.chatHistory.addAssistantEntry(
+        message,
+        context.requestId,
+        schemaName,
+        entities,
+        additionalInstructions,
+        activityContext,
+    );
+
+    if (context.conversationManager && entities) {
+        const newEntities = entities.filter(
+            (e) => !conversation.isMemorizedEntity(e.type),
+        );
+        if (newEntities.length > 0) {
+            context.conversationManager.queueAddMessage(
+                {
+                    text: message,
+                    knowledge: newEntities,
+                    timestamp: new Date(),
+                },
+                false,
+            );
+        }
+    }
+
+    if (context.conversationMemory) {
+        const concreteEntity = entities
+            ? toConcreteEntity(getAppAgentName(schemaName), entities)
+            : undefined;
+        context.conversationMemory.queueAddMessage(
+            new ConversationMessage(
+                message,
+                new ConversationMessageMeta("assistant", ["user"]),
+                undefined,
+                concreteEntity
+                    ? {
+                          entities: concreteEntity,
+                          actions: [],
+                          inverseActions: [],
+                          topics: [],
+                      }
+                    : undefined,
+            ),
+        );
+    }
+}
+
+export function addActionResultToMemory(
+    context: CommandHandlerContext,
+    executableAction: ExecutableAction,
+    schemaName: string,
+    result: ActionResult,
+): void {
+    if (result.error !== undefined) {
+        addResultToMemory(
+            context,
+            `Action ${getFullActionName(executableAction)} failed: ${result.error}`,
+            schemaName,
+        );
+    } else {
+        const combinedEntities = [...result.entities];
+        if (result.resultEntity) {
+            combinedEntities.push(result.resultEntity);
+        }
+
+        addResultToMemory(
+            context,
+            result.literalText
+                ? result.literalText
+                : `Action ${getFullActionName(executableAction)} completed.`,
+            schemaName,
+            combinedEntities,
+            result.additionalInstructions,
+            result.activityContext,
+        );
+    }
+}

--- a/ts/packages/dispatcher/src/translation/confirmTranslation.ts
+++ b/ts/packages/dispatcher/src/translation/confirmTranslation.ts
@@ -51,7 +51,7 @@ export async function confirmTranslation(
     requestAction: RequestAction,
     context: ActionContext<CommandHandlerContext>,
 ): Promise<{
-    requestAction: RequestAction | undefined | null;
+    requestAction: RequestAction;
     replacedAction?: ExecutableAction[];
 }> {
     const actions = requestAction.actions;

--- a/ts/packages/dispatcher/src/translation/matchRequest.ts
+++ b/ts/packages/dispatcher/src/translation/matchRequest.ts
@@ -35,59 +35,57 @@ export async function matchRequest(
     request: string,
     context: ActionContext<CommandHandlerContext>,
     history?: HistoryContext,
-): Promise<TranslationResult | undefined | null> {
+): Promise<TranslationResult | undefined> {
     const systemContext = context.sessionContext.agentContext;
     const constructionStore = systemContext.agentCache.constructionStore;
-    if (constructionStore.isEnabled()) {
-        const startTime = performance.now();
-        const config = systemContext.session.getConfig();
-        const activeSchemaNames = systemContext.agents.getActiveSchemas();
-        const matches = constructionStore.match(request, {
-            wildcard: config.cache.matchWildcard,
-            rejectReferences: config.explainer.filter.reference.list,
-            namespaceKeys:
-                systemContext.agentCache.getNamespaceKeys(activeSchemaNames),
+    if (!constructionStore.isEnabled()) {
+        return undefined;
+    }
+    const startTime = performance.now();
+    const config = systemContext.session.getConfig();
+    const activeSchemaNames = systemContext.agents.getActiveSchemas();
+    const matches = constructionStore.match(request, {
+        wildcard: config.cache.matchWildcard,
+        rejectReferences: config.explainer.filter.reference.list,
+        namespaceKeys:
+            systemContext.agentCache.getNamespaceKeys(activeSchemaNames),
+        history,
+    });
+
+    const elapsedMs = performance.now() - startTime;
+
+    const match = await getValidatedMatch(matches, systemContext);
+    if (match === undefined) {
+        return undefined;
+    }
+    const { requestAction, replacedAction } = await confirmTranslation(
+        elapsedMs,
+        unicodeChar.constructionSign,
+        match.match,
+        context,
+    );
+
+    if (!systemContext.batchMode) {
+        systemContext.logger?.logEvent("match", {
+            elapsedMs,
+            request,
+            actions: requestAction.actions,
+            replacedAction,
+            developerMode: systemContext.developerMode,
+            translators: activeSchemaNames,
+            explainerName: systemContext.agentCache.explainerName,
+            matchWildcard: config.cache.matchWildcard,
+            allMatches: matches.map((m) => {
+                const { construction: _, match, ...rest } = m;
+                return { action: match.actions, ...rest };
+            }),
             history,
         });
-
-        const elapsedMs = performance.now() - startTime;
-
-        const match = await getValidatedMatch(matches, systemContext);
-        if (match !== undefined) {
-            const { requestAction, replacedAction } = await confirmTranslation(
-                elapsedMs,
-                unicodeChar.constructionSign,
-                match.match,
-                context,
-            );
-
-            if (requestAction) {
-                if (!systemContext.batchMode) {
-                    systemContext.logger?.logEvent("match", {
-                        elapsedMs,
-                        request,
-                        actions: requestAction.actions,
-                        replacedAction,
-                        developerMode: systemContext.developerMode,
-                        translators: activeSchemaNames,
-                        explainerName: systemContext.agentCache.explainerName,
-                        matchWildcard: config.cache.matchWildcard,
-                        allMatches: matches.map((m) => {
-                            const { construction: _, match, ...rest } = m;
-                            return { action: match.actions, ...rest };
-                        }),
-                        history,
-                    });
-                }
-                return {
-                    requestAction,
-                    elapsedMs,
-                    fromUser: replacedAction !== undefined,
-                    fromCache: true,
-                };
-            }
-            return requestAction;
-        }
     }
-    return undefined;
+    return {
+        requestAction,
+        elapsedMs,
+        fromUser: replacedAction !== undefined,
+        fromCache: true,
+    };
 }

--- a/ts/packages/memory/conversation/src/conversationMemory.ts
+++ b/ts/packages/memory/conversation/src/conversationMemory.ts
@@ -15,7 +15,7 @@ import {
     Message,
     MessageMetadata,
 } from "./memory.js";
-const debugLogger = registerDebug("conversation-memory.podcast");
+const debugLogger = registerDebug("conversation-memory.conversation");
 
 export class ConversationMessageMeta extends MessageMetadata {
     constructor(
@@ -202,7 +202,7 @@ export class ConversationMemory
 
     public queueAddMessage(
         message: ConversationMessage,
-        completionCallback: ConversationTaskCallback,
+        completionCallback?: ConversationTaskCallback,
     ): void {
         this.updatesTaskQueue.push({
             type: "addMessage",

--- a/ts/pnpm-lock.yaml
+++ b/ts/pnpm-lock.yaml
@@ -2536,6 +2536,9 @@ importers:
       common-utils:
         specifier: workspace:*
         version: link:../commonUtils
+      conversation-memory:
+        specifier: workspace:*
+        version: link:../memory/conversation
       debug:
         specifier: ^4.4.0
         version: 4.4.1(supports-color@8.1.1)


### PR DESCRIPTION
- Using `conversation-memory` to start remembering conversation (in addition to conversation manager, which we will deprecate in the future). The data is not used yet.  
- Refactor the translation flow to use exception for error and record it in the conversation history and memory if it failed.