### PR TITLE
Add inline ghost text completions and fix NFA wildcard completion

### DIFF
--- a/ts/packages/actionGrammar/examples/globalModule.agr
+++ b/ts/packages/actionGrammar/examples/globalModule.agr
@@ -1,72 +1,24 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-// This grammar defines common number patterns (Ordinal and Cardinal)
-// These are defined inline and don't require entity declarations
+// This grammar demonstrates built-in entity types (Ordinal and Cardinal)
+// which are registered at runtime and don't need inline definitions
 
-// Ordinal numbers
-@ <Ordinal> =
-    first -> 1
-|   second -> 2
-|   third -> 3
-|   fourth -> 4
-|   fifth -> 5
-|   sixth -> 6
-|   seventh -> 7
-|   eighth -> 8
-|   ninth -> 9
-|   tenth -> 10
-|   eleventh -> 11
-|   twelfth -> 12
-|   thirteenth -> 13
-|   fourteenth -> 14
-|   fifteenth -> 15
-|   sixteenth -> 16
-|   seventeenth -> 17
-|   eighteenth -> 18
-|   nineteenth -> 19
-|   twentieth -> 20
-|   twenty\-first -> 21
-|   twenty\-second -> 22
-|   twenty\-third -> 23
-|   twenty\-fourth -> 24
-|   twenty\-fifth -> 25
-|   twenty\-sixth -> 26
-|   twenty\-seventh -> 27
-|   twenty\-eighth -> 28
-|   twenty\-ninth -> 29
-|   thirtieth -> 30
+entity Ordinal, Cardinal;
 
-// Cardinal numbers
-@ <Cardinal> =
-    $(x:number)
-|   one -> 1
-|   two -> 2
-|   three -> 3
-|   four -> 4
-|   five -> 5
-|   six -> 6
-|   seven -> 7
-|   eight -> 8
-|   nine -> 9
-|   ten -> 10
-|   eleven -> 11
-|   twelve -> 12
-|   thirteen -> 13
-|   fourteen -> 14
-|   fifteen -> 15
-|   sixteen -> 16
-|   seventeen -> 17
-|   eighteen -> 18
-|   nineteen -> 19
-|   twenty -> 20
-|   twenty\-one -> 21
-|   twenty\-two -> 22
-|   twenty\-three -> 23
-|   twenty\-four -> 24
-|   twenty\-five -> 25
-|   twenty\-six -> 26
-|   twenty\-seven -> 27
-|   twenty\-eight -> 28
-|   twenty\-nine -> 29
-|   thirty -> 30
+// Example usage of built-in entities
+@ <Start> = <PlayTrackNumber>
+
+@ <PlayTrackNumber> =
+    play (the)? $(n:Ordinal) (track | song)? -> {
+        actionName: "playFromCurrentTrackList",
+        parameters: {
+            trackNumber: $(n)
+        }
+    }
+| play track $(n:Cardinal) -> {
+        actionName: "playFromCurrentTrackList",
+        parameters: {
+            trackNumber: $(n)
+        }
+   }

--- a/ts/packages/actionGrammar/src/builtInEntities.ts
+++ b/ts/packages/actionGrammar/src/builtInEntities.ts
@@ -379,6 +379,63 @@ export const CalendarTimeRange: EntityConverter<string> = createConverter(
 );
 
 // ============================================================================
+// Percentage Entity
+// ============================================================================
+
+function validatePercentage(token: string): boolean {
+    const lower = token.toLowerCase().trim();
+
+    // "35%" or "100%"
+    if (/^\d+%$/.test(lower)) {
+        return true;
+    }
+
+    // Bare numbers: "35", "100"
+    if (/^\d+$/.test(lower)) {
+        return true;
+    }
+
+    // Word numbers (reuse cardinal map keys)
+    if (lower in cardinalMap) {
+        return true;
+    }
+
+    return false;
+}
+
+function convertPercentage(token: string): number | undefined {
+    const lower = token.toLowerCase().trim();
+
+    // "35%" → 35
+    if (lower.endsWith("%")) {
+        const num = parseInt(lower.slice(0, -1), 10);
+        return isNaN(num) ? undefined : num;
+    }
+
+    // Bare number: "35" → 35
+    const num = parseInt(lower, 10);
+    if (!isNaN(num)) {
+        return num;
+    }
+
+    // Word number: "fifty" → 50 (via cardinal map)
+    if (lower in cardinalMap) {
+        return cardinalMap[lower];
+    }
+
+    return undefined;
+}
+
+/**
+ * Percentage entity converter
+ * Validates and converts percentage expressions: "35%", "100", "twenty"
+ */
+export const Percentage: EntityConverter<number> = createConverter(
+    validatePercentage,
+    convertPercentage,
+);
+
+// ============================================================================
 // Registration
 // ============================================================================
 
