### PR TITLE
Smoke test: Fix alternate spec

### DIFF
--- a/ts/packages/defaultAgentProvider/test/data/translate-gate-e2e.json
+++ b/ts/packages/defaultAgentProvider/test/data/translate-gate-e2e.json
@@ -348,7 +348,7 @@
               }
             },
             "alternates": {
-              "internetLookups": [
+              "internetLookups.0": [
                 "president of the united states in 1837",
                 "us president in 1837"
               ]
@@ -389,7 +389,7 @@
             },
             "alternates": {
               "trackName": "toccata and fugue",
-              "artists": "johann sebastian bach"
+              "artists.0": "johann sebastian bach"
             }
           }
         ]

--- a/ts/packages/defaultAgentProvider/test/data/translate-history-e2e.json
+++ b/ts/packages/defaultAgentProvider/test/data/translate-history-e2e.json
@@ -83,7 +83,7 @@
               }
             },
             "alternates": {
-              "internetLookups": "shepherd's pie ingredients"
+              "internetLookups.0": "shepherd's pie ingredients"
             }
           }
         ]


### PR DESCRIPTION
- Fix some alternate spec to point to the right property (with array index).
- Add validation code to makes sure alternates are replacing the same type as the property