### PR TITLE
AGR: Add spacing=none mode for zero-width flex-space matching

### DIFF
--- a/ts/packages/actionGrammar/src/grammarMatcher.ts
+++ b/ts/packages/actionGrammar/src/grammarMatcher.ts
@@ -66,6 +66,13 @@ function requiresSeparator(a: string, b: string, mode: SpacingMode): boolean {
             return true;
         case "optional":
             return false;
+        case "none":
+            // "none" mode is handled directly by the caller (matchStringPart
+            // short-circuits with an empty separator string).  If we ever
+            // reach this branch it indicates a logic error.
+            throw new Error(
+                "Internal error: requiresSeparator should not be called for 'none' mode",
+            );
         case undefined: // auto
             return needsSeparatorInAutoMode(a, b);
     }
@@ -90,6 +97,13 @@ function isBoundarySatisfied(
             separatorRegExp.lastIndex = index;
             return separatorRegExp.test(request);
         case "optional":
+        case "none":
+            // In both "optional" and "none" modes there is no constraint on
+            // the outer boundary.  "none" enforces zero-width flex-space
+            // *between* tokens (handled by the regex builder in
+            // matchStringPart), but must not reject a match simply because a
+            // literal space from an escaped character (e.g. "\ ") happens to
+            // sit at the boundary.
             return true;
         case undefined: // auto: requires a separator only when BOTH characters
             // adjacent to the boundary belong to word-boundary scripts.  If
@@ -379,8 +393,19 @@ function createValue(
     }
 }
 
