### PR TITLE
Capture history context before adding the current user request

### DIFF
--- a/ts/packages/dispatcher/src/context/dispatcher/handlers/requestCommandHandler.ts
+++ b/ts/packages/dispatcher/src/context/dispatcher/handlers/requestCommandHandler.ts
@@ -45,6 +45,7 @@ import { addRequestToMemory, addResultToMemory } from "../../memory.js";
 import { requestCompletion } from "../../../translation/requestCompletion.js";
 import {
     getCannotUseCacheReason,
+    getHistoryContext,
     interpretRequest,
     InterpretResult,
 } from "../../../translation/interpretRequest.js";
@@ -346,6 +347,8 @@ export class RequestCommandHandler implements CommandHandler {
 
             // Translate to action
 
+            // Get the history context before adding the request to memory
+            const history = getHistoryContext(systemContext);
             addRequestToMemory(systemContext, request, cachedAttachments);
             let interpretResult: InterpretResult;
             try {
@@ -353,6 +356,7 @@ export class RequestCommandHandler implements CommandHandler {
                     context,
                     request,
                     cachedAttachments,
+                    history,
                 );
             } catch (e: any) {
                 addResultToMemory(

--- a/ts/packages/dispatcher/src/translation/interpretRequest.ts
+++ b/ts/packages/dispatcher/src/translation/interpretRequest.ts
@@ -215,10 +215,10 @@ async function interpretRequestWithActivityContext(
 export async function interpretRequest(
     context: ActionContext<CommandHandlerContext>,
     request: string,
-    attachments?: CachedImageWithDetails[] | undefined,
+    attachments: CachedImageWithDetails[] | undefined,
+    history: HistoryContext | undefined,
 ): Promise<InterpretResult> {
     const systemContext = context.sessionContext.agentContext;
-    const history = getHistoryContext(systemContext);
     const activeSchemaNames = systemContext.agents.getActiveSchemas();
 
     const tokenUsage: ai.CompletionUsageStats = {


### PR DESCRIPTION
Avoid duplicate user request in the translation prompt.