### PR TITLE
Fix: Shell: Browser action hang when no inline browser open

### DIFF
--- a/ts/packages/agents/browser/src/agent/actionHandler.mts
+++ b/ts/packages/agents/browser/src/agent/actionHandler.mts
@@ -243,9 +243,7 @@ async function updateBrowserContext(
 
                 if (data.error) {
                     console.error(data.error);
-                    // TODO: Handle the case where no clients were found. Prompt the user
-                    //       to launch inline browser or run automation in the headless browser.
-                    return;
+                    throw new Error(data.error);
                 }
 
                 if (data.method) {
@@ -1049,175 +1047,180 @@ async function executeBrowserAction(
 
     context: ActionContext<BrowserActionContext>,
 ) {
-    switch (action.schemaName) {
-        case "browser":
-            switch (action.actionName) {
-                case "openWebPage":
-                    return openWebPage(context, action);
-                case "closeWebPage":
-                    return closeWebPage(context);
-                case "getWebsiteStats":
-                    return getWebsiteStats(context, action);
-                case "searchWebMemories":
-                    return searchWebMemoriesAction(context, action);
-                case "goForward":
-                    await getActionBrowserControl(context).goForward();
-                    return;
-                case "goBack":
-                    await getActionBrowserControl(context).goBack();
-                    return;
-                case "reloadPage":
-                    // REVIEW: do we need to clear page schema?
-                    await getActionBrowserControl(context).reload();
-                    return;
-                case "scrollUp":
-                    await getActionBrowserControl(context).scrollUp();
-                    return;
-                case "scrollDown":
-                    await getActionBrowserControl(context).scrollDown();
-                    return;
-                case "zoomIn":
-                    await getActionBrowserControl(context).zoomIn();
-                    return;
-                case "zoomOut":
-                    await getActionBrowserControl(context).zoomOut();
-                    return;
-                case "zoomReset":
-                    await getActionBrowserControl(context).zoomReset();
-                    return;
-                case "search":
-                    await getActionBrowserControl(context).search(
-                        action.parameters.query,
-                    );
-                    return createActionResultFromTextDisplay(
-                        `Opened new tab with query ${action.parameters.query}`,
-                    );
-                case "readPage":
-                    await getActionBrowserControl(context).readPage();
-                    return;
-                case "stopReadPage":
-                    await getActionBrowserControl(context).stopReadPage();
-                    return;
-                case "captureScreenshot":
-                    const dataUrl =
-                        await getActionBrowserControl(
-                            context,
-                        ).captureScreenshot();
-                    return createActionResultFromHtmlDisplay(
-                        `<img src="${dataUrl}" alt="Screenshot" width="100%" />`,
-                    );
-                case "followLinkByText": {
-                    const control = getActionBrowserControl(context);
-                    const { keywords, openInNewTab } = action.parameters;
-                    const url = await control.followLinkByText(
-                        keywords,
-                        openInNewTab,
-                    );
-                    if (!url) {
-                        throw new Error(`No link found for '${keywords}'`);
-                    }
+    try {
+        switch (action.schemaName) {
+            case "browser":
+                switch (action.actionName) {
+                    case "openWebPage":
+                        return openWebPage(context, action);
+                    case "closeWebPage":
+                        return closeWebPage(context);
+                    case "getWebsiteStats":
+                        return getWebsiteStats(context, action);
+                    case "searchWebMemories":
+                        return searchWebMemoriesAction(context, action);
+                    case "goForward":
+                        await getActionBrowserControl(context).goForward();
+                        return;
+                    case "goBack":
+                        await getActionBrowserControl(context).goBack();
+                        return;
+                    case "reloadPage":
+                        await getActionBrowserControl(context).reload();
+                        return;
+                    case "scrollUp":
+                        await getActionBrowserControl(context).scrollUp();
+                        return;
+                    case "scrollDown":
+                        await getActionBrowserControl(context).scrollDown();
+                        return;
+                    case "zoomIn":
+                        await getActionBrowserControl(context).zoomIn();
+                        return;
+                    case "zoomOut":
+                        await getActionBrowserControl(context).zoomOut();
+                        return;
+                    case "zoomReset":
+                        await getActionBrowserControl(context).zoomReset();
+                        return;
+                    case "search":
+                        await getActionBrowserControl(context).search(
+                            action.parameters.query,
+                        );
+                        return createActionResultFromTextDisplay(
+                            `Opened new tab with query ${action.parameters.query}`,
+                        );
+                    case "readPage":
+                        await getActionBrowserControl(context).readPage();
+                        return;
+                    case "stopReadPage":
+                        await getActionBrowserControl(context).stopReadPage();
+                        return;
+                    case "captureScreenshot":
+                        const dataUrl =
+                            await getActionBrowserControl(
+                                context,
+                            ).captureScreenshot();
+                        return createActionResultFromHtmlDisplay(
+                            `<img src="${dataUrl}" alt="Screenshot" width="100%" />`,
+                        );
+                    case "followLinkByText": {
+                        const control = getActionBrowserControl(context);
+                        const { keywords, openInNewTab } = action.parameters;
+                        const url = await control.followLinkByText(
+                            keywords,
+                            openInNewTab,
+                        );
+                        if (!url) {
+                            throw new Error(`No link found for '${keywords}'`);
+                        }
 
-                    return createActionResultFromMarkdownDisplay(
-                        `Navigated to link for [${keywords}](${url})`,
-                        `Navigated to link for '${keywords}'`,
-                    );
-                }
-                case "followLinkByPosition":
-                    const control = getActionBrowserControl(context);
-                    const url = await control.followLinkByPosition(
-                        action.parameters.position,
-                        action.parameters.openInNewTab,
-                    );
-                    if (!url) {
+                        return createActionResultFromMarkdownDisplay(
+                            `Navigated to link for [${keywords}](${url})`,
+                            `Navigated to link for '${keywords}'`,
+                        );
+                    }
+                    case "followLinkByPosition":
+                        const control = getActionBrowserControl(context);
+                        const url = await control.followLinkByPosition(
+                            action.parameters.position,
+                            action.parameters.openInNewTab,
+                        );
+                        if (!url) {
+                            throw new Error(
+                                `No link found at position ${action.parameters.position}`,
+                            );
+                        }
+                        return createActionResultFromMarkdownDisplay(
+                            `Navigated to [link](${url}) at position ${action.parameters.position}`,
+                            `Navigated to link at position ${action.parameters.position}`,
+                        );
+                    case "openSearchResult":
+                        return openSearchResult(context, action);
+                    default:
+                        // Should never happen.
                         throw new Error(
-                            `No link found at position ${action.parameters.position}`,
+                            `Internal error: unknown browser action: ${(action as any).actionName}`,
                         );
-                    }
-                    return createActionResultFromMarkdownDisplay(
-                        `Navigated to [link](${url}) at position ${action.parameters.position}`,
-                        `Navigated to link at position ${action.parameters.position}`,
-                    );
-                case "openSearchResult":
-                    return openSearchResult(context, action);
-                default:
-                    // Should never happen.
-                    throw new Error(
-                        `Internal error: unknown browser action: ${(action as any).actionName}`,
-                    );
-            }
-        case "browser.external":
-            switch (action.actionName) {
-                case "closeWindow": {
-                    const control = getActionBrowserControl(context);
-                    await control.closeWindow();
-                    return;
                 }
-            }
-            break;
-    }
-    const webSocketEndpoint = context.sessionContext.agentContext.webSocket;
-    const connector = context.sessionContext.agentContext.browserConnector;
-    if (webSocketEndpoint) {
-        try {
-            context.actionIO.setDisplay("Running remote action.");
-
-            let schemaName = "browser";
-            if (action.schemaName === "browser.crossword") {
-                const crosswordResult = await handleCrosswordAction(
-                    action,
-                    context.sessionContext,
-                );
-                return createActionResult(crosswordResult);
-            } else if (action.schemaName === "browser.commerce") {
-                const commerceResult = await handleCommerceAction(
-                    action,
-                    context,
-                );
-                if (commerceResult !== undefined) {
-                    if (commerceResult instanceof String) {
-                        return createActionResult(
-                            commerceResult as unknown as string,
-                        );
-                    } else {
-                        return commerceResult as ActionResult;
+            case "browser.external":
+                switch (action.actionName) {
+                    case "closeWindow": {
+                        const control = getActionBrowserControl(context);
+                        await control.closeWindow();
+                        return;
                     }
                 }
-            } else if (action.schemaName === "browser.instacart") {
-                const instacartResult = await handleInstacartAction(
-                    action,
-                    context.sessionContext,
-                );
-
-                return createActionResult(
-                    instacartResult.displayText,
-                    undefined,
-                    instacartResult.entities,
-                );
-
-                // return createActionResult(instacartResult);
-            } else if (action.schemaName === "browser.actionDiscovery") {
-                const discoveryResult = await handleSchemaDiscoveryAction(
-                    action,
-                    context.sessionContext,
-                );
-
-                return createActionResult(discoveryResult.displayText);
-            }
-
-            await connector?.sendActionToBrowser(action, schemaName);
-        } catch (ex: any) {
-            if (ex instanceof Error) {
-                console.error(ex);
-            } else {
-                console.error(JSON.stringify(ex));
-            }
-
-            throw new Error("Unable to contact browser backend.");
+                break;
         }
-    } else {
-        throw new Error("No websocket connection.");
+        const webSocketEndpoint = context.sessionContext.agentContext.webSocket;
+        const connector = context.sessionContext.agentContext.browserConnector;
+        if (webSocketEndpoint) {
+            try {
+                context.actionIO.setDisplay("Running remote action.");
+
+                let schemaName = "browser";
+                if (action.schemaName === "browser.crossword") {
+                    const crosswordResult = await handleCrosswordAction(
+                        action,
+                        context.sessionContext,
+                    );
+                    return createActionResult(crosswordResult);
+                } else if (action.schemaName === "browser.commerce") {
+                    const commerceResult = await handleCommerceAction(
+                        action,
+                        context,
+                    );
+                    if (commerceResult !== undefined) {
+                        if (commerceResult instanceof String) {
+                            return createActionResult(
+                                commerceResult as unknown as string,
+                            );
+                        } else {
+                            return commerceResult as ActionResult;
+                        }
+                    }
+                } else if (action.schemaName === "browser.instacart") {
+                    const instacartResult = await handleInstacartAction(
+                        action,
+                        context.sessionContext,
+                    );
+
+                    return createActionResult(
+                        instacartResult.displayText,
+                        undefined,
+                        instacartResult.entities,
+                    );
+
+                    // return createActionResult(instacartResult);
+                } else if (action.schemaName === "browser.actionDiscovery") {
+                    const discoveryResult = await handleSchemaDiscoveryAction(
+                        action,
+                        context.sessionContext,
+                    );
+
+                    return createActionResult(discoveryResult.displayText);
+                }
+
+                await connector?.sendActionToBrowser(action, schemaName);
+            } catch (ex: any) {
+                if (ex instanceof Error) {
+                    console.error(ex);
+                } else {
+                    console.error(JSON.stringify(ex));
+                }
+
+                throw new Error("Unable to contact browser backend.");
+            }
+        } else {
+            throw new Error("No websocket connection.");
+        }
+        return undefined;
+    } catch (error) {
+        return createActionResultFromTextDisplay(
+            error instanceof Error ? error.message : String(error),
+        );
     }
-    return undefined;
 }
 
 async function handleTabIndexActions(

--- a/ts/packages/agents/browser/src/agent/browserConnector.mts
+++ b/ts/packages/agents/browser/src/agent/browserConnector.mts
@@ -44,7 +44,7 @@ export class BrowserConnector {
                 } catch {
                     console.log("Unable to contact browser backend.");
                     reject(
-                        "Unable to contact browser backend (from connector).",
+                        "Unable to connect to browser extension. Please ensure the TypeAgent browser extension is installed and active.",
                     );
                 }
             } else {

--- a/ts/packages/agents/browser/src/extension/serviceWorker/externalBrowserControlServer.ts
+++ b/ts/packages/agents/browser/src/extension/serviceWorker/externalBrowserControlServer.ts
@@ -19,7 +19,9 @@ import { ContentScriptRpc } from "../../common/contentScriptRpc/types.mjs";
 async function ensureActiveTab() {
     const targetTab = await getActiveTab();
     if (!targetTab || targetTab.id === undefined) {
-        throw new Error("No active tab found.");
+        throw new Error(
+            "No browser tabs are currently open. Please open a browser tab to continue.",
+        );
     }
     return targetTab;
 }

--- a/ts/packages/agents/browser/src/extension/serviceWorker/messageHandlers.ts
+++ b/ts/packages/agents/browser/src/extension/serviceWorker/messageHandlers.ts
@@ -303,7 +303,9 @@ export async function handleMessage(
                     return { error: "Failed to extract knowledge from page" };
                 }
             }
-            return { error: "No active tab found" };
+            return {
+                error: "No browser tabs are currently open. Please open a browser tab to continue.",
+            };
         }
 
         case "queryKnowledge": {
@@ -407,7 +409,10 @@ export async function handleMessage(
                 );
                 return { success };
             }
-            return { success: false, error: "No active tab found" };
+            return {
+                success: false,
+                error: "No browser tabs are currently open. Please open a browser tab to continue.",
+            };
         }
 
         case "autoIndexPage": {

--- a/ts/packages/shell/src/main/index.ts
+++ b/ts/packages/shell/src/main/index.ts
@@ -55,6 +55,7 @@ import {
     startBackgroundUpdateCheck,
 } from "./commands/update.js";
 import { createInlineBrowserControl } from "./inlineBrowserControl.js";
+import { BrowserControl } from "browser-typeagent/agent/types";
 
 debugShell("App name", app.getName());
 debugShell("App version", app.getVersion());
@@ -295,6 +296,11 @@ async function initializeDispatcher(
             },
         };
 
+        let browserControl: BrowserControl | undefined;
+        try {
+            browserControl = createInlineBrowserControl(shellWindow);
+        } catch {}
+
         // Set up dispatcher
         const newDispatcher = await createDispatcher("shell", {
             appAgentProviders: [
@@ -302,7 +308,7 @@ async function initializeDispatcher(
                 ...getDefaultAppAgentProviders(instanceDir),
             ],
             agentInitOptions: {
-                browser: createInlineBrowserControl(shellWindow),
+                browser: browserControl,
             },
             agentInstaller: getDefaultAppAgentInstaller(instanceDir),
             persistSession: true,

--- a/ts/packages/shell/src/main/inlineBrowserControl.ts
+++ b/ts/packages/shell/src/main/inlineBrowserControl.ts
@@ -12,20 +12,17 @@ export function createInlineBrowserControl(
 ): BrowserControl {
     // Helper function to get the active browser WebContents for automation
     function getActiveBrowserWebContents() {
-        // Always use multi-tab browser
         const activeBrowserView = shellWindow.getActiveBrowserView();
         if (!activeBrowserView) {
-            throw new Error("No active browser tab available");
+            throw new Error(
+                "No browser tabs are currently open. Please open a browser tab to continue.",
+            );
         }
         return activeBrowserView.webContentsView.webContents;
     }
     const contentScriptRpcChannel = createGenericChannel((message) => {
-        try {
-            const webContents = getActiveBrowserWebContents();
-            webContents.send("inline-browser-rpc-call", message);
-        } catch (error) {
-            console.warn("Failed to send RPC message to browser:", error);
-        }
+        const webContents = getActiveBrowserWebContents();
+        webContents.send("inline-browser-rpc-call", message);
     });
 
     // Handle RPC replies from browser views
@@ -48,7 +45,9 @@ export function createInlineBrowserControl(
             // Always use multi-tab browser
             const activeBrowserView = shellWindow.getActiveBrowserView();
             if (!activeBrowserView) {
-                throw new Error("No browser tab is currently open.");
+                throw new Error(
+                    "No browser tabs are currently open. Please open a browser tab to continue.",
+                );
             }
 
             if (!shellWindow.closeBrowserTab(activeBrowserView.id)) {
@@ -57,17 +56,23 @@ export function createInlineBrowserControl(
         },
         async goForward() {
             if (!shellWindow.browserGoForward()) {
-                throw new Error("Cannot go forward in history");
+                throw new Error(
+                    "Cannot go forward in browser history. No active browser tab or no forward history available.",
+                );
             }
         },
         async goBack() {
             if (!shellWindow.browserGoBack()) {
-                throw new Error("Cannot go back in history");
+                throw new Error(
+                    "Cannot go back in browser history. No active browser tab or no back history available.",
+                );
             }
         },
         async reload() {
             if (!shellWindow.browserReload()) {
-                throw new Error("No active browser to reload");
+                throw new Error(
+                    "Cannot reload page. No browser tabs are currently open.",
+                );
             }
         },
         async getPageUrl() {

--- a/ts/packages/shell/src/renderer/newTab.html
+++ b/ts/packages/shell/src/renderer/newTab.html
@@ -77,13 +77,25 @@
     </div>
     <script>
       function navigate() {
-        const url = document.getElementById("urlInput").value;
+        const url = document.getElementById("urlInput").value.trim();
         if (url) {
           let fullUrl = url;
           if (!url.startsWith("http://") && !url.startsWith("https://")) {
             fullUrl = "https://" + url;
           }
-          window.location.href = fullUrl;
+          try {
+            const parsedUrl = new URL(fullUrl);
+            if (
+              parsedUrl.protocol === "http:" ||
+              parsedUrl.protocol === "https:"
+            ) {
+              window.location.href = parsedUrl.href;
+            } else {
+              alert("Only HTTP and HTTPS protocols are allowed.");
+            }
+          } catch (e) {
+            alert("Invalid URL.");
+          }
         }
       }
 


### PR DESCRIPTION
- FIx https://github.com/microsoft/TypeAgent/issues/1483
     - Propagate error messages from inlinebrowsercontrol and show the message to the user.
- Fix codescan warning https://github.com/microsoft/TypeAgent/security/code-scanning/181