### PR TITLE
Allow cache behavior to be specified during activity.

### DIFF
--- a/ts/packages/agentSdk/src/agentInterface.ts
+++ b/ts/packages/agentSdk/src/agentInterface.ts
@@ -18,9 +18,10 @@ export type IndexingServiceConfig = {
 
 export type IndexingServicesManifest = Record<string, IndexingServiceConfig>;
 
+// if "separate", each activity is cache separately, or if "shared", it will share the cache with as if no activity is active.
+// If true, default to "separate".
 // If false, cache is disabled.
-// Otherwise, if "separate", each activity is cache separately, or if true, it will share the cache with as if no activity is active.
-export type ActivityCacheSpec = "separate" | boolean;
+export type ActivityCacheSpec = "separate" | "shared" | boolean;
 
 //==============================================================================
 // Manifest

--- a/ts/packages/agentSdk/src/agentInterface.ts
+++ b/ts/packages/agentSdk/src/agentInterface.ts
@@ -18,6 +18,10 @@ export type IndexingServiceConfig = {
 
 export type IndexingServicesManifest = Record<string, IndexingServiceConfig>;
 
+// If false, cache is disabled.
+// Otherwise, if "separate", each activity is cache separately, or if true, it will share the cache with as if no activity is active.
+export type ActivityCacheSpec = "separate" | boolean;
+
 //==============================================================================
 // Manifest
 //==============================================================================
@@ -28,6 +32,7 @@ export type AppAgentManifest = {
     localView?: boolean; // whether the agent serve a local view, default is false
     sharedLocalView?: string[]; // list of agents to share the local view with, default is none
     indexingServices?: IndexingServicesManifest;
+    cachedActivities?: Record<string, ActivityCacheSpec>; // Key is activity name, default (if not specified) is false
 } & ActionManifest;
 
 export type SchemaTypeNames = {

--- a/ts/packages/agentSdk/src/index.ts
+++ b/ts/packages/agentSdk/src/index.ts
@@ -18,6 +18,7 @@ export {
     ActivityContext,
     AppAgentInitSettings,
     ResolveEntityResult,
+    ActivityCacheSpec,
 } from "./agentInterface.js";
 
 export {

--- a/ts/packages/agents/browser/src/agent/manifest.json
+++ b/ts/packages/agents/browser/src/agent/manifest.json
@@ -9,6 +9,9 @@
       "description": "Enhanced website indexing with knowledge extraction"
     }
   },
+  "cachedActivities": {
+    "browsingWebPage": "shared"
+  },
   "schema": {
     "description": "Browser agent that allows you control an existing browser window and perform actions such as opening a new tab, closing a tab, scrolling, zooming and navigating to a specific URL.",
     "schemaFile": "./actionsSchema.mts",

--- a/ts/packages/cache/src/cache/cache.ts
+++ b/ts/packages/cache/src/cache/cache.ts
@@ -66,6 +66,7 @@ export function getSchemaNamespaceKeys(
 export class AgentCache {
     private _constructionStore: ConstructionStoreImpl;
     private readonly explainWorkQueue: ExplainWorkQueue;
+    // Function to return whether the namespace key matches to the current schema file's hash.
     private readonly namespaceKeyFilter?: NamespaceKeyFilter;
     private readonly logger: Telemetry.Logger | undefined;
     public model?: string;

--- a/ts/packages/cache/src/cache/explainWorkQueue.ts
+++ b/ts/packages/cache/src/cache/explainWorkQueue.ts
@@ -63,6 +63,7 @@ function checkExplainableValues(
 }
 
 export type ExplanationOptions = {
+    namespaceSuffix?: string | undefined; // suffix to add to namespace keys
     concurrent?: boolean; // whether to limit to run one at a time, require cache to be false
     valueInRequest?: boolean;
     noReferences?: boolean;

--- a/ts/packages/cache/src/constructions/importConstructions.ts
+++ b/ts/packages/cache/src/constructions/importConstructions.ts
@@ -67,6 +67,7 @@ function createConstructions(
         const requestAction = new RequestAction(
             entry.request,
             fromJsonActions(entry.action),
+            // REVIEW: imported construction doesn't support history or activities.
         );
 
         try {
@@ -81,6 +82,7 @@ function createConstructions(
             const explanation = entry.explanation;
             const namespaceKeys = getSchemaNamespaceKeys(
                 getTranslationNamesForActions(actions),
+                undefined, // REVIEW: imported construction doesn't support history or activities.
                 schemaInfoProvider,
             );
             const construction = createConstruction(

--- a/ts/packages/cache/src/explanation/requestAction.ts
+++ b/ts/packages/cache/src/explanation/requestAction.ts
@@ -40,7 +40,7 @@ export function equalNormalizedParamValue(
     return a === b || normalizeParamValue(a) === normalizeParamValue(b);
 }
 
-export function equalNormalizedObject(a: any, b: any) {
+export function equalNormalizedObject(a: object = {}, b: object = {}) {
     return (
         normalizeParamString(JSON.stringify(a)) ===
         normalizeParamString(JSON.stringify(b))

--- a/ts/packages/dispatcher/src/translation/actionConfig.ts
+++ b/ts/packages/dispatcher/src/translation/actionConfig.ts
@@ -5,6 +5,7 @@ import {
     ActionManifest,
     AppAgentManifest,
     SchemaManifest,
+    ActivityCacheSpec,
 } from "@typeagent/agent-sdk";
 import registerDebug from "debug";
 const debugConfig = registerDebug("typeagent:dispatcher:schema:config");
@@ -12,6 +13,9 @@ const debugConfig = registerDebug("typeagent:dispatcher:schema:config");
 // A flatten AppAgentManifest
 export type ActionConfig = {
     emojiChar: string;
+
+    // Key is activity name. Default (if not specified) is not cached during activity.
+    cachedActivities: Record<string, ActivityCacheSpec> | undefined;
 
     schemaDefaultEnabled: boolean;
     actionDefaultEnabled: boolean;
@@ -24,6 +28,7 @@ function collectActionConfigs(
     manifest: ActionManifest,
     schemaName: string,
     emojiChar: string,
+    cachedActivities: Record<string, ActivityCacheSpec> | undefined,
     transient: boolean,
     schemaDefaultEnabled: boolean,
     actionDefaultEnabled: boolean,
@@ -43,6 +48,7 @@ function collectActionConfigs(
         actionConfigs[schemaName] = {
             schemaName,
             emojiChar,
+            cachedActivities,
             ...manifest.schema,
             transient,
             schemaDefaultEnabled,
@@ -61,6 +67,7 @@ function collectActionConfigs(
                 subManifest,
                 `${schemaName}.${subName}`,
                 emojiChar,
+                cachedActivities, // propagate cachedActivities
                 transient, // propagate default transient
                 schemaDefaultEnabled, // propagate default schemaDefaultEnabled
                 actionDefaultEnabled, // propagate default actionDefaultEnabled
@@ -90,6 +97,7 @@ export function convertToActionConfig(
         config,
         name,
         emojiChar,
+        config.cachedActivities,
         false, // transient default to false if not specified
         true, // translationDefaultEnable default to true if not specified
         true, // actionDefaultEnabled default to true if not specified

--- a/ts/packages/dispatcher/src/translation/actionSchemaFileCache.ts
+++ b/ts/packages/dispatcher/src/translation/actionSchemaFileCache.ts
@@ -190,9 +190,11 @@ export class ActionSchemaFileCache {
         const { source, config, fullPath, format } =
             this.getSchemaSource(actionConfig);
 
-        const hash = config ? hashStrings(source, config) : hashStrings(source);
-        const cacheKey = `${format}|${actionConfig.schemaName}|${JSON.stringify(actionConfig.schemaType)}|${fullPath ?? ""}`;
-
+        const schemaTypeString = JSON.stringify(actionConfig.schemaType);
+        const hash = config
+            ? hashStrings(schemaTypeString, source, config)
+            : hashStrings(schemaTypeString, source);
+        const cacheKey = `${format}|${actionConfig.schemaName}|${schemaTypeString}|${fullPath ?? ""}`;
         const lastCached = this.prevSaved.get(cacheKey);
         if (lastCached !== undefined) {
             this.prevSaved.delete(cacheKey);
@@ -212,9 +214,6 @@ export class ActionSchemaFileCache {
             }
         }
 
-        const schemaConfig: SchemaConfig | undefined = config
-            ? JSON.parse(config)
-            : undefined;
         const parsed: ActionSchemaFile =
             format === "pas"
                 ? loadParsedActionSchema(
@@ -231,7 +230,7 @@ export class ActionSchemaFileCache {
                           actionConfig.schemaName,
                           actionConfig.schemaType,
                           fullPath,
-                          schemaConfig,
+                          config ? <SchemaConfig>JSON.parse(config) : undefined,
                           true,
                       ),
                   };

--- a/ts/packages/dispatcher/src/translation/translateRequest.ts
+++ b/ts/packages/dispatcher/src/translation/translateRequest.ts
@@ -879,7 +879,6 @@ export async function translateRequest(
         );
     }
 
-    // Start with the last translator used
     const startTime = performance.now();
     const activeSchemaNames = systemContext.agents.getActiveSchemas();
     debugTranslate(`Active schemas: ${activeSchemaNames.join(",")}`);


### PR DESCRIPTION
For now, add capability to enable caching during activity.
- By default, use of cache is disabled during activity.   
- Add property under `cachedActivites` in the agent manifest to enable cache.   
  - Activity name is used as the property name.
  - If the value is true then cache is enable (and shared with non-activity cache).
  - If the value is `separate` then it will have a separate namespace in the cache. for the activity.
- Enable matching using activity app agent's cache (separate or shared based on config).
  - PENDING: Second chance translation (with non-activity app agent) doesn't use cache yet.
- Completion will resolve completion for both activity (based on config) and non-activity cache.  (And will disable completion for the activity agent if config say to not cache)