### PR TITLE
Initial integration of reasoning and cleanup delegable action feature.

### DIFF
--- a/ts/packages/agentSdk/src/agentInterface.ts
+++ b/ts/packages/agentSdk/src/agentInterface.ts
@@ -67,7 +67,6 @@ export type SchemaManifest = {
     injected?: boolean; // whether the translator is injected into other domains, default is false
     cached?: boolean; // whether the translator's action should be cached, default is true
     streamingActions?: string[];
-    delegatable?: boolean; // whether actions can be delegated to external service for protocol requests, default is false
 };
 
 export type ActionManifest = {

--- a/ts/packages/agents/browser/src/agent/manifest.json
+++ b/ts/packages/agents/browser/src/agent/manifest.json
@@ -28,8 +28,7 @@
         "description": "Actions to lookup information from the web and answer user queries.",
         "schemaFile": "./lookupAndAnswerSchema.mts",
         "schemaType": "LookupAndAnswerActions",
-        "injected": true,
-        "delegatable": true
+        "injected": true
       }
     },
     "external": {

--- a/ts/packages/agents/chat/src/chatManifest.json
+++ b/ts/packages/agents/chat/src/chatManifest.json
@@ -7,7 +7,6 @@
     "schemaType": "ChatResponseAction",
     "injected": true,
     "cached": false,
-    "streamingActions": ["generateResponse"],
-    "delegatable": true
+    "streamingActions": ["generateResponse"]
   }
 }

--- a/ts/packages/dispatcher/dispatcher/package.json
+++ b/ts/packages/dispatcher/dispatcher/package.json
@@ -38,6 +38,7 @@
     "tsc": "tsc -b"
   },
   "dependencies": {
+    "@anthropic-ai/claude-agent-sdk": "^0.2.12",
     "@azure/ai-agents": "^1.0.0-beta.3",
     "@azure/ai-projects": "^1.0.0-beta.8",
     "@azure/identity": "^4.10.0",
@@ -67,7 +68,8 @@
     "typeagent": "workspace:*",
     "typechat": "^0.1.1",
     "typechat-utils": "workspace:*",
-    "website-memory": "workspace:*"
+    "website-memory": "workspace:*",
+    "zod": "^4.1.13"
   },
   "devDependencies": {
     "@types/debug": "^4.1.12",

--- a/ts/packages/dispatcher/dispatcher/src/context/dispatcher/dispatcherAgent.ts
+++ b/ts/packages/dispatcher/dispatcher/src/context/dispatcher/dispatcherAgent.ts
@@ -39,6 +39,8 @@ import { ClarifyEntityAction } from "../../execute/pendingActions.js";
 import { MatchCommandHandler } from "./handlers/matchCommandHandler.js";
 import { DispatcherEmoji } from "./dispatcherUtils.js";
 import { getHistoryContext } from "../../translation/interpretRequest.js";
+import { ReasoningAction } from "./schema/reasoningActionSchema.js";
+import { executeReasoningAction } from "../../reasoning/claude.js";
 
 const dispatcherHandlers: CommandHandlerTable = {
     description: "Type Agent Dispatcher Commands",
@@ -58,6 +60,7 @@ async function executeDispatcherAction(
         | LookupActivity
         | ActivityActions
         | ClarifyEntityAction
+        | ReasoningAction
     >,
     context: ActionContext<CommandHandlerContext>,
 ) {
@@ -118,6 +121,11 @@ async function executeDispatcherAction(
                     result.activityContext = null; // clear the activity context.
 
                     return result;
+            }
+            break;
+        case "dispatcher.reasoning":
+            if (action.actionName === "reasoningAction") {
+                return executeReasoningAction(action, context);
             }
             break;
     }
@@ -294,6 +302,18 @@ export const dispatcherManifest: AppAgentManifest = {
                 injected: true,
                 cached: false,
             },
+        },
+        reasoning: {
+            schema: {
+                description:
+                    "Action that helps you reason through requests that require multiple steps.",
+                schemaFile:
+                    "./src/context/dispatcher/schema/reasoningActionSchema.ts",
+                schemaType: "ReasoningAction",
+                injected: true,
+                cached: false,
+            },
+            defaultEnabled: false,
         },
     },
 };

