### PR TITLE
AGR: Add per-rule spacing mode annotation and script-aware boundary matching

### DIFF
--- a/ts/packages/actionGrammar/src/grammarCompiler.ts
+++ b/ts/packages/actionGrammar/src/grammarCompiler.ts
@@ -14,6 +14,7 @@ import {
     ImportStatement,
     parseGrammarRules,
     ValueNode,
+    SpacingMode,
 } from "./grammarRuleParser.js";
 import { getLineCol } from "./utils.js";
 import { globalEntityRegistry } from "./entityRegistry.js";
@@ -26,15 +27,14 @@ export type FileLoader = {
 };
 
 type DefinitionRecord = {
-    rules: Rule[];
-    pos: number | undefined;
+    definitions: RuleDefinition[];
     grammarRules?: GrammarRule[];
     hasValue: boolean;
     compiling: boolean; // true while grammarRules is being populated
     nullable?: boolean; // set after compilation; true if any alternative matches ε
 };
 
-type CompletedDefinitionRecord = DefinitionRecord & {
+type ResolvedDefinitionRecord = DefinitionRecord & {
     grammarRules: GrammarRule[];
 };
 type DefinitionMap = Map<string, DefinitionRecord>;
@@ -135,14 +135,13 @@ function createCompileContext(
         const existing = ruleDefMap.get(def.name);
         if (existing === undefined) {
             ruleDefMap.set(def.name, {
-                rules: [...def.rules],
-                pos: def.pos,
+                definitions: [def],
                 // Set this to true to allow recursion to assume that it has value.
                 hasValue: true,
                 compiling: false,
             });
         } else {
-            existing.rules.push(...def.rules);
+            existing.definitions.push(def);
         }
     }
 
@@ -238,7 +237,7 @@ export function compileGrammar(
         if (record.grammarRules === undefined) {
             context.warnings.push({
                 message: `Rule '<${name}>' is defined but never used.`,
-                pos: record.pos,
+                pos: record.definitions[0]?.pos,
             });
         }
     }
@@ -299,9 +298,10 @@ function convertCompileError(
     });
 }
 
