### PR TITLE
Shell: reload

### DIFF
--- a/ts/packages/dispatcher/src/context/system/handlers/serviceHost/service.ts
+++ b/ts/packages/dispatcher/src/context/system/handlers/serviceHost/service.ts
@@ -154,8 +154,7 @@ try {
         process.exit(1);
     });
 } catch (e: any) {
-    console.error(
-        `WebSocket server could not be started at ${hostEndpoint}: Error ${e.message}`,
-    );
-    process.send?.("Failure");
+    const message = `WebSocket server could not be started at ${hostEndpoint}: Error ${e.message}`;
+    console.error(message);
+    process.send?.(message);
 }

--- a/ts/packages/dispatcher/src/context/system/handlers/serviceHost/serviceHostCommandHandler.ts
+++ b/ts/packages/dispatcher/src/context/system/handlers/serviceHost/serviceHostCommandHandler.ts
@@ -19,7 +19,7 @@ export async function createServiceHost() {
             if (message === "Success") {
                 resolve(childProcess);
             } else {
-                resolve(undefined);
+                reject(new Error(message as string));
             }
         });
     });

--- a/ts/packages/shell/src/main/agent.ts
+++ b/ts/packages/shell/src/main/agent.ts
@@ -25,7 +25,7 @@ import { getLocalWhisperCommandHandlers } from "./localWhisperCommandHandler.js"
 import { ShellWindow } from "./shellWindow.js";
 import { getObjectProperty, getObjectPropertyNames } from "common-utils";
 import { installAndRestart, updateHandlerTable } from "./commands/update.js";
-import { isProd } from "./index.js";
+import { isProd, reloadInstance } from "./index.js";
 import { ShellWindowState } from "./shellSettings.js";
 
 export type ShellContext = {
@@ -320,6 +320,13 @@ const handlers: CommandHandlerTable = {
         },
         setWindowState: new ShellSetWindowSizeCommandHandler(),
         setWindowZoomLevel: new ShellSetZoomLevelCommandHandler(),
+        reload: {
+            description: "Reload the shell",
+            run: async () => {
+                reloadInstance();
+                // displaySuccess("Reloading shell...", context);
+            },
+        },
     },
 };
 

--- a/ts/packages/shell/src/main/debug.ts
+++ b/ts/packages/shell/src/main/debug.ts
@@ -2,5 +2,7 @@
 // Licensed under the MIT License.
 
 import registerDebug from "debug";
+export const debugShellInit = registerDebug("typeagent:shell:init");
+export const debugShellCleanup = registerDebug("typeagent:shell:cleanup");
 export const debugShell = registerDebug("typeagent:shell");
 export const debugShellError = registerDebug("typeagent:shell:error");

--- a/ts/packages/shell/src/main/electronSearchMenuUI.ts
+++ b/ts/packages/shell/src/main/electronSearchMenuUI.ts
@@ -6,11 +6,11 @@ import { ipcMain, WebContents, WebContentsView } from "electron";
 import {
     getShellWindowForChatViewIpcEvent,
     getShellWindowForIpcEvent,
-    ShellWindow,
-} from "./shellWindow.js";
+} from "./instance.js";
 import type { SearchMenuUIUpdateData } from "../preload/electronTypes.js";
 import path from "node:path";
 import registerDebug from "debug";
+import { ShellWindow } from "./shellWindow.js";
 const debug = registerDebug("typeagent:shell:searchMenuUI");
 const debugError = registerDebug("typeagent:shell:searchMenuUI:error");
 

