### PR TITLE
NFA: first-token index, DFA compiler/matcher, parity tests, benchmark

### DIFF
--- a/ts/packages/actionGrammar/src/agentGrammarRegistry.ts
+++ b/ts/packages/actionGrammar/src/agentGrammarRegistry.ts
@@ -4,7 +4,12 @@
 import registerDebug from "debug";
 import { Grammar } from "./grammarTypes.js";
 import { NFA } from "./nfa.js";
-import { matchNFA, NFAMatchResult } from "./nfaInterpreter.js";
+import {
+    matchNFAWithIndex,
+    buildFirstTokenIndex,
+    NFAMatchResult,
+    type FirstTokenIndex,
+} from "./nfaInterpreter.js";
 import { compileGrammarToNFA } from "./nfaCompiler.js";
 import { loadGrammarRulesNoThrow } from "./grammarLoader.js";
 import { mergeGrammarRules } from "./grammarMerger.js";
@@ -25,9 +30,11 @@ const debug = registerDebug("typeagent:actionGrammar:registry");
 export class AgentGrammar {
     private grammar: Grammar;
     private nfa: NFA;
+    private firstTokenIndex: FirstTokenIndex;
     private ruleCount: number;
     private readonly baseGrammar: Grammar; // Store original grammar for reset
     private readonly baseNFA: NFA; // Store original NFA for reset
+    private readonly baseFirstTokenIndex: FirstTokenIndex;
 
     constructor(
         public readonly agentId: string,
@@ -36,10 +43,12 @@ export class AgentGrammar {
     ) {
         this.grammar = grammar;
         this.nfa = nfa;
+        this.firstTokenIndex = buildFirstTokenIndex(nfa);
         this.ruleCount = grammar.rules.length;
         // Store deep copy of base grammar for reset capability
         this.baseGrammar = JSON.parse(JSON.stringify(grammar));
         this.baseNFA = nfa; // NFA is immutable, safe to share reference
+        this.baseFirstTokenIndex = this.firstTokenIndex;
     }
 
     /**
@@ -141,6 +150,7 @@ export class AgentGrammar {
             const previousRuleCount = this.ruleCount;
             this.grammar = mergedGrammar;
             this.nfa = newNFA;
+            this.firstTokenIndex = buildFirstTokenIndex(newNFA);
             this.ruleCount = mergedGrammar.rules.length;
 
             // Log the newly added grammar rules for debugging/testing
@@ -178,6 +188,7 @@ export class AgentGrammar {
         );
         this.grammar = JSON.parse(JSON.stringify(this.baseGrammar));
         this.nfa = this.baseNFA;
+        this.firstTokenIndex = this.baseFirstTokenIndex;
         this.ruleCount = this.baseGrammar.rules.length;
     }
 
@@ -185,7 +196,7 @@ export class AgentGrammar {
      * Match tokens against this agent's grammar
      */
     match(tokens: string[]): NFAMatchResult {
-        return matchNFA(this.nfa, tokens);
+        return matchNFAWithIndex(this.nfa, this.firstTokenIndex, tokens);
     }
 
     /**

--- a/ts/packages/actionGrammar/src/dfa.ts
+++ b/ts/packages/actionGrammar/src/dfa.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+import type { NFA } from "./nfa.js";
+
 /**
  * DFA (Deterministic Finite Automaton) types for grammar matching
  *
@@ -108,6 +110,27 @@ export interface DFATransition {
 }
 
 /**
+ * PhraseSet transition that matches a named phrase set at match time
+ *
+ * PhraseSet membership is dynamic (phrases can be added at runtime), so
+ * phrase sets are kept as a special transition type resolved at match time
+ * rather than expanded into token transitions at compile time.
+ */
+export interface DFAPhraseSetTransition {
+    /** Registry key of the phrase set matcher, resolved at match time */
+    matcherName: string;
+
+    /** Destination DFA state ID after the phrase is consumed */
+    to: number;
+
+    /** Slot operations to execute before consuming the phrase */
+    preOps?: DFASlotOperation[] | undefined;
+
+    /** Slot operations to execute after consuming the phrase */
+    postOps?: DFASlotOperation[] | undefined;
+}
+
+/**
  * Wildcard transition that matches any token not matched by specific transitions
  *
  * Slot operations are organized into:
@@ -137,6 +160,10 @@ export interface DFAWildcardTransition {
         slotIndex?: number | undefined;
         /** Which execution contexts this capture applies to */
         contextIndices: number[];
+        /** For property completions: action name from the matched rule (mirrors NFA transition.actionName) */
+        actionName?: string | undefined;
+        /** For property completions: property path in the action (mirrors NFA transition.propertyPath) */
+        propertyPath?: string | undefined;
     }>;
 }
 
