### PR TITLE
AGR: Refactor grammar writer with column-aware GrammarWriter class

### DIFF
--- a/ts/packages/actionGrammar/src/grammarRuleWriter.ts
+++ b/ts/packages/actionGrammar/src/grammarRuleWriter.ts
@@ -240,6 +240,10 @@ function writeValueNode(result: GrammarWriter, value: ValueNode, col: number) {
         case "array": {
             let first = true;
             const nestedCol = col + result.indentSize;
+            if (value.value.length === 0) {
+                result.write("[]");
+                break;
+            }
             for (const item of value.value) {
                 result.writeLine(first ? "[" : ", ");
                 first = false;

--- a/ts/packages/actionGrammar/src/index.ts
+++ b/ts/packages/actionGrammar/src/index.ts
@@ -15,7 +15,7 @@ export type {
 } from "./grammarRuleParser.js";
 
 // Writer / formatter
-export { writeGrammarRules, writeGrammarFile } from "./grammarRuleWriter.js";
+export { writeGrammarRules } from "./grammarRuleWriter.js";
 
 export {
     matchGrammar,

--- a/ts/packages/actionGrammar/test/grammarRuleWriter.spec.ts
+++ b/ts/packages/actionGrammar/test/grammarRuleWriter.spec.ts
@@ -10,7 +10,7 @@ import { escapedSpaces, spaces } from "./testUtils.js";
 
 function validateRoundTrip(grammar: string) {
     const result = parseGrammarRules("orig", grammar, false);
-    const str = writeGrammarRules(result.definitions);
+    const str = writeGrammarRules(result);
     const parsedResult = parseGrammarRules("test", str, false);
     expect(parsedResult).toStrictEqual(result);
 }
@@ -90,5 +90,18 @@ describe("Grammar Rule Writer", () => {
         validateRoundTrip(
             `<test> = hello $(x: number)? world -> { "type": "test", "var": x };`,
         );
+    });
+    it("with wildcard import", () => {
+        validateRoundTrip(`import * from "someGrammar";
+<test> = hello world;`);
+    });
+    it("with named imports", () => {
+        validateRoundTrip(`import { RuleA, RuleB } from "someGrammar";
+<test> = hello world;`);
+    });
+    it("with multiple imports", () => {
+        validateRoundTrip(`import * from "grammarA";
+import { RuleX } from "grammarB";
+<test> = hello world;`);
     });
 });

--- a/ts/packages/actionGrammarCompiler/src/commands/format.ts
+++ b/ts/packages/actionGrammarCompiler/src/commands/format.ts
@@ -4,7 +4,7 @@
 import { Command, Flags } from "@oclif/core";
 import path from "node:path";
 import fs from "node:fs";
-import { parseGrammarRules, writeGrammarFile } from "action-grammar";
+import { parseGrammarRules, writeGrammarRules } from "action-grammar";
 
 export default class Format extends Command {
     static description = "Format action grammar (.agr) files";
@@ -46,7 +46,7 @@ export default class Format extends Command {
             process.exit(1);
         }
 
-        const formatted = writeGrammarFile(parseResult);
+        const formatted = writeGrammarRules(parseResult);
 
         if (flags.check) {
             if (content !== formatted) {

--- a/ts/packages/cache/src/grammar/exportGrammar.ts
+++ b/ts/packages/cache/src/grammar/exportGrammar.ts
@@ -52,7 +52,11 @@ export async function convertConstructionFileToGrammar(fileName: string) {
         }
         convertConstructions(state, constructions.constructions);
     }
-    return writeGrammarRules(Array.from(state.definitions));
+    return writeGrammarRules({
+        definitions: Array.from(state.definitions),
+        imports: [],
+        entities: [],
+    });
 }
 
 export function convertConstructionsToGrammar(constructions: Construction[]) {
@@ -62,7 +66,11 @@ export function convertConstructionsToGrammar(constructions: Construction[]) {
         ruleNameNextIds: new Map(),
     };
     convertConstructions(state, constructions);
-    return writeGrammarRules(Array.from(state.definitions));
+    return writeGrammarRules({
+        definitions: Array.from(state.definitions),
+        imports: [],
+        entities: [],
+    });
 }
 
 function convertConstructions(state: State, constructions: Construction[]) {


### PR DESCRIPTION
## Summary

- Unifies `writeGrammarFile` and `writeGrammarRules` into a single `writeGrammarRules` function that accepts the full `GrammarParseResult` (including imports and entities)
- Replaces the plain `string[]` accumulator with a `GrammarWriter` class that tracks the current column position for line-length-aware formatting
- Adds `GrammarWriterOptions` type with configurable `maxLineLength` and `indentSize`
- Updates all callers (`format.ts`, `exportGrammar.ts`) and tests to use the unified API
- Adds round-trip tests for import statements (wildcard, named, multiple)

🤖 Generated with [Claude Code](https://claude.com/claude-code)