### PR TITLE
Translate test: enable specifying alternate values

### DIFF
--- a/ts/packages/cache/src/explanation/requestAction.ts
+++ b/ts/packages/cache/src/explanation/requestAction.ts
@@ -103,7 +103,7 @@ export function createExecutableAction(
 const format =
     "'<request> => translator.action(<parameters>)' or '<request> => [ translator.action1(<parameters1>), translator.action2(<parameters2>), ... ]'";
 
-function parseFullActionNameParts(fullActionName: string) {
+export function splitFullActionName(fullActionName: string) {
     const parts = fullActionName.split(".");
     const schemaName = parts.slice(0, -1).join(".");
     const actionName = parts.at(-1)!;
@@ -118,7 +118,7 @@ function parseAction(action: string, index: number = -1) {
         );
     }
     const functionName = action.substring(0, leftParan);
-    const { schemaName, actionName } = parseFullActionNameParts(functionName);
+    const { schemaName, actionName } = splitFullActionName(functionName);
     if (!actionName) {
         throw new Error(
             `${index !== -1 ? `Action ${index}: ` : ""}Unable to parse action name from '${functionName}'. Input must be in the form of ${format}`,
@@ -196,7 +196,7 @@ function executableActionsToString(actions: ExecutableAction[]): string {
 function fromJsonAction(actionJSON: JSONAction) {
     const { schemaName, actionName } =
         actionJSON.fullActionName !== undefined
-            ? parseFullActionNameParts(actionJSON.fullActionName)
+            ? splitFullActionName(actionJSON.fullActionName)
             : { schemaName: undefined as any, actionName: undefined as any };
 
     return createExecutableAction(

--- a/ts/packages/cache/src/index.ts
+++ b/ts/packages/cache/src/index.ts
@@ -43,6 +43,7 @@ export {
     toJsonActions,
     fromJsonActions,
     getFullActionName,
+    splitFullActionName,
     createExecutableAction,
     toExecutableActions,
     toFullActions,

--- a/ts/packages/cli/src/commands/replay.ts
+++ b/ts/packages/cli/src/commands/replay.ts
@@ -167,7 +167,7 @@ export default class ReplayCommand extends Command {
                     const result = await dispatcher.processCommand(entry.user);
                     steps.push({
                         request: entry.user,
-                        action: result?.actions,
+                        expected: result?.actions,
                         history: entry.assistant,
                     });
 

--- a/ts/packages/commonUtils/src/objectProperty.ts
+++ b/ts/packages/commonUtils/src/objectProperty.ts
@@ -10,7 +10,7 @@ export function getObjectPropertyNames(obj: object) {
                 names.push(`${key}.${child}`);
             }
         } else if (typeof value === "function") {
-            throw new Error("Function is a valid value");
+            throw new Error("Function is not a valid value");
         } else {
             names.push(key);
         }

--- a/ts/packages/defaultAgentProvider/src/mcpAgentProvider.ts
+++ b/ts/packages/defaultAgentProvider/src/mcpAgentProvider.ts
@@ -172,7 +172,6 @@ function createMcpAppAgentRecord(
                     `Invalid app agent config ${appAgentName}: No tools found`,
                 );
             }
-
             schemaFile.content = convertSchema(tools);
 
             agent = {

--- a/ts/packages/defaultAgentProvider/src/mcpDefaultAgentProvider.ts
+++ b/ts/packages/defaultAgentProvider/src/mcpDefaultAgentProvider.ts
@@ -7,26 +7,38 @@ import { InstanceConfigProvider, getProviderConfig } from "./utils/config.js";
 import { createMcpAppAgentProvider } from "./mcpAgentProvider.js";
 
 let mcpAppAgentProvider: AppAgentProvider | undefined;
+
+function initializeMcpAppAgentProvider(
+    instanceConfigs?: InstanceConfigProvider,
+) {
+    const servers = structuredClone(getProviderConfig().mcpServers);
+    if (servers === undefined) {
+        return undefined;
+    }
+
+    for (const entry of Object.values(servers)) {
+        if (entry.serverScript !== undefined) {
+            entry.serverScript = getPackageFilePath(entry.serverScript);
+        }
+    }
+    return createMcpAppAgentProvider(
+        "typeagent",
+        "0.0.1",
+        servers,
+        instanceConfigs,
+    );
+}
+
 export function getDefaultMcpAppAgentProvider(
     instanceConfigs?: InstanceConfigProvider,
 ): AppAgentProvider | undefined {
-    if (mcpAppAgentProvider === undefined) {
-        const servers = structuredClone(getProviderConfig().mcpServers);
-        if (servers === undefined) {
-            return undefined;
-        }
+    if (instanceConfigs !== undefined) {
+        return initializeMcpAppAgentProvider(instanceConfigs);
+    }
 
-        for (const entry of Object.values(servers)) {
-            if (entry.serverScript !== undefined) {
-                entry.serverScript = getPackageFilePath(entry.serverScript);
-            }
-        }
-        mcpAppAgentProvider = createMcpAppAgentProvider(
-            "typeagent",
-            "0.0.1",
-            servers,
-            instanceConfigs,
-        );
+    // Only reuse if there is no instanceConfigs provided
+    if (mcpAppAgentProvider === undefined) {
+        mcpAppAgentProvider = initializeMcpAppAgentProvider();
     }
     return mcpAppAgentProvider;
 }

--- a/ts/packages/defaultAgentProvider/test/constructionCacheTestCommon.ts
+++ b/ts/packages/defaultAgentProvider/test/constructionCacheTestCommon.ts
@@ -25,6 +25,7 @@ import {
     fromJsonActions,
     toJsonActions,
     ExecutableAction,
+    FullAction,
 } from "agent-cache";
 import { glob } from "glob";
 import { fileURLToPath } from "node:url";
@@ -149,7 +150,7 @@ function normalizeParams(obj: any) {
     }
 }
 
-function normalizeAction(action: JSONAction) {
+export function normalizeAction(action: JSONAction | FullAction) {
     if (action.parameters !== undefined) {
         normalizeParams(action.parameters);
     }

--- a/ts/packages/defaultAgentProvider/test/data/translate-browser-e2e.json
+++ b/ts/packages/defaultAgentProvider/test/data/translate-browser-e2e.json
@@ -1,13 +1,22 @@
 [
-    {
-        "request": "Open the portugal consulate website",
-        "action": {
+  {
+    "request": "Open the portugal consulate website",
+    "expected": {
+      "anyof": [
+        {
+          "action": {
             "schemaName": "browser",
             "actionName": "openWebPage",
             "parameters": {
-                "site": "portugal consulate",
-                "tab": "current"
+              "site": "portugal consulate",
+              "tab": "current"
             }
+          },
+          "alternates": {
+            "site": "portugal consulate website"
+          }
         }
+      ]
     }
+  }
 ]

--- a/ts/packages/defaultAgentProvider/test/data/translate-e2e.json
+++ b/ts/packages/defaultAgentProvider/test/data/translate-e2e.json
@@ -1,14 +1,14 @@
 [
   {
     "request": "why do birds suddenly appear every time you are near",
-    "action": "chat.generateResponse"
+    "expected": "chat.generateResponse"
   },
-  { "request": "add play to the To do list", "action": "list.addItems" },
-  { "request": "add homework to To do list", "action": "list.addItems" },
-  { "request": "add plan holiday to To do list.", "action": "list.addItems" },
+  { "request": "add play to the To do list", "expected": "list.addItems" },
+  { "request": "add homework to To do list", "expected": "list.addItems" },
+  { "request": "add plan holiday to To do list.", "expected": "list.addItems" },
   {
     "request": "play some EDM please",
-    "action": {
+    "expected": {
       "schemaName": "player",
       "actionName": "playGenre",
       "parameters": {
@@ -18,7 +18,7 @@
   },
   {
     "request": "play some Symphony by Beethoven please",
-    "action": {
+    "expected": {
       "schemaName": "player",
       "actionName": "playTrack",
       "parameters": {
@@ -29,7 +29,7 @@
   },
   {
     "request": "play Hello by Adele",
-    "action": {
+    "expected": {
       "schemaName": "player",
       "actionName": "playTrack",
       "parameters": {
@@ -40,7 +40,7 @@
   },
   {
     "request": "get my top 50 favorite songs, filter the current list to Bach pieces, and create a playlist call test",
-    "action": [
+    "expected": [
       "player.getFavorites",
       "player.filterTracks",
       "player.createPlaylist"
@@ -48,14 +48,14 @@
   },
   {
     "request": "look up information about Oregon and write a poem using what you found",
-    "action": [
+    "expected": [
       "browser.lookupAndAnswer.lookupAndAnswerInternet",
       "dispatcher.pendingRequestAction"
     ]
   },
   {
     "request": "look up the recipe for tarte a l'oignan and add the ingredients to my grocery list",
-    "action": [
+    "expected": [
       "browser.lookupAndAnswer.lookupAndAnswerInternet",
       "dispatcher.pendingRequestAction"
     ]
@@ -63,7 +63,7 @@
   [
     {
       "request": "add ham to the list",
-      "action": "dispatcher.clarify.clarifyMissingParameter",
+      "expected": "dispatcher.clarify.clarifyMissingParameter",
       "history": {
         "text": "Which list would you like to add ham to?",
         "source": "list",
@@ -74,7 +74,7 @@
     },
     {
       "request": "grocery",
-      "action": {
+      "expected": {
         "schemaName": "list",
         "actionName": "addItems",
         "parameters": {

--- a/ts/packages/defaultAgentProvider/test/data/translate-gate-e2e.json
+++ b/ts/packages/defaultAgentProvider/test/data/translate-gate-e2e.json
@@ -41,15 +41,22 @@
     },
     {
       "request": "follow link speaker johnson",
-      "action": [
-        {
-          "schemaName": "browser",
-          "actionName": "followLinkByText",
-          "parameters": {
-            "keywords": "speaker johnson"
+      "expected": {
+        "anyof": [
+          {
+            "action": {
+              "schemaName": "browser",
+              "actionName": "followLinkByText",
+              "parameters": {
+                "keywords": "speaker johnson"
+              }
+            },
+            "alternates": {
+              "openInNewTab": false
+            }
           }
-        }
-      ],
+        ]
+      },
       "history": [
         {
           "text": "Navigated to link for 'speaker johnson'",
@@ -60,7 +67,7 @@
     },
     {
       "request": "back",
-      "action": [
+      "expected": [
         {
           "schemaName": "browser",
           "actionName": "goBack"
@@ -76,7 +83,7 @@
     },
     {
       "request": "play Cruel Summer by Taylor Swift",
-      "action": [
+      "expected": [
         {
           "schemaName": "player",
           "actionName": "playTrack",
@@ -121,7 +128,7 @@
     },
     {
       "request": "add ham to my grocery list",
-      "action": [
+      "expected": [
         {
           "schemaName": "list",
           "actionName": "addItems",
@@ -156,18 +163,22 @@
     },
     {
       "request": "schedule lunch at 12:00 tomorrow",
-      "action": [
-        {
-          "schemaName": "calendar",
-          "actionName": "addEvent",
-          "parameters": {
-            "event": {
-              "description": "lunch"
-            }
+      "expected": { 
+        "anyof": [
+          {
+            "action": {
+              "schemaName": "calendar",
+              "actionName": "addEvent",
+              "parameters": {
+                "event": {
+                  "description": "lunch"
+                }
+              }
+            },
+            "partial": true
           }
-        }
-      ],
-      "match": "partial", 
+        ]
+      },      
       "comment": "Datetime translation not stable",
       "history": [
         {
@@ -178,7 +189,7 @@
     },
     {
       "request": "play Symphony No 5 by Beethoven",
-      "action": [
+      "expected": [
         {
           "schemaName": "player",
           "actionName": "playTrack",
@@ -237,18 +248,23 @@
     },
     {
       "request": "how much wood can a woodchuck chuck",
-      "action": [
-        {
-          "schemaName": "browser.lookupAndAnswer",
-          "actionName": "lookupAndAnswerInternet",
-          "parameters": {
-            "originalRequest": "how much wood can a woodchuck chuck",
-            "internetLookups": [
-              "how much wood can a woodchuck chuck"
-            ]
-          }
-        }
-      ],
+      "expected": {
+        "anyof": [
+          "chat.generateResponse",
+          {
+            "action": {
+              "schemaName": "browser.lookupAndAnswer",
+              "actionName": "lookupAndAnswerInternet",
+              "parameters": {
+                "originalRequest": "how much wood can a woodchuck chuck",
+                "internetLookups": [
+                  "how much wood can a woodchuck chuck"
+                ]
+              }
+            }
+          }                    
+        ]
+      },
       "history": [
         {
           "text": "A woodchuck can chuck approximately 700 pounds of wood per day, according to various humorous interpretations of the phrase. While woodchucks don't actually chuck wood, they can move around 35 cubic feet of dirt when digging out a burrow, which is roughly equivalent to the same weight.",
@@ -267,7 +283,7 @@
     },
     {
       "request": "add eggs to my grocery list",
-      "action": [
+      "expected": [
         {
           "schemaName": "list",
           "actionName": "addItems",
@@ -318,28 +334,25 @@
     },
     {
       "request": "who was president in 1837",
-      "action": { "anyof" :[
-        {
-          "schemaName": "browser.lookupAndAnswer",
-          "actionName": "lookupAndAnswerInternet",
-          "parameters": {
-            "originalRequest": "who was president in 1837",
-            "internetLookups": [
-              "president of the United States in 1837"
-            ]
+      "expected": {
+        "anyof": [
+          {
+            "action": {
+              "schemaName": "browser.lookupAndAnswer",
+              "actionName": "lookupAndAnswerInternet",
+              "parameters": {
+                "originalRequest": "who was president in 1837",
+                "internetLookups": [
+                  "president in 1837"
+                ]
+              }
+            },
+            "alternates": {
+              "internetLookups.0": "president of the United States in 1837"
+            }            
           }
-        },
-        {
-          "schemaName": "browser.lookupAndAnswer",
-          "actionName": "lookupAndAnswerInternet",
-          "parameters": {
-            "originalRequest": "who was president in 1837",
-            "internetLookups": [
-              "President of the United States in 1837"
-            ]
-          }
-        }
-      ]},
+        ]
+      },
       "history": [
         {
           "text": "Martin Van Buren was the eighth president of the United States, serving from 1837 to 1841.",
@@ -358,7 +371,7 @@
     },
     {
       "request": "play Toccata and Fugue by Bach",
-      "action": [
+      "expected": [
         {
           "schemaName": "player",
           "actionName": "playTrack",
@@ -410,7 +423,7 @@
     },
     {
       "request": "pause the music",
-      "action": [
+      "expected": [
         {
           "schemaName": "player",
           "actionName": "pause"

--- a/ts/packages/defaultAgentProvider/test/data/translate-history-e2e.json
+++ b/ts/packages/defaultAgentProvider/test/data/translate-history-e2e.json
@@ -2,7 +2,7 @@
   [
     {
       "request": "play Soruwienf from album Wxifiel by artist Bnefisoe",
-      "action": {
+      "expected": {
         "schemaName": "player",
         "actionName": "playTrack",
         "parameters": {
@@ -35,7 +35,7 @@
     },
     {
       "request": "play that song again",
-      "action": {
+      "expected": {
         "schemaName": "player",
         "actionName": "playTrack",
         "parameters": {
@@ -71,17 +71,22 @@
   [
     {
       "request": "look up the ingredient for shepherd's pie for me please",
-      "action": {
-        "schemaName": "browser.lookupAndAnswer",
-        "actionName": "lookupAndAnswerInternet",
-        "parameters": {
-          "originalRequest": "look up the ingredient for shepherd's pie for me please",
-          "question": "What are the ingredients for shepherd's pie?",
-          "lookup": {
-            "source": "internet",
-            "internetLookups": ["ingredient for shepherd's pie"]
+      "expected": {
+        "anyof": [
+          {
+            "action": {          
+              "schemaName": "browser.lookupAndAnswer",
+              "actionName": "lookupAndAnswerInternet",
+              "parameters": {
+                "originalRequest": "look up the ingredient for shepherd's pie for me please",          
+                "internetLookups": ["ingredient for shepherd's pie"]          
+              }
+            },
+            "alternates": {
+              "internetLookups.0": "shepherd's pie ingredients"
+            }
           }
-        }
+        ]
       },
       "history": {
         "text": "- Ground beef or lamb\n- Onions\n- Carrots\n- Peas\n- Worcestershire sauce\n- Beef broth\n- Mashed potatoes\n- Butter\n",
@@ -132,7 +137,7 @@
     },
     {
       "request": "add them to the grocery list",
-      "action": {
+      "expected": {
         "schemaName": "list",
         "actionName": "addItems",
         "parameters": {
@@ -195,7 +200,7 @@
     },
     {
       "request": "don't need the potatoes",
-      "action": {
+      "expected": {
         "schemaName": "list",
         "actionName": "removeItems",
         "parameters": {
@@ -222,7 +227,7 @@
   [
     {
       "request": "add eggs to the grocery list",
-      "action": {
+      "expected": {
         "schemaName": "list",
         "actionName": "addItems",
         "parameters": {
@@ -247,7 +252,7 @@
     },
     {
       "request": "add cheese",
-      "action": {
+      "expected": {
         "schemaName": "list",
         "actionName": "addItems",
         "parameters": {

--- a/ts/packages/defaultAgentProvider/test/data/translate-image-history-e2e.json
+++ b/ts/packages/defaultAgentProvider/test/data/translate-image-history-e2e.json
@@ -2,17 +2,23 @@
   [
     {
       "request": "Tell me what images are in our chat history.",
-      "match": "partial",
-      "action": {
-        "schemaName": "dispatcher.lookup",
-        "actionName": "lookupAndAnswer",
-        "parameters": {
-          "originalRequest": "Tell me what images are in our chat history.",
-          "question": "What images are in our chat history?",
-          "lookup": {
-            "source": "conversation"
+      "expected": {
+        "anyof": [
+          {
+            "action": {
+              "schemaName": "dispatcher.lookup",
+              "actionName": "lookupAndAnswer",
+              "parameters": {
+                "originalRequest": "Tell me what images are in our chat history.",
+                "question": "What images are in our chat history?",
+                "lookup": {
+                  "source": "conversation"
+                }
+              }
+            },
+            "partial": true
           }
-        }
+        ]      
       },
       "history": {
         "text": "There is a list of images in the chat history:\n - image\n - non-existent image\n - attachment__0.png",
@@ -36,7 +42,7 @@
     {
       "request": "show me attachment__0.png",
       "question": "show me attachment__0.png",
-      "action": {
+      "expected": {
         "schemaName": "chat",
         "actionName": "showImageFile",
         "parameters": {

--- a/ts/packages/defaultAgentProvider/test/data/translate-lookup-e2e.json
+++ b/ts/packages/defaultAgentProvider/test/data/translate-lookup-e2e.json
@@ -1,31 +1,31 @@
 [
   {
     "request": "I am planning a trip to Spain. can you look up some of the cities I should visit.",
-    "action": "browser.lookupAndAnswer.lookupAndAnswerInternet"
+    "expected": "browser.lookupAndAnswer.lookupAndAnswerInternet"
   },
   {
     "request": "Look up the ingredients for lemon meringue pie",
-    "action": "browser.lookupAndAnswer.lookupAndAnswerInternet"
+    "expected": "browser.lookupAndAnswer.lookupAndAnswerInternet"
   },
   {
     "request": "Did duke win its bball game",
-    "action": "browser.lookupAndAnswer.lookupAndAnswerInternet"
+    "expected": "browser.lookupAndAnswer.lookupAndAnswerInternet"
   },
   {
     "request": "Lookup duke result on the web",
-    "action": "browser.lookupAndAnswer.lookupAndAnswerInternet"
+    "expected": "browser.lookupAndAnswer.lookupAndAnswerInternet"
   },
   {
     "request": "lookup snowdrop flowers",
-    "action": "browser.lookupAndAnswer.lookupAndAnswerInternet"
+    "expected": "browser.lookupAndAnswer.lookupAndAnswerInternet"
   },
   {
     "request": "lookup snowdrops on the web",
-    "action": "browser.lookupAndAnswer.lookupAndAnswerInternet"
+    "expected": "browser.lookupAndAnswer.lookupAndAnswerInternet"
   },
   {
     "request": "I'd like to look up something on the web",
-    "action": {
+    "expected": {
       "schemaName": "dispatcher.lookup",
       "actionName": "startLookup",
       "parameters": {
@@ -37,7 +37,7 @@
   },
   {
     "request": "I'd like to look up something on https://wikipedia.com",
-    "action": {
+    "expected": {
       "schemaName": "dispatcher.lookup",
       "actionName": "startLookup",
       "parameters": {
@@ -50,10 +50,10 @@
   },
   {
     "request": "play the song by Bach we talked about yesterday",
-    "action": "dispatcher.clarify.clarifyUnresolvedReference"
+    "expected": "dispatcher.clarify.clarifyUnresolvedReference"
   },
   {
     "request": "play song from the artist that we talked about when we were discussing flower",
-    "action": "dispatcher.clarify.clarifyUnresolvedReference"
+    "expected": "dispatcher.clarify.clarifyUnresolvedReference"
   }
 ]

--- a/ts/packages/defaultAgentProvider/test/data/translate-mcpfs-e2e.json
+++ b/ts/packages/defaultAgentProvider/test/data/translate-mcpfs-e2e.json
@@ -3,7 +3,7 @@
     { "request": "@config schema mcpfilesystem" },
     {
       "request": "can you list all allowed directories",
-      "action": {
+      "expected": {
         "schemaName": "mcpfilesystem",
         "actionName": "list_allowed_directories",
         "parameters": {}
@@ -15,7 +15,7 @@
     },
     {
       "request": "show me the files in that directory",
-      "action": {
+      "expected": {
         "schemaName": "mcpfilesystem",
         "actionName": "list_directory",
         "parameters": { "path": "/data" }
@@ -27,7 +27,7 @@
     },
     {
       "request": "read that file",
-      "action": {
+      "expected": {
         "schemaName": "mcpfilesystem",
         "actionName": "read_file",
         "parameters": { "path": "/data/hello.txt" }
@@ -39,7 +39,7 @@
     },
     {
       "request": "can you rename that file to /data/world.txt.",
-      "action": {
+      "expected": {
         "schemaName": "mcpfilesystem",
         "actionName": "move_file",
         "parameters": {
@@ -54,7 +54,7 @@
     },
     {
       "request": "list the files in that directory",
-      "action": {
+      "expected": {
         "schemaName": "mcpfilesystem",
         "actionName": "list_directory",
         "parameters": { "path": "/data" }

--- a/ts/packages/defaultAgentProvider/test/data/translate-player-e2e.json
+++ b/ts/packages/defaultAgentProvider/test/data/translate-player-e2e.json
@@ -1,7 +1,7 @@
 [  
   {  
     "request": "Could you please play Blinding Lights by The Weeknd?",  
-    "action": {  
+    "expected": {  
       "schemaName": "player",  
       "actionName": "playTrack",  
       "parameters": {  
@@ -12,7 +12,7 @@
   },  
   {  
     "request": "Hey, would you mind putting on Rolling in the Deep by Adele?",  
-    "action": {  
+    "expected": {  
       "schemaName": "player",  
       "actionName": "playTrack",  
       "parameters": {  
@@ -23,7 +23,7 @@
   },  
   {  
     "request": "If it's not too much trouble, play Uptown Funk by Mark Ronson featuring Bruno Mars.",  
-    "action": {  
+    "expected": {  
       "schemaName": "player",  
       "actionName": "playTrack",  
       "parameters": {  
@@ -34,7 +34,7 @@
   },  
   {  
     "request": "Please could you play Bad Guy by Billie Eilish?",  
-    "action": {  
+    "expected": {  
       "schemaName": "player",  
       "actionName": "playTrack",  
       "parameters": {  
@@ -45,7 +45,7 @@
   },  
   {  
     "request": "Whenever you get a chance, play Shape of You by Ed Sheeran.",  
-    "action": {  
+    "expected": {  
       "schemaName": "player",  
       "actionName": "playTrack",  
       "parameters": {  
@@ -56,7 +56,7 @@
   },  
   {  
     "request": "Could I trouble you to start playing Royals by Lorde?",  
-    "action": {  
+    "expected": {  
       "schemaName": "player",  
       "actionName": "playTrack",  
       "parameters": {  
@@ -67,7 +67,7 @@
   },  
   {  
     "request": "Please, play Seven Nation Army by The White Stripes for me.",  
-    "action": {  
+    "expected": {  
       "schemaName": "player",  
       "actionName": "playTrack",  
       "parameters": {  
@@ -78,7 +78,7 @@
   },  
   {  
     "request": "Mind putting on Happy by Pharrell Williams?",  
-    "action": {  
+    "expected": {  
       "schemaName": "player",  
       "actionName": "playTrack",  
       "parameters": {  
@@ -89,7 +89,7 @@
   },  
   {  
     "request": "Could you kindly play Someone Like You by Adele?",  
-    "action": {  
+    "expected": {  
       "schemaName": "player",  
       "actionName": "playTrack",  
       "parameters": {  
@@ -100,7 +100,7 @@
   },  
   {  
     "request": "Would you be so kind as to put on Viva La Vida by Coldplay?",  
-    "action": {  
+    "expected": {  
       "schemaName": "player",  
       "actionName": "playTrack",  
       "parameters": {  
@@ -111,7 +111,7 @@
   },  
   {  
     "request": "If you don't mind, play Can't Stop the Feeling! by Justin Timberlake.",  
-    "action": {  
+    "expected": {  
       "schemaName": "player",  
       "actionName": "playTrack",  
       "parameters": {  
@@ -122,7 +122,7 @@
   },  
   {  
     "request": "Whenever possible, please play Poker Face by Lady Gaga.",  
-    "action": {  
+    "expected": {  
       "schemaName": "player",  
       "actionName": "playTrack",  
       "parameters": {  
@@ -133,7 +133,7 @@
   },  
   {  
     "request": "Start Mr. Brightside by The Killers, please?",  
-    "action": {  
+    "expected": {  
       "schemaName": "player",  
       "actionName": "playTrack",  
       "parameters": {  
@@ -144,7 +144,7 @@
   },  
   {  
     "request": "Do you mind playing Chandelier by Sia for me?",  
-    "action": {  
+    "expected": {  
       "schemaName": "player",  
       "actionName": "playTrack",  
       "parameters": {  
@@ -155,7 +155,7 @@
   },  
   {  
     "request": "I’d really appreciate it if you could play Radioactive by Imagine Dragons.",  
-    "action": {  
+    "expected": {  
       "schemaName": "player",  
       "actionName": "playTrack",  
       "parameters": {  
@@ -166,7 +166,7 @@
   },  
   {  
     "request": "Would you please play Take Me to Church by Hozier?",  
-    "action": {  
+    "expected": {  
       "schemaName": "player",  
       "actionName": "playTrack",  
       "parameters": {  
@@ -177,7 +177,7 @@
   },  
   {  
     "request": "Could you be so kind as to start playing Levitating by Dua Lipa?",  
-    "action": {  
+    "expected": {  
       "schemaName": "player",  
       "actionName": "playTrack",  
       "parameters": {  
@@ -188,7 +188,7 @@
   },  
   {  
     "request": "If it's okay, play Somebody That I Used to Know by Gotye featuring Kimbra.",  
-    "action": {  
+    "expected": {  
       "schemaName": "player",  
       "actionName": "playTrack",  
       "parameters": {  
@@ -199,7 +199,7 @@
   },  
   {  
     "request": "Would you mind playing Hey Ya! by OutKast, please?",  
-    "action": {  
+    "expected": {  
       "schemaName": "player",  
       "actionName": "playTrack",  
       "parameters": {  
@@ -210,7 +210,7 @@
   },  
   {  
     "request": "Please could you put on Fireflies by Owl City?",  
-    "action": {  
+    "expected": {  
       "schemaName": "player",  
       "actionName": "playTrack",  
       "parameters": {  

--- a/ts/packages/defaultAgentProvider/test/translateTestCommon.ts
+++ b/ts/packages/defaultAgentProvider/test/translateTestCommon.ts
@@ -84,7 +84,7 @@ export type TranslateTestStep = {
 export type TranslateTestEntry = TranslateTestStep | TranslateTestStep[];
 export type TranslateTestFile = TranslateTestEntry[];
 
-const repeat = 1;
+const repeat = 5;
 const concurrency = 5;
 const embeddingCacheDir = path.join(os.tmpdir(), ".typeagent", "cache");
 export async function defineTranslateTest(

--- a/ts/packages/defaultAgentProvider/test/translateTestCommon.ts
+++ b/ts/packages/defaultAgentProvider/test/translateTestCommon.ts
@@ -8,13 +8,65 @@ import { getPackageFilePath } from "../src/utils/getPackageFilePath.js";
 import { getDefaultAppAgentProviders } from "../src/defaultAgentProviders.js";
 import { CommandResult, createDispatcher, Dispatcher } from "agent-dispatcher";
 import { ChatHistoryInputAssistant } from "agent-dispatcher/internal";
-import { FullAction } from "agent-cache";
+import {
+    FullAction,
+    normalizeParamValue,
+    ParamValueType,
+    splitFullActionName,
+} from "agent-cache";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { InstanceConfigProvider } from "../src/utils/config.js";
+import { setObjectProperty } from "common-utils";
+import chalk from "chalk";
+import { normalizeAction } from "./constructionCacheTestCommon.js";
 
-type ActionMatch = string | string[] | FullAction | FullAction[];
+type SimpleActionMatch = string | FullAction;
+
+type ActionMatchWithAlternates = {
+    action: FullAction;
+    partial?: boolean;
+    alternates?: Record<string, ParamValueType | ParamValueType[]>;
+};
+
+type OneActionMatch = SimpleActionMatch | ActionMatchWithAlternates;
+type AnyOfActionMatch = {
+    anyof: OneActionMatch[];
+};
+
+type ActionMatch = SimpleActionMatch | AnyOfActionMatch;
+
+function isActionMatchWithAlternates(
+    a: OneActionMatch,
+): a is ActionMatchWithAlternates {
+    return typeof a === "object" && "action" in a;
+}
+
+function isAnyOfActionMatch(a: ActionMatch): a is AnyOfActionMatch {
+    return typeof a === "object" && "anyof" in a;
+}
+
+function toActionMatchWithAlternates(
+    match: OneActionMatch,
+): ActionMatchWithAlternates {
+    return isActionMatchWithAlternates(match)
+        ? match
+        : typeof match === "string"
+          ? { action: splitFullActionName(match), partial: true }
+          : { action: match };
+}
+function normalizeActionMatches(
+    match: ActionMatch | ActionMatch[],
+): ActionMatchWithAlternates[][] {
+    const actionMatches = Array.isArray(match) ? match : [match];
+    return actionMatches.map((m) =>
+        isAnyOfActionMatch(m)
+            ? m.anyof.map(toActionMatchWithAlternates)
+            : [toActionMatchWithAlternates(m)],
+    );
+}
+
 export type TranslateTestStep = {
     // Input
     request: string;
@@ -22,13 +74,7 @@ export type TranslateTestStep = {
 
     // Output
     // If not specified, translation is not checked, only whether validate whether it can be translated.
-    action?:
-        | ActionMatch
-        | {
-              anyof: ActionMatch[];
-          }
-        | undefined;
-    match?: "exact" | "partial"; // default to "exact"
+    expected?: ActionMatch | ActionMatch[] | undefined;
 
     // Execution result:
     // History insertion after translation (if any)
@@ -38,7 +84,7 @@ export type TranslateTestStep = {
 export type TranslateTestEntry = TranslateTestStep | TranslateTestStep[];
 export type TranslateTestFile = TranslateTestEntry[];
 
-const repeat = 5;
+const repeat = 1;
 const concurrency = 5;
 const embeddingCacheDir = path.join(os.tmpdir(), ".typeagent", "cache");
 export async function defineTranslateTest(
@@ -186,7 +232,6 @@ async function setupOneStep(
 
 async function runOneStep(step: TranslateTestStep, dispatcher: Dispatcher) {
     const { request, attachments } = step;
-
     return await dispatcher.processCommand(request, undefined, attachments);
 }
 
@@ -194,61 +239,129 @@ function validateCommandResult(
     step: TranslateTestStep,
     result?: CommandResult,
 ) {
-    const { request, action, match } = step;
+    const { request, expected } = step;
     if (result?.hasError) {
         throw new Error(`Request '${request}' failed: ${result.exception}`);
     }
 
-    if (action !== undefined) {
-        const actions = result?.actions;
-        expect(actions).toBeDefined();
-
-        if (
-            !Array.isArray(action) &&
-            typeof action === "object" &&
-            "anyof" in action
-        ) {
-            for (const expected of action.anyof) {
-                try {
-                    validateExpectedActions(expected, actions!, match);
-                    return;
-                } catch {}
-            }
+    if (expected !== undefined) {
+        const actionMatches = normalizeActionMatches(expected);
+        const actions = result?.actions!;
+        if (actions === undefined) {
             throw new Error(
-                `None of the expected actions matched:\n  received:${JSON.stringify(actions!)}\n. expected:${JSON.stringify(
-                    action.anyof,
-                )}`,
+                `Request '${request}' did not return any actions, expected ${JSON.stringify(expected)}`,
             );
-        } else {
-            validateExpectedActions(action, actions!, match);
+        }
+        expect(actions).toHaveLength(actionMatches.length);
+
+        for (let i = 0; i < actionMatches.length; i++) {
+            const actionMatch = actionMatches[i];
+            const action = actions[i];
+            validateExpectedAction(actionMatch, action);
         }
     }
 }
 
-function validateExpectedActions(
-    expected: ActionMatch,
-    actions: FullAction[],
-    match?: "exact" | "partial",
-) {
-    const expectedValues = Array.isArray(expected) ? expected : [expected];
-    expect(actions).toHaveLength(expectedValues.length);
+type PossibleMatch = {
+    action: FullAction;
+    partial: boolean;
+};
 
-    for (let i = 0; i < expectedValues.length; i++) {
-        const action = actions![i];
-        const expected = expectedValues[i];
-        if (typeof expected === "string") {
-            const actualFullActionName = `${action.schemaName}.${action.actionName}`;
-            if (match === "partial") {
-                expect(actualFullActionName).toContain(expected);
-            } else {
-                expect(actualFullActionName).toBe(expected);
-            }
-        } else {
-            if (match === "partial") {
-                expect(action).toMatchObject(expected);
-            } else {
-                expect(action).toEqual(expected);
-            }
+function expandAlternates(
+    expectedMatch: ActionMatchWithAlternates,
+): { action: FullAction; partial: boolean }[] {
+    const expandedActions = [
+        {
+            action: structuredClone(expectedMatch.action),
+            partial: expectedMatch.partial === true,
+        },
+    ];
+    normalizeAction(expandedActions[0].action);
+    if (expectedMatch.alternates !== undefined) {
+        for (const [name, v] of Object.entries(expectedMatch.alternates)) {
+            const values = Array.isArray(v) ? v : [v];
+            expandedActions.push(
+                ...values.flatMap((v) =>
+                    expandedActions.map((a) => {
+                        const n = structuredClone(a);
+                        setObjectProperty(
+                            n.action,
+                            "parameters",
+                            name,
+                            normalizeParamValue(v),
+                        );
+                        return n;
+                    }),
+                ),
+            );
         }
     }
+    return expandedActions;
+}
+
+function checkPossibleMatch(action: FullAction, possibleMatch: PossibleMatch) {
+    if (possibleMatch.partial) {
+        expect(action).toMatchObject(possibleMatch.action);
+    } else {
+        expect(action).toEqual(possibleMatch.action);
+    }
+}
+
+function validateExpectedAction(
+    match: ActionMatchWithAlternates[],
+    action: FullAction,
+) {
+    const filtered = match.filter(
+        (em) =>
+            em.action.schemaName === action.schemaName &&
+            em.action.actionName === action.actionName,
+    );
+    if (filtered.length === 0) {
+        throw new Error(
+            [
+                "Action does not match any of the expected actions",
+                ,
+                chalk.red(
+                    `Received: ${action.schemaName}.${action.actionName}`,
+                ),
+                chalk.green(
+                    `Expected: ${JSON.stringify(
+                        match.map(
+                            (e) =>
+                                `${e.action.schemaName}.${e.action.actionName}`,
+                        ),
+                        null,
+                        2,
+                    )}`,
+                ),
+            ].join("\n"),
+        );
+    }
+
+    const possibleMatches = filtered.flatMap(expandAlternates);
+    const normalizedAction = structuredClone(action);
+    normalizeAction(normalizedAction);
+    if (possibleMatches.length === 1) {
+        checkPossibleMatch(normalizedAction, possibleMatches[0]);
+        return;
+    }
+
+    const errors: string[] = [];
+    for (const possibleMatch of possibleMatches) {
+        try {
+            checkPossibleMatch(normalizedAction, possibleMatch);
+            return;
+        } catch (e: any) {
+            errors.push(e.message);
+        }
+    }
+
+    throw new Error(
+        [
+            "Error: No matches found",
+            ,
+            chalk.green(`Expected: ${JSON.stringify(possibleMatches)}`),
+            chalk.red(`Received: ${JSON.stringify(normalizedAction, null, 2)}`),
+        ].join("\n"),
+    );
 }

--- a/ts/packages/dispatcher/src/context/session.ts
+++ b/ts/packages/dispatcher/src/context/session.ts
@@ -215,7 +215,7 @@ const defaultSessionConfig: SessionConfig = {
     },
     execution: {
         history: true,
-        activity: true,
+        activity: true, // TODO: experimental.
         memory: {
             legacy: true, // use the new memory behavior
         },


### PR DESCRIPTION
- LLM may generate slight variation of the translate value.  Update the test step format to allow that to be specified.
- Fix the MCP provider to not use the cached instance if config is provided.