-function getWildcardStr(request: string, start: number, end: number) {
+function getWildcardStr(
+    request: string,
+    start: number,
+    end: number,
+    spacingMode?: SpacingMode,
+) {
     const string = request.substring(start, end);
+    if (spacingMode === "none") {
+        // In "none" mode there are no flex-space separator positions, so any
+        // whitespace or punctuation between tokens belongs to the wildcard
+        // value itself.  Only reject truly empty wildcards.
+        return string.length > 0 ? string : undefined;
+    }
     wildcardTrimRegExp.lastIndex = 0;
     const match = wildcardTrimRegExp.exec(string);
     return match?.[1];
@@ -394,7 +419,12 @@ function captureWildcard(
     pending: MatchState[] = [],
 ) {
     const { start: wildcardStart, valueId } = state.pendingWildcard!;
-    const wildcardStr = getWildcardStr(request, wildcardStart, wildcardEnd);
+    const wildcardStr = getWildcardStr(
+        request,
+        wildcardStart,
+        wildcardEnd,
+        state.spacingMode,
+    );
     if (wildcardStr === undefined) {
         return false;
     }
@@ -471,6 +501,7 @@ function finalizeState(state: MatchState, request: string) {
             request,
             pendingWildcard.start,
             request.length,
+            state.spacingMode,
         );
         if (value === undefined) {
             return false;
@@ -701,18 +732,31 @@ function matchStringPart(
     // not use word spaces such as CJK).
     const regexpSegments: string[] = [escaped[0]];
     for (let i = 1; i < escaped.length; i++) {
-        const sep = requiresSeparator(
-            // Invariant: segments are always non-empty (guaranteed by the parser).
-            part.value[i - 1].at(-1)!,
-            part.value[i][0],
-            state.spacingMode,
-        )
-            ? `[${separatorRegExpStr}]+`
-            : `[${separatorRegExpStr}]*`;
+        // In "none" mode flex-space positions must match exactly zero
+        // characters — tokens are directly adjacent.  Any literal spaces
+        // (e.g. from "\ ") are already part of the segment text and will
+        // be matched by the regex itself.
+        const sep =
+            state.spacingMode === "none"
+                ? ""
+                : requiresSeparator(
+                        // Invariant: segments are always non-empty (guaranteed by the parser).
+                        part.value[i - 1].at(-1)!,
+                        part.value[i][0],
+                        state.spacingMode,
+                    )
+                  ? `[${separatorRegExpStr}]+`
+                  : `[${separatorRegExpStr}]*`;
         regexpSegments.push(sep, escaped[i]);
     }
     const joined = regexpSegments.join("");
-    const regExpStr = `[${separatorRegExpStr}]*?${joined}`;
+    // In "none" mode no leading separator is consumed; the match must start
+    // exactly at the current position (or, for wildcards, at whatever index
+    // the global scan finds the pattern text).
+    const regExpStr =
+        state.spacingMode === "none"
+            ? joined
+            : `[${separatorRegExpStr}]*?${joined}`;
     return state.pendingWildcard !== undefined
         ? matchStringPartWithWildcard(regExpStr, request, part, state, pending)
         : matchStringPartWithoutWildcard(regExpStr, request, part, state);
@@ -720,6 +764,9 @@ function matchStringPart(
 
 const matchNumberPartWithWildcardRegExp =
     /[\s\p{P}]*?(0o[0-7]+|0x[0-9a-f]+|0b[01]+|([+-]?[0-9]+)(\.[0-9]+)?(e[+-]?[1-9][0-9]*)?)/giu;
+// "none" mode variant: no leading separator allowed.
+const matchNumberPartWithWildcardNoSepRegExp =
+    /(0o[0-7]+|0x[0-9a-f]+|0b[01]+|([+-]?[0-9]+)(\.[0-9]+)?(e[+-]?[1-9][0-9]*)?)/giu;
 function matchVarNumberPartWithWildcard(
     request: string,
     state: MatchState,
@@ -727,9 +774,13 @@ function matchVarNumberPartWithWildcard(
     pending: MatchState[],
 ) {
     const curr = state.index;
-    matchNumberPartWithWildcardRegExp.lastIndex = curr;
+    const re =
+        state.spacingMode === "none"
+            ? matchNumberPartWithWildcardNoSepRegExp
+            : matchNumberPartWithWildcardRegExp;
+    re.lastIndex = curr;
     while (true) {
-        const match = matchNumberPartWithWildcardRegExp.exec(request);
+        const match = re.exec(request);
         if (match === null) {
             return false;
         }
@@ -767,14 +818,21 @@ function matchVarNumberPartWithWildcard(
 
 const matchNumberPartRegexp =
     /[\s\p{P}]*?(0o[0-7]+|0x[0-9a-f]+|0b[01]+|([+-]?[0-9]+)(\.[0-9]+)?(e[+-]?[1-9][0-9]*)?)/iuy;
+// "none" mode variant: no leading separator allowed.
+const matchNumberPartNoSepRegexp =
+    /(0o[0-7]+|0x[0-9a-f]+|0b[01]+|([+-]?[0-9]+)(\.[0-9]+)?(e[+-]?[1-9][0-9]*)?)/iuy;
 function matchVarNumberPartWithoutWildcard(
     request: string,
     state: MatchState,
     part: VarNumberPart,
 ) {
     const curr = state.index;
-    matchNumberPartRegexp.lastIndex = curr;
-    const m = matchNumberPartRegexp.exec(request);
+    const re =
+        state.spacingMode === "none"
+            ? matchNumberPartNoSepRegexp
+            : matchNumberPartRegexp;
+    re.lastIndex = curr;
+    const m = re.exec(request);
     if (m === null) {
         return false;
     }

--- a/ts/packages/actionGrammar/src/grammarRuleParser.ts
+++ b/ts/packages/actionGrammar/src/grammarRuleParser.ts
@@ -15,7 +15,7 @@ const debugParse = registerDebug("typeagent:grammar:parse");
  *   <RuleDefinition> ::= <RuleName> <RuleAnnotation>? "=" <Rules> ";"
  *   <RuleAnnotation> ::= "[" <AnnotationKey> "=" <AnnotationValue> "]"
  *   // Currently the only supported annotation key is "spacing":
- *   //   [spacing=required], [spacing=optional], [spacing=auto]
+ *   //   [spacing=required], [spacing=optional], [spacing=auto], [spacing=none]
  *   <Rules> ::= <Rule> ( "|" <Rule> )*
  *   <Rule> ::= <Expression> ( "->" <Value> )?
  *
@@ -29,11 +29,14 @@ const debugParse = registerDebug("typeagent:grammar:parse");
  *   // spacing mode (set via "set spacing ...;"):
  *   //
  *   //   - "required": always requires at least one whitespace/punctuation character.
- *   //   - "optional": accepts zero or more — no separator is needed.
+ *   //   - "optional": zero or more separator characters allowed; tokens may be adjacent
+ *   //                 but spaces are permitted.
  *   //   - "auto"    : (default) requires a separator only when both adjacent tokens belong to
  *   //                 space-separated scripts (e.g. Latin, Cyrillic). Tokens in non-spaced scripts
  *   //                 (e.g. CJK), or tokens that are whitespace/punctuation characters themselves,
  *   //                 do not require a separator.
+ *   //   - "none"     : no separator characters allowed; tokens must be directly adjacent.
+ *   //                 Any whitespace or punctuation between them causes a mismatch.
  *   //
  *   // The spacing mode is set per-rule via a [spacing=<mode>] annotation immediately
  *   // after the rule name: <rule> [spacing=required] = ...;
@@ -187,14 +190,17 @@ export type ImportStatement = {
 /**
  * Controls how flex-space separator positions between tokens are matched at runtime.
  *   "required" – at least one whitespace/punctuation character must be present.
- *   "optional" – zero or more separators; tokens may be adjacent.
+ *   "optional" – zero or more separator characters allowed; tokens may be adjacent
+ *               but spaces are permitted.
+ *   "none"     – no separator characters allowed; tokens must be directly adjacent.
+ *               Any whitespace or punctuation between them causes a mismatch.
  *   undefined  – auto (default): a separator is required only when both adjacent
  *                characters belong to scripts that normally use word spaces (e.g.
  *                Latin, Cyrillic). Scripts such as CJK do not require one.
  *
  * Note: the grammar source keyword "auto" is stored as undefined internally.
  */
-export type SpacingMode = "required" | "optional" | undefined;
+export type SpacingMode = "required" | "optional" | "none" | undefined;
 
 // Grammar Parse Result (includes entity declarations and imports)
 export type GrammarParseResult = {
@@ -712,9 +718,14 @@ class GrammarRuleParser {
         }
         this.consume("=", "in spacing annotation");
         const value = this.parseId("spacing value");
-        if (value !== "required" && value !== "optional" && value !== "auto") {
+        if (
+            value !== "required" &&
+            value !== "optional" &&
+            value !== "auto" &&
+            value !== "none"
+        ) {
             this.throwError(
-                `Invalid value '${value}' for spacing annotation. Expected 'required', 'optional', or 'auto'.`,
+                `Invalid value '${value}' for spacing annotation. Expected 'required', 'optional', 'auto', or 'none'.`,
             );
         }
         this.consume("]", "at end of spacing annotation");

--- a/ts/packages/actionGrammar/test/grammarMatcher.spec.ts
+++ b/ts/packages/actionGrammar/test/grammarMatcher.spec.ts
@@ -679,6 +679,565 @@ describe("Grammar Matcher", () => {
             });
         });
 
+        describe("spacing=none annotation", () => {
+            const g = `<Start> [spacing=none] = hello world -> true;`;
+            const grammar = loadGrammarRules("test.grammar", g);
+            it("matches without space (tokens must be adjacent)", () => {
+                expect(testMatchGrammar(grammar, "helloworld")).toStrictEqual([
+                    true,
+                ]);
+            });
+            it("does not match with space (flex-space must be zero-width)", () => {
+                expect(testMatchGrammar(grammar, "hello world")).toStrictEqual(
+                    [],
+                );
+            });
+        });
+
+        describe("spacing=none with escaped space in literal", () => {
+            // An escaped space is a literal character, part of the segment text.
+            // It must be matched exactly and must not be confused with a
+            // flex-space position.
+            const g = `<Start> [spacing=none] = hello\\ world -> true;`;
+            const grammar = loadGrammarRules("test.grammar", g);
+            it("matches when the literal space is present", () => {
+                expect(testMatchGrammar(grammar, "hello world")).toStrictEqual([
+                    true,
+                ]);
+            });
+            it("does not match without the literal space", () => {
+                expect(testMatchGrammar(grammar, "helloworld")).toStrictEqual(
+                    [],
+                );
+            });
+            it("does not match with extra space", () => {
+                // "hello  world" has two spaces; only one is in the literal.
+                expect(testMatchGrammar(grammar, "hello  world")).toStrictEqual(
+                    [],
+                );
+            });
+        });
+
+        describe("spacing=none with escaped space at boundary", () => {
+            // Literal trailing space must not cause the boundary check to reject
+            // the match when the next character in the input is non-separator.
+            const g = `<Start> [spacing=none] = hello\\  -> true;`;
+            const grammar = loadGrammarRules("test.grammar", g);
+            it("matches input with trailing space", () => {
+                expect(testMatchGrammar(grammar, "hello ")).toStrictEqual([
+                    true,
+                ]);
+            });
+        });
+
+        describe("spacing=none in per-rule mode switching", () => {
+            const g = `
+                <NoneRule> [spacing=none] = hello world -> "none";
+                <OptionalRule> [spacing=optional] = hello world -> "optional";
+                <Start> = $(x:<NoneRule>) -> x | $(x:<OptionalRule>) -> x;
+            `;
+            const grammar = loadGrammarRules("test.grammar", g);
+            it("both match when tokens are adjacent", () => {
+                expect(testMatchGrammar(grammar, "helloworld")).toStrictEqual([
+                    "none",
+                    "optional",
+                ]);
+            });
+            it("only optional matches with space", () => {
+                expect(testMatchGrammar(grammar, "hello world")).toStrictEqual([
+                    "optional",
+                ]);
+            });
+        });
+
+        // ---- spacing=none between different part types ----
+
+        describe("spacing=none: string → number variable", () => {
+            const g = `<Start> [spacing=none] = hello $(n:number) -> n;`;
+            const grammar = loadGrammarRules("test.grammar", g);
+            it("matches when number is adjacent to string", () => {
+                expect(testMatchGrammar(grammar, "hello42")).toStrictEqual([
+                    42,
+                ]);
+            });
+            it("does not match when space separates string and number", () => {
+                expect(testMatchGrammar(grammar, "hello 42")).toStrictEqual([]);
+            });
+        });
+
+        describe("spacing=none: number variable → string", () => {
+            const g = `<Start> [spacing=none] = $(n:number) world -> n;`;
+            const grammar = loadGrammarRules("test.grammar", g);
+            it("matches when string is adjacent to number", () => {
+                expect(testMatchGrammar(grammar, "42world")).toStrictEqual([
+                    42,
+                ]);
+            });
+            it("does not match when space separates number and string", () => {
+                expect(testMatchGrammar(grammar, "42 world")).toStrictEqual([]);
+            });
+        });
+
+        describe("spacing=none: string → wildcard → string", () => {
+            const g = `<Start> [spacing=none] = hello $(x) world -> x;`;
+            const grammar = loadGrammarRules("test.grammar", g);
+            it("matches when all parts are adjacent", () => {
+                expect(
+                    testMatchGrammar(grammar, "hellofooworld"),
+                ).toStrictEqual(["foo"]);
+            });
+            it("captures separators in wildcard value", () => {
+                expect(
+                    testMatchGrammar(grammar, "hello foo world"),
+                ).toStrictEqual([" foo "]);
+            });
+        });
+
+        describe("spacing=none: string → rule reference", () => {
+            const g = `
+                <Other> [spacing=none] = world -> "world";
+                <Start> [spacing=none] = hello $(x:<Other>) -> x;
+            `;
+            const grammar = loadGrammarRules("test.grammar", g);
+            it("matches when nested rule is adjacent", () => {
+                expect(testMatchGrammar(grammar, "helloworld")).toStrictEqual([
+                    "world",
+                ]);
+            });
+            it("does not match when space separates string and rule", () => {
+                expect(testMatchGrammar(grammar, "hello world")).toStrictEqual(
+                    [],
+                );
+            });
+        });
+
+        describe("spacing=none: group expressions", () => {
+            const g = `<Start> [spacing=none] = (hello | hi) world -> true;`;
+            const grammar = loadGrammarRules("test.grammar", g);
+            it("matches when group and following token are adjacent", () => {
+                expect(testMatchGrammar(grammar, "helloworld")).toStrictEqual([
+                    true,
+                ]);
+                expect(testMatchGrammar(grammar, "hiworld")).toStrictEqual([
+                    true,
+                ]);
+            });
+            it("does not match when space follows group", () => {
+                expect(testMatchGrammar(grammar, "hello world")).toStrictEqual(
+                    [],
+                );
+                expect(testMatchGrammar(grammar, "hi world")).toStrictEqual([]);
+            });
+        });
+
+        describe("spacing=none: escaped space mixed with flex-space", () => {
+            // Grammar: "hello\ " followed by flex-space followed by "world"
+            // The escaped space is a literal; the whitespace between the two
+            // quoted-like segments is a flex-space that must be zero-width.
+            const g = `<Start> [spacing=none] = hello\\  world -> true;`;
+            const grammar = loadGrammarRules("test.grammar", g);
+            it("matches when literal space is present and no flex-space", () => {
+                expect(testMatchGrammar(grammar, "hello world")).toStrictEqual([
+                    true,
+                ]);
+            });
+            it("does not match with extra space (flex-space consumed)", () => {
+                expect(testMatchGrammar(grammar, "hello  world")).toStrictEqual(
+                    [],
+                );
+            });
+            it("does not match without literal space", () => {
+                expect(testMatchGrammar(grammar, "helloworld")).toStrictEqual(
+                    [],
+                );
+            });
+        });
+
+        describe("spacing=none: string → number → string", () => {
+            const g = `<Start> [spacing=none] = item $(n:number) done -> n;`;
+            const grammar = loadGrammarRules("test.grammar", g);
+            it("matches when all parts are adjacent", () => {
+                expect(testMatchGrammar(grammar, "item7done")).toStrictEqual([
+                    7,
+                ]);
+            });
+            it("does not match with any spaces", () => {
+                expect(testMatchGrammar(grammar, "item 7 done")).toStrictEqual(
+                    [],
+                );
+                expect(testMatchGrammar(grammar, "item7 done")).toStrictEqual(
+                    [],
+                );
+                expect(testMatchGrammar(grammar, "item 7done")).toStrictEqual(
+                    [],
+                );
+            });
+        });
+
+        describe("spacing=none rejects punctuation separators", () => {
+            const g = `<Start> [spacing=none] = hello world -> true;`;
+            const grammar = loadGrammarRules("test.grammar", g);
+            it("does not match with comma separator", () => {
+                expect(testMatchGrammar(grammar, "hello,world")).toStrictEqual(
+                    [],
+                );
+            });
+            it("does not match with period separator", () => {
+                expect(testMatchGrammar(grammar, "hello.world")).toStrictEqual(
+                    [],
+                );
+            });
+        });
+
+        describe("repeat group ()+ with none mode", () => {
+            const g = `<Start> [spacing=none] = hello (world)+ -> true;`;
+            const grammar = loadGrammarRules("test.grammar", g);
+            it("matches one repetition without space", () => {
+                expect(testMatchGrammar(grammar, "helloworld")).toStrictEqual([
+                    true,
+                ]);
+            });
+            it("matches two repetitions without space", () => {
+                expect(
+                    testMatchGrammar(grammar, "helloworldworld"),
+                ).toStrictEqual([true]);
+            });
+            it("does not match with space before group", () => {
+                expect(testMatchGrammar(grammar, "hello world")).toStrictEqual(
+                    [],
+                );
+            });
+            it("does not match with space between repetitions", () => {
+                expect(
+                    testMatchGrammar(grammar, "helloworld world"),
+                ).toStrictEqual([]);
+            });
+        });
+
+        describe("repeat group ()* with none mode", () => {
+            const g = `<Start> [spacing=none] = hello (world)* -> true;`;
+            const grammar = loadGrammarRules("test.grammar", g);
+            it("matches zero repetitions", () => {
+                expect(testMatchGrammar(grammar, "hello")).toStrictEqual([
+                    true,
+                ]);
+            });
+            it("matches one repetition without space", () => {
+                expect(testMatchGrammar(grammar, "helloworld")).toStrictEqual([
+                    true,
+                ]);
+            });
+            it("does not match with space before group", () => {
+                expect(testMatchGrammar(grammar, "hello world")).toStrictEqual(
+                    [],
+                );
+            });
+        });
+
+        describe("spacing=none: optional part", () => {
+            const g = `<Start> [spacing=none] = hello $(x)? world -> x;`;
+            const grammar = loadGrammarRules("test.grammar", g);
+            it("matches when optional part is absent", () => {
+                expect(testMatchGrammar(grammar, "helloworld")).toStrictEqual([
+                    undefined,
+                ]);
+            });
+            it("matches when optional part is present and adjacent", () => {
+                expect(
+                    testMatchGrammar(grammar, "hellofooworld"),
+                ).toStrictEqual(["foo"]);
+            });
+            it("captures separators in optional wildcard value", () => {
+                expect(
+                    testMatchGrammar(grammar, "hello foo world"),
+                ).toStrictEqual([" foo "]);
+            });
+        });
+
+        describe("spacing=none: optional group expression", () => {
+            const g = `<Start> [spacing=none] = (please)? help -> true;`;
+            const grammar = loadGrammarRules("test.grammar", g);
+            it("matches when optional group is present and adjacent", () => {
+                expect(testMatchGrammar(grammar, "pleasehelp")).toStrictEqual([
+                    true,
+                ]);
+            });
+            it("matches when optional group is absent", () => {
+                expect(testMatchGrammar(grammar, "help")).toStrictEqual([true]);
+            });
+            it("does not match when space separates group and following token", () => {
+                expect(testMatchGrammar(grammar, "please help")).toStrictEqual(
+                    [],
+                );
+            });
+        });
+
+        describe("separator AFTER nested rule with none parent mode", () => {
+            const g = `
+                <Inner> [spacing=none] = hello world -> true;
+                <Start> [spacing=none] = $(x:<Inner>) end -> x;
+            `;
+            const grammar = loadGrammarRules("test.grammar", g);
+            it("matches when all parts are adjacent", () => {
+                expect(
+                    testMatchGrammar(grammar, "helloworldend"),
+                ).toStrictEqual([true]);
+            });
+            it("does not match with space after nested rule", () => {
+                expect(
+                    testMatchGrammar(grammar, "helloworld end"),
+                ).toStrictEqual([]);
+            });
+        });
+
+        describe("merged rules with none mode", () => {
+            const g = `
+                <Start> [spacing=none] = hello world -> "none";
+                <Start> [spacing=required] = hello world -> "required";
+            `;
+            const grammar = loadGrammarRules("test.grammar", g);
+            it("only none matches when adjacent", () => {
+                expect(testMatchGrammar(grammar, "helloworld")).toStrictEqual([
+                    "none",
+                ]);
+            });
+            it("only required matches with space", () => {
+                expect(testMatchGrammar(grammar, "hello world")).toStrictEqual([
+                    "required",
+                ]);
+            });
+        });
+
+        describe("spacing=none: trailing wildcard (end of rule)", () => {
+            const g = `<Start> [spacing=none] = hello $(x) -> x;`;
+            const grammar = loadGrammarRules("test.grammar", g);
+            it("captures trailing text without trimming", () => {
+                expect(testMatchGrammar(grammar, "helloworld")).toStrictEqual([
+                    "world",
+                ]);
+            });
+            it("captures trailing text with spaces as part of value", () => {
+                // In "none" mode wildcards do not trim leading/trailing
+                // separators because there are no flex-space positions to trim
+                // at.  The space before "world" is part of the wildcard value.
+                expect(testMatchGrammar(grammar, "hello world")).toStrictEqual([
+                    " world",
+                ]);
+            });
+            it("does not match when wildcard would be empty", () => {
+                expect(testMatchGrammar(grammar, "hello")).toStrictEqual([]);
+            });
+        });
+
+        describe("spacing=none: empty wildcard rejection", () => {
+            const g = `<Start> [spacing=none] = hello $(x) world -> x;`;
+            const grammar = loadGrammarRules("test.grammar", g);
+            it("rejects when wildcard captures empty string", () => {
+                // "helloworld" means the wildcard between hello and world is empty
+                expect(testMatchGrammar(grammar, "helloworld")).toStrictEqual(
+                    [],
+                );
+            });
+        });
+
+        describe("empty wildcard rejection - spacing=auto (default)", () => {
+            // wildcardTrimRegExp uses .+? so all-whitespace or empty content is rejected
+            const g = `<Start> = hello $(x) world -> x;`;
+            const grammar = loadGrammarRules("test.grammar", g);
+            it("rejects when wildcard is pure whitespace (trims to empty)", () => {
+                expect(
+                    testMatchGrammar(grammar, "hello   world"),
+                ).toStrictEqual([]);
+            });
+            it("matches when wildcard has non-separator content", () => {
+                expect(
+                    testMatchGrammar(grammar, "hello foo world"),
+                ).toStrictEqual(["foo"]);
+            });
+        });
+
+        describe("empty wildcard rejection - spacing=required", () => {
+            const g = `<Start> [spacing=required] = hello $(x) world -> x;`;
+            const grammar = loadGrammarRules("test.grammar", g);
+            it("rejects when wildcard is pure whitespace", () => {
+                expect(
+                    testMatchGrammar(grammar, "hello   world"),
+                ).toStrictEqual([]);
+            });
+            it("matches when wildcard has non-separator content", () => {
+                expect(
+                    testMatchGrammar(grammar, "hello foo world"),
+                ).toStrictEqual(["foo"]);
+            });
+        });
+
+        describe("empty wildcard rejection - spacing=optional", () => {
+            const g = `<Start> [spacing=optional] = hello $(x) world -> x;`;
+            const grammar = loadGrammarRules("test.grammar", g);
+            it("rejects when wildcard is pure whitespace", () => {
+                expect(
+                    testMatchGrammar(grammar, "hello   world"),
+                ).toStrictEqual([]);
+            });
+            it("matches when wildcard has non-separator content", () => {
+                expect(
+                    testMatchGrammar(grammar, "hello foo world"),
+                ).toStrictEqual(["foo"]);
+            });
+        });
+
+        describe("spacing=none: wildcard before number variable", () => {
+            const g = `<Start> [spacing=none] = $(x) $(n:number) -> n;`;
+            const grammar = loadGrammarRules("test.grammar", g);
+            it("matches wildcard followed by number", () => {
+                expect(testMatchGrammar(grammar, "abc42")).toStrictEqual([42]);
+            });
+            it("captures wildcard value correctly", () => {
+                const gVal = `<Start> [spacing=none] = $(x) $(n:number) -> x;`;
+                const grammar2 = loadGrammarRules("test.grammar", gVal);
+                expect(testMatchGrammar(grammar2, "abc42")).toStrictEqual([
+                    "abc",
+                ]);
+            });
+        });
+
+        describe("spacing=none: negative and special number formats", () => {
+            const g = `<Start> [spacing=none] = item $(n:number) done -> n;`;
+            const grammar = loadGrammarRules("test.grammar", g);
+            it("matches negative integer", () => {
+                expect(testMatchGrammar(grammar, "item-42done")).toStrictEqual([
+                    -42,
+                ]);
+            });
+            it("matches hex number", () => {
+                // Use suffix starting with non-hex char to avoid greedy capture
+                // TODO: Review the case item0xFFdone and see if we should make that work.
+                const gHex = `<Start> [spacing=none] = item $(n:number) stop -> n;`;
+                const grammarHex = loadGrammarRules("test.grammar", gHex);
+                expect(
+                    testMatchGrammar(grammarHex, "item0xFFstop"),
+                ).toStrictEqual([0xff]);
+            });
+            it("matches octal number", () => {
+                expect(testMatchGrammar(grammar, "item0o77done")).toStrictEqual(
+                    [0o77],
+                );
+            });
+            it("matches binary number", () => {
+                expect(
+                    testMatchGrammar(grammar, "item0b101done"),
+                ).toStrictEqual([0b101]);
+            });
+            it("matches float number", () => {
+                expect(testMatchGrammar(grammar, "item3.14done")).toStrictEqual(
+                    [3.14],
+                );
+            });
+        });
+
+        describe("spacing=none: rule-level alternatives", () => {
+            const g = `<Start> [spacing=none] = hello world -> 1 | foo bar -> 2;`;
+            const grammar = loadGrammarRules("test.grammar", g);
+            it("matches first alternative when adjacent", () => {
+                expect(testMatchGrammar(grammar, "helloworld")).toStrictEqual([
+                    1,
+                ]);
+            });
+            it("matches second alternative when adjacent", () => {
+                expect(testMatchGrammar(grammar, "foobar")).toStrictEqual([2]);
+            });
+            it("does not match first alternative with space", () => {
+                expect(testMatchGrammar(grammar, "hello world")).toStrictEqual(
+                    [],
+                );
+            });
+            it("does not match second alternative with space", () => {
+                expect(testMatchGrammar(grammar, "foo bar")).toStrictEqual([]);
+            });
+        });
+
+        describe("spacing=none: case insensitivity", () => {
+            const g = `<Start> [spacing=none] = hello world -> true;`;
+            const grammar = loadGrammarRules("test.grammar", g);
+            it("matches mixed case without space", () => {
+                expect(testMatchGrammar(grammar, "HelloWorld")).toStrictEqual([
+                    true,
+                ]);
+            });
+            it("matches all caps without space", () => {
+                expect(testMatchGrammar(grammar, "HELLOWORLD")).toStrictEqual([
+                    true,
+                ]);
+            });
+            it("does not match mixed case with space", () => {
+                expect(testMatchGrammar(grammar, "Hello World")).toStrictEqual(
+                    [],
+                );
+            });
+        });
+
+        describe("spacing=none: leading/trailing whitespace in input", () => {
+            const g = `<Start> [spacing=none] = hello world -> true;`;
+            const grammar = loadGrammarRules("test.grammar", g);
+            it("does not match with leading whitespace", () => {
+                // In none mode, no leading separator is consumed
+                expect(testMatchGrammar(grammar, "  helloworld")).toStrictEqual(
+                    [],
+                );
+            });
+            it("matches with trailing whitespace", () => {
+                expect(testMatchGrammar(grammar, "helloworld  ")).toStrictEqual(
+                    [true],
+                );
+            });
+            it("does not match with both leading and trailing whitespace", () => {
+                expect(
+                    testMatchGrammar(grammar, "  helloworld  "),
+                ).toStrictEqual([]);
+            });
+        });
+
+        describe("spacing=none vs other modes: leading whitespace", () => {
+            // Counter-test: other modes still consume leading whitespace
+            // even though none mode rejects it.
+            it("auto mode accepts leading whitespace", () => {
+                const g = `<Start> = hello world -> true;`;
+                const grammar = loadGrammarRules("test.grammar", g);
+                expect(
+                    testMatchGrammar(grammar, "  hello world"),
+                ).toStrictEqual([true]);
+            });
+            it("required mode accepts leading whitespace", () => {
+                const g = `<Start> [spacing=required] = hello world -> true;`;
+                const grammar = loadGrammarRules("test.grammar", g);
+                expect(
+                    testMatchGrammar(grammar, "  hello world"),
+                ).toStrictEqual([true]);
+            });
+            it("optional mode accepts leading whitespace", () => {
+                const g = `<Start> [spacing=optional] = hello world -> true;`;
+                const grammar = loadGrammarRules("test.grammar", g);
+                expect(testMatchGrammar(grammar, "  helloworld")).toStrictEqual(
+                    [true],
+                );
+            });
+        });
+
+        describe("spacing=none: CJK characters", () => {
+            const g = `<Start> [spacing=none] = 你好 世界 -> true;`;
+            const grammar = loadGrammarRules("test.grammar", g);
+            it("matches when CJK tokens are adjacent", () => {
+                expect(testMatchGrammar(grammar, "你好世界")).toStrictEqual([
+                    true,
+                ]);
+            });
+            it("does not match when CJK tokens have space", () => {
+                expect(testMatchGrammar(grammar, "你好 世界")).toStrictEqual(
+                    [],
+                );
+            });
+        });
+
         describe("spacing=auto annotation - CJK (Han)", () => {
             // In the grammar, whitespace creates a flex-space boundary.
             // With auto mode, Han characters don't need spaces between them.

--- a/ts/packages/actionGrammar/test/grammarRuleParser.spec.ts
+++ b/ts/packages/actionGrammar/test/grammarRuleParser.spec.ts
@@ -944,6 +944,14 @@ describe("Grammar Rule Parser", () => {
             expect(result[0].spacingMode).toBeUndefined();
         });
 
+        it("attaches spacingMode none via annotation", () => {
+            const result = testParamGrammarRules(
+                "test.agr",
+                `<Rule> [spacing=none] = hello;`,
+            );
+            expect(result[0].spacingMode).toBe("none");
+        });
+
         it("rule without annotation has undefined spacingMode", () => {
             const result = testParamGrammarRules("test.agr", `<Rule> = hello;`);
             expect(result[0].spacingMode).toBeUndefined();

--- a/ts/packages/actionGrammar/test/grammarRuleWriter.spec.ts
+++ b/ts/packages/actionGrammar/test/grammarRuleWriter.spec.ts
@@ -119,6 +119,9 @@ import { RuleX } from "grammarB";
     it("with spacing=optional annotation", () => {
         validateRoundTrip(`<test> [spacing=optional] = hello world;`);
     });
+    it("with spacing=none annotation", () => {
+        validateRoundTrip(`<test> [spacing=none] = hello world;`);
+    });
     it("with spacing=auto annotation (normalized away by writer)", () => {
         // "auto" is the default (undefined); the writer omits the annotation
         const result = parseGrammarRules(

--- a/ts/packages/actionGrammar/test/grammarSerialization.spec.ts
+++ b/ts/packages/actionGrammar/test/grammarSerialization.spec.ts
@@ -60,5 +60,16 @@ describe("Grammar Serialization", () => {
             ]);
             expect(testMatchGrammar(reloaded, "helloworld")).toStrictEqual([]);
         });
+
+        it("preserves none mode through grammarToJson/grammarFromJson", () => {
+            const g = `<Start> [spacing=none] = hello world -> true;`;
+            const reloaded = grammarFromJson(
+                grammarToJson(loadGrammarRules("test.grammar", g)),
+            );
+            expect(testMatchGrammar(reloaded, "helloworld")).toStrictEqual([
+                true,
+            ]);
+            expect(testMatchGrammar(reloaded, "hello world")).toStrictEqual([]);
+        });
     });
 });


### PR DESCRIPTION
## Motivation

The existing spacing modes (`required`, `optional`, `auto`) all allow at least some separator characters (whitespace or punctuation) between grammar tokens. However, certain use cases require tokens to be matched with **zero separation** — for example, parsing compound identifiers (`helloWorld`), concatenated codes (`item42done`), or languages/notations where whitespace is semantically significant and must not be silently consumed. Without a `none` mode, grammar authors had no way to express "these tokens must appear directly adjacent with nothing in between."

## Summary

Introduce a new `spacing=none` mode for the action grammar system that requires tokens to be directly adjacent with no separator characters between them. This complements the existing `required`, `optional`, and `auto` modes.

In `none` mode:
- Flex-space positions between tokens match exactly zero characters (tokens must be directly adjacent)
- No leading separator is consumed at the start of a match
- Wildcards retain all captured content without separator trimming
- Escaped spaces (e.g. `\ `) are still treated as literal characters in the segment text

## Parser changes
- Add `"none"` to the `SpacingMode` type and annotation parser
- Update error messages and documentation comments

## Matcher changes
- `matchStringPart`: emit empty separator regex in `none` mode
- `matchVarNumberPart`: use no-leading-separator regex variants
- `isBoundarySatisfied`: treat `none` like `optional` at outer boundaries
- `requiresSeparator`: throw on `none` (caller must short-circuit)
- `getWildcardStr`: skip separator trimming in `none` mode

## Tests
- 50+ new test cases covering string, number, wildcard, rule reference, group expressions, repeat groups, optional parts, escaped spaces, CJK characters, case insensitivity, and leading/trailing whitespace
- Serialization round-trip and writer round-trip tests
- Parser annotation test
