### PR TITLE
Allow secondary non-activity translation to use the cache

### DIFF
--- a/ts/packages/dispatcher/src/context/dispatcher/handlers/translateCommandHandler.ts
+++ b/ts/packages/dispatcher/src/context/dispatcher/handlers/translateCommandHandler.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 import { CommandHandlerContext } from "../../commandHandlerContext.js";
+import { openai as ai } from "aiclient";
 import {
     ActionContext,
     CompletionGroup,
@@ -13,6 +14,7 @@ import { displayResult } from "@typeagent/agent-sdk/helpers/display";
 import { getColorElapsedString } from "common-utils";
 import { translateRequest } from "../../../translation/translateRequest.js";
 import { requestCompletion } from "../../../translation/requestCompletion.js";
+import { createHistoryContext } from "../../../translation/interpretRequest.js";
 
 export class TranslateCommandHandler implements CommandHandler {
     public readonly description = "Translate a request";
@@ -23,19 +25,43 @@ export class TranslateCommandHandler implements CommandHandler {
                 implicitQuotes: true,
             },
         },
+        flags: {
+            history: {
+                description: "Use history in translation",
+                default: false,
+            },
+        },
     } as const;
     public async run(
         context: ActionContext<CommandHandlerContext>,
         params: ParsedCommandParams<typeof this.parameters>,
     ) {
+        const tokenUsage: ai.CompletionUsageStats = {
+            completion_tokens: 0,
+            prompt_tokens: 0,
+            total_tokens: 0,
+        };
+
+        const usageCallback = (usage: ai.CompletionUsageStats) => {
+            tokenUsage.completion_tokens += usage.completion_tokens;
+            tokenUsage.prompt_tokens += usage.prompt_tokens;
+            tokenUsage.total_tokens += usage.total_tokens;
+        };
         const translationResult = await translateRequest(
             context,
             params.args.request,
+            params.flags.history
+                ? createHistoryContext(context.sessionContext.agentContext)
+                : undefined,
+            undefined,
+            undefined,
+            undefined,
+            usageCallback,
         );
 
         const elapsedStr = getColorElapsedString(translationResult.elapsedMs);
-        const usageStr = translationResult.tokenUsage
-            ? `(Tokens: ${translationResult.tokenUsage.prompt_tokens} + ${translationResult.tokenUsage.completion_tokens} = ${translationResult.tokenUsage.total_tokens})`
+        const usageStr = tokenUsage
+            ? `(Tokens: ${tokenUsage.prompt_tokens} + ${tokenUsage.completion_tokens} = ${tokenUsage.total_tokens})`
             : "";
         displayResult(
             `${translationResult.requestAction} ${elapsedStr}${usageStr}\n\nJSON:\n${JSON.stringify(

--- a/ts/packages/dispatcher/src/translation/interpretRequest.ts
+++ b/ts/packages/dispatcher/src/translation/interpretRequest.ts
@@ -3,15 +3,25 @@
 
 import { openai as ai } from "aiclient";
 import { HistoryContext, RequestAction } from "agent-cache";
-import { getActivityCacheSpec, matchRequest } from "./matchRequest.js";
+import {
+    getActivityActiveSchemas,
+    getActivityCacheSpec,
+    getNonActivityActiveSchemas,
+    matchRequest,
+} from "./matchRequest.js";
 import { translateRequest } from "./translateRequest.js";
 import { CommandHandlerContext } from "../context/commandHandlerContext.js";
 import { ActionContext } from "@typeagent/agent-sdk";
 import { CachedImageWithDetails } from "common-utils";
 import { unicodeChar } from "../command/command.js";
 import { confirmTranslation } from "./confirmTranslation.js";
-import { DispatcherEmoji } from "../context/dispatcher/dispatcherUtils.js";
-
+import {
+    DispatcherEmoji,
+    isUnknownAction,
+} from "../context/dispatcher/dispatcherUtils.js";
+import registerDebug from "debug";
+import { ProfileNames } from "../utils/profileNames.js";
+const debugInterpret = registerDebug("typeagent:interpret");
 export function getHistoryContext(context: CommandHandlerContext) {
     const config = context.session.getConfig();
     return config.translation.history.enabled
@@ -19,7 +29,9 @@ export function getHistoryContext(context: CommandHandlerContext) {
         : undefined;
 }
 
-function createHistoryContext(context: CommandHandlerContext): HistoryContext {
+export function createHistoryContext(
+    context: CommandHandlerContext,
+): HistoryContext {
     const promptSections = context.chatHistory.getPromptSections();
     if (promptSections.length !== 0) {
         promptSections.unshift({
@@ -50,7 +62,6 @@ export type InterpretResult = {
     fromUser: boolean;
     fromCache: boolean;
     tokenUsage?: ai.CompletionUsageStats | undefined;
-    cannotUseCacheReason?: string | undefined;
 };
 
 export function getCannotUseCacheReason(
@@ -76,6 +87,131 @@ export function getCannotUseCacheReason(
     return undefined;
 }
 
+async function interpretRequestWithActiveSchemas(
+    context: ActionContext<CommandHandlerContext>,
+    request: string,
+    attachments: CachedImageWithDetails[] | undefined,
+    history: HistoryContext | undefined,
+    streamingActionIndex: number | undefined,
+    activeSchemaNames: string[],
+    usageCallback: (usage: ai.CompletionUsageStats) => void,
+) {
+    const cannotUseCacheReason = getCannotUseCacheReason(
+        context.sessionContext.agentContext,
+        attachments,
+        history,
+    );
+    const canUseCacheMatch = cannotUseCacheReason === undefined;
+    const match = canUseCacheMatch
+        ? await matchRequest(context, request, history, activeSchemaNames)
+        : undefined;
+
+    return (
+        match ??
+        (await translateRequest(
+            context,
+            request,
+            history,
+            attachments,
+            streamingActionIndex,
+            activeSchemaNames,
+            usageCallback,
+        ))
+    );
+}
+
+async function interpretRequestWithActivityContext(
+    context: ActionContext<CommandHandlerContext>,
+    request: string,
+    attachments: CachedImageWithDetails[] | undefined,
+    history: HistoryContext,
+    streamingActionIndex: number | undefined,
+    activeSchemaNames: string[],
+    usageCallback: (usage: ai.CompletionUsageStats) => void,
+) {
+    // Translate the request with only the activity schemas
+    const activityContext = history.activityContext!;
+    const activitySchemas = getActivityActiveSchemas(
+        activeSchemaNames,
+        activityContext,
+    );
+
+    debugInterpret(`Activity schemas: ${activitySchemas.join(",")}`);
+    const translationResult = await interpretRequestWithActiveSchemas(
+        context,
+        request,
+        attachments,
+        history,
+        streamingActionIndex,
+        activitySchemas,
+        usageCallback,
+    );
+
+    if (activityContext.restricted) {
+        // Don't try non-activity schemas if restricted
+        return translationResult;
+    }
+
+    const activityActions = translationResult.requestAction.actions;
+    const hasUnknownAction = activityActions.some((e) =>
+        isUnknownAction(e.action),
+    );
+    if (!hasUnknownAction) {
+        // No more unknown action to translate
+        return translationResult;
+    }
+
+    // Translate the unknown requests with non-activity schemas
+    const nonActivitySchemas = getNonActivityActiveSchemas(
+        activeSchemaNames,
+        activityContext,
+    );
+    debugInterpret(
+        `Non-activity schemas: ${Array.from(nonActivitySchemas).join(",")}`,
+    );
+    // Activity context should not be used for non-activity schemas
+    const historyWithNoActivity = {
+        ...history!,
+        activityContext: undefined, // Clear activity context for non-activity schemas
+    };
+
+    if (activityActions.length <= 1) {
+        return interpretRequestWithActiveSchemas(
+            context,
+            request,
+            attachments,
+            historyWithNoActivity,
+            streamingActionIndex,
+            nonActivitySchemas,
+            usageCallback,
+        );
+    }
+    const executableAction = [];
+    for (const action of activityActions) {
+        if (!isUnknownAction(action.action)) {
+            executableAction.push(action);
+        } else {
+            const newResult = await interpretRequestWithActiveSchemas(
+                context,
+                action.action.parameters.request,
+                attachments,
+                historyWithNoActivity,
+                streamingActionIndex,
+                nonActivitySchemas,
+                usageCallback,
+            );
+            executableAction.push(...newResult.requestAction.actions);
+            translationResult.elapsedMs += newResult.elapsedMs;
+        }
+    }
+    translationResult.requestAction = RequestAction.create(
+        request,
+        executableAction,
+        history,
+    );
+    return translationResult;
+}
+
 export async function interpretRequest(
     context: ActionContext<CommandHandlerContext>,
     request: string,
@@ -83,29 +219,39 @@ export async function interpretRequest(
 ): Promise<InterpretResult> {
     const systemContext = context.sessionContext.agentContext;
     const history = getHistoryContext(systemContext);
-
-    const cannotUseCacheReason = getCannotUseCacheReason(
-        systemContext,
-        attachments,
-        history,
-    );
-    const canUseCacheMatch = cannotUseCacheReason === undefined;
-
     const activeSchemaNames = systemContext.agents.getActiveSchemas();
-    const match = canUseCacheMatch
-        ? await matchRequest(context, request, history, activeSchemaNames)
-        : undefined;
 
-    const translateResult =
-        match ??
-        (await translateRequest(
-            context,
-            request,
-            history,
-            attachments,
-            0,
-            activeSchemaNames,
-        ));
+    const tokenUsage: ai.CompletionUsageStats = {
+        completion_tokens: 0,
+        prompt_tokens: 0,
+        total_tokens: 0,
+    };
+
+    const usageCallback = (usage: ai.CompletionUsageStats) => {
+        tokenUsage.completion_tokens += usage.completion_tokens;
+        tokenUsage.prompt_tokens += usage.prompt_tokens;
+        tokenUsage.total_tokens += usage.total_tokens;
+    };
+
+    const translateResult = history?.activityContext
+        ? await interpretRequestWithActivityContext(
+              context,
+              request,
+              attachments,
+              history,
+              0,
+              activeSchemaNames,
+              usageCallback,
+          )
+        : await interpretRequestWithActiveSchemas(
+              context,
+              request,
+              attachments,
+              history,
+              0,
+              activeSchemaNames,
+              usageCallback,
+          );
 
     const { requestAction, replacedAction } = await confirmTranslation(
         translateResult.elapsedMs,
@@ -126,7 +272,12 @@ export async function interpretRequest(
             schemaNames: activeSchemaNames,
             developerMode: systemContext.developerMode,
             config: translateResult.config,
-            metrics: translateResult.metrics,
+            metrics: systemContext.metricsManager?.getMeasures(
+                systemContext.requestId!,
+                ProfileNames.translate,
+            ),
+            allMatches: translateResult.allMatches,
+            tokenUsage,
         });
     }
 
@@ -135,7 +286,6 @@ export async function interpretRequest(
         requestAction,
         fromUser: replacedAction !== undefined,
         fromCache: translateResult.type === "match",
-        tokenUsage: translateResult.tokenUsage,
-        cannotUseCacheReason,
+        tokenUsage,
     };
 }


### PR DESCRIPTION
Last part of #1466 to enable using cache during activity.
Refactor the logic that try to "interpret" using schemas associated with the activity app agent first so that we can use the use the cache on when we do a secondary interpretation.


Close #1466 