### PR TITLE
Conversation memory entity merge stop forcing data to become lower case.

### DIFF
--- a/ts/packages/dispatcher/src/context/memory.ts
+++ b/ts/packages/dispatcher/src/context/memory.ts
@@ -82,7 +82,11 @@ function toConcreteEntity(
         if (e.uniqueId) {
             concreteEntity.facets = [
                 {
-                    name: `agent:${appAgentName}.uniqueId`,
+                    name: `typeagent.appAgentName`,
+                    value: appAgentName,
+                },
+                {
+                    name: `typeagent.uniqueId`,
                     value: e.uniqueId,
                 },
             ];

--- a/ts/packages/knowPro/src/index.ts
+++ b/ts/packages/knowPro/src/index.ts
@@ -20,6 +20,11 @@ export * from "./queryCmp.js";
 
 export * from "./knowledge.js";
 
+// TODO: mergeConcreteEntitiesEx avoids forcing the data to be lower case.
+// Replace mergeConcreteEntities once it has switch over to the Ex version.
+export { mergeConcreteEntities } from "./knowledgeMerge.js";
+export { mergeConcreteEntities as mergeConcreteEntitiesEx } from "./knowledgeMergeEx.js";
+
 export * from "./dateTimeSchema.js";
 export * as querySchema from "./searchQuerySchema.js";
 export * from "./searchQueryTranslator.js";

--- a/ts/packages/knowPro/src/knowledge.ts
+++ b/ts/packages/knowPro/src/knowledge.ts
@@ -6,10 +6,6 @@ import { async, asyncArray } from "typeagent";
 import { error, Result } from "typechat";
 import { ChatModel } from "aiclient";
 import { createKnowledgeModel } from "./conversationIndex.js";
-import {
-    concreteToMergedEntities,
-    mergedToConcreteEntity,
-} from "./knowledgeMerge.js";
 import { BatchTask, runInBatches } from "./taskQueue.js";
 import { SearchSelectExpr } from "./interfaces.js";
 import {
@@ -60,18 +56,6 @@ export function extractKnowledgeFromTextBatch(
     return asyncArray.mapAsync(textBatch, concurrency, (text) =>
         extractKnowledgeFromText(knowledgeExtractor, text, maxRetries),
     );
-}
-
-export function mergeConcreteEntities(
-    entities: kpLib.ConcreteEntity[],
-): kpLib.ConcreteEntity[] {
-    let mergedEntities = concreteToMergedEntities(entities);
-
-    const mergedConcreteEntities: kpLib.ConcreteEntity[] = [];
-    for (const mergedEntity of mergedEntities.values()) {
-        mergedConcreteEntities.push(mergedToConcreteEntity(mergedEntity));
-    }
-    return mergedConcreteEntities;
 }
 
 export function mergeTopics(topics: string[]): string[] {

--- a/ts/packages/knowPro/src/knowledgeMergeEx.ts
+++ b/ts/packages/knowPro/src/knowledgeMergeEx.ts
@@ -4,6 +4,8 @@
 /**
  * INTERNAL LIBRARY
  * Functions to merge/combine more granular knowledge
+ *
+ * A newer version of knowledgeMerge.ts, where the entity merge doesn't force the data to become lower case.
  */
 
 import { conversation as kpLib } from "knowledge-processor";

--- a/ts/packages/knowPro/src/knowledgeMergeEx.ts
+++ b/ts/packages/knowPro/src/knowledgeMergeEx.ts
@@ -7,8 +7,6 @@
  */
 
 import { conversation as kpLib } from "knowledge-processor";
-import { collections } from "typeagent";
-import { unionArrays } from "./collections.js";
 import { Scored } from "./common.js";
 import {
     ISemanticRefCollection,
@@ -77,11 +75,9 @@ export interface MergedTopic extends MergedKnowledge {
 
 export interface MergedEntity extends MergedKnowledge {
     name: string;
-    type: string[];
+    type: Map<string, string>;
     facets?: MergedFacets | undefined;
 }
-
-type MergedFacets = collections.MultiMap<string, string>;
 
 export function mergeScoredTopics(
     scoredTopics: Iterable<Scored<SemanticRef>>,
@@ -109,18 +105,28 @@ export function mergeScoredTopics(
     return mergedTopics;
 }
 
+export type EntityMergeOptions = {
+    /* Case sensitive when merging for entity names, types and facets. */
+    caseSensitive?: boolean; // default to false
+};
+
 export function mergeScoredConcreteEntities(
     scoredEntities: Iterable<Scored<SemanticRef>>,
     mergeOrdinals: boolean,
+    options?: EntityMergeOptions,
 ): Map<string, Scored<MergedEntity>> {
     let mergedEntities = new Map<string, Scored<MergedEntity>>();
     for (let scoredEntity of scoredEntities) {
-        const mergedEntity = concreteToMergedEntity(
-            scoredEntity.item.knowledge as kpLib.ConcreteEntity,
-        );
-        let existing = mergedEntities.get(mergedEntity.name);
+        const concreteEntity = scoredEntity.item
+            .knowledge as kpLib.ConcreteEntity;
+
+        const caseSensitive = options?.caseSensitive === true;
+        const nameKey = caseSensitive
+            ? concreteEntity.name
+            : concreteEntity.name.toLowerCase();
+        let existing = mergedEntities.get(nameKey);
         if (existing) {
-            if (unionEntities(existing.item, mergedEntity)) {
+            if (unionEntities(existing.item, concreteEntity, options)) {
                 if (existing.score < scoredEntity.score) {
                     existing.score = scoredEntity.score;
                 }
@@ -129,10 +135,10 @@ export function mergeScoredConcreteEntities(
             }
         } else {
             existing = {
-                item: mergedEntity,
+                item: concreteToMergedEntity(concreteEntity, options),
                 score: scoredEntity.score,
             };
-            mergedEntities.set(mergedEntity.name, existing);
+            mergedEntities.set(nameKey, existing);
         }
         if (existing && mergeOrdinals) {
             mergeMessageOrdinals(existing.item, scoredEntity.item);
@@ -143,8 +149,9 @@ export function mergeScoredConcreteEntities(
 
 export function mergeConcreteEntities(
     entities: kpLib.ConcreteEntity[],
+    options?: EntityMergeOptions,
 ): kpLib.ConcreteEntity[] {
-    let mergedEntities = concreteToMergedEntities(entities);
+    let mergedEntities = concreteToMergedEntities(entities, options);
 
     const mergedConcreteEntities: kpLib.ConcreteEntity[] = [];
     for (const mergedEntity of mergedEntities.values()) {
@@ -158,29 +165,44 @@ function mergeMessageOrdinals(mergedEntity: MergedKnowledge, sr: SemanticRef) {
     mergedEntity.sourceMessageOrdinals.add(sr.range.start.messageOrdinal);
 }
 
-export function concreteToMergedEntities(
+function concreteToMergedEntities(
     entities: kpLib.ConcreteEntity[],
+    options?: EntityMergeOptions,
 ): Map<string, MergedEntity> {
     let mergedEntities = new Map<string, MergedEntity>();
     for (let entity of entities) {
-        const mergedEntity = concreteToMergedEntity(entity);
-        const existing = mergedEntities.get(mergedEntity.name);
+        const caseSensitive = options?.caseSensitive === true;
+        const nameKey = caseSensitive ? entity.name : entity.name.toLowerCase();
+        const existing = mergedEntities.get(nameKey);
         if (existing) {
-            unionEntities(existing, mergedEntity);
+            unionEntities(existing, entity, options);
         } else {
-            mergedEntities.set(mergedEntity.name, mergedEntity);
+            mergedEntities.set(
+                nameKey,
+                concreteToMergedEntity(entity, options),
+            );
         }
     }
     return mergedEntities;
 }
 
-function concreteToMergedEntity(entity: kpLib.ConcreteEntity): MergedEntity {
-    let type = [...entity.type];
-    collections.lowerAndSort(type);
+function concreteToMergedEntity(
+    entity: kpLib.ConcreteEntity,
+    options?: EntityMergeOptions,
+): MergedEntity {
+    const caseSensitive = options?.caseSensitive === true;
+    const name = entity.name;
+    const type = new Map<string, string>(
+        caseSensitive
+            ? entity.type.map((t) => [t, t])
+            : entity.type.map((t) => [t.toLowerCase(), t]),
+    );
     return {
-        name: entity.name.toLowerCase(),
-        type: type,
-        facets: entity.facets ? facetsToMergedFacets(entity.facets) : undefined,
+        name,
+        type,
+        facets: entity.facets
+            ? facetsToMergedFacets(entity.facets, options)
+            : undefined,
     };
 }
 
@@ -189,7 +211,7 @@ export function mergedToConcreteEntity(
 ): kpLib.ConcreteEntity {
     const entity: kpLib.ConcreteEntity = {
         name: mergedEntity.name,
-        type: mergedEntity.type,
+        type: [...mergedEntity.type.values()].sort(), // sort just for stability
     };
     if (mergedEntity.facets && mergedEntity.facets.size > 0) {
         entity.facets = mergedFacetsToFacets(mergedEntity.facets);
@@ -197,30 +219,54 @@ export function mergedToConcreteEntity(
     return entity;
 }
 
-function facetsToMergedFacets(facets: kpLib.Facet[]): MergedFacets {
-    const mergedFacets: MergedFacets = new collections.MultiMap<
-        string,
-        string
-    >();
-    for (const facet of facets) {
-        const name = facet.name.toLowerCase();
-        const value = facetValueToString(facet).toLowerCase();
-        mergedFacets.addUnique(name, value);
-    }
+type MergedFacets = Map<string, { name: string; values: Map<string, string> }>;
+
+function facetsToMergedFacets(
+    facets: kpLib.Facet[],
+    options?: EntityMergeOptions,
+): MergedFacets {
+    const mergedFacets: MergedFacets = new Map();
+    addMergeFacets(mergedFacets, facets, options);
     return mergedFacets;
+}
+
+function addMergeFacets(
+    mergedFacets: MergedFacets,
+    facets: kpLib.Facet[],
+    options?: EntityMergeOptions,
+) {
+    for (const facet of facets) {
+        const name = facet.name;
+        const value = facetValueToString(facet);
+        const caseSensitive = options?.caseSensitive === true;
+        const nameKey = caseSensitive ? name : name.toLowerCase();
+        const valueKey = caseSensitive ? value : value.toLowerCase();
+
+        const existing = mergedFacets.get(nameKey);
+        if (existing) {
+            // For case-sensitive, keep using existing name/value when merging.
+            const existingValues = existing.values.get(valueKey);
+            if (existingValues) {
+                continue;
+            }
+            existing.values.set(valueKey, value);
+        } else {
+            mergedFacets.set(nameKey, {
+                name,
+                values: new Map([[valueKey, value]]),
+            });
+        }
+    }
 }
 
 function mergedFacetsToFacets(mergedFacets: MergedFacets): kpLib.Facet[] {
     const facets: kpLib.Facet[] = [];
-    for (const facetName of mergedFacets.keys()) {
-        const facetValues = mergedFacets.get(facetName);
-        if (facetValues && facetValues.length > 0) {
-            const facet: kpLib.Facet = {
-                name: facetName,
-                value: facetValues.join("; "),
-            };
-            facets.push(facet);
-        }
+    for (const { name, values } of mergedFacets.values()) {
+        const facet: kpLib.Facet = {
+            name,
+            value: [...values.values()].join("; "),
+        };
+        facets.push(facet);
     }
     return facets;
 }
@@ -228,12 +274,30 @@ function mergedFacetsToFacets(mergedFacets: MergedFacets): kpLib.Facet[] {
 /**
  * In place union
  */
-function unionEntities(to: MergedEntity, other: MergedEntity): boolean {
-    if (to.name !== other.name) {
-        return false;
+function unionEntities(
+    to: MergedEntity,
+    other: kpLib.ConcreteEntity,
+    options: EntityMergeOptions | undefined,
+): boolean {
+    addTypes(to.type, other.type, options);
+    to.facets = unionFacets(to.facets, other.facets, options);
+    return true;
+}
+
+function addTypes(
+    to: Map<string, string>,
+    other: string[],
+    options: EntityMergeOptions | undefined,
+): boolean {
+    const caseSensitive = options?.caseSensitive === true;
+    for (const t of other) {
+        const key = caseSensitive ? t : t.toLowerCase();
+        if (to.has(key)) {
+            // Already exists, skip
+            continue;
+        }
+        to.set(key, t);
     }
-    to.type = unionArrays(to.type, other.type)!;
-    to.facets = unionFacets(to.facets, other.facets);
     return true;
 }
 
@@ -242,21 +306,15 @@ function unionEntities(to: MergedEntity, other: MergedEntity): boolean {
  */
 function unionFacets(
     to: MergedFacets | undefined,
-    other: MergedFacets | undefined,
+    other: kpLib.Facet[] | undefined,
+    options: EntityMergeOptions | undefined,
 ): MergedFacets | undefined {
-    if (to === undefined) {
-        return other;
-    }
     if (other === undefined) {
         return to;
     }
-    for (const facetName of other.keys()) {
-        const facetValues = other.get(facetName);
-        if (facetValues) {
-            for (let i = 0; i < facetValues.length; ++i) {
-                to.addUnique(facetName, facetValues[i]);
-            }
-        }
+    if (to === undefined) {
+        return facetsToMergedFacets(other, options);
     }
+    addMergeFacets(to, other, options);
     return to;
 }

--- a/ts/packages/knowPro/test/knowledgeMerge.spec.ts
+++ b/ts/packages/knowPro/test/knowledgeMerge.spec.ts
@@ -1,0 +1,102 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { mergeConcreteEntities } from "../src/knowledgeMergeEx.js";
+
+describe("knowledge.merge", () => {
+    it("should merge concrete entities with case sensitivity", () => {
+        const entity1 = {
+            type: ["Person"],
+            name: "Alice",
+            facets: [{ name: "Location", value: "Seattle" }],
+        };
+        const entity2 = {
+            type: ["person"],
+            name: "alice",
+            facets: [{ name: "location", value: "seattle" }],
+        };
+        const merged = mergeConcreteEntities([entity1, entity2], {
+            caseSensitive: true,
+        });
+        expect(merged).toHaveLength(2);
+        expect(merged).toContainEqual(entity1);
+        expect(merged).toContainEqual(entity2);
+    });
+    it("should merge concrete entities with case insensitivity", () => {
+        const entity1 = {
+            type: ["Person"],
+            name: "Alice",
+            facets: [{ name: "Location", value: "Seattle" }],
+        };
+        const entity2 = {
+            type: ["person"],
+            name: "alice",
+            facets: [{ name: "location", value: "seattle" }],
+        };
+        const merged = mergeConcreteEntities([entity1, entity2]);
+        expect(merged).toHaveLength(1);
+        expect(merged).toContainEqual(entity1);
+    });
+    it("Merge additional type and facet with case sensitivity", () => {
+        const entity1 = {
+            type: ["Person"],
+            name: "Alice",
+            facets: [
+                { name: "Location", value: "Seattle" },
+                { name: "Location", value: "portland" },
+            ],
+        };
+        const entity2 = {
+            type: ["person", "artist"],
+            name: "Alice",
+            facets: [
+                { name: "Location", value: "seattle" },
+                { name: "Location", value: "portland" },
+                { name: "Location", value: "portland" },
+                { name: "location", value: "Vancouver" },
+                { name: "Profession", value: "Artist" },
+            ],
+        };
+        const expected = {
+            type: ["Person", "artist", "person"], // sorted.
+            name: "Alice",
+            facets: [
+                { name: "Location", value: "Seattle; portland; seattle" }, // REVIEW: should the merge value be in an array
+                { name: "location", value: "Vancouver" },
+                { name: "Profession", value: "Artist" },
+            ],
+        };
+        const merged = mergeConcreteEntities([entity1, entity2], {
+            caseSensitive: true,
+        });
+        expect(merged).toHaveLength(1);
+        expect(merged).toContainEqual(expected);
+    });
+    it("Merge additional type and facet with case insensitivity", () => {
+        const entity1 = {
+            type: ["Person"],
+            name: "Alice",
+            facets: [{ name: "Location", value: "Seattle" }],
+        };
+        const entity2 = {
+            type: ["person", "artist"],
+            name: "alice",
+            facets: [
+                { name: "location", value: "seattle" },
+                { name: "location", value: "portland" },
+                { name: "Profession", value: "Artist" },
+            ],
+        };
+        const expected = {
+            type: ["Person", "artist"], // sorted.
+            name: "Alice",
+            facets: [
+                { name: "Location", value: "Seattle; portland" }, // REVIEW: should the merge value be in an array
+                { name: "Profession", value: "Artist" },
+            ],
+        };
+        const merged = mergeConcreteEntities([entity1, entity2]);
+        expect(merged).toHaveLength(1);
+        expect(merged).toContainEqual(expected);
+    });
+});

--- a/ts/packages/memory/conversation/src/memory.ts
+++ b/ts/packages/memory/conversation/src/memory.ts
@@ -155,7 +155,9 @@ export class Message<TMeta extends MessageMetadata = MessageMetadata>
         newKnowledge: kpLib.KnowledgeResponse,
     ): kpLib.KnowledgeResponse {
         if (this.knowledge !== undefined) {
-            this.knowledge.entities = kp.mergeConcreteEntities([
+            // TODO: using mergeConcreteEntitiesEx to avoid forcing the data to be lower case.
+            // Replace with mergeConcreteEntities once it has switch over to the Ex version.
+            this.knowledge.entities = kp.mergeConcreteEntitiesEx([
                 ...this.knowledge.entities,
                 ...newKnowledge.entities,
             ]);
@@ -183,7 +185,9 @@ export class Message<TMeta extends MessageMetadata = MessageMetadata>
             ...this.knowledge,
         };
         combinedKnowledge.entities.push(...metaKnowledge.entities);
-        combinedKnowledge.entities = kp.mergeConcreteEntities(
+        // TODO: using mergeConcreteEntitiesEx to avoid forcing the data to be lower case.
+        // Replace with mergeConcreteEntities once it has switch over to the Ex version.
+        combinedKnowledge.entities = kp.mergeConcreteEntitiesEx(
             combinedKnowledge.entities,
         );
         combinedKnowledge.topics.push(...metaKnowledge.topics);


### PR DESCRIPTION
- Create a new function `mergeConcreteEntitiesEx` (based on current `mergeConcretEntities`
  - won't force data to be lower case regardless of whether merge is case-sensitive or not.  
  - In the case-insensitive case, it will pick the first version it encountered.
  - The new code avoid extra conversion of concrete entity to merged entity for the RHS and directly merge to and existing merged entity compare to the old code.
  - Added unit test for this new function.
- TOOD: after more testing for stability, replace `mergeConcreteEntities` which currently forces all the resulting entity data to be lower case.
- 