### PR TITLE
Player: improve device management and max volume settings

### DIFF
--- a/ts/packages/agentSdk/src/display.ts
+++ b/ts/packages/agentSdk/src/display.ts
@@ -23,7 +23,7 @@ export type DisplayContent =
     | {
           type: DisplayType; // Type of the content
           content: MessageContent; // each string in the MessageContext is treated as what `type` specifies
-          kind?: DisplayMessageKind; // Optional message kind for client specific styling
+          kind?: DisplayMessageKind | undefined; // Optional message kind for client specific styling
           speak?: boolean; // Optional flag to indicate if the content should be spoken
       };
 

--- a/ts/packages/agentSdk/src/helpers/actionHelpers.ts
+++ b/ts/packages/agentSdk/src/helpers/actionHelpers.ts
@@ -7,6 +7,7 @@ import {
     ActionResultSuccess,
     ActionResultSuccessNoDisplay,
 } from "../action.js";
+import { DisplayMessageKind } from "../display.js";
 import { Entity } from "../memory.js";
 
 export function createActionResultNoDisplay(
@@ -21,18 +22,34 @@ export function createActionResultNoDisplay(
 
 export function createActionResult(
     literalText: string,
-    speak?: boolean | undefined,
-    entities?: Entity[] | undefined,
+    options?:
+        | {
+              kind?: DisplayMessageKind;
+              speak?: boolean;
+          }
+        | DisplayMessageKind
+        | boolean,
+    entities?: Entity | Entity[],
 ): ActionResultSuccess {
-    entities ??= [];
+    const displayOptions =
+        typeof options === "boolean"
+            ? { speak: options }
+            : typeof options === "string"
+              ? { kind: options }
+              : options;
+
     return {
         literalText,
-        entities,
-        displayContent: speak
+        entities: entities
+            ? Array.isArray(entities)
+                ? entities
+                : [entities]
+            : [],
+        displayContent: displayOptions
             ? {
                   type: "text",
                   content: literalText,
-                  speak: true,
+                  ...displayOptions,
               }
             : literalText,
     };

--- a/ts/packages/agentSdk/src/memory.ts
+++ b/ts/packages/agentSdk/src/memory.ts
@@ -8,5 +8,5 @@ export interface Entity {
     type: string[];
 
     // Stable unique id for this entity, will be round tripped back to the source agent if user refer to the entity in the future.
-    uniqueId?: string;
+    uniqueId?: string | undefined;
 }

--- a/ts/packages/agents/player/src/agent/playerHandlers.ts
+++ b/ts/packages/agents/player/src/agent/playerHandlers.ts
@@ -55,11 +55,13 @@ async function executePlayerAction(
     action: TypeAgentAction<PlayerAction>,
     context: ActionContext<PlayerActionContext>,
 ) {
-    if (context.sessionContext.agentContext.spotify) {
+    const clientContext = context.sessionContext.agentContext.spotify;
+    if (clientContext) {
         return handleCall(
             action,
-            context.sessionContext.agentContext.spotify,
+            clientContext,
             context.actionIO,
+            context.sessionContext.instanceStorage,
         );
     }
 

--- a/ts/packages/agents/player/src/agent/playerSchema.json
+++ b/ts/packages/agents/player/src/agent/playerSchema.json
@@ -34,6 +34,9 @@
     "changeVolume": {
       "volumeChangePercentage": "percentage"
     },
+    "setMaxVolume": {
+      "newMaxVolumeLevel": "number"
+    },
     "getFavorites": {
       "count": "number"
     }

--- a/ts/packages/agents/player/src/agent/playerSchema.ts
+++ b/ts/packages/agents/player/src/agent/playerSchema.ts
@@ -15,8 +15,11 @@ export type PlayerAction =
     | PreviousAction
     | ShuffleAction
     | ListDevicesAction
+    | SetDefaultDeviceAction
     | SelectDeviceAction
+    | ShowSelectedDeviceAction
     | SetVolumeAction
+    | SetMaxVolumeAction
     | ChangeVolumeAction
     | SearchTracksAction
     | ListPlaylistsAction
@@ -116,13 +119,26 @@ export interface ListDevicesAction {
     actionName: "listDevices";
 }
 
+export interface SetDefaultDeviceAction {
+    actionName: "setDefaultDevice";
+    parameters: {
+        // keyword to match against device name.  If not specified, the current selected device is used.
+        deviceName?: string;
+    };
+}
+
 // select playback device by keyword
 export interface SelectDeviceAction {
     actionName: "selectDevice";
     parameters: {
         // keyword to match against device name
-        keyword: string;
+        deviceName: string;
     };
+}
+
+// show the selected playback device
+export interface ShowSelectedDeviceAction {
+    actionName: "showSelectedDevice";
 }
 
 // set volume
@@ -131,6 +147,15 @@ export interface SetVolumeAction {
     parameters: {
         // new volume level
         newVolumeLevel: number;
+    };
+}
+
+// set max volume for the current device
+export interface SetMaxVolumeAction {
+    actionName: "setMaxVolume";
+    parameters: {
+        // new volume level
+        newMaxVolumeLevel: number;
     };
 }
 

--- a/ts/packages/agents/player/src/client.ts
+++ b/ts/packages/agents/player/src/client.ts
@@ -3,7 +3,6 @@
 
 import path from "node:path";
 import {
-    ChangeVolumeAction,
     DeletePlaylistAction,
     GetFavoritesAction,
     GetPlaylistAction,
@@ -15,9 +14,6 @@ import {
     PlayRandomAction,
     PlayTrackAction,
     SearchTracksAction,
-    SelectDeviceAction,
-    SetVolumeAction,
-    ShuffleAction,
 } from "./agent/playerSchema.js";
 import { createTokenProvider } from "./defaultTokenProvider.js";
 import chalk from "chalk";
@@ -34,15 +30,11 @@ import { applyFilterExpr } from "./trackFilter.js";
 import {
     play,
     getUserProfile,
-    getDevices,
     search,
-    setVolume,
-    limitMax,
     getFavoriteTracks,
     createPlaylist,
     deletePlaylist,
     getPlaylists,
-    getPlaybackState,
     getPlaylistTracks,
     pause,
     next,
@@ -51,15 +43,9 @@ import {
     getQueue,
     getAlbum,
 } from "./endpoints.js";
-import {
-    htmlStatus,
-    listAvailableDevices,
-    printStatus,
-    selectDevice,
-} from "./playback.js";
+import { htmlStatus, printStatus } from "./playback.js";
 import { SpotifyService } from "./service.js";
 import { fileURLToPath } from "node:url";
-import { hostname } from "node:os";
 import {
     initializeUserData,
     mergeUserDataKind,
@@ -67,7 +53,7 @@ import {
     addUserDataStrings,
     UserData,
 } from "./userData.js";
-import registerDebug from "debug";
+
 import {
     ActionIO,
     DisplayContent,
@@ -89,9 +75,27 @@ import {
     getTrackFromEntity,
 } from "./search.js";
 import { toTrackObjectFull } from "./spotifyUtils.js";
-
-const debugSpotify = registerDebug("typeagent:spotify");
-const debugSpotifyError = registerDebug("typeagent:spotify:error");
+import { debugSpotify, debugSpotifyError } from "./debug.js";
+import {
+    LocalSettings,
+    RoamingSettings,
+    loadLocalSettings,
+    loadRoamingSettings,
+} from "./settings.js";
+import {
+    DeviceInfo,
+    ensureCurrentDeviceId,
+    getCurrentDevicePlaybackState,
+    listDevicesAction,
+    selectDeviceAction,
+    setDefaultDeviceAction,
+    showSelectedDeviceAction,
+} from "./devices.js";
+import {
+    changeVolumeAction,
+    setMaxVolumeAction,
+    setVolumeAction,
+} from "./volume.js";
 
 function createWarningActionResult(message: string) {
     debugSpotifyError(message);
@@ -122,13 +126,15 @@ function getTypeChatLanguageModel() {
 
 export interface IClientContext {
     service: SpotifyService;
-    deviceId?: string | undefined;
     currentTrackList?: ITrackCollection;
     lastTrackStartIndex?: number;
     lastTrackEndIndex?: number;
     trackListMap: Map<string, ITrackCollection>;
     trackListCount: number;
     userData?: UserData | undefined;
+    localSettings: LocalSettings;
+    roamingSettings: RoamingSettings;
+    currentDeviceInfo?: DeviceInfo | undefined;
 }
 
 async function printTrackNames(
@@ -360,17 +366,12 @@ export async function getClientContext(
         id: userdata?.id,
         username: userdata?.display_name,
     });
-    const devices = await getDevices(service);
-    let deviceId: string | undefined;
-    if (devices && devices.devices.length > 0) {
-        const activeDevice =
-            devices.devices.find((device) => device.is_active) ??
-            devices.devices.find((device) => device.name === hostname()) ??
-            devices.devices[0];
-        deviceId = activeDevice.id ?? undefined;
-    }
+
+    const roamingSettings = await loadRoamingSettings(instanceStorage);
+    const localSettings = await loadLocalSettings(instanceStorage);
     return {
-        deviceId,
+        localSettings,
+        roamingSettings,
         service,
         trackListMap: new Map<string, ITrackCollection>(),
         trackListCount: 0,
@@ -410,23 +411,19 @@ async function playTrackCollection(
     trackCollection: ITrackCollection,
     clientContext: IClientContext,
 ) {
-    if (clientContext.deviceId) {
-        const tracks = trackCollection.getTracks();
-        const uris = tracks.map((track) => track.uri);
-        console.log(chalk.cyanBright("Playing..."));
-        await printTrackNames(trackCollection, clientContext);
-        const actionResult = await htmlTrackNames(trackCollection, "Playing");
-        await play(
-            clientContext.service,
-            clientContext.deviceId,
-            uris,
-            trackCollection.getContext(),
-        );
-        return actionResult;
-    } else {
-        const message = "No active device found";
-        return createActionResultFromTextDisplay(chalk.red(message), message);
-    }
+    const deviceId = await ensureCurrentDeviceId(clientContext);
+    const tracks = trackCollection.getTracks();
+    const uris = tracks.map((track) => track.uri);
+    console.log(chalk.cyanBright("Playing..."));
+    await printTrackNames(trackCollection, clientContext);
+    const actionResult = await htmlTrackNames(trackCollection, "Playing");
+    await play(
+        clientContext.service,
+        deviceId,
+        uris,
+        trackCollection.getContext(),
+    );
+    return actionResult;
 }
 
 async function playRandomAction(
@@ -650,32 +647,16 @@ async function playGenreAction(
     return playTrackCollection(collection, clientContext);
 }
 
-function ensureClientId(state: SpotifyApi.CurrentPlaybackResponse) {
-    if (state.device.id !== null) {
-        return state.device.id;
-    }
-    console.log(
-        chalk.red(
-            `Current device '${state.device.name}' is a restricted device and cannot be controlled.`,
-        ),
-    );
-    return undefined;
-}
-
 async function resumeActionCall(clientContext: IClientContext) {
-    const state = await getPlaybackState(clientContext.service);
+    const state = await getCurrentDevicePlaybackState(clientContext);
     if (!state) {
         return createWarningActionResult("No active playback to resume");
-    }
-    const deviceId = ensureClientId(state);
-    if (deviceId === undefined) {
-        return createWarningActionResult("No device active");
     }
 
     if (state.is_playing) {
         console.log(chalk.yellow("Music already playing"));
     } else {
-        await play(clientContext.service, deviceId);
+        await play(clientContext.service, state.device.id!);
     }
     await printStatus(clientContext);
     const status = await htmlStatus(clientContext);
@@ -685,18 +666,14 @@ async function resumeActionCall(clientContext: IClientContext) {
 async function pauseActionCall(
     clientContext: IClientContext,
 ): Promise<ActionResult> {
-    const state = await getPlaybackState(clientContext.service);
+    const state = await getCurrentDevicePlaybackState(clientContext);
     if (!state) {
         return createWarningActionResult("No active playback to pause");
-    }
-    const deviceId = ensureClientId(state);
-    if (deviceId === undefined) {
-        return createWarningActionResult("No device active");
     }
     if (!state.is_playing) {
         console.log(chalk.yellow("Music already stopped."));
     } else {
-        await pause(clientContext.service, deviceId);
+        await pause(clientContext.service, state.device.id!);
     }
     await printStatus(clientContext);
     const statusHtml = await htmlStatus(clientContext);
@@ -704,50 +681,38 @@ async function pauseActionCall(
 }
 
 async function nextActionCall(clientContext: IClientContext) {
-    const state = await getPlaybackState(clientContext.service);
+    const state = await getCurrentDevicePlaybackState(clientContext);
     if (!state) {
         return createWarningActionResult("No active playback to move next to");
     }
-    const deviceId = ensureClientId(state);
-    if (deviceId === undefined) {
-        return createWarningActionResult("No device active");
-    }
 
-    await next(clientContext.service, deviceId);
+    await next(clientContext.service, state.device.id!);
     await printStatus(clientContext);
     const statusHtml = await htmlStatus(clientContext);
     return statusHtml;
 }
 
 async function previousActionCall(clientContext: IClientContext) {
-    const state = await getPlaybackState(clientContext.service);
+    const state = await getCurrentDevicePlaybackState(clientContext);
     if (!state) {
         return createWarningActionResult(
             "No active playback to move previous to",
         );
     }
-    const deviceId = ensureClientId(state);
-    if (deviceId === undefined) {
-        return createWarningActionResult("No device active");
-    }
 
-    await previous(clientContext.service, deviceId);
+    await previous(clientContext.service, state.device.id!);
     await printStatus(clientContext);
     const statusHtml = await htmlStatus(clientContext);
     return statusHtml;
 }
 
 async function shuffleActionCall(clientContext: IClientContext, on: boolean) {
-    const state = await getPlaybackState(clientContext.service);
+    const state = await getCurrentDevicePlaybackState(clientContext);
     if (!state) {
         return createWarningActionResult("No active playback to shuffle");
     }
-    const deviceId = ensureClientId(state);
-    if (deviceId === undefined) {
-        return createWarningActionResult("No device active");
-    }
 
-    await shuffle(clientContext.service, deviceId, on);
+    await shuffle(clientContext.service, state.device.id!, on);
     await printStatus(clientContext);
     const statusHtml = await htmlStatus(clientContext);
     return statusHtml;
@@ -763,6 +728,7 @@ export async function handleCall(
     action: TypeAgentAction<PlayerAction>,
     clientContext: IClientContext,
     actionIO: ActionIO,
+    instanceStorage?: Storage,
 ): Promise<ActionResult> {
     switch (action.actionName) {
         case "playRandom":
@@ -814,62 +780,47 @@ export async function handleCall(
             return previousActionCall(clientContext);
         }
         case "shuffle": {
-            const shuffleAction = action as ShuffleAction;
-            return shuffleActionCall(
-                clientContext,
-                shuffleAction.parameters.on,
-            );
+            return shuffleActionCall(clientContext, action.parameters.on);
         }
         case "resume": {
             return resumeActionCall(clientContext);
         }
         case "listDevices": {
-            const result = await listAvailableDevices(clientContext);
-            return result
-                ? createActionResultFromHtmlDisplay(result.html, result.lit)
-                : createErrorActionResult("No devices found");
+            return listDevicesAction(clientContext);
         }
         case "selectDevice": {
-            const selectDeviceAction = action as SelectDeviceAction;
-            const keyword = selectDeviceAction.parameters.keyword;
-            const result = await selectDevice(keyword, clientContext);
-            if (result) {
-                const { html, text } = result;
-                return createActionResultFromHtmlDisplay(html, text);
-            } else return createErrorActionResult("No devices found");
+            return selectDeviceAction(
+                clientContext,
+                action.parameters.deviceName,
+            );
+        }
+
+        case "setDefaultDevice":
+            return setDefaultDeviceAction(
+                clientContext,
+                action.parameters.deviceName,
+            );
+        case "showSelectedDevice": {
+            return showSelectedDeviceAction(clientContext);
         }
         case "setVolume": {
-            const setVolumeAction = action as SetVolumeAction;
-            let newVolumeLevel = setVolumeAction.parameters.newVolumeLevel;
-            if (newVolumeLevel > 50) {
-                newVolumeLevel = 50;
-            }
-            actionIO.setDisplay(
-                chalk.yellowBright(`setting volume to ${newVolumeLevel} ...`),
+            const newVolumeLevel = action.parameters.newVolumeLevel;
+            return setVolumeAction(clientContext, newVolumeLevel, actionIO);
+        }
+        case "setMaxVolume": {
+            return setMaxVolumeAction(
+                clientContext,
+                action.parameters.newMaxVolumeLevel,
+                actionIO,
+                instanceStorage,
             );
-            await setVolume(clientContext.service, newVolumeLevel);
-            return htmlStatus(clientContext);
         }
         case "changeVolume": {
-            const changeVolumeAction = action as ChangeVolumeAction;
-            const volumeChangeAmount =
-                changeVolumeAction.parameters.volumeChangePercentage;
-            const playback = await getPlaybackState(clientContext.service);
-            if (playback && playback.device) {
-                const volpct = playback.device.volume_percent || 50;
-                let nv = Math.floor(
-                    (1.0 + volumeChangeAmount / 100.0) * volpct,
-                );
-                if (nv > 50) {
-                    nv = 50;
-                }
-                actionIO.setDisplay(
-                    chalk.yellowBright(`setting volume to ${nv} ...`),
-                );
-                await setVolume(clientContext.service, nv);
-                return htmlStatus(clientContext);
-            }
-            return createErrorActionResult("No active device found");
+            return changeVolumeAction(
+                clientContext,
+                action.parameters.volumeChangePercentage,
+                actionIO,
+            );
         }
         case "searchTracks": {
             const searchTracksAction = action as SearchTracksAction;
@@ -928,7 +879,7 @@ export async function handleCall(
             let status: SpotifyApi.CurrentPlaybackResponse | undefined =
                 undefined;
             // get album of current playing track and load it as track collection
-            status = await getPlaybackState(clientContext.service);
+            status = await getCurrentDevicePlaybackState(clientContext);
             if (status && status.item && status.item.type === "track") {
                 const track = status.item as SpotifyApi.TrackObjectFull;
                 album = track.album;
@@ -946,7 +897,7 @@ export async function handleCall(
                 ) {
                     await play(
                         clientContext.service,
-                        clientContext.deviceId!,
+                        await ensureCurrentDeviceId(clientContext),
                         [],
                         album.uri,
                         status.item.track_number - 1,
@@ -969,11 +920,7 @@ export async function handleCall(
         }
         case "getFavorites": {
             const getFavoritesAction = action as GetFavoritesAction;
-            const countOption = getFavoritesAction.parameters?.count;
-            let count = limitMax;
-            if (countOption !== undefined) {
-                count = countOption;
-            }
+            const count = getFavoritesAction.parameters?.count;
             const tops = await getFavoriteTracks(clientContext.service, count);
             if (tops) {
                 const tracks = tops.map((pto) => pto.track!);

--- a/ts/packages/agents/player/src/debug.ts
+++ b/ts/packages/agents/player/src/debug.ts
@@ -1,0 +1,7 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import registerDebug from "debug";
+
+export const debugSpotify = registerDebug("typeagent:spotify");
+export const debugSpotifyError = registerDebug("typeagent:spotify:error");

--- a/ts/packages/agents/player/src/devices.ts
+++ b/ts/packages/agents/player/src/devices.ts
@@ -1,0 +1,254 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { hostname } from "os";
+import { IClientContext } from "./client.js";
+import { getDevices, getPlaybackState, transferPlayback } from "./endpoints.js";
+import { SpotifyService } from "./service.js";
+import { Entity } from "@typeagent/agent-sdk";
+import {
+    createActionResult,
+    createActionResultFromMarkdownDisplay,
+} from "@typeagent/agent-sdk/helpers/action";
+import chalk from "chalk";
+
+export type DeviceInfo = {
+    name: string;
+    id: string;
+};
+
+export type DeviceSettings = {
+    maxVolume: number;
+};
+
+async function getDevice(service: SpotifyService, name: string) {
+    const devices = await getDevices(service);
+    if (devices === undefined || devices.devices.length === 0) {
+        return undefined;
+    }
+    return devices.devices.find((d) => d.name === name && d.id !== null);
+}
+
+function getCurrentDeviceName(clientContext: IClientContext): string {
+    return (
+        clientContext.currentDeviceInfo?.name ??
+        clientContext.localSettings.defaultDeviceName ??
+        hostname()
+    );
+}
+export async function getCurrentDevice(clientContext: IClientContext) {
+    const name = getCurrentDeviceName(clientContext);
+    const device = await getDevice(clientContext.service, name);
+    if (device === undefined) {
+        throw new Error(
+            `Unable to find default device '${clientContext.localSettings.defaultDeviceName ?? hostname()}'`,
+        );
+    }
+    return device;
+}
+
+async function getCurrentDeviceInfo(clientContext: IClientContext) {
+    if (clientContext.currentDeviceInfo) {
+        return clientContext.currentDeviceInfo;
+    }
+    const device = await getDevice(
+        clientContext.service,
+        clientContext.localSettings.defaultDeviceName ?? hostname(),
+    );
+    const current = device
+        ? {
+              name: device.name,
+              id: device.id!,
+          }
+        : undefined;
+    clientContext.currentDeviceInfo = current;
+    return current;
+}
+
+export async function ensureCurrentDeviceInfo(clientContext: IClientContext) {
+    const currentDevice = await getCurrentDeviceInfo(clientContext);
+    if (currentDevice === undefined) {
+        throw new Error(
+            `Unable to find default device '${clientContext.localSettings.defaultDeviceName ?? hostname()}'`,
+        );
+    }
+    return currentDevice;
+}
+
+export async function getCurrentDevicePlaybackState(
+    clientContext: IClientContext,
+) {
+    const [currentDevice, state] = await Promise.all([
+        ensureCurrentDeviceInfo(clientContext),
+        getPlaybackState(clientContext.service),
+    ]);
+
+    if (state === undefined || state.device.id === currentDevice.id) {
+        return state;
+    }
+
+    if (state.is_playing === true) {
+        throw new Error(
+            `Music is currently playing on device '${state.device.name}', not the current device '${currentDevice.name}'`,
+        );
+    }
+
+    return undefined;
+}
+
+export async function ensureCurrentDeviceId(
+    clientContext: IClientContext,
+): Promise<string> {
+    const [currentDevice, state] = await Promise.all([
+        ensureCurrentDeviceInfo(clientContext),
+        getPlaybackState(clientContext.service),
+    ]);
+
+    if (
+        state !== undefined &&
+        state.device.id !== currentDevice.id &&
+        state.is_playing === true
+    ) {
+        throw new Error(
+            `Music is currently playing on device '${state.device.name}', not the current device '${currentDevice.name}'`,
+        );
+    }
+    return currentDevice.id;
+}
+
+function toDeviceEntity(name: string): Entity {
+    return {
+        name,
+        type: ["MusicDevice"],
+        uniqueId: name, // can't use device.id as it is not always stable.
+    };
+}
+
+async function getDevicesMarkdown(
+    context: IClientContext,
+    device: SpotifyApi.UserDevice[],
+): Promise<string[]> {
+    const markdown: string[] = [];
+    markdown.push("Available devices:");
+    const currentDeviceInfo = await getCurrentDeviceInfo(context);
+
+    const state = await getPlaybackState(context.service);
+    const playingId = state?.is_playing ? state.device.id : undefined;
+    for (const d of device) {
+        const selected = d.id === currentDeviceInfo?.id;
+        const str = `${d.name} (${d.type})${selected ? " [selected]" : ""}${playingId === d.id ? " ▶️" : ""}`;
+        markdown.push(`- ${selected ? chalk.green(str) : str}`);
+    }
+    return markdown;
+}
+
+async function ensureGetDevices(
+    context: IClientContext,
+): Promise<SpotifyApi.UserDevice[]> {
+    const devicesResponse = await getDevices(context.service);
+    const devices = devicesResponse?.devices?.filter((d) => d.id !== null);
+    if (devices === undefined || devices.length === 0) {
+        throw new Error("No devices found.");
+    }
+    return devices;
+}
+
+export async function listDevicesAction(context: IClientContext) {
+    const devices = await ensureGetDevices(context);
+    return createActionResultFromMarkdownDisplay(
+        await getDevicesMarkdown(context, devices),
+        undefined,
+        devices.map((d) => toDeviceEntity(d.name)),
+    );
+}
+
+async function findDevice(
+    clientContext: IClientContext,
+    deviceName: string,
+): Promise<SpotifyApi.UserDevice | undefined> {
+    const devices = await ensureGetDevices(clientContext);
+    return devices.find(
+        (d) =>
+            d.name.toLowerCase().includes(deviceName.toLowerCase()) ||
+            d.type.toLowerCase().includes(deviceName.toLowerCase()),
+    );
+}
+
+export async function selectDeviceAction(
+    context: IClientContext,
+    deviceName: string,
+) {
+    const device = await findDevice(context, deviceName);
+    if (device !== undefined) {
+        const status = await getPlaybackState(context.service);
+        if (status && status.device.id !== device.id) {
+            await transferPlayback(
+                context.service,
+                device.id!,
+                status.is_playing,
+            );
+        }
+        if (device.name === context.currentDeviceInfo?.name) {
+            return createActionResult(
+                `Device ${device.name} is already selected`,
+                "warning",
+                toDeviceEntity(device.name),
+            );
+        }
+        context.currentDeviceInfo = {
+            name: device.name,
+            id: device.id!,
+        };
+        return createActionResult(
+            `Selected device ${device.name} of type ${device.type}`,
+            "success",
+            toDeviceEntity(device.name),
+        );
+    }
+
+    const state = await getPlaybackState(context.service);
+    if (
+        state &&
+        state.is_playing &&
+        state.device.name.toLowerCase().includes(deviceName.toLowerCase())
+    ) {
+        if (state.device.is_restricted) {
+            throw new Error(
+                `Cannot select device currently playing music '${state.device.name}' because it is restricted'`,
+            );
+        }
+
+        throw new Error(
+            `Cannot select device currently playing music '${state.device.name}' because it is not in the available devices list`,
+        );
+    }
+
+    throw new Error(`No matching device found for '${deviceName}'`);
+}
+
+export async function showSelectedDeviceAction(clientContext: IClientContext) {
+    const { name } = await ensureCurrentDeviceInfo(clientContext);
+    return createActionResult(
+        `Current device: ${name}`,
+        undefined,
+        toDeviceEntity(name),
+    );
+}
+
+export async function setDefaultDeviceAction(
+    clientContext: IClientContext,
+    deviceName?: string,
+) {
+    const name =
+        deviceName ?? (await ensureCurrentDeviceInfo(clientContext)).name;
+    const device = await findDevice(clientContext, name);
+    if (device === undefined) {
+        throw new Error(`Unable to find device '${deviceName}'`);
+    }
+    clientContext.localSettings.defaultDeviceName = device.name;
+    return createActionResult(
+        `Default device set to '${device.name}' and will be used on next startup.  Current device not changed: '${getCurrentDeviceName(clientContext)}'`,
+        "success",
+        toDeviceEntity(device.name),
+    );
+}

--- a/ts/packages/agents/player/src/endpoints.ts
+++ b/ts/packages/agents/player/src/endpoints.ts
@@ -8,7 +8,7 @@ import { createFetchError } from "./utils.js";
 const debugSpotifyRest = registerDebug("typeagent:spotify:rest");
 const debugSpotifyRestVerbose = registerDebug("typeagent:spotify-verbose:rest");
 
-export const limitMax = 50;
+const limitMax = 50;
 
 export async function search(
     query: SpotifyApi.SearchForItemParameterObject,
@@ -592,10 +592,14 @@ export async function createPlaylist(
     );
 }
 
-export async function setVolume(service: SpotifyService, amt = limitMax) {
+export async function setVolume(
+    service: SpotifyService,
+    deviceId: string,
+    amt: number,
+) {
     const volumeUrl = getUrlWithParams(
         "https://api.spotify.com/v1/me/player/volume?volume_percent",
-        { volume_percent: amt },
+        { volume_percent: amt, device_id: deviceId },
     );
     return fetchPutEmptyResult(service, volumeUrl);
 }

--- a/ts/packages/agents/player/src/playback.ts
+++ b/ts/packages/agents/player/src/playback.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { getDevices, getPlaybackState, transferPlayback } from "./endpoints.js";
+import { getDevices, getPlaybackState } from "./endpoints.js";
 import { IClientContext } from "./client.js";
 import chalk from "chalk";
 import { DisplayContent, ActionResultSuccess } from "@typeagent/agent-sdk";
@@ -157,52 +157,3 @@ export async function printStatus(context: IClientContext) {
     }
 }
 
-export async function selectDevice(keyword: string, context: IClientContext) {
-    const devices = await getDevices(context.service);
-
-    if (devices && devices.devices.length > 0) {
-        for (const device of devices.devices) {
-            if (
-                device.name.toLowerCase().includes(keyword.toLowerCase()) ||
-                device.type.toLowerCase().includes(keyword.toLowerCase())
-            ) {
-                let html = "";
-                const status = await getPlaybackState(context.service);
-                if (status) {
-                    if (status.device.id === device.id) {
-                        const text = `Device ${device.name} is already selected`;
-                        html += `<div>${text}</div>\n`;
-                        console.log(chalk.yellow(text));
-                        return { html, text };
-                    }
-                    await transferPlayback(
-                        context.service,
-                        device.id!,
-                        status.is_playing,
-                    );
-                }
-                context.deviceId = device.id!;
-                const text = `Selected device ${device.name} of type ${device.type}`;
-                html += `<div>${text}</div>\n`;
-                console.log(chalk.green(text));
-                return { html, text };
-            }
-        }
-    }
-}
-
-export async function listAvailableDevices(context: IClientContext) {
-    const devices = await getDevices(context.service);
-    if (devices && devices.devices.length > 0) {
-        let devHTML = "<div><div>Available Devices...</div><ul>\n";
-        let literalText = "Available devices:\n";
-        for (const device of devices.devices) {
-            const description = `${device.name} (${device.type})${device.is_active ? " [active]" : ""}`;
-            console.log(chalk.magenta(`Device ${description}`));
-            devHTML += `<li>${description}</li>\n`;
-            literalText += `    ${description}\n`;
-        }
-        devHTML += "</ul></div>";
-        return { html: devHTML, lit: literalText };
-    }
-}

--- a/ts/packages/agents/player/src/settings.ts
+++ b/ts/packages/agents/player/src/settings.ts
@@ -1,0 +1,96 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { Storage } from "@typeagent/agent-sdk";
+import { debugSpotifyError } from "./debug.js";
+import { DeviceSettings } from "./devices.js";
+
+// Roaming settings
+export type RoamingSettings = {
+    deviceSettings: Map<string, DeviceSettings>;
+};
+
+type RoamingSettingsJSON = {
+    deviceSettings: [string, DeviceSettings][];
+};
+
+// local settings
+export type LocalSettings = {
+    defaultDeviceName?: string | undefined;
+};
+
+async function loadSettingData<T>(
+    storage: Storage | undefined,
+    fileName: string,
+): Promise<T | undefined> {
+    if (storage) {
+        try {
+            const data = await storage.read(fileName, "utf8");
+            if (data) {
+                return JSON.parse(data) as T;
+            }
+        } catch (error) {
+            // ignore loading error.
+            debugSpotifyError("Error loading device settings:", error);
+        }
+    }
+    return undefined;
+}
+
+async function saveSettingData<T>(
+    storage: Storage,
+    settings: T,
+    fileName: string,
+): Promise<void> {
+    const data = JSON.stringify(settings, null, 2);
+    await storage.write(fileName, data, "utf8");
+}
+
+const localSettingFileName = "localSettings.json";
+export async function loadLocalSettings(
+    storage: Storage | undefined,
+): Promise<LocalSettings> {
+    return (
+        (await loadSettingData<LocalSettings>(storage, localSettingFileName)) ??
+        {}
+    );
+}
+
+export async function saveLocalSettings(
+    storage: Storage | undefined,
+    settings: LocalSettings,
+): Promise<void> {
+    if (storage !== undefined) {
+        await saveSettingData(storage, settings, localSettingFileName);
+    }
+}
+
+const roamingSettingsFileName = "settings.json";
+export async function loadRoamingSettings(
+    storage: Storage | undefined,
+): Promise<RoamingSettings> {
+    const json = await loadSettingData<RoamingSettingsJSON>(
+        storage,
+        roamingSettingsFileName,
+    );
+    if (json === undefined) {
+        return {
+            deviceSettings: new Map<string, DeviceSettings>(),
+        };
+    }
+    return {
+        deviceSettings: new Map(json.deviceSettings),
+    };
+}
+
+export async function saveRoamingSettings(
+    storage: Storage | undefined,
+    settings: RoamingSettings,
+): Promise<void> {
+    if (storage !== undefined) {
+        const data: RoamingSettingsJSON = {
+            deviceSettings: Array.from(settings.deviceSettings.entries()),
+        };
+        await saveSettingData(storage, data, roamingSettingsFileName);
+    }
+}

--- a/ts/packages/agents/player/src/volume.ts
+++ b/ts/packages/agents/player/src/volume.ts
@@ -1,0 +1,107 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { ensureCurrentDeviceInfo, getCurrentDevice } from "./devices.js";
+import { IClientContext } from "./client.js";
+import { ActionIO, Storage } from "@typeagent/agent-sdk";
+import { setVolume } from "./endpoints.js";
+import { saveRoamingSettings } from "./settings.js";
+import {
+    createActionResult,
+    createActionResultFromTextDisplay,
+} from "@typeagent/agent-sdk/helpers/action";
+import { SpotifyService } from "./service.js";
+
+export async function setVolumeAction(
+    clientContext: IClientContext,
+    newVolumeLevel: number,
+    actionIO: ActionIO,
+) {
+    if (newVolumeLevel < 0 || newVolumeLevel > 100) {
+        throw new Error(`Invalid volume: ${newVolumeLevel}`);
+    }
+    const deviceSettings = clientContext.roamingSettings.deviceSettings;
+    const { name, id } = await ensureCurrentDeviceInfo(clientContext);
+
+    const maxVolume = deviceSettings.get(name)?.maxVolume ?? 100;
+    const volume = Math.min(newVolumeLevel, maxVolume);
+    if (volume !== newVolumeLevel) {
+        actionIO.appendDisplay({
+            type: "text",
+            kind: "warning",
+            content: `Volume ${newVolumeLevel} exceeds maximum limit of ${maxVolume} for device '${name}'. Setting to ${volume}.`,
+        });
+    }
+    return setVolumeAmount(clientContext.service, name, volume, id!, actionIO);
+}
+
+export async function setMaxVolumeAction(
+    clientContext: IClientContext,
+    newMaxVolume: number,
+    actionIO: ActionIO,
+    instanceStorage: Storage | undefined,
+) {
+    if (newMaxVolume < 0 || newMaxVolume > 100) {
+        throw new Error(`Invalid max volume: ${newMaxVolume}`);
+    }
+    const { name, id } = await ensureCurrentDeviceInfo(clientContext);
+
+    const deviceSettings = clientContext.roamingSettings.deviceSettings;
+    if (deviceSettings.has(name)) {
+        const settings = deviceSettings.get(name)!;
+        settings.maxVolume = newMaxVolume;
+    } else {
+        deviceSettings.set(name, { maxVolume: newMaxVolume });
+    }
+    await saveRoamingSettings(instanceStorage, clientContext.roamingSettings);
+    const { volume_percent } = await getCurrentDevice(clientContext);
+    if (volume_percent === null || volume_percent > newMaxVolume) {
+        await setVolume(clientContext.service, id, newMaxVolume);
+        actionIO.appendDisplay({
+            type: "text",
+            kind: "warning",
+            content: `Device '${name}' volume set to ${newMaxVolume} to match new max volume.`,
+        });
+    }
+    return createActionResultFromTextDisplay(
+        `Device '${name}' max volume set to ${newMaxVolume}`,
+    );
+}
+
+export async function changeVolumeAction(
+    clientContext: IClientContext,
+    volumeChangePercentage: number,
+    actionIO: ActionIO,
+) {
+    const { name, id, volume_percent } = await getCurrentDevice(clientContext);
+    const deviceSettings = clientContext.roamingSettings.deviceSettings;
+    const maxVolume = deviceSettings.get(name)?.maxVolume ?? 100;
+    const volpct = volume_percent ?? maxVolume;
+    const volumeChangeFactor = 1 + volumeChangePercentage / 100;
+    const newVolumeLevel = Math.floor(volumeChangeFactor * volpct);
+    const volume = Math.min(newVolumeLevel, maxVolume);
+    if (volume !== newVolumeLevel) {
+        actionIO.appendDisplay({
+            type: "text",
+            kind: "warning",
+            content: `Volume ${newVolumeLevel} exceeds maximum limit of ${maxVolume} for device '${name}'. Setting to ${volume}.`,
+        });
+    }
+    return setVolumeAmount(clientContext.service, name, volume, id!, actionIO);
+}
+
+async function setVolumeAmount(
+    service: SpotifyService,
+    name: string,
+    volume: number,
+    id: string,
+    actionIO: ActionIO,
+) {
+    actionIO.appendDisplay({
+        type: "text",
+        kind: "status",
+        content: `Setting device '${name}' volume to ${volume} ...`,
+    });
+    await setVolume(service, id, volume);
+    return createActionResult(`Device '${name}' volume set to ${volume}`);
+}

--- a/ts/packages/agents/player/src/volume.ts
+++ b/ts/packages/agents/player/src/volume.ts
@@ -97,11 +97,14 @@ async function setVolumeAmount(
     id: string,
     actionIO: ActionIO,
 ) {
-    actionIO.appendDisplay({
-        type: "text",
-        kind: "status",
-        content: `Setting device '${name}' volume to ${volume} ...`,
-    });
+    actionIO.appendDisplay(
+        {
+            type: "text",
+            kind: "status",
+            content: `Setting device '${name}' volume to ${volume} ...`,
+        },
+        "temporary",
+    );
     await setVolume(service, id, volume);
     return createActionResult(`Device '${name}' volume set to ${volume}`);
 }

--- a/ts/packages/dispatcher/src/execute/actionHandlers.ts
+++ b/ts/packages/dispatcher/src/execute/actionHandlers.ts
@@ -168,7 +168,7 @@ async function executeAction(
         displayError(result.error, actionContext);
     } else {
         if (result.displayContent !== undefined) {
-            actionContext.actionIO.setDisplay(result.displayContent);
+            actionContext.actionIO.appendDisplay(result.displayContent);
         }
         if (result.dynamicDisplayId !== undefined) {
             systemContext.clientIO.setDynamicDisplay(


### PR DESCRIPTION
- Make max volume for device a setting (instead of hard coded to 50)
- Player agent keep track of a user defined default device to use.
- Track the current device as user change it explicitly (instead of relying on "active" device from the server).   
- User configurable maximum volume per "device".   
- Add action to change the user defined default device, and maximum volume