### PR TITLE
Fix message routing when both the external browser and inline browser are active

### DIFF
--- a/ts/packages/agents/browser/src/agent/actionHandler.mts
+++ b/ts/packages/agents/browser/src/agent/actionHandler.mts
@@ -995,14 +995,10 @@ async function updateBrowserContext(
 
                     if (
                         (context.agentContext.useExternalBrowserControl &&
-                            client.type !== "extension") ||
+                            client.type === "extension") ||
                         (!context.agentContext.useExternalBrowserControl &&
-                            client.type === "extension")
+                            client.type === "electron")
                     ) {
-                        console.log(
-                            `ignoring ${client.type} browser message when in ${context.agentContext.useExternalBrowserControl ? "external" : "internal"} browser control mode`,
-                        );
-                    } else {
                         if (browserControls) {
                             await processBrowserAgentMessage(
                                 data,
@@ -1011,6 +1007,10 @@ async function updateBrowserContext(
                                 client,
                             );
                         }
+                    } else {
+                        debug(
+                            `ignoring ${client.type} browser message when in ${context.agentContext.useExternalBrowserControl ? "external" : "internal"} browser control mode`,
+                        );                        
                     }
                 }
             };
@@ -1771,7 +1771,7 @@ async function saveKnowledgeToIndex(
         // Use the existing indexWebPageContent function with extracted knowledge
         const parameters = {
             url,
-            title: knowledge.title || "Extracted Page",
+            title: knowledge.title,
             extractKnowledge: true,
             timestamp: new Date().toISOString(),
             extractedKnowledge: knowledge,

--- a/ts/packages/agents/browser/src/agent/actionHandler.mts
+++ b/ts/packages/agents/browser/src/agent/actionHandler.mts
@@ -1010,7 +1010,7 @@ async function updateBrowserContext(
                     } else {
                         debug(
                             `ignoring ${client.type} browser message when in ${context.agentContext.useExternalBrowserControl ? "external" : "internal"} browser control mode`,
-                        );                        
+                        );
                     }
                 }
             };

