### PR TITLE
Shell: Fix title bar layout

### DIFF
--- a/ts/packages/shell/src/renderer/viewHost.html
+++ b/ts/packages/shell/src/renderer/viewHost.html
@@ -53,7 +53,9 @@
       .title-bar {
         position: fixed;
         top: 0;
-        left: var(--layout-button-area-width); /* Start after the layout toggle button */
+        left: var(
+          --layout-button-area-width
+        ); /* Start after the layout toggle button */
         right: 0;
         height: var(--title-bar-height);
         background: var(--title-bar-bg);
@@ -425,7 +427,9 @@
       .sidebar-title-bar {
         position: fixed;
         top: 0;
-        left: var(--layout-button-area-width); /* Start after the layout toggle button */
+        left: var(
+          --layout-button-area-width
+        ); /* Start after the layout toggle button */
         width: calc(
           var(--sidebar-width, 400px) - var(--layout-button-area-width)
         ); /* Adjust width to account for offset */


### PR DESCRIPTION
- Make sure the layout button in all platform and traffic light in mac is not covered by the title bar and not able to click because of drag being enabled.