### PR TITLE
Improve entity resolution and filtering using memory

### DIFF
--- a/ts/packages/dispatcher/src/translation/entityResolution.ts
+++ b/ts/packages/dispatcher/src/translation/entityResolution.ts
@@ -10,32 +10,43 @@ import { Result, success, error } from "typechat";
 import { createJsonTranslatorWithValidator } from "common-utils";
 
 import { FullAction } from "agent-cache";
-import { ResolveEntityResult } from "@typeagent/agent-sdk";
 import registerDebug from "debug";
+import { Entity } from "@typeagent/agent-sdk";
 const debugActionEntities = registerDebug(
     "typeagent:dispatcher:actions:entities",
 );
 
 type EntitySelection = {
-    selections: {
-        name: string;
-        index: number;
-    }[];
+    name: string;
+    index: number;
+    reason: "same" | "category" | string;
+};
+type EntitySelections = {
+    selections: EntitySelection[];
+};
+
+export type DispatcherResolveEntityResult = {
+    match: "exact" | "same" | "category" | "fuzzy";
+    entities: Entity[];
 };
 
 export async function filterEntitySelection(
     action: FullAction,
     type: string,
     name: string,
-    result: ResolveEntityResult,
+    result: DispatcherResolveEntityResult,
 ) {
     const selectionSchema = sc.type(
-        "EntitySelection",
+        "EntitySelections",
         sc.obj({
             selections: sc.array(
                 sc.obj({
                     name: sc.field(
-                        sc.string(...result.entities.map((e) => e.name)),
+                        sc.string(
+                            ...new Set(
+                                result.entities.map((e) => e.name),
+                            ).values(),
+                        ),
                         `Name of a '${type}' entity that '${name}' could mean from the list of '${type}' entities.`,
                     ),
                     index: sc.field(
@@ -43,6 +54,21 @@ export async function filterEntitySelection(
                         `The index of the '${type}' entity`,
                     ),
                     reason: sc.field(
+                        sc.union(
+                            sc.string("same"),
+                            sc.string("category"),
+                            sc.string("similar"),
+                            sc.string(),
+                        ),
+                        [
+                            "reason for selection:",
+                            `- same: the name and '${name}' refer to the same entity`,
+                            `- category: the name is a category that includes '${name}'`,
+                            `- similar: the name has common characteristics to '${name}'`,
+                        ],
+                    ),
+
+                    explanation: sc.field(
                         sc.string(),
                         `Explain why '${name}' could mean the selected entity`,
                     ),
@@ -53,16 +79,16 @@ export async function filterEntitySelection(
     const validator = {
         getSchemaText: () => generateSchemaTypeDefinition(selectionSchema),
         getTypeName: () => "EntitySelection",
-        validate(jsonObject: unknown): Result<EntitySelection> {
+        validate(jsonObject: unknown): Result<EntitySelections> {
             try {
                 validateType(selectionSchema.type, jsonObject);
-                return success(jsonObject as EntitySelection);
+                return success(jsonObject as EntitySelections);
             } catch (e: any) {
                 return error(e.message);
             }
         },
     };
-    const translator = createJsonTranslatorWithValidator<EntitySelection>(
+    const translator = createJsonTranslatorWithValidator<EntitySelections>(
         validator.getTypeName().toLowerCase(),
         validator,
     );
@@ -91,11 +117,44 @@ export async function filterEntitySelection(
         debugActionEntities(
             `Filtered entity selection: ${JSON.stringify(selectionResult.data)}`,
         );
-        result.entities = selectionResult.data.selections.map(
-            // TODO: Should we use the index here? Probably need the translation to validate the index to match the name.
-            (selection) =>
-                result.entities.find((e) => e.name === selection.name)!,
-        );
+        const same: EntitySelection[] = [];
+        const categories: EntitySelection[] = [];
+        const others: EntitySelection[] = [];
+        for (const selection of selectionResult.data.selections) {
+            switch (selection.reason) {
+                case "same":
+                    same.push(selection);
+                    break;
+                case "category":
+                    categories.push(selection);
+                    break;
+                default:
+                    others.push(selection);
+                    break;
+            }
+        }
+        if (same.length > 0) {
+            result.match = "same";
+            result.entities = same.map(
+                // TODO: Should we use the index here? Probably need the translation to validate the index to match the name.
+                (selection) =>
+                    result.entities.find((e) => e.name === selection.name)!,
+            );
+        } else if (categories.length > 0) {
+            result.match = "category";
+            result.entities = categories.map(
+                // TODO: Should we use the index here? Probably need the translation to validate the index to match the name.
+                (selection) =>
+                    result.entities.find((e) => e.name === selection.name)!,
+            );
+        } else {
+            result.match = "fuzzy";
+            result.entities = others.map(
+                // TODO: Should we use the index here? Probably need the translation to validate the index to match the name.
+                (selection) =>
+                    result.entities.find((e) => e.name === selection.name)!,
+            );
+        }
     } else {
         debugActionEntities(
             `No entity selection made, using all entities: ${JSON.stringify(


### PR DESCRIPTION
- Uniquify the entities returned from memory based on `name` and `uniqueId`.
- Only do exact match for entity match when validating entity type wildcard match.
- Refine the LLM based filtering 
  - classify entities as "same", "category", "similar" or other.
  - Do classification for fuzzy result even if there are only one result.
  - Only use entities that are "exact" or "same" for now.  
- Try to resolve with agent if we can't resolve a single entity to use using memory.