### PR TITLE
[python/knowpro] Solve the "first 15 minutes" problem by switching to timezone-unaware times in stage 1

### DIFF
--- a/python/ta/TODO.md
+++ b/python/ta/TODO.md
@@ -16,27 +16,27 @@ Then combine the ones that most improve effectiveless.  **[DONE]**
 ### Left to do here
 
 - Look more into why the search query schema is so instable
-- Implement at least a subset of the @kpBlah commands in ui.py
+- Implement at least a subset of the @kpBlah commands in utool.py
 - More debug options (turn on/off various debug prints dynamically)
-- Unify ui.py and cmp [CLI args done; should share diffing code too]
+- Unify ui.py and cmp [**done**]
 - Try pydantic.ai again
 
 ## General: Look for things marked as incomplete in source
 
 - `TODO` comments (too numerous)
-- `raise NotImplementedError("TODO")` (all part of indexing)
+- `raise NotImplementedError("TODO")` (three found indexing)
 
 ## Cleanup:
 
-- Remove a bunch of `XxxData` TypedDicts that can be dealt with using
-  `deserialize_object` and `serialize_object`
-- Catch and report `DeserializationError` better
 - Sort out why `IConversation` needs two generic parameters;
   especially `TTermToSemanticRefIndex` is annoying. Can we do better?
 - Unify or align or refactor `VectorBase` and `EmbeddingIndex`.
 
 ## Serialization
 
+- Remove a bunch of `XxxData` TypedDicts that can be dealt with using
+  `deserialize_object` and `serialize_object`
+- Catch and report `DeserializationError` better
 - Look into whether Pydantic can do our (de)serialization --
   if it can, presumably it's faster?
 
@@ -86,18 +86,21 @@ so we have some end-to-end functionality.
 
 The TODO items include (in no particular order):
 
-- Fix handling of datetime range queries.
-- Use fallback query and other fallback stuff in search_conv*_w*_lang*.
+- Implement token budgets -- may leave out messages, favoring only knowledge,
+  if it answers the question.
+- Fix handling of datetime range queries. [**DONE**]
+- Use fallback query and other fallback stuff in search_conv*_w*_lang*. [**DONE**]
 - Change the context to be text, including message texts and timestamps,
   rather than JSON (and especially not just semantic ref ordinals).
-- Property translate time range filters.
-- Add message timestamp to context.
-- Move out of `demo` into `knowpro` what belongs there.
-- Complete the implementation of each stage (3b is missing a lot).
+- Property translate time range filters. [**DONE**]
+- Add message timestamp to context. [**DONE**]
+- Move out of `demo` into `knowpro` what belongs there. [**DONE**]
+- Complete the implementation of each stage (3b is missing a lot). [**DONE**]
 - Split large contexts to avoid overflowing the answer generator's
   context buffer (4b).
 - Fix all the TODOs left in the code.
-- Redesign the whole pipeline now that I understand the archtecture better.
+- Redesign the whole pipeline now that I understand the archtecture better;
+  notably make each stage its own function with simpler API.
 
 # Older TODO action items
 

--- a/python/ta/TODO.md
+++ b/python/ta/TODO.md
@@ -23,8 +23,8 @@ Then combine the ones that most improve effectiveless.  **[DONE]**
 
 ## General: Look for things marked as incomplete in source
 
-- `TODO` comments
-- `raise NotImplementedError` with TODO in arg or comment
+- `TODO` comments (too numerous)
+- `raise NotImplementedError("TODO")` (all part of indexing)
 
 ## Cleanup:
 

