### PR TITLE
Show current activity app agent in the title bar

### DIFF
--- a/ts/packages/api/src/webDispatcher.ts
+++ b/ts/packages/api/src/webDispatcher.ts
@@ -2,7 +2,9 @@
 // Licensed under the MIT License.
 
 import { createDispatcher } from "agent-dispatcher";
+import { getConsolePrompt } from "agent-dispatcher/helpers/console";
 import { getInstanceDir, getClientId } from "agent-dispatcher/helpers/data";
+import { getStatusSummary } from "agent-dispatcher/helpers/status";
 import { createClientIORpcClient } from "agent-dispatcher/rpc/clientio/client";
 import { createDispatcherRpcServer } from "agent-dispatcher/rpc/dispatcher/server";
 import { createGenericChannel } from "agent-rpc/channel";
@@ -45,20 +47,24 @@ export async function createWebDispatcher(): Promise<WebDispatcher> {
 
     let settingSummary: string = "";
     const updateSettingSummary = (force: boolean = false) => {
-        const newSettingSummary = dispatcher.getSettingSummary();
+        const status = dispatcher.getStatus();
+        const newSettingSummary = getStatusSummary(status);
         if (force || newSettingSummary !== settingSummary) {
             settingSummary = newSettingSummary;
             ws?.send(
                 JSON.stringify({
                     message: "setting-summary-changed",
                     data: {
-                        registeredAgents: [
-                            ...dispatcher.getTranslatorNameToEmojiMap(),
-                        ],
+                        registeredAgents: status.agents.map((agent) => [
+                            agent.name,
+                            agent.emoji,
+                        ]),
                     },
                 }),
             );
         }
+
+        return newSettingSummary;
     };
 
     async function processShellRequest(
@@ -69,7 +75,13 @@ export async function createWebDispatcher(): Promise<WebDispatcher> {
         if (typeof text !== "string" || typeof id !== "string") {
             throw new Error("Invalid request");
         }
-        console.log(dispatcher.getPrompt(), text);
+
+        // Update before processing the command in case there was change outside of command processing
+        const summary = updateSettingSummary();
+        console.log(getConsolePrompt(summary), text);
+
+        // Update before processing the command in case there was change outside of command processing
+        updateSettingSummary();
 
         const result = await dispatcher.processCommand(text, id, images);
 

--- a/ts/packages/cli/src/commands/interactive.ts
+++ b/ts/packages/cli/src/commands/interactive.ts
@@ -17,9 +17,11 @@ import {
 import inspector from "node:inspector";
 import { getChatModelNames } from "aiclient";
 import {
+    getConsolePrompt,
     processCommands,
     withConsoleClientIO,
 } from "agent-dispatcher/helpers/console";
+import { getStatusSummary } from "agent-dispatcher/helpers/status";
 
 const modelNames = await getChatModelNames();
 const instanceDir = getInstanceDir();
@@ -99,7 +101,12 @@ export default class Interactive extends Command {
                 }
 
                 await processCommands(
-                    () => dispatcher.getPrompt(),
+                    (dispatcher: Dispatcher) =>
+                        getConsolePrompt(
+                            getStatusSummary(dispatcher.getStatus(), {
+                                showPrimaryName: false,
+                            }),
+                        ),
                     (command: string, dispatcher: Dispatcher) =>
                         dispatcher.processCommand(command),
                     dispatcher,

--- a/ts/packages/dispatcher/package.json
+++ b/ts/packages/dispatcher/package.json
@@ -20,6 +20,7 @@
     "./helpers/console": "./dist/helpers/console.js",
     "./helpers/data": "./dist/helpers/userData.js",
     "./helpers/config": "./dist/helpers/config.js",
+    "./helpers/status": "./dist/helpers/status.js",
     "./helpers/npmAgentProvider": "./dist/npmAgentProvider.js",
     "./internal": "./dist/internal.js",
     "./explorer": "./dist/explorer.js"

--- a/ts/packages/dispatcher/src/context/dispatcher/dispatcherAgent.ts
+++ b/ts/packages/dispatcher/src/context/dispatcher/dispatcherAgent.ts
@@ -40,6 +40,7 @@ import {
 import { ActivityActions } from "./schema/activityActionSchema.js";
 import { ClarifyEntityAction } from "../../execute/pendingActions.js";
 import { MatchCommandHandler } from "./handlers/matchCommandHandler.js";
+import { DispatcherEmoji } from "./dispatcherUtils.js";
 
 const dispatcherHandlers: CommandHandlerTable = {
     description: "Type Agent Dispatcher Commands",
@@ -251,7 +252,7 @@ function clarifyEntityAction(
 }
 
 export const dispatcherManifest: AppAgentManifest = {
-    emojiChar: "🤖",
+    emojiChar: DispatcherEmoji,
     description: "Built-in agent to dispatch requests",
     schema: {
         description: "",

--- a/ts/packages/dispatcher/src/context/dispatcher/dispatcherUtils.ts
+++ b/ts/packages/dispatcher/src/context/dispatcher/dispatcherUtils.ts
@@ -7,6 +7,7 @@ import { UnknownAction } from "./schema/dispatcherActionSchema.js";
 export const DispatcherName = "dispatcher";
 export const DispatcherClarifyName = "dispatcher.clarify";
 export const DispatcherActivityName = "dispatcher.activity";
+export const DispatcherEmoji = "🤖";
 
 export function isUnknownAction(action: AppAction): action is UnknownAction {
     return action.actionName === "unknown";

--- a/ts/packages/dispatcher/src/context/system/handlers/runScriptCommandHandler.ts
+++ b/ts/packages/dispatcher/src/context/system/handlers/runScriptCommandHandler.ts
@@ -4,11 +4,15 @@
 import { ActionContext, ParsedCommandParams } from "@typeagent/agent-sdk";
 import { CommandHandler } from "@typeagent/agent-sdk/helpers/command";
 import { CommandHandlerContext } from "../../commandHandlerContext.js";
-import { processCommands } from "../../../helpers/console.js";
-import { getPrompt, processCommandNoLock } from "../../../command/command.js";
+import { getConsolePrompt, processCommands } from "../../../helpers/console.js";
+import {
+    getDispatcherStatus,
+    processCommandNoLock,
+} from "../../../command/command.js";
 import fs from "node:fs";
 import path from "node:path";
 import { expandHome } from "../../../utils/fsUtils.js";
+import { getStatusSummary } from "../../../helpers/status.js";
 
 export class RunCommandScriptHandler implements CommandHandler {
     public readonly description = "Run a command script file";
@@ -39,7 +43,12 @@ export class RunCommandScriptHandler implements CommandHandler {
 
             // Process the commands in the file.
             await processCommands(
-                getPrompt,
+                (context) =>
+                    getConsolePrompt(
+                        getStatusSummary(getDispatcherStatus(context), {
+                            showPrimaryName: false,
+                        }),
+                    ),
                 processCommandNoLock,
                 systemContext,
                 inputs,

--- a/ts/packages/dispatcher/src/dispatcher.ts
+++ b/ts/packages/dispatcher/src/dispatcher.ts
@@ -6,12 +6,7 @@ import {
     DynamicDisplay,
     TemplateSchema,
 } from "@typeagent/agent-sdk";
-import {
-    getPrompt,
-    getSettingSummary,
-    getTranslatorNameToEmojiMap,
-    processCommand,
-} from "./command/command.js";
+import { getDispatcherStatus, processCommand } from "./command/command.js";
 import {
     CommandCompletionResult,
     getCommandCompletion,
@@ -33,6 +28,20 @@ export type CommandResult = {
     actions?: FullAction[];
     metrics?: RequestMetrics;
     tokenUsage?: ai.CompletionUsageStats;
+};
+
+export type AppAgentStatus = {
+    emoji: string;
+    name: string;
+    lastUsed: boolean;
+    priority: boolean;
+    request: boolean;
+    active: boolean;
+};
+
+export type DispatcherStatus = {
+    agents: AppAgentStatus[];
+    details: string;
 };
 
 /**
@@ -88,10 +97,7 @@ export interface Dispatcher {
         prefix: string,
     ): Promise<CommandCompletionResult | undefined>;
 
-    // TODO: Review these APIs
-    getPrompt(): string;
-    getSettingSummary(): string;
-    getTranslatorNameToEmojiMap(): Map<string, string>;
+    getStatus(): DispatcherStatus;
 }
 
 async function getDynamicDisplay(
@@ -194,14 +200,8 @@ export async function createDispatcher(
         async close() {
             await closeCommandHandlerContext(context);
         },
-        getPrompt() {
-            return getPrompt(context);
-        },
-        getSettingSummary() {
-            return getSettingSummary(context);
-        },
-        getTranslatorNameToEmojiMap() {
-            return getTranslatorNameToEmojiMap(context);
+        getStatus() {
+            return getDispatcherStatus(context);
         },
     };
 }

--- a/ts/packages/dispatcher/src/helpers/console.ts
+++ b/ts/packages/dispatcher/src/helpers/console.ts
@@ -357,3 +357,7 @@ export async function processCommands<T>(
         );
     }
 }
+
+export function getConsolePrompt(text: string): string {
+    return `${text}> `;
+}

--- a/ts/packages/dispatcher/src/helpers/status.ts
+++ b/ts/packages/dispatcher/src/helpers/status.ts
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import {
+    DispatcherEmoji,
+    DispatcherName,
+} from "../context/dispatcher/dispatcherUtils.js";
+import type { DispatcherStatus } from "../dispatcher.js";
+
+export function getStatusSummary(
+    state: DispatcherStatus,
+    options?: {
+        showPrimaryName?: boolean; // default true
+    },
+): string {
+    const active: string[] = [];
+    const showPrimaryName = options?.showPrimaryName ?? true;
+    let primary: string = showPrimaryName
+        ? `${DispatcherEmoji} ${DispatcherName} - `
+        : `${DispatcherEmoji}:`;
+    for (const agent of state.agents) {
+        if (agent.request && agent.name !== DispatcherName) {
+            return `{{${agent.emoji} ${agent.name.toUpperCase()}}}`;
+        }
+        if (agent.lastUsed) {
+            active.unshift(agent.emoji);
+        }
+        if (agent.active) {
+            active.push(agent.emoji);
+        }
+        if (agent.priority) {
+            primary = showPrimaryName
+                ? `${agent.emoji} ${agent.name} - `
+                : `${agent.emoji}:`;
+        }
+    }
+    return `${primary} [${Array.from(new Set(active)).join("")}]${state.details}`;
+}

--- a/ts/packages/dispatcher/src/rpc/dispatcherClient.ts
+++ b/ts/packages/dispatcher/src/rpc/dispatcherClient.ts
@@ -50,8 +50,6 @@ export function createDispatcherRpcClient(channel: RpcChannel): Dispatcher {
         async close() {
             return rpc.invoke("close");
         },
-        getPrompt: remoteCallNotSupported,
-        getSettingSummary: remoteCallNotSupported,
-        getTranslatorNameToEmojiMap: remoteCallNotSupported,
+        getStatus: remoteCallNotSupported,
     };
 }

--- a/ts/packages/dispatcher/src/translation/translateRequest.ts
+++ b/ts/packages/dispatcher/src/translation/translateRequest.ts
@@ -32,6 +32,7 @@ import {
 import { UnknownAction } from "../context/dispatcher/schema/dispatcherActionSchema.js";
 import {
     DispatcherActivityName,
+    DispatcherEmoji,
     DispatcherName,
     isUnknownAction,
 } from "../context/dispatcher/dispatcherUtils.js";
@@ -45,7 +46,6 @@ import {
     createPendingRequestAction,
     PendingRequestAction,
 } from "./pendingRequest.js";
-import { unicodeChar } from "../command/command.js";
 import registerDebug from "debug";
 import { confirmTranslation } from "./confirmTranslation.js";
 import { ActionConfig } from "./actionConfig.js";
@@ -924,7 +924,7 @@ export async function translateRequest(
     const elapsedMs = performance.now() - startTime;
     const { requestAction, replacedAction } = await confirmTranslation(
         elapsedMs,
-        unicodeChar.robotFace,
+        DispatcherEmoji,
         translated,
         context,
     );

--- a/ts/packages/shell/src/preload/electronTypes.ts
+++ b/ts/packages/shell/src/preload/electronTypes.ts
@@ -47,7 +47,7 @@ export interface ClientAPI {
 // Functions that are called from the main process to the renderer process.
 export interface Client {
     clientIO: ClientIO;
-    updateRegisterAgents(agents: Map<string, string>): void;
+    updateRegisterAgents(agents: [string, string][]): void;
     showInputText(message: string): Promise<void>;
     showDialog(key: string): void;
     updateSettings(settings: ShellUserSettings): void;

--- a/ts/packages/shell/src/renderer/src/main.ts
+++ b/ts/packages/shell/src/renderer/src/main.ts
@@ -289,9 +289,9 @@ function registerClient(
 
     const client: Client = {
         clientIO,
-        updateRegisterAgents(updatedAgents: Map<string, string>): void {
+        updateRegisterAgents(updatedAgents: [string, string][]): void {
             agents.clear();
-            for (const [key, value] of updatedAgents.entries()) {
+            for (const [key, value] of updatedAgents) {
                 agents.set(key, value);
             }
         },

--- a/ts/packages/shell/src/renderer/src/webSocketAPI.ts
+++ b/ts/packages/shell/src/renderer/src/webSocketAPI.ts
@@ -98,10 +98,7 @@ export async function createWebSocket(autoReconnect: boolean = true) {
                     break;
 
                 case "setting-summary-changed":
-                    const agentsMap = new Map<string, string>(
-                        msgObj.data.registeredAgents,
-                    );
-                    client?.updateRegisterAgents(agentsMap);
+                    client?.updateRegisterAgents(msgObj.data.registeredAgents);
                     break;
                 /* TODO: Not implemented yet.
                 case "listen-event":


### PR DESCRIPTION
- Refactor the "summary API" to return dispatcher status.
- Provide helper function to convert the dispatcher status to string summary.
- Change the summary to display the "primary" agent.  If there isn't any primary agent, the dispatcher will be shown.

Close #1468 