### PR TITLE
Deduplicate grammar and completion architecture docs

### DIFF
--- a/ts/docs/architecture/actionGrammar.md
+++ b/ts/docs/architecture/actionGrammar.md
@@ -1,0 +1,516 @@
+# Action Grammar — Architecture & Design
+
+## Overview
+
+The `action-grammar` package is TypeAgent's natural language understanding
+engine. It compiles declarative grammar rule files (`.agr`) into efficient
+matching automata that convert free-form user requests into structured,
+typed action objects — without invoking an LLM at match time.
+
+```
+"play Yesterday by the Beatles"
+        ↓  grammar match
+{ actionName: "play", parameters: { track: "Yesterday", artist: "the Beatles" } }
+```
+
+The package sits between raw user input and the dispatcher, providing the
+first — and fastest — route to action resolution. When a grammar match
+succeeds, it eliminates the latency and cost of an LLM call entirely.
+
+### Key concepts
+
+| Term                | Meaning                                                                                                                                                                         |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Typed action**    | A structured object (`{ actionName, parameters }`) representing a user intent, validated against an agent's TypeScript action schema.                                           |
+| **ActionResult**    | The return value from an agent's `executeAction()` handler after processing a typed action.                                                                                     |
+| **Grammar matcher** | The system that matches user input against compiled grammar rules to produce typed actions. Accessed through the cache layer (`GrammarStoreImpl` in the `agent-cache` package). |
+
+---
+
+## Grammar concepts
+
+### The `.agr` language
+
+Grammars are written in `.agr` files — a purpose-built syntax resembling
+BNF with extensions for wildcards, entities, spacing modes, and value
+expressions. Agents never write matching code; they declare patterns.
+
+#### Declarations
+
+```agr
+entity CalendarDate, Ordinal;              // Entity type declarations
+import { helper } from "./other.agr";      // Named import
+import * from "./global.agr";             // Wildcard import
+```
+
+Entity declarations register typed validators (see [Entities](#entities)
+below). Imports pull rules from other `.agr` files:
+
+- **Named imports** (`import { helper } from "./other.agr"`) bring in
+  specific named rules from the target file.
+- **Wildcard imports** (`import * from "./global.agr"`) import all rules
+  and entity declarations from the target file into the current scope.
+  Name conflicts between wildcard-imported rules and locally defined
+  rules are detected and reported as errors during compilation.
+
+#### Rule definitions
+
+A rule has a name, optional annotation, and one or more alternatives
+separated by `|`:
+
+```agr
+<RuleName> [spacing=mode] = alternative1 | alternative2 ;
+
+// Example:
+<PlaySong> =
+    play $(track:wildcard) by $(artist:wildcard)
+    -> { actionName: "play", parameters: { track, artist } }
+  | put on $(track:wildcard)
+    -> { actionName: "play", parameters: { track } };
+```
+
+#### Expression types
+
+| Syntax              | Meaning                                |
+| ------------------- | -------------------------------------- |
+| `word`              | Literal token (case-insensitive match) |
+| `$(var:wildcard)`   | Capture any tokens as string           |
+| `$(var:number)`     | Capture numeric token                  |
+| `$(var:EntityType)` | Capture with entity validation         |
+| `$(var:<RuleName>)` | Capture via sub-rule match             |
+| `<RuleName>`        | Reference another rule (no capture)    |
+| `( expr )`          | Grouping                               |
+| `expr?`             | Optional (zero or one)                 |
+| `expr*`             | Zero or more                           |
+| `expr+`             | One or more                            |
+| `alt1 \| alt2`      | Alternation                            |
+
+#### Value expressions
+
+The `->` operator maps a matched rule to a structured action object.
+Captured variables are referenced by name:
+
+```agr
+<AddEvent> =
+    (add | create | schedule) $(title:wildcard)
+        on $(date:CalendarDate) at $(time:CalendarTime)
+    -> {
+        actionName: "addEvent",
+        parameters: {
+            title,
+            date,
+            time
+        }
+    };
+```
+
+#### Spacing modes
+
+Rules can annotate how tokens are separated, which matters for CJK
+languages and punctuation-adjacent matching:
+
+| Mode       | Behavior                                          |
+| ---------- | ------------------------------------------------- |
+| `required` | At least one whitespace separator between tokens  |
+| `optional` | Zero or more separators between tokens            |
+| `none`     | No separators (tokens must be adjacent)           |
+| `auto`     | Smart: Latin/Cyrillic require space; CJK does not |
+
+At matching time, the annotation sets a `CompiledSpacingMode` that is
+evaluated against the adjacent characters to produce a `separatorMode`
+(used by the completion pipeline — see
+[Completion matching](#completion-matching-matchgrammarcompletion) and
+`completion.md`):
+
+| Annotation           | `CompiledSpacingMode` | Resulting `separatorMode`                                                                                                                                             |
+| -------------------- | --------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| _(none / default)_   | `auto`                | `"spacePunctuation"` if both adjacent characters are word-boundary scripts (Latin, Cyrillic, etc.); `"optional"` if either is CJK or another non-word-boundary script |
+| `[spacing=required]` | `"required"`          | Always `"spacePunctuation"`                                                                                                                                           |
+| `[spacing=optional]` | `"optional"`          | Always `"optional"`                                                                                                                                                   |
+| `[spacing=none]`     | `"none"`              | Always `"none"` — no separator consumed or required                                                                                                                   |
+
+### Entities
+
+Entities are typed validators and converters for captured wildcards.
+A grammar declares which entity types it uses (`entity CalendarDate;`),
+and wildcards reference them with `$(var:EntityType)`.
+
+#### Built-in entities
+
+| Entity              | Matches                                   | Converts to         |
+| ------------------- | ----------------------------------------- | ------------------- |
+| `Ordinal`           | "first", "second", …, "twentieth"         | `number` (1, 2, …)  |
+| `Cardinal`          | "one", "two", numeric strings, multi-word | `number`            |
+| `CalendarDate`      | Relative/absolute date expressions        | Date object / ISO   |
+| `CalendarTime`      | "3pm", "half past 2", etc.                | Time representation |
+| `CalendarTimeRange` | Multi-token time ranges                   | Time range          |
+| `CalendarDayRange`  | Multi-token day ranges                    | Day range           |
+| `Percentage`        | Percentage expressions                    | `number`            |
+
+Custom entities can be registered at runtime via the `EntityRegistry`.
+
+---
+
+## How grammars are used in TypeAgent
+
+### Dispatcher integration
+
+The dispatcher maintains a grammar per registered agent. Grammar
+matching is not invoked directly by the dispatcher — it is delegated
+through the **cache layer** (`GrammarStoreImpl` in the `agent-cache`
+package). On each user request:
+
+1. The dispatcher calls `matchRequest()`, which delegates to
+   `AgentCache.match()`, which routes to `GrammarStoreImpl.match()`
+2. `GrammarStoreImpl` iterates over agent grammars and runs the
+   matching backend (selected by session config)
+3. If a high-confidence match is found, the action is dispatched directly
+   — no LLM call needed
+4. If no grammar match, the request falls through to LLM-based translation
+5. After LLM confirmation, a new grammar rule may be generated and added
+   dynamically
+
+### Dynamic grammar loading
+
+Grammars can be augmented at runtime — typically after the user confirms
+an LLM-generated action:
+
+```
+User request → LLM generates action → User confirms
+                                          ↓
+                               Grammar rule generated
+                                          ↓
+                     ┌────────────────────┼──────────────────────┐
+                     │                    │                      │
+              Syntax validated      Matcher recompiled    Persisted to
+              (parse + compile)     (hot reload)          grammar store
+```
+
+**`GrammarStore`** — Persistent storage of dynamically generated grammar
+rules. The file path is configurable (typically under `~/.typeagent/`).
+Each stored rule includes a stable ID, the source `.agr` text, the
+originating user request, the target action name, schema name, and a
+timestamp. Rules are organized by schema name. Supports add, delete
+(by index or by ID), and schema-scoped retrieval.
+
+**`DynamicGrammarLoader`** — Validates grammar text (parse + compile),
+checks entity references, detects symbol conflicts, and recompiles the
+matcher. On failure, returns structured error information including:
+parse errors (syntax problems in the `.agr` text), unresolved references
+(rule or entity names that don't exist), and symbol conflicts (names
+that collide with existing rules).
+
+**`AgentGrammar`** — Per-agent wrapper that manages a base grammar
+(from `.agr` files) plus dynamically added rules. Supports `resetToBase()`
+to revert to the original base grammar and `addGeneratedRules()` to
+extend. **`AgentGrammarRegistry`** manages the collection of per-agent
+`AgentGrammar` instances and provides `resetAllToBase()` to reset all
+agents at once.
+
+### Grammar generation
+
+The `generation/` subsystem uses LLMs to automatically create grammar
+rules from action schemas or confirmed user interactions.
+
+**Three generation strategies:**
+
+1. **`ClaudeGrammarGenerator`** — Analyzes individual request/action pairs.
+   Given a natural language request and its confirmed action, Claude
+   extracts linguistic patterns, parameter mappings, and alternative
+   phrasings. Produces `GrammarAnalysis` with rule patterns.
+
+2. **`SchemaToGrammarGenerator`** — Batch generation from action schemas.
+   Reads `.pas.json` (Parameter Action Schema) files — JSON
+   representations of an agent's TypeScript action types, containing
+   action names, parameter types, and descriptions extracted from the
+   agent's schema `.ts` file. From these schemas, the generator
+   produces example natural language requests for each action and
+   synthesizes complete `.agr` grammar text with test cases.
+
+3. **`ScenarioBasedGrammarGenerator`** — Uses pre-defined scenario templates
+   (music player, calendar, lists) to generate grammar rules for common
+   action patterns without LLM calls.
+
+**Coverage optimization:** `GrammarWarmer` tracks hit-rate metrics —
+which rules match, which miss, and which user requests fall through to
+LLM — and uses this data to prioritize generation of new rules.
+
+### Completion integration
+
+The grammar matcher provides completion support via
+`matchGrammarCompletion()` (see
+[Completion matching](#completion-matching-matchgrammarcompletion)
+below). The layers above the grammar matcher — cache merging, dispatcher
+orchestration, agent SDK, the shell state machine, and CLI integration —
+are documented in `completion.md`.
+
+---
+
+## Internal architecture
+
+### Design principles
+
+1. **Declarative grammar representation** — Grammars are compiled from
+   `.agr` source into an in-memory `Grammar` structure that is
+   independent of any particular matching backend.
+
+2. **Entity-aware validation** — Typed wildcards (`CalendarDate`, `Ordinal`,
+   etc.) can validate captured values against registered entity converters.
+
+### Core data model
+
+#### Grammar types (in-memory representation)
+
+```
+Grammar
+├── rules: GrammarRule[]                    # Top-level alternatives
+└── entities?: string[]                     # Referenced entity types
+
+GrammarRule
+├── parts: GrammarPart[]                    # Ordered sequence
+├── value?: CompiledValueNode               # Action value expression
+└── spacingMode?: "required"|"optional"|"none"|undefined  # undefined = auto
+
+GrammarPart (discriminated union)
+├── StringPart      { type:"string",    value: string[] }
+├── VarStringPart   { type:"wildcard",  variable, typeName, optional }
+├── VarNumberPart   { type:"number",    variable, optional }
+├── RulesPart       { type:"rules",     rules[], optional, repeat, variable }
+```
+
+#### Value expressions
+
+Value nodes form a tree that is evaluated against captured variables at
+match time to produce the final action object:
+
+```
+CompiledValueNode
+├── literal   → constant value
+├── variable  → variable reference (resolved by name)
+├── object    → { key: CompiledValueNode, … }
+└── array     → [ CompiledValueNode, … ]
+```
+
+### Processing pipeline
+
+```
+                      .agr file (text)
+                            │
+               ┌────────────▼─────────────┐
+               │    grammarRuleParser     │  Recursive descent parser
+               │    parseGrammarRules()   │  Produces GrammarParseResult AST
+               └────────────┬─────────────┘  (with comment preservation)
+                            │
+               ┌────────────▼─────────────┐
+               │    grammarCompiler       │  Resolves imports, validates
+               │    compileGrammar()      │  references, builds Grammar
+               └────────────┬─────────────┘
+                            │
+               ┌────────────▼─────────────┐
+               │    Matching backend      │  matchGrammar() or other
+               │    (Grammar → match)     │  backend
+               └────────────┬─────────────┘
+                            │
+                     Matched action object
+                     { actionName, parameters }
+```
+
+#### Parsing (`.agr` → AST)
+
+The parser in `grammarRuleParser.ts` implements a hand-written recursive
+descent parser for the `.agr` grammar syntax. It handles:
+
+- **Entity declarations**: `entity CalendarDate, Ordinal;`
+- **Imports**: `import { helper } from "./other.agr";` and wildcard imports
+- **Rule definitions**: `<RuleName> [annotation] = alternatives ;`
+- **Expressions**: string literals, wildcards (`$(var:type)`), rule
+  references (`<Rule>`), grouping with `( )`, quantifiers (`?`, `*`, `+`)
+- **Value mappings**: `-> { actionName: "play", parameters: { track } }`
+- **Comments**: Preserved in the AST for round-trip formatting
+
+The output `GrammarParseResult` (referred to as the "AST" in the
+pipeline diagram above) captures the full source structure:
+
+```typescript
+GrammarParseResult {
+  definitions: RuleDefinition[]   // Named rules with alternatives
+  imports: ImportStatement[]       // File imports
+  entities: string[]               // Entity declarations
+}
+```
+
+#### Compilation (AST → Grammar)
+
+`grammarCompiler.ts` walks the parsed AST to build the in-memory `Grammar`:
+
+1. Resolves import statements by loading and recursively compiling
+   referenced `.agr` files via the `FileLoader` interface — an
+   abstraction over file system access that allows the compiler to
+   load `.agr` source text by path, supporting both disk-based and
+   in-memory file resolution
+2. Validates that all rule references (`<RuleName>`) resolve to defined
+   rules (within the file or imports)
+3. Validates entity references against the global entity registry
+4. Compiles value expressions into `CompiledValueNode` trees
+5. Resolves spacing mode annotations
+6. Produces the flat `Grammar` structure ready for matching
+
+### Matching backend
+
+#### Full matching (`matchGrammar`)
+
+`grammarMatcher.ts` provides a direct interpreter over the `Grammar`:
+
+**Algorithm:**
+
+1. Operate directly on the raw request string (no pre-tokenization —
+   uses character-by-character regex matching with Unicode-aware
+   separator detection: `[\s\p{P}]+`)
+2. For each top-level rule alternative, attempt recursive matching
+3. At each rule part:
+   - **String**: match literal tokens (case-insensitive)
+   - **Wildcard**: greedily consume characters, backtrack on failure;
+     typed wildcards record the type name but do not validate at match
+     time
+   - **Rules**: recursively match nested alternatives
+4. Backtrack on failure; try next alternative
+5. Collect all successful matches (no priority ranking — returns all
+   matches to the caller)
+
+**Value construction:** Uses its own `createValue()` function to build
+action objects from the captured value tree.
+
+**Trade-offs:** Simple and flexible for complex nesting; character-level
+matching handles spacing modes naturally. Backtracking can be expensive
+on ambiguous grammars with long inputs. No built-in priority ranking.
+
+#### Completion matching (`matchGrammarCompletion`)
+
+`matchGrammarCompletion(grammar, prefix, minPrefixLength)` runs a partial
+match against an incomplete input prefix and returns the set of valid
+next-tokens, enabling real-time autocompletion.
+
+`minPrefixLength` controls the minimum number of characters that must be
+matched before completions are offered. When set to a value greater than
+zero, rules that consume fewer prefix characters than the threshold are
+skipped, preventing overly broad matches on very short inputs.
+
+**Algorithm:**
+
+1. Seed a work-list with one match state per top-level rule. Each state
+   tracks the current position in both the rule and the input prefix.
+2. Greedily advance each state through the prefix. Track the furthest
+   character position any rule consumed (`maxPrefixLength`).
+3. When `maxPrefixLength` advances, discard all shorter-prefix completions.
+4. Categorize each state's outcome:
+
+| Category           | Condition                                               | Example (`play <song> by <artist>`)     | Forward completion                              | Backward completion                                                                                                                                                                               |
+| ------------------ | ------------------------------------------------------- | --------------------------------------- | ----------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1 — Exact          | Rule fully matched, prefix fully consumed               | `play Never by Nirvana`                 | None                                            | Last matched word/wildcard                                                                                                                                                                        |
+| 2 — Clean partial  | Prefix consumed, rule has remaining parts               | `play ` (wildcard next)                 | Next part of rule                               | Previous keyword/wildcard at its start position; or if a partial keyword is detected inside a preceding wildcard (see step 6 below), the partial keyword at its position within the wildcard text |
+| 3a — Pending wc    | Wildcard still consuming; no keyword yet finalizes it   | `play Never` (`<song>` still absorbing) | Wildcard property completion                    | Last matched part (if after wc)                                                                                                                                                                   |
+| 3b — Dirty partial | Input extends beyond what the current rule part matched | `pla` (`"pla"` ≈ partial `play`)        | Current part (all alternatives; caller filters) | Current part (all alternatives; caller filters)                                                                                                                                                   |
+
+5. Multi-word string parts use `tryPartialStringMatch()` to offer one word
+   at a time instead of the entire phrase.
+
+**Note on Category 3b filtering:** In category 3b, the grammar matcher
+reports **all** valid completions at the longest matched prefix length
+without filtering by the trailing text. For example, with alternatives
+`music | movies` and input `"play mx"`, both `"music"` and `"movies"`
+are reported at `matchedPrefixLength=4`. The **caller** (shell trie or
+CLI) is responsible for filtering the completions against the remaining
+text `"mx"`. This applies equally to forward and backward directions.
+
+6. **Partial keyword detection in wildcards** (Category 2 backward only):
+   When a wildcard absorbs all remaining input and the next grammar part
+   is a keyword, `findPartialKeywordInWildcard()` checks whether the
+   wildcard text ends with a prefix of that keyword. For example, with
+   `play <song> by <artist>` and input `"play Never b"`, the wildcard
+   absorbs `"Never b"` but `"b"` is a prefix of `"by"`. Backward
+   completion offers `"by"` at the partial keyword position (after
+   `"Never "`), with `openWildcard=true`, instead of backing up to the
+   wildcard start. This handles multi-word keywords as well: for
+   `play <song> played by <artist>` and input `"play Never played b"`,
+   the function recognizes `"played b"` as a full match of the first
+   keyword word plus a partial match of the second, and offers `"by"`.
+   The function honors `spacingMode` for inter-word separator matching.
+
+**Metadata produced:**
+
+- `matchedPrefixLength` — characters consumed; becomes `startIndex`
+  upstream in the completion pipeline.
+- `properties` — an array of `GrammarCompletionProperty` entries, each
+  carrying a partially-constructed action value and the names of wildcard
+  property slots that need entity completions from the agent. The cache and
+  dispatcher translate these into agent `getActionCompletion()` calls to
+  populate the completion list with domain-specific values (e.g., song
+  titles, contact names). When the grammar offers only keyword completions
+  (no wildcards), `properties` is empty.
+- `separatorMode` — determined by the grammar rule's `[spacing=...]`
+  annotation (see [Spacing modes](#spacing-modes) above).
+  The dispatcher may override to `"space"` for structured commands
+  (e.g., `@agent` prefixes, flags). When `matchedPrefixLength=0`
+  (nothing consumed), `separatorMode` is always `"optional"` (or
+  `"none"` for `[spacing=none]` rules) because there is no preceding
+  character to require a separator against.
+- `closedSet` is `true` when all completions are grammar keywords
+  (no entity/wildcard values).
+- `directionSensitive` is `true` when the matched state has a fully
+  matched word without a trailing separator — meaning backward
+  completion would produce different results (see `completion.md`
+  for how downstream layers use this field).
+- `openWildcard` is `true` when the matched position sits at an ambiguous
+  wildcard boundary (e.g., a wildcard finalized at end-of-input in the
+  forward direction, or a keyword that had pinned a wildcard's end in the
+  backward direction).
+
+See `completion.md` for full definitions of how these metadata fields
+flow through the cache, dispatcher, and shell layers.
+
+### Entity registry
+
+`entityRegistry.ts` provides a global registry (`globalEntityRegistry`)
+for typed entity validators and converters:
+
+```typescript
+interface EntityValidator {
+  validate(token: string): boolean;
+}
+
+interface EntityConverter<T> {
+  validate(token: string): boolean;
+  convert(token: string): T | undefined;
+}
+```
+
+The registry maps entity type names to their validator/converter
+implementations. During grammar compilation, entity references are
+validated against this registry. At action construction time,
+`convert()` produces the typed runtime value.
+
+### Variable capture
+
+The backtracking matcher uses a linked-list tree of `MatchedValueEntry`
+nodes that accumulates captured values during recursive descent. Each
+entry links to its predecessor via a `prev` pointer, forming an
+immutable chain that naturally supports backtracking — when a branch
+fails, the matcher simply discards the chain without needing to undo
+writes.
+
+### Serialization
+
+#### JSON format (`.ag.json`)
+
+`grammarSerializer.ts` / `grammarDeserializer.ts` convert between the
+in-memory `Grammar` and a JSON representation used for caching and
+transport. Rules are de-duplicated via index references to avoid
+redundant inline copies of shared sub-rules.
+
+#### Round-trip formatting
+
+`grammarRuleWriter.ts` converts the parse AST back to `.agr` text format
+with intelligent line-breaking. It preserves comments from the original
+parse, supports compact (single-line) and expanded (multi-line) layouts,
+and respects a configurable line-length limit. This enables tooling
+workflows where grammars are programmatically modified and re-serialized.

--- a/ts/docs/architecture/completion.md
+++ b/ts/docs/architecture/completion.md
@@ -4,16 +4,22 @@
 
 TypeAgent's completion system provides real-time, context-aware completions
 as the user types `@`-commands, subcommands, flags, and parameter values.
-The system spans five layers — from the grammar matcher at the bottom to
-the shell/CLI UI at the top — connected by a structured metadata contract
-that eliminates client-side heuristics.
+The system spans four backend layers — grammar matcher, cache, agent SDK,
+and dispatcher — plus a shell layer (with sub-components for session
+management, DOM integration, and the search menu) and a CLI adapter.
+These are connected by a structured metadata contract that eliminates
+client-side heuristics.
+
+For grammar concepts (`.agr` syntax, entities, compilation pipeline) and
+the full grammar matching algorithm (including completion categories and
+metadata production), see `actionGrammar.md`.
 
 ### Design principles
 
 1. **Backend-authoritative** — The dispatcher (and the grammar/cache layers
    beneath it) decides where completions start (`startIndex`), what separates
    them from the prefix (`separatorMode`), whether the list is exhaustive
-   (`closedSet`), and when to advance to the next hierarchical level
+   (`closedSet`), and when to advance to the next hierarchical level.
    The host provides a `direction` signal ("forward" or "backward") to
    resolve structural ambiguity when the input is valid.
    Clients never split input on spaces or guess token boundaries — doing
@@ -25,8 +31,9 @@ that eliminates client-side heuristics.
    prefix survive. Shorter matches are eagerly discarded.
 
 3. **Progressive disclosure** — Multi-word phrases are offered one word at a
-   time. Hierarchical commands (`@agent subcommand param`) re-fetch at each
-   level boundary.
+   time (e.g., for a grammar token `"played by"`, completion first offers
+   `"played"`, then on the next fetch offers `"by"`). Hierarchical commands
+   (`@agent subcommand param`) re-fetch at each level boundary.
 
 4. **Minimal re-fetch** — A client-side state machine categorizes every
    keystroke into one of six triggers and only contacts the backend when
@@ -102,9 +109,8 @@ Brief definitions here; see [Key types](#key-types) for full semantics.
   indicating whether the user is advancing (appending characters) or
   reconsidering (backspacing). Resolves structural ambiguity at command
   and flag boundaries.
-- **Anchor** — The prefix string up to `startIndex`. The shell uses it as
-  a stable reference point: everything the user types after the anchor is
-  matched against the local completion trie.
+- **Anchor** — The prefix string up to `startIndex`. See
+  [Anchor](#anchor) in Key types for full semantics.
 
 ---
 
@@ -142,8 +148,8 @@ The user types `play Never` (free-form, no `@` prefix).
 
 4. **Dispatcher**: Assembles `CommandCompletionResult` with `startIndex=5`
    (after `"play "`), `closedSet=false` (entity values are not
-   exhaustive), `openWildcard=false` (no keyword yet reached to create
-   an ambiguous boundary).
+   exhaustive), `openWildcard=false` (the `startIndex` position is
+   pinned by the keyword `"play "` — it cannot shift with more typing).
 
 5. **Shell**: Receives result. Sets anchor to `"play "` (the first 5
    characters). Completion prefix is `"Never"`. Populates trie with
@@ -157,24 +163,26 @@ The user types `play Never` (free-form, no `@` prefix).
 
 7. **Re-fetch** with `"play Nevermind"`: grammar now finalizes the
    `<song>` wildcard at end-of-input and offers keyword `"by"` as a
-   completion (category 2). Returns `closedSet=true`,
-   `openWildcard=true` (the wildcard boundary is ambiguous — the user
-   may still be typing within the song name). Shell sets
-   `noMatchPolicy="slide"`.
+   completion (category 2). This time, unlike step 4, the completions
+   are grammar keywords (not agent entity values), and the keyword
+   position sits at an end-of-input wildcard boundary — so
+   `closedSet=true` (keyword set is exhaustive) and `openWildcard=true`
+   (the wildcard boundary is ambiguous — the user may still be typing
+   within the song name). Shell sets `noMatchPolicy="slide"`.
 
 ### Scenario 2 — Grammar categories in action
 
 Using the same `play <song> by <artist>` rule, here is what category
 the grammar matcher assigns at different input states:
 
-| User input       | Category     | Why                                                                    |
-| ---------------- | ------------ | ---------------------------------------------------------------------- |
-| `play Never by ` | 1 — Exact    | Rule could be fully matched (`<artist>` is empty wc)                   |
-| `play `          | 2 — Clean    | Prefix consumed; `<song>` wildcard is next                             |
-| `play Never`     | 3a — Pending | `<song>` wildcard still consuming `"Never"`                            |
-| `play Never b`   | 2 — Clean    | Wildcard absorbs `"Never b"`; backward detects `"b"` as partial `"by"` |
-| `play Nev`       | 3a — Pending | Same — no keyword yet finalizes the wildcard                           |
-| `pla`            | 3b — Dirty   | `"pla"` partially matches the keyword `"play"`                         |
+| User input       | Category     | Why                                                                                                                                                                                                                                                                                                       |
+| ---------------- | ------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `play Never by ` | 1 — Exact    | Rule could be fully matched (`<artist>` is empty wc)                                                                                                                                                                                                                                                      |
+| `play `          | 2 — Clean    | Prefix consumed; `<song>` wildcard is next                                                                                                                                                                                                                                                                |
+| `play Never`     | 3a — Pending | `<song>` wildcard still consuming `"Never"`                                                                                                                                                                                                                                                               |
+| `play Never b`   | 2 — Clean    | Backward direction only: wildcard absorbs `"Never b"`, then `findPartialKeywordInWildcard()` detects `"b"` as a prefix of keyword `"by"` and offers it as a completion at the partial keyword position (after `"Never "`). In the forward direction this would be category 3a (wildcard still consuming). |
+| `play Nev`       | 3a — Pending | Same — no keyword yet finalizes the wildcard                                                                                                                                                                                                                                                              |
+| `pla`            | 3b — Dirty   | `"pla"` partially matches the keyword `"play"`                                                                                                                                                                                                                                                            |
 
 ---
 
@@ -186,50 +194,31 @@ the grammar matcher assigns at different input states:
 **Entry point:** `matchGrammarCompletion(grammar, prefix, minPrefixLength)`
 
 Computes the set of valid next-tokens for a partial input against compiled
-grammar rules.
+grammar rules. For the full algorithm, per-direction behavior, partial
+keyword detection, and spacing annotation semantics, see
+`actionGrammar.md`.
 
-**Algorithm:**
+**Completion categories** — The matcher categorizes each match state into
+one of four outcomes:
 
-1. Seed a work-list with one match state per top-level rule. Each state
-   tracks the current position in both the rule and the input prefix.
-2. Greedily advance each state through the prefix. Track the furthest
-   character position any rule consumed (`maxPrefixLength`).
-3. When `maxPrefixLength` advances, discard all shorter-prefix completions.
-4. Categorize each state's outcome:
-
-| Category           | Condition                                               | Example (`play <song> by <artist>`)     | Forward completion           | Backward completion                                |
-| ------------------ | ------------------------------------------------------- | --------------------------------------- | ---------------------------- | -------------------------------------------------- |
-| 1 — Exact          | Rule fully matched, prefix fully consumed               | `play Never by Nirvana`                 | None                         | Last matched word/wildcard                         |
-| 2 — Clean partial  | Prefix consumed, rule has remaining parts               | `play ` (wildcard next)                 | Next part of rule            | Last matched part (or partial keyword — see below) |
-| 3a — Pending wc    | Wildcard still consuming; no keyword yet finalizes it   | `play Never` (`<song>` still absorbing) | Wildcard property completion | Last matched part (if after wc)                    |
-| 3b — Dirty partial | Input extends beyond what the current rule part matched | `pla` (`"pla"` ≈ partial `play`)        | Current part (prefix-filter) | Current part (prefix-filter)                       |
-
-5. Multi-word string parts use `tryPartialStringMatch()` to offer one word
-   at a time instead of the entire phrase.
-6. **Partial keyword detection in wildcards** (Category 2 backward only):
-   When a wildcard absorbs all remaining input and the next grammar part
-   is a keyword, `findPartialKeywordInWildcard()` checks whether the
-   wildcard text ends with a prefix of that keyword. For example, with
-   `play <song> by <artist>` and input `"play Never b"`, the wildcard
-   absorbs `"Never b"` but `"b"` is a prefix of `"by"`. Backward
-   completion offers `"by"` at the partial keyword position (after
-   `"Never "`), with `openWildcard=true`, instead of backing up to the
-   wildcard start. This handles multi-word keywords as well: for
-   `play <song> played by <artist>` and input `"play Never played b"`,
-   the function recognizes `"played b"` as a full match of the first
-   keyword word plus a partial match of the second, and offers `"by"`.
-   The function honors `spacingMode` for inter-word separator matching.
+| Category           | Condition                                               | Result                                               |
+| ------------------ | ------------------------------------------------------- | ---------------------------------------------------- |
+| 1 — Exact          | Rule fully matched, prefix fully consumed               | No forward completions; backward re-offers last part |
+| 2 — Clean partial  | Prefix consumed, rule has remaining parts               | Next part of rule offered                            |
+| 3a — Pending wc    | Wildcard still consuming; no keyword finalizes it       | Wildcard property completion                         |
+| 3b — Dirty partial | Input extends beyond what the current rule part matched | All alternatives at matched prefix; caller filters   |
 
 **Metadata produced:**
 
-- `matchedPrefixLength` — characters consumed; becomes `startIndex` upstream.
-- `separatorMode`, `closedSet`, `openWildcard` — see [Key types](#key-types)
-  for definitions. The grammar matcher is the originating source of these
-  fields: `closedSet` is `true` when all completions are grammar keywords
-  (no entity/wildcard values); `openWildcard` is `true` when the matched
-  position sits at an ambiguous wildcard boundary (e.g., a wildcard
-  finalized at end-of-input in the forward direction, or a keyword that
-  had pinned a wildcard's end in the backward direction).
+- `matchedPrefixLength` — characters consumed; becomes `startIndex` upstream
+- `properties` — wildcard property slots needing entity completions from the agent
+- `separatorMode` — determined by the rule's `[spacing=...]` annotation
+- `closedSet` — `true` when all completions are grammar keywords
+- `directionSensitive` — `true` when backward completion would differ
+  (see [`directionSensitive`](#directionsensitive))
+- `openWildcard` — `true` at ambiguous wildcard boundaries
+
+See [Key types](#key-types) for full definitions of these fields.
 
 ---
 
@@ -248,9 +237,15 @@ Merges results from two sources:
 **Merge rules (`mergeCompletionResults`):**
 
 - Keep only completions from the longer `matchedPrefixLength`.
-- AND-merge `closedSet` (closed only if _both_ sources are closed).
+  When one source has a defined `matchedPrefixLength` and the other does
+  not, `undefined` is treated as `0` — defined wins unless both are `0`.
+  When both are `undefined`, the merged result preserves `undefined`.
+- AND-merge `closedSet` (closed only if _both_ sources are closed;
+  `undefined` is treated as `false`).
 - OR-merge `separatorMode` (strongest requirement wins;
   see [merge semantics](#closedset) and [`SeparatorMode`](#separatormode)).
+- OR-merge `directionSensitive` (sensitive if _any_ source is sensitive).
+- Merge `properties` arrays by concatenation.
 
 When NFA grammar matching is enabled, only the grammar store is consulted.
 
@@ -343,7 +338,14 @@ whether the user is still editing or has committed the last token.
 
 ---
 
-### 5. Shell — Completion Session
+### 5. Shell
+
+The shell layer comprises three sub-components: a completion session
+(state machine), a DOM adapter (input extraction and menu positioning),
+and a search menu (trie-backed filtering). Together they form the
+client-side half of the completion system.
+
+#### 5a. Completion Session
 
 **Package:** `packages/shell`
 **Class:** `PartialCompletionSession`
@@ -403,9 +405,7 @@ contiguous within each category.
 - **Session preservation**: `hide()` cancels in-flight fetches but preserves
   anchor and menu state for quick re-activation on re-focus.
 
----
-
-### 6. Shell — DOM Adapter
+#### 5b. DOM Adapter
 
 **Class:** `PartialCompletion`
 
@@ -417,9 +417,7 @@ Bridges the DOM text editor and the session state machine:
 - On user selection: computes replacement range from completion prefix,
   performs DOM text replacement, repositions cursor, triggers fresh completion
 
----
-
-### 7. Shell — Search Menu
+#### 5c. Search Menu
 
 **Classes:** `SearchMenuBase` (abstract), `SearchMenu` (concrete)
 
@@ -443,12 +441,49 @@ Trie-backed prefix filtering:
 Controls what character is required between the matched prefix and completion
 text.
 
-| Value                | Meaning                             | Use case                                                                                                                                                                                                                                                                         |
-| -------------------- | ----------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `"space"`            | Whitespace required                 | Commands, flags, agent names                                                                                                                                                                                                                                                     |
-| `"spacePunctuation"` | Whitespace or Unicode punctuation   | Latin-script grammar completions                                                                                                                                                                                                                                                 |
-| `"optional"`         | Separator accepted but not required | CJK / mixed-script grammars                                                                                                                                                                                                                                                      |
-| `"none"`             | No separator                        | `[spacing=none]` grammars; at top level, no leading or trailing whitespace is consumed. For nested rules, the nearest ancestor with a flex-space boundary controls surrounding spacing (or the top-level rule if no ancestor has one); the child controls only internal spacing. |
+| Value                | Meaning                             | Use case                                                                                                                                                                                                                                                                   |
+| -------------------- | ----------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `"space"`            | Whitespace required                 | Commands, flags, agent names                                                                                                                                                                                                                                               |
+| `"spacePunctuation"` | Whitespace or Unicode punctuation   | Latin-script grammar completions                                                                                                                                                                                                                                           |
+| `"optional"`         | Separator accepted but not required | CJK / mixed-script grammars                                                                                                                                                                                                                                                |
+| `"none"`             | No separator                        | Grammar rules annotated with `[spacing=none]`. At the top level, no leading or trailing whitespace is consumed. For nested rules, the parent rule's spacing controls the boundaries around the child; the child's `"none"` only affects its own internal token boundaries. |
+
+### `directionSensitive`
+
+A boolean flowing through the backend pipeline (grammar → cache →
+dispatcher), indicating that the result would differ if the opposite
+`direction` had been sent. The shell uses this for trigger A4: when
+the user changes direction (e.g., starts backspacing after typing),
+the session only re-fetches if the current result is
+`directionSensitive=true`. If `false`, the same completions apply
+regardless of direction, so no re-fetch is needed.
+
+**Origin:** The grammar matcher is the primary source. It sets
+`directionSensitive=true` when the matched state has a part the user
+could "back up" to — specifically, when at least one word has been
+fully matched **without** a trailing separator committing it. A
+trailing space (or punctuation, depending on `spacingMode`) "commits"
+the match position and clears direction sensitivity.
+
+Examples with rule `play <song> by <artist>`:
+
+| Input         | `directionSensitive` | Why                                               |
+| ------------- | -------------------- | ------------------------------------------------- |
+| `play`        | `true`               | `"play"` fully matched, no trailing space         |
+| `play `       | `false`              | Trailing space commits — backward same as forward |
+| `play music`  | `true`               | `"music"` fully matched, no trailing space        |
+| `play music ` | `false`              | Trailing space commits                            |
+| `pla`         | `false`              | Only partial match — nothing to back up to        |
+
+Exception: in `[spacing=none]` mode, whitespace is not a separator,
+so `directionSensitive` is always `true` when any word has been fully
+matched — trailing spaces do not commit.
+
+The dispatcher may additionally set `directionSensitive=true` at the
+command level — for example, when a subcommand name is both a valid
+complete command and a prefix of a longer one.
+
+Merge rule: OR across sources (sensitive if _any_ source is sensitive).
 
 ### `CompletionDirection`
 
@@ -510,6 +545,17 @@ in two cases:
   of a preceding wildcard. Backing up un-pins that boundary — the
   wildcard could extend to absorb the keyword text.
 
+**Persistence:** `openWildcard` remains `true` even after the user types
+the full keyword text (e.g., `"play hello by"` and `"play hello by "`)
+because the grammar matcher always forks two parse paths at a
+wildcard-keyword boundary: one where the keyword is consumed, and one
+where the wildcard absorbs the keyword text. Both paths produce
+completions at the same prefix length, so neither can eliminate the
+other. `openWildcard` only becomes `false` when the ambiguity is
+structurally resolved by further context (e.g., the user types enough
+after the keyword that the wildcard-absorbing path can no longer produce
+a match at the same prefix length).
+
 Values:
 
 - **`true`** — the position is ambiguous. The keyword following the
@@ -523,6 +569,34 @@ Merge rule: OR across sources (open wildcard if _any_ source has one).
 
 The shell does not store `openWildcard` directly; it is folded into
 `noMatchPolicy` (see below).
+
+### Anchor
+
+The prefix string from the start of the input up to `startIndex`. The
+shell captures this string when a backend result arrives and uses it as a
+stable reference point for the lifetime of the completion session.
+
+Everything the user types after the anchor is the **completion prefix** —
+the string filtered against the local trie. For example, if the input is
+`"play Never"` and `startIndex=5`, the anchor is `"play "` and the
+completion prefix is `"Never"`.
+
+The anchor serves three purposes:
+
+1. **Trie filtering** — only the text after the anchor is matched against
+   completion entries.
+2. **Invalidation** — if the user edits text within the anchor (trigger A2),
+   the session is invalidated and a re-fetch is required.
+3. **Sliding** — when `noMatchPolicy="slide"`, the anchor advances to
+   the full current input on each keystroke, preserving the trie and
+   metadata. The menu is hidden during sliding. When the user eventually
+   types a separator character, the raw prefix after the (now-advanced)
+   anchor is just the separator itself; stripping it yields an empty
+   completion prefix, which matches **all** entries in the preserved
+   trie — so the full completion list reappears without a re-fetch.
+   If the user then types the keyword (e.g., `"by"`), it uniquely
+   matches in the trie, triggering B1 (unique match) which re-fetches
+   for the next grammar part.
 
 ### `NoMatchPolicy` (shell-internal)
 
@@ -578,5 +652,26 @@ contract but with simpler plumbing:
 2. Uses `result.startIndex` as the readline filter position.
 3. Prepends a space separator when `separatorMode` is `"space"` or
    `"spacePunctuation"` to prevent fused display (e.g., `"playmusic"`).
+
+Because `direction` is always `"forward"`, the CLI cannot trigger
+backward-specific completions (e.g., reconsidering a flag name). In
+practice this is a minor limitation: readline tab-completion is
+inherently forward-looking, and users backspace-and-retype rather than
+expecting the completion menu to adapt to deletions.
+
+---
+
+## Edge cases
+
+- **Empty input:** The dispatcher returns the top-level command list
+  (agent names and built-in commands) with `closedSet=true`.
+- **No grammar match:** When no rule matches the input at all, the
+  grammar matcher returns an empty completion set with
+  `matchedPrefixLength=0`. The cache and dispatcher propagate this
+  upward; the shell receives an empty menu and takes no action.
+- **Concurrent requests:** The shell's `PENDING` state cancels any
+  in-flight fetch when a new fetch is triggered (e.g., rapid typing).
+  Only the most recent request's result is applied. The backend is
+  stateless, so stale responses are harmlessly discarded.
 
 ---

--- a/ts/packages/actionGrammar/README.md
+++ b/ts/packages/actionGrammar/README.md
@@ -123,6 +123,43 @@ npm test
 
 # Run integration tests (requires API keys)
 npm run test:integration
+
+# Run a specific test suite
+pnpm run jest-esm --testPathPattern="grammarMatcherBasic"
+```
+
+Key test suites:
+
+- `grammarMatcherBasic.spec.ts` — Core recursive backtracking behavior
+- `grammarMatcherVariables.spec.ts` — Variable capture and value expressions
+- `grammarMatcherSpacingBasic.spec.ts` — Spacing mode handling
+- `nfa.spec.ts` — NFA builder and compilation
+- `nfaDfaParity.spec.ts` — NFA/DFA equivalence verification
+- `nfaPriority.spec.ts` — Match priority and ranking
+- `nfaRealGrammars.spec.ts` — End-to-end tests with production grammars
+- `dfa.spec.ts` — DFA compiler correctness
+- `dfaBenchmark.spec.ts` — Performance benchmarks
+
+## Downstream consumers
+
+| Package                 | Usage                                              |
+| ----------------------- | -------------------------------------------------- |
+| `dispatcher`            | Per-agent grammar matching; dynamic rule loading   |
+| `cache`                 | Serialized grammar storage; grammar store          |
+| `agentSdkWrapper`       | Schema-to-grammar generation bridge                |
+| `defaultAgentProvider`  | Grammar integration tests with real agent grammars |
+| `cli`                   | Grammar matching commands                          |
+| `actionGrammarCompiler` | Standalone compilation and formatting tools        |
+
+## Debugging
+
+Enable debug logging with environment variables:
+
+```bash
+DEBUG=typeagent:grammar:*        # Parsing and matching
+DEBUG=typeagent:nfa:*            # NFA execution
+DEBUG=typeagent:dfa:*            # DFA operations
+DEBUG=typeagent:actionGrammar:*  # Grammar generation
 ```
 
 ## Dependencies


### PR DESCRIPTION
## Summary

Restructures the two architecture docs (`actionGrammar.md` and `completion.md`) to eliminate content duplication while keeping each doc self-sufficient for its primary audience.

### Changes to `actionGrammar.md`
- **Spacing modes**: Added the runtime `CompiledSpacingMode` → `separatorMode` mapping table alongside the existing authoring-syntax table
- **Completion integration**: Replaced one-liner with a forward-reference to `completion.md` for pipeline layers above the matcher
- **Matching backend**: Split into two subsections:
  - **Full matching (`matchGrammar`)** — existing algorithm (unchanged)
  - **Completion matching (`matchGrammarCompletion`)** — detailed algorithm moved from `completion.md`: work-list, categories table (with per-direction behavior), `tryPartialStringMatch()`, Category 3b filtering, `findPartialKeywordInWildcard()`, and metadata fields

### Changes to `completion.md`
- **Overview**: Added back-reference to `actionGrammar.md` for grammar concepts and the full matching algorithm
- **Grammar Matcher section**: Replaced ~180 lines of detailed algorithm with a ~30-line compact summary: entry point, compact categories table (sufficient vocabulary for end-to-end examples), one-line metadata bullets, and cross-reference to `actionGrammar.md`

### What stays where
- **`actionGrammar.md`** is authoritative for: `.agr` syntax, compilation, core data model, entities, grammar generation, serialization, and both matching algorithms (full + completion)
- **`completion.md`** is authoritative for: the completion pipeline (cache merging, dispatcher, agent SDK, shell state machine, CLI), all Key Types (`SeparatorMode`, `directionSensitive`, `openWildcard`, `closedSet`, `Anchor`, `NoMatchPolicy`, `CompletionDirection`), end-to-end examples, and edge cases