### PR TITLE
Refactor grammar matcher and improve completion architecture

### DIFF
--- a/ts/docs/architecture/completion.md
+++ b/ts/docs/architecture/completion.md
@@ -167,13 +167,14 @@ The user types `play Never` (free-form, no `@` prefix).
 Using the same `play <song> by <artist>` rule, here is what category
 the grammar matcher assigns at different input states:
 
-| User input       | Category     | Why                                                  |
-| ---------------- | ------------ | ---------------------------------------------------- |
-| `play Never by ` | 1 — Exact    | Rule could be fully matched (`<artist>` is empty wc) |
-| `play `          | 2 — Clean    | Prefix consumed; `<song>` wildcard is next           |
-| `play Never`     | 3a — Pending | `<song>` wildcard still consuming `"Never"`          |
-| `play Nev`       | 3a — Pending | Same — no keyword yet finalizes the wildcard         |
-| `pla`            | 3b — Dirty   | `"pla"` partially matches the keyword `"play"`       |
+| User input       | Category     | Why                                                                    |
+| ---------------- | ------------ | ---------------------------------------------------------------------- |
+| `play Never by ` | 1 — Exact    | Rule could be fully matched (`<artist>` is empty wc)                   |
+| `play `          | 2 — Clean    | Prefix consumed; `<song>` wildcard is next                             |
+| `play Never`     | 3a — Pending | `<song>` wildcard still consuming `"Never"`                            |
+| `play Never b`   | 2 — Clean    | Wildcard absorbs `"Never b"`; backward detects `"b"` as partial `"by"` |
+| `play Nev`       | 3a — Pending | Same — no keyword yet finalizes the wildcard                           |
+| `pla`            | 3b — Dirty   | `"pla"` partially matches the keyword `"play"`                         |
 
 ---
 
@@ -196,15 +197,28 @@ grammar rules.
 3. When `maxPrefixLength` advances, discard all shorter-prefix completions.
 4. Categorize each state's outcome:
 
-| Category           | Condition                                               | Example (`play <song> by <artist>`)     | Forward completion           | Backward completion             |
-| ------------------ | ------------------------------------------------------- | --------------------------------------- | ---------------------------- | ------------------------------- |
-| 1 — Exact          | Rule fully matched, prefix fully consumed               | `play Never by Nirvana`                 | None                         | Last matched word/wildcard      |
-| 2 — Clean partial  | Prefix consumed, rule has remaining parts               | `play ` (wildcard next)                 | Next part of rule            | Last matched part               |
-| 3a — Pending wc    | Wildcard still consuming; no keyword yet finalizes it   | `play Never` (`<song>` still absorbing) | Wildcard property completion | Last matched part (if after wc) |
-| 3b — Dirty partial | Input extends beyond what the current rule part matched | `pla` (`"pla"` ≈ partial `play`)        | Current part (prefix-filter) | Current part (prefix-filter)    |
+| Category           | Condition                                               | Example (`play <song> by <artist>`)     | Forward completion           | Backward completion                                |
+| ------------------ | ------------------------------------------------------- | --------------------------------------- | ---------------------------- | -------------------------------------------------- |
+| 1 — Exact          | Rule fully matched, prefix fully consumed               | `play Never by Nirvana`                 | None                         | Last matched word/wildcard                         |
+| 2 — Clean partial  | Prefix consumed, rule has remaining parts               | `play ` (wildcard next)                 | Next part of rule            | Last matched part (or partial keyword — see below) |
+| 3a — Pending wc    | Wildcard still consuming; no keyword yet finalizes it   | `play Never` (`<song>` still absorbing) | Wildcard property completion | Last matched part (if after wc)                    |
+| 3b — Dirty partial | Input extends beyond what the current rule part matched | `pla` (`"pla"` ≈ partial `play`)        | Current part (prefix-filter) | Current part (prefix-filter)                       |
 
 5. Multi-word string parts use `tryPartialStringMatch()` to offer one word
    at a time instead of the entire phrase.
+6. **Partial keyword detection in wildcards** (Category 2 backward only):
+   When a wildcard absorbs all remaining input and the next grammar part
+   is a keyword, `findPartialKeywordInWildcard()` checks whether the
+   wildcard text ends with a prefix of that keyword. For example, with
+   `play <song> by <artist>` and input `"play Never b"`, the wildcard
+   absorbs `"Never b"` but `"b"` is a prefix of `"by"`. Backward
+   completion offers `"by"` at the partial keyword position (after
+   `"Never "`), with `openWildcard=true`, instead of backing up to the
+   wildcard start. This handles multi-word keywords as well: for
+   `play <song> played by <artist>` and input `"play Never played b"`,
+   the function recognizes `"played b"` as a full match of the first
+   keyword word plus a partial match of the second, and offers `"by"`.
+   The function honors `spacingMode` for inter-word separator matching.
 
 **Metadata produced:**
 

--- a/ts/docs/architecture/completion.md
+++ b/ts/docs/architecture/completion.md
@@ -1,11 +1,11 @@
-# Command Completion Architecture
+# Completion Architecture
 
 ## Overview
 
-TypeAgent's command completion system provides real-time, context-aware
-completions as the user types `@`-commands, subcommands, flags, and parameter
-values. The system spans five layers — from the grammar matcher at the bottom
-to the shell/CLI UI at the top — connected by a structured metadata contract
+TypeAgent's completion system provides real-time, context-aware completions
+as the user types `@`-commands, subcommands, flags, and parameter values.
+The system spans five layers — from the grammar matcher at the bottom to
+the shell/CLI UI at the top — connected by a structured metadata contract
 that eliminates client-side heuristics.
 
 ### Design principles
@@ -16,7 +16,9 @@ that eliminates client-side heuristics.
    (`closedSet`), and when to advance to the next hierarchical level
    The host provides a `direction` signal ("forward" or "backward") to
    resolve structural ambiguity when the input is valid.
-   Clients never split input on spaces or guess token boundaries.
+   Clients never split input on spaces or guess token boundaries — doing
+   so breaks on multi-word completions, CJK scripts without whitespace
+   delimiters, and quoted parameter values.
 
 2. **Longest-match wins** — At every layer (grammar, construction cache,
    grammar store merge), only completions anchored at the longest matched
