### PR TITLE
Enable completion routing for natural language requests

### DIFF
--- a/ts/packages/agentSdk/src/parameters.ts
+++ b/ts/packages/agentSdk/src/parameters.ts
@@ -49,7 +49,7 @@ export type FlagDefinitions = Record<string, FlagDefinition>;
 // Arguments
 export type ArgDefinition = {
     description: string;
-    type?: "string" | "number" | "json"; // default is "string"
+    type?: "boolean" | "string" | "number" | "json"; // default is "string"
     optional?: boolean;
     multiple?: boolean;
     implicitQuotes?: boolean; // implicitly assume there are quotes and take the whole string as the argument
@@ -77,7 +77,7 @@ export type FlagValueTypes =
     | readonly ObjectValue[];
 
 // For converting the type name to the actual type
-type FlagValueTypeFromLiteral<
+type ValueTypeFromLiteral<
     T extends "json" | "string" | "number" | "boolean" | undefined,
 > = T extends "json"
     ? ObjectValue
@@ -87,7 +87,7 @@ type FlagValueTypeFromLiteral<
         ? boolean
         : string;
 
-// For infering the type based on the default value
+// For inferring the type based on the default value
 type FlagValueTypeFromValue<T> = T extends never[]
     ? string[]
     : T extends Array<infer Item extends FlagValueTypes>
@@ -110,8 +110,8 @@ type FlagOutputType<T extends FlagDefinition> =
         ? FlagValueTypeFromValue<Writeable<T["default"]>>
         : // Base the value on the type name literal, and value is undefined not flag is not specified
           T["multiple"] extends true
-          ? FlagValueTypeFromLiteral<T["type"]>[] | undefined
-          : FlagValueTypeFromLiteral<T["type"]> | undefined;
+          ? ValueTypeFromLiteral<T["type"]>[] | undefined
+          : ValueTypeFromLiteral<T["type"]> | undefined;
 
 type FlagsOutput<T extends FlagDefinitions | undefined> =
     T extends FlagDefinitions
@@ -123,16 +123,13 @@ type FlagsOutput<T extends FlagDefinitions | undefined> =
 // -------------------------------
 // Arg output types
 // -------------------------------
-type ArgTypeFromLiteral<T extends "number" | "string" | "json" | undefined> =
-    T extends "json" ? ObjectValue : T extends "number" ? number : string;
-
 type ArgOutputType<T extends ArgDefinition> = T["multiple"] extends true
     ? T["optional"] extends true
-        ? ArgTypeFromLiteral<T["type"]>[] | undefined
-        : ArgTypeFromLiteral<T["type"]>[]
+        ? ValueTypeFromLiteral<T["type"]>[] | undefined
+        : ValueTypeFromLiteral<T["type"]>[]
     : T["optional"] extends true
-      ? ArgTypeFromLiteral<T["type"]> | undefined
-      : ArgTypeFromLiteral<T["type"]>;
+      ? ValueTypeFromLiteral<T["type"]> | undefined
+      : ValueTypeFromLiteral<T["type"]>;
 
 type ArgsOutput<T extends ArgDefinitions | undefined> = T extends ArgDefinitions
     ? {
@@ -143,8 +140,12 @@ type ArgsOutput<T extends ArgDefinitions | undefined> = T extends ArgDefinitions
 export type ParsedCommandParams<T extends ParameterDefinitions> = {
     args: ArgsOutput<T["args"]>;
     flags: FlagsOutput<T["flags"]>;
-    tokens: string[];
-    nextArgs: string[];
+
+    // Information for partial command completion.
+    tokens: string[]; // The list of tokens parsed from the command.
+    lastCompletableParam: string | undefined; // The last parameter that was parsed that can be completed.
+    lastParamImplicitQuotes: boolean; // If the last parameter is implicitly quoted.
+    nextArgs: string[]; // A list of potential arguments next.
 };
 
 export type PartialParsedCommandParams<T extends ParameterDefinitions> =

--- a/ts/packages/dispatcher/src/command/command.ts
+++ b/ts/packages/dispatcher/src/command/command.ts
@@ -170,17 +170,23 @@ export async function resolveCommand(
     return result;
 }
 
+export function normalizeCommand(
+    originalInput: string,
+    context: CommandHandlerContext,
+) {
+    const input = originalInput.trim();
+    if (!input.startsWith("@")) {
+        const requestHandlerAgent = context.session.getConfig().request;
+        return `${requestHandlerAgent} request ${input}`;
+    }
+    return input.substring(1);
+}
+
 async function parseCommand(
     originalInput: string,
     context: CommandHandlerContext,
 ) {
-    let input = originalInput.trim();
-    if (!input.startsWith("@")) {
-        const requestHandlerAgent = context.session.getConfig().request;
-        input = `${requestHandlerAgent} request ${input}`;
-    } else {
-        input = input.substring(1);
-    }
+    const input = normalizeCommand(originalInput, context);
     const result = await resolveCommand(input, context);
     if (result.descriptor !== undefined) {
         context.logger?.logEvent("command", {

--- a/ts/packages/dispatcher/src/command/completion.ts
+++ b/ts/packages/dispatcher/src/command/completion.ts
@@ -17,53 +17,40 @@ import {
 import { parseParams } from "./parameters.js";
 import {
     getDefaultSubCommandDescriptor,
+    normalizeCommand,
     resolveCommand,
     ResolveCommandResult,
 } from "./command.js";
 
 export type CommandCompletionResult = {
-    partial: string; // The head part of the completion
-    space: boolean; // require space between partial and prefix
-    prefix: string; // the prefix for completion match
+    startIndex: number; // the index for the input where completion starts
     completions: string[]; // All the partial completions available after partial (and space if true)
+    space: boolean; // require space before the completion   (e.g. false if we are trying to complete a command)
 };
 
-// Determine the command to resolve for partial completion
-// If there is a trailing space, then it will just be the input (minus the @)
-// If there is no space, then it will the input without the last word
-function getPartialCompletedCommand(input: string) {
+// Return the index of the last incomplete term for completion.
+// if the last term is the '@' command itself, return the index right after the '@'.
+// Input with trailing space doesn't have incomplete term, so return -1.
+function getCompletionStartIndex(input: string) {
     const commandPrefix = input.match(/^\s*@/);
-    if (commandPrefix === null) {
-        return undefined;
-    }
-
-    const command = input.substring(commandPrefix.length);
-    if (!/\s/.test(command)) {
-        // No space no command yet.
-        return { partial: commandPrefix[0], prefix: command };
-    }
-
-    const trimmedEnd = input.trimEnd();
-    if (trimmedEnd !== input) {
-        // There is trailing space, just resolve the whole command
-        return { partial: trimmedEnd, prefix: "" };
+    if (commandPrefix !== null) {
+        // Input is a command
+        const command = input.substring(commandPrefix.length);
+        if (!/\s/.test(command)) {
+            // No space no command yet just return right after the '@' as the start of the last term.
+            return commandPrefix.length;
+        }
     }
 
     const suffix = input.match(/\s\S+$/);
-    if (suffix === null) {
-        // No suffix, resolve the whole command
-        return { partial: trimmedEnd, prefix: "" };
-    }
-    const split = input.length - suffix[0].length;
-    return {
-        partial: input.substring(0, split).trimEnd(),
-        prefix: input.substring(split).trimStart(),
-    };
+    return suffix !== null ? input.length - suffix[0].length : -1;
 }
 
+// Return the full flag name if we are waiting a flag value.  Add boolean values for completions and return undefined if the flag is boolean.
 function getPendingFlag(
     params: ParsedCommandParams<ParameterDefinitions>,
     flags: FlagDefinitions | undefined,
+    completions: string[],
 ) {
     if (params.tokens.length === 0 || flags === undefined) {
         return undefined;
@@ -75,13 +62,35 @@ function getPendingFlag(
     }
     const type = getFlagType(resolvedFlag[1]);
     if (type === "boolean") {
-        return undefined;
+        completions.push("true", "false");
+        return undefined; // doesn't require a value.
     }
     if (type === "json") {
-        return `${lastToken}`;
+        return lastToken;
     }
 
     return `--${resolvedFlag[0]}`; // use the full flag name in case it was a short flag
+}
+
+// True if surrounded by quotes at both ends (matching single or double quotes).
+// False if only start with a quote.
+// Undefined if no starting quote.
+
+function isFullyQuoted(value: string) {
+    const len = value.length;
+    if (len === 0) {
+        return undefined;
+    }
+    const firstChar = value[0];
+    if (firstChar !== "'" && firstChar !== '"') {
+        return undefined;
+    }
+
+    return (
+        len > 1 &&
+        value[len - 1] === firstChar &&
+        !(len > 2 && value[len - 2] === "\\")
+    );
 }
 
 async function getCommandParameterCompletion(
@@ -100,10 +109,11 @@ async function getCommandParameterCompletion(
         result.actualAppAgentName,
     );
 
-    const pendingFlag = getPendingFlag(params, flags);
+    const pendingFlag = getPendingFlag(params, flags, completions);
 
     const pendingCompletions: string[] = [];
     if (pendingFlag === undefined) {
+        // TODO: auto inject boolean value for boolean args.
         pendingCompletions.push(...params.nextArgs);
         if (flags !== undefined) {
             const parsedFlags = params.flags;
@@ -131,30 +141,44 @@ async function getCommandParameterCompletion(
     }
 
     if (agent.getCommandCompletion) {
-        completions.push(
-            ...(await agent.getCommandCompletion(
-                result.commands,
-                params,
-                pendingCompletions,
-                sessionContext,
-            )),
-        );
+        const { tokens, lastCompletableParam, lastParamImplicitQuotes } =
+            params;
+        if (lastCompletableParam !== undefined && tokens.length > 0) {
+            const valueToken = tokens[tokens.length - 1];
+            const quoted = isFullyQuoted(valueToken);
+            if (
+                quoted === false ||
+                (quoted === undefined && lastParamImplicitQuotes)
+            ) {
+                pendingCompletions.push(lastCompletableParam);
+            }
+        }
+        if (pendingCompletions.length > 0) {
+            completions.push(
+                ...(await agent.getCommandCompletion(
+                    result.commands,
+                    params,
+                    pendingCompletions,
+                    sessionContext,
+                )),
+            );
+        }
     }
     return completions;
 }
+
 export async function getCommandCompletion(
     input: string,
     context: CommandHandlerContext,
 ): Promise<CommandCompletionResult | undefined> {
-    const partialCompletedCommand = getPartialCompletedCommand(input);
-
-    if (partialCompletedCommand === undefined) {
-        // TODO: request completions
-        return undefined;
-    }
-
+    const completionStartIndex = getCompletionStartIndex(input);
     // Trim spaces and remove leading '@'
-    const partialCommand = partialCompletedCommand.partial.trim().substring(1);
+    const partialCommand = normalizeCommand(
+        completionStartIndex !== -1
+            ? input.substring(0, completionStartIndex)
+            : input,
+        context,
+    );
 
     const result = await resolveCommand(partialCommand, context);
 
@@ -164,6 +188,7 @@ export async function getCommandCompletion(
         return undefined;
     }
 
+    // Collect completions
     let completions: string[] = [];
     const descriptor = result.descriptor;
     if (descriptor !== undefined) {
@@ -212,9 +237,11 @@ export async function getCommandCompletion(
         }
     }
 
+    const space =
+        completionStartIndex > 0 && input[completionStartIndex - 1] !== "@";
     return {
-        ...partialCompletedCommand,
-        space: partialCommand !== "",
+        startIndex: completionStartIndex,
         completions,
+        space,
     };
 }

--- a/ts/packages/dispatcher/src/context/dispatcher/handlers/requestCommandHandler.ts
+++ b/ts/packages/dispatcher/src/context/dispatcher/handlers/requestCommandHandler.ts
@@ -32,7 +32,11 @@ import {
 import registerDebug from "debug";
 import ExifReader from "exifreader";
 import { ProfileNames } from "../../../utils/profileNames.js";
-import { ActionContext, ParsedCommandParams } from "@typeagent/agent-sdk";
+import {
+    ActionContext,
+    ParsedCommandParams,
+    SessionContext,
+} from "@typeagent/agent-sdk";
 import { CommandHandler } from "@typeagent/agent-sdk/helpers/command";
 import { DispatcherName, isUnknownAction } from "../dispatcherUtils.js";
 import {
@@ -406,5 +410,25 @@ export class RequestCommandHandler implements CommandHandler {
         } finally {
             profiler?.stop();
         }
+    }
+    public async getCompletion(
+        context: SessionContext<CommandHandlerContext>,
+        params: ParsedCommandParams<typeof this.parameters>,
+        names: string[],
+    ): Promise<string[]> {
+        const completions: string[] = [];
+        for (const name of names) {
+            if (name === "request") {
+                const requestPrefix = params.args.request;
+                if (requestPrefix === undefined) {
+                    // Don't have any request prefix, don't provide any completion as it will be too many.
+                    continue;
+                }
+                // TODO: use the agent cache to provide completion.
+                console.log(requestPrefix);
+            }
+        }
+
+        return completions;
     }
 }

--- a/ts/packages/shell/src/renderer/src/partial.ts
+++ b/ts/packages/shell/src/renderer/src/partial.ts
@@ -177,7 +177,15 @@ export class PartialCompletion {
                     return;
                 }
 
-                this.current = result.partial;
+                const partial =
+                    result.startIndex > 0
+                        ? input.substring(0, result.startIndex)
+                        : input;
+                const prefix =
+                    result.startIndex > 0
+                        ? input.substring(result.startIndex)
+                        : "";
+                this.current = partial;
                 this.space = result.space;
 
                 if (result.completions.length === 0) {
@@ -201,7 +209,7 @@ export class PartialCompletion {
 
                 const currentInput = this.getCurrentInputForCompletion();
                 if (currentInput === input) {
-                    this.updateSearchMenuPrefix(result.prefix);
+                    this.updateSearchMenuPrefix(prefix);
                 } else if (!this.reuseSearchMenu(currentInput)) {
                     this.updatePartialCompletion(currentInput);
                 }


### PR DESCRIPTION
Full completion is not implemented yet. This change will allow completion for natural language requests to be routed to the command handler so that it can be implemented.

- Partial routing now support request (natural language input that doesn't start with '@'

Other changes:
- Add `boolean` arg type to mirror what flags has.
- Add `--` as a terminator for multiple args or boolean flags.
- Add true/false to completions for boolean flags/args.