@@ -400,6 +457,8 @@ export function registerBuiltInEntities(): void {
         CalendarTimeRange,
     );
 
+    globalEntityRegistry.registerConverter("Percentage", Percentage);
+
     // Lowercase aliases (paramSpec convention from .pas.json schemas)
     globalEntityRegistry.registerConverter("ordinal", Ordinal);
     globalEntityRegistry.registerConverter("cardinal", Cardinal);
@@ -409,4 +468,5 @@ export function registerBuiltInEntities(): void {
         "calendarTimeRange",
         CalendarTimeRange,
     );
+    globalEntityRegistry.registerConverter("percentage", Percentage);
 }

--- a/ts/packages/actionGrammar/src/grammarStore.ts
+++ b/ts/packages/actionGrammar/src/grammarStore.ts
@@ -126,7 +126,6 @@ export class GrammarStore {
 
         this.data.schemas[rule.schemaName].push(storedRule);
         this.modified = true;
-
         await this.doAutoSave();
     }
 
@@ -231,11 +230,8 @@ export class GrammarStore {
         }
 
         // Write the store data as JSON
-        await fs.promises.writeFile(
-            outFile,
-            JSON.stringify(this.data, null, 2),
-            "utf-8",
-        );
+        const jsonStr = JSON.stringify(this.data, null, 2);
+        await fs.promises.writeFile(outFile, jsonStr, "utf-8");
 
         this.filePath = outFile;
         this.modified = false;

--- a/ts/packages/actionGrammar/src/nfaCompiler.ts
+++ b/ts/packages/actionGrammar/src/nfaCompiler.ts
@@ -870,6 +870,7 @@ function compileWildcardPartWithSlots(
         );
 
         // Loop: loopState -> loopState (append to slot)
