### PR TITLE
Fix spurious completion re-fetch from contenteditable NBSP

### DIFF
--- a/ts/packages/shell/src/renderer/src/partial.ts
+++ b/ts/packages/shell/src/renderer/src/partial.ts
@@ -155,7 +155,14 @@ export class PartialCompletion {
     }
 
     private getCurrentInputForCompletion() {
-        return this.getCurrentInput().trimStart();
+        // Normalize non-breaking spaces (U+00A0) that contenteditable
+        // inserts for trailing whitespace.  When the user types a
+        // character after a trailing \u00A0, Chromium may convert it
+        // back to a regular space — breaking the session's startsWith
+        // anchor check and causing unnecessary re-fetches.
+        return this.getCurrentInput()
+            .trimStart()
+            .replace(/\u00a0/g, " ");
     }
 
     private isSelectionAtEnd(trace: boolean = false) {


### PR DESCRIPTION
Chromium's `contenteditable` inserts `\u00A0` (non-breaking space) for trailing whitespace to prevent collapsing. When the user types the next character, Chromium converts it back to a regular space — breaking the session's `startsWith` anchor check (trigger A2) and causing an unnecessary backend re-fetch.

**Fix:** Normalize NBSP → regular space in `getCurrentInputForCompletion()` so both the anchor (captured at session start) and subsequent reads use consistent space encoding.

**Repro:** Type `play Gravity ` (space), wait for completions, type `b` — previously triggered a re-fetch instead of filtering the trie to "by".