@@ -81,6 +83,98 @@ The return path carries `CommandCompletionResult`:
 }
 ```
 
+These fields are cross-cutting concepts that flow through every layer.
+Brief definitions here; see [Key types](#key-types) for full semantics.
+
+- **`startIndex` / `matchedPrefixLength`** — The character position where
+  the backend's matched prefix ends. Everything before this position is
+  "consumed" input; completions apply after it.
+- **`separatorMode`** — Whether a separator character (space, punctuation)
+  is required between the consumed prefix and the completion text. Ranges
+  from `"space"` (strictest) to `"none"` (no separator needed).
+- **`closedSet`** — `true` when the completion list is exhaustive (all
+  valid values are present); `false` when additional values may exist
+  (e.g., entity names the backend cannot enumerate).
+- **`openWildcard`** — `true` when the `startIndex` position is ambiguous
+  because it sits at a wildcard boundary that could shift with more
+  typing. Controls anchor-sliding behavior in the shell.
+- **`direction`** — A `"forward"` or `"backward"` signal from the host,
+  indicating whether the user is advancing (appending characters) or
+  reconsidering (backspacing). Resolves structural ambiguity at command
+  and flag boundaries.
+- **Anchor** — The prefix string up to `startIndex`. The shell uses it as
+  a stable reference point: everything the user types after the anchor is
+  matched against the local completion trie.
+
+---
+
+## End-to-end example
+
+To ground the abstractions above, here is a concrete scenario tracing a
+user interaction through every layer.
+
+**Setup:** A player agent has the grammar rule
+`play <song> by <artist>`, where `<song>` and `<artist>` are wildcards.
+
+### Scenario 1 — Typing a new command
+
+The user types `play Never` (free-form, no `@` prefix).
+
+1. **Shell** (`PartialCompletionSession`): No active session → trigger A1
+   → calls `dispatcher.getCommandCompletion("play Never", "forward")`.
+
+2. **Dispatcher**: `normalizeCommand()` detects no `@` prefix and wraps
+   the input as `system request play Never` — routing it through the
+   system agent's `request` handler. `resolveCommand()` matches the
+   `system` agent and `request` subcommand; the suffix `"play Never"`
+   becomes the parameter value. `resolveCompletionTarget()` → case 2a-i
+   (free-form string with implicit quotes). The request handler delegates
+   to `requestCompletion()`, which calls `agentCache.completion()` with
+   the original text `"play Never"`.
+
+3. **Cache / Grammar**: The grammar matcher runs `"play Never"` against
+   compiled rules from all enabled agents. The player agent's
+   `play <song> by <artist>` rule matches: `"play "` consumed as keyword,
+   `"Never"` absorbed by the `<song>` wildcard (category 3a — pending
+   wildcard). For the `<song>` property slot, the dispatcher calls the
+   player agent's `getActionCompletion()`, which queries its song library
+   and returns entity values `["Never Gonna Give You Up", "Nevermind"]`.
+
+4. **Dispatcher**: Assembles `CommandCompletionResult` with `startIndex=5`
+   (after `"play "`), `closedSet=false` (entity values are not
+   exhaustive), `openWildcard=false` (no keyword yet reached to create
+   an ambiguous boundary).
+
+5. **Shell**: Receives result. Sets anchor to `"play "` (the first 5
+   characters). Completion prefix is `"Never"`. Populates trie with
+   `["Never Gonna Give You Up", "Nevermind"]`. Both match the prefix →
+   shows menu. `noMatchPolicy="refetch"` (closedSet=false,
+   openWildcard=false).
+
+6. **User types `mind`** → prefix becomes `"Nevermind"` → trie filters
+   to one match → trigger B1 (unique match) → re-fetch for the next
+   grammar part.
+
+7. **Re-fetch** with `"play Nevermind"`: grammar now finalizes the
+   `<song>` wildcard at end-of-input and offers keyword `"by"` as a
+   completion (category 2). Returns `closedSet=true`,
+   `openWildcard=true` (the wildcard boundary is ambiguous — the user
+   may still be typing within the song name). Shell sets
+   `noMatchPolicy="slide"`.
+
+### Scenario 2 — Grammar categories in action
+
+Using the same `play <song> by <artist>` rule, here is what category
+the grammar matcher assigns at different input states:
+
+| User input       | Category     | Why                                                  |
+| ---------------- | ------------ | ---------------------------------------------------- |
+| `play Never by ` | 1 — Exact    | Rule could be fully matched (`<artist>` is empty wc) |
+| `play `          | 2 — Clean    | Prefix consumed; `<song>` wildcard is next           |
+| `play Never`     | 3a — Pending | `<song>` wildcard still consuming `"Never"`          |
+| `play Nev`       | 3a — Pending | Same — no keyword yet finalizes the wildcard         |
+| `pla`            | 3b — Dirty   | `"pla"` partially matches the keyword `"play"`       |
+
 ---
 
 ## Layer details
@@ -95,18 +189,19 @@ grammar rules.
 
 **Algorithm:**
 
-1. Seed a work-list with one `MatchState` per top-level rule.
-2. Greedily advance each state through the prefix. Track
-   `maxPrefixLength` — the furthest character position any rule consumed.
+1. Seed a work-list with one match state per top-level rule. Each state
+   tracks the current position in both the rule and the input prefix.
+2. Greedily advance each state through the prefix. Track the furthest
+   character position any rule consumed (`maxPrefixLength`).
 3. When `maxPrefixLength` advances, discard all shorter-prefix completions.
 4. Categorize each state's outcome:
 
-| Category           | Condition                                 | Forward completion source      | Backward completion source           |
-| ------------------ | ----------------------------------------- | ------------------------------ | ------------------------------------ |
-| 1 — Exact          | Rule fully matched, prefix fully consumed | None                           | Last matched word/wildcard           |
-| 2 — Clean partial  | Prefix consumed, rule has remaining parts | Next part of rule              | Last matched part                    |
-| 3a — Pending wc    | Unfinalizable pending wildcard            | Wildcard property completion   | Last matched part (if afterWildcard) |
-| 3b — Dirty partial | Trailing text remains                     | Current part (prefix-filtered) | Current part (prefix-filtered)       |
+| Category           | Condition                                               | Example (`play <song> by <artist>`)     | Forward completion           | Backward completion             |
+| ------------------ | ------------------------------------------------------- | --------------------------------------- | ---------------------------- | ------------------------------- |
+| 1 — Exact          | Rule fully matched, prefix fully consumed               | `play Never by Nirvana`                 | None                         | Last matched word/wildcard      |
+| 2 — Clean partial  | Prefix consumed, rule has remaining parts               | `play ` (wildcard next)                 | Next part of rule            | Last matched part               |
+| 3a — Pending wc    | Wildcard still consuming; no keyword yet finalizes it   | `play Never` (`<song>` still absorbing) | Wildcard property completion | Last matched part (if after wc) |
+| 3b — Dirty partial | Input extends beyond what the current rule part matched | `pla` (`"pla"` ≈ partial `play`)        | Current part (prefix-filter) | Current part (prefix-filter)    |
 
 5. Multi-word string parts use `tryPartialStringMatch()` to offer one word
    at a time instead of the entire phrase.
@@ -114,28 +209,13 @@ grammar rules.
 **Metadata produced:**
 
 - `matchedPrefixLength` — characters consumed; becomes `startIndex` upstream.
-- `separatorMode` — per-candidate analysis of whether space/punctuation is
-  needed at the boundary (Latin vs CJK, `[spacing=none]` rules).
-- `closedSet` — `true` for pure keyword alternatives; `false` when
-  property/wildcard completions are emitted (entity values are external).
-- `openWildcard` — `true` when the `matchedPrefixLength` position is
-  **ambiguous** — i.e., adjacent to a wildcard whose extent is not fully
-  determined. This happens in two cases:
-
-  - **Forward (Category 2):** a keyword completion follows a wildcard that
-    was finalized at end-of-input (`finalizeState`). The wildcard consumed
-    everything up to EOI, but the user may still be typing within it.
-  - **Backward (Category 2 or 3a):** completion backs up to a keyword that
-    was matched after a captured wildcard (`afterWildcard` on
-    `lastMatchedPartInfo`). The wildcard's end was pinned by this keyword,
-    but backing up un-pins it — the wildcard could extend to absorb the
-    keyword text.
-
-  By contrast, a position is **definite** when it is structurally pinned
-  by matched grammar tokens and cannot shift with more typing. Examples:
-  the start of a wildcard (pinned by the preceding keyword), or a keyword
-  matched without a preceding wildcard. Backward completion to a wildcard's
-  start position reports `openWildcard=false`.
+- `separatorMode`, `closedSet`, `openWildcard` — see [Key types](#key-types)
+  for definitions. The grammar matcher is the originating source of these
+  fields: `closedSet` is `true` when all completions are grammar keywords
+  (no entity/wildcard values); `openWildcard` is `true` when the matched
+  position sits at an ambiguous wildcard boundary (e.g., a wildcard
+  finalized at end-of-input in the forward direction, or a keyword that
+  had pinned a wildcard's end in the backward direction).
 
 ---
 
@@ -154,11 +234,11 @@ Merges results from two sources:
 **Merge rules (`mergeCompletionResults`):**
 
 - Keep only completions from the longer `matchedPrefixLength`.
-- AND-merge `closedSet`: result is closed only if both sources are closed.
-- OR-merge `separatorMode`: strongest separator requirement wins
-  (`space > spacePunctuation > optional > none`).
+- AND-merge `closedSet` (closed only if _both_ sources are closed).
+- OR-merge `separatorMode` (strongest requirement wins;
+  see [merge semantics](#closedset) and [`SeparatorMode`](#separatormode)).
 
-When `_useNFAGrammar` is enabled, only the grammar store is consulted.
+When NFA grammar matching is enabled, only the grammar store is consulted.
 
 ---
 
@@ -202,13 +282,11 @@ strongest requirement.
 **Package:** `packages/dispatcher`
 **Entry point:** `getCommandCompletion(input, direction, context)` → `CommandCompletionResult`
 
-The `direction` parameter is a `CompletionDirection` (`"forward" | "backward"`) provided
-by the host. It resolves structural ambiguity when the full input is valid —
-for example, when a typed command name matches both a complete subcommand and
-a prefix of a longer one, direction tells the backend whether to proceed
-forward (show what follows) or reconsider backward (show alternatives).
-For free-form parameter values, the backend derives mid-token status from
-the input's trailing whitespace instead.
+The `direction` parameter (see [`CompletionDirection`](#completiondirection))
+resolves structural ambiguity when the full input is valid — for example,
+when a command name matches both a complete subcommand and a prefix of a
+longer one. For free-form parameter values, the backend derives mid-token
+status from the input's trailing whitespace instead.
 
 Orchestrates command resolution, parameter parsing, agent invocation, and
 built-in completions.
@@ -231,16 +309,19 @@ input
   → CommandCompletionResult
 ```
 
