### PR TITLE
Update dependency versions in pnpm-lock.yaml

### DIFF
--- a/ts/pnpm-lock.yaml
+++ b/ts/pnpm-lock.yaml
@@ -358,8 +358,8 @@ importers:
         specifier: ^16.3.1
         version: 16.5.0
       fast-xml-parser:
-        specifier: 5.3.6
-        version: 5.3.6
+        specifier: 5.3.8
+        version: 5.3.8
       interactive-app:
         specifier: workspace:*
         version: link:../../packages/interactiveApp
@@ -9651,8 +9651,8 @@ packages:
     resolution: {integrity: sha512-jE8ugADnYOBsu1uaoayVl1tVKAMNOXyjwvv2U6udEA2ORBhDooJDWoGxTkhd4Qn4yh59JVVt/pKXtjPwx9OguQ==}
     hasBin: true
 
-  fast-xml-parser@5.3.6:
-    resolution: {integrity: sha512-QNI3sAvSvaOiaMl8FYU4trnEzCwiRr8XMWgAHzlrWpTSj+QaCSvOf1h82OEP1s4hiAXhnbXSyFWCf4ldZzZRVA==}
+  fast-xml-parser@5.3.8:
+    resolution: {integrity: sha512-53jIF4N6u/pxvaL1eb/hEZts/cFLWZ92eCfLrNyCI0k38lettCG/Bs40W9pPwoPXyHQlKu2OUbQtiEIZK/J6Vw==}
     hasBin: true
 
   fastest-levenshtein@1.0.16:
@@ -21332,7 +21332,7 @@ snapshots:
     dependencies:
       strnum: 1.1.2
 
-  fast-xml-parser@5.3.6:
+  fast-xml-parser@5.3.8:
     dependencies:
       strnum: 2.1.2
 


### PR DESCRIPTION
## Dependency Version Updates

Bump transitive dependency versions in `pnpm-lock.yaml` to pick up latest patches and minor releases.

### Package Changes

| Package | Old Version | New Version |
|---------|------------|-------------|
| ajv | 6.12.6 | 6.14.0 |
| ajv | 8.17.1 | 8.18.0 |
| basic-ftp | 5.0.5 | 5.2.0 |
| fast-xml-parser | 4.5.3 | 4.5.4 |
| hono | 4.11.8 | 4.12.3 |
| jwa | 1.4.1 | 1.4.2 |
| jws | 3.2.2 | 3.2.3 |
| lodash | 4.17.21 | 4.17.23 |
| lodash-es | 4.17.21 | 4.17.23 |
| minimatch | 3.1.2 | 3.1.5 |
| minimatch | 5.1.6 | 5.1.9 |
| minimatch | 8.0.4 | 8.0.7 |
| minimatch | 9.0.3, 9.0.5 | 9.0.9 |
| minimatch | 10.0.1, 10.1.1, 10.2.2 | 10.2.4 |
| qs | 6.14.0, 6.14.1 | 6.14.2, 6.15.0 |
| rollup | 4.52.5 | 4.59.0 |
| undici | 6.21.3 | 6.23.0 |
| undici | 7.11.0 | 7.22.0 |
