### PR TITLE
Change action result to display as append block

### DIFF
--- a/ts/packages/agentSdk/src/action.ts
+++ b/ts/packages/agentSdk/src/action.ts
@@ -21,8 +21,8 @@ export type ActionResultActivityContext = Omit<
 > | null;
 
 export type ActionResultSuccess = {
-    literalText?: string | undefined;
-    displayContent: DisplayContent;
+    historyText?: string | undefined;
+    displayContent: DisplayContent; // the display content to be appended with "block" mode
     entities: Entity[];
     resultEntity?: Entity | undefined;
     dynamicDisplayId?: string | undefined;

--- a/ts/packages/agentSdk/src/helpers/actionHelpers.ts
+++ b/ts/packages/agentSdk/src/helpers/actionHelpers.ts
@@ -11,17 +11,17 @@ import { DisplayMessageKind } from "../display.js";
 import { Entity } from "../memory.js";
 
 export function createActionResultNoDisplay(
-    literalText: string,
+    historyText: string,
     entities?: Entity[] | undefined,
 ): ActionResultSuccessNoDisplay {
     return {
-        literalText,
+        historyText,
         entities: entities ? entities : [],
     };
 }
 
 export function createActionResult(
-    literalText: string,
+    displayAndHistoryText: string,
     options?:
         | {
               kind?: DisplayMessageKind;
@@ -39,7 +39,7 @@ export function createActionResult(
               : options;
 
     return {
-        literalText,
+        historyText: displayAndHistoryText,
         entities: entities
             ? Array.isArray(entities)
                 ? entities
@@ -48,19 +48,19 @@ export function createActionResult(
         displayContent: displayOptions
             ? {
                   type: "text",
-                  content: literalText,
+                  content: displayAndHistoryText,
                   ...displayOptions,
               }
-            : literalText,
+            : displayAndHistoryText,
     };
 }
 
 export function createActionResultFromTextDisplay(
     displayText: string,
-    literalText?: string,
+    historyText?: string,
 ): ActionResultSuccess {
     return {
-        literalText,
+        historyText,
         entities: [],
         displayContent: displayText,
     };
@@ -68,11 +68,11 @@ export function createActionResultFromTextDisplay(
 
 export function createActionResultFromHtmlDisplay(
     displayText: string,
-    literalText?: string,
+    historyText?: string,
     entities?: Entity[] | undefined,
 ): ActionResultSuccess {
     return {
-        literalText,
+        historyText,
         entities: entities ? entities : [],
         displayContent: {
             type: "html",
@@ -83,10 +83,10 @@ export function createActionResultFromHtmlDisplay(
 
 export function createActionResultFromHtmlDisplayWithScript(
     displayText: string,
-    literalText?: string,
+    historyText?: string,
 ): ActionResultSuccess {
     return {
-        literalText,
+        historyText,
         entities: [],
         displayContent: {
             type: "iframe",
@@ -104,13 +104,13 @@ export function createActionResultFromHtmlDisplayWithScript(
  */
 export function createActionResultFromMarkdownDisplay(
     markdownText: string | string[],
-    literalText?: string,
+    historyText?: string,
     entities: Entity[] = [],
     resultEntity?: Entity,
 ): ActionResultSuccess {
     return {
-        literalText:
-            literalText ??
+        historyText:
+            historyText ??
             (Array.isArray(markdownText)
                 ? markdownText.join("\n")
                 : markdownText),

--- a/ts/packages/agents/browser/src/agent/actionHandler.mts
+++ b/ts/packages/agents/browser/src/agent/actionHandler.mts
@@ -1779,7 +1779,7 @@ async function handleWebsiteAction(
             );
             return {
                 success: !statsResult.error,
-                result: statsResult.literalText || "Stats retrieved",
+                result: statsResult.historyText || "Stats retrieved",
                 error: statsResult.error,
             };
 
@@ -1976,8 +1976,8 @@ async function handleWebsiteLibraryStats(
 
         // Parse and format the response - extract text from ActionResult
         let responseText = "";
-        if (statsResult.literalText) {
-            responseText = statsResult.literalText;
+        if (statsResult.historyText) {
+            responseText = statsResult.historyText;
         } else if (statsResult.displayContent) {
             // Handle different types of display content
             if (typeof statsResult.displayContent === "string") {

--- a/ts/packages/agents/greeting/src/greetingCommandHandler.ts
+++ b/ts/packages/agents/greeting/src/greetingCommandHandler.ts
@@ -19,7 +19,6 @@ import { ChatModelWithStreaming, CompletionSettings, openai } from "aiclient";
 import { PromptSection, Result } from "typechat";
 import {
     displayError,
-    displayResult,
     displayStatus,
 } from "@typeagent/agent-sdk/helpers/display";
 import {
@@ -153,7 +152,10 @@ export class GreetingCommandHandler implements CommandHandlerNoParams {
                         context,
                     )) as ActionResultSuccess;
 
-                    displayResult(result.literalText!, context);
+                    context.actionIO.appendDisplay(
+                        result.displayContent,
+                        "block",
+                    );
                     break;
 
                 // case "contextualGreetingAction":

--- a/ts/packages/agents/player/src/agent/playerHandlers.ts
+++ b/ts/packages/agents/player/src/agent/playerHandlers.ts
@@ -280,7 +280,7 @@ async function getPlayerDynamicDisplay(
         const status = await htmlStatus(context.agentContext.spotify);
         return {
             content:
-                type === "html" ? status.displayContent : status.literalText!,
+                type === "html" ? status.displayContent : status.historyText!,
 
             nextRefreshMs: 1000,
         };

--- a/ts/packages/agents/player/src/client.ts
+++ b/ts/packages/agents/player/src/client.ts
@@ -223,7 +223,7 @@ async function htmlTrackNames(
 
     const actionResult: ActionResult = {
         displayContent,
-        literalText: "",
+        historyText: "",
         entities: [],
     };
     let prevUrl = "";
@@ -279,7 +279,7 @@ async function htmlTrackNames(
             }
         }
         displayContent.content += "</ol></div>";
-        actionResult.literalText =
+        actionResult.historyText =
             "Updated the current track list with the numbered list of tracks on the screen";
     } else if (selectedTracks.length === 1) {
         const track = selectedTracks[0];
@@ -312,7 +312,7 @@ async function htmlTrackNames(
         const litArtists =
             litArtistsPrefix +
             track.artists.map((artist) => artist.name).join(", ");
-        actionResult.literalText = `Now playing: ${track.name} from album ${track.album.name} with ${litArtists}`;
+        actionResult.historyText = `Now playing: ${track.name} from album ${track.album.name} with ${litArtists}`;
         if (track.album.images.length > 0 && track.album.images[0].url) {
             displayContent.content = "<div class='track-list scroll_enabled'>";
             displayContent.content +=

--- a/ts/packages/agents/player/src/playback.ts
+++ b/ts/packages/agents/player/src/playback.ts
@@ -73,7 +73,7 @@ function htmlPlaybackStatus(
             }
             const pp = status.is_playing ? "" : "(paused)";
             const album = status.item.album.name;
-            actionResult.literalText += `Now playing${pp}: ${status.item.name} from album ${album} with ${artists}`;
+            actionResult.historyText += `Now playing${pp}: ${status.item.name} from album ${album} with ${artists}`;
             actionResult.entities.push({
                 name: status.item.name,
                 type: ["track"],
@@ -107,7 +107,7 @@ export async function htmlStatus(context: IClientContext) {
         content: "<div data-group='status'>Status...",
     };
     const actionResult: ActionResultSuccess = {
-        literalText: "",
+        historyText: "",
         entities: [],
         displayContent,
     };
@@ -117,10 +117,10 @@ export async function htmlStatus(context: IClientContext) {
         const aux = `Volume is ${activeDevice.volume_percent}%. ${status.shuffle_state ? "Shuffle on" : ""}`;
         displayContent.content += `<div>Active device: ${activeDevice.name} of type ${activeDevice.type}</div>`;
         displayContent.content += `<div>${aux}</div>`;
-        actionResult.literalText += `\nActive device: ${activeDevice.name} of type ${activeDevice.type}\n${aux}`;
+        actionResult.historyText += `\nActive device: ${activeDevice.name} of type ${activeDevice.type}\n${aux}`;
     } else {
         displayContent.content += "<div>Nothing playing.</div>";
-        actionResult.literalText = "Nothing playing.";
+        actionResult.historyText = "Nothing playing.";
     }
     displayContent.content += "</div>";
     actionResult.dynamicDisplayId = "status";

--- a/ts/packages/dispatcher/src/context/dispatcher/dispatcherAgent.ts
+++ b/ts/packages/dispatcher/src/context/dispatcher/dispatcherAgent.ts
@@ -182,7 +182,7 @@ async function clarifyWithLookup(
 
     if (
         lookupResult.error !== undefined ||
-        lookupResult.literalText === undefined
+        lookupResult.historyText === undefined
     ) {
         return undefined;
     }
@@ -196,7 +196,7 @@ async function clarifyWithLookup(
 
     history.promptSections.push({
         role: "assistant",
-        content: lookupResult.literalText,
+        content: lookupResult.historyText,
     });
 
     const translationResult = await translateRequest(

--- a/ts/packages/dispatcher/src/context/memory.ts
+++ b/ts/packages/dispatcher/src/context/memory.ts
@@ -201,8 +201,8 @@ export function addActionResultToMemory(
 
         addResultToMemory(
             context,
-            result.literalText
-                ? result.literalText
+            result.historyText
+                ? result.historyText
                 : `Action ${getFullActionName(executableAction)} completed.`,
             schemaName,
             combinedEntities,
@@ -227,19 +227,19 @@ export async function lookupAndAnswerFromMemory(
         throw new Error(`Conversation memory search failed: ${result.message}`);
     }
 
-    const literalText: string[] = [];
+    const historyText: string[] = [];
     for (const [searchResult, answer] of result.data) {
         debug("Conversation memory search result:", searchResult);
         if (answer.type === "Answered") {
-            literalText.push(answer.answer!);
+            historyText.push(answer.answer!);
             displayResult(answer.answer!, context);
         } else {
-            literalText.push(answer.whyNoAnswer!);
+            historyText.push(answer.whyNoAnswer!);
             displayError(answer.whyNoAnswer!, context);
         }
     }
     // TODO: how about entities?
-    return literalText;
+    return historyText;
 }
 
 function ensureMemory(context: ActionContext<CommandHandlerContext>) {

--- a/ts/packages/dispatcher/src/execute/actionHandlers.ts
+++ b/ts/packages/dispatcher/src/execute/actionHandlers.ts
@@ -168,7 +168,10 @@ async function executeAction(
         displayError(result.error, actionContext);
     } else {
         if (result.displayContent !== undefined) {
-            actionContext.actionIO.setDisplay(result.displayContent);
+            actionContext.actionIO.appendDisplay(
+                result.displayContent,
+                "block",
+            );
         }
         if (result.dynamicDisplayId !== undefined) {
             systemContext.clientIO.setDynamicDisplay(

--- a/ts/packages/dispatcher/src/search/internet.ts
+++ b/ts/packages/dispatcher/src/search/internet.ts
@@ -4,13 +4,11 @@
 import fs from "node:fs";
 import { LookupOptions, extractEntities } from "typeagent";
 import { ChatModel, openai } from "aiclient";
+import { ActionContext, ActionResult, Entity } from "@typeagent/agent-sdk";
 import {
-    ActionContext,
-    ActionResult,
-    ActionResultSuccess,
-    Entity,
-} from "@typeagent/agent-sdk";
-import { createActionResult } from "@typeagent/agent-sdk/helpers/action";
+    createActionResultFromError,
+    createActionResultNoDisplay,
+} from "@typeagent/agent-sdk/helpers/action";
 import { CommandHandlerContext } from "../context/commandHandlerContext.js";
 import { AIProjectClient } from "@azure/ai-projects";
 import { displayError } from "@typeagent/agent-sdk/helpers/display";
@@ -150,10 +148,8 @@ export async function handleLookup(
     settings: LookupSettings,
     originalRequest: string,
 ): Promise<ActionResult> {
-    let literalResponse = createActionResult("No information found");
-
     if (!lookups || lookups.length === 0) {
-        return literalResponse;
+        return createActionResultFromError("No lookups provided.");
     }
 
     context.actionIO.setDisplay({
@@ -165,21 +161,16 @@ export async function handleLookup(
     const results = await runGroundingLookup(request, lookups, sites, context);
 
     if (results.length > 0) {
-        updateActionResult(literalResponse, results);
-        context.actionIO.setDisplay(literalResponse.displayContent);
-
-        if (settings.entityGenModel) {
-            const entities = await runEntityExtraction(results, settings);
-            literalResponse.entities =
-                literalResponse.entities.concat(entities);
-        }
-    } else {
-        literalResponse = createActionResult(
-            "There was an error searching for information on Grounding with Bing.",
-        );
+        context.actionIO.setDisplay({
+            type: "html",
+            content: answersToHtml(results),
+        });
+        return await createActionResultWithMessage(results, settings);
     }
 
-    return literalResponse;
+    return createActionResultFromError(
+        "There was an error searching for information on Grounding with Bing.",
+    );
 }
 
 export async function getLookupSettings(
@@ -231,43 +222,25 @@ export async function getLookupSettings(
 //     return [promptLib.dateTimePromptSection()];
 // }
 
-function updateActionResult(
-    literalResponse: ActionResultSuccess,
-    messages: ThreadMessage[],
-): ActionResultSuccess {
-    if (messages.length > 0) {
-        literalResponse.literalText = "";
-        literalResponse.displayContent = {
-            type: "html",
-            content: answersToHtml(messages),
-        };
-    }
-
-    return literalResponse;
-}
-
-async function runEntityExtraction(
+async function createActionResultWithMessage(
     messages: ThreadMessage[],
     settings: LookupSettings,
-): Promise<Entity[]> {
-    if (!settings.entityGenModel) {
-        return [];
-    }
-    let entityText = "";
-    let linkEntities: Array<Entity> = [];
+): Promise<ActionResult> {
+    let historyText = "";
+    let linkEntities: Entity[] = [];
     let refCount = 0;
     for (const message of messages) {
         for (const content of message.content) {
             const textContent = content as MessageTextContent;
 
             if (textContent) {
-                entityText += `${textContent.text.value}\n`;
+                historyText += `${textContent.text.value}\n`;
 
                 for (const a of textContent.text.annotations) {
                     switch (a.type) {
                         case "url_citation":
                             const url = a as MessageTextUrlCitationAnnotation;
-                            entityText += `Reference: ${url.urlCitation.title} - ${url.urlCitation.url}`;
+                            historyText += `Reference: ${url.urlCitation.title} - ${url.urlCitation.url}`;
                             linkEntities.push({
                                 type: ["link", "url", "website"],
                                 name: `Reference #${++refCount} - ${url.urlCitation.title} - ${url.urlCitation.url}`,
@@ -282,17 +255,26 @@ async function runEntityExtraction(
             }
         }
     }
-    if (!entityText) {
-        return [];
-    }
-    if (entityText.length > settings.maxEntityTextLength) {
-        entityText = entityText.slice(0, settings.maxEntityTextLength);
+
+    if (!historyText) {
+        return createActionResultFromError(
+            "Grounding with Bing returned not text in the result.",
+        );
     }
 
-    return [
+    if (!settings.entityGenModel) {
+        return createActionResultNoDisplay(historyText, linkEntities);
+    }
+
+    const entityText =
+        historyText.length > settings.maxEntityTextLength
+            ? historyText.slice(0, settings.maxEntityTextLength)
+            : historyText;
+
+    return createActionResultNoDisplay(historyText, [
         ...(await extractEntities(settings.entityGenModel, entityText)),
         ...linkEntities,
-    ];
+    ]);
 }
 
 let groundingConfig: bingWithGrounding.ApiSettings | undefined;

--- a/ts/packages/dispatcher/src/search/search.ts
+++ b/ts/packages/dispatcher/src/search/search.ts
@@ -118,12 +118,12 @@ export async function lookupAndAnswer(
                     lookupAction.parameters.lookup.conversationLookupFilters,
                 );
             }
-            const literalText = await lookupAndAnswerFromMemory(
+            const historyText = await lookupAndAnswerFromMemory(
                 context,
                 lookupAction.parameters.question,
             );
             // TODO: how about entities?
-            return createActionResultNoDisplay(literalText.join("\n"));
+            return createActionResultNoDisplay(historyText.join("\n"));
         }
         default:
             throw new Error(`Unknown lookup source: ${source}`);


### PR DESCRIPTION
- Action result display content should be appended as block so that it can work with using `actionIO` within the action.  Other display option can be access thru `actionIO`
  - Make sure the chat `generateResponse` and `lookupAndAnswer` doesn't display twice.
- Rename the action result's `literalText` to `historyText` to indicate that the text is used for chat history.
- Change `lookupAndAnswer` to return the resulting text in `historyText` as well along with the entities for used for chat history.