-**`resolveCompletionTarget`** — pure decision function:
+**`resolveCompletionTarget`** — pure decision function. The two top-level
+cases correspond to partial vs. full parse; sub-cases of 2 distinguish
+whether the user is still editing or has committed the last token.
 
 | Spec case | Condition                                         | Behavior                                             |
 | --------- | ------------------------------------------------- | ---------------------------------------------------- |
 | 1         | `remainderLength > 0` (partial parse)             | Offer what follows longest valid prefix              |
-| 3a-i      | Full parse, no trailing whitespace, string param  | Editing free-form value → invoke agent, prefix-match |
-| 3a-ii     | Full parse, direction="backward", flag name       | Reconsidering flag → offer flag alternatives         |
-| 3b        | Full parse, direction="forward" (or fully quoted) | Offer completions for next parameter/flag            |
+| 2a-i      | Full parse, no trailing whitespace, string param  | Editing free-form value → invoke agent, prefix-match |
+| 2a-ii     | Full parse, direction="backward", flag name       | Reconsidering flag → offer flag alternatives         |
+| 2b        | Full parse, direction="forward" (or fully quoted) | Offer completions for next parameter/flag            |
 
-**`computeClosedSet`** heuristic:
+**`computeClosedSet`** — determines `closedSet` for the final result
+(see [`closedSet`](#closedset) for the general contract):
 
 - Agent was invoked → use agent's `closedSet` (agent is authoritative)
 - Free-form text, no agent → `false`
@@ -279,15 +360,19 @@ lifecycle of a completion interaction.
 
 **Re-fetch decision tree (`reuseSession`):**
 
+Each trigger has a code: the letter is the category
+(A = invalidation, B = navigation, C = discovery) and the number is
+contiguous within each category.
+
 | Code | Trigger                                          | Category     | Action              |
 | ---- | ------------------------------------------------ | ------------ | ------------------- |
 | A1   | No active session                                | Invalidation | Re-fetch            |
 | A2   | Input no longer extends anchor                   | Invalidation | Re-fetch            |
 | A3   | Non-separator char typed when separator required | Invalidation | Re-fetch (or slide) |
-| A7   | Direction changed on direction-sensitive result  | Invalidation | Re-fetch            |
-| B4   | Unique match (always fires)                      | Navigation   | Re-fetch next level |
-| B5   | Separator typed after exact match                | Navigation   | Re-fetch next level |
-| C6   | No trie matches                                  | Discovery    | Per `noMatchPolicy` |
+| A4   | Direction changed on direction-sensitive result  | Invalidation | Re-fetch            |
+| B1   | Unique match (always fires)                      | Navigation   | Re-fetch next level |
+| B2   | Separator typed after exact match                | Navigation   | Re-fetch next level |
+| C1   | No trie matches                                  | Discovery    | Per `noMatchPolicy` |
 | —    | Trie has matches                                 | —            | Reuse locally       |
 
 **Key concepts:**
@@ -299,7 +384,7 @@ lifecycle of a completion interaction.
   leading separator character in the raw prefix is stripped before trie lookup.
 - **`noMatchPolicy`**: computed once from the backend's descriptive fields
   (`closedSet`, `openWildcard`) when a result arrives (see `NoMatchPolicy`
-  below). Drives the A3 and C6 decisions as a simple `switch` instead of
+  below). Drives the A3 and C1 decisions as a simple `switch` instead of
   checking two booleans independently.
 - **Session preservation**: `hide()` cancels in-flight fetches but preserves
   anchor and menu state for quick re-activation on re-focus.
@@ -367,9 +452,13 @@ and flag-level resolution). For free-form parameter values the backend
 uses the input's trailing whitespace to decide whether the last token is
 complete.
 