+        // No completion metadata — same rationale as required wildcard.
         builder.addWildcardTransition(
             loopState,
             loopState,
@@ -878,8 +879,6 @@ function compileWildcardPartWithSlots(
             isChecked,
             slotIndex,
             true, // Subsequent tokens, append
-            completionActionName,
-            completionPropertyPath,
         );
 
         builder.addEpsilonTransition(loopState, toState);
@@ -904,6 +903,11 @@ function compileWildcardPartWithSlots(
     );
 
     // Loop: loopState -> loopState (append to slot)
+    // No completion metadata on self-loop: property completions should only
+    // fire at the entry point (fromState), not after tokens have already been
+    // consumed.  Wildcard is token+ so once in the loop, completions come
+    // from whatever follows the wildcard (e.g. "by"), not from the wildcard
+    // entity list again.
     builder.addWildcardTransition(
         loopState,
         loopState,
@@ -912,8 +916,6 @@ function compileWildcardPartWithSlots(
         isChecked,
         slotIndex,
         true, // Subsequent tokens, append
-        completionActionName,
-        completionPropertyPath,
     );
 
     builder.addEpsilonTransition(loopState, toState);

--- a/ts/packages/actionGrammar/test/nfaRealGrammars.spec.ts
+++ b/ts/packages/actionGrammar/test/nfaRealGrammars.spec.ts
@@ -7,6 +7,7 @@ import { fileURLToPath } from "url";
 import { loadGrammarRules } from "../src/grammarLoader.js";
 import { compileGrammarToNFA } from "../src/nfaCompiler.js";
 import { matchNFA, printNFA, printMatchResult } from "../src/nfaInterpreter.js";
+import { registerBuiltInEntities } from "../src/builtInEntities.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -22,6 +23,10 @@ function fileExists(filePath: string): boolean {
 }
 
 describe("NFA with Real Grammars", () => {
+    // Register built-in entities (Ordinal, Cardinal, etc.) so entity-type
+    // wildcards in .agr grammars can be validated at runtime.
+    registerBuiltInEntities();
+
     describe("Player Grammar", () => {
         it("should compile and match player grammar", () => {
             // Load player grammar

--- a/ts/packages/agentSdk/src/index.ts
+++ b/ts/packages/agentSdk/src/index.ts
@@ -48,8 +48,10 @@ export {
     DynamicDisplay,
     MessageContent,
     DisplayContent,
+    TypedDisplayContent,
     DisplayAppendMode,
     DisplayMessageKind,
+    getContentForType,
 } from "./display.js";
 
 export {

--- a/ts/packages/agents/player/src/agent/playerSchema.agr
+++ b/ts/packages/agents/player/src/agent/playerSchema.agr
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+entity Ordinal, Cardinal;
+
 @ <Start> = <Pause>
           | <Resume>
           | <Next>
@@ -17,13 +19,13 @@
          | skip <TrackTerm>   ->  { actionName: "nextTrack" }
 @ <PlayCommand> = <PlayTrackNumberCommand> | <PlaySpecificTrack>
 @ <PlayTrackNumberCommand> =
-    play (the)? $(n:<Ordinal>) (<Item>)? -> {
+    play (the)? $(n:Ordinal) (<Item>)? -> {
         actionName: "playFromCurrentTrackList",
         parameters: {
             trackNumber: $(n)
         }
     }
-| play track $(n:<Cardinal>) -> {
+| play track $(n:Cardinal) -> {
         actionName: "playFromCurrentTrackList",
         parameters: {
             trackNumber: $(n)
@@ -38,72 +40,6 @@
 
 @ <Item> = one | cut | <TrackTerm> 
 @ <TrackTerm> = track | song
-
-@ <Cardinal> = 
-  $(x:number) 
-|   one -> 1
-|   two -> 2
-|   three -> 3
-|   four -> 4
-|   five -> 5
-|   six -> 6
-|   seven -> 7
-|   eight -> 8
-|   nine -> 9
-|   ten -> 10
-|   eleven -> 11
-|   twelve -> 12
-|   thirteen -> 13
-|   fourteen -> 14
-|   fifteen -> 15
-|   sixteen -> 16
-|   seventeen -> 17
-|   eighteen -> 18
-|   nineteen -> 19
-|   twenty -> 20
-|   twenty\-one -> 21
-|   twenty\-two -> 22
-|   twenty\-three -> 23
-|   twenty\-four -> 24
-|   twenty\-five -> 25
-|   twenty\-six -> 26
-|   twenty\-seven -> 27
-|   twenty\-eight -> 28
-|   twenty\-nine -> 29
-|   thirty -> 30
-
-
-@ <Ordinal> = 
-    first -> 1
-|   second -> 2
-|   third -> 3
-|   fourth -> 4
-|   fifth -> 5
-|   sixth -> 6
-|   seventh -> 7
-|   eighth -> 8
-|   ninth -> 9
-|   tenth -> 10
-|   eleventh -> 11
-|   twelfth -> 12
-|   thirteenth -> 13
-|   fourteenth -> 14
-|   fifteenth -> 15
-|   sixteenth -> 16
-|   seventeenth -> 17
-|   eighteenth -> 18
-|   nineteenth -> 19
-|   twentieth -> 20
-|   twenty\-first -> 21
-|   twenty\-second -> 22
-|   twenty\-third -> 23
-|   twenty\-fourth -> 24
-|   twenty\-fifth -> 25
-|   twenty\-sixth -> 26
-|   twenty\-seventh -> 27
-|   twenty\-eighth -> 28
-|   twenty\-ninth -> 29
-|   thirtieth -> 30
 
 @ <TrackPhrase> = $(trackName:<TrackName>)  -> $(trackName)
                 | the <TrackTerm> $(trackName:<TrackName>)  -> $(trackName)

--- a/ts/packages/agents/playerLocal/src/agent/localPlayerSchema.agr
+++ b/ts/packages/agents/playerLocal/src/agent/localPlayerSchema.agr
@@ -3,6 +3,8 @@
 
 // Grammar rules for Local Music Player
 
+entity Ordinal, Cardinal;
+
 @ <Start> = <Pause>
           | <Resume>
           | <Stop>
@@ -31,13 +33,13 @@
 @ <PlayCommand> = <PlayTrackNumberCommand>
 
 @ <PlayTrackNumberCommand> =
-    play (the)? $(n:<Ordinal>) (track | song)? -> {
+    play (the)? $(n:Ordinal) (track | song)? -> {
         actionName: "playFromQueue",
         parameters: {
             trackNumber: $(n)
         }
     }
-| play track $(n:<Cardinal>) -> {
+| play track $(n:Cardinal) -> {
         actionName: "playFromQueue",
         parameters: {
             trackNumber: $(n)
@@ -71,27 +73,3 @@
 
 @ <ClearQueue> = clear (the)? queue   ->  { actionName: "clearQueue" }
 
-@ <Cardinal> = 
-  $(x:number) 
-|   one -> 1
-|   two -> 2
-|   three -> 3
-|   four -> 4
-|   five -> 5
-|   six -> 6
-|   seven -> 7
-|   eight -> 8
-|   nine -> 9
-|   ten -> 10
-
-@ <Ordinal> = 
-    first -> 1
-|   second -> 2
-|   third -> 3
-|   fourth -> 4
-|   fifth -> 5
-|   sixth -> 6
-|   seventh -> 7
-|   eighth -> 8
-|   ninth -> 9
-|   tenth -> 10

--- a/ts/packages/cache/src/cache/cache.ts
+++ b/ts/packages/cache/src/cache/cache.ts
@@ -407,9 +407,6 @@ export class AgentCache {
                             debug(
                                 `Calling populateCache for request: "${requestAction.request}"`,
                             );
-                            console.log(
-                                `[GRAMMAR] populateCache input: request="${requestAction.request}", action=${actionName}, params=${JSON.stringify(parameters)}`,
-                            );
                             // Generate grammar rule
                             const genResult = await populateCache({
                                 request: requestAction.request,
@@ -420,10 +417,6 @@ export class AgentCache {
                                 },
                                 schemaPath,
                             });
-                            console.log(
-                                `[GRAMMAR] populateCache result: success=${genResult.success}, rule=${genResult.generatedRule ?? "none"}, rejection=${genResult.rejectionReason ?? "none"}`,
-                            );
-
                             if (genResult.success && genResult.generatedRule) {
                                 debug(
                                     `Grammar rule generated for ${schemaName}.${actionName}: ${genResult.generatedRule}`,
@@ -444,17 +437,11 @@ export class AgentCache {
                                     debug(
                                         `Adding rule to agent grammar registry...`,
                                     );
-                                    console.log(
-                                        `[GRAMMAR] Adding to registry: checkedVars=${genResult.checkedVariables ? [...genResult.checkedVariables].join(",") : "none"}`,
-                                    );
                                     const addResult =
                                         agentGrammar.addGeneratedRules(
                                             genResult.generatedRule,
                                             genResult.checkedVariables,
                                         );
-                                    console.log(
-                                        `[GRAMMAR] addGeneratedRules: success=${addResult.success}, errors=${addResult.errors.join("; ") || "none"}, unresolved=${addResult.unresolvedEntities?.join(", ") || "none"}`,
-                                    );
                                     if (addResult.success) {
                                         // Sync to the grammar store used for matching
                                         this.syncAgentGrammar(schemaName);
@@ -539,8 +526,8 @@ export class AgentCache {
             }
 
             if (grammarResult && !grammarResult.success) {
-                console.log(
-                    `[GRAMMAR] Rule generation failed: ${grammarResult.message}${grammarResult.generatedRule ? `, rule=${grammarResult.generatedRule}` : ""}`,
+                debug(
+                    `Rule generation failed: ${grammarResult.message}${grammarResult.generatedRule ? `, rule=${grammarResult.generatedRule}` : ""}`,
                 );
             }
 

--- a/ts/packages/chat-ui/src/setContent.ts
+++ b/ts/packages/chat-ui/src/setContent.ts
@@ -8,6 +8,7 @@ import {
     DisplayType,
     DisplayMessageKind,
     MessageContent,
+    getContentForType,
 } from "@typeagent/agent-sdk";
 import DOMPurify from "dompurify";
 import MarkdownIt from "markdown-it";
@@ -193,8 +194,15 @@ export function setContent(
         message = content;
         speak = false;
     } else {
-        type = content.type;
-        message = content.content;
+        // Prefer HTML alternates when available
+        const htmlContent = getContentForType(content, "html");
+        if (htmlContent !== undefined && content.type !== "html") {
+            type = "html";
+            message = htmlContent;
+        } else {
+            type = content.type;
+            message = content.content;
+        }
         kind = content.kind;
         speak = content.speak ?? false;
     }

--- a/ts/packages/cli/src/enhancedConsole.ts
+++ b/ts/packages/cli/src/enhancedConsole.ts
@@ -17,6 +17,7 @@ import {
     DisplayAppendMode,
     DisplayContent,
     MessageContent,
+    getContentForType,
 } from "@typeagent/agent-sdk";
 import type {
     RequestId,
@@ -209,8 +210,15 @@ export function createEnhancedClientIO(
         if (typeof content === "string" || Array.isArray(content)) {
             message = content;
         } else {
-            message = content.content;
-            contentType = content.type || "text";
+            // CLI prefers text alternates when available
+            const textContent = getContentForType(content, "text");
+            if (textContent !== undefined && content.type !== "text") {
+                message = textContent;
+                contentType = "text";
+            } else {
+                message = content.content;
+                contentType = content.type || "text";
+            }
             switch (content.kind) {
                 case "status":
                     colorFn = chalk.grey;

--- a/ts/packages/dispatcher/dispatcher/src/helpers/console.ts
+++ b/ts/packages/dispatcher/dispatcher/src/helpers/console.ts
@@ -6,6 +6,7 @@ import {
     DisplayAppendMode,
     DisplayContent,
     MessageContent,
+    getContentForType,
 } from "@typeagent/agent-sdk";
 import type {
     RequestId,
@@ -76,8 +77,13 @@ function createConsoleClientIO(rl?: readline.promises.Interface): ClientIO {
         if (typeof content === "string" || Array.isArray(content)) {
             message = content;
         } else {
-            // TODO: should reject html content
-            message = content.content;
+            // Console prefers text alternates when available
+            const textContent = getContentForType(content, "text");
+            if (textContent !== undefined && content.type !== "text") {
+                message = textContent;
+            } else {
+                message = content.content;
+            }
             switch (content.kind) {
                 case "status":
                     message = chalk.grey(content.content);

--- a/ts/packages/shell/src/preload/shellSettingsType.ts
+++ b/ts/packages/shell/src/preload/shellSettingsType.ts
@@ -14,6 +14,7 @@ export type UISettings = {
     dev: boolean;
     darkMode: boolean;
     disableCompletionRemoteUI: boolean;
+    inlineCompletions: boolean;
 };
 export type ShellUserSettings = {
     microphoneId: string | undefined;
@@ -54,6 +55,7 @@ export const defaultUserSettings: ShellUserSettings = {
         dev: false,
         darkMode: false,
         disableCompletionRemoteUI: false,
+        inlineCompletions: true,
     },
     partialCompletion: true,
     disallowedDisplayType: "",

--- a/ts/packages/shell/src/renderer/assets/styles.less
+++ b/ts/packages/shell/src/renderer/assets/styles.less
@@ -76,6 +76,10 @@ body {
     }
   }
 
+  .inline-ghost {
+    color: #6b7280;
+  }
+
   .chat-message-agent {
     background-color: #2a2a40;
   }
@@ -300,6 +304,12 @@ body {
   font-family: inherit;
   font-size: inherit;
   align-self: flex-start;
+}
+
+.inline-ghost {
+  color: #9ca3af;
+  pointer-events: none;
+  user-select: none;
 }
 
 .replacement-textarea {

--- a/ts/packages/shell/src/renderer/src/chat/chatView.ts
+++ b/ts/packages/shell/src/renderer/src/chat/chatView.ts
@@ -40,7 +40,7 @@ export class ChatView {
     private _settingsView: SettingsView | undefined;
     private _dispatcher: Dispatcher | undefined;
     private partialCompletionEnabled: boolean = false;
-    private partialCompletionDisableRemoteUI: boolean = false;
+    private partialCompletionInline: boolean = true;
     private partialCompletion: PartialCompletion | undefined;
     private commandBackStack: string[] = [];
     private commandBackStackIndex = 0;
@@ -150,18 +150,18 @@ export class ChatView {
                 this.inputContainer,
                 this.chatInput.textarea,
                 this.getDispatcher(),
-                this.partialCompletionDisableRemoteUI,
+                this.partialCompletionInline,
             );
         }
     }
 
-    public enablePartialInput(enabled: boolean, disableRemoteUI: boolean) {
+    public enablePartialInput(enabled: boolean, inline: boolean) {
         this.partialCompletionEnabled = enabled;
-        if (this.partialCompletionDisableRemoteUI !== disableRemoteUI) {
-            // Reinitialize partial completion
+        if (this.partialCompletionInline !== inline) {
+            // Reinitialize partial completion with new mode
             this.partialCompletion?.close();
             this.partialCompletion = undefined;
-            this.partialCompletionDisableRemoteUI = disableRemoteUI;
+            this.partialCompletionInline = inline;
         }
 
         if (enabled) {

--- a/ts/packages/shell/src/renderer/src/search.ts
+++ b/ts/packages/shell/src/renderer/src/search.ts
@@ -1,10 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { isElectron } from "./main";
 import { TST } from "./prefixTree";
+import { InlineSearchMenuUI } from "./searchMenuUI/inlineSearchMenuUI";
 import { LocalSearchMenuUI } from "./searchMenuUI/localSearchMenuUI";
-import { RemoteSearchMenuUI } from "./searchMenuUI/remoteSearchMenuUI";
 import {
     SearchMenuItem,
     SearchMenuPosition,
@@ -26,8 +25,8 @@ export class SearchMenu {
     private prefix: string | undefined;
     constructor(
         private readonly onCompletion: (item: SearchMenuItem) => void,
-        private readonly visibleItems: number = 15,
-        private readonly remoteUI: boolean = isElectron(),
+        private readonly inline: boolean,
+        private readonly textEntry?: HTMLSpanElement,
     ) {}
 
     public isActive() {
@@ -69,15 +68,9 @@ export class SearchMenu {
 
         if (showMenu) {
             if (this.searchMenuUI === undefined) {
-                this.searchMenuUI = this.remoteUI
-                    ? new RemoteSearchMenuUI(
-                          this.onCompletion,
-                          this.visibleItems,
-                      )
-                    : new LocalSearchMenuUI(
-                          this.onCompletion,
-                          this.visibleItems,
-                      );
+                this.searchMenuUI = this.inline
+                    ? new InlineSearchMenuUI(this.onCompletion, this.textEntry!)
+                    : new LocalSearchMenuUI(this.onCompletion);
             }
             this.searchMenuUI.update({ position, prefix, items });
         } else {

--- a/ts/packages/shell/src/renderer/src/searchMenuUI/inlineSearchMenuUI.ts
+++ b/ts/packages/shell/src/renderer/src/searchMenuUI/inlineSearchMenuUI.ts
@@ -1,0 +1,122 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import {
+    SearchMenuItem,
+    SearchMenuUI,
+    SearchMenuUIUpdateData,
+} from "./searchMenuUI";
+
+export class InlineSearchMenuUI implements SearchMenuUI {
+    private ghostSpan: HTMLSpanElement | null = null;
+    private selected: number = -1;
+    private items: SearchMenuItem[] = [];
+    private prefix: string = "";
+
+    constructor(
+        private readonly onCompletion: (item: SearchMenuItem) => void,
+        private readonly textEntry: HTMLSpanElement,
+    ) {}
+
+    public close() {
+        this.removeGhost();
+        this.items = [];
+        this.selected = -1;
+    }
+
+    public selectCompletion() {
+        if (this.selected >= 0 && this.selected < this.items.length) {
+            this.removeGhost();
+            this.onCompletion(this.items[this.selected]);
+        }
+    }
+
+    public update(data: SearchMenuUIUpdateData) {
+        let changed = false;
+        if (data.prefix !== undefined) {
+            this.prefix = data.prefix;
+            changed = true;
+        }
+        if (data.items !== undefined) {
+            this.items = data.items;
+            this.selected = this.items.length > 0 ? 0 : -1;
+            changed = true;
+        }
+        // Only re-render ghost when items or prefix changed, not for
+        // position-only updates, to avoid a selectionchange feedback loop.
+        if (changed) {
+            this.renderGhost();
+        }
+    }
+
+    public adjustSelection(deltaY: number) {
+        if (this.items.length === 0) {
+            return;
+        }
+        if (deltaY > 0 && this.selected < this.items.length - 1) {
+            this.selected++;
+        } else if (deltaY < 0 && this.selected > 0) {
+            this.selected--;
+        }
+        this.renderGhost();
+    }
+
+    private removeGhost() {
+        if (this.ghostSpan && this.ghostSpan.parentNode) {
+            this.ghostSpan.parentNode.removeChild(this.ghostSpan);
+        }
+        this.ghostSpan = null;
+    }
+
+    private renderGhost() {
+        this.removeGhost();
+        if (
+            this.items.length === 0 ||
+            this.selected < 0 ||
+            this.selected >= this.items.length
+        ) {
+            return;
+        }
+
+        const item = this.items[this.selected];
+        const matchText = item.matchText;
+
+        // Compute the suffix: portion of the completion after the typed prefix
+        const suffix =
+            matchText.length > this.prefix.length
+                ? matchText.substring(this.prefix.length)
+                : "";
+
+        // Build counter text
+        const counter = ` ${this.selected + 1}/${this.items.length}`;
+
+        // Create ghost span
+        const ghost = document.createElement("span");
+        ghost.className = "inline-ghost";
+        ghost.contentEditable = "false";
+        ghost.textContent = suffix + counter;
+        this.ghostSpan = ghost;
+
+        // Append ghost to text entry
+        this.textEntry.appendChild(ghost);
+
+        // Restore cursor position before the ghost span
+        this.setCursorBeforeGhost();
+    }
+
+    private setCursorBeforeGhost() {
+        if (!this.ghostSpan) {
+            return;
+        }
+        const s = document.getSelection();
+        if (!s) {
+            return;
+        }
+        const r = document.createRange();
+        // Set cursor right before the ghost span
+        r.setStartBefore(this.ghostSpan);
+        r.collapse(true);
+        s.removeAllRanges();
+        s.addRange(r);
+    }
+}

--- a/ts/packages/shell/src/renderer/src/searchMenuUI/localSearchMenuUI.ts
+++ b/ts/packages/shell/src/renderer/src/searchMenuUI/localSearchMenuUI.ts
@@ -170,8 +170,13 @@ export class LocalSearchMenuUI implements SearchMenuUI {
             this.searchContainer.appendChild(this.completions);
             this.searchContainer.style.visibility = "visible";
 
-            // calculate scrollbar indicator offset and height
-            this.setScrollBarPosition();
+            // Show scrollbar only when items overflow the visible area
+            if (this.items.length > this.visibleItemsCount) {
+                this.scrollBar.style.visibility = "visible";
+                this.setScrollBarPosition();
+            } else {
+                this.scrollBar.style.visibility = "hidden";
+            }
         }
     }
 

--- a/ts/packages/shell/src/renderer/src/setContent.ts
+++ b/ts/packages/shell/src/renderer/src/setContent.ts
@@ -8,6 +8,7 @@ import {
     DisplayType,
     DisplayMessageKind,
     MessageContent,
+    getContentForType,
 } from "@typeagent/agent-sdk";
 import DOMPurify from "dompurify";
 import { SettingsView } from "./settingsView";
@@ -184,8 +185,15 @@ export function setContent(
         message = content;
         speak = false;
     } else {
-        type = content.type;
-        message = content.content;
+        // Shell prefers HTML alternates when available
+        const htmlContent = getContentForType(content, "html");
+        if (htmlContent !== undefined && content.type !== "html") {
+            type = "html";
+            message = htmlContent;
+        } else {
+            type = content.type;
+            message = content.content;
+        }
         kind = content.kind;
         speak = content.speak ?? false;
     }

--- a/ts/packages/shell/src/renderer/src/settingsView.ts
+++ b/ts/packages/shell/src/renderer/src/settingsView.ts
@@ -88,6 +88,7 @@ export class SettingsView {
     private ttsVoice: HTMLSelectElement;
     private agentGreetingCheckBox: HTMLInputElement;
     private intellisenseCheckBox: HTMLInputElement;
+    private inlineCompletionsCheckBox: HTMLInputElement;
     private _shellSettings: ShellUserSettings =
         structuredClone(defaultUserSettings);
     private updateFromSettings: () => Promise<void>;
@@ -102,6 +103,7 @@ export class SettingsView {
         this.ttsCheckBox.checked = value.tts;
         this.microphoneSources.value = value.microphoneId ?? "";
         this.intellisenseCheckBox.checked = value.partialCompletion;
+        this.inlineCompletionsCheckBox.checked = value.ui.inlineCompletions;
         this.agentGreetingCheckBox.checked = value.agentGreeting;
         this.devUICheckBox.checked = !value.ui.dev;
         this.saveChatHistoryCheckBox.checked = value.chatHistory;
@@ -175,7 +177,7 @@ export class SettingsView {
 
             chatView.enablePartialInput(
                 this.shellSettings.partialCompletion,
-                this.shellSettings.ui.disableCompletionRemoteUI,
+                this.shellSettings.ui.inlineCompletions,
             );
             chatView.setMetricsVisible(this.shellSettings.ui.dev);
             chatView.setInputMode(this.shellSettings.ui.verticalLayout);
@@ -278,9 +280,21 @@ export class SettingsView {
                 this.intellisenseCheckBox.checked;
             chatView.enablePartialInput(
                 this.intellisenseCheckBox.checked,
-                this._shellSettings.ui.disableCompletionRemoteUI,
+                this._shellSettings.ui.inlineCompletions,
             );
         });
+
+        this.inlineCompletionsCheckBox = this.addCheckbox(
+            "Inline completions",
+            () => {
+                this._shellSettings.ui.inlineCompletions =
+                    this.inlineCompletionsCheckBox.checked;
+                chatView.enablePartialInput(
+                    this._shellSettings.partialCompletion,
+                    this.inlineCompletionsCheckBox.checked,
+                );
+            },
+        );
 
         this.agentGreetingCheckBox = this.addCheckbox("Agent greeting", () => {
             this._shellSettings.agentGreeting =

--- a/ts/packages/shell/src/renderer/src/templateEditor.ts
+++ b/ts/packages/shell/src/renderer/src/templateEditor.ts
@@ -491,7 +491,7 @@ class FieldScalar extends FieldBase {
         const searchMenu = new SearchMenu((item) => {
             input.value = item.matchText;
             this.data.setEditing(this.getNextScalarField());
-        });
+        }, false);
         searchMenu.setChoices(choices);
         input.addEventListener("input", () => {
             this.updateSearchMenu();


### PR DESCRIPTION
## Summary
- **Inline ghost text completions**: New `InlineSearchMenuUI` renders completions as grayed-out ghost text after the cursor (like VS Code), with arrow key cycling and Tab accept. Toggleable via `@shell set ui.inlineCompletions true/false`
- **Fix completion sort order**: Preserve backend group ordering so grammar completions ("by") appear before entity completions (song titles), matching CLI behavior
- **Fix NFA wildcard self-loop completions**: Property completions only fire at the wildcard entry state (before any tokens consumed), not from the self-loop state — prevents stale entity suggestions after partial wildcard matches

## Test plan
- [ ] Type `play ` → ghost text shows first completion with counter (e.g., "1/N")
- [ ] Arrow up/down cycles through completions
- [ ] Tab accepts the completion, ghost disappears
- [ ] Type `play Shake It Off ` → ghost shows "by" (not "Shake It Off" again)
- [ ] `@shell set ui.inlineCompletions false` → switches to dropdown menu mode
- [ ] `@shell set ui.inlineCompletions true` → switches back to inline ghost
- [ ] `@config` commands also show inline completions
- [ ] Escape dismisses ghost text

🤖 Generated with [Claude Code](https://claude.com/claude-code)