### PR TITLE
Configurable reasoning

### DIFF
--- a/ts/packages/agentServer/server/src/server.ts
+++ b/ts/packages/agentServer/server/src/server.ts
@@ -40,6 +40,7 @@ async function main() {
             requestKnowledgeExtraction: false,
             actionResultKnowledgeExtraction: false,
         },
+        collectCommandResult: true,
     });
 
     await createWebSocketChannelServer(

--- a/ts/packages/dispatcher/dispatcher/src/context/session.ts
+++ b/ts/packages/dispatcher/dispatcher/src/context/session.ts
@@ -136,6 +136,7 @@ export type DispatcherConfig = {
         memory: {
             legacy: boolean; // use legacy memory behavior
         };
+        reasoning: "claude" | "none";
     };
     explainer: {
         enabled: boolean;
@@ -222,6 +223,7 @@ const defaultSessionConfig: SessionConfig = {
         memory: {
             legacy: true, // use the new memory behavior
         },
+        reasoning: "none",
     },
     explainer: {
         enabled: true,

--- a/ts/packages/dispatcher/dispatcher/src/context/system/handlers/configCommandHandlers.ts
+++ b/ts/packages/dispatcher/dispatcher/src/context/system/handlers/configCommandHandlers.ts
@@ -1280,6 +1280,38 @@ const configExplainerCommandHandlers: CommandHandlerTable = {
     },
 };
 
+class ConfigExecutionReasoningCommandHandler implements CommandHandler {
+    public readonly description = "Set reasoning engine";
+    public readonly parameters = {
+        args: {
+            engine: {
+                description: "Reasoning engine to use (claude or none)",
+            },
+        },
+    };
+    public async run(
+        context: ActionContext<CommandHandlerContext>,
+        params: ParsedCommandParams<typeof this.parameters>,
+    ) {
+        const engine = params.args.engine;
+        if (engine === "claude" || engine === "none") {
+            const agentToggle = {
+                "dispatcher.reasoning": engine === "claude",
+            } as const;
+            await changeContextConfig(
+                {
+                    translation: { multiple: { enabled: engine !== "claude" } },
+                    execution: { reasoning: engine },
+                    schemas: agentToggle,
+                    actions: agentToggle,
+                },
+                context,
+            );
+            displayResult(`Reasoning model is set to '${engine}'`, context);
+        }
+    }
+}
+
 const configExecutionCommandHandlers: CommandHandlerTable = {
     description: "Execution configuration",
     commands: {
@@ -1292,6 +1324,7 @@ const configExecutionCommandHandlers: CommandHandlerTable = {
                 );
             },
         ),
+        reasoning: new ConfigExecutionReasoningCommandHandler(),
     },
 };
 

--- a/ts/packages/dispatcher/dispatcher/src/reasoning/claude.ts
+++ b/ts/packages/dispatcher/dispatcher/src/reasoning/claude.ts
@@ -178,6 +178,12 @@ export async function executeReasoningAction(
     action: TypeAgentAction<ReasoningAction>,
     context: ActionContext<CommandHandlerContext>,
 ): Promise<any> {
+    const systemContext = context.sessionContext.agentContext;
+    if (systemContext.session.getConfig().execution.reasoning !== "claude") {
+        throw new Error(
+            `Reasoning model is not set to 'claude' for this session.`,
+        );
+    }
     const originalRequest = action.parameters.originalRequest;
 
     // Display initial message
@@ -198,10 +204,13 @@ export async function executeReasoningAction(
                 if (content.type === "text") {
                     // Update display with current thinking content
                     // REVIEW: assume markdown?
-                    context.actionIO.appendDisplay({
-                        type: "markdown",
-                        content: content.text,
-                    });
+                    context.actionIO.appendDisplay(
+                        {
+                            type: "markdown",
+                            content: content.text,
+                        },
+                        "block",
+                    );
                 } else if (content.type === "tool_use") {
                     const toolName = content.name;
                     if (


### PR DESCRIPTION
- Add `@config` command to configure reasoning behavior.
- Make sure claude output are in separately blocks.