### PR TITLE
Player: music device entity and completion

### DIFF
--- a/ts/packages/actionSchema/src/index.ts
+++ b/ts/packages/actionSchema/src/index.ts
@@ -32,7 +32,6 @@ export { validateAction } from "./validate.js";
 // Utils for any schemas
 export {
     getPropertyType,
-    getPropertyResolvedType,
     getParameterNames,
     resolveTypeReference,
     resolveUnionType,

--- a/ts/packages/actionSchemaCompiler/src/index.ts
+++ b/ts/packages/actionSchemaCompiler/src/index.ts
@@ -36,10 +36,15 @@ export default class Compile extends Command {
             required: true,
             char: "o",
         }),
-        schemaType: Flags.string({
-            description: "Entry type name for the schema",
+        actionType: Flags.string({
+            description: "Entry type name for the action schemas",
             required: true,
             char: "t",
+        }),
+        entityType: Flags.string({
+            description: "Entity type name for the entity types",
+            required: false,
+            char: "e",
         }),
     };
 
@@ -48,10 +53,16 @@ export default class Compile extends Command {
 
         const name = path.basename(flags.input);
 
+        const type = flags.entityType
+            ? {
+                  action: flags.actionType,
+                  entity: flags.entityType,
+              }
+            : flags.actionType;
         const actionSchemaFile = parseActionSchemaSource(
             fs.readFileSync(flags.input, "utf-8"),
             name,
-            flags.schemaType,
+            type,
             flags.input,
             getSchemaConfig(flags.input),
             true,

--- a/ts/packages/agentRpc/src/client.ts
+++ b/ts/packages/agentRpc/src/client.ts
@@ -563,14 +563,16 @@ export async function createAgentRpcClient(
             });
         },
         getActionCompletion(
+            context: SessionContext<ShimContext>,
             partialAction,
             propertyName,
-            context: SessionContext<ShimContext>,
+            entityTypeName,
         ) {
             return rpc.invoke("getActionCompletion", {
                 ...getContextParam(context),
                 partialAction,
                 propertyName,
+                entityTypeName,
             });
         },
     };

--- a/ts/packages/agentRpc/src/server.ts
+++ b/ts/packages/agentRpc/src/server.ts
@@ -227,9 +227,10 @@ export function createAgentRpcServer(
                 throw new Error("Invalid invocation of getActionCompletion");
             }
             return agent.getActionCompletion(
+                getSessionContextShim(param),
                 param.partialAction,
                 param.propertyName,
-                getSessionContextShim(param),
+                param.entityTypeName,
             );
         },
     };

--- a/ts/packages/agentRpc/src/types.ts
+++ b/ts/packages/agentRpc/src/types.ts
@@ -202,13 +202,14 @@ export type AgentInvokeFunctions = {
             data: unknown;
             propertyName: string;
         },
