### PR TITLE
Fix space handling in search menu

### DIFF
--- a/ts/packages/cache/src/explanation/requestAction.ts
+++ b/ts/packages/cache/src/explanation/requestAction.ts
@@ -21,9 +21,11 @@ export type HistoryContext = {
 };
 
 export function normalizeParamString(str: string) {
+    // Remove diacritical marks, and case replace any space characters with the normalized ' '.
     return str
         .normalize("NFD")
         .replace(/\p{Diacritic}/gu, "")
+        .replace(/\s/g, " ")
         .toLowerCase();
 }
 

--- a/ts/packages/dispatcher/src/command/completion.ts
+++ b/ts/packages/dispatcher/src/command/completion.ts
@@ -101,6 +101,33 @@ function isFullyQuoted(value: string) {
     );
 }
 
+function collectFlags(
+    agentCommandCompletions: string[],
+    flags: FlagDefinitions,
+    parsedFlags: any,
+) {
+    const flagCompletions: string[] = [];
+    for (const [key, value] of Object.entries(flags)) {
+        const multiple = getFlagMultiple(value);
+        if (!multiple) {
+            if (getFlagType(value) === "json") {
+                // JSON property flags
+                agentCommandCompletions.push(`--${key}.`);
+            }
+            if (parsedFlags?.[key] !== undefined) {
+                // filter out non-multiple flags that is already set.
+                continue;
+            }
+        }
+        flagCompletions.push(`--${key}`);
+        if (value.char !== undefined) {
+            flagCompletions.push(`-${value.char}`);
+        }
+    }
+
+    return flagCompletions;
+}
+
 async function getCommandParameterCompletion(
     descriptor: CommandDescriptor,
     context: CommandHandlerContext,
@@ -113,38 +140,17 @@ async function getCommandParameterCompletion(
     }
     const flags = descriptor.parameters.flags;
     const params = parseParams(result.suffix, descriptor.parameters, true);
-    const agent = context.agents.getAppAgent(result.actualAppAgentName);
-    const sessionContext = context.agents.getSessionContext(
-        result.actualAppAgentName,
-    );
-
     const pendingFlag = getPendingFlag(params, flags, completions);
-
-    const pendingCompletions: string[] = [];
+    const agentCommandCompletions: string[] = [];
     if (pendingFlag === undefined) {
         // TODO: auto inject boolean value for boolean args.
-        pendingCompletions.push(...params.nextArgs);
+        agentCommandCompletions.push(...params.nextArgs);
         if (flags !== undefined) {
-            const parsedFlags = params.flags;
-            const flagCompletions: string[] = [];
-            for (const [key, value] of Object.entries(flags)) {
-                const multiple = getFlagMultiple(value);
-                if (!multiple) {
-                    if (getFlagType(value) === "json") {
-                        // JSON property flags
-                        pendingCompletions.push(`--${key}.`);
-                    }
-                    if (parsedFlags?.[key] !== undefined) {
-                        // filter out non-multiple flags that is already set.
-                        continue;
-                    }
-                }
-                flagCompletions.push(`--${key}`);
-                if (value.char !== undefined) {
-                    flagCompletions.push(`-${value.char}`);
-                }
-            }
-
+            const flagCompletions = collectFlags(
+                agentCommandCompletions,
+                flags,
+                params.flags,
+            );
             if (flagCompletions.length > 0) {
                 completions.push({
                     name: "Command Flags",
@@ -154,9 +160,10 @@ async function getCommandParameterCompletion(
         }
     } else {
         // get the potential values for the pending flag
-        pendingCompletions.push(pendingFlag);
+        agentCommandCompletions.push(pendingFlag);
     }
 
+    const agent = context.agents.getAppAgent(result.actualAppAgentName);
     if (agent.getCommandCompletion) {
         const { tokens, lastCompletableParam, lastParamImplicitQuotes } =
             params;
@@ -168,15 +175,18 @@ async function getCommandParameterCompletion(
                 quoted === false ||
                 (quoted === undefined && lastParamImplicitQuotes)
             ) {
-                pendingCompletions.push(lastCompletableParam);
+                agentCommandCompletions.push(lastCompletableParam);
             }
         }
-        if (pendingCompletions.length > 0) {
+        if (agentCommandCompletions.length > 0) {
+            const sessionContext = context.agents.getSessionContext(
+                result.actualAppAgentName,
+            );
             completions.push(
                 ...(await agent.getCommandCompletion(
                     result.commands,
                     params,
-                    pendingCompletions,
+                    agentCommandCompletions,
                     sessionContext,
                 )),
             );

--- a/ts/packages/shell/src/renderer/src/partial.ts
+++ b/ts/packages/shell/src/renderer/src/partial.ts
@@ -95,6 +95,8 @@ export class PartialCompletion {
         const trimmed = prefix.trimStart();
         return trimmed === prefix ? undefined : trimmed;
     }
+
+    // Determine if the current search menu can still be reused, or if we need to update the completions.
     private reuseSearchMenu(input: string) {
         if (!this.current || !input.startsWith(this.current)) {
             return false;
@@ -117,14 +119,11 @@ export class PartialCompletion {
             return false;
         }
 
-        // Space are delimiters.  Don't reuse the search menu if we have a space at the end.
-        // space.  We will try to refresh the completion.
-        if (prefix.trimEnd() !== prefix) {
-            return false;
-        }
-
         this.updateSearchMenuPrefix(prefix);
-        return true;
+
+        // If the search menu is still matching continue to use it.
+        // Otherwise, space are delimiters and we only refresh the completions
+        return this.searchMenu.isActive() || prefix.trimEnd() === prefix;
     }
 
     private updateSearchMenuPrefix(prefix: string) {
@@ -133,10 +132,11 @@ export class PartialCompletion {
             return;
         }
         const items = this.searchMenu.completePrefix(prefix);
-        if (
+        const showMenu =
             items.length !== 0 &&
-            (items.length !== 1 || items[0].matchText !== prefix)
-        ) {
+            (items.length !== 1 || items[0].matchText !== prefix);
+
+        if (showMenu) {
             debug(
                 `Partial completion updated: '${prefix}' with ${items.length} items`,
             );

--- a/ts/packages/shell/src/renderer/src/search.ts
+++ b/ts/packages/shell/src/renderer/src/search.ts
@@ -5,10 +5,20 @@ import { TST } from "./prefixTree";
 
 export type SearchMenuItem = {
     matchText: string;
-    selectedText: string;
     emojiChar?: string;
+
+    selectedText: string;
     needQuotes?: boolean; // default is true, and will add quote to the selectedText if it has spaces.
 };
+
+function normalizeMatchText(text: string): string {
+    // Remove diacritical marks, and case replace any space characters with the normalized ' '.
+    return text
+        .normalize("NFD")
+        .replace(/\p{Diacritic}/gu, "")
+        .replace(/\s/g, " ")
+        .toLowerCase();
+}
 
 export class SearchMenu {
     private searchContainer: HTMLDivElement;
@@ -113,7 +123,7 @@ export class SearchMenu {
     public setChoices(choices: SearchMenuItem[]) {
         this.trie.init();
         for (const choice of choices) {
-            this.trie.insert(choice.matchText, choice);
+            this.trie.insert(normalizeMatchText(choice.matchText), choice);
         }
     }
 
@@ -130,7 +140,7 @@ export class SearchMenu {
     }
 
     public completePrefix(prefix: string) {
-        const items = this.trie.dataWithPrefix(prefix);
+        const items = this.trie.dataWithPrefix(normalizeMatchText(prefix));
         this.replaceItems(prefix, items);
         return items;
     }


### PR DESCRIPTION
Fix to make sure completion works with items with space.

- Make search menu's match to be diacritical/case-insensitive and ignore difference kind of space characters.  (The chat view input always uses NBSP instead of just SP)
- Make sure we continue reuse the existing unmatched completion even when there are space.
