### PR TITLE
Update actionGrammar and actionGrammarCompiler README.md

### DIFF
--- a/ts/packages/actionGrammar/README.md
+++ b/ts/packages/actionGrammar/README.md
@@ -1,6 +1,137 @@
 # Action Grammar
 
-Library to allow specify grammar to parse input to produce JSON values (action).
+A grammar engine for [TypeAgent](../../README.md) that parses, compiles, and matches natural language input against grammar rules to produce structured JSON action objects. It converts user utterances like `"play Shape of You by Ed Sheeran"` into typed actions like `{ actionName: "play", parameters: { track: "Shape of You", artist: "Ed Sheeran" } }`.
+
+Grammar rules are defined in **`.agr` files** — a custom DSL that supports literals, wildcards, alternation, optionals, repetition, rule references, imports, and entity declarations.
+
+## Architecture
+
+```
+.agr file → parseGrammarRules() → GrammarParseResult (AST)
+                                       ↓
+                                 compileGrammar() → Grammar (in-memory)
+                                       ↓
+              ┌────────────────────────┴────────────────────────┐
+              │ Recursive Backtracking                          │ NFA/DFA Pipeline
+              │ matchGrammar()                                  │ compileGrammarToNFA()
+              │                                                 │       ↓
+              │                                                 │   matchNFA()
+              │                                                 │       ↓
+              │                                                 │ compileNFAToDFA()
+              │                                                 │       ↓
+              │                                                 │   matchDFA()
+              └─────────────────────────────────────────────────┘
+```
+
+Two matching backends are available, each with different trade-offs:
+
+- **Recursive backtracking matcher** (`matchGrammar()`) — Operates directly on the `Grammar` AST with backtracking for wildcards and nested rules. Simpler and more flexible for certain grammar patterns.
+- **NFA/DFA pipeline** (`compileGrammarToNFA()` → `matchNFA()` / `matchDFA()`) — Compiles grammar to a token-based NFA with parallel execution threads, epsilon closures, and priority-based result selection; optionally further compiled to a deterministic DFA for faster matching.
+
+## `.agr` Grammar Syntax
+
+```agr
+entity CalendarDate, Ordinal;                         // Entity declarations
+import { Helper } from "./other.agr";                 // Grammar imports
+
+<Start> = <PlaySong> | <SkipTrack>;                   // Start rule
+<PlaySong> [spacing=optional] =                        // Spacing annotation
+    play $(track:wildcard) by $(artist:wildcard)        // Wildcards with captures
+    -> { actionName: "play",                            // Action value expression
+         parameters: { track, artist } };
+<SkipTrack> = (skip | next) (track | song)?            // Optionals, alternation
+    -> { actionName: "skip" };
+<Items> = $(item:string) (, $(item:string))*;          // Repetition (Kleene star)
+```
+
+## Exports
+
+The package exposes three entry points:
+
+### Main (`"."`)
+
+Core grammar types, parsing, compilation, matching, serialization, entity system, NFA/DFA system, and dynamic loading:
+
+| Category                | Key Exports                                                                                                                      |
+| ----------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| **Loading/Parsing**     | `loadGrammarRules()`, `loadGrammarRulesNoThrow()`, `parseGrammarRules()`                                                         |
+| **Serialization**       | `grammarToJson()`, `grammarFromJson()`                                                                                           |
+| **Recursive Matching**  | `matchGrammar()`, `matchGrammarCompletion()`                                                                                     |
+| **NFA/DFA**             | `NFA`, `compileGrammarToNFA()`, `matchNFA()`, `matchNFAWithIndex()`, `buildFirstTokenIndex()`, `compileNFAToDFA()`, `matchDFA()` |
+| **Writer**              | `writeGrammarRules()`                                                                                                            |
+| **Entity System**       | `EntityRegistry`, `globalEntityRegistry`, `createValidator()`, `createConverter()`                                               |
+| **Built-in Entities**   | `Ordinal`, `Cardinal`, `CalendarDate`, `CalendarTime`, `CalendarTimeRange`, `CalendarDayRange`                                   |
+| **Phrase Set Matchers** | `globalPhraseSetRegistry`, `PhraseSetMatcher`                                                                                    |
+| **Dynamic Loading**     | `DynamicGrammarLoader`, `DynamicGrammarCache`                                                                                    |
+| **Environment**         | `Environment`, `SlotMap`, `SlotAssignment`, `ValueExpression`                                                                    |
+
+### Rules (`"./rules"`)
+
+Lightweight export for tooling — exposes parser AST types and the pretty-printer:
+
+- `ValueNode`, `Expr`, `Rule`, `RuleDefinition`
+- `writeGrammarRules()`
+
+### Generation (`"./generation"`)
+
+LLM-powered grammar generation from schemas and examples:
+
+- `ClaudeGrammarGenerator` — Uses Claude to analyze request/action pairs and generate grammar rules
+- `SchemaToGrammarGenerator` — Auto-generates `.agr` grammar from a full action schema (`.pas.json`)
+- `ScenarioBasedGrammarGenerator` — Generates grammar using predefined scenario templates
+- `loadSchemaInfo()`, `SchemaInfo`, `ActionInfo` — Schema reading utilities
+
+## Key Source Files
+
+| File                       | Purpose                                                                   |
+| -------------------------- | ------------------------------------------------------------------------- |
+| `grammarRuleParser.ts`     | Recursive descent parser for `.agr` files                                 |
+| `grammarCompiler.ts`       | Compiles parsed rules into the in-memory `Grammar` representation         |
+| `grammarTypes.ts`          | Types for in-memory and serialized grammar representations                |
+| `grammarMatcher.ts`        | Recursive backtracking matcher and completion system                      |
+| `nfaCompiler.ts`           | Compiles `Grammar` → token-based NFA with slot-based variable capture     |
+| `nfaInterpreter.ts`        | Parallel NFA execution with priority ranking                              |
+| `dfaCompiler.ts`           | NFA→DFA subset construction                                               |
+| `dfaMatcher.ts`            | DFA-based matching and completion                                         |
+| `entityRegistry.ts`        | Entity registry with validators and converters                            |
+| `builtInEntities.ts`       | Built-in entity converters (dates, times, ordinals, cardinals)            |
+| `builtInPhraseMatchers.ts` | Phrase set registry (Polite, Greeting, Acknowledgement, FillerWord)       |
+| `environment.ts`           | Slot-based environment system for NFA/DFA variable capture                |
+| `grammarStore.ts`          | Persists dynamically generated grammar rules with auto-save               |
+| `grammarMerger.ts`         | Utilities for merging and combining grammars                              |
+| `grammarMetadata.ts`       | Enriches grammars with checked-variable metadata from `.pas.json` schemas |
+| `dynamicGrammarLoader.ts`  | Runtime rule loading, entity validation, NFA compilation                  |
+| `agentGrammarRegistry.ts`  | Per-agent grammar management with dynamic rule addition                   |
+| `grammarRuleWriter.ts`     | Pretty-prints grammar parse results back to `.agr` format                 |
+
+## File Formats
+
+| Format      | Description                                                                                               |
+| ----------- | --------------------------------------------------------------------------------------------------------- |
+| `.agr`      | Source grammar files — human-readable DSL with entities, imports, rules, wildcards, and value expressions |
+| `.ag.json`  | Compiled grammar JSON (`GrammarJson`) for sharing/caching without re-parsing                              |
+| `.pas.json` | Parsed Action Schema JSON (from `action-schema`) used for checked-variable enrichment                     |
+
+## Building
+
+```bash
+# Build
+npm run build
+
+# Run unit tests
+npm test
+
+# Run integration tests (requires API keys)
+npm run test:integration
+```
+
+## Dependencies
+
+| Dependency                  | Purpose                                                                               |
+| --------------------------- | ------------------------------------------------------------------------------------- |
+| `action-schema` (workspace) | Reading `.pas.json` schema files for checked-variable enrichment                      |
+| `debug`                     | Debug logging (`typeagent:grammar:*`, `typeagent:nfa:*`, `typeagent:actionGrammar:*`) |
+| `regexp.escape`             | Safe regex escaping for the legacy matcher                                            |
 
 ## Trademarks
 

