### PR TITLE
Refactor shell init code and check IPC sender

### DIFF
--- a/ts/packages/shell/src/main/shellWindow.ts
+++ b/ts/packages/shell/src/main/shellWindow.ts
@@ -1241,3 +1241,12 @@ function setupDevicePermissions(mainWindow: BrowserWindow) {
         },
     );
 }
+
+export function getShellWindowForChatViewIpcEvent(
+    event: Electron.IpcMainEvent | Electron.IpcMainInvokeEvent,
+): ShellWindow | undefined {
+    const shellWindow = ShellWindow.getInstance();
+    return event.sender === shellWindow?.chatView.webContents
+        ? shellWindow
+        : undefined;
+}

--- a/ts/packages/shell/src/main/speech.ts
+++ b/ts/packages/shell/src/main/speech.ts
@@ -1,0 +1,110 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { dialog, globalShortcut, ipcMain } from "electron";
+import { AzureSpeech } from "./azureSpeech.js";
+import { isLocalWhisperEnabled } from "./localWhisperCommandHandler.js";
+
+import registerDebug from "debug";
+import {
+    getShellWindowForChatViewIpcEvent,
+    ShellWindow,
+} from "./shellWindow.js";
+const debugShell = registerDebug("typeagent:shell:speech");
+const debugShellError = registerDebug("typeagent:shell:speech:error");
+
+let speechToken:
+    | { token: string; expire: number; region: string; endpoint: string }
+    | undefined;
+
+async function getSpeechToken(silent: boolean) {
+    const instance = AzureSpeech.getInstance();
+    if (instance === undefined) {
+        if (!silent) {
+            dialog.showErrorBox(
+                "Azure Speech Service: Missing configuration",
+                "Environment variable SPEECH_SDK_KEY or SPEECH_SDK_REGION is missing.  Switch to local whisper or provide the configuration and restart.",
+            );
+        }
+        return undefined;
+    }
+
+    if (speechToken !== undefined && speechToken.expire > Date.now()) {
+        return speechToken;
+    }
+    try {
+        debugShell("Getting speech token");
+        const tokenResponse = await instance.getTokenAsync();
+        speechToken = {
+            token: tokenResponse.token,
+            expire: Date.now() + 9 * 60 * 1000, // 9 minutes (token expires in 10 minutes)
+            region: tokenResponse.region,
+            endpoint: tokenResponse.endpoint,
+        };
+        return speechToken;
+    } catch (e: any) {
+        debugShellError("Error getting speech token", e);
+        if (!silent) {
+            dialog.showErrorBox(
+                "Azure Speech Service: Error getting token",
+                e.message,
+            );
+        }
+        return undefined;
+    }
+}
+
+export async function triggerRecognitionOnce() {
+    const shellWindow = ShellWindow.getInstance();
+    if (shellWindow === undefined) {
+        return;
+    }
+    const chatView = shellWindow.chatView;
+    const speechToken = await getSpeechToken(false);
+    const useLocalWhisper = isLocalWhisperEnabled();
+    chatView.webContents.send("listen-event", speechToken, useLocalWhisper);
+}
+
+export function initializeSpeech() {
+    const key = process.env["SPEECH_SDK_KEY"] ?? "identity";
+    const region = process.env["SPEECH_SDK_REGION"];
+    const endpoint = process.env["SPEECH_SDK_ENDPOINT"] as string;
+    if (region) {
+        AzureSpeech.initialize({
+            azureSpeechSubscriptionKey: key,
+            azureSpeechRegion: region,
+            azureSpeechEndpoint: endpoint,
+        });
+    } else {
+        debugShellError("Speech: no key or region");
+    }
+
+    ipcMain.handle("get-speech-token", async (event, silent: boolean) => {
+        // Make sure the request comes from the chat view
+        const shellWindow = getShellWindowForChatViewIpcEvent(event);
+        if (shellWindow === undefined) {
+            return undefined;
+        }
+        return getSpeechToken(silent);
+    });
+
+    ipcMain.handle("get-localWhisper-status", async (event) => {
+        // Make sure the request comes from the chat view
+        const shellWindow = getShellWindowForChatViewIpcEvent(event);
+        if (shellWindow === undefined) {
+            return undefined;
+        }
+        return isLocalWhisperEnabled();
+    });
+
+    const ret = globalShortcut.register("Alt+M", triggerRecognitionOnce);
+
+    if (ret) {
+        // Double check whether a shortcut is registered.
+        debugShell(
+            `Global shortcut Alt+M: ${globalShortcut.isRegistered("Alt+M")}`,
+        );
+    } else {
+        debugShellError("Global shortcut registration failed");
+    }
+}

