### PR TITLE
Fix dotnet pipeline

### DIFF
--- a/.github/workflows/build-dotnet.yml
+++ b/.github/workflows/build-dotnet.yml
@@ -48,18 +48,20 @@ jobs:
       - name: Setup NuGet
         if: ${{ github.event_name != 'pull_request' || steps.filter.outputs.dotnet != 'false' }}
         uses: NuGet/setup-nuget@v2.0.0
-      - name: Restore Packages
+      - name: Restore Packages (AutoShell)
         if: ${{ github.event_name != 'pull_request' || steps.filter.outputs.dotnet != 'false' }}
         working-directory: dotnet
         run: nuget restore autoShell/AutoShell.sln
-      - name: Build Solution
+      - name: Build Solution (AutoShell)
         if: ${{ github.event_name != 'pull_request' || steps.filter.outputs.dotnet != 'false' }}
         working-directory: dotnet
         run: |
           msbuild.exe autoShell/AutoShell.sln /p:platform="Any CPU" /p:configuration="${{ matrix.configuration }}"
       - name: Restore Packages (TypeAgent)
+        if: ${{ github.event_name != 'pull_request' || steps.filter.outputs.dotnet != 'false' }}
         working-directory: dotnet
         run: nuget restore typeagent/TypeAgent.sln
       - name: Build Solution (TypeAgent)
+        if: ${{ github.event_name != 'pull_request' || steps.filter.outputs.dotnet != 'false' }}
         working-directory: dotnet
         run: msbuild.exe typeagent/TypeAgent.sln /p:platform="Any CPU" /p:configuration="${{ matrix.configuration }}"


### PR DESCRIPTION
For PR, the dotnet solution build needs to be skipped when files in dotnet directory didn't change.