--- a/ts/packages/shell/src/main/instance.ts
+++ b/ts/packages/shell/src/main/instance.ts
@@ -1,0 +1,396 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { app, BrowserWindow, dialog, ipcMain, Notification } from "electron";
+import {
+    debugShell,
+    debugShellCleanup,
+    debugShellError,
+    debugShellInit,
+} from "./debug.js";
+import { ShellSettingManager } from "./shellSettings.js";
+import { createDispatcherRpcServer } from "agent-dispatcher/rpc/dispatcher/server";
+import { ShellWindow } from "./shellWindow.js";
+import { createGenericChannel } from "agent-rpc/channel";
+import { getConsolePrompt } from "agent-dispatcher/helpers/console";
+import {
+    getDefaultAppAgentInstaller,
+    getDefaultAppAgentProviders,
+    getDefaultConstructionProvider,
+    getIndexingServiceRegistry,
+} from "default-agent-provider";
+import { getClientId } from "agent-dispatcher/helpers/data";
+import { createShellAgentProvider } from "./agent.js";
+import { createInlineBrowserControl } from "./inlineBrowserControl.js";
+import { ClientIO, createDispatcher, Dispatcher } from "agent-dispatcher";
+import { getStatusSummary } from "agent-dispatcher/helpers/status";
+import {
+    hasPendingUpdate,
+    setPendingUpdateCallback,
+} from "./commands/update.js";
+import { createClientIORpcClient } from "agent-dispatcher/rpc/clientio/client";
+import { isProd } from "./index.js";
+
+type ShellInstance = {
+    shellWindow: ShellWindow;
+    dispatcherP: Promise<Dispatcher | undefined>;
+};
+
+let instance: ShellInstance | undefined;
+let cleanupP: Promise<void> | undefined;
+let quitting: boolean = false;
+
+async function initializeDispatcher(
+    instanceDir: string,
+    shellWindow: ShellWindow,
+    updateSummary: (dispatcher: Dispatcher) => string,
+    startTime: number,
+): Promise<Dispatcher | undefined> {
+    if (cleanupP !== undefined) {
+        // Make sure the previous cleanup is done.
+        await cleanupP;
+    }
+    try {
+        const clientIOChannel = createGenericChannel((message: any) => {
+            shellWindow.chatView.webContents.send("clientio-rpc-call", message);
+        });
+        const onClientIORpcReply = (event, message) => {
+            if (getShellWindowForChatViewIpcEvent(event) !== shellWindow) {
+                return;
+            }
+            clientIOChannel.message(message);
+        };
+        ipcMain.on("clientio-rpc-reply", onClientIORpcReply);
+
+        const newClientIO = createClientIORpcClient(clientIOChannel.channel);
+        const clientIO: ClientIO = {
+            ...newClientIO,
+            // Main process intercepted clientIO calls
+            popupQuestion: async (
+                message: string,
+                choices: string[],
+                defaultId: number | undefined,
+                source: string,
+            ) => {
+                const result = await dialog.showMessageBox(
+                    shellWindow.mainWindow,
+                    {
+                        type: "question",
+                        buttons: choices,
+                        defaultId,
+                        message,
+                        icon: source,
+                    },
+                );
+                return result.response;
+            },
+            openLocalView: (port: number) => {
+                debugShell(`Opening local view on port ${port}`);
+                shellWindow.createBrowserTab(
+                    new URL(`http://localhost:${port}/`),
+                    { background: false },
+                );
+                return Promise.resolve();
+            },
+            closeLocalView: (port: number) => {
+                const targetUrl = `http://localhost:${port}/`;
+                debugShell(
+                    `Closing local view on port ${port}, target url: ${targetUrl}`,
+                );
+
+                // Find and close the tab with the matching URL
+                const allTabs = shellWindow.getAllBrowserTabs();
+                const matchingTab = allTabs.find(
+                    (tab) => tab.url === targetUrl,
+                );
+
+                if (matchingTab) {
+                    shellWindow.closeBrowserTab(matchingTab.id);
+                    debugShell(`Closed tab with URL: ${targetUrl}`);
+                } else {
+                    debugShell(`No tab found with URL: ${targetUrl}`);
+                }
+            },
+            exit: () => {
+                app.quit();
+            },
+        };
+
+        const browserControl = createInlineBrowserControl(shellWindow);
+
+        // Set up dispatcher
+        const newDispatcher = await createDispatcher("shell", {
+            appAgentProviders: [
+                createShellAgentProvider(shellWindow),
+                ...getDefaultAppAgentProviders(instanceDir),
+            ],
+            agentInitOptions: {
+                browser: browserControl.control,
+            },
+            agentInstaller: getDefaultAppAgentInstaller(instanceDir),
+            persistSession: true,
+            persistDir: instanceDir,
+            enableServiceHost: true,
+            metrics: true,
+            dblogging: true,
+            clientId: getClientId(),
+            clientIO,
+            indexingServiceRegistry:
+                await getIndexingServiceRegistry(instanceDir),
+            constructionProvider: getDefaultConstructionProvider(),
+            allowSharedLocalView: ["browser"],
+            portBase: isProd ? 9001 : 9050,
+        });
+
+        async function processShellRequest(
+            text: string,
+            id: string,
+            images: string[],
+        ) {
+            if (typeof text !== "string" || typeof id !== "string") {
+                throw new Error("Invalid request");
+            }
+
+            // Update before processing the command in case there was change outside of command processing
+            const summary = updateSummary(dispatcher);
+
+            if (debugShell.enabled) {
+                debugShell(getConsolePrompt(summary), text);
+            }
+
+            const commandResult = await newDispatcher.processCommand(
+                text,
+                id,
+                images,
+            );
+            shellWindow.chatView.webContents.send(
+                "send-demo-event",
+                "CommandProcessed",
+            );
+
+            // Give the chat view the focus back after the command for the next command.
+            shellWindow.chatView.webContents.focus();
+
+            // Update the summary after processing the command in case state changed.
+            updateSummary(dispatcher);
+            return commandResult;
+        }
+
+        const dispatcher = {
+            ...newDispatcher,
+            processCommand: processShellRequest,
+            close: async () => {
+                ipcMain.removeListener(
+                    "dispatcher-rpc-call",
+                    onDispatcherRpcCall,
+                );
+                dispatcherChannel.disconnect();
+                await newDispatcher.close();
+                clientIOChannel.disconnect();
+                ipcMain.removeListener(
+                    "clientio-rpc-reply",
+                    onClientIORpcReply,
+                );
+                browserControl.close();
+            },
+        };
+
+        // Set up the RPC
+        const dispatcherChannel = createGenericChannel((message: any) => {
+            shellWindow.chatView.webContents.send(
+                "dispatcher-rpc-reply",
+                message,
+            );
+        });
+        const onDispatcherRpcCall = (event, message) => {
+            if (getShellWindowForChatViewIpcEvent(event) !== shellWindow) {
+                return;
+            }
+            dispatcherChannel.message(message);
+        };
+        ipcMain.on("dispatcher-rpc-call", onDispatcherRpcCall);
+        createDispatcherRpcServer(dispatcher, dispatcherChannel.channel);
+
+        shellWindow.dispatcherInitialized();
+
+        debugShellInit("Dispatcher initialized", performance.now() - startTime);
+
+        return dispatcher;
+    } catch (e: any) {
+        dialog.showErrorBox("Exception initializing dispatcher", e.stack);
+        return undefined;
+    }
+}
+
+export async function initializeInstance(
+    instanceDir: string,
+    shellSettings: ShellSettingManager,
+    startTime: number = performance.now(),
+) {
+    if (instance !== undefined) {
+        throw new Error("Instance already initialized");
+    }
+
+    debugShellInit(
+        "Start initializing Instance",
+        performance.now() - startTime,
+    );
+
+    const shellWindow = new ShellWindow(shellSettings);
+    const { mainWindow, chatView } = shellWindow;
+    let title: string = "";
+    function updateTitle(dispatcher: Dispatcher) {
+        const status = dispatcher.getStatus();
+
+        const newSettingSummary = getStatusSummary(status);
+        const zoomFactor = chatView.webContents.zoomFactor;
+        const pendingUpdate = hasPendingUpdate() ? " [Pending Update]" : "";
+        const zoomFactorTitle =
+            zoomFactor === 1 ? "" : ` Zoom: ${Math.round(zoomFactor * 100)}%`;
+        const newTitle = `${app.getName()} v${app.getVersion()} - ${newSettingSummary}${pendingUpdate}${zoomFactorTitle}`;
+        if (newTitle !== title) {
+            title = newTitle;
+            chatView.webContents.send(
+                "setting-summary-changed",
+                status.agents.map((agent) => [agent.name, agent.emoji]),
+            );
+
+            mainWindow.setTitle(newTitle);
+        }
+
+        return newSettingSummary;
+    }
+
+    // Note: Make sure dom ready before using dispatcher.
+    const dispatcherP = initializeDispatcher(
+        instanceDir,
+        shellWindow,
+        updateTitle,
+        startTime,
+    );
+
+    const onDomReady = async (event: Electron.IpcMainEvent) => {
+        const eventWindow = getShellWindowForChatViewIpcEvent(event);
+        if (eventWindow !== shellWindow) {
+            return;
+        }
+        ipcMain.removeListener("chat-view-ready", onDomReady);
+        debugShellInit("Showing window", performance.now() - startTime);
+
+        // The dispatcher can be use now that dom is ready and the client is ready to receive messages
+        const dispatcher = await dispatcherP;
+        if (dispatcher === undefined) {
+            app.quit();
+            return;
+        }
+        updateTitle(dispatcher);
+        setPendingUpdateCallback((version, background) => {
+            updateTitle(dispatcher);
+            if (background) {
+                new Notification({
+                    title: `New version ${version.version} available`,
+                    body: `Restart to install the update.`,
+                }).show();
+            }
+        });
+
+        // send the agent greeting if it's turned on
+        if (shellSettings.user.agentGreeting) {
+            dispatcher.processCommand("@greeting", "agent-0", []);
+        }
+    };
+    ipcMain.on("chat-view-ready", onDomReady);
+
+    shellWindow.mainWindow.on("closed", () => {
+        ensureCleanupInstance();
+        ipcMain.removeListener("chat-view-ready", onDomReady);
+    });
+
+    instance = { shellWindow, dispatcherP };
+    return shellWindow.waitForContentLoaded();
+}
+
+async function cleanupInstance() {
+    if (instance === undefined) {
+        return undefined;
+    }
+
+    debugShellCleanup("Closing dispatcher");
+    try {
+        const { dispatcherP } = instance;
+        instance = undefined;
+        const dispatcher = await dispatcherP;
+        if (dispatcher) {
+            await dispatcher.close();
+        }
+        cleanupP = undefined;
+
+        debugShellCleanup("Cleaned up instance");
+    } catch (e: any) {
+        if (quitting) {
+            debugShellError("Error closing instance", e);
+        } else {
+            dialog.showErrorBox("Error closing instance", e.stack);
+            app.quit();
+        }
+    }
+}
+
+async function ensureCleanupInstance() {
+    if (cleanupP === undefined) {
+        cleanupP = cleanupInstance();
+    }
+    return cleanupP;
+}
+
+export async function closeInstance(quit: boolean = false) {
+    if (quit) {
+        quitting = true;
+    }
+    if (instance === undefined) {
+        return;
+    }
+
+    debugShellCleanup("Closing window");
+    const shellWindow = instance.shellWindow;
+
+    // Close the window first without clearing the instance
+    await shellWindow.mainWindow.close();
+
+    // Ensure the instance is fulling cleaned up.
+    return ensureCleanupInstance();
+}
+
+export function getShellWindow(): ShellWindow | undefined {
+    return instance?.shellWindow;
+}
+
+export function getShellWindowForIpcEvent(
+    event: Electron.IpcMainEvent | Electron.IpcMainInvokeEvent,
+): ShellWindow | undefined {
+    const mainWindow = BrowserWindow.fromWebContents(event.sender);
+    if (mainWindow === undefined) {
+        return undefined;
+    }
+    const shellWindow = getShellWindow();
+    return shellWindow?.mainWindow === mainWindow ? shellWindow : undefined;
+}
+
+export function getShellWindowForMainWindowIpcEvent(
+    event: Electron.IpcMainEvent | Electron.IpcMainInvokeEvent,
+): ShellWindow | undefined {
+    const shellWindow = getShellWindow();
+    return event.sender === shellWindow?.mainWindow.webContents
+        ? shellWindow
+        : undefined;
+}
+
+// Returns the shell window for IPC events from the current chat view.
+export function getShellWindowForChatViewIpcEvent(
+    event: Electron.IpcMainEvent | Electron.IpcMainInvokeEvent,
+): ShellWindow | undefined {
+    const shellWindow = getShellWindow();
+    return event.sender === shellWindow?.chatView.webContents
+        ? shellWindow
+        : undefined;
+}