-const emptyRecord = {
-    rules: [],
-    pos: undefined,
+// Sentinel for missing rule definitions. Pre-populated grammarRules suppress
+// re-compilation; empty definitions yield undefined for any pos lookup.
+const emptyRecord: ResolvedDefinitionRecord = {
+    definitions: [],
     grammarRules: [],
     hasValue: true, // Pretend to have value to avoid cascading errors
     compiling: false,
@@ -393,7 +393,7 @@ function createNamedGrammarRules(
     referenceVariable?: string,
     epsilonReachable: Set<string> = new Set(),
     referenceContext: CompileContext = context,
-): CompletedDefinitionRecord {
+): ResolvedDefinitionRecord {
     const record = context.ruleDefMap.get(name);
     if (record === undefined) {
         // Check if this rule name is imported from a grammar file
@@ -440,12 +440,19 @@ function createNamedGrammarRules(
         // directly into it. Any RulesPart.rules captured during a circular
         // back-reference holds a reference to this same array object and will
         // see the populated rules without a separate copy step.
-        const { hasValue, nullable } = createGrammarRules(
-            context,
-            record.rules,
-            eprWithSelf,
-            record.grammarRules,
-        );
+        let hasValue = true;
+        let nullable = false;
+        for (const entry of record.definitions) {
+            const result = createGrammarRules(
+                context,
+                entry.rules,
+                eprWithSelf,
+                entry.spacingMode,
+                record.grammarRules,
+            );
+            hasValue = hasValue && result.hasValue;
+            nullable = nullable || result.nullable;
+        }
         record.hasValue = hasValue;
         record.compiling = false;
         record.nullable = nullable;
@@ -456,23 +463,28 @@ function createNamedGrammarRules(
         referenceContext.errors.push({
             message: `Referenced rule '<${name}>' does not produce a value for variable '${referenceVariable}'`,
             definition: referenceContext.currentDefinition,
-            pos: record.pos,
+            pos: referencePosition,
         });
     }
-    return record as CompletedDefinitionRecord;
+    return record as ResolvedDefinitionRecord;
 }
 
 function createGrammarRules(
     context: CompileContext,
     rules: Rule[],
     epsilonReachable: Set<string>,
-    out: GrammarRule[] = [],
+    spacingMode: SpacingMode,
+    grammarRules: GrammarRule[] = [],
 ): { grammarRules: GrammarRule[]; hasValue: boolean; nullable: boolean } {
-    const grammarRules = out;
     let hasValue = true;
     let nullable = false; // nullable if ANY alternative is nullable
     for (const r of rules) {
-        const result = createGrammarRule(context, r, epsilonReachable);
+        const result = createGrammarRule(
+            context,
+            r,
+            epsilonReachable,
+            spacingMode,
+        );
         grammarRules.push(result.grammarRule);
         hasValue = hasValue && result.hasValue;
         nullable = nullable || result.nullable;
@@ -484,6 +496,7 @@ function createGrammarRule(
     context: CompileContext,
     rule: Rule,
     epsilonReachable: Set<string>,
+    spacingMode: SpacingMode,
 ): { grammarRule: GrammarRule; hasValue: boolean; nullable: boolean } {
     const { expressions, value } = rule;
     const parts: GrammarPart[] = [];
@@ -650,7 +663,7 @@ function createGrammarRule(
                     grammarRules,
                     hasValue: groupHasValue,
                     nullable: groupNullable,
-                } = createGrammarRules(context, rules, currentEpr);
+                } = createGrammarRules(context, rules, currentEpr, spacingMode);
                 defaultValue = groupHasValue;
                 const rulesPart: RulesPart = {
                     type: "rules",
@@ -684,6 +697,7 @@ function createGrammarRule(
         grammarRule: {
             parts,
             value,
+            spacingMode,
         },
         hasValue:
             value !== undefined ||

--- a/ts/packages/actionGrammar/src/grammarDeserializer.ts
+++ b/ts/packages/actionGrammar/src/grammarDeserializer.ts
@@ -17,6 +17,7 @@ export function grammarFromJson(json: GrammarJson): Grammar {
         return {
             parts: r.parts.map((p) => grammarPartFromJson(p, json)),
             value: r.value,
+            spacingMode: r.spacingMode,
         };
     }
     function grammarPartFromJson(

--- a/ts/packages/actionGrammar/src/grammarMatcher.ts
+++ b/ts/packages/actionGrammar/src/grammarMatcher.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { ValueNode } from "./grammarRuleParser.js";
+import { SpacingMode, ValueNode } from "./grammarRuleParser.js";
 import registerDebug from "debug";
 // REVIEW: switch to RegExp.escape() when it becomes available.
 import escapeMatch from "regexp.escape";
@@ -20,14 +20,86 @@ const debugCompletion = registerDebug("typeagent:grammar:completion");
 // Treats spaces and punctuation as word separators
 const separatorRegExpStr = "\\s\\p{P}";
 const separatorRegExp = new RegExp(`[${separatorRegExpStr}]+`, "yu");
+const wildcardTrimRegExp = new RegExp(
+    `[${separatorRegExpStr}]*(.+?)[${separatorRegExpStr}]*$`,
+    "yu",
+);
 
-const separatedRegExp = /[^\s\p{P}][\s\p{P}]|[\s\p{P}]./uy;
-function isSeparated(request: string, index: number) {
+// Scripts that use explicit word-space boundaries (Latin, Cyrillic, Greek,
+// Armenian, Georgian, Hangul, Arabic, Hebrew, Devanagari, Bengali, Tamil,
+// Telugu, Kannada, Malayalam, Gujarati, Gurmukhi, Oriya, Sinhala, Ethiopic,
+// Mongolian). In "auto" mode, a separator is required between two adjacent
+// characters only when BOTH belong to one of these scripts. Unknown/unlisted
+// scripts (e.g. CJK) default to no separator needed.
+const wordBoundaryScriptRe =
+    /\p{Script=Latin}|\p{Script=Cyrillic}|\p{Script=Greek}|\p{Script=Armenian}|\p{Script=Georgian}|\p{Script=Hangul}|\p{Script=Arabic}|\p{Script=Hebrew}|\p{Script=Devanagari}|\p{Script=Bengali}|\p{Script=Tamil}|\p{Script=Telugu}|\p{Script=Kannada}|\p{Script=Malayalam}|\p{Script=Gujarati}|\p{Script=Gurmukhi}|\p{Script=Oriya}|\p{Script=Sinhala}|\p{Script=Ethiopic}|\p{Script=Mongolian}/u;
+
+// Decimal digits are not part of any word-space script, but two adjacent
+// digit characters must still be separated: "123456" is a different token from
+// "123 456", so concatenating two digit segments without a separator is ambiguous.
+const digitRe = /[0-9]/;
+
+// In auto mode (undefined), a separator is required between two segments only
+// if both adjacent characters belong to a word-boundary script. This allows users
+// to omit separators when the scripts differ (e.g. Latin followed by CJK),
+// while still requiring them when both sides use word spaces
+// (e.g. Latin followed by Latin).
+function isWordBoundaryScript(c: string): boolean {
+    // Fast path: all ASCII letters are Latin-script (boundary required).
+    // ASCII digits and punctuation/space fall through to return false here
+    // (digits are handled separately by digitRe, punctuation/space never need a boundary).
+    const code = c.charCodeAt(0);
+    if (code < 128) {
+        return (code >= 65 && code <= 90) || (code >= 97 && code <= 122); // A-Z, a-z
+    }
+    return wordBoundaryScriptRe.test(c);
+}
+function needsSeparatorInAutoMode(a: string, b: string): boolean {
+    if (digitRe.test(a) && digitRe.test(b)) {
+        return true;
+    }
+    return isWordBoundaryScript(a) && isWordBoundaryScript(b);
+}
+function requiresSeparator(a: string, b: string, mode: SpacingMode): boolean {
+    switch (mode) {
+        case "required":
+            return true;
+        case "optional":
+            return false;
+        case undefined: // auto
+            return needsSeparatorInAutoMode(a, b);
+    }
+}
+
+function isBoundarySatisfied(
+    request: string,
+    index: number,
+    mode: SpacingMode,
+) {
     if (index === 0 || index === request.length) {
         return true;
     }
-    separatedRegExp.lastIndex = index - 1;
-    return separatedRegExp.test(request);
+    switch (mode) {
+        case "required":
+            // In "required" mode, the input at `index` must begin with a
+            // separator sequence ([\s\p{P}]+).  Separators already consumed
+            // *inside* the match pattern (e.g. the infix [\s\p{P}]+ between
+            // tokens) do not satisfy this trailing-edge check; one or more
+            // separator characters must immediately follow the entire matched
+            // phrase in the input.
+            separatorRegExp.lastIndex = index;
+            return separatorRegExp.test(request);
+        case "optional":
+            return true;
+        case undefined: // auto: requires a separator only when BOTH characters
+            // adjacent to the boundary belong to word-boundary scripts.  If
+            // either side is punctuation, CJK, or another no-space script, no
+            // separator is required.
+            return !needsSeparatorInAutoMode(
+                request[index - 1],
+                request[index],
+            );
+    }
 }
 
 type MatchedValue =
@@ -60,6 +132,7 @@ type ParentMatchState = {
     valueIds: ValueIdNode | undefined | null; // null means we don't need any value
     parent: ParentMatchState | undefined;
     repeatPartIndex?: number | undefined; // defined for ()* / )+ — holds the part index to loop back to
+    spacingMode: SpacingMode; // parent rule's spacingMode, restored in MatchState on return from nested rule
 };
 type MatchState = {
     // Current context
@@ -77,6 +150,8 @@ type MatchState = {
     nestedLevel: number; // for debugging
 
     inRepeat?: boolean | undefined; // true when re-entering a repeat group after a successful match
+
+    spacingMode: SpacingMode; // active spacing mode for this rule
 
     index: number;
     pendingWildcard?:
@@ -305,14 +380,9 @@ function createValue(
 }
 
 function getWildcardStr(request: string, start: number, end: number) {
-    const wildcardRegexp = new RegExp(
-        `[${separatorRegExpStr}]*(.+?)[${separatorRegExpStr}]*$`,
-        "yu",
-    );
-
     const string = request.substring(start, end);
-    wildcardRegexp.lastIndex = 0;
-    const match = wildcardRegexp.exec(string);
+    wildcardTrimRegExp.lastIndex = 0;
+    const match = wildcardTrimRegExp.exec(string);
     return match?.[1];
 }
 
@@ -519,6 +589,7 @@ function finalizeNestedRule(
         state.name = parent.name;
         state.parts = parent.parts;
         state.partIndex = parent.partIndex;
+        state.spacingMode = parent.spacingMode;
 
         // For repeat parts ()*  or )+: after each successful match, queue a state
         // that tries to match the same group again.  inRepeat suppresses the
@@ -553,7 +624,7 @@ function matchStringPartWithWildcard(
         }
         const wildcardEnd = match.index;
         const newIndex = wildcardEnd + match[0].length;
-        if (!isSeparated(request, newIndex)) {
+        if (!isBoundarySatisfied(request, newIndex, state.spacingMode)) {
             debugMatch(
                 state,
                 `Rejected non-separated matched string '${part.value.join(" ")}' at ${wildcardEnd}`,
@@ -589,7 +660,7 @@ function matchStringPartWithoutWildcard(
         return false;
     }
     const newIndex = match.index + match[0].length;
-    if (!isSeparated(request, newIndex)) {
+    if (!isBoundarySatisfied(request, newIndex, state.spacingMode)) {
         debugMatch(
             state,
             `Rejected non-separated matched string ${part.value.join(" ")}`,
@@ -621,8 +692,27 @@ function matchStringPart(
         state,
         `Checking string expr "${part.value.join(" ")}" with${state.pendingWildcard ? "" : "out"} wildcard`,
     );
-    // REVIEW: better separator policy
-    const regExpStr = `[${separatorRegExpStr}]*?${part.value.map(escapeMatch).join(`[${separatorRegExpStr}]+`)}`;
+    const escaped = part.value.map(escapeMatch);
+    // Build the joined regex string using an array to avoid O(N²) string concatenation.
+    // "required" → [\s\p{P}]+, "optional" → [\s\p{P}]*.
+    // In "auto" mode, + is used only when both adjacent characters belong to
+    // word-space scripts; otherwise * allows zero separators (e.g. when a
+    // segment ends/starts with punctuation, or the neighboring script does
+    // not use word spaces such as CJK).
+    const regexpSegments: string[] = [escaped[0]];
+    for (let i = 1; i < escaped.length; i++) {
+        const sep = requiresSeparator(
+            // Invariant: segments are always non-empty (guaranteed by the parser).
+            part.value[i - 1].at(-1)!,
+            part.value[i][0],
+            state.spacingMode,
+        )
+            ? `[${separatorRegExpStr}]+`
+            : `[${separatorRegExpStr}]*`;
+        regexpSegments.push(sep, escaped[i]);
+    }
+    const joined = regexpSegments.join("");
+    const regExpStr = `[${separatorRegExpStr}]*?${joined}`;
     return state.pendingWildcard !== undefined
         ? matchStringPartWithWildcard(regExpStr, request, part, state, pending)
         : matchStringPartWithoutWildcard(regExpStr, request, part, state);
@@ -650,6 +740,14 @@ function matchVarNumberPartWithWildcard(
 
         const wildcardEnd = match.index;
         const newIndex = wildcardEnd + match[0].length;
+
+        if (!isBoundarySatisfied(request, newIndex, state.spacingMode)) {
+            debugMatch(
+                state,
+                `Rejected non-separated matched number at ${wildcardEnd}`,
+            );
+            continue;
+        }
 
         if (captureWildcard(state, request, wildcardEnd, newIndex, pending)) {
             debugMatch(
@@ -686,6 +784,12 @@ function matchVarNumberPartWithoutWildcard(
     }
 
     const newIndex = curr + m[0].length;
+
+    if (!isBoundarySatisfied(request, newIndex, state.spacingMode)) {
+        debugMatch(state, `Rejected non-separated matched number`);
+        return false;
+    }
+
     debugMatch(state, `Matched number to ${newIndex}`);
 
     addValue(state, part.variable, n);
@@ -729,6 +833,23 @@ function matchState(state: MatchState, request: string, pending: MatchState[]) {
                 // Finish matching this state.
                 return true;
             }
+
+            // Check the trailing boundary after the nested rule using the
+            // parent's (now-restored) spacingMode, but only if the
+            // parent still has parts remaining.  If the parent is also
+            // exhausted, skip the check here: the loop will call
+            // finalizeNestedRule again and the check will fire once we
+            // reach an ancestor that actually has a following part — using
+            // that ancestor's mode instead of an intermediate pass-through
+            // rule's mode.
+            if (
+                state.partIndex < state.parts.length &&
+                state.pendingWildcard === undefined &&
+                !isBoundarySatisfied(request, state.index, state.spacingMode)
+            ) {
+                return false;
+            }
+
             continue;
         }
 
@@ -780,6 +901,7 @@ function matchState(state: MatchState, request: string, pending: MatchState[]) {
                     valueIds: state.valueIds,
                     parent: state.parent,
                     repeatPartIndex: part.repeat ? state.partIndex : undefined,
+                    spacingMode: state.spacingMode,
                 };
 
                 // The nested rule needs to track values if the current rule is tracking value AND
@@ -799,6 +921,7 @@ function matchState(state: MatchState, request: string, pending: MatchState[]) {
                 state.parent = parent;
                 state.nestedLevel++;
                 state.inRepeat = undefined; // entering nested rules, clear repeat flag
+                state.spacingMode = rules[0].spacingMode;
 
                 // queue up the other rules (backwards to search in the original order)
                 for (let i = rules.length - 1; i > 0; i--) {
@@ -807,6 +930,7 @@ function matchState(state: MatchState, request: string, pending: MatchState[]) {
                         name: getNestedStateName(state, part, i),
                         parts: rules[i].parts,
                         value: rules[i].value,
+                        spacingMode: rules[i].spacingMode,
                     });
                 }
                 // continue the loop (without incrementing partIndex)
@@ -827,6 +951,7 @@ function initialMatchState(grammar: Grammar): MatchState[] {
             index: 0,
             nextValueId: 0,
             nestedLevel: 0,
+            spacingMode: r.spacingMode,
         }))
         .reverse();
 }

--- a/ts/packages/actionGrammar/src/grammarRuleParser.ts
+++ b/ts/packages/actionGrammar/src/grammarRuleParser.ts
@@ -12,7 +12,10 @@ const debugParse = registerDebug("typeagent:grammar:parse");
  *   <ImportStatement> ::= "import" (<ImportAll> | <ImportNames>) "from" <StringLiteral> ";"
  *   <ImportAll> ::= "*"
  *   <ImportNames> ::= "{" <Identifier> ("," <Identifier>)* "}"
- *   <RuleDefinition> ::= <RuleName> "=" <Rules> ";"
+ *   <RuleDefinition> ::= <RuleName> <RuleAnnotation>? "=" <Rules> ";"
+ *   <RuleAnnotation> ::= "[" <AnnotationKey> "=" <AnnotationValue> "]"
+ *   // Currently the only supported annotation key is "spacing":
+ *   //   [spacing=required], [spacing=optional], [spacing=auto]
  *   <Rules> ::= <Rule> ( "|" <Rule> )*
  *   <Rule> ::= <Expression> ( "->" <Value> )?
  *
@@ -20,10 +23,23 @@ const debugParse = registerDebug("typeagent:grammar:parse");
  *
  *   // <Char> is any character except special chars (| ( ) < > $ - ; { } [ ]) and backslash,
  *   // and not the start of a comment sequence ("//" or "/*").
- *   // Whitespace (<WS>) and comments (<Comment>) are not stored literally; instead each
- *   // occurrence creates a "flex space" boundary, splitting the string into segments that can
- *   // match any amount of whitespace at runtime.  An escaped whitespace character (e.g. "\ ")
- *   // bypasses this behavior and is stored as a literal space within the current segment.
+ *   // A "flex space" is a separator position in the grammar source, created by any unescaped
+ *   // whitespace or comment between tokens. When matching input, a flex space accepts any run of
+ *   // whitespace or punctuation characters. The minimum number required is controlled by the
+ *   // spacing mode (set via "set spacing ...;"):
+ *   //
+ *   //   - "required": always requires at least one whitespace/punctuation character.
+ *   //   - "optional": accepts zero or more — no separator is needed.
+ *   //   - "auto"    : (default) requires a separator only when both adjacent tokens belong to
+ *   //                 space-separated scripts (e.g. Latin, Cyrillic). Tokens in non-spaced scripts
+ *   //                 (e.g. CJK), or tokens that are whitespace/punctuation characters themselves,
+ *   //                 do not require a separator.
+ *   //
+ *   // The spacing mode is set per-rule via a [spacing=<mode>] annotation immediately
+ *   // after the rule name: <rule> [spacing=required] = ...;
+ *   // Omitting the annotation is equivalent to [spacing=auto].
+ *   //
+ *   // An escaped space (e.g. "\ ") is treated as a literal character, not a flex space.
  *   // Special chars must be escaped with backslash to appear as literal text.
  *   <StringExpr> ::= ( <EscapeSequence> | <WS> | <Comment> | <Char> )+
  *   <EscapeSequence> ::= "\\"<EscapedChar>
@@ -157,6 +173,7 @@ export type Rule = {
 export type RuleDefinition = {
     name: string;
     rules: Rule[];
+    spacingMode?: SpacingMode;
     pos?: number | undefined;
 };
 
@@ -166,6 +183,18 @@ export type ImportStatement = {
     source: string; // File path or module name
     pos?: number | undefined;
 };
+
+/**
+ * Controls how flex-space separator positions between tokens are matched at runtime.
+ *   "required" – at least one whitespace/punctuation character must be present.
+ *   "optional" – zero or more separators; tokens may be adjacent.
+ *   undefined  – auto (default): a separator is required only when both adjacent
+ *                characters belong to scripts that normally use word spaces (e.g.
+ *                Latin, Cyrillic). Scripts such as CJK do not require one.
+ *
+ * Note: the grammar source keyword "auto" is stored as undefined internally.
+ */
+export type SpacingMode = "required" | "optional" | undefined;
 
 // Grammar Parse Result (includes entity declarations and imports)
 export type GrammarParseResult = {
@@ -673,13 +702,37 @@ class GrammarRuleParser {
         return rules;
     }
 
+    private parseSpacingAnnotation(): SpacingMode {
+        this.skipWhitespace(1); // skip "["
+        const key = this.parseId("annotation key");
+        if (key !== "spacing") {
+            this.throwError(
+                `Unknown rule annotation '${key}'. Expected 'spacing'.`,
+            );
+        }
+        this.consume("=", "in spacing annotation");
+        const value = this.parseId("spacing value");
+        if (value !== "required" && value !== "optional" && value !== "auto") {
+            this.throwError(
+                `Invalid value '${value}' for spacing annotation. Expected 'required', 'optional', or 'auto'.`,
+            );
+        }
+        this.consume("]", "at end of spacing annotation");
+        // "auto" is the default behavior; stored as undefined internally
+        return value === "auto" ? undefined : (value as SpacingMode);
+    }
+
     private parseRuleDefinition(): RuleDefinition {
         const pos = this.pos;
         const name = this.parseRuleName();
+        let spacingMode: SpacingMode;
+        if (this.isAt("[")) {
+            spacingMode = this.parseSpacingAnnotation();
+        }
         this.consume("=", "after rule identifier");
         const rules = this.parseRules();
         this.consume(";", "at end of rule definition");
-        return { name, rules, pos };
+        return { name, rules, spacingMode, pos };
     }
 
     private consume(expected: string, reason?: string) {

--- a/ts/packages/actionGrammar/src/grammarRuleWriter.ts
+++ b/ts/packages/actionGrammar/src/grammarRuleWriter.ts
@@ -92,7 +92,11 @@ export function writeGrammarRules(
 }
 
 function writeRuleDefinition(result: GrammarWriter, def: RuleDefinition) {
-    result.write(`<${def.name}> = `);
+    result.write(`<${def.name}>`);
+    if (def.spacingMode !== undefined) {
+        result.write(` [spacing=${def.spacingMode}]`);
+    }
+    result.write(` = `);
     writeRules(result, def.rules, result.column - 2);
     result.writeLine(";");
 }

--- a/ts/packages/actionGrammar/src/grammarSerializer.ts
+++ b/ts/packages/actionGrammar/src/grammarSerializer.ts
@@ -49,6 +49,7 @@ export function grammarToJson(grammar: Grammar): GrammarJson {
         return {
             parts: r.parts.map(grammarPartToJson),
             value: r.value,
+            spacingMode: r.spacingMode,
         };
     }
 

--- a/ts/packages/actionGrammar/src/grammarTypes.ts
+++ b/ts/packages/actionGrammar/src/grammarTypes.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { ValueNode } from "./grammarRuleParser.js";
+import { SpacingMode, ValueNode } from "./grammarRuleParser.js";
 
 /**
  * Grammar Types - in memory
@@ -60,6 +60,7 @@ export type GrammarPart =
 export type GrammarRule = {
     parts: GrammarPart[];
     value?: ValueNode | undefined;
+    spacingMode?: SpacingMode; // undefined = auto (default)
 };
 
 export type Grammar = {
@@ -113,6 +114,7 @@ export type GrammarPartJson =
 export type GrammarRuleJson = {
     parts: GrammarPartJson[];
     value?: ValueNode | undefined;
+    spacingMode?: SpacingMode; // undefined = auto (default)
 };
 export type GrammarRulesJson = GrammarRuleJson[];
 export type GrammarJson = GrammarRulesJson[];

--- a/ts/packages/actionGrammar/src/index.ts
+++ b/ts/packages/actionGrammar/src/index.ts
@@ -12,6 +12,7 @@ export type {
     GrammarParseResult,
     ImportStatement,
     RuleDefinition,
+    SpacingMode,
 } from "./grammarRuleParser.js";
 
 // Writer / formatter

--- a/ts/packages/actionGrammar/src/nfaCompiler.ts
+++ b/ts/packages/actionGrammar/src/nfaCompiler.ts
@@ -220,6 +220,7 @@ function normalizeRule(
                 },
             ],
             value: { type: "variable", name: "_result" }, // Add value expression
+            spacingMode: rule.spacingMode,
         };
     }
 
@@ -230,6 +231,7 @@ function normalizeRule(
         return {
             parts: normalizedParts,
             value: { type: "literal", value: singleLiteral.literal },
+            spacingMode: rule.spacingMode,
         };
     }
 

--- a/ts/packages/actionGrammar/test/grammarCompileError.spec.ts
+++ b/ts/packages/actionGrammar/test/grammarCompileError.spec.ts
@@ -61,6 +61,27 @@ describe("Grammar Compiler", () => {
                 "error: Referenced rule '<Pause>' does not produce a value for variable 'x' in definition '<Start>'",
             );
         });
+        it("Variable reference to non-value rule reports reference position, not definition position", () => {
+            // Use a compact grammar with no leading whitespace so positions are predictable.
+            // refPos of <Pause> inside $(x:<Pause>) is at line 1, col 15.
+            // def.pos of <Pause> definition is at line 2, col 1.
+            // The error must point to the reference site (line 1), not the definition (line 2).
+            const grammarText =
+                "<Start> = $(x:<Pause>);\n" +
+                "<Pause> = <Wait> <Stop>;\n" +
+                "<Wait> = wait;\n" +
+                "<Stop> = stop;\n";
+            const errors: string[] = [];
+            loadGrammarRulesNoThrow("test", grammarText, errors);
+            expect(errors.length).toBe(1);
+            expect(errors[0]).toContain(
+                "error: Referenced rule '<Pause>' does not produce a value for variable 'x'",
+            );
+            // Error must be attributed to the reference site on line 1, not the definition on line 2.
+            expect(errors[0]).toContain("test(1,");
+            expect(errors[0]).not.toContain("test(2,");
+        });
+
         it("Variable reference to non-value rules with multiple values", () => {
             const grammarText = `
             <Start> = $(x:<Pause>);
@@ -267,6 +288,31 @@ describe("Grammar Compiler", () => {
             expect(warnings[0]).toContain(
                 "warning: Rule '<Unused>' is defined but never used.",
             );
+            // Warning must point to the definition of <Unused> (line 4, col 13).
+            expect(warnings[0]).toContain("test(4,13)");
+        });
+
+        it("Unused merged rule: warning position points to first definition", () => {
+            // When the same rule name is defined twice (merged), the unused-rule
+            // warning must report the position of the FIRST definition, not the
+            // second.  Use compact grammar with no leading whitespace so positions
+            // are predictable.
+            const grammarText =
+                "<Start> = <Pause>;\n" +
+                "<Pause> = pause;\n" +
+                "<Merged> = one;\n" +
+                "<Merged> = two;\n";
+            const errors: string[] = [];
+            const warnings: string[] = [];
+            loadGrammarRulesNoThrow("test", grammarText, errors, warnings);
+            expect(errors.length).toBe(0);
+            expect(warnings.length).toBe(1);
+            expect(warnings[0]).toContain(
+                "warning: Rule '<Merged>' is defined but never used.",
+            );
+            // Line 3 col 1 is the first definition of <Merged>; line 4 is the second.
+            expect(warnings[0]).toContain("test(3,1)");
+            expect(warnings[0]).not.toContain("test(4,");
         });
 
         it("Multiple variables without explicit value expression", () => {

--- a/ts/packages/actionGrammar/test/grammarMatcher.spec.ts
+++ b/ts/packages/actionGrammar/test/grammarMatcher.spec.ts
@@ -96,12 +96,25 @@ describe("Grammar Matcher", () => {
                 testMatchGrammar(grammar, `hello${spaces} \r\vworld`),
             ).toStrictEqual([true]);
         });
-        it("escaped space infix - not match", () => {
+        it("escaped space infix - literal as separator", () => {
+            // The escaped-space segment ends with \u3000 (ideographic space).
+            // \u3000 is not a word-boundary-script character (not in
+            // wordBoundaryScriptRe and not an ASCII letter), so
+            // needsSeparatorInAutoMode('\u3000', 'w') returns false.
+            // The flex-space between the segment and "world" therefore allows
+            // zero separators in auto mode — no extra separator is required.
             const g = `<Start> = hello${escapedSpaces} world -> true;`;
             const grammar = loadGrammarRules("test.grammar", g);
             expect(
                 testMatchGrammar(grammar, `hello${spaces}world`),
-            ).toStrictEqual([]);
+            ).toStrictEqual([true]);
+        });
+        it("escaped space infix - not match", () => {
+            const g = `<Start> = hello${escapedSpaces} world -> true;`;
+            const grammar = loadGrammarRules("test.grammar", g);
+            // An extra space before the escaped-spaces block is a content mismatch:
+            // segment 1 literal is "hello \t…\u3000" but the input "hello  \t…"
+            // has a double space at that position.
             expect(
                 testMatchGrammar(grammar, `hello ${spaces} world`),
             ).toStrictEqual([]);
@@ -115,6 +128,129 @@ describe("Grammar Matcher", () => {
             expect(
                 testMatchGrammar(grammar, `hello ${spaces} world`),
             ).toStrictEqual([]);
+        });
+    });
+    describe("Punctuation as Separator", () => {
+        // In "auto" and "optional" modes a punctuation character adjacent to a
+        // flex-space position — at the end of the preceding literal or at the
+        // start of the following literal — satisfies the separator requirement;
+        // no additional separator is required in the input.
+        // In "required" mode at least one separator character must always be
+        // present in the input, regardless of adjacent literal content.
+        describe("auto mode", () => {
+            it("punctuation at end of preceding literal", () => {
+                const g = `<Start> = hello, world -> true;`;
+                const grammar = loadGrammarRules("test.grammar", g);
+                // comma satisfies the flex-space; no extra separator needed
+                expect(testMatchGrammar(grammar, "hello,world")).toStrictEqual([
+                    true,
+                ]);
+                // extra separator also accepted
+                expect(testMatchGrammar(grammar, "hello, world")).toStrictEqual(
+                    [true],
+                );
+                // literal comma must be present
+                expect(testMatchGrammar(grammar, "hello world")).toStrictEqual(
+                    [],
+                );
+            });
+            it("punctuation at start of following literal", () => {
+                const g = `<Start> = hello ,world -> true;`;
+                const grammar = loadGrammarRules("test.grammar", g);
+                // comma satisfies the flex-space from the following side
+                expect(testMatchGrammar(grammar, "hello,world")).toStrictEqual([
+                    true,
+                ]);
+                expect(testMatchGrammar(grammar, "hello ,world")).toStrictEqual(
+                    [true],
+                );
+                expect(testMatchGrammar(grammar, "hello world")).toStrictEqual(
+                    [],
+                );
+            });
+            it("punctuation trailing boundary", () => {
+                // Use a wildcard to consume the remaining input so finalizeState
+                // does not reject trailing non-separator content. isBoundarySatisfied
+                // is what determines whether the boundary after the comma passes.
+                const g = `<Start> = hello,$(x) -> true;`;
+                const grammar = loadGrammarRules("test.grammar", g);
+                // trailing comma is a sufficient boundary; wildcard captures rest
+                expect(testMatchGrammar(grammar, "hello,world")).toStrictEqual([
+                    true,
+                ]);
+                expect(testMatchGrammar(grammar, "hello, world")).toStrictEqual(
+                    [true],
+                );
+            });
+        });
+        describe("required mode", () => {
+            it("punctuation at end of preceding literal", () => {
+                const g = `<Start> [spacing=required] = hello, world -> true;`;
+                const grammar = loadGrammarRules("test.grammar", g);
+                // comma alone does not satisfy the boundary; a separator in the
+                // input is still required
+                expect(testMatchGrammar(grammar, "hello, world")).toStrictEqual(
+                    [true],
+                );
+                expect(testMatchGrammar(grammar, "hello,world")).toStrictEqual(
+                    [],
+                );
+            });
+            it("punctuation at start of following literal", () => {
+                const g = `<Start> [spacing=required] = hello ,world -> true;`;
+                const grammar = loadGrammarRules("test.grammar", g);
+                expect(testMatchGrammar(grammar, "hello ,world")).toStrictEqual(
+                    [true],
+                );
+                // comma is consumed by the required separator, leaving nothing
+                // to match the leading comma of the next literal
+                expect(testMatchGrammar(grammar, "hello,world")).toStrictEqual(
+                    [],
+                );
+            });
+            it("punctuation trailing boundary", () => {
+                const g = `<Start> [spacing=required] = hello,$(x) -> true;`;
+                const grammar = loadGrammarRules("test.grammar", g);
+                // separator must come from the input after the comma
+                expect(testMatchGrammar(grammar, "hello, world")).toStrictEqual(
+                    [true],
+                );
+                expect(testMatchGrammar(grammar, "hello,world")).toStrictEqual(
+                    [],
+                );
+            });
+        });
+        describe("optional mode", () => {
+            it("punctuation at end of preceding literal", () => {
+                const g = `<Start> [spacing=optional] = hello, world -> true;`;
+                const grammar = loadGrammarRules("test.grammar", g);
+                expect(testMatchGrammar(grammar, "hello,world")).toStrictEqual([
+                    true,
+                ]);
+                expect(testMatchGrammar(grammar, "hello, world")).toStrictEqual(
+                    [true],
+                );
+            });
+            it("punctuation at start of following literal", () => {
+                const g = `<Start> [spacing=optional] = hello ,world -> true;`;
+                const grammar = loadGrammarRules("test.grammar", g);
+                expect(testMatchGrammar(grammar, "hello,world")).toStrictEqual([
+                    true,
+                ]);
+                expect(testMatchGrammar(grammar, "hello ,world")).toStrictEqual(
+                    [true],
+                );
+            });
+            it("punctuation trailing boundary", () => {
+                const g = `<Start> [spacing=optional] = hello,$(x) -> true;`;
+                const grammar = loadGrammarRules("test.grammar", g);
+                expect(testMatchGrammar(grammar, "hello,world")).toStrictEqual([
+                    true,
+                ]);
+                expect(testMatchGrammar(grammar, "hello, world")).toStrictEqual(
+                    [true],
+                );
+            });
         });
     });
     describe("Variable Match", () => {
@@ -494,6 +630,795 @@ describe("Grammar Matcher", () => {
             `;
             const grammar = loadGrammarRules("test.grammar", g);
             expect(testMatchGrammar(grammar, "foo bar")).toStrictEqual(["bar"]);
+        });
+    });
+
+    describe("Space Separator Mode", () => {
+        describe("default (auto) - Latin requires space", () => {
+            const g = `<Start> = hello world -> true;`;
+            const grammar = loadGrammarRules("test.grammar", g);
+            it("matches with space", () => {
+                expect(testMatchGrammar(grammar, "hello world")).toStrictEqual([
+                    true,
+                ]);
+            });
+            it("does not match without space", () => {
+                expect(testMatchGrammar(grammar, "helloworld")).toStrictEqual(
+                    [],
+                );
+            });
+        });
+
+        describe("spacing=required annotation", () => {
+            const g = `<Start> [spacing=required] = hello world -> true;`;
+            const grammar = loadGrammarRules("test.grammar", g);
+            it("matches with space", () => {
+                expect(testMatchGrammar(grammar, "hello world")).toStrictEqual([
+                    true,
+                ]);
+            });
+            it("does not match without space", () => {
+                expect(testMatchGrammar(grammar, "helloworld")).toStrictEqual(
+                    [],
+                );
+            });
+        });
+
+        describe("spacing=optional annotation", () => {
+            const g = `<Start> [spacing=optional] = hello world -> true;`;
+            const grammar = loadGrammarRules("test.grammar", g);
+            it("matches with space", () => {
+                expect(testMatchGrammar(grammar, "hello world")).toStrictEqual([
+                    true,
+                ]);
+            });
+            it("matches without space", () => {
+                expect(testMatchGrammar(grammar, "helloworld")).toStrictEqual([
+                    true,
+                ]);
+            });
+        });
+
+        describe("spacing=auto annotation - CJK (Han)", () => {
+            // In the grammar, whitespace creates a flex-space boundary.
+            // With auto mode, Han characters don't need spaces between them.
+            const g = `<Start> [spacing=auto] = 你好 世界 -> true;`;
+            const grammar = loadGrammarRules("test.grammar", g);
+            it("matches without space", () => {
+                expect(testMatchGrammar(grammar, "你好世界")).toStrictEqual([
+                    true,
+                ]);
+            });
+            it("matches with space", () => {
+                expect(testMatchGrammar(grammar, "你好 世界")).toStrictEqual([
+                    true,
+                ]);
+            });
+        });
+
+        describe("no annotation is identical to [spacing=auto]", () => {
+            // Omitting the annotation must produce the same behavior as
+            // explicitly writing [spacing=auto] — both store spacingMode as
+            // undefined and both enforce word-boundary rules for Latin scripts
+            // while allowing adjacent CJK characters.
+            it("Latin words without space are rejected in both", () => {
+                const gNoAnnotation = loadGrammarRules(
+                    "test.grammar",
+                    `<Start> = hello world -> true;`,
+                );
+                const gAutoExplicit = loadGrammarRules(
+                    "test.grammar",
+                    `<Start> [spacing=auto] = hello world -> true;`,
+                );
+                expect(
+                    testMatchGrammar(gNoAnnotation, "helloworld"),
+                ).toStrictEqual([]);
+                expect(
+                    testMatchGrammar(gAutoExplicit, "helloworld"),
+                ).toStrictEqual([]);
+            });
+            it("CJK characters without space match in both", () => {
+                const gNoAnnotation = loadGrammarRules(
+                    "test.grammar",
+                    `<Start> = 你好 世界 -> true;`,
+                );
+                const gAutoExplicit = loadGrammarRules(
+                    "test.grammar",
+                    `<Start> [spacing=auto] = 你好 世界 -> true;`,
+                );
+                expect(
+                    testMatchGrammar(gNoAnnotation, "你好世界"),
+                ).toStrictEqual([true]);
+                expect(
+                    testMatchGrammar(gAutoExplicit, "你好世界"),
+                ).toStrictEqual([true]);
+            });
+        });
+
+        describe("spacing=auto annotation - mixed Latin+CJK boundary", () => {
+            // At the Latin→CJK boundary no space is needed (CJK side is no-space)
+            const g = `<Start> [spacing=auto] = hello 世界 -> true;`;
+            const grammar = loadGrammarRules("test.grammar", g);
+            it("matches without space at Latin-CJK boundary", () => {
+                expect(testMatchGrammar(grammar, "hello世界")).toStrictEqual([
+                    true,
+                ]);
+            });
+            it("matches with space at Latin-CJK boundary", () => {
+                expect(testMatchGrammar(grammar, "hello 世界")).toStrictEqual([
+                    true,
+                ]);
+            });
+        });
+
+        describe("per-rule mode switching", () => {
+            // <Start> references two sub-rules declared with different modes.
+            const g = `
+                <RequiredRule> [spacing=required] = hello world -> "required";
+                <OptionalRule> [spacing=optional] = hello world -> "optional";
+                <Start> = $(x:<RequiredRule>) -> x | $(x:<OptionalRule>) -> x;
+            `;
+            const grammar = loadGrammarRules("test.grammar", g);
+            it("both sub-rules match when space is present", () => {
+                expect(testMatchGrammar(grammar, "hello world")).toStrictEqual([
+                    "required",
+                    "optional",
+                ]);
+            });
+            it("only the optional sub-rule matches without space", () => {
+                expect(testMatchGrammar(grammar, "helloworld")).toStrictEqual([
+                    "optional",
+                ]);
+            });
+        });
+
+        describe("nested rule uses its own mode", () => {
+            // EnglishRule uses required; NoSpaceRule uses optional.
+            // <Start> references both — each sub-rule uses its own declared mode.
+            const g = `
+                <EnglishRule> [spacing=required] = hello world -> "english";
+                <NoSpaceRule> [spacing=optional] = hi there -> "nospace";
+                <Start> = $(x:<EnglishRule>) $(y:<NoSpaceRule>) -> { x, y };
+            `;
+            const grammar = loadGrammarRules("test.grammar", g);
+            it("each nested rule uses its own declared mode", () => {
+                // EnglishRule requires space between "hello" and "world";
+                // NoSpaceRule allows "hithere" without space.
+                expect(
+                    testMatchGrammar(grammar, "hello world hithere"),
+                ).toStrictEqual([{ x: "english", y: "nospace" }]);
+            });
+        });
+
+        describe("merged rules - same rule name, different modes", () => {
+            // Two definitions of <Start> with different spacing modes.
+            // The compiler merges them into one rule with two alternatives,
+            // each carrying its own declared mode.
+            const g = `
+                <Start> [spacing=required] = hello world -> "required";
+                <Start> [spacing=optional] = hello world -> "optional";
+            `;
+            const grammar = loadGrammarRules("test.grammar", g);
+            it("both alternatives match when space is present", () => {
+                expect(testMatchGrammar(grammar, "hello world")).toStrictEqual([
+                    "required",
+                    "optional",
+                ]);
+            });
+            it("only the optional alternative matches without space", () => {
+                expect(testMatchGrammar(grammar, "helloworld")).toStrictEqual([
+                    "optional",
+                ]);
+            });
+        });
+
+        describe("inline group inherits enclosing rule mode", () => {
+            const g = `<Start> [spacing=optional] = hello (world | earth) -> true;`;
+            const grammar = loadGrammarRules("test.grammar", g);
+            it("matches with space", () => {
+                expect(testMatchGrammar(grammar, "hello world")).toStrictEqual([
+                    true,
+                ]);
+            });
+            it("matches without space (inherits optional)", () => {
+                expect(testMatchGrammar(grammar, "helloworld")).toStrictEqual([
+                    true,
+                ]);
+            });
+            it("matches second alternative without space", () => {
+                expect(testMatchGrammar(grammar, "helloearth")).toStrictEqual([
+                    true,
+                ]);
+            });
+        });
+
+        describe("same-name rule with different modes merged", () => {
+            // <Greeting> is defined twice with different modes; each alternative
+            // must respect its own declared spacingMode.
+            const g = `
+                <Greeting> [spacing=optional] = hello world -> "optional";
+                <Greeting> [spacing=required] = good morning -> "required";
+                <Start> = <Greeting>;
+            `;
+            const grammar = loadGrammarRules("test.grammar", g);
+            it("optional alternative matches without space", () => {
+                expect(testMatchGrammar(grammar, "helloworld")).toStrictEqual([
+                    "optional",
+                ]);
+            });
+            it("required alternative matches with space", () => {
+                expect(testMatchGrammar(grammar, "good morning")).toStrictEqual(
+                    ["required"],
+                );
+            });
+            it("required alternative does not match without space", () => {
+                expect(testMatchGrammar(grammar, "goodmorning")).toStrictEqual(
+                    [],
+                );
+            });
+        });
+
+        describe("rule without annotation uses auto/default mode", () => {
+            // <Before> has no annotation — must behave identically to
+            // [spacing=auto]: Latin words require a separator, CJK do not.
+            const g = `
+                <Before> = hello world -> "before";
+                <After> [spacing=optional] = hello world -> "after";
+                <Start> = $(x:<Before>) -> x | $(x:<After>) -> x;
+            `;
+            const grammar = loadGrammarRules("test.grammar", g);
+            it("<Before> requires space between Latin words (auto default)", () => {
+                expect(testMatchGrammar(grammar, "hello world")).toStrictEqual([
+                    "before",
+                    "after",
+                ]);
+            });
+            it("<Before> does not match without space (auto default)", () => {
+                // Only the optional <After> alternative should match.
+                expect(testMatchGrammar(grammar, "helloworld")).toStrictEqual([
+                    "after",
+                ]);
+            });
+        });
+
+        describe("parse error - unknown annotation key", () => {
+            it("throws on unknown annotation key", () => {
+                expect(() =>
+                    loadGrammarRules(
+                        "test.grammar",
+                        `<Start> [unknown=auto] = hello -> true;`,
+                    ),
+                ).toThrow("Unknown rule annotation");
+            });
+        });
+
+        describe("parse error - invalid spacing value", () => {
+            it("throws on invalid value", () => {
+                expect(() =>
+                    loadGrammarRules(
+                        "test.grammar",
+                        `<Start> [spacing=never] = hello -> true;`,
+                    ),
+                ).toThrow("Invalid value");
+            });
+        });
+
+        describe("spacing=auto annotation - Hangul (Korean)", () => {
+            // Hangul is in wordBoundaryScriptRe so adjacent Hangul syllables
+            // require a separator, just like Latin.
+            const g = `<Start> [spacing=auto] = 안녕 세계 -> true;`;
+            const grammar = loadGrammarRules("test.grammar", g);
+            it("does not match without space (Hangul requires separator)", () => {
+                expect(testMatchGrammar(grammar, "안녕세계")).toStrictEqual([]);
+            });
+            it("matches with space", () => {
+                expect(testMatchGrammar(grammar, "안녕 세계")).toStrictEqual([
+                    true,
+                ]);
+            });
+        });
+
+        describe("spacing=auto annotation - CJK→Latin boundary", () => {
+            // Reverse of the Latin→CJK test: CJK on the left, Latin on the right.
+            // CJK is not in wordBoundaryScriptRe so no space is needed at this boundary.
+            const g = `<Start> [spacing=auto] = 世界 hello -> true;`;
+            const grammar = loadGrammarRules("test.grammar", g);
+            it("matches without space at CJK-Latin boundary", () => {
+                expect(testMatchGrammar(grammar, "世界hello")).toStrictEqual([
+                    true,
+                ]);
+            });
+            it("matches with space at CJK-Latin boundary", () => {
+                expect(testMatchGrammar(grammar, "世界 hello")).toStrictEqual([
+                    true,
+                ]);
+            });
+        });
+
+        describe("spacing=required annotation - punctuation-only separator in input", () => {
+            // required mode uses [\s\p{P}]+ which accepts punctuation characters.
+            const g = `<Start> [spacing=required] = hello world -> true;`;
+            const grammar = loadGrammarRules("test.grammar", g);
+            it("accepts a comma as the separator", () => {
+                expect(testMatchGrammar(grammar, "hello,world")).toStrictEqual([
+                    true,
+                ]);
+            });
+            it("accepts a period as the separator", () => {
+                expect(testMatchGrammar(grammar, "hello.world")).toStrictEqual([
+                    true,
+                ]);
+            });
+        });
+
+        describe("repeat group ()* inherits optional mode", () => {
+            const g = `<Start> [spacing=optional] = hello (world)* -> true;`;
+            const grammar = loadGrammarRules("test.grammar", g);
+            it("matches zero repetitions", () => {
+                expect(testMatchGrammar(grammar, "hello")).toStrictEqual([
+                    true,
+                ]);
+            });
+            it("matches one repetition without space (optional mode)", () => {
+                expect(testMatchGrammar(grammar, "helloworld")).toStrictEqual([
+                    true,
+                ]);
+            });
+            it("matches two repetitions without space (optional mode)", () => {
+                expect(
+                    testMatchGrammar(grammar, "helloworldworld"),
+                ).toStrictEqual([true]);
+            });
+        });
+
+        describe("repeat group ()+ with required mode", () => {
+            const g = `<Start> [spacing=required] = hello (world)+ -> true;`;
+            const grammar = loadGrammarRules("test.grammar", g);
+            it("matches one repetition with space", () => {
+                expect(testMatchGrammar(grammar, "hello world")).toStrictEqual([
+                    true,
+                ]);
+            });
+            it("does not match without space before group", () => {
+                expect(testMatchGrammar(grammar, "helloworld")).toStrictEqual(
+                    [],
+                );
+            });
+            it("matches two repetitions with spaces", () => {
+                expect(
+                    testMatchGrammar(grammar, "hello world world"),
+                ).toStrictEqual([true]);
+            });
+            it("does not match when repetitions are not space-separated", () => {
+                // The first 'world' ends with 'w' at index 11 in input; required
+                // mode rejects a match unless a separator follows the token.
+                expect(
+                    testMatchGrammar(grammar, "hello worldworld"),
+                ).toStrictEqual([]);
+            });
+        });
+
+        describe("repeat group ()+ with optional mode", () => {
+            const g = `<Start> [spacing=optional] = hello (world)+ -> true;`;
+            const grammar = loadGrammarRules("test.grammar", g);
+            it("matches one repetition without space (optional mode)", () => {
+                expect(testMatchGrammar(grammar, "helloworld")).toStrictEqual([
+                    true,
+                ]);
+            });
+            it("matches two repetitions without space (optional mode)", () => {
+                expect(
+                    testMatchGrammar(grammar, "helloworldworld"),
+                ).toStrictEqual([true]);
+            });
+            it("matches two repetitions with spaces (optional mode)", () => {
+                expect(
+                    testMatchGrammar(grammar, "hello world world"),
+                ).toStrictEqual([true]);
+            });
+        });
+
+        describe("[spacing=auto] - digit-Latin boundary does not require space", () => {
+            // One side being a digit and the other Latin: no space needed.
+            const g = `<Start> = 123 hello -> true;`;
+            const grammar = loadGrammarRules("test.grammar", g);
+            it("matches without space at digit-Latin boundary", () => {
+                expect(testMatchGrammar(grammar, "123hello")).toStrictEqual([
+                    true,
+                ]);
+            });
+            it("matches with space at digit-Latin boundary", () => {
+                expect(testMatchGrammar(grammar, "123 hello")).toStrictEqual([
+                    true,
+                ]);
+            });
+        });
+
+        describe("[spacing=auto] - digit-digit boundary requires space", () => {
+            // Both sides are digits: a separator is required because "123456"
+            // is a different token from "123 456".
+            const g = `<Start> = 123 456 -> true;`;
+            const grammar = loadGrammarRules("test.grammar", g);
+            it("does not match without space at digit-digit boundary", () => {
+                expect(testMatchGrammar(grammar, "123456")).toStrictEqual([]);
+            });
+            it("matches with space at digit-digit boundary", () => {
+                expect(testMatchGrammar(grammar, "123 456")).toStrictEqual([
+                    true,
+                ]);
+            });
+        });
+
+        describe("number variable respects spacingMode", () => {
+            describe("required mode - trailing separator after number", () => {
+                const g = `<Start> [spacing=required] = set $(n:number) items -> n;`;
+                const grammar = loadGrammarRules("test.grammar", g);
+                it("rejects number immediately followed by word (no separator)", () => {
+                    expect(
+                        testMatchGrammar(grammar, "set 50items"),
+                    ).toStrictEqual([]);
+                });
+                it("accepts number followed by space then word", () => {
+                    expect(
+                        testMatchGrammar(grammar, "set 50 items"),
+                    ).toStrictEqual([50]);
+                });
+            });
+
+            describe("optional mode - trailing separator after number", () => {
+                const g = `<Start> [spacing=optional] = set $(n:number) items -> n;`;
+                const grammar = loadGrammarRules("test.grammar", g);
+                it("accepts number immediately followed by word (no separator needed)", () => {
+                    expect(
+                        testMatchGrammar(grammar, "set 50items"),
+                    ).toStrictEqual([50]);
+                });
+                it("accepts number followed by space then word", () => {
+                    expect(
+                        testMatchGrammar(grammar, "set 50 items"),
+                    ).toStrictEqual([50]);
+                });
+            });
+
+            describe("auto mode - digit-Latin boundary does not require space", () => {
+                // Digit followed by Latin: not both in wordBoundaryScriptRe, so no separator needed.
+                const g = `<Start> = set $(n:number) items -> n;`;
+                const grammar = loadGrammarRules("test.grammar", g);
+                it("accepts number immediately followed by Latin word (auto mode)", () => {
+                    expect(
+                        testMatchGrammar(grammar, "set 50items"),
+                    ).toStrictEqual([50]);
+                });
+            });
+
+            describe("required mode - number at start of rule (no preceding part)", () => {
+                // Verifies the trailing separator check fires even when there is no
+                // preceding string part whose own isBoundarySatisfied check would have
+                // enforced a separator earlier.
+                const g = `<Start> [spacing=required] = $(n:number) items -> n;`;
+                const grammar = loadGrammarRules("test.grammar", g);
+                it("rejects number immediately followed by word (no separator)", () => {
+                    expect(testMatchGrammar(grammar, "50items")).toStrictEqual(
+                        [],
+                    );
+                });
+                it("accepts number followed by space then word", () => {
+                    expect(testMatchGrammar(grammar, "50 items")).toStrictEqual(
+                        [50],
+                    );
+                });
+            });
+
+            describe("auto mode - digit-digit boundary requires space after number variable", () => {
+                // Both the end of the matched number and the start of the next
+                // literal are digits → isBoundarySatisfied returns false in auto mode.
+                const g = `<Start> = $(n:number) 456 -> n;`;
+                const grammar = loadGrammarRules("test.grammar", g);
+                it("rejects number immediately followed by digit literal (no separator)", () => {
+                    expect(testMatchGrammar(grammar, "123456")).toStrictEqual(
+                        [],
+                    );
+                });
+                it("accepts number followed by space then digit literal", () => {
+                    expect(testMatchGrammar(grammar, "123 456")).toStrictEqual([
+                        123,
+                    ]);
+                });
+            });
+
+            describe("required mode - number with wildcard trailing separator", () => {
+                const g = `<Start> [spacing=required] = $(x) $(n:number) end -> n;`;
+                const grammar = loadGrammarRules("test.grammar", g);
+                it("rejects number immediately followed by word (no separator)", () => {
+                    expect(
+                        testMatchGrammar(grammar, "set 50end"),
+                    ).toStrictEqual([]);
+                });
+                it("accepts number followed by space then word", () => {
+                    expect(
+                        testMatchGrammar(grammar, "set 50 end"),
+                    ).toStrictEqual([50]);
+                });
+            });
+
+            describe("optional mode - number with wildcard trailing separator", () => {
+                // In optional mode the wildcard path should accept no separator.
+                const g = `<Start> [spacing=optional] = $(x) $(n:number) end -> n;`;
+                const grammar = loadGrammarRules("test.grammar", g);
+                it("accepts number immediately followed by word (no separator needed)", () => {
+                    expect(testMatchGrammar(grammar, "set50end")).toStrictEqual(
+                        [50],
+                    );
+                });
+                it("accepts number followed by space then word", () => {
+                    expect(
+                        testMatchGrammar(grammar, "set 50 end"),
+                    ).toStrictEqual([50]);
+                });
+            });
+        });
+
+        describe("separator AFTER a rule reference follows parent mode", () => {
+            // The nested rule uses optional mode, so its own isBoundarySatisfied check
+            // always passes. The separator AFTER the rule reference must be
+            // validated using the parent (outer) rule's spacingMode.
+            describe("parent required, nested optional", () => {
+                const g = `
+                    <Inner> [spacing=optional] = hello world -> true;
+                    <Start> [spacing=required] = $(x:<Inner>) end -> x;
+                `;
+                const grammar = loadGrammarRules("test.grammar", g);
+                it("matches when space is present after rule reference", () => {
+                    expect(
+                        testMatchGrammar(grammar, "helloworld end"),
+                    ).toStrictEqual([true]);
+                });
+                it("does not match without space after rule reference (parent required)", () => {
+                    expect(
+                        testMatchGrammar(grammar, "helloworldend"),
+                    ).toStrictEqual([]);
+                });
+            });
+
+            describe("parent optional, nested required", () => {
+                // The nested rule's own required mode enforces a separator
+                // after its last token, so "hello worldend" is rejected by
+                // the inner rule itself regardless of the outer mode.
+                const g = `
+                    <Inner> [spacing=required] = hello world -> true;
+                    <Start> [spacing=optional] = $(x:<Inner>) end -> x;
+                `;
+                const grammar = loadGrammarRules("test.grammar", g);
+                it("matches when space is present after rule reference", () => {
+                    expect(
+                        testMatchGrammar(grammar, "hello world end"),
+                    ).toStrictEqual([true]);
+                });
+                it("does not match without space (inner required mode enforces the boundary)", () => {
+                    expect(
+                        testMatchGrammar(grammar, "hello worldend"),
+                    ).toStrictEqual([]);
+                });
+            });
+            describe("deeply nested: grandparent optional, parent required pass-through, grandchild optional", () => {
+                // Bug: A(optional) -> B(required, single-part pass-through) -> C(optional)
+                // After C finishes, finalizeNestedRule restores B's "required" mode and
+                // the separator check fires against it — rejecting "barbaz" even though
+                // A (the nearest ancestor with a following part) uses "optional" mode.
+                // The correct behaviour is to walk up to the first ancestor that still
+                // has remaining parts and use *that* ancestor's spacingMode.
+                const g = `
+                    <Inner> [spacing=optional] = bar -> true;
+                    <Middle> [spacing=required] = $(x:<Inner>) -> x;
+                    <Start> [spacing=optional] = $(x:<Middle>) baz -> x;
+                `;
+                const grammar = loadGrammarRules("test.grammar", g);
+                it("matches with space (works today)", () => {
+                    expect(testMatchGrammar(grammar, "bar baz")).toStrictEqual([
+                        true,
+                    ]);
+                });
+                it("matches without space (grandparent optional mode governs the separator after the pass-through)", () => {
+                    expect(testMatchGrammar(grammar, "barbaz")).toStrictEqual([
+                        true,
+                    ]);
+                });
+            });
+            describe("deeply nested: grandparent required, parent optional pass-through, grandchild optional", () => {
+                // The separator check is deferred past the exhausted optional parent
+                // and fires at the grandparent level with "required" mode.
+                const g = `
+                    <Inner> [spacing=optional] = bar -> true;
+                    <Middle> [spacing=optional] = $(x:<Inner>) -> x;
+                    <Start> [spacing=required] = $(x:<Middle>) baz -> x;
+                `;
+                const grammar = loadGrammarRules("test.grammar", g);
+                it("matches with space", () => {
+                    expect(testMatchGrammar(grammar, "bar baz")).toStrictEqual([
+                        true,
+                    ]);
+                });
+                it("does not match without space (grandparent required governs)", () => {
+                    expect(testMatchGrammar(grammar, "barbaz")).toStrictEqual(
+                        [],
+                    );
+                });
+            });
+            describe("deeply nested: grandparent auto (default), parent required pass-through, grandchild optional", () => {
+                // auto mode: both "bar" and "baz" are Latin → space is required.
+                const g = `
+                    <Inner> [spacing=optional] = bar -> true;
+                    <Middle> [spacing=required] = $(x:<Inner>) -> x;
+                    <Start> = $(x:<Middle>) baz -> x;
+                `;
+                const grammar = loadGrammarRules("test.grammar", g);
+                it("matches with space", () => {
+                    expect(testMatchGrammar(grammar, "bar baz")).toStrictEqual([
+                        true,
+                    ]);
+                });
+                it("does not match without space (auto mode: Latin-Latin boundary requires space)", () => {
+                    expect(testMatchGrammar(grammar, "barbaz")).toStrictEqual(
+                        [],
+                    );
+                });
+            });
+            describe("deeply nested: grandchild required enforces its own internal separator", () => {
+                // grandchild=required: the string-match isBoundarySatisfied check inside
+                // grandchild rejects "bar" immediately followed by "baz" before
+                // the nested-rule separator logic even runs.
+                const g = `
+                    <Inner> [spacing=required] = bar -> true;
+                    <Middle> [spacing=optional] = $(x:<Inner>) -> x;
+                    <Start> [spacing=optional] = $(x:<Middle>) baz -> x;
+                `;
+                const grammar = loadGrammarRules("test.grammar", g);
+                it("matches with space", () => {
+                    expect(testMatchGrammar(grammar, "bar baz")).toStrictEqual([
+                        true,
+                    ]);
+                });
+                it("does not match without space (grandchild required catches it internally)", () => {
+                    expect(testMatchGrammar(grammar, "barbaz")).toStrictEqual(
+                        [],
+                    );
+                });
+            });
+            describe("4 levels deep: great-grandparent optional, two required pass-through levels, leaf optional", () => {
+                // The fix must skip multiple exhausted ancestors and fire only at
+                // the great-grandparent which has a following part ("baz").
+                const g = `
+                    <Leaf> [spacing=optional] = bar -> true;
+                    <LevelA> [spacing=required] = $(x:<Leaf>) -> x;
+                    <LevelB> [spacing=required] = $(x:<LevelA>) -> x;
+                    <Start> [spacing=optional] = $(x:<LevelB>) baz -> x;
+                `;
+                const grammar = loadGrammarRules("test.grammar", g);
+                it("matches with space", () => {
+                    expect(testMatchGrammar(grammar, "bar baz")).toStrictEqual([
+                        true,
+                    ]);
+                });
+                it("matches without space (great-grandparent optional governs after two exhausted pass-through levels)", () => {
+                    expect(testMatchGrammar(grammar, "barbaz")).toStrictEqual([
+                        true,
+                    ]);
+                });
+            });
+            describe("4 levels deep: great-grandparent required, two optional pass-through levels, leaf optional", () => {
+                // The boundary check defers past two exhausted optional ancestors
+                // and fires at the great-grandparent with "required" mode.
+                const g = `
+                    <Leaf> [spacing=optional] = bar -> true;
+                    <LevelA> [spacing=optional] = $(x:<Leaf>) -> x;
+                    <LevelB> [spacing=optional] = $(x:<LevelA>) -> x;
+                    <Start> [spacing=required] = $(x:<LevelB>) baz -> x;
+                `;
+                const grammar = loadGrammarRules("test.grammar", g);
+                it("matches with space", () => {
+                    expect(testMatchGrammar(grammar, "bar baz")).toStrictEqual([
+                        true,
+                    ]);
+                });
+                it("does not match without space (great-grandparent required governs)", () => {
+                    expect(testMatchGrammar(grammar, "barbaz")).toStrictEqual(
+                        [],
+                    );
+                });
+            });
+        });
+
+        describe("separator BEFORE a nested rule reference uses ancestor mode", () => {
+            // Symmetric to the "after" tests: when a pass-through chain (A->X) ends
+            // and the next sibling part in the ancestor is another nested rule (B),
+            // the inter-rule separator is governed by the common ancestor's
+            // spacingMode — not by any intermediate exhausted rule's mode.
+            describe("grandparent optional, pass-through chain before sibling rule", () => {
+                // Start(optional): [A(required)->X(optional) "foo"] then [B(optional) "bar"]
+                // The separator between "foo" and "bar" uses Start's "optional" mode.
+                const g = `
+                    <X> [spacing=optional] = foo -> "x";
+                    <A> [spacing=required] = $(x:<X>) -> x;
+                    <B> [spacing=optional] = bar -> "b";
+                    <Start> [spacing=optional] = $(a:<A>) $(b:<B>) -> [a, b];
+                `;
+                const grammar = loadGrammarRules("test.grammar", g);
+                it("matches with space", () => {
+                    expect(testMatchGrammar(grammar, "foo bar")).toStrictEqual([
+                        ["x", "b"],
+                    ]);
+                });
+                it("matches without space (Start optional governs the inter-rule boundary)", () => {
+                    expect(testMatchGrammar(grammar, "foobar")).toStrictEqual([
+                        ["x", "b"],
+                    ]);
+                });
+            });
+            describe("grandparent required, pass-through chain before sibling rule", () => {
+                // Start(required): [A(optional)->X(optional) "foo"] then [B(optional) "bar"]
+                // The separator uses Start's "required" mode regardless of A and X being optional.
+                const g = `
+                    <X> [spacing=optional] = foo -> "x";
+                    <A> [spacing=optional] = $(x:<X>) -> x;
+                    <B> [spacing=optional] = bar -> "b";
+                    <Start> [spacing=required] = $(a:<A>) $(b:<B>) -> [a, b];
+                `;
+                const grammar = loadGrammarRules("test.grammar", g);
+                it("matches with space", () => {
+                    expect(testMatchGrammar(grammar, "foo bar")).toStrictEqual([
+                        ["x", "b"],
+                    ]);
+                });
+                it("does not match without space (Start required governs)", () => {
+                    expect(testMatchGrammar(grammar, "foobar")).toStrictEqual(
+                        [],
+                    );
+                });
+            });
+            describe("4 levels deep, great-grandparent optional, pass-through chain before sibling rule", () => {
+                // Start(optional): [A(required)->B(required)->X(optional) "foo"] then [C(optional) "bar"]
+                // Two exhausted required pass-through levels; Start's optional mode governs.
+                const g = `
+                    <X> [spacing=optional] = foo -> "x";
+                    <B> [spacing=required] = $(x:<X>) -> x;
+                    <A> [spacing=required] = $(b:<B>) -> b;
+                    <C> [spacing=optional] = bar -> "c";
+                    <Start> [spacing=optional] = $(a:<A>) $(c:<C>) -> [a, c];
+                `;
+                const grammar = loadGrammarRules("test.grammar", g);
+                it("matches with space", () => {
+                    expect(testMatchGrammar(grammar, "foo bar")).toStrictEqual([
+                        ["x", "c"],
+                    ]);
+                });
+                it("matches without space (Start optional governs after two exhausted pass-through levels)", () => {
+                    expect(testMatchGrammar(grammar, "foobar")).toStrictEqual([
+                        ["x", "c"],
+                    ]);
+                });
+            });
+            describe("4 levels deep, great-grandparent required, pass-through chain before sibling rule", () => {
+                // Start(required): [A(optional)->B(optional)->X(optional) "foo"] then [C(optional) "bar"]
+                // Start's required mode governs even though all intermediates are optional.
+                const g = `
+                    <X> [spacing=optional] = foo -> "x";
+                    <B> [spacing=optional] = $(x:<X>) -> x;
+                    <A> [spacing=optional] = $(b:<B>) -> b;
+                    <C> [spacing=optional] = bar -> "c";
+                    <Start> [spacing=required] = $(a:<A>) $(c:<C>) -> [a, c];
+                `;
+                const grammar = loadGrammarRules("test.grammar", g);
+                it("matches with space", () => {
+                    expect(testMatchGrammar(grammar, "foo bar")).toStrictEqual([
+                        ["x", "c"],
+                    ]);
+                });
+                it("does not match without space (Start required governs)", () => {
+                    expect(testMatchGrammar(grammar, "foobar")).toStrictEqual(
+                        [],
+                    );
+                });
+            });
         });
     });
 });

--- a/ts/packages/actionGrammar/test/grammarRuleParser.spec.ts
+++ b/ts/packages/actionGrammar/test/grammarRuleParser.spec.ts
@@ -917,6 +917,88 @@ describe("Grammar Rule Parser", () => {
         });
     });
 
+    describe("Spacing Annotation", () => {
+        it("attaches spacingMode optional via annotation", () => {
+            const result = testParamGrammarRules(
+                "test.agr",
+                `<Rule> [spacing=optional] = hello;`,
+            );
+            expect(result).toHaveLength(1);
+            expect(result[0].spacingMode).toBe("optional");
+        });
+
+        it("attaches spacingMode required via annotation", () => {
+            const result = testParamGrammarRules(
+                "test.agr",
+                `<Rule> [spacing=required] = hello;`,
+            );
+            expect(result[0].spacingMode).toBe("required");
+        });
+
+        it("attaches spacingMode auto via annotation (stored as undefined)", () => {
+            const result = testParamGrammarRules(
+                "test.agr",
+                `<Rule> [spacing=auto] = hello;`,
+            );
+            // "auto" is the default; stored as undefined
+            expect(result[0].spacingMode).toBeUndefined();
+        });
+
+        it("rule without annotation has undefined spacingMode", () => {
+            const result = testParamGrammarRules("test.agr", `<Rule> = hello;`);
+            expect(result[0].spacingMode).toBeUndefined();
+        });
+
+        it("each rule carries its own independently declared mode", () => {
+            const result = testParamGrammarRules(
+                "test.agr",
+                `<A> [spacing=optional] = a;
+                 <B> [spacing=required] = b;
+                 <C> = c;`,
+            );
+            expect(result[0].spacingMode).toBe("optional");
+            expect(result[1].spacingMode).toBe("required");
+            // "auto" is the default; stored as undefined
+            expect(result[2].spacingMode).toBeUndefined();
+        });
+
+        it("throws on unknown annotation key", () => {
+            expect(() =>
+                testParamGrammarRules(
+                    "test.agr",
+                    `<Rule> [unknown=auto] = hello;`,
+                ),
+            ).toThrow("Unknown rule annotation");
+        });
+
+        it("throws on invalid spacing value", () => {
+            expect(() =>
+                testParamGrammarRules(
+                    "test.agr",
+                    `<Rule> [spacing=never] = hello;`,
+                ),
+            ).toThrow("Invalid value");
+        });
+
+        it("throws when '=' is missing in annotation", () => {
+            expect(() =>
+                testParamGrammarRules(
+                    "test.agr",
+                    `<Rule> [spacing required] = hello;`,
+                ),
+            ).toThrow("'=' expected in spacing annotation");
+        });
+
+        it("throws when ']' is missing in annotation", () => {
+            expect(() =>
+                testParamGrammarRules(
+                    "test.agr",
+                    `<Rule> [spacing=required = hello;`,
+                ),
+            ).toThrow("']' expected at end of spacing annotation");
+        });
+    });
+
     describe("Complex Integration", () => {
         it("should handle deeply nested value structures", () => {
             const grammar = `

--- a/ts/packages/actionGrammar/test/grammarRuleWriter.spec.ts
+++ b/ts/packages/actionGrammar/test/grammarRuleWriter.spec.ts
@@ -113,4 +113,32 @@ describe("Grammar Rule Writer", () => {
 import { RuleX } from "grammarB";
 <test> = hello world;`);
     });
+    it("with spacing=required annotation", () => {
+        validateRoundTrip(`<test> [spacing=required] = hello world;`);
+    });
+    it("with spacing=optional annotation", () => {
+        validateRoundTrip(`<test> [spacing=optional] = hello world;`);
+    });
+    it("with spacing=auto annotation (normalized away by writer)", () => {
+        // "auto" is the default (undefined); the writer omits the annotation
+        const result = parseGrammarRules(
+            "orig",
+            `<test> [spacing=auto] = hello world;`,
+            false,
+        );
+        expect(result.definitions[0].spacingMode).toBeUndefined();
+        expect(writeGrammarRules(result)).toBe("<test> = hello world;\n");
+    });
+    it("per-rule annotations — mixed modes", () => {
+        validateRoundTrip(`<before> = one two;
+<after> [spacing=required] = hello world;`);
+    });
+    it("multiple rules with different annotations", () => {
+        validateRoundTrip(`<rule1> [spacing=required] = hello world;
+<rule2> [spacing=optional] = hello world;`);
+    });
+    it("annotation then unannotated rule (auto default)", () => {
+        validateRoundTrip(`<rule1> [spacing=required] = hello world;
+<rule2> = hello world;`);
+    });
 });

--- a/ts/packages/actionGrammar/test/grammarSerialization.spec.ts
+++ b/ts/packages/actionGrammar/test/grammarSerialization.spec.ts
@@ -3,7 +3,13 @@
 
 import { grammarFromJson } from "../src/grammarDeserializer.js";
 import { loadGrammarRules } from "../src/grammarLoader.js";
+import { matchGrammar } from "../src/grammarMatcher.js";
 import { grammarToJson } from "../src/grammarSerializer.js";
+import { Grammar } from "../src/grammarTypes.js";
+
+function testMatchGrammar(grammar: Grammar, request: string) {
+    return matchGrammar(grammar, request)?.map((m) => m.match);
+}
 
 describe("Grammar Serialization", () => {
     it("Round trip", () => {
@@ -17,5 +23,42 @@ describe("Grammar Serialization", () => {
         expect(deserialized).toEqual(grammar);
         const serialized2 = grammarToJson(deserialized);
         expect(serialized2).toEqual(serialized);
+    });
+
+    describe("spacingMode preservation", () => {
+        it("preserves optional mode through grammarToJson/grammarFromJson", () => {
+            const g = `<Start> [spacing=optional] = hello world -> true;`;
+            const reloaded = grammarFromJson(
+                grammarToJson(loadGrammarRules("test.grammar", g)),
+            );
+            expect(testMatchGrammar(reloaded, "helloworld")).toStrictEqual([
+                true,
+            ]);
+            expect(testMatchGrammar(reloaded, "hello world")).toStrictEqual([
+                true,
+            ]);
+        });
+
+        it("preserves required mode through grammarToJson/grammarFromJson", () => {
+            const g = `<Start> [spacing=required] = hello world -> true;`;
+            const reloaded = grammarFromJson(
+                grammarToJson(loadGrammarRules("test.grammar", g)),
+            );
+            expect(testMatchGrammar(reloaded, "hello world")).toStrictEqual([
+                true,
+            ]);
+            expect(testMatchGrammar(reloaded, "helloworld")).toStrictEqual([]);
+        });
+
+        it("preserves auto mode through grammarToJson/grammarFromJson", () => {
+            const g = `<Start> [spacing=auto] = hello world -> true;`;
+            const reloaded = grammarFromJson(
+                grammarToJson(loadGrammarRules("test.grammar", g)),
+            );
+            expect(testMatchGrammar(reloaded, "hello world")).toStrictEqual([
+                true,
+            ]);
+            expect(testMatchGrammar(reloaded, "helloworld")).toStrictEqual([]);
+        });
     });
 });


### PR DESCRIPTION
## Purpose

The grammar matcher previously used a single hard-coded word-boundary check between matched phrases and the surrounding input text.  This caused two categories of problems:

1. **Languages that do not use word spaces (e.g. CJK)** — Japanese, Chinese, and Korean text does not separate words with spaces, so requiring a separator at every phrase boundary made it impossible to match grammar rules embedded in CJK text without explicit punctuation.
2. **Grammar rules where separators should be optional** — Some grammars (e.g. those matching structured codes, identifiers, or mixed-script strings) need to accept adjacent tokens with no whitespace between them.

This PR adds a per-rule `[spacing=...]` annotation that lets grammar authors opt in to the right policy for their use case, and upgrades the default `auto` mode to use Unicode script detection so that CJK and other no-space scripts work correctly out of the box.

## Bug fixes (independent of the spacing feature)

**1. Number variable parts had no boundary check.**
`matchVarNumberPartWithWildcard` and `matchVarNumberPartWithoutWildcard` never verified that the matched number was followed by a word boundary. A grammar like `<Start> = $(x) $(n:number) end` would incorrectly match `set50end` because `50` was accepted mid-word with no check that a separator (or end-of-string) followed. The fix adds an `isBoundarySatisfied` call after every number match.

**2. Compiler error position pointed at the rule definition instead of the reference site.**
When reporting "Referenced rule does not produce a value for variable `$x`", the error position was `record.pos` — the position of the *definition* of the referenced rule. The fix uses `referencePosition`, which is the position of the `$(x:<RuleName>)` expression in the *referencing* rule, pointing the user to the actual problem site.

**3. `wildcardRegExp` was re-allocated on every wildcard match.**
`getWildcardStr` constructed a new `RegExp` object on every invocation. The regexp is constant, so it is now hoisted to a module-level `wildcardTrimRegExp` constant.

## Summary

- Adds a `[spacing=required|optional|auto]` annotation on grammar rule definitions that controls how flex-space separator positions between tokens are matched at runtime.
- Replaces the single `isSeparated` boundary check in the matcher with a `SpacingMode`-aware `isBoundarySatisfied` that handles `required`, `optional`, and `auto` (default) modes.
- In `auto` mode, a separator is required only when both adjacent characters belong to word-boundary scripts (Latin, Cyrillic, Greek, Hangul, Arabic, Hebrew, Devanagari, and others); scripts such as CJK that do not use word spaces never require one. Digit–digit adjacency is always treated as requiring a separator.

## Changes

| File | What changed |
|---|---|
| `grammarRuleParser.ts` | Parses `<rule> [spacing=...] = ...;` annotation; exports `SpacingMode` type |
| `grammarCompiler.ts` | Refactors `DefinitionRecord` to store `definitions: RuleDefinition[]` (preserving per-definition `spacingMode`); fixes error position to use `referencePosition`; threads `spacingMode` into `createGrammarRules` / `createGrammarRule` and stores it on each `GrammarRule` |
| `grammarMatcher.ts` | Adds `spacingMode` to `MatchState` and `ParentMatchState`; replaces `isSeparated` with `isBoundarySatisfied(mode)` and `requiresSeparator` for the infix quantifier in multi-token regexps; adds missing boundary checks to number parts; hoists `wildcardTrimRegExp` to module scope |
| `grammarTypes.ts` | Adds `spacingMode?: SpacingMode` to `GrammarRule` |
| `grammarRuleWriter.ts` | Emits `[spacing=mode]` annotation when non-default |
| `grammarSerializer.ts` / `grammarDeserializer.ts` | Round-trips `spacingMode` in JSON |
| `nfaCompiler.ts` | Propagates `spacingMode` when normalizing rules |
| `index.ts` | Exports `SpacingMode` |
| Tests | Extensive new coverage for spacing modes, script-aware boundaries, number boundary checks, parser annotation syntax, writer output, serialization, and compile-error cases |

🤖 Generated with [Claude Code](https://claude.com/claude-code)