--- a/ts/packages/actionGrammarCompiler/README.md
+++ b/ts/packages/actionGrammarCompiler/README.md
@@ -1,7 +1,115 @@
-# action-schema-compiler
+# Action Grammar Compiler
 
-A command line tool to preprocess action schema authored in TypeScript, save the result in ParsedActionSchemaGroup JSON format.
-Dispatcher can load the result instead of having the typescript compiler parse the TypeScript schema at runtime.
+A CLI tool for compiling and formatting `.agr` (Action Grammar) files. It wraps the [action-grammar](../actionGrammar/README.md) library's parsing and serialization APIs behind an [oclif](https://oclif.io)-based command-line interface.
+
+## Installation
+
+The package provides two CLI entry points:
+
+- **`agc`** — production binary
+- **`agc-dev`** — development binary (with ts-node loader)
+
+Both support a legacy invocation style: if the first argument isn't a recognized command name, the `compile` command is assumed automatically.
+
+## Commands
+
+### `compile`
+
+Compiles an `.agr` grammar file into `.ag.json` format.
+
+```bash
+agc compile -i input.agr -o output.ag.json
+```
+
+| Flag       | Alias | Required | Description                    |
+| ---------- | ----- | -------- | ------------------------------ |
+| `--input`  | `-i`  | Yes      | Input `.agr` grammar file path |
+| `--output` | `-o`  | Yes      | Output JSON file path          |
+
+**Flow:**
+
+1. Parses the `.agr` file via `loadGrammarRulesNoThrow()` from `action-grammar`
+2. Reports any errors/warnings; exits with code 1 on parse failure
+3. Serializes the parsed `Grammar` to JSON via `grammarToJson()`
+4. Writes the `.ag.json` output, creating directories as needed
+
+### `format`
+
+Formats (pretty-prints) `.agr` grammar files — analogous to `prettier` but for the `.agr` DSL.
+
+```bash
+agc format -i input.agr -w        # Format in-place
+agc format -i input.agr -c        # Check formatting (CI mode)
+agc format -i input.agr -o out.agr # Write to different file
+agc format -i input.agr            # Print to stdout
+```
+
+| Flag       | Alias | Required | Description                                             |
+| ---------- | ----- | -------- | ------------------------------------------------------- |
+| `--input`  | `-i`  | Yes      | Input `.agr` file                                       |
+| `--write`  | `-w`  | No       | Overwrite input file in-place                           |
+| `--output` | `-o`  | No       | Write formatted output to a different file              |
+| `--check`  | `-c`  | No       | Exit non-zero if file isn't already formatted (CI mode) |
+
+**Flow:**
+
+1. Parses the `.agr` file via `parseGrammarRules()`
+2. Re-serializes via `writeGrammarRules()` to produce canonical formatting
+3. Writes or checks output based on the flags provided
+
+## Architecture
+
+```
+.agr file
+    │
+    ▼
+agc compile -i input.agr -o output.ag.json
+    │
+    ├─ loadGrammarRulesNoThrow()  ← action-grammar (parser)
+    │       ↓
+    │   Grammar object (in-memory AST)
+    │       ↓
+    ├─ grammarToJson()            ← action-grammar (serializer)
+    │       ↓
+    └─ .ag.json file (compiled grammar)
+
+agc format -i input.agr -w
+    │
+    ├─ parseGrammarRules()        ← action-grammar (parser)
+    │       ↓
+    │   ParseResult (in-memory AST)
+    │       ↓
+    ├─ writeGrammarRules()        ← action-grammar (writer)
+    │       ↓
+    └─ Formatted .agr text
+```
+
+This package is a thin CLI wrapper — all parsing, compilation, and serialization logic lives in the [action-grammar](../actionGrammar/README.md) library.
+
+## Exports
+
+The package exports a `COMMANDS` object for oclif's explicit command registration:
+
+```typescript
+import { COMMANDS } from "action-grammar-compiler";
+// { compile: Compile, format: Format }
+```
+
+This is a CLI-only package. For programmatic grammar APIs, use `action-grammar` directly.
+
+## Building
+
+```bash
+npm run build
+```
+
+## Dependencies
+
+| Dependency                   | Purpose                                                  |
+| ---------------------------- | -------------------------------------------------------- |
+| `action-grammar` (workspace) | Core grammar parsing, serialization, and formatting APIs |
+| `@oclif/core`                | CLI framework (command parsing, flags, help)             |
+| `@oclif/plugin-help`         | Auto-generated `--help` output                           |
 
 ## Trademarks
 


### PR DESCRIPTION
Update the README files for the `actionGrammar` and `actionGrammarCompiler` packages with comprehensive documentation.

### actionGrammar README
- Architecture overview with both matching backends (recursive backtracking and NFA/DFA pipeline)
- `.agr` grammar syntax examples
- All three export entry points (main, rules, generation) with key exports
- Key source files table
- File formats (`.agr`, `.ag.json`, `.pas.json`)
- Build/test commands and dependencies

### actionGrammarCompiler README
- Fixed incorrect title (was 'action-schema-compiler')
- Documented both CLI commands (`compile` and `format`) with flags and usage examples
- Architecture diagram showing compilation and formatting flows
- Relationship to the `action-grammar` library
- Exports, build instructions, and dependencies