### PR TITLE
AGR: Add grammar formatter and refactor compiler into subcommands

### DIFF
--- a/ts/packages/actionGrammar/src/grammarRuleWriter.ts
+++ b/ts/packages/actionGrammar/src/grammarRuleWriter.ts
@@ -3,12 +3,37 @@
 
 import {
     Expr,
+    GrammarParseResult,
+    ImportStatement,
     isExpressionSpecialChar,
     isWhitespace,
     Rule,
     RuleDefinition,
     ValueNode,
 } from "./grammarRuleParser.js";
+
+export function writeGrammarFile(result: GrammarParseResult): string {
+    const parts: string[] = [];
+
+    if (result.entities.length > 0) {
+        parts.push(`entity ${result.entities.join(", ")};\n\n`);
+    }
+
+    if (result.imports.length > 0) {
+        for (const imp of result.imports) {
+            parts.push(writeImportStatement(imp));
+        }
+        parts.push("\n");
+    }
+
+    parts.push(writeGrammarRules(result.definitions));
+    return parts.join("");
+}
+
+function writeImportStatement(imp: ImportStatement): string {
+    const names = imp.names === "*" ? "*" : `{ ${imp.names.join(", ")} }`;
+    return `import ${names} from "${imp.source}";\n`;
+}
 
 export function writeGrammarRules(grammar: RuleDefinition[]): string {
     const result: string[] = [];
@@ -43,7 +68,7 @@ function writeRule(result: string[], rule: Rule, indent: number) {
     writeExpression(result, rule.expressions, indent);
     if (rule.value !== undefined) {
         result.push(" -> ");
-        writeValueNode(result, rule.value);
+        writeValueNode(result, rule.value, 0);
     }
 }
 
@@ -132,7 +157,7 @@ function writeExpression(
         }
     }
 }
