### PR TITLE
Update agent context with disable on close

### DIFF
--- a/ts/packages/agents/browser/src/agent/actionHandler.mts
+++ b/ts/packages/agents/browser/src/agent/actionHandler.mts
@@ -2148,7 +2148,7 @@ async function handleGetActionRequest(
     }
 }
 
-export async function createViewServiceHost(
+async function createViewServiceHost(
     context: SessionContext<BrowserActionContext>,
 ) {
     let timeoutHandle: NodeJS.Timeout;

--- a/ts/packages/agents/markdown/src/agent/markdownActionHandler.ts
+++ b/ts/packages/agents/markdown/src/agent/markdownActionHandler.ts
@@ -878,7 +878,7 @@ async function getDocumentContentFromView(
 // NOTE: Function commented out per Flow 1 consolidation
 // Collaboration server now managed by view process
 
-export async function createViewServiceHost(filePath: string, port: number) {
+async function createViewServiceHost(filePath: string, port: number) {
     let timeoutHandle: NodeJS.Timeout;
 
     const timeoutPromise = new Promise<undefined>((_resolve, reject) => {

--- a/ts/packages/agents/montage/src/agent/montageActionHandler.ts
+++ b/ts/packages/agents/montage/src/agent/montageActionHandler.ts
@@ -293,21 +293,22 @@ async function updateMontageContext(
                 agentContext.localHostPort,
             );
 
-            const folders: string[] = [];
-            agentContext.indexes.forEach((idx) => {
-                folders.push(idx.location);
-            });
-
             // send the folder info
-            const indexPath = path.join(agentContext.indexes[0].path, "cache");
-            folders.push(indexPath);
-            agentContext.viewProcess?.send({
-                folders: {
-                    allowedFolders: folders,
-                    indexCachePath: indexPath,
-                    indexedLocation: agentContext.indexes[0].location,
-                },
-            });
+            if (agentContext.indexes.length !== 0) {
+                const folders = agentContext.indexes.map((idx) => idx.location);
+                const indexPath = path.join(
+                    agentContext.indexes[0].path,
+                    "cache",
+                );
+                folders.push(indexPath);
+                agentContext.viewProcess?.send({
+                    folders: {
+                        allowedFolders: folders,
+                        indexCachePath: indexPath,
+                        indexedLocation: agentContext.indexes[0].location,
+                    },
+                });
+            }
 
             // send initial state and allowed folder(s)
             if (agentContext.activeMontageId > -1) {
@@ -323,6 +324,7 @@ async function updateMontageContext(
         // shut down service
         if (agentContext.viewProcess) {
             agentContext.viewProcess.kill();
+            agentContext.viewProcess = undefined;
         }
     }
 }


### PR DESCRIPTION
Agent has a reasonable expectation that if action is enabled with `updateAgentContext`, that it will get a call for disable on close as well.

Fix montage initialization exception if there are no image index.