-    ): Promise<string[]>;
+    ): Promise<string[] | undefined>;
     getActionCompletion(
         param: Partial<ContextParams> & {
             partialAction: AppAction;
             propertyName: string;
+            entityTypeName: string | undefined;
         },
-    ): Promise<string[]>;
+    ): Promise<string[] | undefined>;
 };
 
 export type ContextParams = {

--- a/ts/packages/agentSdk/src/agentInterface.ts
+++ b/ts/packages/agentSdk/src/agentInterface.ts
@@ -115,13 +115,14 @@ export interface AppAgent extends Partial<AppAgentCommandInterface> {
         data: unknown,
         propertyName: string,
         context: SessionContext,
-    ): Promise<string[]>;
-    // For action template
+    ): Promise<string[] | undefined>;
+    // For action completion (template, request/action command  completion)
     getActionCompletion?(
+        context: SessionContext,
         partialAction: AppAction, // action schemaName and actionName are validated by the dispatcher.
         propertyName: string,
-        context: SessionContext,
-    ): Promise<string[]>;
+        entityTypeName?: string, // the type of the entity if the property is an entity
+    ): Promise<string[] | undefined>;
     // Output
     getDynamicDisplay?(
         type: DisplayType,

--- a/ts/packages/agents/player/package.json
+++ b/ts/packages/agents/player/package.json
@@ -17,7 +17,7 @@
     "./agent/handlers": "./dist/agent/playerHandlers.js"
   },
   "scripts": {
-    "asc": "asc -i ./src/agent/playerSchema.ts -o ./dist/agent/playerSchema.pas.json -t PlayerAction",
+    "asc": "asc -i ./src/agent/playerSchema.ts -o ./dist/agent/playerSchema.pas.json -t PlayerActions -e PlayerEntities",
     "build": "concurrently npm:tsc npm:asc",
     "clean": "rimraf --glob dist *.tsbuildinfo *.done.build.log",
     "tsc": "tsc -p src"

--- a/ts/packages/agents/player/src/agent/playerHandlers.ts
+++ b/ts/packages/agents/player/src/agent/playerHandlers.ts
@@ -12,6 +12,7 @@ import {
     AppAgentEvent,
     DynamicDisplay,
     TypeAgentAction,
+    ResolveEntityResult,
 } from "@typeagent/agent-sdk";
 import { createActionResultFromError } from "@typeagent/agent-sdk/helpers/action";
 import { searchTracks } from "../client.js";
@@ -24,8 +25,10 @@ import {
     toQueryString,
     searchAlbums,
 } from "../search.js";
-import { PlayerAction } from "./playerSchema.js";
+import { PlayerActions } from "./playerSchema.js";
 import registerDebug from "debug";
+import { resolveMusicDeviceEntity } from "../devices.js";
+import { getDevices } from "../endpoints.js";
 
 const debugSpotify = registerDebug("typeagent:spotify");
 
@@ -35,6 +38,7 @@ export function instantiate(): AppAgent {
         updateAgentContext: updatePlayerContext,
         executeAction: executePlayerAction,
         validateWildcardMatch: validatePlayerWildcardMatch,
+        resolveEntity: resolvePlayerEntity,
         getDynamicDisplay: getPlayerDynamicDisplay,
         ...getPlayerCommandInterface(),
         getActionCompletion: getPlayerActionCompletion,
@@ -52,7 +56,7 @@ async function initializePlayerContext() {
 }
 
 async function executePlayerAction(
-    action: TypeAgentAction<PlayerAction>,
+    action: TypeAgentAction<PlayerActions>,
     context: ActionContext<PlayerActionContext>,
 ) {
     const clientContext = context.sessionContext.agentContext.spotify;
@@ -123,7 +127,7 @@ export async function disableSpotify(
 }
 
 async function validatePlayerWildcardMatch(
-    action: PlayerAction,
+    action: PlayerActions,
     context: SessionContext<PlayerActionContext>,
 ) {
     const clientContext = context.agentContext.spotify;
@@ -155,6 +159,22 @@ async function validatePlayerWildcardMatch(
             return false;
     }
     return true;
+}
+
+async function resolvePlayerEntity(
+    type: string,
+    name: string,
+    context: SessionContext<PlayerActionContext>,
+): Promise<ResolveEntityResult | undefined> {
+    const clientContext = context.agentContext.spotify;
+    if (clientContext === undefined) {
+        return undefined;
+    }
+    switch (type) {
+        case "MusicDevice":
+            return resolveMusicDeviceEntity(clientContext, name);
+    }
+    return undefined;
 }
 
 async function validateTrack(
@@ -269,17 +289,31 @@ async function getPlayerDynamicDisplay(
 }
 
 async function getPlayerActionCompletion(
+    context: SessionContext<PlayerActionContext>,
     action: AppAction,
     propertyName: string,
-    context: SessionContext<PlayerActionContext>,
+    entityType?: string,
 ): Promise<string[]> {
+    const result: string[] = [];
     const clientContext = context.agentContext.spotify;
     if (clientContext === undefined) {
-        return [];
+        return result;
     }
+
+    if (entityType === "MusicDevice") {
+        const devices = await getDevices(clientContext.service);
+        if (devices !== undefined) {
+            result.push(
+                ...devices.devices
+                    .filter((device) => device.id !== null)
+                    .map((device) => device.name),
+            );
+        }
+    }
+
     const userData = clientContext.userData;
     if (userData === undefined) {
-        return [];
+        return result;
     }
 
     let track = false;
@@ -311,7 +345,6 @@ async function getPlayerActionCompletion(
             break;
     }
 
-    const result: string[] = [];
     if (track) {
         for (const track of userData.data.tracks.values()) {
             result.push(track.name);

--- a/ts/packages/agents/player/src/agent/playerManifest.json
+++ b/ts/packages/agents/player/src/agent/playerManifest.json
@@ -5,6 +5,9 @@
     "description": "Music Player agent that lets you search for, play and control music.",
     "schemaFile": "../../dist/agent/playerSchema.pas.json",
     "originalSchemaFile": "playerSchema.ts",
-    "schemaType": "PlayerAction"
+    "schemaType": {
+      "action": "PlayerActions",
+      "entity": "PlayerEntities"
+    }
   }
 }

--- a/ts/packages/agents/player/src/agent/playerSchema.ts
+++ b/ts/packages/agents/player/src/agent/playerSchema.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-export type PlayerAction =
+export type PlayerActions =
     | PlayRandomAction
     | PlayTrackAction
     | PlayFromCurrentTrackListAction
@@ -30,6 +30,9 @@ export type PlayerAction =
     | CreatePlaylistAction
     | DeletePlaylistAction
     | GetQueueAction;
+
+export type PlayerEntities = MusicDevice;
+export type MusicDevice = string;
 
 // Use playRandom when the user asks for some music to play
 export interface PlayRandomAction {
@@ -122,8 +125,8 @@ export interface ListDevicesAction {
 export interface SetDefaultDeviceAction {
     actionName: "setDefaultDevice";
     parameters: {
-        // keyword to match against device name.  If not specified, the current selected device is used.
-        deviceName?: string;
+        // device name.  If not specified, the current selected device is set as the default.
+        deviceName?: MusicDevice;
     };
 }
 
@@ -131,8 +134,7 @@ export interface SetDefaultDeviceAction {
 export interface SelectDeviceAction {
     actionName: "selectDevice";
     parameters: {
-        // keyword to match against device name
-        deviceName: string;
+        deviceName: MusicDevice;
     };
 }
 

--- a/ts/packages/agents/player/src/client.ts
+++ b/ts/packages/agents/player/src/client.ts
@@ -9,7 +9,7 @@ import {
     PlayAlbumAction,
     PlayFromCurrentTrackListAction,
     PlayArtistAction,
-    PlayerAction,
+    PlayerActions,
     PlayGenreAction,
     PlayRandomAction,
     PlayTrackAction,
@@ -725,7 +725,7 @@ export function getUserDataStrings(clientContext: IClientContext) {
 }
 
 export async function handleCall(
-    action: TypeAgentAction<PlayerAction>,
+    action: TypeAgentAction<PlayerActions>,
     clientContext: IClientContext,
     actionIO: ActionIO,
     instanceStorage?: Storage,
@@ -799,6 +799,7 @@ export async function handleCall(
             return setDefaultDeviceAction(
                 clientContext,
                 action.parameters.deviceName,
+                instanceStorage,
             );
         case "showSelectedDevice": {
             return showSelectedDeviceAction(clientContext);

--- a/ts/packages/dispatcher/src/execute/pendingActions.ts
+++ b/ts/packages/dispatcher/src/execute/pendingActions.ts
@@ -260,18 +260,6 @@ export function getEntityPropertyTypeName(
         actionName,
         actionSchemaFile,
     );
-    return resolveEntityPropertyTypeName(
-        actionParametersType,
-        paramName,
-        entitySchemas,
-    );
-}
-
-export function resolveEntityPropertyTypeName(
-    actionParametersType: ActionParamType,
-    paramName: string,
-    entitySchemas: Map<string, ActionSchemaEntityTypeDefinition>,
-) {
     const parameterType = getPropertyType(actionParametersType, paramName);
     if (parameterType === undefined) {
         throw new Error(`Unable to get type for parameter ${paramName}`);
@@ -282,14 +270,22 @@ export function resolveEntityPropertyTypeName(
             `Unable to resolve type reference for parameter ${paramName}`,
         );
     }
-    // resolve union type pretending to be a string value for wildcard.
-    // REVIEW: what if the union type include empty string?
-    const resolvedType = resolveUnionType(
+
+    return resolveEntityTypeName(
         parameterType,
         resolvedParameterType,
-        "",
+        entitySchemas,
     );
+}
 
+export function resolveEntityTypeName(
+    type: ActionParamType,
+    resolved: ActionResolvedParamType,
+    entitySchemas: Map<string, ActionSchemaEntityTypeDefinition>,
+) {
+    // resolve union type pretending to be a string value for wildcard.
+    // REVIEW: what if the union type include empty string?
+    const resolvedType = resolveUnionType(type, resolved, "");
     if (resolvedType === undefined) {
         return undefined;
     }
@@ -764,7 +760,7 @@ async function getParameterEntities(
     }
 }
 
-function getActionParametersType(
+export function getActionParametersType(
     actionName: string,
     actionSchemaFile: ActionSchemaFile,
 ): ActionParamObject {


### PR DESCRIPTION
- Make player music device an entity to enable action completion.
- Provide entity type (if any) to the action completion as a category on top of specific action and parameter name combo.
- Add type union support for parameter name (for `@action` flag name completion)
- Unified parameter completion between template, action command and request completions.  Better support for string literal types with entity types.
- Add support to specify entity entry type in action schema compiler.
- Make sure default device setting is saved after changed.
