### PR TITLE
player: Ignore error when updating user data

### DIFF
--- a/ts/packages/agents/player/src/endpoints.ts
+++ b/ts/packages/agents/player/src/endpoints.ts
@@ -6,6 +6,7 @@ import registerDebug from "debug";
 import { createFetchError } from "./utils.js";
 
 const debugSpotifyRest = registerDebug("typeagent:spotify:rest");
+const debugSpotifyRestVerbose = registerDebug("typeagent:spotify-verbose:rest");
 
 export const limitMax = 50;
 
@@ -26,8 +27,18 @@ async function getK<T>(
         count: number,
         offset: number,
     ) => Promise<SpotifyApi.PagingObject<T> | undefined>,
+    ignoreError: boolean,
 ): Promise<T[] | undefined> {
-    let data = await get(Math.min(k, limitMax), 0);
+    const getOnce = ignoreError
+        ? async (count: number, offset: number) => {
+              try {
+                  return await get(count, offset);
+              } catch (e: any) {
+                  return null;
+              }
+          }
+        : get;
+    const data = await getOnce(Math.min(k, limitMax), 0);
     if (!data || data.items.length === 0) {
         return undefined;
     }
@@ -35,18 +46,30 @@ async function getK<T>(
     if (k <= limitMax) {
         return results;
     }
+
+    let total = data.total;
+    let offset = limitMax;
     while (results.length < k) {
-        const offset = results.length;
-        if (offset >= data.total) {
+        if (offset >= total) {
             break;
         }
-        data = await get(Math.min(k - results.length, limitMax), offset);
+        const count = Math.min(k - results.length, limitMax);
+        const data = await getOnce(count, offset);
+
+        if (data === null) {
+            // ignore error and continue;
+            offset += count;
+            continue;
+        }
         if (!data || data.items.length === 0) {
             return undefined;
         }
         results.push(...data.items);
+        total = data.total;
+        offset = data.offset + data.items.length;
     }
-    return results;
+
+    return results.length > 0 ? results : undefined;
 }
 
 async function callFetch<T>(
@@ -109,7 +132,7 @@ async function callFetch<T>(
                     case 200:
                     case 201:
                         const content = await result.text();
-                        debugSpotifyRest("Response content:", content);
+                        debugSpotifyRestVerbose("Response content:", content);
                         if (content === "") {
                             return {} as T;
                         }
@@ -177,7 +200,11 @@ async function fetchDelete<T>(
     return callFetch<T>(service, "DELETE", restUrl, undefined, 200);
 }
 
-export async function getFavoriteAlbums(service: SpotifyService, k = limitMax) {
+export async function getFavoriteAlbums(
+    service: SpotifyService,
+    k = limitMax,
+    ignoreError: boolean = false,
+) {
     const get = async (limit: number, offset: number) =>
         fetchGet<SpotifyApi.UsersSavedAlbumsResponse>(
             service,
@@ -187,10 +214,14 @@ export async function getFavoriteAlbums(service: SpotifyService, k = limitMax) {
                 offset,
             },
         );
-    return getK(k, get);
+    return getK(k, get, ignoreError);
 }
 
-export async function getFavoriteTracks(service: SpotifyService, k = limitMax) {
+export async function getFavoriteTracks(
+    service: SpotifyService,
+    k = limitMax,
+    ignoreError: boolean = false,
+) {
     const get = async (limit: number, offset: number) =>
         fetchGet<SpotifyApi.UsersSavedTracksResponse>(
             service,
@@ -200,10 +231,14 @@ export async function getFavoriteTracks(service: SpotifyService, k = limitMax) {
                 offset,
             },
         );
-    return getK(k, get);
+    return getK(k, get, ignoreError);
 }
 
-export async function getTopUserArtists(service: SpotifyService, k = limitMax) {
+export async function getTopUserArtists(
+    service: SpotifyService,
+    k = limitMax,
+    ignoreError: boolean = false,
+) {
     const get = async (limit: number, offset: number) =>
         fetchGet<SpotifyApi.UsersTopArtistsResponse>(
             service,
@@ -213,10 +248,14 @@ export async function getTopUserArtists(service: SpotifyService, k = limitMax) {
                 offset,
             },
         );
-    return getK(k, get);
+    return getK(k, get, ignoreError);
 }
 
-export async function getTopUserTracks(service: SpotifyService, k = limitMax) {
+export async function getTopUserTracks(
+    service: SpotifyService,
+    k = limitMax,
+    ignoreError: boolean = false,
+) {
     const get = async (limit: number, offset: number) =>
         fetchGet<SpotifyApi.UsersTopTracksResponse>(
             service,
@@ -226,7 +265,8 @@ export async function getTopUserTracks(service: SpotifyService, k = limitMax) {
                 offset,
             },
         );
-    return getK(k, get);
+
+    return getK(k, get, ignoreError);
 }
 
 async function getKCursor<T>(
@@ -235,8 +275,18 @@ async function getKCursor<T>(
         count: number,
         after: string | undefined,
     ) => Promise<SpotifyApi.CursorBasedPagingObject<T> | undefined>,
+    ignoreError: boolean,
 ): Promise<T[] | undefined> {
-    let data = await get(Math.min(k, limitMax), undefined);
+    const getOnce = ignoreError
+        ? async (count: number, after: string | undefined) => {
+              try {
+                  return await get(count, after);
+              } catch (e: any) {
+                  return null;
+              }
+          }
+        : get;
+    let data = await getOnce(Math.min(k, limitMax), undefined);
     if (!data || data.items.length === 0) {
         return undefined;
     }
@@ -249,7 +299,11 @@ async function getKCursor<T>(
         if (after === null) {
             break;
         }
-        data = await get(Math.min(k - results.length, limitMax), after);
+        data = await getOnce(Math.min(k - results.length, limitMax), after);
+        if (data === null) {
+            // Ignore error and return what is available so far.
+            break;
+        }
         if (!data || data.items.length === 0) {
             return undefined;
         }
@@ -261,6 +315,7 @@ async function getKCursor<T>(
 export async function getFollowedArtists(
     service: SpotifyService,
     k = limitMax,
+    ignoreError: boolean = false,
 ) {
     const get = async (limit: number, after: string | undefined) => {
         const param: any = {
@@ -279,10 +334,14 @@ export async function getFollowedArtists(
         return response?.artists;
     };
 
-    return getKCursor(k, get);
+    return getKCursor(k, get, ignoreError);
 }
 
-export async function getRecentlyPlayed(service: SpotifyService, k = limitMax) {
+export async function getRecentlyPlayed(
+    service: SpotifyService,
+    k = limitMax,
+    ignoreError: boolean = false,
+) {
     const get = async (limit: number, after: string | undefined) =>
         fetchGet<SpotifyApi.UsersRecentlyPlayedTracksResponse>(
             service,
@@ -294,7 +353,7 @@ export async function getRecentlyPlayed(service: SpotifyService, k = limitMax) {
                   }
                 : { limit },
         );
-    return getKCursor(limitMax, get);
+    return getKCursor(k, get, ignoreError);
 }
 
 export async function getArtist(service: SpotifyService, id: string) {

--- a/ts/packages/agents/player/src/userData.ts
+++ b/ts/packages/agents/player/src/userData.ts
@@ -225,12 +225,12 @@ async function updateUserData(
             topTracks,
             recentlyPlayed,
         ] = await Promise.all([
-            getFavoriteTracks(service, Infinity),
-            getFavoriteAlbums(service, Infinity),
-            getFollowedArtists(service, Infinity),
-            getTopUserArtists(service, Infinity),
-            getTopUserTracks(service, Infinity),
-            getRecentlyPlayed(service, Infinity),
+            getFavoriteTracks(service, Infinity, true),
+            getFavoriteAlbums(service, Infinity, true),
+            getFollowedArtists(service, Infinity, true),
+            getTopUserArtists(service, Infinity, true),
+            getTopUserTracks(service, Infinity, true),
+            getRecentlyPlayed(service, Infinity, true),
         ]);
 
         const updates: { [key: string]: [number, number, number, number] } = {};


### PR DESCRIPTION
Spotify API sometimes return 502.  Don't abort updating the user data when there are errors for only part of the calls
