### PR TITLE
Add "imported type not used" warning and tests

### DIFF
--- a/ts/packages/actionGrammar/test/grammarCompileError.spec.ts
+++ b/ts/packages/actionGrammar/test/grammarCompileError.spec.ts
@@ -392,5 +392,64 @@ describe("Grammar Compiler", () => {
                 "error: Missing rule definition for '<SomeType>'",
             );
         });
+
+        it("Unused imported type warns", () => {
+            const grammarText = `
+            @import { UnusedType } from "types.ts"
+
+            @<Start> = play music
+        `;
+            const errors: string[] = [];
+            const warnings: string[] = [];
+            loadGrammarRulesNoThrow("test", grammarText, errors, warnings);
+            expect(errors.length).toBe(0);
+            expect(warnings.length).toBe(1);
+            expect(warnings[0]).toContain(
+                "warning: Imported type 'UnusedType' is declared but never used.",
+            );
+        });
+
+        it("Used imported type does not warn", () => {
+            const grammarText = `
+            @import { UsedType } from "types.ts"
+
+            @<Start> = $(x:UsedType)
+        `;
+            const errors: string[] = [];
+            const warnings: string[] = [];
+            loadGrammarRulesNoThrow("test", grammarText, errors, warnings);
+            expect(errors.length).toBe(0);
+            expect(warnings.length).toBe(0);
+        });
+
+        it("Only unused imported types warn when mixed with used ones", () => {
+            const grammarText = `
+            @import { UsedType } from "types.ts"
+            @import { UnusedType } from "types.ts"
+
+            @<Start> = $(x:UsedType)
+        `;
+            const errors: string[] = [];
+            const warnings: string[] = [];
+            loadGrammarRulesNoThrow("test", grammarText, errors, warnings);
+            expect(errors.length).toBe(0);
+            expect(warnings.length).toBe(1);
+            expect(warnings[0]).toContain(
+                "warning: Imported type 'UnusedType' is declared but never used.",
+            );
+        });
+
+        it("Wildcard type import does not warn when types are unused", () => {
+            const grammarText = `
+            @import * from "types.ts"
+
+            @<Start> = play music
+        `;
+            const errors: string[] = [];
+            const warnings: string[] = [];
+            loadGrammarRulesNoThrow("test", grammarText, errors, warnings);
+            expect(errors.length).toBe(0);
+            expect(warnings.length).toBe(0);
+        });
     });
 });


### PR DESCRIPTION
## Summary

- Refactors `CompileContext` to track named `.ts` type imports separately from entity/wildcard imports, enabling precise position-aware warning reporting
- Adds a compiler warning when a named type import is declared but never referenced in a variable
- Adds 4 tests covering the new warning behavior

## Changes

### `src/grammarCompiler.ts`

`CompileContext` previously used a single `importedTypeNames: Set<string>` for both entity names and explicitly imported `.ts` types, with a sentinel `"*"` value to signal wildcard imports. This made it impossible to:
- Know the source position of a named import (needed for accurate warning locations)
- Distinguish between entity-declared names and explicitly imported ones
- Detect which named imports were never used

The type is now split into three distinct fields:

| Field | Type | Purpose |
|---|---|---|
| `knownTypeNames` | `Set<string>` | Entity declarations (`entity Foo;`) and other implicitly valid type names |
| `importedTypeNames` | `Map<string, number \| undefined>` | Named `.ts` imports with their source positions |
| `hasStarImport` | `boolean` | Whether a wildcard (`* from "..."`) import is present |

After compilation, the compiler iterates all contexts and emits a warning for any entry in `importedTypeNames` not present in `usedImportedTypes`.

### `test/grammarCompileError.spec.ts`

Four new tests added to the existing "Type Imports" describe block:

- **Unused imported type warns** — a named import with no variable reference produces the expected warning
- **Used imported type does not warn** — a named import that is used produces no warning
- **Only unused imported types warn when mixed with used ones** — only the unreferenced import warns when some are used and some are not
- **Wildcard type import does not warn when types are unused** — `@import * from "..."` never triggers the warning
