### PR TITLE
Match command and completion for match and translate commands

### DIFF
--- a/ts/packages/dispatcher/src/context/dispatcher/dispatcherAgent.ts
+++ b/ts/packages/dispatcher/src/context/dispatcher/dispatcherAgent.ts
@@ -39,11 +39,13 @@ import {
 } from "../../translation/translateRequest.js";
 import { ActivityActions } from "./schema/activityActionSchema.js";
 import { ClarifyEntityAction } from "../../execute/pendingActions.js";
+import { MatchCommandHandler } from "./handlers/matchCommandHandler.js";
 
 const dispatcherHandlers: CommandHandlerTable = {
     description: "Type Agent Dispatcher Commands",
     commands: {
         request: new RequestCommandHandler(),
+        match: new MatchCommandHandler(),
         translate: new TranslateCommandHandler(),
         explain: new ExplainCommandHandler(),
     },

--- a/ts/packages/dispatcher/src/context/dispatcher/handlers/matchCommandHandler.ts
+++ b/ts/packages/dispatcher/src/context/dispatcher/handlers/matchCommandHandler.ts
@@ -1,0 +1,69 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { CommandHandlerContext } from "../../commandHandlerContext.js";
+import {
+    ActionContext,
+    CompletionGroup,
+    ParsedCommandParams,
+    SessionContext,
+} from "@typeagent/agent-sdk";
+import { CommandHandler } from "@typeagent/agent-sdk/helpers/command";
+import {
+    displayError,
+    displayResult,
+} from "@typeagent/agent-sdk/helpers/display";
+import { getColorElapsedString } from "common-utils";
+import { matchRequest } from "../../../translation/matchRequest.js";
+import { requestCompletion } from "../../../translation/requestCompletion.js";
+
+export class MatchCommandHandler implements CommandHandler {
+    public readonly description = "Match a request";
+    public readonly parameters = {
+        args: {
+            request: {
+                description: "Request to match",
+                implicitQuotes: true,
+            },
+        },
+    } as const;
+    public async run(
+        context: ActionContext<CommandHandlerContext>,
+        params: ParsedCommandParams<typeof this.parameters>,
+    ) {
+        const matchResult = await matchRequest(params.args.request, context);
+        if (matchResult) {
+            const elapsedStr = getColorElapsedString(matchResult.elapsedMs);
+
+            displayResult(
+                `${matchResult.requestAction} ${elapsedStr}\n\nJSON:\n${JSON.stringify(
+                    matchResult.requestAction.actions,
+                    undefined,
+                    2,
+                )}`,
+                context,
+            );
+        } else {
+            displayError("No match found for the request.", context);
+        }
+    }
+    public async getCompletion(
+        context: SessionContext<CommandHandlerContext>,
+        params: ParsedCommandParams<typeof this.parameters>,
+        names: string[],
+    ): Promise<CompletionGroup[]> {
+        const completions: CompletionGroup[] = [];
+        for (const name of names) {
+            if (name === "request") {
+                const requestPrefix = params.args.request;
+                completions.push(
+                    ...(await requestCompletion(
+                        requestPrefix,
+                        context.agentContext,
+                    )),
+                );
+            }
+        }
+        return completions;
+    }
+}


### PR DESCRIPTION
Add `@dispatcher match` command to go thru the match request code path only similar to `@dispatcher translate`.
Reuse the same completion using the cache used by the request command handler for translate and match command.