### PR TITLE
Prevent tabs and navigation controls from zooming.

### DIFF
--- a/ts/packages/shell/src/main/shellWindow.ts
+++ b/ts/packages/shell/src/main/shellWindow.ts
@@ -121,7 +121,7 @@ export class ShellWindow {
         );
 
         setupDevicePermissions(mainWindow);
-        this.setupWebContents(mainWindow.webContents);
+        //this.setupWebContents(mainWindow.webContents);
 
         // Initialize browser view manager
         this.browserViewManager = new BrowserViewManager(mainWindow);


### PR DESCRIPTION
Previously tab and navigation controls would zoom when zooming page/chat view in/out.  