### PR TITLE
ResolveWebPage now returns multiple URLs to allow for Clarification (if enabled)

### DIFF
--- a/docs/content/help/commandReference.md
+++ b/docs/content/help/commandReference.md
@@ -22,6 +22,21 @@ Usage: `@browser launch standalone`
 ## @browser close - Close the new Web Content view  
 Usage: `@browser close`  
 
+## @browser resolver list - List all available URL resolvers
+Usage: `@browser resolver list` 
+
+## @browser resolver search - Toggle search resolver
+Usage: `@browser resolver search` 
+
+## @browser resolver keyword - Toggle keyword resolver
+Usage: `@browser resolver keyword` 
+
+## @browser resolver wikipedia - Toggle Wikipedia resolver
+Usage: `@browser resolver wikipedia` 
+
+## @browser resolver history - Toggle history resolver
+Usage: `@browser resolver history` 
+
 ## @calendar login - Log into MS Graph to access calendar  
 Usage: `@calendar login`  
 
@@ -409,6 +424,14 @@ Usage: `@history delete <index>`
 ### Arguments:  
   - &lt;index&gt; - Chat history index to delete. (type: number)  
    
+## @history entities list - Shows all of the entities currently in 'working memory.'
+Usage: `@history entities list` 
+
+## @history entities delete - Delete entities from the chat history (working memory).
+Usage: `@history entities delete <entityId>`
+Arguments:
+  - &lt;entityId&gt; - The UniqueId of the entity (type: string)
+
 ## @history insert - Insert messages to chat history  
 Usage: `@history insert <messages>`  
 ### Arguments:  