-Trigger B4 (unique match) always fires a re-fetch regardless of direction,
+Trigger B1 (unique match) always fires a re-fetch regardless of direction,
 since the session can determine locally that the completion is uniquely
 satisfied.
+
+Direction is advisory: an incorrect signal (e.g., `"forward"` during
+backspace) may produce suboptimal completions but cannot crash or corrupt
+state, since the backend is stateless per-request.
 
 ### `closedSet`
 
@@ -400,11 +489,12 @@ that could absorb more text, moving the boundary forward. This happens
 in two cases:
 
 - **Forward:** a keyword completion follows a wildcard that was finalized
-  at end-of-input (via `finalizeState`). The wildcard consumed everything
-  up to EOI, but the user may still be typing within it.
-- **Backward:** completion backs up to a keyword that was matched after a
-  captured wildcard (`afterWildcard` on `lastMatchedPartInfo`). Backing up
-  un-pins the wildcard boundary — it could extend to absorb the keyword.
+  at end-of-input (the matcher treats EOI as a tentative wildcard
+  boundary). The wildcard consumed everything up to EOI, but the user
+  may still be typing within it.
+- **Backward:** completion backs up to a keyword that had pinned the end
+  of a preceding wildcard. Backing up un-pins that boundary — the
+  wildcard could extend to absorb the keyword text.
 
 Values:
 
@@ -431,7 +521,7 @@ for the user's typed prefix.
 says whether the anchor position is ambiguous. These are grammar-level
 facts that don't depend on the shell's UI. The shell translates them into
 a single actionable policy on arrival, keeping the decision points (A3
-and C6) simple: each is a `switch` on one enum rather than reasoning
+and C1) simple: each is a `switch` on one enum rather than reasoning
 about two independent booleans.
 
 **Why `openWildcard` wins over `closedSet`:** When a wildcard boundary is
@@ -442,7 +532,7 @@ keywords at a shifted position (wasteful), and `"accept"` would leave the
 user stuck (no menu, no re-fetch). Sliding is the only useful action, so
 `openWildcard=true` maps to `"slide"` regardless of `closedSet`.
 
-| Policy      | Derived from                            | Shell action at A3 / C6          |
+| Policy      | Derived from                            | Shell action at A3 / C1          |
 | ----------- | --------------------------------------- | -------------------------------- |
 | `"accept"`  | `closedSet=true`, `openWildcard=false`  | Reuse (menu hidden, no re-fetch) |
 | `"refetch"` | `closedSet=false`, `openWildcard=false` | Re-fetch (backend may know more) |
@@ -452,12 +542,12 @@ This replaces independent checks on two booleans with a single `switch`:
 
 - **A3** (non-separator after anchor): `"slide"` slides the anchor forward;
   `"accept"` / `"refetch"` trigger a re-fetch.
-- **C6** (trie empty): `"slide"` slides the anchor forward; `"accept"`
+- **C1** (trie empty): `"slide"` slides the anchor forward; `"accept"`
   reuses silently; `"refetch"` re-fetches.
 
 Anchor sliding preserves the trie and metadata so the menu re-appears at
-the next word boundary. Recovery is automatic: when the user eventually
-types the keyword and it uniquely matches (trigger B4), the session
+the next whitespace boundary. Recovery is automatic: when the user eventually
+types the keyword and it uniquely matches (trigger B1), the session
 re-fetches for the next grammar part.
 
 ---
@@ -467,7 +557,8 @@ re-fetches for the next grammar part.
 The CLI (`packages/cli/src/commands/interactive.ts`) follows the same
 contract but with simpler plumbing:
 
-1. Sends full input and a `direction` (always `"forward"` for tab-completion)
+1. Sends full input and a `direction` (always `"forward"` for tab-completion,
+   since readline has no equivalent of backspace-triggered recompletion)
    to `dispatcher.getCommandCompletion(line, direction)` (no
    token-boundary heuristics).
 2. Uses `result.startIndex` as the readline filter position.

--- a/ts/packages/actionGrammar/src/grammarMatcher.ts
+++ b/ts/packages/actionGrammar/src/grammarMatcher.ts
@@ -796,6 +796,196 @@ function matchStringPartWithWildcard(
     }
 }
 
