### PR TITLE
Fix WebSocket event type imports in agent-server-client

### DIFF
--- a/ts/packages/agentServer/client/src/agentServerClient.ts
+++ b/ts/packages/agentServer/client/src/agentServerClient.ts
@@ -6,11 +6,7 @@ import { createRpc } from "@typeagent/agent-rpc/rpc";
 import { createClientIORpcServer } from "@typeagent/dispatcher-rpc/clientio/server";
 import { createDispatcherRpcClient } from "@typeagent/dispatcher-rpc/dispatcher/client";
 import type { ClientIO, Dispatcher } from "@typeagent/dispatcher-rpc/types";
-import WebSocket, {
-    type MessageEvent,
-    type CloseEvent,
-    type ErrorEvent,
-} from "isomorphic-ws";
+import WebSocket from "isomorphic-ws";
 
 import registerDebug from "debug";
 import {
@@ -67,19 +63,19 @@ export async function connectDispatcher(
                     reject(err);
                 });
         };
-        ws.onmessage = (event: MessageEvent) => {
+        ws.onmessage = (event: WebSocket.MessageEvent) => {
             debug("Received message from server:", event.data);
 
             channel.notifyMessage(JSON.parse(event.data.toString()));
         };
-        ws.onclose = (event: CloseEvent) => {
+        ws.onclose = (event: WebSocket.CloseEvent) => {
             debug("WebSocket connection closed", event.code, event.reason);
             channel.notifyDisconnected();
             if (!resolved) {
                 reject(new Error(`Failed to connect to dispatcher at ${url}`));
             }
         };
-        ws.onerror = (error: ErrorEvent) => {
+        ws.onerror = (error: WebSocket.ErrorEvent) => {
             debugErr("WebSocket error:", error);
         };
     });


### PR DESCRIPTION
## Summary

- Fix TypeScript compilation errors in agent-server-client caused by invalid type imports
- Use namespaced WebSocket types instead of importing directly from isomorphic-ws

## Details

The `isomorphic-ws` package doesn't actually export `MessageEvent`, `CloseEvent`, or `ErrorEvent` types. It only re-exports the WebSocket class from the `ws` package. The event types are defined in the `WebSocket` namespace via `@types/ws`.

**Changes:**
- Removed invalid imports: `type MessageEvent`, `type CloseEvent`, `type ErrorEvent` from `isomorphic-ws`
- Updated event handler type annotations to use:
  - `WebSocket.MessageEvent`
  - `WebSocket.CloseEvent`
  - `WebSocket.ErrorEvent`

**Fixes these TypeScript compilation errors:**
```
error TS2305: Module '"isomorphic-ws"' has no exported member 'MessageEvent'
error TS2305: Module '"isomorphic-ws"' has no exported member 'CloseEvent'
error TS2305: Module '"isomorphic-ws"' has no exported member 'ErrorEvent'
```

## Test plan

- [x] TypeScript compilation passes: `pnpm exec tsc -b` in agent-server-client package
- [x] Full project build succeeds: `pnpm build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)