-function writeValueNode(result: string[], value: ValueNode) {
+function writeValueNode(result: string[], value: ValueNode, indent: number) {
     switch (value.type) {
         case "literal":
             result.push(JSON.stringify(value.value));
@@ -141,23 +166,30 @@ function writeValueNode(result: string[], value: ValueNode) {
             result.push(value.name);
             break;
         case "object": {
-            result.push("{");
+            const entries = Object.entries(value.value);
+            if (entries.length === 0) {
+                result.push("{}");
+                break;
+            }
+            result.push("{\n");
             let first = true;
-            for (const [key, val] of Object.entries(value.value)) {
+            const innerIndent = indent + 4;
+            for (const [key, val] of entries) {
                 if (!first) {
-                    result.push(", ");
+                    result.push(",\n");
                 }
                 first = false;
+                result.push(" ".repeat(innerIndent));
                 if (val === null) {
                     // Shorthand form: { key } instead of { key: key }
                     result.push(key);
                 } else {
                     // Full form: { key: value }
-                    result.push(`${key}:`);
-                    writeValueNode(result, val);
+                    result.push(`${key}: `);
+                    writeValueNode(result, val, innerIndent);
                 }
             }
-            result.push("}");
+            result.push(`\n${" ".repeat(indent)}}`);
             break;
         }
         case "array": {
@@ -168,7 +200,7 @@ function writeValueNode(result: string[], value: ValueNode) {
                     result.push(", ");
                 }
                 first = false;
-                writeValueNode(result, item);
+                writeValueNode(result, item, indent);
             }
             result.push("]");
             break;

--- a/ts/packages/actionGrammar/src/index.ts
+++ b/ts/packages/actionGrammar/src/index.ts
@@ -6,6 +6,17 @@ export { grammarFromJson } from "./grammarDeserializer.js";
 export { grammarToJson } from "./grammarSerializer.js";
 export { loadGrammarRules, loadGrammarRulesNoThrow } from "./grammarLoader.js";
 
+// Parser (for tooling — formatter, linters, etc.)
+export { parseGrammarRules } from "./grammarRuleParser.js";
+export type {
+    GrammarParseResult,
+    ImportStatement,
+    RuleDefinition,
+} from "./grammarRuleParser.js";
+
+// Writer / formatter
+export { writeGrammarRules, writeGrammarFile } from "./grammarRuleWriter.js";
+
 export {
     matchGrammar,
     GrammarMatchResult,

--- a/ts/packages/actionGrammarCompiler/bin/dev.js
+++ b/ts/packages/actionGrammarCompiler/bin/dev.js
@@ -2,8 +2,15 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+import { COMMANDS } from "../dist/index.js";
+
 async function main() {
     const { execute } = await import("@oclif/core");
+    // Backward compat: if first arg is not a command
+    const firstArg = process.argv[2];
+    if (firstArg !== undefined && COMMANDS[firstArg] === undefined) {
+        process.argv.splice(2, 0, "compile");
+    }
     await execute({ development: true, dir: import.meta.url });
 }
 

--- a/ts/packages/actionGrammarCompiler/bin/run.js
+++ b/ts/packages/actionGrammarCompiler/bin/run.js
@@ -2,8 +2,15 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+import { COMMANDS } from "../dist/index.js";
+
 async function main() {
     const { execute } = await import("@oclif/core");
+    // Backward compat: if first arg is not a command
+    const firstArg = process.argv[2];
+    if (firstArg !== undefined && COMMANDS[firstArg] === undefined) {
+        process.argv.splice(2, 0, "compile");
+    }
     await execute({ dir: import.meta.url });
 }
 

--- a/ts/packages/actionGrammarCompiler/package.json
+++ b/ts/packages/actionGrammarCompiler/package.json
@@ -31,8 +31,9 @@
   "oclif": {
     "bin": "agc",
     "commands": {
-      "strategy": "single",
-      "target": "./dist/index.js"
+      "strategy": "explicit",
+      "target": "./dist/index.js",
+      "identifier": "COMMANDS"
     },
     "dirname": "agc",
     "plugins": [

--- a/ts/packages/actionGrammarCompiler/package.json
+++ b/ts/packages/actionGrammarCompiler/package.json
@@ -31,9 +31,9 @@
   "oclif": {
     "bin": "agc",
     "commands": {
+      "identifier": "COMMANDS",
       "strategy": "explicit",
-      "target": "./dist/index.js",
-      "identifier": "COMMANDS"
+      "target": "./dist/index.js"
     },
     "dirname": "agc",
     "plugins": [

--- a/ts/packages/actionGrammarCompiler/src/commands/compile.ts
+++ b/ts/packages/actionGrammarCompiler/src/commands/compile.ts
@@ -1,0 +1,58 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { Command, Flags } from "@oclif/core";
+import path from "node:path";
+import fs from "node:fs";
+import { grammarToJson, loadGrammarRulesNoThrow } from "action-grammar";
+
+export default class Compile extends Command {
+    static description = "Compile action grammar files";
+
+    static flags = {
+        input: Flags.file({
+            description: "Input action grammar definition in typescript",
+            required: true,
+            exists: true,
+            char: "i",
+        }),
+        output: Flags.string({
+            description: "Output file for action grammar",
+            required: true,
+            char: "o",
+        }),
+    };
+
+    async run(): Promise<void> {
+        const { flags } = await this.parse(Compile);
+
+        const errors: string[] = [];
+        const warnings: string[] = [];
+        const grammar = loadGrammarRulesNoThrow(
+            flags.input,
+            undefined,
+            errors,
+            warnings,
+            { startValueRequired: true },
+        );
+
+        if (grammar === undefined) {
+            console.error(
+                `Failed to compile action grammar due to the following errors:\n${errors.join(
+                    "\n",
+                )}`,
+            );
+            process.exit(1);
+        }
+
+        if (warnings.length > 0) {
+            console.warn(warnings.join("\n"));
+        }
+        const outputDir = path.dirname(flags.output);
+        if (!fs.existsSync(outputDir)) {
+            fs.mkdirSync(outputDir, { recursive: true });
+        }
+        fs.writeFileSync(flags.output, JSON.stringify(grammarToJson(grammar)));
+        console.log(`Action grammar written: ${flags.output}`);
+    }
+}

--- a/ts/packages/actionGrammarCompiler/src/commands/format.ts
+++ b/ts/packages/actionGrammarCompiler/src/commands/format.ts
@@ -1,0 +1,75 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { Command, Flags } from "@oclif/core";
+import path from "node:path";
+import fs from "node:fs";
+import { parseGrammarRules, writeGrammarFile } from "action-grammar";
+
+export default class Format extends Command {
+    static description = "Format action grammar (.agr) files";
+
+    static flags = {
+        input: Flags.file({
+            description: "Input .agr grammar file to format",
+            required: true,
+            exists: true,
+            char: "i",
+        }),
+        write: Flags.boolean({
+            description: "Overwrite the input file with formatted output",
+            char: "w",
+            default: false,
+        }),
+        output: Flags.string({
+            description: "Write formatted output to a different file",
+            char: "o",
+        }),
+        check: Flags.boolean({
+            description:
+                "Exit with non-zero status if the file is not already formatted (no output written)",
+            char: "c",
+            default: false,
+        }),
+    };
+
+    async run(): Promise<void> {
+        const { flags } = await this.parse(Format);
+
+        const content = fs.readFileSync(flags.input, "utf-8");
+
+        let parseResult;
+        try {
+            parseResult = parseGrammarRules(flags.input, content);
+        } catch (e) {
+            console.error(`Failed to parse action grammar: ${e}`);
+            process.exit(1);
+        }
+
+        const formatted = writeGrammarFile(parseResult);
+
+        if (flags.check) {
+            if (content !== formatted) {
+                console.error(
+                    `${flags.input} is not formatted. Run 'agc format --write' to fix.`,
+                );
+                process.exit(1);
+            }
+            return;
+        }
+
+        if (flags.write) {
+            fs.writeFileSync(flags.input, formatted);
+            console.log(`Formatted: ${flags.input}`);
+        } else if (flags.output) {
+            const outputDir = path.dirname(flags.output);
+            if (!fs.existsSync(outputDir)) {
+                fs.mkdirSync(outputDir, { recursive: true });
+            }
+            fs.writeFileSync(flags.output, formatted);
+            console.log(`Formatted grammar written: ${flags.output}`);
+        } else {
+            process.stdout.write(formatted);
+        }
+    }
+}

--- a/ts/packages/actionGrammarCompiler/src/index.ts
+++ b/ts/packages/actionGrammarCompiler/src/index.ts
@@ -1,58 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { Command, Flags } from "@oclif/core";
-import path from "node:path";
-import fs from "node:fs";
-import { grammarToJson, loadGrammarRulesNoThrow } from "action-grammar";
+import Compile from "./commands/compile.js";
+import Format from "./commands/format.js";
 
-export default class Compile extends Command {
-    static description = "Compile action schema files";
-
-    static flags = {
-        input: Flags.file({
-            description: "Input action schema definition in typescript",
-            required: true,
-            exists: true,
-            char: "i",
-        }),
-        output: Flags.string({
-            description: "Output file for parsed action schema group",
-            required: true,
-            char: "o",
-        }),
-    };
-
-    async run(): Promise<void> {
-        const { flags } = await this.parse(Compile);
-
-        const errors: string[] = [];
-        const warnings: string[] = [];
-        const grammar = loadGrammarRulesNoThrow(
-            flags.input,
-            undefined,
-            errors,
-            warnings,
-            { startValueRequired: true },
-        );
-
-        if (grammar === undefined) {
-            console.error(
-                `Failed to compile action grammar due to the following errors:\n${errors.join(
-                    "\n",
-                )}`,
-            );
-            process.exit(1);
-        }
-
-        if (warnings.length > 0) {
-            console.warn(warnings.join("\n"));
-        }
-        const outputDir = path.dirname(flags.output);
-        if (!fs.existsSync(outputDir)) {
-            fs.mkdirSync(outputDir, { recursive: true });
-        }
-        fs.writeFileSync(flags.output, JSON.stringify(grammarToJson(grammar)));
-        console.log(`Action grammar written: ${flags.output}`);
-    }
-}
+export const COMMANDS = {
+    compile: Compile,
+    format: Format,
+};


### PR DESCRIPTION
## Summary

- Adds `writeGrammarFile` function to `actionGrammar` for formatting full grammar files (entities, imports, rules) with proper pretty-printing of object values
- Exports parser types (`GrammarParseResult`, `ImportStatement`, `RuleDefinition`) and `parseGrammarRules` from `actionGrammar` index for tooling use
- Refactors `actionGrammarCompiler` from a single-command CLI into a multi-command CLI with `compile` and `format` subcommands
- Adds `agc format` command supporting stdout output, `--write` (in-place), `--output <file>`, and `--check` (CI-friendly) modes
- Adds backward compatibility so existing `agc -i <file> -o <file>` invocations still work without specifying `compile`

🤖 Generated with [Claude Code](https://claude.com/claude-code)