### PR TITLE
Finding balance

### DIFF
--- a/ts/packages/agents/browser/src/agent/actionHandler.mts
+++ b/ts/packages/agents/browser/src/agent/actionHandler.mts
@@ -1175,7 +1175,7 @@ async function executeBrowserAction(
                     return openSearchResult(context, action);
                 case "changeSearchProvider":
                     return changeSearchProvider(context, action);
-                case "findImageAction": {
+                case "searchImageAction": {
                     return openWebPage(context, {
                         schemaName: "browser",
                         actionName: "openWebPage",

--- a/ts/packages/agents/browser/src/agent/actionHandler.mts
+++ b/ts/packages/agents/browser/src/agent/actionHandler.mts
@@ -104,7 +104,10 @@ import {
     saveSettings,
 } from "./browserActions.mjs";
 import { ChunkChatResponse, generateAnswer } from "typeagent";
-import { BrowserLookupActions, LookupAndAnswerInternet } from "./lookupAndAnswerSchema.mjs";
+import {
+    BrowserLookupActions,
+    LookupAndAnswerInternet,
+} from "./lookupAndAnswerSchema.mjs";
 
 const debug = registerDebug("typeagent:browser:action");
 const debugWebSocket = registerDebug("typeagent:browser:ws");
@@ -1071,7 +1074,7 @@ async function executeBrowserAction(
         | TypeAgentAction<ShoppingActions, "browser.commerce">
         | TypeAgentAction<InstacartActions, "browser.instacart">
         | TypeAgentAction<SchemaDiscoveryActions, "browser.actionDiscovery">
-        | TypeAgentAction<BrowserLookupActions, "browser.lookupAndAnswer">,        
+        | TypeAgentAction<BrowserLookupActions, "browser.lookupAndAnswer">,
 
     context: ActionContext<BrowserActionContext>,
 ) {
@@ -1121,7 +1124,7 @@ async function executeBrowserAction(
                             .activeSearchProvider,
                         {
                             newTab: action.parameters.newTab,
-                        }
+                        },
                     );
                     return createActionResultFromTextDisplay(
                         `Opened new tab with query ${action.parameters.query}`,
@@ -1200,12 +1203,14 @@ async function executeBrowserAction(
                 }
             }
             break;
-        case "browser.lookupAndAnswer": 
-            switch(action.actionName) {
+        case "browser.lookupAndAnswer":
+            switch (action.actionName) {
                 case "lookupAndAnswerInternet":
                     return await lookup(context, action);
                 default: {
-                    throw new Error(`Unknown action for lookupAndAnswer: ${(action as any).actionName}`);
+                    throw new Error(
+                        `Unknown action for lookupAndAnswer: ${(action as any).actionName}`,
+                    );
                 }
             }
     }

--- a/ts/packages/agents/browser/src/agent/actionsSchema.mts
+++ b/ts/packages/agents/browser/src/agent/actionsSchema.mts
@@ -4,7 +4,7 @@
 export type BrowserActions =
     | OpenWebPage
     | CloseWebPage
-    | SwitchTabs
+    | ChangeTabs
     | GoBack
     | GoForward
     | ScrollDown
@@ -23,7 +23,6 @@ export type BrowserActions =
     | SearchWebMemories
     | OpenSearchResult
     | ChangeSearchProvider
-    | LookupAndAnswerInternet
     | FindImageAction;
 
 export type WebPage = string;
@@ -54,9 +53,9 @@ export type OpenWebPage = {
     };
 };
 
-// Switch to a different tab
-export type SwitchTabs = {
-    actionName: "switchTabs";
+// Make another tab the activbe tab
+export type ChangeTabs = {
+    actionName: "changeTab";
     parameters: {
         tabDescription: string;
         // The numerical index referred to by the descripton if applicable.  (i.e. first = 1, second = 2, etc.)
@@ -73,6 +72,7 @@ export type Search = {
     actionName: "search";
     parameters: {
         query?: string;
+        newTab: boolean // default is false;
     };
 };
 
@@ -207,25 +207,6 @@ export type ChangeSearchProvider = {
     parameters: {
         // The name of the search provider to switch to
         name: string;
-    };
-};
-
-// The user request is a question about general knowledge that can be found from the internet.
-// (e.g. "what is the current price of Microsoft stock?")
-// look up for contemporary internet information including sports scores, news events, or current commerce offerings, use the lookups parameter to request a lookup of the information on the user's behalf; the assistant will generate a response based on the lookup results
-// Lookup *facts* you don't know or if your facts are out of date.
-// E.g. stock prices, time sensitive data, etc
-// the search strings to look up on the user's behalf should be specific enough to return the correct information
-// it is recommended to include the same entities as in the user request
-export type LookupAndAnswerInternet = {
-    actionName: "lookupAndAnswerInternet";
-    parameters: {
-        // the original request of the user
-        originalRequest: string;
-        // the internet search terms to use
-        internetLookups: string[];
-        // specific sites to look up in.
-        sites?: string[];
     };
 };
 

--- a/ts/packages/agents/browser/src/agent/actionsSchema.mts
+++ b/ts/packages/agents/browser/src/agent/actionsSchema.mts
@@ -72,7 +72,7 @@ export type Search = {
     actionName: "search";
     parameters: {
         query?: string;
-        newTab: boolean // default is false;
+        newTab: boolean; // default is false;
     };
 };
 

--- a/ts/packages/agents/browser/src/agent/actionsSchema.mts
+++ b/ts/packages/agents/browser/src/agent/actionsSchema.mts
@@ -23,7 +23,7 @@ export type BrowserActions =
     | SearchWebMemories
     | OpenSearchResult
     | ChangeSearchProvider
-    | FindImageAction;
+    | SearchImageAction;
 
 export type WebPage = string;
 export type WebSearchResult = string;
@@ -210,11 +210,10 @@ export type ChangeSearchProvider = {
     };
 };
 
-// Choose this action if the user wants to "see", "show", "find", "lookup" pictures/images/photos/memes or otherwise requesting visual output
-// Finds images on the internet to show the user
+// Searches (finds) for images on the internet to show the user
 // if the user asks doesn't specify a quantity, randomly select anywhere between 3 and 10 images
-export type FindImageAction = {
-    actionName: "findImageAction";
+export type SearchImageAction = {
+    actionName: "searchImageAction";
     parameters: {
         // the original request of the user
         originalRequest: string;

--- a/ts/packages/agents/browser/src/agent/lookupAndAnswerSchema.mts
+++ b/ts/packages/agents/browser/src/agent/lookupAndAnswerSchema.mts
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+export type BrowserLookupActions = LookupAndAnswerInternet;
+
+// The user request is a question about general knowledge that can be found from the internet.
+// (e.g. "what is the current price of Microsoft stock?")
+// look up for contemporary internet information including sports scores, news events, or current commerce offerings, use the lookups parameter to request a lookup of the information on the user's behalf; the assistant will generate a response based on the lookup results
+// Lookup *facts* you don't know or if your facts are out of date.
+// E.g. stock prices, time sensitive data, etc
+// the search strings to look up on the user's behalf should be specific enough to return the correct information
+// it is recommended to include the same entities as in the user request
+export type LookupAndAnswerInternet = {
+    actionName: "lookupAndAnswerInternet";
+    parameters: {
+        // the original request of the user
+        originalRequest: string;
+        // the internet search terms to use
+        internetLookups: string[];
+        // specific sites to look up in.
+        sites?: string[];
+    };
+};

--- a/ts/packages/agents/browser/src/agent/manifest.json
+++ b/ts/packages/agents/browser/src/agent/manifest.json
@@ -14,14 +14,23 @@
   },
   "schema": {
     "description": "Browser agent that allows you control an existing browser window and perform actions such as opening a new tab, closing a tab, scrolling, zooming and navigating to a specific URL.",
-    "schemaFile": "./actionsSchema.mts",
-    "injected": true,
+    "schemaFile": "./actionsSchema.mts",    
     "schemaType": {
       "action": "BrowserActions",
       "entity": "BrowserEntities"
     }
   },
   "subActionManifests": {
+    "lookupAndAnswer": {
+      "defaultEnabled": true,
+      "transient": false,
+      "schema": {
+        "description": "Actions to lookup information from the web and answer user queries.",
+        "schemaFile": "./lookupAndAnswerSchema.mts",
+        "schemaType": "BrowserLookupActions",
+        "inject": true
+      }
+    },
     "external": {
       "defaultEnabled": false,
       "transient": true,

--- a/ts/packages/agents/browser/src/agent/manifest.json
+++ b/ts/packages/agents/browser/src/agent/manifest.json
@@ -14,7 +14,7 @@
   },
   "schema": {
     "description": "Browser agent that allows you control an existing browser window and perform actions such as opening a new tab, closing a tab, scrolling, zooming and navigating to a specific URL.",
-    "schemaFile": "./actionsSchema.mts",    
+    "schemaFile": "./actionsSchema.mts",
     "schemaType": {
       "action": "BrowserActions",
       "entity": "BrowserEntities"

--- a/ts/packages/agents/browser/src/common/browserControl.mts
+++ b/ts/packages/agents/browser/src/common/browserControl.mts
@@ -37,7 +37,7 @@ export type BrowserControlInvokeFunctions = {
         query?: string,
         sites?: string[],
         searchProvider?: SearchProvider,
-        options?: { waitForPageLoad?: boolean },
+        options?: { waitForPageLoad?: boolean, newTab?: boolean },
     ): Promise<URL>;
     switchTabs(tabDescription: string, tabIndex?: number): Promise<boolean>;
 

--- a/ts/packages/agents/browser/src/common/browserControl.mts
+++ b/ts/packages/agents/browser/src/common/browserControl.mts
@@ -37,7 +37,7 @@ export type BrowserControlInvokeFunctions = {
         query?: string,
         sites?: string[],
         searchProvider?: SearchProvider,
-        options?: { waitForPageLoad?: boolean, newTab?: boolean },
+        options?: { waitForPageLoad?: boolean; newTab?: boolean },
     ): Promise<URL>;
     switchTabs(tabDescription: string, tabIndex?: number): Promise<boolean>;
 

--- a/ts/packages/agents/image/src/imageManifest.json
+++ b/ts/packages/agents/image/src/imageManifest.json
@@ -1,8 +1,8 @@
 {
   "emojiChar": "🖼️",
-  "description": "Agent to find images and create AI images",
+  "description": "Agent to create AI images",
   "schema": {
-    "description": "Image agent that finds images online or creates them using AI image modes.",
+    "description": "Image agent that creates images using AI image modes.",
     "schemaFile": "./imageActionSchema.ts",
     "schemaType": "ImageAction"
   }

--- a/ts/packages/shell/src/main/inlineBrowserControl.ts
+++ b/ts/packages/shell/src/main/inlineBrowserControl.ts
@@ -263,7 +263,7 @@ export function createInlineBrowserControl(
             query: string,
             sites: string[],
             searchProvider: SearchProvider,
-            options: { waitForPageLoad?: boolean },
+            options: { waitForPageLoad?: boolean, newTab?: boolean } = {},
         ): Promise<URL> {
             // append any site specific scoping
             if (sites && sites.length > 0) {
@@ -284,10 +284,15 @@ export function createInlineBrowserControl(
             );
 
             // Always use tabs
-            await shellWindow.createBrowserTab(searchUrl, {
-                background: false,
-                waitForPageLoad: options?.waitForPageLoad,
-            });
+            const activeTab = shellWindow.getActiveBrowserView();
+            if (options?.newTab || !activeTab) {
+                await shellWindow.createBrowserTab(searchUrl, {
+                    background: false,
+                    waitForPageLoad: options?.waitForPageLoad,
+                });
+            } else {
+                activeTab.webContentsView.webContents.loadURL(searchUrl.toString());
+            }
 
             return searchUrl;
         },

--- a/ts/packages/shell/src/main/inlineBrowserControl.ts
+++ b/ts/packages/shell/src/main/inlineBrowserControl.ts
@@ -263,7 +263,7 @@ export function createInlineBrowserControl(
             query: string,
             sites: string[],
             searchProvider: SearchProvider,
-            options: { waitForPageLoad?: boolean, newTab?: boolean } = {},
+            options: { waitForPageLoad?: boolean; newTab?: boolean } = {},
         ): Promise<URL> {
             // append any site specific scoping
             if (sites && sites.length > 0) {
@@ -291,7 +291,9 @@ export function createInlineBrowserControl(
                     waitForPageLoad: options?.waitForPageLoad,
                 });
             } else {
-                activeTab.webContentsView.webContents.loadURL(searchUrl.toString());
+                activeTab.webContentsView.webContents.loadURL(
+                    searchUrl.toString(),
+                );
             }
 
             return searchUrl;


### PR DESCRIPTION
- Search tab opens by default in current tab but you can override by saying "in a new tab"
- Changed "SwitchTab" action to "ChangeTab"
- Inject only LookupAndAnswerInternet action and not all browser actions (stops taking over play action)