--- a/python/ta/tools/utool.py
+++ b/python/ta/tools/utool.py
@@ -586,8 +586,6 @@ def print_result[TMessage: IMessage, TIndex: ITermToSemanticRefIndex](
                     msg = conversation.messages[msg_ord]
                     print(
                         f"({score:5.1f}) M={msg_ord}: "
-                        # f"{msg.speaker:>15.15s}: "  # type: ignore  # It's a PodcastMessage
-                        # f"{repr(msg.text_chunks[chunk_ord].strip())[1:-1]:<50.50s}  "
                         f"S={summarize_knowledge(sem_ref)}"
                     )
 

--- a/python/ta/typeagent/knowpro/convindex.py
+++ b/python/ta/typeagent/knowpro/convindex.py
@@ -629,7 +629,7 @@ async def build_conversation_index[TMessage: IMessage](
         and conversation.semantic_ref_index
     ):
         result.secondary_index_results = await secindex.build_secondary_indexes(
-            conversation,  # type: ignore  # TODO
+            conversation,
             conversation_settings,
             event_handler,
         )
@@ -684,7 +684,7 @@ def begin_indexing[
     conversation: IConversation[TMessage, TTermToSemanticRefIndex],
 ) -> None:
     if conversation.semantic_ref_index is None:
-        conversation.semantic_ref_index = ConversationIndex()  # type: ignore  # TODO: Why doesn't strict mode like this?
+        conversation.semantic_ref_index = ConversationIndex()  # type: ignore  # TODO: Why doesn't pyright like this?
     if conversation.semantic_refs is None:
         conversation.semantic_refs = SemanticRefCollection()
 
@@ -698,7 +698,7 @@ def dump(
     semantic_ref_index: ConversationIndex, semantic_refs: ISemanticRefCollection
 ) -> None:
     print("semantic_ref_index = {")
-    for k, v in semantic_ref_index._map.items():  # type: ignore  # Need internal access to dump.
+    for k, v in semantic_ref_index._map.items():
         print(f"    {k!r}: {v},")
     print("}\n")
     print("semantic_refs = []")

--- a/python/ta/typeagent/knowpro/convknowledge.py
+++ b/python/ta/typeagent/knowpro/convknowledge.py
@@ -83,7 +83,7 @@ class KnowledgeExtractor:
         translator = typechat.TypeChatJsonTranslator[kplib.KnowledgeResponse](
             model, validator, kplib.KnowledgeResponse
         )
-        schema_text = translator.schema_str.rstrip()  # type: ignore  # Must access internal.
+        schema_text = translator.schema_str.rstrip()
 
         def create_request_prompt(intent: str) -> str:
             return (
@@ -101,7 +101,7 @@ class KnowledgeExtractor:
                 + f"with 2 spaces of indentation and no properties with the value undefined:\n"
             )
 
-        translator._create_request_prompt = create_request_prompt  # type: ignore  # Must overwrite internal.
+        translator._create_request_prompt = create_request_prompt
         return translator
 
     def merge_action_knowledge_into_response(

--- a/python/ta/typeagent/knowpro/convutils.py
+++ b/python/ta/typeagent/knowpro/convutils.py
@@ -19,10 +19,14 @@ def get_time_range_prompt_section_for_conversation[
 ) -> typechat.PromptSection | None:
     time_range = get_time_range_for_conversation(conversation)
     if time_range is not None:
+        start = time_range.start.replace(tzinfo=None).isoformat()
+        end = (
+            time_range.end.replace(tzinfo=None).isoformat() if time_range.end else "now"
+        )
         return typechat.PromptSection(
             role="system",
             content=f"ONLY IF user request explicitly asks for time ranges, "
-            f'THEN use the CONVERSATION TIME RANGE: "{time_range.start} to {time_range.end}"',
+            f'THEN use the CONVERSATION TIME RANGE: "{start} to {end}"',
         )
 
 

--- a/python/ta/typeagent/knowpro/interfaces.py
+++ b/python/ta/typeagent/knowpro/interfaces.py
@@ -5,7 +5,7 @@ from collections.abc import Iterable, Sequence
 from dataclasses import field
 from datetime import (
     datetime as Datetime,  # For export.
-    timedelta as Timedelta,  # type: ignore  # For export.
+    timedelta as Timedelta,  # For export.
 )
 from typing import (
     Any,

--- a/python/ta/typeagent/knowpro/messageindex.py
+++ b/python/ta/typeagent/knowpro/messageindex.py
@@ -125,7 +125,7 @@ class MessageTextIndex(IMessageTextEmbeddingIndex):
         # Note: if you rename generate_embedding, be sure to also fix is_message_text_embedding_index.
         # TODO: Retries?
         # TODO: Find a prettier API to get an embedding rather than using _vector_base?
-        return await self.text_location_index.generate_embedding(text)  # type: ignore  # Must use internal.
+        return await self.text_location_index.generate_embedding(text)
 
     def lookup_in_subset_by_embedding(
         self,

--- a/python/ta/typeagent/knowpro/searchlang.py
+++ b/python/ta/typeagent/knowpro/searchlang.py
@@ -4,7 +4,6 @@
 import copy
 from dataclasses import dataclass, replace
 import datetime
-import zoneinfo
 from typing import Callable, Literal, TypeGuard, cast
 
 import typechat
@@ -697,7 +696,8 @@ def date_range_from_datetime_range(date_time_range: DateTimeRange) -> DateRange:
 
 
 def datetime_from_date_time(date_time: DateTime) -> Datetime:
-    local_tz = zoneinfo.ZoneInfo("America/Los_Angeles")
+    # We ASSUME that the LLM gave the DateTime in UTC.
+    # If it didn't, well, how would we know???
     dt = Datetime(
         year=date_time.date.year,
         month=date_time.date.month,
@@ -705,9 +705,9 @@ def datetime_from_date_time(date_time: DateTime) -> Datetime:
         hour=date_time.time.hour if date_time.time else 0,
         minute=date_time.time.minute if date_time.time else 0,
         second=date_time.time.seconds if date_time.time else 0,
-        tzinfo=local_tz,
+        tzinfo=datetime.timezone.utc,
     )
-    return dt.astimezone(datetime.timezone.utc)
+    return dt
 
 
 def create_property_search_term(

--- a/python/ta/typeagent/knowpro/secindex.py
+++ b/python/ta/typeagent/knowpro/secindex.py
@@ -38,7 +38,7 @@ async def build_secondary_indexes[
     if conversation.secondary_indexes is None:
         conversation.secondary_indexes = ConversationSecondaryIndexes()
     result: SecondaryIndexingResults = build_transient_secondary_indexes(
-        conversation,  # type: ignore  # TODO
+        conversation,
     )
     result.related_terms = await build_related_terms_index(
         conversation, conversation_settings, event_handler
@@ -60,7 +60,7 @@ def build_transient_secondary_indexes[
     conversation: IConversation[TMessage, TTermToSemanticRefIndex],
 ) -> SecondaryIndexingResults:
     if conversation.secondary_indexes is None:
-        conversation.secondary_indexes = ConversationSecondaryIndexes()  # type: ignore  # TODO
+        conversation.secondary_indexes = ConversationSecondaryIndexes()
     result = SecondaryIndexingResults()
     result.properties = build_property_index(conversation)
     result.timestamps = build_timestamp_index(conversation)

--- a/python/ta/typeagent/knowpro/serialization.py
+++ b/python/ta/typeagent/knowpro/serialization.py
@@ -161,7 +161,7 @@ def serialize_object(arg: Any) -> Any | None:
     assert hasattr(arg, "__dict__"), f"Cannot serialize knowledge of type {type(arg)}"
     result = to_json(arg)
     assert isinstance(result, dict), f"Serialized knowledge is not a dict: {result}"
-    return result  # type: ignore  # Make strict checking level happy
+    return result
 
 
 def to_json(obj: Any) -> Any:

--- a/python/ta/typeagent/knowpro/storage.py
+++ b/python/ta/typeagent/knowpro/storage.py
@@ -33,8 +33,8 @@ class Collection[T, TOrdinal: int](ICollection[T, TOrdinal]):
 
     def __getitem__(self, arg: Any) -> Any:
         if isinstance(arg, slice):
-            assert arg.step in (None, 1)  # type: ignore  # slice weirdness
-            return self._get_slice(arg.start, arg.stop)  # type: ignore  # Use of internal; slice weirdness
+            assert arg.step in (None, 1)
+            return self._get_slice(arg.start, arg.stop)
         if isinstance(arg, int):
             return self._get(arg)
         if isinstance(arg, list):


### PR DESCRIPTION
By feeding the question-generating LLM times in UTC that aren't marked with a timezone, and assuming that times we receive back (which can't be marked with a timezone) are also in UTC, we get consistent times in time-range when-clauses, and we can answer questions like "which books were mentioned in the first 15 minutes".

Also some cleanup of TODO.md and removed redundant `# type: inore` directives. Of the latter, we now only have 8 left in podcast.py and one in convindex.py (and some in tests that I didn't look at yet).