### PR TITLE
Doc Memory: Html to Markdown improvements

### DIFF
--- a/ts/examples/chat/src/memory/knowproTest.ts
+++ b/ts/examples/chat/src/memory/knowproTest.ts
@@ -73,6 +73,7 @@ export async function createKnowproTestCommands(
             },
             options: {
                 rootTag: arg("Root tag", "body"),
+                knowledge: argBool("Extract knowledge", true),
             },
         };
     }
@@ -90,9 +91,12 @@ export async function createKnowproTestCommands(
         const destPath = changeFileExt(filePath, ".md");
         fs.writeFileSync(destPath, markdown);
 
-        let mdDom = tp.tokenizeMarkdown(markdown);
-        context.printer.writeJsonInColor(chalk.gray, mdDom);
+        if (!namedArgs.knowledge) {
+            return;
+        }
 
+        let mdDom = tp.tokenizeMarkdown(markdown);
+        //context.printer.writeJsonInColor(chalk.gray, mdDom);
         const [textBlocks, knowledgeBlocks] =
             tp.textAndKnowledgeBlocksFromMarkdown(mdDom);
         assert(textBlocks.length === knowledgeBlocks.length);

--- a/ts/packages/textPro/src/common.ts
+++ b/ts/packages/textPro/src/common.ts
@@ -1,0 +1,10 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+export function escapeMarkdownText(text: string): string {
+    text = text.replace(/([\\`*_{}[\]()#+-.!|])/g, "\\$1");
+    if (/\\\\/.test(text)) {
+        console.log(text);
+    }
+    return text;
+}

--- a/ts/packages/textPro/src/common.ts
+++ b/ts/packages/textPro/src/common.ts
@@ -2,9 +2,6 @@
 // Licensed under the MIT License.
 
 export function escapeMarkdownText(text: string): string {
-    text = text.replace(/([\\`*_{}[\]()#+-.!|])/g, "\\$1");
-    if (/\\\\/.test(text)) {
-        console.log(text);
-    }
+    text = text.replace(/([`*_{}\[\]()#+-.!|])/g, "\\$1");
     return text;
 }

--- a/ts/packages/textPro/src/html.ts
+++ b/ts/packages/textPro/src/html.ts
@@ -771,6 +771,9 @@ export class HtmlToMdConvertor {
                 // Markup require table headers
                 this.appendMarkup("|---".repeat(colCount));
                 this.appendMarkup("|\n");
+                if (!hasHeaders) {
+                    this.convertRow(columns, colCount);
+                }
             } else {
                 this.convertRow(columns, colCount);
             }

--- a/ts/packages/textPro/src/html.ts
+++ b/ts/packages/textPro/src/html.ts
@@ -499,6 +499,7 @@ export class HtmlToMdConvertor {
                             if (childElement.children.length > 0) {
                                 let text = this.getInnerText(childElement);
                                 if (text) {
+                                    text = escapeMarkdownText(text);
                                     const href = childElement.attribs["href"];
                                     this.appendMarkup(`[${text}](${href})`);
                                     this.eventHandler?.onLink(text, href);
@@ -521,6 +522,9 @@ export class HtmlToMdConvertor {
                 case "text":
                     let text = this.getInnerText(child);
                     if (text && text.length > 0) {
+                        if (text.includes("edit")) {
+                            console.log(text);
+                        }
                         this.append(text);
                     }
                     break;
@@ -548,7 +552,7 @@ export class HtmlToMdConvertor {
                 spacesAdded++;
             }
             if (spacesAdded === 0 || text.length > spacesAdded) {
-                return escapeMarkdownText(text);
+                return text;
             }
         }
         return undefined;
@@ -598,8 +602,8 @@ export class HtmlToMdConvertor {
     }
 
     private append(text: string): void {
-        text = escapeMarkdownText(text);
-        this.curBlock += text;
+        let markdownText = escapeMarkdownText(text);
+        this.curBlock += markdownText;
     }
 
     private appendMarkup(text: string): void {

--- a/ts/packages/textPro/src/html.ts
+++ b/ts/packages/textPro/src/html.ts
@@ -256,6 +256,7 @@ function getTypicalTagNames(): string[] {
         "blockquote",
         "code",
         "figure",
+        "abbr",
     ];
 }
 

--- a/ts/packages/textPro/src/html.ts
+++ b/ts/packages/textPro/src/html.ts
@@ -693,7 +693,7 @@ export class HtmlToMdConvertor {
     private appendInnerText(element: cheerio.Element): void {
         let text = this.$(element).text();
         if (text && text.length > 0) {
-            text = text.replace("\n", " ");
+            text = text.replaceAll("\n", " ");
             if (!text.startsWith(" ")) {
                 this.appendMarkup(" ");
             }
@@ -704,7 +704,7 @@ export class HtmlToMdConvertor {
     private appendInnerHtml(element: cheerio.Element): void {
         let html = this.$(element).html();
         if (html && html.length > 0) {
-            html = html.replace("\n", " ");
+            html = html.replaceAll("\n", " ");
             this.appendMarkup(html);
         }
     }


### PR DESCRIPTION
Html to markdown conversion:
- Now converts nested Wikipedia articles correctly
- Reworked table conversion
- Handle nested tables, lists etc. better
- Escape reserved markdown characters found in html