### PR TITLE
Consolidate knowledge extraction and page Q&A into chat panel

### DIFF
--- a/ts/packages/agents/browser/src/agent/browserActionHandler.mts
+++ b/ts/packages/agents/browser/src/agent/browserActionHandler.mts
@@ -65,7 +65,7 @@ import {
 } from "./knowledge/actions/extractionActions.mjs";
 import { initializeWebSocketBridge } from "./knowledge/progress/knowledgeWebSocketBridge.mjs";
 import {
-    generateDetailedKnowledgeCards,
+    generateLiveKnowledgePreview,
     generateDynamicKnowledgeHtml,
 } from "./knowledge/ui/knowledgeCardRenderer.mjs";
 import { runningExtractionsCache } from "./knowledge/cache/extractionCache.mjs";
@@ -1204,17 +1204,29 @@ async function openWebPage(
         const topicsCount = existingKnowledge.topics?.length || 0;
         const relationshipsCount = existingKnowledge.relationships?.length || 0;
 
-        // Display existing knowledge with detailed cards
-        const knowledgeMarkdown =
-            generateDetailedKnowledgeCards(existingKnowledge);
+        // Display existing knowledge with HTML bubble cards
+        const knowledgeHtml = generateLiveKnowledgePreview(
+            {
+                entities: existingKnowledge.entities || [],
+                topics:
+                    existingKnowledge.topics ||
+                    existingKnowledge.keyTopics ||
+                    [],
+                relationships: existingKnowledge.relationships || [],
+            },
+            "complete",
+        );
         context.actionIO.appendDisplay(
             {
-                type: "markdown",
-                content: `> 📖 **Existing Knowledge Found**
->
-> Found ${entitiesCount} entities, ${topicsCount} topics, and ${relationshipsCount} relationships from previous extraction
-
-${knowledgeMarkdown}`,
+                type: "html",
+                content: `
+                <div style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; margin: 8px 0; padding: 12px; background: #d1ecf1; border-left: 4px solid #17a2b8; border-radius: 4px;">
+                    <div style="font-weight: 600; color: #0c5460;">📖 Existing Knowledge Found</div>
+                    <div style="font-size: 13px; color: #0c5460; margin-top: 4px;">
+                        Found ${entitiesCount} entities, ${topicsCount} topics, and ${relationshipsCount} relationships from previous extraction
+                    </div>
+                </div>
+                ${knowledgeHtml}`,
             },
             "block",
         );
@@ -2832,6 +2844,45 @@ async function handleDownloadImage(
     }
 }
 
+class StartAuthoringHandler implements CommandHandlerNoParams {
+    public readonly description =
+        "Start an interactive session to create a new web automation action by describing it";
+    public async run(context: ActionContext<BrowserActionContext>) {
+        const agentContext = context.sessionContext.agentContext;
+        if (!agentContext.browserControl) {
+            displayError("No browser connection available.", context);
+            return;
+        }
+
+        context.actionIO.appendDisplay(
+            "Starting authoring session...",
+            "temporary",
+        );
+
+        try {
+            const result = await handleSchemaDiscoveryAction(
+                {
+                    actionName: "startAuthoringSession",
+                    parameters: {},
+                } as any,
+                context.sessionContext,
+            );
+
+            context.actionIO.setDisplay({
+                type: "markdown",
+                content:
+                    result.displayText ||
+                    "Authoring session started. Describe the action you want to create.",
+            });
+        } catch (error: any) {
+            displayError(
+                `Failed to start authoring: ${error?.message || error}`,
+                context,
+            );
+        }
+    }
+}
+
 class RecordActionHandler implements CommandHandler {
     public readonly description =
         "Record a new browser action by capturing user interactions";
@@ -2895,6 +2946,110 @@ class StopRecordingHandler implements CommandHandler {
                     ? ` Description: ${params.args.description}`
                     : ""),
         });