--- a/ts/packages/agents/browser/src/agent/actionHandler.mts
+++ b/ts/packages/agents/browser/src/agent/actionHandler.mts
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { createWebSocket } from "common-utils/ws";
-import { WebSocket } from "ws";
 import {
     ActionContext,
     ActionIO,
@@ -36,6 +34,7 @@ import {
 } from "./crossword/actionHandler.mjs";
 
 import { BrowserConnector } from "./browserConnector.mjs";
+import { BrowserClient } from "./agentWebSocketServer.mjs";
 import { handleCommerceAction } from "./commerce/actionHandler.mjs";
 import { createTabTitleIndex } from "./tabTitleIndex.mjs";
 import { ChildProcess, fork } from "child_process";
@@ -101,7 +100,6 @@ import {
 } from "../common/browserControl.mjs";
 import { openai } from "aiclient";
 import { urlResolver } from "azure-ai-foundry";
-import { createExternalBrowserClient } from "./rpc/externalBrowserControlClient.mjs";
 import { deleteCachedSchema } from "./crossword/cachedSchema.mjs";
 import { getCrosswordCommandHandlerTable } from "./crossword/commandHandler.mjs";
 import {
@@ -125,6 +123,7 @@ import {
     LookupAndAnswerActions,
     LookupAndAnswerInternet,
 } from "./lookupAndAnswerSchema.mjs";
+import { createExternalBrowserClient } from "./rpc/externalBrowserControlClient.mjs";
 
 const debug = registerDebug("typeagent:browser:action");
 const debugWebSocket = registerDebug("typeagent:browser:ws");
@@ -871,9 +870,11 @@ async function initializeBrowserContext(
     return {
         clientBrowserControl,
         useExternalBrowserControl: clientBrowserControl === undefined,
+        preferredClientType:
+            clientBrowserControl === undefined ? "extension" : "electron",
         index: undefined,
         localHostPort,
-        macrosStore: undefined, // Will be initialized in updateBrowserContext
+        macrosStore: undefined,
         resolverSettings: {
             searchResolver: true,
             keywordResolver: true,
@@ -931,28 +932,51 @@ async function updateBrowserContext(
                 await createViewServiceHost(context);
         }
 
-        if (context.agentContext.webSocket?.readyState === WebSocket.OPEN) {
-            return;
-        }
-
-        const webSocket = await createWebSocket("browser", "dispatcher");
-        if (webSocket) {
-            context.agentContext.webSocket = webSocket;
-            const browserControls = createExternalBrowserClient(webSocket);
-            context.agentContext.externalBrowserControl = browserControls;
-            context.agentContext.browserConnector = new BrowserConnector(
-                webSocket,
-                browserControls,
+        if (!context.agentContext.agentWebSocketServer) {
+            const { AgentWebSocketServer } = await import(
+                "./agentWebSocketServer.mjs"
             );
+            context.agentContext.agentWebSocketServer =
+                new AgentWebSocketServer(8081);
 
-            webSocket.onclose = (event: object) => {
-                debugWebSocket("Browser webSocket connection closed.");
-                context.agentContext.webSocket = undefined;
+            context.agentContext.agentWebSocketServer.getPreferredClientType =
+                () => {
+                    return context.agentContext.preferredClientType;
+                };
+
+            context.agentContext.agentWebSocketServer.onClientConnected = (
+                client: BrowserClient,
+            ) => {
+                // Recreate externalBrowserControl when a new extension client connects
+                if (client.type === "extension") {
+                    debug(
+                        `Extension client connected: ${client.id}, recreating externalBrowserControl`,
+                    );
+                    context.agentContext.externalBrowserControl =
+                        createExternalBrowserClient(
+                            context.agentContext.agentWebSocketServer!,
+                        );
+                }
             };
-            webSocket.addEventListener("message", async (event: any) => {
-                const text = event.data.toString();
-                const data = JSON.parse(text);
-                debugWebSocket(`Received message from browser: ${text}`);
+
+            context.agentContext.agentWebSocketServer.onClientDisconnected = (
+                client: BrowserClient,
+            ) => {
+                // Log disconnection for debugging
+                if (client.type === "extension") {
+                    debug(`Extension client disconnected: ${client.id}`);
+                }
+            };
+
+            context.agentContext.agentWebSocketServer.onClientMessage = async (
+                client: BrowserClient,
+                message: string,
+            ) => {
+                const data = JSON.parse(message);
+                debugWebSocket(
+                    `Received message from browser client ${client.id}: ${message}`,
+                );
+
                 if (isWebAgentMessage(data)) {
                     await processWebAgentMessage(data, context);
                     return;
@@ -964,19 +988,62 @@ async function updateBrowserContext(
                 }
 
                 if (data.method) {
-                    await processBrowserAgentMessage(
-                        data,
-                        browserControls,
-                        context,
-                        webSocket,
-                    );
-                }
-            });
+                    const browserControls = context.agentContext
+                        .useExternalBrowserControl
+                        ? context.agentContext.externalBrowserControl
+                        : context.agentContext.clientBrowserControl;
 
-            initializeWebSocketBridge(context);
-            initializeImportWebSocketHandler(context);
-            debug("Import progress event system initialized");
+                    if (
+                        (context.agentContext.useExternalBrowserControl &&
+                            client.type !== "extension") ||
+                        (!context.agentContext.useExternalBrowserControl &&
+                            client.type === "extension")
+                    ) {
+                        console.log(
+                            `ignoring ${client.type} browser message when in ${context.agentContext.useExternalBrowserControl ? "external" : "internal"} browser control mode`,
+                        );
+                    } else {
+                        if (browserControls) {
+                            await processBrowserAgentMessage(
+                                data,
+                                browserControls,
+                                context,
+                                client,
+                            );
+                        }
+                    }
+                }
+            };
         }
+
+        // Initialize external browser control using the AgentWebSocketServer
+        if (
+            !context.agentContext.externalBrowserControl &&
+            context.agentContext.agentWebSocketServer
+        ) {
+            context.agentContext.externalBrowserControl =
+                createExternalBrowserClient(
+                    context.agentContext.agentWebSocketServer,
+                );
+        }
+
+        if (!context.agentContext.browserConnector) {
+            const browserControls = context.agentContext
+                .useExternalBrowserControl
+                ? context.agentContext.externalBrowserControl
+                : context.agentContext.clientBrowserControl;
+
+            if (browserControls && context.agentContext.agentWebSocketServer) {
+                context.agentContext.browserConnector = new BrowserConnector(
+                    context.agentContext.agentWebSocketServer,
+                    browserControls,
+                );
+            }
+        }
+
+        initializeWebSocketBridge(context);
+        initializeImportWebSocketHandler(context);
+        debug("Browser agent WebSocket server initialized");
 
         // rehydrate cached settings
         const sessionDir: string | undefined =
@@ -1007,13 +1074,10 @@ async function updateBrowserContext(
                 context.agentContext.searchProviders[0];
         }
     } else {
-        const webSocket = context.agentContext.webSocket;
-        if (webSocket) {
-            webSocket.onclose = null;
-            webSocket.close();
+        if (context.agentContext.agentWebSocketServer) {
+            context.agentContext.agentWebSocketServer.stop();
+            delete context.agentContext.agentWebSocketServer;
         }
-
-        context.agentContext.webSocket = undefined;
 
         // shut down service
         if (context.agentContext.browserProcess) {
@@ -1085,7 +1149,7 @@ async function processBrowserAgentMessage(
     data: any,
     browserControls: BrowserControl,
     context: SessionContext<BrowserActionContext>,
-    webSocket: WebSocket,
+    client: BrowserClient,
 ) {
     switch (data.method) {
         case "knowledgeExtractionProgress": {
@@ -1168,7 +1232,7 @@ async function processBrowserAgentMessage(
                 context,
             );
 
-            webSocket.send(
+            client.socket.send(
                 JSON.stringify({
                     id: data.id,
                     result: discoveryResult.data,
@@ -1203,7 +1267,7 @@ async function processBrowserAgentMessage(
                 context,
             );
 
-            webSocket.send(
+            client.socket.send(
                 JSON.stringify({
                     id: data.id,
                     result: knowledgeResult,
@@ -1231,7 +1295,7 @@ async function processBrowserAgentMessage(
                 context,
             );
 
-            webSocket.send(
+            client.socket.send(
                 JSON.stringify({
                     id: data.id,
                     result: websiteResult,
@@ -1246,7 +1310,7 @@ async function processBrowserAgentMessage(
                 context,
             );
 
-            webSocket.send(
+            client.socket.send(
                 JSON.stringify({
                     id: data.id,
                     result: libraryStatsResult,
@@ -1263,7 +1327,7 @@ async function processBrowserAgentMessage(
                 context,
             );
 
-            webSocket.send(
+            client.socket.send(
                 JSON.stringify({
                     id: data.id,
                     result: macrosResult,
@@ -1276,7 +1340,7 @@ async function processBrowserAgentMessage(
             const actionsResult = {
                 url: `http://localhost:${context.agentContext.localHostPort}`,
             };
-            webSocket.send(
+            client.socket.send(
                 JSON.stringify({
                     id: data.id,
                     result: actionsResult,
@@ -2708,9 +2772,8 @@ async function executeBrowserAction(
                 }
             }
     }
-    const webSocketEndpoint = context.sessionContext.agentContext.webSocket;
     const connector = context.sessionContext.agentContext.browserConnector;
-    if (webSocketEndpoint) {
+    if (connector) {
         try {
             context.actionIO.setDisplay("Running remote action.");
 
@@ -2768,7 +2831,7 @@ async function executeBrowserAction(
             throw new Error("Unable to contact browser backend.");
         }
     } else {
-        throw new Error("No websocket connection.");
+        throw new Error("No WebSocket server available.");
     }
     return undefined;
 }
@@ -3102,10 +3165,10 @@ async function handleTabIndexActions(
     context: SessionContext<BrowserActionContext>,
     requestId: string | undefined,
 ) {
-    const webSocketEndpoint = context.agentContext.webSocket;
+    const agentServer = context.agentContext.agentWebSocketServer;
     const tabTitleIndex = context.agentContext.tabTitleIndex;
 
-    if (webSocketEndpoint && tabTitleIndex) {
+    if (agentServer && tabTitleIndex) {
         try {
             const actionName =
                 action.actionName ?? action.fullActionName.split(".").at(-1);
@@ -3144,12 +3207,15 @@ async function handleTabIndexActions(
                 }
             }
 
-            webSocketEndpoint.send(
-                JSON.stringify({
-                    id: requestId,
-                    result: responseBody,
-                }),
-            );
+            const activeClient = agentServer.getActiveClient();
+            if (activeClient) {
+                activeClient.socket.send(
+                    JSON.stringify({
+                        id: requestId,
+                        result: responseBody,
+                    }),
+                );
+            }
         } catch (ex: any) {
             if (ex instanceof Error) {
                 console.error(ex);
@@ -3160,7 +3226,7 @@ async function handleTabIndexActions(
             throw new Error("Unable to contact browser backend.");
         }
     } else {
-        throw new Error("No websocket connection.");
+        throw new Error("No WebSocket server available.");
     }
     return undefined;
 }
@@ -4211,6 +4277,15 @@ export const handlers: CommandHandlerTable = {
                             );
                         }
                         agentContext.useExternalBrowserControl = true;
+                        agentContext.preferredClientType = "extension";
+
+                        // Re-select active client based on new preference
+                        if (agentContext.agentWebSocketServer) {
+                            agentContext.agentWebSocketServer.selectActiveClient(
+                                "extension",
+                            );
+                        }
+
                         await context.queueToggleTransientAgent(
                             "browser.external",
                             true,
@@ -4234,6 +4309,15 @@ export const handlers: CommandHandlerTable = {
                             );
                         }
                         agentContext.useExternalBrowserControl = false;
+                        agentContext.preferredClientType = "electron";
+
+                        // Re-select active client based on new preference
+                        if (agentContext.agentWebSocketServer) {
+                            agentContext.agentWebSocketServer.selectActiveClient(
+                                "electron",
+                            );
+                        }
+
                         await context.queueToggleTransientAgent(
                             "browser.external",
                             false,

--- a/ts/packages/agents/browser/src/agent/actionHandler.mts
+++ b/ts/packages/agents/browser/src/agent/actionHandler.mts
@@ -1771,7 +1771,7 @@ async function saveKnowledgeToIndex(
         // Use the existing indexWebPageContent function with extracted knowledge
         const parameters = {
             url,
-            title: knowledge.title,
+            title: knowledge.title || "Extracted Page",
             extractKnowledge: true,
             timestamp: new Date().toISOString(),
             extractedKnowledge: knowledge,

--- a/ts/packages/agents/browser/src/agent/agentWebSocketServer.mts
+++ b/ts/packages/agents/browser/src/agent/agentWebSocketServer.mts
@@ -1,0 +1,224 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { WebSocketServer, WebSocket } from "ws";
+import { IncomingMessage } from "http";
+import registerDebug from "debug";
+
+const debug = registerDebug("typeagent:browser:agent-ws");
+
+export interface BrowserClient {
+    id: string;
+    type: 'extension' | 'electron';
+    socket: WebSocket;
+    connectedAt: Date;
+    lastActivity: Date;
+}
+
+export class AgentWebSocketServer {
+    private server: WebSocketServer;
+    private clients = new Map<string, BrowserClient>();
+    private activeClientId: string | null = null;
+    public onClientMessage?: (client: BrowserClient, message: string) => void;
+    public getPreferredClientType?: () => 'extension' | 'electron' | undefined;
+    public onClientConnected?: (client: BrowserClient) => void;
+    public onClientDisconnected?: (client: BrowserClient) => void;
+
+    constructor(port: number = 8081) {
+        this.server = new WebSocketServer({ port });
+        this.setupHandlers();
+        debug(`Agent WebSocket server started on port ${port}`);
+    }
+
+    private setupHandlers(): void {
+        this.server.on("connection", (ws: WebSocket, req: IncomingMessage) => {
+            this.handleNewConnection(ws, req);
+        });
+
+        this.server.on("error", (error) => {
+            console.error(`Agent WebSocket server error:`, error);
+        });
+    }
+
+    private handleNewConnection(ws: WebSocket, req: IncomingMessage): void {
+        const params = new URLSearchParams(req.url?.split("?")[1]);
+        const clientId = params.get("clientId");
+
+        if (!clientId) {
+            ws.send(JSON.stringify({ error: "Missing clientId" }));
+            ws.close();
+            return;
+        }
+
+        const existing = this.clients.get(clientId);
+        if (existing) {
+            debug(`Closing duplicate connection for ${clientId}`);
+            existing.socket.close(1013, "duplicate");
+            this.clients.delete(clientId);
+        }
+
+        const client: BrowserClient = {
+            id: clientId,
+            type: clientId === 'inlineBrowser' ? 'electron' : 'extension',
+            socket: ws,
+            connectedAt: new Date(),
+            lastActivity: new Date()
+        };
+
+        this.clients.set(clientId, client);
+        debug(`Client connected: ${clientId} (${client.type})`);
+
+        if (!this.activeClientId) {
+            this.selectActiveClient(this.getPreferredClientType?.());
+        }
+
+        ws.send(JSON.stringify({
+            type: 'welcome',
+            clientId: clientId,
+            isActive: this.activeClientId === clientId
+        }));
+
+        // Notify about new client connection
+        if (this.onClientConnected) {
+            this.onClientConnected(client);
+        }
+
+        ws.on("message", (message: string) => {
+            client.lastActivity = new Date();
+
+            try {
+                const data = JSON.parse(message);
+                if (data.method === "keepAlive" || data.messageType === "keepAlive") {
+                    return;
+                }
+            } catch {}
+
+            if (this.onClientMessage) {
+                this.onClientMessage(client, message);
+            }
+        });
+
+        ws.on("close", () => {
+            debug(`Client disconnected: ${clientId}`);
+
+            // Notify about client disconnection before removing from clients map
+            if (this.onClientDisconnected) {
+                this.onClientDisconnected(client);
+            }
+
+            this.clients.delete(clientId);
+
+            if (this.activeClientId === clientId) {
+                this.selectNewActiveClient();
+            }
+        });
+
+        ws.on("error", (error) => {
+            debug(`WebSocket error for client ${clientId}:`, error);
+        });
+    }
+
+    public selectActiveClient(preferredClientType?: 'extension' | 'electron'): void {
+        // If we have a preferred client type, use it
+        if (preferredClientType) {
+            for (const [id, client] of this.clients) {
+                if (client.type === preferredClientType) {
+                    this.setActiveClient(id);
+                    return;
+                }
+            }
+        }
+
+        // Default behavior: prefer electron over extension
+        for (const [id, client] of this.clients) {
+            if (client.type === 'electron') {
+                this.setActiveClient(id);
+                return;
+            }
+        }
+
+        // Fallback to first available client
+        const firstClient = this.clients.keys().next();
+        this.activeClientId = firstClient.done ? null : firstClient.value;
+
+        if (this.activeClientId) {
+            debug(`Auto-selected new active client: ${this.activeClientId}`);
+        }
+    }
+
+    private selectNewActiveClient(): void {
+        this.selectActiveClient(this.getPreferredClientType?.());
+    }
+
+    public getActiveClient(fallbackType?: 'extension' | 'electron'): BrowserClient | null {
+        // First try to get the currently active client
+        const activeClient = this.activeClientId ? this.clients.get(this.activeClientId) || null : null;
+
+        // If we have an active client and either no fallback type specified
+        // or the active client matches the fallback type, return it
+        if (activeClient && (!fallbackType || activeClient.type === fallbackType)) {
+            return activeClient;
+        }
+
+        // If we need a specific type and active client doesn't match, find one
+        if (fallbackType) {
+            for (const [_, client] of this.clients) {
+                if (client.type === fallbackType) {
+                    return client;
+                }
+            }
+        }
+
+        // Return the active client even if it doesn't match the fallback type,
+        // or null if there's no active client
+        return activeClient;
+    }
+
+    public getClient(clientId: string): BrowserClient | null {
+        return this.clients.get(clientId) || null;
+    }
+
+    public listClients(): BrowserClient[] {
+        return Array.from(this.clients.values());
+    }
+
+    public setActiveClient(clientId: string): boolean {
+        if (this.clients.has(clientId)) {
+            this.activeClientId = clientId;
+
+            for (const [id, client] of this.clients) {
+                client.socket.send(JSON.stringify({
+                    type: 'active-status-changed',
+                    isActive: id === clientId
+                }));
+            }
+
+            debug(`Active client set to: ${clientId}`);
+            return true;
+        }
+        return false;
+    }
+
+    public sendToClient(clientId: string, message: string): boolean {
+        const client = this.clients.get(clientId);
+        if (client && client.socket.readyState === WebSocket.OPEN) {
+            client.socket.send(message);
+            return true;
+        }
+        return false;
+    }
+
+    public sendToActiveClient(message: string): boolean {
+        const client = this.getActiveClient();
+        if (client && client.socket.readyState === WebSocket.OPEN) {
+            client.socket.send(message);
+            return true;
+        }
+        return false;
+    }
+
+    public stop(): void {
+        this.server.close();
+        debug("Agent WebSocket server stopped");
+    }
+}

--- a/ts/packages/agents/browser/src/agent/agentWebSocketServer.mts
+++ b/ts/packages/agents/browser/src/agent/agentWebSocketServer.mts
@@ -9,7 +9,7 @@ const debug = registerDebug("typeagent:browser:agent-ws");
 
 export interface BrowserClient {
     id: string;
-    type: 'extension' | 'electron';
+    type: "extension" | "electron";
     socket: WebSocket;
     connectedAt: Date;
     lastActivity: Date;
@@ -20,7 +20,7 @@ export class AgentWebSocketServer {
     private clients = new Map<string, BrowserClient>();
     private activeClientId: string | null = null;
     public onClientMessage?: (client: BrowserClient, message: string) => void;
-    public getPreferredClientType?: () => 'extension' | 'electron' | undefined;
+    public getPreferredClientType?: () => "extension" | "electron" | undefined;
     public onClientConnected?: (client: BrowserClient) => void;
     public onClientDisconnected?: (client: BrowserClient) => void;
 
@@ -59,10 +59,10 @@ export class AgentWebSocketServer {
 
         const client: BrowserClient = {
             id: clientId,
-            type: clientId === 'inlineBrowser' ? 'electron' : 'extension',
+            type: clientId === "inlineBrowser" ? "electron" : "extension",
             socket: ws,
             connectedAt: new Date(),
-            lastActivity: new Date()
+            lastActivity: new Date(),
         };
 
         this.clients.set(clientId, client);
@@ -72,11 +72,13 @@ export class AgentWebSocketServer {
             this.selectActiveClient(this.getPreferredClientType?.());
         }
 
-        ws.send(JSON.stringify({
-            type: 'welcome',
-            clientId: clientId,
-            isActive: this.activeClientId === clientId
-        }));
+        ws.send(
+            JSON.stringify({
+                type: "welcome",
+                clientId: clientId,
+                isActive: this.activeClientId === clientId,
+            }),
+        );
 
         // Notify about new client connection
         if (this.onClientConnected) {
@@ -88,7 +90,10 @@ export class AgentWebSocketServer {
 
             try {
                 const data = JSON.parse(message);
-                if (data.method === "keepAlive" || data.messageType === "keepAlive") {
+                if (
+                    data.method === "keepAlive" ||
+                    data.messageType === "keepAlive"
+                ) {
                     return;
                 }
             } catch {}
@@ -118,7 +123,9 @@ export class AgentWebSocketServer {
         });
     }
 
-    public selectActiveClient(preferredClientType?: 'extension' | 'electron'): void {
+    public selectActiveClient(
+        preferredClientType?: "extension" | "electron",
+    ): void {
         // If we have a preferred client type, use it
         if (preferredClientType) {
             for (const [id, client] of this.clients) {
@@ -131,7 +138,7 @@ export class AgentWebSocketServer {
 
         // Default behavior: prefer electron over extension
         for (const [id, client] of this.clients) {
-            if (client.type === 'electron') {
+            if (client.type === "electron") {
                 this.setActiveClient(id);
                 return;
             }
@@ -150,13 +157,20 @@ export class AgentWebSocketServer {
         this.selectActiveClient(this.getPreferredClientType?.());
     }
 
-    public getActiveClient(fallbackType?: 'extension' | 'electron'): BrowserClient | null {
+    public getActiveClient(
+        fallbackType?: "extension" | "electron",
+    ): BrowserClient | null {
         // First try to get the currently active client
-        const activeClient = this.activeClientId ? this.clients.get(this.activeClientId) || null : null;
+        const activeClient = this.activeClientId
+            ? this.clients.get(this.activeClientId) || null
+            : null;
 
         // If we have an active client and either no fallback type specified
         // or the active client matches the fallback type, return it
-        if (activeClient && (!fallbackType || activeClient.type === fallbackType)) {
+        if (
+            activeClient &&
+            (!fallbackType || activeClient.type === fallbackType)
+        ) {
             return activeClient;
         }
 
@@ -187,10 +201,12 @@ export class AgentWebSocketServer {
             this.activeClientId = clientId;
 
             for (const [id, client] of this.clients) {
-                client.socket.send(JSON.stringify({
-                    type: 'active-status-changed',
-                    isActive: id === clientId
-                }));
+                client.socket.send(
+                    JSON.stringify({
+                        type: "active-status-changed",
+                        isActive: id === clientId,
+                    }),
+                );
             }
 
             debug(`Active client set to: ${clientId}`);

--- a/ts/packages/agents/browser/src/agent/browserActions.mts
+++ b/ts/packages/agents/browser/src/agent/browserActions.mts
@@ -11,13 +11,16 @@ import * as website from "website-memory";
 import { ActionContext, SessionContext } from "@typeagent/agent-sdk";
 import { MacroStore } from "./storage/index.mjs";
 import { WebAgentChannels } from "./webTypeAgent.mjs";
-import { BrowserClient, AgentWebSocketServer } from "./agentWebSocketServer.mjs";
+import {
+    BrowserClient,
+    AgentWebSocketServer,
+} from "./agentWebSocketServer.mjs";
 
 export type BrowserActionContext = {
     clientBrowserControl?: BrowserControl | undefined;
     externalBrowserControl?: BrowserControl | undefined;
     useExternalBrowserControl: boolean;
-    preferredClientType?: 'extension' | 'electron';
+    preferredClientType?: "extension" | "electron";
     agentWebSocketServer?: AgentWebSocketServer;
     browserConnector?: BrowserConnector;
     currentClient?: BrowserClient;

--- a/ts/packages/agents/browser/src/agent/browserActions.mts
+++ b/ts/packages/agents/browser/src/agent/browserActions.mts
@@ -11,17 +11,20 @@ import * as website from "website-memory";
 import { ActionContext, SessionContext } from "@typeagent/agent-sdk";
 import { MacroStore } from "./storage/index.mjs";
 import { WebAgentChannels } from "./webTypeAgent.mjs";
-import { WebSocket } from "ws";
+import { BrowserClient, AgentWebSocketServer } from "./agentWebSocketServer.mjs";
 
 export type BrowserActionContext = {
     clientBrowserControl?: BrowserControl | undefined;
     externalBrowserControl?: BrowserControl | undefined;
     useExternalBrowserControl: boolean;
-    webSocket?: WebSocket | undefined;
+    preferredClientType?: 'extension' | 'electron';
+    agentWebSocketServer?: AgentWebSocketServer;
+    browserConnector?: BrowserConnector;
+    currentClient?: BrowserClient;
+    extractionClients?: Map<string, string>;
     webAgentChannels?: WebAgentChannels | undefined;
     crosswordCachedSchemas?: Map<string, Crossword> | undefined;
     crossWordState?: Crossword | undefined;
-    browserConnector?: BrowserConnector | undefined;
     browserProcess?: ChildProcess | undefined;
     tabTitleIndex?: TabTitleIndex | undefined;
     allowDynamicAgentDomains?: string[];

--- a/ts/packages/agents/browser/src/agent/browserConnector.mts
+++ b/ts/packages/agents/browser/src/agent/browserConnector.mts
@@ -3,110 +3,97 @@
 
 import { AppAction } from "@typeagent/agent-sdk";
 import { BrowserControl } from "../common/browserControl.mjs";
-import { WebSocket } from "ws";
+import { BrowserClient, AgentWebSocketServer } from "./agentWebSocketServer.mjs";
 
 export class BrowserConnector {
     constructor(
-        private readonly webSocket: WebSocket,
+        private readonly agentServer: AgentWebSocketServer,
         private readonly browserControl: BrowserControl,
     ) {}
 
-    async sendActionToBrowser(action: AppAction, schemaName?: string) {
-        return new Promise<any | undefined>((resolve, reject) => {
-            if (this.webSocket) {
+    async sendActionToBrowser(
+        action: AppAction,
+        schemaName?: string,
+        targetClientId?: string
+    ): Promise<any> {
+        const client = targetClientId
+            ? this.agentServer.getClient(targetClientId)
+            : this.agentServer.getActiveClient();
+
+        if (!client) {
+            throw new Error("No browser client available");
+        }
+
+        return this.sendToClient(client, action, schemaName);
+    }
+
+    private async sendToClient(
+        client: BrowserClient,
+        action: AppAction,
+        schemaName?: string
+    ): Promise<any> {
+        return new Promise((resolve, reject) => {
+            const callId = `${Date.now()}_${Math.random().toString(36).substring(7)}`;
+            const message = {
+                id: callId,
+                method: `${schemaName || "browser"}/${action.actionName}`,
+                params: action.parameters
+            };
+
+            const timeout = setTimeout(() => {
+                client.socket.removeListener("message", messageHandler);
+                reject(new Error(`Action ${action.actionName} timed out`));
+            }, 30000);
+
+            const messageHandler = (data: any) => {
                 try {
-                    const callId = new Date().getTime().toString();
-                    if (!schemaName) {
-                        schemaName = "browser";
-                    }
+                    const response = JSON.parse(data.toString());
+                    if (response.id === callId) {
+                        clearTimeout(timeout);
+                        client.socket.removeListener("message", messageHandler);
 
-                    this.webSocket.send(
-                        JSON.stringify({
-                            id: callId,
-                            method: `${schemaName}/${action.actionName}`,
-                            params: action.parameters,
-                        }),
-                    );
-
-                    const handler = (event: any) => {
-                        const text = event.data.toString();
-                        const data = JSON.parse(text);
-                        if (data.id == callId && data.result) {
-                            this.webSocket.removeEventListener(
-                                "message",
-                                handler,
-                            );
-                            resolve(data.result);
+                        if (response.error) {
+                            reject(new Error(response.error));
+                        } else {
+                            resolve(response.result);
                         }
-                    };
-
-                    this.webSocket.addEventListener("message", handler);
-                } catch {
-                    console.log("Unable to contact browser backend.");
-                    reject(
-                        "Unable to connect to browser extension. Please ensure the TypeAgent browser extension is installed and active.",
-                    );
+                    }
+                } catch (error) {
+                    // Ignore parsing errors for non-response messages
                 }
-            } else {
-                throw new Error("No websocket connection.");
-            }
+            };
+
+            client.socket.on("message", messageHandler);
+            client.socket.send(JSON.stringify(message));
         });
     }
 
-    private async getPageDataFromBrowser(action: any) {
-        return new Promise<string | undefined>(async (resolve, reject) => {
-            const response = await this.sendActionToBrowser(action, "browser");
-            if (response.data) {
-                resolve(response.data);
-            } else {
-                resolve(undefined);
-            }
-        });
-    }
 
-    async getHtmlFragments(useTimestampIds?: boolean) {
-        const timeoutPromise = new Promise((f) => setTimeout(f, 120000));
-        const htmlAction = {
+    async getHtmlFragments(useTimestampIds?: boolean): Promise<any[]> {
+        const result = await this.sendActionToBrowser({
             actionName: "getHTML",
             parameters: {
                 fullHTML: false,
                 downloadAsFile: false,
                 extractText: true,
                 useTimestampIds: useTimestampIds,
-            },
-        };
-
-        const actionPromise = this.getPageDataFromBrowser(htmlAction);
-        const liveHtml = await Promise.race([actionPromise, timeoutPromise]);
-        if (liveHtml && Array.isArray(liveHtml)) {
-            return liveHtml;
-        }
-
-        return [];
+            }
+        });
+        return Array.isArray(result?.data) ? result.data : [];
     }
 
     async getFilteredHtmlFragments(
         inputHtmlFragments: any[],
         cssSelectorsToKeep: string[],
-    ) {
-        let htmlFragments: any[] = [];
-        const timeoutPromise = new Promise((f) => setTimeout(f, 5000));
-        const filterAction = {
+    ): Promise<any[]> {
+        const result = await this.sendActionToBrowser({
             actionName: "getFilteredHTMLFragments",
             parameters: {
                 fragments: inputHtmlFragments,
                 cssSelectorsToKeep: cssSelectorsToKeep,
-            },
-        };
-
-        const actionPromise = this.getPageDataFromBrowser(filterAction);
-        const result = await Promise.race([actionPromise, timeoutPromise]);
-
-        if (result && Array.isArray(result)) {
-            htmlFragments = result;
-        }
-
-        return htmlFragments;
+            }
+        });
+        return Array.isArray(result?.data) ? result.data : [];
     }
 
     async getCurrentPageScreenshot(): Promise<string> {
@@ -137,81 +124,57 @@ export class BrowserConnector {
         ]);
     }
 
-    async getCurrentPageAnnotatedScreenshot() {
-        const timeoutPromise = new Promise((f) => setTimeout(f, 3000));
-        const screenshotAction = {
+    async getCurrentPageAnnotatedScreenshot(): Promise<string> {
+        const result = await this.sendActionToBrowser({
             actionName: "captureAnnotatedScreenshot",
             parameters: {
                 downloadAsFile: true,
-            },
-        };
-
-        const actionPromise = this.getPageDataFromBrowser(screenshotAction);
-        let screenshot = "";
-        const liveScreenshot = await Promise.race([
-            actionPromise,
-            timeoutPromise,
-        ]);
-
-        if (liveScreenshot && typeof liveScreenshot == "string") {
-            screenshot = liveScreenshot;
-        }
-
-        return screenshot;
+            }
+        });
+        return typeof result?.data === "string" ? result.data : "";
     }
 
-    async clickOn(cssSelector: string) {
-        const clickAction = {
+    async clickOn(cssSelector: string): Promise<any> {
+        return this.sendActionToBrowser({
             actionName: "clickOnElement",
-            parameters: {
-                cssSelector: cssSelector,
-            },
-        };
-        return this.sendActionToBrowser(clickAction);
+            parameters: { cssSelector }
+        });
     }
 
-    async setDropdown(cssSelector: string, optionLabel: string) {
-        const clickAction = {
+    async setDropdown(cssSelector: string, optionLabel: string): Promise<any> {
+        return this.sendActionToBrowser({
             actionName: "setDropdownValue",
-            parameters: {
-                cssSelector: cssSelector,
-                optionLabel: optionLabel,
-            },
-        };
-        return this.sendActionToBrowser(clickAction);
+            parameters: { cssSelector, optionLabel }
+        });
     }
 
     async enterTextIn(
         textValue: string,
         cssSelector?: string,
         submitForm?: boolean,
-    ) {
-        let actionName = cssSelector ? "enterTextInElement" : "enterTextOnPage";
-
-        const textAction = {
-            actionName: actionName,
+    ): Promise<any> {
+        const actionName = cssSelector ? "enterTextInElement" : "enterTextOnPage";
+        return this.sendActionToBrowser({
+            actionName,
             parameters: {
                 value: textValue,
-                cssSelector: cssSelector,
-                submitForm: submitForm,
-            },
-        };
-
-        return this.sendActionToBrowser(textAction);
+                cssSelector,
+                submitForm
+            }
+        });
     }
 
-    async awaitPageLoad(timeout?: number) {
-        const action = {
-            actionName: "awaitPageLoad",
-        };
+    async awaitPageLoad(timeout?: number): Promise<any> {
+        const actionPromise = this.sendActionToBrowser({
+            actionName: "awaitPageLoad"
+        });
 
-        const actionPromise = this.sendActionToBrowser(action, "browser");
         if (timeout) {
             const timeoutPromise = new Promise((f) => setTimeout(f, timeout));
             return Promise.race([actionPromise, timeoutPromise]);
-        } else {
-            return actionPromise;
         }
+
+        return actionPromise;
     }
 
     async awaitPageInteraction(timeout?: number) {

--- a/ts/packages/agents/browser/src/agent/browserConnector.mts
+++ b/ts/packages/agents/browser/src/agent/browserConnector.mts
@@ -3,7 +3,10 @@
 
 import { AppAction } from "@typeagent/agent-sdk";
 import { BrowserControl } from "../common/browserControl.mjs";
-import { BrowserClient, AgentWebSocketServer } from "./agentWebSocketServer.mjs";
+import {
+    BrowserClient,
+    AgentWebSocketServer,
+} from "./agentWebSocketServer.mjs";
 
 export class BrowserConnector {
     constructor(
@@ -14,7 +17,7 @@ export class BrowserConnector {
     async sendActionToBrowser(
         action: AppAction,
         schemaName?: string,
-        targetClientId?: string
+        targetClientId?: string,
     ): Promise<any> {
         const client = targetClientId
             ? this.agentServer.getClient(targetClientId)
@@ -30,14 +33,14 @@ export class BrowserConnector {
     private async sendToClient(
         client: BrowserClient,
         action: AppAction,
-        schemaName?: string
+        schemaName?: string,
     ): Promise<any> {
         return new Promise((resolve, reject) => {
             const callId = `${Date.now()}_${Math.random().toString(36).substring(7)}`;
             const message = {
                 id: callId,
                 method: `${schemaName || "browser"}/${action.actionName}`,
-                params: action.parameters
+                params: action.parameters,
             };
 
             const timeout = setTimeout(() => {
@@ -68,7 +71,6 @@ export class BrowserConnector {
         });
     }
 
-
     async getHtmlFragments(useTimestampIds?: boolean): Promise<any[]> {
         const result = await this.sendActionToBrowser({
             actionName: "getHTML",
@@ -77,7 +79,7 @@ export class BrowserConnector {
                 downloadAsFile: false,
                 extractText: true,
                 useTimestampIds: useTimestampIds,
-            }
+            },
         });
         return Array.isArray(result?.data) ? result.data : [];
     }
@@ -91,7 +93,7 @@ export class BrowserConnector {
             parameters: {
                 fragments: inputHtmlFragments,
                 cssSelectorsToKeep: cssSelectorsToKeep,
-            }
+            },
         });
         return Array.isArray(result?.data) ? result.data : [];
     }
@@ -129,7 +131,7 @@ export class BrowserConnector {
             actionName: "captureAnnotatedScreenshot",
             parameters: {
                 downloadAsFile: true,
-            }
+            },
         });
         return typeof result?.data === "string" ? result.data : "";
     }
@@ -137,14 +139,14 @@ export class BrowserConnector {
     async clickOn(cssSelector: string): Promise<any> {
         return this.sendActionToBrowser({
             actionName: "clickOnElement",
-            parameters: { cssSelector }
+            parameters: { cssSelector },
         });
     }
 
     async setDropdown(cssSelector: string, optionLabel: string): Promise<any> {
         return this.sendActionToBrowser({
             actionName: "setDropdownValue",
-            parameters: { cssSelector, optionLabel }
+            parameters: { cssSelector, optionLabel },
         });
     }
 
@@ -153,20 +155,22 @@ export class BrowserConnector {
         cssSelector?: string,
         submitForm?: boolean,
     ): Promise<any> {
-        const actionName = cssSelector ? "enterTextInElement" : "enterTextOnPage";
+        const actionName = cssSelector
+            ? "enterTextInElement"
+            : "enterTextOnPage";
         return this.sendActionToBrowser({
             actionName,
             parameters: {
                 value: textValue,
                 cssSelector,
-                submitForm
-            }
+                submitForm,
+            },
         });
     }
 
     async awaitPageLoad(timeout?: number): Promise<any> {
         const actionPromise = this.sendActionToBrowser({
-            actionName: "awaitPageLoad"
+            actionName: "awaitPageLoad",
         });
 
         if (timeout) {

--- a/ts/packages/agents/browser/src/agent/contentService.mts
+++ b/ts/packages/agents/browser/src/agent/contentService.mts
@@ -20,9 +20,9 @@ export class ContentService {
         this.sessionContext = sessionContext;
 
         const agentContext = sessionContext?.agentContext;
-        if (agentContext?.webSocket && agentContext.externalBrowserControl) {
+        if (agentContext?.agentWebSocketServer && agentContext.externalBrowserControl) {
             this.browserConnector = new BrowserConnector(
-                agentContext.webSocket,
+                agentContext.agentWebSocketServer,
                 agentContext.externalBrowserControl,
             );
             debug("Initialized with browser download capabilities");
@@ -144,7 +144,7 @@ export class ContentService {
     isBrowserAvailable(): boolean {
         return (
             !!this.browserConnector &&
-            !!this.sessionContext?.agentContext.webSocket
+            !!this.sessionContext?.agentContext.agentWebSocketServer
         );
     }
 
@@ -153,16 +153,16 @@ export class ContentService {
      */
     getStatus(): {
         browserAvailable: boolean;
-        webSocketConnected: boolean;
+        agentWebSocketServerConnected: boolean;
         capabilities: string[];
     } {
-        const webSocketConnected =
-            !!this.sessionContext?.agentContext.webSocket;
+        const agentWebSocketServerConnected =
+            !!this.sessionContext?.agentContext.agentWebSocketServer;
         const browserAvailable = this.isBrowserAvailable();
 
         return {
             browserAvailable,
-            webSocketConnected,
+            agentWebSocketServerConnected,
             capabilities: browserAvailable
                 ? [
                       "content-download",

--- a/ts/packages/agents/browser/src/agent/contentService.mts
+++ b/ts/packages/agents/browser/src/agent/contentService.mts
@@ -20,7 +20,10 @@ export class ContentService {
         this.sessionContext = sessionContext;
 
         const agentContext = sessionContext?.agentContext;
-        if (agentContext?.agentWebSocketServer && agentContext.externalBrowserControl) {
+        if (
+            agentContext?.agentWebSocketServer &&
+            agentContext.externalBrowserControl
+        ) {
             this.browserConnector = new BrowserConnector(
                 agentContext.agentWebSocketServer,
                 agentContext.externalBrowserControl,

--- a/ts/packages/agents/browser/src/agent/import/importWebSocketHandler.mts
+++ b/ts/packages/agents/browser/src/agent/import/importWebSocketHandler.mts
@@ -25,8 +25,8 @@ export class ImportWebSocketHandler {
 
     private forwardProgressToWebSocket(progress: ImportProgressEvent) {
         try {
-            const webSocket = this.context.agentContext.webSocket;
-            if (webSocket && webSocket.readyState === WebSocket.OPEN) {
+            const client = this.context.agentContext.currentClient;
+            if (client && client.socket.readyState === WebSocket.OPEN) {
                 const websocketProgress = {
                     type: "importProgress",
                     totalItems: progress.total,
@@ -60,7 +60,7 @@ export class ImportWebSocketHandler {
                     source: "browserAgent",
                 };
 
-                webSocket.send(JSON.stringify(progressMessage));
+                client.socket.send(JSON.stringify(progressMessage));
             }
         } catch (error) {
             console.error(

--- a/ts/packages/agents/browser/src/agent/knowledge/knowledgeHandler.mts
+++ b/ts/packages/agents/browser/src/agent/knowledge/knowledgeHandler.mts
@@ -3,6 +3,7 @@
 
 import { SessionContext } from "@typeagent/agent-sdk";
 import { WebSocket } from "ws";
+import { BrowserClient } from "../agentWebSocketServer.mjs";
 import { BrowserActionContext } from "../browserActions.mjs";
 import { searchByEntities, searchWebMemories } from "../searchWebMemories.mjs";
 import * as website from "website-memory";
@@ -47,12 +48,12 @@ const debug = registerDebug("typeagent:browser:knowledge");
  * Knowledge extraction progress update helper function
  */
 export function sendKnowledgeExtractionProgressViaWebSocket(
-    webSocket: WebSocket | undefined,
+    client: BrowserClient | undefined,
     extractionId: string,
     progress: KnowledgeExtractionProgress,
 ) {
     try {
-        if (webSocket && webSocket.readyState === WebSocket.OPEN) {
+        if (client && client.socket.readyState === WebSocket.OPEN) {
             // Send progress update message via WebSocket
             const progressMessage = {
                 method: "knowledgeExtractionProgress",
@@ -63,9 +64,9 @@ export function sendKnowledgeExtractionProgressViaWebSocket(
                 source: "browserAgent",
             };
 
-            webSocket.send(JSON.stringify(progressMessage));
+            client.socket.send(JSON.stringify(progressMessage));
             debug(
-                `Knowledge Extraction Progress [${extractionId}] sent via WebSocket:`,
+                `Knowledge Extraction Progress [${extractionId}] sent to client ${client.id}:`,
                 progress,
             );
         } else {
@@ -921,7 +922,7 @@ export async function extractKnowledgeFromPageStreaming(
         };
 
         sendKnowledgeExtractionProgressViaWebSocket(
-            context.agentContext.webSocket,
+            context.agentContext.currentClient,
             extractionId,
             errorProgress,
         );

--- a/ts/packages/agents/browser/src/agent/knowledge/knowledgeHandler.mts
+++ b/ts/packages/agents/browser/src/agent/knowledge/knowledgeHandler.mts
@@ -516,6 +516,7 @@ export async function extractKnowledgeFromPage(
 
     if (extractionInputs.length === 0) {
         return {
+            title: parameters.title,
             entities: [],
             relationships: [],
             keyTopics: [],
@@ -540,8 +541,9 @@ export async function extractKnowledgeFromPage(
 
         // Aggregate results from all fragments
         const aggregatedResults = aggregateExtractionResults(extractionResults);
-
+        
         return {
+            title: parameters.title,
             ...aggregatedResults,
         };
     } catch (error) {
@@ -612,6 +614,7 @@ export async function extractKnowledgeFromPageStreaming(
                 "Insufficient content to extract knowledge",
             );
             return {
+                title: parameters.title,
                 entities: [],
                 relationships: [],
                 keyTopics: [],
@@ -638,6 +641,7 @@ export async function extractKnowledgeFromPageStreaming(
         await sendProgressUpdate("basic", "Processing basic page information");
 
         let aggregatedResults: any = {
+            title: parameters.title,
             entities: [],
             relationships: [],
             keyTopics: [],
@@ -686,6 +690,7 @@ export async function extractKnowledgeFromPageStreaming(
                 3,
             );
             aggregatedResults = aggregateExtractionResults(basicResults);
+            aggregatedResults.title = parameters.title;
 
             await sendProgressUpdate(
                 "basic",
@@ -2136,6 +2141,7 @@ export async function getPageIndexedKnowledge(
                 return {
                     isIndexed: true,
                     knowledge: {
+                        title: "",
                         entities: [],
                         relationships: [],
                         keyTopics: [],
@@ -2230,6 +2236,7 @@ export async function getPageIndexedKnowledge(
             return {
                 isIndexed: true,
                 knowledge: {
+                    title: (knowledge as any).title || "",
                     entities,
                     relationships,
                     keyTopics,
@@ -2251,6 +2258,7 @@ export async function getPageIndexedKnowledge(
             return {
                 isIndexed: true,
                 knowledge: {
+                    title:"",
                     entities: [],
                     relationships: [],
                     keyTopics: [],

--- a/ts/packages/agents/browser/src/agent/knowledge/knowledgeHandler.mts
+++ b/ts/packages/agents/browser/src/agent/knowledge/knowledgeHandler.mts
@@ -541,7 +541,7 @@ export async function extractKnowledgeFromPage(
 
         // Aggregate results from all fragments
         const aggregatedResults = aggregateExtractionResults(extractionResults);
-        
+
         return {
             title: parameters.title,
             ...aggregatedResults,
@@ -2258,7 +2258,7 @@ export async function getPageIndexedKnowledge(
             return {
                 isIndexed: true,
                 knowledge: {
-                    title:"",
+                    title: "",
                     entities: [],
                     relationships: [],
                     keyTopics: [],

--- a/ts/packages/agents/browser/src/agent/knowledge/knowledgeWebSocketBridge.mts
+++ b/ts/packages/agents/browser/src/agent/knowledge/knowledgeWebSocketBridge.mts
@@ -41,7 +41,7 @@ export class KnowledgeWebSocketBridge {
         };
 
         sendKnowledgeExtractionProgressViaWebSocket(
-            this.context.agentContext.webSocket,
+            this.context.agentContext.currentClient,
             progress.extractionId,
             websocketProgress,
         );

--- a/ts/packages/agents/browser/src/agent/knowledge/schema/knowledgeExtraction.mts
+++ b/ts/packages/agents/browser/src/agent/knowledge/schema/knowledgeExtraction.mts
@@ -12,6 +12,7 @@ export interface KnowledgeExtractionResult {
 
 export interface EnhancedKnowledgeExtractionResult
     extends KnowledgeExtractionResult {
+    title: string;
     contentActions?: kpLib.Action[];
     detectedActions?: DetectedAction[];
     actionSummary?: ActionSummary;

--- a/ts/packages/agents/browser/src/agent/rpc/externalBrowserControlClient.mts
+++ b/ts/packages/agents/browser/src/agent/rpc/externalBrowserControlClient.mts
@@ -10,36 +10,55 @@ import {
 import { createGenericChannel } from "agent-rpc/channel";
 import { createRpc } from "agent-rpc/rpc";
 import { WebSocketMessageV2 } from "common-utils";
+import { AgentWebSocketServer } from "../agentWebSocketServer.mjs";
 
 export function createExternalBrowserClient(
-    webSocket: WebSocket,
+    agentWebSocketServer: AgentWebSocketServer,
 ): BrowserControl {
     const browserControlChannel = createGenericChannel((message) => {
-        // Message to the browser extension
-        webSocket.send(
-            JSON.stringify({
-                source: "browserAgent",
-                method: "browserControl/message",
-                params: message,
-            }),
-        );
-    });
-
-    webSocket.on("message", (message) => {
-        // Message from the browser extension
-        const text = message.toString();
-        const data: WebSocketMessageV2 = JSON.parse(text);
-        if (
-            data.source === "browserExtension" &&
-            data.method === "browserControl/message"
-        ) {
-            browserControlChannel.message(data.params);
+        // Message to the active browser extension client (fallback to extension type only)
+        const activeClient = agentWebSocketServer.getActiveClient('extension');
+        if (activeClient && activeClient.socket.readyState === WebSocket.OPEN) {
+            activeClient.socket.send(
+                JSON.stringify({
+                    source: "browserAgent",
+                    method: "browserControl/message",
+                    params: message,
+                }),
+            );
         }
     });
 
-    webSocket.on("close", () => {
-        browserControlChannel.disconnect();
-    });
+    // Add browser control message handling to existing message handler
+    // This approach avoids replacing the entire handler and allows multiple instances
+    const handleBrowserControlMessage = (client: any, message: string) => {
+        try {
+            const data: WebSocketMessageV2 = JSON.parse(message);
+            if (
+                data.source === "browserExtension" &&
+                data.method === "browserControl/message"
+            ) {
+                browserControlChannel.message(data.params);
+            }
+        } catch (error) {
+            // Ignore parsing errors for non-JSON messages
+        }
+    };
+
+    // Store reference to our handler so it can be cleaned up if needed
+    (browserControlChannel as any)._messageHandler = handleBrowserControlMessage;
+
+    // Wrap the existing onClientMessage handler to include our browser control handling
+    const originalOnClientMessage = agentWebSocketServer.onClientMessage;
+    agentWebSocketServer.onClientMessage = (client, message) => {
+        // Call the original handler first
+        if (originalOnClientMessage) {
+            originalOnClientMessage(client, message);
+        }
+
+        // Handle browser control messages
+        handleBrowserControlMessage(client, message);
+    };
 
     const rpc = createRpc<
         BrowserControlInvokeFunctions,

--- a/ts/packages/agents/browser/src/agent/rpc/externalBrowserControlClient.mts
+++ b/ts/packages/agents/browser/src/agent/rpc/externalBrowserControlClient.mts
@@ -17,7 +17,7 @@ export function createExternalBrowserClient(
 ): BrowserControl {
     const browserControlChannel = createGenericChannel((message) => {
         // Message to the active browser extension client (fallback to extension type only)
-        const activeClient = agentWebSocketServer.getActiveClient('extension');
+        const activeClient = agentWebSocketServer.getActiveClient("extension");
         if (activeClient && activeClient.socket.readyState === WebSocket.OPEN) {
             activeClient.socket.send(
                 JSON.stringify({
@@ -46,7 +46,8 @@ export function createExternalBrowserClient(
     };
 
     // Store reference to our handler so it can be cleaned up if needed
-    (browserControlChannel as any)._messageHandler = handleBrowserControlMessage;
+    (browserControlChannel as any)._messageHandler =
+        handleBrowserControlMessage;
 
     // Wrap the existing onClientMessage handler to include our browser control handling
     const originalOnClientMessage = agentWebSocketServer.onClientMessage;

--- a/ts/packages/agents/browser/src/agent/webTypeAgent.mts
+++ b/ts/packages/agents/browser/src/agent/webTypeAgent.mts
@@ -102,29 +102,35 @@ function ensureWebAgentChannels(context: SessionContext<BrowserActionContext>) {
         return existing;
     }
 
-    const webSocket = context.agentContext.webSocket;
-    if (webSocket === undefined) {
+    const agentServer = context.agentContext.agentWebSocketServer;
+    if (agentServer === undefined) {
         return undefined;
     }
 
     const channelProvider = createGenericChannelProvider((message) => {
-        webSocket.send(
-            JSON.stringify({
-                source: "dispatcher",
-                method: "webAgent/message",
-                params: message,
-            }),
-        );
+        const client = agentServer.getActiveClient();
+        if (client) {
+            client.socket.send(
+                JSON.stringify({
+                    source: "dispatcher",
+                    method: "webAgent/message",
+                    params: message,
+                }),
+            );
+        }
     });
 
     const registerChannel = createGenericChannel((message) => {
-        webSocket.send(
-            JSON.stringify({
-                source: "dispatcher",
-                method: "webAgent/register",
-                params: message,
-            }),
-        );
+        const client = agentServer.getActiveClient();
+        if (client) {
+            client.socket.send(
+                JSON.stringify({
+                    source: "dispatcher",
+                    method: "webAgent/register",
+                    params: message,
+                }),
+            );
+        }
     });
 
     createRpc("webagent", registerChannel.channel, {

--- a/ts/packages/agents/browser/src/extension/serviceWorker/storage.ts
+++ b/ts/packages/agents/browser/src/extension/serviceWorker/storage.ts
@@ -62,7 +62,7 @@ export async function clearRecordedActions(): Promise<void> {
  */
 export async function getSettings(): Promise<Record<string, string>> {
     const settings = await chrome.storage.sync.get({
-        websocketHost: "ws://localhost:8080/",
+        websocketHost: "ws://localhost:8081/",
     });
     return settings;
 }

--- a/ts/packages/agents/browser/src/extension/serviceWorker/websocket.ts
+++ b/ts/packages/agents/browser/src/extension/serviceWorker/websocket.ts
@@ -51,7 +51,7 @@ export async function createWebSocket(): Promise<WebSocket | undefined> {
         settings = await getSettings();
     }
 
-    let socketEndpoint = settings.websocketHost ?? "ws://localhost:8080/";
+    let socketEndpoint = settings.websocketHost ?? "ws://localhost:8081/";
 
     socketEndpoint += `?channel=browser&role=client&clientId=${chrome.runtime.id}`;
     return new Promise<WebSocket | undefined>((resolve, reject) => {

--- a/ts/packages/agents/browser/src/extension/views/options.html
+++ b/ts/packages/agents/browser/src/extension/views/options.html
@@ -44,7 +44,7 @@
               type="text"
               class="form-control"
               id="websocketHost"
-              placeholder="ws://localhost:8080"
+              placeholder="ws://localhost:8081"
             />
             <div class="form-text">
               Specify the WebSocket host address for TypeAgent connection

--- a/ts/packages/agents/browser/src/extension/views/options.ts
+++ b/ts/packages/agents/browser/src/extension/views/options.ts
@@ -17,7 +17,7 @@ interface AIModelStatus {
 }
 
 const DEFAULT_SETTINGS: ExtensionSettings = {
-    websocketHost: "ws://localhost:8080/",
+    websocketHost: "ws://localhost:8081/",
     defaultExtractionMode: "content",
     maxConcurrentExtractions: 3,
     qualityThreshold: 0.3,

--- a/ts/packages/commonUtils/src/webSockets.ts
+++ b/ts/packages/commonUtils/src/webSockets.ts
@@ -25,9 +25,10 @@ export async function createWebSocket(
     channel: string,
     role: "dispatcher" | "client",
     clientId?: string,
+    port: number = 8081,
 ) {
     return new Promise<WebSocket | undefined>((resolve, reject) => {
-        let endpoint = "ws://localhost:8080";
+        let endpoint = `ws://localhost:${port}`;
         if (process.env["WEBSOCKET_HOST"]) {
             endpoint = process.env["WEBSOCKET_HOST"];
         } else {

--- a/ts/packages/shell/src/main/browserIpc.ts
+++ b/ts/packages/shell/src/main/browserIpc.ts
@@ -54,6 +54,7 @@ export class BrowserAgentIpc {
                     "browser",
                     "client",
                     "inlineBrowser",
+                    8081
                 );
                 if (!this.webSocket) {
                     this.webSocketPromise = null;

--- a/ts/packages/shell/src/main/browserIpc.ts
+++ b/ts/packages/shell/src/main/browserIpc.ts
@@ -54,7 +54,7 @@ export class BrowserAgentIpc {
                     "browser",
                     "client",
                     "inlineBrowser",
-                    8081
+                    8081,
                 );
                 if (!this.webSocket) {
                     this.webSocketPromise = null;


### PR DESCRIPTION
- Update websocket clients to identify the source as extension or inline electron browser
- Use the `@browser external on/off` command to determine which client to prefer
- Implement the websocket host in the agent process to make it easier to track and route to clients