### PR TITLE
Enable progressive enhancement on the page knowledge sidepanel

### DIFF
--- a/ts/packages/agents/browser/src/agent/actionHandler.mts
+++ b/ts/packages/agents/browser/src/agent/actionHandler.mts
@@ -396,6 +396,7 @@ async function processBrowserAgentMessage(
         }
 
         case "extractKnowledgeFromPage":
+        case "extractKnowledgeFromPageStreaming":
         case "indexWebPageContent":
         case "checkPageIndexStatus":
         case "getPageIndexedKnowledge":

--- a/ts/packages/agents/browser/src/extension/interfaces/knowledgeExtraction.types.ts
+++ b/ts/packages/agents/browser/src/extension/interfaces/knowledgeExtraction.types.ts
@@ -1,0 +1,91 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// Progress tracking for knowledge extraction (based on ImportProgress pattern)
+export interface KnowledgeExtractionProgress {
+    extractionId: string;
+    phase:
+        | "content"
+        | "basic"
+        | "summary"
+        | "analyzing"
+        | "extracting"
+        | "complete"
+        | "error";
+    totalItems: number;
+    processedItems: number;
+    currentItem?: string;
+    estimatedTimeRemaining?: number;
+    errors: ExtractionError[];
+    incrementalData?: Partial<KnowledgeData>;
+}
+
+// Error tracking for extraction operations
+export interface ExtractionError {
+    message: string;
+    timestamp: number;
+    phase?: string;
+    recoverable?: boolean;
+}
+
+// Knowledge data structure for incremental updates
+export interface KnowledgeData {
+    entities: Entity[];
+    relationships: Relationship[];
+    keyTopics: string[];
+    summary: string;
+    contentActions?: Action[];
+    detectedActions?: DetectedAction[];
+    actionSummary?: ActionSummary;
+    contentMetrics?: {
+        readingTime: number;
+        wordCount: number;
+    };
+}
+
+// Supporting interfaces (referencing existing types)
+export interface Entity {
+    name: string;
+    type: string;
+    confidence?: number;
+    context?: string;
+}
+
+export interface Relationship {
+    from: string;
+    to: string;
+    relationship: string;
+    confidence?: number;
+}
+
+export interface Action {
+    name: string;
+    description: string;
+    parameters?: any;
+}
+
+export interface DetectedAction {
+    action: string;
+    confidence: number;
+    context: string;
+}
+
+export interface ActionSummary {
+    totalActions: number;
+    primaryActions: string[];
+    actionTypes: string[];
+}
+
+// Progress callback type for knowledge extraction
+export type KnowledgeProgressCallback = (
+    progress: KnowledgeExtractionProgress,
+) => void;
+
+// Extraction result interface
+export interface KnowledgeExtractionResult {
+    success: boolean;
+    extractionId: string;
+    duration: number;
+    errors: ExtractionError[];
+    finalData: KnowledgeData;
+}

--- a/ts/packages/agents/browser/src/extension/serviceWorker/websocket.ts
+++ b/ts/packages/agents/browser/src/extension/serviceWorker/websocket.ts
@@ -169,6 +169,27 @@ export async function ensureWebsocketConnected(): Promise<
                 return;
             }
 
+            if (data.method === "knowledgeExtractionProgress") {
+                // Handle knowledge extraction progress updates from the agent
+                if (data.source === "browserAgent" && data.params) {
+                    // Forward progress update directly to the registered callback
+                    try {
+                        const { handleKnowledgeExtractionProgress } =
+                            await import("./messageHandlers");
+                        handleKnowledgeExtractionProgress(
+                            data.params.extractionId,
+                            data.params.progress,
+                        );
+                    } catch (error) {
+                        console.error(
+                            "Failed to handle knowledge extraction progress:",
+                            error,
+                        );
+                    }
+                }
+                return;
+            }
+
             if (data.method && data.method.indexOf("/") > 0) {
                 const [schema, actionName] = data.method?.split("/");
 

--- a/ts/packages/agents/browser/src/extension/views/extensionServiceBase.ts
+++ b/ts/packages/agents/browser/src/extension/views/extensionServiceBase.ts
@@ -12,6 +12,11 @@ import type {
     ImportResult,
     ProgressCallback,
 } from "../interfaces/websiteImport.types";
+import type {
+    KnowledgeExtractionProgress,
+    KnowledgeProgressCallback,
+    KnowledgeExtractionResult,
+} from "../interfaces/knowledgeExtraction.types";
 
 // ===================================================================
 // INTERFACE DEFINITIONS
@@ -241,6 +246,38 @@ export abstract class ExtensionServiceBase {
         });
     }
 