+    }
+}
+
+class AskAboutPageHandler implements CommandHandler {
+    public readonly description =
+        "Ask a question about the current web page using extracted knowledge";
+    public readonly parameters = {
+        args: {
+            question: {
+                description: "Question to ask about the page",
+                implicitQuotes: true,
+            },
+        },
+    } as const;
+    public async run(
+        context: ActionContext<BrowserActionContext>,
+        params: ParsedCommandParams<typeof this.parameters>,
+    ) {
+        const agentContext = context.sessionContext.agentContext;
+        if (!agentContext.browserControl) {
+            displayError("No browser connection available.", context);
+            return;
+        }
+
+        const question = params.args.question;
+        if (!question) {
+            context.actionIO.setDisplay({
+                type: "text",
+                content:
+                    "Please provide a question. Example: @browser ask What is this page about?",
+            });
+            return;
+        }
+
+        context.actionIO.appendDisplay(
+            "Searching page knowledge...",
+            "temporary",
+        );
+
+        try {
+            const url = await agentContext.browserControl.getPageUrl();
+            if (!url) {
+                displayError("No active page found.", context);
+                return;
+            }
+
+            // Query knowledge for this page
+            const { handleKnowledgeAction } = await import(
+                "./knowledge/actions/knowledgeActionRouter.mjs"
+            );
+            const result = await handleKnowledgeAction(
+                "searchWebMemories",
+                {
+                    query: question,
+                    searchScope: "current_page",
+                    metadata: { url },
+                },
+                context.sessionContext,
+            );
+
+            if (result?.error) {
+                displayError(
+                    `Knowledge query failed: ${result.error}`,
+                    context,
+                );
+                return;
+            }
+
+            // Format the answer
+            let md = "";
+            if (result?.answer) {
+                md += `${result.answer}\n\n`;
+            } else if (result?.websites && result.websites.length > 0) {
+                for (const site of result.websites.slice(0, 3)) {
+                    md += `**${site.title || site.url}**\n`;
+                    if (site.summary) md += `${site.summary}\n`;
+                    md += "\n";
+                }
+            } else {
+                md += "No relevant knowledge found for this page. ";
+                md +=
+                    "Try extracting knowledge first with `@browser extractKnowledge`.\n";
+            }
+
+            if (
+                result?.suggestedFollowups &&
+                result.suggestedFollowups.length > 0
+            ) {
+                md += "\n**You might also ask:**\n";
+                for (const q of result.suggestedFollowups.slice(0, 3)) {
+                    md += `- ${q}\n`;
+                }
+            }
+
+            context.actionIO.setDisplay({
+                type: "markdown",
+                content: md,
+            });
+        } catch (error: any) {
+            displayError(
+                `Failed to query page: ${error?.message || error}`,
+                context,
+            );
+        }
     }
 }
 
@@ -3175,7 +3330,9 @@ export const handlers: CommandHandlerTable = {
             },
         },
         extractKnowledge: new ExtractKnowledgeHandler(),
+        ask: new AskAboutPageHandler(),
         discover: new DiscoverActionsHandler(),
