### PR TITLE
Fixes

### DIFF
--- a/ts/packages/agentSdk/src/command.ts
+++ b/ts/packages/agentSdk/src/command.ts
@@ -61,14 +61,15 @@ export interface AppAgentCommandInterface {
     // Get the command descriptors
     getCommands(context: SessionContext): Promise<CommandDescriptors>;
 
+    // Provide completion for a partial command
     getCommandCompletion?(
         commands: string[], // path to the command descriptors
         params: ParsedCommandParams<ParameterDefinitions> | undefined,
-        names: string[], // array of <argName> or --<flagName> or --<jsonFlagName>.
+        names: string[], // array of <argName> or --<flagName> or --<jsonFlagName> for completion
         context: SessionContext<unknown>,
     ): Promise<CompletionGroup[]>;
 
-    // Execute a resolved command
+    // Execute a resolved command.  Exception from the execution are treated as errors and displayed to the user.
     executeCommand(
         commands: string[], // path to the command descriptors
         params: ParsedCommandParams<ParameterDefinitions> | undefined,

--- a/ts/packages/dispatcher/src/command/command.ts
+++ b/ts/packages/dispatcher/src/command/command.ts
@@ -427,10 +427,10 @@ function getDispatcherStatusDetails(context: CommandHandlerContext) {
 export function getDispatcherStatus(
     context: CommandHandlerContext,
 ): DispatcherStatus {
-    const agentsWithActions = new Set<string>();
+    const names = new Set<string>();
     const agents = context.agents.getActionConfigs().map((config) => {
         const appAgentName = getAppAgentName(config.schemaName);
-        agentsWithActions.add(appAgentName);
+        names.add(config.schemaName);
         return {
             emoji: config.emojiChar,
             name: config.schemaName,
@@ -446,7 +446,7 @@ export function getDispatcherStatus(
 
     // Make sure we include app agents that do not have actions.
     for (const agentName of context.agents.getAppAgentNames()) {
-        if (!agentsWithActions.has(agentName)) {
+        if (!names.has(agentName)) {
             agents.push({
                 emoji: context.agents.getAppAgentEmoji(agentName),
                 name: agentName,

--- a/ts/packages/dispatcher/src/context/appAgentManager.ts
+++ b/ts/packages/dispatcher/src/context/appAgentManager.ts
@@ -94,7 +94,6 @@ export const alwaysEnabledAgents = {
 export class AppAgentManager implements ActionConfigProvider {
     private readonly agents = new Map<string, AppAgentRecord>();
     private readonly actionConfigs = new Map<string, ActionConfig>();
-    private readonly emojis: Record<string, string> = {};
     private readonly transientAgents: Record<string, boolean | undefined> = {};
     private readonly actionSemanticMap?: ActionSchemaSemanticMap;
     private readonly actionSchemaFileCache: ActionSchemaFileCache;
@@ -223,10 +222,6 @@ export class AppAgentManager implements ActionConfigProvider {
             : undefined;
     }
 
-    public getEmojis(): Readonly<Record<string, string>> {
-        return this.emojis;
-    }
-
     public async semanticSearchActionSchema(
         request: string,
         maxMatches: number = 1,
@@ -278,7 +273,6 @@ export class AppAgentManager implements ActionConfigProvider {
         for (const [schemaName, config] of entries) {
             debug(`Adding action config: ${schemaName}`);
             this.actionConfigs.set(schemaName, config);
-            this.emojis[schemaName] = config.emojiChar;
             if (config.transient) {
                 this.transientAgents[schemaName] = false;
             }
@@ -299,8 +293,6 @@ export class AppAgentManager implements ActionConfigProvider {
                 schemaErrors.set(schemaName, e);
             }
         }
-
-        this.emojis[appAgentName] = manifest.emojiChar;
 
         const port = manifest.localView
             ? this.portBase + this.nextPortIndex++
@@ -349,12 +341,10 @@ export class AppAgentManager implements ActionConfigProvider {
     }
 
     private cleanupAgent(appAgentName: string) {
-        delete this.emojis[appAgentName];
         for (const [schemaName, config] of this.actionConfigs) {
             if (getAppAgentName(schemaName) !== appAgentName) {
                 continue;
             }
-            delete this.emojis[schemaName];
             this.actionConfigs.delete(schemaName);
             this.actionSchemaFileCache.unloadActionSchemaFile(schemaName);
             this.actionSemanticMap?.removeActionSchemaFile(schemaName);

--- a/ts/packages/dispatcher/src/context/commandHandlerContext.ts
+++ b/ts/packages/dispatcher/src/context/commandHandlerContext.ts
@@ -22,7 +22,10 @@ import {
     setupBuiltInCache,
 } from "./session.js";
 import { IndexingServiceRegistry } from "./indexingServiceRegistry.js";
-import { TypeAgentTranslator } from "../translation/agentTranslators.js";
+import {
+    getAppAgentName,
+    TypeAgentTranslator,
+} from "../translation/agentTranslators.js";
 import { ActionConfigProvider } from "../translation/actionConfigProvider.js";
 import { getCacheFactory } from "../utils/cacheFactory.js";
 import { createServiceHost } from "./system/handlers/serviceHost/serviceHostCommandHandler.js";
@@ -564,7 +567,9 @@ function processSetAppAgentStateResult(
             hasFailed = true;
             const prefix =
                 stateName === "commands"
-                    ? systemContext.agents.getEmojis()[schemaName]
+                    ? systemContext.agents.getAppAgentEmoji(
+                          getAppAgentName(schemaName),
+                      )
                     : getSchemaNamePrefix(schemaName, systemContext);
             debugError(e);
             cbError(

--- a/ts/packages/dispatcher/src/context/system/handlers/configCommandHandlers.ts
+++ b/ts/packages/dispatcher/src/context/system/handlers/configCommandHandlers.ts
@@ -278,7 +278,7 @@ function showAgentStatus(
     for (const [name, { schemas, actions, commands }] of entries) {
         const isAppAgentName = getAppAgentName(name) === name;
         const displayName = isAppAgentName ? name : `  ${name}`;
-        const emoji = isAppAgentName ? agents.getEmojis()[name] : "";
+        const emoji = isAppAgentName ? agents.getAppAgentEmoji(name) : "";
         table.push(getRow(emoji, displayName, schemas, actions, commands));
     }
 
@@ -634,16 +634,15 @@ class ConfigPortsCommandHandler implements CommandHandler {
     public async run(context: ActionContext<CommandHandler>) {
         const ports: string[][] = [["", "Agent", "Port"]];
         const cmdContext = context.sessionContext.agentContext as any;
-        const emojis: Record<string, string> = cmdContext.agents.getEmojis();
 
         cmdContext.agents.getAppAgentNames().forEach((name: string) => {
             const port = cmdContext.agents.getLocalHostPort(name);
 
             if (port !== undefined) {
                 ports.push([
-                    emojis[name],
+                    cmdContext.agents.getAppAgentEmoji(name),
                     name,
-                    cmdContext.agents.getLocalHostPort(name)!.toString(),
+                    port.toString(),
                 ]);
             }
         });

--- a/ts/packages/dispatcher/src/dispatcher.ts
+++ b/ts/packages/dispatcher/src/dispatcher.ts
@@ -23,8 +23,13 @@ import { FullAction } from "agent-cache";
 import { openai as ai } from "aiclient";
 
 export type CommandResult = {
+    // true if there are any error message
     hasError?: boolean;
+    // Exceptions while processing the command.
+    // Does not capture exception from the execution of the commands as they are treated as errors.
     exception?: string;
+
+    // Actions that were executed as part of the command.
     actions?: FullAction[];
     metrics?: RequestMetrics;
     tokenUsage?: ai.CompletionUsageStats;

--- a/ts/packages/dispatcher/src/execute/actionHandlers.ts
+++ b/ts/packages/dispatcher/src/execute/actionHandlers.ts
@@ -542,12 +542,16 @@ export async function executeCommand(
             true,
         );
 
-        return await appAgent.executeCommand(
-            commands,
-            params,
-            actionContext,
-            attachments,
-        );
+        try {
+            return await appAgent.executeCommand(
+                commands,
+                params,
+                actionContext,
+                attachments,
+            );
+        } catch (e: any) {
+            displayError(e.message, actionContext);
+        }
     } finally {
         actionContext.profiler?.stop();
         actionContext.profiler = undefined;

--- a/ts/packages/shell/src/renderer/assets/styles.less
+++ b/ts/packages/shell/src/renderer/assets/styles.less
@@ -195,6 +195,7 @@ body {
   display: flex;
   flex-direction: column;
   height: 100%;
+  width: 100%;
   bottom: 0px;
   position: absolute;
   background-color: @chat-bg;

--- a/ts/packages/shell/src/renderer/src/chatView.ts
+++ b/ts/packages/shell/src/renderer/src/chatView.ts
@@ -46,7 +46,7 @@ export class ChatView {
     private isScrolling = false;
     constructor(
         private idGenerator: IdGenerator,
-        public agents: Map<string, string>,
+        private readonly agents: Map<string, string>,
         public tts?: TTS,
     ) {
         this.topDiv = document.createElement("div");


### PR DESCRIPTION
- Fixes the `systems` command emoji with base agent name doesn't have actions.
- Exceptions from executing commands should have the app agent as the source.
- Fix the chat view width to 100% to make sure it maintains its size even after `@clear`