### PR TITLE
knowpro: Better diagnostics, replayability

### DIFF
--- a/ts/examples/chat/src/memory/knowproMemory.ts
+++ b/ts/examples/chat/src/memory/knowproMemory.ts
@@ -387,7 +387,7 @@ export async function createKnowproCommands(
         );
         getAnswerRequest.searchResponse = searchResponse;
         getAnswerRequest.knowledgeTopK = options.entitiesTopK;
-        await kpTest.execGetAnswerRequest(
+        const answerResponse = await kpTest.execGetAnswerRequest(
             context,
             getAnswerRequest,
             (i: number, q: string, answer) => {
@@ -395,6 +395,7 @@ export async function createKnowproCommands(
                 return;
             },
         );
+        context.log.writeFile("kpAnswer", answerResponse);
         context.printer.writeLine();
     }
 

--- a/ts/examples/chat/src/memory/knowproPrinter.ts
+++ b/ts/examples/chat/src/memory/knowproPrinter.ts
@@ -569,6 +569,11 @@ export class KnowProPrinter extends MemoryConsoleWriter {
         return this;
     }
 
+    public writeSearchQuery(searchQuery: kp.querySchema.SearchQuery) {
+        this.writeHeading("Search Query");
+        this.writeJson(searchQuery);
+    }
+
     public writeDebugContext(context: kp.LanguageSearchDebugContext) {
         if (context.searchQuery) {
             this.writeHeading("Search Query");

--- a/ts/examples/chat/src/memory/knowproTest.ts
+++ b/ts/examples/chat/src/memory/knowproTest.ts
@@ -515,7 +515,7 @@ export async function createKnowproTestCommands(
     }
 
     async function saveReport(srcPath: string, report: any) {
-        const outputDir = path.join(context.basePath, "testReports");
+        const outputDir = path.join(context.basePath, "logs/testReports");
         await ensureDir(outputDir);
         const outputPath = path.join(outputDir, getFileName(srcPath) + ".json");
         await writeJsonFile(outputPath, report);

--- a/ts/examples/chat/src/memory/knowproTest.ts
+++ b/ts/examples/chat/src/memory/knowproTest.ts
@@ -442,11 +442,12 @@ export async function createKnowproTestCommands(
     ): boolean {
         const error = result.error;
         if (error !== undefined && error.length > 0) {
-            context.printer.writeInColor(
-                chalk.redBright,
-                `[${error}]: ${result.expected.cmd!}`,
+            context.printer.writeLineInColor(
+                chalk.gray,
+                result.actual.searchText,
             );
-            context.printer.writeInColor(chalk.red, `Error: ${error}`);
+            context.printer.writeInColor(chalk.red, `${result.expected.cmd!}`);
+            context.printer.writeInColor(chalk.red, `Error:\n ${error}`);
             if (verbose) {
                 context.printer.writeLine("===========");
                 context.printer.writeJsonInColor(

--- a/ts/packages/knowPro/src/search.ts
+++ b/ts/packages/knowPro/src/search.ts
@@ -229,6 +229,27 @@ export async function runSearchQuery(
 }
 
 /**
+ * Run multiple queries
+ * @param conversation
+ * @param queries queries to run
+ * @param options
+ * @returns
+ */
+export async function runSearchQueries(
+    conversation: IConversation,
+    queries: SearchQueryExpr[],
+    options?: SearchOptions,
+): Promise<ConversationSearchResult[][]> {
+    // FUTURE: do these in parallel
+    const results: ConversationSearchResult[][] = [];
+    for (let i = 0; i < queries.length; ++i) {
+        const result = await runSearchQuery(conversation, queries[i], options);
+        results.push(result);
+    }
+    return results;
+}
+
+/**
  * Run the search query. For each selectExpr:
  * - only match messages using similarity to the rawQuery on each expression
  * - scope messages using the when filter

--- a/ts/packages/knowPro/src/searchLang.ts
+++ b/ts/packages/knowPro/src/searchLang.ts
@@ -145,12 +145,23 @@ export async function searchConversationWithLanguage(
     }
     return success(searchResults);
 
+    //
+    // Scoping queries can be precise. However, there may be random variations in how LLMs
+    // translate some user utterances into queries.. .particularly verbs. They verbs
+    // may not match action verbs actually in the index.. related terms may not meet the similarity
+    // cutoff.
+    // If configured (compileOptions.exactScope == false), we can do a fallback query that does
+    // not enforce verb matching. This improves recall while still providing a reasonable level of scoping because it
+    //
     function compileFallbackQuery(
         query: querySchema.SearchQuery,
         compileOptions: LanguageQueryCompileOptions,
         langSearchFilter?: LanguageSearchFilter,
     ): SearchQueryExpr[] | undefined {
         const verbScope = compileOptions.verbScope;
+        //
+        // If no exact scope... and verbScope is not provided or true,
+        // then we can build a fallback query that is more forgiving
         if (
             !compileOptions.exactScope &&
             (verbScope == undefined || verbScope)
@@ -165,6 +176,9 @@ export async function searchConversationWithLanguage(
                 langSearchFilter,
             );
         }
+        //
+        // No fallback query currently possible
+        //
         return undefined;
     }
 
@@ -249,6 +263,9 @@ export type LanguageQueryCompileOptions = {
      * Is fuzzy matching enabled when applying scope?
      */
     exactScope?: boolean | undefined;
+    /**
+     * Should use verbs in scoping expressions (default true)
+     */
     verbScope?: boolean | undefined;
     // Use to ignore noise terms etc.
     termFilter?: (text: string) => boolean;

--- a/ts/packages/knowProTest/src/common.ts
+++ b/ts/packages/knowProTest/src/common.ts
@@ -14,6 +14,26 @@ export function ensureDirSync(folderPath: string): string {
     return folderPath;
 }
 
+export function ensureUniqueFilePath(filePath: string): string {
+    if (!fs.existsSync(filePath)) {
+        return filePath;
+    }
+
+    for (let i = 1; i < 1000; ++i) {
+        const tempPath = addFileNameSuffixToPath(filePath, `_${i}`);
+        if (!fs.existsSync(tempPath)) {
+            return tempPath;
+        }
+    }
+
+    throw new Error(`Could not ensure unique ${filePath}`);
+}
+
+export function writeObjectToUniqueFile(filePath: string, obj: any): void {
+    filePath = ensureUniqueFilePath(filePath);
+    fs.writeFileSync(filePath, stringifyReadable(obj));
+}
+
 export function getCommandArgs(line: string | undefined): string[] {
     if (line !== undefined && line.length > 0) {
         const args = parseCommandLine(line);

--- a/ts/packages/knowProTest/src/common.ts
+++ b/ts/packages/knowProTest/src/common.ts
@@ -102,6 +102,17 @@ export function isJsonEqual(x: any | undefined, y: any | undefined): boolean {
     return false;
 }
 
+export function compareObject(
+    x: any,
+    y: any,
+    label: string,
+): string | undefined {
+    if (!isJsonEqual(x, y)) {
+        return `${label}: ${stringifyReadable(x)}\n !== \n${stringifyReadable(y)}`;
+    }
+    return undefined;
+}
+
 export function compareArray(
     name: string,
     x: any[] | undefined,
@@ -128,4 +139,8 @@ export function compareArray(
 
 export function queryError(query: string, result: Error): Error {
     return error(`${query}\n${result.message}`);
+}
+
+export function stringifyReadable(value: any): string {
+    return JSON.stringify(value, undefined, 2);
 }

--- a/ts/packages/knowProTest/src/index.ts
+++ b/ts/packages/knowProTest/src/index.ts
@@ -3,6 +3,7 @@
 
 export * from "./types.js";
 export * from "./models.js";
+export * from "./logging.js";
 export * from "./knowproContext.js";
 export * from "./searchTest.js";
 export * from "./answerTest.js";

--- a/ts/packages/knowProTest/src/knowproCommands.ts
+++ b/ts/packages/knowProTest/src/knowproCommands.ts
@@ -39,7 +39,10 @@ export async function execSearchRequest(
             searchRequestDef(),
         );
     }
-    const langQuery = request.query; // Natural language query to run
+    const langQuery = request.query.trim(); // Natural language query to run
+    if (!langQuery) {
+        throw new Error("No query provided");
+    }
     const debugContext: AnswerDebugContext = { searchText: langQuery };
     //
     // Set up options  for the search API Call
@@ -98,6 +101,8 @@ export async function execSearchRequest(
             compiledQueries,
             options,
         );
+        debugContext.searchQuery = preTranslatedQuery;
+        debugContext.searchQueryExpr = compiledQueries;
         searchResults = success(queryResults.flat());
     } else {
         //

--- a/ts/packages/knowProTest/src/knowproCommands.ts
+++ b/ts/packages/knowProTest/src/knowproCommands.ts
@@ -24,11 +24,13 @@ import { async } from "typeagent";
  * @see ../../knowPro/src/search.ts
  * @param context
  * @param {SearchRequest} request Structured request or Named Arguments
+ * @param {kp.querySchema.SearchQuery} preTranslatedQuery already have turned request.query into query expressions
  * @returns
  */
 export async function execSearchRequest(
     context: KnowproContext,
     request: SearchRequest | string[] | NamedArgs,
+    preTranslatedQuery?: kp.querySchema.SearchQuery | undefined,
 ): Promise<SearchResponse> {
     const conversation = context.ensureConversationLoaded();
     if (shouldParseRequest(request)) {
@@ -83,11 +85,11 @@ export async function execSearchRequest(
     }
 
     let searchResults: Result<kp.ConversationSearchResult[]>;
-    if (request.queryExpr) {
+    if (preTranslatedQuery) {
         // Pre-existing query expr for request.query
         const compiledQueries = kp.compileSearchQuery(
             conversation,
-            request.queryExpr,
+            preTranslatedQuery,
             options.compileOptions,
             langFilter,
         );

--- a/ts/packages/knowProTest/src/knowproContext.ts
+++ b/ts/packages/knowProTest/src/knowproContext.ts
@@ -5,6 +5,8 @@ import { ChatModel } from "aiclient";
 import * as kp from "knowpro";
 import { createKnowledgeModel } from "./models.js";
 import * as cm from "conversation-memory";
+import { KnowproLog } from "./logging.js";
+import path from "path";
 
 export class KnowproContext {
     public knowledgeModel: ChatModel;
@@ -14,9 +16,11 @@ export class KnowproContext {
     public answerGenerator: kp.AnswerGenerator;
     public termParser: cm.SearchTermParser;
     public retryNoAnswer: boolean;
+    public log: KnowproLog;
 
     constructor(basePath?: string) {
         this.basePath = basePath ?? "/data/testChat/knowpro";
+        this.log = new KnowproLog(path.join(this.basePath, "logs"));
         this.knowledgeModel = createKnowledgeModel();
         this.queryTranslator = kp.createSearchQueryTranslator(
             this.knowledgeModel,

--- a/ts/packages/knowProTest/src/logging.ts
+++ b/ts/packages/knowProTest/src/logging.ts
@@ -1,0 +1,37 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { AnswerDebugContext } from "./types.js";
+import { ensureDirSync, writeObjectToUniqueFile } from "./common.js";
+import { dateTime } from "typeagent";
+import path from "path";
+
+export class KnowproLog {
+    constructor(public baseLogDir: string) {
+        ensureDirSync(baseLogDir);
+    }
+
+    public writeFile(commandName: string, debugContext: AnswerDebugContext) {
+        try {
+            const timestamp = new Date();
+            const dirPath = this.ensureLogDir(timestamp, commandName);
+            const fileName = `${dateTime.timestampString(timestamp)}.json`;
+            let filePath = path.join(dirPath, fileName);
+            writeObjectToUniqueFile(filePath, debugContext);
+        } catch (ex) {
+            console.log(`Error while writing log file:\n{ex}`);
+        }
+    }
+
+    public ensureLogDir(timestamp: Date, commandName?: string): string {
+        let dirName: string;
+        if (commandName) {
+            dirName = `${commandName}_${dateTime.timestampStringShort(timestamp)}`;
+        } else {
+            dirName = dateTime.timestampStringShort(timestamp);
+        }
+        const dirPath = path.join(this.baseLogDir, dirName);
+        ensureDirSync(dirPath);
+        return dirPath;
+    }
+}

--- a/ts/packages/knowProTest/src/logging.ts
+++ b/ts/packages/knowProTest/src/logging.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { AnswerDebugContext } from "./types.js";
 import { ensureDirSync, writeObjectToUniqueFile } from "./common.js";
 import { dateTime } from "typeagent";
 import path from "path";
@@ -11,13 +10,13 @@ export class KnowproLog {
         ensureDirSync(baseLogDir);
     }
 
-    public writeFile(commandName: string, debugContext: AnswerDebugContext) {
+    public writeFile(commandName: string, obj: any) {
         try {
             const timestamp = new Date();
             const dirPath = this.ensureLogDir(timestamp, commandName);
             const fileName = `${dateTime.timestampString(timestamp)}.json`;
             let filePath = path.join(dirPath, fileName);
-            writeObjectToUniqueFile(filePath, debugContext);
+            writeObjectToUniqueFile(filePath, obj);
         } catch (ex) {
             console.log(`Error while writing log file:\n{ex}`);
         }

--- a/ts/packages/knowProTest/src/searchTest.ts
+++ b/ts/packages/knowProTest/src/searchTest.ts
@@ -7,8 +7,8 @@ import { error, Result, success } from "typechat";
 import { BatchCallback, Comparison } from "./types.js";
 import {
     compareArray,
+    compareObject,
     getCommandArgs,
-    isJsonEqual,
     queryError,
 } from "./common.js";
 import { getLangSearchResult } from "./knowproCommands.js";
@@ -216,31 +216,11 @@ function getMatchedSemanticRefOrdinals(
         ?.semanticRefMatches.map((sr) => sr.semanticRefOrdinal);
 }
 
-function compareSearchExpr(
-    s1: kp.querySchema.SearchQuery,
-    s2: kp.querySchema.SearchQuery,
-): string | undefined {
-    if (s1.searchExpressions.length !== s2?.searchExpressions.length) {
-        return "searchQuery expressions Length";
-    }
-    for (let i = 0; i < s1.searchExpressions.length; ++i) {
-        if (
-            !isJsonEqual(
-                s1.searchExpressions[i].filters,
-                s2.searchExpressions[i].filters,
-            )
-        ) {
-            return `searchExpr.Filter #${i}`;
-        }
-    }
-    return undefined;
-}
-
 function compareLangSearchResults(
     lr1: LangSearchResults,
     lr2: LangSearchResults,
 ): string | undefined {
-    let error = compareSearchExpr(lr1.searchQueryExpr, lr2.searchQueryExpr);
+    let error = compareSearchQuery(lr1.searchQueryExpr, lr2.searchQueryExpr);
     if (error !== undefined && error.length > 0) {
         return error;
     }
@@ -275,6 +255,65 @@ function compareLangSearchResult(
     error = compareArray("action", lr1.actionMatches, lr2.actionMatches);
     if (error !== undefined) {
         return error;
+    }
+    return undefined;
+}
+
+function compareSearchQuery(
+    s1: kp.querySchema.SearchQuery,
+    s2: kp.querySchema.SearchQuery,
+): string | undefined {
+    if (s1.searchExpressions.length !== s2?.searchExpressions.length) {
+        return `searchQuery.searchExpressions.length: ${s1.searchExpressions.length} !== ${s2.searchExpressions.length}`;
+    }
+    for (let i = 0; i < s1.searchExpressions.length; ++i) {
+        const error = compareSearchExpr(
+            s1.searchExpressions[i],
+            s2.searchExpressions[i],
+        );
+        if (error !== undefined) {
+            return error;
+        }
+    }
+    return undefined;
+}
+
+function compareSearchExpr(
+    s1: kp.querySchema.SearchExpr,
+    s2: kp.querySchema.SearchExpr,
+): string | undefined {
+    if (s1.filters.length !== s2.filters.length) {
+        return `SearchExpr.filters.length: ${s1.filters.length} !== ${s2.filters.length}`;
+    }
+
+    for (let i = 0; i < s1.filters.length; ++i) {
+        const f1 = s1.filters[i];
+        const f2 = s2.filters[i];
+
+        let error = compareObject(
+            f1.entitySearchTerms,
+            f2.entitySearchTerms,
+            "entitySearchTerms",
+        );
+        if (error !== undefined) {
+            return error;
+        }
+        error = compareObject(
+            f1.actionSearchTerm,
+            f2.actionSearchTerm,
+            "actionSearchTerm",
+        );
+        if (error !== undefined) {
+            return error;
+        }
+        error = compareObject(f1.searchTerms, f2.searchTerms, "searchTerms");
+        if (error !== undefined) {
+            return error;
+        }
+        error = compareObject(f1.timeRange, f2.timeRange, "searchTerms");
+        if (error !== undefined) {
+            return error;
+        }
     }
     return undefined;
 }

--- a/ts/packages/knowProTest/src/searchTest.ts
+++ b/ts/packages/knowProTest/src/searchTest.ts
@@ -82,7 +82,7 @@ async function getSearchResults(
     return success(results);
 }
 
-export function collectLangSearchResults(
+function collectLangSearchResults(
     searchText: string,
     searchResults: kp.ConversationSearchResult[],
     debugContext: kp.LanguageSearchDebugContext,

--- a/ts/packages/knowProTest/src/types.ts
+++ b/ts/packages/knowProTest/src/types.ts
@@ -15,7 +15,14 @@ export interface SearchRequest {
     // Required args
     query: string;
 
-    // Optional
+    //
+    // Optional args
+    //
+
+    /**
+     * query was already translated into a queryExpr.
+     */
+    queryExpr?: kp.querySchema.SearchQuery | undefined;
 
     // Search processing settings
     applyScope?: boolean | undefined; // If false, don't infer scopes. Useful for debugging
@@ -67,6 +74,10 @@ export interface GetAnswerRequest extends SearchRequest {
     fastStop?: boolean | undefined;
     knowledgeTopK?: number | undefined;
     choices?: string | undefined;
+    /**
+     * Use an existing searchResponse for this request to generate an answer
+     * If not provided, will run a search using the properties set for SearchRequest
+     */
     searchResponse?: SearchResponse | undefined;
     /**
      * If searchResponse.searchResults.length > 1, use answers for individual

--- a/ts/packages/knowProTest/src/types.ts
+++ b/ts/packages/knowProTest/src/types.ts
@@ -15,14 +15,7 @@ export interface SearchRequest {
     // Required args
     query: string;
 
-    //
     // Optional args
-    //
-
-    /**
-     * query was already translated into a queryExpr.
-     */
-    queryExpr?: kp.querySchema.SearchQuery | undefined;
 
     // Search processing settings
     applyScope?: boolean | undefined; // If false, don't infer scopes. Useful for debugging

--- a/ts/packages/typeagent/src/dateTime.ts
+++ b/ts/packages/typeagent/src/dateTime.ts
@@ -56,6 +56,13 @@ export function timestampStringUtc(date: Date, sep: boolean = true): string {
         : `${year}${month}${day}${hour}${minute}${seconds}${ms}`;
 }
 
+export function timestampStringShort(date: Date, sep: boolean = true): string {
+    const year = date.getFullYear().toString();
+    const month = numberToString(date.getMonth() + 1, 2);
+    const day = numberToString(date.getDate(), 2);
+    return sep ? `${year}_${month}_${day}` : `${year}${month}${day}`;
+}
+
 export type TimestampRange = {
     startTimestamp: string;
     endTimestamp?: string | undefined;


### PR DESCRIPTION
For debugging, testing and co-dev with Python:
* Automatically dump kpSearch and kpAnswer results with timestamps in log folder
*  kpSearch: Run previously saved, or hand edited NLP SearchQuery expr from file
* Better search expression comparison - for diffs
* Save validation run report
* Some comments
* Wrapper API to run multiple searches

