### PR TITLE
Fix duplicate navigation events detected on some pages

### DIFF
--- a/ts/packages/agents/browser/src/common/browserControl.mts
+++ b/ts/packages/agents/browser/src/common/browserControl.mts
@@ -5,7 +5,6 @@ export type ExtractionMode = "basic" | "summary" | "content" | "full";
 
 export interface BrowserSettings {
     autoIndexing: boolean;
-    indexingDelay: number;
     extractionMode: ExtractionMode;
 }
 

--- a/ts/packages/agents/browser/src/extension/contentScript/autoIndexing.ts
+++ b/ts/packages/agents/browser/src/extension/contentScript/autoIndexing.ts
@@ -3,7 +3,6 @@
 
 interface AutoIndexingSettings {
     autoIndexing: boolean;
-    indexingDelay: number;
     excludeSensitiveSites: boolean;
     indexingQuality: "fast" | "balanced" | "deep";
     indexOnlyTextContent: boolean;
@@ -15,7 +14,6 @@ class AutoIndexingManager {
     private isIndexing: boolean = false;
     private settings: AutoIndexingSettings = {
         autoIndexing: false,
-        indexingDelay: 3,
         excludeSensitiveSites: true,
         indexingQuality: "balanced",
         indexOnlyTextContent: false,
@@ -46,7 +44,6 @@ class AutoIndexingManager {
     }): boolean {
         const relevantKeys = [
             "autoIndexing",
-            "indexingDelay",
             "excludeSensitiveSites",
             "indexingQuality",
             "indexOnlyTextContent",
@@ -58,7 +55,6 @@ class AutoIndexingManager {
         try {
             const result = await chrome.storage.sync.get([
                 "autoIndexing",
-                "indexingDelay",
                 "excludeSensitiveSites",
                 "indexingQuality",
                 "indexOnlyTextContent",
@@ -66,7 +62,6 @@ class AutoIndexingManager {
 
             this.settings = {
                 autoIndexing: result.autoIndexing || false,
-                indexingDelay: result.indexingDelay || 3,
                 excludeSensitiveSites: result.excludeSensitiveSites !== false, // default true
                 indexingQuality: result.indexingQuality || "balanced",
                 indexOnlyTextContent: result.indexOnlyTextContent || false,
@@ -170,7 +165,7 @@ class AutoIndexingManager {
             return;
         }
 
-        const delay = this.settings.indexingDelay * 1000;
+        const delay = 500; // Fixed 500ms delay
 
         this.indexingTimeout = window.setTimeout(async () => {
             if (!this.isIndexing && this.isPageReady()) {

--- a/ts/packages/agents/browser/src/extension/serviceWorker/externalBrowserControlServer.ts
+++ b/ts/packages/agents/browser/src/extension/serviceWorker/externalBrowserControlServer.ts
@@ -374,20 +374,17 @@ export function createExternalBrowserServer(channel: RpcChannel) {
             try {
                 const result = await chrome.storage.sync.get([
                     "autoIndexing",
-                    "indexingDelay",
                     "extractionMode",
                 ]);
 
                 return {
                     autoIndexing: result.autoIndexing === true,
-                    indexingDelay: result.indexingDelay || 3000,
                     extractionMode: result.extractionMode || "content",
                 };
             } catch (error) {
                 console.error("Failed to get browser settings:", error);
                 return {
                     autoIndexing: false,
-                    indexingDelay: 3000,
                     extractionMode: "content",
                 };
             }

--- a/ts/packages/shell/src/main/extensionStorage.ts
+++ b/ts/packages/shell/src/main/extensionStorage.ts
@@ -8,14 +8,12 @@ import { debugShell } from "./debug.js";
 
 export type ExtensionStorageData = {
     autoIndexing?: boolean;
-    indexingDelay?: number;
     extractionMode?: string;
     [key: string]: any;
 };
 
 const defaultExtensionStorage: ExtensionStorageData = {
     autoIndexing: false,
-    indexingDelay: 3000,
     extractionMode: "content",
 };
 

--- a/ts/packages/shell/src/main/inlineBrowserControl.ts
+++ b/ts/packages/shell/src/main/inlineBrowserControl.ts
@@ -366,20 +366,17 @@ export function createInlineBrowserControl(
                             if (window.electronAPI) {
                                 const storage = await window.electronAPI.getStorage([
                                     'autoIndexing',
-                                    'indexingDelay', 
                                     'extractionMode'
                                 ]);
                                 
                                 return {
                                     autoIndexing: storage.autoIndexing === true,
-                                    indexingDelay: storage.indexingDelay || 3000,
                                     extractionMode: storage.extractionMode || 'content'
                                 };
                             } else {
                                 console.error('electronAPI not available');
                                 return {
                                     autoIndexing: false,
-                                    indexingDelay: 3000,
                                     extractionMode: 'content'
                                 };
                             }
@@ -387,7 +384,6 @@ export function createInlineBrowserControl(
                             console.error('Failed to get browser settings:', error);
                             return {
                                 autoIndexing: false,
-                                indexingDelay: 3000,
                                 extractionMode: 'content'
                             };
                         }
@@ -402,7 +398,6 @@ export function createInlineBrowserControl(
                 );
                 return {
                     autoIndexing: false,
-                    indexingDelay: 3000,
                     extractionMode: "content",
                 };
             }

--- a/ts/packages/shell/src/main/navigationUtils.ts
+++ b/ts/packages/shell/src/main/navigationUtils.ts
@@ -1,0 +1,200 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+export interface TabNavigationState {
+    url: string;
+    title: string;
+    lastNavigationTime: number;
+    navigationSent: boolean;
+    isUserRefresh: boolean;
+    pendingTimer: NodeJS.Timeout | null;
+}
+
+export type NavigationType = "new" | "refresh" | "duplicate" | "tracking";
+
+const tabNavigationStates = new Map<string, TabNavigationState>();
+
+const trackingParams = [
+    "utm_source",
+    "utm_medium",
+    "utm_campaign",
+    "utm_term",
+    "utm_content",
+    "fbclid",
+    "gclid",
+    "msclkid",
+    "rdr",
+    "rdrig",
+    "_ga",
+    "_gl",
+    "mc_cid",
+    "mc_eid",
+    "yclid",
+    "zanpid",
+    "kenshoo_id",
+    "guccounter",
+];
+
+const analyticsPatterns = [
+    /analytics\./i,
+    /\/analytics\//i,
+    /zephr-templates/i,
+    /google-analytics/i,
+    /googletagmanager/i,
+    /doubleclick/i,
+    /scorecardresearch/i,
+    /quantserve/i,
+    /facebook\.com\/tr/i,
+    /amazon-adsystem/i,
+    /googlesyndication/i,
+    /chartbeat/i,
+    /newrelic/i,
+];
+
+export function normalizeUrl(url: string): string {
+    try {
+        const parsed = new URL(url);
+
+        trackingParams.forEach((param) => parsed.searchParams.delete(param));
+
+        parsed.searchParams.sort();
+
+        parsed.hash = "";
+
+        return parsed.toString();
+    } catch {
+        return url;
+    }
+}
+
+export function isSamePageWithTracking(url1: string, url2: string): boolean {
+    if (!url1 || !url2) return false;
+    return normalizeUrl(url1) === normalizeUrl(url2);
+}
+
+export function isAnalyticsUrl(url: string): boolean {
+    return analyticsPatterns.some((pattern) => pattern.test(url));
+}
+
+export function detectNavigationType(
+    tabId: string,
+    url: string,
+    title: string,
+    isUserInitiated: boolean = false,
+): NavigationType {
+    const tabState = tabNavigationStates.get(tabId);
+
+    if (!tabState) {
+        return "new";
+    }
+
+    if (isUserInitiated && tabState.url === url) {
+        return "refresh";
+    }
+
+    if (tabState.url === url && tabState.title === title) {
+        const timeSinceLastNav = Date.now() - tabState.lastNavigationTime;
+
+        if (tabState.navigationSent && timeSinceLastNav < 2000) {
+            return "duplicate";
+        }
+
+        if (tabState.navigationSent && timeSinceLastNav >= 2000) {
+            return "refresh";
+        }
+    }
+
+    if (isSamePageWithTracking(tabState.url, url) && tabState.title === title) {
+        return "tracking";
+    }
+
+    return "new";
+}
+
+export function getTabState(tabId: string): TabNavigationState | undefined {
+    return tabNavigationStates.get(tabId);
+}
+
+export function createTabState(tabId: string): TabNavigationState {
+    const state: TabNavigationState = {
+        url: "",
+        title: "",
+        lastNavigationTime: 0,
+        navigationSent: false,
+        isUserRefresh: false,
+        pendingTimer: null,
+    };
+    tabNavigationStates.set(tabId, state);
+    return state;
+}
+
+export function updateTabState(
+    tabId: string,
+    url: string,
+    title: string,
+    navigationSent: boolean = true,
+    isUserRefresh: boolean = false,
+): void {
+    const state = tabNavigationStates.get(tabId) || createTabState(tabId);
+    state.url = url;
+    state.title = title;
+    state.lastNavigationTime = Date.now();
+    state.navigationSent = navigationSent;
+    state.isUserRefresh = isUserRefresh;
+    state.pendingTimer = null;
+}
+
+export function markUserRefresh(tabId: string): void {
+    const state = tabNavigationStates.get(tabId);
+    if (state) {
+        state.isUserRefresh = true;
+    }
+}
+
+export function clearPendingTimer(tabId: string): void {
+    const state = tabNavigationStates.get(tabId);
+    if (state?.pendingTimer) {
+        clearTimeout(state.pendingTimer);
+        state.pendingTimer = null;
+    }
+}
+
+export function setPendingTimer(tabId: string, timer: NodeJS.Timeout): void {
+    const state = tabNavigationStates.get(tabId) || createTabState(tabId);
+    state.pendingTimer = timer;
+}
+
+export function cleanupTabState(tabId: string): void {
+    clearPendingTimer(tabId);
+    tabNavigationStates.delete(tabId);
+}
+
+export function shouldProcessRefresh(
+    tabState: TabNavigationState,
+    currentTime: number = Date.now(),
+): { process: boolean; reason: string } {
+    const timeSinceLastNav = currentTime - tabState.lastNavigationTime;
+
+    if (tabState.isUserRefresh) {
+        return { process: true, reason: "User-initiated refresh" };
+    }
+
+    if (timeSinceLastNav < 10000) {
+        return { process: false, reason: "Too rapid - likely duplicate" };
+    }
+
+    if (timeSinceLastNav < 60000) {
+        if (tabState.url.match(/dashboard|monitor|live|feed|stream/i)) {
+            return {
+                process: false,
+                reason: "Dashboard auto-refresh - skipping",
+            };
+        }
+        return {
+            process: true,
+            reason: "Auto-refresh after reasonable interval",
+        };
+    }
+
+    return { process: true, reason: "Refresh after significant time" };
+}

--- a/ts/packages/shell/src/preload/webView.ts
+++ b/ts/packages/shell/src/preload/webView.ts
@@ -125,9 +125,24 @@ export async function awaitPageLoad() {
     /*
     return new Promise<string | undefined>((resolve, reject) => {
         // use window API to await pageload
-        
+
     });
     */
+}
+
+export async function awaitPageIncrementalLoad(): Promise<boolean> {
+    try {
+        const result = await sendScriptAction(
+            {
+                type: "await_page_incremental_load",
+            },
+            5000,
+        );
+        return result === "true";
+    } catch (error) {
+        console.error("Content script page load detection failed:", error);
+        return true; // fallback - assume page is ready
+    }
 }
 
 export async function getTabHTMLFragments(


### PR DESCRIPTION
- Debounce navigation events from a tab. This accounts for pages with tracking iframes that were being detected as new page load events.
- Track duplicate refreshes for a given url in the tab. This accounts for pages with meta-refresh tags set up.
- Remove 3s auto-indexing delay. Instead, rely on mutation observers in the rendered page to indicate when the page has settled/finished loading. This re-uses logic built for commerce scenarios.