### PR TITLE
WebMemories: Add a new "summary" extraction mode

### DIFF
--- a/ts/packages/agentSdk/src/agentInterface.ts
+++ b/ts/packages/agentSdk/src/agentInterface.ts
@@ -9,6 +9,16 @@ import { Profiler } from "./profiler.js";
 import { TemplateSchema } from "./templateInput.js";
 
 //==============================================================================
+// Indexing Service Types
+//==============================================================================
+export type IndexingServiceConfig = {
+    serviceScript: string;
+    description?: string;
+};
+
+export type IndexingServicesManifest = Record<string, IndexingServiceConfig>;
+
+//==============================================================================
 // Manifest
 //==============================================================================
 export type AppAgentManifest = {
@@ -17,6 +27,7 @@ export type AppAgentManifest = {
     commandDefaultEnabled?: boolean;
     localView?: boolean; // whether the agent serve a local view, default is false
     sharedLocalView?: string[]; // list of agents to share the local view with, default is none
+    indexingServices?: IndexingServicesManifest;
 } & ActionManifest;
 
 export type SchemaTypeNames = {

--- a/ts/packages/agents/browser/package.json
+++ b/ts/packages/agents/browser/package.json
@@ -17,6 +17,7 @@
     "./agent/manifest": "./src/agent/manifest.json",
     "./agent/handlers": "./dist/agent/actionHandler.mjs",
     "./agent/types": "./dist/common/browserControl.mjs",
+    "./agent/indexing": "./dist/agent/indexing/browserIndexingService.js",
     "./contentScriptRpc/types": "./dist/common/contentScriptRpc/types.mjs",
     "./contentScriptRpc/client": "./dist/common/contentScriptRpc/client.mjs"
   },

--- a/ts/packages/agents/browser/src/agent/indexing/browserIndexingService.ts
+++ b/ts/packages/agents/browser/src/agent/indexing/browserIndexingService.ts
@@ -1,0 +1,363 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import registerDebug from "debug";
+
+import { 
+    importWebsites, 
+    Website, 
+    WebsiteCollection
+} from "website-memory";
+
+import { IndexingKnowledgeExtractor } from "./indexingKnowledgeExtractor.mjs";
+
+const debug = registerDebug("typeagent:browserIndexingService");
+
+// Types from website-memory (re-exported for clarity)
+export type IndexSource = "website" | "image" | "email";
+
+export type IndexData = {
+    source: IndexSource;
+    name: string;
+    location: string;
+    size: number;
+    path: string;
+    state: "new" | "indexing" | "finished" | "stopped" | "idle" | "error";
+    progress: number;
+    sizeOnDisk: number;
+    sourceType?: "bookmarks" | "history";
+    browserType?: "chrome" | "edge";
+};
+
+/**
+ * Browser Agent Indexing Service
+ * Runs as separate process, uses browser agent knowledge processing infrastructure
+ * Provides AI-enhanced indexing with content summarization and quality assessment
+ */
+export class BrowserIndexingService {
+    private knowledgeExtractor: IndexingKnowledgeExtractor;
+    private index: IndexData | undefined = undefined;
+
+    constructor() {
+        this.knowledgeExtractor = new IndexingKnowledgeExtractor();
+    }
+
+    /**
+     * Initialize the service with AI models and adapters
+     */
+    async initialize(): Promise<void> {
+        debug("Initializing browser indexing service...");
+        
+        try {
+            await this.knowledgeExtractor.initialize();
+            debug("Knowledge extractor initialized");
+            
+            debug("Browser indexing service ready");
+            debug("Capabilities:", this.knowledgeExtractor.getCapabilities());
+            
+        } catch (error) {
+            debug("Initialization error:", error);
+            throw error;
+        }
+    }
+
+    /**
+     * Start indexing process with provided index data
+     */
+    async startIndexing(indexData: IndexData): Promise<void> {
+        this.index = indexData;
+        debug(`Starting indexing for: ${indexData.name} (${indexData.sourceType} from ${indexData.browserType})`);
+
+        try {
+            // Load existing collection first (maintains existing behavior)
+            const websites = await this.loadExistingCollection();
+            
+            // Import bookmarks/history using browser agent processing
+            const importedWebsites = await this.importWithBrowserAgent(
+                indexData.browserType || "chrome",
+                indexData.sourceType || "bookmarks", 
+                indexData.location
+            );
+            
+            // Filter websites that already exist in the collection
+            const existingUrls = new Set(websites.getWebsites().map(w => w.metadata.url));
+            const newWebsites = importedWebsites.filter(w => !existingUrls.has(w.metadata.url));
+            
+            if (newWebsites.length === 0) {
+                debug("No new websites to index");
+                this.index.state = "finished";
+                this.index.progress = 100;
+                this.sendIndexStatus();
+                return;
+            }
+            
+            debug(`Processing ${newWebsites.length} new websites with enhanced knowledge extraction`);
+            
+            // Process with enhanced knowledge extraction
+            await this.processWebsitesWithKnowledge(newWebsites);
+            
+            // Add new websites to collection using incremental method
+            await this.addWebsitesIncremental(websites, newWebsites);
+            
+            // Build and save index
+            await this.buildAndSaveIndex(websites);
+            
+            this.index.state = "finished";
+            this.index.progress = 100;
+            this.index.size = websites.getWebsites().length;
+            this.sendIndexStatus();
+            
+            debug("Enhanced indexing completed successfully");
+            
+        } catch (error) {
+            debug("Indexing failed:", error);
+            this.index.state = "error";
+            this.sendIndexStatus();
+        }
+    }
+
+    /**
+     * Load existing website collection from the index path
+     */
+    private async loadExistingCollection(): Promise<WebsiteCollection> {
+        try {
+            const websites = await WebsiteCollection.readFromFile(this.index!.path, "index");
+            if (websites && websites.messages.length > 0) {
+                debug(`Loaded existing collection with ${websites.messages.length} websites`);
+                return websites;
+            } else {
+                debug("No existing collection found or empty, creating new one");
+                return new WebsiteCollection();
+            }
+        } catch (error) {
+            debug(`Failed to load existing collection: ${error}. Creating new collection.`);
+            return new WebsiteCollection();
+        }
+    }
+
+    /**
+     * Import websites using browser agent infrastructure
+     */
+    private async importWithBrowserAgent(
+        browserType: string,
+        sourceType: string,
+        location: string
+    ): Promise<Website[]> {
+        debug(`Importing ${sourceType} from ${browserType} at ${location}`);
+        
+        return await importWebsites(
+            browserType as "chrome" | "edge",
+            sourceType as "bookmarks" | "history",
+            location,
+            { 
+                limit: 10000,
+                // Standard content extractor - enhanced processing happens later
+            },
+            this.indexingProgress.bind(this)
+        );
+    }
+
+    /**
+     * Add websites incrementally to the collection
+     */
+    private async addWebsitesIncremental(
+        websiteCollection: WebsiteCollection,
+        newWebsites: Website[]
+    ): Promise<void> {
+        for (const website of newWebsites) {
+            try {
+                const { WebsiteDocPart } = await import("website-memory");
+                const docPart = WebsiteDocPart.fromWebsite(website);
+                await websiteCollection.addWebsiteToIndex(docPart);
+            } catch (error) {
+                debug(`Error adding website incrementally: ${error}, falling back to batch add`);
+                websiteCollection.addWebsites([website]);
+            }
+        }
+    }
+
+    /**
+     * Process websites with enhanced knowledge extraction
+     */
+    private async processWebsitesWithKnowledge(websites: Website[]): Promise<void> {
+        debug(`Starting enhanced knowledge processing for ${websites.length} websites`);
+        
+        let enhancedCount = 0;
+        let errorCount = 0;
+        
+        for (let i = 0; i < websites.length; i++) {
+            const website = websites[i];
+            
+            try {
+                // Determine extraction mode based on URL
+                const extractionMode = this.knowledgeExtractor.getExtractionModeForUrl(website.metadata.url);
+                
+                debug(`Processing ${website.metadata.url} with ${extractionMode} mode`);
+                
+                // Enhanced knowledge extraction for each website with context information
+                // Includes URL, title, and bookmark folder hierarchy for better AI analysis
+                const result = await this.knowledgeExtractor.extractKnowledge({
+                    url: website.metadata.url,
+                    title: website.metadata.title || "",
+                    textContent: website.textChunks?.join('\n') || website.metadata.description || "",
+                    source: "import" as const,
+                    timestamp: new Date().toISOString(),
+                    // Add folder information for context enhancement
+                    folder: website.metadata.folder,
+                } as any, extractionMode);
+                
+                if (result.success) {
+                    // Update website with extracted knowledge
+                    if (result.knowledge) {
+                        website.knowledge = result.knowledge;
+                        enhancedCount++;
+                    }
+                    
+                    // Add processing metadata (store as additional properties - not ideal but works)
+                    (website.metadata as any).extractionMode = extractionMode;
+                    (website.metadata as any).processingTime = result.processingTime;
+                    (website.metadata as any).aiProcessingUsed = result.aiProcessingUsed;
+                    
+                    // Add quality metrics if available
+                    if (result.qualityMetrics) {
+                        (website.metadata as any).qualityScore = this.calculateQualityScore(result.qualityMetrics);
+                    }
+                    
+                    // Add summary data if enhanced with summarization
+                    if ((result as any).summaryData) {
+                        (website as any).summaryData = (result as any).summaryData;
+                        (website.metadata as any).enhancedWithSummary = true;
+                    }
+                    
+                    debug(`Successfully processed ${website.metadata.url} (AI: ${result.aiProcessingUsed})`);
+                } else {
+                    debug(`Failed to process ${website.metadata.url}: ${result.error}`);
+                    errorCount++;
+                }
+                
+            } catch (error) {
+                debug(`Error processing ${website.metadata.url}:`, error);
+                errorCount++;
+            }
+            
+            // Report progress
+            this.indexingProgress(i + 1, websites.length, website.metadata.title || website.metadata.url);
+        }
+        
+        debug(`Enhanced processing complete: ${enhancedCount} enhanced, ${errorCount} errors`);
+    }
+
+    /**
+     * Calculate overall quality score from extraction metrics
+     */
+    private calculateQualityScore(metrics: any): number {
+        // Combine multiple factors into overall quality score (0-1)
+        const factors = [
+            Math.min(metrics.confidence || 0, 1),
+            Math.min((metrics.entityCount || 0) / 10, 1), // Normalize entity count
+            Math.min((metrics.topicCount || 0) / 5, 1),   // Normalize topic count
+            metrics.aiProcessingTime ? 0.2 : 0,          // Bonus for AI processing
+        ];
+        
+        return factors.reduce((sum, factor) => sum + factor, 0) / factors.length;
+    }
+
+    /**
+     * Build and save the search index
+     */
+    private async buildAndSaveIndex(websites: WebsiteCollection): Promise<void> {
+        debug("Building search index...");
+        
+        try {
+            // Build the index using the collection's built-in method
+            await websites.addToIndex();
+            
+            debug(`Index built successfully`);
+            
+            // Save the index to disk
+            await websites.writeToFile(this.index!.path, "index");
+            debug(`Index saved to ${this.index!.path}`);
+            
+        } catch (error) {
+            debug("Error building index:", error);
+            throw error;
+        }
+    }
+
+    /**
+     * Report indexing progress
+     */
+    private indexingProgress(current: number, total: number, itemName: string): void {
+        if (!this.index) return;
+        
+        this.index.progress = current;
+        this.index.size = current;
+        this.index.state = "indexing";
+        
+        debug(`Progress: ${current}/${total} - ${itemName}`);
+        
+        // Send progress to parent process (every 10 items or at completion)
+        if (current % 10 === 0 || current === total) {
+            this.sendIndexStatus();
+        }
+    }
+
+    /**
+     * Send index status to parent process
+     */
+    private sendIndexStatus(): void {
+        process.send?.(this.index);
+    }
+}
+
+// Process entry point for separate process execution
+if (
+    process.argv.filter((value: string) => {
+        const thisFile = fileURLToPath(import.meta.url);
+        return path.basename(value) === path.basename(thisFile);
+    }).length > 0
+) {
+    const service = new BrowserIndexingService();
+
+    /**
+     * Indicate to the host/parent process that we've started successfully
+     */
+    process.send?.("Success");
+
+    /**
+     * Process messages received from the host/parent process
+     */
+    process.on("message", async (message: any) => {
+        debug("Received message from parent:", message);
+
+        if (message !== undefined) {
+            try {
+                // Initialize service
+                await service.initialize();
+                
+                // Start indexing with provided data
+                await service.startIndexing(message as IndexData);
+                
+            } catch (error) {
+                debug("Error in message handling:", error);
+                process.send?.({
+                    ...message,
+                    state: "error",
+                    error: error instanceof Error ? error.message : "Unknown error"
+                });
+            }
+        }
+    });
+
+    /**
+     * Closes this process at the request of the host/parent process
+     */
+    process.on("disconnect", () => {
+        debug("Parent process disconnected, exiting");
+        process.exit(1);
+    });
+
+    debug("Browser indexing service started successfully and waiting for instructions");
+}

--- a/ts/packages/agents/browser/src/agent/indexing/contentSummaryAdapter.mts
+++ b/ts/packages/agents/browser/src/agent/indexing/contentSummaryAdapter.mts
@@ -1,0 +1,319 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { createJsonTranslator, TypeChatJsonTranslator } from "typechat";
+import { createTypeScriptJsonValidator } from "typechat/ts";
+import { openai as ai } from "aiclient";
+import { ExtractionMode } from "website-memory";
+
+/**
+ * Schema for page summarization output
+ */
+export interface PageSummary {
+    summary: string; // Concise summary of main content (1000 characters or less)
+    keyPoints: string[]; // Main points or key information (max 5)
+    entities: string[]; // Important entities mentioned (people, organizations, technologies)
+    topics: string[]; // Main topics or themes
+    contentType: string; // Type of content (e.g., 'article', 'documentation', 'news', 'reference', 'tutorial', 'blog', 'forum', 'other')
+    intent: string; // Likely user intent for bookmarking (e.g., 'research', 'reference', 'learning', 'entertainment', 'shopping', 'work', 'news', 'other')
+}
+
+/**
+ * ContentSummaryAdapter enhances knowledge extraction with page summarization.
+ * Follows the same pattern as ActionDetectionAdapter for consistency.
+ * 
+ * Inserts summarization step in the HTML→text→knowledge pipeline:
+ * HTML Content → Text Extraction → SUMMARIZATION → Knowledge Processing
+ */
+export class ContentSummaryAdapter {
+    private summaryTranslator: TypeChatJsonTranslator<PageSummary> | null = null;
+    private isInitialized: boolean = false;
+    
+    private readonly schemaText = `
+interface PageSummary {
+    summary: string; // Concise summary of main content (1000 characters or less)
+    keyPoints: string[]; // Main points or key information (max 5)
+    entities: string[]; // Important entities mentioned (people, organizations, technologies)
+    topics: string[]; // Main topics or themes
+    contentType: string; // Type of content (e.g., 'article', 'documentation', 'news', 'reference', 'tutorial', 'blog', 'forum', 'other')
+    intent: string; // Likely user intent for bookmarking (e.g., 'research', 'reference', 'learning', 'entertainment', 'shopping', 'work', 'news', 'other')
+}`;
+
+    constructor() {}
+
+    /**
+     * Main entry point: Enhance text content with summarization for specified mode
+     */
+    async enhanceWithSummary(
+        textContent: string,
+        mode: ExtractionMode,
+        options: {
+            maxInputLength?: number;
+            targetSummaryLength?: number;
+            includeKeyPoints?: boolean;
+            // Context enhancement options
+            url?: string;
+            title?: string;
+            bookmarkFolder?: string;
+            includeContextInEnhancedText?: boolean;
+        } = {}
+    ): Promise<{
+        enhancedText: string;
+        summaryData?: PageSummary;
+        processingTime?: number;
+    }> {
+        const startTime = Date.now();
+        
+        try {
+            // Only process summary mode - same pattern as ActionDetectionAdapter
+            if (mode !== ("summary" as ExtractionMode)) {
+                return { 
+                    enhancedText: textContent, 
+                    processingTime: Date.now() - startTime 
+                };
+            }
+
+            // Skip if content is too short or empty
+            if (!textContent || textContent.length < 200) {
+                console.log("Content too short for summarization, using original text");
+                return { 
+                    enhancedText: textContent, 
+                    processingTime: Date.now() - startTime 
+                };
+            }
+
+            // Initialize translator if needed
+            await this.ensureInitialized();
+
+            if (!this.summaryTranslator) {
+                console.warn("Summary translator not available, using original text");
+                return { 
+                    enhancedText: textContent, 
+                    processingTime: Date.now() - startTime 
+                };
+            }
+
+            // Optimize content length for processing
+            const maxLength = options.maxInputLength || 8000;
+            const contentToSummarize = textContent.length > maxLength 
+                ? this.smartTruncate(textContent, maxLength)
+                : textContent;
+
+            console.log(`Processing summarization for ${contentToSummarize.length} characters`);
+
+            // Create and execute summary prompt
+            const prompt = this.createSummaryPrompt(contentToSummarize, options);
+            const result = await this.summaryTranslator.translate(prompt);
+            
+            if (!result.success) {
+                console.warn("Summary generation failed:", result.message);
+                return { 
+                    enhancedText: textContent, 
+                    processingTime: Date.now() - startTime 
+                };
+            }
+
+            const summaryData = result.data;
+            console.log(`Summary generated: ${summaryData.summary.substring(0, 100)}...`);
+
+            // Create enhanced text that combines summary with structured information and context
+            const enhancedText = this.createEnhancedText(summaryData, textContent, options);
+            
+            return { 
+                enhancedText, 
+                summaryData,
+                processingTime: Date.now() - startTime
+            };
+            
+        } catch (error) {
+            console.error("Error in content summarization:", error);
+            return { 
+                enhancedText: textContent, 
+                processingTime: Date.now() - startTime 
+            };
+        }
+    }
+
+    /**
+     * Initialize summary translator with lazy loading and error handling
+     * Following ActionDetectionAdapter pattern
+     */
+    async ensureInitialized(): Promise<void> {
+        if (this.isInitialized) {
+            return;
+        }
+
+        try {
+            // Use same model initialization as browser agent
+            const apiSettings = ai.azureApiSettingsFromEnv(ai.ModelType.Chat);
+            const languageModel = ai.createChatModel(apiSettings);
+            
+            // Create TypeScript schema validator
+            const validator = createTypeScriptJsonValidator<PageSummary>(this.schemaText, "PageSummary");
+            
+            this.summaryTranslator = createJsonTranslator(
+                languageModel, 
+                validator
+            );
+            
+            this.isInitialized = true;
+            console.log("Content summary adapter initialized successfully");
+            
+        } catch (error) {
+            console.warn("Failed to initialize content summary adapter:", error);
+            this.summaryTranslator = null;
+            this.isInitialized = true; // Mark as attempted to avoid retries
+        }
+    }
+
+    /**
+     * Create enhanced text that combines summary with key extracted information and context
+     */
+    private createEnhancedText(
+        summaryData: PageSummary, 
+        originalText: string,
+        options: {
+            url?: string;
+            title?: string;
+            bookmarkFolder?: string;
+            includeContextInEnhancedText?: boolean;
+        } = {}
+    ): string {
+        const parts = [];
+
+        // Add context information if requested and available
+        if (options.includeContextInEnhancedText !== false) { // Default to true
+            if (options.url) {
+                parts.push(`URL: ${options.url}`);
+            }
+            
+            if (options.title) {
+                parts.push(`Page Title: ${options.title}`);
+            }
+            
+            if (options.bookmarkFolder) {
+                // Parse folder hierarchy if it contains separators
+                const folderHierarchy = this.parseFolderHierarchy(options.bookmarkFolder);
+                parts.push(`Bookmark Location: ${folderHierarchy}`);
+            }
+        }
+
+        // Add summary information
+        parts.push(`Summary: ${summaryData.summary}`);
+        parts.push(`Content Type: ${summaryData.contentType}`);
+        parts.push(`User Intent: ${summaryData.intent}`);
+
+        if (summaryData.keyPoints.length > 0) {
+            parts.push(`Key Points: ${summaryData.keyPoints.join('; ')}`);
+        }
+
+        if (summaryData.topics.length > 0) {
+            parts.push(`Main Topics: ${summaryData.topics.join(', ')}`);
+        }
+
+        if (summaryData.entities.length > 0) {
+            parts.push(`Entities: ${summaryData.entities.join(', ')}`);
+        }
+
+        // Include truncated original text for additional context
+        const contextLength = Math.min(2000, originalText.length * 0.3);
+        if (originalText.length > contextLength) {
+            parts.push(`Additional Context: ${originalText.substring(0, contextLength)}...`);
+        } else {
+            parts.push(`Original Content: ${originalText}`);
+        }
+
+        return parts.join('\n\n');
+    }
+
+    /**
+     * Parse folder hierarchy from bookmark folder string
+     */
+    private parseFolderHierarchy(folderPath: string): string {
+        if (!folderPath) return folderPath;
+        
+        // Handle common folder separators and create readable hierarchy
+        const separators = ['/', '\\', '>', '|', ' > '];
+        let hierarchy = folderPath;
+        
+        // Find which separator is used
+        for (const sep of separators) {
+            if (folderPath.includes(sep)) {
+                const parts = folderPath.split(sep).map(part => part.trim()).filter(part => part.length > 0);
+                if (parts.length > 1) {
+                    hierarchy = parts.join(' → ');
+                    break;
+                }
+            }
+        }
+        
+        return hierarchy;
+    }
+
+    /**
+     * Create summarization prompt with TypeAgent style
+     */
+    private createSummaryPrompt(
+        textContent: string, 
+        options: { targetSummaryLength?: number; includeKeyPoints?: boolean } = {}
+    ): string {
+        const prompt = `
+You are an expert at creating concise, informative summaries of web content.
+Generate a SINGLE "PageSummary" response using the typescript schema below.
+
+'''
+${this.schemaText}
+'''
+
+Analyze and summarize the following content:
+
+${textContent}`;
+
+        return prompt;
+    }
+
+    /**
+     * Smart truncation that tries to find good breaking points
+     */
+    private smartTruncate(text: string, maxLength: number): string {
+        if (text.length <= maxLength) return text;
+        
+        // Try to find a good breaking point (end of sentence/paragraph)
+        const truncated = text.substring(0, maxLength);
+        const lastSentence = truncated.lastIndexOf('.');
+        const lastParagraph = truncated.lastIndexOf('\n\n');
+        
+        const breakPoint = Math.max(lastSentence, lastParagraph);
+        
+        // Use break point if it's not too far back (at least 70% of max length)
+        return breakPoint > maxLength * 0.7 
+            ? truncated.substring(0, breakPoint + 1)
+            : truncated + "...";
+    }
+
+    /**
+     * Check if content summarization is available
+     */
+    isAvailable(): boolean {
+        return this.isInitialized && this.summaryTranslator !== null;
+    }
+
+    /**
+     * Get summary of content summarization capabilities
+     */
+    getCapabilities() {
+        return {
+            available: this.isAvailable(),
+            supportedModes: ["summary"],
+            features: [
+                "Content Summarization",
+                "Key Point Extraction", 
+                "Entity Identification",
+                "Topic Classification",
+                "Content Type Detection",
+                "Intent Analysis"
+            ],
+            aiModelRequired: true,
+        };
+    }
+}

--- a/ts/packages/agents/browser/src/agent/indexing/index.mts
+++ b/ts/packages/agents/browser/src/agent/indexing/index.mts
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+/**
+ * Browser Agent Indexing Service
+ * Enhanced indexing with ContentSummaryAdapter and browser agent infrastructure
+ */
+
+export { BrowserIndexingService } from "./browserIndexingService.js";
+export { ContentSummaryAdapter } from "./contentSummaryAdapter.mjs";
+export { IndexingKnowledgeExtractor } from "./indexingKnowledgeExtractor.mjs";
+
+// Types and schemas
+export * from "./schema/indexingTypes.mjs";

--- a/ts/packages/agents/browser/src/agent/indexing/indexingKnowledgeExtractor.mts
+++ b/ts/packages/agents/browser/src/agent/indexing/indexingKnowledgeExtractor.mts
@@ -1,0 +1,308 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { conversation as kpLib } from "knowledge-processor";
+import { openai as ai } from "aiclient";
+import { 
+    ContentExtractor,
+    ExtractionMode,
+    ExtractionInput,
+    ExtractionResult
+} from "website-memory";
+import { ContentSummaryAdapter } from "./contentSummaryAdapter.mjs";
+
+/**
+ * Specialized knowledge extractor for indexing service
+ * Runs without full session context but uses browser agent infrastructure
+ */
+export class IndexingKnowledgeExtractor {
+    private contentSummaryAdapter: ContentSummaryAdapter;
+    private knowledgeExtractor: any | undefined;
+    private isInitialized: boolean = false;
+
+    constructor() {
+        this.contentSummaryAdapter = new ContentSummaryAdapter();
+    }
+
+    /**
+     * Initialize AI models and adapters
+     */
+    async initialize(): Promise<void> {
+        if (this.isInitialized) {
+            return;
+        }
+
+        try {
+            console.log("Initializing indexing knowledge extractor...");
+            
+            // Initialize AI models (same pattern as BrowserKnowledgeExtractor)
+            const apiSettings = ai.azureApiSettingsFromEnv(ai.ModelType.Chat);
+            const languageModel = ai.createChatModel(apiSettings);
+            this.knowledgeExtractor = kpLib.createKnowledgeExtractor(languageModel);
+            
+            // Initialize content summary adapter
+            await this.contentSummaryAdapter.ensureInitialized();
+            
+            this.isInitialized = true;
+            console.log("Indexing knowledge extractor initialized successfully");
+            
+        } catch (error) {
+            console.warn("AI model initialization failed for indexing:", error);
+            this.knowledgeExtractor = undefined;
+            this.isInitialized = true; // Mark as attempted
+        }
+    }
+
+    /**
+     * Extract knowledge with optional summary enhancement
+     */
+    async extractKnowledge(
+        content: ExtractionInput, 
+        mode: ExtractionMode
+    ): Promise<ExtractionResult> {
+        const startTime = Date.now();
+        
+        try {
+            console.log(`Extracting knowledge for ${content.url} using ${mode} mode`);
+            
+            // Create content extractor with our knowledge extractor
+            const config: any = { mode };
+            if (this.knowledgeExtractor) {
+                config.knowledgeExtractor = this.knowledgeExtractor;
+            }
+            
+            const extractor = new ContentExtractor(config);
+            const result = await extractor.extract(content, mode);
+            
+            // Apply summary enhancement for summary mode when AI is available
+            if (mode === ("summary" as ExtractionMode) && 
+                this.contentSummaryAdapter.isAvailable() && 
+                this.knowledgeExtractor) {
+                await this.enhanceWithSummary(result, content);
+            }
+            
+            // Update processing time
+            result.processingTime = Date.now() - startTime;
+            result.extractionTime = result.processingTime;
+            
+            console.log(`Knowledge extraction completed in ${result.processingTime}ms`);
+            return result;
+            
+        } catch (error) {
+            console.error("Knowledge extraction failed:", error);
+            
+            // Return basic result with error information
+            return {
+                success: false,
+                knowledge: {} as any,
+                extractionMode: mode,
+                aiProcessingUsed: false,
+                source: content.url || "unknown",
+                timestamp: new Date().toISOString(),
+                processingTime: Date.now() - startTime,
+                extractionTime: Date.now() - startTime,
+                error: error instanceof Error ? error.message : "Unknown error",
+                qualityMetrics: {
+                    confidence: 0,
+                    entityCount: 0,
+                    topicCount: 0,
+                    actionCount: 0,
+                    extractionTime: Date.now() - startTime,
+                    knowledgeStrategy: "basic" as const,
+                }
+            };
+        }
+    }
+
+    /**
+     * Apply summary enhancement to extraction result
+     */
+    private async enhanceWithSummary(result: any, content: ExtractionInput): Promise<void> {
+        try {
+            console.log("Applying summary enhancement...");
+            
+            // Get text content from extraction result or input
+            const textContent = this.prepareTextFromResult(result, content);
+            
+            if (!textContent || textContent.length < 200) {
+                console.log("Insufficient text content for summarization");
+                return;
+            }
+
+            const startTime = Date.now();
+            
+            // Apply summary enhancement with context information
+            const enhancementOptions: any = {
+                url: content.url,
+                title: content.title,
+                includeContextInEnhancedText: true,
+            };
+            
+            const bookmarkFolder = this.extractBookmarkFolder(content);
+            if (bookmarkFolder) {
+                enhancementOptions.bookmarkFolder = bookmarkFolder;
+            }
+            
+            const { enhancedText, summaryData, processingTime } = 
+                await this.contentSummaryAdapter.enhanceWithSummary(textContent, ("summary" as ExtractionMode), enhancementOptions);
+
+            if (summaryData) {
+                console.log(`Summary generated in ${processingTime}ms, enhancing extraction result...`);
+                
+                // Add summary data to result
+                result.summaryData = summaryData;
+                result.enhancedWithSummary = true;
+                result.summaryProcessingTime = processingTime;
+                
+                // If we have knowledge extractor, re-process with enhanced text
+                if (this.knowledgeExtractor && enhancedText !== textContent) {
+                    try {
+                        const enhancedKnowledge = await this.knowledgeExtractor.extractKnowledge(
+                            enhancedText, 
+                            ("summary" as ExtractionMode)
+                        );
+
+                        if (enhancedKnowledge) {
+                            // Merge enhanced knowledge with existing
+                            if (typeof result.knowledge === 'object' && typeof enhancedKnowledge === 'object') {
+                                result.knowledge = { ...result.knowledge, ...enhancedKnowledge };
+                            } else {
+                                result.knowledge = enhancedKnowledge;
+                            }
+                            
+                            console.log("Knowledge enhanced with summary data and context");
+                        }
+                    } catch (enhanceError) {
+                        console.warn("Failed to enhance knowledge with summary:", enhanceError);
+                    }
+                }
+                
+                // Update quality metrics with summary bonus
+                if (result.qualityMetrics) {
+                    result.qualityMetrics.confidence = Math.min(1.0, result.qualityMetrics.confidence + 0.2);
+                    if (summaryData.entities?.length > 0) {
+                        result.qualityMetrics.entityCount += summaryData.entities.length;
+                    }
+                    if (summaryData.topics?.length > 0) {
+                        result.qualityMetrics.topicCount += summaryData.topics.length;
+                    }
+                }
+                
+                console.log(`Enhanced extraction completed in ${Date.now() - startTime}ms total`);
+            }
+
+        } catch (error) {
+            console.warn("Summary enhancement failed:", error);
+            // Don't fail the entire extraction - graceful degradation
+        }
+    }
+
+    /**
+     * Extract bookmark folder information from content input
+     */
+    private extractBookmarkFolder(content: ExtractionInput): string | undefined {
+        // Check if content has folder information
+        // This might come from the website metadata or import process
+        if ((content as any).folder) {
+            return (content as any).folder;
+        }
+        
+        // Could also extract from URL path for some cases
+        if (content.url) {
+            try {
+                const url = new URL(content.url);
+                // For some bookmark systems, folder info might be in URL parameters
+                const folderParam = url.searchParams.get('folder') || url.searchParams.get('path');
+                if (folderParam) {
+                    return folderParam;
+                }
+            } catch {
+                // Invalid URL, continue without folder info
+            }
+        }
+        
+        return undefined;
+    }
+
+    /**
+     * Prepare text content from extraction result for summarization
+     */
+    private prepareTextFromResult(result: any, content: ExtractionInput): string {
+        const parts: string[] = [];
+        
+        // Add title
+        if (content.title) {
+            parts.push(`Title: ${content.title}`);
+        }
+        
+        // Add main content from extraction
+        if (result.pageContent?.mainContent) {
+            parts.push(result.pageContent.mainContent);
+        } else if (result.pageContent?.textContent) {
+            parts.push(result.pageContent.textContent);
+        } else if (content.textContent) {
+            parts.push(content.textContent);
+        }
+        
+        // Add headings if available
+        if (result.pageContent?.headings && Array.isArray(result.pageContent.headings)) {
+            const headingText = result.pageContent.headings
+                .map((h: any) => h.text || h.content || h)
+                .filter((text: string) => text && text.length > 0)
+                .join(". ");
+            if (headingText) {
+                parts.push(`Headings: ${headingText}`);
+            }
+        }
+        
+        // Add meta description if available
+        if (result.pageContent?.metaTags?.description) {
+            parts.push(`Description: ${result.pageContent.metaTags.description}`);
+        }
+        
+        // Add any existing knowledge as context
+        if (result.knowledge && typeof result.knowledge === 'string') {
+            parts.push(`Existing Knowledge: ${result.knowledge}`);
+        } else if (result.knowledge?.text) {
+            parts.push(`Existing Knowledge: ${result.knowledge.text}`);
+        }
+        
+        return parts.join('\n\n').trim();
+    }
+
+    /**
+     * Get extraction mode based on URL domain
+     */
+    getExtractionModeForUrl(url: string): ExtractionMode {
+        // Default to summary mode for balanced processing
+        return "summary" as ExtractionMode;
+    }
+
+    /**
+     * Check if the extractor is properly initialized
+     */
+    isReady(): boolean {
+        return this.isInitialized;
+    }
+
+    /**
+     * Check if AI processing is available
+     */
+    hasAICapabilities(): boolean {
+        return this.knowledgeExtractor !== undefined;
+    }
+
+    /**
+     * Get capabilities summary
+     */
+    getCapabilities() {
+        return {
+            initialized: this.isReady(),
+            aiAvailable: this.hasAICapabilities(),
+            summaryEnhancement: this.contentSummaryAdapter.isAvailable(),
+            supportedModes: ["basic", "summary", "content", "actions", "full"],
+            defaultMode: "summary",
+            domainOptimization: false,
+        };
+    }
+}

--- a/ts/packages/agents/browser/src/agent/indexing/schema/indexingTypes.mts
+++ b/ts/packages/agents/browser/src/agent/indexing/schema/indexingTypes.mts
@@ -1,0 +1,163 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { ExtractionMode } from "website-memory";
+
+/**
+ * Enhanced website metadata for indexing
+ */
+export interface EnhancedWebsiteMetadata {
+    url: string;
+    title: string;
+    folder?: string;
+    description?: string;
+    extractionMode?: ExtractionMode;
+    qualityScore?: number;
+    processingTime?: number;
+    aiProcessingUsed?: boolean;
+    enhancedWithSummary?: boolean;
+    extractedAt?: Date;
+}
+
+/**
+ * Summary data attached to websites
+ */
+export interface WebsiteSummaryData {
+    summary: string;
+    keyPoints: string[];
+    entities: string[];
+    topics: string[];
+    contentType: string;
+    intent: string;
+}
+
+/**
+ * Extended Website interface with enhanced properties
+ */
+export interface EnhancedWebsite {
+    metadata: EnhancedWebsiteMetadata;
+    content?: string;
+    knowledge?: any;
+    summaryData?: WebsiteSummaryData;
+}
+
+/**
+ * Enhanced indexing configuration
+ */
+export interface IndexingConfig {
+    extractionMode: ExtractionMode;
+    enableSummaryEnhancement: boolean;
+    domainModeOverrides: Record<string, ExtractionMode>;
+    performance: {
+        maxConcurrentExtractions: number;
+        timeoutMs: number;
+        maxContentSize: number;
+        enableCaching: boolean;
+    };
+    quality: {
+        minimumQualityThreshold: number;
+        enableFallbackMode: boolean;
+        fallbackMode: ExtractionMode;
+    };
+}
+
+/**
+ * Enhanced website data with summary information
+ */
+export interface EnhancedWebsite {
+    metadata: {
+        url: string;
+        title: string;
+        folder?: string;
+        description?: string;
+        extractionMode?: ExtractionMode;
+        qualityScore?: number;
+        extractedAt?: Date;
+        enhancedWithSummary?: boolean;
+        processingTime?: number;
+        aiProcessingUsed?: boolean;
+    };
+    knowledge?: any; // From knowledge-processor
+    summaryData?: {
+        summary: string;
+        keyPoints: string[];
+        entities: string[];
+        topics: string[];
+        contentType: string;
+        intent: string;
+    };
+    processingMetrics?: {
+        extractionTime: number;
+        summaryTime?: number;
+        totalTime: number;
+    };
+}
+
+/**
+ * Indexing performance metrics
+ */
+export interface IndexingPerformanceMetrics {
+    totalProcessed: number;
+    summaryEnhanced: number;
+    averageProcessingTime: number;
+    averageSummaryTime: number;
+    errorCount: number;
+    successRate: number;
+    enhancementRate: number;
+    modeDistribution: Record<ExtractionMode, number>;
+    domainStatistics: Record<string, {
+        count: number;
+        averageQuality: number;
+        preferredMode: ExtractionMode;
+    }>;
+}
+
+/**
+ * Indexing result for a single item
+ */
+export interface IndexingResult {
+    url: string;
+    success: boolean;
+    extractionMode: ExtractionMode;
+    processingTime: number;
+    qualityScore?: number;
+    summaryGenerated?: boolean;
+    error?: string;
+    knowledge?: any;
+    summaryData?: any;
+}
+
+/**
+ * Batch indexing progress
+ */
+export interface IndexingProgress {
+    current: number;
+    total: number;
+    currentItem: string;
+    phase: "importing" | "enhancing" | "building" | "saving";
+    estimatedTimeRemaining?: number;
+    performanceMetrics?: Partial<IndexingPerformanceMetrics>;
+}
+
+/**
+ * Default indexing configuration
+ */
+export const DEFAULT_INDEXING_CONFIG: IndexingConfig = {
+    extractionMode: "summary" as ExtractionMode,
+    enableSummaryEnhancement: true,
+    domainModeOverrides: {
+        // Domain-specific overrides can be added here if needed
+        // Currently using summary mode for all domains
+    },
+    performance: {
+        maxConcurrentExtractions: 3,
+        timeoutMs: 15000,
+        maxContentSize: 500000,
+        enableCaching: true,
+    },
+    quality: {
+        minimumQualityThreshold: 0.2,
+        enableFallbackMode: true,
+        fallbackMode: "basic" as ExtractionMode,
+    },
+};

--- a/ts/packages/agents/browser/src/agent/indexing/schema/indexingTypes.mts
+++ b/ts/packages/agents/browser/src/agent/indexing/schema/indexingTypes.mts
@@ -105,11 +105,14 @@ export interface IndexingPerformanceMetrics {
     successRate: number;
     enhancementRate: number;
     modeDistribution: Record<ExtractionMode, number>;
-    domainStatistics: Record<string, {
-        count: number;
-        averageQuality: number;
-        preferredMode: ExtractionMode;
-    }>;
+    domainStatistics: Record<
+        string,
+        {
+            count: number;
+            averageQuality: number;
+            preferredMode: ExtractionMode;
+        }
+    >;
 }
 
 /**

--- a/ts/packages/agents/browser/src/agent/indexing/schema/summarization.mts
+++ b/ts/packages/agents/browser/src/agent/indexing/schema/summarization.mts
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// Schema for page summarization output
+
+export interface PageSummary {
+    summary: string; // Concise summary of main content (1000 characters or less)
+    keyPoints: string[]; // Main points or key information (max 5)
+    entities: string[]; // Important entities mentioned (people, organizations, technologies)
+    topics: string[]; // Main topics or themes
+    contentType: string; // Type of content (e.g., 'article', 'documentation', 'news', 'reference', 'tutorial', 'blog', 'forum', 'other')
+    intent: string; // Likely user intent for bookmarking (e.g., 'research', 'reference', 'learning', 'entertainment', 'shopping', 'work', 'news', 'other')
+}

--- a/ts/packages/agents/browser/src/agent/knowledge/browserKnowledgeExtractor.mts
+++ b/ts/packages/agents/browser/src/agent/knowledge/browserKnowledgeExtractor.mts
@@ -15,6 +15,7 @@ import { BrowserActionContext } from "../actionHandler.mjs";
 import { conversation as kpLib } from "knowledge-processor";
 import { openai as ai } from "aiclient";
 import { ActionDetectionAdapter } from "./actionDetectionAdapter.mjs";
+import { ContentSummaryAdapter } from "../indexing/contentSummaryAdapter.mjs";
 
 /**
  * Browser Knowledge Extractor that delegates to the website-memory package
@@ -23,6 +24,7 @@ export class BrowserKnowledgeExtractor {
     private contentExtractor: ContentExtractor;
     private batchProcessor: BatchProcessor;
     private actionDetectionAdapter: ActionDetectionAdapter;
+    private contentSummaryAdapter: ContentSummaryAdapter;
 
     constructor(context: SessionContext<BrowserActionContext>) {
         // Create knowledge extractor from session context
@@ -49,6 +51,17 @@ export class BrowserKnowledgeExtractor {
 
         // Initialize action detection adapter
         this.actionDetectionAdapter = new ActionDetectionAdapter();
+
+        // Initialize content summary adapter
+        this.contentSummaryAdapter = new ContentSummaryAdapter();
+
+        // Ensure content summary adapter is ready for summary mode
+        this.contentSummaryAdapter.ensureInitialized().catch((error) => {
+            console.warn(
+                "Content summary adapter initialization failed:",
+                error,
+            );
+        });
     }
 
     /**
@@ -59,6 +72,14 @@ export class BrowserKnowledgeExtractor {
         mode: ExtractionMode = "content",
     ) {
         try {
+            // For summary mode, prepare the content with summarized text
+            if (
+                mode === ("summary" as ExtractionMode) &&
+                this.contentSummaryAdapter.isAvailable()
+            ) {
+                content = await this.prepareSummarizedContent(content);
+            }
+
             // Simple delegation - mode automatically determines AI usage and knowledge strategy
             return await this.contentExtractor.extract(content, mode);
         } catch (error) {
@@ -232,5 +253,147 @@ export class BrowserKnowledgeExtractor {
      */
     isActionDetectionAvailable(): boolean {
         return this.actionDetectionAdapter.isActionDetectionAvailable();
+    }
+
+    /**
+     * Prepare content with summarized text for summary mode
+     * This replaces the main content with an AI-generated summary before knowledge extraction
+     */
+    private async prepareSummarizedContent(
+        content: ExtractionInput,
+    ): Promise<ExtractionInput> {
+        try {
+            console.log("Preparing summarized content for summary mode...");
+
+            // Get text content from the original input
+            const textContent = this.prepareTextFromInput(content);
+
+            if (!textContent || textContent.length < 200) {
+                console.log(
+                    "Insufficient text content for summarization, using original content",
+                );
+                return content;
+            }
+
+            const startTime = Date.now();
+
+            // Apply summary enhancement with context information
+            const enhancementOptions: any = {
+                url: content.url,
+                title: content.title,
+                includeContextInEnhancedText: true,
+            };
+
+            const bookmarkFolder = this.extractBookmarkFolder(content);
+            if (bookmarkFolder) {
+                enhancementOptions.bookmarkFolder = bookmarkFolder;
+            }
+
+            const { enhancedText, summaryData, processingTime } =
+                await this.contentSummaryAdapter.enhanceWithSummary(
+                    textContent,
+                    "summary" as ExtractionMode,
+                    enhancementOptions,
+                );
+
+            if (enhancedText && enhancedText !== textContent) {
+                console.log(
+                    `Summary generated in ${processingTime}ms, replacing main content...`,
+                );
+
+                // Create a new content object with summarized text replacing the main content
+                const summarizedContent: ExtractionInput = {
+                    ...content,
+                    textContent: enhancedText,
+                    // Store the summary metadata for potential later use
+                    summaryData,
+                    summaryProcessingTime: processingTime,
+                } as any;
+
+                console.log(
+                    `Content preparation completed in ${Date.now() - startTime}ms total`,
+                );
+
+                return summarizedContent;
+            } else {
+                console.log(
+                    "No enhanced text generated, using original content",
+                );
+                return content;
+            }
+        } catch (error) {
+            console.warn("Summary content preparation failed:", error);
+            // Return original content as fallback
+            return content;
+        }
+    }
+
+    /**
+     * Extract bookmark folder information from content input
+     */
+    private extractBookmarkFolder(
+        content: ExtractionInput,
+    ): string | undefined {
+        // Check if content has folder information
+        if ((content as any).folder) {
+            return (content as any).folder;
+        }
+
+        // Could also extract from URL path for some cases
+        if (content.url) {
+            try {
+                const url = new URL(content.url);
+                // For some bookmark systems, folder info might be in URL parameters
+                const folderParam =
+                    url.searchParams.get("folder") ||
+                    url.searchParams.get("path");
+                if (folderParam) {
+                    return folderParam;
+                }
+            } catch {
+                // Invalid URL, continue without folder info
+            }
+        }
+
+        return undefined;
+    }
+
+    /**
+     * Prepare text content from extraction input for summarization
+     */
+    private prepareTextFromInput(content: ExtractionInput): string {
+        const parts: string[] = [];
+
+        // Add title
+        if (content.title) {
+            parts.push(`Title: ${content.title}`);
+        }
+
+        // Add main text content
+        if (content.textContent) {
+            parts.push(content.textContent);
+        }
+
+        // If we have HTML fragments, extract text from them
+        if (content.htmlFragments && content.htmlFragments.length > 0) {
+            const fragmentTexts = content.htmlFragments
+                .map((fragment: any) => {
+                    if (typeof fragment === "string") {
+                        return fragment;
+                    } else if (fragment.content) {
+                        return fragment.content;
+                    } else if (fragment.textContent) {
+                        return fragment.textContent;
+                    }
+                    return "";
+                })
+                .filter((text: string) => text && text.length > 0);
+
+            if (fragmentTexts.length > 0) {
+                parts.push(fragmentTexts.join("\n\n"));
+            }
+        }
+
+        return parts.join("\n\n").trim();
     }
 }