@@ -155,6 +182,9 @@ export interface DFAState {
 
     /** Wildcard transition (catch-all for unmatched tokens) */
     wildcardTransition?: DFAWildcardTransition;
+
+    /** PhraseSet transitions resolved at match time */
+    phraseSetTransitions?: DFAPhraseSetTransition[];
 
     /** Whether this state accepts input */
     accepting: boolean;
@@ -205,8 +235,14 @@ export interface DFA {
     /** IDs of accepting states */
     acceptingStates: number[];
 
-    /** Reference to the original NFA (for fallback and debugging) */
-    sourceNFA?: any; // TODO: import NFA type without circular dependency
+    /** Reference to the original NFA — used by matchDFA for thread-based value computation */
+    sourceNFA?: NFA;
+
+    /**
+     * Split candidates for two-pass matching (collected from NFA states).
+     * Sorted longest-first so that longer candidates are tried before shorter ones.
+     */
+    splitCandidates?: string[];
 }
 
 /**
@@ -288,6 +324,35 @@ export class DFABuilder {
             transition.postOps = postOps;
         }
         state.transitions.push(transition);
+    }
+
+    /**
+     * Add a phraseSet transition from one state to another
+     */
+    addPhraseSetTransition(
+        from: number,
+        matcherName: string,
+        to: number,
+        preOps?: DFASlotOperation[],
+        postOps?: DFASlotOperation[],
+    ): void {
+        const state = this.states[from];
+        if (!state) {
+            throw new Error(`State ${from} does not exist`);
+        }
+
+        const pst: DFAPhraseSetTransition = { matcherName, to };
+        if (preOps && preOps.length > 0) {
+            pst.preOps = preOps;
+        }
+        if (postOps && postOps.length > 0) {
+            pst.postOps = postOps;
+        }
+
+        if (!state.phraseSetTransitions) {
+            state.phraseSetTransitions = [];
+        }
+        state.phraseSetTransitions.push(pst);
     }
 
     /**
@@ -424,6 +489,7 @@ export class DFABuilder {
         startState: number,
         acceptingStates: Set<number>,
         name?: string,
+        splitCandidates?: string[],
     ): DFA {
         const dfa: DFA = {
             states: this.states,
@@ -432,6 +498,9 @@ export class DFABuilder {
         };
         if (name !== undefined) {
             dfa.name = name;
+        }
+        if (splitCandidates && splitCandidates.length > 0) {
+            dfa.splitCandidates = splitCandidates;
         }
         return dfa;
     }

--- a/ts/packages/actionGrammar/src/dfaCompiler.ts
+++ b/ts/packages/actionGrammar/src/dfaCompiler.ts
@@ -7,24 +7,35 @@ import {
     DFABuilder,
     DFAExecutionContext,
     DFAWildcardTransition,
-    DFASlotOperation,
 } from "./dfa.js";
 
 /**
- * Compile an NFA to a DFA using subset construction
+ * Compile an NFA to a DFA using subset construction.
  *
- * This preserves:
- * - Priority information for rule ranking
- * - Variable bindings for captures
- * - Completion support for prefix matching
+ * The DFA structure is used for two purposes:
+ *   1. getDFACompletions — deterministic prefix traversal + completion metadata
+ *   2. matchDFA — delegates value computation to matchNFA(dfa.sourceNFA, tokens)
  *
- * The DFA is deterministic but tracks multiple execution contexts
- * to maintain information from all possible NFA paths.
+ * Because value computation is handled by the NFA interpreter at match time,
+ * slot operations (preOps/postOps/consumeOp/actionValue) are NOT computed here.
+ * The compiler records only what is needed for state traversal and completions:
+ *   - transitions: token → targetState, wildcardTransition, phraseSetTransitions
+ *   - captureInfo on wildcardTransitions: variable/typeName/checked/actionName/propertyPath
+ *   - context.ruleIndex: for grouping completions by grammar rule
+ *   - state.accepting: for prefix-complete detection
  */
 export function compileNFAToDFA(nfa: NFA, name?: string): DFA {
     const builder = new DFABuilder();
 
-    // Start with epsilon closure of NFA start state
+    // Collect split candidates from NFA states (sorted longest-first)
+    const allSplitCandidates = new Set<string>();
+    for (const state of nfa.states) {
+        if (state.splitCandidates) {
+            for (const c of state.splitCandidates) allSplitCandidates.add(c);
+        }
+    }
+
+    // Bootstrap: epsilon closure from the NFA start state
     const initialContext: DFAExecutionContext = {
         nfaStateIds: new Set([nfa.startState]),
         priority: {
@@ -32,258 +43,139 @@ export function compileNFAToDFA(nfa: NFA, name?: string): DFA {
             checkedWildcardCount: 0,
             uncheckedWildcardCount: 0,
         },
-        ruleIndex: undefined,
-        slotOps: [],
     };
 
     const initialContexts = epsilonClosure(nfa, [initialContext]);
     const startState = builder.createState(initialContexts);
 
-    // Work queue for DFA states to process
     const worklist: number[] = [startState];
     const processed = new Set<number>();
     const acceptingStates = new Set<number>();
-
-    // NFA accepting states set for priority computation
     const nfaAcceptingStates = new Set(nfa.acceptingStates);
 
     while (worklist.length > 0) {
         const dfaStateId = worklist.shift()!;
-
-        if (processed.has(dfaStateId)) {
-            continue;
-        }
+        if (processed.has(dfaStateId)) continue;
         processed.add(dfaStateId);
 
         const dfaState = builder.getState(dfaStateId);
         if (!dfaState) continue;
 
-        // Check if this is an accepting state
-        let isAccepting = false;
+        // Mark accepting if any NFA state in any context is accepting
         for (const ctx of dfaState.contexts) {
             for (const nfaStateId of ctx.nfaStateIds) {
                 if (nfaAcceptingStates.has(nfaStateId)) {
-                    isAccepting = true;
+                    acceptingStates.add(dfaStateId);
+                    builder.markAccepting(dfaStateId, nfaAcceptingStates);
                     break;
                 }
             }
-            if (isAccepting) break;
+            if (acceptingStates.has(dfaStateId)) break;
         }
 
-        if (isAccepting) {
-            acceptingStates.add(dfaStateId);
-            builder.markAccepting(dfaStateId, nfaAcceptingStates);
-
-            // Now get the action value from the BEST PRIORITY context
-            const markedState = builder.getState(dfaStateId);
-            const bestPriorityCtx = markedState?.bestPriority;
-            let bestContext: DFAExecutionContext | undefined;
-            let bestNfaAcceptState: number | undefined;
-
-            if (bestPriorityCtx !== undefined) {
-                bestContext = dfaState.contexts[bestPriorityCtx.contextIndex];
-                // Find the accepting NFA state in this context
-                if (bestContext) {
-                    for (const nfaStateId of bestContext.nfaStateIds) {
-                        if (nfaAcceptingStates.has(nfaStateId)) {
-                            bestNfaAcceptState = nfaStateId;
-                            break;
-                        }
-                    }
-                }
-            }
-
-            // Get action value from the best context's NFA state or its rule index
-            let actionValue: any = undefined;
-            let slotCount: number | undefined;
-            let debugSlotMap: Map<string, number> | undefined;
-
-            if (bestNfaAcceptState !== undefined) {
-                const nfaState = nfa.states[bestNfaAcceptState];
-                actionValue = nfaState?.actionValue;
-                slotCount = nfaState?.slotCount;
-                debugSlotMap = nfaState?.slotMap;
-            }
-
-            // If no direct actionValue, try getting from rule index
-            if (
-                actionValue === undefined &&
-                bestContext?.ruleIndex !== undefined
-            ) {
-                actionValue = nfa.actionValues?.[bestContext.ruleIndex];
-            }
-
-            // Fallback to debugSlotMap from context if not on NFA state
-            if (!debugSlotMap && bestContext?.debugSlotMap) {
-                debugSlotMap = bestContext.debugSlotMap;
-            }
-
-            builder.setAcceptingStateInfo(
-                dfaStateId,
-                actionValue,
-                slotCount,
-                debugSlotMap,
-            );
-        }
-
-        // Compute transitions from this DFA state
+        // Compute and wire up transitions
         const transitions = computeTransitions(nfa, dfaState.contexts);
 
-        // Add token transitions with slot operations
-        for (const [token, transInfo] of transitions.tokenTransitions) {
-            const targetStateId = builder.createState(transInfo.targetContexts);
-            builder.addTransition(
-                dfaStateId,
-                token,
-                targetStateId,
-                transInfo.preOps.length > 0 ? transInfo.preOps : undefined,
-                transInfo.postOps.length > 0 ? transInfo.postOps : undefined,
-            );
-
-            if (!processed.has(targetStateId)) {
-                worklist.push(targetStateId);
-            }
+        for (const [token, info] of transitions.tokenTransitions) {
+            const targetStateId = builder.createState(info.targetContexts);
+            builder.addTransition(dfaStateId, token, targetStateId);
+            if (!processed.has(targetStateId)) worklist.push(targetStateId);
         }
 
-        // Add wildcard transition if present
         if (transitions.wildcardTransition) {
-            const { targetContexts, captureInfo, preOps, consumeOp, postOps } =
+            const { targetContexts, captureInfo } =
                 transitions.wildcardTransition;
             const targetStateId = builder.createState(targetContexts);
             builder.addWildcardTransition(
                 dfaStateId,
                 targetStateId,
                 captureInfo,
-                preOps.length > 0 ? preOps : undefined,
-                consumeOp,
-                postOps.length > 0 ? postOps : undefined,
             );
+            if (!processed.has(targetStateId)) worklist.push(targetStateId);
+        }
 
-            if (!processed.has(targetStateId)) {
-                worklist.push(targetStateId);
-            }
+        for (const pst of transitions.phraseSetTransitions ?? []) {
+            const targetStateId = builder.createState(pst.targetContexts);
+            builder.addPhraseSetTransition(
+                dfaStateId,
+                pst.matcherName,
+                targetStateId,
+            );
+            if (!processed.has(targetStateId)) worklist.push(targetStateId);
         }
     }
 
-    return builder.build(startState, acceptingStates, name);
+    const splitCandidates =
+        allSplitCandidates.size > 0
+            ? Array.from(allSplitCandidates).sort((a, b) => b.length - a.length)
+            : undefined;
+
+    const dfa = builder.build(
+        startState,
+        acceptingStates,
+        name,
+        splitCandidates,
+    );
+    // Store NFA reference so matchDFA can use thread-based value computation
+    dfa.sourceNFA = nfa;
+    return dfa;
 }
 
 /**
- * Compute epsilon closure of a set of execution contexts
+ * Compute the epsilon closure of a set of execution contexts.
  *
- * Follows epsilon transitions to find all reachable NFA states
- * without consuming input.
- *
- * Tracks slot operations encountered during closure:
- * - pushEnv: When entering a state with slotCount (nested rule entry)
- * - evalAndWriteToParent: When following an epsilon with writeToParent (nested rule exit)
+ * Follows epsilon transitions to find all reachable NFA states without
+ * consuming input.  Only ruleIndex is propagated — slot operations and
+ * priority counters are not tracked because matchDFA delegates value
+ * computation to matchNFA.
  */
 function epsilonClosure(
     nfa: NFA,
     contexts: DFAExecutionContext[],
 ): DFAExecutionContext[] {
     const result: DFAExecutionContext[] = [];
-    const visited = new Map<string, DFAExecutionContext>(); // key -> context
+    // Key: sorted NFA state IDs + ruleIndex (to keep distinct rules separate for completion grouping)
+    const visited = new Set<string>();
 
     const queue = [...contexts];
-
     while (queue.length > 0) {
         const ctx = queue.shift()!;
 
-        // Create key for this context based on NFA states, priority, and slot ops count
-        // Include slot ops length to distinguish contexts with different accumulated operations
-        const slotOpsKey = ctx.slotOps ? ctx.slotOps.length : 0;
-        const key = `${Array.from(ctx.nfaStateIds).sort().join(",")}-${ctx.priority.fixedStringPartCount}-${ctx.priority.checkedWildcardCount}-${ctx.priority.uncheckedWildcardCount}-${slotOpsKey}`;
-
-        if (visited.has(key)) {
-            continue;
-        }
-        visited.set(key, ctx);
+        const key = `${Array.from(ctx.nfaStateIds).sort().join(",")}-${ctx.ruleIndex ?? ""}`;
+        if (visited.has(key)) continue;
+        visited.add(key);
         result.push(ctx);
 
-        // Follow epsilon transitions from all NFA states in this context
         for (const nfaStateId of ctx.nfaStateIds) {
             const nfaState = nfa.states[nfaStateId];
             if (!nfaState) continue;
 
-            // Pick up rule index from this state if present
+            // Propagate rule index from the NFA state if not already set
             const ruleIndex =
                 ctx.ruleIndex !== undefined
                     ? ctx.ruleIndex
                     : nfaState.ruleIndex;
 
-            // Check if this state has slot info (rule entry point)
-            // and add pushEnv operation if we don't already have one for this state
-            let newSlotOps = ctx.slotOps ? [...ctx.slotOps] : [];
-            if (nfaState.slotCount !== undefined && nfaState.slotCount > 0) {
-                // Check if we've already pushed env for this rule
-                const alreadyPushed = newSlotOps.some(
-                    (op) =>
-                        op.type === "pushEnv" &&
-                        op.slotCount === nfaState.slotCount,
-                );
-                if (!alreadyPushed) {
-                    const pushOp: DFASlotOperation = {
-                        type: "pushEnv",
-                        slotCount: nfaState.slotCount,
-                    };
-                    if (nfaState.parentSlotIndex !== undefined) {
-                        pushOp.parentSlotIndex = nfaState.parentSlotIndex;
-                    }
-                    newSlotOps.push(pushOp);
-                }
-            }
-
-            // Pick up debug slot map
-            let debugSlotMap = ctx.debugSlotMap;
-            if (nfaState.slotMap) {
-                debugSlotMap = new Map(nfaState.slotMap);
-            }
-
             for (const trans of nfaState.transitions) {
-                if (trans.type === "epsilon") {
-                    // Get target state to check for rule index
-                    const targetState = nfa.states[trans.to];
+                if (trans.type !== "epsilon") continue;
 
-                    // Clone slot ops for this path
-                    let pathSlotOps = [...newSlotOps];
+                const targetState = nfa.states[trans.to];
+                const newContext: DFAExecutionContext = {
+                    nfaStateIds: new Set([trans.to]),
+                    priority: {
+                        fixedStringPartCount: 0,
+                        checkedWildcardCount: 0,
+                        uncheckedWildcardCount: 0,
+                    },
+                };
 
-                    // Check for writeToParent on this epsilon transition (nested rule exit)
-                    if (
-                        trans.writeToParent &&
-                        trans.valueToWrite !== undefined
-                    ) {
-                        pathSlotOps.push({
-                            type: "evalAndWriteToParent",
-                            valueExpr: trans.valueToWrite,
-                        });
-                        // After writing to parent, pop the environment
-                        pathSlotOps.push({
-                            type: "popEnv",
-                        });
-                    }
-
-                    // Create new context with epsilon transition target
-                    const newContext: DFAExecutionContext = {
-                        nfaStateIds: new Set([trans.to]),
-                        priority: { ...ctx.priority },
-                        slotOps: pathSlotOps,
-                    };
-
-                    // Propagate debug slot map
-                    if (debugSlotMap) {
-                        newContext.debugSlotMap = debugSlotMap;
-                    }
-
-                    // Propagate or pick up rule index
-                    if (ruleIndex !== undefined) {
-                        newContext.ruleIndex = ruleIndex;
-                    } else if (targetState?.ruleIndex !== undefined) {
-                        newContext.ruleIndex = targetState.ruleIndex;
-                    }
-
-                    queue.push(newContext);
+                if (ruleIndex !== undefined) {
+                    newContext.ruleIndex = ruleIndex;
+                } else if (targetState?.ruleIndex !== undefined) {
+                    newContext.ruleIndex = targetState.ruleIndex;
                 }
+
+                queue.push(newContext);
             }
         }
     }
@@ -292,347 +184,174 @@ function epsilonClosure(
 }
 
 /**
- * Result of computing transitions from a DFA state
+ * Transition result — no slot operations, just state routing and completion metadata.
  */
 interface TransitionResult {
-    /** Token-specific transitions with slot operations */
-    tokenTransitions: Map<
-        string,
-        {
-            targetContexts: DFAExecutionContext[];
-            preOps: DFASlotOperation[];
-            postOps: DFASlotOperation[];
-        }
-    >;
+    tokenTransitions: Map<string, { targetContexts: DFAExecutionContext[] }>;
 
-    /** Wildcard transition (if any) */
     wildcardTransition?: {
         targetContexts: DFAExecutionContext[];
+        /** Completion metadata: variable name, type, checked flag, property path */
         captureInfo: DFAWildcardTransition["captureInfo"];
-        preOps: DFASlotOperation[];
-        consumeOp?: DFASlotOperation;
-        postOps: DFASlotOperation[];
     };
+
+    phraseSetTransitions?: Array<{
+        matcherName: string;
+        targetContexts: DFAExecutionContext[];
+    }>;
 }
 
 /**
- * Compute all transitions from a set of execution contexts
+ * Compute all outgoing transitions from a DFA state's execution contexts.
  *
- * Groups NFA transitions by token and computes target contexts.
- * Tracks slot operations:
- * - preOps: From context.slotOps (accumulated during epsilon closure before this point)
- * - consumeOp: For wildcard transitions, the slot write operation
- * - postOps: From epsilon closure after consuming the token
+ * Groups NFA transitions by token/wildcard/phraseSet.  No slot operations
+ * are computed — the DFA is used for state traversal and completions only.
  */
 function computeTransitions(
     nfa: NFA,
     contexts: DFAExecutionContext[],
 ): TransitionResult {
-    // Map token -> { contexts, preOps from source contexts }
-    const tokenTransitionsRaw = new Map<
-        string,
-        {
-            targetContexts: DFAExecutionContext[];
-            preOps: DFASlotOperation[];
-        }
-    >();
+    // token → raw target contexts (before epsilon closure)
+    const tokenTargetsRaw = new Map<string, DFAExecutionContext[]>();
 
-    const wildcardContexts: Array<{
+    // wildcard sources
+    const wildcardSources: Array<{
         context: DFAExecutionContext;
         transition: NFATransition;
-        preOps: DFASlotOperation[];
     }> = [];
 
-    // Process each execution context
-    for (let ctxIndex = 0; ctxIndex < contexts.length; ctxIndex++) {
-        const ctx = contexts[ctxIndex];
-        // Collect preOps from this context's accumulated slot operations
-        const ctxPreOps = ctx.slotOps ? [...ctx.slotOps] : [];
+    // phraseSet matcherName → raw target contexts
+    const phraseSetTargetsRaw = new Map<string, DFAExecutionContext[]>();
 
-        // Process each NFA state in this context
+    for (const ctx of contexts) {
         for (const nfaStateId of ctx.nfaStateIds) {
             const nfaState = nfa.states[nfaStateId];
             if (!nfaState) continue;
 
-            // Process each transition from this NFA state
             for (const trans of nfaState.transitions) {
                 if (trans.type === "token" && trans.tokens) {
-                    // Token transition - add to token map
                     for (const token of trans.tokens) {
-                        if (!tokenTransitionsRaw.has(token)) {
-                            tokenTransitionsRaw.set(token, {
-                                targetContexts: [],
-                                preOps: [],
-                            });
+                        if (!tokenTargetsRaw.has(token)) {
+                            tokenTargetsRaw.set(token, []);
                         }
-
-                        const entry = tokenTransitionsRaw.get(token)!;
-
-                        // Create new context after consuming this token
-                        const newContext: DFAExecutionContext = {
+                        const newCtx: DFAExecutionContext = {
                             nfaStateIds: new Set([trans.to]),
                             priority: {
-                                ...ctx.priority,
-                                fixedStringPartCount:
-                                    ctx.priority.fixedStringPartCount + 1,
+                                fixedStringPartCount: 0,
+                                checkedWildcardCount: 0,
+                                uncheckedWildcardCount: 0,
                             },
-                            slotOps: [], // Reset slot ops for post-consume epsilon closure
                         };
-
-                        // Propagate rule index
                         if (ctx.ruleIndex !== undefined) {
-                            newContext.ruleIndex = ctx.ruleIndex;
+                            newCtx.ruleIndex = ctx.ruleIndex;
                         }
-
-                        // Propagate debug slot map
-                        if (ctx.debugSlotMap) {
-                            newContext.debugSlotMap = ctx.debugSlotMap;
-                        }
-
-                        entry.targetContexts.push(newContext);
-
-                        // Merge preOps (deduplicate if same ops already present)
-                        for (const op of ctxPreOps) {
-                            if (
-                                !entry.preOps.some((existing) =>
-                                    slotOpsEqual(existing, op),
-                                )
-                            ) {
-                                entry.preOps.push(op);
-                            }
-                        }
+                        tokenTargetsRaw.get(token)!.push(newCtx);
                     }
                 } else if (trans.type === "wildcard") {
-                    // Wildcard transition - collect for later processing
-                    wildcardContexts.push({
-                        context: ctx,
-                        transition: trans,
-                        preOps: ctxPreOps,
-                    });
+                    wildcardSources.push({ context: ctx, transition: trans });
+                } else if (trans.type === "phraseSet" && trans.matcherName) {
+                    const mn = trans.matcherName;
+                    if (!phraseSetTargetsRaw.has(mn)) {
+                        phraseSetTargetsRaw.set(mn, []);
+                    }
+                    const newCtx: DFAExecutionContext = {
+                        nfaStateIds: new Set([trans.to]),
+                        priority: {
+                            fixedStringPartCount: 0,
+                            checkedWildcardCount: 0,
+                            uncheckedWildcardCount: 0,
+                        },
+                    };
+                    if (ctx.ruleIndex !== undefined) {
+                        newCtx.ruleIndex = ctx.ruleIndex;
+                    }
+                    phraseSetTargetsRaw.get(mn)!.push(newCtx);
                 }
             }
         }
     }
 
-    // Apply epsilon closure to all token transitions and extract postOps
+    // Token transitions — apply epsilon closure
     const tokenTransitions = new Map<
         string,
-        {
-            targetContexts: DFAExecutionContext[];
-            preOps: DFASlotOperation[];
-            postOps: DFASlotOperation[];
-        }
+        { targetContexts: DFAExecutionContext[] }
     >();
-
-    for (const [token, entry] of tokenTransitionsRaw) {
-        const closedContexts = epsilonClosure(nfa, entry.targetContexts);
-
-        // Collect postOps from the epsilon closure results
-        const postOps: DFASlotOperation[] = [];
-        for (const ctx of closedContexts) {
-            if (ctx.slotOps) {
-                for (const op of ctx.slotOps) {
-                    if (
-                        !postOps.some((existing) => slotOpsEqual(existing, op))
-                    ) {
-                        postOps.push(op);
-                    }
-                }
-            }
-        }
-
+    for (const [token, rawCtxs] of tokenTargetsRaw) {
         tokenTransitions.set(token, {
-            targetContexts: closedContexts,
-            preOps: entry.preOps,
-            postOps,
+            targetContexts: epsilonClosure(nfa, rawCtxs),
         });
     }
 
-    // Process wildcard transitions
+    // Wildcard transition — merge all sources into one, build captureInfo
     let wildcardTransition: TransitionResult["wildcardTransition"];
-    if (wildcardContexts.length > 0) {
-        const targetContexts: DFAExecutionContext[] = [];
-        // Track which wildcard transition created each context (before epsilon closure)
-        const contextSources: Array<{
-            variable: string;
-            typeName: string | undefined;
-            checked: boolean;
-            slotIndex: number | undefined;
-            appendToSlot: boolean | undefined;
-        }> = [];
+    if (wildcardSources.length > 0) {
+        const rawTargets: DFAExecutionContext[] = [];
+        // Keyed by "variable:typeName" to deduplicate capture entries
+        const captureMap = new Map<
+            string,
+            DFAWildcardTransition["captureInfo"][number]
+        >();
 
-        // Collect all preOps from wildcard source contexts
-        const allPreOps: DFASlotOperation[] = [];
-
-        // Determine the consumeOp (slot write for the wildcard)
-        let consumeOp: DFASlotOperation | undefined;
-
-        for (const { context, transition, preOps } of wildcardContexts) {
-            // Determine if this wildcard is checked
+        for (const { context, transition } of wildcardSources) {
             const isChecked =
                 transition.checked === true ||
                 !!(transition.typeName && transition.typeName !== "string");
 
-            // Create new context after consuming wildcard
-            const newContext: DFAExecutionContext = {
+            const newCtx: DFAExecutionContext = {
                 nfaStateIds: new Set([transition.to]),
                 priority: {
-                    fixedStringPartCount: context.priority.fixedStringPartCount,
-                    checkedWildcardCount: isChecked
-                        ? context.priority.checkedWildcardCount + 1
-                        : context.priority.checkedWildcardCount,
-                    uncheckedWildcardCount: isChecked
-                        ? context.priority.uncheckedWildcardCount
-                        : context.priority.uncheckedWildcardCount + 1,
+                    fixedStringPartCount: 0,
+                    checkedWildcardCount: 0,
+                    uncheckedWildcardCount: 0,
                 },
-                slotOps: [], // Reset for post-consume epsilon closure
             };
-
-            // Propagate rule index
             if (context.ruleIndex !== undefined) {
-                newContext.ruleIndex = context.ruleIndex;
+                newCtx.ruleIndex = context.ruleIndex;
             }
+            rawTargets.push(newCtx);
 
-            // Propagate debug slot map
-            if (context.debugSlotMap) {
-                newContext.debugSlotMap = context.debugSlotMap;
-            }
-
-            targetContexts.push(newContext);
-
-            // Track what variable this context should capture
-            contextSources.push({
-                variable: transition.variable || "",
-                typeName: transition.typeName,
-                checked: isChecked,
-                slotIndex: transition.slotIndex,
-                appendToSlot: transition.appendToSlot,
-            });
-
-            // Merge preOps
-            for (const op of preOps) {
-                if (!allPreOps.some((existing) => slotOpsEqual(existing, op))) {
-                    allPreOps.push(op);
-                }
-            }
-
-            // Build consumeOp from the wildcard transition
-            if (transition.slotIndex !== undefined && !consumeOp) {
-                consumeOp = {
-                    type: "writeSlot",
-                    slotIndex: transition.slotIndex,
-                    append: transition.appendToSlot,
-                    debugVariable: transition.variable,
+            // Build captureInfo entry (variable/typeName/checked + property path for completions)
+            const captureKey = `${transition.variable ?? ""}:${transition.typeName ?? "string"}`;
+            if (!captureMap.has(captureKey)) {
+                const entry: DFAWildcardTransition["captureInfo"][number] = {
+                    variable: transition.variable ?? "",
+                    checked: isChecked,
+                    contextIndices: [], // unused — kept for type compatibility
                 };
+                if (transition.typeName !== undefined) {
+                    entry.typeName = transition.typeName;
+                }
+                if (transition.actionName !== undefined) {
+                    entry.actionName = transition.actionName;
+                }
+                if (transition.propertyPath !== undefined) {
+                    entry.propertyPath = transition.propertyPath;
+                }
+                captureMap.set(captureKey, entry);
             }
         }
 
-        // Apply epsilon closure to get final target contexts
-        const finalTargetContexts = epsilonClosure(nfa, targetContexts);
-
-        // Collect postOps from epsilon closure results
-        const allPostOps: DFASlotOperation[] = [];
-        for (const ctx of finalTargetContexts) {
-            if (ctx.slotOps) {
-                for (const op of ctx.slotOps) {
-                    if (
-                        !allPostOps.some((existing) =>
-                            slotOpsEqual(existing, op),
-                        )
-                    ) {
-                        allPostOps.push(op);
-                    }
-                }
-            }
-        }
-
-        // Build captureInfo for completions/debugging
-        // Track by slotIndex now instead of matching captures map
-        const captureInfoMap = new Map<
-            string,
-            {
-                variable: string;
-                typeName?: string;
-                checked: boolean;
-                slotIndex?: number;
-                contextIndices: number[];
-            }
-        >();
-
-        for (
-            let finalIndex = 0;
-            finalIndex < finalTargetContexts.length;
-            finalIndex++
-        ) {
-            // Match by index since we maintain order through epsilon closure
-            const sourceIndex = finalIndex % contextSources.length;
-            const source = contextSources[sourceIndex];
-            if (!source.variable) continue;
-
-            // Create unique key for variable+typeName combination
-            const captureKey = `${source.variable}:${source.typeName || "string"}`;
-
-            if (!captureInfoMap.has(captureKey)) {
-                const info: {
-                    variable: string;
-                    typeName?: string;
-                    checked: boolean;
-                    slotIndex?: number;
-                    contextIndices: number[];
-                } = {
-                    variable: source.variable,
-                    checked: source.checked,
-                    contextIndices: [],
-                };
-                if (source.typeName !== undefined) {
-                    info.typeName = source.typeName;
-                }
-                if (source.slotIndex !== undefined) {
-                    info.slotIndex = source.slotIndex;
-                }
-                captureInfoMap.set(captureKey, info);
-            }
-            const info = captureInfoMap.get(captureKey)!;
-            // Only add this index if not already present
-            if (!info.contextIndices.includes(finalIndex)) {
-                info.contextIndices.push(finalIndex);
-            }
-        }
-
-        const captureInfo = Array.from(captureInfoMap.values());
-
-        // Build the wildcard transition object, only including consumeOp if defined
-        const wildcardTransitionData: TransitionResult["wildcardTransition"] = {
-            targetContexts: finalTargetContexts,
-            captureInfo,
-            preOps: allPreOps,
-            postOps: allPostOps,
+        wildcardTransition = {
+            targetContexts: epsilonClosure(nfa, rawTargets),
+            captureInfo: Array.from(captureMap.values()),
         };
-        if (consumeOp !== undefined) {
-            wildcardTransitionData!.consumeOp = consumeOp;
-        }
-        wildcardTransition = wildcardTransitionData;
     }
 
-    const result: TransitionResult = {
-        tokenTransitions,
-    };
+    // PhraseSet transitions — apply epsilon closure
+    const phraseSetTransitions: TransitionResult["phraseSetTransitions"] = [];
+    for (const [matcherName, rawCtxs] of phraseSetTargetsRaw) {
+        phraseSetTransitions.push({
+            matcherName,
+            targetContexts: epsilonClosure(nfa, rawCtxs),
+        });
+    }
+
+    const result: TransitionResult = { tokenTransitions };
     if (wildcardTransition !== undefined) {
         result.wildcardTransition = wildcardTransition;
     }
+    if (phraseSetTransitions.length > 0) {
+        result.phraseSetTransitions = phraseSetTransitions;
+    }
     return result;
-}
-
-/**
- * Check if two slot operations are equal (for deduplication)
- */
-function slotOpsEqual(a: DFASlotOperation, b: DFASlotOperation): boolean {
-    if (a.type !== b.type) return false;
-    if (a.slotCount !== b.slotCount) return false;
-    if (a.parentSlotIndex !== b.parentSlotIndex) return false;
-    if (a.slotIndex !== b.slotIndex) return false;
-    if (a.append !== b.append) return false;
-    // For valueExpr, do a simple reference equality (deep equality would be expensive)
-    if (a.valueExpr !== b.valueExpr) return false;
-    return true;
 }

--- a/ts/packages/actionGrammar/src/dfaMatcher.ts
+++ b/ts/packages/actionGrammar/src/dfaMatcher.ts
@@ -2,6 +2,12 @@
 // Licensed under the MIT License.
 
 import { DFA, DFASlotOperation, DFATransition } from "./dfa.js";
+import { globalEntityRegistry } from "./entityRegistry.js";
+import { globalPhraseSetRegistry } from "./builtInPhraseMatchers.js";
+import { normalizeToken } from "./nfaMatcher.js";
+import { applySplitToTokens } from "./tokenSplit.js";
+import { matchNFA } from "./nfaInterpreter.js";
+import type { NFAMatchResult } from "./nfaInterpreter.js";
 
 /**
  * Environment for slot-based variable storage
@@ -11,6 +17,8 @@ interface DFAEnvironment {
     slots: (string | number | undefined)[];
     parent?: DFAEnvironment | undefined;
     parentSlotIndex?: number | undefined;
+    /** Debug: slot map saved at pushEnv time for restoration at popEnv (debug only) */
+    parentDebugSlotMap?: Map<string, number> | undefined;
 }
 
 /**
@@ -162,13 +170,17 @@ function evaluateActionValue(env: DFAEnvironment, valueExpr: any): any {
 }
 
 /**
- * Apply slot operations to the environment stack
- * Returns the updated current environment
+ * Apply slot operations to the environment stack.
+ * @param ops         Slot operations to execute
+ * @param envStack    Mutable stack of environments (mutated in place)
+ * @param consumedValue The token/value just consumed (for writeSlot ops)
+ * @param debugSlotMapRef Mutable ref-box for the active debug slot map (for pushEnv/popEnv)
  */
 function applySlotOps(
     ops: DFASlotOperation[] | undefined,
     envStack: DFAEnvironment[],
     consumedValue?: string | number,
+    debugSlotMapRef?: { value: Map<string, number> | undefined },
 ): void {
     if (!ops || ops.length === 0) return;
 
@@ -184,6 +196,10 @@ function applySlotOps(
                     currentEnv,
                     op.parentSlotIndex,
                 );
+                // Save parent debug slot map for restoration at popEnv
+                if (debugSlotMapRef) {
+                    newEnv.parentDebugSlotMap = debugSlotMapRef.value;
+                }
                 envStack.push(newEnv);
                 break;
             }
@@ -213,7 +229,11 @@ function applySlotOps(
 
             case "popEnv": {
                 if (envStack.length > 1) {
-                    envStack.pop();
+                    const popped = envStack.pop()!;
+                    // Restore parent debug slot map (debug only)
+                    if (debugSlotMapRef) {
+                        debugSlotMapRef.value = popped.parentDebugSlotMap;
+                    }
                 }
                 break;
             }
@@ -222,32 +242,224 @@ function applySlotOps(
 }
 
 /**
+ * Adapt an NFAMatchResult to the DFAMatchResult interface.
+ * Used when matchDFA delegates value computation to the NFA interpreter.
+ */
+function adaptNFAResult(
+    nfaResult: NFAMatchResult,
+    tokensLength: number,
+): DFAMatchResult {
+    if (!nfaResult.matched) {
+        return {
+            matched: false,
+            fixedStringPartCount: 0,
+            checkedWildcardCount: 0,
+            uncheckedWildcardCount: 0,
+            tokensConsumed: nfaResult.tokensConsumed ?? tokensLength,
+        };
+    }
+    const result: DFAMatchResult = {
+        matched: true,
+        actionValue: nfaResult.actionValue,
+        fixedStringPartCount: nfaResult.fixedStringPartCount,
+        checkedWildcardCount: nfaResult.checkedWildcardCount,
+        uncheckedWildcardCount: nfaResult.uncheckedWildcardCount,
+        tokensConsumed: nfaResult.tokensConsumed ?? tokensLength,
+    };
+    if (nfaResult.ruleIndex !== undefined) {
+        result.ruleIndex = nfaResult.ruleIndex;
+    }
+    if (nfaResult.visitedStates) {
+        result.visitedStates = nfaResult.visitedStates;
+    }
+    if (nfaResult.debugSlotMap) {
+        result.debugSlotMap = nfaResult.debugSlotMap;
+    }
+    return result;
+}
+
+/** Maximum number of extra tokens to try when validating a multi-token entity */
+const MAX_ENTITY_LOOKAHEAD = 4;
+
+/**
+ * Try to match a checked entity wildcard spanning more than one token.
+ * Returns the captured value and the total span length (>= 2), or undefined
+ * if no multi-token span validates.
+ */
+function tryMultiTokenSpan(
+    tokens: string[],
+    startIndex: number,
+    typeName: string,
+): { value: string | object; spanLen: number } | undefined {
+    const validator = globalEntityRegistry.getValidator(typeName);
+    if (!validator) return undefined;
+
+    const maxLen = Math.min(
+        MAX_ENTITY_LOOKAHEAD + 1,
+        tokens.length - startIndex,
+    );
+
+    // Try longest spans first (maximal munch)
+    for (let len = maxLen; len >= 2; len--) {
+        const span = tokens.slice(startIndex, startIndex + len).join(" ");
+        if (!validator.validate(span)) continue;
+
+        // Try to convert the span
+        const converter = globalEntityRegistry.getConverter(typeName);
+        if (converter) {
+            const converted = converter.convert(span);
+            if (converted === undefined) continue;
+            return { value: converted as string | object, spanLen: len };
+        }
+        return { value: span, spanLen: len };
+    }
+    return undefined;
+}
+
+/**
+ * O(tokens) DFA accept/reject decision — no value computation.
+ *
+ * Walks the precomputed DFA state machine:
+ *   - specific token match  → follow token transition
+ *   - phraseSet match       → follow phraseSet transition (multi-token with skipCount)
+ *   - wildcard fallback     → follow wildcard transition for any unmatched token
+ *   - no transition         → reject immediately
+ *
+ * Returns true only if all tokens are consumed and the final state is accepting.
+ * Entity wildcard type-checking is intentionally skipped here — the DFA wildcard
+ * transition is followed for any token (conservative: may produce false positives).
+ * False positives mean an unnecessary NFA call; false negatives are impossible.
+ */
+function dfaAccepts(dfa: DFA, tokens: string[]): boolean {
+    let stateId = dfa.startState;
+    let i = 0;
+
+    while (i < tokens.length) {
+        const token = normalizeToken(tokens[i]);
+        const state = dfa.states[stateId];
+        if (!state) return false;
+
+        // Try specific token transition
+        let next: number | undefined;
+        for (const t of state.transitions) {
+            if (t.token === token) {
+                next = t.to;
+                break;
+            }
+        }
+
+        // Try phraseSet transitions (proper multi-token check, no slot ops)
+        let phraseSkip = 0;
+        if (next === undefined && state.phraseSetTransitions) {
+            for (const pst of state.phraseSetTransitions) {
+                const matcher = globalPhraseSetRegistry.getMatcher(
+                    pst.matcherName,
+                );
+                if (!matcher) continue;
+                for (const phrase of matcher.phrases) {
+                    if (i + phrase.length > tokens.length) continue;
+                    if (
+                        phrase.every(
+                            (p, pi) => normalizeToken(tokens[i + pi]) === p,
+                        )
+                    ) {
+                        next = pst.to;
+                        phraseSkip = phrase.length - 1;
+                        break;
+                    }
+                }
+                if (next !== undefined) break;
+            }
+        }
+
+        // Wildcard fallback (conservative: accept any token, skip entity validation)
+        if (next === undefined && state.wildcardTransition) {
+            next = state.wildcardTransition.to;
+        }
+
+        if (next === undefined) return false;
+        stateId = next;
+        i += 1 + phraseSkip;
+    }
+
+    return dfa.states[stateId]?.accepting ?? false;
+}
+
+/**
  * Match tokens against a DFA
+ *
+ * When the DFA carries its source NFA (dfa.sourceNFA), value computation is
+ * delegated to the NFA interpreter, which correctly maintains one environment
+ * per live NFA thread.  This handles multi-word wildcards (appendToSlot), Kleene
+ * plus loops, entity wildcards, and any other pattern where multiple NFA paths
+ * share a DFA state — all cases where the old single-envStack approach was wrong.
+ *
+ * The DFA pre-filters with a fast O(tokens) state-machine walk before committing
+ * to NFA threading.  Non-matching inputs are rejected without spawning any NFA
+ * threads — 100–460× faster than full NFA match for the rejection case.
+ *
+ * The DFA structure is also used for the getDFACompletions path (prefix traversal
+ * and completion generation stay deterministic and fast).
  *
  * @param dfa The DFA to match against
  * @param tokens Array of tokens to match
- * @param debug Whether to track visited states for debugging
+ * @param debugMode Whether to track visited states for debugging
  * @returns Match result with actionValue and priority
  */
 export function matchDFA(
     dfa: DFA,
     tokens: string[],
-    debug: boolean = false,
+    debugMode: boolean = false,
 ): DFAMatchResult {
+    if (dfa.sourceNFA) {
+        // Fast pre-filter: O(tokens) DFA traversal before paying for NFA threading.
+        // dfaAccepts is conservative (wildcards skip entity validation) so it never
+        // produces false negatives — any input it rejects the NFA would also reject.
+        if (!dfaAccepts(dfa, tokens)) {
+            return {
+                matched: false,
+                fixedStringPartCount: 0,
+                checkedWildcardCount: 0,
+                uncheckedWildcardCount: 0,
+                tokensConsumed: tokens.length,
+            };
+        }
+        // DFA accepted — delegate to NFA for correct value computation
+        const nfaResult = matchNFA(dfa.sourceNFA, tokens, debugMode);
+        return adaptNFAResult(nfaResult, tokens.length);
+    }
+
     let currentStateId = dfa.startState;
-    const visitedStates: number[] = debug ? [currentStateId] : [];
+    const visitedStates: number[] = debugMode ? [currentStateId] : [];
 
     // Initialize environment stack
-    // Start with a root environment - the actual slot count will be set by pushEnv operations
-    const envStack: DFAEnvironment[] = [createEnvironment(32)]; // Start with reasonable default
+    const envStack: DFAEnvironment[] = [createEnvironment(32)];
+
+    // Debug slot map reference — updated by pushEnv/popEnv operations
+    const debugSlotMapRef: { value: Map<string, number> | undefined } = {
+        value: undefined,
+    };
+
+    // Runtime priority counters (more accurate than compile-time bestPriority)
+    let fixedStringPartCount = 0;
+    let checkedWildcardCount = 0;
+    let uncheckedWildcardCount = 0;
+
+    // skipCount: number of tokens to skip after a multi-token entity or multi-token phrase
+    let skipCount = 0;
 
     // Process each token
     for (let i = 0; i < tokens.length; i++) {
+        // Skip tokens that were consumed as part of a multi-token span
+        if (skipCount > 0) {
+            skipCount--;
+            continue;
+        }
+
         const token = tokens[i];
         const currentState = dfa.states[currentStateId];
 
         if (!currentState) {
-            // Invalid state
             const result: DFAMatchResult = {
                 matched: false,
                 fixedStringPartCount: 0,
@@ -255,60 +467,171 @@ export function matchDFA(
                 uncheckedWildcardCount: 0,
                 tokensConsumed: i,
             };
-            if (debug) {
+            if (debugMode) {
                 result.visitedStates = visitedStates;
             }
             return result;
         }
 
-        // Try to find a matching token transition
+        // Try to find a matching token transition (normalized comparison)
         let nextStateId: number | undefined;
         let matchedTransition: DFATransition | undefined;
+        const normalizedToken = normalizeToken(token);
 
         for (const trans of currentState.transitions) {
-            if (trans.token === token) {
+            if (trans.token === normalizedToken) {
                 nextStateId = trans.to;
                 matchedTransition = trans;
                 break;
             }
         }
 
-        // If token matched, apply slot operations
+        // If token matched, apply slot operations and update priority
         if (matchedTransition) {
-            // Apply preOps before consuming token
-            applySlotOps(matchedTransition.preOps, envStack);
-            // Apply postOps after consuming token
-            applySlotOps(matchedTransition.postOps, envStack);
+            applySlotOps(
+                matchedTransition.preOps,
+                envStack,
+                undefined,
+                debugSlotMapRef,
+            );
+            applySlotOps(
+                matchedTransition.postOps,
+                envStack,
+                undefined,
+                debugSlotMapRef,
+            );
+            fixedStringPartCount++;
         }
 
         // If no token match, try wildcard
         if (nextStateId === undefined && currentState.wildcardTransition) {
             const wildcard = currentState.wildcardTransition;
-            nextStateId = wildcard.to;
 
-            // Determine the captured value based on type
-            let capturedValue: string | number = token;
-            if (wildcard.consumeOp) {
-                // Check captureInfo for type information
-                const captureInfo = wildcard.captureInfo[0];
-                if (captureInfo?.typeName === "number") {
+            // Find the best-priority match among captureInfo entries.
+            // Checked (entity-typed) captures take priority over unchecked ones:
+            // try each checked entry in order and use the first that validates.
+            let isChecked = false;
+            let capturedValue: string | number | object = token;
+
+            for (const capture of wildcard.captureInfo) {
+                const capTypeName = capture.typeName;
+                const entryIsChecked =
+                    capture.checked === true ||
+                    !!(capTypeName && capTypeName !== "string");
+                if (!entryIsChecked) continue; // handle unchecked as fallback
+
+                if (capTypeName === "number") {
                     const num = parseFloat(token);
                     if (!isNaN(num)) {
+                        isChecked = true;
                         capturedValue = num;
+                        break;
+                    }
+                } else if (capTypeName && capTypeName !== "string") {
+                    const validator =
+                        globalEntityRegistry.getValidator(capTypeName);
+                    if (validator) {
+                        if (validator.validate(token)) {
+                            const converter =
+                                globalEntityRegistry.getConverter(capTypeName);
+                            if (converter) {
+                                const converted = converter.convert(token);
+                                if (converted !== undefined) {
+                                    isChecked = true;
+                                    capturedValue = converted as
+                                        | string
+                                        | number
+                                        | object;
+                                    break;
+                                }
+                            } else {
+                                isChecked = true;
+                                break;
+                            }
+                        } else {
+                            // Single token didn't validate — try multi-token span
+                            const multiResult = tryMultiTokenSpan(
+                                tokens,
+                                i,
+                                capTypeName,
+                            );
+                            if (multiResult) {
+                                isChecked = true;
+                                capturedValue = multiResult.value;
+                                skipCount = multiResult.spanLen - 1;
+                                break;
+                            }
+                        }
                     }
                 }
             }
 
+            nextStateId = wildcard.to;
+
             // Apply preOps before consuming
-            applySlotOps(wildcard.preOps, envStack);
+            applySlotOps(wildcard.preOps, envStack, undefined, debugSlotMapRef);
 
             // Apply consumeOp (write to slot)
             if (wildcard.consumeOp) {
-                applySlotOps([wildcard.consumeOp], envStack, capturedValue);
+                applySlotOps(
+                    [wildcard.consumeOp],
+                    envStack,
+                    capturedValue as string | number,
+                    debugSlotMapRef,
+                );
             }
 
             // Apply postOps after consuming
-            applySlotOps(wildcard.postOps, envStack);
+            applySlotOps(
+                wildcard.postOps,
+                envStack,
+                undefined,
+                debugSlotMapRef,
+            );
+
+            if (isChecked) {
+                checkedWildcardCount++;
+            } else {
+                uncheckedWildcardCount++;
+            }
+        }
+
+        // If no token or wildcard match, try phraseSet transitions
+        if (nextStateId === undefined && currentState.phraseSetTransitions) {
+            for (const pst of currentState.phraseSetTransitions) {
+                const matcher = globalPhraseSetRegistry.getMatcher(
+                    pst.matcherName,
+                );
+                if (!matcher) continue;
+
+                for (const phrase of matcher.phrases) {
+                    if (i + phrase.length > tokens.length) continue;
+                    const allMatch = phrase.every(
+                        (p, pi) => normalizeToken(tokens[i + pi]) === p,
+                    );
+                    if (allMatch) {
+                        applySlotOps(
+                            pst.preOps,
+                            envStack,
+                            undefined,
+                            debugSlotMapRef,
+                        );
+                        applySlotOps(
+                            pst.postOps,
+                            envStack,
+                            undefined,
+                            debugSlotMapRef,
+                        );
+                        nextStateId = pst.to;
+                        if (phrase.length > 1) {
+                            skipCount = phrase.length - 1;
+                        }
+                        fixedStringPartCount += phrase.length;
+                        break;
+                    }
+                }
+                if (nextStateId !== undefined) break;
+            }
         }
 
         // If still no match, fail
@@ -320,21 +643,21 @@ export function matchDFA(
                 uncheckedWildcardCount: 0,
                 tokensConsumed: i,
             };
-            if (debug) {
+            if (debugMode) {
                 result.visitedStates = visitedStates;
             }
             return result;
         }
 
         currentStateId = nextStateId;
-        if (debug) {
+        if (debugMode) {
             visitedStates.push(currentStateId);
         }
     }
 
     // Check if we're in an accepting state
     const finalState = dfa.states[currentStateId];
-    if (!finalState || !finalState.accepting || !finalState.bestPriority) {
+    if (!finalState || !finalState.accepting) {
         const result: DFAMatchResult = {
             matched: false,
             fixedStringPartCount: 0,
@@ -342,7 +665,7 @@ export function matchDFA(
             uncheckedWildcardCount: 0,
             tokensConsumed: tokens.length,
         };
-        if (debug) {
+        if (debugMode) {
             result.visitedStates = visitedStates;
         }
         return result;
@@ -356,15 +679,17 @@ export function matchDFA(
         actionValue = evaluateActionValue(currentEnv, finalState.actionValue);
     }
 
-    const bestContext =
-        finalState.contexts[finalState.bestPriority.contextIndex];
+    const bestContext = finalState.bestPriority
+        ? finalState.contexts[finalState.bestPriority.contextIndex]
+        : undefined;
 
     const result: DFAMatchResult = {
         matched: true,
         actionValue,
-        fixedStringPartCount: finalState.bestPriority.fixedStringPartCount,
-        checkedWildcardCount: finalState.bestPriority.checkedWildcardCount,
-        uncheckedWildcardCount: finalState.bestPriority.uncheckedWildcardCount,
+        // Use runtime counts (more accurate than compile-time bestPriority)
+        fixedStringPartCount,
+        checkedWildcardCount,
+        uncheckedWildcardCount,
         tokensConsumed: tokens.length,
     };
 
@@ -374,10 +699,11 @@ export function matchDFA(
     }
 
     // Include debug info
-    if (debug) {
+    if (debugMode) {
         result.visitedStates = visitedStates;
-        if (finalState.debugSlotMap) {
-            result.debugSlotMap = finalState.debugSlotMap;
+        const slotMap = debugSlotMapRef.value ?? finalState.debugSlotMap;
+        if (slotMap) {
+            result.debugSlotMap = slotMap;
         }
         if (currentEnv) {
             result.debugSlots = [...currentEnv.slots];
@@ -385,6 +711,54 @@ export function matchDFA(
     }
 
     return result;
+}
+
+/**
+ * Compare two DFA match results using the same 3-rule priority as sortNFAMatches:
+ * 1. Prefer no unchecked wildcards
+ * 2. Prefer more fixed string parts
+ * 3. Prefer more checked wildcards
+ * Returns negative if a is better, positive if b is better, 0 if equal.
+ */
+function compareDFAMatchPriority(a: DFAMatchResult, b: DFAMatchResult): number {
+    if (a.uncheckedWildcardCount === 0 && b.uncheckedWildcardCount !== 0)
+        return -1;
+    if (a.uncheckedWildcardCount !== 0 && b.uncheckedWildcardCount === 0)
+        return 1;
+    if (a.fixedStringPartCount !== b.fixedStringPartCount)
+        return b.fixedStringPartCount - a.fixedStringPartCount;
+    if (a.checkedWildcardCount !== b.checkedWildcardCount)
+        return b.checkedWildcardCount - a.checkedWildcardCount;
+    return a.uncheckedWildcardCount - b.uncheckedWildcardCount;
+}
+
+/**
+ * Match tokens against a DFA, performing a two-pass split-candidate strategy
+ * when the DFA has split candidates (for spacing=optional/auto grammars).
+ *
+ * Pass 1 — original whitespace tokens.
+ * Pass 2 — pre-split tokens using dfa.splitCandidates (e.g. "Swift's" → ["Swift", "'s"]).
+ * The higher-priority result is returned.
+ */
+export function matchDFAWithSplitting(
+    dfa: DFA,
+    tokens: string[],
+    debugMode: boolean = false,
+): DFAMatchResult {
+    const origResult = matchDFA(dfa, tokens, debugMode);
+
+    if (!dfa.splitCandidates?.length) return origResult;
+
+    const splitTokens = applySplitToTokens(tokens, dfa.splitCandidates);
+    if (!splitTokens) return origResult;
+
+    const splitResult = matchDFA(dfa, splitTokens, debugMode);
+    if (!splitResult.matched) return origResult;
+    if (!origResult.matched) return splitResult;
+
+    return compareDFAMatchPriority(origResult, splitResult) <= 0
+        ? origResult
+        : splitResult;
 }
 
 /**
@@ -422,6 +796,16 @@ export interface DFACompletionGroup {
 }
 
 /**
+ * Property completion entry — mirrors GrammarCompletionProperty for parity with NFA
+ */
+export interface DFAPropertyCompletion {
+    /** Action name (e.g., "play") */
+    actionName: string;
+    /** Property path in the action parameters (e.g., "parameters.artist") */
+    propertyPath: string;
+}
+
+/**
  * Completion result for prefix matching
  */
 export interface DFACompletionResult {
@@ -433,6 +817,9 @@ export interface DFACompletionResult {
 
     /** Legacy: All completions (not grouped) - for backward compatibility */
     completions?: string[];
+
+    /** Property completions from checked wildcards (parity with NFA computeNFACompletions) */
+    properties?: DFAPropertyCompletion[];
 }
 
 /**
@@ -449,7 +836,14 @@ export function getDFACompletions(
     let currentStateId = dfa.startState;
 
     // Follow the prefix through the DFA
-    for (const token of tokens) {
+    let skipCount = 0;
+    for (let pi = 0; pi < tokens.length; pi++) {
+        if (skipCount > 0) {
+            skipCount--;
+            continue;
+        }
+        const token = tokens[pi];
+        const normalizedToken = normalizeToken(token);
         const currentState = dfa.states[currentStateId];
         if (!currentState) {
             return { groups: [], prefixMatches: false, completions: [] };
@@ -459,7 +853,7 @@ export function getDFACompletions(
         let nextStateId: number | undefined;
 
         for (const trans of currentState.transitions) {
-            if (trans.token === token) {
+            if (trans.token === normalizedToken) {
                 nextStateId = trans.to;
                 break;
             }
@@ -468,6 +862,28 @@ export function getDFACompletions(
         // Try wildcard if no token match
         if (nextStateId === undefined && currentState.wildcardTransition) {
             nextStateId = currentState.wildcardTransition.to;
+        }
+
+        // Try phraseSet transitions
+        if (nextStateId === undefined && currentState.phraseSetTransitions) {
+            for (const pst of currentState.phraseSetTransitions) {
+                const matcher = globalPhraseSetRegistry.getMatcher(
+                    pst.matcherName,
+                );
+                if (!matcher) continue;
+                for (const phrase of matcher.phrases) {
+                    if (pi + phrase.length > tokens.length) continue;
+                    const allMatch = phrase.every(
+                        (p, idx) => normalizeToken(tokens[pi + idx]) === p,
+                    );
+                    if (allMatch) {
+                        nextStateId = pst.to;
+                        if (phrase.length > 1) skipCount = phrase.length - 1;
+                        break;
+                    }
+                }
+                if (nextStateId !== undefined) break;
+            }
         }
 
         if (nextStateId === undefined) {
@@ -495,6 +911,19 @@ export function getDFACompletions(
     const allTokens = new Set<string>();
     for (const trans of currentState.transitions) {
         allTokens.add(trans.token);
+    }
+
+    // Collect first token of each phrase set phrase as literal completions
+    if (currentState.phraseSetTransitions) {
+        for (const pst of currentState.phraseSetTransitions) {
+            const matcher = globalPhraseSetRegistry.getMatcher(pst.matcherName);
+            if (!matcher) continue;
+            for (const phrase of matcher.phrases) {
+                if (phrase.length > 0) {
+                    allTokens.add(phrase[0]);
+                }
+            }
+        }
     }
 
     // Collect wildcard completions with metadata
@@ -555,20 +984,48 @@ export function getDFACompletions(
         });
     }
 
-    // Also collect all completions for legacy compatibility
+    // Collect literal token completions only.
+    // Wildcard display strings are NOT included here — this matches NFA completion
+    // behavior where unchecked wildcards are dropped and checked wildcards appear
+    // only in `properties`, never in the flat `completions` array.
     const allCompletions = new Set<string>();
     for (const token of allTokens) {
         allCompletions.add(token);
     }
-    for (const displayStr of wildcardDisplayStrings) {
-        allCompletions.add(displayStr);
+
+    // Build property completions from checked wildcard captureInfo entries
+    // (parity with NFA computeNFACompletions: checked wildcards with actionName/propertyPath)
+    const properties: DFAPropertyCompletion[] = [];
+    const seenPropertyKeys = new Set<string>();
+    if (currentState.wildcardTransition) {
+        for (const capture of currentState.wildcardTransition.captureInfo) {
+            if (
+                !capture.checked ||
+                !capture.actionName ||
+                !capture.propertyPath
+            ) {
+                continue;
+            }
+            const key = `${capture.actionName}:${capture.propertyPath}`;
+            if (!seenPropertyKeys.has(key)) {
+                seenPropertyKeys.add(key);
+                properties.push({
+                    actionName: capture.actionName,
+                    propertyPath: capture.propertyPath,
+                });
+            }
+        }
     }
 
-    return {
+    const result: DFACompletionResult = {
         groups,
         prefixMatches: currentState.accepting,
         completions: Array.from(allCompletions),
     };
+    if (properties.length > 0) {
+        result.properties = properties;
+    }
+    return result;
 }
 
 /**
@@ -607,6 +1064,12 @@ export function printDFA(dfa: DFA): string {
             lines.push(
                 `      * (${captures || "no captures"}) -> ${state.wildcardTransition.to}`,
             );
+        }
+
+        if (state.phraseSetTransitions) {
+            for (const pst of state.phraseSetTransitions) {
+                lines.push(`      <phraseSet:${pst.matcherName}> -> ${pst.to}`);
+            }
         }
     }
 

--- a/ts/packages/actionGrammar/src/index.ts
+++ b/ts/packages/actionGrammar/src/index.ts
@@ -76,7 +76,11 @@ export type {
 export {
     matchNFA,
     sortNFAMatches,
+    buildFirstTokenIndex,
+    matchNFAWithIndex,
     type NFAMatchResult,
+    type NFAExecutionState,
+    type FirstTokenIndex,
 } from "./nfaInterpreter.js";
 export { compileGrammarToNFA, normalizeGrammar } from "./nfaCompiler.js";
 export { enrichGrammarWithCheckedVariables } from "./grammarMetadata.js";
@@ -122,18 +126,22 @@ export type {
     DFAExecutionContext,
     DFATransition,
     DFAWildcardTransition,
+    DFAPhraseSetTransition,
 } from "./dfa.js";
 export { DFABuilder } from "./dfa.js";
 export { compileNFAToDFA } from "./dfaCompiler.js";
 export {
     matchDFA,
+    matchDFAWithSplitting,
     getDFACompletions,
     printDFA,
     type DFAMatchResult,
     type DFACompletionResult,
     type DFACompletionGroup,
+    type DFAPropertyCompletion,
     type WildcardCompletionInfo,
 } from "./dfaMatcher.js";
+export { splitToken, applySplitToTokens } from "./tokenSplit.js";
 export {
     DFACompilationManager,
     globalDFACompilationManager,

--- a/ts/packages/actionGrammar/src/nfaInterpreter.ts
+++ b/ts/packages/actionGrammar/src/nfaInterpreter.ts
@@ -41,7 +41,7 @@ export interface NFAMatchResult {
     debugSlotMap?: Map<string, number> | undefined;
 }
 
-interface NFAExecutionState {
+export interface NFAExecutionState {
     stateId: number;
     tokenIndex: number;
     path: number[]; // For debugging
@@ -106,11 +106,33 @@ export function matchNFA(
     debugNFA(
         `Initial states after epsilon closure: ${initialStates.length} state(s)`,
     );
+    return matchNFACore(nfa, initialStates, tokens, 0, debug);
+}
+
+/**
+ * Core NFA matching loop — shared by matchNFA and matchNFAWithIndex.
+ * Runs NFA threading from a pre-computed initial state set starting at
+ * the given token index.  The caller is responsible for building
+ * `initialStates` via epsilonClosure() before invoking this function.
+ */
+function matchNFACore(
+    nfa: NFA,
+    initialStates: NFAExecutionState[],
+    tokens: string[],
+    startTokenIndex: number,
+    debug: boolean,
+): NFAMatchResult {
     let currentStates = initialStates;
-    const allVisitedStates = new Set<number>([nfa.startState]);
+    const allVisitedStates = new Set<number>(
+        initialStates.map((s) => s.stateId),
+    );
 
     // Process each token
-    for (let tokenIndex = 0; tokenIndex < tokens.length; tokenIndex++) {
+    for (
+        let tokenIndex = startTokenIndex;
+        tokenIndex < tokens.length;
+        tokenIndex++
+    ) {
         const token = tokens[tokenIndex];
         debugNFA(
             `Token ${tokenIndex}: "${token}", currentStates: ${currentStates.length}`,
@@ -959,4 +981,124 @@ export function sortNFAMatches<T extends NFAMatchResult>(matches: T[]): T[] {
         // Rule 3: Prefer fewer unchecked wildcards
         return a.uncheckedWildcardCount - b.uncheckedWildcardCount;
     });
+}
+
+// ─── First-Token Index ────────────────────────────────────────────────────────
+
+/**
+ * Pre-computed dispatch index: maps each possible first token to the NFA
+ * threads that are active after consuming it (epsilon-closed and ready to
+ * continue from tokens[1]).
+ *
+ * For action grammars (command-prefix structure — "pause", "play", "set", …),
+ * virtually no rule starts with a wildcard, so the index eliminates all but
+ * the relevant rules' threads from the very first token.
+ */
+export interface FirstTokenIndex {
+    /** NFA threads active after consuming each possible first token */
+    readonly tokenMap: ReadonlyMap<string, NFAExecutionState[]>;
+    /** Whether any rule starts with a wildcard or phraseSet transition */
+    readonly hasWildcardStart: boolean;
+}
+
+/**
+ * Build a FirstTokenIndex from an NFA.
+ * Cost: O(initial-states × vocabulary) — one epsilonClosure per distinct
+ * first token.  Typically very cheap for action grammars.
+ */
+export function buildFirstTokenIndex(nfa: NFA): FirstTokenIndex {
+    const initialStates = epsilonClosure(nfa, [
+        {
+            stateId: nfa.startState,
+            tokenIndex: 0,
+            path: [nfa.startState],
+            fixedStringPartCount: 0,
+            checkedWildcardCount: 0,
+            uncheckedWildcardCount: 0,
+            ruleIndex: undefined,
+            actionValue: undefined,
+        },
+    ]);
+
+    const tokenToRaw = new Map<string, NFAExecutionState[]>();
+    let hasWildcardStart = false;
+
+    for (const state of initialStates) {
+        const nfaState = nfa.states[state.stateId];
+        if (!nfaState) continue;
+
+        for (const trans of nfaState.transitions) {
+            if (trans.type === "token" && trans.tokens) {
+                for (const tok of trans.tokens) {
+                    const normalized = normalizeToken(tok);
+                    const nextState = tryTransition(nfa, trans, tok, state, 0, [
+                        tok,
+                    ]);
+                    if (nextState) {
+                        if (!tokenToRaw.has(normalized)) {
+                            tokenToRaw.set(normalized, []);
+                        }
+                        tokenToRaw.get(normalized)!.push(nextState);
+                    }
+                }
+            } else if (
+                trans.type === "wildcard" ||
+                trans.type === "phraseSet"
+            ) {
+                hasWildcardStart = true;
+            }
+        }
+    }
+
+    const tokenMap = new Map<string, NFAExecutionState[]>();
+    for (const [token, rawStates] of tokenToRaw) {
+        tokenMap.set(token, epsilonClosure(nfa, rawStates));
+    }
+
+    return { tokenMap, hasWildcardStart };
+}
+
+/**
+ * Match an NFA using a pre-built FirstTokenIndex for fast dispatch.
+ *
+ * - If the first token is in the index AND no wildcard-start rules exist:
+ *   NFA threading begins with only the relevant threads (typically 1–5),
+ *   skipping token[0] processing entirely.
+ * - If the first token is unknown AND no wildcard-start rules exist:
+ *   immediate O(1) rejection — no threading at all.
+ * - Otherwise: falls back to matchNFA (wildcard-start grammars are uncommon
+ *   in action grammars but handled correctly).
+ */
+export function matchNFAWithIndex(
+    nfa: NFA,
+    index: FirstTokenIndex,
+    tokens: string[],
+    debug: boolean = false,
+): NFAMatchResult {
+    if (tokens.length === 0) {
+        return matchNFA(nfa, tokens, debug);
+    }
+
+    const firstToken = normalizeToken(tokens[0]);
+    const precomputed = index.tokenMap.get(firstToken);
+
+    if (!precomputed || index.hasWildcardStart) {
+        if (!precomputed && !index.hasWildcardStart) {
+            // Unknown first token, no wildcard rules — immediate rejection
+            return {
+                matched: false,
+                fixedStringPartCount: 0,
+                checkedWildcardCount: 0,
+                uncheckedWildcardCount: 0,
+                tokensConsumed: 0,
+            };
+        }
+        // Wildcard-start rules exist (or first token found but wildcards too)
+        return matchNFA(nfa, tokens, debug);
+    }
+
+    debugNFA(
+        `matchNFAWithIndex: "${firstToken}" → ${precomputed.length} thread(s), starting at token[1]`,
+    );
+    return matchNFACore(nfa, precomputed, tokens, 1, debug);
 }

--- a/ts/packages/actionGrammar/src/nfaMatcher.ts
+++ b/ts/packages/actionGrammar/src/nfaMatcher.ts
@@ -4,7 +4,24 @@
 import registerDebug from "debug";
 import { Grammar } from "./grammarTypes.js";
 import { NFA } from "./nfa.js";
-import { matchNFA, sortNFAMatches } from "./nfaInterpreter.js";
+import {
+    matchNFAWithIndex,
+    buildFirstTokenIndex,
+    sortNFAMatches,
+    type FirstTokenIndex,
+} from "./nfaInterpreter.js";
+import { applySplitToTokens } from "./tokenSplit.js";
+
+// Lazy-built, NFA-lifetime cache: one index per NFA object.
+const indexCache = new WeakMap<NFA, FirstTokenIndex>();
+function getIndex(nfa: NFA): FirstTokenIndex {
+    let idx = indexCache.get(nfa);
+    if (!idx) {
+        idx = buildFirstTokenIndex(nfa);
+        indexCache.set(nfa, idx);
+    }
+    return idx;
+}
 
 const debug = registerDebug("typeagent:actionGrammar:nfaMatcher");
 
@@ -83,63 +100,7 @@ function collectNFASplitCandidates(nfa: NFA): string[] {
     return Array.from(candidates).sort((a, b) => b.length - a.length);
 }
 
-/**
- * Try to split a single whitespace-tokenized token using a list of split
- * candidates (sorted longest-first).  Uses greedy left-to-right scanning:
- * at each position, tries every candidate as a prefix; if none matches,
- * advances one character.  Unmatched characters are emitted as a residual
- * segment between matched candidates.
- *
- * Examples:
- *   "Swift's"  + ["'s"] → ["Swift", "'s"]
- *   "黃色汽車" + ["黃色","汽車"] → ["黃色", "汽車"]
- *   "don't"    + ["'t"] → ["don", "'t"]
- *   "play"     + ["'s"] → ["play"]  (no change — returned as single element)
- */
-function splitToken(token: string, candidates: string[]): string[] {
-    const result: string[] = [];
-    let pos = 0;
-    let segStart = 0;
-    while (pos < token.length) {
-        let matched = false;
-        for (const candidate of candidates) {
-            if (
-                pos + candidate.length <= token.length &&
-                token.startsWith(candidate, pos)
-            ) {
-                if (pos > segStart) result.push(token.slice(segStart, pos));
-                result.push(candidate);
-                pos += candidate.length;
-                segStart = pos;
-                matched = true;
-                break;
-            }
-        }
-        if (!matched) pos++;
-    }
-    if (segStart < token.length) result.push(token.slice(segStart));
-    return result;
-}
-
-/**
- * Apply split candidates to every token in the array.
- * Returns a new (longer) array when at least one token was split, or null
- * when nothing changed (avoids an extra NFA run when there is nothing to do).
- */
-function applySplitToTokens(
-    tokens: string[],
-    candidates: string[],
-): string[] | null {
-    if (candidates.length === 0) return null;
-    let anyChange = false;
-    const result: string[] = [];
-    for (const token of tokens) {
-        const parts = splitToken(token, candidates);
-        result.push(...parts);
-        if (parts.length > 1) anyChange = true;
-    }
-    return anyChange ? result : null;
-}
+// splitToken and applySplitToTokens are imported from tokenSplit.ts
 
 // ---------------------------------------------------------------------------
 // Public API
@@ -172,8 +133,10 @@ export function matchGrammarWithNFA(
         return [];
     }
 
+    const index = getIndex(nfa);
+
     // Pass 1: original token array (handles spacing=required correctly)
-    const origResult = matchNFA(nfa, tokens);
+    const origResult = matchNFAWithIndex(nfa, index, tokens);
 
     // Pass 2: pre-split fused tokens for optional/auto rules
     let bestResult = origResult;
@@ -183,7 +146,7 @@ export function matchGrammarWithNFA(
         debug(
             `Split tokens: [${splitTokens.join(", ")}] (${splitTokens.length} tokens)`,
         );
-        const splitResult = matchNFA(nfa, splitTokens);
+        const splitResult = matchNFAWithIndex(nfa, index, splitTokens);
         if (splitResult.matched) {
             if (!origResult.matched) {
                 bestResult = splitResult;

--- a/ts/packages/actionGrammar/src/tokenSplit.ts
+++ b/ts/packages/actionGrammar/src/tokenSplit.ts
@@ -1,0 +1,71 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+/**
+ * Shared token-splitting utilities for NFA and DFA matchers.
+ *
+ * Used for two-pass matching with spacing=optional/auto grammars:
+ *   Pass 1 — original whitespace-tokenised input
+ *   Pass 2 — tokens pre-split on registered split candidates
+ *             (e.g. "Swift's" → ["Swift", "'s"] for possessive rules,
+ *              "黃色汽車" → ["黃色", "汽車"] for CJK compounds)
+ */
+
+/**
+ * Split a single token at every occurrence of any candidate substring.
+ *
+ * Candidates are tried at each position longest-first (caller is responsible
+ * for passing them sorted longest-first).  The greedy scan never back-tracks;
+ * unmatched characters are collected into a residual segment and emitted when
+ * the next match (or end-of-token) is reached.
+ *
+ * Examples:
+ *   "Swift's"  + ["'s"] → ["Swift", "'s"]
+ *   "黃色汽車" + ["黃色","汽車"] → ["黃色", "汽車"]
+ *   "don't"    + ["'t"] → ["don", "'t"]
+ *   "play"     + ["'s"] → ["play"]  (no change — returned as single element)
+ */
+export function splitToken(token: string, candidates: string[]): string[] {
+    const result: string[] = [];
+    let pos = 0;
+    let segStart = 0;
+    while (pos < token.length) {
+        let matched = false;
+        for (const candidate of candidates) {
+            if (
+                pos + candidate.length <= token.length &&
+                token.startsWith(candidate, pos)
+            ) {
+                if (pos > segStart) result.push(token.slice(segStart, pos));
+                result.push(candidate);
+                pos += candidate.length;
+                segStart = pos;
+                matched = true;
+                break;
+            }
+        }
+        if (!matched) pos++;
+    }
+    if (segStart < token.length) result.push(token.slice(segStart));
+    return result;
+}
+
+/**
+ * Apply split candidates to every token in the array.
+ * Returns a new (longer) array when at least one token was split, or null
+ * when nothing changed (avoids an extra matcher run when there is nothing to do).
+ */
+export function applySplitToTokens(
+    tokens: string[],
+    candidates: string[],
+): string[] | null {
+    if (candidates.length === 0) return null;
+    let anyChange = false;
+    const result: string[] = [];
+    for (const token of tokens) {
+        const parts = splitToken(token, candidates);
+        result.push(...parts);
+        if (parts.length > 1) anyChange = true;
+    }
+    return anyChange ? result : null;
+}

--- a/ts/packages/actionGrammar/test/dfa.spec.ts
+++ b/ts/packages/actionGrammar/test/dfa.spec.ts
@@ -443,9 +443,16 @@ describe("DFA Compilation", () => {
 
         // Should show the literal "music"
         expect(completions.completions).toContain("music");
-        // Should show wildcard categories
-        expect(completions.completions).toContain("$(track)");
-        expect(completions.completions).toContain("$(id:number)");
+        // Wildcard categories are in wildcardCompletions (not in the flat completions array)
+        const wildcards = completions.groups.flatMap(
+            (g) => g.wildcardCompletions,
+        );
+        expect(wildcards.some((wc) => wc.variable === "track")).toBe(true);
+        expect(
+            wildcards.some(
+                (wc) => wc.variable === "id" && wc.typeName === "number",
+            ),
+        ).toBe(true);
         expect(completions.prefixMatches).toBe(false);
     });
 
@@ -821,7 +828,10 @@ describe("DFA Compilation", () => {
         expect(completions.groups.length).toBeGreaterThan(0);
         expect(completions.completions).toContain("the");
         expect(completions.completions).toContain("track");
-        expect(completions.completions).toContain("$(trackName)");
+        const wildcards2 = completions.groups.flatMap(
+            (g) => g.wildcardCompletions,
+        );
+        expect(wildcards2.some((wc) => wc.variable === "trackName")).toBe(true);
     });
 
     test("DFA completions on real player grammar - after 'play kodachrome by'", () => {
@@ -893,7 +903,10 @@ describe("DFA Compilation", () => {
         ]);
 
         expect(completions.groups.length).toBeGreaterThan(0);
-        expect(completions.completions).toContain("$(artist)");
+        const wildcards3 = completions.groups.flatMap(
+            (g) => g.wildcardCompletions,
+        );
+        expect(wildcards3.some((wc) => wc.variable === "artist")).toBe(true);
         expect(completions.prefixMatches).toBe(false);
     });
 
@@ -1077,9 +1090,7 @@ describe("DFA Compilation", () => {
             expect(albumCompletion?.displayString).toBe("$(album:AlbumName)");
         }
 
-        // Legacy completions should contain all display strings
-        expect(completions.completions).toContain("$(artist:ArtistName)");
-        expect(completions.completions).toContain("$(track:TrackName)");
-        expect(completions.completions).toContain("$(album:AlbumName)");
+        // Wildcard display strings are in wildcardCompletions (not in the flat completions array)
+        // The groups loop above already verified all three wildcardCompletions entries.
     });
 });

--- a/ts/packages/actionGrammar/test/dfaBenchmark.spec.ts
+++ b/ts/packages/actionGrammar/test/dfaBenchmark.spec.ts
@@ -1,0 +1,441 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+/**
+ * DFA vs NFA trade-off benchmark
+ *
+ * Measures for real grammars (player, etc.):
+ *
+ * SPACE
+ *   - NFA state count vs DFA state count
+ *   - Serialized size (KB) of each structure
+ *
+ * TIME
+ *   - Compilation: grammar → NFA, NFA → DFA
+ *   - Match (N iterations):
+ *       · NFA full match  — NFA threading + slot writes + action-value eval
+ *       · DFA traversal   — pure state-machine walk, no slot ops, no value eval
+ *       · Value overhead  — ratio NFA/DFA-traversal (how much value computation costs)
+ *
+ * All assertions are informational (expect(...).toBeDefined()).
+ */
+
+import * as path from "path";
+import * as fs from "fs";
+import { fileURLToPath } from "url";
+import { loadGrammarRulesNoThrow } from "../src/grammarLoader.js";
+import { compileGrammarToNFA } from "../src/nfaCompiler.js";
+import { matchNFA } from "../src/nfaInterpreter.js";
+import { normalizeToken } from "../src/nfaMatcher.js";
+import {
+    compileNFAToDFA,
+    matchDFAWithSplitting,
+    tokenizeRequest,
+    buildFirstTokenIndex,
+    matchNFAWithIndex,
+    type DFA,
+    type FirstTokenIndex,
+} from "../src/index.js";
+import { registerBuiltInEntities } from "../src/builtInEntities.js";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const ITERATIONS = 1000;
+
+function fileExists(filePath: string): boolean {
+    try {
+        fs.accessSync(filePath, fs.constants.R_OK);
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+function timeMs(fn: () => void): number {
+    const start = performance.now();
+    fn();
+    return performance.now() - start;
+}
+
+function timeMsN(fn: () => void, n: number): number {
+    const start = performance.now();
+    for (let i = 0; i < n; i++) fn();
+    return performance.now() - start;
+}
+
+/**
+ * Pure DFA state-machine traversal — no value computation, no phraseSet membership check.
+ * Represents the theoretical minimum: follow transitions or wildcard, stop if stuck.
+ * Used to isolate traversal cost from everything else.
+ */
+function traverseDFAOnly(dfa: DFA, tokens: string[]): boolean {
+    let stateId = dfa.startState;
+    for (const raw of tokens) {
+        const token = normalizeToken(raw);
+        const state = dfa.states[stateId];
+        if (!state) return false;
+        let next: number | undefined;
+        for (const t of state.transitions) {
+            if (t.token === token) {
+                next = t.to;
+                break;
+            }
+        }
+        // Conservative phraseSet: assume any token could start a phrase
+        if (next === undefined && state.phraseSetTransitions?.length) {
+            next = state.phraseSetTransitions[0].to;
+        }
+        if (next === undefined && state.wildcardTransition) {
+            next = state.wildcardTransition.to;
+        }
+        if (next === undefined) return false;
+        stateId = next;
+    }
+    return dfa.states[stateId]?.accepting ?? false;
+}
+
+/**
+ * Estimate serialized size of an object in KB (JSON proxy for heap footprint).
+ * For the DFA we exclude the sourceNFA back-reference (it's a reference, not
+ * unique data), so we get the size of the compiled DFA structure only.
+ */
+function sizeKb(obj: object): number {
+    return JSON.stringify(obj).length / 1024;
+}
+
+// ─── Result types ────────────────────────────────────────────────────────────
+
+interface SpaceResult {
+    grammar: string;
+    nfaStates: number;
+    dfaStates: number;
+    stateRatio: number; // dfaStates / nfaStates
+    nfaSizeKb: number;
+    dfaSizeKb: number; // DFA without sourceNFA
+    dfaTotalKb: number; // DFA + NFA (what you pay if you want both)
+    memRatio: number; // dfaSizeKb / nfaSizeKb
+}
+
+interface TimingResult {
+    grammar: string;
+    request: string;
+    matched: boolean;
+    nfaMatchMs: number; // NFA full match (threading + value eval)
+    nfaIndexMs: number; // NFA with first-token index dispatch
+    dfaTraverseMs: number; // pure DFA traversal (accept/reject only)
+    dfaHybridMs: number; // DFA pre-filter + NFA only when accepted
+    nfaMatchMsPerCall: number; // μs/call
+    nfaIndexMsPerCall: number; // μs/call
+    dfaTraverseMsPerCall: number; // μs/call
+    dfaHybridMsPerCall: number; // μs/call
+    indexSpeedup: number; // nfaMatchMs / nfaIndexMs
+    hybridSpeedup: number; // nfaMatchMs / dfaHybridMs
+}
+
+interface CompileResult {
+    grammar: string;
+    nfaCompileMs: number;
+    dfaCompileMs: number; // NFA→DFA step only
+    totalCompileMs: number;
+}
+
+// ─── Printing ────────────────────────────────────────────────────────────────
+
+function printSpaceTable(rows: SpaceResult[]): void {
+    if (!rows.length) return;
+
+    console.log("\n╔══ SPACE ══════════════════════════════════════════════╗");
+    const header = [
+        "Grammar",
+        "NFA states",
+        "DFA states",
+        "State ratio",
+        "NFA (KB)",
+        "DFA (KB)",
+        "NFA+DFA (KB)",
+        "Mem ratio",
+    ];
+    const data = rows.map((r) => [
+        r.grammar,
+        String(r.nfaStates),
+        String(r.dfaStates),
+        r.stateRatio.toFixed(2) + "x",
+        r.nfaSizeKb.toFixed(1),
+        r.dfaSizeKb.toFixed(1),
+        r.dfaTotalKb.toFixed(1),
+        r.memRatio.toFixed(2) + "x",
+    ]);
+    printAligned(header, data);
+}
+
+function printCompileTable(rows: CompileResult[]): void {
+    if (!rows.length) return;
+
+    console.log("\n╔══ COMPILATION TIME ════════════════════════════════════╗");
+    const header = [
+        "Grammar",
+        "NFA compile (ms)",
+        "DFA compile (ms)",
+        "Total (ms)",
+        "DFA overhead",
+    ];
+    const data = rows.map((r) => [
+        r.grammar,
+        r.nfaCompileMs.toFixed(2),
+        r.dfaCompileMs.toFixed(2),
+        r.totalCompileMs.toFixed(2),
+        (r.dfaCompileMs / r.nfaCompileMs).toFixed(2) + "x",
+    ]);
+    printAligned(header, data);
+}
+
+function printTimingTable(rows: TimingResult[]): void {
+    if (!rows.length) return;
+
+    console.log(
+        `\n╔══ MATCH TIMING (${ITERATIONS} iterations) ═══════════════════╗`,
+    );
+    const header = [
+        "Grammar",
+        "Request",
+        "Match?",
+        "NFA μs/call",
+        "NFA+idx μs/call",
+        "DFA trav μs/call",
+        "DFA hybrid μs/call",
+        "Idx speedup",
+        "Hybrid speedup",
+    ];
+    const data = rows.map((r) => [
+        r.grammar,
+        r.request.length > 30 ? r.request.slice(0, 27) + "..." : r.request,
+        r.matched ? "✓" : "✗",
+        r.nfaMatchMsPerCall.toFixed(2),
+        r.nfaIndexMsPerCall.toFixed(2),
+        r.dfaTraverseMsPerCall.toFixed(2),
+        r.dfaHybridMsPerCall.toFixed(2),
+        r.indexSpeedup.toFixed(1) + "x",
+        r.hybridSpeedup.toFixed(1) + "x",
+    ]);
+    printAligned(header, data);
+
+    const matched = rows.filter((r) => r.matched);
+    const unmatched = rows.filter((r) => !r.matched);
+    if (matched.length) {
+        const avgIdx =
+            matched.reduce((s, r) => s + r.indexSpeedup, 0) / matched.length;
+        const avgHybrid =
+            matched.reduce((s, r) => s + r.hybridSpeedup, 0) / matched.length;
+        console.log(
+            `  Avg speedup (matched):   idx=${avgIdx.toFixed(1)}x  hybrid=${avgHybrid.toFixed(1)}x`,
+        );
+    }
+    if (unmatched.length) {
+        const avgIdx =
+            unmatched.reduce((s, r) => s + r.indexSpeedup, 0) /
+            unmatched.length;
+        const avgHybrid =
+            unmatched.reduce((s, r) => s + r.hybridSpeedup, 0) /
+            unmatched.length;
+        console.log(
+            `  Avg speedup (unmatched): idx=${avgIdx.toFixed(1)}x  hybrid=${avgHybrid.toFixed(1)}x`,
+        );
+    }
+}
+
+function printAligned(header: string[], rows: string[][]): void {
+    const widths = header.map((h, i) =>
+        Math.max(h.length, ...rows.map((r) => (r[i] ?? "").length)),
+    );
+    const sep = widths.map((w) => "-".repeat(w)).join(" | ");
+    const fmt = (row: string[]) =>
+        row.map((c, i) => (c ?? "").padStart(widths[i])).join(" | ");
+    console.log(fmt(header));
+    console.log(sep);
+    for (const row of rows) console.log(fmt(row));
+    console.log();
+}
+
+// ─── Benchmark runner ────────────────────────────────────────────────────────
+
+describe("DFA vs NFA Benchmark", () => {
+    registerBuiltInEntities();
+
+    const spaceResults: SpaceResult[] = [];
+    const compileResults: CompileResult[] = [];
+    const timingResults: TimingResult[] = [];
+
+    function runBenchmark(
+        grammarName: string,
+        grammarPath: string,
+        testRequests: string[],
+    ): void {
+        if (!fileExists(grammarPath)) {
+            console.log(`Skipping ${grammarName}: grammar file not found`);
+            return;
+        }
+
+        const content = fs.readFileSync(grammarPath, "utf-8");
+        const errors: string[] = [];
+        const grammar = loadGrammarRulesNoThrow(
+            path.basename(grammarPath),
+            content,
+            errors,
+        );
+        if (!grammar || errors.length > 0) {
+            console.log(`Skipping ${grammarName}: ${errors.join(", ")}`);
+            return;
+        }
+
+        // ── Compilation ───────────────────────────────────────────────────
+        let nfa: ReturnType<typeof compileGrammarToNFA>;
+        const nfaCompileMs = timeMs(
+            () => (nfa = compileGrammarToNFA(grammar, grammarName)),
+        );
+
+        let dfa: ReturnType<typeof compileNFAToDFA>;
+        const dfaCompileMs = timeMs(
+            () => (dfa = compileNFAToDFA(nfa!, grammarName)),
+        );
+
+        compileResults.push({
+            grammar: grammarName,
+            nfaCompileMs,
+            dfaCompileMs,
+            totalCompileMs: nfaCompileMs + dfaCompileMs,
+        });
+
+        // ── Space ─────────────────────────────────────────────────────────
+        const nfaSizeKb = sizeKb(nfa!);
+        // DFA structure only (exclude sourceNFA back-reference)
+        const dfaOnly = { ...dfa!, sourceNFA: undefined };
+        const dfaSizeKb = sizeKb(dfaOnly);
+        // Total memory if you keep both NFA and DFA in RAM
+        const dfaTotalKb = nfaSizeKb + dfaSizeKb;
+
+        spaceResults.push({
+            grammar: grammarName,
+            nfaStates: nfa!.states.length,
+            dfaStates: dfa!.states.length,
+            stateRatio: dfa!.states.length / nfa!.states.length,
+            nfaSizeKb,
+            dfaSizeKb,
+            dfaTotalKb,
+            memRatio: dfaSizeKb / nfaSizeKb,
+        });
+
+        // ── Build first-token index ───────────────────────────────────────
+        let index: FirstTokenIndex;
+        const indexBuildMs = timeMs(() => (index = buildFirstTokenIndex(nfa!)));
+        console.log(
+            `  ${grammarName} index: ${index!.tokenMap.size} first-token entries, ` +
+                `hasWildcardStart=${index!.hasWildcardStart}, built in ${indexBuildMs.toFixed(2)} ms`,
+        );
+
+        // ── Per-request timing ────────────────────────────────────────────
+        for (const request of testRequests) {
+            const tokens = tokenizeRequest(request);
+
+            // Warm up JIT
+            matchNFA(nfa!, tokens, false);
+            matchNFAWithIndex(nfa!, index!, tokens, false);
+            matchDFAWithSplitting(dfa!, tokens);
+            traverseDFAOnly(dfa!, tokens);
+
+            // NFA full match (threading + slot ops + value eval) — baseline
+            const nfaMatchMs = timeMsN(
+                () => matchNFA(nfa!, tokens, false),
+                ITERATIONS,
+            );
+
+            // NFA with first-token index dispatch
+            const nfaIndexMs = timeMsN(
+                () => matchNFAWithIndex(nfa!, index!, tokens, false),
+                ITERATIONS,
+            );
+
+            // Pure DFA traversal (accept/reject decision only, no value)
+            const dfaTraverseMs = timeMsN(
+                () => traverseDFAOnly(dfa!, tokens),
+                ITERATIONS,
+            );
+
+            // DFA hybrid = matchDFAWithSplitting which now does:
+            //   DFA pre-filter → fast reject OR DFA accept → NFA value computation
+            const dfaHybridMs = timeMsN(
+                () => matchDFAWithSplitting(dfa!, tokens),
+                ITERATIONS,
+            );
+
+            const matched = matchNFA(nfa!, tokens, false).matched;
+
+            timingResults.push({
+                grammar: grammarName,
+                request,
+                matched,
+                nfaMatchMs,
+                nfaIndexMs,
+                dfaTraverseMs,
+                dfaHybridMs,
+                nfaMatchMsPerCall: (nfaMatchMs / ITERATIONS) * 1000,
+                nfaIndexMsPerCall: (nfaIndexMs / ITERATIONS) * 1000,
+                dfaTraverseMsPerCall: (dfaTraverseMs / ITERATIONS) * 1000,
+                dfaHybridMsPerCall: (dfaHybridMs / ITERATIONS) * 1000,
+                indexSpeedup: nfaIndexMs > 0 ? nfaMatchMs / nfaIndexMs : 0,
+                hybridSpeedup: dfaHybridMs > 0 ? nfaMatchMs / dfaHybridMs : 0,
+            });
+        }
+    }
+
+    afterAll(() => {
+        printSpaceTable(spaceResults);
+        printCompileTable(compileResults);
+        printTimingTable(timingResults);
+    });
+
+    // ── Player grammar ────────────────────────────────────────────────────────
+    describe("Player Grammar", () => {
+        const playerGrammarPath = path.resolve(
+            __dirname,
+            "../../../agents/player/src/agent/playerSchema.agr",
+        );
+
+        // Mix of matching and non-matching requests to show value-computation
+        // overhead in both cases.
+        const testRequests = [
+            // Literal-only (matched) — minimal value computation
+            "pause",
+            "resume",
+            // Wildcard (matched) — slot writes + string join
+            "play Shake It Off by Taylor Swift",
+            "select kitchen",
+            // Number entity (matched) — entity validation + slot write
+            "set volume to 50",
+            // Ordinal entity (matched)
+            "play the first track",
+            // Non-matching inputs — NFA threads die early
+            "play some music",
+            "skip to the next track",
+        ];
+
+        it("benchmarks NFA vs DFA on player grammar", () => {
+            runBenchmark("player", playerGrammarPath, testRequests);
+            expect(spaceResults.length).toBeGreaterThanOrEqual(0);
+        });
+
+        it("state count ratio is defined", () => {
+            const r = spaceResults.find((s) => s.grammar === "player");
+            if (r) {
+                expect(r.stateRatio).toBeDefined();
+                console.log(
+                    `Player: NFA=${r.nfaStates} states (${r.nfaSizeKb.toFixed(1)} KB), ` +
+                        `DFA=${r.dfaStates} states (${r.dfaSizeKb.toFixed(1)} KB), ` +
+                        `state-ratio=${r.stateRatio.toFixed(2)}x`,
+                );
+            } else {
+                expect(true).toBe(true); // grammar not available — skip
+            }
+        });
+    });
+});

--- a/ts/packages/actionGrammar/test/nfaDfaParity.spec.ts
+++ b/ts/packages/actionGrammar/test/nfaDfaParity.spec.ts
@@ -1,0 +1,1229 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+/**
+ * NFA / DFA Parity Tests
+ *
+ * For every test case the same input is run through both the NFA matcher and the
+ * DFA matcher.  The results are then compared field-by-field:
+ *   - matched / not matched
+ *   - actionValue (the extracted action object)
+ *   - matchedValueCount  (fixedString + checked + unchecked wildcard counts)
+ *   - wildcardCharCount  (unchecked wildcard token count)
+ *   - completions (sorted literal token suggestions)
+ *   - property completions (sorted actionName:propertyPath pairs)
+ *
+ * A failure here means the DFA diverges from the NFA and cannot be used as a
+ * drop-in replacement.
+ */
+
+import { loadGrammarRules } from "../src/grammarLoader.js";
+import { compileGrammarToNFA } from "../src/nfaCompiler.js";
+import {
+    matchGrammarWithNFA,
+    tokenizeRequest,
+    type NFAGrammarMatchResult,
+} from "../src/nfaMatcher.js";
+import { computeNFACompletions } from "../src/nfaCompletion.js";
+import { compileNFAToDFA } from "../src/dfaCompiler.js";
+import {
+    matchDFAWithSplitting,
+    getDFACompletions,
+    type DFAMatchResult,
+} from "../src/dfaMatcher.js";
+import { registerBuiltInEntities } from "../src/builtInEntities.js";
+import type { Grammar } from "../src/grammarTypes.js";
+import type { NFA } from "../src/nfa.js";
+import type { DFA } from "../src/dfa.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function compile(
+    name: string,
+    agr: string,
+): { grammar: Grammar; nfa: NFA; dfa: DFA } {
+    const grammar = loadGrammarRules(name, agr);
+    const nfa = compileGrammarToNFA(grammar, name);
+    const dfa = compileNFAToDFA(nfa, name);
+    return { grammar, nfa, dfa };
+}
+
+/** Adapt a DFA match result into the same shape as NFAGrammarMatchResult */
+function adaptDFA(
+    raw: DFAMatchResult,
+    request: string,
+): NFAGrammarMatchResult | null {
+    if (!raw.matched) return null;
+    return {
+        match: raw.actionValue ?? request,
+        matchedValueCount:
+            raw.fixedStringPartCount +
+            raw.checkedWildcardCount +
+            raw.uncheckedWildcardCount,
+        wildcardCharCount: raw.uncheckedWildcardCount,
+        entityWildcardPropertyNames: [],
+    };
+}
+
+/**
+ * Assert that NFA and DFA produce identical match results for `request`.
+ * Compares: matched flag, actionValue, matchedValueCount, wildcardCharCount.
+ */
+function assertMatchParity(
+    grammar: Grammar,
+    nfa: NFA,
+    dfa: DFA,
+    request: string,
+): void {
+    const nfaResults = matchGrammarWithNFA(grammar, nfa, request);
+    const tokens = tokenizeRequest(request);
+    const dfaRaw = matchDFAWithSplitting(dfa, tokens);
+    const dfaResult = adaptDFA(dfaRaw, request);
+    const nfaResult = nfaResults.length > 0 ? nfaResults[0] : null;
+
+    // Matched / not-matched must agree
+    expect(dfaResult !== null).toBe(
+        nfaResult !== null,
+        // Helpful context on failure:
+    );
+
+    if (nfaResult === null || dfaResult === null) return;
+
+    // Action value (deep equality — same structure AND values)
+    expect(dfaResult.match).toEqual(nfaResult.match);
+
+    // Priority counters
+    expect(dfaResult.matchedValueCount).toBe(nfaResult.matchedValueCount);
+    expect(dfaResult.wildcardCharCount).toBe(nfaResult.wildcardCharCount);
+}
+
+/**
+ * Assert that NFA and DFA produce identical completion results for `prefixTokens`.
+ * Compares: sorted literal completions, sorted actionName:propertyPath pairs.
+ */
+function assertCompletionParity(
+    nfa: NFA,
+    dfa: DFA,
+    prefixTokens: string[],
+): void {
+    const nfaComp = computeNFACompletions(nfa, prefixTokens);
+    const dfaComp = getDFACompletions(dfa, prefixTokens);
+
+    // Literal token completions (sort for deterministic comparison)
+    const nfaLiterals = [...(nfaComp.completions ?? [])].sort();
+    const dfaLiterals = [...(dfaComp.completions ?? [])].sort();
+    expect(dfaLiterals).toEqual(nfaLiterals);
+
+    // Property completions: compare as "actionName:propertyPath" pairs
+    const nfaProps = (nfaComp.properties ?? [])
+        .map((p) => `${(p.match as any).actionName}:${p.propertyNames[0]}`)
+        .sort();
+    const dfaProps = (dfaComp.properties ?? [])
+        .map((p) => `${p.actionName}:${p.propertyPath}`)
+        .sort();
+    expect(dfaProps).toEqual(nfaProps);
+}
+
+// ---------------------------------------------------------------------------
+// Test suite
+// ---------------------------------------------------------------------------
+
+describe("NFA/DFA Parity", () => {
+    // Register built-in entity validators (Ordinal, Cardinal, CalendarDate …)
+    // Must happen before matching (compilation is fine without them).
+    registerBuiltInEntities();
+
+    // -----------------------------------------------------------------------
+    // 1. Literal-only matches
+    // -----------------------------------------------------------------------
+    describe("literal matches", () => {
+        const { grammar, nfa, dfa } = compile(
+            "literals",
+            `
+            <pause>  = pause  -> { actionName: "pause" };
+            <resume> = resume -> { actionName: "resume" };
+            <stop>   = stop   -> { actionName: "stop" };
+            <Start>  = <pause> | <resume> | <stop>;
+            `,
+        );
+
+        it.each([["pause"], ["resume"], ["stop"]])("matches '%s'", (req) => {
+            assertMatchParity(grammar, nfa, dfa, req);
+        });
+
+        it.each([["play"], [""], ["pause the music"]])(
+            "does not match '%s'",
+            (req) => {
+                assertMatchParity(grammar, nfa, dfa, req);
+            },
+        );
+    });
+
+    // -----------------------------------------------------------------------
+    // 2. Unchecked (string/wildcard) wildcard
+    // -----------------------------------------------------------------------
+    describe("unchecked wildcard", () => {
+        const { grammar, nfa, dfa } = compile(
+            "unchecked",
+            `
+            <play> = play $(track:wildcard) -> { actionName: "play", parameters: { track } };
+            <Start> = <play>;
+            `,
+        );
+
+        it.each([
+            ["play Roxanne"],
+            ["play Shake It Off"],
+            ["play Big Red Sun"],
+        ])("captures wildcard in '%s'", (req) => {
+            assertMatchParity(grammar, nfa, dfa, req);
+        });
+
+        it.each([
+            ["stop Roxanne"],
+            ["play"], // no value for wildcard
+            [""],
+        ])("no match for '%s'", (req) => {
+            assertMatchParity(grammar, nfa, dfa, req);
+        });
+
+        it("preserves original casing in captured value", () => {
+            const nfaResults = matchGrammarWithNFA(
+                grammar,
+                nfa,
+                "play Shake It Off",
+            );
+            const dfaRaw = matchDFAWithSplitting(
+                dfa,
+                tokenizeRequest("play Shake It Off"),
+            );
+            expect(dfaRaw.matched).toBe(true);
+            expect(nfaResults.length).toBeGreaterThan(0);
+            const nfaTrack = (nfaResults[0].match as any)?.parameters?.track;
+            const dfaTrack = (dfaRaw.actionValue as any)?.parameters?.track;
+            expect(dfaTrack).toBe(nfaTrack);
+            expect(dfaTrack).toBe("Shake It Off"); // original casing
+        });
+    });
+
+    // -----------------------------------------------------------------------
+    // 3. Number wildcard (checked)
+    // -----------------------------------------------------------------------
+    describe("number wildcard", () => {
+        const { grammar, nfa, dfa } = compile(
+            "number",
+            `
+            <setVolume> = set volume to $(vol:number)
+                -> { actionName: "setVolume", parameters: { volume: vol } };
+            <Start> = <setVolume>;
+            `,
+        );
+
+        it.each([
+            ["set volume to 50"],
+            ["set volume to 0"],
+            ["set volume to 100"],
+        ])("captures number in '%s'", (req) => {
+            assertMatchParity(grammar, nfa, dfa, req);
+        });
+
+        it.each([["set volume to max"], ["set volume to"], ["volume 50"]])(
+            "no match for '%s'",
+            (req) => {
+                assertMatchParity(grammar, nfa, dfa, req);
+            },
+        );
+
+        it("number is stored as numeric value", () => {
+            const dfaRaw = matchDFAWithSplitting(
+                dfa,
+                tokenizeRequest("set volume to 75"),
+            );
+            expect(dfaRaw.matched).toBe(true);
+            expect((dfaRaw.actionValue as any)?.parameters?.volume).toBe(75);
+        });
+    });
+
+    // -----------------------------------------------------------------------
+    // 4. Two sequential wildcards
+    // -----------------------------------------------------------------------
+    describe("two sequential wildcards", () => {
+        const { grammar, nfa, dfa } = compile(
+            "twoWild",
+            `
+            <playBy> = play $(track:wildcard) by $(artist:wildcard)
+                -> { actionName: "play", parameters: { track, artist } };
+            <Start> = <playBy>;
+            `,
+        );
+
+        it.each([
+            ["play Roxanne by The Police"],
+            ["play Shake It Off by Taylor Swift"],
+            ["play Yesterday by The Beatles"],
+        ])("captures both wildcards in '%s'", (req) => {
+            assertMatchParity(grammar, nfa, dfa, req);
+        });
+
+        it.each([
+            ["play Roxanne"], // missing 'by artist'
+            ["Roxanne by The Police"], // missing 'play'
+        ])("no match for '%s'", (req) => {
+            assertMatchParity(grammar, nfa, dfa, req);
+        });
+
+        it("multi-word captures are joined correctly", () => {
+            const nfaResults = matchGrammarWithNFA(
+                grammar,
+                nfa,
+                "play Shake It Off by Taylor Swift",
+            );
+            const dfaRaw = matchDFAWithSplitting(
+                dfa,
+                tokenizeRequest("play Shake It Off by Taylor Swift"),
+            );
+            expect(dfaRaw.matched).toBe(true);
+            expect(nfaResults.length).toBeGreaterThan(0);
+            const nfaParams = (nfaResults[0].match as any)?.parameters;
+            const dfaParams = (dfaRaw.actionValue as any)?.parameters;
+            expect(dfaParams?.track).toBe(nfaParams?.track);
+            expect(dfaParams?.artist).toBe(nfaParams?.artist);
+            expect(dfaParams?.track).toBe("Shake It Off");
+            expect(dfaParams?.artist).toBe("Taylor Swift");
+        });
+    });
+
+    // -----------------------------------------------------------------------
+    // 5. Priority: fixed-string rule beats wildcard rule
+    // -----------------------------------------------------------------------
+    describe("priority: fixed string over wildcard", () => {
+        const { grammar, nfa, dfa } = compile(
+            "priority",
+            `
+            <specific> = play the music -> { actionName: "playMusic" };
+            <generic>  = play $(what:wildcard) -> { actionName: "playGeneric", parameters: { what } };
+            <Start> = <specific> | <generic>;
+            `,
+        );
+
+        it("fixed-string rule wins for 'play the music'", () => {
+            assertMatchParity(grammar, nfa, dfa, "play the music");
+            const nfaResults = matchGrammarWithNFA(
+                grammar,
+                nfa,
+                "play the music",
+            );
+            const dfaRaw = matchDFAWithSplitting(
+                dfa,
+                tokenizeRequest("play the music"),
+            );
+            expect((nfaResults[0].match as any)?.actionName).toBe("playMusic");
+            expect((dfaRaw.actionValue as any)?.actionName).toBe("playMusic");
+        });
+
+        it("wildcard rule wins for 'play Roxanne'", () => {
+            assertMatchParity(grammar, nfa, dfa, "play Roxanne");
+            const nfaResults = matchGrammarWithNFA(
+                grammar,
+                nfa,
+                "play Roxanne",
+            );
+            const dfaRaw = matchDFAWithSplitting(
+                dfa,
+                tokenizeRequest("play Roxanne"),
+            );
+            expect((nfaResults[0].match as any)?.actionName).toBe(
+                "playGeneric",
+            );
+            expect((dfaRaw.actionValue as any)?.actionName).toBe("playGeneric");
+        });
+
+        it("fixed-string matchedValueCount > wildcard matchedValueCount", () => {
+            const nfaFixed = matchGrammarWithNFA(
+                grammar,
+                nfa,
+                "play the music",
+            );
+            const nfaWild = matchGrammarWithNFA(grammar, nfa, "play Roxanne");
+            expect(nfaFixed[0].matchedValueCount).toBeGreaterThan(
+                nfaWild[0].matchedValueCount,
+            );
+
+            const dfaFixed = matchDFAWithSplitting(
+                dfa,
+                tokenizeRequest("play the music"),
+            );
+            const dfaWild = matchDFAWithSplitting(
+                dfa,
+                tokenizeRequest("play Roxanne"),
+            );
+            const dfaFixedCount =
+                dfaFixed.fixedStringPartCount + dfaFixed.checkedWildcardCount;
+            const dfaWildCount =
+                dfaWild.fixedStringPartCount + dfaWild.checkedWildcardCount;
+            expect(dfaFixedCount).toBeGreaterThan(dfaWildCount);
+        });
+    });
+
+    // -----------------------------------------------------------------------
+    // 6. Optional prefix
+    // -----------------------------------------------------------------------
+    describe("optional prefix", () => {
+        const { grammar, nfa, dfa } = compile(
+            "optional",
+            `
+            <play> = (please)? play $(track:wildcard)
+                -> { actionName: "play", parameters: { track } };
+            <Start> = <play>;
+            `,
+        );
+
+        it.each([
+            ["please play Roxanne"],
+            ["play Roxanne"],
+            ["please play Shake It Off"],
+            ["play Shake It Off"],
+        ])("matches '%s'", (req) => {
+            assertMatchParity(grammar, nfa, dfa, req);
+        });
+
+        it("captured track is the same with and without 'please'", () => {
+            const nfaWith = matchGrammarWithNFA(
+                grammar,
+                nfa,
+                "please play Roxanne",
+            );
+            const nfaWithout = matchGrammarWithNFA(
+                grammar,
+                nfa,
+                "play Roxanne",
+            );
+            const dfaWith = matchDFAWithSplitting(
+                dfa,
+                tokenizeRequest("please play Roxanne"),
+            );
+            const dfaWithout = matchDFAWithSplitting(
+                dfa,
+                tokenizeRequest("play Roxanne"),
+            );
+            const track = (r: any) => r?.parameters?.track;
+            expect(track(nfaWith[0].match)).toBe(track(nfaWithout[0].match));
+            expect(track(dfaWith.actionValue)).toBe(
+                track(dfaWithout.actionValue),
+            );
+            expect(track(dfaWith.actionValue)).toBe(track(nfaWith[0].match));
+        });
+    });
+
+    // -----------------------------------------------------------------------
+    // 7. Kleene plus (one-or-more)
+    // -----------------------------------------------------------------------
+    describe("Kleene plus (one-or-more)", () => {
+        const { grammar, nfa, dfa } = compile(
+            "kleenePlus",
+            `
+            <knock> = (knock)+ -> { actionName: "knock" };
+            <Start> = <knock>;
+            `,
+        );
+
+        it.each([["knock"], ["knock knock"], ["knock knock knock"]])(
+            "matches '%s'",
+            (req) => {
+                assertMatchParity(grammar, nfa, dfa, req);
+            },
+        );
+
+        it("does not match empty", () => {
+            assertMatchParity(grammar, nfa, dfa, "");
+        });
+    });
+
+    // -----------------------------------------------------------------------
+    // 8. Ordinal entity (checked wildcard, multi-token capable)
+    // -----------------------------------------------------------------------
+    describe("Ordinal entity", () => {
+        const { grammar, nfa, dfa } = compile(
+            "ordinal",
+            `
+            entity Ordinal;
+            <playNth> = play the $(n:Ordinal) song
+                -> { actionName: "playNth", parameters: { index: n } };
+            <Start> = <playNth>;
+            `,
+        );
+
+        it.each([
+            ["play the first song"],
+            ["play the second song"],
+            ["play the third song"],
+            ["play the 3rd song"],
+            ["play the 10th song"],
+        ])("matches ordinal '%s'", (req) => {
+            assertMatchParity(grammar, nfa, dfa, req);
+        });
+
+        it("does not match non-ordinal", () => {
+            assertMatchParity(grammar, nfa, dfa, "play the excellent song");
+        });
+
+        it("ordinal is a checked wildcard (checkedWildcardCount === 1)", () => {
+            const dfaRaw = matchDFAWithSplitting(
+                dfa,
+                tokenizeRequest("play the first song"),
+            );
+            expect(dfaRaw.matched).toBe(true);
+            expect(dfaRaw.checkedWildcardCount).toBe(1);
+            expect(dfaRaw.uncheckedWildcardCount).toBe(0);
+        });
+    });
+
+    // -----------------------------------------------------------------------
+    // 9. Cardinal entity (checked wildcard)
+    // -----------------------------------------------------------------------
+    describe("Cardinal entity", () => {
+        const { grammar, nfa, dfa } = compile(
+            "cardinal",
+            `
+            entity Cardinal;
+            <skipN> = skip $(n:Cardinal) songs
+                -> { actionName: "skip", parameters: { count: n } };
+            <Start> = <skipN>;
+            `,
+        );
+
+        it.each([["skip three songs"], ["skip 5 songs"], ["skip one song"]])(
+            "matches cardinal '%s'",
+            (req) => {
+                assertMatchParity(grammar, nfa, dfa, req);
+            },
+        );
+    });
+
+    // -----------------------------------------------------------------------
+    // 10. Trailing punctuation normalisation
+    // -----------------------------------------------------------------------
+    describe("trailing punctuation", () => {
+        const { grammar, nfa, dfa } = compile(
+            "punct",
+            `
+            <pause>  = pause  -> { actionName: "pause" };
+            <play>   = play $(track:wildcard) -> { actionName: "play", parameters: { track } };
+            <Start>  = <pause> | <play>;
+            `,
+        );
+
+        it.each([["pause."], ["pause!"], ["pause?"]])(
+            "matches literal with trailing punct '%s'",
+            (req) => {
+                assertMatchParity(grammar, nfa, dfa, req);
+            },
+        );
+
+        it.each([["play Roxanne!"], ["play Shake It Off."]])(
+            "matches wildcard with trailing punct '%s'",
+            (req) => {
+                assertMatchParity(grammar, nfa, dfa, req);
+            },
+        );
+    });
+
+    // -----------------------------------------------------------------------
+    // 11. Case insensitivity
+    // -----------------------------------------------------------------------
+    describe("case insensitivity", () => {
+        const { grammar, nfa, dfa } = compile(
+            "caseInsensitive",
+            `
+            <pause> = pause -> { actionName: "pause" };
+            <play>  = play $(track:wildcard) -> { actionName: "play", parameters: { track } };
+            <Start> = <pause> | <play>;
+            `,
+        );
+
+        it.each([
+            ["PAUSE"],
+            ["Pause"],
+            ["PLAY Roxanne"],
+            ["Play Shake It Off"],
+        ])("case-insensitive match for '%s'", (req) => {
+            assertMatchParity(grammar, nfa, dfa, req);
+        });
+    });
+
+    // -----------------------------------------------------------------------
+    // 12. Multiple alternatives — best match selected
+    // -----------------------------------------------------------------------
+    describe("multiple alternatives", () => {
+        const { grammar, nfa, dfa } = compile(
+            "multiAlt",
+            `
+            <pauseMusic>  = pause the music  -> { actionName: "pauseMusic" };
+            <pause>       = pause            -> { actionName: "pause" };
+            <playMusic>   = play the music   -> { actionName: "playMusic" };
+            <playGeneric> = play $(track:wildcard) -> { actionName: "play", parameters: { track } };
+            <Start> = <pauseMusic> | <pause> | <playMusic> | <playGeneric>;
+            `,
+        );
+
+        it.each([
+            ["pause"],
+            ["pause the music"],
+            ["play the music"],
+            ["play Roxanne"],
+        ])("selects correct action for '%s'", (req) => {
+            assertMatchParity(grammar, nfa, dfa, req);
+        });
+    });
+
+    // -----------------------------------------------------------------------
+    // 13. Completions parity
+    // -----------------------------------------------------------------------
+    describe("completions", () => {
+        // Grammar with both literal and wildcard rules
+        const { nfa: nfaA, dfa: dfaA } = compile(
+            "completions-A",
+            `
+            <pause>  = pause  -> { actionName: "pause" };
+            <resume> = resume -> { actionName: "resume" };
+            <play>   = play $(track:wildcard)  -> { actionName: "play", parameters: { track } };
+            <Start>  = <pause> | <resume> | <play>;
+            `,
+        );
+
+        it("empty prefix: suggests all starting tokens", () => {
+            assertCompletionParity(nfaA, dfaA, []);
+        });
+
+        it("after 'play': wildcard position (no literal completions)", () => {
+            assertCompletionParity(nfaA, dfaA, ["play"]);
+        });
+
+        it("no completions after non-matching prefix", () => {
+            assertCompletionParity(nfaA, dfaA, ["stop"]);
+        });
+
+        // Grammar with a checked (number) wildcard — exercises property completions
+        const { nfa: nfaB, dfa: dfaB } = compile(
+            "completions-B",
+            `
+            <setVolume>  = set volume to $(vol:number)
+                -> { actionName: "setVolume", parameters: { volume: vol } };
+            <setBalance> = set balance to $(bal:number)
+                -> { actionName: "setBalance", parameters: { balance: bal } };
+            <Start> = <setVolume> | <setBalance>;
+            `,
+        );
+
+        it("empty prefix: both 'set' starts", () => {
+            assertCompletionParity(nfaB, dfaB, []);
+        });
+
+        it("after 'set volume to': property completion for checked wildcard", () => {
+            assertCompletionParity(nfaB, dfaB, ["set", "volume", "to"]);
+        });
+
+        it("after 'set balance to': property completion for checked wildcard", () => {
+            assertCompletionParity(nfaB, dfaB, ["set", "balance", "to"]);
+        });
+
+        it("after 'set': suggests next literal tokens", () => {
+            assertCompletionParity(nfaB, dfaB, ["set"]);
+        });
+
+        it("after 'set volume': suggests next literal token", () => {
+            assertCompletionParity(nfaB, dfaB, ["set", "volume"]);
+        });
+    });
+
+    // -----------------------------------------------------------------------
+    // 15. Three sequential wildcards (track / artist / playlist)
+    // -----------------------------------------------------------------------
+    describe("three sequential wildcards", () => {
+        const { grammar, nfa, dfa } = compile(
+            "threeWild",
+            `
+            <add> = add $(track:wildcard) by $(artist:wildcard) to $(playlist:wildcard)
+                -> { actionName: "addToQueue", parameters: { track, artist, playlist } };
+            <Start> = <add>;
+            `,
+        );
+
+        it.each([
+            ["add Roxanne by The Police to Rock"],
+            ["add Shake It Off by Taylor Swift to Pop Playlist"],
+            ["add Yesterday by Beatles to Classics"],
+        ])("captures three wildcards in '%s'", (req) => {
+            assertMatchParity(grammar, nfa, dfa, req);
+        });
+
+        it("joins multi-word tokens for all three positions", () => {
+            const dfaRaw = matchDFAWithSplitting(
+                dfa,
+                tokenizeRequest("add Shake It Off by Taylor Swift to My Queue"),
+            );
+            expect(dfaRaw.matched).toBe(true);
+            const params = (dfaRaw.actionValue as any)?.parameters;
+            expect(params?.track).toBe("Shake It Off");
+            expect(params?.artist).toBe("Taylor Swift");
+            expect(params?.playlist).toBe("My Queue");
+        });
+    });
+
+    // -----------------------------------------------------------------------
+    // 16. Nested rule returning a variable (single-wildcard inner rule)
+    // -----------------------------------------------------------------------
+    describe("nested rule returning variable", () => {
+        const { grammar, nfa, dfa } = compile(
+            "nestedVar",
+            `
+            <TrackName> = $(x:wildcard) -> x;
+            <play> = play $(trackName:<TrackName>)
+                -> { actionName: "play", parameters: { trackName } };
+            <Start> = <play>;
+            `,
+        );
+
+        it.each([["play Roxanne"], ["play Shake It Off"], ["play Yesterday"]])(
+            "matches '%s' via nested rule",
+            (req) => {
+                assertMatchParity(grammar, nfa, dfa, req);
+            },
+        );
+
+        it("captured track value propagates through nested rule", () => {
+            const dfaRaw = matchDFAWithSplitting(
+                dfa,
+                tokenizeRequest("play Shake It Off"),
+            );
+            expect(dfaRaw.matched).toBe(true);
+            expect((dfaRaw.actionValue as any)?.parameters?.trackName).toBe(
+                "Shake It Off",
+            );
+        });
+    });
+
+    // -----------------------------------------------------------------------
+    // 17. Nested rule returning an object (two captures in inner rule)
+    // -----------------------------------------------------------------------
+    describe("nested rule returning object with two captures", () => {
+        const { grammar, nfa, dfa } = compile(
+            "nestedObj",
+            `
+            <Song> = $(title:wildcard) by $(artist:wildcard) -> { title, artist };
+            <play> = play $(song:<Song>)
+                -> { actionName: "play", parameters: { song } };
+            <Start> = <play>;
+            `,
+        );
+
+        it.each([
+            ["play Roxanne by The Police"],
+            ["play Shake It Off by Taylor Swift"],
+        ])("captures nested object in '%s'", (req) => {
+            assertMatchParity(grammar, nfa, dfa, req);
+        });
+
+        it("nested object has correct title and artist", () => {
+            const dfaRaw = matchDFAWithSplitting(
+                dfa,
+                tokenizeRequest("play Roxanne by The Police"),
+            );
+            expect(dfaRaw.matched).toBe(true);
+            const song = (dfaRaw.actionValue as any)?.parameters?.song;
+            expect(song?.title).toBe("Roxanne");
+            expect(song?.artist).toBe("The Police");
+        });
+
+        it("multi-word title and artist captured correctly", () => {
+            const dfaRaw = matchDFAWithSplitting(
+                dfa,
+                tokenizeRequest("play Shake It Off by Taylor Swift"),
+            );
+            expect(dfaRaw.matched).toBe(true);
+            const song = (dfaRaw.actionValue as any)?.parameters?.song;
+            expect(song?.title).toBe("Shake It Off");
+            expect(song?.artist).toBe("Taylor Swift");
+        });
+    });
+
+    // -----------------------------------------------------------------------
+    // 18. Two alternatives in nested rule — each with its own action
+    // -----------------------------------------------------------------------
+    describe("alternation in nested rule", () => {
+        const { grammar, nfa, dfa } = compile(
+            "nestedAlt",
+            `
+            <Mode> = my music   -> { type: "music" }
+                   | my playlist -> { type: "playlist" };
+            <play> = play $(m:<Mode>)
+                -> { actionName: "play", parameters: { mode: m } };
+            <Start> = <play>;
+            `,
+        );
+
+        it("matches 'play my music'", () => {
+            assertMatchParity(grammar, nfa, dfa, "play my music");
+        });
+
+        it("matches 'play my playlist'", () => {
+            assertMatchParity(grammar, nfa, dfa, "play my playlist");
+        });
+
+        it("does not match 'play something'", () => {
+            assertMatchParity(grammar, nfa, dfa, "play something");
+        });
+
+        it("correct mode type is returned", () => {
+            const dfaRaw = matchDFAWithSplitting(
+                dfa,
+                tokenizeRequest("play my playlist"),
+            );
+            expect(dfaRaw.matched).toBe(true);
+            expect((dfaRaw.actionValue as any)?.parameters?.mode?.type).toBe(
+                "playlist",
+            );
+        });
+    });
+
+    // -----------------------------------------------------------------------
+    // 19. Optional second wildcard via alternation: play X [by Y]
+    // (grammar doesn't allow captures inside optional groups — use alternation)
+    // -----------------------------------------------------------------------
+    describe("optional second wildcard (via alternation)", () => {
+        const { grammar, nfa, dfa } = compile(
+            "optSecondWild",
+            `
+            <playWithArtist>    = play $(track:wildcard) by $(artist:wildcard)
+                -> { actionName: "play", parameters: { track, artist } };
+            <playWithoutArtist> = play $(track:wildcard)
+                -> { actionName: "play", parameters: { track } };
+            <Start> = <playWithArtist> | <playWithoutArtist>;
+            `,
+        );
+
+        it.each([
+            ["play Roxanne by The Police"],
+            ["play Roxanne"],
+            ["play Shake It Off by Taylor Swift"],
+            ["play Shake It Off"],
+        ])("matches '%s'", (req) => {
+            assertMatchParity(grammar, nfa, dfa, req);
+        });
+
+        it("artist is undefined when not supplied", () => {
+            const dfaRaw = matchDFAWithSplitting(
+                dfa,
+                tokenizeRequest("play Roxanne"),
+            );
+            expect(dfaRaw.matched).toBe(true);
+            expect((dfaRaw.actionValue as any)?.parameters?.track).toBe(
+                "Roxanne",
+            );
+            // playWithoutArtist rule has no artist key
+            expect(
+                (dfaRaw.actionValue as any)?.parameters?.artist,
+            ).toBeUndefined();
+        });
+    });
+
+    // -----------------------------------------------------------------------
+    // 20. Ordinal entity in rule with surrounding fixed tokens
+    // -----------------------------------------------------------------------
+    describe("Ordinal entity with surrounding words", () => {
+        const { grammar, nfa, dfa } = compile(
+            "ordinalContext",
+            `
+            entity Ordinal;
+            <play> = play the $(n:Ordinal) track on my device
+                -> { actionName: "playNth", parameters: { index: n } };
+            <Start> = <play>;
+            `,
+        );
+
+        it.each([
+            ["play the first track on my device"],
+            ["play the second track on my device"],
+            ["play the 5th track on my device"],
+        ])("matches '%s'", (req) => {
+            assertMatchParity(grammar, nfa, dfa, req);
+        });
+
+        it("does not match missing surrounding words", () => {
+            assertMatchParity(grammar, nfa, dfa, "play the first track");
+        });
+    });
+
+    // -----------------------------------------------------------------------
+    // 21. Two entity wildcards in same rule (Ordinal + Cardinal)
+    // -----------------------------------------------------------------------
+    describe("two entity wildcards: Ordinal and Cardinal", () => {
+        const { grammar, nfa, dfa } = compile(
+            "twoEntities",
+            `
+            entity Ordinal, Cardinal;
+            <playRange> = play from the $(start:Ordinal) to the $(end:Ordinal) track
+                -> { actionName: "playRange", parameters: { start, end } };
+            <Start> = <playRange>;
+            `,
+        );
+
+        it.each([
+            ["play from the first to the third track"],
+            ["play from the second to the fifth track"],
+        ])("matches '%s'", (req) => {
+            assertMatchParity(grammar, nfa, dfa, req);
+        });
+
+        it("both ordinals are checked wildcards", () => {
+            const dfaRaw = matchDFAWithSplitting(
+                dfa,
+                tokenizeRequest("play from the first to the third track"),
+            );
+            expect(dfaRaw.matched).toBe(true);
+            expect(dfaRaw.checkedWildcardCount).toBe(2);
+            expect(dfaRaw.uncheckedWildcardCount).toBe(0);
+        });
+    });
+
+    // -----------------------------------------------------------------------
+    // 22. Three alternatives with 0, 1, 2 variables respectively
+    // -----------------------------------------------------------------------
+    describe("three alternatives: 0 / 1 / 2 variables", () => {
+        const { grammar, nfa, dfa } = compile(
+            "varCountAlts",
+            `
+            <play0> = play -> { actionName: "play" };
+            <play1> = play $(track:wildcard) -> { actionName: "playTrack", parameters: { track } };
+            <play2> = play $(track:wildcard) by $(artist:wildcard)
+                -> { actionName: "playBy", parameters: { track, artist } };
+            <Start> = <play0> | <play1> | <play2>;
+            `,
+        );
+
+        it.each([
+            ["play"],
+            ["play Roxanne"],
+            ["play Roxanne by The Police"],
+            ["play Shake It Off by Taylor Swift"],
+        ])("selects correct alternative for '%s'", (req) => {
+            assertMatchParity(grammar, nfa, dfa, req);
+        });
+
+        it("bare 'play' returns actionName-only action", () => {
+            const dfaRaw = matchDFAWithSplitting(dfa, tokenizeRequest("play"));
+            expect(dfaRaw.matched).toBe(true);
+            expect((dfaRaw.actionValue as any)?.actionName).toBe("play");
+        });
+
+        it("two-wildcard match captures both values", () => {
+            const dfaRaw = matchDFAWithSplitting(
+                dfa,
+                tokenizeRequest("play Roxanne by The Police"),
+            );
+            expect(dfaRaw.matched).toBe(true);
+            expect((dfaRaw.actionValue as any)?.actionName).toBe("playBy");
+            expect((dfaRaw.actionValue as any)?.parameters?.track).toBe(
+                "Roxanne",
+            );
+            expect((dfaRaw.actionValue as any)?.parameters?.artist).toBe(
+                "The Police",
+            );
+        });
+    });
+
+    // -----------------------------------------------------------------------
+    // 23. Two-level deep nesting: play (song (title + artist))
+    // -----------------------------------------------------------------------
+    describe("two-level deep nesting", () => {
+        const { grammar, nfa, dfa } = compile(
+            "twoLevelNest",
+            `
+            <ArtistRef> = by $(name:wildcard) -> name;
+            <Song> = $(title:wildcard) $(artist:<ArtistRef>) -> { title, artist };
+            <play> = play $(song:<Song>)
+                -> { actionName: "play", parameters: { song } };
+            <Start> = <play>;
+            `,
+        );
+
+        it.each([
+            ["play Roxanne by The Police"],
+            ["play Shake It Off by Taylor Swift"],
+        ])("matches two-level '%s'", (req) => {
+            assertMatchParity(grammar, nfa, dfa, req);
+        });
+
+        it("deeply-nested artist propagates correctly", () => {
+            const dfaRaw = matchDFAWithSplitting(
+                dfa,
+                tokenizeRequest("play Roxanne by The Police"),
+            );
+            expect(dfaRaw.matched).toBe(true);
+            const song = (dfaRaw.actionValue as any)?.parameters?.song;
+            expect(song?.title).toBe("Roxanne");
+            expect(song?.artist).toBe("The Police");
+        });
+    });
+
+    // -----------------------------------------------------------------------
+    // 24. Two calls to the same nested rule within one rule
+    // -----------------------------------------------------------------------
+    describe("two references to same nested rule", () => {
+        const { grammar, nfa, dfa } = compile(
+            "twoNestedRefs",
+            `
+            <Item> = $(name:wildcard) -> name;
+            <compare> = compare $(a:<Item>) with $(b:<Item>)
+                -> { actionName: "compare", parameters: { first: a, second: b } };
+            <Start> = <compare>;
+            `,
+        );
+
+        it.each([
+            ["compare Roxanne with Havana"],
+            ["compare The Police with Taylor Swift"],
+        ])("matches '%s'", (req) => {
+            assertMatchParity(grammar, nfa, dfa, req);
+        });
+
+        it("both items captured independently", () => {
+            const dfaRaw = matchDFAWithSplitting(
+                dfa,
+                tokenizeRequest("compare Roxanne with Havana"),
+            );
+            expect(dfaRaw.matched).toBe(true);
+            const p = (dfaRaw.actionValue as any)?.parameters;
+            expect(p?.first).toBe("Roxanne");
+            expect(p?.second).toBe("Havana");
+        });
+
+        it("multi-word items captured independently", () => {
+            const dfaRaw = matchDFAWithSplitting(
+                dfa,
+                tokenizeRequest(
+                    "compare Shake It Off with My Heart Will Go On",
+                ),
+            );
+            expect(dfaRaw.matched).toBe(true);
+            const p = (dfaRaw.actionValue as any)?.parameters;
+            expect(p?.first).toBe("Shake It Off");
+            expect(p?.second).toBe("My Heart Will Go On");
+        });
+    });
+
+    // -----------------------------------------------------------------------
+    // 25. Number wildcard with optional surrounding words
+    // -----------------------------------------------------------------------
+    describe("number wildcard with optional words", () => {
+        const { grammar, nfa, dfa } = compile(
+            "numOptional",
+            `
+            <vol> = set (the)? volume (to)? $(n:number)
+                -> { actionName: "setVolume", parameters: { volume: n } };
+            <Start> = <vol>;
+            `,
+        );
+
+        it.each([
+            ["set volume 50"],
+            ["set volume to 50"],
+            ["set the volume 75"],
+            ["set the volume to 75"],
+        ])("matches '%s'", (req) => {
+            assertMatchParity(grammar, nfa, dfa, req);
+        });
+
+        it("volume value is numeric", () => {
+            const dfaRaw = matchDFAWithSplitting(
+                dfa,
+                tokenizeRequest("set the volume to 80"),
+            );
+            expect(dfaRaw.matched).toBe(true);
+            expect((dfaRaw.actionValue as any)?.parameters?.volume).toBe(80);
+        });
+    });
+
+    // -----------------------------------------------------------------------
+    // 26. Cardinal entity in nested rule
+    // -----------------------------------------------------------------------
+    describe("Cardinal entity in nested rule", () => {
+        const { grammar, nfa, dfa } = compile(
+            "cardinalNested",
+            `
+            entity Cardinal;
+            <Qty> = $(n:Cardinal) -> n;
+            <skip> = skip $(count:<Qty>) songs
+                -> { actionName: "skip", parameters: { count } };
+            <Start> = <skip>;
+            `,
+        );
+
+        it.each([["skip three songs"], ["skip five songs"], ["skip one song"]])(
+            "matches '%s' with Cardinal in nested rule",
+            (req) => {
+                assertMatchParity(grammar, nfa, dfa, req);
+            },
+        );
+
+        it("Cardinal count propagates through nested rule", () => {
+            const dfaRaw = matchDFAWithSplitting(
+                dfa,
+                tokenizeRequest("skip three songs"),
+            );
+            expect(dfaRaw.matched).toBe(true);
+            expect(
+                (dfaRaw.actionValue as any)?.parameters?.count,
+            ).toBeDefined();
+        });
+    });
+
+    // -----------------------------------------------------------------------
+    // 27. Multi-token wildcard accumulation (greedy trailing wildcard)
+    // A trailing $(var:wildcard) greedily consumes all remaining tokens.
+    // -----------------------------------------------------------------------
+    describe("multi-token wildcard accumulation (greedy)", () => {
+        const { grammar, nfa, dfa } = compile(
+            "greedyWild",
+            `
+            <search> = search $(query:wildcard)
+                -> { actionName: "search", parameters: { query } };
+            <Start> = <search>;
+            `,
+        );
+
+        it.each([
+            ["search jazz"],
+            ["search happy upbeat music"],
+            ["search rock classics from the 80s"],
+        ])("matches '%s' accumulating all words", (req) => {
+            assertMatchParity(grammar, nfa, dfa, req);
+        });
+
+        it("multi-word query is joined correctly", () => {
+            const dfaRaw = matchDFAWithSplitting(
+                dfa,
+                tokenizeRequest("search happy upbeat music"),
+            );
+            expect(dfaRaw.matched).toBe(true);
+            expect((dfaRaw.actionValue as any)?.parameters?.query).toBe(
+                "happy upbeat music",
+            );
+        });
+    });
+
+    // -----------------------------------------------------------------------
+    // 28. Mixed: fixed prefix + wildcard + optional entity suffix (via alternation)
+    // (grammar doesn't allow captures inside optional groups — use alternation)
+    // -----------------------------------------------------------------------
+    describe("fixed prefix, wildcard, optional entity suffix (via alternation)", () => {
+        const { grammar, nfa, dfa } = compile(
+            "mixedOptEntity",
+            `
+            entity Ordinal;
+            <playWithRepeat> = play $(track:wildcard) the $(n:Ordinal) time
+                -> { actionName: "play", parameters: { track, repeat: n } };
+            <playOnce> = play $(track:wildcard)
+                -> { actionName: "play", parameters: { track } };
+            <Start> = <playWithRepeat> | <playOnce>;
+            `,
+        );
+
+        it.each([
+            ["play Roxanne"],
+            ["play Roxanne the second time"],
+            ["play Shake It Off"],
+            ["play Shake It Off the first time"],
+        ])("matches '%s'", (req) => {
+            assertMatchParity(grammar, nfa, dfa, req);
+        });
+    });
+
+    // -----------------------------------------------------------------------
+    // 29. Completions parity for multi-variable grammar
+    // -----------------------------------------------------------------------
+    describe("completions parity: multi-variable grammar", () => {
+        const { nfa, dfa } = compile(
+            "multiVarComp",
+            `
+            entity Ordinal, Cardinal;
+            <playNth>   = play the $(n:Ordinal) song
+                -> { actionName: "playNth", parameters: { index: n } };
+            <playTrack> = play $(track:wildcard) by $(artist:wildcard)
+                -> { actionName: "playTrack", parameters: { track, artist } };
+            <skipN>     = skip $(n:Cardinal) songs
+                -> { actionName: "skip", parameters: { count: n } };
+            <Start> = <playNth> | <playTrack> | <skipN>;
+            `,
+        );
+
+        it("empty prefix: shows 'play' and 'skip'", () => {
+            assertCompletionParity(nfa, dfa, []);
+        });
+
+        it("after 'play': shows 'the' (for playNth) and wildcard (for playTrack)", () => {
+            assertCompletionParity(nfa, dfa, ["play"]);
+        });
+
+        it("after 'play the': shows ordinal-position completion", () => {
+            assertCompletionParity(nfa, dfa, ["play", "the"]);
+        });
+
+        it("after 'skip': shows Cardinal wildcard position", () => {
+            assertCompletionParity(nfa, dfa, ["skip"]);
+        });
+    });
+
+    // -----------------------------------------------------------------------
+    // 14. Priority counters are consistent
+    // -----------------------------------------------------------------------
+    describe("priority counter consistency", () => {
+        const { grammar, nfa, dfa } = compile(
+            "counters",
+            `
+            entity Cardinal;
+            <fixed>   = play the music      -> { actionName: "playFixed" };
+            <checked> = play $(n:Cardinal) songs -> { actionName: "playN", parameters: { count: n } };
+            <unchecked> = play $(track:wildcard) -> { actionName: "play", parameters: { track } };
+            <Start> = <fixed> | <checked> | <unchecked>;
+            `,
+        );
+
+        it("fixed-string: checked=0, unchecked=0", () => {
+            const dfa1 = matchDFAWithSplitting(
+                dfa,
+                tokenizeRequest("play the music"),
+            );
+            const nfa1 = matchGrammarWithNFA(grammar, nfa, "play the music");
+            expect(dfa1.matched).toBe(true);
+            expect(nfa1.length).toBeGreaterThan(0);
+            expect(dfa1.checkedWildcardCount).toBe(0);
+            expect(dfa1.uncheckedWildcardCount).toBe(0);
+            assertMatchParity(grammar, nfa, dfa, "play the music");
+        });
+
+        it("checked wildcard: checkedWildcardCount=1, unchecked=0", () => {
+            const dfaRaw = matchDFAWithSplitting(
+                dfa,
+                tokenizeRequest("play three songs"),
+            );
+            expect(dfaRaw.matched).toBe(true);
+            expect(dfaRaw.checkedWildcardCount).toBe(1);
+            expect(dfaRaw.uncheckedWildcardCount).toBe(0);
+            assertMatchParity(grammar, nfa, dfa, "play three songs");
+        });
+
+        it("unchecked wildcard: checkedWildcardCount=0, unchecked tokens", () => {
+            const dfaRaw = matchDFAWithSplitting(
+                dfa,
+                tokenizeRequest("play Roxanne"),
+            );
+            expect(dfaRaw.matched).toBe(true);
+            expect(dfaRaw.checkedWildcardCount).toBe(0);
+            expect(dfaRaw.uncheckedWildcardCount).toBeGreaterThan(0);
+            assertMatchParity(grammar, nfa, dfa, "play Roxanne");
+        });
+    });
+});

--- a/ts/packages/cache/src/cache/grammarStore.ts
+++ b/ts/packages/cache/src/cache/grammarStore.ts
@@ -10,6 +10,11 @@ import {
     compileGrammarToNFA,
     matchGrammarWithNFA,
     computeNFACompletions,
+    DFA,
+    compileNFAToDFA,
+    matchDFAWithSplitting,
+    getDFACompletions,
+    tokenizeRequest,
 } from "action-grammar";
 
 const debug = registerDebug("typeagent:cache:grammarStore");
@@ -30,12 +35,14 @@ import { sortMatches } from "./sortMatches.js";
 interface GrammarEntry {
     grammar: Grammar;
     nfa?: NFA;
+    dfa?: DFA;
 }
 
 export class GrammarStoreImpl implements GrammarStore {
     private readonly grammars: Map<string, GrammarEntry> = new Map();
     private enabled: boolean = true;
     private useNFA: boolean = false;
+    private useDFA: boolean = false;
 
     public constructor(
         private readonly schemaInfoProvider: SchemaInfoProvider | undefined,
@@ -68,6 +75,36 @@ export class GrammarStoreImpl implements GrammarStore {
         }
         this.useNFA = useNFA;
     }
+    /**
+     * Enable or disable DFA matching.
+     * DFA requires NFA to be enabled first.
+     * When enabling DFA for the first time, compiles existing NFAs to DFAs.
+     */
+    public setUseDFA(useDFA: boolean): void {
+        if (useDFA && !this.useDFA) {
+            // Ensure NFA is compiled first
+            if (!this.useNFA) {
+                this.setUseNFA(true);
+            }
+            // Compile existing NFAs to DFAs
+            for (const [key, entry] of this.grammars) {
+                if (entry.nfa && !entry.dfa) {
+                    try {
+                        const schemaName =
+                            splitSchemaNamespaceKey(key).schemaName;
+                        entry.dfa = compileNFAToDFA(entry.nfa, schemaName);
+                    } catch (error) {
+                        console.error(
+                            `Failed to compile NFA to DFA for ${key}:`,
+                            error,
+                        );
+                    }
+                }
+            }
+        }
+        this.useDFA = useDFA;
+    }
+
     public addGrammar(schemaName: string, grammar: Grammar): void {
         const namespaceKey = getSchemaNamespaceKey(
             schemaName,
@@ -84,6 +121,16 @@ export class GrammarStoreImpl implements GrammarStore {
                     error,
                 );
                 // Fall back to old matcher if compilation fails
+            }
+        }
+        if (this.useDFA && entry.nfa) {
+            try {
+                entry.dfa = compileNFAToDFA(entry.nfa, schemaName);
+            } catch (error) {
+                console.error(
+                    `Failed to compile NFA to DFA for ${schemaName}:`,
+                    error,
+                );
             }
         }
         this.grammars.set(namespaceKey, entry);
@@ -133,15 +180,44 @@ export class GrammarStoreImpl implements GrammarStore {
             }
 
             const { schemaName } = splitSchemaNamespaceKey(name);
+            const matchMode =
+                this.useDFA && entry.dfa
+                    ? "DFA"
+                    : this.useNFA && entry.nfa
+                      ? "NFA"
+                      : "legacy";
             debug(
-                `Matching "${request}" against ${schemaName} (${this.useNFA ? "NFA" : "legacy"}) - NFA states: ${entry.nfa?.states.length || 0}, rules: ${entry.grammar.rules.length}`,
+                `Matching "${request}" against ${schemaName} (${matchMode}) - NFA states: ${entry.nfa?.states.length || 0}, DFA states: ${entry.dfa?.states.length || 0}, rules: ${entry.grammar.rules.length}`,
             );
 
-            // Use NFA matcher if available, otherwise fall back to old matcher
-            const grammarMatches =
-                this.useNFA && entry.nfa
-                    ? matchGrammarWithNFA(entry.grammar, entry.nfa, request)
-                    : matchGrammar(entry.grammar, request);
+            // Choose matcher: DFA > NFA > legacy
+            let grammarMatches;
+            if (this.useDFA && entry.dfa) {
+                const tokens = tokenizeRequest(request);
+                const dfaResult = matchDFAWithSplitting(entry.dfa, tokens);
+                grammarMatches = dfaResult.matched
+                    ? [
+                          {
+                              match: dfaResult.actionValue ?? request,
+                              matchedValueCount:
+                                  dfaResult.fixedStringPartCount +
+                                  dfaResult.checkedWildcardCount +
+                                  dfaResult.uncheckedWildcardCount,
+                              wildcardCharCount:
+                                  dfaResult.uncheckedWildcardCount,
+                              entityWildcardPropertyNames: [],
+                          },
+                      ]
+                    : [];
+            } else if (this.useNFA && entry.nfa) {
+                grammarMatches = matchGrammarWithNFA(
+                    entry.grammar,
+                    entry.nfa,
+                    request,
+                );
+            } else {
+                grammarMatches = matchGrammar(entry.grammar, request);
+            }
 
             if (grammarMatches.length === 0) {
                 debug(`No matches in ${schemaName} grammar`);
@@ -201,7 +277,40 @@ export class GrammarStoreImpl implements GrammarStore {
             if (filter && !filter.has(name)) {
                 continue;
             }
-            if (this.useNFA && entry.nfa) {
+            if (this.useDFA && entry.dfa) {
+                // DFA-based completions
+                const tokens = requestPrefix
+                    ? requestPrefix
+                          .trim()
+                          .split(/\s+/)
+                          .filter((t) => t.length > 0)
+                    : [];
+                const dfaCompResult = getDFACompletions(entry.dfa, tokens);
+                if (
+                    dfaCompResult.completions &&
+                    dfaCompResult.completions.length > 0
+                ) {
+                    completions.push(...dfaCompResult.completions);
+                }
+                if (
+                    dfaCompResult.properties &&
+                    dfaCompResult.properties.length > 0
+                ) {
+                    const { schemaName } = splitSchemaNamespaceKey(name);
+                    for (const p of dfaCompResult.properties) {
+                        properties.push({
+                            actions: [
+                                createExecutableAction(
+                                    schemaName,
+                                    p.actionName,
+                                    {},
+                                ),
+                            ],
+                            names: [p.propertyPath],
+                        });
+                    }
+                }
+            } else if (this.useNFA && entry.nfa) {
                 // NFA-based completions: tokenize into complete whole tokens
                 const tokens = requestPrefix
                     ? requestPrefix

--- a/ts/packages/cache/src/cache/types.ts
+++ b/ts/packages/cache/src/cache/types.ts
@@ -20,4 +20,5 @@ export interface GrammarStore {
     addGrammar(namespace: string, grammar: any): void;
     removeGrammar(namespace: string): void;
     setUseNFA(useNFA: boolean): void;
+    setUseDFA(useDFA: boolean): void;
 }

--- a/ts/packages/dispatcher/dispatcher/src/context/commandHandlerContext.ts
+++ b/ts/packages/dispatcher/dispatcher/src/context/commandHandlerContext.ts
@@ -805,6 +805,12 @@ async function setupGrammarGeneration(context: CommandHandlerContext) {
         context.agentCache.syncAgentGrammar(schemaName);
     }
 
+    // Enable DFA if configured (NFA must be active first, which it now is)
+    if (config.cache.useDFA) {
+        context.agentCache.grammarStore.setUseDFA(true);
+        debug("DFA matching enabled");
+    }
+
     // Mark as initialized to prevent re-initialization
     context.grammarGenerationInitialized = true;
     debug("Grammar generation configured for NFA system");
@@ -968,6 +974,14 @@ export async function changeContextConfig(
             !systemContext.grammarGenerationInitialized
         ) {
             await setupGrammarGeneration(systemContext);
+        }
+
+        // If useDFA toggled at runtime (only takes effect when NFA grammar system is active)
+        if (
+            changed.cache.useDFA !== undefined &&
+            systemContext.grammarGenerationInitialized
+        ) {
+            agentCache.grammarStore.setUseDFA(changed.cache.useDFA);
         }
     }
 

--- a/ts/packages/dispatcher/dispatcher/src/context/session.ts
+++ b/ts/packages/dispatcher/dispatcher/src/context/session.ts
@@ -158,6 +158,7 @@ export type DispatcherConfig = {
         enabled: boolean;
         grammar: boolean;
         grammarSystem: "completionBased" | "nfa"; // Which grammar system to use for matching
+        useDFA: boolean; // Use DFA within the NFA grammar system (faster matching; requires grammarSystem=nfa)
         autoSave: boolean;
         builtInCache: boolean;
         matchWildcard: boolean;
@@ -244,6 +245,7 @@ const defaultSessionConfig: SessionConfig = {
         enabled: true,
         grammar: true,
         grammarSystem: "completionBased", // default to completion-based grammar system
+        useDFA: false, // DFA is opt-in; NFA is the default within the NFA grammar system
         autoSave: true,
         mergeMatchSets: true, // the session default is different then the default in the cache
         cacheConflicts: true, // the session default is different then the default in the cache

--- a/ts/packages/dispatcher/dispatcher/src/context/system/handlers/configCommandHandlers.ts
+++ b/ts/packages/dispatcher/dispatcher/src/context/system/handlers/configCommandHandlers.ts
@@ -842,6 +842,50 @@ class GrammarSystemCommandHandler implements CommandHandler {
         return completions;
     }
 }
+class GrammarUseDFACommandHandler implements CommandHandler {
+    public readonly description =
+        "Enable or disable DFA matching within the NFA grammar system (faster; requires grammarSystem=nfa)";
+    public readonly parameters = {
+        args: {
+            enabled: {
+                description: "true or false",
+            },
+        },
+    } as const;
+    public async run(
+        context: ActionContext<CommandHandlerContext>,
+        params: ParsedCommandParams<typeof this.parameters>,
+    ) {
+        const value = params.args.enabled;
+        if (value !== "true" && value !== "false") {
+            displayWarn(
+                `Invalid value '${value}'. Must be 'true' or 'false'.`,
+                context,
+            );
+            return;
+        }
+        const useDFA = value === "true";
+        await changeContextConfig({ cache: { useDFA } }, context);
+        displayResult(
+            `DFA matching ${useDFA ? "enabled" : "disabled"}.`,
+            context,
+        );
+    }
+    public async getCompletion(
+        context: SessionContext<CommandHandlerContext>,
+        params: PartialParsedCommandParams<typeof this.parameters>,
+        names: string[],
+    ) {
+        const completions: CompletionGroup[] = [];
+        for (const name of names) {
+            if (name === "enabled") {
+                completions.push({ name, completions: ["true", "false"] });
+            }
+        }
+        return completions;
+    }
+}
+
 const configTranslationCommandHandlers: CommandHandlerTable = {
     description: "Translation configuration",
     defaultSubCommand: "on",
@@ -1457,6 +1501,7 @@ export function getConfigCommandHandlers(): CommandHandlerTable {
                 description: "Configure cache behavior",
                 commands: {
                     grammarSystem: new GrammarSystemCommandHandler(),
+                    useDFA: new GrammarUseDFACommandHandler(),
                 },
             },
             translation: configTranslationCommandHandlers,


### PR DESCRIPTION
## Summary

- **First-token index** — new default NFA matching path: `buildFirstTokenIndex(nfa)` pre-computes, per possible first token, the NFA threads active after consuming it. `matchNFAWithIndex` dispatches in O(1) for unknown first tokens (immediate rejection) and starts threading with 1–5 relevant threads instead of all 20+, giving 10–50× speedup on matched inputs and 120× avg on unmatched. Wired as default in `nfaMatcher.ts` (WeakMap cache) and `AgentGrammar` (field rebuilt on NFA recompile/reset).

- **DFA compiler/matcher** — full DFA via subset construction for completions use case: phraseSet transitions, split-candidate propagation, wildcard `captureInfo` for completions. Compiler stripped of dead slot-op computation (813→352 lines, DFA serialized size −55%). `dfaAccepts()` pre-filter and `matchDFAWithSplitting` in `dfaMatcher.ts`. Shared `tokenSplit.ts` used by both NFA and DFA paths. `GrammarStore` in the cache package gets `setUseDFA` / DFA compilation support.

- **Tests** — `nfaDfaParity.spec.ts` (29 cases asserting NFA and DFA produce identical results across rule types, wildcards, typed entities, phrase-sets, and split-candidate rules); `dfaBenchmark.spec.ts` (space/compile/timing tables for NFA baseline, NFA+index, DFA traversal, DFA hybrid on the player grammar).

## Test plan

- [x] All 766 existing tests pass (`npm test` in `packages/actionGrammar`)
- [x] `npx tsc --noEmit` clean across `actionGrammar` and `cache`
- [x] `node tools/scripts/repo-policy-check.mjs` — 2645 checks passed
- [x] `pnpm run prettier:fix` applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)