### PR TITLE
Add validation for undefined variable references in grammar value expressions

### DIFF
--- a/ts/packages/actionGrammar/test/grammarCompileError.spec.ts
+++ b/ts/packages/actionGrammar/test/grammarCompileError.spec.ts
@@ -71,6 +71,18 @@ describe("Grammar Compiler", () => {
                 "error: Referenced rule '<Pause>' does not produce a value for variable 'x' in definition '<Start>'",
             );
         });
+
+        it("Undefined variable reference in value expression", () => {
+            const grammarText = `
+            @<Start> = $(name) plays music -> { player: $(name), action: $(undefinedVar) }
+        `;
+            const errors: string[] = [];
+            loadGrammarRules("test", grammarText, errors);
+            expect(errors.length).toBe(1);
+            expect(errors[0]).toContain(
+                "error: Variable 'undefinedVar' is referenced in the value but not defined in the rule",
+            );
+        });
     });
     describe("Warning", () => {
         it("Unused", () => {


### PR DESCRIPTION
- Adds compile-time validation to detect when variables are referenced in value expressions but not defined in the rule
- Implements `validateVariableReferences` function that recursively checks variable usage in value nodes (objects, arrays, and variables)
- Tracks all defined variables during rule compilation and validates against them
- Adds test coverage for the new validation error case