### PR TITLE
Change chat history prompt to prevent retranslating old requests.

### DIFF
--- a/ts/packages/dispatcher/src/context/session.ts
+++ b/ts/packages/dispatcher/src/context/session.ts
@@ -106,7 +106,7 @@ export type DispatcherConfig = {
         multiple: MultipleActionConfig;
         history: {
             enabled: boolean;
-            limit: number;
+            limit: number; // number of entities,
         };
         schema: {
             generation: {

--- a/ts/packages/dispatcher/src/translation/interpretRequest.ts
+++ b/ts/packages/dispatcher/src/translation/interpretRequest.ts
@@ -36,7 +36,8 @@ export function createHistoryContext(
     if (promptSections.length !== 0) {
         promptSections.unshift({
             content:
-                "The following is a history of the conversation with the user that can be used for context to translate the current user request.",
+                "The following is the chat history of requests and action results with the user, used for context to translate the current user request." +
+                "Do NOT translate actions from requests in the chat history unless the current user request refers to it.",
             role: "system",
         });
     }

--- a/ts/packages/dispatcher/src/translation/multipleActionSchema.ts
+++ b/ts/packages/dispatcher/src/translation/multipleActionSchema.ts
@@ -102,7 +102,7 @@ export function createMultipleActionSchema(
                 requests: sc.array(requestEntryType),
             }),
         }),
-        undefined,
+        "ONLY use when the current user request has multiple parts and require multiple actions. Do NOT include completed requests from chat history.",
         true,
     );
     return schema;


### PR DESCRIPTION
Also change the translation test code to able to independently set concurrent vs number of repeats.