### PR TITLE
Shell: improve playwright tests stability

### DIFF
--- a/ts/packages/shell/src/main/shellWindow.ts
+++ b/ts/packages/shell/src/main/shellWindow.ts
@@ -367,6 +367,7 @@ export class ShellWindow {
     public startChatServer(port: number) {
         if (this.chatViewServer !== undefined) {
             debugShellWindow("Chat server already started");
+            return;
         }
 
         if (port > 0) {

--- a/ts/packages/shell/test/configCommands.spec.ts
+++ b/ts/packages/shell/test/configCommands.spec.ts
@@ -1,19 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import test, {
-    _electron,
-    _electron as electron,
-    expect,
-    Page,
-} from "@playwright/test";
+import test, { expect, Page } from "@playwright/test";
 import {
     exitApplication,
-    getAppPath,
-    sendUserRequest,
     sendUserRequestAndWaitForResponse,
     startShell,
-    waitForAgentMessage,
 } from "./testHelper";
 
 // Annotate entire file as serial.

--- a/ts/packages/shell/test/sessionCommands.spec.ts
+++ b/ts/packages/shell/test/sessionCommands.spec.ts
@@ -1,23 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import test, {
-    _electron,
-    _electron as electron,
-    expect,
-    Page,
-} from "@playwright/test";
+import test, { expect, Page } from "@playwright/test";
 import {
     exitApplication,
-    getAppPath,
-    getLastAgentMessage,
-    sendUserRequest,
     sendUserRequestAndWaitForCompletion,
     sendUserRequestFast,
     startShell,
-    waitForAgentMessage,
 } from "./testHelper";
-import { session } from "electron";
 
 // Annotate entire file as serial.
 test.describe.configure({ mode: "serial" });

--- a/ts/packages/shell/test/simple.spec.ts
+++ b/ts/packages/shell/test/simple.spec.ts
@@ -28,7 +28,10 @@ test("simple", { tag: "@smoke" }, async ({}, testInfo) => {
 });
 
 test("startShell", { tag: "@smoke" }, async ({}) => {
-    await startShell();
+    const mainWindow = await startShell();
+
+    // close the application
+    await exitApplication(mainWindow);
 });
 
 test("why is the sky blue?", { tag: "@smoke" }, async ({}, testInfo) => {

--- a/ts/packages/shell/test/testHelper.ts
+++ b/ts/packages/shell/test/testHelper.ts
@@ -25,8 +25,9 @@ export async function startShell(
     waitForAgentGreeting: boolean = true,
 ): Promise<Page> {
     // this is needed to isolate these tests session from other concurrently running tests
-    process.env["INSTANCE_NAME"] =
-        `test_${process.env["TEST_WORKER_INDEX"]}_${process.env["TEST_PARALLEL_INDEX"]}`;
+    const instanceName = `test_${process.env["TEST_WORKER_INDEX"]}_${process.env["TEST_PARALLEL_INDEX"]}`;
+
+    process.env["INSTANCE_NAME"] = instanceName;
 
     // other related multi-instance variables that need to be modified to ensure we can run multiple shell instances
     // Use 3001 as test port and assuming less then 50 port is needed per worker instance
@@ -43,43 +44,39 @@ export async function startShell(
 
     do {
         try {
-            if (runningApplications.has(process.env["INSTANCE_NAME"]!)) {
+            if (runningApplications.has(instanceName)) {
                 throw new Error(
                     "Application instance already running. Did you shutdown cleanly?",
                 );
             }
 
-            console.log(
-                `Starting electron instance '${process.env["INSTANCE_NAME"]}'`,
-            );
+            console.log(`Starting electron instance '${instanceName}'`);
             const app: ElectronApplication = await electron.launch({
                 args: getLaunchArgs(),
             });
-            runningApplications.set(process.env["INSTANCE_NAME"]!, app);
+            runningApplications.set(instanceName, app);
 
             // get the main window
-            const mainWindow: Page = await getMainWindow(app);
+            const mainWindow: Page = await getChatViewWindow(app);
 
             // wait for agent greeting
             if (waitForAgentGreeting) {
-                await waitForAgentMessage(mainWindow, 30000, 1, true, ["..."]);
+                await waitForAgentMessage(mainWindow, 30000, 1, false, ["..."]);
             }
 
             return mainWindow;
         } catch (e) {
             console.warn(
-                `Unable to start electrom application (${process.env["INSTANCE_NAME"]}). Attempt ${retryAttempt} of ${maxRetries}. Error: ${e}`,
+                `Unable to start electron application (${instanceName}). Attempt ${retryAttempt} of ${maxRetries}. Error: ${e}`,
             );
             retryAttempt++;
 
-            if (runningApplications.get(process.env["INSTANCE_NAME"])) {
-                console.log(`Closing instance ${process.env["INSTANCE_NAME"]}`);
-                await runningApplications
-                    .get(process.env["INSTANCE_NAME"]!)!
-                    .close();
+            const existing = runningApplications.get(instanceName);
+            if (existing) {
+                console.log(`Closing instance ${instanceName}`);
+                await existing.close();
+                runningApplications.delete(instanceName);
             }
-
-            runningApplications.delete(process.env["INSTANCE_NAME"]!);
         }
     } while (retryAttempt <= maxRetries);
 
@@ -88,40 +85,30 @@ export async function startShell(
     );
 }
 
-async function getMainWindow(app: ElectronApplication): Promise<Page> {
+const chatViewTitle = "Chat View"; // See chatView.html title tag
+async function getChatViewWindow(app: ElectronApplication): Promise<Page> {
     let attempts = 0;
     do {
         let windows: Page[] = await app.windows();
-
-        // if we change the # of windows beyond 2 we'll have to update this function to correctly disambiguate which window is the correct one
-        if (windows.length > 2) {
-            console.log(`Found ${app.windows.length} windows.  Expected 2`);
-            throw "Please update this logic to select the correct main window. (testHelper.ts->getMainWindow())";
-        }
-
         // wait for each window to load and return the one we are interested in
-        for (let i = 0; i < windows.length; i++) {
+        for (const window of windows) {
             try {
-                if (windows[i] !== undefined) {
-                    await windows[i].waitForLoadState("domcontentloaded");
+                await window.waitForLoadState("domcontentloaded");
 
-                    // is this the correct window?
-                    const title = await windows[i].title();
-                    if (title.length > 0) {
-                        console.log(`Found window ${title}`);
-                        return windows[i];
-                    }
+                // is this the correct window?
+                const title = await window.title();
+                if (title === chatViewTitle) {
+                    return window;
                 }
             } catch (e) {
                 console.log(e);
             }
         }
 
-        console.log("waiting...");
         await new Promise((resolve) => setTimeout(resolve, 1000));
     } while (++attempts < 30);
 
-    throw "Unable to find window...timeout";
+    throw new Error("Unable to find chat view...timeout");
 }
 
 /**
@@ -130,10 +117,9 @@ async function getMainWindow(app: ElectronApplication): Promise<Page> {
  */
 export async function exitApplication(page: Page): Promise<void> {
     await sendUserRequestFast("@exit", page);
-
-    await runningApplications.get(process.env["INSTANCE_NAME"]!)!.close();
-
-    runningApplications.delete(process.env["INSTANCE_NAME"]!);
+    const instanceName = process.env["INSTANCE_NAME"]!;
+    await runningApplications.get(instanceName)!.close();
+    runningApplications.delete(instanceName);
 }
 
 /**
@@ -216,10 +202,7 @@ export async function sendUserRequestAndWaitForResponse(
     await sendUserRequest(prompt, page);
 
     // wait for agent response
-    await waitForAgentMessage(page, 30000, locators.length + 1);
-
-    // return the response
-    return await getLastAgentMessageText(page);
+    return waitForAgentMessage(page, 30000, locators.length + 1);
 }
 
 /**
@@ -242,34 +225,7 @@ export async function sendUserRequestAndWaitForCompletion(
     await sendUserRequest(prompt, page);
 
     // wait for agent response
-    await waitForAgentMessage(page, 30000, locators.length + 1, true);
-
-    // return the response
-    return await getLastAgentMessageText(page);
-}
-
-/**
- * Gets the last agent message from the chat view
- * @param page The main page from the electron host application.
- */
-export async function getLastAgentMessageText(page: Page): Promise<string> {
-    const locators: Locator[] = await page
-        .locator(".chat-message-agent .chat-message-content")
-        .all();
-
-    return await locators[0].innerText();
-}
-
-/**
- * Gets the last agent message from the chat view
- * @param page The maing page from the electron host application.
- */
-export async function getLastAgentMessage(page: Page): Promise<Locator> {
-    const locators: Locator[] = await page
-        .locator(".chat-message-container-agent")
-        .all();
-
-    return locators[0];
+    return waitForAgentMessage(page, 30000, locators.length + 1, true);
 }
 
 /**
@@ -277,7 +233,7 @@ export async function getLastAgentMessage(page: Page): Promise<Locator> {
  *
  * @param msg The agent message to check for completion
  */
-export async function isMessageCompleted(msg: Locator): Promise<boolean> {
+async function isMessageCompleted(msg: Locator): Promise<boolean> {
     // Agent message is complete once the metrics have been reported
     try {
         const details: Locator = await msg.locator(".metrics-details", {
@@ -294,6 +250,13 @@ export async function isMessageCompleted(msg: Locator): Promise<boolean> {
     return false;
 }
 
+async function getAgentMessageFromContainer(locator: Locator): Promise<string> {
+    const locators = await locator
+        .locator(".chat-message-agent .chat-message-content")
+        .all();
+    return locators[0].innerText();
+}
+
 /**
  *
  * @param page The page where the chatview is hosted
@@ -304,49 +267,47 @@ export async function isMessageCompleted(msg: Locator): Promise<boolean> {
  *          i.e. [".."] and this method will ignore agent messages that are "..." and will continue waiting.
  *          This is useful when an agent sends status messages.
  *
- * @returns When the expected # of messages is reached or the timeout is reached.  Whichever occurrs first.
+ * @returns the agent message.
  */
-export async function waitForAgentMessage(
+async function waitForAgentMessage(
     page: Page,
     timeout: number,
     expectedMessageCount: number,
     waitForMessageCompletion: boolean = false,
     ignore: string[] = [],
-): Promise<void> {
+): Promise<string> {
     let timeWaited = 0;
-    let locators: Locator[] = await page
-        .locator(".chat-message-container-agent")
-        .all();
-    let originalAgentMessageCount = locators.length;
-    let messageCount = originalAgentMessageCount;
 
-    do {
-        if (
-            expectedMessageCount == messageCount &&
-            (!waitForMessageCompletion ||
-                (await isMessageCompleted(await getLastAgentMessage(page))))
-        ) {
-            return;
-        }
-
-        await page.waitForTimeout(1000);
-        timeWaited += 1000;
-
-        locators = await page.locator(".chat-message-container-agent").all();
-        messageCount = locators.length;
-
-        // is this message ignorable?
-        if (locators.length > 0) {
-            const lastMessage = await getLastAgentMessageText(page);
-            if (ignore.indexOf(lastMessage) > -1) {
-                console.log(`Ignore agent message '${lastMessage}'`);
-                messageCount = originalAgentMessageCount;
+    while (true) {
+        const locators = await page
+            .locator(".chat-message-container-agent")
+            .all();
+        const messageCount = locators.length;
+        if (messageCount >= expectedMessageCount) {
+            // Chat view message are in reverse order, so the last one is in index 0
+            const lastLocator = locators[0];
+            const classNames = await lastLocator.getAttribute("class");
+            if (!classNames?.includes("history")) {
+                if (
+                    !waitForMessageCompletion ||
+                    (await isMessageCompleted(lastLocator))
+                ) {
+                    // If we are waiting for completion, check that first before getting the message content.
+                    const lastMessage =
+                        await getAgentMessageFromContainer(lastLocator);
+                    if (ignore.indexOf(lastMessage) === -1) {
+                        return lastMessage;
+                    }
+                }
             }
         }
-    } while (
-        timeWaited <= timeout &&
-        messageCount == originalAgentMessageCount
-    );
+
+        if (timeWaited > timeout) {
+            throw new Error("Timeout waiting for agent message");
+        }
+        await page.waitForTimeout(1000);
+        timeWaited += 1000;
+    }
 }
 
 /**


### PR DESCRIPTION
- Fix the window detection to not check number windows (currently is 3 since we default create browser pane, but there is not much point to we have only 2 windows.)
- Use the chat view title explicitly for the window detection
- Close application in startShell smoke test.
- throw when timeout during waitForAgentMessage (instead of just return and error when the test condition is not met.
- Ignore history messages in waitForAgentMessage
- ShellWindow.startChatServer needs to return when one is already started.