### PR TITLE
Cache completion

### DIFF
--- a/ts/packages/cache/src/constructions/constructionCache.ts
+++ b/ts/packages/cache/src/constructions/constructionCache.ts
@@ -70,6 +70,9 @@ export type MatchOptions = {
     rejectReferences?: boolean; // default is true
     conflicts?: boolean; // default is false
     history?: HistoryContext | undefined;
+
+    // Partial (prefix) match, for completions.
+    partial?: boolean; // default is false
 };
 
 export class ConstructionCache {
@@ -269,6 +272,7 @@ export class ConstructionCache {
             history: options?.history,
             conflicts: options?.conflicts,
             matchPartsCache: createMatchPartsCache(request),
+            partial: options?.partial ?? false, // default to false.
         };
 
         // If the useTranslators is undefined use all the translators

--- a/ts/packages/cache/src/constructions/constructionPrint.ts
+++ b/ts/packages/cache/src/constructions/constructionPrint.ts
@@ -204,6 +204,7 @@ export function printConstructionCache(
                 {
                     enableWildcard: false,
                     rejectReferences: false,
+                    partial: false,
                 },
                 printMatchedValueTranslator,
             );

--- a/ts/packages/cache/src/constructions/constructions.ts
+++ b/ts/packages/cache/src/constructions/constructions.ts
@@ -45,6 +45,9 @@ export type ConstructionPart = {
     equals(other: ConstructionPart): boolean;
 
     toString(verbose?: boolean): string;
+
+    // For partial match, return completion value for this part.
+    getCompletion(): Iterable<string> | undefined;
 };
 
 function getDefaultTranslator(transformNamespaces: Map<string, Transforms>) {
@@ -126,6 +129,7 @@ export class Construction {
         const actionProps = createActionProps(
             matchedValues.values,
             this.emptyArrayParameters,
+            config.partial,
         );
         return [
             {
@@ -139,6 +143,7 @@ export class Construction {
                 matchedCount: matchedValues.matchedCount,
                 wildcardCharCount: matchedValues.wildcardCharCount,
                 nonOptionalCount: this.parts.filter((p) => !p.optional).length,
+                partialPartCount: matchedValues.partialPartCount,
             },
         ];
     }
@@ -308,6 +313,7 @@ export type MatchResult = {
     wildcardCharCount: number;
     nonOptionalCount: number;
     conflictValues?: [string, ParamValueType[]][] | undefined;
+    partialPartCount?: number | undefined; // Only used for partial match
 };
 
 export function convertConstructionV2ToV3(

--- a/ts/packages/cache/src/constructions/importConstructions.ts
+++ b/ts/packages/cache/src/constructions/importConstructions.ts
@@ -107,6 +107,7 @@ function createConstructions(
             const matched = construction.match(entry.request, {
                 enableWildcard: false,
                 rejectReferences: false,
+                partial: false,
             });
             if (explainer.validate !== undefined) {
                 const error = explainer.validate(requestAction, explanation);

--- a/ts/packages/cache/src/constructions/matchPart.ts
+++ b/ts/packages/cache/src/constructions/matchPart.ts
@@ -180,6 +180,10 @@ export class MatchPart {
                 toTransformInfosKey(this.transformInfos)
         );
     }
+
+    public getCompletion(): Iterable<string> | undefined {
+        return this.matchSet.matches.values();
+    }
 }
 
 export function createMatchPart(

--- a/ts/packages/cache/src/constructions/parsePart.ts
+++ b/ts/packages/cache/src/constructions/parsePart.ts
@@ -46,6 +46,11 @@ export class ParsePart implements ConstructionPart {
     public toString(verbose: boolean = false) {
         return `<P:${this.parser.name}${verbose ? `=${this.propertyName}` : ""}>`;
     }
+
+    public getCompletion(): Iterable<string> | undefined {
+        // Parse parts don't have completions.
+        return undefined;
+    }
 }
 
 export type ParsePartJSON = {

--- a/ts/packages/cache/src/index.ts
+++ b/ts/packages/cache/src/index.ts
@@ -12,6 +12,7 @@ export type {
 } from "./explanation/requestAction.js";
 
 export type { ConstructionStore } from "./cache/store.js";
+export type { MatchOptions } from "./constructions/constructionCache.js";
 export type {
     GenericExplanationResult,
     CorrectionRecord,

--- a/ts/packages/defaultAgentProvider/test/construction.spec.ts
+++ b/ts/packages/defaultAgentProvider/test/construction.spec.ts
@@ -33,6 +33,7 @@ const testInput = inputs.flatMap((f) =>
 const matchConfig = {
     enableWildcard: false,
     rejectReferences: false,
+    partial: false,
 };
 
 const schemaInfoProvider = createSchemaInfoProvider(

--- a/ts/packages/defaultAgentProvider/test/constructionCacheTestCommon.ts
+++ b/ts/packages/defaultAgentProvider/test/constructionCacheTestCommon.ts
@@ -185,6 +185,7 @@ function expandActions(
                     createActionProps(
                         [[name, normalizeParamValue(v)]],
                         undefined,
+                        false,
                         e,
                     ),
                 ),

--- a/ts/packages/dispatcher/src/context/dispatcher/dispatcherAgent.ts
+++ b/ts/packages/dispatcher/src/context/dispatcher/dispatcherAgent.ts
@@ -34,7 +34,7 @@ import {
     LookupAndAnswerAction,
 } from "./schema/lookupActionSchema.js";
 import {
-    getHistoryContext,
+    getHistoryContextForTranslation,
     translateRequest,
 } from "../../translation/translateRequest.js";
 import { ActivityActions } from "./schema/activityActionSchema.js";
@@ -188,7 +188,11 @@ async function clarifyWithLookup(
     }
 
     // TODO: This translation can probably more scoped based on the `actionName` field.
-    const history = getHistoryContext(systemContext);
+    const history = getHistoryContextForTranslation(systemContext);
+    if (history === undefined) {
+        // Can't do clarify without history.
+        return undefined;
+    }
 
     history.promptSections.push({
         role: "assistant",

--- a/ts/packages/dispatcher/src/translation/translateRequest.ts
+++ b/ts/packages/dispatcher/src/translation/translateRequest.ts
@@ -697,9 +697,16 @@ async function finalizeMultipleActions(
     return actions;
 }
 
-export function getHistoryContext(
+export function getHistoryContextForTranslation(
     context: CommandHandlerContext,
-): HistoryContext {
+) {
+    const config = context.session.getConfig();
+    return config.translation.history.enabled
+        ? getHistoryContext(context)
+        : undefined;
+}
+
+function getHistoryContext(context: CommandHandlerContext): HistoryContext {
     const promptSections = context.chatHistory.getPromptSections();
     if (promptSections.length !== 0) {
         promptSections.unshift({
@@ -841,7 +848,7 @@ export function translatePendingRequestAction(
 ) {
     try {
         const systemContext = context.sessionContext.agentContext;
-        const history = getHistoryContext(systemContext);
+        const history = getHistoryContextForTranslation(systemContext);
         return translateRequest(
             action.parameters.pendingRequest,
             context,


### PR DESCRIPTION
Initial version only provide completion for "matched" parts.
Use the cache to provide completions for natural language request by configuration to match algorithm to allow a prefix match.