+// Greedily match keyword words against text starting at startIndex.
+// Returns the number of fully matched words and cursor positions.
+//
+// The first word allows an optional non-greedy leading separator
+// ([\s\p{P}]*?) so callers don't need to pre-skip whitespace.
+// Subsequent words use strict separators based on requiresSeparator.
+// isBoundarySatisfied is checked after every word — this is a no-op
+// at end-of-text and otherwise prevents partial-word matches
+// (e.g. "play" inside "playback").
+function matchWordsGreedily(
+    words: string[],
+    text: string,
+    startIndex: number,
+    spacingMode: CompiledSpacingMode,
+): { matchedWords: number; endIndex: number; prevEndIndex: number } {
+    let index = startIndex;
+    let prevIndex = startIndex;
+    let matchedWords = 0;
+
+    for (let k = 0; k < words.length; k++) {
+        const word = words[k];
+        const escaped = escapeMatch(word);
+
+        let regExpStr: string;
+        if (spacingMode === "none") {
+            regExpStr = escaped;
+        } else if (k === 0) {
+            regExpStr = `[${separatorRegExpStr}]*?${escaped}`;
+        } else {
+            const sep = requiresSeparator(
+                words[k - 1].at(-1)!,
+                word[0],
+                spacingMode,
+            )
+                ? `[${separatorRegExpStr}]+`
+                : `[${separatorRegExpStr}]*`;
+            regExpStr = sep + escaped;
+        }
+
+        const re = new RegExp(regExpStr, "iuy");
+        re.lastIndex = index;
+        const m = re.exec(text);
+        if (m === null) break;
+
+        const newIndex = m.index + m[0].length;
+        if (!isBoundarySatisfied(text, newIndex, spacingMode)) {
+            break;
+        }
+
+        prevIndex = index;
+        index = newIndex;
+        matchedWords++;
+    }
+
+    return { matchedWords, endIndex: index, prevEndIndex: prevIndex };
+}
+
+// Try matching keyword words forward from startIndex in prefix.
+// Returns the position and completion word if a partial match is found,
+// or undefined if no match or all words matched fully.
+function matchKeywordWordsFrom(
+    prefix: string,
+    startIndex: number,
+    words: string[],
+    spacingMode: CompiledSpacingMode,
+): { position: number; completionWord: string } | undefined {
+    const { matchedWords, endIndex } = matchWordsGreedily(
+        words,
+        prefix,
+        startIndex,
+        spacingMode,
+    );
+
+    // All words matched fully — not a partial match.
+    if (matchedWords >= words.length) return undefined;
+
+    // Consumed to end of prefix with more words remaining.
+    if (matchedWords > 0 && endIndex === prefix.length) {
+        return {
+            position: prefix.length,
+            completionWord: words[matchedWords],
+        };
+    }
+
+    // Check if remaining text is a partial prefix of the next word.
+    const word = words[matchedWords];
+    let textToCheck = prefix.slice(endIndex);
+    if (matchedWords > 0 && spacingMode !== "none") {
+        const sepMatch = textToCheck.match(
+            new RegExp(`^[${separatorRegExpStr}]+`, "u"),
+        );
+        if (sepMatch) {
+            textToCheck = textToCheck.slice(sepMatch[0].length);
+        } else if (
+            requiresSeparator(
+                words[matchedWords - 1].at(-1)!,
+                word[0],
+                spacingMode,
+            )
+        ) {
+            return undefined;
+        }
+    }
+
+    if (
+        textToCheck.length > 0 &&
+        textToCheck.length < word.length &&
+        word.toLowerCase().startsWith(textToCheck.toLowerCase())
+    ) {
+        return {
+            position: prefix.length - textToCheck.length,
+            completionWord: word,
+        };
+    }
+    return undefined;
+}
+
+// When a wildcard has absorbed all remaining input (via finalizeState),
+// check whether the absorbed text ends with a separator-delimited prefix
+// of the first word of the next keyword part.  Returns the position where
+// the partial keyword starts (i.e. the first non-separator character after
+// the last separator), or undefined if no partial keyword is found.
+//
+// Used in Category 2 backward to offer the keyword at the partial keyword
+// position instead of backing up to the wildcard start.
+//
+// Handles both single-word and multi-word keyword parts.  For a keyword
+// like ["played", "by"], the function recognizes:
+//   "p"        → partial of word 0 → completion = "played"
+//   "played"   → full word 0       → completion = "by"
+//   "played b" → full word 0 + partial of word 1 → completion = "by"
+//
+// Honors spacingMode between keyword words, using the same separator
+// logic as matchStringPart:
+//   "none"     → words are directly adjacent (no separators)
+//   "required" → [\s\p{P}]+ between words
+//   "optional" → [\s\p{P}]* between words
+//   auto       → + or * depending on requiresSeparator() for adjacent chars
+function findPartialKeywordInWildcard(
+    prefix: string,
+    wildcardStart: number,
+    part: StringPart,
+    spacingMode: CompiledSpacingMode,
+): { position: number; completionWord: string } | undefined {
+    const sepCharRe = /[\s\p{P}]/u;
+    const minStart = wildcardStart + 1;
+
+    // Scan candidate start positions from right to left.
+    for (
+        let candidateStart = prefix.length - 1;
+        candidateStart >= minStart;
+        candidateStart--
+    ) {
+        // In non-"none" modes, candidateStart must be preceded by a
+        // separator (to delimit wildcard content from the keyword
+        // fragment).  In "none" mode, no separator is needed.
+        if (
+            spacingMode !== "none" &&
+            !sepCharRe.test(prefix[candidateStart - 1])
+        ) {
+            continue;
+        }
+
+        const result = matchKeywordWordsFrom(
+            prefix,
+            candidateStart,
+            part.value,
+            spacingMode,
+        );
+        if (result === undefined) {
+            continue;
+        }
+
+        // Verify the wildcard content before the candidate is valid.
+        if (
+            getWildcardStr(
+                prefix,
+                wildcardStart,
+                candidateStart,
+                spacingMode,
+            ) === undefined
+        ) {
+            continue;
+        }
+
+        return result;
+    }
+    return undefined;
+}
+
 function matchStringPartWithoutWildcard(
     regExpStr: string,
     request: string,
@@ -1305,41 +1495,23 @@ function tryPartialStringMatch(
       }
     | undefined {
     const words = part.value;
-    let index = startIndex;
-    let matchedWords = 0;
-    let prevIndex = startIndex;
-
-    for (const word of words) {
-        const escaped = escapeMatch(word);
-        const regExpStr =
-            spacingMode === "none"
-                ? escaped
-                : `[${separatorRegExpStr}]*?${escaped}`;
-        const re = new RegExp(regExpStr, "iuy");
-        re.lastIndex = index;
-        const m = re.exec(prefix);
-        if (m === null) {
-            break;
-        }
-        const newIndex = m.index + m[0].length;
-        if (!isBoundarySatisfied(prefix, newIndex, spacingMode)) {
-            break;
-        }
-        prevIndex = index;
-        index = newIndex;
-        matchedWords++;
-    }
+    const { matchedWords, endIndex, prevEndIndex } = matchWordsGreedily(
+        words,
+        prefix,
+        startIndex,
+        spacingMode,
+    );
 
     // Direction matters when at least one word fully matched and no
     // trailing separator commits the last matched word.
     const couldBackUp =
         matchedWords > 0 &&
         (spacingMode === "none" ||
-            nextNonSeparatorIndex(prefix, index) === index);
+            nextNonSeparatorIndex(prefix, endIndex) === endIndex);
 
     if (direction === "backward" && couldBackUp) {
         return {
-            consumedLength: prevIndex,
+            consumedLength: prevEndIndex,
             remainingText: words[matchedWords - 1],
             directionSensitive: true,
         };
@@ -1352,7 +1524,7 @@ function tryPartialStringMatch(
     }
 
     return {
-        consumedLength: index,
+        consumedLength: endIndex,
         remainingText: words[matchedWords],
         directionSensitive: couldBackUp,
     };
@@ -1545,7 +1717,7 @@ export function matchGrammarCompletion(
     function emitBackwardCompletion(
         state: MatchState,
         savedWildcard: PendingWildcard | undefined,
-    ): boolean {
+    ): void {
         const wildcardStart = savedWildcard?.start;
         const partStart = state.lastMatchedPartInfo?.start;
         if (
@@ -1559,7 +1731,6 @@ export function matchGrammarCompletion(
                 savedWildcard.valueId,
                 savedWildcard.start,
             );
-            return true;
         } else if (state.lastMatchedPartInfo !== undefined) {
             const info = state.lastMatchedPartInfo;
             if (info.type === "string") {
@@ -1590,11 +1761,7 @@ export function matchGrammarCompletion(
                     openWildcard = true;
                 }
             }
-            return true;
         }
-        // Nothing to back up to — caller should fall through to
-        // forward behavior.
-        return false;
     }
 
     // --- Main loop: process every pending state ---
@@ -1634,12 +1801,8 @@ export function matchGrammarCompletion(
             // --- Category 1: Exact match ---
             // All parts matched AND prefix was fully consumed.
             if (matched) {
-                if (
-                    direction === "backward" &&
-                    hasPartToReconsider &&
-                    emitBackwardCompletion(state, savedPendingWildcard)
-                ) {
-                    // Backward emitted a completion — done with this state.
+                if (direction === "backward" && hasPartToReconsider) {
+                    emitBackwardCompletion(state, savedPendingWildcard);
                 } else {
                     debugCompletion("Matched. Nothing to complete.");
                     updateMaxPrefixLength(state.index);
@@ -1656,14 +1819,36 @@ export function matchGrammarCompletion(
             // That next part is what we offer as a completion.
             const nextPart = state.parts[state.partIndex];
 
-            if (
-                direction === "backward" &&
-                hasPartToReconsider &&
-                emitBackwardCompletion(state, savedPendingWildcard)
-            ) {
-                // Backward emitted a completion — openWildcard is
-                // set inside emitBackwardCompletion when the position
-                // is ambiguous (afterWildcard).
+            if (direction === "backward" && hasPartToReconsider) {
+                // When a wildcard absorbed text ending with a partial
+                // keyword prefix (e.g. "Never b" where "b" prefixes
+                // "by"), offer the keyword at the partial keyword
+                // position instead of backing up to the wildcard start.
+                // The partial keyword position has a higher
+                // matchedPrefixLength and is more useful to the user.
+                if (
+                    savedPendingWildcard?.valueId !== undefined &&
+                    nextPart.type === "string"
+                ) {
+                    const partialResult = findPartialKeywordInWildcard(
+                        prefix,
+                        savedPendingWildcard.start,
+                        nextPart,
+                        state.spacingMode,
+                    );
+                    if (partialResult !== undefined) {
+                        emitStringCompletion(
+                            state,
+                            partialResult.position,
+                            partialResult.completionWord,
+                        );
+                        openWildcard = true;
+                    } else {
+                        emitBackwardCompletion(state, savedPendingWildcard);
+                    }
+                } else {
+                    emitBackwardCompletion(state, savedPendingWildcard);
+                }
             } else {
                 debugCompletion(
                     `Completing ${nextPart.type} part ${state.name}`,

--- a/ts/packages/actionGrammar/test/grammarCompletionLongestMatch.spec.ts
+++ b/ts/packages/actionGrammar/test/grammarCompletionLongestMatch.spec.ts
@@ -822,5 +822,199 @@ describeForEachCompletion(
                 });
             });
         });
+
+        describe("partial keyword after wildcard — 'play Never b'", () => {
+            const g = [
+                `<Start> = play $(name) by $(artist) -> { name, artist };`,
+            ].join("\n");
+            const grammar = loadGrammarRules("test.grammar", g);
+
+            it("forward: offers 'by' with openWildcard=true", () => {
+                const result = matchGrammarCompletion(grammar, "play Never b");
+                expect(result.completions).toContain("by");
+                expect(result.matchedPrefixLength).toBe(12);
+                expect(result.separatorMode).toBe("spacePunctuation");
+                expect(result.closedSet).toBe(true);
+                expect(result.directionSensitive).toBe(true);
+                expect(result.openWildcard).toBe(true);
+            });
+
+            it("backward: offers 'by' (partial keyword wins over wildcard start)", () => {
+                const result = matchGrammarCompletion(
+                    grammar,
+                    "play Never b",
+                    undefined,
+                    "backward",
+                );
+                expect(result.completions).toContain("by");
+                expect(result.matchedPrefixLength).toBe(11);
+                expect(result.separatorMode).toBe("optional");
+                expect(result.closedSet).toBe(true);
+                expect(result.directionSensitive).toBe(true);
+                expect(result.openWildcard).toBe(true);
+            });
+
+            it("forward: partial keyword with multi-word wildcard", () => {
+                const result = matchGrammarCompletion(
+                    grammar,
+                    "play my favorite song b",
+                );
+                expect(result.completions).toContain("by");
+                expect(result.matchedPrefixLength).toBe(23);
+                expect(result.separatorMode).toBe("spacePunctuation");
+                expect(result.closedSet).toBe(true);
+                expect(result.directionSensitive).toBe(true);
+                expect(result.openWildcard).toBe(true);
+            });
+
+            it("backward: partial keyword with multi-word wildcard", () => {
+                const result = matchGrammarCompletion(
+                    grammar,
+                    "play my favorite song b",
+                    undefined,
+                    "backward",
+                );
+                expect(result.completions).toContain("by");
+                expect(result.matchedPrefixLength).toBe(22);
+                expect(result.separatorMode).toBe("optional");
+                expect(result.closedSet).toBe(true);
+                expect(result.directionSensitive).toBe(true);
+                expect(result.openWildcard).toBe(true);
+            });
+        });
+
+        describe("partial multi-word keyword after wildcard — 'played by'", () => {
+            const g = [
+                `<Start> = play $(name) played by $(artist) -> { name, artist };`,
+            ].join("\n");
+            const grammar = loadGrammarRules("test.grammar", g);
+
+            it("backward: partial first keyword word offers 'played'", () => {
+                const result = matchGrammarCompletion(
+                    grammar,
+                    "play Never p",
+                    undefined,
+                    "backward",
+                );
+                expect(result.completions).toContain("played");
+                expect(result.matchedPrefixLength).toBe(11);
+                expect(result.separatorMode).toBe("optional");
+                expect(result.closedSet).toBe(true);
+                expect(result.directionSensitive).toBe(true);
+                expect(result.openWildcard).toBe(true);
+            });
+
+            it("backward: full first keyword word offers 'by'", () => {
+                const result = matchGrammarCompletion(
+                    grammar,
+                    "play Never played",
+                    undefined,
+                    "backward",
+                );
+                expect(result.completions).toContain("by");
+                expect(result.matchedPrefixLength).toBe(17);
+                expect(result.separatorMode).toBe("spacePunctuation");
+                expect(result.closedSet).toBe(true);
+                expect(result.directionSensitive).toBe(true);
+                expect(result.openWildcard).toBe(true);
+            });
+
+            it("backward: full first keyword word + partial second offers 'by'", () => {
+                const result = matchGrammarCompletion(
+                    grammar,
+                    "play Never played b",
+                    undefined,
+                    "backward",
+                );
+                expect(result.completions).toContain("by");
+                expect(result.matchedPrefixLength).toBe(18);
+                expect(result.separatorMode).toBe("optional");
+                expect(result.closedSet).toBe(true);
+                expect(result.directionSensitive).toBe(true);
+                expect(result.openWildcard).toBe(true);
+            });
+
+            it("backward: multi-word wildcard + full first keyword word + partial second", () => {
+                const result = matchGrammarCompletion(
+                    grammar,
+                    "play my song played b",
+                    undefined,
+                    "backward",
+                );
+                expect(result.completions).toContain("by");
+                expect(result.matchedPrefixLength).toBe(20);
+                expect(result.separatorMode).toBe("optional");
+                expect(result.closedSet).toBe(true);
+                expect(result.directionSensitive).toBe(true);
+                expect(result.openWildcard).toBe(true);
+            });
+
+            it("backward: multi-word wildcard + full first keyword word offers 'by'", () => {
+                const result = matchGrammarCompletion(
+                    grammar,
+                    "play my song played",
+                    undefined,
+                    "backward",
+                );
+                expect(result.completions).toContain("by");
+                expect(result.matchedPrefixLength).toBe(19);
+                expect(result.separatorMode).toBe("spacePunctuation");
+                expect(result.closedSet).toBe(true);
+                expect(result.directionSensitive).toBe(true);
+                expect(result.openWildcard).toBe(true);
+            });
+        });
+
+        describe("partial keyword after wildcard — spacing=none", () => {
+            const g = [
+                `<Start> [spacing=none] = play $(name) playedby $(artist) -> { name, artist };`,
+            ].join("\n");
+            const grammar = loadGrammarRules("test.grammar", g);
+
+            it("backward: partial keyword prefix in none mode", () => {
+                const result = matchGrammarCompletion(
+                    grammar,
+                    "playNeverp",
+                    undefined,
+                    "backward",
+                );
+                expect(result.completions).toContain("playedby");
+                expect(result.matchedPrefixLength).toBe(9);
+                expect(result.separatorMode).toBe("none");
+                expect(result.closedSet).toBe(true);
+                expect(result.directionSensitive).toBe(true);
+                expect(result.openWildcard).toBe(true);
+            });
+
+            it("backward: longer partial keyword prefix in none mode", () => {
+                const result = matchGrammarCompletion(
+                    grammar,
+                    "playNeverplayedb",
+                    undefined,
+                    "backward",
+                );
+                expect(result.completions).toContain("playedby");
+                expect(result.matchedPrefixLength).toBe(9);
+                expect(result.separatorMode).toBe("none");
+                expect(result.closedSet).toBe(true);
+                expect(result.directionSensitive).toBe(true);
+                expect(result.openWildcard).toBe(true);
+            });
+
+            it("backward: multi-word wildcard with partial keyword in none mode", () => {
+                const result = matchGrammarCompletion(
+                    grammar,
+                    "playMyFavSongplayedb",
+                    undefined,
+                    "backward",
+                );
+                expect(result.completions).toContain("playedby");
+                expect(result.matchedPrefixLength).toBe(13);
+                expect(result.separatorMode).toBe("none");
+                expect(result.closedSet).toBe(true);
+                expect(result.directionSensitive).toBe(true);
+                expect(result.openWildcard).toBe(true);
+            });
+        });
     },
 );

--- a/ts/packages/dispatcher/dispatcher/src/command/completion.ts
+++ b/ts/packages/dispatcher/dispatcher/src/command/completion.ts
@@ -214,7 +214,7 @@ function resolveCompletionTarget(
     // ── Pending flag detection ───────────────────────────────────────
     const { pendingFlag, booleanFlagName } = detectPendingFlag(params, flags);
 
-    // ── Spec case 2: partial parse (remainderLength > 0) ────────────
+    // ── Spec case 1: partial parse (remainderLength > 0) ────────────
     // Parsing stopped partway.  Offer what can follow the longest
     // valid prefix.
     if (params.remainderLength > 0) {
@@ -231,12 +231,12 @@ function resolveCompletionTarget(
         };
     }
 
-    // ── Spec case 3: full parse (remainderLength === 0) ─────────────
+    // ── Spec case 2: full parse (remainderLength === 0) ─────────────
     const { tokens, lastCompletableParam, lastParamImplicitQuotes } = params;
 
-    // ── Spec case 3a: user is still editing the last token ──────
+    // ── Spec case 2a: user is still editing the last token ──────
 
-    // 3a-i: free-form parameter value.  lastCompletableParam is set
+    // 2a-i: free-form parameter value.  lastCompletableParam is set
     // only for string-type params — the only type whose partial text
     // is meaningful for prefix-match completion.
     if (lastCompletableParam !== undefined && tokens.length > 0) {
@@ -265,7 +265,7 @@ function resolveCompletionTarget(
         }
     }
 
-    // 3a-ii: reconsidering flag name.  A recognized flag was consumed
+    // 2a-ii: reconsidering flag name.  A recognized flag was consumed
     // but the user is backing up (direction="backward") — they
     // want to reconsider their choice (e.g. replace "--level" with
     // "--debug").  Back up to the flag token's start and offer flag
@@ -274,7 +274,7 @@ function resolveCompletionTarget(
     //
     // Trailing whitespace commits the flag — direction no longer matters.
     // When the user typed "--level " (with whitespace), they've moved on;
-    // fall through to 3b for value completions regardless of direction.
+    // fall through to 2b for value completions regardless of direction.
     const trailingWhitespace = hasWhitespaceBefore(input, remainderIndex);
     if (
         pendingFlag !== undefined &&
@@ -296,7 +296,7 @@ function resolveCompletionTarget(
         };
     }
 
-    // ── Spec case 3b: last token committed, complete next ───────
+    // ── Spec case 2b: last token committed, complete next ───────
     // startIndex is the raw position — includes any trailing
     // whitespace that the user typed.  When trailing whitespace is
     // present, separatorMode becomes "optional" because the
@@ -331,14 +331,12 @@ function resolveCompletionTarget(
 //
 // ── Spec ──────────────────────────────────────────────────────────────────
 //
-// 1. Parse parameters partially up to the longest valid index.
-//
-// 2. If parsing did NOT consume all input (remainderLength > 0):
+// 1. If parsing did NOT consume all input (remainderLength > 0):
 //    → startIndex = position after the longest valid prefix.
 //    → Offer completions for whatever can validly follow that prefix
 //      (next positional args, flag names).
 //
-// 3. If parsing consumed all input (remainderLength === 0):
+// 2. If parsing consumed all input (remainderLength === 0):
 //
 //    a. The user is still editing the last token — return startIndex
 //       at the *beginning* of that token:
@@ -361,12 +359,12 @@ function resolveCompletionTarget(
 //       When trailing whitespace is present, separatorMode is
 //       "optional" because the whitespace is already consumed.
 //
-// ── Exceptions to case 3a ────────────────────────────────────────────────
+// ── Exceptions to case 2a ────────────────────────────────────────────────
 //
-// Case 3a depends on lastCompletableParam (for 3a-i) and pendingFlag
-// (for 3a-ii).  parseParams only sets lastCompletableParam for
+// Case 2a depends on lastCompletableParam (for 2a-i) and pendingFlag
+// (for 2a-ii).  parseParams only sets lastCompletableParam for
 // *string*-type parameters: number, boolean, and json params leave it
-// undefined.  This means the following scenarios fall through to 3b
+// undefined.  This means the following scenarios fall through to 2b
 // even when direction="forward":
 //
 //   • A number arg being edited             (e.g. "cmd 42")

--- a/ts/packages/shell/src/renderer/src/partialCompletionSession.ts
+++ b/ts/packages/shell/src/renderer/src/partialCompletionSession.ts
@@ -198,7 +198,7 @@ export class PartialCompletionSession {
     //                         immediately after anchor, but a non-separator
     //                         character was typed instead. The constraint can
     //                         never be satisfied, so treat as new input.
-    //   7. Direction changed — the user switched between forward and backward
+    //   4. Direction changed — the user switched between forward and backward
     //                         AND the last result was direction-sensitive
     //                         AND the input is at the exact anchor (no text
     //                         typed past it).  Once the user types past the
@@ -207,10 +207,10 @@ export class PartialCompletionSession {
     //
     // B. Hierarchical navigation — user completed this level; re-fetch for
     //    the NEXT level's completions.
-    //   4. Uniquely satisfied — typed prefix exactly matches one completion and
+    //   1. Uniquely satisfied — typed prefix exactly matches one completion and
     //                         is not a prefix of any other. Always re-fetch
     //                         for the NEXT level.
-    //   5. Committed past boundary — prefix contains a separator after a valid
+    //   2. Committed past boundary — prefix contains a separator after a valid
     //                         completion match (e.g. "set " where "set" matches
     //                         but so does "setWindowState"). The user committed
     //                         by typing a separator; re-fetch for next level.
@@ -218,7 +218,7 @@ export class PartialCompletionSession {
     // C. Open-set discovery — trie has zero matches and the set is not
     //    exhaustive; the backend may know about completions not yet loaded.
     //    Gated by closedSet === false.
-    //   6. No matches + open set — trie has zero matches for the typed prefix
+    //   1. No matches + open set — trie has zero matches for the typed prefix
     //                         AND noMatchPolicy is "refetch". The backend may
     //                         know about completions not yet loaded.
     private reuseSession(
@@ -241,7 +241,7 @@ export class PartialCompletionSession {
         // ACTIVE from here.
         const { anchor, separatorMode: sepMode, noMatchPolicy } = this;
 
-        // [A7] Direction changed on a direction-sensitive result.
+        // [A4] Direction changed on a direction-sensitive result.
         // The loaded completions were computed for the opposite direction
         // and would differ — but only at the anchor boundary itself.
         // Once the user has typed past the anchor (rawPrefix is
@@ -351,7 +351,7 @@ export class PartialCompletionSession {
                 position,
             );
 
-            // [B4] The user has typed text that exactly matches one
+            // [B1] The user has typed text that exactly matches one
             // completion and is not a prefix of any other.
             // Always re-fetch for the next level — the direction
             // for the re-fetch comes from the caller.
@@ -362,7 +362,7 @@ export class PartialCompletionSession {
                 return false; // RE-FETCH (hierarchical navigation)
             }
 
-            // [B5] Committed-past-boundary: the prefix contains whitespace
+            // [B2] Committed-past-boundary: the prefix contains whitespace
             // or punctuation, meaning the user typed past a completion entry.
             // If the text before the first separator exactly matches a
             // completion, re-fetch for the next level.  This handles the
@@ -383,7 +383,7 @@ export class PartialCompletionSession {
             this.menu.hide();
         }
 
-        // [C6] When the menu is still active (trie has matches) we always
+        // [C1] When the menu is still active (trie has matches) we always
         // reuse — the loaded completions are still useful.  When there are
         // NO matches, the decision depends on `noMatchPolicy`:
         //   "accept"  → the set is exhaustive; the user typed past all
@@ -401,7 +401,7 @@ export class PartialCompletionSession {
             switch (noMatchPolicy) {
                 case "slide":
                     debug(
-                        `Partial completion anchor slide (C6): '${anchor}' → '${input}' (slide)`,
+                        `Partial completion anchor slide (C1): '${anchor}' → '${input}' (slide)`,
                     );
                     this.anchor = input;
                     this.menu.hide();


### PR DESCRIPTION
## Summary

Extract and unify the word-matching logic in the grammar matcher into shared helper functions, add backward completion support for partial keywords inside wildcards, and align documentation numbering with the code.

## Changes

### Extract shared word-matching helpers (`grammarMatcher.ts`)

`tryPartialStringMatch` and `findPartialKeywordInWildcard` both contained near-identical word-by-word matching loops with separator/boundary handling. This PR extracts the common logic into two new functions:

- **`matchWordsGreedily(words, text, startIndex, spacingMode)`** — greedily matches keyword words against text, returning the count of fully matched words plus cursor positions (`endIndex`, `prevEndIndex`). Handles first-word leading separator, inter-word separator selection via `requiresSeparator`, and `isBoundarySatisfied` checks after each word.
- **`matchKeywordWordsFrom(prefix, startIndex, words, spacingMode)`** — wraps `matchWordsGreedily` to detect partial matches: fully-matched-with-more-words-remaining, or a trailing partial prefix of the next unmatched word. Returns `{ position, completionWord }` or `undefined` when all words matched.

`tryPartialStringMatch` now delegates to `matchWordsGreedily` instead of maintaining its own loop. `findPartialKeywordInWildcard` now delegates to `matchKeywordWordsFrom` for each candidate position instead of inlining the matching logic.

### Backward completion for partial keywords in wildcards (Category 2)

When a wildcard absorbs text ending with a partial keyword prefix — e.g. `"play Never b"` where `"b"` prefixes the keyword `"by"` — backward completion previously backed up to the wildcard start. Now it detects the partial keyword via `findPartialKeywordInWildcard` and offers the keyword at the partial-keyword position instead.

This is handled inline in the Category 2 backward path: when `savedPendingWildcard` has a `valueId` and the next part is a string, scan the wildcard region for a partial keyword match before falling back to `emitBackwardCompletion`.

**`emitBackwardCompletion` simplified:** Changed from `boolean` return to `void`. Callers no longer branch on the return value — the partial-keyword-in-wildcard logic is handled before calling it.

### Documentation and numbering

- **`docs/architecture/completion.md`**: Added an end-to-end example tracing a user interaction through all five completion layers, a key-types glossary, and expanded design principles.
- **Dispatcher spec numbering** (`packages/dispatcher`): Renumbered spec cases from 2/3/3a/3b to 1/2/2a/2b (the old case 1 "parse parameters" was just a preamble, not a distinct case).
- **Shell session numbering** (`packages/shell`): Renumbered re-fetch trigger comments to sequential within each category (A1–A4, B1–B2, C1).

### Tests

Added tests for partial-keyword-after-wildcard scenarios in `grammarCompletionLongestMatch.spec.ts`:

- Forward and backward for single-word keyword (`"by"`) with single and multi-word wildcards
- Backward for multi-word keyword (`"played by"`) — partial first word, full first word, full first + partial second
- Backward in `spacing=none` mode — partial keyword prefix, longer partial, multi-word wildcard

All tests verify `completions`, `matchedPrefixLength`, `separatorMode`, `closedSet`, `directionSensitive`, and `openWildcard`.