### PR TITLE
Changed Browser IPC error to debug message 

### DIFF
--- a/ts/packages/shell/src/main/browserIpc.ts
+++ b/ts/packages/shell/src/main/browserIpc.ts
@@ -135,7 +135,8 @@ export class BrowserAgentIpc {
     public async send(message: WebSocketMessageV2) {
         const webSocket = await this.ensureWebsocketConnected();
         if (!webSocket) {
-            throw new Error("WebSocket not connected");
+            debugBrowserIPC("WebSocket not [yet] connected!");
+            return;
         }
         debugBrowserIPC("Browser -> Dispatcher", message);
         webSocket.send(JSON.stringify(message));


### PR DESCRIPTION
There are cases where browser messages are being sent before the web socket is available.  These are ignorable so am changing the error to a debug message.

FYI: @hillary-mutisya 