--- a/ts/packages/shell/src/main/webViewIpcHandlers.ts
+++ b/ts/packages/shell/src/main/webViewIpcHandlers.ts
@@ -1,0 +1,201 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { ipcMain, session } from "electron";
+import { ShellWindow } from "./shellWindow.js";
+import { debugShellError } from "./debug.js";
+import { ExtensionStorageManager } from "./extensionStorage.js";
+import { BrowserAgentIpc } from "./browserIpc.js";
+import { WebSocketMessageV2 } from "common-utils";
+import path from "path";
+
+export function initializeExternalStorageIpcHandlers(instanceDir: string) {
+    const extensionStorage = new ExtensionStorageManager(instanceDir);
+    // Extension storage IPC handlers
+    ipcMain.handle("extension-storage-get", async (_, keys: string[]) => {
+        try {
+            return extensionStorage.get(keys);
+        } catch (error) {
+            debugShellError("Error getting extension storage:", error);
+            return {};
+        }
+    });
+
+    ipcMain.handle(
+        "extension-storage-set",
+        async (_, items: Record<string, any>) => {
+            try {
+                extensionStorage.set(items);
+                return { success: true };
+            } catch (error) {
+                debugShellError("Error setting extension storage:", error);
+                return { success: false, error: (error as Error).message };
+            }
+        },
+    );
+
+    ipcMain.handle("extension-storage-remove", async (_, keys: string[]) => {
+        try {
+            extensionStorage.remove(keys);
+            return { success: true };
+        } catch (error) {
+            debugShellError("Error removing extension storage:", error);
+            return { success: false, error: (error as Error).message };
+        }
+    });
+}
+
+export function initializePDFViewerIpcHandlers() {
+    // PDF viewer IPC handlers
+    ipcMain.handle("check-typeagent-connection", async () => {
+        const shellWindow = ShellWindow.getInstance();
+        if (shellWindow) {
+            const connected = await shellWindow.checkTypeAgentConnection();
+            return { connected };
+        }
+        return { connected: false };
+    });
+
+    ipcMain.handle("open-pdf-viewer", async (_, pdfUrl: string) => {
+        const shellWindow = ShellWindow.getInstance();
+        if (shellWindow) {
+            try {
+                await shellWindow.openPDFViewer(pdfUrl);
+                return { success: true };
+            } catch (error) {
+                debugShellError("Error opening PDF viewer:", error);
+                return {
+                    success: false,
+                    error:
+                        error instanceof Error
+                            ? error.message
+                            : "Unknown error",
+                };
+            }
+        }
+        return { success: false, error: "Shell window not available" };
+    });
+}
+
+export async function initializeBrowserExtension(appPath: string) {
+    const browserExtensionPath = path.join(
+        // HACK HACK for packaged build: The browser extension cannot be loaded from ASAR, so it is not packed.
+        // Assume we can just replace app.asar with app.asar.unpacked in all cases.
+        path.basename(appPath) === "app.asar"
+            ? path.join(path.dirname(appPath), "app.asar.unpacked")
+            : appPath,
+        "node_modules/browser-typeagent/dist/electron",
+    );
+    const extension = await session.defaultSession.extensions.loadExtension(
+        browserExtensionPath,
+        {
+            allowFileAccess: true,
+        },
+    );
+
+    // Store extension info for later URL construction
+    (global as any).browserExtensionId = extension.id;
+    (global as any).browserExtensionUrls = {
+        "/annotationsLibrary.html": `chrome-extension://${extension.id}/views/annotationsLibrary.html`,
+        "/knowledgeLibrary.html": `chrome-extension://${extension.id}/views/knowledgeLibrary.html`,
+        "/macrosLibrary.html": `chrome-extension://${extension.id}/views/macrosLibrary.html`,
+        "/entityGraphView.html": `chrome-extension://${extension.id}/views/entityGraphView.html`,
+    };
+
+    ipcMain.handle("init-browser-ipc", async () => {
+        await BrowserAgentIpc.getinstance().ensureWebsocketConnected();
+
+        BrowserAgentIpc.getinstance().onMessageReceived = (
+            message: WebSocketMessageV2,
+        ) => {
+            const shellWindow = ShellWindow.getInstance();
+            shellWindow?.sendMessageToInlineWebContent(message);
+        };
+    });
+
+    ipcMain.on("send-to-browser-ipc", async (_, data: WebSocketMessageV2) => {
+        await BrowserAgentIpc.getinstance().send(data);
+    });
+
+    // Extension service adapter IPC handlers - Must handle async response waiting
+    ipcMain.handle("browser-extension-message", async (_, message) => {
+        try {
+            // Route message through browser IPC to TypeAgent backend
+            const browserIpc = BrowserAgentIpc.getinstance();
+
+            // Check if this is a long-running import operation
+            // Note: ExtensionServiceBase sends with 'type', but it might also come as 'method'
+            const methodName = message.method || message.type;
+            const isImportOperation =
+                methodName === "importWebsiteDataWithProgress" ||
+                methodName === "importHtmlFolder";
+
+            // For import operations, use a longer timeout and handle differently
+            const timeout = isImportOperation ? 600000 : 30000; // 10 minutes for imports, 30 seconds for others
+
+            // Create a promise to wait for the WebSocket response
+            return new Promise((resolve, reject) => {
+                const messageId = Date.now().toString();
+
+                // Set up one-time response listener
+                const originalHandler = browserIpc.onMessageReceived;
+                browserIpc.onMessageReceived = (response) => {
+                    if (response.id === messageId) {
+                        // Restore original handler
+                        browserIpc.onMessageReceived = originalHandler;
+
+                        // Extract the actual data from the ActionResult if it's an extension message
+                        let result = response.result || response;
+                        if (result && result.data !== undefined) {
+                            // This is likely an ActionResult with data field containing the actual extension response
+                            result = result.data;
+                        }
+
+                        resolve(result);
+                    } else if (originalHandler) {
+                        // Forward other messages to original handler
+                        originalHandler(response);
+                    }
+                };
+
+                // Send the message directly using the method/params from the message
+                browserIpc
+                    .send({
+                        method: message.method || message.type,
+                        params: message.params || message.parameters || message,
+                        id: messageId,
+                    })
+                    .catch(reject);
+
+                // Set timeout to prevent hanging
+                setTimeout(() => {
+                    browserIpc.onMessageReceived = originalHandler;
+                    const method = message.method || message.type || "unknown";
+                    const messageInfo = JSON.stringify({
+                        method,
+                        messageId,
+                        hasParams: !!(message.params || message.parameters),
+                    });
+                    reject(
+                        new Error(
+                            `Inline-browser message timeout - ${messageInfo}`,
+                        ),
+                    );
+                }, timeout);
+            });
+        } catch (error) {
+            return { error: (error as Error).message };
+        }
+    });
+
+    // Direct WebSocket connection check via browserIPC
+    ipcMain.handle("check-websocket-connection", async () => {
+        try {
+            const browserIpc = BrowserAgentIpc.getinstance();
+            const connected = browserIpc.isConnected();
+            return { connected };
+        } catch (error) {
+            return { connected: false };
+        }
+    });
+}


### PR DESCRIPTION
- Check IPC call sender, and use the current shell window instead of the first shell window (to eventually enable reactivation in MacOS).
- Reorganize shell init code.