+        author: new StartAuthoringHandler(),
         record: new RecordActionHandler(),
         stop: {
             description: "Stop operations",

--- a/ts/packages/agents/browser/src/agent/knowledge/extractKnowledgeCommand.mts
+++ b/ts/packages/agents/browser/src/agent/knowledge/extractKnowledgeCommand.mts
@@ -19,7 +19,7 @@ import {
     KnowledgeExtractionProgressEvent,
 } from "./progress/knowledgeProgressEvents.mjs";
 import {
-    generateDetailedKnowledgeCards,
+    generateLiveKnowledgePreview,
     updateExtractionProgressState,
     ActiveKnowledgeExtraction,
 } from "./ui/knowledgeCardRenderer.mjs";
@@ -367,9 +367,18 @@ export class ExtractKnowledgeHandler implements CommandHandlerNoParams {
                 const relationshipsCount =
                     existingKnowledge.relationships?.length || 0;
 
-                // Display existing knowledge with detailed cards
-                const knowledgeHtml =
-                    generateDetailedKnowledgeCards(existingKnowledge);
+                // Display existing knowledge with HTML bubble cards
+                const knowledgeHtml = generateLiveKnowledgePreview(
+                    {
+                        entities: existingKnowledge.entities || [],
+                        topics:
+                            existingKnowledge.topics ||
+                            existingKnowledge.keyTopics ||
+                            [],
+                        relationships: existingKnowledge.relationships || [],
+                    },
+                    "complete",
+                );
                 context.actionIO.appendDisplay(
                     {
                         type: "html",
@@ -452,9 +461,19 @@ export class ExtractKnowledgeHandler implements CommandHandlerNoParams {
                             const relationshipsCount =
                                 latestKnowledge.relationships?.length || 0;
 
-                            // Generate detailed knowledge cards for the extracted knowledge
-                            const knowledgeHtml =
-                                generateDetailedKnowledgeCards(latestKnowledge);
+                            // Generate HTML knowledge cards (same format as live preview)
+                            const knowledgeHtml = generateLiveKnowledgePreview(
+                                {
+                                    entities: latestKnowledge.entities || [],
+                                    topics:
+                                        latestKnowledge.topics ||
+                                        latestKnowledge.keyTopics ||
+                                        [],
+                                    relationships:
+                                        latestKnowledge.relationships || [],
+                                },
+                                "complete",
+                            );
 
                             const headerText = existingKnowledge
                                 ? "✅ Knowledge Re-extraction Complete"

--- a/ts/packages/agents/browser/src/common/serviceTypes.mts
+++ b/ts/packages/agents/browser/src/common/serviceTypes.mts
@@ -399,6 +399,14 @@ export type ChatPanelInvokeFunctions = {
         source: string;
         displayId: string;
     }): Promise<{ content: any; nextRefreshMs: number }>;
+    chatPanelQueryKnowledge(params: {
+        query: string;
+        url: string;
+    }): Promise<any>;
+    chatPanelGenerateQuestions(params: {
+        url: string;
+        knowledge?: any;
+    }): Promise<any>;
     chatPanelStartRecording(): Promise<{ success: boolean; error?: string }>;
     chatPanelStopRecording(): Promise<{
         success: boolean;

--- a/ts/packages/agents/browser/src/extension/serviceWorker/contextMenu.ts
+++ b/ts/packages/agents/browser/src/extension/serviceWorker/contextMenu.ts
@@ -34,6 +34,28 @@ async function openChatAndInjectCommand(
  */
 export function initializeContextMenu(): void {
     chrome.contextMenus.create({
+        title: "Open TypeAgent Chat",
+        id: "openChatPanel",
+        documentUrlPatterns: ["http://*/*", "https://*/*"],
+    });
+
+    chrome.contextMenus.create({
+        type: "separator",
+        id: "menuSeparator1",
+    });
+
+    chrome.contextMenus.create({
+        title: "Learn more from page",
+        id: "learnMoreFromPage",
+        documentUrlPatterns: ["http://*/*", "https://*/*"],
+    });
+
+    chrome.contextMenus.create({
+        type: "separator",
+        id: "menuSeparator2",
+    });
+
+    chrome.contextMenus.create({
         title: "Discover page macros",
         id: "discoverPageActions",
         documentUrlPatterns: ["http://*/*", "https://*/*"],
@@ -54,12 +76,12 @@ export function initializeContextMenu(): void {
 
     chrome.contextMenus.create({
         type: "separator",
-        id: "menuSeparator2",
+        id: "menuSeparator3",
     });
 
     chrome.contextMenus.create({
-        title: "Open TypeAgent Chat",
-        id: "openChatPanel",
+        title: "Knowledge Library",
+        id: "showWebsiteLibrary",
         documentUrlPatterns: ["http://*/*", "https://*/*"],
     });
 }
@@ -120,7 +142,10 @@ export async function handleContextMenuClick(
         }
 
         case "learnMoreFromPage": {
-            await openChatAndInjectCommand(tab.id!, "What is this page about?");
+            await openChatAndInjectCommand(
+                tab.id!,
+                "@browser ask What is this page about?",
+            );
             break;
         }
 

--- a/ts/packages/agents/browser/src/extension/serviceWorker/serviceWorkerRpcHandlers.ts
+++ b/ts/packages/agents/browser/src/extension/serviceWorker/serviceWorkerRpcHandlers.ts
@@ -333,6 +333,31 @@ export function createAllHandlers(): AllServiceWorkerInvokeFunctions {
             }
         },
 
+        async chatPanelQueryKnowledge(params: any) {
+            try {
+                return await forward("searchWebMemories", {
+                    query: params.query,
+                    searchScope: "current_page",
+                    metadata: { url: params.url },
+                });
+            } catch (error: any) {
+                return { error: error?.message || "Query failed" };
+            }
+        },
+
+        async chatPanelGenerateQuestions(params: any) {
+            try {
+                return await forward("generatePageQuestions", {
+                    url: params.url,
+                    pageKnowledge: params.knowledge,
+                });
+            } catch (error: any) {
+                return {
+                    error: error?.message || "Failed to generate questions",
+                };
+            }
+        },
+
         async chatPanelStartRecording() {
             try {
                 await startRecording();

--- a/ts/packages/agents/browser/src/extension/views/chatPanel.ts
+++ b/ts/packages/agents/browser/src/extension/views/chatPanel.ts
@@ -21,6 +21,11 @@ import type {
 // Platform adapter: open links in a real Chrome tab
 const platformAdapter: PlatformAdapter = {
     handleLinkClick(href: string, _target: string | null) {
+        // Rewrite typeagent-browser:// URLs to the actual extension URL
+        if (href.startsWith("typeagent-browser://")) {
+            const path = href.replace("typeagent-browser://", "");
+            href = chrome.runtime.getURL(path);
+        }
         chrome.tabs.create({ url: href });
     },
 };
@@ -98,7 +103,7 @@ function initialize() {
                 chatPanel.setDisplayInfo(data.source, data.actionIndex);
             },
             dispatcherSetDisplay(data) {
-                chatPanel.addAgentMessage(
+                chatPanel.replaceAgentMessage(
                     data.message.message as DisplayContent,
                     data.message.source,
                     data.message.sourceIcon,
@@ -319,16 +324,17 @@ function addContextualFollowUps(command: string) {
                 label: "Record New Action",
                 command: "@browser record New Action",
             },
-            {
-                label: "Create Action (describe)",
-                command: "@browser start authoring",
-            },
+            // {
+            //     label: "Create Action (describe)",
+            //     command: "@browser author",
+            // ,
         ]);
-    } else if (normalized.includes("@browser extractknowledge")) {
+    } else if (normalized.startsWith("@browser ask")) {
+        // After a Q&A answer, offer to extract full knowledge
         chatPanel.addFollowUpButtons([
             {
-                label: "Ask about this page",
-                command: "What is this page about?",
+                label: "Extract full knowledge",
+                command: "@browser extractKnowledge",
             },
         ]);
     } else if (normalized.startsWith("@browser record")) {

--- a/ts/packages/chat-ui/src/chatPanel.ts
+++ b/ts/packages/chat-ui/src/chatPanel.ts
@@ -80,6 +80,7 @@ export class ChatPanel {
         nextRefreshTime: number;
     }[] = [];
     private dynamicTimer?: ReturnType<typeof setTimeout>;
+    private dynamicContainers = new Map<string, AgentMessageContainer>();
 
     // Pending image attachments (base64 data URLs)
     private pendingAttachments: string[] = [];
@@ -447,6 +448,30 @@ export class ChatPanel {
     }
 
     /**
+     * Replace the current agent message content (reuses existing container).
+     * If no container exists, creates one.
+     */
+    public replaceAgentMessage(
+        content: DisplayContent,
+        source?: string,
+        sourceIcon?: string,
+    ) {
+        if (this.statusContainer) {
+            this.statusContainer.remove();
+            this.statusContainer = undefined;
+        }
+
+        if (!this.currentAgentContainer) {
+            this.currentAgentContainer = this.createAgentContainer(
+                source ?? "assistant",
+                sourceIcon ?? "🤖",
+            );
+        }
+        this.currentAgentContainer.setMessage(content, source, undefined);
+        this.scrollToBottom();
+    }
+
+    /**
      * Display or append an agent message.
      * Call with appendMode to add to the current agent message.
      */
@@ -668,7 +693,18 @@ export class ChatPanel {
                     item.source,
                     item.displayId,
                 );
-                this.addAgentMessage(result.content, item.source);
+
+                // Reuse the same container so refreshes replace content
+                const key = `${item.source}:${item.displayId}`;
+                let container = this.dynamicContainers.get(key);
+                if (!container) {
+                    container = this.createAgentContainer(item.source, "🌐");
+                    this.dynamicContainers.set(key, container);
+                }
+                // Replace content (no append mode = replace)
+                container.setMessage(result.content, item.source, undefined);
+                this.scrollToBottom();
+
                 if (result.nextRefreshMs > 0) {
                     this.dynamicDisplays.push({
                         source: item.source,
@@ -676,6 +712,9 @@ export class ChatPanel {
                         nextRefreshTime:
                             Date.now() + Math.max(result.nextRefreshMs, 500),
                     });
+                } else {
+                    // Display is done — remove from tracking
+                    this.dynamicContainers.delete(key);
                 }
             } catch {
                 // Refresh failed — don't re-register


### PR DESCRIPTION
- Add @browser ask command for querying page knowledge directly
- Route "Learn more from page" context menu to @browser ask in chat
- Register missing context menu items (knowledge, learn more, library)
- Fix dynamic display refresh replacing content in-place instead of creating new chat bubbles on each refresh
- Add knowledge query and question generation RPC handlers for chat