### PR TITLE
Shell browser tab manager view bound and focus input fixes.

### DIFF
--- a/ts/packages/shell/src/main/agent.ts
+++ b/ts/packages/shell/src/main/agent.ts
@@ -91,8 +91,10 @@ class ShellSetSettingCommandHandler implements CommandHandler {
                 description: "Name of the setting to set",
             },
             value: {
-                description: "The new value for the setting",
+                description:
+                    "The new value for the setting (reset to default if omitted)",
                 implicitQuotes: true,
+                optional: true,
             },
         },
     } as const;
@@ -120,7 +122,7 @@ class ShellSetSettingCommandHandler implements CommandHandler {
                     name,
                     completions: getObjectPropertyNames(
                         context.agentContext.shellWindow.getUserSettings(),
-                    ),
+                    ).sort(),
                 });
             }
 

--- a/ts/packages/shell/src/main/browserViewManager.ts
+++ b/ts/packages/shell/src/main/browserViewManager.ts
@@ -32,7 +32,7 @@ export class BrowserViewManager {
     private onTabUpdateCallback?: () => void;
     private onNavigationUpdateCallback?: () => void;
     private onPageLoadCompleteCallback?: (tabId: string) => void;
-
+    private viewBounds: Electron.Rectangle | null = null;
     constructor(mainWindow: BrowserWindow) {
         this.mainWindow = mainWindow;
         debug("BrowserViewManager initialized");
@@ -326,38 +326,27 @@ export class BrowserViewManager {
     }
 
     /**
+     * Set the bounds for the browser view area
+     * @param bounds Bounds rectangle
+     */
+    public setBounds(bounds: Electron.Rectangle): void {
+        this.viewBounds = bounds;
+        this.updateActiveBrowserViewBounds();
+    }
+
+    /**
      * Update bounds for the active browser view
      */
-    updateActiveBrowserViewBounds(): void {
+    private updateActiveBrowserViewBounds(): void {
         const activeView = this.getActiveBrowserView();
-        if (!activeView) {
+        if (!activeView || !this.viewBounds) {
             return;
         }
 
-        // Get main window content bounds
-        const bounds = this.mainWindow.getContentBounds();
-
-        // Calculate browser view bounds (accounting for header and chat panel)
         const headerHeight = 40; // Height of the tab/navigation header
-
-        // Get the current chat view bounds to calculate browser area
-        const chatViewBounds = this.mainWindow.contentView.children
-            .find(
-                (child) =>
-                    child instanceof WebContentsView &&
-                    child !== activeView.webContentsView,
-            )
-            ?.getBounds();
-
-        const chatWidth =
-            chatViewBounds?.width || Math.floor(bounds.width * 0.5);
-
-        const browserViewBounds = {
-            x: chatWidth + 4, // 4px divider
-            y: headerHeight,
-            width: bounds.width - chatWidth - 4,
-            height: bounds.height - headerHeight,
-        };
+        const browserViewBounds = { ...this.viewBounds };
+        browserViewBounds.y = headerHeight;
+        browserViewBounds.height -= headerHeight;
 
         activeView.webContentsView.setBounds(browserViewBounds);
         debug(`Updated active browser view bounds:`, browserViewBounds);

--- a/ts/packages/shell/src/main/index.ts
+++ b/ts/packages/shell/src/main/index.ts
@@ -23,8 +23,7 @@ import {
 import {
     ensureShellDataDir,
     getShellDataDir,
-    loadShellSettings,
-    ShellSettings,
+    ShellSettingManager,
     ShellUserSettings,
 } from "./shellSettings.js";
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
@@ -126,11 +125,11 @@ if (parsedArgs.update) {
 const time = performance.now();
 debugShell("Starting...");
 
-function createWindow(shellSettings: ShellSettings) {
+function createWindow(shellSettings: ShellSettingManager) {
     debugShell("Creating window", performance.now() - time);
 
     // Create the browser window.
-    const shellWindow = new ShellWindow(shellSettings, instanceDir);
+    const shellWindow = new ShellWindow(shellSettings);
 
     initializeSpeech(shellWindow.chatView);
 
@@ -393,7 +392,7 @@ async function initializeDispatcher(
 
 async function initializeInstance(
     instanceDir: string,
-    shellSettings: ShellSettings,
+    shellSettings: ShellSettingManager,
 ) {
     const shellWindow = createWindow(shellSettings);
     const { mainWindow, chatView } = shellWindow;
@@ -528,7 +527,7 @@ async function initialize() {
         "/macrosLibrary.html": `chrome-extension://${extension.id}/views/macrosLibrary.html`,
     };
 
-    const shellSettings = loadShellSettings(instanceDir);
+    const shellSettings = new ShellSettingManager(instanceDir);
     const settings = shellSettings.user;
     const dataDir = getShellDataDir(instanceDir);
     const chatHistory: string = path.join(dataDir, "chat_history.html");

--- a/ts/packages/shell/src/main/shellSettings.ts
+++ b/ts/packages/shell/src/main/shellSettings.ts
@@ -76,29 +76,8 @@ export function ensureShellDataDir(instanceDir: string) {
     return shellDataDir;
 }
 
-export function getSettingsPath(instanceDir: string) {
+function getSettingsPath(instanceDir: string) {
     return path.join(getShellDataDir(instanceDir), "shellSettings.json");
-}
-
-export function loadShellSettings(instanceDir: string): ShellSettings {
-    const settingsPath = getSettingsPath(instanceDir);
-    debugShell(
-        `Loading shell settings from '${settingsPath}'`,
-        performance.now(),
-    );
-    const settings = cloneConfig(defaultSettings);
-    if (existsSync(settingsPath)) {
-        try {
-            const existingSettings = JSON.parse(
-                readFileSync(settingsPath, "utf-8"),
-            );
-            mergeConfig(settings, existingSettings);
-        } catch (e) {
-            debugShell(`Error loading shell settings: ${e}`);
-        }
-    }
-    debugShell(`Shell settings: ${JSON.stringify(settings, undefined, 2)}`);
-    return settings;
 }
 
 export class ShellSettingManager {

--- a/ts/packages/shell/src/main/shellSettings.ts
+++ b/ts/packages/shell/src/main/shellSettings.ts
@@ -11,6 +11,7 @@ import { cloneConfig, mergeConfig } from "agent-dispatcher/helpers/config";
 import { ReadonlyDeep } from "type-fest";
 import path from "path";
 import {
+    DeepPartialUndefined,
     getObjectProperty,
     getObjectPropertyNames,
     setObjectProperty,
@@ -40,12 +41,12 @@ export type ShellWindowState = {
     activeBrowserTabId?: string; // which tab is active
 };
 
-export type ShellSettings = {
+type ShellSettings = {
     window: ShellWindowState;
     user: ShellUserSettings;
 };
 
-export const defaultSettings: ShellSettings = {
+const defaultSettings: ShellSettings = {
     window: {
         x: -1,
         y: -1,
@@ -101,10 +102,37 @@ export function loadShellSettings(instanceDir: string): ShellSettings {
 }
 
 export class ShellSettingManager {
-    constructor(
-        private readonly settings: ShellSettings,
-        private readonly instanceDir: string,
-    ) {}
+    private readonly settings: ShellSettings;
+    private readonly savedSettings: DeepPartialUndefined<ShellSettings>;
+    constructor(private readonly instanceDir: string) {
+        const settingsPath = getSettingsPath(instanceDir);
+        debugShell(
+            `Loading shell settings from '${settingsPath}'`,
+            performance.now(),
+        );
+
+        const settings = cloneConfig(defaultSettings);
+        this.settings = settings;
+        this.savedSettings = {};
+        if (existsSync(settingsPath)) {
+            try {
+                const existingSettings = JSON.parse(
+                    readFileSync(settingsPath, "utf-8"),
+                );
+                this.savedSettings = existingSettings;
+                mergeConfig(settings, existingSettings);
+            } catch (e) {
+                debugShell(`Error loading shell settings: ${e}`);
+            }
+        }
+
+        debugShell(
+            `Shell loaded settings: ${JSON.stringify(this.savedSettings, undefined, 2)}`,
+        );
+        debugShell(
+            `Shell settings: ${JSON.stringify(this.settings, undefined, 2)}`,
+        );
+    }
 
     public get window(): ReadonlyDeep<ShellWindowState> {
         return this.settings.window;
@@ -131,65 +159,60 @@ export class ShellSettingManager {
         if (!names.includes(name)) {
             throw new Error(`Invalid property name '${name}'.`);
         }
-        const currentValue = getObjectProperty(this.settings.user, name);
+
+        const defaultValue = getObjectProperty(defaultSettings.user, name);
         let newValue: any = value;
-        let valueType = typeof currentValue;
-        if (valueType !== typeof value) {
-            // Coerce the type
-            switch (valueType) {
-                case "string":
-                    if (value === undefined) {
-                        // use default value to determine if the value is optional
-                        const defaultValue = getObjectProperty(
-                            defaultSettings,
-                            name,
-                        );
-                        if (defaultValue !== undefined) {
+        if (value !== undefined) {
+            const expectedType = typeof defaultValue; // The default value determines the type
+            if (expectedType !== typeof value) {
+                // Coerce the type
+                switch (expectedType) {
+                    case "string":
+                    case "undefined": // undefined default means string
+                        newValue = String(value);
+                        break;
+
+                    case "number":
+                        newValue = Number(value);
+                        if (isNaN(newValue)) {
                             throw new Error(
-                                `Invalid undefined for property '${name}`,
+                                `Invalid number value '${value}' for property '${name}'.`,
                             );
                         }
                         break;
-                    }
-                case "undefined": // only allow optional on string types
-                    newValue = String(value);
-                    break;
-
-                case "number":
-                    newValue = Number(value);
-                    if (isNaN(newValue)) {
+                    case "boolean":
+                        switch (value) {
+                            case "true":
+                            case "1":
+                                newValue = true;
+                                break;
+                            case "false":
+                            case "0":
+                                newValue = false;
+                                break;
+                            default:
+                                throw new Error(
+                                    `Invalid boolean value '${value}' for property '${name}'.`,
+                                );
+                        }
+                        break;
+                    default:
                         throw new Error(
-                            `Invalid number value '${value}' for property '${name}'.`,
+                            `Property '${name}' has unknown type ${expectedType} and cannot be set.`,
                         );
-                    }
-                    break;
-                case "boolean":
-                    switch (value) {
-                        case "true":
-                        case "1":
-                            newValue = true;
-                            break;
-                        case "false":
-                        case "0":
-                            newValue = false;
-                            break;
-                        default:
-                            throw new Error(
-                                `Invalid boolean value '${value}' for property '${name}'.`,
-                            );
-                    }
-                    break;
-                default:
-                    throw new Error(
-                        `Property '${name}' has unknown type ${valueType} and cannot be set.`,
-                    );
+                }
             }
         }
-
-        if (newValue === currentValue) {
+        if (newValue === getObjectProperty(this.savedSettings.user, name)) {
             return false;
         }
-        setObjectProperty(this.settings, "user", name, newValue);
+        setObjectProperty(this.savedSettings, "user", name, newValue);
+        setObjectProperty(
+            this.settings,
+            "user",
+            name,
+            newValue ?? defaultValue,
+        );
         return true;
     }
 
@@ -197,7 +220,7 @@ export class ShellSettingManager {
         const settingsPath = getSettingsPath(this.instanceDir);
         debugShell(`Saving settings to '${settingsPath}'.`);
 
-        const settings = this.settings;
+        const settings = this.savedSettings;
         settings.window = windowState;
         debugShell(JSON.stringify(settings, undefined, 2));
         writeFileSync(settingsPath, JSON.stringify(settings));

--- a/ts/packages/shell/src/main/shellWindow.ts
+++ b/ts/packages/shell/src/main/shellWindow.ts
@@ -14,7 +14,6 @@ import path from "node:path";
 import { WebSocketMessageV2 } from "common-utils";
 import { runDemo } from "./demo.js";
 import {
-    ShellSettings,
     ShellUserSettings,
     ShellWindowState,
     ShellSettingManager,
@@ -76,7 +75,6 @@ export class ShellWindow {
     private inlineWidth: number;
     private readonly contentLoadP: Promise<void>[];
     private readonly handlers = new Map<string, (event: any) => void>();
-    private readonly settings: ShellSettingManager;
     private closing: boolean = false;
 
     // Multi-tab browser support
@@ -91,15 +89,13 @@ export class ShellWindow {
         }
         return activeBrowserView.webContentsView;
     }
-    constructor(shellSettings: ShellSettings, instanceDir: string) {
+    constructor(private readonly settings: ShellSettingManager) {
         if (ShellWindow.instance !== undefined) {
             throw new Error("ShellWindow already created");
         }
-        this.settings = new ShellSettingManager(shellSettings, instanceDir);
 
-        this.inlineWidth = shellSettings.window.inlineWidth;
-
-        const state = shellSettings.window;
+        const state = this.settings.window;
+        this.inlineWidth = state.inlineWidth;
         const mainWindow = createMainWindow(state);
 
         setupDevicePermissions(mainWindow);
@@ -464,8 +460,15 @@ export class ShellWindow {
             const inlineWidth = width - chatWidth;
             this.inlineWidth = inlineWidth;
 
+            const browserViewBounds = {
+                x: chatWidth + 4, // 4px divider
+                y: 0,
+                width: width - chatWidth - 4,
+                height: height,
+            };
+
             // Update browser view manager for multi-tab layout
-            this.browserViewManager.updateActiveBrowserViewBounds();
+            this.browserViewManager.setBounds(browserViewBounds);
         } else {
             // No browser content - chat should fill the entire width
             chatWidth = width;

--- a/ts/packages/shell/src/preload/electronTypes.ts
+++ b/ts/packages/shell/src/preload/electronTypes.ts
@@ -53,6 +53,7 @@ export interface Client {
     updateSettings(settings: ShellUserSettings): void;
     fileSelected(fileName: string, fileContent: string): void;
     listen(token: SpeechToken | undefined, useLocalWhisper: boolean): void;
+    focusInput(): void;
 }
 
 export interface ElectronWindowFields {

--- a/ts/packages/shell/src/preload/index.ts
+++ b/ts/packages/shell/src/preload/index.ts
@@ -53,16 +53,7 @@ function registerClient(client: Client) {
     );
 
     ipcRenderer.on("focus-chat-input", () => {
-        // Focus the chat input element
-        const inputElement = document.querySelector(
-            'input[type="text"], textarea',
-        ) as HTMLElement;
-        if (inputElement) {
-            inputElement.focus();
-            if ("select" in inputElement) {
-                (inputElement as HTMLInputElement).select();
-            }
-        }
+        client.focusInput();
     });
 
     // Signal the main process that the client has been registered

--- a/ts/packages/shell/src/renderer/src/main.ts
+++ b/ts/packages/shell/src/renderer/src/main.ts
@@ -318,6 +318,9 @@ function registerClient(
 
             chatView.chatInput.recognizeOnce(token, useLocalWhisper);
         },
+        focusInput(): void {
+            chatView.chatInput.focus();
+        },
     };
 
     getClientAPI().registerClient(client);


### PR DESCRIPTION
- Shell browser tab manager view bound should be set by the mainWindow instead of detecting the chat input and set based on it.  This is so that we can move the layout around easier later
- Shell save settings for values that the user explicitly set, allow following the default that can change from build to build.
- Fix the focus input code, that might pick the wrong text area if the chat history has other text input box.