--- a/ts/examples/schemaStudio/src/urlCommands.ts
+++ b/ts/examples/schemaStudio/src/urlCommands.ts
@@ -94,10 +94,10 @@ export function createURLResolverCommands(
                 // unable to resolve
                 passFail = "FAIL";
                 failCount++;
-            } else if (sitesMatch(resolved, site, io.writer)) {
+            } else if (sitesMatch(resolved[0], site, io.writer)) {
                 passFail = "PASS";
                 passCount++;
-            } else if (resolved?.startsWith(site)) {
+            } else if (resolved[0]?.startsWith(site)) {
                 // resolved site starts with expected site, indicating a redirect
                 passFail = "REDIRECT";
                 redirectCount++;

--- a/ts/examples/websiteAliases/src/main.ts
+++ b/ts/examples/websiteAliases/src/main.ts
@@ -162,8 +162,11 @@ const keyCount = Object.keys(keywordToSites).length;
 let processed = 0;
 for (const keyword of Object.keys(keywordToSites)) {
     console.log(`Resolving URL for keyword: ${keyword}`);
-    keywordToSiteWithURLResolver[keyword] =
-        await urlResolver.resolveURLWithSearch(keyword, groundingConfig);
+    const sites = await urlResolver.resolveURLWithSearch(keyword, groundingConfig);
+
+    if (sites) {
+        keywordToSiteWithURLResolver[keyword] = sites[0];
+    }
     console.log(
         `\tResolved URL for keyword ${keyword}: ${keywordToSiteWithURLResolver[keyword]}`,
     );

--- a/ts/examples/websiteAliases/src/main.ts
+++ b/ts/examples/websiteAliases/src/main.ts
@@ -162,7 +162,10 @@ const keyCount = Object.keys(keywordToSites).length;
 let processed = 0;
 for (const keyword of Object.keys(keywordToSites)) {
     console.log(`Resolving URL for keyword: ${keyword}`);
-    const sites = await urlResolver.resolveURLWithSearch(keyword, groundingConfig);
+    const sites = await urlResolver.resolveURLWithSearch(
+        keyword,
+        groundingConfig,
+    );
 
     if (sites) {
         keywordToSiteWithURLResolver[keyword] = sites[0];

--- a/ts/packages/agentSdk/src/helpers/displayHelpers.ts
+++ b/ts/packages/agentSdk/src/helpers/displayHelpers.ts
@@ -19,7 +19,7 @@ function gatherMessages(callback: (log: (message?: string) => void) => void) {
 }
 
 type LogFn = (log: (message?: string) => void) => void;
-function getMessage(
+export function getMessage(
     input: MessageContent | LogFn,
     kind?: DisplayMessageKind,
 ): DisplayContent {

--- a/ts/packages/agents/browser/src/agent/actionHandler.mts
+++ b/ts/packages/agents/browser/src/agent/actionHandler.mts
@@ -92,7 +92,6 @@ import { createExternalBrowserClient } from "./rpc/externalBrowserControlClient.
 import { deleteCachedSchema } from "./crossword/cachedSchema.mjs";
 import { getCrosswordCommandHandlerTable } from "./crossword/commandHandler.mjs";
 import { MacroStore } from "./storage/index.mjs";
-import { start } from "node:repl";
 
 const debug = registerDebug("typeagent:browser:action");
 const debugWebSocket = registerDebug("typeagent:browser:ws");

--- a/ts/packages/agents/browser/src/agent/actionHandler.mts
+++ b/ts/packages/agents/browser/src/agent/actionHandler.mts
@@ -25,8 +25,7 @@ import {
     displayError,
     displayStatus,
     displaySuccess,
-    getMessage
-    
+    getMessage,
 } from "@typeagent/agent-sdk/helpers/display";
 import { Crossword } from "./crossword/schema/pageSchema.mjs";
 import {
@@ -665,7 +664,7 @@ async function resolveEntity(
     if (type === "WebPage") {
         try {
             const resolveStarted = Date.now();
-            
+
             const urls = await resolveWebPage(context, name);
             const duration = Date.now() - resolveStarted;
 
@@ -700,7 +699,7 @@ async function resolveEntity(
 async function resolveWebPage(
     context: SessionContext<BrowserActionContext>,
     site: string,
-    io?: ActionIO
+    io?: ActionIO,
 ): Promise<string[]> {
     debug(`Resolving site '${site}'`);
 
@@ -761,9 +760,7 @@ async function resolveWebPage(
             if (context.agentContext.resolverSettings.keywordResolver) {
                 const cachehitUrl = await urlResolver.resolveURLByKeyword(site);
                 if (cachehitUrl) {
-                    debug(
-                        `Resolved URL from cache: ${cachehitUrl}`,
-                    );
+                    debug(`Resolved URL from cache: ${cachehitUrl}`);
 
                     if (
                         cachehitUrl.indexOf("https://") !== 0 &&
@@ -774,7 +771,7 @@ async function resolveWebPage(
                         return [cachehitUrl];
                     }
                 }
-            }            
+            }
 
             // Search for the URL based on heuristics (history, wikipedia, web-search)
             // if we get singular matches we assume those are correct and we just return it.
@@ -786,19 +783,29 @@ async function resolveWebPage(
             // try to resolve URL using website visit history first
             if (context.agentContext.resolverSettings.historyResolver) {
                 const startTime = Date.now();
-                io?.appendDisplay(getMessage(`Trying to resolve '${site}' by looking at browsing history.\n`, "status"), "temporary");
+                io?.appendDisplay(
+                    getMessage(
+                        `Trying to resolve '${site}' by looking at browsing history.\n`,
+                        "status",
+                    ),
+                    "temporary",
+                );
                 promises.push(
                     resolveURLWithHistory(context, site).then((historyUrls) => {
-
                         if (historyUrls) {
                             const msg = `Found ${historyUrls.length} in browser history.`;
                             debug(msg);
-                            io?.appendDisplay(getMessage(msg, "status"), "temporary");
+                            io?.appendDisplay(
+                                getMessage(msg, "status"),
+                                "temporary",
+                            );
 
                             urls.push(...historyUrls!);
                         }
 
-                        debug(`History resolution duration: ${Date.now () - startTime}`);
+                        debug(
+                            `History resolution duration: ${Date.now() - startTime}`,
+                        );
                     }),
                 );
             }
@@ -806,7 +813,13 @@ async function resolveWebPage(
             // try to resolve URL by using the Wikipedia API
             if (context.agentContext.resolverSettings.wikipediaResolver) {
                 const startTime = Date.now();
-                io?.appendDisplay(getMessage(`Resolving URL using Wikipedia for: '${site}'\n`, "status"), "temporary");
+                io?.appendDisplay(
+                    getMessage(
+                        `Resolving URL using Wikipedia for: '${site}'\n`,
+                        "status",
+                    ),
+                    "temporary",
+                );
                 promises.push(
                     urlResolver
                         .resolveURLWithWikipedia(
@@ -814,14 +827,18 @@ async function resolveWebPage(
                             wikipedia.apiSettingsFromEnv(),
                         )
                         .then((wikiPediaUrls) => {
-
                             const msg = `Found ${wikiPediaUrls.length} urls from Wikipedia.`;
                             debug(msg);
-                            io?.appendDisplay(getMessage(msg, "status"), "temporary");
+                            io?.appendDisplay(
+                                getMessage(msg, "status"),
+                                "temporary",
+                            );
 
                             urls.push(...wikiPediaUrls);
 
-                            debug(`Wikipedia resolution duration: ${Date.now () - startTime}`);
+                            debug(
+                                `Wikipedia resolution duration: ${Date.now() - startTime}`,
+                            );
                         }),
                 );
             }
@@ -829,7 +846,13 @@ async function resolveWebPage(
             // try to resolve URL using LLM + internet search
             if (context.agentContext.resolverSettings.searchResolver) {
                 const startTime = Date.now();
-                io?.appendDisplay(getMessage(`Resolving URL using web search for: '${site}'\n`, "status"), "temporary");
+                io?.appendDisplay(
+                    getMessage(
+                        `Resolving URL using web search for: '${site}'\n`,
+                        "status",
+                    ),
+                    "temporary",
+                );
                 promises.push(
                     urlResolver
                         .resolveURLWithSearch(
@@ -837,16 +860,20 @@ async function resolveWebPage(
                             bingWithGrounding.apiSettingsFromEnv(),
                         )
                         .then((search_urls) => {
-
                             const msg = `Found ${search_urls?.length} urls using Bing With Grounding (search).`;
                             debug(msg);
-                            io?.appendDisplay(getMessage(msg, "status"), "temporary");
+                            io?.appendDisplay(
+                                getMessage(msg, "status"),
+                                "temporary",
+                            );
 
                             if (search_urls) {
                                 urls.push(...search_urls);
                             }
 
-                            debug(`Search (Bing with Grounding) resolution duration: ${Date.now () - startTime}`);
+                            debug(
+                                `Search (Bing with Grounding) resolution duration: ${Date.now() - startTime}`,
+                            );
                         }),
                 );
             }
@@ -882,11 +909,11 @@ async function resolveWebPage(
                     dedupedUrls.push(url);
                 }
             }
-            urls.length = 0;            //clear out urls
-            urls.push(...dedupedUrls);  // add deduped
+            urls.length = 0; //clear out urls
+            urls.push(...dedupedUrls); // add deduped
 
             const msg = `Found ${urls.length} possible urls for '${site}'`;
-            debug (msg);
+            debug(msg);
             io?.appendDisplay(getMessage(msg, "info"));
 
             if (urls.length > 0) {
@@ -929,11 +956,13 @@ async function openWebPage(
     const browserControl = getActionBrowserControl(context);
 
     displayStatus(`Opening web page for ${action.parameters.site}.`, context);
-    const url = (await resolveWebPage(
-                      context.sessionContext,
-                      action.parameters.site,
-                      context.actionIO
-                  ))[0];
+    const url = (
+        await resolveWebPage(
+            context.sessionContext,
+            action.parameters.site,
+            context.actionIO,
+        )
+    )[0];
 
     if (url !== action.parameters.site) {
         displayStatus(

--- a/ts/packages/agents/browser/src/agent/websiteMemory.mts
+++ b/ts/packages/agents/browser/src/agent/websiteMemory.mts
@@ -82,7 +82,7 @@ const debug = registerDebug("typeagent:browser:website-memory");
 export async function resolveURLWithHistory(
     context: { agentContext: BrowserActionContext },
     site: string,
-): Promise<string | undefined> {
+): Promise<string[] | undefined> {
     debug(`Attempting to resolve '${site}' using website visit history`);
 
     const websiteCollection = context.agentContext.websiteCollection;
@@ -154,16 +154,18 @@ export async function resolveURLWithHistory(
             (a, b) => b.score - a.score,
         );
 
-        const bestMatch = sortedCandidates[0];
+        // Take the best 3 matches above a reasonable threshold
+        const topMatches = sortedCandidates.filter((c, index) => c.score >= 0.75 || index == 0).slice(0, 3);
+        topMatches.forEach((match) => {
+            debug(
+                `Found match from searchWebMemories (score: ${match.score.toFixed(2)}): '${match.metadata.title || match.url}' -> ${match.url}`,
+            );
+            debug(
+                `Match details: domain=${match.metadata.domain}, source=${match.metadata.source}`,
+            );
+        });
 
-        debug(
-            `Found best match from searchWebMemories (score: ${bestMatch.score.toFixed(2)}): '${bestMatch.metadata.title || bestMatch.url}' -> ${bestMatch.url}`,
-        );
-        debug(
-            `Match details: domain=${bestMatch.metadata.domain}, source=${bestMatch.metadata.source}`,
-        );
-
-        return bestMatch.url;
+        return topMatches.map((m) => m.url);
     } catch (error) {
         debug(
             `Error in resolveURLWithHistory using searchWebMemories: ${error}`,

--- a/ts/packages/agents/browser/src/agent/websiteMemory.mts
+++ b/ts/packages/agents/browser/src/agent/websiteMemory.mts
@@ -155,7 +155,9 @@ export async function resolveURLWithHistory(
         );
 
         // Take the best 3 matches above a reasonable threshold
-        const topMatches = sortedCandidates.filter((c, index) => c.score >= 0.75 || index == 0).slice(0, 3);
+        const topMatches = sortedCandidates
+            .filter((c, index) => c.score >= 0.75 || index == 0)
+            .slice(0, 3);
         topMatches.forEach((match) => {
             debug(
                 `Found match from searchWebMemories (score: ${match.score.toFixed(2)}): '${match.metadata.title || match.url}' -> ${match.url}`,

--- a/ts/packages/agents/chat/src/chatResponseHandler.ts
+++ b/ts/packages/agents/chat/src/chatResponseHandler.ts
@@ -103,7 +103,10 @@ async function generateResponse(
         }
 
         // Add the related files.
-        if (generateResponseAction.parameters.relatedFiles && generateResponseAction.parameters.relatedFiles.length > 0) {
+        if (
+            generateResponseAction.parameters.relatedFiles &&
+            generateResponseAction.parameters.relatedFiles.length > 0
+        ) {
             context.actionIO.appendDisplay(
                 `<div class='chat-smallImage'>${await rehydrateImages(context, generateResponseAction.parameters.relatedFiles!)}</div>`,
                 "block",

--- a/ts/packages/agents/chat/src/chatResponseHandler.ts
+++ b/ts/packages/agents/chat/src/chatResponseHandler.ts
@@ -103,7 +103,7 @@ async function generateResponse(
         }
 
         // Add the related files.
-        if (generateResponseAction.parameters.relatedFiles) {
+        if (generateResponseAction.parameters.relatedFiles && generateResponseAction.parameters.relatedFiles.length > 0) {
             context.actionIO.appendDisplay(
                 `<div class='chat-smallImage'>${await rehydrateImages(context, generateResponseAction.parameters.relatedFiles!)}</div>`,
                 "block",

--- a/ts/packages/azure-ai-foundry/src/urlResolver.ts
+++ b/ts/packages/azure-ai-foundry/src/urlResolver.ts
@@ -456,7 +456,9 @@ export async function resolveURLWithWikipedia(
                     }
                 } else {
                     // no "official website" found, so just use the wikipedia page URL
-                    retVal.push(`https://en.wikipedia.org/wiki/${encodeWikipediaTitle(data.pages[i].title)}`);
+                    retVal.push(
+                        `https://en.wikipedia.org/wiki/${encodeWikipediaTitle(data.pages[i].title)}`,
+                    );
                 }
             }
         })

--- a/ts/packages/dispatcher/src/context/chatHistory.ts
+++ b/ts/packages/dispatcher/src/context/chatHistory.ts
@@ -110,6 +110,7 @@ export interface ChatHistory {
         | undefined;
     count(): number;
     delete(index: number): void;
+    deleteEntityById(entityId: string): boolean;
     clear(): void;
     getStrings(): string[];
     export(): ChatHistoryInputEntry | ChatHistoryInputEntry[] | undefined;
@@ -325,6 +326,22 @@ export function createChatHistory(init: boolean): ChatHistory {
             }
 
             entries.splice(index, 1);
+        },
+        deleteEntityById(entityId: string): boolean {
+            for (let i = entries.length - 1; i >= 0; i--) {
+                const entry = entries[i];
+                if (entry.role === "user" || entry.entities === undefined) {
+                    continue;
+                }
+                for (const entity of entry.entities) {
+                    if (entity.uniqueId === entityId) {
+                        entry.entities.unshift(entity);
+                        return true;
+                    }
+                }
+            }
+
+            return false;
         },
         clear(): void {
             entries.length = 0;

--- a/ts/packages/dispatcher/src/context/system/handlers/historyCommandHandler.ts
+++ b/ts/packages/dispatcher/src/context/system/handlers/historyCommandHandler.ts
@@ -152,7 +152,8 @@ class HistoryInsertCommandHandler implements CommandHandler {
 }
 
 class HistoryEntityListCommandHandler implements CommandHandler {
-    public readonly description = "Shows all of the entities currently in 'working memory.'";
+    public readonly description =
+        "Shows all of the entities currently in 'working memory.'";
     public readonly parameters = {} as const;
 
     public async run(
@@ -165,13 +166,16 @@ class HistoryEntityListCommandHandler implements CommandHandler {
             translateConfig.history.limit,
         );
 
-
-        displayResult(entities.map((e) => JSON.stringify(e, null, 2) ), context);
+        displayResult(
+            entities.map((e) => JSON.stringify(e, null, 2)),
+            context,
+        );
     }
 }
 
 class HistoryEntityDeleteCommandHandler implements CommandHandler {
-    public readonly description = "Delete entities from the chat history (working memory).";
+    public readonly description =
+        "Delete entities from the chat history (working memory).";
     public readonly parameters = {
         args: {
             entityId: {
@@ -182,20 +186,22 @@ class HistoryEntityDeleteCommandHandler implements CommandHandler {
         },
     } as const;
 
-
     public async run(
         context: ActionContext<CommandHandlerContext>,
         param: ParsedCommandParams<typeof this.parameters>,
     ) {
         const systemContext = context.sessionContext.agentContext;
         const entityId = param.args.entityId;
-        
+
         const deleted = systemContext.chatHistory.deleteEntityById(entityId);
 
         if (deleted) {
             displayResult(`Entity with id '${entityId}' was deleted.`, context);
         } else {
-            displayResult(`Entity with id '${entityId}' was not deleted because it was not found.`, context);
+            displayResult(
+                `Entity with id '${entityId}' was not deleted because it was not found.`,
+                context,
+            );
         }
     }
 }
@@ -215,9 +221,9 @@ export function getHistoryCommandHandlers(): CommandHandlerTable {
                 defaultSubCommand: "list",
                 commands: {
                     list: new HistoryEntityListCommandHandler(),
-                    delete: new HistoryEntityDeleteCommandHandler()
-                }
-            }
+                    delete: new HistoryEntityDeleteCommandHandler(),
+                },
+            },
         },
     };
 }

--- a/ts/packages/dispatcher/src/context/system/handlers/historyCommandHandler.ts
+++ b/ts/packages/dispatcher/src/context/system/handlers/historyCommandHandler.ts
@@ -151,6 +151,55 @@ class HistoryInsertCommandHandler implements CommandHandler {
     }
 }
 
+class HistoryEntityListCommandHandler implements CommandHandler {
+    public readonly description = "Shows all of the entities currently in 'working memory.'";
+    public readonly parameters = {} as const;
+
+    public async run(
+        context: ActionContext<CommandHandlerContext>,
+        param: ParsedCommandParams<typeof this.parameters>,
+    ) {
+        const systemContext = context.sessionContext.agentContext;
+        const translateConfig = systemContext.session.getConfig().translation;
+        const entities = systemContext.chatHistory.getTopKEntities(
+            translateConfig.history.limit,
+        );
+
+
+        displayResult(entities.map((e) => JSON.stringify(e, null, 2) ), context);
+    }
+}
+
+class HistoryEntityDeleteCommandHandler implements CommandHandler {
+    public readonly description = "Delete entities from the chat history (working memory).";
+    public readonly parameters = {
+        args: {
+            entityId: {
+                description: "The UniqueId of the entity",
+                type: "string",
+                implicitQuotes: true,
+            },
+        },
+    } as const;
+
+
+    public async run(
+        context: ActionContext<CommandHandlerContext>,
+        param: ParsedCommandParams<typeof this.parameters>,
+    ) {
+        const systemContext = context.sessionContext.agentContext;
+        const entityId = param.args.entityId;
+        
+        const deleted = systemContext.chatHistory.deleteEntityById(entityId);
+
+        if (deleted) {
+            displayResult(`Entity with id '${entityId}' was deleted.`, context);
+        } else {
+            displayResult(`Entity with id '${entityId}' was not deleted because it was not found.`, context);
+        }
+    }
+}
+
 export function getHistoryCommandHandlers(): CommandHandlerTable {
     return {
         description: "History commands",
@@ -161,6 +210,14 @@ export function getHistoryCommandHandlers(): CommandHandlerTable {
             delete: new HistoryDeleteCommandHandler(),
             insert: new HistoryInsertCommandHandler(),
             save: new HistorySaveCommandHandler(),
+            entities: {
+                description: "History entity commands",
+                defaultSubCommand: "list",
+                commands: {
+                    list: new HistoryEntityListCommandHandler(),
+                    delete: new HistoryEntityDeleteCommandHandler()
+                }
+            }
         },
     };
 }

--- a/ts/packages/dispatcher/src/execute/pendingActions.ts
+++ b/ts/packages/dispatcher/src/execute/pendingActions.ts
@@ -427,10 +427,8 @@ async function resolveEntityWithMemory(
         )?.value as string;
         if (
             entityAppAgentName === undefined ||
-            (
-                entityAppAgentName !== appAgentName && 
-                entityAppAgentName !== "dispatcher" // allow dispatcher to provide entities for entity resolution
-            )
+            (entityAppAgentName !== appAgentName &&
+                entityAppAgentName !== "dispatcher") // allow dispatcher to provide entities for entity resolution
         ) {
             // Our search specify app agent name to match, so we should expect the result to match.
             throw new Error(
@@ -545,7 +543,11 @@ async function processResolvedEntityResult(
     clarifyEntities: ClarifyResolvedEntity[],
     options?: ParameterEntityResolverOptions,
 ) {
-    if (options?.filter && result.match === "fuzzy" && result.entities.length > 1) {
+    if (
+        options?.filter &&
+        result.match === "fuzzy" &&
+        result.entities.length > 1
+    ) {
         // An extra pass to use LLM to narrow down the selection for fuzzy match.
         await filterEntitySelection(action, type, value, result);
     }
@@ -557,7 +559,11 @@ async function processResolvedEntityResult(
         });
         return;
     }
-    if (result.match === "exact" || result.match === "same" || result.entities.length === 1) {
+    if (
+        result.match === "exact" ||
+        result.match === "same" ||
+        result.entities.length === 1
+    ) {
         // If it is exact or same match, return the first entity.
         // TODO: use last access to get the latest one?
         return {

--- a/ts/packages/dispatcher/src/execute/pendingActions.ts
+++ b/ts/packages/dispatcher/src/execute/pendingActions.ts
@@ -427,7 +427,10 @@ async function resolveEntityWithMemory(
         )?.value as string;
         if (
             entityAppAgentName === undefined ||
-            entityAppAgentName !== appAgentName
+            (
+                entityAppAgentName !== appAgentName && 
+                entityAppAgentName !== "dispatcher" // allow dispatcher to provide entities for entity resolution
+            )
         ) {
             // Our search specify app agent name to match, so we should expect the result to match.
             throw new Error(
@@ -542,7 +545,7 @@ async function processResolvedEntityResult(
     clarifyEntities: ClarifyResolvedEntity[],
     options?: ParameterEntityResolverOptions,
 ) {
-    if (options?.filter && result.match === "fuzzy") {
+    if (options?.filter && result.match === "fuzzy" && result.entities.length > 1) {
         // An extra pass to use LLM to narrow down the selection for fuzzy match.
         await filterEntitySelection(action, type, value, result);
     }
@@ -554,7 +557,7 @@ async function processResolvedEntityResult(
         });
         return;
     }
-    if (result.match === "exact" || result.match === "same") {
+    if (result.match === "exact" || result.match === "same" || result.entities.length === 1) {
         // If it is exact or same match, return the first entity.
         // TODO: use last access to get the latest one?
         return {

--- a/ts/packages/dispatcher/src/translation/entityResolution.ts
+++ b/ts/packages/dispatcher/src/translation/entityResolution.ts
@@ -97,7 +97,7 @@ export async function filterEntitySelection(
     const selectionResult = await translator.translate(
         [
             `Select the '${type.toLowerCase()}' entities that '${name}' in the user requested action could refer to.`,
-            "The user requested is",
+            "The user request is",
             JSON.stringify(action, undefined, 2),
             `The following possible '${type}' entities:`,
             JSON.stringify(


### PR DESCRIPTION
- Keyword lookups for URLs happens first and can short circuit other lookups
- URL lookups happen in parallel
- Also fixed a display bug in chatResponse.
- Added @history entites commands to show/delete history entities
- Removed entity reference from openWebPage, polluted by irrelevant entities being resolved