### PR TITLE
AGR: Fix comment handling in StringExpr and update grammar docs

### DIFF
--- a/ts/packages/actionGrammar/test/grammarRuleParser.spec.ts
+++ b/ts/packages/actionGrammar/test/grammarRuleParser.spec.ts
@@ -698,6 +698,46 @@ describe("Grammar Rule Parser", () => {
                 },
             });
         });
+
+        it("should treat // comment with no preceding space as flex space in string expression", () => {
+            const grammar = "<rule> = hello//comment\nworld;";
+            const result = testParamGrammarRules("test.agr", grammar);
+
+            expect(result[0].rules[0].expressions[0]).toEqual({
+                type: "string",
+                value: ["hello", "world"],
+            });
+        });
+
+        it("should treat /* */ comment with no preceding space as flex space in string expression", () => {
+            const grammar = "<rule> = hello/*comment*/world;";
+            const result = testParamGrammarRules("test.agr", grammar);
+
+            expect(result[0].rules[0].expressions[0]).toEqual({
+                type: "string",
+                value: ["hello", "world"],
+            });
+        });
+
+        it("should collapse multiple consecutive comments to a single flex space", () => {
+            const grammar = "<rule> = hello//c1\n//c2\nworld;";
+            const result = testParamGrammarRules("test.agr", grammar);
+
+            expect(result[0].rules[0].expressions[0]).toEqual({
+                type: "string",
+                value: ["hello", "world"],
+            });
+        });
+
+        it("should collapse mixed adjacent comment styles to a single flex space", () => {
+            const grammar = "<rule> = hello//line\n/*block*/world;";
+            const result = testParamGrammarRules("test.agr", grammar);
+
+            expect(result[0].rules[0].expressions[0]).toEqual({
+                type: "string",
+                value: ["hello", "world"],
+            });
+        });
     });
 
     describe("Error Handling", () => {


### PR DESCRIPTION
## Summary

- **Fix**: Comments (`//` and `/*`) inside `<StringExpr>` now create flex space boundaries just like whitespace. Previously, a comment flush against text (e.g. `hello//comment\nworld`) was parsed as literal characters; it now correctly yields `["hello", "world"]`.
- **Refactor**: `skipWhitespace()` returns `boolean` (whether any skipping occurred), allowing `parseStrExpr()` to be simplified — the whitespace/comment check moves to the top of the loop and the two conditions collapse into a single `skipWhitespace()` call.
- **Docs**: Updated grammar BNF comment — `<StringExpr>` now lists `<Comment>` as an explicit alternative alongside `<WS>` and `<Char>`; the general whitespace note is reworded to accurately describe the flex-space behaviour of `<StringExpr>`.
- **Tests**: Four new cases in `grammarRuleParser.spec.ts` covering `//` with no preceding space, `/* */` with no preceding space, consecutive comments, and mixed comment styles.

## Test plan

- [x] `npm run test:local` — all 356 tests pass
- [x] New tests exercise the four comment-as-flex-space scenarios added in this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)