### PR TITLE
AGR: Detect epsilon-reachable cycles in grammar compiler

### DIFF
--- a/ts/packages/actionGrammar/test/grammarMatcher.spec.ts
+++ b/ts/packages/actionGrammar/test/grammarMatcher.spec.ts
@@ -414,4 +414,32 @@ describe("Grammar Matcher", () => {
             expect(testMatchGrammar(grammar, "+0x123")).toStrictEqual([]);
         });
     });
+
+    describe("Recursive rules", () => {
+        // Regression: when a rule has a non-epsilon back-reference to itself,
+        // the compiled RulesPart.rules must point to the final populated array,
+        // not the empty sentinel assigned before compilation begins.
+        // If the sentinel is captured (bug), the recursive match silently fails.
+        it("right-recursive rule reference can match multi-token input", () => {
+            // <Start> = foo <Start> -> "hit" | bar -> "bar"
+            // "foo bar": foo consumes mandatory input, then <Start> matches "bar"
+            const g = `
+                <Start> = foo <Start> -> "hit"
+                        | bar -> "bar";
+            `;
+            const grammar = loadGrammarRules("test.grammar", g);
+            expect(testMatchGrammar(grammar, "foo bar")).toStrictEqual(["hit"]);
+        });
+
+        it("right-recursive variable rule can match multi-token input", () => {
+            // <Start> = foo $(x:<Start>) -> x | bar -> "bar"
+            // "foo bar": foo consumes mandatory input, then $(x:<Start>) captures "bar"
+            const g = `
+                <Start> = foo $(x:<Start>) -> x
+                        | bar -> "bar";
+            `;
+            const grammar = loadGrammarRules("test.grammar", g);
+            expect(testMatchGrammar(grammar, "foo bar")).toStrictEqual(["bar"]);
+        });
+    });
 });

--- a/ts/packages/actionGrammar/test/grammarStore.spec.ts
+++ b/ts/packages/actionGrammar/test/grammarStore.spec.ts
@@ -48,7 +48,7 @@ describe("GrammarStore", () => {
             const store = new GrammarStore();
 
             await store.addRule({
-                grammarText: '<playTrack> = "play" $(track:string)',
+                grammarText: "<playTrack> = play $(track:string);",
                 schemaName: "player",
                 sourceRequest: "play Bohemian Rhapsody",
                 actionName: "playTrack",
@@ -70,12 +70,12 @@ describe("GrammarStore", () => {
             const store = new GrammarStore();
 
             await store.addRule({
-                grammarText: '<playTrack> = "play" $(track:string)',
+                grammarText: "<playTrack> = play $(track:string);",
                 schemaName: "player",
             });
 
             await store.addRule({
-                grammarText: '<scheduleEvent> = "schedule" $(event:string)',
+                grammarText: "<scheduleEvent> = schedule $(event:string);",
                 schemaName: "calendar",
             });
 
@@ -91,12 +91,12 @@ describe("GrammarStore", () => {
             const store = new GrammarStore();
 
             await store.addRule({
-                grammarText: '<playTrack> = "play" $(track:string)',
+                grammarText: "<playTrack> = play $(track:string);",
                 schemaName: "player",
             });
 
             await store.addRule({
-                grammarText: '<pause> = "pause"',
+                grammarText: "<pause> = pause;",
                 schemaName: "player",
             });
 
@@ -111,7 +111,7 @@ describe("GrammarStore", () => {
             const store = new GrammarStore();
 
             store.addRule({
-                grammarText: '<playTrack> = "play" $(track:string)',
+                grammarText: "<playTrack> = play $(track:string);",
                 schemaName: "player",
             });
 
@@ -128,7 +128,7 @@ describe("GrammarStore", () => {
             const store1 = new GrammarStore();
 
             await store1.addRule({
-                grammarText: '<playTrack> = "play" $(track:string)',
+                grammarText: "<playTrack> = play $(track:string);",
                 schemaName: "player",
                 sourceRequest: "play music",
                 actionName: "playTrack",
@@ -156,7 +156,7 @@ describe("GrammarStore", () => {
             await store.setAutoSave(true);
 
             await store.addRule({
-                grammarText: '<playTrack> = "play" $(track:string)',
+                grammarText: "<playTrack> = play $(track:string);",
                 schemaName: "player",
             });
 
@@ -190,13 +190,13 @@ describe("GrammarStore", () => {
             const store = new GrammarStore();
 
             await store.addRule({
-                grammarText: '<playTrack> = "play" $(track:string)',
+                grammarText: "<playTrack> = play $(track:string);",
                 schemaName: "player",
                 sourceRequest: "play music",
             });
 
             await store.addRule({
-                grammarText: '<pause> = "pause"',
+                grammarText: "<pause> = pause;",
                 schemaName: "player",
                 sourceRequest: "pause",
             });
@@ -205,8 +205,8 @@ describe("GrammarStore", () => {
 
             expect(agr).toContain("# Dynamic Grammar Rules for player");
             expect(agr).toContain("# 2 rule(s)");
-            expect(agr).toContain('<playTrack> = "play" $(track:string)');
-            expect(agr).toContain('<pause> = "pause"');
+            expect(agr).toContain("<playTrack> = play $(track:string);");
+            expect(agr).toContain("<pause> = pause;");
             expect(agr).toContain('Source: "play music"');
         });
 
@@ -220,7 +220,7 @@ describe("GrammarStore", () => {
 
             store.addRule({
                 grammarText:
-                    '<playTrack> = "play" $(track:string) -> { actionName: "playTrack", parameters: { track } };',
+                    '<playTrack> = play $(track:string) -> { actionName: "playTrack", parameters: { track } };',
                 schemaName: "player",
             });
 


### PR DESCRIPTION
## Summary

- **Epsilon-reachable cycle detection** in `grammarCompiler.ts`: adds `compiling` and `nullable` fields to `DefinitionRecord` to track in-progress rule compilation and whether a rule alternative can match the empty string (ε). During compilation, the set of rule names entered since the last mandatory token was consumed (`epsilonReachable`) is threaded through `createNamedGrammarRules` / `createGrammarRules` / `createGrammarRule`. A compile-time error is raised when a rule reference is encountered whose name is already in that set, meaning the grammar would loop infinitely at match time.
- **New tests** (`grammarCompileError.spec.ts`): 13 error cases (direct self-reference, mutual cycles, optional parts before back-references, Kleene-star groups, multiple independent cycles, etc.) and 10 valid-grammar cases confirming that non-epsilon recursion (mandatory literal before back-reference, Kleene-plus, number/wildcard variables, etc.) is accepted without error.
- **Matcher tests** (`grammarMatcher.spec.ts`): 2 new tests verifying that right-recursive rules (which are valid) correctly match multi-token input at runtime.
- **Grammar store tests** (`grammarStore.spec.ts`): minor updates to align with the revised compiler behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)