### PR TITLE
Shell: auto empty tab

### DIFF
--- a/ts/.vscode/settings.json
+++ b/ts/.vscode/settings.json
@@ -20,7 +20,7 @@
         "typechat"
     ],
     "[html]": {
-        "editor.defaultFormatter": "vscode.html-language-features"
+        "editor.defaultFormatter": "esbenp.prettier-vscode"
     },
     "jest.virtualFolders": [
         {"name": "actionSchema", "rootPath": "packages/actionSchema"},

--- a/ts/packages/shell/src/main/browserViewManager.ts
+++ b/ts/packages/shell/src/main/browserViewManager.ts
@@ -22,7 +22,7 @@ export interface BrowserViewContext {
 
 export interface TabCreationOptions {
     url: string;
-    background?: boolean;
+    background?: boolean; // default to false
     parentTabId?: string;
     waitForPageLoad?: boolean;
 }

--- a/ts/packages/shell/src/preload/shellSettingsType.ts
+++ b/ts/packages/shell/src/preload/shellSettingsType.ts
@@ -10,6 +10,7 @@ export type UISettings = {
     verticalLayout: boolean;
     verticalContentAlwaysVisible: boolean;
     horizontalContentAlwaysVisible: boolean;
+    autoEmptyTab: boolean;
     dev: boolean;
     darkMode: boolean;
 };
@@ -48,6 +49,7 @@ export const defaultUserSettings: ShellUserSettings = {
         verticalLayout: true,
         verticalContentAlwaysVisible: true,
         horizontalContentAlwaysVisible: false,
+        autoEmptyTab: true,
         dev: false,
         darkMode: false,
     },

--- a/ts/packages/shell/src/renderer/viewHost.html
+++ b/ts/packages/shell/src/renderer/viewHost.html
@@ -793,10 +793,6 @@
       layoutToggleBtn.addEventListener("click", async () => {
         try {
           const result = await ipcRenderer.invoke("toggle-layout");
-          if (result && result.verticalLayout && tabs.length === 0) {
-            // If switching to vertical layout with no tabs, create a new tab
-            ipcRenderer.send("browser-new-tab");
-          }
         } catch (error) {
           console.error("Failed to toggle layout:", error);
         }


### PR DESCRIPTION
- Default to auto create empty tab if the content pane is open.  Consistently apply it on any layout.
- Add setting to able to control the default behavior.
- Set VScode to use prettier for HTML files as well.