### PR TITLE
Web Memories: Add getAnalyticsData to populate data in the analytics view

### DIFF
--- a/ts/packages/agents/browser/src/agent/actionHandler.mts
+++ b/ts/packages/agents/browser/src/agent/actionHandler.mts
@@ -398,6 +398,7 @@ async function updateBrowserContext(
                         case "getRecentKnowledgeItems":
                         case "getTopDomains":
                         case "getActivityTrends":
+                        case "getAnalyticsData":
                         case "getDiscoverInsights":
                         case "getKnowledgeIndexStats":
                         case "getKnowledgeStats":

--- a/ts/packages/agents/browser/src/agent/actionHandler.mts
+++ b/ts/packages/agents/browser/src/agent/actionHandler.mts
@@ -400,6 +400,7 @@ async function updateBrowserContext(
                         case "getActivityTrends":
                         case "getDiscoverInsights":
                         case "getKnowledgeIndexStats":
+                        case "getKnowledgeStats":
                         case "clearKnowledgeIndex": {
                             const knowledgeResult = await handleKnowledgeAction(
                                 data.method,

--- a/ts/packages/agents/browser/src/agent/actionHandler.mts
+++ b/ts/packages/agents/browser/src/agent/actionHandler.mts
@@ -396,12 +396,9 @@ async function updateBrowserContext(
                         case "checkPageIndexStatus":
                         case "getPageIndexedKnowledge":
                         case "getRecentKnowledgeItems":
-                        case "getTopDomains":
-                        case "getActivityTrends":
                         case "getAnalyticsData":
                         case "getDiscoverInsights":
                         case "getKnowledgeIndexStats":
-                        case "getKnowledgeStats":
                         case "clearKnowledgeIndex": {
                             const knowledgeResult = await handleKnowledgeAction(
                                 data.method,

--- a/ts/packages/agents/browser/src/agent/browserKnowledgeSchema.ts
+++ b/ts/packages/agents/browser/src/agent/browserKnowledgeSchema.ts
@@ -202,6 +202,10 @@ export type GetKnowledgeStats = {
         limit?: number;
         /** Time range for statistics (in days) */
         timeRange?: number;
+        /** Include quality distribution analysis */
+        includeQuality?: boolean;
+        /** Include progress metrics */
+        includeProgress?: boolean;
     };
 };
 
@@ -291,6 +295,28 @@ export interface KnowledgeStats {
         entitiesBytes: number;
         contentBytes: number;
         metadataBytes: number;
+    };
+}
+
+export interface DetailedKnowledgeStats extends KnowledgeStats {
+    /** Knowledge extraction progress percentages */
+    extractionProgress: {
+        entityProgress: number;
+        topicProgress: number; 
+        actionProgress: number;
+    };
+    /** Quality distribution metrics */
+    qualityDistribution: {
+        highQuality: number;    // >=80% confidence
+        mediumQuality: number;  // 50-79% confidence  
+        lowQuality: number;     // <50% confidence
+    };
+    /** Extraction completion rates */
+    completionRates: {
+        pagesWithEntities: number;
+        pagesWithTopics: number;
+        pagesWithActions: number;
+        totalProcessedPages: number;
     };
 }
 

--- a/ts/packages/agents/browser/src/agent/browserKnowledgeSchema.ts
+++ b/ts/packages/agents/browser/src/agent/browserKnowledgeSchema.ts
@@ -302,14 +302,14 @@ export interface DetailedKnowledgeStats extends KnowledgeStats {
     /** Knowledge extraction progress percentages */
     extractionProgress: {
         entityProgress: number;
-        topicProgress: number; 
+        topicProgress: number;
         actionProgress: number;
     };
     /** Quality distribution metrics */
     qualityDistribution: {
-        highQuality: number;    // >=80% confidence
-        mediumQuality: number;  // 50-79% confidence  
-        lowQuality: number;     // <50% confidence
+        highQuality: number; // >=80% confidence
+        mediumQuality: number; // 50-79% confidence
+        lowQuality: number; // <50% confidence
     };
     /** Extraction completion rates */
     completionRates: {

--- a/ts/packages/agents/browser/src/agent/knowledge/knowledgeHandler.mts
+++ b/ts/packages/agents/browser/src/agent/knowledge/knowledgeHandler.mts
@@ -1963,7 +1963,6 @@ function hasIndexingErrors(result: any): boolean {
     );
 }
 
-
 export async function getDetailedKnowledgeStats(
     parameters: {
         includeQuality?: boolean;
@@ -1973,31 +1972,32 @@ export async function getDetailedKnowledgeStats(
     context: SessionContext<BrowserActionContext>,
 ): Promise<DetailedKnowledgeStats> {
     const websiteCollection = context.agentContext.websiteCollection;
-    
+
     if (!websiteCollection) {
         return createEmptyKnowledgeStats();
     }
 
     const websites = websiteCollection.messages.getAll();
-    
+
     // Calculate base stats
     const baseStats = await calculateBaseStats(websites);
-    
-    // Calculate extraction progress  
+
+    // Calculate extraction progress
     const extractionProgress = calculateExtractionProgress(websites);
-    
+
     // Calculate quality distribution
-    const qualityDistribution = parameters.includeQuality !== false
-        ? calculateQualityDistribution(websites)
-        : { highQuality: 0, mediumQuality: 0, lowQuality: 0 };
-    
+    const qualityDistribution =
+        parameters.includeQuality !== false
+            ? calculateQualityDistribution(websites)
+            : { highQuality: 0, mediumQuality: 0, lowQuality: 0 };
+
     // Calculate completion rates
     const completionRates = calculateCompletionRates(websites);
-    
+
     return {
         ...baseStats,
         extractionProgress,
-        qualityDistribution, 
+        qualityDistribution,
         completionRates,
     };
 }
@@ -2062,13 +2062,16 @@ async function calculateBaseStats(websites: any[]): Promise<{
         try {
             const knowledge = site.getKnowledge();
             const metadata = site.metadata as website.WebsiteDocPartMeta;
-            
+
             // Extract domain from URL
             if (metadata?.url) {
                 try {
                     const domain = new URL(metadata.url).hostname;
                     domains.add(domain);
-                    domainCounts.set(domain, (domainCounts.get(domain) || 0) + 1);
+                    domainCounts.set(
+                        domain,
+                        (domainCounts.get(domain) || 0) + 1,
+                    );
                 } catch (error) {
                     // Invalid URL, skip domain extraction
                 }
@@ -2079,8 +2082,11 @@ async function calculateBaseStats(websites: any[]): Promise<{
                 if (knowledge.entities?.length > 0) {
                     totalEntities += knowledge.entities.length;
                     knowledge.entities.forEach((entity: any) => {
-                        const type = entity.type || 'Unknown';
-                        entityTypeCounts.set(type, (entityTypeCounts.get(type) || 0) + 1);
+                        const type = entity.type || "Unknown";
+                        entityTypeCounts.set(
+                            type,
+                            (entityTypeCounts.get(type) || 0) + 1,
+                        );
                     });
                 }
 
@@ -2124,7 +2130,7 @@ async function calculateBaseStats(websites: any[]): Promise<{
         storageSize: {
             totalBytes: totalContent,
             entitiesBytes: Math.round(totalContent * 0.3), // Estimate
-            contentBytes: Math.round(totalContent * 0.6),  // Estimate
+            contentBytes: Math.round(totalContent * 0.6), // Estimate
             metadataBytes: Math.round(totalContent * 0.1), // Estimate
         },
     };
@@ -2132,14 +2138,14 @@ async function calculateBaseStats(websites: any[]): Promise<{
 
 function calculateExtractionProgress(websites: any[]): {
     entityProgress: number;
-    topicProgress: number; 
+    topicProgress: number;
     actionProgress: number;
 } {
     let pagesWithEntities = 0;
     let pagesWithTopics = 0;
     let pagesWithActions = 0;
-    
-    websites.forEach(site => {
+
+    websites.forEach((site) => {
         try {
             const knowledge = site.getKnowledge();
             if (knowledge) {
@@ -2151,9 +2157,9 @@ function calculateExtractionProgress(websites: any[]): {
             // Skip sites with knowledge extraction errors
         }
     });
-    
+
     const total = websites.length || 1; // Prevent division by zero
-    
+
     return {
         entityProgress: Math.round((pagesWithEntities / total) * 100),
         topicProgress: Math.round((pagesWithTopics / total) * 100),
@@ -2166,23 +2172,27 @@ function calculateQualityDistribution(websites: any[]): {
     mediumQuality: number;
     lowQuality: number;
 } {
-    let high = 0, medium = 0, low = 0;
+    let high = 0,
+        medium = 0,
+        low = 0;
     let totalPagesWithKnowledge = 0;
-    
-    websites.forEach(site => {
+
+    websites.forEach((site) => {
         try {
             const knowledge = site.getKnowledge();
             if (knowledge && knowledge.entities?.length > 0) {
                 totalPagesWithKnowledge++;
-                
+
                 // Calculate average confidence across entities
                 const confidences = knowledge.entities
                     .map((e: any) => e.confidence || 0)
                     .filter((c: number) => c > 0);
-                    
+
                 if (confidences.length > 0) {
-                    const avgConfidence = confidences.reduce((a: number, b: number) => a + b) / confidences.length;
-                    
+                    const avgConfidence =
+                        confidences.reduce((a: number, b: number) => a + b) /
+                        confidences.length;
+
                     if (avgConfidence >= 0.8) high++;
                     else if (avgConfidence >= 0.5) medium++;
                     else low++;
@@ -2195,12 +2205,12 @@ function calculateQualityDistribution(websites: any[]): {
             // Skip sites with knowledge extraction errors
         }
     });
-    
+
     const total = totalPagesWithKnowledge || 1;
-    
+
     return {
         highQuality: Math.round((high / total) * 100),
-        mediumQuality: Math.round((medium / total) * 100), 
+        mediumQuality: Math.round((medium / total) * 100),
         lowQuality: Math.round((low / total) * 100),
     };
 }
@@ -2214,8 +2224,8 @@ function calculateCompletionRates(websites: any[]): {
     let pagesWithEntities = 0;
     let pagesWithTopics = 0;
     let pagesWithActions = 0;
-    
-    websites.forEach(site => {
+
+    websites.forEach((site) => {
         try {
             const knowledge = site.getKnowledge();
             if (knowledge) {
@@ -2227,7 +2237,7 @@ function calculateCompletionRates(websites: any[]): {
             // Skip sites with knowledge extraction errors
         }
     });
-    
+
     return {
         pagesWithEntities,
         pagesWithTopics,
@@ -2236,37 +2246,42 @@ function calculateCompletionRates(websites: any[]): {
     };
 }
 
-function generateRecentActivity(websites: any[]): Array<{ date: string; pagesIndexed: number }> {
+function generateRecentActivity(
+    websites: any[],
+): Array<{ date: string; pagesIndexed: number }> {
     const activityMap = new Map<string, number>();
     const now = new Date();
-    
+
     // Initialize last 7 days with 0
     for (let i = 6; i >= 0; i--) {
         const date = new Date(now);
         date.setDate(date.getDate() - i);
-        const dateStr = date.toISOString().split('T')[0];
+        const dateStr = date.toISOString().split("T")[0];
         activityMap.set(dateStr, 0);
     }
-    
+
     // Count pages by date
-    websites.forEach(site => {
+    websites.forEach((site) => {
         try {
             const metadata = site.metadata as website.WebsiteDocPartMeta;
             const siteDate = metadata?.visitDate || metadata?.bookmarkDate;
-            
+
             if (siteDate) {
                 const date = new Date(siteDate);
-                const dateStr = date.toISOString().split('T')[0];
-                
+                const dateStr = date.toISOString().split("T")[0];
+
                 if (activityMap.has(dateStr)) {
-                    activityMap.set(dateStr, (activityMap.get(dateStr) || 0) + 1);
+                    activityMap.set(
+                        dateStr,
+                        (activityMap.get(dateStr) || 0) + 1,
+                    );
                 }
             }
         } catch (error) {
             // Skip sites with invalid dates
         }
     });
-    
+
     return Array.from(activityMap.entries())
         .map(([date, pagesIndexed]) => ({ date, pagesIndexed }))
         .sort((a, b) => a.date.localeCompare(b.date));
@@ -2278,9 +2293,9 @@ export async function getAnalyticsData(
         includeQuality?: boolean;
         includeProgress?: boolean;
         topDomainsLimit?: number;
-        activityGranularity?: 'day' | 'week' | 'month';
+        activityGranularity?: "day" | "week" | "month";
     },
-    context: SessionContext<BrowserActionContext>
+    context: SessionContext<BrowserActionContext>,
 ): Promise<AnalyticsDataResponse> {
     try {
         // Single coordinated data collection using Promise.all for efficiency
@@ -2288,23 +2303,35 @@ export async function getAnalyticsData(
             knowledgeStats,
             topDomains,
             activityTrends,
-            extractionAnalytics
+            extractionAnalytics,
         ] = await Promise.all([
-            getDetailedKnowledgeStats({
-                includeQuality: parameters.includeQuality !== false,
-                includeProgress: parameters.includeProgress !== false,
-                timeRange: 30
-            }, context),
-            getTopDomains({ 
-                limit: parameters.topDomainsLimit || 10 
-            }, context),
-            getActivityTrends({
-                timeRange: parameters.timeRange || '30d',
-                granularity: parameters.activityGranularity || 'day'
-            }, context),
-            getExtractionAnalytics({
-                timeRange: parameters.timeRange || '30d'
-            }, context)
+            getDetailedKnowledgeStats(
+                {
+                    includeQuality: parameters.includeQuality !== false,
+                    includeProgress: parameters.includeProgress !== false,
+                    timeRange: 30,
+                },
+                context,
+            ),
+            getTopDomains(
+                {
+                    limit: parameters.topDomainsLimit || 10,
+                },
+                context,
+            ),
+            getActivityTrends(
+                {
+                    timeRange: parameters.timeRange || "30d",
+                    granularity: parameters.activityGranularity || "day",
+                },
+                context,
+            ),
+            getExtractionAnalytics(
+                {
+                    timeRange: parameters.timeRange || "30d",
+                },
+                context,
+            ),
         ]);
 
         // Get basic website statistics from websiteCollection
@@ -2316,9 +2343,9 @@ export async function getAnalyticsData(
         if (websiteCollection) {
             const websites = websiteCollection.messages.getAll();
             totalSites = websites.length;
-            
+
             // Count bookmarks vs history
-            websites.forEach(site => {
+            websites.forEach((site) => {
                 const metadata = site.metadata as website.WebsiteDocPartMeta;
                 if (metadata?.bookmarkDate) {
                     totalBookmarks++;
@@ -2334,28 +2361,28 @@ export async function getAnalyticsData(
                 totalBookmarks,
                 totalHistory,
                 topDomains: topDomains.domains?.length || 0,
-                knowledgeExtracted: knowledgeStats.totalPages || 0
+                knowledgeExtracted: knowledgeStats.totalPages || 0,
             },
             knowledge: {
                 extractionProgress: knowledgeStats.extractionProgress || {
                     entityProgress: 0,
                     topicProgress: 0,
-                    actionProgress: 0
+                    actionProgress: 0,
                 },
                 qualityDistribution: knowledgeStats.qualityDistribution || {
                     highQuality: 0,
                     mediumQuality: 0,
-                    lowQuality: 0
+                    lowQuality: 0,
                 },
                 totalEntities: knowledgeStats.totalEntities || 0,
                 totalTopics: knowledgeStats.topEntityTypes?.length || 0,
                 totalActions: 0, // Actions not tracked in current schema
                 totalRelationships: knowledgeStats.totalRelationships || 0,
-                recentItems: knowledgeStats.recentActivity || []
+                recentItems: knowledgeStats.recentActivity || [],
             },
             domains: {
                 topDomains: topDomains.domains || [],
-                totalSites: topDomains.totalSites || 0
+                totalSites: topDomains.totalSites || 0,
             },
             activity: {
                 trends: activityTrends.trends || [],
@@ -2363,13 +2390,13 @@ export async function getAnalyticsData(
                     totalActivity: 0,
                     peakDay: null,
                     averagePerDay: 0,
-                    timeRange: parameters.timeRange || '30d'
-                }
+                    timeRange: parameters.timeRange || "30d",
+                },
             },
             analytics: {
                 extractionMetrics: extractionAnalytics.analytics || {},
-                qualityReport: extractionAnalytics.analytics || {}
-            }
+                qualityReport: extractionAnalytics.analytics || {},
+            },
         };
     } catch (error) {
         console.error("Error aggregating analytics data:", error);
@@ -2380,28 +2407,28 @@ export async function getAnalyticsData(
                 totalBookmarks: 0,
                 totalHistory: 0,
                 topDomains: 0,
-                knowledgeExtracted: 0
+                knowledgeExtracted: 0,
             },
             knowledge: {
                 extractionProgress: {
                     entityProgress: 0,
                     topicProgress: 0,
-                    actionProgress: 0
+                    actionProgress: 0,
                 },
                 qualityDistribution: {
                     highQuality: 0,
                     mediumQuality: 0,
-                    lowQuality: 0
+                    lowQuality: 0,
                 },
                 totalEntities: 0,
                 totalTopics: 0,
                 totalActions: 0,
                 totalRelationships: 0,
-                recentItems: []
+                recentItems: [],
             },
             domains: {
                 topDomains: [],
-                totalSites: 0
+                totalSites: 0,
             },
             activity: {
                 trends: [],
@@ -2409,13 +2436,13 @@ export async function getAnalyticsData(
                     totalActivity: 0,
                     peakDay: null,
                     averagePerDay: 0,
-                    timeRange: parameters.timeRange || '30d'
-                }
+                    timeRange: parameters.timeRange || "30d",
+                },
             },
             analytics: {
                 extractionMetrics: {},
-                qualityReport: {}
-            }
+                qualityReport: {},
+            },
         };
     }
 }

--- a/ts/packages/agents/browser/src/agent/knowledge/knowledgeHandler.mts
+++ b/ts/packages/agents/browser/src/agent/knowledge/knowledgeHandler.mts
@@ -25,6 +25,7 @@ import {
     AIModelRequiredError,
 } from "website-memory";
 import { BrowserKnowledgeExtractor } from "./browserKnowledgeExtractor.mjs";
+import { DetailedKnowledgeStats } from "../browserKnowledgeSchema.js";
 
 // Helper function to convert HTML fragments to ExtractionInput objects
 function createExtractionInputsFromFragments(
@@ -178,6 +179,9 @@ export async function handleKnowledgeAction(
 
         case "getKnowledgeIndexStats":
             return await getKnowledgeIndexStats(parameters, context);
+
+        case "getKnowledgeStats":
+            return await getDetailedKnowledgeStats(parameters, context);
 
         case "clearKnowledgeIndex":
             return await clearKnowledgeIndex(parameters, context);
@@ -1901,4 +1905,313 @@ function hasIndexingErrors(result: any): boolean {
     return !!(
         result?.semanticRefs?.error || result?.secondaryIndexResults?.error
     );
+}
+
+
+export async function getDetailedKnowledgeStats(
+    parameters: {
+        includeQuality?: boolean;
+        includeProgress?: boolean;
+        timeRange?: number;
+    },
+    context: SessionContext<BrowserActionContext>,
+): Promise<DetailedKnowledgeStats> {
+    const websiteCollection = context.agentContext.websiteCollection;
+    
+    if (!websiteCollection) {
+        return createEmptyKnowledgeStats();
+    }
+
+    const websites = websiteCollection.messages.getAll();
+    
+    // Calculate base stats
+    const baseStats = await calculateBaseStats(websites);
+    
+    // Calculate extraction progress  
+    const extractionProgress = calculateExtractionProgress(websites);
+    
+    // Calculate quality distribution
+    const qualityDistribution = parameters.includeQuality !== false
+        ? calculateQualityDistribution(websites)
+        : { highQuality: 0, mediumQuality: 0, lowQuality: 0 };
+    
+    // Calculate completion rates
+    const completionRates = calculateCompletionRates(websites);
+    
+    return {
+        ...baseStats,
+        extractionProgress,
+        qualityDistribution, 
+        completionRates,
+    };
+}
+
+function createEmptyKnowledgeStats(): DetailedKnowledgeStats {
+    return {
+        totalPages: 0,
+        totalEntities: 0,
+        totalRelationships: 0,
+        uniqueDomains: 0,
+        topEntityTypes: [],
+        topDomains: [],
+        recentActivity: [],
+        storageSize: {
+            totalBytes: 0,
+            entitiesBytes: 0,
+            contentBytes: 0,
+            metadataBytes: 0,
+        },
+        extractionProgress: {
+            entityProgress: 0,
+            topicProgress: 0,
+            actionProgress: 0,
+        },
+        qualityDistribution: {
+            highQuality: 0,
+            mediumQuality: 0,
+            lowQuality: 0,
+        },
+        completionRates: {
+            pagesWithEntities: 0,
+            pagesWithTopics: 0,
+            pagesWithActions: 0,
+            totalProcessedPages: 0,
+        },
+    };
+}
+
+async function calculateBaseStats(websites: any[]): Promise<{
+    totalPages: number;
+    totalEntities: number;
+    totalRelationships: number;
+    uniqueDomains: number;
+    topEntityTypes: Array<{ type: string; count: number }>;
+    topDomains: Array<{ domain: string; pageCount: number }>;
+    recentActivity: Array<{ date: string; pagesIndexed: number }>;
+    storageSize: {
+        totalBytes: number;
+        entitiesBytes: number;
+        contentBytes: number;
+        metadataBytes: number;
+    };
+}> {
+    let totalEntities = 0;
+    let totalRelationships = 0;
+    const domains = new Set<string>();
+    const entityTypeCounts = new Map<string, number>();
+    const domainCounts = new Map<string, number>();
+    let totalContent = 0;
+
+    for (const site of websites) {
+        try {
+            const knowledge = site.getKnowledge();
+            const metadata = site.metadata as website.WebsiteDocPartMeta;
+            
+            // Extract domain from URL
+            if (metadata?.url) {
+                try {
+                    const domain = new URL(metadata.url).hostname;
+                    domains.add(domain);
+                    domainCounts.set(domain, (domainCounts.get(domain) || 0) + 1);
+                } catch (error) {
+                    // Invalid URL, skip domain extraction
+                }
+            }
+
+            if (knowledge) {
+                // Count entities and their types
+                if (knowledge.entities?.length > 0) {
+                    totalEntities += knowledge.entities.length;
+                    knowledge.entities.forEach((entity: any) => {
+                        const type = entity.type || 'Unknown';
+                        entityTypeCounts.set(type, (entityTypeCounts.get(type) || 0) + 1);
+                    });
+                }
+
+                // Count relationships/actions
+                if (knowledge.actions?.length > 0) {
+                    totalRelationships += knowledge.actions.length;
+                }
+            }
+
+            // Calculate content size
+            const textContent = site.textChunks?.join("") || "";
+            totalContent += textContent.length;
+        } catch (error) {
+            console.warn("Error processing site for stats:", error);
+        }
+    }
+
+    // Convert entity types to sorted array
+    const topEntityTypes = Array.from(entityTypeCounts.entries())
+        .sort(([, a], [, b]) => b - a)
+        .slice(0, 10)
+        .map(([type, count]) => ({ type, count }));
+
+    // Convert domains to sorted array
+    const topDomains = Array.from(domainCounts.entries())
+        .sort(([, a], [, b]) => b - a)
+        .slice(0, 10)
+        .map(([domain, pageCount]) => ({ domain, pageCount }));
+
+    // Simple recent activity (last 7 days)
+    const recentActivity = generateRecentActivity(websites);
+
+    return {
+        totalPages: websites.length,
+        totalEntities,
+        totalRelationships,
+        uniqueDomains: domains.size,
+        topEntityTypes,
+        topDomains,
+        recentActivity,
+        storageSize: {
+            totalBytes: totalContent,
+            entitiesBytes: Math.round(totalContent * 0.3), // Estimate
+            contentBytes: Math.round(totalContent * 0.6),  // Estimate
+            metadataBytes: Math.round(totalContent * 0.1), // Estimate
+        },
+    };
+}
+
+function calculateExtractionProgress(websites: any[]): {
+    entityProgress: number;
+    topicProgress: number; 
+    actionProgress: number;
+} {
+    let pagesWithEntities = 0;
+    let pagesWithTopics = 0;
+    let pagesWithActions = 0;
+    
+    websites.forEach(site => {
+        try {
+            const knowledge = site.getKnowledge();
+            if (knowledge) {
+                if (knowledge.entities?.length > 0) pagesWithEntities++;
+                if (knowledge.keyTopics?.length > 0) pagesWithTopics++;
+                if (knowledge.actions?.length > 0) pagesWithActions++;
+            }
+        } catch (error) {
+            // Skip sites with knowledge extraction errors
+        }
+    });
+    
+    const total = websites.length || 1; // Prevent division by zero
+    
+    return {
+        entityProgress: Math.round((pagesWithEntities / total) * 100),
+        topicProgress: Math.round((pagesWithTopics / total) * 100),
+        actionProgress: Math.round((pagesWithActions / total) * 100),
+    };
+}
+
+function calculateQualityDistribution(websites: any[]): {
+    highQuality: number;
+    mediumQuality: number;
+    lowQuality: number;
+} {
+    let high = 0, medium = 0, low = 0;
+    let totalPagesWithKnowledge = 0;
+    
+    websites.forEach(site => {
+        try {
+            const knowledge = site.getKnowledge();
+            if (knowledge && knowledge.entities?.length > 0) {
+                totalPagesWithKnowledge++;
+                
+                // Calculate average confidence across entities
+                const confidences = knowledge.entities
+                    .map((e: any) => e.confidence || 0)
+                    .filter((c: number) => c > 0);
+                    
+                if (confidences.length > 0) {
+                    const avgConfidence = confidences.reduce((a: number, b: number) => a + b) / confidences.length;
+                    
+                    if (avgConfidence >= 0.8) high++;
+                    else if (avgConfidence >= 0.5) medium++;
+                    else low++;
+                } else {
+                    // No confidence scores, assume medium quality
+                    medium++;
+                }
+            }
+        } catch (error) {
+            // Skip sites with knowledge extraction errors
+        }
+    });
+    
+    const total = totalPagesWithKnowledge || 1;
+    
+    return {
+        highQuality: Math.round((high / total) * 100),
+        mediumQuality: Math.round((medium / total) * 100), 
+        lowQuality: Math.round((low / total) * 100),
+    };
+}
+
+function calculateCompletionRates(websites: any[]): {
+    pagesWithEntities: number;
+    pagesWithTopics: number;
+    pagesWithActions: number;
+    totalProcessedPages: number;
+} {
+    let pagesWithEntities = 0;
+    let pagesWithTopics = 0;
+    let pagesWithActions = 0;
+    
+    websites.forEach(site => {
+        try {
+            const knowledge = site.getKnowledge();
+            if (knowledge) {
+                if (knowledge.entities?.length > 0) pagesWithEntities++;
+                if (knowledge.keyTopics?.length > 0) pagesWithTopics++;
+                if (knowledge.actions?.length > 0) pagesWithActions++;
+            }
+        } catch (error) {
+            // Skip sites with knowledge extraction errors
+        }
+    });
+    
+    return {
+        pagesWithEntities,
+        pagesWithTopics,
+        pagesWithActions,
+        totalProcessedPages: websites.length,
+    };
+}
+
+function generateRecentActivity(websites: any[]): Array<{ date: string; pagesIndexed: number }> {
+    const activityMap = new Map<string, number>();
+    const now = new Date();
+    
+    // Initialize last 7 days with 0
+    for (let i = 6; i >= 0; i--) {
+        const date = new Date(now);
+        date.setDate(date.getDate() - i);
+        const dateStr = date.toISOString().split('T')[0];
+        activityMap.set(dateStr, 0);
+    }
+    
+    // Count pages by date
+    websites.forEach(site => {
+        try {
+            const metadata = site.metadata as website.WebsiteDocPartMeta;
+            const siteDate = metadata?.visitDate || metadata?.bookmarkDate;
+            
+            if (siteDate) {
+                const date = new Date(siteDate);
+                const dateStr = date.toISOString().split('T')[0];
+                
+                if (activityMap.has(dateStr)) {
+                    activityMap.set(dateStr, (activityMap.get(dateStr) || 0) + 1);
+                }
+            }
+        } catch (error) {
+            // Skip sites with invalid dates
+        }
+    });
+    
+    return Array.from(activityMap.entries())
+        .map(([date, pagesIndexed]) => ({ date, pagesIndexed }))
+        .sort((a, b) => a.date.localeCompare(b.date));
 }

--- a/ts/packages/agents/browser/src/extension/serviceWorker/messageHandlers.ts
+++ b/ts/packages/agents/browser/src/extension/serviceWorker/messageHandlers.ts
@@ -783,7 +783,8 @@ export async function handleMessage(
                         includeQuality: message.includeQuality !== false,
                         includeProgress: message.includeProgress !== false,
                         topDomainsLimit: message.topDomainsLimit || 10,
-                        activityGranularity: message.activityGranularity || "day"
+                        activityGranularity:
+                            message.activityGranularity || "day",
                     },
                 });
 
@@ -796,7 +797,10 @@ export async function handleMessage(
                 console.error("Error getting analytics data:", error);
                 return {
                     success: false,
-                    error: error instanceof Error ? error.message : "Unknown error",
+                    error:
+                        error instanceof Error
+                            ? error.message
+                            : "Unknown error",
                 };
             }
         }

--- a/ts/packages/agents/browser/src/extension/serviceWorker/messageHandlers.ts
+++ b/ts/packages/agents/browser/src/extension/serviceWorker/messageHandlers.ts
@@ -858,6 +858,33 @@ export async function handleMessage(
             }
         }
 
+        case "getAnalyticsData": {
+            try {
+                const result = await sendActionToAgent({
+                    actionName: "getAnalyticsData",
+                    parameters: {
+                        timeRange: message.timeRange || "30d",
+                        includeQuality: message.includeQuality !== false,
+                        includeProgress: message.includeProgress !== false,
+                        topDomainsLimit: message.topDomainsLimit || 10,
+                        activityGranularity: message.activityGranularity || "day"
+                    },
+                });
+
+                return {
+                    success: !result.error,
+                    analytics: result,
+                    error: result.error,
+                };
+            } catch (error) {
+                console.error("Error getting analytics data:", error);
+                return {
+                    success: false,
+                    error: error instanceof Error ? error.message : "Unknown error",
+                };
+            }
+        }
+
         default:
             return null;
     }

--- a/ts/packages/agents/browser/src/extension/serviceWorker/messageHandlers.ts
+++ b/ts/packages/agents/browser/src/extension/serviceWorker/messageHandlers.ts
@@ -530,6 +530,31 @@ export async function handleMessage(
             }
         }
 
+        case "getKnowledgeStats": {
+            try {
+                const result = await sendActionToAgent({
+                    actionName: "getKnowledgeStats", 
+                    parameters: {
+                        includeQuality: true,
+                        includeProgress: true,
+                        timeRange: message.timeRange || 30,
+                    },
+                });
+
+                return {
+                    success: !result.error,
+                    stats: result,
+                    error: result.error,
+                };
+            } catch (error) {
+                console.error("Error getting knowledge stats:", error);
+                return {
+                    success: false,
+                    error: error instanceof Error ? error.message : "Unknown error",
+                };
+            }
+        }
+
         case "checkConnection": {
             const webSocket = getWebSocket();
             return {
@@ -966,14 +991,20 @@ async function handleGetWebsiteLibraryStats() {
         );
 
         return {
-            success: true,
-            stats: stats,
+            totalWebsites: stats.totalWebsites,
+            totalBookmarks: stats.totalBookmarks,
+            totalHistory: stats.totalHistory,
+            topDomains: stats.topDomains,
         };
     } catch (error) {
         console.error("Error getting website library stats:", error);
         return {
             success: false,
             error: error instanceof Error ? error.message : "Unknown error",
+            totalWebsites: 0,
+            totalBookmarks: 0,
+            totalHistory: 0,
+            topDomains: 0,
         };
     }
 }

--- a/ts/packages/agents/browser/src/extension/serviceWorker/messageHandlers.ts
+++ b/ts/packages/agents/browser/src/extension/serviceWorker/messageHandlers.ts
@@ -37,65 +37,6 @@ export async function handleMessage(
             return await handleGetWebsiteLibraryStats();
         }
 
-        case "getTopDomains": {
-            try {
-                const result = await sendActionToAgent({
-                    actionName: "getTopDomains",
-                    parameters: {
-                        limit: message.limit || 10,
-                    },
-                });
-
-                return {
-                    success: result.success || false,
-                    domains: {
-                        domains: result.domains || [],
-                        totalSites: result.totalSites || 0,
-                    },
-                };
-            } catch (error) {
-                console.error("Error getting top domains:", error);
-                return {
-                    success: false,
-                    error:
-                        error instanceof Error
-                            ? error.message
-                            : "Unknown error",
-                    domains: { domains: [], totalSites: 0 },
-                };
-            }
-        }
-
-        case "getActivityTrends": {
-            try {
-                const result = await sendActionToAgent({
-                    actionName: "getActivityTrends",
-                    parameters: {
-                        timeRange: message.timeRange || "30d",
-                        granularity: message.granularity || "day",
-                    },
-                });
-
-                return {
-                    success: result.success || false,
-                    trends: {
-                        trends: result.trends || [],
-                        summary: result.summary || {},
-                    },
-                };
-            } catch (error) {
-                console.error("Error getting activity trends:", error);
-                return {
-                    success: false,
-                    error:
-                        error instanceof Error
-                            ? error.message
-                            : "Unknown error",
-                    trends: { trends: [], summary: {} },
-                };
-            }
-        }
-
         case "getSearchSuggestions": {
             return await handleGetSearchSuggestions(message);
         }
@@ -526,31 +467,6 @@ export async function handleMessage(
                     totalRelationships: 0,
                     lastIndexed: "Error",
                     indexSize: "Unknown",
-                };
-            }
-        }
-
-        case "getKnowledgeStats": {
-            try {
-                const result = await sendActionToAgent({
-                    actionName: "getKnowledgeStats", 
-                    parameters: {
-                        includeQuality: true,
-                        includeProgress: true,
-                        timeRange: message.timeRange || 30,
-                    },
-                });
-
-                return {
-                    success: !result.error,
-                    stats: result,
-                    error: result.error,
-                };
-            } catch (error) {
-                console.error("Error getting knowledge stats:", error);
-                return {
-                    success: false,
-                    error: error instanceof Error ? error.message : "Unknown error",
                 };
             }
         }

--- a/ts/packages/agents/browser/src/extension/views/knowledgeLibrary.css
+++ b/ts/packages/agents/browser/src/extension/views/knowledgeLibrary.css
@@ -693,6 +693,63 @@ body {
   line-height: 1.6;
 }
 
+/* Related Entities */
+.entities-section {
+  background: linear-gradient(135deg, #f0f8f0 0%, #e8f5e8 100%);
+  border-left: 4px solid #28a745;
+  padding: var(--spacing-lg);
+  margin: var(--spacing-lg);
+  border-radius: var(--border-radius-sm);
+}
+
+.entities-header {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  font-weight: 600;
+  color: #28a745;
+  margin-bottom: var(--spacing-sm);
+}
+
+.entities-content {
+  color: var(--text-primary);
+}
+
+.entity-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-sm);
+}
+
+.entity-tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  background: rgba(40, 167, 69, 0.1);
+  color: #28a745;
+  padding: 4px 8px;
+  border-radius: var(--border-radius-sm);
+  font-size: 0.85rem;
+  font-weight: 500;
+  border: 1px solid rgba(40, 167, 69, 0.2);
+  transition: all 0.2s ease;
+}
+
+.entity-tag:hover {
+  background: rgba(40, 167, 69, 0.15);
+  border-color: rgba(40, 167, 69, 0.3);
+  transform: translateY(-1px);
+}
+
+.entity-count {
+  background: rgba(40, 167, 69, 0.8);
+  color: white;
+  padding: 1px 5px;
+  border-radius: 8px;
+  font-size: 0.75rem;
+  margin-left: 2px;
+}
+
 /* Results Container */
 .results-container {
   padding: var(--spacing-lg);

--- a/ts/packages/agents/browser/src/extension/views/knowledgeLibrary.html
+++ b/ts/packages/agents/browser/src/extension/views/knowledgeLibrary.html
@@ -234,6 +234,15 @@
               <div id="summaryContent" class="summary-content"></div>
             </div>
 
+            <!-- Related Entities -->
+            <div id="entitiesSection" class="entities-section" style="display: none">
+              <div class="entities-header">
+                <i class="bi bi-diagram-2"></i>
+                <span>Related Entities</span>
+              </div>
+              <div id="entitiesContent" class="entities-content"></div>
+            </div>
+
             <!-- Results Container -->
             <div id="resultsContainer" class="results-container"></div>
 

--- a/ts/packages/agents/browser/src/extension/views/knowledgeLibrary.html
+++ b/ts/packages/agents/browser/src/extension/views/knowledgeLibrary.html
@@ -235,7 +235,11 @@
             </div>
 
             <!-- Related Entities -->
-            <div id="entitiesSection" class="entities-section" style="display: none">
+            <div
+              id="entitiesSection"
+              class="entities-section"
+              style="display: none"
+            >
               <div class="entities-header">
                 <i class="bi bi-diagram-2"></i>
                 <span>Related Entities</span>

--- a/ts/packages/agents/browser/src/extension/views/knowledgeLibrary.ts
+++ b/ts/packages/agents/browser/src/extension/views/knowledgeLibrary.ts
@@ -16,14 +16,14 @@ import {
     ImportProgress,
     ImportResult,
 } from "../interfaces/websiteImport.types";
-import { 
-    notificationManager, 
-    chromeExtensionService, 
-    TemplateHelpers, 
+import {
+    notificationManager,
+    chromeExtensionService,
+    TemplateHelpers,
     FormatUtils,
     EventManager,
-    ConnectionManager
-} from './knowledgeUtilities';
+    ConnectionManager,
+} from "./knowledgeUtilities";
 
 interface FullPageNavigation {
     currentPage: "search" | "discover" | "analytics";
@@ -205,7 +205,7 @@ class WebsiteLibraryPanelFullPage {
     private searchDebounceTimer: number | null = null;
     private recentSearches: string[] = [];
     private currentQuery: string = "";
-    
+
     // Data storage
     private libraryStats: LibraryStats = {
         totalWebsites: 0,
@@ -369,13 +369,11 @@ class WebsiteLibraryPanelFullPage {
         });
 
         // Listen for progress messages from service worker
-        EventManager.setupMessageListener(
-            (message, sender, sendResponse) => {
-                if (message.type === "importProgress") {
-                    this.handleImportProgressMessage(message);
-                }
-            },
-        );
+        EventManager.setupMessageListener((message, sender, sendResponse) => {
+            if (message.type === "importProgress") {
+                this.handleImportProgressMessage(message);
+            }
+        });
 
         // Setup import UI callbacks
         this.importUI.onProgressUpdate((progress: ImportProgress) => {
@@ -398,7 +396,8 @@ class WebsiteLibraryPanelFullPage {
 
     private async checkConnectionStatus(): Promise<boolean> {
         try {
-            const response = await chromeExtensionService.checkWebSocketConnection();
+            const response =
+                await chromeExtensionService.checkWebSocketConnection();
             this.isConnected = response?.connected === true;
             return this.isConnected;
         } catch (error) {
@@ -636,14 +635,18 @@ class WebsiteLibraryPanelFullPage {
 
         // Listen for knowledge extraction events to invalidate cache
         EventManager.setupMessageListener((message, sender, sendResponse) => {
-            if (message.type === "knowledgeExtracted" || 
+            if (
+                message.type === "knowledgeExtracted" ||
                 message.type === "importComplete" ||
-                message.type === "contentIndexed") {
+                message.type === "contentIndexed"
+            ) {
                 // Reload analytics data when new knowledge is extracted
                 if (this.navigation.currentPage === "analytics") {
-                    this.loadAnalyticsData().then(() => {
-                        return this.renderAnalyticsContent();
-                    }).catch(console.error);
+                    this.loadAnalyticsData()
+                        .then(() => {
+                            return this.renderAnalyticsContent();
+                        })
+                        .catch(console.error);
                 }
             }
         });
@@ -730,16 +733,28 @@ class WebsiteLibraryPanelFullPage {
         try {
             // Check cache first for improved performance
             const filters: SearchFilters = {};
-            
-            const dateFrom = (document.getElementById("dateFrom") as HTMLInputElement)?.value;
-            const dateTo = (document.getElementById("dateTo") as HTMLInputElement)?.value;
-            const sourceType = (document.getElementById("sourceFilter") as HTMLSelectElement)?.value;
-            const domain = (document.getElementById("domainFilter") as HTMLInputElement)?.value;
-            const minRelevance = parseInt((document.getElementById("relevanceFilter") as HTMLInputElement)?.value || "0");
+
+            const dateFrom = (
+                document.getElementById("dateFrom") as HTMLInputElement
+            )?.value;
+            const dateTo = (
+                document.getElementById("dateTo") as HTMLInputElement
+            )?.value;
+            const sourceType = (
+                document.getElementById("sourceFilter") as HTMLSelectElement
+            )?.value;
+            const domain = (
+                document.getElementById("domainFilter") as HTMLInputElement
+            )?.value;
+            const minRelevance = parseInt(
+                (document.getElementById("relevanceFilter") as HTMLInputElement)
+                    ?.value || "0",
+            );
 
             if (dateFrom) filters.dateFrom = dateFrom;
             if (dateTo) filters.dateTo = dateTo;
-            if (sourceType) filters.sourceType = sourceType as "bookmarks" | "history";
+            if (sourceType)
+                filters.sourceType = sourceType as "bookmarks" | "history";
             if (domain) filters.domain = domain;
             if (minRelevance > 0) filters.minRelevance = minRelevance;
 
@@ -1260,21 +1275,25 @@ class WebsiteLibraryPanelFullPage {
         if (entitiesSection && entitiesContent && entities.length > 0) {
             // Sort entities by count descending
             const sortedEntities = entities.sort((a, b) => b.count - a.count);
-            
+
             // Create entity tags HTML
-            const entityTagsHtml = sortedEntities.map(entity => `
-                <div class="entity-tag" title="${entity.type}: found ${entity.count} time${entity.count !== 1 ? 's' : ''}">
+            const entityTagsHtml = sortedEntities
+                .map(
+                    (entity) => `
+                <div class="entity-tag" title="${entity.type}: found ${entity.count} time${entity.count !== 1 ? "s" : ""}">
                     <span>${entity.entity}</span>
                     <span class="entity-count">${entity.count}</span>
                 </div>
-            `).join('');
+            `,
+                )
+                .join("");
 
             entitiesContent.innerHTML = `
                 <div class="entity-tags">
                     ${entityTagsHtml}
                 </div>
             `;
-            
+
             entitiesSection.style.display = "block";
         } else if (entitiesSection) {
             entitiesSection.style.display = "none";
@@ -1450,11 +1469,10 @@ class WebsiteLibraryPanelFullPage {
         }
 
         try {
-            const response =
-                await chromeExtensionService.getDiscoverInsights(
-                    10,
-                    "30d",
-                );
+            const response = await chromeExtensionService.getDiscoverInsights(
+                10,
+                "30d",
+            );
 
             if (response.success) {
                 this.discoverData = {
@@ -1653,29 +1671,36 @@ class WebsiteLibraryPanelFullPage {
 
         try {
             // Single call to get all analytics data
-            const analyticsResponse = await chromeExtensionService.getAnalyticsData({
-                timeRange: "30d",
-                includeQuality: true,
-                includeProgress: true,
-                topDomainsLimit: 10,
-                activityGranularity: "day"
-            });
+            const analyticsResponse =
+                await chromeExtensionService.getAnalyticsData({
+                    timeRange: "30d",
+                    includeQuality: true,
+                    includeProgress: true,
+                    topDomainsLimit: 10,
+                    activityGranularity: "day",
+                });
 
             if (analyticsResponse.success) {
                 // Transform to internal format
                 this.analyticsData = {
                     overview: analyticsResponse.analytics.overview,
                     trends: analyticsResponse.analytics.activity.trends,
-                    insights: this.transformKnowledgeInsights(analyticsResponse.analytics.knowledge),
+                    insights: this.transformKnowledgeInsights(
+                        analyticsResponse.analytics.knowledge,
+                    ),
                     domains: analyticsResponse.analytics.domains,
                     knowledge: analyticsResponse.analytics.knowledge,
-                    activity: analyticsResponse.analytics.activity
+                    activity: analyticsResponse.analytics.activity,
                 };
 
                 // Cache for knowledge visualization
-                this.updateKnowledgeVisualizationData(analyticsResponse.analytics.knowledge);
+                this.updateKnowledgeVisualizationData(
+                    analyticsResponse.analytics.knowledge,
+                );
             } else {
-                throw new Error(analyticsResponse.error || "Failed to get analytics data");
+                throw new Error(
+                    analyticsResponse.error || "Failed to get analytics data",
+                );
             }
         } catch (error) {
             console.error("Failed to load analytics data:", error);
@@ -1712,7 +1737,7 @@ class WebsiteLibraryPanelFullPage {
                 change: 0,
             },
             {
-                category: "Relationships", 
+                category: "Relationships",
                 value: knowledge.totalRelationships || 0,
                 change: 0,
             },
@@ -1769,14 +1794,17 @@ class WebsiteLibraryPanelFullPage {
 
     private calculateKnowledgeQualityFromData(knowledge: any): number {
         if (!knowledge || !knowledge.qualityDistribution) return 0;
-        
-        const { highQuality, mediumQuality, lowQuality } = knowledge.qualityDistribution;
+
+        const { highQuality, mediumQuality, lowQuality } =
+            knowledge.qualityDistribution;
         const total = highQuality + mediumQuality + lowQuality;
-        
+
         if (total === 0) return 0;
-        
+
         // Weighted score: high=100%, medium=60%, low=20%
-        return Math.round(((highQuality * 100) + (mediumQuality * 60) + (lowQuality * 20)) / total);
+        return Math.round(
+            (highQuality * 100 + mediumQuality * 60 + lowQuality * 20) / total,
+        );
     }
 
     private updateKnowledgeVisualizationData(knowledge: any) {
@@ -1936,7 +1964,8 @@ class WebsiteLibraryPanelFullPage {
 
     private async loadRecentKnowledgeItems(knowledge: any) {
         try {
-            const response = await chromeExtensionService.getRecentKnowledgeItems(10);
+            const response =
+                await chromeExtensionService.getRecentKnowledgeItems(10);
 
             if (response && response.success) {
                 this.updateRecentEntitiesDisplay(response.entities || []);
@@ -1949,7 +1978,6 @@ class WebsiteLibraryPanelFullPage {
                 this.updateRecentEntitiesDisplay([]);
                 this.updateRecentTopicsDisplay([]);
             }
-        
         } catch (error) {
             console.error("Failed to load recent knowledge items:", error);
             // Update with empty arrays to show appropriate "no data" messages
@@ -2120,8 +2148,8 @@ class WebsiteLibraryPanelFullPage {
                         </div>
                     </div>
                 `,
-                )
-                .join("");
+            )
+            .join("");
 
         container.innerHTML = domainsHtml;
     }
@@ -2374,22 +2402,15 @@ class WebsiteLibraryPanelFullPage {
         const chartBars = recentTrends
             .map((trend: any) => {
                 const totalActivity = trend.visits + trend.bookmarks;
-                const date = new Date(trend.date).toLocaleDateString(
-                    "en-US",
-                    {
-                        month: "short",
-                        day: "numeric",
-                    },
-                );
+                const date = new Date(trend.date).toLocaleDateString("en-US", {
+                    month: "short",
+                    day: "numeric",
+                });
 
                 const visitsHeight =
-                    maxActivity > 0
-                        ? (trend.visits / maxActivity) * 100
-                        : 0;
+                    maxActivity > 0 ? (trend.visits / maxActivity) * 100 : 0;
                 const bookmarksHeight =
-                    maxActivity > 0
-                        ? (trend.bookmarks / maxActivity) * 100
-                        : 0;
+                    maxActivity > 0 ? (trend.bookmarks / maxActivity) * 100 : 0;
 
                 return `
                     <div class="chart-bar" title="${date}: ${totalActivity} activities">
@@ -2541,9 +2562,7 @@ class WebsiteLibraryPanelFullPage {
 
             if (this.isConnected) {
                 const suggestionTexts =
-                    await chromeExtensionService.getSearchSuggestions(
-                        query,
-                    );
+                    await chromeExtensionService.getSearchSuggestions(query);
                 suggestions = suggestionTexts.map((text) => ({
                     text,
                     type: "auto" as const,
@@ -3014,7 +3033,6 @@ interface UserPreferences {
     enableNotifications: boolean;
     theme: "light" | "dark" | "auto";
 }
-
 
 // ===================================================================
 // INITIALIZATION

--- a/ts/packages/agents/browser/src/extension/views/knowledgeLibrary.ts
+++ b/ts/packages/agents/browser/src/extension/views/knowledgeLibrary.ts
@@ -904,6 +904,16 @@ class WebsiteLibraryPanelFullPage {
             emptyState.style.display = "none";
         }
 
+        // Hide AI summary and entities sections
+        const aiSummary = document.getElementById("aiSummary");
+        const entitiesSection = document.getElementById("entitiesSection");
+        if (aiSummary) {
+            aiSummary.style.display = "none";
+        }
+        if (entitiesSection) {
+            entitiesSection.style.display = "none";
+        }
+
         // Show loading state (create if it doesn't exist)
         if (!loadingState) {
             this.createSearchLoadingState();
@@ -982,6 +992,11 @@ class WebsiteLibraryPanelFullPage {
         // Show AI summary if available
         if (results.summary.text) {
             this.showAISummary(results.summary.text);
+        }
+
+        // Show related entities if available
+        if (results.summary.entities && results.summary.entities.length > 0) {
+            this.showEntities(results.summary.entities);
         }
     }
 
@@ -1281,6 +1296,34 @@ class WebsiteLibraryPanelFullPage {
         }
     }
 
+    private showEntities(entities: EntityMatch[]) {
+        const entitiesSection = document.getElementById("entitiesSection");
+        const entitiesContent = document.getElementById("entitiesContent");
+
+        if (entitiesSection && entitiesContent && entities.length > 0) {
+            // Sort entities by count descending
+            const sortedEntities = entities.sort((a, b) => b.count - a.count);
+            
+            // Create entity tags HTML
+            const entityTagsHtml = sortedEntities.map(entity => `
+                <div class="entity-tag" title="${entity.type}: found ${entity.count} time${entity.count !== 1 ? 's' : ''}">
+                    <span>${entity.entity}</span>
+                    <span class="entity-count">${entity.count}</span>
+                </div>
+            `).join('');
+
+            entitiesContent.innerHTML = `
+                <div class="entity-tags">
+                    ${entityTagsHtml}
+                </div>
+            `;
+            
+            entitiesSection.style.display = "block";
+        } else if (entitiesSection) {
+            entitiesSection.style.display = "none";
+        }
+    }
+
     private showSearchError(message: string) {
         const resultsContainer = document.getElementById("searchResults");
         const emptyState = document.getElementById("searchEmptyState");
@@ -1294,6 +1337,16 @@ class WebsiteLibraryPanelFullPage {
         // Hide empty state
         if (emptyState) {
             emptyState.style.display = "none";
+        }
+
+        // Hide AI summary and entities sections
+        const aiSummary = document.getElementById("aiSummary");
+        const entitiesSection = document.getElementById("entitiesSection");
+        if (aiSummary) {
+            aiSummary.style.display = "none";
+        }
+        if (entitiesSection) {
+            entitiesSection.style.display = "none";
         }
 
         // Show error in results container without destroying its structure

--- a/ts/packages/agents/browser/src/extension/views/knowledgeLibrary.ts
+++ b/ts/packages/agents/browser/src/extension/views/knowledgeLibrary.ts
@@ -2343,133 +2343,104 @@ class WebsiteLibraryPanelFullPage {
 
     private async renderActivityCharts() {
         const container = document.getElementById("activityCharts");
-        if (!container) return;
+        if (!container || !this.analyticsData?.activity) return;
 
-        try {
-            // Show loading state
+        // Use cached activity data instead of making API call
+        const activityData = this.analyticsData.activity;
+
+        if (!activityData.trends || activityData.trends.length === 0) {
             container.innerHTML = `
                 <div class="card">
                     <div class="card-body">
                         <h6 class="card-title">Activity Trends</h6>
-                        <div class="loading-message">
-                            <i class="bi bi-hourglass-split"></i>
-                            <span>Loading activity trends...</span>
+                        <div class="empty-message">
+                            <i class="bi bi-bar-chart"></i>
+                            <span>No activity data available</span>
+                            <small>Import bookmarks or browse websites to see trends</small>
                         </div>
                     </div>
                 </div>
             `;
+            return;
+        }
 
-            // Fetch activity trends data
-            const trendsData =
-                await chromeExtensionService.getActivityTrends("30d");
+        // Create bar chart visualization
+        const trends = activityData.trends;
+        const maxActivity = Math.max(
+            ...trends.map((t: any) => t.visits + t.bookmarks),
+        );
+        const recentTrends = trends.slice(-14); // Show last 14 data points
 
-            if (!trendsData.trends || trendsData.trends.length === 0) {
-                container.innerHTML = `
-                    <div class="card">
-                        <div class="card-body">
-                            <h6 class="card-title">Activity Trends</h6>
-                            <div class="empty-message">
-                                <i class="bi bi-bar-chart"></i>
-                                <span>No activity data available</span>
-                                <small>Import bookmarks or browse websites to see trends</small>
-                            </div>
-                        </div>
+        const chartBars = recentTrends
+            .map((trend: any) => {
+                const totalActivity = trend.visits + trend.bookmarks;
+                const date = new Date(trend.date).toLocaleDateString(
+                    "en-US",
+                    {
+                        month: "short",
+                        day: "numeric",
+                    },
+                );
+
+                const visitsHeight =
+                    maxActivity > 0
+                        ? (trend.visits / maxActivity) * 100
+                        : 0;
+                const bookmarksHeight =
+                    maxActivity > 0
+                        ? (trend.bookmarks / maxActivity) * 100
+                        : 0;
+
+                return `
+                    <div class="chart-bar" title="${date}: ${totalActivity} activities">
+                        <div class="bar-segment visits" style="height: ${visitsHeight}%" title="Visits: ${trend.visits}"></div>
+                        <div class="bar-segment bookmarks" style="height: ${bookmarksHeight}%" title="Bookmarks: ${trend.bookmarks}"></div>
+                        <div class="bar-label">${date}</div>
                     </div>
                 `;
-                return;
-            }
+            })
+            .join("");
 
-            // Create bar chart visualization
-            const trends = trendsData.trends;
-            const maxActivity = Math.max(
-                ...trends.map((t: any) => t.visits + t.bookmarks),
-            );
-            const recentTrends = trends.slice(-14); // Show last 14 data points
+        const summary = activityData.summary || {};
 
-            const chartBars = recentTrends
-                .map((trend: any) => {
-                    const totalActivity = trend.visits + trend.bookmarks;
-                    const date = new Date(trend.date).toLocaleDateString(
-                        "en-US",
-                        {
-                            month: "short",
-                            day: "numeric",
-                        },
-                    );
-
-                    const visitsHeight =
-                        maxActivity > 0
-                            ? (trend.visits / maxActivity) * 100
-                            : 0;
-                    const bookmarksHeight =
-                        maxActivity > 0
-                            ? (trend.bookmarks / maxActivity) * 100
-                            : 0;
-
-                    return `
-                        <div class="chart-bar" title="${date}: ${totalActivity} activities">
-                            <div class="bar-segment visits" style="height: ${visitsHeight}%" title="Visits: ${trend.visits}"></div>
-                            <div class="bar-segment bookmarks" style="height: ${bookmarksHeight}%" title="Bookmarks: ${trend.bookmarks}"></div>
-                            <div class="bar-label">${date}</div>
+        container.innerHTML = `
+            <div class="card">
+                <div class="card-body">
+                    <h6 class="card-title">Activity Trends</h6>
+                    
+                    <div class="activity-summary mb-3">
+                        <div class="summary-stat">
+                            <span class="stat-label">Total Activity</span>
+                            <span class="stat-value">${summary.totalActivity || 0}</span>
                         </div>
-                    `;
-                })
-                .join("");
-
-            const summary = trendsData.summary || {};
-
-            container.innerHTML = `
-                <div class="card">
-                    <div class="card-body">
-                        <h6 class="card-title">Activity Trends</h6>
-                        
-                        <div class="activity-summary mb-3">
-                            <div class="summary-stat">
-                                <span class="stat-label">Total Activity</span>
-                                <span class="stat-value">${summary.totalActivity || 0}</span>
-                            </div>
-                            <div class="summary-stat">
-                                <span class="stat-label">Daily Average</span>
-                                <span class="stat-value">${Math.round(summary.averagePerDay || 0)}</span>
-                            </div>
-                            <div class="summary-stat">
-                                <span class="stat-label">Peak Day</span>
-                                <span class="stat-value">${summary.peakDay ? new Date(summary.peakDay).toLocaleDateString("en-US", { month: "short", day: "numeric" }) : "N/A"}</span>
-                            </div>
+                        <div class="summary-stat">
+                            <span class="stat-label">Daily Average</span>
+                            <span class="stat-value">${Math.round(summary.averagePerDay || 0)}</span>
                         </div>
-                        
-                        <div class="activity-chart">
-                            <div class="chart-container">
-                                ${chartBars}
+                        <div class="summary-stat">
+                            <span class="stat-label">Peak Day</span>
+                            <span class="stat-value">${summary.peakDay ? new Date(summary.peakDay).toLocaleDateString("en-US", { month: "short", day: "numeric" }) : "N/A"}</span>
+                        </div>
+                    </div>
+                    
+                    <div class="activity-chart">
+                        <div class="chart-container">
+                            ${chartBars}
+                        </div>
+                        <div class="chart-legend">
+                            <div class="legend-item">
+                                <div class="legend-color visits"></div>
+                                <span>Visits</span>
                             </div>
-                            <div class="chart-legend">
-                                <div class="legend-item">
-                                    <div class="legend-color visits"></div>
-                                    <span>Visits</span>
-                                </div>
-                                <div class="legend-item">
-                                    <div class="legend-color bookmarks"></div>
-                                    <span>Bookmarks</span>
-                                </div>
+                            <div class="legend-item">
+                                <div class="legend-color bookmarks"></div>
+                                <span>Bookmarks</span>
                             </div>
                         </div>
                     </div>
                 </div>
-            `;
-        } catch (error) {
-            console.error("Failed to render activity charts:", error);
-            container.innerHTML = `
-                <div class="card">
-                    <div class="card-body">
-                        <h6 class="card-title">Activity Trends</h6>
-                        <div class="error-message">
-                            <i class="bi bi-exclamation-triangle"></i>
-                            <span>Failed to load activity data</span>
-                        </div>
-                    </div>
-                </div>
-            `;
-        }
+            </div>
+        `;
     }
 
     private renderKnowledgeBadges(knowledge?: KnowledgeStatus): string {

--- a/ts/packages/agents/browser/src/extension/views/knowledgeUtilities.ts
+++ b/ts/packages/agents/browser/src/extension/views/knowledgeUtilities.ts
@@ -228,13 +228,6 @@ export class ChromeExtensionService {
         });
     }
 
-    async getKnowledgeStats(timeRange?: number): Promise<any> {
-        return this.sendMessage({
-            type: "getKnowledgeStats",
-            timeRange: timeRange || 30,
-        });
-    }
-
     async getAnalyticsData(options?: {
         timeRange?: string;
         includeQuality?: boolean;
@@ -494,20 +487,6 @@ export class ChromeExtensionService {
     async getRecentSearches(): Promise<string[]> {
         return this.sendMessage({
             action: "getRecentSearches",
-        });
-    }
-
-    async getTopDomains(limit: number = 10): Promise<any> {
-        return this.sendMessage({
-            type: "getTopDomains",
-            limit,
-        });
-    }
-
-    async getActivityTrends(timeRange: string = "30d"): Promise<any> {
-        return this.sendMessage({
-            type: "getActivityTrends",
-            timeRange,
         });
     }
 

--- a/ts/packages/agents/browser/src/extension/views/knowledgeUtilities.ts
+++ b/ts/packages/agents/browser/src/extension/views/knowledgeUtilities.ts
@@ -439,6 +439,76 @@ export class ChromeExtensionService {
         });
     }
 
+    async getRecentKnowledgeItems(limit: number = 10): Promise<any> {
+        return this.sendMessage({
+            type: "getRecentKnowledgeItems",
+            limit,
+        });
+    }
+
+    async extractKnowledge(url: string): Promise<any> {
+        return this.sendMessage({
+            type: "extractKnowledge",
+            url,
+        });
+    }
+
+    async checkKnowledgeStatus(url: string): Promise<any> {
+        return this.sendMessage({
+            action: "checkKnowledgeStatus",
+            url,
+        });
+    }
+
+    async getSearchSuggestions(query: string): Promise<string[]> {
+        return this.sendMessage({
+            type: "getSearchSuggestions",
+            query,
+        });
+    }
+
+    async getRecentSearches(): Promise<string[]> {
+        return this.sendMessage({
+            action: "getRecentSearches",
+        });
+    }
+
+    async getTopDomains(limit: number = 10): Promise<any> {
+        return this.sendMessage({
+            type: "getTopDomains",
+            limit,
+        });
+    }
+
+    async getActivityTrends(timeRange: string = "30d"): Promise<any> {
+        return this.sendMessage({
+            type: "getActivityTrends",
+            timeRange,
+        });
+    }
+
+    async getDiscoverInsights(limit: number = 10, timeframe: string = "30d"): Promise<any> {
+        return this.sendMessage({
+            type: "getDiscoverInsights",
+            limit,
+            timeframe,
+        });
+    }
+
+    async saveSearch(query: string, results: any): Promise<void> {
+        return this.sendMessage({
+            type: "saveSearch",
+            query,
+            results,
+        });
+    }
+
+    async checkWebSocketConnection(): Promise<any> {
+        return this.sendMessage({
+            type: "checkWebSocketConnection",
+        });
+    }
+
     private async sendMessage<T>(message: any): Promise<T> {
         if (typeof chrome !== "undefined" && chrome.runtime) {
             try {
@@ -551,6 +621,15 @@ export class KnowledgeTemplateHelpers {
 
         return this.createAlert("info", "bi bi-lightbulb", content);
     }
+
+    static createEmptyState(icon: string, message: string): string {
+        return `
+            <div class="text-muted text-center">
+                <i class="${icon}"></i>
+                ${message}
+            </div>
+        `;
+    }
 }
 
 export class KnowledgeConnectionManager {
@@ -605,6 +684,14 @@ export class ChromeEventManager {
             });
         } catch (error) {
             console.error("Failed to setup tab listeners:", error);
+        }
+    }
+
+    static setupMessageListener(callback: (message: any, sender: any, sendResponse: any) => void): void {
+        try {
+            chrome.runtime.onMessage.addListener(callback);
+        } catch (error) {
+            console.error("Failed to setup message listener:", error);
         }
     }
 }

--- a/ts/packages/agents/browser/src/extension/views/knowledgeUtilities.ts
+++ b/ts/packages/agents/browser/src/extension/views/knowledgeUtilities.ts
@@ -228,6 +228,13 @@ export class ChromeExtensionService {
         });
     }
 
+    async getKnowledgeStats(timeRange?: number): Promise<any> {
+        return this.sendMessage({
+            type: "getKnowledgeStats",
+            timeRange: timeRange || 30,
+        });
+    }
+
     async searchWebMemories(query: string, filters: SearchFilters): Promise<SearchResult> {
         return this.sendMessage({
             type: "searchWebMemories",

--- a/ts/packages/agents/browser/src/extension/views/knowledgeUtilities.ts
+++ b/ts/packages/agents/browser/src/extension/views/knowledgeUtilities.ts
@@ -235,6 +235,23 @@ export class ChromeExtensionService {
         });
     }
 
+    async getAnalyticsData(options?: {
+        timeRange?: string;
+        includeQuality?: boolean;
+        includeProgress?: boolean;
+        topDomainsLimit?: number;
+        activityGranularity?: 'day' | 'week' | 'month';
+    }): Promise<any> {
+        return this.sendMessage({
+            type: "getAnalyticsData",
+            timeRange: options?.timeRange || "30d",
+            includeQuality: options?.includeQuality !== false,
+            includeProgress: options?.includeProgress !== false,
+            topDomainsLimit: options?.topDomainsLimit || 10,
+            activityGranularity: options?.activityGranularity || "day"
+        });
+    }
+
     async searchWebMemories(query: string, filters: SearchFilters): Promise<SearchResult> {
         return this.sendMessage({
             type: "searchWebMemories",

--- a/ts/packages/agents/browser/src/extension/views/knowledgeUtilities.ts
+++ b/ts/packages/agents/browser/src/extension/views/knowledgeUtilities.ts
@@ -1,0 +1,624 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+/**
+ * Shared utilities for knowledge extraction features
+ * Consolidates common functionality from knowledgeLibrary.ts and pageKnowledge.ts
+ */
+
+// ===================================================================
+// INTERFACES AND TYPES
+// ===================================================================
+
+export interface NotificationAction {
+    label: string;
+    action: () => void;
+    style?: "primary" | "secondary" | "success" | "danger";
+}
+
+export interface LibraryStats {
+    totalWebsites: number;
+    totalBookmarks: number;
+    totalHistory: number;
+    topDomains: number;
+    lastImport?: number;
+}
+
+export interface SearchFilters {
+    dateFrom?: string;
+    dateTo?: string;
+    sourceType?: "bookmarks" | "history";
+    domain?: string;
+    minRelevance?: number;
+}
+
+export interface KnowledgeStatus {
+    hasKnowledge: boolean;
+    extractionDate?: string;
+    entityCount?: number;
+    topicCount?: number;
+    suggestionCount?: number;
+    status: "extracted" | "pending" | "error" | "none" | "extracting";
+    confidence?: number;
+}
+
+export interface SearchResult {
+    websites: Website[];
+    summary: {
+        text: string;
+        totalFound: number;
+        searchTime: number;
+        sources: SourceReference[];
+        entities: EntityMatch[];
+    };
+    query: string;
+    filters: SearchFilters;
+}
+
+export interface Website {
+    url: string;
+    title: string;
+    domain: string;
+    visitCount?: number;
+    lastVisited?: string;
+    source: "bookmarks" | "history";
+    score?: number;
+    snippet?: string;
+    knowledge?: KnowledgeStatus;
+}
+
+export interface SourceReference {
+    url: string;
+    title: string;
+    relevance: number;
+}
+
+export interface EntityMatch {
+    entity: string;
+    type: string;
+    count: number;
+}
+
+// ===================================================================
+// NOTIFICATION MANAGER
+// ===================================================================
+
+export class NotificationManager {
+    private notifications: Map<string, HTMLElement> = new Map();
+    private notificationCounter = 0;
+
+    showSuccess(message: string, actions?: NotificationAction[]): void {
+        this.showNotification("success", message, actions);
+    }
+
+    showError(message: string, retry?: () => void): void {
+        const actions = retry
+            ? [{ label: "Retry", action: retry, style: "primary" as const }]
+            : undefined;
+        this.showNotification("danger", message, actions);
+    }
+
+    showWarning(message: string): void {
+        this.showNotification("warning", message);
+    }
+
+    showInfo(message: string): void {
+        this.showNotification("info", message);
+    }
+
+    showProgress(message: string, progress?: number): void {
+        this.showNotification("info", message, undefined, progress);
+    }
+
+    showEnhancedNotification(
+        type: "success" | "danger" | "info" | "warning",
+        title: string,
+        message: string,
+        icon: string = "bi-info-circle"
+    ): void {
+        const notification = document.createElement("div");
+        notification.className = `alert alert-${type} alert-dismissible fade show position-fixed`;
+        notification.style.cssText = `
+            top: 20px; 
+            right: 20px; 
+            z-index: 9999; 
+            min-width: 350px; 
+            max-width: 400px;
+            box-shadow: 0 4px 12px rgba(0,0,0,0.15);
+            border: none;
+            border-radius: 8px;
+        `;
+
+        notification.innerHTML = `
+            <div class="d-flex align-items-start">
+                <i class="${icon} me-3 mt-1" style="font-size: 1.2rem;"></i>
+                <div class="flex-grow-1">
+                    <div class="fw-bold mb-1">${title}</div>
+                    <div class="small">${message}</div>
+                </div>
+                <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+            </div>
+        `;
+
+        document.body.appendChild(notification);
+
+        setTimeout(() => {
+            if (notification.parentNode) {
+                notification.classList.remove("show");
+                setTimeout(() => {
+                    if (notification.parentNode) {
+                        notification.parentNode.removeChild(notification);
+                    }
+                }, 300);
+            }
+        }, 6000);
+    }
+
+    showTemporaryStatus(message: string, type: "success" | "danger" | "info"): void {
+        const alertClass = "alert-" + type;
+        const iconClass =
+            type === "success"
+                ? "bi-check-circle"
+                : type === "danger"
+                  ? "bi-exclamation-triangle"
+                  : "bi-info-circle";
+
+        const statusDiv = document.createElement("div");
+        statusDiv.className = `alert ${alertClass} alert-dismissible fade show position-fixed`;
+        statusDiv.style.cssText = "top: 1rem; right: 1rem; z-index: 1050; min-width: 250px;";
+        statusDiv.innerHTML = `
+            <i class="${iconClass} me-2"></i>
+            ${message}
+            <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
+        `;
+
+        document.body.appendChild(statusDiv);
+
+        setTimeout(() => {
+            if (statusDiv.parentNode) {
+                statusDiv.remove();
+            }
+        }, 3000);
+    }
+
+    hide(id: string): void {
+        const notification = this.notifications.get(id);
+        if (notification) {
+            notification.remove();
+            this.notifications.delete(id);
+        }
+    }
+
+    clear(): void {
+        this.notifications.forEach((notification) => {
+            notification.remove();
+        });
+        this.notifications.clear();
+    }
+
+    private showNotification(
+        type: string,
+        message: string,
+        actions?: NotificationAction[],
+        progress?: number
+    ): string {
+        const id = `notification-${++this.notificationCounter}`;
+        // Simplified implementation for now
+        return id;
+    }
+
+    public handleNotificationAction(id: string, actionLabel: string): void {
+        // Implementation here
+    }
+
+    public hideNotification(id: string): void {
+        this.hide(id);
+    }
+}
+
+// ===================================================================
+// CHROME EXTENSION SERVICE
+// ===================================================================
+
+export class ChromeExtensionService {
+    async getLibraryStats(): Promise<LibraryStats> {
+        return this.sendMessage({
+            type: "getLibraryStats",
+            includeKnowledge: true,
+        });
+    }
+
+    async searchWebMemories(query: string, filters: SearchFilters): Promise<SearchResult> {
+        return this.sendMessage({
+            type: "searchWebMemories",
+            parameters: {
+                query,
+                generateAnswer: true,
+                includeRelatedEntities: true,
+                enableAdvancedSearch: true,
+                limit: 50,
+                minScore: filters.minRelevance || 0.3,
+                domain: filters.domain,
+            },
+        });
+    }
+
+    async getCurrentTab(): Promise<chrome.tabs.Tab | null> {
+        try {
+            const tabs = await chrome.tabs.query({ active: true, currentWindow: true });
+            return tabs.length > 0 ? tabs[0] : null;
+        } catch (error) {
+            console.error("Failed to get current tab:", error);
+            return null;
+        }
+    }
+
+    async getPageIndexStatus(url: string): Promise<any> {
+        return this.sendMessage({
+            type: "getPageIndexStatus",
+            url,
+        });
+    }
+
+    async indexPageContent(url: string, mode: string): Promise<any> {
+        return this.sendMessage({
+            type: "indexPageContentDirect",
+            url,
+            mode,
+        });
+    }
+
+    async extractPageKnowledge(url: string, mode: string, extractionSettings: any): Promise<any> {
+        return this.sendMessage({
+            type: "extractPageKnowledge",
+            url,
+            mode,
+            extractionSettings,
+        });
+    }
+
+    async queryKnowledge(parameters: any): Promise<any> {
+        return this.sendMessage({
+            type: "queryKnowledge",
+            parameters,
+        });
+    }
+
+    async checkConnection(): Promise<any> {
+        return this.sendMessage({
+            type: "checkConnection",
+        });
+    }
+
+    async getAutoIndexSetting(): Promise<boolean> {
+        try {
+            const settings = await chrome.storage.sync.get(["autoIndexing"]);
+            return settings.autoIndexing || false;
+        } catch (error) {
+            console.error("Failed to get auto-index setting:", error);
+            return false;
+        }
+    }
+
+    async setAutoIndexSetting(enabled: boolean): Promise<void> {
+        try {
+            await chrome.storage.sync.set({ autoIndexing: enabled });
+        } catch (error) {
+            console.error("Failed to set auto-index setting:", error);
+            throw error;
+        }
+    }
+
+    async getExtractionSettings(): Promise<any> {
+        try {
+            const settings = await chrome.storage.sync.get(["extractionSettings"]);
+            return settings.extractionSettings || null;
+        } catch (error) {
+            console.error("Failed to get extraction settings:", error);
+            return null;
+        }
+    }
+
+    async saveExtractionSettings(settings: any): Promise<void> {
+        try {
+            await chrome.storage.sync.set({
+                extractionMode: settings.mode,
+                suggestQuestions: settings.suggestQuestions,
+            });
+        } catch (error) {
+            console.error("Failed to save extraction settings:", error);
+            throw error;
+        }
+    }
+
+    async openOptionsPage(): Promise<void> {
+        try {
+            chrome.runtime.openOptionsPage();
+        } catch (error) {
+            console.error("Failed to open options page:", error);
+            throw error;
+        }
+    }
+
+    async createTab(url: string, active: boolean = true): Promise<chrome.tabs.Tab> {
+        try {
+            return await chrome.tabs.create({ url, active });
+        } catch (error) {
+            console.error("Failed to create tab:", error);
+            throw error;
+        }
+    }
+
+    async getIndexStats(): Promise<any> {
+        return this.sendMessage({
+            type: "getIndexStats",
+        });
+    }
+
+    async getPageSourceInfo(url: string): Promise<any> {
+        return this.sendMessage({
+            type: "getPageSourceInfo",
+            url,
+        });
+    }
+
+    async getPageIndexedKnowledge(url: string): Promise<any> {
+        return this.sendMessage({
+            type: "getPageIndexedKnowledge",
+            url,
+        });
+    }
+
+    async discoverRelationships(url: string, knowledge: any, maxResults: number): Promise<any> {
+        return this.sendMessage({
+            type: "discoverRelationships",
+            url,
+            knowledge,
+            maxResults,
+        });
+    }
+
+    async generateTemporalSuggestions(maxSuggestions: number): Promise<any> {
+        return this.sendMessage({
+            type: "generateTemporalSuggestions",
+            maxSuggestions,
+        });
+    }
+
+    async searchByEntities(entities: string[], url: string, maxResults: number): Promise<any> {
+        return this.sendMessage({
+            type: "searchByEntities",
+            entities,
+            url,
+            maxResults,
+        });
+    }
+
+    async searchByTopics(topics: string[], url: string, maxResults: number): Promise<any> {
+        return this.sendMessage({
+            type: "searchByTopics",
+            topics,
+            url,
+            maxResults,
+        });
+    }
+
+    async hybridSearch(query: string, url: string, maxResults: number): Promise<any> {
+        return this.sendMessage({
+            type: "hybridSearch",
+            query,
+            url,
+            maxResults,
+        });
+    }
+
+    async searchWebMemoriesAdvanced(parameters: any): Promise<any> {
+        return this.sendMessage({
+            type: "searchWebMemories",
+            parameters,
+        });
+    }
+
+    async checkAIModelAvailability(): Promise<any> {
+        return this.sendMessage({
+            type: "checkAIModelAvailability",
+        });
+    }
+
+    async getPageQualityMetrics(url: string): Promise<any> {
+        return this.sendMessage({
+            type: "getPageQualityMetrics",
+            url,
+        });
+    }
+
+    async notifyAutoIndexSettingChanged(enabled: boolean): Promise<void> {
+        return this.sendMessage({
+            type: "autoIndexSettingChanged",
+            enabled,
+        });
+    }
+
+    private async sendMessage<T>(message: any): Promise<T> {
+        if (typeof chrome !== "undefined" && chrome.runtime) {
+            try {
+                const response = await chrome.runtime.sendMessage(message);
+                if (response && response.error) {
+                    throw new Error(response.error);
+                }
+                return response;
+            } catch (error) {
+                console.error("Chrome runtime message failed:", error);
+                throw error;
+            }
+        }
+        throw new Error("Chrome extension not available");
+    }
+}
+
+// ===================================================================
+// UTILITIES
+// ===================================================================
+
+export class KnowledgeFormatUtils {
+    static escapeHtml(text: string): string {
+        const div = document.createElement("div");
+        div.textContent = text;
+        return div.innerHTML;
+    }
+
+    static formatDate(dateString: string): string {
+        if (!dateString || dateString === "Never") return "Never";
+        try {
+            const date = new Date(dateString);
+            return date.toLocaleDateString();
+        } catch {
+            return "Unknown";
+        }
+    }
+
+    static extractDomainFromUrl(url: string): string {
+        try {
+            const urlObj = new URL(url);
+            return urlObj.hostname;
+        } catch {
+            return url;
+        }
+    }
+}
+
+export class KnowledgeTemplateHelpers {
+    static createAlert(type: string, icon: string, content: string): string {
+        return `
+            <div class="alert alert-${type} mb-0">
+                <div class="d-flex align-items-start">
+                    <i class="${icon} me-2 mt-1"></i>
+                    <div class="flex-grow-1">${content}</div>
+                </div>
+            </div>
+        `;
+    }
+
+    static createLoadingState(message: string, subtext?: string): string {
+        const subtextHtml = subtext ? `<small class="text-muted">${subtext}</small>` : "";
+        return `
+            <div class="knowledge-card card">
+                <div class="card-body text-center">
+                    <div class="spinner-border text-primary" role="status">
+                        <span class="visually-hidden">Loading...</span>
+                    </div>
+                    <p class="mt-3 mb-0">${message}</p>
+                    ${subtextHtml}
+                </div>
+            </div>
+        `;
+    }
+
+    static createCard(title: string, content: string, icon: string, badge?: string): string {
+        const badgeHtml = badge ? `<span id="${badge}" class="badge bg-secondary ms-2">0</span>` : "";
+        return `
+            <div class="knowledge-card card">
+                <div class="card-header">
+                    <h6 class="mb-0">
+                        <i class="${icon}"></i> ${title}
+                        ${badgeHtml}
+                    </h6>
+                </div>
+                <div class="card-body">${content}</div>
+            </div>
+        `;
+    }
+
+    static createSearchLoadingState(): string {
+        return `
+            <div class="d-flex align-items-center text-muted">
+                <div class="spinner-border spinner-border-sm me-2" role="status"></div>
+                <span>Searching knowledge...</span>
+            </div>
+        `;
+    }
+
+    static createQueryAnswer(answer: string, sources: any[]): string {
+        const sourcesHtml = sources && sources.length > 0
+            ? `<hr class="my-2"><small class="text-muted"><strong>Sources:</strong> ${sources.map((s: any) => s.title).join(", ")}</small>`
+            : "";
+
+        const content = `
+            <div class="fw-semibold">Answer:</div>
+            <p class="mb-2">${answer}</p>
+            ${sourcesHtml}
+        `;
+
+        return this.createAlert("info", "bi bi-lightbulb", content);
+    }
+}
+
+export class KnowledgeConnectionManager {
+    static async checkConnectionStatus(): Promise<boolean> {
+        try {
+            if (typeof chrome === "undefined" || !chrome.runtime) {
+                return false;
+            }
+            const response = await chrome.runtime.sendMessage({
+                type: "checkWebSocketConnection",
+            });
+            return response?.connected === true;
+        } catch (error) {
+            console.error("Connection check failed:", error);
+            return false;
+        }
+    }
+
+    static updateConnectionStatus(isConnected: boolean): void {
+        const statusElement = document.getElementById("connectionStatus");
+        if (statusElement) {
+            const indicator = statusElement.querySelector(".status-indicator");
+            const text = statusElement.querySelector("span:last-child");
+            if (indicator && text) {
+                if (isConnected) {
+                    indicator.className = "status-indicator status-connected";
+                    text.textContent = "Connected";
+                } else {
+                    indicator.className = "status-indicator status-disconnected";
+                    text.textContent = "Disconnected";
+                }
+            }
+        }
+    }
+}
+
+// ===================================================================
+// CHROME EVENT MANAGER
+// ===================================================================
+
+export class ChromeEventManager {
+    static setupTabListeners(onTabChange: () => void): void {
+        try {
+            chrome.tabs.onActivated.addListener(() => {
+                onTabChange();
+            });
+
+            chrome.tabs.onUpdated.addListener((tabId, changeInfo) => {
+                if (changeInfo.status === "complete") {
+                    onTabChange();
+                }
+            });
+        } catch (error) {
+            console.error("Failed to setup tab listeners:", error);
+        }
+    }
+}
+
+// ===================================================================
+// EXPORTS
+// ===================================================================
+
+export const notificationManager = new NotificationManager();
+export const chromeExtensionService = new ChromeExtensionService();
+
+export { 
+    KnowledgeTemplateHelpers as TemplateHelpers,
+    KnowledgeFormatUtils as FormatUtils,
+    KnowledgeConnectionManager as ConnectionManager,
+    ChromeEventManager as EventManager
+};

--- a/ts/packages/agents/browser/src/extension/views/knowledgeUtilities.ts
+++ b/ts/packages/agents/browser/src/extension/views/knowledgeUtilities.ts
@@ -114,7 +114,7 @@ export class NotificationManager {
         type: "success" | "danger" | "info" | "warning",
         title: string,
         message: string,
-        icon: string = "bi-info-circle"
+        icon: string = "bi-info-circle",
     ): void {
         const notification = document.createElement("div");
         notification.className = `alert alert-${type} alert-dismissible fade show position-fixed`;
@@ -154,7 +154,10 @@ export class NotificationManager {
         }, 6000);
     }
 
-    showTemporaryStatus(message: string, type: "success" | "danger" | "info"): void {
+    showTemporaryStatus(
+        message: string,
+        type: "success" | "danger" | "info",
+    ): void {
         const alertClass = "alert-" + type;
         const iconClass =
             type === "success"
@@ -165,7 +168,8 @@ export class NotificationManager {
 
         const statusDiv = document.createElement("div");
         statusDiv.className = `alert ${alertClass} alert-dismissible fade show position-fixed`;
-        statusDiv.style.cssText = "top: 1rem; right: 1rem; z-index: 1050; min-width: 250px;";
+        statusDiv.style.cssText =
+            "top: 1rem; right: 1rem; z-index: 1050; min-width: 250px;";
         statusDiv.innerHTML = `
             <i class="${iconClass} me-2"></i>
             ${message}
@@ -200,7 +204,7 @@ export class NotificationManager {
         type: string,
         message: string,
         actions?: NotificationAction[],
-        progress?: number
+        progress?: number,
     ): string {
         const id = `notification-${++this.notificationCounter}`;
         // Simplified implementation for now
@@ -233,7 +237,7 @@ export class ChromeExtensionService {
         includeQuality?: boolean;
         includeProgress?: boolean;
         topDomainsLimit?: number;
-        activityGranularity?: 'day' | 'week' | 'month';
+        activityGranularity?: "day" | "week" | "month";
     }): Promise<any> {
         return this.sendMessage({
             type: "getAnalyticsData",
@@ -241,11 +245,14 @@ export class ChromeExtensionService {
             includeQuality: options?.includeQuality !== false,
             includeProgress: options?.includeProgress !== false,
             topDomainsLimit: options?.topDomainsLimit || 10,
-            activityGranularity: options?.activityGranularity || "day"
+            activityGranularity: options?.activityGranularity || "day",
         });
     }
 
-    async searchWebMemories(query: string, filters: SearchFilters): Promise<SearchResult> {
+    async searchWebMemories(
+        query: string,
+        filters: SearchFilters,
+    ): Promise<SearchResult> {
         return this.sendMessage({
             type: "searchWebMemories",
             parameters: {
@@ -262,7 +269,10 @@ export class ChromeExtensionService {
 
     async getCurrentTab(): Promise<chrome.tabs.Tab | null> {
         try {
-            const tabs = await chrome.tabs.query({ active: true, currentWindow: true });
+            const tabs = await chrome.tabs.query({
+                active: true,
+                currentWindow: true,
+            });
             return tabs.length > 0 ? tabs[0] : null;
         } catch (error) {
             console.error("Failed to get current tab:", error);
@@ -285,7 +295,11 @@ export class ChromeExtensionService {
         });
     }
 
-    async extractPageKnowledge(url: string, mode: string, extractionSettings: any): Promise<any> {
+    async extractPageKnowledge(
+        url: string,
+        mode: string,
+        extractionSettings: any,
+    ): Promise<any> {
         return this.sendMessage({
             type: "extractPageKnowledge",
             url,
@@ -328,7 +342,9 @@ export class ChromeExtensionService {
 
     async getExtractionSettings(): Promise<any> {
         try {
-            const settings = await chrome.storage.sync.get(["extractionSettings"]);
+            const settings = await chrome.storage.sync.get([
+                "extractionSettings",
+            ]);
             return settings.extractionSettings || null;
         } catch (error) {
             console.error("Failed to get extraction settings:", error);
@@ -357,7 +373,10 @@ export class ChromeExtensionService {
         }
     }
 
-    async createTab(url: string, active: boolean = true): Promise<chrome.tabs.Tab> {
+    async createTab(
+        url: string,
+        active: boolean = true,
+    ): Promise<chrome.tabs.Tab> {
         try {
             return await chrome.tabs.create({ url, active });
         } catch (error) {
@@ -386,7 +405,11 @@ export class ChromeExtensionService {
         });
     }
 
-    async discoverRelationships(url: string, knowledge: any, maxResults: number): Promise<any> {
+    async discoverRelationships(
+        url: string,
+        knowledge: any,
+        maxResults: number,
+    ): Promise<any> {
         return this.sendMessage({
             type: "discoverRelationships",
             url,
@@ -402,7 +425,11 @@ export class ChromeExtensionService {
         });
     }
 
-    async searchByEntities(entities: string[], url: string, maxResults: number): Promise<any> {
+    async searchByEntities(
+        entities: string[],
+        url: string,
+        maxResults: number,
+    ): Promise<any> {
         return this.sendMessage({
             type: "searchByEntities",
             entities,
@@ -411,7 +438,11 @@ export class ChromeExtensionService {
         });
     }
 
-    async searchByTopics(topics: string[], url: string, maxResults: number): Promise<any> {
+    async searchByTopics(
+        topics: string[],
+        url: string,
+        maxResults: number,
+    ): Promise<any> {
         return this.sendMessage({
             type: "searchByTopics",
             topics,
@@ -420,7 +451,11 @@ export class ChromeExtensionService {
         });
     }
 
-    async hybridSearch(query: string, url: string, maxResults: number): Promise<any> {
+    async hybridSearch(
+        query: string,
+        url: string,
+        maxResults: number,
+    ): Promise<any> {
         return this.sendMessage({
             type: "hybridSearch",
             query,
@@ -490,7 +525,10 @@ export class ChromeExtensionService {
         });
     }
 
-    async getDiscoverInsights(limit: number = 10, timeframe: string = "30d"): Promise<any> {
+    async getDiscoverInsights(
+        limit: number = 10,
+        timeframe: string = "30d",
+    ): Promise<any> {
         return this.sendMessage({
             type: "getDiscoverInsights",
             limit,
@@ -573,7 +611,9 @@ export class KnowledgeTemplateHelpers {
     }
 
     static createLoadingState(message: string, subtext?: string): string {
-        const subtextHtml = subtext ? `<small class="text-muted">${subtext}</small>` : "";
+        const subtextHtml = subtext
+            ? `<small class="text-muted">${subtext}</small>`
+            : "";
         return `
             <div class="knowledge-card card">
                 <div class="card-body text-center">
@@ -587,8 +627,15 @@ export class KnowledgeTemplateHelpers {
         `;
     }
 
-    static createCard(title: string, content: string, icon: string, badge?: string): string {
-        const badgeHtml = badge ? `<span id="${badge}" class="badge bg-secondary ms-2">0</span>` : "";
+    static createCard(
+        title: string,
+        content: string,
+        icon: string,
+        badge?: string,
+    ): string {
+        const badgeHtml = badge
+            ? `<span id="${badge}" class="badge bg-secondary ms-2">0</span>`
+            : "";
         return `
             <div class="knowledge-card card">
                 <div class="card-header">
@@ -612,9 +659,10 @@ export class KnowledgeTemplateHelpers {
     }
 
     static createQueryAnswer(answer: string, sources: any[]): string {
-        const sourcesHtml = sources && sources.length > 0
-            ? `<hr class="my-2"><small class="text-muted"><strong>Sources:</strong> ${sources.map((s: any) => s.title).join(", ")}</small>`
-            : "";
+        const sourcesHtml =
+            sources && sources.length > 0
+                ? `<hr class="my-2"><small class="text-muted"><strong>Sources:</strong> ${sources.map((s: any) => s.title).join(", ")}</small>`
+                : "";
 
         const content = `
             <div class="fw-semibold">Answer:</div>
@@ -661,7 +709,8 @@ export class KnowledgeConnectionManager {
                     indicator.className = "status-indicator status-connected";
                     text.textContent = "Connected";
                 } else {
-                    indicator.className = "status-indicator status-disconnected";
+                    indicator.className =
+                        "status-indicator status-disconnected";
                     text.textContent = "Disconnected";
                 }
             }
@@ -690,7 +739,9 @@ export class ChromeEventManager {
         }
     }
 
-    static setupMessageListener(callback: (message: any, sender: any, sendResponse: any) => void): void {
+    static setupMessageListener(
+        callback: (message: any, sender: any, sendResponse: any) => void,
+    ): void {
         try {
             chrome.runtime.onMessage.addListener(callback);
         } catch (error) {
@@ -706,9 +757,9 @@ export class ChromeEventManager {
 export const notificationManager = new NotificationManager();
 export const chromeExtensionService = new ChromeExtensionService();
 
-export { 
+export {
     KnowledgeTemplateHelpers as TemplateHelpers,
     KnowledgeFormatUtils as FormatUtils,
     KnowledgeConnectionManager as ConnectionManager,
-    ChromeEventManager as EventManager
+    ChromeEventManager as EventManager,
 };

--- a/ts/packages/agents/browser/src/extension/views/pageKnowledge.ts
+++ b/ts/packages/agents/browser/src/extension/views/pageKnowledge.ts
@@ -1,13 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { 
-    notificationManager, 
-    chromeExtensionService, 
-    TemplateHelpers, 
+import {
+    notificationManager,
+    chromeExtensionService,
+    TemplateHelpers,
     FormatUtils,
-    EventManager
-} from './knowledgeUtilities';
+    EventManager,
+} from "./knowledgeUtilities";
 
 interface KnowledgeData {
     entities: Entity[];
@@ -246,7 +246,9 @@ class KnowledgePanel {
 
     private async getPageIndexStatus(retryCount: number = 0): Promise<string> {
         try {
-            const response = await chromeExtensionService.getPageIndexStatus(this.currentUrl);
+            const response = await chromeExtensionService.getPageIndexStatus(
+                this.currentUrl,
+            );
 
             if (response.isIndexed) {
                 const lastIndexedDate = response.lastIndexed
@@ -345,7 +347,10 @@ class KnowledgePanel {
             const statusText = enabled
                 ? "Auto-indexing enabled"
                 : "Auto-indexing disabled";
-            notificationManager.showTemporaryStatus(statusText, enabled ? "success" : "info");
+            notificationManager.showTemporaryStatus(
+                statusText,
+                enabled ? "success" : "info",
+            );
 
             // Notify background script
             await chromeExtensionService.notifyAutoIndexSettingChanged(enabled);
@@ -374,10 +379,12 @@ class KnowledgePanel {
             if (this.extractionSettings.mode !== "basic") {
                 // Defensive check: ensure AI availability is properly determined
                 if (this.aiModelAvailable === undefined) {
-                    console.log("AI availability not yet determined, checking now...");
+                    console.log(
+                        "AI availability not yet determined, checking now...",
+                    );
                     await this.checkAIModelAvailability();
                 }
-                
+
                 if (!this.aiModelAvailable) {
                     this.showAIRequiredError();
                     return;
@@ -475,10 +482,12 @@ class KnowledgePanel {
             if (this.extractionSettings.mode !== "basic") {
                 // Defensive check: ensure AI availability is properly determined
                 if (this.aiModelAvailable === undefined) {
-                    console.log("AI availability not yet determined, checking now...");
+                    console.log(
+                        "AI availability not yet determined, checking now...",
+                    );
                     await this.checkAIModelAvailability();
                 }
-                
+
                 if (!this.aiModelAvailable) {
                     this.showAIRequiredError();
                     return;
@@ -504,17 +513,23 @@ class KnowledgePanel {
             let actualEntityCount = 0;
             let attempts = 0;
             const maxAttempts = 10;
-            
+
             while (attempts < maxAttempts) {
-                await new Promise(resolve => setTimeout(resolve, 500));
+                await new Promise((resolve) => setTimeout(resolve, 500));
                 try {
-                    const status = await chromeExtensionService.getPageIndexStatus(this.currentUrl);
+                    const status =
+                        await chromeExtensionService.getPageIndexStatus(
+                            this.currentUrl,
+                        );
                     if (status.isIndexed && status.entityCount !== undefined) {
                         actualEntityCount = status.entityCount;
                         break;
                     }
                 } catch (error) {
-                    console.warn("Error checking index status during entity count polling:", error);
+                    console.warn(
+                        "Error checking index status during entity count polling:",
+                        error,
+                    );
                 }
                 attempts++;
             }
@@ -937,32 +952,35 @@ class KnowledgePanel {
         }
 
         // Add any other categories that didn't fit the main ones
-        Array.from(categoryMap.entries()).forEach(([categoryName, questions]) => {
-            if (
-                ![
-                    "relationship",
-                    "learning",
-                    "technical",
-                    "discovery",
-                    "content",
-                    "temporal",
-                ].includes(categoryName)
-            ) {
-                categories.push({
-                    name:
-                        categoryName.charAt(0).toUpperCase() +
-                        categoryName.slice(1),
-                    icon: "bi-question-circle",
-                    color: "light",
-                    questions: questions.sort(
-                        (a, b) =>
-                            this.getQuestionScore(b) - this.getQuestionScore(a),
-                    ),
-                    priority: 6,
-                    count: questions.length,
-                });
-            }
-        });
+        Array.from(categoryMap.entries()).forEach(
+            ([categoryName, questions]) => {
+                if (
+                    ![
+                        "relationship",
+                        "learning",
+                        "technical",
+                        "discovery",
+                        "content",
+                        "temporal",
+                    ].includes(categoryName)
+                ) {
+                    categories.push({
+                        name:
+                            categoryName.charAt(0).toUpperCase() +
+                            categoryName.slice(1),
+                        icon: "bi-question-circle",
+                        color: "light",
+                        questions: questions.sort(
+                            (a, b) =>
+                                this.getQuestionScore(b) -
+                                this.getQuestionScore(a),
+                        ),
+                        priority: 6,
+                        count: questions.length,
+                    });
+                }
+            },
+        );
 
         return categories.sort((a, b) => a.priority - b.priority);
     }
@@ -1362,7 +1380,9 @@ class KnowledgePanel {
 
     private async loadPageSourceInfo() {
         try {
-            const response = await chromeExtensionService.getPageSourceInfo(this.currentUrl);
+            const response = await chromeExtensionService.getPageSourceInfo(
+                this.currentUrl,
+            );
 
             this.pageSourceInfo = response.sourceInfo;
             this.updatePageSourceDisplay();
@@ -1406,7 +1426,8 @@ class KnowledgePanel {
 
     private async loadExtractionSettings() {
         try {
-            const settings = await chromeExtensionService.getExtractionSettings();
+            const settings =
+                await chromeExtensionService.getExtractionSettings();
             if (settings) {
                 this.extractionSettings = {
                     ...this.extractionSettings,
@@ -1537,7 +1558,9 @@ class KnowledgePanel {
 
     private async loadFreshKnowledge() {
         try {
-            const indexStatus = await chromeExtensionService.getPageIndexStatus(this.currentUrl);
+            const indexStatus = await chromeExtensionService.getPageIndexStatus(
+                this.currentUrl,
+            );
 
             if (indexStatus.isIndexed) {
                 await this.loadIndexedKnowledge();
@@ -1586,7 +1609,10 @@ class KnowledgePanel {
 
     private async loadIndexedKnowledge() {
         try {
-            const response = await chromeExtensionService.getPageIndexedKnowledge(this.currentUrl);
+            const response =
+                await chromeExtensionService.getPageIndexedKnowledge(
+                    this.currentUrl,
+                );
 
             if (response.isIndexed && response.knowledge) {
                 this.knowledgeData = response.knowledge;
@@ -1671,7 +1697,11 @@ class KnowledgePanel {
                 "No topics identified yet",
             ),
         );
-        return TemplateHelpers.createCard("Key Topics", content, "bi bi-bookmark");
+        return TemplateHelpers.createCard(
+            "Key Topics",
+            content,
+            "bi bi-bookmark",
+        );
     }
 
     // Template utility functions for knowledge panel
@@ -1729,7 +1759,10 @@ class KnowledgePanel {
     private renderActionsCard(): string {
         const content = this.createContainer(
             "detectedActionsContainer",
-            TemplateHelpers.createEmptyState("bi bi-info-circle", "No actions detected"),
+            TemplateHelpers.createEmptyState(
+                "bi bi-info-circle",
+                "No actions detected",
+            ),
         );
         return TemplateHelpers.createCard(
             "Detected Actions",
@@ -2356,7 +2389,8 @@ class KnowledgePanel {
 
     private async loadTemporalSuggestions() {
         try {
-            const response = await chromeExtensionService.generateTemporalSuggestions(6);
+            const response =
+                await chromeExtensionService.generateTemporalSuggestions(6);
 
             if (response.success && response.suggestions.length > 0) {
                 this.addTemporalSuggestions(
@@ -2893,19 +2927,20 @@ class KnowledgePanel {
         queryResults.innerHTML = this.createEnhancedSearchLoadingState();
 
         try {
-            const response = await chromeExtensionService.searchWebMemoriesAdvanced({
-                query: query,
-                searchScope: "all_indexed",
-                generateAnswer: true,
-                includeRelatedEntities: true,
-                enableAdvancedSearch: true,
-                limit: 10,
-                domain: filters.domain,
-                source: filters.source,
-                pageType: filters.pageType,
-                temporalSort: filters.temporalSort,
-                frequencySort: filters.frequencySort,
-            });
+            const response =
+                await chromeExtensionService.searchWebMemoriesAdvanced({
+                    query: query,
+                    searchScope: "all_indexed",
+                    generateAnswer: true,
+                    includeRelatedEntities: true,
+                    enableAdvancedSearch: true,
+                    limit: 10,
+                    domain: filters.domain,
+                    source: filters.source,
+                    pageType: filters.pageType,
+                    temporalSort: filters.temporalSort,
+                    frequencySort: filters.frequencySort,
+                });
 
             this.renderEnhancedQueryResults(response);
 
@@ -3206,7 +3241,8 @@ class KnowledgePanel {
 
     private async checkAIModelAvailability() {
         try {
-            const response = await chromeExtensionService.checkAIModelAvailability();
+            const response =
+                await chromeExtensionService.checkAIModelAvailability();
 
             this.aiModelAvailable = response.available || false;
         } catch (error) {
@@ -3253,7 +3289,9 @@ class KnowledgePanel {
 
     private async updateQualityIndicator() {
         try {
-            const response = await chromeExtensionService.getPageQualityMetrics(this.currentUrl);
+            const response = await chromeExtensionService.getPageQualityMetrics(
+                this.currentUrl,
+            );
 
             const indicator = document.getElementById("qualityIndicator");
             if (indicator && response.quality) {
@@ -3287,7 +3325,9 @@ class KnowledgePanel {
 
     private async saveExtractionSettings() {
         try {
-            await chromeExtensionService.saveExtractionSettings(this.extractionSettings);
+            await chromeExtensionService.saveExtractionSettings(
+                this.extractionSettings,
+            );
         } catch (error) {
             console.warn("Could not save extraction settings:", error);
         }

--- a/ts/packages/agents/browser/src/extension/views/pageKnowledge.ts
+++ b/ts/packages/agents/browser/src/extension/views/pageKnowledge.ts
@@ -430,7 +430,7 @@ class KnowledgePanel {
                 this.showKnowledgeError(
                     "Failed to extract knowledge. Please check your connection.",
                 );
-                this.showEnhancedNotification(
+                notificationManager.showEnhancedNotification(
                     "danger",
                     "Knowledge Extraction Failed",
                     (error as Error).message ||
@@ -516,7 +516,7 @@ class KnowledgePanel {
             if ((error as Error).message?.includes("AI model required")) {
                 this.showAIRequiredError();
             } else {
-                this.showEnhancedNotification(
+                notificationManager.showEnhancedNotification(
                     "danger",
                     "Indexing Failed",
                     (error as Error).message || "Failed to index page",
@@ -583,7 +583,7 @@ class KnowledgePanel {
     private showKnowledgeLoading() {
         const knowledgeSection = document.getElementById("knowledgeSection")!;
         knowledgeSection.className = "";
-        knowledgeSection.innerHTML = this.createLoadingState(
+        knowledgeSection.innerHTML = TemplateHelpers.createLoadingState(
             "Extracting knowledge from page...",
             "This may take a few seconds",
         );
@@ -906,7 +906,7 @@ class KnowledgePanel {
         }
 
         // Add any other categories that didn't fit the main ones
-        for (const [categoryName, questions] of categoryMap.entries()) {
+        Array.from(categoryMap.entries()).forEach(([categoryName, questions]) => {
             if (
                 ![
                     "relationship",
@@ -931,7 +931,7 @@ class KnowledgePanel {
                     count: questions.length,
                 });
             }
-        }
+        });
 
         return categories.sort((a, b) => a.priority - b.priority);
     }
@@ -1595,116 +1595,6 @@ class KnowledgePanel {
         }
     }
 
-    private showTemporaryStatus(
-        message: string,
-        type: "success" | "danger" | "info",
-    ) {
-        const alertClass = "alert-" + type;
-        const iconClass =
-            type === "success"
-                ? "bi-check-circle"
-                : type === "danger"
-                  ? "bi-exclamation-triangle"
-                  : "bi-info-circle";
-
-        const statusDiv = document.createElement("div");
-        statusDiv.className = `alert ${alertClass} alert-dismissible fade show position-fixed`;
-        statusDiv.style.cssText =
-            "top: 1rem; right: 1rem; z-index: 1050; min-width: 250px;";
-        statusDiv.innerHTML = `
-            <i class="${iconClass} me-2"></i>
-            ${message}
-            <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
-        `;
-
-        document.body.appendChild(statusDiv);
-
-        setTimeout(() => {
-            if (statusDiv.parentNode) {
-                statusDiv.remove();
-            }
-        }, 3000);
-    }
-
-    private showEnhancedNotification(
-        type: "success" | "danger" | "info" | "warning",
-        title: string,
-        message: string,
-        icon: string = "bi-info-circle",
-    ) {
-        const notification = document.createElement("div");
-        notification.className = `alert alert-${type} alert-dismissible fade show position-fixed`;
-        notification.style.cssText = `
-            top: 20px; 
-            right: 20px; 
-            z-index: 9999; 
-            min-width: 350px; 
-            max-width: 400px;
-            box-shadow: 0 4px 12px rgba(0,0,0,0.15);
-            border: none;
-            border-radius: 8px;
-        `;
-
-        notification.innerHTML = `
-            <div class="d-flex align-items-start">
-                <i class="${icon} me-3 mt-1" style="font-size: 1.2rem;"></i>
-                <div class="flex-grow-1">
-                    <div class="fw-bold mb-1">${title}</div>
-                    <div class="small">${message}</div>
-                </div>
-                <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
-            </div>
-        `;
-
-        document.body.appendChild(notification);
-
-        // Auto-remove after 6 seconds for enhanced notifications
-        setTimeout(() => {
-            if (notification.parentNode) {
-                notification.classList.remove("show");
-                setTimeout(() => {
-                    if (notification.parentNode) {
-                        notification.parentNode.removeChild(notification);
-                    }
-                }, 300);
-            }
-        }, 6000);
-    }
-
-    // Template utility functions for knowledge panel
-    private createCard(
-        title: string,
-        content: string,
-        icon: string,
-        badge?: string,
-    ): string {
-        const badgeHtml = badge
-            ? `<span id="${badge}" class="badge bg-secondary ms-2">0</span>`
-            : "";
-        return `
-            <div class="knowledge-card card">
-                <div class="card-header">
-                    <h6 class="mb-0">
-                        <i class="${icon}"></i> ${title}
-                        ${badgeHtml}
-                    </h6>
-                </div>
-                <div class="card-body">
-                    ${content}
-                </div>
-            </div>
-        `;
-    }
-
-    private createEmptyState(icon: string, message: string): string {
-        return `
-            <div class="text-muted text-center">
-                <i class="${icon}"></i>
-                ${message}
-            </div>
-        `;
-    }
-
     private createContainer(id: string, defaultContent: string): string {
         return `<div id="${id}">${defaultContent}</div>`;
     }
@@ -1713,12 +1603,12 @@ class KnowledgePanel {
     private renderEntitiesCard(): string {
         const content = this.createContainer(
             "entitiesContainer",
-            this.createEmptyState(
+            TemplateHelpers.createEmptyState(
                 "bi bi-info-circle",
                 "No entities extracted yet",
             ),
         );
-        return this.createCard(
+        return TemplateHelpers.createCard(
             "Entities",
             content,
             "bi bi-tags",
@@ -1729,12 +1619,12 @@ class KnowledgePanel {
     private renderRelationshipsCard(): string {
         const content = this.createContainer(
             "relationshipsContainer",
-            this.createEmptyState(
+            TemplateHelpers.createEmptyState(
                 "bi bi-info-circle",
                 "No relationships found yet",
             ),
         );
-        return this.createCard(
+        return TemplateHelpers.createCard(
             "Relationships",
             content,
             "bi bi-diagram-3",
@@ -1745,76 +1635,12 @@ class KnowledgePanel {
     private renderTopicsCard(): string {
         const content = this.createContainer(
             "topicsContainer",
-            this.createEmptyState(
+            TemplateHelpers.createEmptyState(
                 "bi bi-info-circle",
                 "No topics identified yet",
             ),
         );
-        return this.createCard("Key Topics", content, "bi bi-bookmark");
-    }
-
-    // Alert and loading state utilities
-    private createAlert(
-        type: "info" | "danger",
-        icon: string,
-        content: string,
-    ): string {
-        return `
-            <div class="alert alert-${type} mb-0">
-                <div class="d-flex align-items-start">
-                    <i class="${icon} me-2 mt-1"></i>
-                    <div class="flex-grow-1">
-                        ${content}
-                    </div>
-                </div>
-            </div>
-        `;
-    }
-
-    private createLoadingState(message: string, subtext?: string): string {
-        const subtextHtml = subtext
-            ? `<small class="text-muted">${subtext}</small>`
-            : "";
-        return `
-            <div class="knowledge-card card">
-                <div class="card-body text-center">
-                    <div class="spinner-border text-primary" role="status">
-                        <span class="visually-hidden">Loading...</span>
-                    </div>
-                    <p class="mt-3 mb-0">${message}</p>
-                    ${subtextHtml}
-                </div>
-            </div>
-        `;
-    }
-
-    private createSearchLoadingState(): string {
-        return `
-            <div class="d-flex align-items-center text-muted">
-                <div class="spinner-border spinner-border-sm me-2" role="status"></div>
-                <span>Searching knowledge...</span>
-            </div>
-        `;
-    }
-
-    private createQueryAnswer(answer: string, sources: any[]): string {
-        const sourcesHtml =
-            sources && sources.length > 0
-                ? `
-            <hr class="my-2">
-            <small class="text-muted">
-                <strong>Sources:</strong> ${sources.map((s: any) => s.title).join(", ")}
-            </small>
-        `
-                : "";
-
-        const content = `
-            <div class="fw-semibold">Answer:</div>
-            <p class="mb-2">${answer}</p>
-            ${sourcesHtml}
-        `;
-
-        return this.createAlert("info", "bi bi-lightbulb", content);
+        return TemplateHelpers.createCard("Key Topics", content, "bi bi-bookmark");
     }
 
     // Template utility functions for knowledge panel
@@ -1841,12 +1667,12 @@ class KnowledgePanel {
     private renderContentMetricsCard(): string {
         const content = this.createContainer(
             "contentMetricsContainer",
-            this.createEmptyState(
+            TemplateHelpers.createEmptyState(
                 "bi bi-info-circle",
                 "No content metrics available",
             ),
         );
-        return this.createCard(
+        return TemplateHelpers.createCard(
             "Content Analysis",
             content,
             "bi bi-bar-chart-line",
@@ -1857,12 +1683,12 @@ class KnowledgePanel {
     private renderRelatedContentCard(): string {
         const content = this.createContainer(
             "relatedContentContainer",
-            this.createEmptyState(
+            TemplateHelpers.createEmptyState(
                 "bi bi-info-circle",
                 "No related content found",
             ),
         );
-        return this.createCard(
+        return TemplateHelpers.createCard(
             "Related Content",
             content,
             "bi bi-link-45deg",
@@ -1872,9 +1698,9 @@ class KnowledgePanel {
     private renderActionsCard(): string {
         const content = this.createContainer(
             "detectedActionsContainer",
-            this.createEmptyState("bi bi-info-circle", "No actions detected"),
+            TemplateHelpers.createEmptyState("bi bi-info-circle", "No actions detected"),
         );
-        return this.createCard(
+        return TemplateHelpers.createCard(
             "Detected Actions",
             content,
             "bi bi-lightning",
@@ -2624,7 +2450,7 @@ class KnowledgePanel {
         const groupedRelationships =
             this.groupRelationshipsByType(relationships);
 
-        container.innerHTML = Array.from(groupedRelationships)
+        container.innerHTML = Object.entries(groupedRelationships)
             .map(
                 ([type, typeRelationships]) => `
                 <div class="relationship-type-group mb-3">
@@ -3058,7 +2884,7 @@ class KnowledgePanel {
             }
         } catch (error) {
             console.error("Error querying enhanced knowledge:", error);
-            queryResults.innerHTML = this.createAlert(
+            queryResults.innerHTML = TemplateHelpers.createAlert(
                 "danger",
                 "bi bi-exclamation-triangle",
                 "Failed to search knowledge base. Please try again.",


### PR DESCRIPTION
- Add single getAnalyticsData action that fetches data for all components in the analytics view. Retires the component-specific calls that are no longer used.
- Refactor common code in the knowledge library page and the sidepanel.
- Ensure knowledge sidepanel ui modules are all updated when an indexing call completes.