--- a/ts/packages/shell/src/main/speech.ts
+++ b/ts/packages/shell/src/main/speech.ts
@@ -7,9 +7,9 @@ import { isLocalWhisperEnabled } from "./localWhisperCommandHandler.js";
 
 import registerDebug from "debug";
 import {
+    getShellWindow,
     getShellWindowForChatViewIpcEvent,
-    ShellWindow,
-} from "./shellWindow.js";
+} from "./instance.js";
 const debugShell = registerDebug("typeagent:shell:speech");
 const debugShellError = registerDebug("typeagent:shell:speech:error");
 
@@ -55,7 +55,7 @@ async function getSpeechToken(silent: boolean) {
 }
 
 export async function triggerRecognitionOnce() {
-    const shellWindow = ShellWindow.getInstance();
+    const shellWindow = getShellWindow();
     if (shellWindow === undefined) {
         return;
     }

--- a/ts/packages/shell/src/main/webViewIpcHandlers.ts
+++ b/ts/packages/shell/src/main/webViewIpcHandlers.ts
@@ -2,12 +2,12 @@
 // Licensed under the MIT License.
 
 import { ipcMain, session } from "electron";
-import { getShellWindowForIpcEvent, ShellWindow } from "./shellWindow.js";
 import { debugShellError } from "./debug.js";
 import { ExtensionStorageManager } from "./extensionStorage.js";
 import { BrowserAgentIpc } from "./browserIpc.js";
 import { WebSocketMessageV2 } from "common-utils";
 import path from "path";
+import { getShellWindow, getShellWindowForIpcEvent } from "./instance.js";
 
 export function initializeExternalStorageIpcHandlers(instanceDir: string) {
     const extensionStorage = new ExtensionStorageManager(instanceDir);
@@ -108,7 +108,7 @@ export async function initializeBrowserExtension(appPath: string) {
         BrowserAgentIpc.getinstance().onMessageReceived = (
             message: WebSocketMessageV2,
         ) => {
-            const shellWindow = ShellWindow.getInstance();
+            const shellWindow = getShellWindow();
             shellWindow?.sendMessageToInlineWebContent(message);
         };
     });

--- a/ts/packages/shell/src/preload/chatView.ts
+++ b/ts/packages/shell/src/preload/chatView.ts
@@ -61,7 +61,7 @@ function registerClient(client: Client) {
     });
 
     // Signal the main process that the client has been registered
-    ipcRenderer.send("dom ready");
+    ipcRenderer.send("chat-view-ready");
 }
 
 const api: ClientAPI = {


### PR DESCRIPTION
- Improve instance management/lifecycle to enable reloading the shell window and instance.
- Add `@shell reload` command which is the same with macOS activate after window is closed.
- Fix BrowserIpc reconnect logic to clear the promise when resolving it so that it doesn't get stuck.
 