### PR TITLE
Fix: remove redundant knowledge extraction for web doc parts

### DIFF
--- a/ts/packages/memory/conversation/src/docMemory.ts
+++ b/ts/packages/memory/conversation/src/docMemory.ts
@@ -198,15 +198,17 @@ export class DocMemory
     public async addDocPartToIndex(
         docPart: DocPart,
         eventHandler?: kp.IndexingEventHandlers,
+        overrideSettings?: DocMemorySettings,
     ): Promise<kp.IndexingResults> {
         this.beginIndexing();
         try {
             this.messages.append(docPart);
             const messageOrdinal = this.messages.length - 1;
 
+            const settings = overrideSettings || this.settings;
             const result = await kp.addToConversationIndex(
                 this,
-                this.settings.conversationSettings,
+                settings.conversationSettings,
                 messageOrdinal,
                 this.semanticRefs.length,
                 eventHandler,

--- a/ts/packages/memory/website/src/websiteCollection.ts
+++ b/ts/packages/memory/website/src/websiteCollection.ts
@@ -505,11 +505,12 @@ export class WebsiteCollection
         eventHandler?: IndexingEventHandlers,
     ): Promise<IndexingResults> {
         const knowledge = website.getKnowledge();
-        const hasKnowledge = knowledge && 
-                           (knowledge.entities?.length > 0 ||
-                            knowledge.topics?.length > 0 ||
-                            knowledge.actions?.length > 0);
-        
+        const hasKnowledge =
+            knowledge &&
+            (knowledge.entities?.length > 0 ||
+                knowledge.topics?.length > 0 ||
+                knowledge.actions?.length > 0);
+
         let overrideSettings;
         if (hasKnowledge) {
             overrideSettings = {
@@ -517,14 +518,19 @@ export class WebsiteCollection
                 conversationSettings: {
                     ...this.settings.conversationSettings,
                     semanticRefIndexSettings: {
-                        ...this.settings.conversationSettings.semanticRefIndexSettings,
-                        autoExtractKnowledge: false
-                    }
-                }
+                        ...this.settings.conversationSettings
+                            .semanticRefIndexSettings,
+                        autoExtractKnowledge: false,
+                    },
+                },
             };
         }
-        
-        const result = await super.addDocPartToIndex(website, eventHandler, overrideSettings);
+
+        const result = await super.addDocPartToIndex(
+            website,
+            eventHandler,
+            overrideSettings,
+        );
 
         if (result && !this.hasErrors(result)) {
             const messageOrdinal = this.messages.length - 1;

--- a/ts/packages/memory/website/src/websiteCollection.ts
+++ b/ts/packages/memory/website/src/websiteCollection.ts
@@ -504,7 +504,27 @@ export class WebsiteCollection
         website: WebsiteDocPart,
         eventHandler?: IndexingEventHandlers,
     ): Promise<IndexingResults> {
-        const result = await super.addDocPartToIndex(website, eventHandler);
+        const knowledge = website.getKnowledge();
+        const hasKnowledge = knowledge && 
+                           (knowledge.entities?.length > 0 ||
+                            knowledge.topics?.length > 0 ||
+                            knowledge.actions?.length > 0);
+        
+        let overrideSettings;
+        if (hasKnowledge) {
+            overrideSettings = {
+                ...this.settings,
+                conversationSettings: {
+                    ...this.settings.conversationSettings,
+                    semanticRefIndexSettings: {
+                        ...this.settings.conversationSettings.semanticRefIndexSettings,
+                        autoExtractKnowledge: false
+                    }
+                }
+            };
+        }
+        
+        const result = await super.addDocPartToIndex(website, eventHandler, overrideSettings);
 
         if (result && !this.hasErrors(result)) {
             const messageOrdinal = this.messages.length - 1;


### PR DESCRIPTION
When indexing web pages through the browser agent, knowledge extraction happens twice:

- First extraction: In indexWebPageContent(), the browser agent extracts knowledge using BrowserKnowledgeExtractor
- Second extraction: In addToConversationIndex(), the KnowPro library re-extracts knowledge if autoExtractKnowledge is true

The fix is to pass customized conversationSettings for the addToConversationIndex() call