--- a/ts/packages/dispatcher/dispatcher/src/context/dispatcher/schema/reasoningActionSchema.ts
+++ b/ts/packages/dispatcher/dispatcher/src/context/dispatcher/schema/reasoningActionSchema.ts
@@ -1,0 +1,11 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// If the user requests requires multiple action or steps, use the reasoning action.
+export interface ReasoningAction {
+    actionName: "reasoningAction";
+    parameters: {
+        // The original user request
+        originalRequest: string;
+    };
+}

--- a/ts/packages/dispatcher/dispatcher/src/execute/actionContext.ts
+++ b/ts/packages/dispatcher/dispatcher/src/execute/actionContext.ts
@@ -100,7 +100,7 @@ export function getActionContext(
         closeActionContext: () => {
             closeContextObject(actionIO);
             closeContextObject(actionContext);
-            // This will cause undefined except if context is access for the rare case
+            // This will cause undefined exception if context is access for the rare case
             // the implementation function are saved.
             (context as any) = undefined;
         },

--- a/ts/packages/dispatcher/dispatcher/src/execute/actionHandlers.ts
+++ b/ts/packages/dispatcher/dispatcher/src/execute/actionHandlers.ts
@@ -96,7 +96,8 @@ function getStreamingActionContext(
     return actionContext;
 }
 
-async function executeAction(
+// REVIEW: don't export this
+export async function executeAction(
     executableAction: ExecutableAction,
     context: ActionContext<CommandHandlerContext>,
     actionIndex: number,
@@ -296,18 +297,6 @@ export async function executeActions(
         const executableAction = pending.executableAction;
 
         const action = executableAction.action;
-
-        // Skip delegated actions - they were already handled in translation phase
-        if (
-            action.schemaName === "system" &&
-            action.actionName === "delegated"
-        ) {
-            debugActions(
-                "[Dispatcher:Execute] Skipping delegated action - delegation signal already sent",
-            );
-            actionIndex++;
-            continue;
-        }
 
         if (isPendingRequestAction(action)) {
             const translationResult = await translatePendingRequestAction(

--- a/ts/packages/dispatcher/dispatcher/src/reasoning/claude.ts
+++ b/ts/packages/dispatcher/dispatcher/src/reasoning/claude.ts
@@ -1,0 +1,249 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import {
+    ActionContext,
+    AppAction,
+    TypeAgentAction,
+} from "@typeagent/agent-sdk";
+import { CommandHandlerContext } from "../context/commandHandlerContext.js";
+import { ReasoningAction } from "../context/dispatcher/schema/reasoningActionSchema.js";
+import {
+    createSdkMcpServer,
+    Options,
+    query,
+    SdkMcpToolDefinition,
+} from "@anthropic-ai/claude-agent-sdk";
+import registerDebug from "debug";
+import { z } from "zod/v4";
+import { getActionSchemaTypeName } from "../translation/agentTranslators.js";
+import {
+    composeActionSchema,
+    createActionSchemaJsonValidator,
+} from "../translation/actionSchemaJsonTranslator.js";
+import { TypeAgentJsonValidator } from "typechat-utils";
+import { executeAction } from "../execute/actionHandlers.js";
+import { nullClientIO } from "../context/interactiveIO.js";
+import { ClientIO, IAgentMessage } from "@typeagent/dispatcher-types";
+import { displayStatus } from "@typeagent/agent-sdk/helpers/display";
+import { createActionResultNoDisplay } from "@typeagent/agent-sdk/helpers/action";
+const debug = registerDebug("typeagent:dispatcher:reasoning:messages");
+
+const model = "claude-sonnet-4-5-20250929";
+
+const mcpServerName = "action-executor";
+const allowedTools = [
+    // "Read",
+    // "Write",
+    // "Edit",
+    // "Bash",
+    // "Glob",
+    // "Grep",
+    "WebSearch",
+    "WebFetch",
+    "Task",
+    // "NotebookEdit",
+    "TodoWrite",
+    // Allow all tools from the command-executor MCP server
+    `mcp__${mcpServerName}__*`,
+];
+
+function getClaudeOptions(
+    context: ActionContext<CommandHandlerContext>,
+): Options {
+    const systemContext = context.sessionContext.agentContext;
+    const activeSchemas = systemContext.agents.getActiveSchemas();
+    const schemaDescriptions: string[] = [];
+    const validators = new Map<string, TypeAgentJsonValidator<AppAction>>();
+    for (const schemaName of activeSchemas) {
+        const actionConfig = systemContext.agents.getActionConfig(schemaName);
+        if (getActionSchemaTypeName(actionConfig.schemaType) === undefined) {
+            continue;
+        }
+        schemaDescriptions.push(`- ${schemaName}: ${actionConfig.description}`);
+        validators.set(
+            schemaName,
+            createActionSchemaJsonValidator(
+                composeActionSchema([actionConfig], [], systemContext.agents, {
+                    activity: false,
+                }),
+            ),
+        );
+    }
+
+    const discoverSchema = {
+        schemaName: z.union(activeSchemas.map((s) => z.literal(s))),
+    };
+    const discoverTool: SdkMcpToolDefinition<typeof discoverSchema> = {
+        name: "discover_actions",
+        description: [
+            "Discover actions available with a schema name.",
+            "Returns a list of action names with parameters as TypeScript schemas in the named schema that can be used with 'execute_action' tool.",
+            "Schema descriptions:",
+            ...schemaDescriptions,
+        ].join("\n"),
+        inputSchema: discoverSchema,
+        handler: async (args) => {
+            const validator = validators.get(args.schemaName);
+            if (!validator) {
+                throw new Error(`Invalid schema name '${args.schemaName}'`);
+            }
+            return {
+                content: [
+                    {
+                        type: "text",
+                        text: validator.getSchemaText(),
+                    },
+                ],
+            };
+        },
+    };
+
+    let actionIndex = 1;
+    const executeSchema = {
+        schemaName: z.union(activeSchemas.map((s) => z.literal(s))),
+        action: z.object({ actionName: z.string(), parameters: z.any() }),
+    };
+    const executeTool: SdkMcpToolDefinition<typeof executeSchema> = {
+        name: "execute_action",
+        description: [
+            "Execute an actions based on action schemas discovered using the 'discover_actions' tool.",
+            "The action parameter must conform to the schema of the specified schema name returned by 'discover_actions' tool.",
+        ].join("\n"),
+        inputSchema: executeSchema,
+        handler: async (args) => {
+            const validator = validators.get(args.schemaName);
+            if (!validator) {
+                throw new Error(`Invalid schema name '${args.schemaName}'`);
+            }
+            const actionJson = args.action;
+            const validationResult = validator.validate(actionJson);
+            if (!validationResult.success) {
+                throw validationResult.message;
+            }
+
+            const result: IAgentMessage[] = [];
+            const capturingClientIO: ClientIO = {
+                ...nullClientIO,
+                setDisplay: (message) => {
+                    result.push(message);
+                },
+                appendDisplay: (message, mode) => {
+                    if (mode !== "temporary") {
+                        result.push(message);
+                    }
+                },
+            };
+            const savedClientIO = systemContext.clientIO;
+            try {
+                systemContext.clientIO = capturingClientIO;
+                await executeAction(
+                    {
+                        action: {
+                            schemaName: args.schemaName,
+                            ...actionJson,
+                        },
+                    },
+                    context,
+                    actionIndex++,
+                );
+            } finally {
+                systemContext.clientIO = savedClientIO;
+            }
+            return {
+                content: [{ type: "text", text: JSON.stringify(result) }],
+            };
+        },
+    };
+
+    const claudeOptions: Options = {
+        model,
+        permissionMode: "acceptEdits",
+        allowedTools,
+        cwd: process.cwd(),
+        // settingSources: ["project"],
+        maxTurns: 20,
+        maxThinkingTokens: 10000,
+        mcpServers: {
+            [mcpServerName]: createSdkMcpServer({
+                name: mcpServerName,
+                tools: [discoverTool, executeTool],
+            }),
+        },
+    };
+    return claudeOptions;
+}
+
+export async function executeReasoningAction(
+    action: TypeAgentAction<ReasoningAction>,
+    context: ActionContext<CommandHandlerContext>,
+): Promise<any> {
+    const originalRequest = action.parameters.originalRequest;
+
+    // Display initial message
+    context.actionIO.appendDisplay("Thinking...", "temporary");
+
+    // Create query to Claude Agent SDK
+    const queryInstance = query({
+        prompt: originalRequest,
+        options: getClaudeOptions(context),
+    });
+
+    let finalResult: string | undefined = undefined;
+    // Process streaming response
+    for await (const message of queryInstance) {
+        debug(message);
+        if (message.type === "assistant") {
+            for (const content of message.message.content) {
+                if (content.type === "text") {
+                    // Update display with current thinking content
+                    // REVIEW: assume markdown?
+                    context.actionIO.appendDisplay({
+                        type: "markdown",
+                        content: content.text,
+                    });
+                } else if (content.type === "tool_use") {
+                    const toolName = content.name;
+                    if (
+                        toolName === `mcp__${mcpServerName}__discover_actions`
+                    ) {
+                        displayStatus(
+                            `Discovering actions in '${(content.input as any).schemaName}'...`,
+                            context,
+                        );
+                    } else if (
+                        toolName === `mcp__${mcpServerName}__execute_action`
+                    ) {
+                        const schemaName = (content.input as any).schemaName;
+                        const actionName = (content.input as any).action
+                            .actionName;
+                        displayStatus(
+                            `Executing action '${schemaName}.${actionName}'...`,
+                            context,
+                        );
+                    } else {
+                        displayStatus(
+                            `Calling tool '${content.name}'...'`,
+                            context,
+                        );
+                    }
+                } else if ((content as any).type === "thinking") {
+                    displayStatus("Thinking...", context);
+                }
+            }
+        } else if (message.type === "result") {
+            // Final result from the agent
+            if (message.subtype === "success") {
+                finalResult = message.result;
+            } else {
+                // Handle error results
+                const errors =
+                    "errors" in message ? (message as any).errors : undefined;
+                const errorMessage = `Error: ${errors?.join(", ") || "Unknown error"}`;
+                throw new Error(errorMessage);
+            }
+        }
+    }
+
+    return finalResult ? createActionResultNoDisplay(finalResult) : undefined;
+}

--- a/ts/packages/dispatcher/dispatcher/src/translation/actionConfig.ts
+++ b/ts/packages/dispatcher/dispatcher/src/translation/actionConfig.ts
@@ -33,7 +33,6 @@ export type ActionConfig = {
     actionDefaultEnabled: boolean;
     transient: boolean;
     schemaName: string;
-    delegatable: boolean;
 
     // Original schema file path string (TypeScript source for prompts/TypeChat)
     schemaFilePath: string | undefined;
@@ -98,7 +97,6 @@ function collectActionConfigs(
     transient: boolean,
     schemaDefaultEnabled: boolean,
     actionDefaultEnabled: boolean,
-    delegatable: boolean,
 ) {
     transient = manifest.transient ?? transient; // inherit from parent if not specified
     schemaDefaultEnabled =
@@ -109,7 +107,6 @@ function collectActionConfigs(
         manifest.actionDefaultEnabled ??
         manifest.defaultEnabled ??
         actionDefaultEnabled; // inherit from parent if not specified
-    delegatable = manifest.schema?.delegatable ?? delegatable; // inherit from parent if not specified
 
     if (manifest.schema) {
         const originalSchemaFile = manifest.schema.schemaFile;
@@ -139,7 +136,6 @@ function collectActionConfigs(
             transient,
             schemaDefaultEnabled,
             actionDefaultEnabled,
-            delegatable,
         };
     }
 
@@ -158,7 +154,6 @@ function collectActionConfigs(
                 transient, // propagate default transient
                 schemaDefaultEnabled, // propagate default schemaDefaultEnabled
                 actionDefaultEnabled, // propagate default actionDefaultEnabled
-                delegatable, // propagate default delegatable
             );
         }
     }
@@ -189,7 +184,6 @@ export function convertToActionConfig(
         false, // transient default to false if not specified
         true, // translationDefaultEnable default to true if not specified
         true, // actionDefaultEnabled default to true if not specified
-        false, // delegatable default to false if not specified
     );
     return actionConfigs;
 }

--- a/ts/pnpm-lock.yaml
+++ b/ts/pnpm-lock.yaml
@@ -3110,12 +3110,15 @@ importers:
 
   packages/dispatcher/dispatcher:
     dependencies:
+      '@anthropic-ai/claude-agent-sdk':
+        specifier: ^0.2.12
+        version: 0.2.12(zod@4.1.13)
       '@azure/ai-agents':
         specifier: ^1.0.0-beta.3
         version: 1.0.0-beta.3
       '@azure/ai-projects':
         specifier: ^1.0.0-beta.8
-        version: 1.0.0-beta.8(ws@8.18.2)(zod@3.24.4)
+        version: 1.0.0-beta.8(ws@8.18.2)(zod@4.1.13)
       '@azure/identity':
         specifier: ^4.10.0
         version: 4.10.0
@@ -3193,13 +3196,16 @@ importers:
         version: link:../../typeagent
       typechat:
         specifier: ^0.1.1
-        version: 0.1.1(typescript@5.4.5)(zod@3.24.4)
+        version: 0.1.1(typescript@5.4.5)(zod@4.1.13)
       typechat-utils:
         specifier: workspace:*
         version: link:../../utils/typechatUtils
       website-memory:
         specifier: workspace:*
         version: link:../../memory/website
+      zod:
+        specifier: ^4.1.13
+        version: 4.1.13
     devDependencies:
       '@types/debug':
         specifier: ^4.1.12
@@ -14377,6 +14383,39 @@ snapshots:
       - ws
       - zod
 
+  '@azure/ai-projects@1.0.0-beta.8(ws@8.18.2)(zod@4.1.13)':
+    dependencies:
+      '@azure-rest/ai-inference': 1.0.0-beta.6
+      '@azure-rest/core-client': 2.4.0
+      '@azure/abort-controller': 2.1.2
+      '@azure/ai-agents': 1.0.0-beta.3
+      '@azure/core-auth': 1.9.0
+      '@azure/core-lro': 3.2.0
+      '@azure/core-paging': 1.6.2
+      '@azure/core-rest-pipeline': 1.20.0
+      '@azure/core-sse': 2.2.0
+      '@azure/core-tracing': 1.2.0
+      '@azure/core-util': 1.11.0
+      '@azure/logger': 1.2.0
+      '@azure/opentelemetry-instrumentation-azure-sdk': 1.0.0-beta.8
+      '@azure/storage-blob': 12.27.0
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api-logs': 0.200.0
+      '@opentelemetry/exporter-logs-otlp-grpc': 0.200.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/exporter-trace-otlp-grpc': 0.200.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-logs': 0.200.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-node': 1.30.1(@opentelemetry/api@1.9.0)
+      '@traceloop/instrumentation-langchain': 0.13.0(@opentelemetry/api@1.9.0)
+      '@traceloop/instrumentation-openai': 0.13.0(@opentelemetry/api@1.9.0)
+      openai: 4.103.0(ws@8.18.2)(zod@4.1.13)
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+      - ws
+      - zod
+
   '@azure/arm-authorization@9.0.0':
     dependencies:
       '@azure/core-auth': 1.9.0
@@ -23430,6 +23469,21 @@ snapshots:
     optionalDependencies:
       ws: 8.18.2
       zod: 3.24.4
+    transitivePeerDependencies:
+      - encoding
+
+  openai@4.103.0(ws@8.18.2)(zod@4.1.13):
+    dependencies:
+      '@types/node': 18.19.130
+      '@types/node-fetch': 2.6.12
+      abort-controller: 3.0.0
+      agentkeepalive: 4.6.0
+      form-data-encoder: 1.7.2
+      formdata-node: 4.4.1
+      node-fetch: 2.7.0(encoding@0.1.13)
+    optionalDependencies:
+      ws: 8.18.2
+      zod: 4.1.13
     transitivePeerDependencies:
       - encoding
 


### PR DESCRIPTION
# Details
Introduces a new reasoning capability powered by the Claude Agent SDK that enables TypeAgent to handle complex multi-step requests. Current by default off, can be enabled using `@config schema dispatcher.reasoning` and `@config action dispatcher.reasoning`.  Additionally, it removes the unused delegatable action feature as a cleanup.

## Add Claude Agent SDK reasoning integration:

- Add new dependencies: @anthropic-ai/claude-agent-sdk@0.2.12 and zod@4.1.13
- Create `reasoningActionSchema.ts` defining the reasoning action schema
- Create `claude.ts` implementing reasoning execution with:
  - Custom MCP server exposing `discover_actions` and `execute_action` tools to Claude
  - Integration with existing TypeAgent action execution pipeline
  - Support for Claude Sonnet 4.5 with extended thinking capabilities
  - Integrate reasoning action into dispatcher manifest in `dispatcherAgent.ts` (disabled by default)
  - Export executeAction function from `actionHandlers.ts` for use by reasoning system

The reasoning system allows Claude to dynamically discover available TypeAgent action schemas and execute actions across different agents, providing an agentic approach to handling complex user requests that require multiple steps.

## Remove delegatable action feature:

- Remove delegatable flag from `SchemaManifest` interface in `agentInterface.ts`
- Remove delegatable from browser and chat agent manifests
- Remove delegated action handling from action execution pipeline in `actionHandlers.ts`
- Clean up `ActionConfig` in `actionConfig.ts` to remove delegatable field and related processing

## Other changes:

Fix typo in `actionContext.ts:103`