### PR TITLE
Add export keyword support for .agr grammar rules

### DIFF
--- a/ts/packages/actionGrammar/src/grammarCompiler.ts
+++ b/ts/packages/actionGrammar/src/grammarCompiler.ts
@@ -51,6 +51,7 @@ type CompileContext = {
     content: string;
     displayPath: string;
     ruleDefMap: DefinitionMap;
+    exportedNames: Set<string>; // Only rules with export keyword are importable
     importedRuleMap: Map<string, CompileContext>; // Rule names imported from .agr files
     knownTypeNames: Set<string>; // Type names imported from .ts files
     importedTypeNames: Map<string, number | undefined>; // Explicitly named .ts type imports with positions (excludes entity names and wildcards)
@@ -113,6 +114,16 @@ function createCompileContext(
     }
     const importedTypeNames = new Map<string, number | undefined>();
     const usedImportedTypes = new Set<string>();
+
+    // Build exportedNames from definitions with exported: true
+    // Only rules explicitly marked with export are importable
+    const exportedNames = new Set<string>();
+    for (const def of definitions) {
+        if (def.exported) {
+            exportedNames.add(def.definitionName.name);
+        }
+    }
+
     // Create the context early and add to the map BEFORE processing anything
     // This prevents infinite recursion on circular dependencies
     const context: CompileContext = {
@@ -120,6 +131,7 @@ function createCompileContext(
         content,
         displayPath,
         ruleDefMap,
+        exportedNames,
         importedRuleMap,
         knownTypeNames,
         importedTypeNames,
@@ -171,6 +183,19 @@ function createCompileContext(
                         : importStmt.names.map((n) => n.name);
 
                 for (const ruleName of ruleNames) {
+                    // Check if the rule is exported from the source file
+                    if (!importContext.exportedNames.has(ruleName)) {
+                        // Rule is not exported from the source file
+                        if (importStmt.names !== "*") {
+                            // Only error for named imports; wildcard silently skips
+                            context.errors.push({
+                                message: `Rule '<${ruleName}>' is not exported from '${importStmt.source}'.`,
+                                definition: ruleName,
+                                pos: importStmt.pos,
+                            });
+                        }
+                        continue;
+                    }
                     // Check if we're trying to import a rule that's already defined locally
                     if (ruleDefMap.has(ruleName)) {
                         context.errors.push({
@@ -235,7 +260,10 @@ export function compileGrammar(
     }
 
     for (const [name, record] of context.ruleDefMap.entries()) {
-        if (record.grammarRules === undefined) {
+        if (
+            record.grammarRules === undefined &&
+            !context.exportedNames.has(name)
+        ) {
             context.warnings.push({
                 message: `Rule '<${name}>' is defined but never used.`,
                 pos: record.definitions[0]?.pos,

--- a/ts/packages/actionGrammar/src/grammarRuleParser.ts
+++ b/ts/packages/actionGrammar/src/grammarRuleParser.ts
@@ -33,7 +33,7 @@ const debugParse = registerDebug("typeagent:grammar:parse");
  *   <ImportStatement> ::= "import" (<ImportAll> | <ImportNames>) "from" <StringLiteral> ";"
  *   <ImportAll> ::= "*"
  *   <ImportNames> ::= "{" <Identifier> ("," <Identifier>)* "}"
- *   <RuleDefinition> ::= <RuleName> <RuleAnnotation>? "=" <Rules> ";"
+ *   <RuleDefinition> ::= "export"? <RuleName> <RuleAnnotation>? "=" <Rules> ";"
  *   <RuleAnnotation> ::= "[" <AnnotationKey> "=" <AnnotationValue> "]"
  *   // Currently the only supported annotation key is "spacing":
  *   //   [spacing=required], [spacing=optional], [spacing=auto], [spacing=none]
@@ -251,9 +251,11 @@ export type Rule = {
 export type RuleDefinition = {
     definitionName: CommentedName;
     rules: Rule[];
+    exported?: boolean | undefined; // true when prefixed with "export" keyword
     spacingMode?: SpacingMode | undefined;
     pos?: number | undefined;
-    leadingComments?: Comment[] | undefined; // comments before <Name>
+    leadingComments?: Comment[] | undefined; // comments before "export" or <Name>
+    afterExportComments?: Comment[] | undefined; // comments between "export" keyword and <Name>
     beforeAnnotationComments?: Comment[] | undefined; // comments between <Name> and [annotation]
     annotationAfterBracketComments?: Comment[] | undefined; // after [
     annotationAfterKeyComments?: Comment[] | undefined; // after "spacing" keyword, before =
@@ -1070,7 +1072,11 @@ class GrammarRuleParser {
         };
     }
 
-    private parseRuleDefinition(leadingComments?: Comment[]): RuleDefinition {
+    private parseRuleDefinition(
+        leadingComments?: Comment[],
+        exported?: boolean,
+        afterExportComments?: Comment[],
+    ): RuleDefinition {
         const pos = this.pos;
         const rn = this.parseRuleName();
         let spacingMode: SpacingMode;
@@ -1109,9 +1115,11 @@ class GrammarRuleParser {
         return {
             definitionName: rn,
             rules,
+            exported,
             spacingMode,
             pos,
             leadingComments,
+            afterExportComments,
             beforeAnnotationComments,
             annotationAfterBracketComments,
             annotationAfterKeyComments,
@@ -1358,6 +1366,23 @@ class GrammarRuleParser {
             }
             if (this.isAt("import")) {
                 imports.push(this.parseImportStatement(constructLeading));
+                continue;
+            }
+            if (this.isAt("export")) {
+                this.skipWhitespace(6); // skip "export"
+                const afterExportComments = this.parseComments();
+                if (!this.isAt("<")) {
+                    this.throwUnexpectedCharError(
+                        "Expected rule definition after 'export'",
+                    );
+                }
+                definitions.push(
+                    this.parseRuleDefinition(
+                        constructLeading,
+                        true,
+                        afterExportComments,
+                    ),
+                );
                 continue;
             }
             if (this.isAt("entity")) {

--- a/ts/packages/actionGrammar/src/grammarRuleWriter.ts
+++ b/ts/packages/actionGrammar/src/grammarRuleWriter.ts
@@ -784,6 +784,11 @@ export function writeGrammarRules(
 
 function writeRuleDefinition(result: GrammarWriter, def: RuleDefinition) {
     writeLeadingComments(result, def.leadingComments);
+    if (def.exported) {
+        result.write("export");
+        writeInlineComments(result, def.afterExportComments, true);
+        result.write(" ");
+    }
     writeBracketedName(result, def.definitionName);
     writeInlineComments(result, def.beforeAnnotationComments, true);
     if (def.spacingMode !== undefined) {

--- a/ts/packages/actionGrammar/test/grammarCompileError.spec.ts
+++ b/ts/packages/actionGrammar/test/grammarCompileError.spec.ts
@@ -315,6 +315,24 @@ describe("Grammar Compiler", () => {
             expect(warnings[0]).not.toContain("test(4,");
         });
 
+        it("Exported rules should not warn as unused", () => {
+            const grammarText = `
+            <Start> = <Used>;
+            <Used> = used;
+            export <Exported> = exported;
+            <Unused> = unused;
+        `;
+            const errors: string[] = [];
+            const warnings: string[] = [];
+            loadGrammarRulesNoThrow("test", grammarText, errors, warnings);
+            expect(errors.length).toBe(0);
+            // Only <Unused> should warn; <Exported> should not
+            expect(warnings.length).toBe(1);
+            expect(warnings[0]).toContain(
+                "warning: Rule '<Unused>' is defined but never used.",
+            );
+        });
+
         it("Multiple variables without explicit value expression", () => {
             const grammarText = `
             <Start> = <Action> -> "action";

--- a/ts/packages/actionGrammar/test/grammarImports.spec.ts
+++ b/ts/packages/actionGrammar/test/grammarImports.spec.ts
@@ -39,7 +39,7 @@ describe("Grammar Imports with File Loading", () => {
         it("should import and use a simple rule from another file", () => {
             const errors: string[] = [];
             const grammarFiles: Record<string, string> = {
-                "greeting.agr": `<Greeting> = (hello | hi | hey) -> "greeting";`,
+                "greeting.agr": `export <Greeting> = (hello | hi | hey) -> "greeting";`,
                 "main.agr": `
                     import { Greeting } from "./greeting.agr";
                     <Start> = $(greeting:<Greeting>) world -> { greeting, target: "world" };
@@ -72,9 +72,9 @@ describe("Grammar Imports with File Loading", () => {
             const errors: string[] = [];
             const grammarFiles: Record<string, string> = {
                 "actions.agr": `
-                                <Play> = play $(track) -> { action: "play", track };
-                                <Pause> = pause -> { action: "pause" };
-                                <Stop> = stop -> { action: "stop" };
+                                export <Play> = play $(track) -> { action: "play", track };
+                                export <Pause> = pause -> { action: "pause" };
+                                export <Stop> = stop -> { action: "stop" };
                             `,
                 "main.agr": `
                                 import { Play, Pause, Stop } from "./actions.agr";
@@ -102,8 +102,8 @@ describe("Grammar Imports with File Loading", () => {
         it("should import from multiple files", () => {
             const errors: string[] = [];
             const grammarFiles: Record<string, string> = {
-                "greeting.agr": `<Greeting> = (hello | hi) -> "greeting";`,
-                "farewell.agr": `<Farewell> = (goodbye | bye) -> "farewell";`,
+                "greeting.agr": `export <Greeting> = (hello | hi) -> "greeting";`,
+                "farewell.agr": `export <Farewell> = (goodbye | bye) -> "farewell";`,
                 "main.agr": `
                                 import { Greeting } from "./greeting.agr";
                                 import { Farewell } from "./farewell.agr";
@@ -130,7 +130,7 @@ describe("Grammar Imports with File Loading", () => {
         it("should use imported rule in a variable reference", () => {
             const errors: string[] = [];
             const grammarFiles: Record<string, string> = {
-                "numbers.agr": `<Number> = one -> 1 | two -> 2 | three -> 3;`,
+                "numbers.agr": `export <Number> = one -> 1 | two -> 2 | three -> 3;`,
                 "main.agr": `
                                 import { Number } from "./numbers.agr";
 
@@ -160,9 +160,9 @@ describe("Grammar Imports with File Loading", () => {
             const errors: string[] = [];
             const grammarFiles: Record<string, string> = {
                 "colors.agr": `
-                                <Red> = red -> "red";
-                                <Blue> = blue -> "blue";
-                                <Green> = green -> "green";
+                                export <Red> = red -> "red";
+                                export <Blue> = blue -> "blue";
+                                export <Green> = green -> "green";
                             `,
                 "main.agr": `
                                 import * from "./colors.agr";
@@ -189,8 +189,8 @@ describe("Grammar Imports with File Loading", () => {
             const errors: string[] = [];
             const grammarFiles: Record<string, string> = {
                 "actions.agr": `
-                                <Action1> = action one -> 1;
-                                <Action2> = action two -> 2;
+                                export <Action1> = action one -> 1;
+                                export <Action2> = action two -> 2;
                             `,
                 "main.agr": `
                                 import * from "./actions.agr";
@@ -217,11 +217,11 @@ describe("Grammar Imports with File Loading", () => {
         it("should handle transitive imports (A imports B, B imports C)", () => {
             const errors: string[] = [];
             const grammarFiles: Record<string, string> = {
-                "base.agr": `<BaseRule> = base value -> "base";`,
+                "base.agr": `export <BaseRule> = base value -> "base";`,
                 "middle.agr": `
                                 import { BaseRule } from "./base.agr";
 
-                                <MiddleRule> = middle <BaseRule> -> "middle";
+                                export <MiddleRule> = middle <BaseRule> -> "middle";
                             `,
                 "main.agr": `
                                 import { MiddleRule } from "./middle.agr";
@@ -247,14 +247,14 @@ describe("Grammar Imports with File Loading", () => {
         it("should handle complex import chains", () => {
             const errors: string[] = [];
             const grammarFiles: Record<string, string> = {
-                "level3.agr": `<L3> = level three -> 3;`,
+                "level3.agr": `export <L3> = level three -> 3;`,
                 "level2.agr": `
                                 import { L3 } from "./level3.agr";
-                                <L2> = level two <L3> -> 2;
+                                export <L2> = level two <L3> -> 2;
                             `,
                 "level1.agr": `
                                 import { L2 } from "./level2.agr";
-                                <L1> = level one <L2> -> 1;
+                                export <L1> = level one <L2> -> 1;
                             `,
                 "main.agr": `
                                 import { L1 } from "./level1.agr";
@@ -279,7 +279,7 @@ describe("Grammar Imports with File Loading", () => {
         it("should handle imports from subdirectories", () => {
             const errors: string[] = [];
             const grammarFiles: Record<string, string> = {
-                "lib/utils.agr": `<UtilRule> = utility -> "util";`,
+                "lib/utils.agr": `export <UtilRule> = utility -> "util";`,
                 "main.agr": `
                                 import { UtilRule } from "./lib/utils.agr";
                                 <Start> = <UtilRule> rule -> "result";
@@ -302,11 +302,11 @@ describe("Grammar Imports with File Loading", () => {
             const errors: string[] = [];
             const grammarFiles: Record<string, string> = {
                 // Deepest level: /dir1/dir2/base.agr
-                "dir1/dir2/base.agr": `<Base> = base -> "base";`,
+                "dir1/dir2/base.agr": `export <Base> = base -> "base";`,
                 // Middle level: /dir1/middle.agr imports from ./dir2/base.agr (relative to /dir1/)
                 "dir1/middle.agr": `
                                 import { Base } from "./dir2/base.agr";
-                                <Middle> = middle <Base> -> "middle";
+                                export <Middle> = middle <Base> -> "middle";
                             `,
                 // Top level: /main.agr imports from ./dir1/middle.agr (relative to /)
                 "main.agr": `
@@ -331,16 +331,16 @@ describe("Grammar Imports with File Loading", () => {
             const errors: string[] = [];
             const grammarFiles: Record<string, string> = {
                 // Shared utility in /shared/common.agr
-                "shared/common.agr": `<Common> = common -> "common";`,
+                "shared/common.agr": `export <Common> = common -> "common";`,
                 // Module in /modules/sub/feature.agr imports from ../../shared/common.agr
                 "modules/sub/feature.agr": `
                                 import { Common } from "../../shared/common.agr";
-                                <Feature> = feature <Common> -> "feature";
+                                export <Feature> = feature <Common> -> "feature";
                             `,
                 // Wrapper in /modules/wrapper.agr imports from ./sub/feature.agr
                 "modules/wrapper.agr": `
                                 import { Feature } from "./sub/feature.agr";
-                                <Wrapper> = wrapper <Feature> -> "wrapper";
+                                export <Wrapper> = wrapper <Feature> -> "wrapper";
                             `,
                 // Main imports from ./modules/wrapper.agr
                 "main.agr": `
@@ -410,7 +410,7 @@ describe("Grammar Imports with File Loading", () => {
         it("should error when imported rule is not defined in the file", () => {
             const errors: string[] = [];
             const grammarFiles: Record<string, string> = {
-                "actions.agr": `<Play> = play -> "play";`,
+                "actions.agr": `export <Play> = play -> "play";`,
                 "main.agr": `
                                 import { Stop } from "./actions.agr";
                                 <Start> = <Stop>;
@@ -423,13 +423,14 @@ describe("Grammar Imports with File Loading", () => {
             );
 
             expect(errors.length).toBeGreaterThan(0);
-            expect(errors[0]).toContain("Missing rule definition for '<Stop>'");
+            expect(errors[0]).toContain("Stop");
+            expect(errors[0]).toContain("not exported");
         });
 
         it("should error when trying to import a locally defined rule", () => {
             const errors: string[] = [];
             const grammarFiles: Record<string, string> = {
-                "rules.agr": `<Action> = imported action -> "imported";`,
+                "rules.agr": `export <Action> = imported action -> "imported";`,
                 "main.agr": `
                                 import { Action } from "./rules.agr";
 
@@ -497,7 +498,7 @@ describe("Grammar Imports with File Loading", () => {
         it("should refer to files using relative paths in error messages - compile error", () => {
             const errors: string[] = [];
             const grammarFiles: Record<string, string> = {
-                "lib/broken.agr": `<Broken> = $(x:UndefinedType);`,
+                "lib/broken.agr": `export <Broken> = $(x:UndefinedType);`,
                 "main.agr": `
                                 import { Broken } from "./lib/broken.agr";
                                 <Start> = <Broken>;
@@ -529,7 +530,7 @@ describe("Grammar Imports with File Loading", () => {
                 "base.agr": `
                                 <Subject> = ( cat | dog | bird ) -> "subject";
                                 <Verb> = ( runs | jumps | flies ) -> "verb";
-                                <Sentence> = the $(subject:<Subject>) $(verb:<Verb>) -> {
+                                export <Sentence> = the $(subject:<Subject>) $(verb:<Verb>) -> {
                                     subject,
                                     verb
                                 };
@@ -564,8 +565,8 @@ describe("Grammar Imports with File Loading", () => {
             const errors: string[] = [];
             const grammarFiles: Record<string, string> = {
                 "imported.agr": `
-                                <ImportedRule1> = imported one -> 1;
-                                <ImportedRule2> = imported two -> 2;
+                                export <ImportedRule1> = imported one -> 1;
+                                export <ImportedRule2> = imported two -> 2;
                             `,
                 "main.agr": `
                                 import { ImportedRule1, ImportedRule2 } from "./imported.agr";
@@ -596,8 +597,8 @@ describe("Grammar Imports with File Loading", () => {
             const errors: string[] = [];
             const grammarFiles: Record<string, string> = {
                 "values.agr": `
-                                <Priority> = high -> 1 | medium -> 2 | low -> 3;
-                                <Status> = active -> "active" | inactive -> "inactive";
+                                export <Priority> = high -> 1 | medium -> 2 | low -> 3;
+                                export <Status> = active -> "active" | inactive -> "inactive";
                             `,
                 "main.agr": `
                                 import { Priority, Status } from "./values.agr";
@@ -631,7 +632,7 @@ describe("Grammar Imports with File Loading", () => {
             const errors: string[] = [];
             const grammarFiles: Record<string, string> = {
                 "optional.agr": `
-                                <Polite> = (please)? $(action) (thank you)? -> action;
+                                export <Polite> = (please)? $(action) (thank you)? -> action;
                             `,
                 "main.agr": `
                                 import { Polite } from "./optional.agr";
@@ -670,7 +671,7 @@ describe("Grammar Imports with File Loading", () => {
             const errors: string[] = [];
             const grammarFiles: Record<string, string> = {
                 "alternatives.agr": `
-                                <Command> =
+                                export <Command> =
                                     start $(service) -> { action: "start", service } |
                                     stop $(service) -> { action: "stop", service } |
                                     restart $(service) -> { action: "restart", service };
@@ -704,14 +705,14 @@ describe("Grammar Imports with File Loading", () => {
         it("should handle same file imported from multiple places", () => {
             const errors: string[] = [];
             const grammarFiles: Record<string, string> = {
-                "utils.agr": `<Common> = common -> "common";`,
+                "utils.agr": `export <Common> = common -> "common";`,
                 "module1.agr": `
                                 import { Common } from "./utils.agr";
-                                <Module1> = module1 <Common> -> "m1";
+                                export <Module1> = module1 <Common> -> "m1";
                             `,
                 "module2.agr": `
                                 import { Common } from "./utils.agr";
-                                <Module2> = module2 <Common> -> "m2";
+                                export <Module2> = module2 <Common> -> "m2";
                             `,
                 "main.agr": `
                                 import { Module1 } from "./module1.agr";
@@ -762,7 +763,7 @@ describe("Grammar Imports with File Loading", () => {
         it("should distinguish between grammar imports and type imports", () => {
             const errors: string[] = [];
             const grammarFiles: Record<string, string> = {
-                "rules.agr": `<MyRule> = my rule -> "rule";`,
+                "rules.agr": `export <MyRule> = my rule -> "rule";`,
                 "main.agr": `
                                 import { MyRule } from "./rules.agr";
                                 import { MyType } from "./types.ts";
@@ -792,12 +793,12 @@ describe("Grammar Imports with File Loading", () => {
             const grammarFiles: Record<string, string> = {
                 "fileA.agr": `
                     import { RuleB } from "./fileB.agr";
-                    <RuleA> = a <RuleB> -> "a";
+                    export <RuleA> = a <RuleB> -> "a";
                     <Start> = <RuleA>;
                 `,
                 "fileB.agr": `
                     import { RuleA } from "./fileA.agr";
-                    <RuleB> = b value -> "b";
+                    export <RuleB> = b value -> "b";
                 `,
             };
 
@@ -821,7 +822,7 @@ describe("Grammar Imports with File Loading", () => {
             const grammarFiles: Record<string, string> = {
                 "fileA.agr": `
                     import { RuleA } from "./fileA.agr";
-                    <RuleA> = a value -> "a";
+                    export <RuleA> = a value -> "a";
                     <Start> = <RuleA>;
                 `,
             };
@@ -845,16 +846,16 @@ describe("Grammar Imports with File Loading", () => {
             const grammarFiles: Record<string, string> = {
                 "fileA.agr": `
                     import { RuleB } from "./fileB.agr";
-                    <RuleA> = a <RuleB> -> "a";
+                    export <RuleA> = a <RuleB> -> "a";
                     <Start> = <RuleA>;
                 `,
                 "fileB.agr": `
                     import { RuleC } from "./fileC.agr";
-                    <RuleB> = b <RuleC> -> "b";
+                    export <RuleB> = b <RuleC> -> "b";
                 `,
                 "fileC.agr": `
                     import { RuleA } from "./fileA.agr";
-                    <RuleC> = c value -> "c";
+                    export <RuleC> = c value -> "c";
                 `,
             };
 
@@ -870,6 +871,178 @@ describe("Grammar Imports with File Loading", () => {
 
             // Test that the grammar works correctly
             expect(testMatch(grammar, "a b c value")).toEqual(["a"]);
+        });
+    });
+
+    describe("Export Keyword on Definitions", () => {
+        it("should allow importing exported rules", () => {
+            const errors: string[] = [];
+            const grammarFiles: Record<string, string> = {
+                "lib.agr": `
+                    export <Greeting> = hello -> "hello";
+                    <Internal> = internal -> "internal";
+                `,
+                "main.agr": `
+                    import { Greeting } from "./lib.agr";
+                    <Start> = <Greeting>;
+                `,
+            };
+            const grammar = loadGrammarRulesNoThrow(
+                "main.agr",
+                getTestFileLoader(grammarFiles),
+                errors,
+            );
+
+            expect(errors).toEqual([]);
+            expect(grammar).toBeDefined();
+            expect(testMatch(grammar, "hello")).toEqual(["hello"]);
+        });
+
+        it("should prevent importing non-exported rules", () => {
+            const errors: string[] = [];
+            const grammarFiles: Record<string, string> = {
+                "lib.agr": `
+                    export <Greeting> = hello -> "hello";
+                    <Internal> = internal -> "internal";
+                `,
+                "main.agr": `
+                    import { Internal } from "./lib.agr";
+                    <Start> = <Internal>;
+                `,
+            };
+            const grammar = loadGrammarRulesNoThrow(
+                "main.agr",
+                getTestFileLoader(grammarFiles),
+                errors,
+            );
+
+            expect(grammar).toBeUndefined();
+            expect(errors.length).toBeGreaterThan(0);
+            expect(errors[0]).toContain("Internal");
+            expect(errors[0]).toContain("not exported");
+        });
+
+        it("should restrict wildcard imports to exported rules only", () => {
+            const errors: string[] = [];
+            const grammarFiles: Record<string, string> = {
+                "lib.agr": `
+                    export <Exported> = exported -> "exported";
+                    <Hidden> = hidden -> "hidden";
+                `,
+                "main.agr": `
+                    import * from "./lib.agr";
+                    <Start> = <Exported>;
+                `,
+            };
+            const grammar = loadGrammarRulesNoThrow(
+                "main.agr",
+                getTestFileLoader(grammarFiles),
+                errors,
+            );
+
+            expect(errors).toEqual([]);
+            expect(grammar).toBeDefined();
+            expect(testMatch(grammar, "exported")).toEqual(["exported"]);
+        });
+
+        it("should not include non-exported rules in wildcard imports", () => {
+            const errors: string[] = [];
+            const grammarFiles: Record<string, string> = {
+                "lib.agr": `
+                    export <Exported> = exported -> "exported";
+                    <Hidden> = hidden -> "hidden";
+                `,
+                "main.agr": `
+                    import * from "./lib.agr";
+                    <Start> = <Exported> | <Hidden>;
+                `,
+            };
+            const grammar = loadGrammarRulesNoThrow(
+                "main.agr",
+                getTestFileLoader(grammarFiles),
+                errors,
+            );
+
+            expect(grammar).toBeUndefined();
+            expect(errors.length).toBeGreaterThan(0);
+            expect(errors[0]).toContain("Hidden");
+        });
+
+        it("should allow importing multiple exported rules", () => {
+            const errors: string[] = [];
+            const grammarFiles: Record<string, string> = {
+                "lib.agr": `
+                    export <Rule1> = one -> 1;
+                    export <Rule2> = two -> 2;
+                    <Rule3> = three -> 3;
+                `,
+                "main.agr": `
+                    import { Rule1, Rule2 } from "./lib.agr";
+                    <Start> = <Rule1> | <Rule2>;
+                `,
+            };
+            const grammar = loadGrammarRulesNoThrow(
+                "main.agr",
+                getTestFileLoader(grammarFiles),
+                errors,
+            );
+
+            expect(errors).toEqual([]);
+            expect(grammar).toBeDefined();
+            expect(testMatch(grammar, "one")).toEqual([1]);
+            expect(testMatch(grammar, "two")).toEqual([2]);
+        });
+
+        it("should handle exports with transitive imports", () => {
+            const errors: string[] = [];
+            const grammarFiles: Record<string, string> = {
+                "base.agr": `
+                    export <BaseRule> = base -> "base";
+                    <InternalBase> = internal -> "internal";
+                `,
+                "middle.agr": `
+                    import { BaseRule } from "./base.agr";
+                    export <MiddleRule> = middle <BaseRule> -> "middle";
+                    <InternalMiddle> = internal middle -> "internal-middle";
+                `,
+                "main.agr": `
+                    import { MiddleRule } from "./middle.agr";
+                    <Start> = <MiddleRule>;
+                `,
+            };
+            const grammar = loadGrammarRulesNoThrow(
+                "main.agr",
+                getTestFileLoader(grammarFiles),
+                errors,
+            );
+
+            expect(errors).toEqual([]);
+            expect(grammar).toBeDefined();
+            expect(testMatch(grammar, "middle base")).toEqual(["middle"]);
+        });
+
+        it("should error when no rules are exported and import is attempted", () => {
+            const errors: string[] = [];
+            const grammarFiles: Record<string, string> = {
+                "lib.agr": `
+                    <Rule1> = one -> 1;
+                    <Rule2> = two -> 2;
+                `,
+                "main.agr": `
+                    import { Rule1 } from "./lib.agr";
+                    <Start> = <Rule1>;
+                `,
+            };
+            const grammar = loadGrammarRulesNoThrow(
+                "main.agr",
+                getTestFileLoader(grammarFiles),
+                errors,
+            );
+
+            expect(grammar).toBeUndefined();
+            expect(errors.length).toBeGreaterThan(0);
+            expect(errors[0]).toContain("Rule1");
+            expect(errors[0]).toContain("not exported");
         });
     });
 });

--- a/ts/packages/actionGrammar/test/grammarRuleParser.spec.ts
+++ b/ts/packages/actionGrammar/test/grammarRuleParser.spec.ts
@@ -1599,6 +1599,89 @@ describe("Grammar Rule Parser", () => {
         });
     });
 
+    describe("Export Keyword on Rule Definitions", () => {
+        it("parse exported rule definition", () => {
+            const grammar = "export <Rule1> = hello;";
+            const result = parseGrammarRules("test.agr", grammar, false);
+
+            expect(result.definitions).toHaveLength(1);
+            expect(result.definitions[0].exported).toBe(true);
+            expect(result.definitions[0].definitionName.name).toBe("Rule1");
+        });
+
+        it("non-exported rule has no exported flag", () => {
+            const grammar = "<Rule1> = hello;";
+            const result = parseGrammarRules("test.agr", grammar, false);
+
+            expect(result.definitions).toHaveLength(1);
+            expect(result.definitions[0].exported).toBeUndefined();
+        });
+
+        it("parse multiple rules with mixed export", () => {
+            const grammar = `
+                export <Rule1> = hello;
+                <Rule2> = world;
+                export <Rule3> = foo;
+            `;
+            const result = parseGrammarRules("test.agr", grammar, false);
+
+            expect(result.definitions).toHaveLength(3);
+            expect(result.definitions[0].exported).toBe(true);
+            expect(result.definitions[0].definitionName.name).toBe("Rule1");
+            expect(result.definitions[1].exported).toBeUndefined();
+            expect(result.definitions[1].definitionName.name).toBe("Rule2");
+            expect(result.definitions[2].exported).toBe(true);
+            expect(result.definitions[2].definitionName.name).toBe("Rule3");
+        });
+
+        it("export with imports and rules", () => {
+            const grammar = `
+                import { BaseRule } from "base.agr";
+                export <Start> = <BaseRule> world;
+            `;
+            const result = parseGrammarRules("test.agr", grammar, false);
+
+            expect(result.imports).toHaveLength(1);
+            expect(result.definitions).toHaveLength(1);
+            expect(result.definitions[0].exported).toBe(true);
+        });
+
+        it("preserves comment between export keyword and rule name", () => {
+            const grammar = "export /* after-export */ <Rule1> = hello;";
+            const result = parseGrammarRules("test.agr", grammar, false);
+
+            expect(result.definitions[0].exported).toBe(true);
+            expect(result.definitions[0].afterExportComments).toEqual([
+                { style: "block", text: " after-export " },
+            ]);
+        });
+
+        it("preserves leading comment before export keyword", () => {
+            const grammar =
+                "<Rule0> = world;\n// leading\nexport <Rule1> = hello;";
+            const result = parseGrammarRules("test.agr", grammar, false);
+
+            expect(result.definitions[1].exported).toBe(true);
+            expect(result.definitions[1].leadingComments).toEqual([
+                { style: "line", text: " leading" },
+            ]);
+        });
+
+        it("exported rule with spacing annotation", () => {
+            const grammar = "export <Rule1> [spacing=required] = hello;";
+            const result = parseGrammarRules("test.agr", grammar, false);
+
+            expect(result.definitions[0].exported).toBe(true);
+            expect(result.definitions[0].spacingMode).toBe("required");
+        });
+
+        it("throws when export is not followed by rule definition", () => {
+            expect(() =>
+                parseGrammarRules("test.agr", "export hello;", false),
+            ).toThrow();
+        });
+    });
+
     describe("Comment preservation at structural positions", () => {
         it("preserves block comment inside rule name angle brackets", () => {
             const result = parseGrammarRules(

--- a/ts/packages/actionGrammar/test/grammarRuleWriter.spec.ts
+++ b/ts/packages/actionGrammar/test/grammarRuleWriter.spec.ts
@@ -1225,4 +1225,37 @@ describe("Comment preservation round-trips (structural positions)", () => {
     it("comments inside empty array value", () => {
         roundTrip(`<A> = x -> [ /* only comment */ ];\n`);
     });
+
+    // Export keyword round-trips
+    it("exported rule definition", () => {
+        roundTrip(`export <Rule1> = hello;
+`);
+    });
+
+    it("multiple rules with mixed export", () => {
+        roundTrip(`export <Rule1> = hello;
+<Rule2> = world;
+`);
+    });
+
+    it("export with leading comment", () => {
+        roundTrip(`// export comment
+export <Rule1> = hello;
+`);
+    });
+
+    it("export with trailing comment", () => {
+        roundTrip(`export <Rule1> = hello; // trailing
+`);
+    });
+
+    it("export with comment after export keyword", () => {
+        roundTrip(`export /* after-export */ <Rule1> = hello;
+`);
+    });
+
+    it("export with spacing annotation", () => {
+        roundTrip(`export <Rule1> [spacing=required] = hello;
+`);
+    });
 });


### PR DESCRIPTION
## Summary

Add `export` keyword syntax for rule definitions in `.agr` grammar files. Only rules explicitly marked with `export` are importable by other files.

### Syntax

```
export <Greeting> = hello -> "hello";
<Internal> = internal helper -> "internal";  // not importable
```

### Changes

- **Parser**: Recognize `export <RuleName> = ...` syntax, set `exported` flag on `RuleDefinition`, preserve comments between the export keyword and rule name
- **Compiler**: Build `exportedNames` set from exported definitions, block imports of non-exported rules (named imports produce errors, wildcard imports silently skip), suppress "defined but never used" warning for exported rules
- **Writer**: Emit `export ` prefix and `afterExportComments` in round-trip output
- **Tests**: Parser (8 tests), writer (6 tests), compiler warning (1 test), and import integration tests (7 tests) — all existing import tests updated to use `export` keyword on importable rules

### Semantics

- Only rules with the `export` keyword can be imported by other `.agr` files
- Named imports of non-exported rules produce a compile error: `Rule '<X>' is not exported from 'file.agr'`
- Wildcard imports (`import * from ...`) silently skip non-exported rules
- Exported rules that aren't used internally don't trigger the "defined but never used" warning