### PR TITLE
[python/knowpro] Fixed three more query bugs

### DIFF
--- a/python/ta/NOTES.md
+++ b/python/ta/NOTES.md
@@ -1,0 +1,56 @@
+Notes
+=====
+
+Weights are slightly off in many places
+---------------------------------------
+
+In particular the weights computed by TS are slightly different from
+those computed by Python from the same LLM-produced query.
+
+- Tried using double precision for dot products between two vectors.
+  - This showed differences in the 6th or 7th digit, whereas what we
+    are seeing is in the 2nd or 3rd digit. So more precise dot product
+    computation is not the fix we'd hoped for.
+
+- Concluding, this is **STILL OPEN**.
+
+Warnings about missing message/semref ordinals
+-----------------------------------------------
+
+When comparing lists of message ordinals:
+
+- Messages 42, 46, 52, 68, 70 are all just Kevin saying "Yeah."
+  So those differences are irrelevant (false positives).
+  - **Fixed by excluding them from the warning.**
+
+- Concluding, the only question that's got a true warning about the
+  query result is 55, "How long did Adrian struggle before he got
+  published?"
+  - **Fixed a bug in how we were calling intersect().**
+  - Now, the result is worse until I implement fallbacks.
+
+- That question also gets an answer that feels correct if verbose,
+  but is scored "low" (0.885), probably due to that verbosity.
+  This is certainly due to the answers.py logic/prompts.
+
+- Steve suggests throwing noise text like "Yeah" out completely.
+  Umesh replies that there's support for stop words etc.
+  but the Podcast import doesn't use it.
+
+Question 55
+-----------
+
+Looking at question 55 ("How long did Adrian struggle before
+he got published?") we see 8 messages missing (none "noise"),
+and many entities, actions and topics missing from the knowledge
+results (which would explain the missing messages).
+
+See above -- **fixed by fixing two intersect() calls.**
+
+Questions 5 and 6
+-----------------
+
+These are variants that look for books in the first 15 minutes.
+The query compilation seems to be off here.
+
+**Fixed date/time conversions to account for proper timezones.**

--- a/python/ta/typeagent/demo/ui.py
+++ b/python/ta/typeagent/demo/ui.py
@@ -188,7 +188,9 @@ def process_inputs[TMessage: IMessage, TIndex: ITermToSemanticRefIndex](
                     print("No semantic references in this conversation.")
                     continue
                 if semref_ord < 0 or semref_ord >= len(sem_refs):
-                    print(f"SemanticRef ordinal {semref_ord} out of range({len(sem_refs)}).")
+                    print(
+                        f"SemanticRef ordinal {semref_ord} out of range({len(sem_refs)})."
+                    )
                     continue
                 pretty_print(sem_refs[semref_ord])
             case _:

--- a/python/ta/typeagent/knowpro/query.py
+++ b/python/ta/typeagent/knowpro/query.py
@@ -389,7 +389,7 @@ class MatchTermsAndExpr(MatchTermsBooleanExpr):
             if all_matches is None:
                 all_matches = term_matches
             else:
-                all_matches.intersect(term_matches)
+                all_matches = all_matches.intersect(term_matches)
         if all_matches is not None:
             all_matches.calculate_total_score()
             all_matches.select_with_hit_count(len(self.term_expressions))
@@ -1009,7 +1009,7 @@ class MatchMessagesAndExpr(MatchMessagesBooleanExpr):
                 all_matches = message_matches
             else:
                 # Intersect the message matches
-                all_matches.intersect(message_matches)
+                all_matches = all_matches.intersect(message_matches)
                 if not all_matches:
                     # If the intersection is empty, we can stop early.
                     break

--- a/python/ta/typeagent/knowpro/reltermsindex.py
+++ b/python/ta/typeagent/knowpro/reltermsindex.py
@@ -134,10 +134,16 @@ async def resolve_related_terms(
     ensure_single_occurrence: bool = True,
     should_resolve_fuzzy: Callable[[SearchTerm], bool] | None = None,
 ) -> None:
-    """
-     * Give searchTerms, resolves related terms for those searchTerms that don't already have them
-     * Optionally ensures that related terms are not duplicated across search terms because this can
-     * skew how semantic references are scored during search (over-counting)
+    """Resolves related terms for those search terms that don't already have them.
+
+    NOTE: This modifies SearchTerm().related_terms in place.
+
+    Optionally ensures that related terms are not duplicated across search terms
+    because this can skew how semantic references are scored during search
+    (over-counting).
+
+    SUBTLE: If a search terms has related_terms == [], don't touch it;
+    only set related_terms if it is None.
     """
     all_search_terms = [term for ct in compiled_terms for term in ct.terms]
     searchable_terms = TermSet()

--- a/python/ta/typeagent/knowpro/searchlang.py
+++ b/python/ta/typeagent/knowpro/searchlang.py
@@ -3,7 +3,9 @@
 
 import copy
 from dataclasses import asdict, dataclass
+import datetime
 from pyexpat.errors import XML_ERROR_RESERVED_PREFIX_XML
+import zoneinfo
 from typing import Callable, Literal, TypeGuard, cast
 
 import typechat
@@ -644,14 +646,17 @@ def date_range_from_datetime_range(date_time_range: DateTimeRange) -> DateRange:
 
 
 def datetime_from_date_time(date_time: DateTime) -> Datetime:
-    return Datetime(
+    local_tz = zoneinfo.ZoneInfo("America/Los_Angeles")
+    dt = Datetime(
         year=date_time.date.year,
         month=date_time.date.month,
         day=date_time.date.day,
         hour=date_time.time.hour if date_time.time else 0,
         minute=date_time.time.minute if date_time.time else 0,
         second=date_time.time.seconds if date_time.time else 0,
+        tzinfo=local_tz,
     )
+    return dt.astimezone(datetime.timezone.utc)
 
 
 def create_property_search_term(

--- a/python/ta/typeagent/podcasts/podcastVerbs.json
+++ b/python/ta/typeagent/podcasts/podcastVerbs.json
@@ -1,0 +1,43 @@
+[
+  {
+    "term": "say",
+    "relatedTerms": [
+      "talk",
+      "talked",
+      "talking",
+      "claimed",
+      "claim",
+      "discuss",
+      "discussed",
+      "discussing",
+      "declare",
+      "declared",
+      "declaring",
+      "express",
+      "expressed",
+      "expressing",
+      "mention",
+      "mentioned",
+      "mentioning",
+      "observe",
+      "said",
+      "speak",
+      "spoke",
+      "speaking",
+      "state",
+      "stated",
+      "stating",
+      "thought",
+      "thoughts",
+      "think",
+      "utter",
+      "uttered",
+      "uttering",
+      "articulate",
+      "articulated",
+      "articulating",
+      "announce",
+      "announced"
+    ]
+  }
+]


### PR DESCRIPTION
A 1000 thanks to @umeshma who spent nearly all day helping me debug these (and the previous commit).

- searchlang.py: Issues with datetime conversions. We established that the podcast is claimed to start on May 1st 2023 at midnight (00:00) US Pacific Time. We don't ask the LLM for a timezone and it just gives times in local time (i.e., US Pacific Time). Our query engine works in UTC so we must convert DateTimes given by the LLM in US Pacific Time to UTC. Simple once you know what the problem is.

- podcast.py: Add synonyms from podcastVerbs.json (store a copy from the TS tree in the Python tree).

- query.py: Fix bugs in how we were calling intersect() -- it returns a value which was never assigned.

- Also some little tweaks, add my NOTES.md, fix a docstring, and reformat a line in ui.py