### PR TITLE
Agent server client export dispatcher types types

### DIFF
--- a/ts/packages/agentServer/client/src/agentServerClient.ts
+++ b/ts/packages/agentServer/client/src/agentServerClient.ts
@@ -5,7 +5,7 @@ import { createChannelProviderAdapter } from "@typeagent/agent-rpc/channel";
 import { createRpc } from "@typeagent/agent-rpc/rpc";
 import { createClientIORpcServer } from "@typeagent/dispatcher-rpc/clientio/server";
 import { createDispatcherRpcClient } from "@typeagent/dispatcher-rpc/dispatcher/client";
-import type { ClientIO, Dispatcher } from "@typeagent/dispatcher-rpc";
+import type { ClientIO, Dispatcher } from "@typeagent/dispatcher-rpc/types";
 
 import registerDebug from "debug";
 import {

--- a/ts/packages/agentServer/client/src/index.ts
+++ b/ts/packages/agentServer/client/src/index.ts
@@ -2,3 +2,4 @@
 // Licensed under the MIT License.
 
 export { connectDispatcher } from "./agentServerClient.js";
+export type * from "@typeagent/dispatcher-rpc/types";

--- a/ts/packages/dispatcher/rpc/package.json
+++ b/ts/packages/dispatcher/rpc/package.json
@@ -12,7 +12,7 @@
   "author": "Microsoft",
   "type": "module",
   "exports": {
-    ".": "./dist/index.js",
+    "./types": "./dist/types.js",
     "./clientio/client": "./dist/clientIOClient.js",
     "./clientio/server": "./dist/clientIOServer.js",
     "./dispatcher/client": "./dist/dispatcherClient.js",

--- a/ts/packages/dispatcher/rpc/src/index.ts
+++ b/ts/packages/dispatcher/rpc/src/index.ts
@@ -1,8 +1,0 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
-
-export * from "@typeagent/dispatcher-types";
-export * from "./clientIOClient.js";
-export * from "./clientIOServer.js";
-export * from "./dispatcherClient.js";
-export * from "./dispatcherServer.js";

--- a/ts/packages/dispatcher/rpc/src/types.ts
+++ b/ts/packages/dispatcher/rpc/src/types.ts
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// Re-export dispatcher-types so dependents don't need to import them directly.
+export type * from "@typeagent/dispatcher-types";
+export type { MessageContent, DisplayType } from "@typeagent/agent-sdk";


### PR DESCRIPTION
Allow the agent server client package to be used without additional packages.
Also re-export types from agent sdk that is also used in the dispatcher types