### PR TITLE
Add NFA/DFA/completion test variants for grammar matcher tests

### DIFF
--- a/ts/packages/actionGrammar/test/grammarCompletionCategory3bLimitation.spec.ts
+++ b/ts/packages/actionGrammar/test/grammarCompletionCategory3bLimitation.spec.ts
@@ -2,290 +2,299 @@
 // Licensed under the MIT License.
 
 import { loadGrammarRules } from "../src/grammarLoader.js";
-import { matchGrammarCompletion } from "../src/grammarMatcher.js";
+import { describeForEachCompletion } from "./testUtils.js";
 
-describe("Grammar Completion - all alternatives after longest match", () => {
-    // After the longest fully matched prefix, ALL valid next-part
-    // completions are reported regardless of trailing partial text.
-    // The caller is responsible for filtering by the trailing text.
+describeForEachCompletion(
+    "Grammar Completion - all alternatives after longest match",
+    (matchGrammarCompletion) => {
+        // After the longest fully matched prefix, ALL valid next-part
+        // completions are reported regardless of trailing partial text.
+        // The caller is responsible for filtering by the trailing text.
 
-    describe("alternatives preserved with partial trailing text", () => {
-        const g = [
-            `<Start> = $(a:<Verb>) $(b:<Object>) $(c:<Modifier>) -> { a, b, c };`,
-            `<Verb> = play -> "play";`,
-            `<Object> = rock -> "rock";`,
-            `<Modifier> = music -> "music";`,
-            `<Modifier> = hard -> "hard";`,
-            `<Modifier> = loud -> "loud";`,
-        ].join("\n");
-        const grammar = loadGrammarRules("test.grammar", g);
+        describe("alternatives preserved with partial trailing text", () => {
+            const g = [
+                `<Start> = $(a:<Verb>) $(b:<Object>) $(c:<Modifier>) -> { a, b, c };`,
+                `<Verb> = play -> "play";`,
+                `<Object> = rock -> "rock";`,
+                `<Modifier> = music -> "music";`,
+                `<Modifier> = hard -> "hard";`,
+                `<Modifier> = loud -> "loud";`,
+            ].join("\n");
+            const grammar = loadGrammarRules("test.grammar", g);
 
-        it("without partial text: all alternatives are offered", () => {
-            const result = matchGrammarCompletion(grammar, "play rock");
-            expect(result.completions.sort()).toEqual([
-                "hard",
-                "loud",
-                "music",
-            ]);
-            expect(result.matchedPrefixLength).toBe(9);
+            it("without partial text: all alternatives are offered", () => {
+                const result = matchGrammarCompletion(grammar, "play rock");
+                expect(result.completions.sort()).toEqual([
+                    "hard",
+                    "loud",
+                    "music",
+                ]);
+                expect(result.matchedPrefixLength).toBe(9);
+            });
+
+            it("with trailing space: all alternatives are still offered", () => {
+                const result = matchGrammarCompletion(grammar, "play rock ");
+                expect(result.completions.sort()).toEqual([
+                    "hard",
+                    "loud",
+                    "music",
+                ]);
+            });
+
+            it("partial text 'm': all alternatives still reported", () => {
+                const result = matchGrammarCompletion(grammar, "play rock m");
+                // All three are reported; caller filters by "m".
+                expect(result.completions.sort()).toEqual([
+                    "hard",
+                    "loud",
+                    "music",
+                ]);
+                expect(result.matchedPrefixLength).toBe(9);
+            });
+
+            it("partial text 'h': all alternatives still reported", () => {
+                const result = matchGrammarCompletion(grammar, "play rock h");
+                expect(result.completions.sort()).toEqual([
+                    "hard",
+                    "loud",
+                    "music",
+                ]);
+                expect(result.matchedPrefixLength).toBe(9);
+            });
+
+            it("non-matching text 'x': all alternatives still reported", () => {
+                const result = matchGrammarCompletion(grammar, "play rock x");
+                // All alternatives are reported even though "x" doesn't
+                // prefix-match any of them; the caller filters.
+                expect(result.completions.sort()).toEqual([
+                    "hard",
+                    "loud",
+                    "music",
+                ]);
+                expect(result.matchedPrefixLength).toBe(9);
+            });
         });
 
-        it("with trailing space: all alternatives are still offered", () => {
-            const result = matchGrammarCompletion(grammar, "play rock ");
-            expect(result.completions.sort()).toEqual([
-                "hard",
-                "loud",
-                "music",
-            ]);
+        describe("inline single-part alternatives preserved", () => {
+            const g = [
+                `<Start> = go (north | south | east | west) -> true;`,
+            ].join("\n");
+            const grammar = loadGrammarRules("test.grammar", g);
+
+            it("all directions offered without partial text", () => {
+                const result = matchGrammarCompletion(grammar, "go");
+                expect(result.completions.sort()).toEqual([
+                    "east",
+                    "north",
+                    "south",
+                    "west",
+                ]);
+            });
+
+            it("'n' trailing: all directions still offered", () => {
+                const result = matchGrammarCompletion(grammar, "go n");
+                expect(result.completions.sort()).toEqual([
+                    "east",
+                    "north",
+                    "south",
+                    "west",
+                ]);
+                expect(result.matchedPrefixLength).toBe(2);
+            });
+
+            it("'z' trailing: all directions still offered", () => {
+                const result = matchGrammarCompletion(grammar, "go z");
+                expect(result.completions.sort()).toEqual([
+                    "east",
+                    "north",
+                    "south",
+                    "west",
+                ]);
+                expect(result.matchedPrefixLength).toBe(2);
+            });
         });
 
-        it("partial text 'm': all alternatives still reported", () => {
-            const result = matchGrammarCompletion(grammar, "play rock m");
-            // All three are reported; caller filters by "m".
-            expect(result.completions.sort()).toEqual([
-                "hard",
-                "loud",
-                "music",
-            ]);
-            expect(result.matchedPrefixLength).toBe(9);
-        });
-
-        it("partial text 'h': all alternatives still reported", () => {
-            const result = matchGrammarCompletion(grammar, "play rock h");
-            expect(result.completions.sort()).toEqual([
-                "hard",
-                "loud",
-                "music",
-            ]);
-            expect(result.matchedPrefixLength).toBe(9);
-        });
-
-        it("non-matching text 'x': all alternatives still reported", () => {
-            const result = matchGrammarCompletion(grammar, "play rock x");
-            // All alternatives are reported even though "x" doesn't
-            // prefix-match any of them; the caller filters.
-            expect(result.completions.sort()).toEqual([
-                "hard",
-                "loud",
-                "music",
-            ]);
-            expect(result.matchedPrefixLength).toBe(9);
-        });
-    });
-
-    describe("inline single-part alternatives preserved", () => {
-        const g = [`<Start> = go (north | south | east | west) -> true;`].join(
-            "\n",
-        );
-        const grammar = loadGrammarRules("test.grammar", g);
-
-        it("all directions offered without partial text", () => {
-            const result = matchGrammarCompletion(grammar, "go");
-            expect(result.completions.sort()).toEqual([
-                "east",
-                "north",
-                "south",
-                "west",
-            ]);
-        });
-
-        it("'n' trailing: all directions still offered", () => {
-            const result = matchGrammarCompletion(grammar, "go n");
-            expect(result.completions.sort()).toEqual([
-                "east",
-                "north",
-                "south",
-                "west",
-            ]);
-            expect(result.matchedPrefixLength).toBe(2);
-        });
-
-        it("'z' trailing: all directions still offered", () => {
-            const result = matchGrammarCompletion(grammar, "go z");
-            expect(result.completions.sort()).toEqual([
-                "east",
-                "north",
-                "south",
-                "west",
-            ]);
-            expect(result.matchedPrefixLength).toBe(2);
-        });
-    });
-
-    describe("all alternatives after consumed prefix", () => {
-        const g = [
-            `<Start> = $(a:<A>) $(b:<B>) -> { a, b };`,
-            `<A> = open -> "open";`,
-            `<B> = file -> "file";`,
-            `<B> = folder -> "folder";`,
-            `<B> = finder -> "finder";`,
-        ].join("\n");
-        const grammar = loadGrammarRules("test.grammar", g);
-
-        it("'open f': all alternatives offered", () => {
-            const result = matchGrammarCompletion(grammar, "open f");
-            expect(result.completions.sort()).toEqual([
-                "file",
-                "finder",
-                "folder",
-            ]);
-        });
-
-        it("'open fi': all alternatives still offered", () => {
-            const result = matchGrammarCompletion(grammar, "open fi");
-            // "folder" is now correctly reported alongside file/finder.
-            expect(result.completions.sort()).toEqual([
-                "file",
-                "finder",
-                "folder",
-            ]);
-            expect(result.matchedPrefixLength).toBe(4);
-        });
-    });
-
-    describe("no false completions when nothing consumed", () => {
-        // When state.index === 0 (no prefix consumed), we should NOT
-        // report unrelated string parts — only partial prefix matches.
-        const g = [
-            `<Start> = play $(g:<Genre>) -> { genre: g };`,
-            `<Genre> = rock -> "rock";`,
-        ].join("\n");
-        const grammar = loadGrammarRules("test.grammar", g);
-
-        it("all first parts offered for unrelated input", () => {
-            const result = matchGrammarCompletion(grammar, "xyz");
-            // Nothing consumed; the first string part is offered
-            // unconditionally.  The caller filters by trailing text.
-            expect(result.completions).toEqual(["play"]);
-            expect(result.matchedPrefixLength).toBe(0);
-        });
-
-        it("partial prefix at start still works", () => {
-            const result = matchGrammarCompletion(grammar, "pl");
-            expect(result.completions).toContain("play");
-        });
-    });
-
-    describe("separatorMode in Category 3b", () => {
-        // Category 3b: finalizeState failed, trailing non-separator text
-        // remains.  separatorMode indicates whether a separator is needed
-        // between matchedPrefixLength and the completion text.
-
-        describe("Latin grammar (auto spacing)", () => {
+        describe("all alternatives after consumed prefix", () => {
             const g = [
                 `<Start> = $(a:<A>) $(b:<B>) -> { a, b };`,
-                `<A> = play -> "a";`,
-                `<B> = music -> "b";`,
-                `<B> = midi -> "b2";`,
+                `<A> = open -> "open";`,
+                `<B> = file -> "file";`,
+                `<B> = folder -> "folder";`,
+                `<B> = finder -> "finder";`,
             ].join("\n");
             const grammar = loadGrammarRules("test.grammar", g);
 
-            it("reports separatorMode after consumed Latin prefix with trailing text", () => {
-                // "play x" → consumed "play" (4 chars), trailing "x" fails.
-                // Completion "music"/"midi" at matchedPrefixLength=4.
-                // Last consumed char: "y" (Latin), first completion char: "m" (Latin)
-                // → separator needed.
-                const result = matchGrammarCompletion(grammar, "play x");
-                expect(result.completions.sort()).toEqual(["midi", "music"]);
-                expect(result.matchedPrefixLength).toBe(4);
-                expect(result.separatorMode).toBe("spacePunctuation");
+            it("'open f': all alternatives offered", () => {
+                const result = matchGrammarCompletion(grammar, "open f");
+                expect(result.completions.sort()).toEqual([
+                    "file",
+                    "finder",
+                    "folder",
+                ]);
             });
 
-            it("reports separatorMode with partial-match trailing text", () => {
-                // "play mu" → consumed "play" (4 chars), trailing "mu".
-                // Same boundary: "y" → "m" → separator needed.
-                const result = matchGrammarCompletion(grammar, "play mu");
-                expect(result.completions.sort()).toEqual(["midi", "music"]);
+            it("'open fi': all alternatives still offered", () => {
+                const result = matchGrammarCompletion(grammar, "open fi");
+                // "folder" is now correctly reported alongside file/finder.
+                expect(result.completions.sort()).toEqual([
+                    "file",
+                    "finder",
+                    "folder",
+                ]);
                 expect(result.matchedPrefixLength).toBe(4);
-                expect(result.separatorMode).toBe("spacePunctuation");
             });
         });
 
-        describe("CJK grammar (auto spacing)", () => {
-            const g = [
-                `<Start> [spacing=auto] = $(a:<A>) $(b:<B>) -> { a, b };`,
-                `<A> [spacing=auto] = 再生 -> "a";`,
-                `<B> [spacing=auto] = 音楽 -> "b";`,
-                `<B> [spacing=auto] = 映画 -> "b2";`,
-            ].join("\n");
-            const grammar = loadGrammarRules("test.grammar", g);
-
-            it("reports optional separatorMode for CJK → CJK", () => {
-                // "再生x" → consumed "再生" (2 chars), trailing "x" fails.
-                // Last consumed char: "生" (CJK), first completion: "音" (CJK)
-                // → separator optional in auto mode.
-                const result = matchGrammarCompletion(grammar, "再生x");
-                expect(result.completions.sort()).toEqual(["映画", "音楽"]);
-                expect(result.matchedPrefixLength).toBe(2);
-                expect(result.separatorMode).toBe("optional");
-            });
-        });
-
-        describe("nothing consumed (index=0)", () => {
+        describe("no false completions when nothing consumed", () => {
+            // When state.index === 0 (no prefix consumed), we should NOT
+            // report unrelated string parts — only partial prefix matches.
             const g = [
                 `<Start> = play $(g:<Genre>) -> { genre: g };`,
                 `<Genre> = rock -> "rock";`,
             ].join("\n");
             const grammar = loadGrammarRules("test.grammar", g);
 
-            it("reports optional separatorMode when nothing consumed", () => {
-                // "xyz" → consumed 0 chars, offers "play" at prefixLength=0.
-                // No last consumed char → no separator check.
+            it("all first parts offered for unrelated input", () => {
                 const result = matchGrammarCompletion(grammar, "xyz");
+                // Nothing consumed; the first string part is offered
+                // unconditionally.  The caller filters by trailing text.
                 expect(result.completions).toEqual(["play"]);
                 expect(result.matchedPrefixLength).toBe(0);
-                expect(result.separatorMode).toBe("optional");
+            });
+
+            it("partial prefix at start still works", () => {
+                const result = matchGrammarCompletion(grammar, "pl");
+                expect(result.completions).toContain("play");
             });
         });
 
-        describe("spacing=required", () => {
-            const g = [
-                `<Start> [spacing=required] = $(a:<A>) $(b:<B>) -> { a, b };`,
-                `<A> [spacing=required] = play -> "a";`,
-                `<B> [spacing=required] = music -> "b";`,
-            ].join("\n");
-            const grammar = loadGrammarRules("test.grammar", g);
+        describe("separatorMode in Category 3b", () => {
+            // Category 3b: finalizeState failed, trailing non-separator text
+            // remains.  separatorMode indicates whether a separator is needed
+            // between matchedPrefixLength and the completion text.
 
-            it("reports separatorMode for spacing=required with trailing text", () => {
-                const result = matchGrammarCompletion(grammar, "play x");
-                expect(result.completions).toEqual(["music"]);
-                expect(result.matchedPrefixLength).toBe(4);
-                expect(result.separatorMode).toBe("spacePunctuation");
+            describe("Latin grammar (auto spacing)", () => {
+                const g = [
+                    `<Start> = $(a:<A>) $(b:<B>) -> { a, b };`,
+                    `<A> = play -> "a";`,
+                    `<B> = music -> "b";`,
+                    `<B> = midi -> "b2";`,
+                ].join("\n");
+                const grammar = loadGrammarRules("test.grammar", g);
+
+                it("reports separatorMode after consumed Latin prefix with trailing text", () => {
+                    // "play x" → consumed "play" (4 chars), trailing "x" fails.
+                    // Completion "music"/"midi" at matchedPrefixLength=4.
+                    // Last consumed char: "y" (Latin), first completion char: "m" (Latin)
+                    // → separator needed.
+                    const result = matchGrammarCompletion(grammar, "play x");
+                    expect(result.completions.sort()).toEqual([
+                        "midi",
+                        "music",
+                    ]);
+                    expect(result.matchedPrefixLength).toBe(4);
+                    expect(result.separatorMode).toBe("spacePunctuation");
+                });
+
+                it("reports separatorMode with partial-match trailing text", () => {
+                    // "play mu" → consumed "play" (4 chars), trailing "mu".
+                    // Same boundary: "y" → "m" → separator needed.
+                    const result = matchGrammarCompletion(grammar, "play mu");
+                    expect(result.completions.sort()).toEqual([
+                        "midi",
+                        "music",
+                    ]);
+                    expect(result.matchedPrefixLength).toBe(4);
+                    expect(result.separatorMode).toBe("spacePunctuation");
+                });
+            });
+
+            describe("CJK grammar (auto spacing)", () => {
+                const g = [
+                    `<Start> [spacing=auto] = $(a:<A>) $(b:<B>) -> { a, b };`,
+                    `<A> [spacing=auto] = 再生 -> "a";`,
+                    `<B> [spacing=auto] = 音楽 -> "b";`,
+                    `<B> [spacing=auto] = 映画 -> "b2";`,
+                ].join("\n");
+                const grammar = loadGrammarRules("test.grammar", g);
+
+                it("reports optional separatorMode for CJK → CJK", () => {
+                    // "再生x" → consumed "再生" (2 chars), trailing "x" fails.
+                    // Last consumed char: "生" (CJK), first completion: "音" (CJK)
+                    // → separator optional in auto mode.
+                    const result = matchGrammarCompletion(grammar, "再生x");
+                    expect(result.completions.sort()).toEqual(["映画", "音楽"]);
+                    expect(result.matchedPrefixLength).toBe(2);
+                    expect(result.separatorMode).toBe("optional");
+                });
+            });
+
+            describe("nothing consumed (index=0)", () => {
+                const g = [
+                    `<Start> = play $(g:<Genre>) -> { genre: g };`,
+                    `<Genre> = rock -> "rock";`,
+                ].join("\n");
+                const grammar = loadGrammarRules("test.grammar", g);
+
+                it("reports optional separatorMode when nothing consumed", () => {
+                    // "xyz" → consumed 0 chars, offers "play" at prefixLength=0.
+                    // No last consumed char → no separator check.
+                    const result = matchGrammarCompletion(grammar, "xyz");
+                    expect(result.completions).toEqual(["play"]);
+                    expect(result.matchedPrefixLength).toBe(0);
+                    expect(result.separatorMode).toBe("optional");
+                });
+            });
+
+            describe("spacing=required", () => {
+                const g = [
+                    `<Start> [spacing=required] = $(a:<A>) $(b:<B>) -> { a, b };`,
+                    `<A> [spacing=required] = play -> "a";`,
+                    `<B> [spacing=required] = music -> "b";`,
+                ].join("\n");
+                const grammar = loadGrammarRules("test.grammar", g);
+
+                it("reports separatorMode for spacing=required with trailing text", () => {
+                    const result = matchGrammarCompletion(grammar, "play x");
+                    expect(result.completions).toEqual(["music"]);
+                    expect(result.matchedPrefixLength).toBe(4);
+                    expect(result.separatorMode).toBe("spacePunctuation");
+                });
+            });
+
+            describe("spacing=optional", () => {
+                const g = [
+                    `<Start> [spacing=optional] = $(a:<A>) $(b:<B>) -> { a, b };`,
+                    `<A> [spacing=optional] = play -> "a";`,
+                    `<B> [spacing=optional] = music -> "b";`,
+                ].join("\n");
+                const grammar = loadGrammarRules("test.grammar", g);
+
+                it("reports optional separatorMode for spacing=optional", () => {
+                    const result = matchGrammarCompletion(grammar, "play x");
+                    expect(result.completions).toEqual(["music"]);
+                    expect(result.matchedPrefixLength).toBe(4);
+                    expect(result.separatorMode).toBe("optional");
+                });
+            });
+
+            describe("mixed scripts (Latin → CJK)", () => {
+                const g = [
+                    `<Start> [spacing=auto] = $(a:<A>) $(b:<B>) -> { a, b };`,
+                    `<A> [spacing=auto] = play -> "a";`,
+                    `<B> [spacing=auto] = 音楽 -> "b";`,
+                ].join("\n");
+                const grammar = loadGrammarRules("test.grammar", g);
+
+                it("reports optional separatorMode for Latin → CJK", () => {
+                    // Last consumed: "y" (Latin), completion: "音" (CJK)
+                    // → different scripts, separator optional in auto mode.
+                    const result = matchGrammarCompletion(grammar, "play x");
+                    expect(result.completions).toEqual(["音楽"]);
+                    expect(result.matchedPrefixLength).toBe(4);
+                    expect(result.separatorMode).toBe("optional");
+                });
             });
         });
-
-        describe("spacing=optional", () => {
-            const g = [
-                `<Start> [spacing=optional] = $(a:<A>) $(b:<B>) -> { a, b };`,
-                `<A> [spacing=optional] = play -> "a";`,
-                `<B> [spacing=optional] = music -> "b";`,
-            ].join("\n");
-            const grammar = loadGrammarRules("test.grammar", g);
-
-            it("reports optional separatorMode for spacing=optional", () => {
-                const result = matchGrammarCompletion(grammar, "play x");
-                expect(result.completions).toEqual(["music"]);
-                expect(result.matchedPrefixLength).toBe(4);
-                expect(result.separatorMode).toBe("optional");
-            });
-        });
-
-        describe("mixed scripts (Latin → CJK)", () => {
-            const g = [
-                `<Start> [spacing=auto] = $(a:<A>) $(b:<B>) -> { a, b };`,
-                `<A> [spacing=auto] = play -> "a";`,
-                `<B> [spacing=auto] = 音楽 -> "b";`,
-            ].join("\n");
-            const grammar = loadGrammarRules("test.grammar", g);
-
-            it("reports optional separatorMode for Latin → CJK", () => {
-                // Last consumed: "y" (Latin), completion: "音" (CJK)
-                // → different scripts, separator optional in auto mode.
-                const result = matchGrammarCompletion(grammar, "play x");
-                expect(result.completions).toEqual(["音楽"]);
-                expect(result.matchedPrefixLength).toBe(4);
-                expect(result.separatorMode).toBe("optional");
-            });
-        });
-    });
-});
+    },
+);

--- a/ts/packages/actionGrammar/test/grammarCompletionDirectionSensitive.spec.ts
+++ b/ts/packages/actionGrammar/test/grammarCompletionDirectionSensitive.spec.ts
@@ -2,493 +2,496 @@
 // Licensed under the MIT License.
 
 import { loadGrammarRules } from "../src/grammarLoader.js";
-import { matchGrammarCompletion } from "../src/grammarMatcher.js";
+import { describeForEachCompletion } from "./testUtils.js";
 
-describe("Grammar Completion - directionSensitive", () => {
-    describe("single string part", () => {
-        const g = `<Start> = play music -> true;`;
-        const grammar = loadGrammarRules("test.grammar", g);
+describeForEachCompletion(
+    "Grammar Completion - directionSensitive",
+    (matchGrammarCompletion) => {
+        describe("single string part", () => {
+            const g = `<Start> = play music -> true;`;
+            const grammar = loadGrammarRules("test.grammar", g);
 
-        it("not sensitive for empty input", () => {
-            const result = matchGrammarCompletion(grammar, "");
-            expect(result.directionSensitive).toBe(false);
+            it("not sensitive for empty input", () => {
+                const result = matchGrammarCompletion(grammar, "");
+                expect(result.directionSensitive).toBe(false);
+            });
+
+            it("not sensitive for partial first word 'pl'", () => {
+                const result = matchGrammarCompletion(grammar, "pl");
+                expect(result.directionSensitive).toBe(false);
+            });
+
+            it("sensitive for first word fully typed 'play'", () => {
+                // "play" fully matched — backward would back up to it.
+                const result = matchGrammarCompletion(
+                    grammar,
+                    "play",
+                    undefined,
+                    "forward",
+                );
+                expect(result.directionSensitive).toBe(true);
+            });
+
+            it("not sensitive for 'play ' with trailing space", () => {
+                // Trailing space commits — backward same as forward.
+                const result = matchGrammarCompletion(
+                    grammar,
+                    "play ",
+                    undefined,
+                    "forward",
+                );
+                expect(result.directionSensitive).toBe(false);
+            });
+
+            it("sensitive for exact match 'play music'", () => {
+                // Exact match with lastMatchedPartInfo — backward would
+                // back up to "music".
+                const result = matchGrammarCompletion(
+                    grammar,
+                    "play music",
+                    undefined,
+                    "forward",
+                );
+                expect(result.directionSensitive).toBe(true);
+            });
+
+            it("not sensitive for exact match with trailing space 'play music '", () => {
+                const result = matchGrammarCompletion(
+                    grammar,
+                    "play music ",
+                    undefined,
+                    "forward",
+                );
+                expect(result.directionSensitive).toBe(false);
+            });
+
+            it("sensitive when backward on exact match", () => {
+                const result = matchGrammarCompletion(
+                    grammar,
+                    "play music",
+                    undefined,
+                    "backward",
+                );
+                expect(result.directionSensitive).toBe(true);
+            });
         });
 
-        it("not sensitive for partial first word 'pl'", () => {
-            const result = matchGrammarCompletion(grammar, "pl");
-            expect(result.directionSensitive).toBe(false);
+        describe("multi-part via nested rule", () => {
+            const g = [
+                `<Start> = $(v:<Verb>) music -> true;`,
+                `<Verb> = play -> true;`,
+            ].join("\n");
+            const grammar = loadGrammarRules("test.grammar", g);
+
+            it("not sensitive for empty input", () => {
+                const result = matchGrammarCompletion(grammar, "");
+                expect(result.directionSensitive).toBe(false);
+            });
+
+            it("sensitive after nested rule consumed 'play'", () => {
+                // "play" consumed the nested rule — backward could
+                // reconsider it.
+                const result = matchGrammarCompletion(
+                    grammar,
+                    "play",
+                    undefined,
+                    "forward",
+                );
+                expect(result.directionSensitive).toBe(true);
+            });
+
+            it("not sensitive for 'play ' (trailing space commits)", () => {
+                const result = matchGrammarCompletion(
+                    grammar,
+                    "play ",
+                    undefined,
+                    "forward",
+                );
+                expect(result.directionSensitive).toBe(false);
+            });
         });
 
-        it("sensitive for first word fully typed 'play'", () => {
-            // "play" fully matched — backward would back up to it.
-            const result = matchGrammarCompletion(
-                grammar,
-                "play",
-                undefined,
-                "forward",
-            );
-            expect(result.directionSensitive).toBe(true);
+        describe("wildcard grammar", () => {
+            const g = [
+                `<Start> = play $(song:<Song>) -> true;`,
+                `<Song> = $(x:wildcard);`,
+            ].join("\n");
+            const grammar = loadGrammarRules("test.grammar", g);
+
+            it("not sensitive for empty input", () => {
+                const result = matchGrammarCompletion(grammar, "");
+                expect(result.directionSensitive).toBe(false);
+            });
+
+            it("not sensitive after 'play' (wildcard not yet captured)", () => {
+                // "play" matched the string part, but the nested wildcard
+                // rule hasn't captured anything yet.  The nested rule
+                // creates a fresh state without lastMatchedPartInfo.
+                const result = matchGrammarCompletion(
+                    grammar,
+                    "play",
+                    undefined,
+                    "forward",
+                );
+                expect(result.directionSensitive).toBe(false);
+            });
+
+            it("sensitive for 'play some song' (wildcard captured)", () => {
+                // Exact match with wildcard — backward would back up to
+                // the wildcard.
+                const result = matchGrammarCompletion(
+                    grammar,
+                    "play some song",
+                    undefined,
+                    "forward",
+                );
+                expect(result.directionSensitive).toBe(true);
+            });
         });
 
-        it("not sensitive for 'play ' with trailing space", () => {
-            // Trailing space commits — backward same as forward.
-            const result = matchGrammarCompletion(
-                grammar,
-                "play ",
-                undefined,
-                "forward",
-            );
-            expect(result.directionSensitive).toBe(false);
+        describe("Category 3b: partial match with direction", () => {
+            const g = [
+                `<Start> = play some music -> true;`,
+                `<Start> = play some video -> true;`,
+            ].join("\n");
+            const grammar = loadGrammarRules("test.grammar", g);
+
+            it("sensitive for 'play some music' (multi-word fully matched, no trailing space)", () => {
+                const result = matchGrammarCompletion(
+                    grammar,
+                    "play some music",
+                    undefined,
+                    "forward",
+                );
+                expect(result.directionSensitive).toBe(true);
+            });
+
+            it("not sensitive for 'play some music ' (trailing space)", () => {
+                const result = matchGrammarCompletion(
+                    grammar,
+                    "play some music ",
+                    undefined,
+                    "forward",
+                );
+                expect(result.directionSensitive).toBe(false);
+            });
+
+            it("sensitive for 'play some' (two words matched, Category 3b)", () => {
+                // "play some" partially matches both rules — "some" is
+                // fully matched without trailing space, so backward would
+                // back up.
+                const result = matchGrammarCompletion(
+                    grammar,
+                    "play some",
+                    undefined,
+                    "forward",
+                );
+                expect(result.directionSensitive).toBe(true);
+            });
+
+            it("not sensitive for 'play som' (trailing space commits 'play')", () => {
+                // "play" fully matched but the space after it commits
+                // that word (trailing separator).  "som" is a partial
+                // match of "some" with no fully matched words at that
+                // position.  So couldBackUp is false.
+                const result = matchGrammarCompletion(
+                    grammar,
+                    "play som",
+                    undefined,
+                    "forward",
+                );
+                expect(result.directionSensitive).toBe(false);
+            });
+
+            it("not sensitive for partial first word 'pla'", () => {
+                const result = matchGrammarCompletion(
+                    grammar,
+                    "pla",
+                    undefined,
+                    "forward",
+                );
+                expect(result.directionSensitive).toBe(false);
+            });
         });
 
-        it("sensitive for exact match 'play music'", () => {
-            // Exact match with lastMatchedPartInfo — backward would
-            // back up to "music".
-            const result = matchGrammarCompletion(
-                grammar,
-                "play music",
-                undefined,
-                "forward",
-            );
-            expect(result.directionSensitive).toBe(true);
+        describe("varNumber part", () => {
+            const g = `<Start> = set volume $(level) -> { actionName: "setVolume", parameters: { level } };`;
+            const grammar = loadGrammarRules("test.grammar", g);
+
+            it("sensitive for 'set volume 42' (number matched)", () => {
+                const result = matchGrammarCompletion(
+                    grammar,
+                    "set volume 42",
+                    undefined,
+                    "forward",
+                );
+                expect(result.directionSensitive).toBe(true);
+            });
+
+            it("sensitive backward on 'set volume 42'", () => {
+                const result = matchGrammarCompletion(
+                    grammar,
+                    "set volume 42",
+                    undefined,
+                    "backward",
+                );
+                expect(result.directionSensitive).toBe(true);
+            });
         });
 
-        it("not sensitive for exact match with trailing space 'play music '", () => {
-            const result = matchGrammarCompletion(
-                grammar,
-                "play music ",
-                undefined,
-                "forward",
-            );
-            expect(result.directionSensitive).toBe(false);
+        describe("optional part ()?", () => {
+            const g = `<Start> = play (shuffle)? music -> true;`;
+            const grammar = loadGrammarRules("test.grammar", g);
+
+            it("sensitive for 'play' (optional not yet consumed)", () => {
+                const result = matchGrammarCompletion(
+                    grammar,
+                    "play",
+                    undefined,
+                    "forward",
+                );
+                expect(result.directionSensitive).toBe(true);
+            });
+
+            it("not sensitive for 'play ' with trailing space", () => {
+                const result = matchGrammarCompletion(
+                    grammar,
+                    "play ",
+                    undefined,
+                    "forward",
+                );
+                expect(result.directionSensitive).toBe(false);
+            });
+
+            it("sensitive for 'play shuffle' (optional consumed, no trailing space)", () => {
+                const result = matchGrammarCompletion(
+                    grammar,
+                    "play shuffle",
+                    undefined,
+                    "forward",
+                );
+                expect(result.directionSensitive).toBe(true);
+            });
+
+            it("backward on 'play shuffle' backs up to 'shuffle'", () => {
+                const result = matchGrammarCompletion(
+                    grammar,
+                    "play shuffle",
+                    undefined,
+                    "backward",
+                );
+                // Backward should back up to offer "shuffle" instead of
+                // the next word "music".
+                expect(result.directionSensitive).toBe(true);
+            });
+
+            it("not sensitive for 'play shuffle ' (trailing space commits)", () => {
+                const result = matchGrammarCompletion(
+                    grammar,
+                    "play shuffle ",
+                    undefined,
+                    "forward",
+                );
+                expect(result.directionSensitive).toBe(false);
+            });
+
+            it("sensitive for exact match 'play shuffle music'", () => {
+                const result = matchGrammarCompletion(
+                    grammar,
+                    "play shuffle music",
+                    undefined,
+                    "forward",
+                );
+                expect(result.directionSensitive).toBe(true);
+            });
+
+            it("sensitive for exact match (optional skipped) 'play music'", () => {
+                const result = matchGrammarCompletion(
+                    grammar,
+                    "play music",
+                    undefined,
+                    "forward",
+                );
+                expect(result.directionSensitive).toBe(true);
+            });
         });
 
-        it("sensitive when backward on exact match", () => {
-            const result = matchGrammarCompletion(
-                grammar,
-                "play music",
-                undefined,
-                "backward",
-            );
-            expect(result.directionSensitive).toBe(true);
-        });
-    });
+        describe("repeat part ()+", () => {
+            const g = `<Start> = play (song)+ now -> true;`;
+            const grammar = loadGrammarRules("test.grammar", g);
 
-    describe("multi-part via nested rule", () => {
-        const g = [
-            `<Start> = $(v:<Verb>) music -> true;`,
-            `<Verb> = play -> true;`,
-        ].join("\n");
-        const grammar = loadGrammarRules("test.grammar", g);
+            it("sensitive for 'play song' (one iteration matched)", () => {
+                const result = matchGrammarCompletion(
+                    grammar,
+                    "play song",
+                    undefined,
+                    "forward",
+                );
+                expect(result.directionSensitive).toBe(true);
+            });
 
-        it("not sensitive for empty input", () => {
-            const result = matchGrammarCompletion(grammar, "");
-            expect(result.directionSensitive).toBe(false);
-        });
+            it("backward on 'play song' backs up", () => {
+                const result = matchGrammarCompletion(
+                    grammar,
+                    "play song",
+                    undefined,
+                    "backward",
+                );
+                expect(result.directionSensitive).toBe(true);
+            });
 
-        it("sensitive after nested rule consumed 'play'", () => {
-            // "play" consumed the nested rule — backward could
-            // reconsider it.
-            const result = matchGrammarCompletion(
-                grammar,
-                "play",
-                undefined,
-                "forward",
-            );
-            expect(result.directionSensitive).toBe(true);
-        });
+            it("sensitive for 'play song song' (two iterations matched)", () => {
+                const result = matchGrammarCompletion(
+                    grammar,
+                    "play song song",
+                    undefined,
+                    "forward",
+                );
+                expect(result.directionSensitive).toBe(true);
+            });
 
-        it("not sensitive for 'play ' (trailing space commits)", () => {
-            const result = matchGrammarCompletion(
-                grammar,
-                "play ",
-                undefined,
-                "forward",
-            );
-            expect(result.directionSensitive).toBe(false);
-        });
-    });
-
-    describe("wildcard grammar", () => {
-        const g = [
-            `<Start> = play $(song:<Song>) -> true;`,
-            `<Song> = $(x:wildcard);`,
-        ].join("\n");
-        const grammar = loadGrammarRules("test.grammar", g);
-
-        it("not sensitive for empty input", () => {
-            const result = matchGrammarCompletion(grammar, "");
-            expect(result.directionSensitive).toBe(false);
+            it("not sensitive for 'play song ' (trailing space commits)", () => {
+                const result = matchGrammarCompletion(
+                    grammar,
+                    "play song ",
+                    undefined,
+                    "forward",
+                );
+                expect(result.directionSensitive).toBe(false);
+            });
         });
 
-        it("not sensitive after 'play' (wildcard not yet captured)", () => {
-            // "play" matched the string part, but the nested wildcard
-            // rule hasn't captured anything yet.  The nested rule
-            // creates a fresh state without lastMatchedPartInfo.
-            const result = matchGrammarCompletion(
-                grammar,
-                "play",
-                undefined,
-                "forward",
-            );
-            expect(result.directionSensitive).toBe(false);
+        describe("repeat part ()*", () => {
+            const g = `<Start> = play (song)* now -> true;`;
+            const grammar = loadGrammarRules("test.grammar", g);
+
+            it("sensitive for 'play' (zero iterations, but 'play' matched)", () => {
+                const result = matchGrammarCompletion(
+                    grammar,
+                    "play",
+                    undefined,
+                    "forward",
+                );
+                expect(result.directionSensitive).toBe(true);
+            });
+
+            it("sensitive for 'play song' (one iteration matched)", () => {
+                const result = matchGrammarCompletion(
+                    grammar,
+                    "play song",
+                    undefined,
+                    "forward",
+                );
+                expect(result.directionSensitive).toBe(true);
+            });
         });
 
-        it("sensitive for 'play some song' (wildcard captured)", () => {
-            // Exact match with wildcard — backward would back up to
-            // the wildcard.
-            const result = matchGrammarCompletion(
-                grammar,
-                "play some song",
-                undefined,
-                "forward",
-            );
-            expect(result.directionSensitive).toBe(true);
-        });
-    });
+        describe("spacing=none with backward", () => {
+            const g = `<Start> [spacing=none] = play music -> true;`;
+            const grammar = loadGrammarRules("test.grammar", g);
 
-    describe("Category 3b: partial match with direction", () => {
-        const g = [
-            `<Start> = play some music -> true;`,
-            `<Start> = play some video -> true;`,
-        ].join("\n");
-        const grammar = loadGrammarRules("test.grammar", g);
+            it("sensitive for 'play' (couldBackUp always true in none mode)", () => {
+                // In none mode, whitespace is not a separator, so
+                // couldBackUp is always true when words match.
+                const result = matchGrammarCompletion(
+                    grammar,
+                    "play",
+                    undefined,
+                    "forward",
+                );
+                expect(result.directionSensitive).toBe(true);
+            });
 
-        it("sensitive for 'play some music' (multi-word fully matched, no trailing space)", () => {
-            const result = matchGrammarCompletion(
-                grammar,
-                "play some music",
-                undefined,
-                "forward",
-            );
-            expect(result.directionSensitive).toBe(true);
-        });
+            it("backward on 'play' backs up to offer 'play'", () => {
+                const result = matchGrammarCompletion(
+                    grammar,
+                    "play",
+                    undefined,
+                    "backward",
+                );
+                expect(result.directionSensitive).toBe(true);
+            });
 
-        it("not sensitive for 'play some music ' (trailing space)", () => {
-            const result = matchGrammarCompletion(
-                grammar,
-                "play some music ",
-                undefined,
-                "forward",
-            );
-            expect(result.directionSensitive).toBe(false);
-        });
+            it("sensitive for 'playmusic' (exact match, none mode)", () => {
+                const result = matchGrammarCompletion(
+                    grammar,
+                    "playmusic",
+                    undefined,
+                    "forward",
+                );
+                expect(result.directionSensitive).toBe(true);
+            });
 
-        it("sensitive for 'play some' (two words matched, Category 3b)", () => {
-            // "play some" partially matches both rules — "some" is
-            // fully matched without trailing space, so backward would
-            // back up.
-            const result = matchGrammarCompletion(
-                grammar,
-                "play some",
-                undefined,
-                "forward",
-            );
-            expect(result.directionSensitive).toBe(true);
+            it("backward on 'playmusic' backs up to 'music'", () => {
+                const result = matchGrammarCompletion(
+                    grammar,
+                    "playmusic",
+                    undefined,
+                    "backward",
+                );
+                expect(result.directionSensitive).toBe(true);
+            });
         });
 
-        it("not sensitive for 'play som' (trailing space commits 'play')", () => {
-            // "play" fully matched but the space after it commits
-            // that word (trailing separator).  "som" is a partial
-            // match of "some" with no fully matched words at that
-            // position.  So couldBackUp is false.
-            const result = matchGrammarCompletion(
-                grammar,
-                "play som",
-                undefined,
-                "forward",
-            );
-            expect(result.directionSensitive).toBe(false);
+        describe("minPrefixLength with backward direction", () => {
+            const g = [
+                `<Start> = play music -> true;`,
+                `<Start> = stop music -> true;`,
+            ].join("\n");
+            const grammar = loadGrammarRules("test.grammar", g);
+
+            it("backward respects minPrefixLength", () => {
+                const result = matchGrammarCompletion(
+                    grammar,
+                    "play music",
+                    5,
+                    "backward",
+                );
+                // minPrefixLength=5 means only completions at position ≥5
+                // are relevant.  Backward on "play music" would back up
+                // to "music" at position 4 (or 5 with space), which should
+                // still be valid since 5 ≥ 5.
+                expect(result.directionSensitive).toBe(true);
+            });
         });
 
-        it("not sensitive for partial first word 'pla'", () => {
-            const result = matchGrammarCompletion(
-                grammar,
-                "pla",
-                undefined,
-                "forward",
-            );
-            expect(result.directionSensitive).toBe(false);
+        describe("forward and backward produce same directionSensitive", () => {
+            const g = `<Start> = play music -> true;`;
+            const grammar = loadGrammarRules("test.grammar", g);
+
+            it("both directions agree on sensitivity for 'play'", () => {
+                const forward = matchGrammarCompletion(
+                    grammar,
+                    "play",
+                    undefined,
+                    "forward",
+                );
+                const backward = matchGrammarCompletion(
+                    grammar,
+                    "play",
+                    undefined,
+                    "backward",
+                );
+                expect(forward.directionSensitive).toBe(true);
+                expect(backward.directionSensitive).toBe(true);
+            });
+
+            it("both directions agree on non-sensitivity for 'play '", () => {
+                const forward = matchGrammarCompletion(
+                    grammar,
+                    "play ",
+                    undefined,
+                    "forward",
+                );
+                const backward = matchGrammarCompletion(
+                    grammar,
+                    "play ",
+                    undefined,
+                    "backward",
+                );
+                expect(forward.directionSensitive).toBe(false);
+                expect(backward.directionSensitive).toBe(false);
+            });
         });
-    });
-
-    describe("varNumber part", () => {
-        const g = `<Start> = set volume $(level) -> { actionName: "setVolume", parameters: { level } };`;
-        const grammar = loadGrammarRules("test.grammar", g);
-
-        it("sensitive for 'set volume 42' (number matched)", () => {
-            const result = matchGrammarCompletion(
-                grammar,
-                "set volume 42",
-                undefined,
-                "forward",
-            );
-            expect(result.directionSensitive).toBe(true);
-        });
-
-        it("sensitive backward on 'set volume 42'", () => {
-            const result = matchGrammarCompletion(
-                grammar,
-                "set volume 42",
-                undefined,
-                "backward",
-            );
-            expect(result.directionSensitive).toBe(true);
-        });
-    });
-
-    describe("optional part ()?", () => {
-        const g = `<Start> = play (shuffle)? music -> true;`;
-        const grammar = loadGrammarRules("test.grammar", g);
-
-        it("sensitive for 'play' (optional not yet consumed)", () => {
-            const result = matchGrammarCompletion(
-                grammar,
-                "play",
-                undefined,
-                "forward",
-            );
-            expect(result.directionSensitive).toBe(true);
-        });
-
-        it("not sensitive for 'play ' with trailing space", () => {
-            const result = matchGrammarCompletion(
-                grammar,
-                "play ",
-                undefined,
-                "forward",
-            );
-            expect(result.directionSensitive).toBe(false);
-        });
-
-        it("sensitive for 'play shuffle' (optional consumed, no trailing space)", () => {
-            const result = matchGrammarCompletion(
-                grammar,
-                "play shuffle",
-                undefined,
-                "forward",
-            );
-            expect(result.directionSensitive).toBe(true);
-        });
-
-        it("backward on 'play shuffle' backs up to 'shuffle'", () => {
-            const result = matchGrammarCompletion(
-                grammar,
-                "play shuffle",
-                undefined,
-                "backward",
-            );
-            // Backward should back up to offer "shuffle" instead of
-            // the next word "music".
-            expect(result.directionSensitive).toBe(true);
-        });
-
-        it("not sensitive for 'play shuffle ' (trailing space commits)", () => {
-            const result = matchGrammarCompletion(
-                grammar,
-                "play shuffle ",
-                undefined,
-                "forward",
-            );
-            expect(result.directionSensitive).toBe(false);
-        });
-
-        it("sensitive for exact match 'play shuffle music'", () => {
-            const result = matchGrammarCompletion(
-                grammar,
-                "play shuffle music",
-                undefined,
-                "forward",
-            );
-            expect(result.directionSensitive).toBe(true);
-        });
-
-        it("sensitive for exact match (optional skipped) 'play music'", () => {
-            const result = matchGrammarCompletion(
-                grammar,
-                "play music",
-                undefined,
-                "forward",
-            );
-            expect(result.directionSensitive).toBe(true);
-        });
-    });
-
-    describe("repeat part ()+", () => {
-        const g = `<Start> = play (song)+ now -> true;`;
-        const grammar = loadGrammarRules("test.grammar", g);
-
-        it("sensitive for 'play song' (one iteration matched)", () => {
-            const result = matchGrammarCompletion(
-                grammar,
-                "play song",
-                undefined,
-                "forward",
-            );
-            expect(result.directionSensitive).toBe(true);
-        });
-
-        it("backward on 'play song' backs up", () => {
-            const result = matchGrammarCompletion(
-                grammar,
-                "play song",
-                undefined,
-                "backward",
-            );
-            expect(result.directionSensitive).toBe(true);
-        });
-
-        it("sensitive for 'play song song' (two iterations matched)", () => {
-            const result = matchGrammarCompletion(
-                grammar,
-                "play song song",
-                undefined,
-                "forward",
-            );
-            expect(result.directionSensitive).toBe(true);
-        });
-
-        it("not sensitive for 'play song ' (trailing space commits)", () => {
-            const result = matchGrammarCompletion(
-                grammar,
-                "play song ",
-                undefined,
-                "forward",
-            );
-            expect(result.directionSensitive).toBe(false);
-        });
-    });
-
-    describe("repeat part ()*", () => {
-        const g = `<Start> = play (song)* now -> true;`;
-        const grammar = loadGrammarRules("test.grammar", g);
-
-        it("sensitive for 'play' (zero iterations, but 'play' matched)", () => {
-            const result = matchGrammarCompletion(
-                grammar,
-                "play",
-                undefined,
-                "forward",
-            );
-            expect(result.directionSensitive).toBe(true);
-        });
-
-        it("sensitive for 'play song' (one iteration matched)", () => {
-            const result = matchGrammarCompletion(
-                grammar,
-                "play song",
-                undefined,
-                "forward",
-            );
-            expect(result.directionSensitive).toBe(true);
-        });
-    });
-
-    describe("spacing=none with backward", () => {
-        const g = `<Start> [spacing=none] = play music -> true;`;
-        const grammar = loadGrammarRules("test.grammar", g);
-
-        it("sensitive for 'play' (couldBackUp always true in none mode)", () => {
-            // In none mode, whitespace is not a separator, so
-            // couldBackUp is always true when words match.
-            const result = matchGrammarCompletion(
-                grammar,
-                "play",
-                undefined,
-                "forward",
-            );
-            expect(result.directionSensitive).toBe(true);
-        });
-
-        it("backward on 'play' backs up to offer 'play'", () => {
-            const result = matchGrammarCompletion(
-                grammar,
-                "play",
-                undefined,
-                "backward",
-            );
-            expect(result.directionSensitive).toBe(true);
-        });
-
-        it("sensitive for 'playmusic' (exact match, none mode)", () => {
-            const result = matchGrammarCompletion(
-                grammar,
-                "playmusic",
-                undefined,
-                "forward",
-            );
-            expect(result.directionSensitive).toBe(true);
-        });
-
-        it("backward on 'playmusic' backs up to 'music'", () => {
-            const result = matchGrammarCompletion(
-                grammar,
-                "playmusic",
-                undefined,
-                "backward",
-            );
-            expect(result.directionSensitive).toBe(true);
-        });
-    });
-
-    describe("minPrefixLength with backward direction", () => {
-        const g = [
-            `<Start> = play music -> true;`,
-            `<Start> = stop music -> true;`,
-        ].join("\n");
-        const grammar = loadGrammarRules("test.grammar", g);
-
-        it("backward respects minPrefixLength", () => {
-            const result = matchGrammarCompletion(
-                grammar,
-                "play music",
-                5,
-                "backward",
-            );
-            // minPrefixLength=5 means only completions at position ≥5
-            // are relevant.  Backward on "play music" would back up
-            // to "music" at position 4 (or 5 with space), which should
-            // still be valid since 5 ≥ 5.
-            expect(result.directionSensitive).toBe(true);
-        });
-    });
-
-    describe("forward and backward produce same directionSensitive", () => {
-        const g = `<Start> = play music -> true;`;
-        const grammar = loadGrammarRules("test.grammar", g);
-
-        it("both directions agree on sensitivity for 'play'", () => {
-            const forward = matchGrammarCompletion(
-                grammar,
-                "play",
-                undefined,
-                "forward",
-            );
-            const backward = matchGrammarCompletion(
-                grammar,
-                "play",
-                undefined,
-                "backward",
-            );
-            expect(forward.directionSensitive).toBe(true);
-            expect(backward.directionSensitive).toBe(true);
-        });
-
-        it("both directions agree on non-sensitivity for 'play '", () => {
-            const forward = matchGrammarCompletion(
-                grammar,
-                "play ",
-                undefined,
-                "forward",
-            );
-            const backward = matchGrammarCompletion(
-                grammar,
-                "play ",
-                undefined,
-                "backward",
-            );
-            expect(forward.directionSensitive).toBe(false);
-            expect(backward.directionSensitive).toBe(false);
-        });
-    });
-});
+    },
+);

--- a/ts/packages/actionGrammar/test/grammarCompletionLongestMatch.spec.ts
+++ b/ts/packages/actionGrammar/test/grammarCompletionLongestMatch.spec.ts
@@ -2,655 +2,13 @@
 // Licensed under the MIT License.
 
 import { loadGrammarRules } from "../src/grammarLoader.js";
-import { matchGrammarCompletion } from "../src/grammarMatcher.js";
-
-describe("Grammar Completion - longest match property", () => {
-    describe("three sequential parts", () => {
-        // Verifies that after matching 2 of 3 parts, completion is the 3rd part.
-        const g = [
-            `<Start> = $(a:<A>) $(b:<B>) $(c:<C>) -> { a, b, c };`,
-            `<A> = first -> "a";`,
-            `<B> = second -> "b";`,
-            `<C> = third -> "c";`,
-        ].join("\n");
-        const grammar = loadGrammarRules("test.grammar", g);
-
-        it("completes first part for empty input", () => {
-            const result = matchGrammarCompletion(grammar, "");
-            expect(result.completions).toContain("first");
-            expect(result.matchedPrefixLength).toBe(0);
-        });
-
-        it("completes second part after first matched", () => {
-            const result = matchGrammarCompletion(grammar, "first");
-            expect(result.completions).toContain("second");
-            expect(result.matchedPrefixLength).toBe(5);
-        });
-
-        it("completes second part after first matched with space", () => {
-            const result = matchGrammarCompletion(grammar, "first ");
-            expect(result.completions).toContain("second");
-            expect(result.matchedPrefixLength).toBe(6);
-        });
-
-        it("completes third part after first two matched", () => {
-            const result = matchGrammarCompletion(grammar, "first second");
-            expect(result.completions).toContain("third");
-            expect(result.matchedPrefixLength).toBe(12);
-        });
-
-        it("completes third part after first two matched with space", () => {
-            const result = matchGrammarCompletion(grammar, "first second ");
-            expect(result.completions).toContain("third");
-            expect(result.matchedPrefixLength).toBe(13);
-        });
-
-        it("no completion for exact full match", () => {
-            const result = matchGrammarCompletion(
-                grammar,
-                "first second third",
-            );
-            expect(result.completions).toHaveLength(0);
-            // Exact match records the full consumed length.
-            expect(result.matchedPrefixLength).toBe(18);
-        });
-
-        it("partial prefix of third part completes correctly", () => {
-            const result = matchGrammarCompletion(grammar, "first second th");
-            expect(result.completions).toContain("third");
-            expect(result.matchedPrefixLength).toBe(12);
-        });
-    });
-
-    describe("four sequential parts", () => {
-        const g = [
-            `<Start> = $(a:<A>) $(b:<B>) $(c:<C>) $(d:<D>) -> { a, b, c, d };`,
-            `<A> = alpha -> "a";`,
-            `<B> = bravo -> "b";`,
-            `<C> = charlie -> "c";`,
-            `<D> = delta -> "d";`,
-        ].join("\n");
-        const grammar = loadGrammarRules("test.grammar", g);
-
-        it("completes delta after three parts matched", () => {
-            const result = matchGrammarCompletion(
-                grammar,
-                "alpha bravo charlie",
-            );
-            expect(result.completions).toContain("delta");
-            expect(result.matchedPrefixLength).toBe(19);
-        });
-
-        it("completes charlie after two parts matched", () => {
-            const result = matchGrammarCompletion(grammar, "alpha bravo");
-            expect(result.completions).toContain("charlie");
-            expect(result.matchedPrefixLength).toBe(11);
-        });
-    });
-
-    describe("competing rules - longer match wins", () => {
-        // Two rules: short (2 parts) and long (3 parts).
-        // When first two parts match, the short rule is a full match (no
-        // completion) and the long rule offers completion for the third part.
-        const g = [
-            `<Start> = $(a:<A>) $(b:<B>) -> { a, b };`,
-            `<Start> = $(a:<A>) $(b:<B>) $(c:<C>) -> { a, b, c };`,
-            `<A> = alpha -> "a";`,
-            `<B> = bravo -> "b";`,
-            `<C> = charlie -> "c";`,
-        ].join("\n");
-        const grammar = loadGrammarRules("test.grammar", g);
-
-        it("short rule is exact match; long rule offers completion", () => {
-            const result = matchGrammarCompletion(grammar, "alpha bravo");
-            // Short rule matches exactly, no completion from it.
-            // Long rule matches alpha + bravo and offers "charlie".
-            expect(result.completions).toContain("charlie");
-            expect(result.matchedPrefixLength).toBe(11);
-        });
-
-        it("both rules offer completions at same depth for first part", () => {
-            const result = matchGrammarCompletion(grammar, "alpha");
-            // Both rules need "bravo" next.
-            expect(result.completions).toContain("bravo");
-            expect(result.matchedPrefixLength).toBe(5);
-        });
-    });
-
-    describe("competing rules - different next parts at same depth", () => {
-        // Two rules that share a prefix but diverge after.
-        const g = [
-            `<Start> = $(a:<A>) suffix_x -> "rx";`,
-            `<Start> = $(a:<A>) suffix_y -> "ry";`,
-            `<A> = prefix -> "a";`,
-        ].join("\n");
-        const grammar = loadGrammarRules("test.grammar", g);
-
-        it("offers both alternatives after shared prefix", () => {
-            const result = matchGrammarCompletion(grammar, "prefix");
-            expect(result.completions).toContain("suffix_x");
-            expect(result.completions).toContain("suffix_y");
-            expect(result.matchedPrefixLength).toBe(6);
-        });
-
-        it("alternative still offered even when one rule matches exactly", () => {
-            const result = matchGrammarCompletion(grammar, "prefix suffix_x");
-            // Rule 1 (suffix_x) matches exactly at length 15.
-            // Rule 2's "suffix_y" at prefixLength 6 is filtered out
-            // because a longer match exists.
-            expect(result.completions).toHaveLength(0);
-            expect(result.matchedPrefixLength).toBe(15);
-        });
-    });
-
-    describe("optional part followed by required part", () => {
-        const g = [
-            `<Start> = $(a:<A>) $(b:<B>)? $(c:<C>) -> { a, c };`,
-            `<A> = begin -> "a";`,
-            `<B> = middle -> "b";`,
-            `<C> = finish -> "c";`,
-        ].join("\n");
-        const grammar = loadGrammarRules("test.grammar", g);
-
-        it("offers both optional and skip alternatives after first part", () => {
-            const result = matchGrammarCompletion(grammar, "begin");
-            // Should offer "middle" (optional) and "finish" (skipping optional)
-            expect(result.completions).toContain("middle");
-            expect(result.completions).toContain("finish");
-            expect(result.matchedPrefixLength).toBe(5);
-        });
-
-        it("offers finish after optional part matched", () => {
-            const result = matchGrammarCompletion(grammar, "begin middle");
-            expect(result.completions).toContain("finish");
-            expect(result.matchedPrefixLength).toBe(12);
-        });
-
-        it("longest path wins for 'finish' completion when optional is matched", () => {
-            // When "begin middle" is typed:
-            //   - Through-optional path: matches "begin" + "middle",
-            //     offers "finish" at matchedPrefixLength=12.
-            //   - Skip-optional path: matches "begin" (index=5),
-            //     offers "finish" at matchedPrefixLength=5 — but this
-            //     is filtered out because a longer match (12) exists.
-            const result = matchGrammarCompletion(grammar, "begin middle");
-            expect(result.completions).toContain("finish");
-            expect(result.matchedPrefixLength).toBe(12);
-        });
-    });
-
-    describe("completion after number variable", () => {
-        const g = [
-            `<Start> = set volume $(n:number) percent -> { volume: n };`,
-        ].join("\n");
-        const grammar = loadGrammarRules("test.grammar", g);
-
-        it("completes 'percent' after number matched", () => {
-            const result = matchGrammarCompletion(grammar, "set volume 50");
-            expect(result.completions).toContain("percent");
-            expect(result.matchedPrefixLength).toBe(13);
-        });
-
-        it("completes 'percent' after number with space", () => {
-            const result = matchGrammarCompletion(grammar, "set volume 50 ");
-            expect(result.completions).toContain("percent");
-            expect(result.matchedPrefixLength).toBe(14);
-        });
-
-        it("no completion for exact match", () => {
-            const result = matchGrammarCompletion(
-                grammar,
-                "set volume 50 percent",
-            );
-            expect(result.completions).toHaveLength(0);
-        });
-    });
-
-    describe("multiple alternatives in nested rule", () => {
-        // After matching a prefix, the nested rule has multiple alternatives
-        // for the next part, all at the same depth.
-        const g = [
-            `<Start> = play $(g:<Genre>) -> { genre: g };`,
-            `<Genre> = rock -> "rock";`,
-            `<Genre> = pop -> "pop";`,
-            `<Genre> = jazz -> "jazz";`,
-        ].join("\n");
-        const grammar = loadGrammarRules("test.grammar", g);
-
-        it("offers all genre alternatives after 'play'", () => {
-            const result = matchGrammarCompletion(grammar, "play");
-            expect(result.completions).toContain("rock");
-            expect(result.completions).toContain("pop");
-            expect(result.completions).toContain("jazz");
-            expect(result.matchedPrefixLength).toBe(4);
-        });
-
-        it("all alternatives offered even with partial trailing text", () => {
-            const result = matchGrammarCompletion(grammar, "play r");
-            // All genre alternatives are reported after the longest
-            // complete match "play"; the caller filters by "r".
-            expect(result.completions).toContain("rock");
-            expect(result.completions).toContain("pop");
-            expect(result.completions).toContain("jazz");
-            expect(result.matchedPrefixLength).toBe(4);
-        });
-
-        it("all alternatives offered with 'p' trailing text", () => {
-            const result = matchGrammarCompletion(grammar, "play p");
-            // All are reported; caller filters by "p".
-            expect(result.completions).toContain("pop");
-            expect(result.completions).toContain("rock");
-            expect(result.completions).toContain("jazz");
-        });
-    });
-
-    describe("wildcard between string parts - longest match", () => {
-        // Grammar: verb WILDCARD terminator
-        // Completion should offer terminator only after wildcard captures text.
-        const g = [
-            `<Start> = play $(name) by $(artist) -> { name, artist };`,
-        ].join("\n");
-        const grammar = loadGrammarRules("test.grammar", g);
-
-        it("offers wildcard property after 'play'", () => {
-            const result = matchGrammarCompletion(grammar, "play");
-            // Wildcard is next, should have property completion
-            expect(result.properties).toBeDefined();
-            expect(result.properties!.length).toBeGreaterThan(0);
-        });
-
-        it("offers 'by' terminator after wildcard text", () => {
-            const result = matchGrammarCompletion(grammar, "play hello");
-            expect(result.completions).toContain("by");
-        });
-
-        it("offers artist wildcard property after 'by'", () => {
-            const result = matchGrammarCompletion(grammar, "play hello by");
-            // After "by", the next part is the artist wildcard
-            expect(result.properties).toBeDefined();
-            expect(result.properties!.length).toBeGreaterThan(0);
-        });
-    });
-
-    describe("deep nesting - three levels of rules", () => {
-        const g = [
-            `<Start> = $(x:<Outer>) done -> { x };`,
-            `<Outer> = $(y:<Inner>) -> y;`,
-            `<Inner> = deep -> "deep";`,
-        ].join("\n");
-        const grammar = loadGrammarRules("test.grammar", g);
-
-        it("completes 'deep' for empty input", () => {
-            const result = matchGrammarCompletion(grammar, "");
-            expect(result.completions).toContain("deep");
-            expect(result.matchedPrefixLength).toBe(0);
-        });
-
-        it("completes 'done' after deeply nested match", () => {
-            const result = matchGrammarCompletion(grammar, "deep");
-            expect(result.completions).toContain("done");
-            expect(result.matchedPrefixLength).toBe(4);
-        });
-    });
-
-    describe("repeat group (+) completion", () => {
-        // Grammar with ()+ repeat group using inline alternatives
-        const g = `<Start> = hello (world | earth)+ done -> true;`;
-        const grammar = loadGrammarRules("test.grammar", g);
-
-        it("offers 'hello' for empty input", () => {
-            const result = matchGrammarCompletion(grammar, "");
-            expect(result.completions).toContain("hello");
-        });
-
-        it("offers repeat alternatives after 'hello'", () => {
-            const result = matchGrammarCompletion(grammar, "hello");
-            // After "hello", the ()+ group requires at least one match
-            expect(result.completions).toContain("world");
-            expect(result.completions).toContain("earth");
-        });
-
-        it("offers 'done' and repeat alternatives after first repeat match", () => {
-            const result = matchGrammarCompletion(grammar, "hello world");
-            // After one repeat match, can repeat or proceed to "done"
-            expect(result.completions).toContain("done");
-            // Also should offer repeat alternatives
-            expect(
-                result.completions.includes("world") ||
-                    result.completions.includes("earth"),
-            ).toBe(true);
-        });
-
-        it("offers 'done' after two repeat matches", () => {
-            const result = matchGrammarCompletion(grammar, "hello world earth");
-            expect(result.completions).toContain("done");
-        });
-    });
-
-    describe("partial prefix vs longest match interaction", () => {
-        // Test that partial prefix matching from a shorter rule does not
-        // interfere with the longest match from a longer rule.
-        //
-        // Rule 1's string part "beta gamma" partially matches "beta" in the
-        // remaining text, while Rule 2 fully matches "beta" as a separate
-        // nested rule and offers "gamma" from the longer match.
-        //
-        // Both completions may appear because they're valid for different
-        // interpretations. The key property is that matchedPrefixLength
-        // reflects the longest consumed prefix.
-        const g = [
-            `<Start> = $(a:<A>) beta gamma -> "r1";`,
-            `<Start> = $(a:<A>) $(b:<B>) gamma -> "r2";`,
-            `<A> = alpha -> "a";`,
-            `<B> = beta -> "b";`,
-        ].join("\n");
-        const grammar = loadGrammarRules("test.grammar", g);
-
-        it("matchedPrefixLength reflects longest consumed prefix", () => {
-            const result = matchGrammarCompletion(grammar, "alpha beta");
-            // Rule 2 matches alpha + beta = 10 chars.
-            // matchedPrefixLength should be at least 10 (from the longest match).
-            expect(result.matchedPrefixLength).toBeGreaterThanOrEqual(10);
-            // "gamma" must appear as completion from the longer match.
-            expect(result.completions).toContain("gamma");
-        });
-
-        it("shorter partial prefix completion also appears (known behavior)", () => {
-            const result = matchGrammarCompletion(grammar, "alpha beta");
-            // Rule 1 may produce "beta gamma" via isPartialPrefixOfStringPart
-            // since "beta" is a prefix of "beta gamma". This is expected:
-            // both rules produce valid completions for the input.
-            // We verify maxPrefixLength is from the longest match.
-            expect(result.matchedPrefixLength).toBe(10);
-        });
-    });
-
-    describe("case insensitive matching for completions", () => {
-        const g = [
-            `<Start> = $(a:<A>) World -> { a };`,
-            `<A> = Hello -> "hello";`,
-        ].join("\n");
-        const grammar = loadGrammarRules("test.grammar", g);
-
-        it("completes after case-insensitive match", () => {
-            const result = matchGrammarCompletion(grammar, "hello");
-            expect(result.completions).toContain("World");
-            expect(result.matchedPrefixLength).toBe(5);
-        });
-
-        it("completes after uppercase input", () => {
-            const result = matchGrammarCompletion(grammar, "HELLO");
-            expect(result.completions).toContain("World");
-            expect(result.matchedPrefixLength).toBe(5);
-        });
-
-        it("partial prefix is case insensitive", () => {
-            const result = matchGrammarCompletion(grammar, "hello WO");
-            expect(result.completions).toContain("World");
-        });
-    });
-
-    describe("no spurious completions from unrelated rules", () => {
-        // Two completely different rules. Only the matching one should
-        // produce completions.
-        const g = [
-            `<Start> = play $(g:<Genre>) -> { action: "play", genre: g };`,
-            `<Start> = stop $(r:<Reason>) -> { action: "stop", reason: r };`,
-            `<Genre> = rock -> "rock";`,
-            `<Reason> = now -> "now";`,
-        ].join("\n");
-        const grammar = loadGrammarRules("test.grammar", g);
-
-        it("only matching rule offers completions for 'play'", () => {
-            const result = matchGrammarCompletion(grammar, "play");
-            expect(result.completions).toContain("rock");
-            expect(result.completions).not.toContain("now");
-            expect(result.completions).not.toContain("stop");
-        });
-
-        it("only matching rule offers completions for 'stop'", () => {
-            const result = matchGrammarCompletion(grammar, "stop");
-            expect(result.completions).toContain("now");
-            expect(result.completions).not.toContain("rock");
-            expect(result.completions).not.toContain("play");
-        });
-
-        it("all first parts offered for unrelated input", () => {
-            const result = matchGrammarCompletion(grammar, "dance");
-            // Nothing consumed; all first string parts from every rule
-            // are offered at prefixLength 0.  The caller filters by
-            // the trailing text "dance".
-            expect(result.completions.sort()).toEqual(["play", "stop"]);
-            expect(result.matchedPrefixLength).toBe(0);
-        });
-    });
-
-    describe("completion with entity wildcard", () => {
-        // Entity wildcards should produce property completions, not string
-        // completions, and matchedPrefixLength should indicate where the
-        // entity value begins.
-        const g = [
-            `entity SongName;`,
-            `<Start> = play $(song:SongName) next -> { song };`,
-        ].join("\n");
-        const grammar = loadGrammarRules("test.grammar", g);
-
-        it("entity wildcard produces property completion", () => {
-            const result = matchGrammarCompletion(grammar, "play");
-            expect(result.properties).toBeDefined();
-            expect(result.properties!.length).toBeGreaterThan(0);
-            expect(result.matchedPrefixLength).toBe(4);
-        });
-
-        it("string terminator after entity text", () => {
-            const result = matchGrammarCompletion(grammar, "play mysong");
-            expect(result.completions).toContain("next");
-        });
-    });
-
-    describe("completion at boundary between consumed and remaining", () => {
-        // Verify that trailing separators (spaces) don't affect
-        // which part is offered for completion.
-        const g = [
-            `<Start> = $(a:<A>) $(b:<B>) -> { a, b };`,
-            `<A> = one -> "a";`,
-            `<B> = two -> "b";`,
-        ].join("\n");
-        const grammar = loadGrammarRules("test.grammar", g);
-
-        it("same completion with and without trailing space", () => {
-            const r1 = matchGrammarCompletion(grammar, "one");
-            const r2 = matchGrammarCompletion(grammar, "one ");
-            const r3 = matchGrammarCompletion(grammar, "one  ");
-            expect(r1.completions).toEqual(r2.completions);
-            expect(r2.completions).toEqual(r3.completions);
-            expect(r1.completions).toContain("two");
-        });
-
-        it("matchedPrefixLength includes trailing whitespace", () => {
-            const r1 = matchGrammarCompletion(grammar, "one");
-            const r2 = matchGrammarCompletion(grammar, "one ");
-            const r3 = matchGrammarCompletion(grammar, "one  ");
-            // Each includes the trailing whitespace in
-            // matchedPrefixLength: "one"=3, "one "=4, "one  "=5.
-            expect(r1.matchedPrefixLength).toBe(3);
-            expect(r2.matchedPrefixLength).toBe(4);
-            expect(r3.matchedPrefixLength).toBe(5);
-        });
-    });
-
-    describe("closedSet flag - exhaustiveness", () => {
-        describe("string-only completions are exhaustive", () => {
-            const g = [
-                `<Start> = play $(g:<Genre>) -> { genre: g };`,
-                `<Genre> = rock -> "rock";`,
-                `<Genre> = pop -> "pop";`,
-                `<Genre> = jazz -> "jazz";`,
-            ].join("\n");
-            const grammar = loadGrammarRules("test.grammar", g);
-
-            it("closedSet=true for first string part on empty input", () => {
-                const result = matchGrammarCompletion(grammar, "");
-                expect(result.completions).toContain("play");
-                expect(result.closedSet).toBe(true);
-                expect(result.openWildcard).toBe(false);
-            });
-
-            it("closedSet=true for alternatives after prefix", () => {
-                const result = matchGrammarCompletion(grammar, "play");
-                expect(result.completions).toContain("rock");
-                expect(result.completions).toContain("pop");
-                expect(result.completions).toContain("jazz");
-                expect(result.closedSet).toBe(true);
-                expect(result.openWildcard).toBe(false);
-            });
-
-            it("closedSet=true for exact match (no completions)", () => {
-                const result = matchGrammarCompletion(grammar, "play rock");
-                expect(result.completions).toHaveLength(0);
-                expect(result.closedSet).toBe(true);
-                expect(result.openWildcard).toBe(false);
-            });
-        });
-
-        describe("wildcard/entity completions are not exhaustive", () => {
-            const g = [
-                `entity SongName;`,
-                `<Start> = play $(song:SongName) next -> { song };`,
-            ].join("\n");
-            const grammar = loadGrammarRules("test.grammar", g);
-
-            it("closedSet=false for entity wildcard property completion", () => {
-                const result = matchGrammarCompletion(grammar, "play");
-                expect(result.properties).toBeDefined();
-                expect(result.properties!.length).toBeGreaterThan(0);
-                expect(result.closedSet).toBe(false);
-            });
-
-            it("closedSet=true for string completion after wildcard", () => {
-                const result = matchGrammarCompletion(grammar, "play mysong");
-                expect(result.completions).toContain("next");
-                // The "next" keyword is the only valid continuation
-                // from the grammar — no property completions at this
-                // point — so completions are exhaustive.
-                expect(result.closedSet).toBe(true);
-            });
-        });
-
-        describe("untyped wildcard produces property completion → not exhaustive", () => {
-            const g = [
-                `<Start> = play $(name) by $(artist) -> { name, artist };`,
-            ].join("\n");
-            const grammar = loadGrammarRules("test.grammar", g);
-
-            it("closedSet=false for untyped wildcard property", () => {
-                const result = matchGrammarCompletion(grammar, "play");
-                expect(result.properties).toBeDefined();
-                expect(result.properties!.length).toBeGreaterThan(0);
-                expect(result.closedSet).toBe(false);
-                expect(result.openWildcard).toBe(false);
-            });
-
-            it("closedSet=true for 'by' keyword after wildcard captured", () => {
-                const result = matchGrammarCompletion(grammar, "play hello");
-                expect(result.completions).toContain("by");
-                expect(result.closedSet).toBe(true);
-                expect(result.openWildcard).toBe(true);
-            });
-
-            it("openWildcard=true for multi-word wildcard before keyword", () => {
-                const result = matchGrammarCompletion(
-                    grammar,
-                    "play my favorite song",
-                );
-                expect(result.completions).toContain("by");
-                expect(result.closedSet).toBe(true);
-                expect(result.openWildcard).toBe(true);
-            });
-
-            it("openWildcard=true for ambiguous keyword boundary", () => {
-                // "play hello by" is ambiguous: "by" could be part of
-                // the track name or the keyword delimiter.  The grammar
-                // produces both interpretations at prefix length 13,
-                // so openWildcard stays true.
-                const result = matchGrammarCompletion(grammar, "play hello by");
-                expect(result.openWildcard).toBe(true);
-            });
-
-            it("openWildcard=true persists with trailing separator", () => {
-                // "play hello by " — still ambiguous: "by " could be
-                // part of the track name in one interpretation.
-                // openWildcard stays true because the grammar considers
-                // both parse paths.  The shell resolves this via B4
-                // (unique match) when the user types "by" in the trie.
-                const result = matchGrammarCompletion(
-                    grammar,
-                    "play hello by ",
-                );
-                expect(result.openWildcard).toBe(true);
-            });
-        });
-
-        describe("mixed string and entity at same prefix length", () => {
-            // Two rules sharing "play" prefix: one leads to string
-            // completion ("shuffle"), one to entity property.
-            // Both completions should be present regardless of rule order.
-
-            it("entity rule first, string rule second", () => {
-                const g = [
-                    `entity SongName;`,
-                    `<Start> = play $(song:SongName) -> { action: "search", song };`,
-                    `<Start> = play shuffle -> { action: "shuffle" };`,
-                ].join("\n");
-                const grammar = loadGrammarRules("test.grammar", g);
-                const result = matchGrammarCompletion(grammar, "play");
-                expect(result.matchedPrefixLength).toBe(4);
-                expect(result.completions).toContain("shuffle");
-                expect(result.properties).toBeDefined();
-                expect(result.properties!.length).toBeGreaterThan(0);
-                expect(result.closedSet).toBe(false);
-            });
-
-            it("string rule first, entity rule second", () => {
-                const g = [
-                    `entity SongName;`,
-                    `<Start> = play shuffle -> { action: "shuffle" };`,
-                    `<Start> = play $(song:SongName) -> { action: "search", song };`,
-                ].join("\n");
-                const grammar = loadGrammarRules("test.grammar", g);
-                const result = matchGrammarCompletion(grammar, "play");
-                expect(result.matchedPrefixLength).toBe(4);
-                expect(result.completions).toContain("shuffle");
-                expect(result.properties).toBeDefined();
-                expect(result.properties!.length).toBeGreaterThan(0);
-                expect(result.closedSet).toBe(false);
-            });
-        });
-
-        describe("competing rules - longer match resets closedSet", () => {
-            const g = [
-                `entity SongName;`,
-                `<Start> = $(a:<A>) $(song:SongName) -> { a, song };`,
-                `<Start> = $(a:<A>) $(b:<B>) finish -> { a, b };`,
-                `<A> = alpha -> "a";`,
-                `<B> = bravo -> "b";`,
-            ].join("\n");
-            const grammar = loadGrammarRules("test.grammar", g);
-
-            it("closedSet reflects longest prefix length result", () => {
-                const result = matchGrammarCompletion(grammar, "alpha bravo");
-                // Rule 2 matches alpha+bravo (11 chars) and offers "finish"
-                // (string → closedSet=true).
-                // Rule 1 matches alpha (5 chars) and offers entity
-                // (closedSet=false) — but this is at a shorter prefix
-                // length so it's discarded.
-                expect(result.completions).toContain("finish");
-                expect(result.matchedPrefixLength).toBe(11);
-                expect(result.closedSet).toBe(true);
-            });
-        });
-
-        describe("sequential parts - closedSet stays true throughout", () => {
+import { describeForEachCompletion } from "./testUtils.js";
+
+describeForEachCompletion(
+    "Grammar Completion - longest match property",
+    (matchGrammarCompletion) => {
+        describe("three sequential parts", () => {
+            // Verifies that after matching 2 of 3 parts, completion is the 3rd part.
             const g = [
                 `<Start> = $(a:<A>) $(b:<B>) $(c:<C>) -> { a, b, c };`,
                 `<A> = first -> "a";`,
@@ -659,35 +17,141 @@ describe("Grammar Completion - longest match property", () => {
             ].join("\n");
             const grammar = loadGrammarRules("test.grammar", g);
 
-            it("closedSet=true for first part", () => {
+            it("completes first part for empty input", () => {
                 const result = matchGrammarCompletion(grammar, "");
                 expect(result.completions).toContain("first");
-                expect(result.closedSet).toBe(true);
+                expect(result.matchedPrefixLength).toBe(0);
             });
 
-            it("closedSet=true for second part", () => {
+            it("completes second part after first matched", () => {
                 const result = matchGrammarCompletion(grammar, "first");
                 expect(result.completions).toContain("second");
-                expect(result.closedSet).toBe(true);
+                expect(result.matchedPrefixLength).toBe(5);
             });
 
-            it("closedSet=true for third part", () => {
+            it("completes second part after first matched with space", () => {
+                const result = matchGrammarCompletion(grammar, "first ");
+                expect(result.completions).toContain("second");
+                expect(result.matchedPrefixLength).toBe(6);
+            });
+
+            it("completes third part after first two matched", () => {
                 const result = matchGrammarCompletion(grammar, "first second");
                 expect(result.completions).toContain("third");
-                expect(result.closedSet).toBe(true);
+                expect(result.matchedPrefixLength).toBe(12);
             });
 
-            it("closedSet=true for exact full match", () => {
+            it("completes third part after first two matched with space", () => {
+                const result = matchGrammarCompletion(grammar, "first second ");
+                expect(result.completions).toContain("third");
+                expect(result.matchedPrefixLength).toBe(13);
+            });
+
+            it("no completion for exact full match", () => {
                 const result = matchGrammarCompletion(
                     grammar,
                     "first second third",
                 );
                 expect(result.completions).toHaveLength(0);
-                expect(result.closedSet).toBe(true);
+                // Exact match records the full consumed length.
+                expect(result.matchedPrefixLength).toBe(18);
+            });
+
+            it("partial prefix of third part completes correctly", () => {
+                const result = matchGrammarCompletion(
+                    grammar,
+                    "first second th",
+                );
+                expect(result.completions).toContain("third");
+                expect(result.matchedPrefixLength).toBe(12);
             });
         });
 
-        describe("optional parts", () => {
+        describe("four sequential parts", () => {
+            const g = [
+                `<Start> = $(a:<A>) $(b:<B>) $(c:<C>) $(d:<D>) -> { a, b, c, d };`,
+                `<A> = alpha -> "a";`,
+                `<B> = bravo -> "b";`,
+                `<C> = charlie -> "c";`,
+                `<D> = delta -> "d";`,
+            ].join("\n");
+            const grammar = loadGrammarRules("test.grammar", g);
+
+            it("completes delta after three parts matched", () => {
+                const result = matchGrammarCompletion(
+                    grammar,
+                    "alpha bravo charlie",
+                );
+                expect(result.completions).toContain("delta");
+                expect(result.matchedPrefixLength).toBe(19);
+            });
+
+            it("completes charlie after two parts matched", () => {
+                const result = matchGrammarCompletion(grammar, "alpha bravo");
+                expect(result.completions).toContain("charlie");
+                expect(result.matchedPrefixLength).toBe(11);
+            });
+        });
+
+        describe("competing rules - longer match wins", () => {
+            // Two rules: short (2 parts) and long (3 parts).
+            // When first two parts match, the short rule is a full match (no
+            // completion) and the long rule offers completion for the third part.
+            const g = [
+                `<Start> = $(a:<A>) $(b:<B>) -> { a, b };`,
+                `<Start> = $(a:<A>) $(b:<B>) $(c:<C>) -> { a, b, c };`,
+                `<A> = alpha -> "a";`,
+                `<B> = bravo -> "b";`,
+                `<C> = charlie -> "c";`,
+            ].join("\n");
+            const grammar = loadGrammarRules("test.grammar", g);
+
+            it("short rule is exact match; long rule offers completion", () => {
+                const result = matchGrammarCompletion(grammar, "alpha bravo");
+                // Short rule matches exactly, no completion from it.
+                // Long rule matches alpha + bravo and offers "charlie".
+                expect(result.completions).toContain("charlie");
+                expect(result.matchedPrefixLength).toBe(11);
+            });
+
+            it("both rules offer completions at same depth for first part", () => {
+                const result = matchGrammarCompletion(grammar, "alpha");
+                // Both rules need "bravo" next.
+                expect(result.completions).toContain("bravo");
+                expect(result.matchedPrefixLength).toBe(5);
+            });
+        });
+
+        describe("competing rules - different next parts at same depth", () => {
+            // Two rules that share a prefix but diverge after.
+            const g = [
+                `<Start> = $(a:<A>) suffix_x -> "rx";`,
+                `<Start> = $(a:<A>) suffix_y -> "ry";`,
+                `<A> = prefix -> "a";`,
+            ].join("\n");
+            const grammar = loadGrammarRules("test.grammar", g);
+
+            it("offers both alternatives after shared prefix", () => {
+                const result = matchGrammarCompletion(grammar, "prefix");
+                expect(result.completions).toContain("suffix_x");
+                expect(result.completions).toContain("suffix_y");
+                expect(result.matchedPrefixLength).toBe(6);
+            });
+
+            it("alternative still offered even when one rule matches exactly", () => {
+                const result = matchGrammarCompletion(
+                    grammar,
+                    "prefix suffix_x",
+                );
+                // Rule 1 (suffix_x) matches exactly at length 15.
+                // Rule 2's "suffix_y" at prefixLength 6 is filtered out
+                // because a longer match exists.
+                expect(result.completions).toHaveLength(0);
+                expect(result.matchedPrefixLength).toBe(15);
+            });
+        });
+
+        describe("optional part followed by required part", () => {
             const g = [
                 `<Start> = $(a:<A>) $(b:<B>)? $(c:<C>) -> { a, c };`,
                 `<A> = begin -> "a";`,
@@ -696,12 +160,578 @@ describe("Grammar Completion - longest match property", () => {
             ].join("\n");
             const grammar = loadGrammarRules("test.grammar", g);
 
-            it("closedSet=true for alternatives after optional", () => {
+            it("offers both optional and skip alternatives after first part", () => {
                 const result = matchGrammarCompletion(grammar, "begin");
+                // Should offer "middle" (optional) and "finish" (skipping optional)
                 expect(result.completions).toContain("middle");
                 expect(result.completions).toContain("finish");
-                expect(result.closedSet).toBe(true);
+                expect(result.matchedPrefixLength).toBe(5);
+            });
+
+            it("offers finish after optional part matched", () => {
+                const result = matchGrammarCompletion(grammar, "begin middle");
+                expect(result.completions).toContain("finish");
+                expect(result.matchedPrefixLength).toBe(12);
+            });
+
+            it("longest path wins for 'finish' completion when optional is matched", () => {
+                // When "begin middle" is typed:
+                //   - Through-optional path: matches "begin" + "middle",
+                //     offers "finish" at matchedPrefixLength=12.
+                //   - Skip-optional path: matches "begin" (index=5),
+                //     offers "finish" at matchedPrefixLength=5 — but this
+                //     is filtered out because a longer match (12) exists.
+                const result = matchGrammarCompletion(grammar, "begin middle");
+                expect(result.completions).toContain("finish");
+                expect(result.matchedPrefixLength).toBe(12);
             });
         });
-    });
-});
+
+        describe("completion after number variable", () => {
+            const g = [
+                `<Start> = set volume $(n:number) percent -> { volume: n };`,
+            ].join("\n");
+            const grammar = loadGrammarRules("test.grammar", g);
+
+            it("completes 'percent' after number matched", () => {
+                const result = matchGrammarCompletion(grammar, "set volume 50");
+                expect(result.completions).toContain("percent");
+                expect(result.matchedPrefixLength).toBe(13);
+            });
+
+            it("completes 'percent' after number with space", () => {
+                const result = matchGrammarCompletion(
+                    grammar,
+                    "set volume 50 ",
+                );
+                expect(result.completions).toContain("percent");
+                expect(result.matchedPrefixLength).toBe(14);
+            });
+
+            it("no completion for exact match", () => {
+                const result = matchGrammarCompletion(
+                    grammar,
+                    "set volume 50 percent",
+                );
+                expect(result.completions).toHaveLength(0);
+            });
+        });
+
+        describe("multiple alternatives in nested rule", () => {
+            // After matching a prefix, the nested rule has multiple alternatives
+            // for the next part, all at the same depth.
+            const g = [
+                `<Start> = play $(g:<Genre>) -> { genre: g };`,
+                `<Genre> = rock -> "rock";`,
+                `<Genre> = pop -> "pop";`,
+                `<Genre> = jazz -> "jazz";`,
+            ].join("\n");
+            const grammar = loadGrammarRules("test.grammar", g);
+
+            it("offers all genre alternatives after 'play'", () => {
+                const result = matchGrammarCompletion(grammar, "play");
+                expect(result.completions).toContain("rock");
+                expect(result.completions).toContain("pop");
+                expect(result.completions).toContain("jazz");
+                expect(result.matchedPrefixLength).toBe(4);
+            });
+
+            it("all alternatives offered even with partial trailing text", () => {
+                const result = matchGrammarCompletion(grammar, "play r");
+                // All genre alternatives are reported after the longest
+                // complete match "play"; the caller filters by "r".
+                expect(result.completions).toContain("rock");
+                expect(result.completions).toContain("pop");
+                expect(result.completions).toContain("jazz");
+                expect(result.matchedPrefixLength).toBe(4);
+            });
+
+            it("all alternatives offered with 'p' trailing text", () => {
+                const result = matchGrammarCompletion(grammar, "play p");
+                // All are reported; caller filters by "p".
+                expect(result.completions).toContain("pop");
+                expect(result.completions).toContain("rock");
+                expect(result.completions).toContain("jazz");
+            });
+        });
+
+        describe("wildcard between string parts - longest match", () => {
+            // Grammar: verb WILDCARD terminator
+            // Completion should offer terminator only after wildcard captures text.
+            const g = [
+                `<Start> = play $(name) by $(artist) -> { name, artist };`,
+            ].join("\n");
+            const grammar = loadGrammarRules("test.grammar", g);
+
+            it("offers wildcard property after 'play'", () => {
+                const result = matchGrammarCompletion(grammar, "play");
+                // Wildcard is next, should have property completion
+                expect(result.properties).toBeDefined();
+                expect(result.properties!.length).toBeGreaterThan(0);
+            });
+
+            it("offers 'by' terminator after wildcard text", () => {
+                const result = matchGrammarCompletion(grammar, "play hello");
+                expect(result.completions).toContain("by");
+            });
+
+            it("offers artist wildcard property after 'by'", () => {
+                const result = matchGrammarCompletion(grammar, "play hello by");
+                // After "by", the next part is the artist wildcard
+                expect(result.properties).toBeDefined();
+                expect(result.properties!.length).toBeGreaterThan(0);
+            });
+        });
+
+        describe("deep nesting - three levels of rules", () => {
+            const g = [
+                `<Start> = $(x:<Outer>) done -> { x };`,
+                `<Outer> = $(y:<Inner>) -> y;`,
+                `<Inner> = deep -> "deep";`,
+            ].join("\n");
+            const grammar = loadGrammarRules("test.grammar", g);
+
+            it("completes 'deep' for empty input", () => {
+                const result = matchGrammarCompletion(grammar, "");
+                expect(result.completions).toContain("deep");
+                expect(result.matchedPrefixLength).toBe(0);
+            });
+
+            it("completes 'done' after deeply nested match", () => {
+                const result = matchGrammarCompletion(grammar, "deep");
+                expect(result.completions).toContain("done");
+                expect(result.matchedPrefixLength).toBe(4);
+            });
+        });
+
+        describe("repeat group (+) completion", () => {
+            // Grammar with ()+ repeat group using inline alternatives
+            const g = `<Start> = hello (world | earth)+ done -> true;`;
+            const grammar = loadGrammarRules("test.grammar", g);
+
+            it("offers 'hello' for empty input", () => {
+                const result = matchGrammarCompletion(grammar, "");
+                expect(result.completions).toContain("hello");
+            });
+
+            it("offers repeat alternatives after 'hello'", () => {
+                const result = matchGrammarCompletion(grammar, "hello");
+                // After "hello", the ()+ group requires at least one match
+                expect(result.completions).toContain("world");
+                expect(result.completions).toContain("earth");
+            });
+
+            it("offers 'done' and repeat alternatives after first repeat match", () => {
+                const result = matchGrammarCompletion(grammar, "hello world");
+                // After one repeat match, can repeat or proceed to "done"
+                expect(result.completions).toContain("done");
+                // Also should offer repeat alternatives
+                expect(
+                    result.completions.includes("world") ||
+                        result.completions.includes("earth"),
+                ).toBe(true);
+            });
+
+            it("offers 'done' after two repeat matches", () => {
+                const result = matchGrammarCompletion(
+                    grammar,
+                    "hello world earth",
+                );
+                expect(result.completions).toContain("done");
+            });
+        });
+
+        describe("partial prefix vs longest match interaction", () => {
+            // Test that partial prefix matching from a shorter rule does not
+            // interfere with the longest match from a longer rule.
+            //
+            // Rule 1's string part "beta gamma" partially matches "beta" in the
+            // remaining text, while Rule 2 fully matches "beta" as a separate
+            // nested rule and offers "gamma" from the longer match.
+            //
+            // Both completions may appear because they're valid for different
+            // interpretations. The key property is that matchedPrefixLength
+            // reflects the longest consumed prefix.
+            const g = [
+                `<Start> = $(a:<A>) beta gamma -> "r1";`,
+                `<Start> = $(a:<A>) $(b:<B>) gamma -> "r2";`,
+                `<A> = alpha -> "a";`,
+                `<B> = beta -> "b";`,
+            ].join("\n");
+            const grammar = loadGrammarRules("test.grammar", g);
+
+            it("matchedPrefixLength reflects longest consumed prefix", () => {
+                const result = matchGrammarCompletion(grammar, "alpha beta");
+                // Rule 2 matches alpha + beta = 10 chars.
+                // matchedPrefixLength should be at least 10 (from the longest match).
+                expect(result.matchedPrefixLength).toBeGreaterThanOrEqual(10);
+                // "gamma" must appear as completion from the longer match.
+                expect(result.completions).toContain("gamma");
+            });
+
+            it("shorter partial prefix completion also appears (known behavior)", () => {
+                const result = matchGrammarCompletion(grammar, "alpha beta");
+                // Rule 1 may produce "beta gamma" via isPartialPrefixOfStringPart
+                // since "beta" is a prefix of "beta gamma". This is expected:
+                // both rules produce valid completions for the input.
+                // We verify maxPrefixLength is from the longest match.
+                expect(result.matchedPrefixLength).toBe(10);
+            });
+        });
+
+        describe("case insensitive matching for completions", () => {
+            const g = [
+                `<Start> = $(a:<A>) World -> { a };`,
+                `<A> = Hello -> "hello";`,
+            ].join("\n");
+            const grammar = loadGrammarRules("test.grammar", g);
+
+            it("completes after case-insensitive match", () => {
+                const result = matchGrammarCompletion(grammar, "hello");
+                expect(result.completions).toContain("World");
+                expect(result.matchedPrefixLength).toBe(5);
+            });
+
+            it("completes after uppercase input", () => {
+                const result = matchGrammarCompletion(grammar, "HELLO");
+                expect(result.completions).toContain("World");
+                expect(result.matchedPrefixLength).toBe(5);
+            });
+
+            it("partial prefix is case insensitive", () => {
+                const result = matchGrammarCompletion(grammar, "hello WO");
+                expect(result.completions).toContain("World");
+            });
+        });
+
+        describe("no spurious completions from unrelated rules", () => {
+            // Two completely different rules. Only the matching one should
+            // produce completions.
+            const g = [
+                `<Start> = play $(g:<Genre>) -> { action: "play", genre: g };`,
+                `<Start> = stop $(r:<Reason>) -> { action: "stop", reason: r };`,
+                `<Genre> = rock -> "rock";`,
+                `<Reason> = now -> "now";`,
+            ].join("\n");
+            const grammar = loadGrammarRules("test.grammar", g);
+
+            it("only matching rule offers completions for 'play'", () => {
+                const result = matchGrammarCompletion(grammar, "play");
+                expect(result.completions).toContain("rock");
+                expect(result.completions).not.toContain("now");
+                expect(result.completions).not.toContain("stop");
+            });
+
+            it("only matching rule offers completions for 'stop'", () => {
+                const result = matchGrammarCompletion(grammar, "stop");
+                expect(result.completions).toContain("now");
+                expect(result.completions).not.toContain("rock");
+                expect(result.completions).not.toContain("play");
+            });
+
+            it("all first parts offered for unrelated input", () => {
+                const result = matchGrammarCompletion(grammar, "dance");
+                // Nothing consumed; all first string parts from every rule
+                // are offered at prefixLength 0.  The caller filters by
+                // the trailing text "dance".
+                expect(result.completions.sort()).toEqual(["play", "stop"]);
+                expect(result.matchedPrefixLength).toBe(0);
+            });
+        });
+
+        describe("completion with entity wildcard", () => {
+            // Entity wildcards should produce property completions, not string
+            // completions, and matchedPrefixLength should indicate where the
+            // entity value begins.
+            const g = [
+                `entity SongName;`,
+                `<Start> = play $(song:SongName) next -> { song };`,
+            ].join("\n");
+            const grammar = loadGrammarRules("test.grammar", g);
+
+            it("entity wildcard produces property completion", () => {
+                const result = matchGrammarCompletion(grammar, "play");
+                expect(result.properties).toBeDefined();
+                expect(result.properties!.length).toBeGreaterThan(0);
+                expect(result.matchedPrefixLength).toBe(4);
+            });
+
+            it("string terminator after entity text", () => {
+                const result = matchGrammarCompletion(grammar, "play mysong");
+                expect(result.completions).toContain("next");
+            });
+        });
+
+        describe("completion at boundary between consumed and remaining", () => {
+            // Verify that trailing separators (spaces) don't affect
+            // which part is offered for completion.
+            const g = [
+                `<Start> = $(a:<A>) $(b:<B>) -> { a, b };`,
+                `<A> = one -> "a";`,
+                `<B> = two -> "b";`,
+            ].join("\n");
+            const grammar = loadGrammarRules("test.grammar", g);
+
+            it("same completion with and without trailing space", () => {
+                const r1 = matchGrammarCompletion(grammar, "one");
+                const r2 = matchGrammarCompletion(grammar, "one ");
+                const r3 = matchGrammarCompletion(grammar, "one  ");
+                expect(r1.completions).toEqual(r2.completions);
+                expect(r2.completions).toEqual(r3.completions);
+                expect(r1.completions).toContain("two");
+            });
+
+            it("matchedPrefixLength includes trailing whitespace", () => {
+                const r1 = matchGrammarCompletion(grammar, "one");
+                const r2 = matchGrammarCompletion(grammar, "one ");
+                const r3 = matchGrammarCompletion(grammar, "one  ");
+                // Each includes the trailing whitespace in
+                // matchedPrefixLength: "one"=3, "one "=4, "one  "=5.
+                expect(r1.matchedPrefixLength).toBe(3);
+                expect(r2.matchedPrefixLength).toBe(4);
+                expect(r3.matchedPrefixLength).toBe(5);
+            });
+        });
+
+        describe("closedSet flag - exhaustiveness", () => {
+            describe("string-only completions are exhaustive", () => {
+                const g = [
+                    `<Start> = play $(g:<Genre>) -> { genre: g };`,
+                    `<Genre> = rock -> "rock";`,
+                    `<Genre> = pop -> "pop";`,
+                    `<Genre> = jazz -> "jazz";`,
+                ].join("\n");
+                const grammar = loadGrammarRules("test.grammar", g);
+
+                it("closedSet=true for first string part on empty input", () => {
+                    const result = matchGrammarCompletion(grammar, "");
+                    expect(result.completions).toContain("play");
+                    expect(result.closedSet).toBe(true);
+                    expect(result.openWildcard).toBe(false);
+                });
+
+                it("closedSet=true for alternatives after prefix", () => {
+                    const result = matchGrammarCompletion(grammar, "play");
+                    expect(result.completions).toContain("rock");
+                    expect(result.completions).toContain("pop");
+                    expect(result.completions).toContain("jazz");
+                    expect(result.closedSet).toBe(true);
+                    expect(result.openWildcard).toBe(false);
+                });
+
+                it("closedSet=true for exact match (no completions)", () => {
+                    const result = matchGrammarCompletion(grammar, "play rock");
+                    expect(result.completions).toHaveLength(0);
+                    expect(result.closedSet).toBe(true);
+                    expect(result.openWildcard).toBe(false);
+                });
+            });
+
+            describe("wildcard/entity completions are not exhaustive", () => {
+                const g = [
+                    `entity SongName;`,
+                    `<Start> = play $(song:SongName) next -> { song };`,
+                ].join("\n");
+                const grammar = loadGrammarRules("test.grammar", g);
+
+                it("closedSet=false for entity wildcard property completion", () => {
+                    const result = matchGrammarCompletion(grammar, "play");
+                    expect(result.properties).toBeDefined();
+                    expect(result.properties!.length).toBeGreaterThan(0);
+                    expect(result.closedSet).toBe(false);
+                });
+
+                it("closedSet=true for string completion after wildcard", () => {
+                    const result = matchGrammarCompletion(
+                        grammar,
+                        "play mysong",
+                    );
+                    expect(result.completions).toContain("next");
+                    // The "next" keyword is the only valid continuation
+                    // from the grammar — no property completions at this
+                    // point — so completions are exhaustive.
+                    expect(result.closedSet).toBe(true);
+                });
+            });
+
+            describe("untyped wildcard produces property completion → not exhaustive", () => {
+                const g = [
+                    `<Start> = play $(name) by $(artist) -> { name, artist };`,
+                ].join("\n");
+                const grammar = loadGrammarRules("test.grammar", g);
+
+                it("closedSet=false for untyped wildcard property", () => {
+                    const result = matchGrammarCompletion(grammar, "play");
+                    expect(result.properties).toBeDefined();
+                    expect(result.properties!.length).toBeGreaterThan(0);
+                    expect(result.closedSet).toBe(false);
+                    expect(result.openWildcard).toBe(false);
+                });
+
+                it("closedSet=true for 'by' keyword after wildcard captured", () => {
+                    const result = matchGrammarCompletion(
+                        grammar,
+                        "play hello",
+                    );
+                    expect(result.completions).toContain("by");
+                    expect(result.closedSet).toBe(true);
+                    expect(result.openWildcard).toBe(true);
+                });
+
+                it("openWildcard=true for multi-word wildcard before keyword", () => {
+                    const result = matchGrammarCompletion(
+                        grammar,
+                        "play my favorite song",
+                    );
+                    expect(result.completions).toContain("by");
+                    expect(result.closedSet).toBe(true);
+                    expect(result.openWildcard).toBe(true);
+                });
+
+                it("openWildcard=true for ambiguous keyword boundary", () => {
+                    // "play hello by" is ambiguous: "by" could be part of
+                    // the track name or the keyword delimiter.  The grammar
+                    // produces both interpretations at prefix length 13,
+                    // so openWildcard stays true.
+                    const result = matchGrammarCompletion(
+                        grammar,
+                        "play hello by",
+                    );
+                    expect(result.openWildcard).toBe(true);
+                });
+
+                it("openWildcard=true persists with trailing separator", () => {
+                    // "play hello by " — still ambiguous: "by " could be
+                    // part of the track name in one interpretation.
+                    // openWildcard stays true because the grammar considers
+                    // both parse paths.  The shell resolves this via B4
+                    // (unique match) when the user types "by" in the trie.
+                    const result = matchGrammarCompletion(
+                        grammar,
+                        "play hello by ",
+                    );
+                    expect(result.openWildcard).toBe(true);
+                });
+            });
+
+            describe("mixed string and entity at same prefix length", () => {
+                // Two rules sharing "play" prefix: one leads to string
+                // completion ("shuffle"), one to entity property.
+                // Both completions should be present regardless of rule order.
+
+                it("entity rule first, string rule second", () => {
+                    const g = [
+                        `entity SongName;`,
+                        `<Start> = play $(song:SongName) -> { action: "search", song };`,
+                        `<Start> = play shuffle -> { action: "shuffle" };`,
+                    ].join("\n");
+                    const grammar = loadGrammarRules("test.grammar", g);
+                    const result = matchGrammarCompletion(grammar, "play");
+                    expect(result.matchedPrefixLength).toBe(4);
+                    expect(result.completions).toContain("shuffle");
+                    expect(result.properties).toBeDefined();
+                    expect(result.properties!.length).toBeGreaterThan(0);
+                    expect(result.closedSet).toBe(false);
+                });
+
+                it("string rule first, entity rule second", () => {
+                    const g = [
+                        `entity SongName;`,
+                        `<Start> = play shuffle -> { action: "shuffle" };`,
+                        `<Start> = play $(song:SongName) -> { action: "search", song };`,
+                    ].join("\n");
+                    const grammar = loadGrammarRules("test.grammar", g);
+                    const result = matchGrammarCompletion(grammar, "play");
+                    expect(result.matchedPrefixLength).toBe(4);
+                    expect(result.completions).toContain("shuffle");
+                    expect(result.properties).toBeDefined();
+                    expect(result.properties!.length).toBeGreaterThan(0);
+                    expect(result.closedSet).toBe(false);
+                });
+            });
+
+            describe("competing rules - longer match resets closedSet", () => {
+                const g = [
+                    `entity SongName;`,
+                    `<Start> = $(a:<A>) $(song:SongName) -> { a, song };`,
+                    `<Start> = $(a:<A>) $(b:<B>) finish -> { a, b };`,
+                    `<A> = alpha -> "a";`,
+                    `<B> = bravo -> "b";`,
+                ].join("\n");
+                const grammar = loadGrammarRules("test.grammar", g);
+
+                it("closedSet reflects longest prefix length result", () => {
+                    const result = matchGrammarCompletion(
+                        grammar,
+                        "alpha bravo",
+                    );
+                    // Rule 2 matches alpha+bravo (11 chars) and offers "finish"
+                    // (string → closedSet=true).
+                    // Rule 1 matches alpha (5 chars) and offers entity
+                    // (closedSet=false) — but this is at a shorter prefix
+                    // length so it's discarded.
+                    expect(result.completions).toContain("finish");
+                    expect(result.matchedPrefixLength).toBe(11);
+                    expect(result.closedSet).toBe(true);
+                });
+            });
+
+            describe("sequential parts - closedSet stays true throughout", () => {
+                const g = [
+                    `<Start> = $(a:<A>) $(b:<B>) $(c:<C>) -> { a, b, c };`,
+                    `<A> = first -> "a";`,
+                    `<B> = second -> "b";`,
+                    `<C> = third -> "c";`,
+                ].join("\n");
+                const grammar = loadGrammarRules("test.grammar", g);
+
+                it("closedSet=true for first part", () => {
+                    const result = matchGrammarCompletion(grammar, "");
+                    expect(result.completions).toContain("first");
+                    expect(result.closedSet).toBe(true);
+                });
+
+                it("closedSet=true for second part", () => {
+                    const result = matchGrammarCompletion(grammar, "first");
+                    expect(result.completions).toContain("second");
+                    expect(result.closedSet).toBe(true);
+                });
+
+                it("closedSet=true for third part", () => {
+                    const result = matchGrammarCompletion(
+                        grammar,
+                        "first second",
+                    );
+                    expect(result.completions).toContain("third");
+                    expect(result.closedSet).toBe(true);
+                });
+
+                it("closedSet=true for exact full match", () => {
+                    const result = matchGrammarCompletion(
+                        grammar,
+                        "first second third",
+                    );
+                    expect(result.completions).toHaveLength(0);
+                    expect(result.closedSet).toBe(true);
+                });
+            });
+
+            describe("optional parts", () => {
+                const g = [
+                    `<Start> = $(a:<A>) $(b:<B>)? $(c:<C>) -> { a, c };`,
+                    `<A> = begin -> "a";`,
+                    `<B> = middle -> "b";`,
+                    `<C> = finish -> "c";`,
+                ].join("\n");
+                const grammar = loadGrammarRules("test.grammar", g);
+
+                it("closedSet=true for alternatives after optional", () => {
+                    const result = matchGrammarCompletion(grammar, "begin");
+                    expect(result.completions).toContain("middle");
+                    expect(result.completions).toContain("finish");
+                    expect(result.closedSet).toBe(true);
+                });
+            });
+        });
+    },
+);

--- a/ts/packages/actionGrammar/test/grammarCompletionNestedWildcard.spec.ts
+++ b/ts/packages/actionGrammar/test/grammarCompletionNestedWildcard.spec.ts
@@ -2,46 +2,49 @@
 // Licensed under the MIT License.
 
 import { loadGrammarRules } from "../src/grammarLoader.js";
-import { matchGrammarCompletion } from "../src/grammarMatcher.js";
+import { describeForEachCompletion } from "./testUtils.js";
 
-describe("Grammar Completion - nested wildcard through rules", () => {
-    // Reproduces the bug where completing "play" returns "by" instead of
-    // a completionProperty for the wildcard <TrackName>.
-    //
-    // Grammar:
-    //   <Start> = play $(trackName:<TrackPhrase>) by $(artist:<ArtistName>)
-    //             -> { actionName: "playTrack", parameters: { trackName, artists: [artist] } }
-    //   <TrackPhrase> = $(trackName:<TrackName>) -> trackName
-    //   <TrackName> = $(x:wildcard)
-    //   <ArtistName> = $(x:wildcard)
-    const g = [
-        `<Start> = play $(trackName:<TrackPhrase>) by $(artist:<ArtistName>) -> { actionName: "playTrack", parameters: { trackName, artists: [artist] } };`,
-        `<TrackPhrase> = $(trackName:<TrackName>) -> trackName;`,
-        `<TrackName> = $(x:wildcard);`,
-        `<ArtistName> = $(x:wildcard);`,
-    ].join("\n");
-    const grammar = loadGrammarRules("test.grammar", g);
+describeForEachCompletion(
+    "Grammar Completion - nested wildcard through rules",
+    (matchGrammarCompletion) => {
+        // Reproduces the bug where completing "play" returns "by" instead of
+        // a completionProperty for the wildcard <TrackName>.
+        //
+        // Grammar:
+        //   <Start> = play $(trackName:<TrackPhrase>) by $(artist:<ArtistName>)
+        //             -> { actionName: "playTrack", parameters: { trackName, artists: [artist] } }
+        //   <TrackPhrase> = $(trackName:<TrackName>) -> trackName
+        //   <TrackName> = $(x:wildcard)
+        //   <ArtistName> = $(x:wildcard)
+        const g = [
+            `<Start> = play $(trackName:<TrackPhrase>) by $(artist:<ArtistName>) -> { actionName: "playTrack", parameters: { trackName, artists: [artist] } };`,
+            `<TrackPhrase> = $(trackName:<TrackName>) -> trackName;`,
+            `<TrackName> = $(x:wildcard);`,
+            `<ArtistName> = $(x:wildcard);`,
+        ].join("\n");
+        const grammar = loadGrammarRules("test.grammar", g);
 
-    it('should return completionProperty for wildcard after "play"', () => {
-        const result = matchGrammarCompletion(grammar, "play");
-        // After matching "play", the next part is $(trackName:<TrackPhrase>)
-        // which ultimately resolves to a wildcard. The completion should
-        // include a property for that wildcard, not just "by".
-        expect(result.properties).toBeDefined();
-        expect(result.properties!.length).toBeGreaterThan(0);
-    });
+        it('should return completionProperty for wildcard after "play"', () => {
+            const result = matchGrammarCompletion(grammar, "play");
+            // After matching "play", the next part is $(trackName:<TrackPhrase>)
+            // which ultimately resolves to a wildcard. The completion should
+            // include a property for that wildcard, not just "by".
+            expect(result.properties).toBeDefined();
+            expect(result.properties!.length).toBeGreaterThan(0);
+        });
 
-    it('should return completionProperty for wildcard after "play "', () => {
-        const result = matchGrammarCompletion(grammar, "play ");
-        // Same as above but with trailing space
-        expect(result.properties).toBeDefined();
-        expect(result.properties!.length).toBeGreaterThan(0);
-    });
+        it('should return completionProperty for wildcard after "play "', () => {
+            const result = matchGrammarCompletion(grammar, "play ");
+            // Same as above but with trailing space
+            expect(result.properties).toBeDefined();
+            expect(result.properties!.length).toBeGreaterThan(0);
+        });
 
-    it('should return "by" as completion after wildcard text', () => {
-        const result = matchGrammarCompletion(grammar, "play some song");
-        // After the wildcard has captured text, "by" should appear as a
-        // completion for the next string part.
-        expect(result.completions).toContain("by");
-    });
-});
+        it('should return "by" as completion after wildcard text', () => {
+            const result = matchGrammarCompletion(grammar, "play some song");
+            // After the wildcard has captured text, "by" should appear as a
+            // completion for the next string part.
+            expect(result.completions).toContain("by");
+        });
+    },
+);

--- a/ts/packages/actionGrammar/test/grammarCompletionPrefixLength.spec.ts
+++ b/ts/packages/actionGrammar/test/grammarCompletionPrefixLength.spec.ts
@@ -2,1173 +2,1176 @@
 // Licensed under the MIT License.
 
 import { loadGrammarRules } from "../src/grammarLoader.js";
-import { matchGrammarCompletion } from "../src/grammarMatcher.js";
+import { describeForEachCompletion } from "./testUtils.js";
 
-describe("Grammar Completion - matchedPrefixLength", () => {
-    describe("single string part", () => {
-        // All words in one string part — when no leading words match,
-        // matchedPrefixLength is 0 and only the first word is offered
-        // as a completion.  When leading words match, matchedPrefixLength
-        // advances and only the remaining words are offered.
-        const g = `<Start> = play music -> true;`;
-        const grammar = loadGrammarRules("test.grammar", g);
-
-        it("returns first word as completion for empty input", () => {
-            const result = matchGrammarCompletion(grammar, "");
-            expect(result.completions).toEqual(["play"]);
-            expect(result.matchedPrefixLength).toBe(0);
-        });
-
-        it("returns first word as completion for partial prefix", () => {
-            const result = matchGrammarCompletion(grammar, "pl");
-            expect(result.completions).toEqual(["play"]);
-            expect(result.matchedPrefixLength).toBe(0);
-        });
-
-        it("returns remaining words as completion for first word typed", () => {
-            const result = matchGrammarCompletion(grammar, "play ");
-            // tryPartialStringMatch splits the multi-word part: "play"
-            // is consumed (4 chars), trailing space advances to 5.
-            expect(result.completions).toEqual(["music"]);
-            expect(result.matchedPrefixLength).toBe(5);
-        });
-
-        it("returns first word for non-matching input", () => {
-            const result = matchGrammarCompletion(grammar, "xyz");
-            // Nothing consumed; only the first word of the string part is
-            // offered so the caller can filter by trailing text.
-            expect(result.completions).toEqual(["play"]);
-            expect(result.matchedPrefixLength).toBe(0);
-        });
-
-        it("returns matchedPrefixLength for exact match", () => {
-            const result = matchGrammarCompletion(grammar, "play music");
-            expect(result.completions).toHaveLength(0);
-            // Exact match now records the full consumed length.
-            expect(result.matchedPrefixLength).toBe(10);
-        });
-    });
-
-    describe("multi-part via nested rule", () => {
-        // Nested rule creates separate parts, so matchedPrefixLength
-        // reflects the position after the consumed nested rule.
-        const g = [
-            `<Start> = $(v:<Verb>) music -> true;`,
-            `<Verb> = play -> true;`,
-        ].join("\n");
-        const grammar = loadGrammarRules("test.grammar", g);
-
-        it("returns nested rule text for empty input", () => {
-            const result = matchGrammarCompletion(grammar, "");
-            expect(result.completions).toEqual(["play"]);
-            expect(result.matchedPrefixLength).toBe(0);
-        });
-
-        it("returns second part after nested rule consumed", () => {
-            const result = matchGrammarCompletion(grammar, "play");
-            expect(result.completions).toEqual(["music"]);
-            expect(result.matchedPrefixLength).toBe(4);
-        });
-
-        it("returns second part after nested rule with trailing space", () => {
-            const result = matchGrammarCompletion(grammar, "play ");
-            expect(result.completions).toEqual(["music"]);
-            expect(result.matchedPrefixLength).toBe(5);
-        });
-
-        it("returns second part for partial second word", () => {
-            const result = matchGrammarCompletion(grammar, "play m");
-            expect(result.completions).toEqual(["music"]);
-            expect(result.matchedPrefixLength).toBe(4);
-        });
-
-        it("returns matchedPrefixLength for complete match", () => {
-            const result = matchGrammarCompletion(grammar, "play music");
-            expect(result.completions).toHaveLength(0);
-            expect(result.matchedPrefixLength).toBe(10);
-        });
-    });
-
-    describe("multiple rules with shared prefix", () => {
-        // Multiple rules that share a prefix via nested rules
-        const g = [
-            `<Start> = $(v:<Verb>) music -> "play_music";`,
-            `<Start> = $(v:<Verb>) video -> "play_video";`,
-            `<Verb> = play -> true;`,
-        ].join("\n");
-        const grammar = loadGrammarRules("test.grammar", g);
-
-        it("returns both completions after shared prefix", () => {
-            const result = matchGrammarCompletion(grammar, "play ");
-            expect(result.completions.sort()).toEqual(["music", "video"]);
-            expect(result.matchedPrefixLength).toBe(5);
-        });
-    });
-
-    describe("wildcard with terminator", () => {
-        // Wildcard between string parts: "play $(name) now"
-        const g = `<Start> = play $(name) now -> { name: name };`;
-        const grammar = loadGrammarRules("test.grammar", g);
-
-        it("returns wildcard property (not terminator) when only separator follows wildcard start", () => {
-            // "play " — the trailing space is only a separator, not valid
-            // wildcard content, so the wildcard can't finalize and we fall
-            // through to the property-completion path instead of offering
-            // the terminator string.  Trailing space advances to 5.
-            const result = matchGrammarCompletion(grammar, "play ");
-            expect(result.completions).toEqual([]);
-            expect(result.matchedPrefixLength).toBe(5);
-        });
-
-        it("returns terminator with matchedPrefixLength tracking wildcard text", () => {
-            const result = matchGrammarCompletion(grammar, "play hello");
-            expect(result.completions).toEqual(["now"]);
-            // Wildcard consumed "hello" — matchedPrefixLength includes it
-            expect(result.matchedPrefixLength).toBe(10);
-        });
-
-        it("returns terminator with matchedPrefixLength for trailing space", () => {
-            const result = matchGrammarCompletion(grammar, "play hello ");
-            expect(result.completions).toEqual(["now"]);
-            expect(result.matchedPrefixLength).toBe(11);
-        });
-    });
-
-    describe("wildcard without terminator", () => {
-        const g = `<Start> = play $(name) -> { name: name };`;
-        const grammar = loadGrammarRules("test.grammar", g);
-
-        it("returns start rule for empty input", () => {
-            const result = matchGrammarCompletion(grammar, "");
-            expect(result.completions).toEqual(["play"]);
-            expect(result.matchedPrefixLength).toBe(0);
-        });
-
-        it("returns property completion for separator-only trailing wildcard", () => {
-            // The trailing space is not valid wildcard content, so the
-            // wildcard can't finalize.  The else-branch produces a
-            // property completion instead.  Trailing space advances
-            // matchedPrefixLength to 5.
-            const result = matchGrammarCompletion(grammar, "play ");
-            expect(result.completions).toHaveLength(0);
-            expect(result.matchedPrefixLength).toBe(5);
-        });
-    });
-
-    describe("CJK multi-part with nested rule", () => {
-        // CJK requires multi-part grammar for meaningful matchedPrefixLength
-        const g = [
-            `<Start> [spacing=auto] = $(v:<Verb>) 音楽 -> true;`,
-            `<Verb> [spacing=auto] = 再生 -> true;`,
-        ].join("\n");
-        const grammar = loadGrammarRules("test.grammar", g);
-
-        it("returns verb for empty input", () => {
-            const result = matchGrammarCompletion(grammar, "");
-            expect(result.completions).toEqual(["再生"]);
-            expect(result.matchedPrefixLength).toBe(0);
-        });
-
-        it("returns noun completion after CJK verb typed", () => {
-            const result = matchGrammarCompletion(grammar, "再生");
-            expect(result.completions).toEqual(["音楽"]);
-            // "再生" is 2 chars; matchedPrefixLength reflects position after verb
-            expect(result.matchedPrefixLength).toBe(2);
-        });
-
-        it("returns noun completion after CJK verb with space", () => {
-            const result = matchGrammarCompletion(grammar, "再生 ");
-            expect(result.completions).toEqual(["音楽"]);
-            expect(result.matchedPrefixLength).toBe(3);
-        });
-
-        it("returns no completions for exact match", () => {
-            const result = matchGrammarCompletion(grammar, "再生音楽");
-            expect(result.completions).toHaveLength(0);
-            expect(result.matchedPrefixLength).toBe(4);
-        });
-    });
-
-    describe("CJK single string part", () => {
-        // Single string part — only the first word is offered initially.
-        // After the first word matches, the remaining words are offered.
-        const g = `<Start> [spacing=auto] = 再生 音楽 -> true;`;
-        const grammar = loadGrammarRules("test.grammar", g);
-
-        it("returns first word for empty input", () => {
-            const result = matchGrammarCompletion(grammar, "");
-            expect(result.completions).toEqual(["再生"]);
-            expect(result.matchedPrefixLength).toBe(0);
-        });
-
-        it("returns remaining words for partial CJK prefix", () => {
-            const result = matchGrammarCompletion(grammar, "再生");
-            // tryPartialStringMatch splits the multi-word part: "再生"
-            // is consumed (2 chars), "音楽" remains as the completion.
-            expect(result.completions).toEqual(["音楽"]);
-            expect(result.matchedPrefixLength).toBe(2);
-        });
-    });
-
-    describe("CJK wildcard", () => {
-        const g = `<Start> [spacing=auto] = 再生 $(name) 停止 -> { name: name };`;
-        const grammar = loadGrammarRules("test.grammar", g);
-
-        it("returns property completion when only separator follows CJK wildcard start", () => {
-            // Same as the Latin case: trailing space is a separator, not
-            // valid wildcard content, so the terminator isn't offered.
-            // Trailing space advances matchedPrefixLength to 3.
-            const result = matchGrammarCompletion(grammar, "再生 ");
-            expect(result.completions).toEqual([]);
-            expect(result.matchedPrefixLength).toBe(3);
-        });
-
-        it("returns terminator after CJK prefix + wildcard text", () => {
-            const result = matchGrammarCompletion(grammar, "再生 hello");
-            expect(result.completions).toEqual(["停止"]);
-            expect(result.matchedPrefixLength).toBe(8);
-        });
-    });
-
-    describe("separatorMode - Latin multi-part", () => {
-        // Latin grammar: "play" → "music" requires a space separator
-        const g = [
-            `<Start> = $(v:<Verb>) music -> true;`,
-            `<Verb> = play -> true;`,
-        ].join("\n");
-        const grammar = loadGrammarRules("test.grammar", g);
-
-        it("reports separatorMode for Latin 'play' → 'music'", () => {
-            const result = matchGrammarCompletion(grammar, "play");
-            expect(result.completions).toEqual(["music"]);
-            expect(result.separatorMode).toBe("spacePunctuation");
-        });
-
-        it("reports separatorMode even when trailing space exists", () => {
-            const result = matchGrammarCompletion(grammar, "play ");
-            expect(result.completions).toEqual(["music"]);
-            // Trailing space consumed: matchedPrefixLength advances to 5,
-            // separatorMode demoted to "optional" (space already included).
-            expect(result.matchedPrefixLength).toBe(5);
-            expect(result.separatorMode).toBe("optional");
-        });
-
-        it("reports optional separatorMode for empty input", () => {
-            const result = matchGrammarCompletion(grammar, "");
-            expect(result.completions).toEqual(["play"]);
-            expect(result.separatorMode).toBe("optional");
-        });
-
-        it("reports optional separatorMode for partial prefix match", () => {
-            // "pl" matches partially → the completion replaces from state.index,
-            // so no separator needed (user is typing the keyword)
-            const result = matchGrammarCompletion(grammar, "pl");
-            expect(result.completions).toEqual(["play"]);
-            expect(result.separatorMode).toBe("optional");
-        });
-    });
-
-    describe("separatorMode - CJK multi-part", () => {
-        // CJK grammar: "再生" → "音楽" does NOT require a space separator
-        const g = [
-            `<Start> [spacing=auto] = $(v:<Verb>) 音楽 -> true;`,
-            `<Verb> [spacing=auto] = 再生 -> true;`,
-        ].join("\n");
-        const grammar = loadGrammarRules("test.grammar", g);
-
-        it("reports optional separatorMode for CJK '再生' → '音楽'", () => {
-            const result = matchGrammarCompletion(grammar, "再生");
-            expect(result.completions).toEqual(["音楽"]);
-            // CJK → CJK in auto mode: separator optional
-            expect(result.separatorMode).toBe("optional");
-        });
-    });
-
-    describe("separatorMode - mixed scripts", () => {
-        // Latin followed by CJK: no separator needed in auto mode
-        const g = [
-            `<Start> [spacing=auto] = $(v:<Verb>) 音楽 -> true;`,
-            `<Verb> [spacing=auto] = play -> true;`,
-        ].join("\n");
-        const grammar = loadGrammarRules("test.grammar", g);
-
-        it("reports optional separatorMode for Latin 'play' → CJK '音楽'", () => {
-            const result = matchGrammarCompletion(grammar, "play");
-            expect(result.completions).toEqual(["音楽"]);
-            // Latin → CJK in auto mode: different scripts, separator optional
-            expect(result.separatorMode).toBe("optional");
-        });
-    });
-
-    describe("separatorMode - spacing=required", () => {
-        const g = [
-            `<Start> [spacing=required] = $(v:<Verb>) music -> true;`,
-            `<Verb> [spacing=required] = play -> true;`,
-        ].join("\n");
-        const grammar = loadGrammarRules("test.grammar", g);
-
-        it("reports separatorMode when spacing=required", () => {
-            const result = matchGrammarCompletion(grammar, "play");
-            expect(result.completions).toEqual(["music"]);
-            expect(result.separatorMode).toBe("spacePunctuation");
-        });
-    });
-
-    describe("separatorMode - spacing=optional", () => {
-        const g = [
-            `<Start> [spacing=optional] = $(v:<Verb>) music -> true;`,
-            `<Verb> [spacing=optional] = play -> true;`,
-        ].join("\n");
-        const grammar = loadGrammarRules("test.grammar", g);
-
-        it("reports optional separatorMode when spacing=optional", () => {
-            const result = matchGrammarCompletion(grammar, "play");
-            expect(result.completions).toEqual(["music"]);
-            expect(result.separatorMode).toBe("optional");
-        });
-    });
-
-    describe("separatorMode - wildcard entity", () => {
-        // Grammar where the completion is a wildcard entity (not a static string).
-        // separatorMode describes the boundary at matchedPrefixLength.
-        const g = [
-            `entity TrackName;`,
-            `<Start> = play $(name:TrackName) -> { actionName: "play", parameters: { name } };`,
-        ].join("\n");
-        const grammar = loadGrammarRules("test.grammar", g);
-
-        it("reports separatorMode for 'play' before wildcard", () => {
-            const result = matchGrammarCompletion(grammar, "play");
-            expect(result.properties?.length).toBeGreaterThan(0);
-            // matchedPrefixLength=4; boundary "y" → entity needs separator.
-            expect(result.separatorMode).toBe("spacePunctuation");
-        });
-
-        it("reports separatorMode for 'play ' before wildcard", () => {
-            // Trailing space consumed: matchedPrefixLength advances to 5,
-            // separatorMode demoted to "optional".
-            const result = matchGrammarCompletion(grammar, "play ");
-            expect(result.properties?.length).toBeGreaterThan(0);
-            expect(result.separatorMode).toBe("optional");
-        });
-    });
-
-    describe("backward direction", () => {
-        describe("all-literal single string part", () => {
+describeForEachCompletion(
+    "Grammar Completion - matchedPrefixLength",
+    (matchGrammarCompletion) => {
+        describe("single string part", () => {
+            // All words in one string part — when no leading words match,
+            // matchedPrefixLength is 0 and only the first word is offered
+            // as a completion.  When leading words match, matchedPrefixLength
+            // advances and only the remaining words are offered.
             const g = `<Start> = play music -> true;`;
             const grammar = loadGrammarRules("test.grammar", g);
 
-            it("exact match backward offers last literal word", () => {
-                const result = matchGrammarCompletion(
-                    grammar,
-                    "play music",
-                    undefined,
-                    "backward",
-                );
-                // Backward backs up to the last matched word "music"
-                // and re-offers it as a completion.
-                expect(result.completions).toEqual(["music"]);
-                expect(result.matchedPrefixLength).toBe(4);
+            it("returns first word as completion for empty input", () => {
+                const result = matchGrammarCompletion(grammar, "");
+                expect(result.completions).toEqual(["play"]);
+                expect(result.matchedPrefixLength).toBe(0);
             });
 
-            it("forward exact match still returns empty completions", () => {
-                const result = matchGrammarCompletion(
-                    grammar,
-                    "play music",
-                    undefined,
-                    "forward",
-                );
+            it("returns first word as completion for partial prefix", () => {
+                const result = matchGrammarCompletion(grammar, "pl");
+                expect(result.completions).toEqual(["play"]);
+                expect(result.matchedPrefixLength).toBe(0);
+            });
+
+            it("returns remaining words as completion for first word typed", () => {
+                const result = matchGrammarCompletion(grammar, "play ");
+                // tryPartialStringMatch splits the multi-word part: "play"
+                // is consumed (4 chars), trailing space advances to 5.
+                expect(result.completions).toEqual(["music"]);
+                expect(result.matchedPrefixLength).toBe(5);
+            });
+
+            it("returns first word for non-matching input", () => {
+                const result = matchGrammarCompletion(grammar, "xyz");
+                // Nothing consumed; only the first word of the string part is
+                // offered so the caller can filter by trailing text.
+                expect(result.completions).toEqual(["play"]);
+                expect(result.matchedPrefixLength).toBe(0);
+            });
+
+            it("returns matchedPrefixLength for exact match", () => {
+                const result = matchGrammarCompletion(grammar, "play music");
                 expect(result.completions).toHaveLength(0);
-                expect(result.matchedPrefixLength).toBe(10);
-            });
-        });
-
-        describe("three-word single string part", () => {
-            const g = `<Start> = play music now -> true;`;
-            const grammar = loadGrammarRules("test.grammar", g);
-
-            it("partial match backward offers last matched word", () => {
-                const result = matchGrammarCompletion(
-                    grammar,
-                    "play music",
-                    undefined,
-                    "backward",
-                );
-                // Backward: "play" and "music" matched, so it backs
-                // up to offer "music" (the last matched word).
-                expect(result.completions).toEqual(["music"]);
-                expect(result.matchedPrefixLength).toBe(4);
-            });
-
-            it("partial match forward offers next unmatched word", () => {
-                const result = matchGrammarCompletion(
-                    grammar,
-                    "play music",
-                    undefined,
-                    "forward",
-                );
-                expect(result.completions).toEqual(["now"]);
+                // Exact match now records the full consumed length.
                 expect(result.matchedPrefixLength).toBe(10);
             });
         });
 
         describe("multi-part via nested rule", () => {
+            // Nested rule creates separate parts, so matchedPrefixLength
+            // reflects the position after the consumed nested rule.
             const g = [
-                `<Start> = $(v:<Verb>) music now -> true;`,
+                `<Start> = $(v:<Verb>) music -> true;`,
                 `<Verb> = play -> true;`,
             ].join("\n");
             const grammar = loadGrammarRules("test.grammar", g);
 
-            it("backward backs up to last matched literal", () => {
-                const result = matchGrammarCompletion(
-                    grammar,
-                    "play music",
-                    undefined,
-                    "backward",
-                );
-                // "play" matched the verb rule, "music" matched the
-                // second word. Backward backs up to "music".
+            it("returns nested rule text for empty input", () => {
+                const result = matchGrammarCompletion(grammar, "");
+                expect(result.completions).toEqual(["play"]);
+                expect(result.matchedPrefixLength).toBe(0);
+            });
+
+            it("returns second part after nested rule consumed", () => {
+                const result = matchGrammarCompletion(grammar, "play");
                 expect(result.completions).toEqual(["music"]);
                 expect(result.matchedPrefixLength).toBe(4);
             });
 
-            it("forward offers next unmatched word", () => {
-                const result = matchGrammarCompletion(
-                    grammar,
-                    "play music",
-                    undefined,
-                    "forward",
-                );
-                expect(result.completions).toEqual(["now"]);
-                expect(result.matchedPrefixLength).toBe(10);
+            it("returns second part after nested rule with trailing space", () => {
+                const result = matchGrammarCompletion(grammar, "play ");
+                expect(result.completions).toEqual(["music"]);
+                expect(result.matchedPrefixLength).toBe(5);
             });
-        });
 
-        describe("wildcard at end", () => {
-            const g = [
-                `entity TrackName;`,
-                `<Start> = play $(name:TrackName) -> { actionName: "play", parameters: { name } };`,
-            ].join("\n");
-            const grammar = loadGrammarRules("test.grammar", g);
-
-            it("backward on exact match backs up to wildcard start with property", () => {
-                const result = matchGrammarCompletion(
-                    grammar,
-                    "play hello",
-                    undefined,
-                    "backward",
-                );
-                // Backward: backs up to wildcard start (after "play" = 4)
-                // and offers entity property completions.
-                expect(result.properties?.length).toBeGreaterThan(0);
+            it("returns second part for partial second word", () => {
+                const result = matchGrammarCompletion(grammar, "play m");
+                expect(result.completions).toEqual(["music"]);
                 expect(result.matchedPrefixLength).toBe(4);
-                expect(result.closedSet).toBe(false);
             });
 
-            it("forward on exact match returns empty completions", () => {
-                const result = matchGrammarCompletion(
-                    grammar,
-                    "play hello",
-                    undefined,
-                    "forward",
-                );
+            it("returns matchedPrefixLength for complete match", () => {
+                const result = matchGrammarCompletion(grammar, "play music");
                 expect(result.completions).toHaveLength(0);
                 expect(result.matchedPrefixLength).toBe(10);
             });
         });
 
-        describe("wildcard in middle", () => {
+        describe("multiple rules with shared prefix", () => {
+            // Multiple rules that share a prefix via nested rules
             const g = [
-                `entity TrackName;`,
-                `<Start> = play $(name:TrackName) now -> { actionName: "play", parameters: { name } };`,
+                `<Start> = $(v:<Verb>) music -> "play_music";`,
+                `<Start> = $(v:<Verb>) video -> "play_video";`,
+                `<Verb> = play -> true;`,
             ].join("\n");
             const grammar = loadGrammarRules("test.grammar", g);
 
-            it("backward on exact match backs up to last literal 'now'", () => {
-                const result = matchGrammarCompletion(
-                    grammar,
-                    "play hello now",
-                    undefined,
-                    "backward",
-                );
-                // Backward: the wildcard was captured mid-match when
-                // "now" matched, so "now" is the last matched part.
-                // Backward backs up to offer "now" (not the wildcard).
+            it("returns both completions after shared prefix", () => {
+                const result = matchGrammarCompletion(grammar, "play ");
+                expect(result.completions.sort()).toEqual(["music", "video"]);
+                expect(result.matchedPrefixLength).toBe(5);
+            });
+        });
+
+        describe("wildcard with terminator", () => {
+            // Wildcard between string parts: "play $(name) now"
+            const g = `<Start> = play $(name) now -> { name: name };`;
+            const grammar = loadGrammarRules("test.grammar", g);
+
+            it("returns wildcard property (not terminator) when only separator follows wildcard start", () => {
+                // "play " — the trailing space is only a separator, not valid
+                // wildcard content, so the wildcard can't finalize and we fall
+                // through to the property-completion path instead of offering
+                // the terminator string.  Trailing space advances to 5.
+                const result = matchGrammarCompletion(grammar, "play ");
+                expect(result.completions).toEqual([]);
+                expect(result.matchedPrefixLength).toBe(5);
+            });
+
+            it("returns terminator with matchedPrefixLength tracking wildcard text", () => {
+                const result = matchGrammarCompletion(grammar, "play hello");
                 expect(result.completions).toEqual(["now"]);
+                // Wildcard consumed "hello" — matchedPrefixLength includes it
                 expect(result.matchedPrefixLength).toBe(10);
             });
 
-            it("forward offers 'now' (greedy wildcard alternative)", () => {
-                const result = matchGrammarCompletion(
-                    grammar,
-                    "play hello now",
-                    undefined,
-                    "forward",
-                );
-                // The wildcard greedily consumed "hello now", so the
-                // "now" string part is still unmatched — it appears
-                // as a completion at the same prefix length.
+            it("returns terminator with matchedPrefixLength for trailing space", () => {
+                const result = matchGrammarCompletion(grammar, "play hello ");
                 expect(result.completions).toEqual(["now"]);
-                expect(result.matchedPrefixLength).toBe(14);
+                expect(result.matchedPrefixLength).toBe(11);
             });
         });
 
-        describe("wildcard followed by multiple literals", () => {
-            const g = [
-                `entity TrackName;`,
-                `<Start> = play $(name:TrackName) right now -> { actionName: "play", parameters: { name } };`,
-            ].join("\n");
+        describe("wildcard without terminator", () => {
+            const g = `<Start> = play $(name) -> { name: name };`;
             const grammar = loadGrammarRules("test.grammar", g);
 
-            it("backward backs up to last literal 'now', not to wildcard", () => {
-                const result = matchGrammarCompletion(
-                    grammar,
-                    "play hello right now",
-                    undefined,
-                    "backward",
-                );
-                // "play" at 0, wildcard "hello" captured at 4-10,
-                // "right" at 10, "now" at 16.
-                // Backward should back up to the LAST literal "now".
-                expect(result.completions).toEqual(["now"]);
-                expect(result.matchedPrefixLength).toBe(16);
-            });
-
-            it("forward on exact match offers greedy wildcard alternative", () => {
-                const result = matchGrammarCompletion(
-                    grammar,
-                    "play hello right now",
-                    undefined,
-                    "forward",
-                );
-                // Greedy wildcard consumed "hello right now", so
-                // "right" is still unmatched as an alternative.
-                expect(result.completions).toEqual(["right"]);
-                expect(result.matchedPrefixLength).toBe(20);
-            });
-        });
-
-        describe("wildcard is last matched part before unmatched literal", () => {
-            const g = [
-                `entity TrackName;`,
-                `entity ArtistName;`,
-                `<Start> = play $(track:TrackName) by $(artist:ArtistName) -> { actionName: "play", parameters: { track, artist } };`,
-            ].join("\n");
-            const grammar = loadGrammarRules("test.grammar", g);
-
-            it("backward on 'play Nocturne' backs up to wildcard $(track)", () => {
-                const result = matchGrammarCompletion(
-                    grammar,
-                    "play Nocturne",
-                    undefined,
-                    "backward",
-                );
-                // "play" matched, $(track) captured "Nocturne",
-                // "by" is unmatched.  Backward should back up to
-                // the wildcard — the last matched item — and offer
-                // property completions for $(track).
-                expect(result.properties?.length).toBeGreaterThan(0);
-                expect(result.properties![0].propertyNames).toContain(
-                    "parameters.track",
-                );
-                expect(result.matchedPrefixLength).toBe(4);
-                expect(result.closedSet).toBe(false);
-            });
-
-            it("forward on 'play Nocturne' offers 'by'", () => {
-                const result = matchGrammarCompletion(
-                    grammar,
-                    "play Nocturne",
-                    undefined,
-                    "forward",
-                );
-                expect(result.completions).toEqual(["by"]);
-                expect(result.matchedPrefixLength).toBe(13);
-            });
-        });
-
-        describe("backward on partial input backs up to first word", () => {
-            const g = `<Start> = play music -> true;`;
-            const grammar = loadGrammarRules("test.grammar", g);
-
-            it("backward on empty input offers first word (same as forward)", () => {
-                const result = matchGrammarCompletion(
-                    grammar,
-                    "",
-                    undefined,
-                    "backward",
-                );
-                // Nothing matched — nothing to back up to, so
-                // backward falls through to forward and offers "play".
+            it("returns start rule for empty input", () => {
+                const result = matchGrammarCompletion(grammar, "");
                 expect(result.completions).toEqual(["play"]);
                 expect(result.matchedPrefixLength).toBe(0);
             });
 
-            it("backward on 'play' (no trailing space) backs up to 'play'", () => {
-                const result = matchGrammarCompletion(
-                    grammar,
-                    "play",
-                    undefined,
-                    "backward",
-                );
-                // No trailing space — backward backs up to offer
-                // "play" at position 0 (reconsider the first word).
-                expect(result.completions).toEqual(["play"]);
-                expect(result.matchedPrefixLength).toBe(0);
-            });
-
-            it("trailing space commits — backward on 'play ' offers next word (same as forward)", () => {
-                const result = matchGrammarCompletion(
-                    grammar,
-                    "play ",
-                    undefined,
-                    "backward",
-                );
-                // Trailing space is a commit signal — direction no
-                // longer matters.  Should offer "music" at position 5,
-                // same as forward.
-                expect(result.completions).toEqual(["music"]);
+            it("returns property completion for separator-only trailing wildcard", () => {
+                // The trailing space is not valid wildcard content, so the
+                // wildcard can't finalize.  The else-branch produces a
+                // property completion instead.  Trailing space advances
+                // matchedPrefixLength to 5.
+                const result = matchGrammarCompletion(grammar, "play ");
+                expect(result.completions).toHaveLength(0);
                 expect(result.matchedPrefixLength).toBe(5);
             });
+        });
 
-            it("forward on 'play ' offers next word", () => {
-                const result = matchGrammarCompletion(
-                    grammar,
-                    "play ",
-                    undefined,
-                    "forward",
-                );
-                expect(result.completions).toEqual(["music"]);
-                expect(result.matchedPrefixLength).toBe(5);
-            });
+        describe("CJK multi-part with nested rule", () => {
+            // CJK requires multi-part grammar for meaningful matchedPrefixLength
+            const g = [
+                `<Start> [spacing=auto] = $(v:<Verb>) 音楽 -> true;`,
+                `<Verb> [spacing=auto] = 再生 -> true;`,
+            ].join("\n");
+            const grammar = loadGrammarRules("test.grammar", g);
 
-            it("backward on partial 'pl' still offers 'play' (no complete token to reconsider)", () => {
-                const result = matchGrammarCompletion(
-                    grammar,
-                    "pl",
-                    undefined,
-                    "backward",
-                );
-                // "pl" is a partial prefix of "play".  No word was
-                // fully matched, so backward has nothing to back up
-                // to — falls through to forward and offers "play".
-                expect(result.completions).toEqual(["play"]);
+            it("returns verb for empty input", () => {
+                const result = matchGrammarCompletion(grammar, "");
+                expect(result.completions).toEqual(["再生"]);
                 expect(result.matchedPrefixLength).toBe(0);
             });
 
-            it("backward on 'play no' (partial second word) still offers 'now'", () => {
-                const result = matchGrammarCompletion(
-                    grammar,
-                    "play no",
-                    undefined,
-                    "backward",
-                );
-                // "play" fully matched but "no" doesn't fully match
-                // "now".  There is remaining unmatched input beyond
-                // the separator, so backward falls through to forward
-                // and offers "now".
-                expect(result.completions).toEqual(["music"]);
+            it("returns noun completion after CJK verb typed", () => {
+                const result = matchGrammarCompletion(grammar, "再生");
+                expect(result.completions).toEqual(["音楽"]);
+                // "再生" is 2 chars; matchedPrefixLength reflects position after verb
+                expect(result.matchedPrefixLength).toBe(2);
+            });
+
+            it("returns noun completion after CJK verb with space", () => {
+                const result = matchGrammarCompletion(grammar, "再生 ");
+                expect(result.completions).toEqual(["音楽"]);
+                expect(result.matchedPrefixLength).toBe(3);
+            });
+
+            it("returns no completions for exact match", () => {
+                const result = matchGrammarCompletion(grammar, "再生音楽");
+                expect(result.completions).toHaveLength(0);
                 expect(result.matchedPrefixLength).toBe(4);
             });
         });
 
-        describe("multi-rule with shared prefix and wildcard", () => {
-            const g = [
-                `entity TrackName;`,
-                `<Start> = play $(name:TrackName) -> { actionName: "play", parameters: { name } };`,
-                `<Start> = play music -> "play_music";`,
-            ].join("\n");
+        describe("CJK single string part", () => {
+            // Single string part — only the first word is offered initially.
+            // After the first word matches, the remaining words are offered.
+            const g = `<Start> [spacing=auto] = 再生 音楽 -> true;`;
             const grammar = loadGrammarRules("test.grammar", g);
 
-            it("backward on 'play music' offers both literal and property at same position", () => {
-                const result = matchGrammarCompletion(
-                    grammar,
-                    "play music",
-                    undefined,
-                    "backward",
-                );
-                // Both rules back up to position 4: the all-literal
-                // rule offers "music", the wildcard rule offers a
-                // property completion.
-                expect(result.completions).toEqual(["music"]);
-                expect(result.properties?.length).toBeGreaterThan(0);
-                expect(result.matchedPrefixLength).toBe(4);
-                expect(result.closedSet).toBe(false);
-            });
-        });
-
-        describe("varNumber part backward", () => {
-            const g = [
-                `<Start> = play $(count) songs -> { actionName: "play", parameters: { count } };`,
-            ].join("\n");
-            const grammar = loadGrammarRules("test.grammar", g);
-
-            it("backward on 'play 5 songs' backs up to number slot", () => {
-                const result = matchGrammarCompletion(
-                    grammar,
-                    "play 5 songs",
-                    undefined,
-                    "backward",
-                );
-                // "play" matched (string), 5 matched (number),
-                // "songs" matched (string).  The last matched part
-                // is the string "songs".  Backward backs up to offer
-                // "songs" at position 6.
-                expect(result.completions).toEqual(["songs"]);
-                expect(result.matchedPrefixLength).toBe(6);
-            });
-
-            it("backward on 'play 5' backs up to number slot (property)", () => {
-                const result = matchGrammarCompletion(
-                    grammar,
-                    "play 5",
-                    undefined,
-                    "backward",
-                );
-                // "play" matched, 5 matched as the number part.
-                // Backward backs up to the number slot and offers
-                // a property completion for $(count).
-                expect(result.properties?.length).toBeGreaterThan(0);
-                expect(result.properties![0].propertyNames).toContain(
-                    "parameters.count",
-                );
-                expect(result.matchedPrefixLength).toBe(4);
-                expect(result.closedSet).toBe(false);
-            });
-
-            it("forward on 'play 5' offers 'songs'", () => {
-                const result = matchGrammarCompletion(
-                    grammar,
-                    "play 5",
-                    undefined,
-                    "forward",
-                );
-                expect(result.completions).toEqual(["songs"]);
-                expect(result.matchedPrefixLength).toBe(6);
-            });
-        });
-    });
-
-    describe("trailing separator commits token across spacing modes", () => {
-        // Trailing separator neutralizes backward direction.
-        // The specific separator characters depend on the spacing mode.
-
-        describe("default (auto) spacing", () => {
-            const g = `<Start> = play music now -> true;`;
-            const grammar = loadGrammarRules("test.grammar", g);
-
-            it("trailing space commits — backward on 'play music ' acts like forward", () => {
-                const result = matchGrammarCompletion(
-                    grammar,
-                    "play music ",
-                    undefined,
-                    "backward",
-                );
-                // Trailing space commits "music"; should offer "now".
-                expect(result.completions).toEqual(["now"]);
-                expect(result.matchedPrefixLength).toBe(11);
-            });
-
-            it("trailing punctuation commits — backward on 'play music,' acts like forward", () => {
-                const result = matchGrammarCompletion(
-                    grammar,
-                    "play music,",
-                    undefined,
-                    "backward",
-                );
-                // Trailing comma is a separator in auto mode; commits "music".
-                expect(result.completions).toEqual(["now"]);
-                expect(result.matchedPrefixLength).toBe(11);
-            });
-
-            it("no trailing separator — backward on 'play music' backs up", () => {
-                const result = matchGrammarCompletion(
-                    grammar,
-                    "play music",
-                    undefined,
-                    "backward",
-                );
-                // No trailing separator; backward backs up to "music".
-                expect(result.completions).toEqual(["music"]);
-                expect(result.matchedPrefixLength).toBe(4);
-            });
-        });
-
-        describe("spacing=required", () => {
-            const g = [
-                `<Start> [spacing=required] = play music now -> true;`,
-            ].join("\n");
-            const grammar = loadGrammarRules("test.grammar", g);
-
-            it("trailing space commits — backward acts like forward", () => {
-                const result = matchGrammarCompletion(
-                    grammar,
-                    "play music ",
-                    undefined,
-                    "backward",
-                );
-                expect(result.completions).toEqual(["now"]);
-                expect(result.matchedPrefixLength).toBe(11);
-            });
-
-            it("no trailing separator — backward backs up", () => {
-                const result = matchGrammarCompletion(
-                    grammar,
-                    "play music",
-                    undefined,
-                    "backward",
-                );
-                expect(result.completions).toEqual(["music"]);
-                expect(result.matchedPrefixLength).toBe(4);
-            });
-        });
-
-        describe("spacing=optional", () => {
-            const g = [
-                `<Start> [spacing=optional] = play music now -> true;`,
-            ].join("\n");
-            const grammar = loadGrammarRules("test.grammar", g);
-
-            it("trailing space commits — backward acts like forward", () => {
-                const result = matchGrammarCompletion(
-                    grammar,
-                    "play music ",
-                    undefined,
-                    "backward",
-                );
-                expect(result.completions).toEqual(["now"]);
-                expect(result.matchedPrefixLength).toBe(11);
-            });
-
-            it("no trailing separator — backward backs up", () => {
-                const result = matchGrammarCompletion(
-                    grammar,
-                    "playmusic",
-                    undefined,
-                    "backward",
-                );
-                expect(result.completions).toEqual(["music"]);
-                expect(result.matchedPrefixLength).toBe(4);
-            });
-        });
-
-        describe("spacing=none", () => {
-            // In none mode, whitespace and punctuation are literal
-            // content, not separators — backward should always work.
-            const g = [`<Start> [spacing=none] = play music -> true;`].join(
-                "\n",
-            );
-            const grammar = loadGrammarRules("test.grammar", g);
-
-            it("trailing space does NOT commit — backward on 'play ' still backs up", () => {
-                // "play " does not match "playmusic" in none mode,
-                // so "play" is the only matched word.  Space is not a
-                // separator in none mode, so backward is not neutralized.
-                const result = matchGrammarCompletion(
-                    grammar,
-                    "play",
-                    undefined,
-                    "backward",
-                );
-                expect(result.completions).toEqual(["play"]);
+            it("returns first word for empty input", () => {
+                const result = matchGrammarCompletion(grammar, "");
+                expect(result.completions).toEqual(["再生"]);
                 expect(result.matchedPrefixLength).toBe(0);
             });
 
-            it("forward on 'play' offers 'music' in none mode", () => {
-                const result = matchGrammarCompletion(
-                    grammar,
-                    "play",
-                    undefined,
-                    "forward",
-                );
-                expect(result.completions).toEqual(["music"]);
-                expect(result.matchedPrefixLength).toBe(4);
-            });
-        });
-
-        describe("auto spacing with CJK", () => {
-            const g = [`<Start> [spacing=auto] = 再生 音楽 停止 -> true;`].join(
-                "\n",
-            );
-            const grammar = loadGrammarRules("test.grammar", g);
-
-            it("trailing space commits — backward on CJK '再生 音楽 ' acts like forward", () => {
-                const result = matchGrammarCompletion(
-                    grammar,
-                    "再生 音楽 ",
-                    undefined,
-                    "backward",
-                );
-                // Trailing space commits; should offer "停止".
-                expect(result.completions).toEqual(["停止"]);
-            });
-
-            it("no trailing separator — backward on CJK '再生音楽' backs up", () => {
-                const result = matchGrammarCompletion(
-                    grammar,
-                    "再生音楽",
-                    undefined,
-                    "backward",
-                );
-                // CJK auto mode: no separator between chars, so no
-                // trailing separator.  Backward backs up to "音楽".
+            it("returns remaining words for partial CJK prefix", () => {
+                const result = matchGrammarCompletion(grammar, "再生");
+                // tryPartialStringMatch splits the multi-word part: "再生"
+                // is consumed (2 chars), "音楽" remains as the completion.
                 expect(result.completions).toEqual(["音楽"]);
                 expect(result.matchedPrefixLength).toBe(2);
             });
         });
-    });
 
-    describe("escaped space in last term", () => {
-        // An escaped space (\ ) makes the space part of the literal
-        // token content.  The trailing separator check should NOT
-        // treat such a space as a commit signal.
-
-        describe("default (auto) spacing — single segment with literal space", () => {
-            // "hello\ world" parses as one segment: "hello world"
-            // The rule has two tokens: ["hello world", "next"]
-            const g = `<Start> = hello\\ world next -> true;`;
+        describe("CJK wildcard", () => {
+            const g = `<Start> [spacing=auto] = 再生 $(name) 停止 -> { name: name };`;
             const grammar = loadGrammarRules("test.grammar", g);
 
-            it("forward on 'hello world' offers 'next'", () => {
+            it("returns property completion when only separator follows CJK wildcard start", () => {
+                // Same as the Latin case: trailing space is a separator, not
+                // valid wildcard content, so the terminator isn't offered.
+                // Trailing space advances matchedPrefixLength to 3.
+                const result = matchGrammarCompletion(grammar, "再生 ");
+                expect(result.completions).toEqual([]);
+                expect(result.matchedPrefixLength).toBe(3);
+            });
+
+            it("returns terminator after CJK prefix + wildcard text", () => {
+                const result = matchGrammarCompletion(grammar, "再生 hello");
+                expect(result.completions).toEqual(["停止"]);
+                expect(result.matchedPrefixLength).toBe(8);
+            });
+        });
+
+        describe("separatorMode - Latin multi-part", () => {
+            // Latin grammar: "play" → "music" requires a space separator
+            const g = [
+                `<Start> = $(v:<Verb>) music -> true;`,
+                `<Verb> = play -> true;`,
+            ].join("\n");
+            const grammar = loadGrammarRules("test.grammar", g);
+
+            it("reports separatorMode for Latin 'play' → 'music'", () => {
+                const result = matchGrammarCompletion(grammar, "play");
+                expect(result.completions).toEqual(["music"]);
+                expect(result.separatorMode).toBe("spacePunctuation");
+            });
+
+            it("reports separatorMode even when trailing space exists", () => {
+                const result = matchGrammarCompletion(grammar, "play ");
+                expect(result.completions).toEqual(["music"]);
+                // Trailing space consumed: matchedPrefixLength advances to 5,
+                // separatorMode demoted to "optional" (space already included).
+                expect(result.matchedPrefixLength).toBe(5);
+                expect(result.separatorMode).toBe("optional");
+            });
+
+            it("reports optional separatorMode for empty input", () => {
+                const result = matchGrammarCompletion(grammar, "");
+                expect(result.completions).toEqual(["play"]);
+                expect(result.separatorMode).toBe("optional");
+            });
+
+            it("reports optional separatorMode for partial prefix match", () => {
+                // "pl" matches partially → the completion replaces from state.index,
+                // so no separator needed (user is typing the keyword)
+                const result = matchGrammarCompletion(grammar, "pl");
+                expect(result.completions).toEqual(["play"]);
+                expect(result.separatorMode).toBe("optional");
+            });
+        });
+
+        describe("separatorMode - CJK multi-part", () => {
+            // CJK grammar: "再生" → "音楽" does NOT require a space separator
+            const g = [
+                `<Start> [spacing=auto] = $(v:<Verb>) 音楽 -> true;`,
+                `<Verb> [spacing=auto] = 再生 -> true;`,
+            ].join("\n");
+            const grammar = loadGrammarRules("test.grammar", g);
+
+            it("reports optional separatorMode for CJK '再生' → '音楽'", () => {
+                const result = matchGrammarCompletion(grammar, "再生");
+                expect(result.completions).toEqual(["音楽"]);
+                // CJK → CJK in auto mode: separator optional
+                expect(result.separatorMode).toBe("optional");
+            });
+        });
+
+        describe("separatorMode - mixed scripts", () => {
+            // Latin followed by CJK: no separator needed in auto mode
+            const g = [
+                `<Start> [spacing=auto] = $(v:<Verb>) 音楽 -> true;`,
+                `<Verb> [spacing=auto] = play -> true;`,
+            ].join("\n");
+            const grammar = loadGrammarRules("test.grammar", g);
+
+            it("reports optional separatorMode for Latin 'play' → CJK '音楽'", () => {
+                const result = matchGrammarCompletion(grammar, "play");
+                expect(result.completions).toEqual(["音楽"]);
+                // Latin → CJK in auto mode: different scripts, separator optional
+                expect(result.separatorMode).toBe("optional");
+            });
+        });
+
+        describe("separatorMode - spacing=required", () => {
+            const g = [
+                `<Start> [spacing=required] = $(v:<Verb>) music -> true;`,
+                `<Verb> [spacing=required] = play -> true;`,
+            ].join("\n");
+            const grammar = loadGrammarRules("test.grammar", g);
+
+            it("reports separatorMode when spacing=required", () => {
+                const result = matchGrammarCompletion(grammar, "play");
+                expect(result.completions).toEqual(["music"]);
+                expect(result.separatorMode).toBe("spacePunctuation");
+            });
+        });
+
+        describe("separatorMode - spacing=optional", () => {
+            const g = [
+                `<Start> [spacing=optional] = $(v:<Verb>) music -> true;`,
+                `<Verb> [spacing=optional] = play -> true;`,
+            ].join("\n");
+            const grammar = loadGrammarRules("test.grammar", g);
+
+            it("reports optional separatorMode when spacing=optional", () => {
+                const result = matchGrammarCompletion(grammar, "play");
+                expect(result.completions).toEqual(["music"]);
+                expect(result.separatorMode).toBe("optional");
+            });
+        });
+
+        describe("separatorMode - wildcard entity", () => {
+            // Grammar where the completion is a wildcard entity (not a static string).
+            // separatorMode describes the boundary at matchedPrefixLength.
+            const g = [
+                `entity TrackName;`,
+                `<Start> = play $(name:TrackName) -> { actionName: "play", parameters: { name } };`,
+            ].join("\n");
+            const grammar = loadGrammarRules("test.grammar", g);
+
+            it("reports separatorMode for 'play' before wildcard", () => {
+                const result = matchGrammarCompletion(grammar, "play");
+                expect(result.properties?.length).toBeGreaterThan(0);
+                // matchedPrefixLength=4; boundary "y" → entity needs separator.
+                expect(result.separatorMode).toBe("spacePunctuation");
+            });
+
+            it("reports separatorMode for 'play ' before wildcard", () => {
+                // Trailing space consumed: matchedPrefixLength advances to 5,
+                // separatorMode demoted to "optional".
+                const result = matchGrammarCompletion(grammar, "play ");
+                expect(result.properties?.length).toBeGreaterThan(0);
+                expect(result.separatorMode).toBe("optional");
+            });
+        });
+
+        describe("backward direction", () => {
+            describe("all-literal single string part", () => {
+                const g = `<Start> = play music -> true;`;
+                const grammar = loadGrammarRules("test.grammar", g);
+
+                it("exact match backward offers last literal word", () => {
+                    const result = matchGrammarCompletion(
+                        grammar,
+                        "play music",
+                        undefined,
+                        "backward",
+                    );
+                    // Backward backs up to the last matched word "music"
+                    // and re-offers it as a completion.
+                    expect(result.completions).toEqual(["music"]);
+                    expect(result.matchedPrefixLength).toBe(4);
+                });
+
+                it("forward exact match still returns empty completions", () => {
+                    const result = matchGrammarCompletion(
+                        grammar,
+                        "play music",
+                        undefined,
+                        "forward",
+                    );
+                    expect(result.completions).toHaveLength(0);
+                    expect(result.matchedPrefixLength).toBe(10);
+                });
+            });
+
+            describe("three-word single string part", () => {
+                const g = `<Start> = play music now -> true;`;
+                const grammar = loadGrammarRules("test.grammar", g);
+
+                it("partial match backward offers last matched word", () => {
+                    const result = matchGrammarCompletion(
+                        grammar,
+                        "play music",
+                        undefined,
+                        "backward",
+                    );
+                    // Backward: "play" and "music" matched, so it backs
+                    // up to offer "music" (the last matched word).
+                    expect(result.completions).toEqual(["music"]);
+                    expect(result.matchedPrefixLength).toBe(4);
+                });
+
+                it("partial match forward offers next unmatched word", () => {
+                    const result = matchGrammarCompletion(
+                        grammar,
+                        "play music",
+                        undefined,
+                        "forward",
+                    );
+                    expect(result.completions).toEqual(["now"]);
+                    expect(result.matchedPrefixLength).toBe(10);
+                });
+            });
+
+            describe("multi-part via nested rule", () => {
+                const g = [
+                    `<Start> = $(v:<Verb>) music now -> true;`,
+                    `<Verb> = play -> true;`,
+                ].join("\n");
+                const grammar = loadGrammarRules("test.grammar", g);
+
+                it("backward backs up to last matched literal", () => {
+                    const result = matchGrammarCompletion(
+                        grammar,
+                        "play music",
+                        undefined,
+                        "backward",
+                    );
+                    // "play" matched the verb rule, "music" matched the
+                    // second word. Backward backs up to "music".
+                    expect(result.completions).toEqual(["music"]);
+                    expect(result.matchedPrefixLength).toBe(4);
+                });
+
+                it("forward offers next unmatched word", () => {
+                    const result = matchGrammarCompletion(
+                        grammar,
+                        "play music",
+                        undefined,
+                        "forward",
+                    );
+                    expect(result.completions).toEqual(["now"]);
+                    expect(result.matchedPrefixLength).toBe(10);
+                });
+            });
+
+            describe("wildcard at end", () => {
+                const g = [
+                    `entity TrackName;`,
+                    `<Start> = play $(name:TrackName) -> { actionName: "play", parameters: { name } };`,
+                ].join("\n");
+                const grammar = loadGrammarRules("test.grammar", g);
+
+                it("backward on exact match backs up to wildcard start with property", () => {
+                    const result = matchGrammarCompletion(
+                        grammar,
+                        "play hello",
+                        undefined,
+                        "backward",
+                    );
+                    // Backward: backs up to wildcard start (after "play" = 4)
+                    // and offers entity property completions.
+                    expect(result.properties?.length).toBeGreaterThan(0);
+                    expect(result.matchedPrefixLength).toBe(4);
+                    expect(result.closedSet).toBe(false);
+                });
+
+                it("forward on exact match returns empty completions", () => {
+                    const result = matchGrammarCompletion(
+                        grammar,
+                        "play hello",
+                        undefined,
+                        "forward",
+                    );
+                    expect(result.completions).toHaveLength(0);
+                    expect(result.matchedPrefixLength).toBe(10);
+                });
+            });
+
+            describe("wildcard in middle", () => {
+                const g = [
+                    `entity TrackName;`,
+                    `<Start> = play $(name:TrackName) now -> { actionName: "play", parameters: { name } };`,
+                ].join("\n");
+                const grammar = loadGrammarRules("test.grammar", g);
+
+                it("backward on exact match backs up to last literal 'now'", () => {
+                    const result = matchGrammarCompletion(
+                        grammar,
+                        "play hello now",
+                        undefined,
+                        "backward",
+                    );
+                    // Backward: the wildcard was captured mid-match when
+                    // "now" matched, so "now" is the last matched part.
+                    // Backward backs up to offer "now" (not the wildcard).
+                    expect(result.completions).toEqual(["now"]);
+                    expect(result.matchedPrefixLength).toBe(10);
+                });
+
+                it("forward offers 'now' (greedy wildcard alternative)", () => {
+                    const result = matchGrammarCompletion(
+                        grammar,
+                        "play hello now",
+                        undefined,
+                        "forward",
+                    );
+                    // The wildcard greedily consumed "hello now", so the
+                    // "now" string part is still unmatched — it appears
+                    // as a completion at the same prefix length.
+                    expect(result.completions).toEqual(["now"]);
+                    expect(result.matchedPrefixLength).toBe(14);
+                });
+            });
+
+            describe("wildcard followed by multiple literals", () => {
+                const g = [
+                    `entity TrackName;`,
+                    `<Start> = play $(name:TrackName) right now -> { actionName: "play", parameters: { name } };`,
+                ].join("\n");
+                const grammar = loadGrammarRules("test.grammar", g);
+
+                it("backward backs up to last literal 'now', not to wildcard", () => {
+                    const result = matchGrammarCompletion(
+                        grammar,
+                        "play hello right now",
+                        undefined,
+                        "backward",
+                    );
+                    // "play" at 0, wildcard "hello" captured at 4-10,
+                    // "right" at 10, "now" at 16.
+                    // Backward should back up to the LAST literal "now".
+                    expect(result.completions).toEqual(["now"]);
+                    expect(result.matchedPrefixLength).toBe(16);
+                });
+
+                it("forward on exact match offers greedy wildcard alternative", () => {
+                    const result = matchGrammarCompletion(
+                        grammar,
+                        "play hello right now",
+                        undefined,
+                        "forward",
+                    );
+                    // Greedy wildcard consumed "hello right now", so
+                    // "right" is still unmatched as an alternative.
+                    expect(result.completions).toEqual(["right"]);
+                    expect(result.matchedPrefixLength).toBe(20);
+                });
+            });
+
+            describe("wildcard is last matched part before unmatched literal", () => {
+                const g = [
+                    `entity TrackName;`,
+                    `entity ArtistName;`,
+                    `<Start> = play $(track:TrackName) by $(artist:ArtistName) -> { actionName: "play", parameters: { track, artist } };`,
+                ].join("\n");
+                const grammar = loadGrammarRules("test.grammar", g);
+
+                it("backward on 'play Nocturne' backs up to wildcard $(track)", () => {
+                    const result = matchGrammarCompletion(
+                        grammar,
+                        "play Nocturne",
+                        undefined,
+                        "backward",
+                    );
+                    // "play" matched, $(track) captured "Nocturne",
+                    // "by" is unmatched.  Backward should back up to
+                    // the wildcard — the last matched item — and offer
+                    // property completions for $(track).
+                    expect(result.properties?.length).toBeGreaterThan(0);
+                    expect(result.properties![0].propertyNames).toContain(
+                        "parameters.track",
+                    );
+                    expect(result.matchedPrefixLength).toBe(4);
+                    expect(result.closedSet).toBe(false);
+                });
+
+                it("forward on 'play Nocturne' offers 'by'", () => {
+                    const result = matchGrammarCompletion(
+                        grammar,
+                        "play Nocturne",
+                        undefined,
+                        "forward",
+                    );
+                    expect(result.completions).toEqual(["by"]);
+                    expect(result.matchedPrefixLength).toBe(13);
+                });
+            });
+
+            describe("backward on partial input backs up to first word", () => {
+                const g = `<Start> = play music -> true;`;
+                const grammar = loadGrammarRules("test.grammar", g);
+
+                it("backward on empty input offers first word (same as forward)", () => {
+                    const result = matchGrammarCompletion(
+                        grammar,
+                        "",
+                        undefined,
+                        "backward",
+                    );
+                    // Nothing matched — nothing to back up to, so
+                    // backward falls through to forward and offers "play".
+                    expect(result.completions).toEqual(["play"]);
+                    expect(result.matchedPrefixLength).toBe(0);
+                });
+
+                it("backward on 'play' (no trailing space) backs up to 'play'", () => {
+                    const result = matchGrammarCompletion(
+                        grammar,
+                        "play",
+                        undefined,
+                        "backward",
+                    );
+                    // No trailing space — backward backs up to offer
+                    // "play" at position 0 (reconsider the first word).
+                    expect(result.completions).toEqual(["play"]);
+                    expect(result.matchedPrefixLength).toBe(0);
+                });
+
+                it("trailing space commits — backward on 'play ' offers next word (same as forward)", () => {
+                    const result = matchGrammarCompletion(
+                        grammar,
+                        "play ",
+                        undefined,
+                        "backward",
+                    );
+                    // Trailing space is a commit signal — direction no
+                    // longer matters.  Should offer "music" at position 5,
+                    // same as forward.
+                    expect(result.completions).toEqual(["music"]);
+                    expect(result.matchedPrefixLength).toBe(5);
+                });
+
+                it("forward on 'play ' offers next word", () => {
+                    const result = matchGrammarCompletion(
+                        grammar,
+                        "play ",
+                        undefined,
+                        "forward",
+                    );
+                    expect(result.completions).toEqual(["music"]);
+                    expect(result.matchedPrefixLength).toBe(5);
+                });
+
+                it("backward on partial 'pl' still offers 'play' (no complete token to reconsider)", () => {
+                    const result = matchGrammarCompletion(
+                        grammar,
+                        "pl",
+                        undefined,
+                        "backward",
+                    );
+                    // "pl" is a partial prefix of "play".  No word was
+                    // fully matched, so backward has nothing to back up
+                    // to — falls through to forward and offers "play".
+                    expect(result.completions).toEqual(["play"]);
+                    expect(result.matchedPrefixLength).toBe(0);
+                });
+
+                it("backward on 'play no' (partial second word) still offers 'now'", () => {
+                    const result = matchGrammarCompletion(
+                        grammar,
+                        "play no",
+                        undefined,
+                        "backward",
+                    );
+                    // "play" fully matched but "no" doesn't fully match
+                    // "now".  There is remaining unmatched input beyond
+                    // the separator, so backward falls through to forward
+                    // and offers "now".
+                    expect(result.completions).toEqual(["music"]);
+                    expect(result.matchedPrefixLength).toBe(4);
+                });
+            });
+
+            describe("multi-rule with shared prefix and wildcard", () => {
+                const g = [
+                    `entity TrackName;`,
+                    `<Start> = play $(name:TrackName) -> { actionName: "play", parameters: { name } };`,
+                    `<Start> = play music -> "play_music";`,
+                ].join("\n");
+                const grammar = loadGrammarRules("test.grammar", g);
+
+                it("backward on 'play music' offers both literal and property at same position", () => {
+                    const result = matchGrammarCompletion(
+                        grammar,
+                        "play music",
+                        undefined,
+                        "backward",
+                    );
+                    // Both rules back up to position 4: the all-literal
+                    // rule offers "music", the wildcard rule offers a
+                    // property completion.
+                    expect(result.completions).toEqual(["music"]);
+                    expect(result.properties?.length).toBeGreaterThan(0);
+                    expect(result.matchedPrefixLength).toBe(4);
+                    expect(result.closedSet).toBe(false);
+                });
+            });
+
+            describe("varNumber part backward", () => {
+                const g = [
+                    `<Start> = play $(count) songs -> { actionName: "play", parameters: { count } };`,
+                ].join("\n");
+                const grammar = loadGrammarRules("test.grammar", g);
+
+                it("backward on 'play 5 songs' backs up to number slot", () => {
+                    const result = matchGrammarCompletion(
+                        grammar,
+                        "play 5 songs",
+                        undefined,
+                        "backward",
+                    );
+                    // "play" matched (string), 5 matched (number),
+                    // "songs" matched (string).  The last matched part
+                    // is the string "songs".  Backward backs up to offer
+                    // "songs" at position 6.
+                    expect(result.completions).toEqual(["songs"]);
+                    expect(result.matchedPrefixLength).toBe(6);
+                });
+
+                it("backward on 'play 5' backs up to number slot (property)", () => {
+                    const result = matchGrammarCompletion(
+                        grammar,
+                        "play 5",
+                        undefined,
+                        "backward",
+                    );
+                    // "play" matched, 5 matched as the number part.
+                    // Backward backs up to the number slot and offers
+                    // a property completion for $(count).
+                    expect(result.properties?.length).toBeGreaterThan(0);
+                    expect(result.properties![0].propertyNames).toContain(
+                        "parameters.count",
+                    );
+                    expect(result.matchedPrefixLength).toBe(4);
+                    expect(result.closedSet).toBe(false);
+                });
+
+                it("forward on 'play 5' offers 'songs'", () => {
+                    const result = matchGrammarCompletion(
+                        grammar,
+                        "play 5",
+                        undefined,
+                        "forward",
+                    );
+                    expect(result.completions).toEqual(["songs"]);
+                    expect(result.matchedPrefixLength).toBe(6);
+                });
+            });
+        });
+
+        describe("trailing separator commits token across spacing modes", () => {
+            // Trailing separator neutralizes backward direction.
+            // The specific separator characters depend on the spacing mode.
+
+            describe("default (auto) spacing", () => {
+                const g = `<Start> = play music now -> true;`;
+                const grammar = loadGrammarRules("test.grammar", g);
+
+                it("trailing space commits — backward on 'play music ' acts like forward", () => {
+                    const result = matchGrammarCompletion(
+                        grammar,
+                        "play music ",
+                        undefined,
+                        "backward",
+                    );
+                    // Trailing space commits "music"; should offer "now".
+                    expect(result.completions).toEqual(["now"]);
+                    expect(result.matchedPrefixLength).toBe(11);
+                });
+
+                it("trailing punctuation commits — backward on 'play music,' acts like forward", () => {
+                    const result = matchGrammarCompletion(
+                        grammar,
+                        "play music,",
+                        undefined,
+                        "backward",
+                    );
+                    // Trailing comma is a separator in auto mode; commits "music".
+                    expect(result.completions).toEqual(["now"]);
+                    expect(result.matchedPrefixLength).toBe(11);
+                });
+
+                it("no trailing separator — backward on 'play music' backs up", () => {
+                    const result = matchGrammarCompletion(
+                        grammar,
+                        "play music",
+                        undefined,
+                        "backward",
+                    );
+                    // No trailing separator; backward backs up to "music".
+                    expect(result.completions).toEqual(["music"]);
+                    expect(result.matchedPrefixLength).toBe(4);
+                });
+            });
+
+            describe("spacing=required", () => {
+                const g = [
+                    `<Start> [spacing=required] = play music now -> true;`,
+                ].join("\n");
+                const grammar = loadGrammarRules("test.grammar", g);
+
+                it("trailing space commits — backward acts like forward", () => {
+                    const result = matchGrammarCompletion(
+                        grammar,
+                        "play music ",
+                        undefined,
+                        "backward",
+                    );
+                    expect(result.completions).toEqual(["now"]);
+                    expect(result.matchedPrefixLength).toBe(11);
+                });
+
+                it("no trailing separator — backward backs up", () => {
+                    const result = matchGrammarCompletion(
+                        grammar,
+                        "play music",
+                        undefined,
+                        "backward",
+                    );
+                    expect(result.completions).toEqual(["music"]);
+                    expect(result.matchedPrefixLength).toBe(4);
+                });
+            });
+
+            describe("spacing=optional", () => {
+                const g = [
+                    `<Start> [spacing=optional] = play music now -> true;`,
+                ].join("\n");
+                const grammar = loadGrammarRules("test.grammar", g);
+
+                it("trailing space commits — backward acts like forward", () => {
+                    const result = matchGrammarCompletion(
+                        grammar,
+                        "play music ",
+                        undefined,
+                        "backward",
+                    );
+                    expect(result.completions).toEqual(["now"]);
+                    expect(result.matchedPrefixLength).toBe(11);
+                });
+
+                it("no trailing separator — backward backs up", () => {
+                    const result = matchGrammarCompletion(
+                        grammar,
+                        "playmusic",
+                        undefined,
+                        "backward",
+                    );
+                    expect(result.completions).toEqual(["music"]);
+                    expect(result.matchedPrefixLength).toBe(4);
+                });
+            });
+
+            describe("spacing=none", () => {
+                // In none mode, whitespace and punctuation are literal
+                // content, not separators — backward should always work.
+                const g = [`<Start> [spacing=none] = play music -> true;`].join(
+                    "\n",
+                );
+                const grammar = loadGrammarRules("test.grammar", g);
+
+                it("trailing space does NOT commit — backward on 'play ' still backs up", () => {
+                    // "play " does not match "playmusic" in none mode,
+                    // so "play" is the only matched word.  Space is not a
+                    // separator in none mode, so backward is not neutralized.
+                    const result = matchGrammarCompletion(
+                        grammar,
+                        "play",
+                        undefined,
+                        "backward",
+                    );
+                    expect(result.completions).toEqual(["play"]);
+                    expect(result.matchedPrefixLength).toBe(0);
+                });
+
+                it("forward on 'play' offers 'music' in none mode", () => {
+                    const result = matchGrammarCompletion(
+                        grammar,
+                        "play",
+                        undefined,
+                        "forward",
+                    );
+                    expect(result.completions).toEqual(["music"]);
+                    expect(result.matchedPrefixLength).toBe(4);
+                });
+            });
+
+            describe("auto spacing with CJK", () => {
+                const g = [
+                    `<Start> [spacing=auto] = 再生 音楽 停止 -> true;`,
+                ].join("\n");
+                const grammar = loadGrammarRules("test.grammar", g);
+
+                it("trailing space commits — backward on CJK '再生 音楽 ' acts like forward", () => {
+                    const result = matchGrammarCompletion(
+                        grammar,
+                        "再生 音楽 ",
+                        undefined,
+                        "backward",
+                    );
+                    // Trailing space commits; should offer "停止".
+                    expect(result.completions).toEqual(["停止"]);
+                });
+
+                it("no trailing separator — backward on CJK '再生音楽' backs up", () => {
+                    const result = matchGrammarCompletion(
+                        grammar,
+                        "再生音楽",
+                        undefined,
+                        "backward",
+                    );
+                    // CJK auto mode: no separator between chars, so no
+                    // trailing separator.  Backward backs up to "音楽".
+                    expect(result.completions).toEqual(["音楽"]);
+                    expect(result.matchedPrefixLength).toBe(2);
+                });
+            });
+        });
+
+        describe("escaped space in last term", () => {
+            // An escaped space (\ ) makes the space part of the literal
+            // token content.  The trailing separator check should NOT
+            // treat such a space as a commit signal.
+
+            describe("default (auto) spacing — single segment with literal space", () => {
+                // "hello\ world" parses as one segment: "hello world"
+                // The rule has two tokens: ["hello world", "next"]
+                const g = `<Start> = hello\\ world next -> true;`;
+                const grammar = loadGrammarRules("test.grammar", g);
+
+                it("forward on 'hello world' offers 'next'", () => {
+                    const result = matchGrammarCompletion(
+                        grammar,
+                        "hello world",
+                        undefined,
+                        "forward",
+                    );
+                    expect(result.completions).toEqual(["next"]);
+                    expect(result.matchedPrefixLength).toBe(11);
+                });
+
+                it("backward on 'hello world' (no trailing separator) backs up to 'hello world'", () => {
+                    const result = matchGrammarCompletion(
+                        grammar,
+                        "hello world",
+                        undefined,
+                        "backward",
+                    );
+                    // "hello world" is one token — no trailing separator
+                    // after it, so backward should back up.
+                    expect(result.completions).toEqual(["hello world"]);
+                    expect(result.matchedPrefixLength).toBe(0);
+                });
+
+                it("forward on partial 'hello ' (mid-token literal space) still matches", () => {
+                    const result = matchGrammarCompletion(
+                        grammar,
+                        "hello ",
+                        undefined,
+                        "forward",
+                    );
+                    // "hello " is a partial match of the "hello world"
+                    // token — forward should offer "hello world".
+                    expect(result.completions).toEqual(["hello world"]);
+                    expect(result.matchedPrefixLength).toBe(0);
+                });
+
+                it("backward on partial 'hello ' (mid-token literal space) falls through to forward", () => {
+                    const result = matchGrammarCompletion(
+                        grammar,
+                        "hello ",
+                        undefined,
+                        "backward",
+                    );
+                    // "hello " is a partial match of the single segment
+                    // "hello world".  No complete segment was matched,
+                    // so backward falls through to forward and offers
+                    // "hello world".
+                    expect(result.completions).toEqual(["hello world"]);
+                    expect(result.matchedPrefixLength).toBe(0);
+                });
+
+                it("trailing separator after complete token — backward on 'hello world ' acts like forward", () => {
+                    const result = matchGrammarCompletion(
+                        grammar,
+                        "hello world ",
+                        undefined,
+                        "backward",
+                    );
+                    // The space after "hello world" IS a real separator.
+                    // Should commit and offer "next".
+                    expect(result.completions).toEqual(["next"]);
+                    expect(result.matchedPrefixLength).toBe(12);
+                });
+            });
+
+            describe("spacing=none — literal space is never a separator", () => {
+                const g = `<Start> [spacing=none] = hello\\ world next -> true;`;
+                const grammar = loadGrammarRules("test.grammar", g);
+
+                it("forward on 'hello world' offers 'next' (tokens directly adjacent)", () => {
+                    const result = matchGrammarCompletion(
+                        grammar,
+                        "hello world",
+                        undefined,
+                        "forward",
+                    );
+                    // In none mode, "hello world" and "next" are adjacent:
+                    // matched input would be "hello worldnext".
+                    expect(result.completions).toEqual(["next"]);
+                    expect(result.matchedPrefixLength).toBe(11);
+                });
+
+                it("backward on 'hello world' backs up (space is literal, not separator)", () => {
+                    const result = matchGrammarCompletion(
+                        grammar,
+                        "hello world",
+                        undefined,
+                        "backward",
+                    );
+                    expect(result.completions).toEqual(["hello world"]);
+                    expect(result.matchedPrefixLength).toBe(0);
+                });
+            });
+        });
+
+        describe("literal space followed by flex-space", () => {
+            // Grammar source: `hello\  world` — escaped space then
+            // unescaped whitespace.  Parser produces segments
+            // ["hello ", "world"]: first segment ends with literal
+            // space, then a flex-space boundary before "world".
+            //
+            // The regex merges the literal and flex-space: the pattern
+            // is approximately `hello\ [\s\p{P}]*world`.  When input is
+            // "hello " the regex matches "hello " as segment 1 completely
+            // and passes through the zero-width flex-space — so the
+            // matcher treats this as a segment boundary, not a mid-token
+            // partial.
+
+            describe("default (auto) spacing", () => {
+                const g = `<Start> = hello\\  world next -> true;`;
+                const grammar = loadGrammarRules("test.grammar", g);
+
+                it("forward on 'hello ' — first segment fully matched, offers second segment", () => {
+                    const result = matchGrammarCompletion(
+                        grammar,
+                        "hello ",
+                        undefined,
+                        "forward",
+                    );
+                    // "hello " matches segment 1 exactly; flex-space
+                    // consumed zero chars.  Offers "world".
+                    expect(result.completions).toEqual(["world"]);
+                    expect(result.matchedPrefixLength).toBe(6);
+                });
+
+                it("backward on 'hello ' — literal space consumed, backs up to 'hello '", () => {
+                    const result = matchGrammarCompletion(
+                        grammar,
+                        "hello ",
+                        undefined,
+                        "backward",
+                    );
+                    // The literal space IS part of the first segment.
+                    // The regex consumed it as token content, so there is
+                    // no trailing separator beyond the match — backward
+                    // backs up to offer "hello " at position 0.
+                    expect(result.completions).toEqual(["hello "]);
+                    expect(result.matchedPrefixLength).toBe(0);
+                });
+
+                it("forward on 'hello  ' — literal space + flex-space offers 'world'", () => {
+                    const result = matchGrammarCompletion(
+                        grammar,
+                        "hello  ",
+                        undefined,
+                        "forward",
+                    );
+                    // "hello " (literal) + " " (flex-space) = 7 chars consumed.
+                    expect(result.completions).toEqual(["world"]);
+                    expect(result.matchedPrefixLength).toBe(7);
+                });
+
+                it("backward on 'hello  ' — real trailing separator commits", () => {
+                    const result = matchGrammarCompletion(
+                        grammar,
+                        "hello  ",
+                        undefined,
+                        "backward",
+                    );
+                    // "hello " (literal) consumed 6 chars.  The extra
+                    // space at position 6 is a real separator beyond the
+                    // match — commits the segment, acts like forward.
+                    expect(result.completions).toEqual(["world"]);
+                    expect(result.matchedPrefixLength).toBe(7);
+                });
+
+                it("forward on 'hello world' offers 'next'", () => {
+                    const result = matchGrammarCompletion(
+                        grammar,
+                        "hello world",
+                        undefined,
+                        "forward",
+                    );
+                    expect(result.completions).toEqual(["next"]);
+                    expect(result.matchedPrefixLength).toBe(11);
+                });
+
+                it("backward on 'hello world' backs up to 'world' at segment boundary", () => {
+                    const result = matchGrammarCompletion(
+                        grammar,
+                        "hello world",
+                        undefined,
+                        "backward",
+                    );
+                    // Full token matched.  Backward backs up to
+                    // "world" at position 6 (after "hello ").
+                    expect(result.completions).toEqual(["world"]);
+                    expect(result.matchedPrefixLength).toBe(6);
+                });
+
+                it("forward on 'hello world ' offers 'next'", () => {
+                    const result = matchGrammarCompletion(
+                        grammar,
+                        "hello world ",
+                        undefined,
+                        "forward",
+                    );
+                    expect(result.completions).toEqual(["next"]);
+                    expect(result.matchedPrefixLength).toBe(12);
+                });
+
+                it("backward on 'hello world ' — trailing separator commits", () => {
+                    const result = matchGrammarCompletion(
+                        grammar,
+                        "hello world ",
+                        undefined,
+                        "backward",
+                    );
+                    // Trailing space after complete token commits.
+                    expect(result.completions).toEqual(["next"]);
+                    expect(result.matchedPrefixLength).toBe(12);
+                });
+            });
+        });
+
+        describe("optional part ()? with backward", () => {
+            const g = `<Start> = play (shuffle)? music -> true;`;
+            const grammar = loadGrammarRules("test.grammar", g);
+
+            it("backward on 'play shuffle' backs up to 'shuffle'", () => {
                 const result = matchGrammarCompletion(
                     grammar,
-                    "hello world",
+                    "play shuffle",
+                    undefined,
+                    "backward",
+                );
+                expect(result.completions).toContain("shuffle");
+                expect(result.matchedPrefixLength).toBe(4);
+            });
+
+            it("forward on 'play shuffle' offers 'music'", () => {
+                const result = matchGrammarCompletion(
+                    grammar,
+                    "play shuffle",
                     undefined,
                     "forward",
                 );
-                expect(result.completions).toEqual(["next"]);
-                expect(result.matchedPrefixLength).toBe(11);
-            });
-
-            it("backward on 'hello world' (no trailing separator) backs up to 'hello world'", () => {
-                const result = matchGrammarCompletion(
-                    grammar,
-                    "hello world",
-                    undefined,
-                    "backward",
-                );
-                // "hello world" is one token — no trailing separator
-                // after it, so backward should back up.
-                expect(result.completions).toEqual(["hello world"]);
-                expect(result.matchedPrefixLength).toBe(0);
-            });
-
-            it("forward on partial 'hello ' (mid-token literal space) still matches", () => {
-                const result = matchGrammarCompletion(
-                    grammar,
-                    "hello ",
-                    undefined,
-                    "forward",
-                );
-                // "hello " is a partial match of the "hello world"
-                // token — forward should offer "hello world".
-                expect(result.completions).toEqual(["hello world"]);
-                expect(result.matchedPrefixLength).toBe(0);
-            });
-
-            it("backward on partial 'hello ' (mid-token literal space) falls through to forward", () => {
-                const result = matchGrammarCompletion(
-                    grammar,
-                    "hello ",
-                    undefined,
-                    "backward",
-                );
-                // "hello " is a partial match of the single segment
-                // "hello world".  No complete segment was matched,
-                // so backward falls through to forward and offers
-                // "hello world".
-                expect(result.completions).toEqual(["hello world"]);
-                expect(result.matchedPrefixLength).toBe(0);
-            });
-
-            it("trailing separator after complete token — backward on 'hello world ' acts like forward", () => {
-                const result = matchGrammarCompletion(
-                    grammar,
-                    "hello world ",
-                    undefined,
-                    "backward",
-                );
-                // The space after "hello world" IS a real separator.
-                // Should commit and offer "next".
-                expect(result.completions).toEqual(["next"]);
+                expect(result.completions).toEqual(["music"]);
                 expect(result.matchedPrefixLength).toBe(12);
             });
         });
-
-        describe("spacing=none — literal space is never a separator", () => {
-            const g = `<Start> [spacing=none] = hello\\ world next -> true;`;
-            const grammar = loadGrammarRules("test.grammar", g);
-
-            it("forward on 'hello world' offers 'next' (tokens directly adjacent)", () => {
-                const result = matchGrammarCompletion(
-                    grammar,
-                    "hello world",
-                    undefined,
-                    "forward",
-                );
-                // In none mode, "hello world" and "next" are adjacent:
-                // matched input would be "hello worldnext".
-                expect(result.completions).toEqual(["next"]);
-                expect(result.matchedPrefixLength).toBe(11);
-            });
-
-            it("backward on 'hello world' backs up (space is literal, not separator)", () => {
-                const result = matchGrammarCompletion(
-                    grammar,
-                    "hello world",
-                    undefined,
-                    "backward",
-                );
-                expect(result.completions).toEqual(["hello world"]);
-                expect(result.matchedPrefixLength).toBe(0);
-            });
-        });
-    });
-
-    describe("literal space followed by flex-space", () => {
-        // Grammar source: `hello\  world` — escaped space then
-        // unescaped whitespace.  Parser produces segments
-        // ["hello ", "world"]: first segment ends with literal
-        // space, then a flex-space boundary before "world".
-        //
-        // The regex merges the literal and flex-space: the pattern
-        // is approximately `hello\ [\s\p{P}]*world`.  When input is
-        // "hello " the regex matches "hello " as segment 1 completely
-        // and passes through the zero-width flex-space — so the
-        // matcher treats this as a segment boundary, not a mid-token
-        // partial.
-
-        describe("default (auto) spacing", () => {
-            const g = `<Start> = hello\\  world next -> true;`;
-            const grammar = loadGrammarRules("test.grammar", g);
-
-            it("forward on 'hello ' — first segment fully matched, offers second segment", () => {
-                const result = matchGrammarCompletion(
-                    grammar,
-                    "hello ",
-                    undefined,
-                    "forward",
-                );
-                // "hello " matches segment 1 exactly; flex-space
-                // consumed zero chars.  Offers "world".
-                expect(result.completions).toEqual(["world"]);
-                expect(result.matchedPrefixLength).toBe(6);
-            });
-
-            it("backward on 'hello ' — literal space consumed, backs up to 'hello '", () => {
-                const result = matchGrammarCompletion(
-                    grammar,
-                    "hello ",
-                    undefined,
-                    "backward",
-                );
-                // The literal space IS part of the first segment.
-                // The regex consumed it as token content, so there is
-                // no trailing separator beyond the match — backward
-                // backs up to offer "hello " at position 0.
-                expect(result.completions).toEqual(["hello "]);
-                expect(result.matchedPrefixLength).toBe(0);
-            });
-
-            it("forward on 'hello  ' — literal space + flex-space offers 'world'", () => {
-                const result = matchGrammarCompletion(
-                    grammar,
-                    "hello  ",
-                    undefined,
-                    "forward",
-                );
-                // "hello " (literal) + " " (flex-space) = 7 chars consumed.
-                expect(result.completions).toEqual(["world"]);
-                expect(result.matchedPrefixLength).toBe(7);
-            });
-
-            it("backward on 'hello  ' — real trailing separator commits", () => {
-                const result = matchGrammarCompletion(
-                    grammar,
-                    "hello  ",
-                    undefined,
-                    "backward",
-                );
-                // "hello " (literal) consumed 6 chars.  The extra
-                // space at position 6 is a real separator beyond the
-                // match — commits the segment, acts like forward.
-                expect(result.completions).toEqual(["world"]);
-                expect(result.matchedPrefixLength).toBe(7);
-            });
-
-            it("forward on 'hello world' offers 'next'", () => {
-                const result = matchGrammarCompletion(
-                    grammar,
-                    "hello world",
-                    undefined,
-                    "forward",
-                );
-                expect(result.completions).toEqual(["next"]);
-                expect(result.matchedPrefixLength).toBe(11);
-            });
-
-            it("backward on 'hello world' backs up to 'world' at segment boundary", () => {
-                const result = matchGrammarCompletion(
-                    grammar,
-                    "hello world",
-                    undefined,
-                    "backward",
-                );
-                // Full token matched.  Backward backs up to
-                // "world" at position 6 (after "hello ").
-                expect(result.completions).toEqual(["world"]);
-                expect(result.matchedPrefixLength).toBe(6);
-            });
-
-            it("forward on 'hello world ' offers 'next'", () => {
-                const result = matchGrammarCompletion(
-                    grammar,
-                    "hello world ",
-                    undefined,
-                    "forward",
-                );
-                expect(result.completions).toEqual(["next"]);
-                expect(result.matchedPrefixLength).toBe(12);
-            });
-
-            it("backward on 'hello world ' — trailing separator commits", () => {
-                const result = matchGrammarCompletion(
-                    grammar,
-                    "hello world ",
-                    undefined,
-                    "backward",
-                );
-                // Trailing space after complete token commits.
-                expect(result.completions).toEqual(["next"]);
-                expect(result.matchedPrefixLength).toBe(12);
-            });
-        });
-    });
-
-    describe("optional part ()? with backward", () => {
-        const g = `<Start> = play (shuffle)? music -> true;`;
-        const grammar = loadGrammarRules("test.grammar", g);
-
-        it("backward on 'play shuffle' backs up to 'shuffle'", () => {
-            const result = matchGrammarCompletion(
-                grammar,
-                "play shuffle",
-                undefined,
-                "backward",
-            );
-            expect(result.completions).toContain("shuffle");
-            expect(result.matchedPrefixLength).toBe(4);
-        });
-
-        it("forward on 'play shuffle' offers 'music'", () => {
-            const result = matchGrammarCompletion(
-                grammar,
-                "play shuffle",
-                undefined,
-                "forward",
-            );
-            expect(result.completions).toEqual(["music"]);
-            expect(result.matchedPrefixLength).toBe(12);
-        });
-    });
-});
+    },
+);

--- a/ts/packages/actionGrammar/test/grammarMatcherBasic.spec.ts
+++ b/ts/packages/actionGrammar/test/grammarMatcherBasic.spec.ts
@@ -2,9 +2,9 @@
 // Licensed under the MIT License.
 
 import { loadGrammarRules } from "../src/grammarLoader.js";
-import { escapedSpaces, spaces, testMatchGrammar } from "./testUtils.js";
+import { describeForEachMatcher, escapedSpaces, spaces } from "./testUtils.js";
 
-describe("Grammar Matcher - Basic", () => {
+describeForEachMatcher("Grammar Matcher - Basic", (testMatchGrammar) => {
     describe("Basic Matched Values", () => {
         const values = [
             true,

--- a/ts/packages/actionGrammar/test/grammarMatcherGroups.spec.ts
+++ b/ts/packages/actionGrammar/test/grammarMatcherGroups.spec.ts
@@ -2,89 +2,98 @@
 // Licensed under the MIT License.
 
 import { loadGrammarRules } from "../src/grammarLoader.js";
-import { testMatchGrammar } from "./testUtils.js";
+import { describeForEachMatcher } from "./testUtils.js";
 
-describe("Grammar Matcher - Groups and Recursion", () => {
-    describe("Repeat GroupExpr", () => {
-        it("()* - zero matches", () => {
-            const g = `<Start> = hello (world)* -> true;`;
-            const grammar = loadGrammarRules("test.grammar", g);
-            expect(testMatchGrammar(grammar, "hello")).toStrictEqual([true]);
+describeForEachMatcher(
+    "Grammar Matcher - Groups and Recursion",
+    (testMatchGrammar) => {
+        describe("Repeat GroupExpr", () => {
+            it("()* - zero matches", () => {
+                const g = `<Start> = hello (world)* -> true;`;
+                const grammar = loadGrammarRules("test.grammar", g);
+                expect(testMatchGrammar(grammar, "hello")).toStrictEqual([
+                    true,
+                ]);
+            });
+            it("()* - one match", () => {
+                const g = `<Start> = hello (world)* -> true;`;
+                const grammar = loadGrammarRules("test.grammar", g);
+                expect(testMatchGrammar(grammar, "hello world")).toStrictEqual([
+                    true,
+                ]);
+            });
+            it("()* - two matches", () => {
+                const g = `<Start> = hello (world)* -> true;`;
+                const grammar = loadGrammarRules("test.grammar", g);
+                expect(
+                    testMatchGrammar(grammar, "hello world world"),
+                ).toStrictEqual([true]);
+            });
+            it("()+ - zero matches not accepted", () => {
+                const g = `<Start> = hello (world)+ -> true;`;
+                const grammar = loadGrammarRules("test.grammar", g);
+                expect(testMatchGrammar(grammar, "hello")).toStrictEqual([]);
+            });
+            it("()+ - one match", () => {
+                const g = `<Start> = hello (world)+ -> true;`;
+                const grammar = loadGrammarRules("test.grammar", g);
+                expect(testMatchGrammar(grammar, "hello world")).toStrictEqual([
+                    true,
+                ]);
+            });
+            it("()+ - two matches", () => {
+                const g = `<Start> = hello (world)+ -> true;`;
+                const grammar = loadGrammarRules("test.grammar", g);
+                expect(
+                    testMatchGrammar(grammar, "hello world world"),
+                ).toStrictEqual([true]);
+            });
+            it("()* - alternates in group", () => {
+                const g = `<Start> = hello (world | earth)* -> true;`;
+                const grammar = loadGrammarRules("test.grammar", g);
+                expect(
+                    testMatchGrammar(grammar, "hello world earth world"),
+                ).toStrictEqual([true]);
+            });
+            it("()+ - suffix after repeat", () => {
+                const g = `<Start> = hello (world)+ end -> true;`;
+                const grammar = loadGrammarRules("test.grammar", g);
+                expect(
+                    testMatchGrammar(grammar, "hello world world end"),
+                ).toStrictEqual([true]);
+            });
         });
-        it("()* - one match", () => {
-            const g = `<Start> = hello (world)* -> true;`;
-            const grammar = loadGrammarRules("test.grammar", g);
-            expect(testMatchGrammar(grammar, "hello world")).toStrictEqual([
-                true,
-            ]);
-        });
-        it("()* - two matches", () => {
-            const g = `<Start> = hello (world)* -> true;`;
-            const grammar = loadGrammarRules("test.grammar", g);
-            expect(
-                testMatchGrammar(grammar, "hello world world"),
-            ).toStrictEqual([true]);
-        });
-        it("()+ - zero matches not accepted", () => {
-            const g = `<Start> = hello (world)+ -> true;`;
-            const grammar = loadGrammarRules("test.grammar", g);
-            expect(testMatchGrammar(grammar, "hello")).toStrictEqual([]);
-        });
-        it("()+ - one match", () => {
-            const g = `<Start> = hello (world)+ -> true;`;
-            const grammar = loadGrammarRules("test.grammar", g);
-            expect(testMatchGrammar(grammar, "hello world")).toStrictEqual([
-                true,
-            ]);
-        });
-        it("()+ - two matches", () => {
-            const g = `<Start> = hello (world)+ -> true;`;
-            const grammar = loadGrammarRules("test.grammar", g);
-            expect(
-                testMatchGrammar(grammar, "hello world world"),
-            ).toStrictEqual([true]);
-        });
-        it("()* - alternates in group", () => {
-            const g = `<Start> = hello (world | earth)* -> true;`;
-            const grammar = loadGrammarRules("test.grammar", g);
-            expect(
-                testMatchGrammar(grammar, "hello world earth world"),
-            ).toStrictEqual([true]);
-        });
-        it("()+ - suffix after repeat", () => {
-            const g = `<Start> = hello (world)+ end -> true;`;
-            const grammar = loadGrammarRules("test.grammar", g);
-            expect(
-                testMatchGrammar(grammar, "hello world world end"),
-            ).toStrictEqual([true]);
-        });
-    });
 
-    describe("Recursive rules", () => {
-        // Regression: when a rule has a non-epsilon back-reference to itself,
-        // the compiled RulesPart.rules must point to the final populated array,
-        // not the empty sentinel assigned before compilation begins.
-        // If the sentinel is captured (bug), the recursive match silently fails.
-        it("right-recursive rule reference can match multi-token input", () => {
-            // <Start> = foo <Start> -> "hit" | bar -> "bar"
-            // "foo bar": foo consumes mandatory input, then <Start> matches "bar"
-            const g = `
+        describe("Recursive rules", () => {
+            // Regression: when a rule has a non-epsilon back-reference to itself,
+            // the compiled RulesPart.rules must point to the final populated array,
+            // not the empty sentinel assigned before compilation begins.
+            // If the sentinel is captured (bug), the recursive match silently fails.
+            it("right-recursive rule reference can match multi-token input", () => {
+                // <Start> = foo <Start> -> "hit" | bar -> "bar"
+                // "foo bar": foo consumes mandatory input, then <Start> matches "bar"
+                const g = `
                 <Start> = foo <Start> -> "hit"
                         | bar -> "bar";
             `;
-            const grammar = loadGrammarRules("test.grammar", g);
-            expect(testMatchGrammar(grammar, "foo bar")).toStrictEqual(["hit"]);
-        });
+                const grammar = loadGrammarRules("test.grammar", g);
+                expect(testMatchGrammar(grammar, "foo bar")).toStrictEqual([
+                    "hit",
+                ]);
+            });
 
-        it("right-recursive variable rule can match multi-token input", () => {
-            // <Start> = foo $(x:<Start>) -> x | bar -> "bar"
-            // "foo bar": foo consumes mandatory input, then $(x:<Start>) captures "bar"
-            const g = `
+            it("right-recursive variable rule can match multi-token input", () => {
+                // <Start> = foo $(x:<Start>) -> x | bar -> "bar"
+                // "foo bar": foo consumes mandatory input, then $(x:<Start>) captures "bar"
+                const g = `
                 <Start> = foo $(x:<Start>) -> x
                         | bar -> "bar";
             `;
-            const grammar = loadGrammarRules("test.grammar", g);
-            expect(testMatchGrammar(grammar, "foo bar")).toStrictEqual(["bar"]);
+                const grammar = loadGrammarRules("test.grammar", g);
+                expect(testMatchGrammar(grammar, "foo bar")).toStrictEqual([
+                    "bar",
+                ]);
+            });
         });
-    });
-});
+    },
+);

--- a/ts/packages/actionGrammar/test/grammarMatcherPunctuation.spec.ts
+++ b/ts/packages/actionGrammar/test/grammarMatcherPunctuation.spec.ts
@@ -2,118 +2,131 @@
 // Licensed under the MIT License.
 
 import { loadGrammarRules } from "../src/grammarLoader.js";
-import { testMatchGrammar } from "./testUtils.js";
+import { describeForEachMatcher } from "./testUtils.js";
 
-describe("Grammar Matcher - Punctuation as Separator", () => {
-    // In "auto" and "optional" modes a punctuation character adjacent to a
-    // flex-space position — at the end of the preceding literal or at the
-    // start of the following literal — satisfies the separator requirement;
-    // no additional separator is required in the input.
-    // In "required" mode at least one separator character must always be
-    // present in the input, regardless of adjacent literal content.
-    describe("auto mode", () => {
-        it("punctuation at end of preceding literal", () => {
-            const g = `<Start> = hello, world -> true;`;
-            const grammar = loadGrammarRules("test.grammar", g);
-            // comma satisfies the flex-space; no extra separator needed
-            expect(testMatchGrammar(grammar, "hello,world")).toStrictEqual([
-                true,
-            ]);
-            // extra separator also accepted
-            expect(testMatchGrammar(grammar, "hello, world")).toStrictEqual([
-                true,
-            ]);
-            // literal comma must be present
-            expect(testMatchGrammar(grammar, "hello world")).toStrictEqual([]);
+describeForEachMatcher(
+    "Grammar Matcher - Punctuation as Separator",
+    (testMatchGrammar) => {
+        // In "auto" and "optional" modes a punctuation character adjacent to a
+        // flex-space position — at the end of the preceding literal or at the
+        // start of the following literal — satisfies the separator requirement;
+        // no additional separator is required in the input.
+        // In "required" mode at least one separator character must always be
+        // present in the input, regardless of adjacent literal content.
+        describe("auto mode", () => {
+            it("punctuation at end of preceding literal", () => {
+                const g = `<Start> = hello, world -> true;`;
+                const grammar = loadGrammarRules("test.grammar", g);
+                // comma satisfies the flex-space; no extra separator needed
+                expect(testMatchGrammar(grammar, "hello,world")).toStrictEqual([
+                    true,
+                ]);
+                // extra separator also accepted
+                expect(testMatchGrammar(grammar, "hello, world")).toStrictEqual(
+                    [true],
+                );
+                // literal comma must be present
+                expect(testMatchGrammar(grammar, "hello world")).toStrictEqual(
+                    [],
+                );
+            });
+            it("punctuation at start of following literal", () => {
+                const g = `<Start> = hello ,world -> true;`;
+                const grammar = loadGrammarRules("test.grammar", g);
+                // comma satisfies the flex-space from the following side
+                expect(testMatchGrammar(grammar, "hello,world")).toStrictEqual([
+                    true,
+                ]);
+                expect(testMatchGrammar(grammar, "hello ,world")).toStrictEqual(
+                    [true],
+                );
+                expect(testMatchGrammar(grammar, "hello world")).toStrictEqual(
+                    [],
+                );
+            });
+            it("punctuation trailing boundary", () => {
+                // Use a wildcard to consume the remaining input so finalizeState
+                // does not reject trailing non-separator content. isBoundarySatisfied
+                // is what determines whether the boundary after the comma passes.
+                const g = `<Start> = hello,$(x) -> true;`;
+                const grammar = loadGrammarRules("test.grammar", g);
+                // trailing comma is a sufficient boundary; wildcard captures rest
+                expect(testMatchGrammar(grammar, "hello,world")).toStrictEqual([
+                    true,
+                ]);
+                expect(testMatchGrammar(grammar, "hello, world")).toStrictEqual(
+                    [true],
+                );
+            });
         });
-        it("punctuation at start of following literal", () => {
-            const g = `<Start> = hello ,world -> true;`;
-            const grammar = loadGrammarRules("test.grammar", g);
-            // comma satisfies the flex-space from the following side
-            expect(testMatchGrammar(grammar, "hello,world")).toStrictEqual([
-                true,
-            ]);
-            expect(testMatchGrammar(grammar, "hello ,world")).toStrictEqual([
-                true,
-            ]);
-            expect(testMatchGrammar(grammar, "hello world")).toStrictEqual([]);
+        describe("required mode", () => {
+            it("punctuation at end of preceding literal", () => {
+                const g = `<Start> [spacing=required] = hello, world -> true;`;
+                const grammar = loadGrammarRules("test.grammar", g);
+                // comma alone does not satisfy the boundary; a separator in the
+                // input is still required
+                expect(testMatchGrammar(grammar, "hello, world")).toStrictEqual(
+                    [true],
+                );
+                expect(testMatchGrammar(grammar, "hello,world")).toStrictEqual(
+                    [],
+                );
+            });
+            it("punctuation at start of following literal", () => {
+                const g = `<Start> [spacing=required] = hello ,world -> true;`;
+                const grammar = loadGrammarRules("test.grammar", g);
+                expect(testMatchGrammar(grammar, "hello ,world")).toStrictEqual(
+                    [true],
+                );
+                // comma is consumed by the required separator, leaving nothing
+                // to match the leading comma of the next literal
+                expect(testMatchGrammar(grammar, "hello,world")).toStrictEqual(
+                    [],
+                );
+            });
+            it("punctuation trailing boundary", () => {
+                const g = `<Start> [spacing=required] = hello,$(x) -> true;`;
+                const grammar = loadGrammarRules("test.grammar", g);
+                // separator must come from the input after the comma
+                expect(testMatchGrammar(grammar, "hello, world")).toStrictEqual(
+                    [true],
+                );
+                expect(testMatchGrammar(grammar, "hello,world")).toStrictEqual(
+                    [],
+                );
+            });
         });
-        it("punctuation trailing boundary", () => {
-            // Use a wildcard to consume the remaining input so finalizeState
-            // does not reject trailing non-separator content. isBoundarySatisfied
-            // is what determines whether the boundary after the comma passes.
-            const g = `<Start> = hello,$(x) -> true;`;
-            const grammar = loadGrammarRules("test.grammar", g);
-            // trailing comma is a sufficient boundary; wildcard captures rest
-            expect(testMatchGrammar(grammar, "hello,world")).toStrictEqual([
-                true,
-            ]);
-            expect(testMatchGrammar(grammar, "hello, world")).toStrictEqual([
-                true,
-            ]);
+        describe("optional mode", () => {
+            it("punctuation at end of preceding literal", () => {
+                const g = `<Start> [spacing=optional] = hello, world -> true;`;
+                const grammar = loadGrammarRules("test.grammar", g);
+                expect(testMatchGrammar(grammar, "hello,world")).toStrictEqual([
+                    true,
+                ]);
+                expect(testMatchGrammar(grammar, "hello, world")).toStrictEqual(
+                    [true],
+                );
+            });
+            it("punctuation at start of following literal", () => {
+                const g = `<Start> [spacing=optional] = hello ,world -> true;`;
+                const grammar = loadGrammarRules("test.grammar", g);
+                expect(testMatchGrammar(grammar, "hello,world")).toStrictEqual([
+                    true,
+                ]);
+                expect(testMatchGrammar(grammar, "hello ,world")).toStrictEqual(
+                    [true],
+                );
+            });
+            it("punctuation trailing boundary", () => {
+                const g = `<Start> [spacing=optional] = hello,$(x) -> true;`;
+                const grammar = loadGrammarRules("test.grammar", g);
+                expect(testMatchGrammar(grammar, "hello,world")).toStrictEqual([
+                    true,
+                ]);
+                expect(testMatchGrammar(grammar, "hello, world")).toStrictEqual(
+                    [true],
+                );
+            });
         });
-    });
-    describe("required mode", () => {
-        it("punctuation at end of preceding literal", () => {
-            const g = `<Start> [spacing=required] = hello, world -> true;`;
-            const grammar = loadGrammarRules("test.grammar", g);
-            // comma alone does not satisfy the boundary; a separator in the
-            // input is still required
-            expect(testMatchGrammar(grammar, "hello, world")).toStrictEqual([
-                true,
-            ]);
-            expect(testMatchGrammar(grammar, "hello,world")).toStrictEqual([]);
-        });
-        it("punctuation at start of following literal", () => {
-            const g = `<Start> [spacing=required] = hello ,world -> true;`;
-            const grammar = loadGrammarRules("test.grammar", g);
-            expect(testMatchGrammar(grammar, "hello ,world")).toStrictEqual([
-                true,
-            ]);
-            // comma is consumed by the required separator, leaving nothing
-            // to match the leading comma of the next literal
-            expect(testMatchGrammar(grammar, "hello,world")).toStrictEqual([]);
-        });
-        it("punctuation trailing boundary", () => {
-            const g = `<Start> [spacing=required] = hello,$(x) -> true;`;
-            const grammar = loadGrammarRules("test.grammar", g);
-            // separator must come from the input after the comma
-            expect(testMatchGrammar(grammar, "hello, world")).toStrictEqual([
-                true,
-            ]);
-            expect(testMatchGrammar(grammar, "hello,world")).toStrictEqual([]);
-        });
-    });
-    describe("optional mode", () => {
-        it("punctuation at end of preceding literal", () => {
-            const g = `<Start> [spacing=optional] = hello, world -> true;`;
-            const grammar = loadGrammarRules("test.grammar", g);
-            expect(testMatchGrammar(grammar, "hello,world")).toStrictEqual([
-                true,
-            ]);
-            expect(testMatchGrammar(grammar, "hello, world")).toStrictEqual([
-                true,
-            ]);
-        });
-        it("punctuation at start of following literal", () => {
-            const g = `<Start> [spacing=optional] = hello ,world -> true;`;
-            const grammar = loadGrammarRules("test.grammar", g);
-            expect(testMatchGrammar(grammar, "hello,world")).toStrictEqual([
-                true,
-            ]);
-            expect(testMatchGrammar(grammar, "hello ,world")).toStrictEqual([
-                true,
-            ]);
-        });
-        it("punctuation trailing boundary", () => {
-            const g = `<Start> [spacing=optional] = hello,$(x) -> true;`;
-            const grammar = loadGrammarRules("test.grammar", g);
-            expect(testMatchGrammar(grammar, "hello,world")).toStrictEqual([
-                true,
-            ]);
-            expect(testMatchGrammar(grammar, "hello, world")).toStrictEqual([
-                true,
-            ]);
-        });
-    });
-});
+    },
+);

--- a/ts/packages/actionGrammar/test/grammarMatcherSpacingBasic.spec.ts
+++ b/ts/packages/actionGrammar/test/grammarMatcherSpacingBasic.spec.ts
@@ -2,428 +2,449 @@
 // Licensed under the MIT License.
 
 import { loadGrammarRules } from "../src/grammarLoader.js";
-import { testMatchGrammar } from "./testUtils.js";
+import { describeForEachMatcher } from "./testUtils.js";
 
-describe("Grammar Matcher - Spacing Modes (Basic)", () => {
-    describe("default (auto) - Latin requires space", () => {
-        const g = `<Start> = hello world -> true;`;
-        const grammar = loadGrammarRules("test.grammar", g);
-        it("matches with space", () => {
-            expect(testMatchGrammar(grammar, "hello world")).toStrictEqual([
-                true,
-            ]);
-        });
-        it("does not match without space", () => {
-            expect(testMatchGrammar(grammar, "helloworld")).toStrictEqual([]);
-        });
-    });
-
-    describe("spacing=required annotation", () => {
-        const g = `<Start> [spacing=required] = hello world -> true;`;
-        const grammar = loadGrammarRules("test.grammar", g);
-        it("matches with space", () => {
-            expect(testMatchGrammar(grammar, "hello world")).toStrictEqual([
-                true,
-            ]);
-        });
-        it("does not match without space", () => {
-            expect(testMatchGrammar(grammar, "helloworld")).toStrictEqual([]);
-        });
-    });
-
-    describe("spacing=optional annotation", () => {
-        const g = `<Start> [spacing=optional] = hello world -> true;`;
-        const grammar = loadGrammarRules("test.grammar", g);
-        it("matches with space", () => {
-            expect(testMatchGrammar(grammar, "hello world")).toStrictEqual([
-                true,
-            ]);
-        });
-        it("matches without space", () => {
-            expect(testMatchGrammar(grammar, "helloworld")).toStrictEqual([
-                true,
-            ]);
-        });
-    });
-
-    describe("spacing=auto annotation - CJK (Han)", () => {
-        // In the grammar, whitespace creates a flex-space boundary.
-        // With auto mode, Han characters don't need spaces between them.
-        const g = `<Start> [spacing=auto] = 你好 世界 -> true;`;
-        const grammar = loadGrammarRules("test.grammar", g);
-        it("matches without space", () => {
-            expect(testMatchGrammar(grammar, "你好世界")).toStrictEqual([true]);
-        });
-        it("matches with space", () => {
-            expect(testMatchGrammar(grammar, "你好 世界")).toStrictEqual([
-                true,
-            ]);
-        });
-    });
-
-    describe("no annotation is identical to [spacing=auto]", () => {
-        // Omitting the annotation must produce the same behavior as
-        // explicitly writing [spacing=auto] — both store spacingMode as
-        // undefined and both enforce word-boundary rules for Latin scripts
-        // while allowing adjacent CJK characters.
-        it("Latin words without space are rejected in both", () => {
-            const gNoAnnotation = loadGrammarRules(
-                "test.grammar",
-                `<Start> = hello world -> true;`,
-            );
-            const gAutoExplicit = loadGrammarRules(
-                "test.grammar",
-                `<Start> [spacing=auto] = hello world -> true;`,
-            );
-            expect(testMatchGrammar(gNoAnnotation, "helloworld")).toStrictEqual(
-                [],
-            );
-            expect(testMatchGrammar(gAutoExplicit, "helloworld")).toStrictEqual(
-                [],
-            );
-        });
-        it("CJK characters without space match in both", () => {
-            const gNoAnnotation = loadGrammarRules(
-                "test.grammar",
-                `<Start> = 你好 世界 -> true;`,
-            );
-            const gAutoExplicit = loadGrammarRules(
-                "test.grammar",
-                `<Start> [spacing=auto] = 你好 世界 -> true;`,
-            );
-            expect(testMatchGrammar(gNoAnnotation, "你好世界")).toStrictEqual([
-                true,
-            ]);
-            expect(testMatchGrammar(gAutoExplicit, "你好世界")).toStrictEqual([
-                true,
-            ]);
-        });
-    });
-
-    describe("spacing=auto annotation - mixed Latin+CJK boundary", () => {
-        // At the Latin→CJK boundary no space is needed (CJK side is no-space)
-        const g = `<Start> [spacing=auto] = hello 世界 -> true;`;
-        const grammar = loadGrammarRules("test.grammar", g);
-        it("matches without space at Latin-CJK boundary", () => {
-            expect(testMatchGrammar(grammar, "hello世界")).toStrictEqual([
-                true,
-            ]);
-        });
-        it("matches with space at Latin-CJK boundary", () => {
-            expect(testMatchGrammar(grammar, "hello 世界")).toStrictEqual([
-                true,
-            ]);
-        });
-    });
-
-    describe("spacing=auto annotation - Hangul (Korean)", () => {
-        // Hangul is in wordBoundaryScriptRe so adjacent Hangul syllables
-        // require a separator, just like Latin.
-        const g = `<Start> [spacing=auto] = 안녕 세계 -> true;`;
-        const grammar = loadGrammarRules("test.grammar", g);
-        it("does not match without space (Hangul requires separator)", () => {
-            expect(testMatchGrammar(grammar, "안녕세계")).toStrictEqual([]);
-        });
-        it("matches with space", () => {
-            expect(testMatchGrammar(grammar, "안녕 세계")).toStrictEqual([
-                true,
-            ]);
-        });
-    });
-
-    describe("spacing=auto annotation - CJK→Latin boundary", () => {
-        // Reverse of the Latin→CJK test: CJK on the left, Latin on the right.
-        // CJK is not in wordBoundaryScriptRe so no space is needed at this boundary.
-        const g = `<Start> [spacing=auto] = 世界 hello -> true;`;
-        const grammar = loadGrammarRules("test.grammar", g);
-        it("matches without space at CJK-Latin boundary", () => {
-            expect(testMatchGrammar(grammar, "世界hello")).toStrictEqual([
-                true,
-            ]);
-        });
-        it("matches with space at CJK-Latin boundary", () => {
-            expect(testMatchGrammar(grammar, "世界 hello")).toStrictEqual([
-                true,
-            ]);
-        });
-    });
-
-    describe("spacing=required annotation - punctuation-only separator in input", () => {
-        // required mode uses [\s\p{P}]+ which accepts punctuation characters.
-        const g = `<Start> [spacing=required] = hello world -> true;`;
-        const grammar = loadGrammarRules("test.grammar", g);
-        it("accepts a comma as the separator", () => {
-            expect(testMatchGrammar(grammar, "hello,world")).toStrictEqual([
-                true,
-            ]);
-        });
-        it("accepts a period as the separator", () => {
-            expect(testMatchGrammar(grammar, "hello.world")).toStrictEqual([
-                true,
-            ]);
-        });
-    });
-
-    describe("[spacing=auto] - digit-Latin boundary does not require space", () => {
-        // One side being a digit and the other Latin: no space needed.
-        const g = `<Start> = 123 hello -> true;`;
-        const grammar = loadGrammarRules("test.grammar", g);
-        it("matches without space at digit-Latin boundary", () => {
-            expect(testMatchGrammar(grammar, "123hello")).toStrictEqual([true]);
-        });
-        it("matches with space at digit-Latin boundary", () => {
-            expect(testMatchGrammar(grammar, "123 hello")).toStrictEqual([
-                true,
-            ]);
-        });
-    });
-
-    describe("[spacing=auto] - digit-digit boundary requires space", () => {
-        // Both sides are digits: a separator is required because "123456"
-        // is a different token from "123 456".
-        const g = `<Start> = 123 456 -> true;`;
-        const grammar = loadGrammarRules("test.grammar", g);
-        it("does not match without space at digit-digit boundary", () => {
-            expect(testMatchGrammar(grammar, "123456")).toStrictEqual([]);
-        });
-        it("matches with space at digit-digit boundary", () => {
-            expect(testMatchGrammar(grammar, "123 456")).toStrictEqual([true]);
-        });
-    });
-
-    describe("empty wildcard rejection - spacing=auto (default)", () => {
-        // wildcardTrimRegExp uses .+? so all-whitespace or empty content is rejected
-        const g = `<Start> = hello $(x) world -> x;`;
-        const grammar = loadGrammarRules("test.grammar", g);
-        it("rejects when wildcard is pure whitespace (trims to empty)", () => {
-            expect(testMatchGrammar(grammar, "hello   world")).toStrictEqual(
-                [],
-            );
-        });
-        it("matches when wildcard has non-separator content", () => {
-            expect(testMatchGrammar(grammar, "hello foo world")).toStrictEqual([
-                "foo",
-            ]);
-        });
-    });
-
-    describe("empty wildcard rejection - spacing=required", () => {
-        const g = `<Start> [spacing=required] = hello $(x) world -> x;`;
-        const grammar = loadGrammarRules("test.grammar", g);
-        it("rejects when wildcard is pure whitespace", () => {
-            expect(testMatchGrammar(grammar, "hello   world")).toStrictEqual(
-                [],
-            );
-        });
-        it("matches when wildcard has non-separator content", () => {
-            expect(testMatchGrammar(grammar, "hello foo world")).toStrictEqual([
-                "foo",
-            ]);
-        });
-    });
-
-    describe("empty wildcard rejection - spacing=optional", () => {
-        const g = `<Start> [spacing=optional] = hello $(x) world -> x;`;
-        const grammar = loadGrammarRules("test.grammar", g);
-        it("rejects when wildcard is pure whitespace", () => {
-            expect(testMatchGrammar(grammar, "hello   world")).toStrictEqual(
-                [],
-            );
-        });
-        it("matches when wildcard has non-separator content", () => {
-            expect(testMatchGrammar(grammar, "hello foo world")).toStrictEqual([
-                "foo",
-            ]);
-        });
-    });
-
-    describe("parse error - unknown annotation key", () => {
-        it("throws on unknown annotation key", () => {
-            expect(() =>
-                loadGrammarRules(
-                    "test.grammar",
-                    `<Start> [unknown=auto] = hello -> true;`,
-                ),
-            ).toThrow("Unknown rule annotation");
-        });
-    });
-
-    describe("parse error - invalid spacing value", () => {
-        it("throws on invalid value", () => {
-            expect(() =>
-                loadGrammarRules(
-                    "test.grammar",
-                    `<Start> [spacing=never] = hello -> true;`,
-                ),
-            ).toThrow("Invalid value");
-        });
-    });
-
-    describe("number variable respects spacingMode", () => {
-        describe("required mode - trailing separator after number", () => {
-            const g = `<Start> [spacing=required] = set $(n:number) items -> n;`;
+describeForEachMatcher(
+    "Grammar Matcher - Spacing Modes (Basic)",
+    (testMatchGrammar) => {
+        describe("default (auto) - Latin requires space", () => {
+            const g = `<Start> = hello world -> true;`;
             const grammar = loadGrammarRules("test.grammar", g);
-            it("rejects number immediately followed by word (no separator)", () => {
-                expect(testMatchGrammar(grammar, "set 50items")).toStrictEqual(
+            it("matches with space", () => {
+                expect(testMatchGrammar(grammar, "hello world")).toStrictEqual([
+                    true,
+                ]);
+            });
+            it("does not match without space", () => {
+                expect(testMatchGrammar(grammar, "helloworld")).toStrictEqual(
                     [],
                 );
             });
-            it("accepts number followed by space then word", () => {
-                expect(testMatchGrammar(grammar, "set 50 items")).toStrictEqual(
-                    [50],
+        });
+
+        describe("spacing=required annotation", () => {
+            const g = `<Start> [spacing=required] = hello world -> true;`;
+            const grammar = loadGrammarRules("test.grammar", g);
+            it("matches with space", () => {
+                expect(testMatchGrammar(grammar, "hello world")).toStrictEqual([
+                    true,
+                ]);
+            });
+            it("does not match without space", () => {
+                expect(testMatchGrammar(grammar, "helloworld")).toStrictEqual(
+                    [],
                 );
             });
         });
 
-        describe("optional mode - trailing separator after number", () => {
-            const g = `<Start> [spacing=optional] = set $(n:number) items -> n;`;
+        describe("spacing=optional annotation", () => {
+            const g = `<Start> [spacing=optional] = hello world -> true;`;
             const grammar = loadGrammarRules("test.grammar", g);
-            it("accepts number immediately followed by word (no separator needed)", () => {
-                expect(testMatchGrammar(grammar, "set 50items")).toStrictEqual([
-                    50,
+            it("matches with space", () => {
+                expect(testMatchGrammar(grammar, "hello world")).toStrictEqual([
+                    true,
                 ]);
             });
-            it("accepts number followed by space then word", () => {
-                expect(testMatchGrammar(grammar, "set 50 items")).toStrictEqual(
-                    [50],
+            it("matches without space", () => {
+                expect(testMatchGrammar(grammar, "helloworld")).toStrictEqual([
+                    true,
+                ]);
+            });
+        });
+
+        describe("spacing=auto annotation - CJK (Han)", () => {
+            // In the grammar, whitespace creates a flex-space boundary.
+            // With auto mode, Han characters don't need spaces between them.
+            const g = `<Start> [spacing=auto] = 你好 世界 -> true;`;
+            const grammar = loadGrammarRules("test.grammar", g);
+            it("matches without space", () => {
+                expect(testMatchGrammar(grammar, "你好世界")).toStrictEqual([
+                    true,
+                ]);
+            });
+            it("matches with space", () => {
+                expect(testMatchGrammar(grammar, "你好 世界")).toStrictEqual([
+                    true,
+                ]);
+            });
+        });
+
+        describe("no annotation is identical to [spacing=auto]", () => {
+            // Omitting the annotation must produce the same behavior as
+            // explicitly writing [spacing=auto] — both store spacingMode as
+            // undefined and both enforce word-boundary rules for Latin scripts
+            // while allowing adjacent CJK characters.
+            it("Latin words without space are rejected in both", () => {
+                const gNoAnnotation = loadGrammarRules(
+                    "test.grammar",
+                    `<Start> = hello world -> true;`,
                 );
+                const gAutoExplicit = loadGrammarRules(
+                    "test.grammar",
+                    `<Start> [spacing=auto] = hello world -> true;`,
+                );
+                expect(
+                    testMatchGrammar(gNoAnnotation, "helloworld"),
+                ).toStrictEqual([]);
+                expect(
+                    testMatchGrammar(gAutoExplicit, "helloworld"),
+                ).toStrictEqual([]);
+            });
+            it("CJK characters without space match in both", () => {
+                const gNoAnnotation = loadGrammarRules(
+                    "test.grammar",
+                    `<Start> = 你好 世界 -> true;`,
+                );
+                const gAutoExplicit = loadGrammarRules(
+                    "test.grammar",
+                    `<Start> [spacing=auto] = 你好 世界 -> true;`,
+                );
+                expect(
+                    testMatchGrammar(gNoAnnotation, "你好世界"),
+                ).toStrictEqual([true]);
+                expect(
+                    testMatchGrammar(gAutoExplicit, "你好世界"),
+                ).toStrictEqual([true]);
             });
         });
 
-        describe("auto mode - digit-Latin boundary does not require space", () => {
-            // Digit followed by Latin: not both in wordBoundaryScriptRe, so no separator needed.
-            const g = `<Start> = set $(n:number) items -> n;`;
+        describe("spacing=auto annotation - mixed Latin+CJK boundary", () => {
+            // At the Latin→CJK boundary no space is needed (CJK side is no-space)
+            const g = `<Start> [spacing=auto] = hello 世界 -> true;`;
             const grammar = loadGrammarRules("test.grammar", g);
-            it("accepts number immediately followed by Latin word (auto mode)", () => {
-                expect(testMatchGrammar(grammar, "set 50items")).toStrictEqual([
-                    50,
+            it("matches without space at Latin-CJK boundary", () => {
+                expect(testMatchGrammar(grammar, "hello世界")).toStrictEqual([
+                    true,
+                ]);
+            });
+            it("matches with space at Latin-CJK boundary", () => {
+                expect(testMatchGrammar(grammar, "hello 世界")).toStrictEqual([
+                    true,
                 ]);
             });
         });
 
-        describe("required mode - number at start of rule (no preceding part)", () => {
-            // Verifies the trailing separator check fires even when there is no
-            // preceding string part whose own isBoundarySatisfied check would have
-            // enforced a separator earlier.
-            const g = `<Start> [spacing=required] = $(n:number) items -> n;`;
+        describe("spacing=auto annotation - Hangul (Korean)", () => {
+            // Hangul is in wordBoundaryScriptRe so adjacent Hangul syllables
+            // require a separator, just like Latin.
+            const g = `<Start> [spacing=auto] = 안녕 세계 -> true;`;
             const grammar = loadGrammarRules("test.grammar", g);
-            it("rejects number immediately followed by word (no separator)", () => {
-                expect(testMatchGrammar(grammar, "50items")).toStrictEqual([]);
+            it("does not match without space (Hangul requires separator)", () => {
+                expect(testMatchGrammar(grammar, "안녕세계")).toStrictEqual([]);
             });
-            it("accepts number followed by space then word", () => {
-                expect(testMatchGrammar(grammar, "50 items")).toStrictEqual([
-                    50,
+            it("matches with space", () => {
+                expect(testMatchGrammar(grammar, "안녕 세계")).toStrictEqual([
+                    true,
                 ]);
             });
         });
 
-        describe("auto mode - digit-digit boundary requires space after number variable", () => {
-            // Both the end of the matched number and the start of the next
-            // literal are digits → isBoundarySatisfied returns false in auto mode.
-            const g = `<Start> = $(n:number) 456 -> n;`;
+        describe("spacing=auto annotation - CJK→Latin boundary", () => {
+            // Reverse of the Latin→CJK test: CJK on the left, Latin on the right.
+            // CJK is not in wordBoundaryScriptRe so no space is needed at this boundary.
+            const g = `<Start> [spacing=auto] = 世界 hello -> true;`;
             const grammar = loadGrammarRules("test.grammar", g);
-            it("rejects number immediately followed by digit literal (no separator)", () => {
+            it("matches without space at CJK-Latin boundary", () => {
+                expect(testMatchGrammar(grammar, "世界hello")).toStrictEqual([
+                    true,
+                ]);
+            });
+            it("matches with space at CJK-Latin boundary", () => {
+                expect(testMatchGrammar(grammar, "世界 hello")).toStrictEqual([
+                    true,
+                ]);
+            });
+        });
+
+        describe("spacing=required annotation - punctuation-only separator in input", () => {
+            // required mode uses [\s\p{P}]+ which accepts punctuation characters.
+            const g = `<Start> [spacing=required] = hello world -> true;`;
+            const grammar = loadGrammarRules("test.grammar", g);
+            it("accepts a comma as the separator", () => {
+                expect(testMatchGrammar(grammar, "hello,world")).toStrictEqual([
+                    true,
+                ]);
+            });
+            it("accepts a period as the separator", () => {
+                expect(testMatchGrammar(grammar, "hello.world")).toStrictEqual([
+                    true,
+                ]);
+            });
+        });
+
+        describe("[spacing=auto] - digit-Latin boundary does not require space", () => {
+            // One side being a digit and the other Latin: no space needed.
+            const g = `<Start> = 123 hello -> true;`;
+            const grammar = loadGrammarRules("test.grammar", g);
+            it("matches without space at digit-Latin boundary", () => {
+                expect(testMatchGrammar(grammar, "123hello")).toStrictEqual([
+                    true,
+                ]);
+            });
+            it("matches with space at digit-Latin boundary", () => {
+                expect(testMatchGrammar(grammar, "123 hello")).toStrictEqual([
+                    true,
+                ]);
+            });
+        });
+
+        describe("[spacing=auto] - digit-digit boundary requires space", () => {
+            // Both sides are digits: a separator is required because "123456"
+            // is a different token from "123 456".
+            const g = `<Start> = 123 456 -> true;`;
+            const grammar = loadGrammarRules("test.grammar", g);
+            it("does not match without space at digit-digit boundary", () => {
                 expect(testMatchGrammar(grammar, "123456")).toStrictEqual([]);
             });
-            it("accepts number followed by space then digit literal", () => {
+            it("matches with space at digit-digit boundary", () => {
                 expect(testMatchGrammar(grammar, "123 456")).toStrictEqual([
-                    123,
+                    true,
                 ]);
             });
         });
 
-        describe("required mode - number with wildcard trailing separator", () => {
-            const g = `<Start> [spacing=required] = $(x) $(n:number) end -> n;`;
+        describe("empty wildcard rejection - spacing=auto (default)", () => {
+            // wildcardTrimRegExp uses .+? so all-whitespace or empty content is rejected
+            const g = `<Start> = hello $(x) world -> x;`;
             const grammar = loadGrammarRules("test.grammar", g);
-            it("rejects number immediately followed by word (no separator)", () => {
-                expect(testMatchGrammar(grammar, "set 50end")).toStrictEqual(
+            it("rejects when wildcard is pure whitespace (trims to empty)", () => {
+                expect(
+                    testMatchGrammar(grammar, "hello   world"),
+                ).toStrictEqual([]);
+            });
+            it("matches when wildcard has non-separator content", () => {
+                expect(
+                    testMatchGrammar(grammar, "hello foo world"),
+                ).toStrictEqual(["foo"]);
+            });
+        });
+
+        describe("empty wildcard rejection - spacing=required", () => {
+            const g = `<Start> [spacing=required] = hello $(x) world -> x;`;
+            const grammar = loadGrammarRules("test.grammar", g);
+            it("rejects when wildcard is pure whitespace", () => {
+                expect(
+                    testMatchGrammar(grammar, "hello   world"),
+                ).toStrictEqual([]);
+            });
+            it("matches when wildcard has non-separator content", () => {
+                expect(
+                    testMatchGrammar(grammar, "hello foo world"),
+                ).toStrictEqual(["foo"]);
+            });
+        });
+
+        describe("empty wildcard rejection - spacing=optional", () => {
+            const g = `<Start> [spacing=optional] = hello $(x) world -> x;`;
+            const grammar = loadGrammarRules("test.grammar", g);
+            it("rejects when wildcard is pure whitespace", () => {
+                expect(
+                    testMatchGrammar(grammar, "hello   world"),
+                ).toStrictEqual([]);
+            });
+            it("matches when wildcard has non-separator content", () => {
+                expect(
+                    testMatchGrammar(grammar, "hello foo world"),
+                ).toStrictEqual(["foo"]);
+            });
+        });
+
+        describe("parse error - unknown annotation key", () => {
+            it("throws on unknown annotation key", () => {
+                expect(() =>
+                    loadGrammarRules(
+                        "test.grammar",
+                        `<Start> [unknown=auto] = hello -> true;`,
+                    ),
+                ).toThrow("Unknown rule annotation");
+            });
+        });
+
+        describe("parse error - invalid spacing value", () => {
+            it("throws on invalid value", () => {
+                expect(() =>
+                    loadGrammarRules(
+                        "test.grammar",
+                        `<Start> [spacing=never] = hello -> true;`,
+                    ),
+                ).toThrow("Invalid value");
+            });
+        });
+
+        describe("number variable respects spacingMode", () => {
+            describe("required mode - trailing separator after number", () => {
+                const g = `<Start> [spacing=required] = set $(n:number) items -> n;`;
+                const grammar = loadGrammarRules("test.grammar", g);
+                it("rejects number immediately followed by word (no separator)", () => {
+                    expect(
+                        testMatchGrammar(grammar, "set 50items"),
+                    ).toStrictEqual([]);
+                });
+                it("accepts number followed by space then word", () => {
+                    expect(
+                        testMatchGrammar(grammar, "set 50 items"),
+                    ).toStrictEqual([50]);
+                });
+            });
+
+            describe("optional mode - trailing separator after number", () => {
+                const g = `<Start> [spacing=optional] = set $(n:number) items -> n;`;
+                const grammar = loadGrammarRules("test.grammar", g);
+                it("accepts number immediately followed by word (no separator needed)", () => {
+                    expect(
+                        testMatchGrammar(grammar, "set 50items"),
+                    ).toStrictEqual([50]);
+                });
+                it("accepts number followed by space then word", () => {
+                    expect(
+                        testMatchGrammar(grammar, "set 50 items"),
+                    ).toStrictEqual([50]);
+                });
+            });
+
+            describe("auto mode - digit-Latin boundary does not require space", () => {
+                // Digit followed by Latin: not both in wordBoundaryScriptRe, so no separator needed.
+                const g = `<Start> = set $(n:number) items -> n;`;
+                const grammar = loadGrammarRules("test.grammar", g);
+                it("accepts number immediately followed by Latin word (auto mode)", () => {
+                    expect(
+                        testMatchGrammar(grammar, "set 50items"),
+                    ).toStrictEqual([50]);
+                });
+            });
+
+            describe("required mode - number at start of rule (no preceding part)", () => {
+                // Verifies the trailing separator check fires even when there is no
+                // preceding string part whose own isBoundarySatisfied check would have
+                // enforced a separator earlier.
+                const g = `<Start> [spacing=required] = $(n:number) items -> n;`;
+                const grammar = loadGrammarRules("test.grammar", g);
+                it("rejects number immediately followed by word (no separator)", () => {
+                    expect(testMatchGrammar(grammar, "50items")).toStrictEqual(
+                        [],
+                    );
+                });
+                it("accepts number followed by space then word", () => {
+                    expect(testMatchGrammar(grammar, "50 items")).toStrictEqual(
+                        [50],
+                    );
+                });
+            });
+
+            describe("auto mode - digit-digit boundary requires space after number variable", () => {
+                // Both the end of the matched number and the start of the next
+                // literal are digits → isBoundarySatisfied returns false in auto mode.
+                const g = `<Start> = $(n:number) 456 -> n;`;
+                const grammar = loadGrammarRules("test.grammar", g);
+                it("rejects number immediately followed by digit literal (no separator)", () => {
+                    expect(testMatchGrammar(grammar, "123456")).toStrictEqual(
+                        [],
+                    );
+                });
+                it("accepts number followed by space then digit literal", () => {
+                    expect(testMatchGrammar(grammar, "123 456")).toStrictEqual([
+                        123,
+                    ]);
+                });
+            });
+
+            describe("required mode - number with wildcard trailing separator", () => {
+                const g = `<Start> [spacing=required] = $(x) $(n:number) end -> n;`;
+                const grammar = loadGrammarRules("test.grammar", g);
+                it("rejects number immediately followed by word (no separator)", () => {
+                    expect(
+                        testMatchGrammar(grammar, "set 50end"),
+                    ).toStrictEqual([]);
+                });
+                it("accepts number followed by space then word", () => {
+                    expect(
+                        testMatchGrammar(grammar, "set 50 end"),
+                    ).toStrictEqual([50]);
+                });
+            });
+
+            describe("optional mode - number with wildcard trailing separator", () => {
+                // In optional mode the wildcard path should accept no separator.
+                const g = `<Start> [spacing=optional] = $(x) $(n:number) end -> n;`;
+                const grammar = loadGrammarRules("test.grammar", g);
+                it("accepts number immediately followed by word (no separator needed)", () => {
+                    expect(testMatchGrammar(grammar, "set50end")).toStrictEqual(
+                        [50],
+                    );
+                });
+                it("accepts number followed by space then word", () => {
+                    expect(
+                        testMatchGrammar(grammar, "set 50 end"),
+                    ).toStrictEqual([50]);
+                });
+            });
+        });
+
+        describe("repeat group ()* inherits optional mode", () => {
+            const g = `<Start> [spacing=optional] = hello (world)* -> true;`;
+            const grammar = loadGrammarRules("test.grammar", g);
+            it("matches zero repetitions", () => {
+                expect(testMatchGrammar(grammar, "hello")).toStrictEqual([
+                    true,
+                ]);
+            });
+            it("matches one repetition without space (optional mode)", () => {
+                expect(testMatchGrammar(grammar, "helloworld")).toStrictEqual([
+                    true,
+                ]);
+            });
+            it("matches two repetitions without space (optional mode)", () => {
+                expect(
+                    testMatchGrammar(grammar, "helloworldworld"),
+                ).toStrictEqual([true]);
+            });
+        });
+
+        describe("repeat group ()+ with required mode", () => {
+            const g = `<Start> [spacing=required] = hello (world)+ -> true;`;
+            const grammar = loadGrammarRules("test.grammar", g);
+            it("matches one repetition with space", () => {
+                expect(testMatchGrammar(grammar, "hello world")).toStrictEqual([
+                    true,
+                ]);
+            });
+            it("does not match without space before group", () => {
+                expect(testMatchGrammar(grammar, "helloworld")).toStrictEqual(
                     [],
                 );
             });
-            it("accepts number followed by space then word", () => {
-                expect(testMatchGrammar(grammar, "set 50 end")).toStrictEqual([
-                    50,
-                ]);
+            it("matches two repetitions with spaces", () => {
+                expect(
+                    testMatchGrammar(grammar, "hello world world"),
+                ).toStrictEqual([true]);
+            });
+            it("does not match when repetitions are not space-separated", () => {
+                // The first 'world' ends with 'w' at index 11 in input; required
+                // mode rejects a match unless a separator follows the token.
+                expect(
+                    testMatchGrammar(grammar, "hello worldworld"),
+                ).toStrictEqual([]);
             });
         });
 
-        describe("optional mode - number with wildcard trailing separator", () => {
-            // In optional mode the wildcard path should accept no separator.
-            const g = `<Start> [spacing=optional] = $(x) $(n:number) end -> n;`;
+        describe("repeat group ()+ with optional mode", () => {
+            const g = `<Start> [spacing=optional] = hello (world)+ -> true;`;
             const grammar = loadGrammarRules("test.grammar", g);
-            it("accepts number immediately followed by word (no separator needed)", () => {
-                expect(testMatchGrammar(grammar, "set50end")).toStrictEqual([
-                    50,
+            it("matches one repetition without space (optional mode)", () => {
+                expect(testMatchGrammar(grammar, "helloworld")).toStrictEqual([
+                    true,
                 ]);
             });
-            it("accepts number followed by space then word", () => {
-                expect(testMatchGrammar(grammar, "set 50 end")).toStrictEqual([
-                    50,
-                ]);
+            it("matches two repetitions without space (optional mode)", () => {
+                expect(
+                    testMatchGrammar(grammar, "helloworldworld"),
+                ).toStrictEqual([true]);
+            });
+            it("matches two repetitions with spaces (optional mode)", () => {
+                expect(
+                    testMatchGrammar(grammar, "hello world world"),
+                ).toStrictEqual([true]);
             });
         });
-    });
-
-    describe("repeat group ()* inherits optional mode", () => {
-        const g = `<Start> [spacing=optional] = hello (world)* -> true;`;
-        const grammar = loadGrammarRules("test.grammar", g);
-        it("matches zero repetitions", () => {
-            expect(testMatchGrammar(grammar, "hello")).toStrictEqual([true]);
-        });
-        it("matches one repetition without space (optional mode)", () => {
-            expect(testMatchGrammar(grammar, "helloworld")).toStrictEqual([
-                true,
-            ]);
-        });
-        it("matches two repetitions without space (optional mode)", () => {
-            expect(testMatchGrammar(grammar, "helloworldworld")).toStrictEqual([
-                true,
-            ]);
-        });
-    });
-
-    describe("repeat group ()+ with required mode", () => {
-        const g = `<Start> [spacing=required] = hello (world)+ -> true;`;
-        const grammar = loadGrammarRules("test.grammar", g);
-        it("matches one repetition with space", () => {
-            expect(testMatchGrammar(grammar, "hello world")).toStrictEqual([
-                true,
-            ]);
-        });
-        it("does not match without space before group", () => {
-            expect(testMatchGrammar(grammar, "helloworld")).toStrictEqual([]);
-        });
-        it("matches two repetitions with spaces", () => {
-            expect(
-                testMatchGrammar(grammar, "hello world world"),
-            ).toStrictEqual([true]);
-        });
-        it("does not match when repetitions are not space-separated", () => {
-            // The first 'world' ends with 'w' at index 11 in input; required
-            // mode rejects a match unless a separator follows the token.
-            expect(testMatchGrammar(grammar, "hello worldworld")).toStrictEqual(
-                [],
-            );
-        });
-    });
-
-    describe("repeat group ()+ with optional mode", () => {
-        const g = `<Start> [spacing=optional] = hello (world)+ -> true;`;
-        const grammar = loadGrammarRules("test.grammar", g);
-        it("matches one repetition without space (optional mode)", () => {
-            expect(testMatchGrammar(grammar, "helloworld")).toStrictEqual([
-                true,
-            ]);
-        });
-        it("matches two repetitions without space (optional mode)", () => {
-            expect(testMatchGrammar(grammar, "helloworldworld")).toStrictEqual([
-                true,
-            ]);
-        });
-        it("matches two repetitions with spaces (optional mode)", () => {
-            expect(
-                testMatchGrammar(grammar, "hello world world"),
-            ).toStrictEqual([true]);
-        });
-    });
-});
+    },
+);

--- a/ts/packages/actionGrammar/test/grammarMatcherSpacingNested.spec.ts
+++ b/ts/packages/actionGrammar/test/grammarMatcherSpacingNested.spec.ts
@@ -2,385 +2,405 @@
 // Licensed under the MIT License.
 
 import { loadGrammarRules } from "../src/grammarLoader.js";
-import { testMatchGrammar } from "./testUtils.js";
+import { describeForEachMatcher, expectMatchResults } from "./testUtils.js";
 
-describe("Grammar Matcher - Spacing Nested Rules and Mode Switching", () => {
-    describe("per-rule mode switching", () => {
-        // <Start> references two sub-rules declared with different modes.
-        const g = `
+describeForEachMatcher(
+    "Grammar Matcher - Spacing Nested Rules and Mode Switching",
+    (testMatchGrammar, variant) => {
+        describe("per-rule mode switching", () => {
+            // <Start> references two sub-rules declared with different modes.
+            const g = `
             <RequiredRule> [spacing=required] = hello world -> "required";
             <OptionalRule> [spacing=optional] = hello world -> "optional";
             <Start> = $(x:<RequiredRule>) -> x | $(x:<OptionalRule>) -> x;
         `;
-        const grammar = loadGrammarRules("test.grammar", g);
-        it("both sub-rules match when space is present", () => {
-            expect(testMatchGrammar(grammar, "hello world")).toStrictEqual([
-                "required",
-                "optional",
-            ]);
+            const grammar = loadGrammarRules("test.grammar", g);
+            it("both sub-rules match when space is present", () => {
+                expectMatchResults(
+                    testMatchGrammar(grammar, "hello world"),
+                    ["required", "optional"],
+                    variant,
+                );
+            });
+            it("only the optional sub-rule matches without space", () => {
+                expect(testMatchGrammar(grammar, "helloworld")).toStrictEqual([
+                    "optional",
+                ]);
+            });
         });
-        it("only the optional sub-rule matches without space", () => {
-            expect(testMatchGrammar(grammar, "helloworld")).toStrictEqual([
-                "optional",
-            ]);
-        });
-    });
 
-    describe("nested rule uses its own mode", () => {
-        // EnglishRule uses required; NoSpaceRule uses optional.
-        // <Start> references both — each sub-rule uses its own declared mode.
-        const g = `
+        describe("nested rule uses its own mode", () => {
+            // EnglishRule uses required; NoSpaceRule uses optional.
+            // <Start> references both — each sub-rule uses its own declared mode.
+            const g = `
             <EnglishRule> [spacing=required] = hello world -> "english";
             <NoSpaceRule> [spacing=optional] = hi there -> "nospace";
             <Start> = $(x:<EnglishRule>) $(y:<NoSpaceRule>) -> { x, y };
         `;
-        const grammar = loadGrammarRules("test.grammar", g);
-        it("each nested rule uses its own declared mode", () => {
-            // EnglishRule requires space between "hello" and "world";
-            // NoSpaceRule allows "hithere" without space.
-            expect(
-                testMatchGrammar(grammar, "hello world hithere"),
-            ).toStrictEqual([{ x: "english", y: "nospace" }]);
+            const grammar = loadGrammarRules("test.grammar", g);
+            it("each nested rule uses its own declared mode", () => {
+                // EnglishRule requires space between "hello" and "world";
+                // NoSpaceRule allows "hithere" without space.
+                expect(
+                    testMatchGrammar(grammar, "hello world hithere"),
+                ).toStrictEqual([{ x: "english", y: "nospace" }]);
+            });
         });
-    });
 
-    describe("merged rules - same rule name, different modes", () => {
-        // Two definitions of <Start> with different spacing modes.
-        // The compiler merges them into one rule with two alternatives,
-        // each carrying its own declared mode.
-        const g = `
+        describe("merged rules - same rule name, different modes", () => {
+            // Two definitions of <Start> with different spacing modes.
+            // The compiler merges them into one rule with two alternatives,
+            // each carrying its own declared mode.
+            const g = `
             <Start> [spacing=required] = hello world -> "required";
             <Start> [spacing=optional] = hello world -> "optional";
         `;
-        const grammar = loadGrammarRules("test.grammar", g);
-        it("both alternatives match when space is present", () => {
-            expect(testMatchGrammar(grammar, "hello world")).toStrictEqual([
-                "required",
-                "optional",
-            ]);
+            const grammar = loadGrammarRules("test.grammar", g);
+            it("both alternatives match when space is present", () => {
+                expectMatchResults(
+                    testMatchGrammar(grammar, "hello world"),
+                    ["required", "optional"],
+                    variant,
+                );
+            });
+            it("only the optional alternative matches without space", () => {
+                expect(testMatchGrammar(grammar, "helloworld")).toStrictEqual([
+                    "optional",
+                ]);
+            });
         });
-        it("only the optional alternative matches without space", () => {
-            expect(testMatchGrammar(grammar, "helloworld")).toStrictEqual([
-                "optional",
-            ]);
-        });
-    });
 
-    describe("inline group inherits enclosing rule mode", () => {
-        const g = `<Start> [spacing=optional] = hello (world | earth) -> true;`;
-        const grammar = loadGrammarRules("test.grammar", g);
-        it("matches with space", () => {
-            expect(testMatchGrammar(grammar, "hello world")).toStrictEqual([
-                true,
-            ]);
+        describe("inline group inherits enclosing rule mode", () => {
+            const g = `<Start> [spacing=optional] = hello (world | earth) -> true;`;
+            const grammar = loadGrammarRules("test.grammar", g);
+            it("matches with space", () => {
+                expect(testMatchGrammar(grammar, "hello world")).toStrictEqual([
+                    true,
+                ]);
+            });
+            it("matches without space (inherits optional)", () => {
+                expect(testMatchGrammar(grammar, "helloworld")).toStrictEqual([
+                    true,
+                ]);
+            });
+            it("matches second alternative without space", () => {
+                expect(testMatchGrammar(grammar, "helloearth")).toStrictEqual([
+                    true,
+                ]);
+            });
         });
-        it("matches without space (inherits optional)", () => {
-            expect(testMatchGrammar(grammar, "helloworld")).toStrictEqual([
-                true,
-            ]);
-        });
-        it("matches second alternative without space", () => {
-            expect(testMatchGrammar(grammar, "helloearth")).toStrictEqual([
-                true,
-            ]);
-        });
-    });
 
-    describe("same-name rule with different modes merged", () => {
-        // <Greeting> is defined twice with different modes; each alternative
-        // must respect its own declared spacingMode.
-        const g = `
+        describe("same-name rule with different modes merged", () => {
+            // <Greeting> is defined twice with different modes; each alternative
+            // must respect its own declared spacingMode.
+            const g = `
             <Greeting> [spacing=optional] = hello world -> "optional";
             <Greeting> [spacing=required] = good morning -> "required";
             <Start> = <Greeting>;
         `;
-        const grammar = loadGrammarRules("test.grammar", g);
-        it("optional alternative matches without space", () => {
-            expect(testMatchGrammar(grammar, "helloworld")).toStrictEqual([
-                "optional",
-            ]);
+            const grammar = loadGrammarRules("test.grammar", g);
+            it("optional alternative matches without space", () => {
+                expect(testMatchGrammar(grammar, "helloworld")).toStrictEqual([
+                    "optional",
+                ]);
+            });
+            it("required alternative matches with space", () => {
+                expect(testMatchGrammar(grammar, "good morning")).toStrictEqual(
+                    ["required"],
+                );
+            });
+            it("required alternative does not match without space", () => {
+                expect(testMatchGrammar(grammar, "goodmorning")).toStrictEqual(
+                    [],
+                );
+            });
         });
-        it("required alternative matches with space", () => {
-            expect(testMatchGrammar(grammar, "good morning")).toStrictEqual([
-                "required",
-            ]);
-        });
-        it("required alternative does not match without space", () => {
-            expect(testMatchGrammar(grammar, "goodmorning")).toStrictEqual([]);
-        });
-    });
 
-    describe("rule without annotation uses auto/default mode", () => {
-        // <Before> has no annotation — must behave identically to
-        // [spacing=auto]: Latin words require a separator, CJK do not.
-        const g = `
+        describe("rule without annotation uses auto/default mode", () => {
+            // <Before> has no annotation — must behave identically to
+            // [spacing=auto]: Latin words require a separator, CJK do not.
+            const g = `
             <Before> = hello world -> "before";
             <After> [spacing=optional] = hello world -> "after";
             <Start> = $(x:<Before>) -> x | $(x:<After>) -> x;
         `;
-        const grammar = loadGrammarRules("test.grammar", g);
-        it("<Before> requires space between Latin words (auto default)", () => {
-            expect(testMatchGrammar(grammar, "hello world")).toStrictEqual([
-                "before",
-                "after",
-            ]);
+            const grammar = loadGrammarRules("test.grammar", g);
+            it("<Before> requires space between Latin words (auto default)", () => {
+                expectMatchResults(
+                    testMatchGrammar(grammar, "hello world"),
+                    ["before", "after"],
+                    variant,
+                );
+            });
+            it("<Before> does not match without space (auto default)", () => {
+                // Only the optional <After> alternative should match.
+                expect(testMatchGrammar(grammar, "helloworld")).toStrictEqual([
+                    "after",
+                ]);
+            });
         });
-        it("<Before> does not match without space (auto default)", () => {
-            // Only the optional <After> alternative should match.
-            expect(testMatchGrammar(grammar, "helloworld")).toStrictEqual([
-                "after",
-            ]);
-        });
-    });
 
-    describe("separator AFTER a rule reference follows parent mode", () => {
-        // The nested rule uses optional mode, so its own isBoundarySatisfied check
-        // always passes. The separator AFTER the rule reference must be
-        // validated using the parent (outer) rule's spacingMode.
-        describe("parent required, nested optional", () => {
-            const g = `
+        describe("separator AFTER a rule reference follows parent mode", () => {
+            // The nested rule uses optional mode, so its own isBoundarySatisfied check
+            // always passes. The separator AFTER the rule reference must be
+            // validated using the parent (outer) rule's spacingMode.
+            describe("parent required, nested optional", () => {
+                const g = `
                 <Inner> [spacing=optional] = hello world -> true;
                 <Start> [spacing=required] = $(x:<Inner>) end -> x;
             `;
-            const grammar = loadGrammarRules("test.grammar", g);
-            it("matches when space is present after rule reference", () => {
-                expect(
-                    testMatchGrammar(grammar, "helloworld end"),
-                ).toStrictEqual([true]);
+                const grammar = loadGrammarRules("test.grammar", g);
+                it("matches when space is present after rule reference", () => {
+                    expect(
+                        testMatchGrammar(grammar, "helloworld end"),
+                    ).toStrictEqual([true]);
+                });
+                it("does not match without space after rule reference (parent required)", () => {
+                    expect(
+                        testMatchGrammar(grammar, "helloworldend"),
+                    ).toStrictEqual([]);
+                });
             });
-            it("does not match without space after rule reference (parent required)", () => {
-                expect(
-                    testMatchGrammar(grammar, "helloworldend"),
-                ).toStrictEqual([]);
-            });
-        });
 
-        describe("parent optional, nested required", () => {
-            // The nested rule's own required mode enforces a separator
-            // after its last token, so "hello worldend" is rejected by
-            // the inner rule itself regardless of the outer mode.
-            const g = `
+            describe("parent optional, nested required", () => {
+                // The nested rule's own required mode enforces a separator
+                // after its last token, so "hello worldend" is rejected by
+                // the inner rule itself regardless of the outer mode.
+                const g = `
                 <Inner> [spacing=required] = hello world -> true;
                 <Start> [spacing=optional] = $(x:<Inner>) end -> x;
             `;
-            const grammar = loadGrammarRules("test.grammar", g);
-            it("matches when space is present after rule reference", () => {
-                expect(
-                    testMatchGrammar(grammar, "hello world end"),
-                ).toStrictEqual([true]);
+                const grammar = loadGrammarRules("test.grammar", g);
+                it("matches when space is present after rule reference", () => {
+                    expect(
+                        testMatchGrammar(grammar, "hello world end"),
+                    ).toStrictEqual([true]);
+                });
+                it("does not match without space (inner required mode enforces the boundary)", () => {
+                    expect(
+                        testMatchGrammar(grammar, "hello worldend"),
+                    ).toStrictEqual([]);
+                });
             });
-            it("does not match without space (inner required mode enforces the boundary)", () => {
-                expect(
-                    testMatchGrammar(grammar, "hello worldend"),
-                ).toStrictEqual([]);
-            });
-        });
-        describe("deeply nested: grandparent optional, parent required pass-through, grandchild optional", () => {
-            // Bug: A(optional) -> B(required, single-part pass-through) -> C(optional)
-            // After C finishes, finalizeNestedRule restores B's "required" mode and
-            // the separator check fires against it — rejecting "barbaz" even though
-            // A (the nearest ancestor with a following part) uses "optional" mode.
-            // The correct behaviour is to walk up to the first ancestor that still
-            // has remaining parts and use *that* ancestor's spacingMode.
-            const g = `
+            describe("deeply nested: grandparent optional, parent required pass-through, grandchild optional", () => {
+                // Bug: A(optional) -> B(required, single-part pass-through) -> C(optional)
+                // After C finishes, finalizeNestedRule restores B's "required" mode and
+                // the separator check fires against it — rejecting "barbaz" even though
+                // A (the nearest ancestor with a following part) uses "optional" mode.
+                // The correct behaviour is to walk up to the first ancestor that still
+                // has remaining parts and use *that* ancestor's spacingMode.
+                const g = `
                 <Inner> [spacing=optional] = bar -> true;
                 <Middle> [spacing=required] = $(x:<Inner>) -> x;
                 <Start> [spacing=optional] = $(x:<Middle>) baz -> x;
             `;
-            const grammar = loadGrammarRules("test.grammar", g);
-            it("matches with space (works today)", () => {
-                expect(testMatchGrammar(grammar, "bar baz")).toStrictEqual([
-                    true,
-                ]);
+                const grammar = loadGrammarRules("test.grammar", g);
+                it("matches with space (works today)", () => {
+                    expect(testMatchGrammar(grammar, "bar baz")).toStrictEqual([
+                        true,
+                    ]);
+                });
+                it("matches without space (grandparent optional mode governs the separator after the pass-through)", () => {
+                    expect(testMatchGrammar(grammar, "barbaz")).toStrictEqual([
+                        true,
+                    ]);
+                });
             });
-            it("matches without space (grandparent optional mode governs the separator after the pass-through)", () => {
-                expect(testMatchGrammar(grammar, "barbaz")).toStrictEqual([
-                    true,
-                ]);
-            });
-        });
-        describe("deeply nested: grandparent required, parent optional pass-through, grandchild optional", () => {
-            // The separator check is deferred past the exhausted optional parent
-            // and fires at the grandparent level with "required" mode.
-            const g = `
+            describe("deeply nested: grandparent required, parent optional pass-through, grandchild optional", () => {
+                // The separator check is deferred past the exhausted optional parent
+                // and fires at the grandparent level with "required" mode.
+                const g = `
                 <Inner> [spacing=optional] = bar -> true;
                 <Middle> [spacing=optional] = $(x:<Inner>) -> x;
                 <Start> [spacing=required] = $(x:<Middle>) baz -> x;
             `;
-            const grammar = loadGrammarRules("test.grammar", g);
-            it("matches with space", () => {
-                expect(testMatchGrammar(grammar, "bar baz")).toStrictEqual([
-                    true,
-                ]);
+                const grammar = loadGrammarRules("test.grammar", g);
+                it("matches with space", () => {
+                    expect(testMatchGrammar(grammar, "bar baz")).toStrictEqual([
+                        true,
+                    ]);
+                });
+                it("does not match without space (grandparent required governs)", () => {
+                    expect(testMatchGrammar(grammar, "barbaz")).toStrictEqual(
+                        [],
+                    );
+                });
             });
-            it("does not match without space (grandparent required governs)", () => {
-                expect(testMatchGrammar(grammar, "barbaz")).toStrictEqual([]);
-            });
-        });
-        describe("deeply nested: grandparent auto (default), parent required pass-through, grandchild optional", () => {
-            // auto mode: both "bar" and "baz" are Latin → space is required.
-            const g = `
+            describe("deeply nested: grandparent auto (default), parent required pass-through, grandchild optional", () => {
+                // auto mode: both "bar" and "baz" are Latin → space is required.
+                const g = `
                 <Inner> [spacing=optional] = bar -> true;
                 <Middle> [spacing=required] = $(x:<Inner>) -> x;
                 <Start> = $(x:<Middle>) baz -> x;
             `;
-            const grammar = loadGrammarRules("test.grammar", g);
-            it("matches with space", () => {
-                expect(testMatchGrammar(grammar, "bar baz")).toStrictEqual([
-                    true,
-                ]);
+                const grammar = loadGrammarRules("test.grammar", g);
+                it("matches with space", () => {
+                    expect(testMatchGrammar(grammar, "bar baz")).toStrictEqual([
+                        true,
+                    ]);
+                });
+                it("does not match without space (auto mode: Latin-Latin boundary requires space)", () => {
+                    expect(testMatchGrammar(grammar, "barbaz")).toStrictEqual(
+                        [],
+                    );
+                });
             });
-            it("does not match without space (auto mode: Latin-Latin boundary requires space)", () => {
-                expect(testMatchGrammar(grammar, "barbaz")).toStrictEqual([]);
-            });
-        });
-        describe("deeply nested: grandchild required enforces its own internal separator", () => {
-            // grandchild=required: the string-match isBoundarySatisfied check inside
-            // grandchild rejects "bar" immediately followed by "baz" before
-            // the nested-rule separator logic even runs.
-            const g = `
+            describe("deeply nested: grandchild required enforces its own internal separator", () => {
+                // grandchild=required: the string-match isBoundarySatisfied check inside
+                // grandchild rejects "bar" immediately followed by "baz" before
+                // the nested-rule separator logic even runs.
+                const g = `
                 <Inner> [spacing=required] = bar -> true;
                 <Middle> [spacing=optional] = $(x:<Inner>) -> x;
                 <Start> [spacing=optional] = $(x:<Middle>) baz -> x;
             `;
-            const grammar = loadGrammarRules("test.grammar", g);
-            it("matches with space", () => {
-                expect(testMatchGrammar(grammar, "bar baz")).toStrictEqual([
-                    true,
-                ]);
+                const grammar = loadGrammarRules("test.grammar", g);
+                it("matches with space", () => {
+                    expect(testMatchGrammar(grammar, "bar baz")).toStrictEqual([
+                        true,
+                    ]);
+                });
+                it("does not match without space (grandchild required catches it internally)", () => {
+                    expect(testMatchGrammar(grammar, "barbaz")).toStrictEqual(
+                        [],
+                    );
+                });
             });
-            it("does not match without space (grandchild required catches it internally)", () => {
-                expect(testMatchGrammar(grammar, "barbaz")).toStrictEqual([]);
-            });
-        });
-        describe("4 levels deep: great-grandparent optional, two required pass-through levels, leaf optional", () => {
-            // The fix must skip multiple exhausted ancestors and fire only at
-            // the great-grandparent which has a following part ("baz").
-            const g = `
+            describe("4 levels deep: great-grandparent optional, two required pass-through levels, leaf optional", () => {
+                // The fix must skip multiple exhausted ancestors and fire only at
+                // the great-grandparent which has a following part ("baz").
+                const g = `
                 <Leaf> [spacing=optional] = bar -> true;
                 <LevelA> [spacing=required] = $(x:<Leaf>) -> x;
                 <LevelB> [spacing=required] = $(x:<LevelA>) -> x;
                 <Start> [spacing=optional] = $(x:<LevelB>) baz -> x;
             `;
-            const grammar = loadGrammarRules("test.grammar", g);
-            it("matches with space", () => {
-                expect(testMatchGrammar(grammar, "bar baz")).toStrictEqual([
-                    true,
-                ]);
+                const grammar = loadGrammarRules("test.grammar", g);
+                it("matches with space", () => {
+                    expect(testMatchGrammar(grammar, "bar baz")).toStrictEqual([
+                        true,
+                    ]);
+                });
+                it("matches without space (great-grandparent optional governs after two exhausted pass-through levels)", () => {
+                    expect(testMatchGrammar(grammar, "barbaz")).toStrictEqual([
+                        true,
+                    ]);
+                });
             });
-            it("matches without space (great-grandparent optional governs after two exhausted pass-through levels)", () => {
-                expect(testMatchGrammar(grammar, "barbaz")).toStrictEqual([
-                    true,
-                ]);
-            });
-        });
-        describe("4 levels deep: great-grandparent required, two optional pass-through levels, leaf optional", () => {
-            // The boundary check defers past two exhausted optional ancestors
-            // and fires at the great-grandparent with "required" mode.
-            const g = `
+            describe("4 levels deep: great-grandparent required, two optional pass-through levels, leaf optional", () => {
+                // The boundary check defers past two exhausted optional ancestors
+                // and fires at the great-grandparent with "required" mode.
+                const g = `
                 <Leaf> [spacing=optional] = bar -> true;
                 <LevelA> [spacing=optional] = $(x:<Leaf>) -> x;
                 <LevelB> [spacing=optional] = $(x:<LevelA>) -> x;
                 <Start> [spacing=required] = $(x:<LevelB>) baz -> x;
             `;
-            const grammar = loadGrammarRules("test.grammar", g);
-            it("matches with space", () => {
-                expect(testMatchGrammar(grammar, "bar baz")).toStrictEqual([
-                    true,
-                ]);
-            });
-            it("does not match without space (great-grandparent required governs)", () => {
-                expect(testMatchGrammar(grammar, "barbaz")).toStrictEqual([]);
+                const grammar = loadGrammarRules("test.grammar", g);
+                it("matches with space", () => {
+                    expect(testMatchGrammar(grammar, "bar baz")).toStrictEqual([
+                        true,
+                    ]);
+                });
+                it("does not match without space (great-grandparent required governs)", () => {
+                    expect(testMatchGrammar(grammar, "barbaz")).toStrictEqual(
+                        [],
+                    );
+                });
             });
         });
-    });
 
-    describe("separator BEFORE a nested rule reference uses ancestor mode", () => {
-        // Symmetric to the "after" tests: when a pass-through chain (A->X) ends
-        // and the next sibling part in the ancestor is another nested rule (B),
-        // the inter-rule separator is governed by the common ancestor's
-        // spacingMode — not by any intermediate exhausted rule's mode.
-        describe("grandparent optional, pass-through chain before sibling rule", () => {
-            // Start(optional): [A(required)->X(optional) "foo"] then [B(optional) "bar"]
-            // The separator between "foo" and "bar" uses Start's "optional" mode.
-            const g = `
+        describe("separator BEFORE a nested rule reference uses ancestor mode", () => {
+            // Symmetric to the "after" tests: when a pass-through chain (A->X) ends
+            // and the next sibling part in the ancestor is another nested rule (B),
+            // the inter-rule separator is governed by the common ancestor's
+            // spacingMode — not by any intermediate exhausted rule's mode.
+            describe("grandparent optional, pass-through chain before sibling rule", () => {
+                // Start(optional): [A(required)->X(optional) "foo"] then [B(optional) "bar"]
+                // The separator between "foo" and "bar" uses Start's "optional" mode.
+                const g = `
                 <X> [spacing=optional] = foo -> "x";
                 <A> [spacing=required] = $(x:<X>) -> x;
                 <B> [spacing=optional] = bar -> "b";
                 <Start> [spacing=optional] = $(a:<A>) $(b:<B>) -> [a, b];
             `;
-            const grammar = loadGrammarRules("test.grammar", g);
-            it("matches with space", () => {
-                expect(testMatchGrammar(grammar, "foo bar")).toStrictEqual([
-                    ["x", "b"],
-                ]);
+                const grammar = loadGrammarRules("test.grammar", g);
+                it("matches with space", () => {
+                    expect(testMatchGrammar(grammar, "foo bar")).toStrictEqual([
+                        ["x", "b"],
+                    ]);
+                });
+                it("matches without space (Start optional governs the inter-rule boundary)", () => {
+                    expect(testMatchGrammar(grammar, "foobar")).toStrictEqual([
+                        ["x", "b"],
+                    ]);
+                });
             });
-            it("matches without space (Start optional governs the inter-rule boundary)", () => {
-                expect(testMatchGrammar(grammar, "foobar")).toStrictEqual([
-                    ["x", "b"],
-                ]);
-            });
-        });
-        describe("grandparent required, pass-through chain before sibling rule", () => {
-            // Start(required): [A(optional)->X(optional) "foo"] then [B(optional) "bar"]
-            // The separator uses Start's "required" mode regardless of A and X being optional.
-            const g = `
+            describe("grandparent required, pass-through chain before sibling rule", () => {
+                // Start(required): [A(optional)->X(optional) "foo"] then [B(optional) "bar"]
+                // The separator uses Start's "required" mode regardless of A and X being optional.
+                const g = `
                 <X> [spacing=optional] = foo -> "x";
                 <A> [spacing=optional] = $(x:<X>) -> x;
                 <B> [spacing=optional] = bar -> "b";
                 <Start> [spacing=required] = $(a:<A>) $(b:<B>) -> [a, b];
             `;
-            const grammar = loadGrammarRules("test.grammar", g);
-            it("matches with space", () => {
-                expect(testMatchGrammar(grammar, "foo bar")).toStrictEqual([
-                    ["x", "b"],
-                ]);
+                const grammar = loadGrammarRules("test.grammar", g);
+                it("matches with space", () => {
+                    expect(testMatchGrammar(grammar, "foo bar")).toStrictEqual([
+                        ["x", "b"],
+                    ]);
+                });
+                it("does not match without space (Start required governs)", () => {
+                    expect(testMatchGrammar(grammar, "foobar")).toStrictEqual(
+                        [],
+                    );
+                });
             });
-            it("does not match without space (Start required governs)", () => {
-                expect(testMatchGrammar(grammar, "foobar")).toStrictEqual([]);
-            });
-        });
-        describe("4 levels deep, great-grandparent optional, pass-through chain before sibling rule", () => {
-            // Start(optional): [A(required)->B(required)->X(optional) "foo"] then [C(optional) "bar"]
-            // Two exhausted required pass-through levels; Start's optional mode governs.
-            const g = `
+            describe("4 levels deep, great-grandparent optional, pass-through chain before sibling rule", () => {
+                // Start(optional): [A(required)->B(required)->X(optional) "foo"] then [C(optional) "bar"]
+                // Two exhausted required pass-through levels; Start's optional mode governs.
+                const g = `
                 <X> [spacing=optional] = foo -> "x";
                 <B> [spacing=required] = $(x:<X>) -> x;
                 <A> [spacing=required] = $(b:<B>) -> b;
                 <C> [spacing=optional] = bar -> "c";
                 <Start> [spacing=optional] = $(a:<A>) $(c:<C>) -> [a, c];
             `;
-            const grammar = loadGrammarRules("test.grammar", g);
-            it("matches with space", () => {
-                expect(testMatchGrammar(grammar, "foo bar")).toStrictEqual([
-                    ["x", "c"],
-                ]);
+                const grammar = loadGrammarRules("test.grammar", g);
+                it("matches with space", () => {
+                    expect(testMatchGrammar(grammar, "foo bar")).toStrictEqual([
+                        ["x", "c"],
+                    ]);
+                });
+                it("matches without space (Start optional governs after two exhausted pass-through levels)", () => {
+                    expect(testMatchGrammar(grammar, "foobar")).toStrictEqual([
+                        ["x", "c"],
+                    ]);
+                });
             });
-            it("matches without space (Start optional governs after two exhausted pass-through levels)", () => {
-                expect(testMatchGrammar(grammar, "foobar")).toStrictEqual([
-                    ["x", "c"],
-                ]);
-            });
-        });
-        describe("4 levels deep, great-grandparent required, pass-through chain before sibling rule", () => {
-            // Start(required): [A(optional)->B(optional)->X(optional) "foo"] then [C(optional) "bar"]
-            // Start's required mode governs even though all intermediates are optional.
-            const g = `
+            describe("4 levels deep, great-grandparent required, pass-through chain before sibling rule", () => {
+                // Start(required): [A(optional)->B(optional)->X(optional) "foo"] then [C(optional) "bar"]
+                // Start's required mode governs even though all intermediates are optional.
+                const g = `
                 <X> [spacing=optional] = foo -> "x";
                 <B> [spacing=optional] = $(x:<X>) -> x;
                 <A> [spacing=optional] = $(b:<B>) -> b;
                 <C> [spacing=optional] = bar -> "c";
                 <Start> [spacing=required] = $(a:<A>) $(c:<C>) -> [a, c];
             `;
-            const grammar = loadGrammarRules("test.grammar", g);
-            it("matches with space", () => {
-                expect(testMatchGrammar(grammar, "foo bar")).toStrictEqual([
-                    ["x", "c"],
-                ]);
-            });
-            it("does not match without space (Start required governs)", () => {
-                expect(testMatchGrammar(grammar, "foobar")).toStrictEqual([]);
+                const grammar = loadGrammarRules("test.grammar", g);
+                it("matches with space", () => {
+                    expect(testMatchGrammar(grammar, "foo bar")).toStrictEqual([
+                        ["x", "c"],
+                    ]);
+                });
+                it("does not match without space (Start required governs)", () => {
+                    expect(testMatchGrammar(grammar, "foobar")).toStrictEqual(
+                        [],
+                    );
+                });
             });
         });
-    });
-});
+    },
+);

--- a/ts/packages/actionGrammar/test/grammarMatcherSpacingNone.spec.ts
+++ b/ts/packages/actionGrammar/test/grammarMatcherSpacingNone.spec.ts
@@ -2,461 +2,523 @@
 // Licensed under the MIT License.
 
 import { loadGrammarRules } from "../src/grammarLoader.js";
-import { testMatchGrammar } from "./testUtils.js";
+import { describeForEachMatcher, expectMatchResults } from "./testUtils.js";
 
-describe("Grammar Matcher - Spacing None Mode", () => {
-    describe("spacing=none annotation", () => {
-        const g = `<Start> [spacing=none] = hello world -> true;`;
-        const grammar = loadGrammarRules("test.grammar", g);
-        it("matches without space (tokens must be adjacent)", () => {
-            expect(testMatchGrammar(grammar, "helloworld")).toStrictEqual([
-                true,
-            ]);
+describeForEachMatcher(
+    "Grammar Matcher - Spacing None Mode",
+    (testMatchGrammar, variant) => {
+        describe("spacing=none annotation", () => {
+            const g = `<Start> [spacing=none] = hello world -> true;`;
+            const grammar = loadGrammarRules("test.grammar", g);
+            it("matches without space (tokens must be adjacent)", () => {
+                expect(testMatchGrammar(grammar, "helloworld")).toStrictEqual([
+                    true,
+                ]);
+            });
+            it("does not match with space (flex-space must be zero-width)", () => {
+                expect(testMatchGrammar(grammar, "hello world")).toStrictEqual(
+                    [],
+                );
+            });
         });
-        it("does not match with space (flex-space must be zero-width)", () => {
-            expect(testMatchGrammar(grammar, "hello world")).toStrictEqual([]);
-        });
-    });
 
-    describe("spacing=none with escaped space in literal", () => {
-        // An escaped space is a literal character, part of the segment text.
-        // It must be matched exactly and must not be confused with a
-        // flex-space position.
-        const g = `<Start> [spacing=none] = hello\\ world -> true;`;
-        const grammar = loadGrammarRules("test.grammar", g);
-        it("matches when the literal space is present", () => {
-            expect(testMatchGrammar(grammar, "hello world")).toStrictEqual([
-                true,
-            ]);
+        describe("spacing=none with escaped space in literal", () => {
+            // An escaped space is a literal character, part of the segment text.
+            // It must be matched exactly and must not be confused with a
+            // flex-space position.
+            const g = `<Start> [spacing=none] = hello\\ world -> true;`;
+            const grammar = loadGrammarRules("test.grammar", g);
+            it("matches when the literal space is present", () => {
+                expect(testMatchGrammar(grammar, "hello world")).toStrictEqual([
+                    true,
+                ]);
+            });
+            it("does not match without the literal space", () => {
+                expect(testMatchGrammar(grammar, "helloworld")).toStrictEqual(
+                    [],
+                );
+            });
+            it("does not match with extra space", () => {
+                // "hello  world" has two spaces; only one is in the literal.
+                expect(testMatchGrammar(grammar, "hello  world")).toStrictEqual(
+                    [],
+                );
+            });
         });
-        it("does not match without the literal space", () => {
-            expect(testMatchGrammar(grammar, "helloworld")).toStrictEqual([]);
-        });
-        it("does not match with extra space", () => {
-            // "hello  world" has two spaces; only one is in the literal.
-            expect(testMatchGrammar(grammar, "hello  world")).toStrictEqual([]);
-        });
-    });
 
-    describe("spacing=none with escaped space at boundary", () => {
-        // Literal trailing space must not cause the boundary check to reject
-        // the match when the next character in the input is non-separator.
-        const g = `<Start> [spacing=none] = hello\\  -> true;`;
-        const grammar = loadGrammarRules("test.grammar", g);
-        it("matches input with trailing space", () => {
-            expect(testMatchGrammar(grammar, "hello ")).toStrictEqual([true]);
+        describe("spacing=none with escaped space at boundary", () => {
+            // Literal trailing space must not cause the boundary check to reject
+            // the match when the next character in the input is non-separator.
+            const g = `<Start> [spacing=none] = hello\\  -> true;`;
+            const grammar = loadGrammarRules("test.grammar", g);
+            it("matches input with trailing space", () => {
+                expect(testMatchGrammar(grammar, "hello ")).toStrictEqual([
+                    true,
+                ]);
+            });
         });
-    });
 
-    describe("spacing=none in per-rule mode switching", () => {
-        const g = `
+        describe("spacing=none in per-rule mode switching", () => {
+            const g = `
             <NoneRule> [spacing=none] = hello world -> "none";
             <OptionalRule> [spacing=optional] = hello world -> "optional";
             <Start> = $(x:<NoneRule>) -> x | $(x:<OptionalRule>) -> x;
         `;
-        const grammar = loadGrammarRules("test.grammar", g);
-        it("both match when tokens are adjacent", () => {
-            expect(testMatchGrammar(grammar, "helloworld")).toStrictEqual([
-                "none",
-                "optional",
-            ]);
+            const grammar = loadGrammarRules("test.grammar", g);
+            it("both match when tokens are adjacent", () => {
+                expectMatchResults(
+                    testMatchGrammar(grammar, "helloworld"),
+                    ["none", "optional"],
+                    variant,
+                );
+            });
+            it("only optional matches with space", () => {
+                expect(testMatchGrammar(grammar, "hello world")).toStrictEqual([
+                    "optional",
+                ]);
+            });
         });
-        it("only optional matches with space", () => {
-            expect(testMatchGrammar(grammar, "hello world")).toStrictEqual([
-                "optional",
-            ]);
-        });
-    });
 
-    // ---- spacing=none between different part types ----
+        // ---- spacing=none between different part types ----
 
-    describe("spacing=none: string → number variable", () => {
-        const g = `<Start> [spacing=none] = hello $(n:number) -> n;`;
-        const grammar = loadGrammarRules("test.grammar", g);
-        it("matches when number is adjacent to string", () => {
-            expect(testMatchGrammar(grammar, "hello42")).toStrictEqual([42]);
+        describe("spacing=none: string → number variable", () => {
+            const g = `<Start> [spacing=none] = hello $(n:number) -> n;`;
+            const grammar = loadGrammarRules("test.grammar", g);
+            it("matches when number is adjacent to string", () => {
+                expect(testMatchGrammar(grammar, "hello42")).toStrictEqual([
+                    42,
+                ]);
+            });
+            it("does not match when space separates string and number", () => {
+                expect(testMatchGrammar(grammar, "hello 42")).toStrictEqual([]);
+            });
         });
-        it("does not match when space separates string and number", () => {
-            expect(testMatchGrammar(grammar, "hello 42")).toStrictEqual([]);
-        });
-    });
 
-    describe("spacing=none: number variable → string", () => {
-        const g = `<Start> [spacing=none] = $(n:number) world -> n;`;
-        const grammar = loadGrammarRules("test.grammar", g);
-        it("matches when string is adjacent to number", () => {
-            expect(testMatchGrammar(grammar, "42world")).toStrictEqual([42]);
+        describe("spacing=none: number variable → string", () => {
+            const g = `<Start> [spacing=none] = $(n:number) world -> n;`;
+            const grammar = loadGrammarRules("test.grammar", g);
+            it("matches when string is adjacent to number", () => {
+                expect(testMatchGrammar(grammar, "42world")).toStrictEqual([
+                    42,
+                ]);
+            });
+            it("does not match when space separates number and string", () => {
+                expect(testMatchGrammar(grammar, "42 world")).toStrictEqual([]);
+            });
         });
-        it("does not match when space separates number and string", () => {
-            expect(testMatchGrammar(grammar, "42 world")).toStrictEqual([]);
-        });
-    });
 
-    describe("spacing=none: string → wildcard → string", () => {
-        const g = `<Start> [spacing=none] = hello $(x) world -> x;`;
-        const grammar = loadGrammarRules("test.grammar", g);
-        it("matches when all parts are adjacent", () => {
-            expect(testMatchGrammar(grammar, "hellofooworld")).toStrictEqual([
-                "foo",
-            ]);
+        describe("spacing=none: string → wildcard → string", () => {
+            const g = `<Start> [spacing=none] = hello $(x) world -> x;`;
+            const grammar = loadGrammarRules("test.grammar", g);
+            it("matches when all parts are adjacent", () => {
+                expect(
+                    testMatchGrammar(grammar, "hellofooworld"),
+                ).toStrictEqual(["foo"]);
+            });
+            it("captures separators in wildcard value", () => {
+                expect(
+                    testMatchGrammar(grammar, "hello foo world"),
+                ).toStrictEqual([" foo "]);
+            });
         });
-        it("captures separators in wildcard value", () => {
-            expect(testMatchGrammar(grammar, "hello foo world")).toStrictEqual([
-                " foo ",
-            ]);
-        });
-    });
 
-    describe("spacing=none: string → rule reference", () => {
-        const g = `
+        describe("spacing=none: string → rule reference", () => {
+            const g = `
             <Other> [spacing=none] = world -> "world";
             <Start> [spacing=none] = hello $(x:<Other>) -> x;
         `;
-        const grammar = loadGrammarRules("test.grammar", g);
-        it("matches when nested rule is adjacent", () => {
-            expect(testMatchGrammar(grammar, "helloworld")).toStrictEqual([
-                "world",
-            ]);
+            const grammar = loadGrammarRules("test.grammar", g);
+            it("matches when nested rule is adjacent", () => {
+                expect(testMatchGrammar(grammar, "helloworld")).toStrictEqual([
+                    "world",
+                ]);
+            });
+            it("does not match when space separates string and rule", () => {
+                expect(testMatchGrammar(grammar, "hello world")).toStrictEqual(
+                    [],
+                );
+            });
         });
-        it("does not match when space separates string and rule", () => {
-            expect(testMatchGrammar(grammar, "hello world")).toStrictEqual([]);
-        });
-    });
 
-    describe("spacing=none: group expressions", () => {
-        const g = `<Start> [spacing=none] = (hello | hi) world -> true;`;
-        const grammar = loadGrammarRules("test.grammar", g);
-        it("matches when group and following token are adjacent", () => {
-            expect(testMatchGrammar(grammar, "helloworld")).toStrictEqual([
-                true,
-            ]);
-            expect(testMatchGrammar(grammar, "hiworld")).toStrictEqual([true]);
+        describe("spacing=none: group expressions", () => {
+            const g = `<Start> [spacing=none] = (hello | hi) world -> true;`;
+            const grammar = loadGrammarRules("test.grammar", g);
+            it("matches when group and following token are adjacent", () => {
+                expect(testMatchGrammar(grammar, "helloworld")).toStrictEqual([
+                    true,
+                ]);
+                expect(testMatchGrammar(grammar, "hiworld")).toStrictEqual([
+                    true,
+                ]);
+            });
+            it("does not match when space follows group", () => {
+                expect(testMatchGrammar(grammar, "hello world")).toStrictEqual(
+                    [],
+                );
+                expect(testMatchGrammar(grammar, "hi world")).toStrictEqual([]);
+            });
         });
-        it("does not match when space follows group", () => {
-            expect(testMatchGrammar(grammar, "hello world")).toStrictEqual([]);
-            expect(testMatchGrammar(grammar, "hi world")).toStrictEqual([]);
-        });
-    });
 
-    describe("spacing=none: escaped space mixed with flex-space", () => {
-        // Grammar: "hello\ " followed by flex-space followed by "world"
-        // The escaped space is a literal; the whitespace between the two
-        // quoted-like segments is a flex-space that must be zero-width.
-        const g = `<Start> [spacing=none] = hello\\  world -> true;`;
-        const grammar = loadGrammarRules("test.grammar", g);
-        it("matches when literal space is present and no flex-space", () => {
-            expect(testMatchGrammar(grammar, "hello world")).toStrictEqual([
-                true,
-            ]);
+        describe("spacing=none: escaped space mixed with flex-space", () => {
+            // Grammar: "hello\ " followed by flex-space followed by "world"
+            // The escaped space is a literal; the whitespace between the two
+            // quoted-like segments is a flex-space that must be zero-width.
+            const g = `<Start> [spacing=none] = hello\\  world -> true;`;
+            const grammar = loadGrammarRules("test.grammar", g);
+            it("matches when literal space is present and no flex-space", () => {
+                expect(testMatchGrammar(grammar, "hello world")).toStrictEqual([
+                    true,
+                ]);
+            });
+            it("does not match with extra space (flex-space consumed)", () => {
+                expect(testMatchGrammar(grammar, "hello  world")).toStrictEqual(
+                    [],
+                );
+            });
+            it("does not match without literal space", () => {
+                expect(testMatchGrammar(grammar, "helloworld")).toStrictEqual(
+                    [],
+                );
+            });
         });
-        it("does not match with extra space (flex-space consumed)", () => {
-            expect(testMatchGrammar(grammar, "hello  world")).toStrictEqual([]);
-        });
-        it("does not match without literal space", () => {
-            expect(testMatchGrammar(grammar, "helloworld")).toStrictEqual([]);
-        });
-    });
 
-    describe("spacing=none: string → number → string", () => {
-        const g = `<Start> [spacing=none] = item $(n:number) done -> n;`;
-        const grammar = loadGrammarRules("test.grammar", g);
-        it("matches when all parts are adjacent", () => {
-            expect(testMatchGrammar(grammar, "item7done")).toStrictEqual([7]);
+        describe("spacing=none: string → number → string", () => {
+            const g = `<Start> [spacing=none] = item $(n:number) done -> n;`;
+            const grammar = loadGrammarRules("test.grammar", g);
+            it("matches when all parts are adjacent", () => {
+                expect(testMatchGrammar(grammar, "item7done")).toStrictEqual([
+                    7,
+                ]);
+            });
+            it("does not match with any spaces", () => {
+                expect(testMatchGrammar(grammar, "item 7 done")).toStrictEqual(
+                    [],
+                );
+                expect(testMatchGrammar(grammar, "item7 done")).toStrictEqual(
+                    [],
+                );
+                expect(testMatchGrammar(grammar, "item 7done")).toStrictEqual(
+                    [],
+                );
+            });
         });
-        it("does not match with any spaces", () => {
-            expect(testMatchGrammar(grammar, "item 7 done")).toStrictEqual([]);
-            expect(testMatchGrammar(grammar, "item7 done")).toStrictEqual([]);
-            expect(testMatchGrammar(grammar, "item 7done")).toStrictEqual([]);
-        });
-    });
 
-    describe("spacing=none rejects punctuation separators", () => {
-        const g = `<Start> [spacing=none] = hello world -> true;`;
-        const grammar = loadGrammarRules("test.grammar", g);
-        it("does not match with comma separator", () => {
-            expect(testMatchGrammar(grammar, "hello,world")).toStrictEqual([]);
+        describe("spacing=none rejects punctuation separators", () => {
+            const g = `<Start> [spacing=none] = hello world -> true;`;
+            const grammar = loadGrammarRules("test.grammar", g);
+            it("does not match with comma separator", () => {
+                expect(testMatchGrammar(grammar, "hello,world")).toStrictEqual(
+                    [],
+                );
+            });
+            it("does not match with period separator", () => {
+                expect(testMatchGrammar(grammar, "hello.world")).toStrictEqual(
+                    [],
+                );
+            });
         });
-        it("does not match with period separator", () => {
-            expect(testMatchGrammar(grammar, "hello.world")).toStrictEqual([]);
-        });
-    });
 
-    describe("repeat group ()+ with none mode", () => {
-        const g = `<Start> [spacing=none] = hello (world)+ -> true;`;
-        const grammar = loadGrammarRules("test.grammar", g);
-        it("matches one repetition without space", () => {
-            expect(testMatchGrammar(grammar, "helloworld")).toStrictEqual([
-                true,
-            ]);
+        describe("repeat group ()+ with none mode", () => {
+            const g = `<Start> [spacing=none] = hello (world)+ -> true;`;
+            const grammar = loadGrammarRules("test.grammar", g);
+            it("matches one repetition without space", () => {
+                expect(testMatchGrammar(grammar, "helloworld")).toStrictEqual([
+                    true,
+                ]);
+            });
+            it("matches two repetitions without space", () => {
+                expect(
+                    testMatchGrammar(grammar, "helloworldworld"),
+                ).toStrictEqual([true]);
+            });
+            it("does not match with space before group", () => {
+                expect(testMatchGrammar(grammar, "hello world")).toStrictEqual(
+                    [],
+                );
+            });
+            it("does not match with space between repetitions", () => {
+                expect(
+                    testMatchGrammar(grammar, "helloworld world"),
+                ).toStrictEqual([]);
+            });
         });
-        it("matches two repetitions without space", () => {
-            expect(testMatchGrammar(grammar, "helloworldworld")).toStrictEqual([
-                true,
-            ]);
-        });
-        it("does not match with space before group", () => {
-            expect(testMatchGrammar(grammar, "hello world")).toStrictEqual([]);
-        });
-        it("does not match with space between repetitions", () => {
-            expect(testMatchGrammar(grammar, "helloworld world")).toStrictEqual(
-                [],
-            );
-        });
-    });
 
-    describe("repeat group ()* with none mode", () => {
-        const g = `<Start> [spacing=none] = hello (world)* -> true;`;
-        const grammar = loadGrammarRules("test.grammar", g);
-        it("matches zero repetitions", () => {
-            expect(testMatchGrammar(grammar, "hello")).toStrictEqual([true]);
+        describe("repeat group ()* with none mode", () => {
+            const g = `<Start> [spacing=none] = hello (world)* -> true;`;
+            const grammar = loadGrammarRules("test.grammar", g);
+            it("matches zero repetitions", () => {
+                expect(testMatchGrammar(grammar, "hello")).toStrictEqual([
+                    true,
+                ]);
+            });
+            it("matches one repetition without space", () => {
+                expect(testMatchGrammar(grammar, "helloworld")).toStrictEqual([
+                    true,
+                ]);
+            });
+            it("does not match with space before group", () => {
+                expect(testMatchGrammar(grammar, "hello world")).toStrictEqual(
+                    [],
+                );
+            });
         });
-        it("matches one repetition without space", () => {
-            expect(testMatchGrammar(grammar, "helloworld")).toStrictEqual([
-                true,
-            ]);
-        });
-        it("does not match with space before group", () => {
-            expect(testMatchGrammar(grammar, "hello world")).toStrictEqual([]);
-        });
-    });
 
-    describe("spacing=none: optional part", () => {
-        const g = `<Start> [spacing=none] = hello $(x)? world -> x;`;
-        const grammar = loadGrammarRules("test.grammar", g);
-        it("matches when optional part is absent", () => {
-            expect(testMatchGrammar(grammar, "helloworld")).toStrictEqual([
-                undefined,
-            ]);
+        describe("spacing=none: optional part", () => {
+            const g = `<Start> [spacing=none] = hello $(x)? world -> x;`;
+            const grammar = loadGrammarRules("test.grammar", g);
+            it("matches when optional part is absent", () => {
+                expect(testMatchGrammar(grammar, "helloworld")).toStrictEqual([
+                    undefined,
+                ]);
+            });
+            it("matches when optional part is present and adjacent", () => {
+                expect(
+                    testMatchGrammar(grammar, "hellofooworld"),
+                ).toStrictEqual(["foo"]);
+            });
+            it("captures separators in optional wildcard value", () => {
+                expect(
+                    testMatchGrammar(grammar, "hello foo world"),
+                ).toStrictEqual([" foo "]);
+            });
         });
-        it("matches when optional part is present and adjacent", () => {
-            expect(testMatchGrammar(grammar, "hellofooworld")).toStrictEqual([
-                "foo",
-            ]);
-        });
-        it("captures separators in optional wildcard value", () => {
-            expect(testMatchGrammar(grammar, "hello foo world")).toStrictEqual([
-                " foo ",
-            ]);
-        });
-    });
 
-    describe("spacing=none: optional group expression", () => {
-        const g = `<Start> [spacing=none] = (please)? help -> true;`;
-        const grammar = loadGrammarRules("test.grammar", g);
-        it("matches when optional group is present and adjacent", () => {
-            expect(testMatchGrammar(grammar, "pleasehelp")).toStrictEqual([
-                true,
-            ]);
+        describe("spacing=none: optional group expression", () => {
+            const g = `<Start> [spacing=none] = (please)? help -> true;`;
+            const grammar = loadGrammarRules("test.grammar", g);
+            it("matches when optional group is present and adjacent", () => {
+                expect(testMatchGrammar(grammar, "pleasehelp")).toStrictEqual([
+                    true,
+                ]);
+            });
+            it("matches when optional group is absent", () => {
+                expect(testMatchGrammar(grammar, "help")).toStrictEqual([true]);
+            });
+            it("does not match when space separates group and following token", () => {
+                expect(testMatchGrammar(grammar, "please help")).toStrictEqual(
+                    [],
+                );
+            });
         });
-        it("matches when optional group is absent", () => {
-            expect(testMatchGrammar(grammar, "help")).toStrictEqual([true]);
-        });
-        it("does not match when space separates group and following token", () => {
-            expect(testMatchGrammar(grammar, "please help")).toStrictEqual([]);
-        });
-    });
 
-    describe("separator AFTER nested rule with none parent mode", () => {
-        const g = `
+        describe("separator AFTER nested rule with none parent mode", () => {
+            const g = `
             <Inner> [spacing=none] = hello world -> true;
             <Start> [spacing=none] = $(x:<Inner>) end -> x;
         `;
-        const grammar = loadGrammarRules("test.grammar", g);
-        it("matches when all parts are adjacent", () => {
-            expect(testMatchGrammar(grammar, "helloworldend")).toStrictEqual([
-                true,
-            ]);
+            const grammar = loadGrammarRules("test.grammar", g);
+            it("matches when all parts are adjacent", () => {
+                expect(
+                    testMatchGrammar(grammar, "helloworldend"),
+                ).toStrictEqual([true]);
+            });
+            it("does not match with space after nested rule", () => {
+                expect(
+                    testMatchGrammar(grammar, "helloworld end"),
+                ).toStrictEqual([]);
+            });
         });
-        it("does not match with space after nested rule", () => {
-            expect(testMatchGrammar(grammar, "helloworld end")).toStrictEqual(
-                [],
-            );
-        });
-    });
 
-    describe("merged rules with none mode", () => {
-        const g = `
+        describe("merged rules with none mode", () => {
+            const g = `
             <Start> [spacing=none] = hello world -> "none";
             <Start> [spacing=required] = hello world -> "required";
         `;
-        const grammar = loadGrammarRules("test.grammar", g);
-        it("only none matches when adjacent", () => {
-            expect(testMatchGrammar(grammar, "helloworld")).toStrictEqual([
-                "none",
-            ]);
-        });
-        it("only required matches with space", () => {
-            expect(testMatchGrammar(grammar, "hello world")).toStrictEqual([
-                "required",
-            ]);
-        });
-    });
-
-    describe("spacing=none: trailing wildcard (end of rule)", () => {
-        const g = `<Start> [spacing=none] = hello $(x) -> x;`;
-        const grammar = loadGrammarRules("test.grammar", g);
-        it("captures trailing text without trimming", () => {
-            expect(testMatchGrammar(grammar, "helloworld")).toStrictEqual([
-                "world",
-            ]);
-        });
-        it("captures trailing text with spaces as part of value", () => {
-            // In "none" mode wildcards do not trim leading/trailing
-            // separators because there are no flex-space positions to trim
-            // at.  The space before "world" is part of the wildcard value.
-            expect(testMatchGrammar(grammar, "hello world")).toStrictEqual([
-                " world",
-            ]);
-        });
-        it("does not match when wildcard would be empty", () => {
-            expect(testMatchGrammar(grammar, "hello")).toStrictEqual([]);
-        });
-    });
-
-    describe("spacing=none: empty wildcard rejection", () => {
-        const g = `<Start> [spacing=none] = hello $(x) world -> x;`;
-        const grammar = loadGrammarRules("test.grammar", g);
-        it("rejects when wildcard captures empty string", () => {
-            // "helloworld" means the wildcard between hello and world is empty
-            expect(testMatchGrammar(grammar, "helloworld")).toStrictEqual([]);
-        });
-    });
-
-    describe("spacing=none: wildcard before number variable", () => {
-        const g = `<Start> [spacing=none] = $(x) $(n:number) -> n;`;
-        const grammar = loadGrammarRules("test.grammar", g);
-        it("matches wildcard followed by number", () => {
-            expect(testMatchGrammar(grammar, "abc42")).toStrictEqual([42]);
-        });
-        it("captures wildcard value correctly", () => {
-            const gVal = `<Start> [spacing=none] = $(x) $(n:number) -> x;`;
-            const grammar2 = loadGrammarRules("test.grammar", gVal);
-            expect(testMatchGrammar(grammar2, "abc42")).toStrictEqual(["abc"]);
-        });
-    });
-
-    describe("spacing=none: negative and special number formats", () => {
-        const g = `<Start> [spacing=none] = item $(n:number) done -> n;`;
-        const grammar = loadGrammarRules("test.grammar", g);
-        it("matches negative integer", () => {
-            expect(testMatchGrammar(grammar, "item-42done")).toStrictEqual([
-                -42,
-            ]);
-        });
-        it("matches hex number", () => {
-            // Use suffix starting with non-hex char to avoid greedy capture
-            // TODO: Review the case item0xFFdone and see if we should make that work.
-            const gHex = `<Start> [spacing=none] = item $(n:number) stop -> n;`;
-            const grammarHex = loadGrammarRules("test.grammar", gHex);
-            expect(testMatchGrammar(grammarHex, "item0xFFstop")).toStrictEqual([
-                0xff,
-            ]);
-        });
-        it("matches octal number", () => {
-            expect(testMatchGrammar(grammar, "item0o77done")).toStrictEqual([
-                0o77,
-            ]);
-        });
-        it("matches binary number", () => {
-            expect(testMatchGrammar(grammar, "item0b101done")).toStrictEqual([
-                0b101,
-            ]);
-        });
-        it("matches float number", () => {
-            expect(testMatchGrammar(grammar, "item3.14done")).toStrictEqual([
-                3.14,
-            ]);
-        });
-    });
-
-    describe("spacing=none: rule-level alternatives", () => {
-        const g = `<Start> [spacing=none] = hello world -> 1 | foo bar -> 2;`;
-        const grammar = loadGrammarRules("test.grammar", g);
-        it("matches first alternative when adjacent", () => {
-            expect(testMatchGrammar(grammar, "helloworld")).toStrictEqual([1]);
-        });
-        it("matches second alternative when adjacent", () => {
-            expect(testMatchGrammar(grammar, "foobar")).toStrictEqual([2]);
-        });
-        it("does not match first alternative with space", () => {
-            expect(testMatchGrammar(grammar, "hello world")).toStrictEqual([]);
-        });
-        it("does not match second alternative with space", () => {
-            expect(testMatchGrammar(grammar, "foo bar")).toStrictEqual([]);
-        });
-    });
-
-    describe("spacing=none: case insensitivity", () => {
-        const g = `<Start> [spacing=none] = hello world -> true;`;
-        const grammar = loadGrammarRules("test.grammar", g);
-        it("matches mixed case without space", () => {
-            expect(testMatchGrammar(grammar, "HelloWorld")).toStrictEqual([
-                true,
-            ]);
-        });
-        it("matches all caps without space", () => {
-            expect(testMatchGrammar(grammar, "HELLOWORLD")).toStrictEqual([
-                true,
-            ]);
-        });
-        it("does not match mixed case with space", () => {
-            expect(testMatchGrammar(grammar, "Hello World")).toStrictEqual([]);
-        });
-    });
-
-    describe("spacing=none: leading/trailing whitespace in input", () => {
-        const g = `<Start> [spacing=none] = hello world -> true;`;
-        const grammar = loadGrammarRules("test.grammar", g);
-        it("does not match with leading whitespace", () => {
-            // In none mode, no leading separator is consumed
-            expect(testMatchGrammar(grammar, "  helloworld")).toStrictEqual([]);
-        });
-        it("matches with trailing whitespace", () => {
-            expect(testMatchGrammar(grammar, "helloworld  ")).toStrictEqual([
-                true,
-            ]);
-        });
-        it("does not match with both leading and trailing whitespace", () => {
-            expect(testMatchGrammar(grammar, "  helloworld  ")).toStrictEqual(
-                [],
-            );
-        });
-    });
-
-    describe("spacing=none vs other modes: leading whitespace", () => {
-        // Counter-test: other modes still consume leading whitespace
-        // even though none mode rejects it.
-        it("auto mode accepts leading whitespace", () => {
-            const g = `<Start> = hello world -> true;`;
             const grammar = loadGrammarRules("test.grammar", g);
-            expect(testMatchGrammar(grammar, "  hello world")).toStrictEqual([
-                true,
-            ]);
+            it("only none matches when adjacent", () => {
+                expect(testMatchGrammar(grammar, "helloworld")).toStrictEqual([
+                    "none",
+                ]);
+            });
+            it("only required matches with space", () => {
+                expect(testMatchGrammar(grammar, "hello world")).toStrictEqual([
+                    "required",
+                ]);
+            });
         });
-        it("required mode accepts leading whitespace", () => {
-            const g = `<Start> [spacing=required] = hello world -> true;`;
-            const grammar = loadGrammarRules("test.grammar", g);
-            expect(testMatchGrammar(grammar, "  hello world")).toStrictEqual([
-                true,
-            ]);
-        });
-        it("optional mode accepts leading whitespace", () => {
-            const g = `<Start> [spacing=optional] = hello world -> true;`;
-            const grammar = loadGrammarRules("test.grammar", g);
-            expect(testMatchGrammar(grammar, "  helloworld")).toStrictEqual([
-                true,
-            ]);
-        });
-    });
 
-    describe("spacing=none: CJK characters", () => {
-        const g = `<Start> [spacing=none] = 你好 世界 -> true;`;
-        const grammar = loadGrammarRules("test.grammar", g);
-        it("matches when CJK tokens are adjacent", () => {
-            expect(testMatchGrammar(grammar, "你好世界")).toStrictEqual([true]);
+        describe("spacing=none: trailing wildcard (end of rule)", () => {
+            const g = `<Start> [spacing=none] = hello $(x) -> x;`;
+            const grammar = loadGrammarRules("test.grammar", g);
+            it("captures trailing text without trimming", () => {
+                expect(testMatchGrammar(grammar, "helloworld")).toStrictEqual([
+                    "world",
+                ]);
+            });
+            it("captures trailing text with spaces as part of value", () => {
+                // In "none" mode wildcards do not trim leading/trailing
+                // separators because there are no flex-space positions to trim
+                // at.  The space before "world" is part of the wildcard value.
+                expect(testMatchGrammar(grammar, "hello world")).toStrictEqual([
+                    " world",
+                ]);
+            });
+            it("does not match when wildcard would be empty", () => {
+                expect(testMatchGrammar(grammar, "hello")).toStrictEqual([]);
+            });
         });
-        it("does not match when CJK tokens have space", () => {
-            expect(testMatchGrammar(grammar, "你好 世界")).toStrictEqual([]);
+
+        describe("spacing=none: empty wildcard rejection", () => {
+            const g = `<Start> [spacing=none] = hello $(x) world -> x;`;
+            const grammar = loadGrammarRules("test.grammar", g);
+            it("rejects when wildcard captures empty string", () => {
+                // "helloworld" means the wildcard between hello and world is empty
+                expect(testMatchGrammar(grammar, "helloworld")).toStrictEqual(
+                    [],
+                );
+            });
         });
-    });
-});
+
+        describe("spacing=none: wildcard before number variable", () => {
+            const g = `<Start> [spacing=none] = $(x) $(n:number) -> n;`;
+            const grammar = loadGrammarRules("test.grammar", g);
+            it("matches wildcard followed by number", () => {
+                expect(testMatchGrammar(grammar, "abc42")).toStrictEqual([42]);
+            });
+            it("captures wildcard value correctly", () => {
+                const gVal = `<Start> [spacing=none] = $(x) $(n:number) -> x;`;
+                const grammar2 = loadGrammarRules("test.grammar", gVal);
+                expect(testMatchGrammar(grammar2, "abc42")).toStrictEqual([
+                    "abc",
+                ]);
+            });
+        });
+
+        describe("spacing=none: negative and special number formats", () => {
+            const g = `<Start> [spacing=none] = item $(n:number) done -> n;`;
+            const grammar = loadGrammarRules("test.grammar", g);
+            it("matches negative integer", () => {
+                expect(testMatchGrammar(grammar, "item-42done")).toStrictEqual([
+                    -42,
+                ]);
+            });
+            it("matches hex number", () => {
+                // Use suffix starting with non-hex char to avoid greedy capture
+                // TODO: Review the case item0xFFdone and see if we should make that work.
+                const gHex = `<Start> [spacing=none] = item $(n:number) stop -> n;`;
+                const grammarHex = loadGrammarRules("test.grammar", gHex);
+                expect(
+                    testMatchGrammar(grammarHex, "item0xFFstop"),
+                ).toStrictEqual([0xff]);
+            });
+            it("matches octal number", () => {
+                expect(testMatchGrammar(grammar, "item0o77done")).toStrictEqual(
+                    [0o77],
+                );
+            });
+            it("matches binary number", () => {
+                expect(
+                    testMatchGrammar(grammar, "item0b101done"),
+                ).toStrictEqual([0b101]);
+            });
+            it("matches float number", () => {
+                expect(testMatchGrammar(grammar, "item3.14done")).toStrictEqual(
+                    [3.14],
+                );
+            });
+        });
+
+        describe("spacing=none: rule-level alternatives", () => {
+            const g = `<Start> [spacing=none] = hello world -> 1 | foo bar -> 2;`;
+            const grammar = loadGrammarRules("test.grammar", g);
+            it("matches first alternative when adjacent", () => {
+                expect(testMatchGrammar(grammar, "helloworld")).toStrictEqual([
+                    1,
+                ]);
+            });
+            it("matches second alternative when adjacent", () => {
+                expect(testMatchGrammar(grammar, "foobar")).toStrictEqual([2]);
+            });
+            it("does not match first alternative with space", () => {
+                expect(testMatchGrammar(grammar, "hello world")).toStrictEqual(
+                    [],
+                );
+            });
+            it("does not match second alternative with space", () => {
+                expect(testMatchGrammar(grammar, "foo bar")).toStrictEqual([]);
+            });
+        });
+
+        describe("spacing=none: case insensitivity", () => {
+            const g = `<Start> [spacing=none] = hello world -> true;`;
+            const grammar = loadGrammarRules("test.grammar", g);
+            it("matches mixed case without space", () => {
+                expect(testMatchGrammar(grammar, "HelloWorld")).toStrictEqual([
+                    true,
+                ]);
+            });
+            it("matches all caps without space", () => {
+                expect(testMatchGrammar(grammar, "HELLOWORLD")).toStrictEqual([
+                    true,
+                ]);
+            });
+            it("does not match mixed case with space", () => {
+                expect(testMatchGrammar(grammar, "Hello World")).toStrictEqual(
+                    [],
+                );
+            });
+        });
+
+        describe("spacing=none: leading/trailing whitespace in input", () => {
+            const g = `<Start> [spacing=none] = hello world -> true;`;
+            const grammar = loadGrammarRules("test.grammar", g);
+            it("does not match with leading whitespace", () => {
+                // In none mode, no leading separator is consumed
+                expect(testMatchGrammar(grammar, "  helloworld")).toStrictEqual(
+                    [],
+                );
+            });
+            it("matches with trailing whitespace", () => {
+                expect(testMatchGrammar(grammar, "helloworld  ")).toStrictEqual(
+                    [true],
+                );
+            });
+            it("does not match with both leading and trailing whitespace", () => {
+                expect(
+                    testMatchGrammar(grammar, "  helloworld  "),
+                ).toStrictEqual([]);
+            });
+        });
+
+        describe("spacing=none vs other modes: leading whitespace", () => {
+            // Counter-test: other modes still consume leading whitespace
+            // even though none mode rejects it.
+            it("auto mode accepts leading whitespace", () => {
+                const g = `<Start> = hello world -> true;`;
+                const grammar = loadGrammarRules("test.grammar", g);
+                expect(
+                    testMatchGrammar(grammar, "  hello world"),
+                ).toStrictEqual([true]);
+            });
+            it("required mode accepts leading whitespace", () => {
+                const g = `<Start> [spacing=required] = hello world -> true;`;
+                const grammar = loadGrammarRules("test.grammar", g);
+                expect(
+                    testMatchGrammar(grammar, "  hello world"),
+                ).toStrictEqual([true]);
+            });
+            it("optional mode accepts leading whitespace", () => {
+                const g = `<Start> [spacing=optional] = hello world -> true;`;
+                const grammar = loadGrammarRules("test.grammar", g);
+                expect(testMatchGrammar(grammar, "  helloworld")).toStrictEqual(
+                    [true],
+                );
+            });
+        });
+
+        describe("spacing=none: CJK characters", () => {
+            const g = `<Start> [spacing=none] = 你好 世界 -> true;`;
+            const grammar = loadGrammarRules("test.grammar", g);
+            it("matches when CJK tokens are adjacent", () => {
+                expect(testMatchGrammar(grammar, "你好世界")).toStrictEqual([
+                    true,
+                ]);
+            });
+            it("does not match when CJK tokens have space", () => {
+                expect(testMatchGrammar(grammar, "你好 世界")).toStrictEqual(
+                    [],
+                );
+            });
+        });
+    },
+);

--- a/ts/packages/actionGrammar/test/grammarMatcherVariables.spec.ts
+++ b/ts/packages/actionGrammar/test/grammarMatcherVariables.spec.ts
@@ -2,250 +2,288 @@
 // Licensed under the MIT License.
 
 import { loadGrammarRules } from "../src/grammarLoader.js";
-import { spaces, testMatchGrammar } from "./testUtils.js";
+import {
+    describeForEachMatcher,
+    expectMatchResults,
+    spaces,
+} from "./testUtils.js";
 
-describe("Grammar Matcher - Variables", () => {
-    describe("Variable Match", () => {
-        it("simple variable - explicit string", () => {
-            const g = `<Start> = $(x:string) -> x;`;
-            const grammar = loadGrammarRules("test.grammar", g);
-            expect(testMatchGrammar(grammar, "value")).toStrictEqual(["value"]);
-        });
-        it("simple variable - explicit type name", () => {
-            const g = `
+describeForEachMatcher(
+    "Grammar Matcher - Variables",
+    (testMatchGrammar, variant) => {
+        describe("Variable Match", () => {
+            it("simple variable - explicit string", () => {
+                const g = `<Start> = $(x:string) -> x;`;
+                const grammar = loadGrammarRules("test.grammar", g);
+                expect(testMatchGrammar(grammar, "value")).toStrictEqual([
+                    "value",
+                ]);
+            });
+            it("simple variable - explicit type name", () => {
+                const g = `
                 import { TrackName } from "types.ts";
                 <Start> = $(x:TrackName) -> x;
             `;
-            const grammar = loadGrammarRules("test.grammar", g);
-            expect(testMatchGrammar(grammar, "value")).toStrictEqual(["value"]);
-        });
-        it("simple variable - implicit string type", () => {
-            const g = `<Start> = $(x) -> x;`;
-            const grammar = loadGrammarRules("test.grammar", g);
-            expect(testMatchGrammar(grammar, "value")).toStrictEqual(["value"]);
-        });
-        it("simple variable - simple integer", () => {
-            const g = `<Start> = $(x:number) -> x;`;
-            const grammar = loadGrammarRules("test.grammar", g);
-            expect(testMatchGrammar(grammar, "1234")).toStrictEqual([1234]);
-        });
-        it("simple variable - minus integer", () => {
-            const g = `<Start> = $(x:number) -> x;`;
-            const grammar = loadGrammarRules("test.grammar", g);
-            expect(testMatchGrammar(grammar, "-1234")).toStrictEqual([-1234]);
-        });
-        it("simple variable - plus integer", () => {
-            const g = `<Start> = $(x:number) -> x;`;
-            const grammar = loadGrammarRules("test.grammar", g);
-            expect(testMatchGrammar(grammar, "+1234")).toStrictEqual([1234]);
-        });
-        it("simple variable - octal", () => {
-            const g = `<Start> = $(x:number) -> x;`;
-            const grammar = loadGrammarRules("test.grammar", g);
-            expect(testMatchGrammar(grammar, "0o123")).toStrictEqual([0o123]);
-        });
-        it("simple variable - binary", () => {
-            const g = `<Start> = $(x:number) -> x;`;
-            const grammar = loadGrammarRules("test.grammar", g);
-            expect(testMatchGrammar(grammar, "0b0101")).toStrictEqual([0b101]);
-        });
-        it("simple variable - hex", () => {
-            const g = `<Start> = $(x:number) -> x;`;
-            const grammar = loadGrammarRules("test.grammar", g);
-            expect(testMatchGrammar(grammar, "0x123")).toStrictEqual([0x123]);
-        });
-        it("simple variable - float", () => {
-            const g = `<Start> = $(x:number) -> x;`;
-            const grammar = loadGrammarRules("test.grammar", g);
-            expect(testMatchGrammar(grammar, "10.123")).toStrictEqual([10.123]);
-        });
+                const grammar = loadGrammarRules("test.grammar", g);
+                expect(testMatchGrammar(grammar, "value")).toStrictEqual([
+                    "value",
+                ]);
+            });
+            it("simple variable - implicit string type", () => {
+                const g = `<Start> = $(x) -> x;`;
+                const grammar = loadGrammarRules("test.grammar", g);
+                expect(testMatchGrammar(grammar, "value")).toStrictEqual([
+                    "value",
+                ]);
+            });
+            it("simple variable - simple integer", () => {
+                const g = `<Start> = $(x:number) -> x;`;
+                const grammar = loadGrammarRules("test.grammar", g);
+                expect(testMatchGrammar(grammar, "1234")).toStrictEqual([1234]);
+            });
+            it("simple variable - minus integer", () => {
+                const g = `<Start> = $(x:number) -> x;`;
+                const grammar = loadGrammarRules("test.grammar", g);
+                expect(testMatchGrammar(grammar, "-1234")).toStrictEqual([
+                    -1234,
+                ]);
+            });
+            it("simple variable - plus integer", () => {
+                const g = `<Start> = $(x:number) -> x;`;
+                const grammar = loadGrammarRules("test.grammar", g);
+                expect(testMatchGrammar(grammar, "+1234")).toStrictEqual([
+                    1234,
+                ]);
+            });
+            it("simple variable - octal", () => {
+                const g = `<Start> = $(x:number) -> x;`;
+                const grammar = loadGrammarRules("test.grammar", g);
+                expect(testMatchGrammar(grammar, "0o123")).toStrictEqual([
+                    0o123,
+                ]);
+            });
+            it("simple variable - binary", () => {
+                const g = `<Start> = $(x:number) -> x;`;
+                const grammar = loadGrammarRules("test.grammar", g);
+                expect(testMatchGrammar(grammar, "0b0101")).toStrictEqual([
+                    0b101,
+                ]);
+            });
+            it("simple variable - hex", () => {
+                const g = `<Start> = $(x:number) -> x;`;
+                const grammar = loadGrammarRules("test.grammar", g);
+                expect(testMatchGrammar(grammar, "0x123")).toStrictEqual([
+                    0x123,
+                ]);
+            });
+            it("simple variable - float", () => {
+                const g = `<Start> = $(x:number) -> x;`;
+                const grammar = loadGrammarRules("test.grammar", g);
+                expect(testMatchGrammar(grammar, "10.123")).toStrictEqual([
+                    10.123,
+                ]);
+            });
 
-        it("simple variable - negative float", () => {
-            const g = `<Start> = $(x:number) -> x;`;
-            const grammar = loadGrammarRules("test.grammar", g);
-            expect(testMatchGrammar(grammar, "-02120.123")).toStrictEqual([
-                -2120.123,
-            ]);
-        });
-        it("simple variable - float with exponent", () => {
-            const g = `<Start> = $(x:number) -> x;`;
-            const grammar = loadGrammarRules("test.grammar", g);
-            expect(testMatchGrammar(grammar, "45.678e-9")).toStrictEqual([
-                45.678e-9,
-            ]);
-        });
-        it("simple variable - optional", () => {
-            const g = `<Start> = hello $(x:number)? -> x;`;
-            const grammar = loadGrammarRules("test.grammar", g);
-            expect(testMatchGrammar(grammar, "hello")).toStrictEqual([
-                undefined,
-            ]);
-        });
-        it("space around variable - string", () => {
-            const g = `<Start> = hello $(x) world -> x;`;
-            const grammar = loadGrammarRules("test.grammar", g);
-            expect(
-                testMatchGrammar(grammar, `hello${spaces}value${spaces}world`),
-            ).toStrictEqual(["value"]);
-        });
-        it("space around variable - number", () => {
-            const g = `<Start> = hello $(x:number) world -> x;`;
-            const grammar = loadGrammarRules("test.grammar", g);
-            expect(
-                testMatchGrammar(grammar, `hello${spaces}123${spaces}world`),
-            ).toStrictEqual([123]);
-        });
+            it("simple variable - negative float", () => {
+                const g = `<Start> = $(x:number) -> x;`;
+                const grammar = loadGrammarRules("test.grammar", g);
+                expect(testMatchGrammar(grammar, "-02120.123")).toStrictEqual([
+                    -2120.123,
+                ]);
+            });
+            it("simple variable - float with exponent", () => {
+                const g = `<Start> = $(x:number) -> x;`;
+                const grammar = loadGrammarRules("test.grammar", g);
+                expect(testMatchGrammar(grammar, "45.678e-9")).toStrictEqual([
+                    45.678e-9,
+                ]);
+            });
+            it("simple variable - optional", () => {
+                const g = `<Start> = hello $(x:number)? -> x;`;
+                const grammar = loadGrammarRules("test.grammar", g);
+                expect(testMatchGrammar(grammar, "hello")).toStrictEqual([
+                    undefined,
+                ]);
+            });
+            it("space around variable - string", () => {
+                const g = `<Start> = hello $(x) world -> x;`;
+                const grammar = loadGrammarRules("test.grammar", g);
+                expect(
+                    testMatchGrammar(
+                        grammar,
+                        `hello${spaces}value${spaces}world`,
+                    ),
+                ).toStrictEqual(["value"]);
+            });
+            it("space around variable - number", () => {
+                const g = `<Start> = hello $(x:number) world -> x;`;
+                const grammar = loadGrammarRules("test.grammar", g);
+                expect(
+                    testMatchGrammar(
+                        grammar,
+                        `hello${spaces}123${spaces}world`,
+                    ),
+                ).toStrictEqual([123]);
+            });
 
-        it("no space around variable - number and string not separated", () => {
-            const g = `<Start> = $(x:number) $(y: string)-> { n: x, s: y };`;
-            const grammar = loadGrammarRules("test.grammar", g);
-            expect(testMatchGrammar(grammar, "1234b")).toStrictEqual([
-                { n: 1234, s: "b" },
-            ]);
-        });
+            it("no space around variable - number and string not separated", () => {
+                const g = `<Start> = $(x:number) $(y: string)-> { n: x, s: y };`;
+                const grammar = loadGrammarRules("test.grammar", g);
+                expect(testMatchGrammar(grammar, "1234b")).toStrictEqual([
+                    { n: 1234, s: "b" },
+                ]);
+            });
 
-        it("no space around variable - number and term not separated", () => {
-            const g = `<Start> = $(x:number)\\-$(y:number)pm -> { a: x, b: y };`;
-            const grammar = loadGrammarRules("test.grammar", g);
-            expect(testMatchGrammar(grammar, "1-2pm")).toStrictEqual([
-                { a: 1, b: 2 },
-            ]);
-        });
-        it("multiple", () => {
-            const g = `
+            it("no space around variable - number and term not separated", () => {
+                const g = `<Start> = $(x:number)\\-$(y:number)pm -> { a: x, b: y };`;
+                const grammar = loadGrammarRules("test.grammar", g);
+                expect(testMatchGrammar(grammar, "1-2pm")).toStrictEqual([
+                    { a: 1, b: 2 },
+                ]);
+            });
+            it("multiple", () => {
+                const g = `
                 <Start> = $(x:number) -> x;
                 <Start> = $(x) -> x;`;
-            const grammar = loadGrammarRules("test.grammar", g);
-            expect(testMatchGrammar(grammar, "13.348")).toStrictEqual([
-                13.348,
-                "13.348",
-            ]);
+                const grammar = loadGrammarRules("test.grammar", g);
+                expectMatchResults(
+                    testMatchGrammar(grammar, "13.348"),
+                    [13.348, "13.348"],
+                    variant,
+                );
+            });
         });
-    });
 
-    describe("Nested Rules", () => {
-        it("nested rules", () => {
-            const g = `
+        describe("Nested Rules", () => {
+            it("nested rules", () => {
+                const g = `
             <Start> = $(x:<Hello>) $(y:<World>) -> { hello: x, world: y };
             <Hello> = hello -> "hello";
             <World> = world -> "world";
             `;
-            const grammar = loadGrammarRules("test.grammar", g);
-            expect(testMatchGrammar(grammar, "hello world")).toStrictEqual([
-                { hello: "hello", world: "world" },
-            ]);
-        });
-        it("nested rules - default value", () => {
-            const g = `
+                const grammar = loadGrammarRules("test.grammar", g);
+                expect(testMatchGrammar(grammar, "hello world")).toStrictEqual([
+                    { hello: "hello", world: "world" },
+                ]);
+            });
+            it("nested rules - default value", () => {
+                const g = `
             <Start> = <Hello>;
             <Hello> = hello -> "first";
             <Hello> = hello -> "second";
             `;
-            const grammar = loadGrammarRules("test.grammar", g);
-            expect(testMatchGrammar(grammar, "hello")).toStrictEqual([
-                "first",
-                "second",
-            ]);
-        });
-        it("nested rules - default value with str expr", () => {
-            const g = `
+                const grammar = loadGrammarRules("test.grammar", g);
+                expectMatchResults(
+                    testMatchGrammar(grammar, "hello"),
+                    ["first", "second"],
+                    variant,
+                );
+            });
+            it("nested rules - default value with str expr", () => {
+                const g = `
             <Start> = A $(h:<Hello>) world -> h;
             <Hello> = hello -> "first";
             <Hello> = hello -> "second";
             `;
-            const grammar = loadGrammarRules("test.grammar", g);
-            expect(testMatchGrammar(grammar, "a hello world")).toStrictEqual([
-                "first",
-                "second",
-            ]);
-        });
+                const grammar = loadGrammarRules("test.grammar", g);
+                expectMatchResults(
+                    testMatchGrammar(grammar, "a hello world"),
+                    ["first", "second"],
+                    variant,
+                );
+            });
 
-        it("nested rules - single string part captures matched text", () => {
-            const g = `
+            it("nested rules - single string part captures matched text", () => {
+                const g = `
             <Start> = $(x:<Hello>) -> x;
             <Hello> = hello;
             `;
-            const grammar = loadGrammarRules("test.grammar", g);
-            expect(testMatchGrammar(grammar, "hello")).toStrictEqual(["hello"]);
-        });
+                const grammar = loadGrammarRules("test.grammar", g);
+                expect(testMatchGrammar(grammar, "hello")).toStrictEqual([
+                    "hello",
+                ]);
+            });
 
-        it("nested rules - single string part with multiple words", () => {
-            const g = `
+            it("nested rules - single string part with multiple words", () => {
+                const g = `
             <Start> = $(x:<Greeting>) -> x;
             <Greeting> = hello world;
             `;
-            const grammar = loadGrammarRules("test.grammar", g);
-            expect(testMatchGrammar(grammar, "hello world")).toStrictEqual([
-                "hello world",
-            ]);
-        });
+                const grammar = loadGrammarRules("test.grammar", g);
+                expect(testMatchGrammar(grammar, "hello world")).toStrictEqual([
+                    "hello world",
+                ]);
+            });
 
-        it("nested rules - single string part in complex expression", () => {
-            const g = `
+            it("nested rules - single string part in complex expression", () => {
+                const g = `
             <Start> = $(a:<First>) and $(b:<Second>) -> { a, b };
             <First> = first;
             <Second> = second;
             `;
-            const grammar = loadGrammarRules("test.grammar", g);
-            expect(testMatchGrammar(grammar, "first and second")).toStrictEqual(
-                [{ a: "first", b: "second" }],
-            );
-        });
+                const grammar = loadGrammarRules("test.grammar", g);
+                expect(
+                    testMatchGrammar(grammar, "first and second"),
+                ).toStrictEqual([{ a: "first", b: "second" }]);
+            });
 
-        it("nested rules - multiple parts should not capture default", () => {
-            const g = `
+            it("nested rules - multiple parts should not capture default", () => {
+                const g = `
             <Start> = $(x:<HelloWorld>) -> x;
             <HelloWorld> = <Hello> <World>;
             <Hello> = hello;
             <World> = world;
             `;
-            expect(() => loadGrammarRules("test.grammar", g)).toThrow(
-                "Referenced rule '<HelloWorld>' does not produce a value for variable 'x' in definition '<Start>'",
-            );
+                expect(() => loadGrammarRules("test.grammar", g)).toThrow(
+                    "Referenced rule '<HelloWorld>' does not produce a value for variable 'x' in definition '<Start>'",
+                );
+            });
         });
-    });
 
-    describe("Wildcards", () => {
-        it("wildcard ", () => {
-            const g = `
+        describe("Wildcards", () => {
+            it("wildcard ", () => {
+                const g = `
             <Start> = hello $(x) world -> x;
             `;
-            const grammar = loadGrammarRules("test.grammar", g);
-            expect(
-                testMatchGrammar(grammar, "hello this is a test world"),
-            ).toStrictEqual(["this is a test"]);
-        });
-        it("wildcard at end of nested rule", () => {
-            const g = `
+                const grammar = loadGrammarRules("test.grammar", g);
+                expect(
+                    testMatchGrammar(grammar, "hello this is a test world"),
+                ).toStrictEqual(["this is a test"]);
+            });
+            it("wildcard at end of nested rule", () => {
+                const g = `
             <Start> = $(h:<Hello>) world -> h;
             <Hello> = hello $(x) -> x;
             `;
-            const grammar = loadGrammarRules("test.grammar", g);
-            expect(
-                testMatchGrammar(grammar, "hello   this is a test   world"),
-            ).toStrictEqual(["this is a test"]);
-        });
+                const grammar = loadGrammarRules("test.grammar", g);
+                expect(
+                    testMatchGrammar(grammar, "hello   this is a test   world"),
+                ).toStrictEqual(["this is a test"]);
+            });
 
-        it("wildcard at before the nested rule", () => {
-            const g = `
+            it("wildcard at before the nested rule", () => {
+                const g = `
             <Start> = hello $(x) <World> -> x;
             <World> = world;
             `;
-            const grammar = loadGrammarRules("test.grammar", g);
-            expect(
-                testMatchGrammar(grammar, "hello   this is a test   world"),
-            ).toStrictEqual(["this is a test"]);
-        });
+                const grammar = loadGrammarRules("test.grammar", g);
+                expect(
+                    testMatchGrammar(grammar, "hello   this is a test   world"),
+                ).toStrictEqual(["this is a test"]);
+            });
 
-        it("wildcard alternates", () => {
-            const g = `<Start> = $(x) by $(y) -> [x, y];`;
-            const grammar = loadGrammarRules("test.grammar", g);
-            expect(
-                testMatchGrammar(grammar, "song by the sea by Bach"),
-            ).toStrictEqual([
-                ["song", "the sea by Bach"],
-                ["song by the sea", "Bach"],
-            ]);
+            it("wildcard alternates", () => {
+                const g = `<Start> = $(x) by $(y) -> [x, y];`;
+                const grammar = loadGrammarRules("test.grammar", g);
+                expectMatchResults(
+                    testMatchGrammar(grammar, "song by the sea by Bach"),
+                    [
+                        ["song", "the sea by Bach"],
+                        ["song by the sea", "Bach"],
+                    ],
+                    variant,
+                );
+            });
         });
-    });
-});
+    },
+);

--- a/ts/packages/actionGrammar/test/testUtils.ts
+++ b/ts/packages/actionGrammar/test/testUtils.ts
@@ -1,7 +1,17 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { matchGrammar } from "../src/grammarMatcher.js";
+import {
+    matchGrammar,
+    matchGrammarCompletion,
+    type GrammarCompletionResult,
+} from "../src/grammarMatcher.js";
+import { compileGrammarToNFA } from "../src/nfaCompiler.js";
+import { matchGrammarWithNFA } from "../src/nfaMatcher.js";
+import { tokenizeRequest } from "../src/nfaMatcher.js";
+import { compileNFAToDFA } from "../src/dfaCompiler.js";
+import { matchDFAWithSplitting, getDFACompletions } from "../src/dfaMatcher.js";
+import { computeNFACompletions } from "../src/nfaCompletion.js";
 import { Grammar } from "../src/grammarTypes.js";
 
 export const spaces =
@@ -9,6 +19,158 @@ export const spaces =
 export const escapedSpaces =
     "\\ \\t\\v\\f\\u00a0\\ufeff\\n\\r\\u2028\\u2029\\u1680\\u2000\\u2001\\u2002\\u2003\\u2004\\u2005\\u2006\\u2007\\u2008\\u2009\\u200A\\u202F\\u205F\\u3000";
 
+export type MatcherVariant = "grammar" | "nfa" | "dfa";
+
+export type TestMatchGrammarFn = (
+    grammar: Grammar,
+    request: string,
+) => unknown[];
+
 export function testMatchGrammar(grammar: Grammar, request: string) {
     return matchGrammar(grammar, request)?.map((m) => m.match);
+}
+
+function testMatchGrammarNFA(grammar: Grammar, request: string): unknown[] {
+    const nfa = compileGrammarToNFA(grammar, "test.grammar");
+    const results = matchGrammarWithNFA(grammar, nfa, request);
+    return results.map((m) => m.match);
+}
+
+function testMatchGrammarDFA(grammar: Grammar, request: string): unknown[] {
+    const nfa = compileGrammarToNFA(grammar, "test.grammar");
+    const dfa = compileNFAToDFA(nfa, "test.grammar");
+    const tokens = tokenizeRequest(request);
+    const result = matchDFAWithSplitting(dfa, tokens);
+    if (!result.matched) {
+        return [];
+    }
+    return [result.actionValue ?? request];
+}
+
+export function createTestMatchGrammar(
+    variant: MatcherVariant,
+): TestMatchGrammarFn {
+    switch (variant) {
+        case "grammar":
+            return testMatchGrammar;
+        case "nfa":
+            return testMatchGrammarNFA;
+        case "dfa":
+            return testMatchGrammarDFA;
+    }
+}
+
+const matcherVariants: MatcherVariant[] = ["grammar"];
+// TODO: Enable "nfa" and "dfa" variants once they match grammarMatcher behavior.
+// const matcherVariants: MatcherVariant[] = ["grammar", "nfa", "dfa"];
+
+/**
+ * Run a test suite with all three matcher variants (grammar, nfa, dfa).
+ * The callback receives the variant name and a testMatchGrammar function
+ * appropriate for that variant.
+ */
+export function describeForEachMatcher(
+    name: string,
+    fn: (testMatchGrammar: TestMatchGrammarFn, variant: MatcherVariant) => void,
+): void {
+    describe.each(matcherVariants)(`${name} [%s]`, (variant) => {
+        fn(createTestMatchGrammar(variant), variant);
+    });
+}
+
+/**
+ * Assert match results, accounting for multi-result differences between
+ * matchers. The grammar matcher can return multiple matches; NFA/DFA return
+ * only the best match.
+ *
+ * For single-element expected arrays all variants are checked with toStrictEqual.
+ * For multi-element expected arrays:
+ *   - grammar variant: exact match with toStrictEqual
+ *   - nfa/dfa variants: checks that exactly one result is returned and that
+ *     it deep-equals one of the expected values.
+ */
+export function expectMatchResults(
+    actual: unknown[],
+    expected: unknown[],
+    variant: MatcherVariant,
+): void {
+    if (variant === "grammar" || expected.length <= 1) {
+        expect(actual).toStrictEqual(expected);
+    } else {
+        // NFA/DFA return the best match only
+        expect(actual.length).toBe(1);
+        expect(expected).toContainEqual(actual[0]);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Completion variant infrastructure
+// ---------------------------------------------------------------------------
+
+export type CompletionVariant = "grammar" | "nfa" | "dfa";
+
+export type TestCompletionFn = (
+    grammar: Grammar,
+    prefix: string,
+    minPrefixLength?: number,
+    direction?: "forward" | "backward",
+) => GrammarCompletionResult;
+
+function testCompletionNFA(
+    grammar: Grammar,
+    prefix: string,
+): GrammarCompletionResult {
+    const nfa = compileGrammarToNFA(grammar, "test.grammar");
+    const tokens = tokenizeRequest(prefix);
+    return computeNFACompletions(nfa, tokens);
+}
+
+function testCompletionDFA(
+    grammar: Grammar,
+    prefix: string,
+): GrammarCompletionResult {
+    const nfa = compileGrammarToNFA(grammar, "test.grammar");
+    const dfa = compileNFAToDFA(nfa, "test.grammar");
+    const tokens = tokenizeRequest(prefix);
+    const result = getDFACompletions(dfa, tokens);
+    return {
+        completions: result.completions ?? [],
+        properties: result.properties?.map((p) => ({
+            match: { actionName: p.actionName },
+            propertyNames: [p.propertyPath],
+        })),
+        directionSensitive: false,
+        openWildcard: false,
+    };
+}
+
+export function createTestCompletion(
+    variant: CompletionVariant,
+): TestCompletionFn {
+    switch (variant) {
+        case "grammar":
+            return matchGrammarCompletion;
+        case "nfa":
+            return testCompletionNFA;
+        case "dfa":
+            return testCompletionDFA;
+    }
+}
+
+const completionVariants: CompletionVariant[] = ["grammar"];
+// TODO: Enable "nfa" and "dfa" variants once they match grammarMatcher completion behavior.
+// const completionVariants: CompletionVariant[] = ["grammar", "nfa", "dfa"];
+
+/**
+ * Run a completion test suite with all enabled completion variants.
+ * The callback receives the variant name and a completion function
+ * appropriate for that variant.
+ */
+export function describeForEachCompletion(
+    name: string,
+    fn: (testCompletion: TestCompletionFn, variant: CompletionVariant) => void,
+): void {
+    describe.each(completionVariants)(`${name} [%s]`, (variant) => {
+        fn(createTestCompletion(variant), variant);
+    });
 }


### PR DESCRIPTION
Refactor grammar matcher and completion test files to run under all three matcher variants (grammar, nfa, dfa) using shared `describeForEachMatcher`/`describeForEachCompletion` helpers in testUtils.

NFA and DFA variants are disabled by default (only grammar runs). Uncomment the variant arrays in `testUtils.ts` to enable them.

### Changes
- **testUtils.ts**: Added variant infrastructure — `createTestMatchGrammar`, `createTestCompletion`, `describeForEachMatcher`, `describeForEachCompletion`, `expectMatchResults`
- **7 grammarMatcher*.spec.ts**: Wrapped with `describeForEachMatcher`
- **5 grammarCompletion*.spec.ts**: Wrapped with `describeForEachCompletion`