### PR TITLE
Shell test: Use URL to detect chat view

### DIFF
--- a/ts/packages/shell/src/main/instance.ts
+++ b/ts/packages/shell/src/main/instance.ts
@@ -210,8 +210,6 @@ async function initializeDispatcher(
         ipcMain.on("dispatcher-rpc-call", onDispatcherRpcCall);
         createDispatcherRpcServer(dispatcher, dispatcherChannel.channel);
 
-        shellWindow.dispatcherInitialized();
-
         debugShellInit("Dispatcher initialized", performance.now() - startTime);
 
         return dispatcher;
@@ -291,6 +289,12 @@ export function initializeInstance(
                 }).show();
             }
         });
+
+        // Notify the renderer process that the dispatcher is initialized
+        chatView.webContents.send("dispatcher-initialized");
+
+        // Give focus to the chat view once initialization is done.
+        chatView.webContents.focus();
 
         // send the agent greeting if it's turned on
         if (shellSettings.user.agentGreeting) {

--- a/ts/packages/shell/src/main/shellWindow.ts
+++ b/ts/packages/shell/src/main/shellWindow.ts
@@ -1019,23 +1019,6 @@ export class ShellWindow {
         }
     }
 
-    private dispatcherReadyPromiseResolvers:
-        | PromiseWithResolvers<void>
-        | undefined = Promise.withResolvers<void>();
-    public dispatcherInitialized() {
-        if (this.dispatcherReadyPromiseResolvers === undefined) {
-            throw new Error("Dispatcher already initialized");
-        }
-        this.dispatcherReadyPromiseResolvers.resolve();
-        this.dispatcherReadyPromiseResolvers = undefined;
-
-        // Notify the renderer process that the dispatcher is initialized
-        this.chatView.webContents.send("dispatcher-initialized");
-
-        // Give focus to the chat view once initialization is done.
-        this.chatView.webContents.focus();
-    }
-
     // ================================================================
     // Zoom Handler
     // ================================================================

--- a/ts/packages/shell/src/preload/electronTypes.ts
+++ b/ts/packages/shell/src/preload/electronTypes.ts
@@ -80,6 +80,7 @@ export interface ClientAPI {
 // Functions that are called from the main process to the renderer process.
 export interface Client {
     clientIO: ClientIO;
+    dispatcherInitialized(dispatcher: Dispatcher): void;
     updateRegisterAgents(agents: [string, string][]): void;
     showInputText(message: string): Promise<void>;
     showDialog(key: string): void;
@@ -94,7 +95,6 @@ export interface Client {
 
 export interface ElectronWindowFields {
     api: ClientAPI;
-    dispatcher: Promise<Dispatcher>;
 }
 
 export type ElectronWindow = typeof globalThis & ElectronWindowFields;

--- a/ts/packages/shell/src/renderer/src/chat/chatView.ts
+++ b/ts/packages/shell/src/renderer/src/chat/chatView.ts
@@ -118,8 +118,8 @@ export class ChatView {
 
         this._dispatcher = dispatcher;
 
-        this.chatInput?.textarea.enable(true);
-        this.chatInput?.focus();
+        this.chatInput.textarea.enable(true);
+        this.chatInput.focus();
 
         // delay initialization.
         if (this.partialCompletionEnabled) {

--- a/ts/packages/shell/src/renderer/src/webSocketAPI.ts
+++ b/ts/packages/shell/src/renderer/src/webSocketAPI.ts
@@ -24,6 +24,8 @@ function registerClient(c: Client) {
     // Establish the clientIO RPC
     client = c;
     createClientIORpcServer(client.clientIO, clientIOChannel.channel);
+
+    c.dispatcherInitialized(webDispatcher);
 }
 
 export const webapi: ClientAPI = {
@@ -81,9 +83,7 @@ const dispatcherChannel = createGenericChannel((message: any) =>
     ),
 );
 
-export const webdispatcher = createDispatcherRpcClient(
-    dispatcherChannel.channel,
-);
+const webDispatcher = createDispatcherRpcClient(dispatcherChannel.channel);
 
 export async function createWebSocket(autoReconnect: boolean = true) {
     let url = window.location;

--- a/ts/packages/shell/test/testHelper.ts
+++ b/ts/packages/shell/test/testHelper.ts
@@ -52,7 +52,7 @@ async function closeInstance(instanceName: string, force: boolean = false) {
         try {
             await waitForPromiseWithTimeout(existing.close(), 10000);
         } catch (e: any) {
-            const errMsg = `Failed to close instance ${instanceName}: ${e.message}.\nKilling instance ${instanceName}`;
+            const errMsg = `Failed to close instance ${instanceName}: ${e.message}.\nKilling instance ${instanceName} PID: ${existing.process().pid}`;
 
             existing.process().kill();
             if (force) {

--- a/ts/packages/shell/test/testHelper.ts
+++ b/ts/packages/shell/test/testHelper.ts
@@ -9,7 +9,7 @@ import {
     Page,
 } from "@playwright/test";
 import fs from "node:fs";
-import path, { relative } from "node:path";
+import path from "node:path";
 import os from "node:os";
 import { fileURLToPath } from "node:url";
 
@@ -52,7 +52,7 @@ async function closeInstance(instanceName: string, force: boolean = false) {
         try {
             await waitForPromiseWithTimeout(existing.close(), 10000);
         } catch (e: any) {
-            const errMsg = `Failed to close instance ${instanceName}: ${e.message}.\nKilling instance ${instanceName} PID: ${existing.process().pid}`;
+            const errMsg = `Failed to close instance ${instanceName}: ${e.message}.\nKilling instance ${instanceName}`;
 
             existing.process().kill();
             if (force) {

--- a/ts/packages/shell/test/testHelper.ts
+++ b/ts/packages/shell/test/testHelper.ts
@@ -14,7 +14,7 @@ import os from "node:os";
 import { fileURLToPath } from "node:url";
 
 // These need to be in sync with the UI
-const chatViewTitle = "Chat View"; // See chatView.html title tag
+const chatViewUrlSuffix = "/chatView.html";
 const inputDivId = "phraseDiv";
 
 const runningApplications: Map<string, ElectronApplication> = new Map<
@@ -133,15 +133,15 @@ export async function startShell(
 async function getChatViewWindow(app: ElectronApplication): Promise<Page> {
     let attempts = 0;
     do {
-        let windows: Page[] = await app.windows();
+        const windows: Page[] = app.windows();
         // wait for each window to load and return the one we are interested in
         for (const window of windows) {
             try {
                 await window.waitForLoadState("domcontentloaded");
 
                 // is this the correct window?
-                const title = await window.title();
-                if (title === chatViewTitle) {
+                const url = window.url();
+                if (url.endsWith(chatViewUrlSuffix)) {
                     return window;
                 }
             } catch (e) {


### PR DESCRIPTION
- Title of the chat view changes after dispatcher is initialized. Use URL to identify the chat view instead.
- Make sure we sent the dispatcher-initialized signal to the chat view after chat-view is ready, and make sure the chat input is enabled synchronously (instead of waiting on the promise).  
  - This improve stability of the playwright test, which uses the greeting message to indicate that finish initialization and the chat input is ready. (whereas before, because of the promise, the input might not be enabled before the greeting message is displayed)
