### PR TITLE
Partial completion fixes

### DIFF
--- a/ts/packages/shell/src/preload/electronTypes.ts
+++ b/ts/packages/shell/src/preload/electronTypes.ts
@@ -57,7 +57,7 @@ export interface Client {
 
 export interface ElectronWindowFields {
     api: ClientAPI;
-    dispatcher: Dispatcher;
+    dispatcher: Promise<Dispatcher>;
 }
 
 export type ElectronWindow = typeof globalThis & ElectronWindowFields;

--- a/ts/packages/shell/src/renderer/assets/styles.less
+++ b/ts/packages/shell/src/renderer/assets/styles.less
@@ -510,8 +510,8 @@ table.table-message td {
   content: attr(data-expl);
   position: absolute;
   text-align: right;
-  top: -10px;
-  right: 0px;
+  top: 0px;
+  right: 30px;
   white-space: nowrap;
   color: gray;
   background-color: lightyellow;

--- a/ts/packages/shell/src/renderer/src/chatInput.ts
+++ b/ts/packages/shell/src/renderer/src/chatInput.ts
@@ -35,7 +35,6 @@ export class ExpandableTextarea {
         this.entryHandlers = handlers;
         const textEntry = document.createElement("span");
         textEntry.className = className;
-        textEntry.contentEditable = "true";
         textEntry.role = "textbox";
         textEntry.id = id;
         textEntry.addEventListener("keydown", (event) => {
@@ -81,6 +80,9 @@ export class ExpandableTextarea {
         this.textEntry = textEntry;
     }
 
+    public enable(enabled: boolean) {
+        this.textEntry.contentEditable = enabled.toString();
+    }
     getTextEntry() {
         return this.textEntry;
     }
@@ -117,20 +119,26 @@ export class ExpandableTextarea {
     public moveCursorToEnd() {
         // Set the cursor to the end of the text
         const r = document.createRange();
-        if (this.textEntry.childNodes.length > 0) {
-            r.selectNode(this.textEntry);
-            r.setStartBefore(this.textEntry.childNodes[0]);
-            r.setEndAfter(
-                this.textEntry.childNodes[this.textEntry.childNodes.length - 1],
-            );
+        const textEntry = this.textEntry;
+        const childNodes = textEntry.childNodes;
+        if (childNodes.length > 0) {
+            r.selectNode(textEntry);
+            r.setStartBefore(childNodes[0]);
+            r.setEndAfter(childNodes[childNodes.length - 1]);
             r.collapse(false);
             const s = document.getSelection();
             if (s) {
                 s.removeAllRanges();
                 s.addRange(r);
             }
-            this.textEntry.scrollTop = this.textEntry.scrollHeight;
+            textEntry.scrollTop = textEntry.scrollHeight;
         }
+    }
+
+    public getSelectionEndNode() {
+        const childNodes = this.textEntry.childNodes;
+        const len = childNodes.length;
+        return len > 0 ? childNodes[len - 1] : this.textEntry;
     }
 
     public replaceTextAtCursor(
@@ -147,16 +155,14 @@ export class ExpandableTextarea {
             if (!currentRange.collapsed) {
                 return;
             }
-            if (currentRange.startContainer === this.textEntry.childNodes[0]) {
+            if (currentRange.startContainer === this.getSelectionEndNode()) {
                 const currentText = this.textEntry.innerText;
                 let offset = currentRange.startOffset + cursorOffset;
                 if (offset < 0 || offset > currentText.length) {
                     return;
                 }
-                const prefix = this.textEntry.innerText.substring(0, offset);
-                const suffix = this.textEntry.innerText.substring(
-                    offset + length,
-                );
+                const prefix = currentText.substring(0, offset);
+                const suffix = currentText.substring(offset + length);
                 this.textEntry.innerText = prefix + text + suffix;
 
                 const newRange = document.createRange();

--- a/ts/packages/shell/src/renderer/src/chatView.ts
+++ b/ts/packages/shell/src/renderer/src/chatView.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { IdGenerator, getDispatcher } from "./main";
+import { IdGenerator } from "./main";
 import { ChatInput, ExpandableTextarea } from "./chatInput";
 import { iconCheckMarkCircle, iconX } from "./icon";
 import {
@@ -12,6 +12,7 @@ import {
 } from "@typeagent/agent-sdk";
 import { TTS } from "./tts/tts";
 import {
+    Dispatcher,
     IAgentMessage,
     NotifyExplainedData,
     RequestId,
@@ -63,13 +64,14 @@ export function getSelectionXCoord() {
 
 const DynamicDisplayMinRefreshIntervalMs = 15;
 export class ChatView {
-    private topDiv: HTMLDivElement;
-    private messageDiv: HTMLDivElement;
-    private inputContainer: HTMLDivElement;
+    private readonly topDiv: HTMLDivElement;
+    private readonly messageDiv: HTMLDivElement;
+    private readonly inputContainer: HTMLDivElement;
     private _settingsView: SettingsView | undefined;
-
-    private idToMessageGroup: Map<string, MessageGroup> = new Map();
+    private _dispatcher: Dispatcher | undefined;
+    private readonly idToMessageGroup: Map<string, MessageGroup> = new Map();
     chatInput: ChatInput;
+    private partialCompletionEnabled: boolean = false;
     private partialCompletion: PartialCompletion | undefined;
 
     private commandBackStack: string[] = [];
@@ -106,6 +108,7 @@ export class ChatView {
         };
         const onChange = (_eta: ExpandableTextarea, isInput: boolean) => {
             if (this.partialCompletion) {
+                console.log(`Partial completion on change: ${isInput}`);
                 if (isInput) {
                     this.partialCompletion.update();
                 } else {
@@ -210,14 +213,45 @@ export class ChatView {
         };
     }
 
+    private getDispatcher(): Dispatcher {
+        if (this._dispatcher === undefined) {
+            throw new Error("Dispatcher is not initialized");
+        }
+        return this._dispatcher;
+    }
+
+    public initializeDispatcher(dispatcher: Dispatcher) {
+        if (this._dispatcher !== undefined) {
+            throw new Error("Dispatcher already initialized");
+        }
+        this._dispatcher = dispatcher;
+
+        this.chatInput.textarea.enable(true);
+        this.chatInput.focus();
+
+        // delay initialization.
+        if (this.partialCompletionEnabled) {
+            this.ensurePartialCompletion();
+        }
+    }
+
+    private ensurePartialCompletion() {
+        if (
+            this.partialCompletion === undefined &&
+            this._dispatcher !== undefined
+        ) {
+            this.partialCompletion = new PartialCompletion(
+                this.inputContainer,
+                this.chatInput.textarea,
+                this.getDispatcher(),
+            );
+        }
+    }
+
     enablePartialInput(enabled: boolean) {
+        this.partialCompletionEnabled = enabled;
         if (enabled) {
-            if (this.partialCompletion === undefined) {
-                this.partialCompletion = new PartialCompletion(
-                    this.inputContainer,
-                    this.chatInput.textarea,
-                );
-            }
+            this.ensurePartialCompletion();
         } else {
             this.partialCompletion?.close();
             this.partialCompletion = undefined;
@@ -300,7 +334,7 @@ export class ChatView {
                 // Only call getDynamicDisplay once if there are multiple
                 let result = currentDisplay.get(`${source}:${displayId}`);
                 if (result === undefined) {
-                    result = await getDispatcher().getDynamicDisplay(
+                    result = await this.getDispatcher().getDynamicDisplay(
                         source,
                         "html",
                         displayId,
@@ -414,7 +448,7 @@ export class ChatView {
             this.settingsView!,
             request,
             this.messageDiv,
-            getDispatcher().processCommand(requestText, id, images),
+            this.getDispatcher().processCommand(requestText, id, images),
             this.agents,
             this.hideMetrics,
         );
@@ -590,7 +624,10 @@ export class ChatView {
         if (agentMessage === undefined) {
             throw new Error(`Invalid requestId ${requestId}`);
         }
-        return agentMessage?.proposeAction(actionTemplates);
+        return agentMessage?.proposeAction(
+            this.getDispatcher(),
+            actionTemplates,
+        );
     }
     getMessageElm() {
         return this.topDiv;

--- a/ts/packages/shell/src/renderer/src/main.ts
+++ b/ts/packages/shell/src/renderer/src/main.ts
@@ -36,7 +36,7 @@ export function getAndroidAPI() {
     return globalThis.Android;
 }
 
-export function getDispatcher(): Dispatcher {
+async function getDispatcher(): Promise<Dispatcher> {
     if (globalThis.dispatcher !== undefined) {
         return globalThis.dispatcher;
     }
@@ -134,7 +134,7 @@ async function initializeChatHistory(chatView: ChatView) {
     }
 }
 
-function addEvents(
+function registerClient(
     chatView: ChatView,
     agents: Map<string, string>,
     settingsView: SettingsView,
@@ -413,7 +413,7 @@ document.addEventListener("DOMContentLoaded", async function () {
     wrapper.appendChild(tabs.getContainer());
 
     document.onkeyup = (ev: KeyboardEvent) => {
-        if (ev.key == "Escape") {
+        if (ev.key === "Escape") {
             tabs.closeTabs();
             ev.preventDefault();
         }
@@ -456,9 +456,7 @@ document.addEventListener("DOMContentLoaded", async function () {
     );
     tabs.getTabContainerByName("Help").append(new HelpView().getContainer());
 
-    addEvents(chatView, agents, settingsView, tabs, cameraView);
-
-    chatView.chatInputFocus();
+    registerClient(chatView, agents, settingsView, tabs, cameraView);
 
     try {
         if (Android !== undefined) {
@@ -484,6 +482,10 @@ document.addEventListener("DOMContentLoaded", async function () {
     }
 
     watchForDOMChanges(chatView.getScrollContainer());
+
+    getDispatcher().then((dispatcher) => {
+        chatView.initializeDispatcher(dispatcher);
+    });
 });
 
 function watchForDOMChanges(element: HTMLDivElement) {

--- a/ts/packages/shell/src/renderer/src/messageContainer.ts
+++ b/ts/packages/shell/src/renderer/src/messageContainer.ts
@@ -11,6 +11,7 @@ import {
     TemplateEditConfig,
     PhaseTiming,
     NotifyExplainedData,
+    Dispatcher,
 } from "agent-dispatcher";
 
 import { ChoicePanel, InputChoice } from "./choicePanel";
@@ -179,7 +180,7 @@ export class MessageContainer {
     }
 
     constructor(
-        private chatView: ChatView,
+        private readonly chatView: ChatView,
         private settingsView: SettingsView,
         private classNameSuffix: "agent" | "user",
         private source: string,
@@ -299,7 +300,10 @@ export class MessageContainer {
         );
     }
 
-    public async proposeAction(actionTemplates: TemplateEditConfig) {
+    public async proposeAction(
+        dispatcher: Dispatcher,
+        actionTemplates: TemplateEditConfig,
+    ) {
         // use this div to show the proposed action
         const actionContainer = document.createElement("div");
         actionContainer.className = "action-container";
@@ -307,6 +311,7 @@ export class MessageContainer {
 
         const actionCascade = new TemplateEditor(
             actionContainer,
+            dispatcher,
             actionTemplates,
         );
 
@@ -621,8 +626,8 @@ export class MessageContainer {
             message = `${cachePart}. Nothing to put in cache: ${data.error}`;
             color = "lightblue";
         }
-        this.messageDiv.setAttribute("data-expl", message);
-        this.messageDiv.classList.add("chat-message-explained");
+        this.div.setAttribute("data-expl", message);
+        this.div.classList.add("chat-message-explained");
         const icon = iconRoadrunner();
         icon.getElementsByTagName("svg")[0].style.fill = color;
         icon.className = "chat-message-explained-icon";

--- a/ts/packages/shell/src/renderer/src/partial.ts
+++ b/ts/packages/shell/src/renderer/src/partial.ts
@@ -1,8 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { CommandCompletionResult } from "agent-dispatcher";
-import { getDispatcher } from "./main";
+import { CommandCompletionResult, Dispatcher } from "agent-dispatcher";
 import { SearchMenu, SearchMenuItem } from "./search";
 
 import registerDebug from "debug";
@@ -23,13 +22,20 @@ export class PartialCompletion {
     constructor(
         private readonly container: HTMLDivElement,
         private readonly input: ExpandableTextarea,
+        private readonly dispatcher: Dispatcher,
     ) {
         this.searchMenu = new SearchMenu((item) => {
             this.handleSelect(item);
         }, false);
         document.addEventListener("selectionchange", () => {
+            debug("Partial completion update on selection changed");
             this.update(true);
         });
+
+        if (document.activeElement === this.input.getTextEntry()) {
+            // If the input is already focused, we need to update immediately.
+            this.update();
+        }
     }
 
     public update(selectionChanged: boolean = false) {
@@ -73,11 +79,7 @@ export class PartialCompletion {
             return false;
         }
 
-        const textEntry = this.input.getTextEntry();
-        const endNode =
-            textEntry.childNodes.length !== 0
-                ? textEntry.childNodes[0]
-                : textEntry;
+        const endNode = this.input.getSelectionEndNode();
         if (r.endContainer !== endNode) {
             if (!selectionChanged) {
                 debug(`Partial completion skipped: selection not in text area`);
@@ -159,7 +161,7 @@ export class PartialCompletion {
 
         if (showMenu) {
             debug(
-                `Partial completion updated: '${prefix}' with ${items.length} items`,
+                `Partial completion selection updated: '${prefix}' with ${items.length} items`,
             );
             this.showCompletionMenu(prefix);
         } else {
@@ -180,7 +182,7 @@ export class PartialCompletion {
         this.noCompletion = false;
         // Clear the choices
         this.searchMenu.setChoices([]);
-        const completionP = getDispatcher().getCommandCompletion(input);
+        const completionP = this.dispatcher.getCommandCompletion(input);
         this.completionP = completionP;
         completionP
             .then((result) => {
@@ -223,6 +225,10 @@ export class PartialCompletion {
                 }
 
                 this.searchMenu.setChoices(completions);
+
+                debug(
+                    `Partial completion selection reloaded: '${partial}' with ${completions.length} items`,
+                );
                 this.update();
             })
             .catch((e) => {
@@ -292,6 +298,10 @@ export class PartialCompletion {
             replaceText,
             -prefix.length,
             prefix.length,
+        );
+
+        debug(
+            `Partial completion input suffix replaced at: ${replaceText} at offset ${prefix.length}`,
         );
     }
 


### PR DESCRIPTION
- Wait for dispatcher initialized before enabling the input box and getting the first completion.
- After dispatcher initialized, get the chat view to focus to be ready for input.
- Fix the bug where input doesn't get updated after partial completion on empty input in `replaceAtCursor`
- Fix the explain hover message clipping because of the `overflow-x: auto` by attaching it to the outer container.