### PR TITLE
Shell: Fix search menu zoom

### DIFF
--- a/ts/packages/shell/src/main/electronSearchMenuUI.ts
+++ b/ts/packages/shell/src/main/electronSearchMenuUI.ts
@@ -132,14 +132,6 @@ export function initializeSearchMenuUI(shellWindow: ShellWindow) {
         }
         const view = await searchMenuViewP;
         debug(`search-menu-size: ${id} ${JSON.stringify(size)}`);
-        const bounds = view.getBounds();
-        const zoomFactor = view.webContents.getZoomFactor();
-        const bottom = bounds.y + bounds.height;
-        view.setBounds({
-            x: bounds.x,
-            y: bottom - size.height * zoomFactor,
-            width: size.width * zoomFactor,
-            height: size.height * zoomFactor,
-        });
+        shellWindow.updateOverlayWebContentsView(view, size);
     });
 }

--- a/ts/packages/shell/src/renderer/assets/styles.less
+++ b/ts/packages/shell/src/renderer/assets/styles.less
@@ -11,6 +11,7 @@ body {
   height: 100%;
   font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
   font-size: 14px;
+  overflow: hidden;
 }
 
 .dark-mode {
@@ -22,7 +23,6 @@ body {
 
   .chat-container {
     background-color: #222;
-
     .scroll_enabled {
       background-color: #222;
     }
@@ -195,6 +195,8 @@ body {
   display: flex;
   flex-direction: column;
   height: 100%;
+  bottom: 0px;
+  position: absolute;
   background-color: @chat-bg;
 }
 

--- a/ts/packages/shell/src/renderer/src/chatView.ts
+++ b/ts/packages/shell/src/renderer/src/chatView.ts
@@ -147,12 +147,6 @@ export class ChatView {
         });
         this.inputContainer = this.chatInput.getInputContainer();
 
-        // Track zoom changes to adjust search menu position
-        const resizeObserver = new ResizeObserver(() => {
-            this.partialCompletion?.update(false);
-        });
-        resizeObserver.observe(this.inputContainer);
-
         this.topDiv.appendChild(this.messageDiv);
 
         // Add the input div at the bottom so it's always visible

--- a/ts/packages/shell/src/renderer/src/partial.ts
+++ b/ts/packages/shell/src/renderer/src/partial.ts
@@ -180,6 +180,9 @@ export class PartialCompletion {
 
         const position = this.getSearchMenuPosition(prefix);
         if (position !== undefined) {
+            debug(
+                `Partial completion update: '${prefix}' @ ${JSON.stringify(position)}`,
+            );
             this.searchMenu.updatePrefix(prefix, position);
         } else {
             this.searchMenu.hide();
@@ -312,7 +315,7 @@ export class PartialCompletion {
         }
 
         const { top } = this.container.getBoundingClientRect();
-        return { left: x, bottom: top };
+        return { left: x, bottom: window.innerHeight - top };
     }
 
     private cancelCompletionMenu() {

--- a/ts/packages/shell/src/renderer/src/searchMenuUI/localSearchMenuUI.ts
+++ b/ts/packages/shell/src/renderer/src/searchMenuUI/localSearchMenuUI.ts
@@ -88,9 +88,8 @@ export class LocalSearchMenuUI implements SearchMenuUI {
     }
 
     private setPosition(position: SearchMenuPosition) {
-        const height = document.documentElement.offsetHeight;
         this.searchContainer.style.left = `${position.left}px`;
-        this.searchContainer.style.bottom = `${height - position.bottom}px`;
+        this.searchContainer.style.bottom = `${position.bottom}px`;
     }
 
     public adjustSelection(deltaY: number) {

--- a/ts/packages/shell/src/renderer/src/searchMenuView.ts
+++ b/ts/packages/shell/src/renderer/src/searchMenuView.ts
@@ -22,7 +22,7 @@ ipcRenderer.on("search-menu-update", (_event, data) => {
     searchMenuUI.update(data);
 
     const elm = document.body.children[0] as HTMLElement;
-    // 2px border all around.
+    // 2px outline all around.
     ipcRenderer.send("search-menu-size", {
         width: elm.offsetWidth + 4,
         height: elm.offsetHeight + 4,
@@ -32,6 +32,7 @@ ipcRenderer.on("search-menu-update", (_event, data) => {
 ipcRenderer.on("search-menu-close", () => {
     debug("search-menu-close");
     searchMenuUI?.close();
+    searchMenuUI = undefined;
 });
 
 ipcRenderer.on("search-menu-adjust-selection", (_, deltaY) => {

--- a/ts/packages/shell/src/renderer/src/templateEditor.ts
+++ b/ts/packages/shell/src/renderer/src/templateEditor.ts
@@ -481,7 +481,7 @@ class FieldScalar extends FieldBase {
             return undefined;
         }
         const rect = this.editUI.div.getBoundingClientRect();
-        return { left: rect.left, bottom: rect.top };
+        return { left: rect.left, bottom: window.innerHeight - rect.top };
     }
 
     private createSearchMenu(


### PR DESCRIPTION
- Clamp zoom between 0.25 to 5, which is the limit for electron/chromium.
- Fix clipping of the search menu after zoom.
- Fix search menu position on changing divider position.
- Disable scrolling of the chat view (if divider becomes too small)