+    async extractPageKnowledgeStreaming(
+        url: string,
+        mode: string,
+        extractionSettings: any,
+        streamingEnabled: boolean = true,
+        extractionId: string,
+    ): Promise<any> {
+        try {
+            const response = await this.sendMessage({
+                type: "extractPageKnowledgeStreaming",
+                url,
+                mode,
+                extractionSettings,
+                streamingEnabled,
+                extractionId,
+            });
+
+            // Make sure we return the extractionId even if response is partial
+            if (!response) {
+                return { extractionId, success: false };
+            }
+
+            return response;
+        } catch (error) {
+            return {
+                extractionId,
+                success: false,
+                error: (error as Error).message || String(error),
+            };
+        }
+    }
+
     async queryKnowledge(parameters: any): Promise<any> {
         return this.sendMessage({
             type: "queryKnowledge",
@@ -467,6 +504,13 @@ export abstract class ExtensionServiceBase {
         this.onImportProgressImpl(importId, callback);
     }
 
+    onExtractionProgress(
+        extractionId: string,
+        callback: KnowledgeProgressCallback,
+    ): void {
+        this.onExtractionProgressImpl(extractionId, callback);
+    }
+
     // Macro methods
     async getMacrosForUrl(
         url: string,
@@ -527,6 +571,15 @@ export abstract class ExtensionServiceBase {
     protected abstract onImportProgressImpl(
         importId: string,
         callback: ProgressCallback,
+    ): void;
+
+    /**
+     * Environment-specific knowledge extraction progress tracking
+     * Concrete classes must implement this method
+     */
+    protected abstract onExtractionProgressImpl(
+        extractionId: string,
+        callback: KnowledgeProgressCallback,
     ): void;
 
     // ===================================================================

--- a/ts/packages/agents/browser/src/extension/views/pageKnowledge.html
+++ b/ts/packages/agents/browser/src/extension/views/pageKnowledge.html
@@ -114,6 +114,31 @@
             </div>
           </div>
 
+          <!-- Progress Indicator (Hidden by default) -->
+          <div id="extractionProgress" class="mb-3 d-none">
+            <div class="d-flex align-items-center mb-2">
+              <div class="spinner-border spinner-border-sm me-2"></div>
+              <span id="knowledgeStatusMessage"
+                >Retrieving page content...</span
+              >
+            </div>
+            <div class="progress" style="height: 6px">
+              <div
+                id="knowledgeProgressBar"
+                class="progress-bar"
+                style="width: 0%"
+                role="progressbar"
+                aria-valuenow="0"
+                aria-valuemin="0"
+                aria-valuemax="100"
+              ></div>
+            </div>
+            <div class="d-flex justify-content-between small text-muted mt-1">
+              <span id="knowledgeProgressText">0 of 0 items processed</span>
+              <span id="timeElapsed">0s</span>
+            </div>
+          </div>
+
           <div id="currentPageInfo">
             <div class="text-center text-muted">
               <i class="bi bi-hourglass-split"></i>


### PR DESCRIPTION
- Add a new mode for page knowledge extraction that streams incremental knowledge (entities, topics, actions) to the UI as it is extracted. This goes through the various knowledge extraction modes from basic (no LLM involved) to the full LLM-enabled analysis if the user selects it.
- Added progress reporting callbacks to enable agent to send incremental progress info to the UI