--- a/ts/packages/agents/browser/src/agent/knowledge/knowledgeHandler.mts
+++ b/ts/packages/agents/browser/src/agent/knowledge/knowledgeHandler.mts
@@ -394,7 +394,7 @@ export async function extractKnowledgeFromPage(
         extractEntities: boolean;
         extractRelationships: boolean;
         suggestQuestions: boolean;
-        mode?: "basic" | "content" | "actions" | "full";
+        mode?: "basic" | "summary" | "content" | "actions" | "full";
     },
     context: SessionContext<BrowserActionContext>,
 ): Promise<EnhancedKnowledgeExtractionResult> {
@@ -421,7 +421,7 @@ export async function extractKnowledgeFromPage(
     }
 
     try {
-        const extractionMode = parameters.mode || "content";
+        const extractionMode = (parameters.mode || "content") as ExtractionMode;
         const extractor = new BrowserKnowledgeExtractor(context);
 
         // Process each fragment individually using batch processing

--- a/ts/packages/agents/browser/src/agent/knowledge/knowledgeHandler.mts
+++ b/ts/packages/agents/browser/src/agent/knowledge/knowledgeHandler.mts
@@ -1436,16 +1436,17 @@ export async function getRecentKnowledgeItems(
                 // Extract relationships from actions data
                 // This provides properly formatted relationship data for the UI
                 if (type === "relationships" || type === "all") {
-                    const actions =
-                        (knowledge as any).actions ||
-                        [];
+                    const actions = (knowledge as any).actions || [];
 
                     if (Array.isArray(actions)) {
                         for (const action of actions) {
                             // Transform action data to relationship format
-                            const from = action.subjectEntityName || "Unknown Entity";
-                            const relationship = action.verbs?.join(", ") || "related to";
-                            const to = action.objectEntityName || "Unknown Target";
+                            const from =
+                                action.subjectEntityName || "Unknown Entity";
+                            const relationship =
+                                action.verbs?.join(", ") || "related to";
+                            const to =
+                                action.objectEntityName || "Unknown Target";
                             const confidence = action.confidence || 0.8;
 
                             recentRelationships.push({

--- a/ts/packages/agents/browser/src/agent/knowledge/knowledgeHandler.mts
+++ b/ts/packages/agents/browser/src/agent/knowledge/knowledgeHandler.mts
@@ -71,6 +71,14 @@ interface AnalyticsDataResponse {
             fromPage: string;
             extractedAt: string;
         }>;
+        recentRelationships?: Array<{
+            from: string;
+            relationship: string;
+            to: string;
+            confidence: number;
+            fromPage: string;
+            extractedAt: string;
+        }>;
     };
     domains: {
         topDomains: Array<{
@@ -1272,7 +1280,7 @@ export async function checkActionDetectionStatus(
 export async function getRecentKnowledgeItems(
     parameters: {
         limit?: number;
-        type?: "entities" | "topics" | "actions" | "all";
+        type?: "entities" | "topics" | "actions" | "relationships" | "all";
     },
     context: SessionContext<BrowserActionContext>,
 ): Promise<{
@@ -1291,6 +1299,14 @@ export async function getRecentKnowledgeItems(
         fromPage: string;
         extractedAt: string;
     }>;
+    relationships: Array<{
+        from: string;
+        relationship: string;
+        to: string;
+        confidence: number;
+        fromPage: string;
+        extractedAt: string;
+    }>;
     success: boolean;
 }> {
     try {
@@ -1301,6 +1317,7 @@ export async function getRecentKnowledgeItems(
                 entities: [],
                 topics: [],
                 actions: [],
+                relationships: [],
                 success: false,
             };
         }
@@ -1324,6 +1341,14 @@ export async function getRecentKnowledgeItems(
             type: string;
             element: string;
             text?: string;
+            confidence: number;
+            fromPage: string;
+            extractedAt: string;
+        }> = [];
+        const recentRelationships: Array<{
+            from: string;
+            relationship: string;
+            to: string;
             confidence: number;
             fromPage: string;
             extractedAt: string;
@@ -1407,6 +1432,33 @@ export async function getRecentKnowledgeItems(
                         }
                     }
                 }
+
+                // Extract relationships from actions data
+                // This provides properly formatted relationship data for the UI
+                if (type === "relationships" || type === "all") {
+                    const actions =
+                        (knowledge as any).actions ||
+                        [];
+
+                    if (Array.isArray(actions)) {
+                        for (const action of actions) {
+                            // Transform action data to relationship format
+                            const from = action.subjectEntityName || "Unknown Entity";
+                            const relationship = action.verbs?.join(", ") || "related to";
+                            const to = action.objectEntityName || "Unknown Target";
+                            const confidence = action.confidence || 0.8;
+
+                            recentRelationships.push({
+                                from: from,
+                                relationship: relationship,
+                                to: to,
+                                confidence: confidence,
+                                fromPage: pageTitle,
+                                extractedAt: extractedAt,
+                            });
+                        }
+                    }
+                }
             }
         }
 
@@ -1422,6 +1474,11 @@ export async function getRecentKnowledgeItems(
                 new Date(a.extractedAt).getTime(),
         );
         recentActions.sort(
+            (a, b) =>
+                new Date(b.extractedAt).getTime() -
+                new Date(a.extractedAt).getTime(),
+        );
+        recentRelationships.sort(
             (a, b) =>
                 new Date(b.extractedAt).getTime() -
                 new Date(a.extractedAt).getTime(),
@@ -1460,10 +1517,23 @@ export async function getRecentKnowledgeItems(
             )
             .slice(0, limit);
 
+        const uniqueRelationships = recentRelationships
+            .filter(
+                (relationship, index, arr) =>
+                    arr.findIndex(
+                        (r) =>
+                            r.from === relationship.from &&
+                            r.relationship === relationship.relationship &&
+                            r.to === relationship.to,
+                    ) === index,
+            )
+            .slice(0, limit);
+
         return {
             entities: uniqueEntities,
             topics: uniqueTopics,
             actions: uniqueActions,
+            relationships: uniqueRelationships,
             success: true,
         };
     } catch (error) {
@@ -1472,6 +1542,7 @@ export async function getRecentKnowledgeItems(
             entities: [],
             topics: [],
             actions: [],
+            relationships: [],
             success: false,
         };
     }
@@ -2653,6 +2724,7 @@ export async function getAnalyticsData(
                 recentEntities: recentKnowledgeItems.entities || [],
                 recentTopics: recentKnowledgeItems.topics || [],
                 recentActions: recentKnowledgeItems.actions || [],
+                recentRelationships: recentKnowledgeItems.relationships || [],
             },
             domains: {
                 topDomains: topDomains.domains || [],

--- a/ts/packages/agents/browser/src/agent/manifest.json
+++ b/ts/packages/agents/browser/src/agent/manifest.json
@@ -3,6 +3,12 @@
   "defaultEnabled": true,
   "description": "Agent that allows you control an existing browser window",
   "localView": true,
+  "indexingServices": {
+    "website": {
+      "serviceScript": "./dist/agent/indexing/browserIndexingService.js",
+      "description": "Enhanced website indexing with knowledge extraction"
+    }
+  },
   "schema": {
     "description": "Browser agent that allows you control an existing browser window and perform actions such as opening a new tab, closing a tab, scrolling, zooming and navigating to a specific URL.",
     "schemaFile": "./actionsSchema.mts",

--- a/ts/packages/agents/browser/src/extension/views/interfaces/analyticsTypes.ts
+++ b/ts/packages/agents/browser/src/extension/views/interfaces/analyticsTypes.ts
@@ -61,6 +61,14 @@ export interface AnalyticsData {
             fromPage: string;
             extractedAt: string;
         }>;
+        recentRelationships?: Array<{
+            from: string;
+            relationship: string;
+            to: string;
+            confidence: number;
+            fromPage: string;
+            extractedAt: string;
+        }>;
     };
     activity?: {
         trends: Array<{

--- a/ts/packages/agents/browser/src/extension/views/knowledgeAnalyticsPanel.ts
+++ b/ts/packages/agents/browser/src/extension/views/knowledgeAnalyticsPanel.ts
@@ -209,9 +209,7 @@ export class KnowledgeAnalyticsPanel {
             knowledge.recentTopics || knowledge.recentItems?.topics || [],
         );
         // Use recentRelationships instead of transforming recentActions
-        this.updateRecentActionsDisplay(
-            knowledge.recentRelationships || [],
-        );
+        this.updateRecentActionsDisplay(knowledge.recentRelationships || []);
     }
 
     private updateKnowledgeVisualizationCards(knowledge: any): void {
@@ -607,7 +605,8 @@ export class KnowledgeAnalyticsPanel {
         // Use the relationship data directly (no transformation needed)
         const relationshipsHtml = recentRelationships
             .slice(0, 10)
-            .map((rel) => `
+            .map(
+                (rel) => `
                 <div class="relationship-item rounded">
                     <span class="fw-semibold">${this.escapeHtml(rel.from)}</span>
                     <i class="bi bi-arrow-right mx-2 text-muted"></i>
@@ -615,7 +614,8 @@ export class KnowledgeAnalyticsPanel {
                     <i class="bi bi-arrow-right mx-2 text-muted"></i>
                     <span class="fw-semibold">${this.escapeHtml(rel.to)}</span>
                 </div>
-            `)
+            `,
+            )
             .join("");
 
         container.innerHTML = relationshipsHtml;

--- a/ts/packages/agents/browser/src/extension/views/knowledgeAnalyticsPanel.ts
+++ b/ts/packages/agents/browser/src/extension/views/knowledgeAnalyticsPanel.ts
@@ -208,8 +208,9 @@ export class KnowledgeAnalyticsPanel {
         this.updateRecentTopicsDisplay(
             knowledge.recentTopics || knowledge.recentItems?.topics || [],
         );
+        // Use recentRelationships instead of transforming recentActions
         this.updateRecentActionsDisplay(
-            knowledge.recentActions || knowledge.recentItems?.actions || [],
+            knowledge.recentRelationships || [],
         );
     }
 
@@ -539,19 +540,13 @@ export class KnowledgeAnalyticsPanel {
             .slice(0, 10)
             .map(
                 (entity) => `
-            <div class="recent-item entity-item">
-                <div class="item-icon">
+            <div class="entity-pill">
+                <div class="pill-icon">
                     <i class="bi bi-diagram-2"></i>
                 </div>
-                <div class="item-content">
-                    <div class="item-name">${this.escapeHtml(entity.name || "Unknown Entity")}</div>
-                    <div class="item-meta">
-                        <span class="entity-type">${this.escapeHtml(entity.type || "Unknown")}</span>
-                        ${entity.confidence ? `<span class="confidence">Confidence: ${Math.round(entity.confidence * 100)}%</span>` : ""}
-                    </div>
-                </div>
-                <div class="item-date">
-                    ${this.formatRelativeDate(entity.extractedAt || entity.createdAt)}
+                <div class="pill-content">
+                    <div class="pill-name">${this.escapeHtml(entity.name || "Unknown Entity")}</div>
+                    <div class="pill-type">${this.escapeHtml(entity.type || "Unknown")}</div>
                 </div>
             </div>
         `,
@@ -579,19 +574,13 @@ export class KnowledgeAnalyticsPanel {
             .slice(0, 10)
             .map(
                 (topic) => `
-            <div class="recent-item topic-item">
-                <div class="item-icon">
+            <div class="topic-pill">
+                <div class="pill-icon">
                     <i class="bi bi-tags"></i>
                 </div>
-                <div class="item-content">
-                    <div class="item-name">${this.escapeHtml(topic.name || topic.topic || "Unknown Topic")}</div>
-                    <div class="item-meta">
-                        ${topic.category ? `<span class="topic-category">${this.escapeHtml(topic.category)}</span>` : ""}
-                        ${topic.relevance ? `<span class="relevance">Relevance: ${Math.round(topic.relevance * 100)}%</span>` : ""}
-                    </div>
-                </div>
-                <div class="item-date">
-                    ${this.formatRelativeDate(topic.identifiedAt || topic.createdAt)}
+                <div class="pill-content">
+                    <div class="pill-name">${this.escapeHtml(topic.name || topic.topic || "Unknown Topic")}</div>
+                    ${topic.category ? `<div class="pill-type">${this.escapeHtml(topic.category)}</div>` : ""}
                 </div>
             </div>
         `,
@@ -601,44 +590,35 @@ export class KnowledgeAnalyticsPanel {
         container.innerHTML = topicsHtml;
     }
 
-    private updateRecentActionsDisplay(recentActions: any[]): void {
+    private updateRecentActionsDisplay(recentRelationships: any[]): void {
         const container = document.getElementById("recentActionsList");
         if (!container) return;
 
-        if (!recentActions || recentActions.length === 0) {
+        if (!recentRelationships || recentRelationships.length === 0) {
             container.innerHTML = `
                 <div class="empty-message">
-                    <i class="bi bi-lightning"></i>
-                    <span>No recent actions suggested</span>
+                    <i class="bi bi-diagram-3"></i>
+                    <span>No recent entity actions identified</span>
                 </div>
             `;
             return;
         }
 
-        const actionsHtml = recentActions
+        // Use the relationship data directly (no transformation needed)
+        const relationshipsHtml = recentRelationships
             .slice(0, 10)
-            .map(
-                (action) => `
-            <div class="recent-item action-item">
-                <div class="item-icon">
-                    <i class="bi bi-lightning"></i>
+            .map((rel) => `
+                <div class="relationship-item rounded">
+                    <span class="fw-semibold">${this.escapeHtml(rel.from)}</span>
+                    <i class="bi bi-arrow-right mx-2 text-muted"></i>
+                    <span class="text-muted">${this.escapeHtml(rel.relationship)}</span>
+                    <i class="bi bi-arrow-right mx-2 text-muted"></i>
+                    <span class="fw-semibold">${this.escapeHtml(rel.to)}</span>
                 </div>
-                <div class="item-content">
-                    <div class="item-name">${this.escapeHtml(action.name || action.action || "Unknown Action")}</div>
-                    <div class="item-meta">
-                        ${action.type ? `<span class="action-type">${this.escapeHtml(action.type)}</span>` : ""}
-                        ${action.confidence ? `<span class="confidence">Confidence: ${Math.round(action.confidence * 100)}%</span>` : ""}
-                    </div>
-                </div>
-                <div class="item-date">
-                    ${this.formatRelativeDate(action.suggestedAt || action.createdAt)}
-                </div>
-            </div>
-        `,
-            )
+            `)
             .join("");
 
-        container.innerHTML = actionsHtml;
+        container.innerHTML = relationshipsHtml;
     }
 
     private formatRelativeDate(dateString?: string): string {

--- a/ts/packages/agents/browser/src/extension/views/knowledgeLibrary.css
+++ b/ts/packages/agents/browser/src/extension/views/knowledgeLibrary.css
@@ -1918,8 +1918,9 @@ body {
   max-height: 120px;
   overflow-y: auto;
   display: flex;
-  flex-direction: column;
-  gap: 0.25rem;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: flex-start;
 }
 
 .recent-item {
@@ -1991,6 +1992,196 @@ body {
   font-size: 0.8rem;
   padding: 1rem;
   font-style: italic;
+}
+
+/* Entity Pills */
+.entity-pill {
+  display: flex;
+  align-items: center;
+  padding: 0.375rem 0.75rem;
+  background: linear-gradient(135deg, #f8f9ff 0%, #e9ecff 100%);
+  border: 1px solid rgba(23, 162, 184, 0.2);
+  border-radius: 20px;
+  transition: all 0.2s ease;
+  cursor: pointer;
+  font-size: 0.8rem;
+  margin-bottom: 0.25rem;
+  max-width: 200px;
+}
+
+.entity-pill:hover {
+  background: linear-gradient(135deg, #e9ecff 0%, #dde2ff 100%);
+  border-color: rgba(23, 162, 184, 0.3);
+  transform: translateY(-1px);
+  box-shadow: 0 2px 8px rgba(23, 162, 184, 0.15);
+}
+
+.entity-pill .pill-icon {
+  color: #17a2b8;
+  margin-right: 0.5rem;
+  font-size: 0.75rem;
+}
+
+.entity-pill .pill-content {
+  flex: 1;
+  min-width: 0;
+}
+
+.entity-pill .pill-name {
+  font-weight: 500;
+  color: var(--text-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  line-height: 1.2;
+}
+
+.entity-pill .pill-type {
+  font-size: 0.7rem;
+  color: #17a2b8;
+  opacity: 0.8;
+  font-weight: 400;
+  margin-top: 0.125rem;
+}
+
+/* Topic Pills */
+.topic-pill {
+  display: flex;
+  align-items: center;
+  padding: 0.375rem 0.75rem;
+  background: linear-gradient(135deg, #f8f2ff 0%, #f0e6ff 100%);
+  border: 1px solid rgba(111, 66, 193, 0.2);
+  border-radius: 20px;
+  transition: all 0.2s ease;
+  cursor: pointer;
+  font-size: 0.8rem;
+  margin-bottom: 0.25rem;
+  max-width: 200px;
+}
+
+.topic-pill:hover {
+  background: linear-gradient(135deg, #f0e6ff 0%, #e6d9ff 100%);
+  border-color: rgba(111, 66, 193, 0.3);
+  transform: translateY(-1px);
+  box-shadow: 0 2px 8px rgba(111, 66, 193, 0.15);
+}
+
+.topic-pill .pill-icon {
+  color: #6f42c1;
+  margin-right: 0.5rem;
+  font-size: 0.75rem;
+}
+
+.topic-pill .pill-content {
+  flex: 1;
+  min-width: 0;
+}
+
+.topic-pill .pill-name {
+  font-weight: 500;
+  color: var(--text-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  line-height: 1.2;
+}
+
+.topic-pill .pill-type {
+  font-size: 0.7rem;
+  color: #6f42c1;
+  opacity: 0.8;
+  font-weight: 400;
+  margin-top: 0.125rem;
+}
+
+/* Relationship Items */
+.relationship-item {
+  display: flex;
+  align-items: center;
+  padding: 0.5rem 0.75rem;
+  background: rgba(255, 255, 255, 0.8);
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  border-radius: var(--border-radius-sm);
+  margin-bottom: 0.25rem;
+  transition: all 0.2s ease;
+  font-size: 0.8rem;
+  max-width: 100%;
+  word-wrap: break-word;
+}
+
+.relationship-item:hover {
+  background: rgba(255, 255, 255, 0.95);
+  border-color: var(--primary-color);
+  transform: translateX(2px);
+  box-shadow: 0 2px 8px rgba(102, 126, 234, 0.1);
+}
+
+.relationship-item .fw-semibold {
+  color: var(--text-primary);
+  font-weight: 600;
+  font-size: 0.8rem;
+}
+
+.relationship-item .text-muted {
+  color: var(--text-secondary);
+  font-style: italic;
+  font-size: 0.75rem;
+}
+
+.relationship-item .bi-arrow-right {
+  color: var(--text-muted);
+  font-size: 0.7rem;
+  opacity: 0.7;
+}
+
+/* Action Pills */
+.action-pill {
+  display: flex;
+  align-items: center;
+  padding: 0.375rem 0.75rem;
+  background: linear-gradient(135deg, #fff8f0 0%, #fff0e6 100%);
+  border: 1px solid rgba(253, 126, 20, 0.2);
+  border-radius: 20px;
+  transition: all 0.2s ease;
+  cursor: pointer;
+  font-size: 0.8rem;
+  margin-bottom: 0.25rem;
+  max-width: 200px;
+}
+
+.action-pill:hover {
+  background: linear-gradient(135deg, #fff0e6 0%, #ffe6d9 100%);
+  border-color: rgba(253, 126, 20, 0.3);
+  transform: translateY(-1px);
+  box-shadow: 0 2px 8px rgba(253, 126, 20, 0.15);
+}
+
+.action-pill .pill-icon {
+  color: #fd7e14;
+  margin-right: 0.5rem;
+  font-size: 0.75rem;
+}
+
+.action-pill .pill-content {
+  flex: 1;
+  min-width: 0;
+}
+
+.action-pill .pill-name {
+  font-weight: 500;
+  color: var(--text-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  line-height: 1.2;
+}
+
+.action-pill .pill-type {
+  font-size: 0.7rem;
+  color: #fd7e14;
+  opacity: 0.8;
+  font-weight: 400;
+  margin-top: 0.125rem;
 }
 
 /* Scrollbar styling for recent items */

--- a/ts/packages/agents/browser/src/extension/views/knowledgeLibrary.css
+++ b/ts/packages/agents/browser/src/extension/views/knowledgeLibrary.css
@@ -4090,8 +4090,8 @@ body {
   background: linear-gradient(
     to right,
     #28a745 0%,
-    #28a745 33.33%,
-    #e9ecef 33.33%,
+    #28a745 20%,
+    #e9ecef 20%,
     #e9ecef 100%
   );
 }
@@ -4104,14 +4104,36 @@ body {
   background: #28a745;
 }
 
+.extraction-mode-slider[data-mode="summary"] {
+  background: linear-gradient(
+    to right,
+    #28a745 0%,
+    #28a745 20%,
+    #ffc107 20%,
+    #ffc107 40%,
+    #e9ecef 40%,
+    #e9ecef 100%
+  );
+}
+
+.extraction-mode-slider[data-mode="summary"]::-webkit-slider-thumb {
+  background: #ffc107;
+}
+
+.extraction-mode-slider[data-mode="summary"]::-moz-range-thumb {
+  background: #ffc107;
+}
+
 .extraction-mode-slider[data-mode="content"] {
   background: linear-gradient(
     to right,
     #28a745 0%,
-    #28a745 33.33%,
-    #667eea 33.33%,
-    #667eea 66.66%,
-    #e9ecef 66.66%,
+    #28a745 20%,
+    #ffc107 20%,
+    #ffc107 40%,
+    #667eea 40%,
+    #667eea 60%,
+    #e9ecef 60%,
     #e9ecef 100%
   );
 }
@@ -4128,11 +4150,15 @@ body {
   background: linear-gradient(
     to right,
     #28a745 0%,
-    #28a745 33.33%,
-    #667eea 33.33%,
-    #667eea 66.66%,
-    #fd7e14 66.66%,
-    #fd7e14 100%
+    #28a745 20%,
+    #ffc107 20%,
+    #ffc107 40%,
+    #667eea 40%,
+    #667eea 60%,
+    #fd7e14 60%,
+    #fd7e14 80%,
+    #e9ecef 80%,
+    #e9ecef 100%
   );
 }
 
@@ -4141,6 +4167,30 @@ body {
 }
 
 .extraction-mode-slider[data-mode="actions"]::-moz-range-thumb {
+  background: #fd7e14;
+}
+
+.extraction-mode-slider[data-mode="full"] {
+  background: linear-gradient(
+    to right,
+    #28a745 0%,
+    #28a745 20%,
+    #ffc107 20%,
+    #ffc107 40%,
+    #667eea 40%,
+    #667eea 60%,
+    #fd7e14 60%,
+    #fd7e14 80%,
+    #dc3545 80%,
+    #dc3545 100%
+  );
+}
+
+.extraction-mode-slider[data-mode="full"]::-webkit-slider-thumb {
+  background: #dc3545;
+}
+
+.extraction-mode-slider[data-mode="full"]::-moz-range-thumb {
   background: #fd7e14;
 }
 

--- a/ts/packages/agents/browser/src/extension/views/knowledgeLibrary.html
+++ b/ts/packages/agents/browser/src/extension/views/knowledgeLibrary.html
@@ -550,9 +550,13 @@
                     </div>
                     <div class="knowledge-label">Actionable Items Found</div>
                     <div class="action-breakdown">
-                      <div class="recent-items-header">Recent Entity Actions</div>
+                      <div class="recent-items-header">
+                        Recent Entity Actions
+                      </div>
                       <div id="recentActionsList" class="recent-items-list">
-                        <div class="empty-message">No recent entity actions</div>
+                        <div class="empty-message">
+                          No recent entity actions
+                        </div>
                       </div>
                     </div>
                   </div>

--- a/ts/packages/agents/browser/src/extension/views/knowledgeLibrary.html
+++ b/ts/packages/agents/browser/src/extension/views/knowledgeLibrary.html
@@ -807,8 +807,8 @@
                             id="webExtractionMode"
                             class="extraction-mode-slider"
                             min="0"
-                            max="3"
-                            value="1"
+                            max="4"
+                            value="2"
                             step="1"
                             data-mode="content"
                           />
@@ -817,12 +817,15 @@
                               >Basic</span
                             >
                             <span class="slider-label" data-value="1"
-                              >Content</span
+                              >Summary</span
                             >
                             <span class="slider-label" data-value="2"
-                              >Actions</span
+                              >Content</span
                             >
                             <span class="slider-label" data-value="3"
+                              >Actions</span
+                            >
+                            <span class="slider-label" data-value="4"
                               >Full</span
                             >
                           </div>
@@ -831,6 +834,7 @@
                             <span class="slider-tick" data-value="1"></span>
                             <span class="slider-tick" data-value="2"></span>
                             <span class="slider-tick" data-value="3"></span>
+                            <span class="slider-tick" data-value="4"></span>
                           </div>
                         </div>
                         <small class="text-muted">
@@ -1083,8 +1087,8 @@
                             id="folderExtractionMode"
                             class="extraction-mode-slider"
                             min="0"
-                            max="3"
-                            value="1"
+                            max="4"
+                            value="2"
                             step="1"
                             data-mode="content"
                           />
@@ -1093,12 +1097,15 @@
                               >Basic</span
                             >
                             <span class="slider-label" data-value="1"
-                              >Content</span
+                              >Summary</span
                             >
                             <span class="slider-label" data-value="2"
-                              >Actions</span
+                              >Content</span
                             >
                             <span class="slider-label" data-value="3"
+                              >Actions</span
+                            >
+                            <span class="slider-label" data-value="4"
                               >Full</span
                             >
                           </div>
@@ -1107,6 +1114,7 @@
                             <span class="slider-tick" data-value="1"></span>
                             <span class="slider-tick" data-value="2"></span>
                             <span class="slider-tick" data-value="3"></span>
+                            <span class="slider-tick" data-value="4"></span>
                           </div>
                         </div>
                         <small class="text-muted">

--- a/ts/packages/agents/browser/src/extension/views/knowledgeLibrary.html
+++ b/ts/packages/agents/browser/src/extension/views/knowledgeLibrary.html
@@ -541,8 +541,8 @@
 
                 <div class="knowledge-card actions">
                   <div class="knowledge-card-header">
-                    <i class="bi bi-lightning"></i>
-                    <h3>Actions</h3>
+                    <i class="bi bi-diagram-3"></i>
+                    <h3>Entity Actions</h3>
                   </div>
                   <div class="knowledge-card-body">
                     <div class="knowledge-metric" id="totalActionsMetric">
@@ -550,9 +550,9 @@
                     </div>
                     <div class="knowledge-label">Actionable Items Found</div>
                     <div class="action-breakdown">
-                      <div class="recent-items-header">Recent Actions</div>
+                      <div class="recent-items-header">Recent Entity Actions</div>
                       <div id="recentActionsList" class="recent-items-list">
-                        <div class="empty-message">No recent actions</div>
+                        <div class="empty-message">No recent entity actions</div>
                       </div>
                     </div>
                   </div>

--- a/ts/packages/agents/browser/src/extension/views/pageKnowledge.html
+++ b/ts/packages/agents/browser/src/extension/views/pageKnowledge.html
@@ -620,8 +620,8 @@
         background: linear-gradient(
           to right,
           #28a745 0%,
-          #28a745 33.33%,
-          #e9ecef 33.33%,
+          #28a745 20%,
+          #e9ecef 20%,
           #e9ecef 100%
         );
       }
@@ -634,15 +634,38 @@
         background: #28a745;
       }
 
+      /* Summary mode color - yellow for enhanced processing */
+      .extraction-mode-slider[data-mode="summary"] {
+        background: linear-gradient(
+          to right,
+          #28a745 0%,
+          #28a745 20%,
+          #ffc107 20%,
+          #ffc107 40%,
+          #e9ecef 40%,
+          #e9ecef 100%
+        );
+      }
+
+      .extraction-mode-slider[data-mode="summary"]::-webkit-slider-thumb {
+        background: #ffc107;
+      }
+
+      .extraction-mode-slider[data-mode="summary"]::-moz-range-thumb {
+        background: #ffc107;
+      }
+
       /* Content mode color - blue for standard */
       .extraction-mode-slider[data-mode="content"] {
         background: linear-gradient(
           to right,
           #28a745 0%,
-          #28a745 33.33%,
-          #667eea 33.33%,
-          #667eea 66.66%,
-          #e9ecef 66.66%,
+          #28a745 20%,
+          #ffc107 20%,
+          #ffc107 40%,
+          #667eea 40%,
+          #667eea 60%,
+          #e9ecef 60%,
           #e9ecef 100%
         );
       }
@@ -660,11 +683,15 @@
         background: linear-gradient(
           to right,
           #28a745 0%,
-          #28a745 33.33%,
-          #667eea 33.33%,
-          #667eea 66.66%,
-          #fd7e14 66.66%,
-          #fd7e14 100%
+          #28a745 20%,
+          #ffc107 20%,
+          #ffc107 40%,
+          #667eea 40%,
+          #667eea 60%,
+          #fd7e14 60%,
+          #fd7e14 80%,
+          #e9ecef 80%,
+          #e9ecef 100%
         );
       }
 
@@ -681,12 +708,14 @@
         background: linear-gradient(
           to right,
           #28a745 0%,
-          #28a745 25%,
-          #667eea 25%,
-          #667eea 50%,
-          #fd7e14 50%,
-          #fd7e14 75%,
-          #dc3545 75%,
+          #28a745 20%,
+          #ffc107 20%,
+          #ffc107 40%,
+          #667eea 40%,
+          #667eea 60%,
+          #fd7e14 60%,
+          #fd7e14 80%,
+          #dc3545 80%,
           #dc3545 100%
         );
       }
@@ -751,9 +780,10 @@
             <div class="extraction-mode-slider-container">
               <div class="slider-labels">
                 <span class="slider-label" data-value="0">Basic</span>
-                <span class="slider-label" data-value="1">Content</span>
-                <span class="slider-label" data-value="2">Actions</span>
-                <span class="slider-label" data-value="3">Full</span>
+                <span class="slider-label" data-value="1">Summary</span>
+                <span class="slider-label" data-value="2">Content</span>
+                <span class="slider-label" data-value="3">Actions</span>
+                <span class="slider-label" data-value="4">Full</span>
               </div>
 
               <input
@@ -761,8 +791,8 @@
                 id="extractionMode"
                 class="extraction-mode-slider"
                 min="0"
-                max="3"
-                value="1"
+                max="4"
+                value="2"
                 step="1"
                 data-mode="content"
               />
@@ -772,6 +802,7 @@
                 <span class="slider-tick" data-value="1"></span>
                 <span class="slider-tick" data-value="2"></span>
                 <span class="slider-tick" data-value="3"></span>
+                <span class="slider-tick" data-value="4"></span>
               </div>
             </div>
             <div class="form-text" id="modeDescription">

--- a/ts/packages/agents/browser/src/extension/views/pageKnowledge.ts
+++ b/ts/packages/agents/browser/src/extension/views/pageKnowledge.ts
@@ -54,7 +54,7 @@ interface Relationship {
 }
 
 interface ExtractionSettings {
-    mode: "basic" | "content" | "actions" | "full";
+    mode: "basic" | "summary" | "content" | "actions" | "full";
 }
 
 interface ExtractionModeInfo {
@@ -71,6 +71,13 @@ const MODE_DESCRIPTIONS: Record<string, ExtractionModeInfo> = {
         requiresAI: false,
         features: ["URL analysis", "Domain classification", "Basic topics"],
         performance: "Fastest",
+    },
+    summary: {
+        description:
+            "AI-enhanced content summarization with key insights extraction",
+        requiresAI: true,
+        features: ["Content summarization", "Key insights", "Enhanced context"],
+        performance: "Fast",
     },
     content: {
         description:
@@ -169,7 +176,13 @@ class KnowledgePanel {
             .getElementById("extractionMode")!
             .addEventListener("input", (e) => {
                 const slider = e.target as HTMLInputElement;
-                const modeMap = ["basic", "content", "actions", "full"];
+                const modeMap = [
+                    "basic",
+                    "summary",
+                    "content",
+                    "actions",
+                    "full",
+                ];
                 const mode = modeMap[parseInt(slider.value)] as any;
                 slider.setAttribute("data-mode", mode);
                 this.updateExtractionMode(mode);
@@ -182,7 +195,13 @@ class KnowledgePanel {
                 const slider = document.getElementById(
                     "extractionMode",
                 ) as HTMLInputElement;
-                const modeMap = ["basic", "content", "actions", "full"];
+                const modeMap = [
+                    "basic",
+                    "summary",
+                    "content",
+                    "actions",
+                    "full",
+                ];
                 slider.value = index.toString();
                 slider.setAttribute("data-mode", modeMap[index]);
                 this.updateExtractionMode(modeMap[index] as any);
@@ -918,7 +937,13 @@ class KnowledgePanel {
                     "extractionMode",
                 ) as HTMLInputElement;
                 if (slider && this.extractionSettings.mode) {
-                    const modeMap = ["basic", "content", "actions", "full"];
+                    const modeMap = [
+                        "basic",
+                        "summary",
+                        "content",
+                        "actions",
+                        "full",
+                    ];
                     const value = modeMap.indexOf(this.extractionSettings.mode);
                     slider.value = value.toString();
                     slider.setAttribute(
@@ -1529,7 +1554,7 @@ class KnowledgePanel {
     }
 
     private updateExtractionMode(
-        mode: "basic" | "content" | "actions" | "full",
+        mode: "basic" | "summary" | "content" | "actions" | "full",
     ) {
         this.extractionSettings.mode = mode;
 

--- a/ts/packages/agents/browser/src/extension/views/websiteImportUI.ts
+++ b/ts/packages/agents/browser/src/extension/views/websiteImportUI.ts
@@ -949,7 +949,7 @@ export class WebsiteImportUI {
             "#folderContainer",
         ) as HTMLElement;
 
-        if (selectedType  && daysBackContainer  && folderContainer) {
+        if (selectedType && daysBackContainer && folderContainer) {
             const type = selectedType.getAttribute("data-type");
             if (type === "history") {
                 daysBackContainer.style.display = "block";

--- a/ts/packages/agents/browser/src/extension/views/websiteImportUI.ts
+++ b/ts/packages/agents/browser/src/extension/views/websiteImportUI.ts
@@ -594,7 +594,7 @@ export class WebsiteImportUI {
         ) as HTMLInputElement;
 
         // Convert slider value to mode string
-        const modeMap = ["basic", "content", "actions", "full"];
+        const modeMap = ["basic", "summary", "content", "actions", "full"];
         const extractionMode = extractionModeInput?.value
             ? (modeMap[parseInt(extractionModeInput.value)] as any)
             : "content";
@@ -662,7 +662,7 @@ export class WebsiteImportUI {
         ) as HTMLInputElement;
 
         // Convert slider value to mode string
-        const modeMap = ["basic", "content", "actions", "full"];
+        const modeMap = ["basic", "summary", "content", "actions", "full"];
         const extractionMode = extractionModeInput?.value
             ? (modeMap[parseInt(extractionModeInput.value)] as any)
             : "content";
@@ -1139,7 +1139,7 @@ export class WebsiteImportUI {
 
         // Handle slider input
         slider.addEventListener("input", () => {
-            const modeMap = ["basic", "content", "actions", "full"];
+            const modeMap = ["basic", "summary", "content", "actions", "full"];
             const mode = modeMap[parseInt(slider.value)];
             slider.setAttribute("data-mode", mode);
             this.updateSliderLabels(slider);
@@ -1150,7 +1150,13 @@ export class WebsiteImportUI {
         const labels = modal.querySelectorAll(".slider-label");
         labels.forEach((label, index) => {
             label.addEventListener("click", () => {
-                const modeMap = ["basic", "content", "actions", "full"];
+                const modeMap = [
+                    "basic",
+                    "summary",
+                    "content",
+                    "actions",
+                    "full",
+                ];
                 slider.value = index.toString();
                 slider.setAttribute("data-mode", modeMap[index]);
                 this.updateSliderLabels(slider);
@@ -1200,6 +1206,8 @@ export class WebsiteImportUI {
 
         const descriptions: Record<string, string> = {
             basic: "Fast metadata extraction without AI - perfect for bulk operations",
+            summary:
+                "AI-enhanced content summarization with key insights extraction",
             content:
                 "AI-powered content analysis with entity and topic extraction",
             actions: "AI analysis plus interaction detection for dynamic pages",

--- a/ts/packages/agents/browser/src/extension/views/websiteImportUI.ts
+++ b/ts/packages/agents/browser/src/extension/views/websiteImportUI.ts
@@ -949,7 +949,7 @@ export class WebsiteImportUI {
             "#folderContainer",
         ) as HTMLElement;
 
-        if (selectedType) {
+        if (selectedType  && daysBackContainer  && folderContainer) {
             const type = selectedType.getAttribute("data-type");
             if (type === "history") {
                 daysBackContainer.style.display = "block";

--- a/ts/packages/agents/browser/test/chrome-api-helper.ts
+++ b/ts/packages/agents/browser/test/chrome-api-helper.ts
@@ -3,7 +3,7 @@
 
 /// <reference path="types/jest-chrome-extensions.d.ts" />
 
-import DOMPurify from 'dompurify';
+import DOMPurify from "dompurify";
 
 /**
  * Removes all <script>...</script> tags from the input HTML, including nested/multiple instances.

--- a/ts/packages/agents/browser/test/chrome-api-helper.ts
+++ b/ts/packages/agents/browser/test/chrome-api-helper.ts
@@ -3,16 +3,14 @@
 
 /// <reference path="types/jest-chrome-extensions.d.ts" />
 
+import DOMPurify from 'dompurify';
+
 /**
  * Removes all <script>...</script> tags from the input HTML, including nested/multiple instances.
  */
 function removeScriptTags(html: string): string {
-    let prev;
-    do {
-        prev = html;
-        html = html.replace(/<script[^>]*>.*?<\/script>/gi, "");
-    } while (html !== prev);
-    return html;
+    const cleanHtml = DOMPurify.sanitize(html);
+    return cleanHtml;
 }
 
 /**

--- a/ts/packages/api/src/webDispatcher.ts
+++ b/ts/packages/api/src/webDispatcher.ts
@@ -9,6 +9,7 @@ import { createGenericChannel } from "agent-rpc/channel";
 import {
     getDefaultAppAgentProviders,
     getDefaultConstructionProvider,
+    getIndexingServiceRegistry,
 } from "default-agent-provider";
 import WebSocket from "ws";
 
@@ -39,6 +40,7 @@ export async function createWebDispatcher(): Promise<WebDispatcher> {
         clientId: getClientId(),
         clientIO: clientIO,
         constructionProvider: getDefaultConstructionProvider(),
+        indexingServiceRegistry: await getIndexingServiceRegistry(instanceDir),
     });
 
     let settingSummary: string = "";

--- a/ts/packages/cli/src/commands/interactive.ts
+++ b/ts/packages/cli/src/commands/interactive.ts
@@ -12,6 +12,7 @@ import {
     getDefaultAppAgentProviders,
     getDefaultConstructionProvider,
     getDefaultAppAgentInstaller,
+    getIndexingServiceRegistry,
 } from "default-agent-provider";
 import inspector from "node:inspector";
 import { getChatModelNames } from "aiclient";
@@ -83,6 +84,9 @@ export default class Interactive extends Command {
                 enableServiceHost: true,
                 clientIO,
                 dblogging: true,
+                indexingServiceRegistry: await getIndexingServiceRegistry(
+                    !flags.memory ? getInstanceDir() : undefined,
+                ),
                 clientId: getClientId(),
                 constructionProvider: getDefaultConstructionProvider(),
             });

--- a/ts/packages/cli/src/commands/replay.ts
+++ b/ts/packages/cli/src/commands/replay.ts
@@ -3,7 +3,10 @@
 
 import { Args, Command, Flags } from "@oclif/core";
 import { ClientIO, createDispatcher } from "agent-dispatcher";
-import { getDefaultAppAgentProviders } from "default-agent-provider";
+import {
+    getDefaultAppAgentProviders,
+    getIndexingServiceRegistry,
+} from "default-agent-provider";
 import { getChatModelNames } from "aiclient";
 import {
     ChatHistoryInput,
@@ -145,6 +148,8 @@ export default class ReplayCommand extends Command {
                 persistDir: instanceDir,
                 dblogging: true,
                 clientId: getClientId(),
+                indexingServiceRegistry:
+                    await getIndexingServiceRegistry(instanceDir),
             });
 
             try {

--- a/ts/packages/cli/src/commands/run/explain.ts
+++ b/ts/packages/cli/src/commands/run/explain.ts
@@ -9,7 +9,10 @@ import {
     getAllActionConfigProvider,
 } from "agent-dispatcher/internal";
 import { getClientId, getInstanceDir } from "agent-dispatcher/helpers/data";
-import { getDefaultAppAgentProviders } from "default-agent-provider";
+import {
+    getDefaultAppAgentProviders,
+    getIndexingServiceRegistry,
+} from "default-agent-provider";
 import { withConsoleClientIO } from "agent-dispatcher/helpers/console";
 import { ClientIO, createDispatcher } from "agent-dispatcher";
 
@@ -103,6 +106,8 @@ export default class ExplainCommand extends Command {
                 },
                 cache: { enabled: false },
                 clientIO,
+                indexingServiceRegistry:
+                    await getIndexingServiceRegistry(instanceDir),
                 persistDir: instanceDir,
                 dblogging: true,
                 clientId: getClientId(),

--- a/ts/packages/cli/src/commands/run/request.ts
+++ b/ts/packages/cli/src/commands/run/request.ts
@@ -8,7 +8,10 @@ import {
     getAllActionConfigProvider,
 } from "agent-dispatcher/internal";
 import { getClientId, getInstanceDir } from "agent-dispatcher/helpers/data";
-import { getDefaultAppAgentProviders } from "default-agent-provider";
+import {
+    getDefaultAppAgentProviders,
+    getIndexingServiceRegistry,
+} from "default-agent-provider";
 import chalk from "chalk";
 import { getChatModelNames } from "aiclient";
 import { readFileSync, existsSync } from "fs";
@@ -68,6 +71,8 @@ export default class RequestCommand extends Command {
             explainer: flags.explainer
                 ? { enabled: true, name: flags.explainer }
                 : { enabled: false },
+            indexingServiceRegistry:
+                await getIndexingServiceRegistry(instanceDir),
             cache: { enabled: false },
             persistDir: instanceDir,
             dblogging: true,

--- a/ts/packages/cli/src/commands/run/translate.ts
+++ b/ts/packages/cli/src/commands/run/translate.ts
@@ -3,7 +3,10 @@
 
 import { Args, Command, Flags } from "@oclif/core";
 import { ClientIO, createDispatcher } from "agent-dispatcher";
-import { getDefaultAppAgentProviders } from "default-agent-provider";
+import {
+    getDefaultAppAgentProviders,
+    getIndexingServiceRegistry,
+} from "default-agent-provider";
 import { getChatModelNames } from "aiclient";
 import { getAllActionConfigProvider } from "agent-dispatcher/internal";
 import { withConsoleClientIO } from "agent-dispatcher/helpers/console";
@@ -113,6 +116,8 @@ export default class TranslateCommand extends Command {
                 clientIO,
                 persistDir: instanceDir,
                 dblogging: true,
+                indexingServiceRegistry:
+                    await getIndexingServiceRegistry(instanceDir),
                 clientId: getClientId(),
             });
             try {

--- a/ts/packages/cli/src/commands/test/translate.ts
+++ b/ts/packages/cli/src/commands/test/translate.ts
@@ -12,6 +12,7 @@ import { getInstanceDir } from "agent-dispatcher/helpers/data";
 import {
     getDefaultAppAgentProviders,
     getDefaultConstructionProvider,
+    getIndexingServiceRegistry,
 } from "default-agent-provider";
 import chalk from "chalk";
 import fs from "node:fs";
@@ -385,6 +386,8 @@ export default class TestTranslateCommand extends Command {
                 cache: { enabled: flags.cache },
                 collectCommandResult: true,
                 constructionProvider: defaultConstructionProvider,
+                indexingServiceRegistry:
+                    await getIndexingServiceRegistry(getInstanceDir()),
             });
             if (flags.cache) {
                 await dispatcher.processCommand("@const import -t");

--- a/ts/packages/defaultAgentProvider/src/defaultAgentProviders.ts
+++ b/ts/packages/defaultAgentProvider/src/defaultAgentProviders.ts
@@ -1,7 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { AppAgentProvider, AppAgentInstaller } from "agent-dispatcher";
+import { 
+    AppAgentProvider, 
+    AppAgentInstaller, 
+    IndexingServiceRegistry,
+    DefaultIndexingServiceRegistry 
+} from "agent-dispatcher";
 import { createNpmAppAgentProvider } from "agent-dispatcher/helpers/npmAgentProvider";
 
 import path from "node:path";
@@ -106,4 +111,75 @@ export function getDefaultAppAgentInstaller(
             );
         },
     };
+}
+
+/**
+ * Build indexing service registry from all available app agent providers
+ * @param instanceDirOrConfigProvider - Either a string pointing to the instance directory where external agent config is stored, or a InstanceConfigProvider.
+ * @returns IndexingServiceRegistry containing all registered indexing services
+ */
+export async function getIndexingServiceRegistry(
+    instanceDirOrConfigProvider?: string | InstanceConfigProvider,
+): Promise<IndexingServiceRegistry> {
+    const providers = getDefaultAppAgentProviders(instanceDirOrConfigProvider);
+    const registry = new DefaultIndexingServiceRegistry();
+    
+    for (const provider of providers) {
+        const agentNames = provider.getAppAgentNames();
+        
+        for (const agentName of agentNames) {
+            try {
+                const manifest = await provider.getAppAgentManifest(agentName);
+                
+                if (manifest.indexingServices) {
+                    for (const [indexSource, serviceConfig] of Object.entries(manifest.indexingServices)) {
+                        // Resolve the absolute path to the service script
+                        let resolvedServicePath: string;
+                        try {
+                            // Get the agent package info to resolve paths correctly
+                            const agentConfigs = getProviderConfig().agents;
+                            const agentConfig = agentConfigs[agentName];
+                            
+                            if (agentConfig) {
+                                const { createRequire } = await import("module");
+                                const requirePath = agentConfig.path 
+                                    ? `${path.resolve(agentConfig.path)}${path.sep}package.json`
+                                    : import.meta.url;
+                                const require = createRequire(requirePath);
+                                
+                                // Try to resolve the service script directly using the package exports
+                                // For browser agent, this will resolve "./agent/indexing" export
+                                try {
+                                    resolvedServicePath = require.resolve(`${agentConfig.name}/agent/indexing`);
+                                } catch (exportError) {
+                                    // Fallback: resolve relative to the agent's main module
+                                    const agentMainPath = require.resolve(agentConfig.name);
+                                    const agentPackageDir = path.dirname(agentMainPath);
+                                    resolvedServicePath = path.resolve(agentPackageDir, serviceConfig.serviceScript);
+                                }
+                            } else {
+                                throw new Error(`Agent config not found for ${agentName}`);
+                            }
+                        } catch (pathError) {
+                            console.warn(`Failed to resolve service path for ${agentName}/${indexSource}: ${pathError}`);
+                            continue;
+                        }
+                        
+                        const serviceInfo = {
+                            agentName,
+                            serviceScript: resolvedServicePath, // Now an absolute path
+                            ...(serviceConfig.description && { description: serviceConfig.description }),
+                        };
+                        
+                        registry.register(indexSource, serviceInfo);
+                    }
+                }
+            } catch (error) {
+                // Agent manifest loading failed, skip this agent
+                continue;
+            }
+        }
+    }
+    
+    return registry;
 }

--- a/ts/packages/defaultAgentProvider/src/index.ts
+++ b/ts/packages/defaultAgentProvider/src/index.ts
@@ -4,5 +4,6 @@
 export {
     getDefaultAppAgentProviders,
     getDefaultAppAgentInstaller,
+    getIndexingServiceRegistry,
 } from "./defaultAgentProviders.js";
 export { getDefaultConstructionProvider } from "./defaultConstructionProvider.js";

--- a/ts/packages/dispatcher/src/context/commandHandlerContext.ts
+++ b/ts/packages/dispatcher/src/context/commandHandlerContext.ts
@@ -110,6 +110,7 @@ export type CommandHandlerContext = {
     readonly embeddingCacheDir: string | undefined;
 
     readonly indexManager: IndexManager;
+    readonly indexingServiceRegistry: IndexingServiceRegistry | undefined;
 
     activityContext?: ActivityContext | undefined;
     conversationManager?: Conversation.ConversationManager | undefined;
@@ -224,18 +225,28 @@ export type DispatcherOptions = DeepPartialUndefined<DispatcherConfig> & {
     embeddingCacheDir?: string | undefined; // default to 'cache' under 'persistDir' if specified
 };
 
-async function getSession(instanceDir?: string, indexingServiceRegistry?: IndexingServiceRegistry) {
+async function getSession(
+    instanceDir?: string,
+    indexingServiceRegistry?: IndexingServiceRegistry,
+) {
     let session: Session | undefined;
     if (instanceDir !== undefined) {
         try {
-            session = await Session.restoreLastSession(instanceDir, indexingServiceRegistry);
+            session = await Session.restoreLastSession(
+                instanceDir,
+                indexingServiceRegistry,
+            );
         } catch (e: any) {
             debugError(`WARNING: ${e.message}. Creating new session.`);
         }
     }
     if (session === undefined) {
         // fill in the translator/action later.
-        session = await Session.create(undefined, instanceDir, indexingServiceRegistry);
+        session = await Session.create(
+            undefined,
+            instanceDir,
+            indexingServiceRegistry,
+        );
     }
     return session;
 }
@@ -465,6 +476,7 @@ export async function initializeCommandHandlerContext(
             constructionProvider,
             collectCommandResult: options?.collectCommandResult ?? false,
             indexManager: IndexManager.getInstance(),
+            indexingServiceRegistry: options?.indexingServiceRegistry,
         };
 
         await initializeMemory(context, sessionDirPath);

--- a/ts/packages/dispatcher/src/context/indexManager.ts
+++ b/ts/packages/dispatcher/src/context/indexManager.ts
@@ -207,8 +207,9 @@ export class IndexManager {
 
                 // Determine which indexing service to use based on source type
                 if (index.source === "website") {
+                    // Use browser agent indexing service for enhanced knowledge extraction
                     serviceRoot = getPackageFilePath(
-                        "./node_modules/website-memory/dist/indexingService.js",
+                        "./node_modules/browser-typeagent/dist/agent/indexing/browserIndexingService.js",
                     );
                 } else {
                     // Default to image memory service

--- a/ts/packages/dispatcher/src/context/indexManager.ts
+++ b/ts/packages/dispatcher/src/context/indexManager.ts
@@ -10,6 +10,7 @@ import path from "node:path";
 import { ensureDir, isDirectoryPath } from "typeagent";
 import { IndexData, IndexSource } from "image-memory";
 import { IndexData as WebsiteIndexData } from "website-memory";
+import { IndexingServiceRegistry } from "./indexingServiceRegistry.js";
 
 const debug = registerDebug("typeagent:indexManager");
 
@@ -23,6 +24,7 @@ export class IndexManager {
     private indexingServices: Map<IndexData, ChildProcess | undefined> =
         new Map<IndexData, ChildProcess | undefined>();
     private static rootPath: string;
+    private static indexingRegistry: IndexingServiceRegistry | undefined;
     //private cacheRoot: string;
     private static imageRoot: string | undefined;
     private static emailRoot: string | undefined;
@@ -38,8 +40,9 @@ export class IndexManager {
     /*
      * Loads the supplied indexes
      */
-    public static load(indexesToLoad: IndexData[], sessionDir: string) {
+    public static async load(indexesToLoad: IndexData[], sessionDir: string, serviceRegistry?: IndexingServiceRegistry) {
         this.rootPath = path.join(sessionDir, "indexes");
+        this.indexingRegistry = serviceRegistry;
 
         ensureDirectory(IndexManager.rootPath);
 
@@ -205,17 +208,20 @@ export class IndexManager {
             try {
                 let serviceRoot: string;
 
-                // Determine which indexing service to use based on source type
-                if (index.source === "website") {
-                    // Use browser agent indexing service for enhanced knowledge extraction
-                    serviceRoot = getPackageFilePath(
-                        "./node_modules/browser-typeagent/dist/agent/indexing/browserIndexingService.js",
-                    );
+                // Try to use registry-based service discovery first
+                if (IndexManager.indexingRegistry) {
+                    const serviceInfo = IndexManager.indexingRegistry.get(index.source);
+                    if (serviceInfo) {
+                        debug(`Using registered indexing service for ${index.source}: ${serviceInfo.agentName}/${serviceInfo.serviceScript}`);
+
+                        serviceRoot = serviceInfo.serviceScript;
+                    } else {
+                        debug(`No registered service found for ${index.source}, falling back to defaults`);
+                        serviceRoot = this.getDefaultServicePath(index.source);
+                    }
                 } else {
-                    // Default to image memory service
-                    serviceRoot = getPackageFilePath(
-                        "./node_modules/image-memory/dist/indexingService.js",
-                    );
+                    debug(`No indexing registry available, using legacy service discovery`);
+                    serviceRoot = this.getDefaultServicePath(index.source);
                 }
 
                 const childProcess = fork(serviceRoot);
@@ -259,5 +265,19 @@ export class IndexManager {
                 resolve(undefined);
             }
         });
+    }
+
+    private getDefaultServicePath(indexSource: IndexSource): string {
+        // Legacy service discovery for backward compatibility
+        if (indexSource === "website") {
+            return getPackageFilePath(
+                   "./node_modules/website-memory/dist/indexingService.js",
+            );
+        } else {
+            // Default to image memory service
+            return getPackageFilePath(
+                "./node_modules/image-memory/dist/indexingService.js",
+            );
+        }
     }
 }

--- a/ts/packages/dispatcher/src/context/indexManager.ts
+++ b/ts/packages/dispatcher/src/context/indexManager.ts
@@ -40,7 +40,11 @@ export class IndexManager {
     /*
      * Loads the supplied indexes
      */
-    public static async load(indexesToLoad: IndexData[], sessionDir: string, serviceRegistry?: IndexingServiceRegistry) {
+    public static async load(
+        indexesToLoad: IndexData[],
+        sessionDir: string,
+        serviceRegistry?: IndexingServiceRegistry,
+    ) {
         this.rootPath = path.join(sessionDir, "indexes");
         this.indexingRegistry = serviceRegistry;
 
@@ -210,17 +214,25 @@ export class IndexManager {
 
                 // Try to use registry-based service discovery first
                 if (IndexManager.indexingRegistry) {
-                    const serviceInfo = IndexManager.indexingRegistry.get(index.source);
+                    const serviceInfo = IndexManager.indexingRegistry.get(
+                        index.source,
+                    );
                     if (serviceInfo) {
-                        debug(`Using registered indexing service for ${index.source}: ${serviceInfo.agentName}/${serviceInfo.serviceScript}`);
+                        debug(
+                            `Using registered indexing service for ${index.source}: ${serviceInfo.agentName}/${serviceInfo.serviceScript}`,
+                        );
 
                         serviceRoot = serviceInfo.serviceScript;
                     } else {
-                        debug(`No registered service found for ${index.source}, falling back to defaults`);
+                        debug(
+                            `No registered service found for ${index.source}, falling back to defaults`,
+                        );
                         serviceRoot = this.getDefaultServicePath(index.source);
                     }
                 } else {
-                    debug(`No indexing registry available, using legacy service discovery`);
+                    debug(
+                        `No indexing registry available, using legacy service discovery`,
+                    );
                     serviceRoot = this.getDefaultServicePath(index.source);
                 }
 
@@ -271,7 +283,7 @@ export class IndexManager {
         // Legacy service discovery for backward compatibility
         if (indexSource === "website") {
             return getPackageFilePath(
-                   "./node_modules/website-memory/dist/indexingService.js",
+                "./node_modules/website-memory/dist/indexingService.js",
             );
         } else {
             // Default to image memory service

--- a/ts/packages/dispatcher/src/context/indexingServiceRegistry.ts
+++ b/ts/packages/dispatcher/src/context/indexingServiceRegistry.ts
@@ -1,0 +1,40 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+/**
+ * Indexing Service Registry
+ * Manages registration and discovery of indexing services from agent manifests
+ */
+
+export interface IndexingServiceInfo {
+    agentName: string;
+    serviceScript: string;
+    description?: string;
+}
+
+export interface IndexingServiceRegistry {
+    get(indexSource: string): IndexingServiceInfo | undefined;
+    register(indexSource: string, serviceInfo: IndexingServiceInfo): void;
+    getRegisteredSources(): string[];
+    size(): number;
+}
+
+export class DefaultIndexingServiceRegistry implements IndexingServiceRegistry {
+    private services = new Map<string, IndexingServiceInfo>();
+
+    get(indexSource: string): IndexingServiceInfo | undefined {
+        return this.services.get(indexSource);
+    }
+
+    register(indexSource: string, serviceInfo: IndexingServiceInfo): void {
+        this.services.set(indexSource, serviceInfo);
+    }
+
+    getRegisteredSources(): string[] {
+        return Array.from(this.services.keys());
+    }
+
+    size(): number {
+        return this.services.size;
+    }
+}

--- a/ts/packages/dispatcher/src/context/session.ts
+++ b/ts/packages/dispatcher/src/context/session.ts
@@ -309,7 +309,11 @@ export class Session {
         return session;
     }
 
-    public static async load(instanceDir: string, dir: string, indexingServiceRegistry?: IndexingServiceRegistry) {
+    public static async load(
+        instanceDir: string,
+        dir: string,
+        indexingServiceRegistry?: IndexingServiceRegistry,
+    ) {
         const dirPath = getSessionDirPath(instanceDir, dir);
         const sessionData = await readSessionData(dirPath);
         debugSession(`Loading session: ${dir}`);
@@ -320,11 +324,18 @@ export class Session {
         return new Session(sessionData, dirPath, indexingServiceRegistry);
     }
 
-    public static async restoreLastSession(instanceDir: string, indexingServiceRegistry?: IndexingServiceRegistry) {
+    public static async restoreLastSession(
+        instanceDir: string,
+        indexingServiceRegistry?: IndexingServiceRegistry,
+    ) {
         const sessionDir = (await loadSessions(instanceDir))?.lastSession;
         if (sessionDir !== undefined) {
             try {
-                return this.load(instanceDir, sessionDir, indexingServiceRegistry);
+                return this.load(
+                    instanceDir,
+                    sessionDir,
+                    indexingServiceRegistry,
+                );
             } catch (e: any) {
                 throw new Error(
                     `Unable to restore last session '${sessionDir}': ${e.message}`,
@@ -356,7 +367,11 @@ export class Session {
             }
 
             // Pass the registry to IndexManager.load
-            IndexManager.load(sessionData.indexes, sessionDirPath, indexingServiceRegistry).catch((error) => {
+            IndexManager.load(
+                sessionData.indexes,
+                sessionDirPath,
+                indexingServiceRegistry,
+            ).catch((error) => {
                 console.warn(`Failed to load indexing services: ${error}`);
             });
         }

--- a/ts/packages/dispatcher/src/context/system/handlers/sessionCommandHandlers.ts
+++ b/ts/packages/dispatcher/src/context/system/handlers/sessionCommandHandlers.ts
@@ -100,6 +100,7 @@ class SessionOpenCommandHandler implements CommandHandler {
         const session = await Session.load(
             systemContext.persistDir,
             params.args.session,
+            systemContext.indexingServiceRegistry,
         );
         await setSessionOnCommandHandlerContext(systemContext, session);
         displaySuccess(`Session opened: ${params.args.session}`, context);

--- a/ts/packages/dispatcher/src/index.ts
+++ b/ts/packages/dispatcher/src/index.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 export { createDispatcher, Dispatcher, CommandResult } from "./dispatcher.js";
+export { IndexManager } from "./context/indexManager.js";
 export type { DispatcherOptions } from "./context/commandHandlerContext.js";
 export type { CommandCompletionResult } from "./command/completion.js";
 export type {
@@ -20,3 +21,8 @@ export type {
     TemplateEditConfig,
     TemplateData,
 } from "./translation/actionTemplate.js";
+export type {
+    IndexingServiceRegistry,
+    IndexingServiceInfo,
+} from "./context/indexingServiceRegistry.js";
+export { DefaultIndexingServiceRegistry } from "./context/indexingServiceRegistry.js";

--- a/ts/packages/memory/website/src/extraction/analytics.ts
+++ b/ts/packages/memory/website/src/extraction/analytics.ts
@@ -143,18 +143,21 @@ export class Analytics {
         // Calculate mode-specific metrics
         const modeUsage: Record<ExtractionMode, number> = {
             basic: 0,
+            summary: 0,
             content: 0,
             actions: 0,
             full: 0,
         };
         const modeTimeSum: Record<ExtractionMode, number> = {
             basic: 0,
+            summary: 0,
             content: 0,
             actions: 0,
             full: 0,
         };
         const modeSuccesses: Record<ExtractionMode, number> = {
             basic: 0,
+            summary: 0,
             content: 0,
             actions: 0,
             full: 0,
@@ -171,6 +174,8 @@ export class Analytics {
         const modeAverageTime: Record<ExtractionMode, number> = {
             basic:
                 modeUsage.basic > 0 ? modeTimeSum.basic / modeUsage.basic : 0,
+            summary:
+                modeUsage.summary > 0 ? modeTimeSum.summary / modeUsage.summary : 0,
             content:
                 modeUsage.content > 0
                     ? modeTimeSum.content / modeUsage.content
@@ -186,6 +191,10 @@ export class Analytics {
             basic:
                 modeUsage.basic > 0
                     ? (modeSuccesses.basic / modeUsage.basic) * 100
+                    : 0,
+            summary:
+                modeUsage.summary > 0
+                    ? (modeSuccesses.summary / modeUsage.summary) * 100
                     : 0,
             content:
                 modeUsage.content > 0
@@ -391,9 +400,9 @@ export class Analytics {
             successRate: 0,
             averageProcessingTime: 0,
             averageConfidence: 0,
-            modeUsage: { basic: 0, content: 0, actions: 0, full: 0 },
-            modeAverageTime: { basic: 0, content: 0, actions: 0, full: 0 },
-            modeSuccessRate: { basic: 0, content: 0, actions: 0, full: 0 },
+            modeUsage: { basic: 0, summary: 0, content: 0, actions: 0, full: 0 },
+            modeAverageTime: { basic: 0, summary: 0, content: 0, actions: 0, full: 0 },
+            modeSuccessRate: { basic: 0, summary: 0, content: 0, actions: 0, full: 0 },
             averageEntityCount: 0,
             averageTopicCount: 0,
             averageActionCount: 0,

--- a/ts/packages/memory/website/src/extraction/analytics.ts
+++ b/ts/packages/memory/website/src/extraction/analytics.ts
@@ -175,7 +175,9 @@ export class Analytics {
             basic:
                 modeUsage.basic > 0 ? modeTimeSum.basic / modeUsage.basic : 0,
             summary:
-                modeUsage.summary > 0 ? modeTimeSum.summary / modeUsage.summary : 0,
+                modeUsage.summary > 0
+                    ? modeTimeSum.summary / modeUsage.summary
+                    : 0,
             content:
                 modeUsage.content > 0
                     ? modeTimeSum.content / modeUsage.content
@@ -400,9 +402,27 @@ export class Analytics {
             successRate: 0,
             averageProcessingTime: 0,
             averageConfidence: 0,
-            modeUsage: { basic: 0, summary: 0, content: 0, actions: 0, full: 0 },
-            modeAverageTime: { basic: 0, summary: 0, content: 0, actions: 0, full: 0 },
-            modeSuccessRate: { basic: 0, summary: 0, content: 0, actions: 0, full: 0 },
+            modeUsage: {
+                basic: 0,
+                summary: 0,
+                content: 0,
+                actions: 0,
+                full: 0,
+            },
+            modeAverageTime: {
+                basic: 0,
+                summary: 0,
+                content: 0,
+                actions: 0,
+                full: 0,
+            },
+            modeSuccessRate: {
+                basic: 0,
+                summary: 0,
+                content: 0,
+                actions: 0,
+                full: 0,
+            },
             averageEntityCount: 0,
             averageTopicCount: 0,
             averageActionCount: 0,

--- a/ts/packages/memory/website/src/extraction/contentExtractor.ts
+++ b/ts/packages/memory/website/src/extraction/contentExtractor.ts
@@ -17,6 +17,8 @@ import {
     AIModelRequiredError,
     AIExtractionFailedError,
 } from "./types.js";
+import registerDebug from "debug";
+const debug = registerDebug("typeagent:browser:indexing");
 
 /**
  * Enhanced ContentExtractor with extraction mode capabilities
@@ -103,7 +105,7 @@ export class ContentExtractor {
                     content.htmlContent = fetchResult.html;
                 } else if (fetchResult.error) {
                     // Log the error but continue with title-only processing
-                    console.warn(
+                    debug(
                         `Failed to fetch ${content.url}: ${fetchResult.error}`,
                     );
                 }
@@ -525,7 +527,7 @@ export class ContentExtractor {
                 links: [], // Basic extraction doesn't include links
             };
         } catch (error) {
-            console.warn(
+            debug(
                 "Cheerio parsing failed, falling back to simple extraction:",
                 error,
             );

--- a/ts/packages/memory/website/src/extraction/types.ts
+++ b/ts/packages/memory/website/src/extraction/types.ts
@@ -28,7 +28,12 @@ import { DetectedAction, ActionSummary } from "../actionExtractor.js";
  * await extractor.extract(content, "full");
  * ```
  */
-export type ExtractionMode = "basic" | "summary" | "content" | "actions" | "full";
+export type ExtractionMode =
+    | "basic"
+    | "summary"
+    | "content"
+    | "actions"
+    | "full";
 
 /**
  * Configuration for content extraction operations

--- a/ts/packages/memory/website/src/extraction/types.ts
+++ b/ts/packages/memory/website/src/extraction/types.ts
@@ -28,7 +28,7 @@ import { DetectedAction, ActionSummary } from "../actionExtractor.js";
  * await extractor.extract(content, "full");
  * ```
  */
-export type ExtractionMode = "basic" | "content" | "actions" | "full";
+export type ExtractionMode = "basic" | "summary" | "content" | "actions" | "full";
 
 /**
  * Configuration for content extraction operations
@@ -89,6 +89,16 @@ export const EXTRACTION_MODE_CONFIGS: Record<
         defaultChunkSize: 500,
         defaultQualityThreshold: 0.2,
         defaultConcurrentExtractions: 10,
+    },
+    summary: {
+        description: "HTML download + text summary + AI knowledge extraction",
+        usesAI: true,
+        extractsActions: false,
+        extractsRelationships: true,
+        knowledgeStrategy: "hybrid",
+        defaultChunkSize: 2000,
+        defaultQualityThreshold: 0.25,
+        defaultConcurrentExtractions: 5,
     },
     content: {
         description: "Full content extraction with AI knowledge processing",

--- a/ts/packages/shell/src/main/index.ts
+++ b/ts/packages/shell/src/main/index.ts
@@ -298,7 +298,8 @@ async function initializeDispatcher(
             dblogging: true,
             clientId: getClientId(),
             clientIO,
-            indexingServiceRegistry: await getIndexingServiceRegistry(instanceDir),
+            indexingServiceRegistry:
+                await getIndexingServiceRegistry(instanceDir),
             constructionProvider: getDefaultConstructionProvider(),
             allowSharedLocalView: ["browser"],
             portBase: isProd ? 9001 : 9050,

--- a/ts/packages/shell/src/main/index.ts
+++ b/ts/packages/shell/src/main/index.ts
@@ -18,6 +18,7 @@ import {
     getDefaultAppAgentProviders,
     getDefaultAppAgentInstaller,
     getDefaultConstructionProvider,
+    getIndexingServiceRegistry,
 } from "default-agent-provider";
 import {
     ensureShellDataDir,
@@ -297,6 +298,7 @@ async function initializeDispatcher(
             dblogging: true,
             clientId: getClientId(),
             clientIO,
+            indexingServiceRegistry: await getIndexingServiceRegistry(instanceDir),
             constructionProvider: getDefaultConstructionProvider(),
             allowSharedLocalView: ["browser"],
             portBase: isProd ? 9001 : 9050,


### PR DESCRIPTION
- add new mode that is more expensive than the manual-only basic mode but not as comprehensive as the content mode.
- Add indexing service in browser agent project. this maximizes code re-use.
- Enable agents to declare their index servers in the manifest. Without this change, we would have needed dispatcher to have a build-time dependency on the particular indexing service provider.