### PR TITLE
Add ScriptFlow reliability benchmark

### DIFF
--- a/ts/packages/agents/scriptflow/benchmark/fixtures/Cleanup-BenchmarkEnv.ps1
+++ b/ts/packages/agents/scriptflow/benchmark/fixtures/Cleanup-BenchmarkEnv.ps1
@@ -1,0 +1,11 @@
+param(
+    [string]$TestRoot = "$env:TEMP\scriptflow-benchmark"
+)
+
+if (-not (Test-Path $TestRoot)) {
+    Write-Output "No benchmark environment found at $TestRoot"
+    return
+}
+
+Remove-Item -Path $TestRoot -Recurse -Force
+Write-Output "Cleaned up benchmark environment at $TestRoot"

--- a/ts/packages/agents/scriptflow/benchmark/fixtures/Setup-BenchmarkEnv.ps1
+++ b/ts/packages/agents/scriptflow/benchmark/fixtures/Setup-BenchmarkEnv.ps1
@@ -1,0 +1,184 @@
+param(
+    [string]$TestRoot = "$env:TEMP\scriptflow-benchmark",
+    [switch]$Force
+)
+
+if ($Force -and (Test-Path $TestRoot)) {
+    Remove-Item -Path $TestRoot -Recurse -Force
+}
+
+if (Test-Path $TestRoot) {
+    Write-Output "Benchmark environment already exists at $TestRoot"
+    Write-Output "Use -Force to recreate."
+    return
+}
+
+New-Item -Path $TestRoot -ItemType Directory -Force | Out-Null
+Write-Output "Creating benchmark environment at $TestRoot..."
+
+# --- files/ directory: known set of files for listFiles scenarios ---
+$filesDir = Join-Path $TestRoot "files"
+New-Item -Path $filesDir -ItemType Directory -Force | Out-Null
+
+@("readme.txt", "config.json", "data.csv", "notes.md", "script.ps1") | ForEach-Object {
+    $content = "Test file: $_ - created for scriptflow benchmark"
+    Set-Content -Path (Join-Path $filesDir $_) -Value $content
+}
+
+# Create some subdirectories with files
+$subDir = Join-Path $filesDir "subdir"
+New-Item -Path $subDir -ItemType Directory -Force | Out-Null
+@("nested1.txt", "nested2.log") | ForEach-Object {
+    Set-Content -Path (Join-Path $subDir $_) -Value "Nested test file: $_"
+}
+
+Write-Output "  Created files/ with 7 test files"
+
+# --- logs/ directory: log files with known error counts ---
+$logsDir = Join-Path $TestRoot "logs"
+New-Item -Path $logsDir -ItemType Directory -Force | Out-Null
+
+$today = Get-Date -Format "yyyy-MM-dd"
+$yesterday = (Get-Date).AddDays(-1).ToString("yyyy-MM-dd")
+
+# Main log with known error/warning counts
+$mainLogContent = @"
+$today 08:00:01 [INFO] Application starting up...
+$today 08:00:02 [INFO] Loading configuration from config.json
+$today 08:00:03 [INFO] Database connection established
+$today 08:01:00 [INFO] Health check: OK
+$today 08:05:12 [ERROR] Payment processing timeout after 30s - OrderId: ORD-2024-1234
+$today 08:05:13 [ERROR] System.TimeoutException: The operation has timed out
+$today 08:05:13 [ERROR]    at PaymentService.ProcessPayment(Order order) in PaymentService.cs:line 142
+$today 08:10:00 [WARN] Slow query detected: SELECT * FROM orders - 2340ms
+$today 08:15:22 [INFO] Request processed: GET /api/users (200, 45ms)
+$today 08:20:00 [INFO] Health check: OK
+$today 08:25:33 [ERROR] Unhandled exception in request pipeline
+$today 08:25:33 [ERROR] System.NullReferenceException: Object reference not set
+$today 08:25:33 [ERROR]    at UserController.GetProfile(int userId) in UserController.cs:line 87
+$today 08:30:15 [WARN] Rate limit approaching: 450/500 requests in window
+$today 08:35:00 [INFO] Cache refreshed: 1234 entries
+$today 08:40:01 [WARN] Certificate expires in 14 days: api.example.com
+$today 08:45:22 [ERROR] Database connection timeout - retrying (attempt 1/3)
+$today 08:45:25 [INFO] Database connection re-established
+$today 08:50:00 [INFO] Health check: OK
+$today 09:00:11 [FATAL] OutOfMemoryException: Insufficient memory to continue execution
+$today 09:00:11 [FATAL]    at System.Runtime.MemoryManager.Allocate() in MemoryManager.cs:line 201
+$today 09:00:15 [INFO] Application restarting after crash...
+$today 09:00:20 [INFO] Application started successfully
+$today 09:05:00 [WARN] Memory usage high: 85% of available
+$today 09:10:33 [ERROR] SMTP delivery failed: Connection refused to mail.example.com:587
+$today 09:15:00 [WARN] Deprecated API endpoint called: /api/v1/legacy
+$today 09:20:00 [INFO] Batch job completed: processed 500 records
+$today 09:25:44 [WARN] Message queue backlog: 1200 pending messages
+"@
+
+$mainLogPath = Join-Path $logsDir "AppServer_${today}.log"
+Set-Content -Path $mainLogPath -Value $mainLogContent
+
+# Worker log
+$workerLogContent = @"
+$today 08:00:05 [INFO] Worker starting...
+$today 08:10:00 [INFO] Processing batch 1/10
+$today 08:15:33 [ERROR] Failed to process item ID-5523: Invalid format
+$today 08:20:00 [INFO] Processing batch 2/10
+$today 08:25:00 [WARN] Retry queue growing: 45 items
+$today 08:30:00 [INFO] Processing batch 3/10
+$today 08:35:22 [ERROR] Connection to external API failed: HTTP 503
+"@
+
+$workerLogPath = Join-Path $logsDir "AppServer_${today}_worker.log"
+Set-Content -Path $workerLogPath -Value $workerLogContent
+
+# Yesterday's log (should NOT be picked up by default today filter)
+$yesterdayLogPath = Join-Path $logsDir "AppServer_${yesterday}.log"
+Set-Content -Path $yesterdayLogPath -Value "$yesterday 23:59:59 [ERROR] Old error from yesterday"
+
+Write-Output "  Created logs/ with 3 log files (main: 8 ERROR, 6 WARN, 1 FATAL)"
+
+# --- csv/ directory: test CSV data ---
+$csvDir = Join-Path $TestRoot "csv"
+New-Item -Path $csvDir -ItemType Directory -Force | Out-Null
+
+# Copy from existing test data if available, otherwise create inline
+$existingCsvDir = Join-Path $PSScriptRoot "..\..\..\test\import-scenarios\data\csv"
+if (Test-Path (Join-Path $existingCsvDir "employees.csv")) {
+    Copy-Item -Path (Join-Path $existingCsvDir "employees.csv") -Destination $csvDir
+    Copy-Item -Path (Join-Path $existingCsvDir "sensor_readings.csv") -Destination $csvDir
+    Write-Output "  Copied csv/ from existing test data"
+} else {
+    # Create employees.csv inline
+    $employeesCsv = @"
+Name,Department,Status,Location,Salary
+Alice Johnson,Engineering,Active,Seattle,125000
+Bob Smith,Engineering,Active,Seattle,118000
+Carol Williams,Engineering,Active,Remote,130000
+David Brown,Engineering,Terminated,Seattle,0
+Eve Davis,Engineering,Active,Austin,122000
+Frank Miller,Engineering,Active,Seattle,115000
+Grace Wilson,Engineering,On Leave,Remote,120000
+Henry Moore,Engineering,Active,Austin,128000
+Iris Taylor,Engineering,Active,Seattle,117000
+Jack Anderson,Engineering,Active,Remote,132000
+Karen Thomas,Engineering,Active,Seattle,121000
+Leo Jackson,Engineering,Active,Austin,119000
+Mary White,Engineering,Active,Remote,126000
+Noah Harris,Sales,Active,Chicago,95000
+Olivia Martin,Sales,Active,New York,98000
+Peter Garcia,Sales,Terminated,Chicago,0
+Quinn Martinez,Sales,Active,New York,92000
+Rachel Robinson,HR,Active,Seattle,88000
+Sam Clark,HR,Active,Seattle,85000
+Tina Rodriguez,HR,On Leave,Remote,90000
+Uma Lewis,Finance,Active,New York,105000
+Victor Lee,Finance,Active,New York,108000
+Wendy Walker,Finance,Active,Remote,102000
+Xavier Hall,Marketing,Active,Chicago,87000
+Yolanda Allen,Marketing,Active,Remote,91000
+"@
+    Set-Content -Path (Join-Path $csvDir "employees.csv") -Value $employeesCsv
+
+    $sensorCsv = @"
+Timestamp,SensorId,Location,Temperature,Humidity,Status
+2026-03-24T08:00:00,SENS-001,BuildingA-Floor1,22.1,45,OK
+2026-03-24T08:00:00,SENS-002,BuildingA-Floor2,23.5,42,OK
+2026-03-24T08:00:00,SENS-003,BuildingB-Floor1,21.8,48,OK
+2026-03-24T08:05:00,SENS-001,BuildingA-Floor1,22.3,44,OK
+2026-03-24T08:05:00,SENS-002,BuildingA-Floor2,25.1,40,WARN
+2026-03-24T08:05:00,SENS-003,BuildingB-Floor1,21.9,47,OK
+2026-03-24T08:10:00,SENS-001,BuildingA-Floor1,22.2,45,OK
+2026-03-24T08:10:00,SENS-002,BuildingA-Floor2,28.7,38,ERROR
+2026-03-24T08:10:00,SENS-003,BuildingB-Floor1,22.0,46,OK
+2026-03-24T08:15:00,SENS-001,BuildingA-Floor1,22.4,44,OK
+2026-03-24T08:15:00,SENS-002,BuildingA-Floor2,31.2,35,CRITICAL
+"@
+    Set-Content -Path (Join-Path $csvDir "sensor_readings.csv") -Value $sensorCsv
+    Write-Output "  Created csv/ with employees.csv (25 rows) and sensor_readings.csv (11 rows)"
+}
+
+# --- Write manifest describing what was created ---
+$manifest = @{
+    testRoot = $TestRoot
+    created = (Get-Date).ToString("yyyy-MM-ddTHH:mm:ss")
+    directories = @{
+        files = @{ path = $filesDir; fileCount = 7 }
+        logs = @{
+            path = $logsDir
+            todayDate = $today
+            mainLog = @{ errors = 8; warnings = 6; fatals = 1 }
+            workerLog = @{ errors = 2; warnings = 1 }
+        }
+        csv = @{
+            path = $csvDir
+            employees = @{ rows = 25; engineeringCount = 13 }
+            sensors = @{ rows = 11 }
+        }
+    }
+} | ConvertTo-Json -Depth 4
+
+$manifestPath = Join-Path $TestRoot "fixtures-manifest.json"
+Set-Content -Path $manifestPath -Value $manifest
+
+Write-Output ""
+Write-Output "Benchmark environment ready at $TestRoot"
+Write-Output "Manifest: $manifestPath"

--- a/ts/packages/agents/scriptflow/benchmark/harness/benchmarkRunner.mts
+++ b/ts/packages/agents/scriptflow/benchmark/harness/benchmarkRunner.mts
@@ -1,0 +1,288 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import type {
+    BenchmarkScenario,
+    ScenarioResult,
+    PipelineTrace,
+    EvaluationResult,
+    Scorecard,
+} from "./types.mjs";
+import { TraceCollector } from "./traceCollector.mjs";
+import { evaluateGrammarMatch } from "./evaluators/grammarEvaluator.mjs";
+import {
+    evaluateExecution,
+    evaluateFallback,
+} from "./evaluators/executionEvaluator.mjs";
+import {
+    buildScorecard,
+    printScorecard,
+} from "./reporters/scorecardReporter.mjs";
+import { writeDetailReport } from "./reporters/detailReporter.mjs";
+import {
+    readFileSync,
+    readdirSync,
+    writeFileSync,
+    mkdirSync,
+    existsSync,
+} from "fs";
+import { join } from "path";
+import registerDebug from "debug";
+
+const debug = registerDebug("typeagent:benchmark");
+
+export interface BenchmarkOptions {
+    category?: string;
+    scenarioId?: string;
+    noLlmJudge?: boolean;
+    compareBaseline?: string;
+    scenarioDir: string;
+    outputDir: string;
+    benchmarkDir: string;
+}
+
+export interface DispatcherAdapter {
+    processCommand(command: string): Promise<unknown>;
+    getDisplayText(): string;
+    close(): Promise<void>;
+}
+
+export class BenchmarkRunner {
+    private traceCollector = new TraceCollector();
+    private results: ScenarioResult[] = [];
+    private flowNameMap: Record<string, string>;
+
+    constructor(
+        private dispatcher: DispatcherAdapter,
+        private options: BenchmarkOptions,
+        flowNameMap?: Record<string, string>,
+    ) {
+        this.flowNameMap = flowNameMap ?? {};
+    }
+
+    private resolveFlowName(canonical: string): string {
+        return this.flowNameMap[canonical] ?? canonical;
+    }
+
+    async run(): Promise<Scorecard> {
+        const startTime = Date.now();
+
+        const scenarios = this.loadScenarios();
+
+        console.log(
+            `\nLoaded ${scenarios.length} scenario(s) from ${this.options.scenarioDir}`,
+        );
+
+        for (const scenario of scenarios) {
+            await this.runScenario(scenario);
+        }
+
+        const scorecard = buildScorecard(this.results, startTime);
+
+        // Compare with baseline if provided
+        if (this.options.compareBaseline) {
+            try {
+                const baseline = JSON.parse(
+                    readFileSync(this.options.compareBaseline, "utf-8"),
+                );
+                const { regressions, improvements } = await import(
+                    "./reporters/scorecardReporter.mjs"
+                ).then((m) => m.compareScorecards(scorecard, baseline));
+                scorecard.regressions = regressions;
+                scorecard.improvements = improvements;
+            } catch (err) {
+                console.error(`Failed to load baseline: ${err}`);
+            }
+        }
+
+        // Write outputs
+        const timestamp = new Date()
+            .toISOString()
+            .replace(/[:.]/g, "")
+            .substring(0, 15);
+        const outputDir = join(this.options.outputDir, timestamp);
+        mkdirSync(outputDir, { recursive: true });
+
+        writeFileSync(
+            join(outputDir, "scorecard.json"),
+            JSON.stringify(scorecard, null, 2),
+        );
+        writeDetailReport(this.results, outputDir);
+
+        printScorecard(scorecard);
+
+        if (scorecard.regressions.length > 0) {
+            console.log("  REGRESSIONS:");
+            for (const r of scorecard.regressions) {
+                console.log(`    - ${r}`);
+            }
+        }
+        if (scorecard.improvements.length > 0) {
+            console.log("  IMPROVEMENTS:");
+            for (const i of scorecard.improvements) {
+                console.log(`    + ${i}`);
+            }
+        }
+
+        console.log(`\nResults written to: ${outputDir}`);
+        return scorecard;
+    }
+
+    private loadScenarios(): BenchmarkScenario[] {
+        const scenarioFiles = [
+            "grammar-match.json",
+            "execution.json",
+            "llm-translation.json",
+            "fallback-chain.json",
+            "end-to-end.json",
+        ];
+
+        const allScenarios: BenchmarkScenario[] = [];
+
+        for (const file of scenarioFiles) {
+            const filePath = join(this.options.scenarioDir, file);
+            try {
+                const scenarios: BenchmarkScenario[] = JSON.parse(
+                    readFileSync(filePath, "utf-8"),
+                );
+                allScenarios.push(...scenarios);
+            } catch {
+                debug(`Scenario file not found or invalid: ${filePath}`);
+            }
+        }
+
+        // Apply filters
+        let filtered = allScenarios;
+        if (this.options.category) {
+            filtered = filtered.filter(
+                (s) => s.category === this.options.category,
+            );
+        }
+        if (this.options.scenarioId) {
+            filtered = filtered.filter((s) => s.id === this.options.scenarioId);
+        }
+
+        return filtered;
+    }
+
+    private async runScenario(scenario: BenchmarkScenario): Promise<void> {
+        for (const utterance of scenario.utterances) {
+            const scenarioStart = Date.now();
+
+            // Expand variables in utterance text
+            let text = utterance.text;
+            const benchmarkDir = process.env.TEMP
+                ? join(process.env.TEMP, "scriptflow-benchmark")
+                : "";
+            const scriptflowPkg = join(this.options.benchmarkDir, "..");
+            text = text.replace(/\$\{BENCHMARK_DIR\}/g, benchmarkDir);
+            text = text.replace(/\$\{SCRIPTFLOW_PKG\}/g, scriptflowPkg);
+
+            debug(`Running [${scenario.id}]: "${text}"`);
+
+            // Collect trace
+            this.traceCollector.startCollecting();
+            this.traceCollector.clearLogs();
+
+            let commandResult: unknown;
+            let trace: PipelineTrace;
+
+            let displayText = "";
+            try {
+                commandResult = await this.dispatcher.processCommand(text);
+                displayText = this.dispatcher.getDisplayText();
+                trace = this.traceCollector.buildTrace(text, scenarioStart);
+                trace.executionResult = {
+                    success: !(commandResult as any)?.lastError,
+                    output: displayText,
+                    error: (commandResult as any)?.lastError,
+                };
+                debug(
+                    `Result for "${text}": ${JSON.stringify(commandResult)?.substring(0, 300)}`,
+                );
+                if (displayText) {
+                    debug(`Display: ${displayText.substring(0, 200)}`);
+                }
+            } catch (err) {
+                trace = this.traceCollector.buildTrace(text, scenarioStart);
+                trace.executionResult = {
+                    success: false,
+                    output: "",
+                    error: String(err),
+                };
+                commandResult = { error: String(err) };
+            } finally {
+                this.traceCollector.stopCollecting();
+            }
+
+            // Detect fallback from display text and CommandResult
+            const resultObj = commandResult as any;
+            if (resultObj?.lastError) {
+                trace.fallbackTriggered = true;
+                trace.fallbackReason = resultObj.lastError;
+            }
+            if (
+                displayText &&
+                /reasoning|editScriptFlow|createScriptFlow/i.test(displayText)
+            ) {
+                trace.reasoningInvoked = true;
+            }
+            // Check if actions include reasoning-produced actions
+            const actions = resultObj?.actions as any[];
+            if (
+                actions?.some(
+                    (a: any) =>
+                        a.actionName === "editScriptFlow" ||
+                        a.actionName === "createScriptFlow",
+                )
+            ) {
+                trace.reasoningInvoked = true;
+                trace.fallbackTriggered = true;
+            }
+
+            // Resolve canonical flow names to actual LLM-generated names
+            const resolvedUtterance = {
+                ...utterance,
+                expected: {
+                    ...utterance.expected,
+                    matchedFlow: utterance.expected.matchedFlow
+                        ? this.resolveFlowName(utterance.expected.matchedFlow)
+                        : utterance.expected.matchedFlow,
+                },
+            };
+
+            // Run evaluators
+            const evaluations: EvaluationResult[] = [];
+
+            evaluations.push(
+                ...evaluateGrammarMatch(
+                    resolvedUtterance,
+                    trace,
+                    commandResult,
+                ),
+            );
+            evaluations.push(
+                ...evaluateExecution(resolvedUtterance, trace, commandResult),
+            );
+            evaluations.push(
+                ...evaluateFallback(resolvedUtterance, trace, commandResult),
+            );
+
+            const passed = evaluations.every((e) => e.passed);
+
+            this.results.push({
+                scenarioId: scenario.id,
+                category: scenario.category,
+                description: scenario.description,
+                utterance: text,
+                passed,
+                evaluations,
+                trace,
+                durationMs: Date.now() - scenarioStart,
+            });
+
+            const status = passed ? "PASS" : "FAIL";
+            console.log(`  [${status}] ${scenario.id}: ${text}`);
+        }
+    }
+}

--- a/ts/packages/agents/scriptflow/benchmark/harness/evaluators/executionEvaluator.mts
+++ b/ts/packages/agents/scriptflow/benchmark/harness/evaluators/executionEvaluator.mts
@@ -1,0 +1,150 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import type {
+    EvaluationResult,
+    PipelineTrace,
+    TestUtterance,
+} from "../types.mjs";
+
+export function evaluateExecution(
+    utterance: TestUtterance,
+    trace: PipelineTrace,
+    commandResult: unknown,
+): EvaluationResult[] {
+    const results: EvaluationResult[] = [];
+    const exec = utterance.expected.execution;
+    if (!exec) return results;
+
+    const output = extractOutput(commandResult, trace);
+    const hasError = extractHasError(commandResult, trace);
+
+    // Check success/failure
+    results.push({
+        passed: exec.shouldSucceed ? !hasError : hasError,
+        component: "execution",
+        expected: exec.shouldSucceed ? "success" : "failure",
+        actual: hasError ? "failure" : "success",
+        message:
+            exec.shouldSucceed === hasError
+                ? `Expected ${exec.shouldSucceed ? "success" : "failure"} but got ${hasError ? "failure" : "success"}`
+                : undefined,
+    });
+
+    // Check outputContains
+    if (exec.outputContains && output) {
+        for (const expected of exec.outputContains) {
+            const found = output.toLowerCase().includes(expected.toLowerCase());
+            results.push({
+                passed: found,
+                component: "execution",
+                expected: `output contains "${expected}"`,
+                actual: found
+                    ? "found"
+                    : `not found in: ${output.substring(0, 200)}...`,
+                message: !found
+                    ? `Expected output to contain "${expected}"`
+                    : undefined,
+            });
+        }
+    }
+
+    // Check outputNotContains
+    if (exec.outputNotContains && output) {
+        for (const notExpected of exec.outputNotContains) {
+            const found = output
+                .toLowerCase()
+                .includes(notExpected.toLowerCase());
+            results.push({
+                passed: !found,
+                component: "execution",
+                expected: `output does NOT contain "${notExpected}"`,
+                actual: found ? "found (unexpected)" : "not found (correct)",
+                message: found
+                    ? `Expected output to NOT contain "${notExpected}"`
+                    : undefined,
+            });
+        }
+    }
+
+    // Check outputPattern
+    if (exec.outputPattern && output) {
+        const regex = new RegExp(exec.outputPattern, "i");
+        const matches = regex.test(output);
+        results.push({
+            passed: matches,
+            component: "execution",
+            expected: `output matches /${exec.outputPattern}/`,
+            actual: matches
+                ? "matched"
+                : `no match in: ${output.substring(0, 200)}...`,
+            message: !matches
+                ? `Expected output to match pattern: ${exec.outputPattern}`
+                : undefined,
+        });
+    }
+
+    return results;
+}
+
+export function evaluateFallback(
+    utterance: TestUtterance,
+    trace: PipelineTrace,
+    _commandResult: unknown,
+): EvaluationResult[] {
+    const results: EvaluationResult[] = [];
+    const fb = utterance.expected.fallback;
+    if (!fb) return results;
+
+    results.push({
+        passed: fb.shouldFallback === trace.fallbackTriggered,
+        component: "fallback",
+        expected: fb.shouldFallback ? "fallback triggered" : "no fallback",
+        actual: trace.fallbackTriggered ? "fallback triggered" : "no fallback",
+        message:
+            fb.shouldFallback !== trace.fallbackTriggered
+                ? `Expected ${fb.shouldFallback ? "fallback" : "no fallback"} but got ${trace.fallbackTriggered ? "fallback" : "no fallback"}`
+                : undefined,
+    });
+
+    if (fb.reasoningShouldFix !== undefined) {
+        results.push({
+            passed: fb.reasoningShouldFix === trace.reasoningInvoked,
+            component: "fallback",
+            expected: fb.reasoningShouldFix
+                ? "reasoning invoked"
+                : "no reasoning",
+            actual: trace.reasoningInvoked
+                ? "reasoning invoked"
+                : "no reasoning",
+        });
+    }
+
+    return results;
+}
+
+function extractOutput(commandResult: unknown, trace: PipelineTrace): string {
+    if (trace.executionResult?.output) return trace.executionResult.output;
+    const result = commandResult as any;
+    if (typeof result === "string") return result;
+    // CommandResult may have displayText or lastError
+    if (result?.displayText) return result.displayText;
+    if (result?.result?.displayText) return result.result.displayText;
+    if (result?.text) return result.text;
+    if (result?.lastError) return result.lastError;
+    // Actions array — the output is typically in the display log, not in CommandResult.
+    // Return a JSON representation for pattern matching.
+    return JSON.stringify(result ?? "");
+}
+
+function extractHasError(
+    commandResult: unknown,
+    trace: PipelineTrace,
+): boolean {
+    if (trace.executionResult) return !trace.executionResult.success;
+    const result = commandResult as any;
+    if (result?.error) return true;
+    if (result?.lastError) return true;
+    if (result?.result?.error) return true;
+    return false;
+}

--- a/ts/packages/agents/scriptflow/benchmark/harness/evaluators/grammarEvaluator.mts
+++ b/ts/packages/agents/scriptflow/benchmark/harness/evaluators/grammarEvaluator.mts
@@ -1,0 +1,176 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import type {
+    EvaluationResult,
+    PipelineTrace,
+    TestUtterance,
+} from "../types.mjs";
+
+export function evaluateGrammarMatch(
+    utterance: TestUtterance,
+    trace: PipelineTrace,
+    commandResult: unknown,
+): EvaluationResult[] {
+    const results: EvaluationResult[] = [];
+    const expected = utterance.expected;
+
+    // Check if the right flow was matched
+    if (expected.matchedFlow !== undefined) {
+        const actualFlow = extractFlowName(commandResult, trace);
+        if (expected.matchedFlow === null) {
+            // Negative test: should NOT match any scriptflow
+            results.push({
+                passed:
+                    actualFlow === null || trace.matchedAgent !== "scriptflow",
+                component: "grammar",
+                expected: "no scriptflow match",
+                actual: actualFlow ?? "no match",
+                message:
+                    actualFlow && trace.matchedAgent === "scriptflow"
+                        ? `Expected no scriptflow match but matched '${actualFlow}'`
+                        : undefined,
+            });
+        } else {
+            results.push({
+                passed:
+                    actualFlow?.toLowerCase() ===
+                    expected.matchedFlow.toLowerCase(),
+                component: "grammar",
+                expected: expected.matchedFlow,
+                actual: actualFlow ?? "no match",
+                message:
+                    actualFlow !== expected.matchedFlow
+                        ? `Expected flow '${expected.matchedFlow}' but got '${actualFlow ?? "no match"}'`
+                        : undefined,
+            });
+        }
+    }
+
+    // Check extracted parameters
+    if (
+        expected.extractedParams &&
+        Object.keys(expected.extractedParams).length > 0
+    ) {
+        const actualParams = extractParams(commandResult, trace);
+        for (const [key, expectedValue] of Object.entries(
+            expected.extractedParams,
+        )) {
+            // Grammar rules rewrite all named captures to flowArgs, so check
+            // both the original param name and flowArgs as fallback
+            let actualValue = findParamCaseInsensitive(actualParams, key);
+            if (actualValue === undefined) {
+                actualValue = findParamCaseInsensitive(
+                    actualParams,
+                    "flowArgs",
+                );
+            }
+            // Also check flowParametersJson for LLM translation results
+            if (actualValue === undefined) {
+                const fpJson = findParamCaseInsensitive(
+                    actualParams,
+                    "flowParametersJson",
+                );
+                if (typeof fpJson === "string") {
+                    try {
+                        const parsed = JSON.parse(fpJson);
+                        actualValue = findParamCaseInsensitive(parsed, key);
+                    } catch {
+                        /* ignore */
+                    }
+                }
+            }
+            const matches = normalizedEqual(actualValue, expectedValue);
+            results.push({
+                passed: matches,
+                component: "parameters",
+                expected: { [key]: expectedValue },
+                actual: { [key]: actualValue },
+                message: !matches
+                    ? `Parameter '${key}': expected '${expectedValue}' but got '${actualValue}'`
+                    : undefined,
+            });
+        }
+    }
+
+    return results;
+}
+
+function extractFlowName(
+    commandResult: unknown,
+    trace: PipelineTrace,
+): string | null {
+    if (trace.matchedAction) return trace.matchedAction;
+    const result = commandResult as any;
+
+    // CommandResult.actions[] from the dispatcher (collectCommandResult: true)
+    // Each action is { schemaName, actionName, parameters }
+    const firstAction = result?.actions?.[0];
+    if (firstAction) {
+        // For executeScriptFlow, the flow name is in parameters.flowName
+        if (firstAction.parameters?.flowName) {
+            return firstAction.parameters.flowName;
+        }
+        // For other scriptflow actions (listScriptFlows, etc.)
+        if (firstAction.schemaName === "scriptflow") {
+            return firstAction.actionName;
+        }
+        // Generic action name
+        return firstAction.actionName ?? null;
+    }
+
+    // Fallback: direct action property
+    if (result?.action?.parameters?.flowName)
+        return result.action.parameters.flowName;
+    if (result?.action?.actionName) return result.action.actionName;
+    return null;
+}
+
+function extractParams(
+    commandResult: unknown,
+    trace: PipelineTrace,
+): Record<string, unknown> {
+    if (trace.extractedParams) return trace.extractedParams;
+    const result = commandResult as any;
+
+    // CommandResult.actions[] — extract parameters from the first action
+    const firstAction = result?.actions?.[0];
+    if (firstAction?.parameters) return firstAction.parameters;
+    if (result?.action?.parameters) return result.action.parameters;
+    return {};
+}
+
+function findParamCaseInsensitive(
+    params: Record<string, unknown>,
+    key: string,
+): unknown {
+    const lowerKey = key.toLowerCase();
+    for (const [k, v] of Object.entries(params)) {
+        if (k.toLowerCase() === lowerKey) return v;
+    }
+    return undefined;
+}
+
+function normalizedEqual(actual: unknown, expected: unknown): boolean {
+    if (actual === expected) return true;
+    if (actual === undefined || actual === null) return false;
+
+    // String comparison: case-insensitive, normalize path separators
+    if (typeof actual === "string" && typeof expected === "string") {
+        const normActual = actual.replace(/\\/g, "/").toLowerCase().trim();
+        const normExpected = expected.replace(/\\/g, "/").toLowerCase().trim();
+        return normActual === normExpected;
+    }
+
+    // Number comparison
+    if (typeof actual === "number" && typeof expected === "number") {
+        return actual === expected;
+    }
+
+    // Coerce string to number
+    if (typeof actual === "string" && typeof expected === "number") {
+        return parseFloat(actual) === expected;
+    }
+
+    return String(actual).toLowerCase() === String(expected).toLowerCase();
+}

--- a/ts/packages/agents/scriptflow/benchmark/harness/reporters/detailReporter.mts
+++ b/ts/packages/agents/scriptflow/benchmark/harness/reporters/detailReporter.mts
@@ -1,0 +1,61 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import type { ScenarioResult } from "../types.mjs";
+import { writeFileSync, mkdirSync } from "fs";
+import { join } from "path";
+
+export function writeDetailReport(
+    results: ScenarioResult[],
+    outputDir: string,
+): void {
+    mkdirSync(outputDir, { recursive: true });
+
+    writeFileSync(
+        join(outputDir, "details.json"),
+        JSON.stringify(results, null, 2),
+    );
+
+    const failures = results.filter((r) => !r.passed);
+    const failureReport = failures.map((r) => ({
+        scenarioId: r.scenarioId,
+        description: r.description,
+        utterance: r.utterance,
+        failedEvaluations: r.evaluations
+            .filter((e) => !e.passed)
+            .map((e) => ({
+                component: e.component,
+                expected: e.expected,
+                actual: e.actual,
+                message: e.message,
+            })),
+        trace: {
+            grammarMatchResult: r.trace.grammarMatchResult,
+            matchedAgent: r.trace.matchedAgent,
+            matchedAction: r.trace.matchedAction,
+            extractedParams: r.trace.extractedParams,
+            fallbackTriggered: r.trace.fallbackTriggered,
+            reasoningInvoked: r.trace.reasoningInvoked,
+            executionResult: r.trace.executionResult,
+        },
+    }));
+
+    writeFileSync(
+        join(outputDir, "failures.json"),
+        JSON.stringify(failureReport, null, 2),
+    );
+
+    // Print failures to console
+    if (failures.length > 0) {
+        console.log(`\n  Failed Scenarios (${failures.length}):`);
+        for (const f of failures) {
+            console.log(`\n    [${f.scenarioId}] ${f.description}`);
+            console.log(`    Utterance: "${f.utterance}"`);
+            for (const ev of f.evaluations.filter((e) => !e.passed)) {
+                console.log(
+                    `    FAIL [${ev.component}]: ${ev.message ?? `expected ${JSON.stringify(ev.expected)}, got ${JSON.stringify(ev.actual)}`}`,
+                );
+            }
+        }
+    }
+}

--- a/ts/packages/agents/scriptflow/benchmark/harness/reporters/scorecardReporter.mts
+++ b/ts/packages/agents/scriptflow/benchmark/harness/reporters/scorecardReporter.mts
@@ -1,0 +1,154 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import type {
+    ScenarioResult,
+    Scorecard,
+    CategorySummary,
+    ComponentAccuracy,
+} from "../types.mjs";
+
+export function buildScorecard(
+    results: ScenarioResult[],
+    startTime: number,
+): Scorecard {
+    const endTime = Date.now();
+
+    const summary = buildSummary(results);
+    const byCategory = buildByCategory(results);
+    const byComponent = buildByComponent(results);
+
+    return {
+        timestamp: new Date().toISOString(),
+        durationSeconds: Math.round((endTime - startTime) / 1000),
+        summary,
+        byCategory,
+        byComponent,
+        regressions: [],
+        improvements: [],
+    };
+}
+
+function buildSummary(results: ScenarioResult[]): CategorySummary {
+    return {
+        total: results.length,
+        passed: results.filter((r) => r.passed).length,
+        failed: results.filter((r) => !r.passed).length,
+        skipped: 0,
+    };
+}
+
+function buildByCategory(
+    results: ScenarioResult[],
+): Record<string, CategorySummary> {
+    const categories = new Map<string, ScenarioResult[]>();
+    for (const r of results) {
+        const list = categories.get(r.category) ?? [];
+        list.push(r);
+        categories.set(r.category, list);
+    }
+
+    const out: Record<string, CategorySummary> = {};
+    for (const [cat, catResults] of categories) {
+        out[cat] = buildSummary(catResults);
+    }
+    return out;
+}
+
+function buildByComponent(
+    results: ScenarioResult[],
+): Record<string, ComponentAccuracy> {
+    const components = new Map<string, { total: number; correct: number }>();
+
+    for (const r of results) {
+        for (const ev of r.evaluations) {
+            const existing = components.get(ev.component) ?? {
+                total: 0,
+                correct: 0,
+            };
+            existing.total++;
+            if (ev.passed) existing.correct++;
+            components.set(ev.component, existing);
+        }
+    }
+
+    const out: Record<string, ComponentAccuracy> = {};
+    for (const [comp, stats] of components) {
+        out[comp] = {
+            accuracy:
+                stats.total > 0
+                    ? Math.round((stats.correct / stats.total) * 1000) / 1000
+                    : 0,
+            total: stats.total,
+            correct: stats.correct,
+        };
+    }
+    return out;
+}
+
+export function printScorecard(scorecard: Scorecard): void {
+    const s = scorecard.summary;
+    const passRate = s.total > 0 ? ((s.passed / s.total) * 100).toFixed(1) : 0;
+
+    console.log("\n========================================");
+    console.log("  ScriptFlow Reliability Benchmark");
+    console.log("========================================");
+    console.log(
+        `  Total: ${s.total} | Passed: ${s.passed} | Failed: ${s.failed} | Pass Rate: ${passRate}%`,
+    );
+    console.log(`  Duration: ${scorecard.durationSeconds}s`);
+
+    console.log("\n  By Category:");
+    for (const [cat, catSummary] of Object.entries(scorecard.byCategory)) {
+        const rate =
+            catSummary.total > 0
+                ? ((catSummary.passed / catSummary.total) * 100).toFixed(1)
+                : "0.0";
+        console.log(
+            `    ${cat.padEnd(20)} ${catSummary.passed}/${catSummary.total} (${rate}%)`,
+        );
+    }
+
+    console.log("\n  By Component:");
+    for (const [comp, acc] of Object.entries(scorecard.byComponent)) {
+        console.log(
+            `    ${comp.padEnd(20)} ${(acc.accuracy * 100).toFixed(1)}% (${acc.correct}/${acc.total})`,
+        );
+    }
+    console.log("========================================\n");
+}
+
+export function compareScorecards(
+    current: Scorecard,
+    baseline: Scorecard,
+): { regressions: string[]; improvements: string[] } {
+    // For now, a simple comparison could be done at the category level
+    const regressions: string[] = [];
+    const improvements: string[] = [];
+
+    for (const [cat, currentSummary] of Object.entries(current.byCategory)) {
+        const baselineSummary = baseline.byCategory[cat];
+        if (!baselineSummary) continue;
+
+        const currentRate =
+            currentSummary.total > 0
+                ? currentSummary.passed / currentSummary.total
+                : 0;
+        const baselineRate =
+            baselineSummary.total > 0
+                ? baselineSummary.passed / baselineSummary.total
+                : 0;
+
+        if (currentRate < baselineRate) {
+            regressions.push(
+                `${cat}: ${(baselineRate * 100).toFixed(1)}% -> ${(currentRate * 100).toFixed(1)}%`,
+            );
+        } else if (currentRate > baselineRate) {
+            improvements.push(
+                `${cat}: ${(baselineRate * 100).toFixed(1)}% -> ${(currentRate * 100).toFixed(1)}%`,
+            );
+        }
+    }
+
+    return { regressions, improvements };
+}

--- a/ts/packages/agents/scriptflow/benchmark/harness/seedInstanceStorage.mts
+++ b/ts/packages/agents/scriptflow/benchmark/harness/seedInstanceStorage.mts
@@ -1,0 +1,165 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+/**
+ * Seeds scriptflow flows into instance storage by importing .ps1 scripts
+ * through the live dispatcher. This tests the real import pipeline
+ * (ScriptAnalyzer LLM analysis) and validates that LLM-generated grammar
+ * patterns are good enough for matching.
+ *
+ * The approach:
+ * 1. Create a temporary dispatcher with persistDir + storageProvider
+ * 2. Run `@scriptflow import <path>` for each .ps1 script
+ * 3. Close the dispatcher (flows are now in instance storage on disk)
+ * 4. The caller creates a fresh dispatcher that loads the flows at startup
+ *
+ * This avoids the RPC reload issue — flows are written to disk during import,
+ * then read back on the second dispatcher startup.
+ */
+
+import { readdirSync, readFileSync, existsSync } from "fs";
+import { join } from "path";
+
+export interface SeedResult {
+    imported: number;
+    failed: number;
+    errors: string[];
+    flowNameMap: Record<string, string>;
+}
+
+/**
+ * After imports, reads the instance storage index to build a mapping from
+ * canonical flow names (used in scenario files) to the actual LLM-generated
+ * action names. Maps by matching description keywords to canonical names.
+ */
+export function buildFlowNameMap(persistDir: string): Record<string, string> {
+    const indexPath = join(persistDir, "scriptflow", "index.json");
+    if (!existsSync(indexPath)) return {};
+
+    const index = JSON.parse(readFileSync(indexPath, "utf-8"));
+    const flows = index.flows as Record<
+        string,
+        { actionName: string; description: string }
+    >;
+
+    // Map canonical names to description keywords for fuzzy matching
+    const canonicalKeywords: Record<string, string[]> = {
+        listFiles: ["list files", "directory"],
+        findLargeFiles: ["large", "bigger", "size"],
+        checkDiskSpace: ["disk", "drive", "space"],
+        checkServiceHealth: ["service", "health", "running", "stopped"],
+        checkPorts: ["port", "listener", "tcp"],
+        scanLogErrors: ["log", "error", "warning", "scan"],
+        filterCsv: ["csv", "filter", "transform"],
+        staleBranches: ["stale", "branch", "git"],
+    };
+
+    const nameMap: Record<string, string> = {};
+
+    for (const [actualName, flow] of Object.entries(flows)) {
+        const desc = (flow.description ?? "").toLowerCase();
+        const name = actualName.toLowerCase();
+
+        for (const [canonical, keywords] of Object.entries(canonicalKeywords)) {
+            if (nameMap[canonical]) continue;
+            if (actualName === canonical) {
+                nameMap[canonical] = actualName;
+                break;
+            }
+            if (keywords.some((kw) => desc.includes(kw) || name.includes(kw))) {
+                nameMap[canonical] = actualName;
+                break;
+            }
+        }
+    }
+
+    return nameMap;
+}
+
+export async function seedViaImport(
+    scriptsDir: string,
+    persistDir: string,
+    createDispatcherFn: () => Promise<{
+        processCommand: (cmd: string) => Promise<unknown>;
+        getDisplayText: () => string;
+        close: () => Promise<void>;
+    }>,
+): Promise<SeedResult> {
+    if (!existsSync(scriptsDir)) {
+        return {
+            imported: 0,
+            failed: 0,
+            errors: [`Scripts directory not found: ${scriptsDir}`],
+            flowNameMap: {},
+        };
+    }
+
+    const scripts = readdirSync(scriptsDir).filter((f) => f.endsWith(".ps1"));
+    if (scripts.length === 0) {
+        return {
+            imported: 0,
+            failed: 0,
+            errors: ["No .ps1 files found"],
+            flowNameMap: {},
+        };
+    }
+
+    console.log(
+        `\nImporting ${scripts.length} script(s) via @scriptflow import...`,
+    );
+
+    const dispatcher = await createDispatcherFn();
+    const result: SeedResult = {
+        imported: 0,
+        failed: 0,
+        errors: [],
+        flowNameMap: {},
+    };
+
+    try {
+        for (const script of scripts) {
+            const scriptPath = join(scriptsDir, script);
+            const cmd = `@scriptflow import ${scriptPath}`;
+            try {
+                await dispatcher.processCommand(cmd);
+                const display = dispatcher.getDisplayText();
+                if (
+                    display.includes("Imported script flow") ||
+                    display.includes("Created script flow")
+                ) {
+                    result.imported++;
+                    console.log(`  Imported: ${script}`);
+                } else if (display.includes("already exists")) {
+                    result.imported++;
+                    console.log(`  Already exists: ${script}`);
+                } else {
+                    result.failed++;
+                    const errMsg = display.substring(0, 120);
+                    result.errors.push(`${script}: ${errMsg}`);
+                    console.log(`  Warning: ${script} — ${errMsg}`);
+                }
+            } catch (err) {
+                result.failed++;
+                result.errors.push(`${script}: ${err}`);
+                console.log(`  Failed: ${script} — ${err}`);
+            }
+        }
+    } finally {
+        await dispatcher.close();
+    }
+
+    console.log(
+        `  Import complete: ${result.imported} imported, ${result.failed} failed`,
+    );
+
+    result.flowNameMap = buildFlowNameMap(persistDir);
+    if (Object.keys(result.flowNameMap).length > 0) {
+        console.log("  Flow name mapping (canonical -> actual):");
+        for (const [canonical, actual] of Object.entries(result.flowNameMap)) {
+            const label = canonical === actual ? "(exact)" : `-> ${actual}`;
+            console.log(`    ${canonical} ${label}`);
+        }
+    }
+
+    return result;
+}

--- a/ts/packages/agents/scriptflow/benchmark/harness/traceCollector.mts
+++ b/ts/packages/agents/scriptflow/benchmark/harness/traceCollector.mts
@@ -1,0 +1,123 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import type { PipelineTrace } from "./types.mjs";
+import registerDebug from "debug";
+
+const debugBenchmark = registerDebug("typeagent:benchmark");
+
+interface DebugLogEntry {
+    namespace: string;
+    message: string;
+    timestamp: number;
+}
+
+export class TraceCollector {
+    private logs: DebugLogEntry[] = [];
+    private originalWrite: typeof process.stderr.write | undefined;
+    private collecting = false;
+
+    startCollecting(): void {
+        if (this.collecting) return;
+        this.collecting = true;
+        this.logs = [];
+
+        // Intercept stderr (where debug writes) to capture log output
+        this.originalWrite = process.stderr.write;
+        const self = this;
+        process.stderr.write = function (
+            chunk: string | Uint8Array,
+            ...args: any[]
+        ): boolean {
+            const text =
+                typeof chunk === "string"
+                    ? chunk
+                    : new TextDecoder().decode(chunk);
+            self.logs.push({
+                namespace: self.extractNamespace(text),
+                message: text,
+                timestamp: Date.now(),
+            });
+            // Still write to stderr for visibility during development
+            return self.originalWrite!.call(process.stderr, chunk, ...args);
+        } as typeof process.stderr.write;
+    }
+
+    stopCollecting(): void {
+        if (!this.collecting) return;
+        this.collecting = false;
+        if (this.originalWrite) {
+            process.stderr.write = this.originalWrite;
+            this.originalWrite = undefined;
+        }
+    }
+
+    buildTrace(utterance: string, startTime: number): PipelineTrace {
+        const trace: PipelineTrace = {
+            utterance,
+            grammarMatchAttempted: false,
+            grammarMatchResult: "no-match",
+            llmTranslationAttempted: false,
+            executionAttempted: false,
+            fallbackTriggered: false,
+            reasoningInvoked: false,
+            totalTimeMs: Date.now() - startTime,
+        };
+
+        for (const log of this.logs) {
+            this.processLogEntry(log, trace);
+        }
+
+        return trace;
+    }
+
+    getCollectedLogs(): DebugLogEntry[] {
+        return [...this.logs];
+    }
+
+    clearLogs(): void {
+        this.logs = [];
+    }
+
+    private extractNamespace(text: string): string {
+        const match = text.match(/^(\s*)(typeagent:\S+)/);
+        return match ? match[2] : "unknown";
+    }
+
+    private processLogEntry(entry: DebugLogEntry, trace: PipelineTrace): void {
+        const msg = entry.message;
+
+        // Grammar match detection
+        if (msg.includes("grammarStore") || msg.includes("Cache Validation")) {
+            trace.grammarMatchAttempted = true;
+            if (
+                msg.includes("Validation Success") ||
+                msg.includes("accepted")
+            ) {
+                trace.grammarMatchResult = "match";
+            } else if (msg.includes("Rejected") || msg.includes("rejected")) {
+                trace.grammarMatchResult = "rejected";
+            }
+        }
+
+        // Agent/action detection from grammar match
+        if (msg.includes("scriptflow") && msg.includes("executeAction")) {
+            trace.matchedAgent = "scriptflow";
+        }
+
+        // Execution detection
+        if (msg.includes("scriptflow:handler")) {
+            trace.executionAttempted = true;
+        }
+
+        // Fallback detection
+        if (msg.includes("fallbackToReasoning")) {
+            trace.fallbackTriggered = true;
+        }
+
+        // Reasoning detection
+        if (msg.includes("executeReasoning") || msg.includes("reasoning")) {
+            trace.reasoningInvoked = true;
+        }
+    }
+}

--- a/ts/packages/agents/scriptflow/benchmark/harness/types.mts
+++ b/ts/packages/agents/scriptflow/benchmark/harness/types.mts
@@ -1,0 +1,109 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+export interface BenchmarkScenario {
+    id: string;
+    category:
+        | "grammar-match"
+        | "llm-translation"
+        | "execution"
+        | "fallback-chain"
+        | "end-to-end";
+    description: string;
+    setup: {
+        requiredFlows: string[];
+        environmentSetup?: string;
+        configOverrides?: Record<string, unknown>;
+    };
+    utterances: TestUtterance[];
+    teardown?: { cleanupScript?: string };
+}
+
+export interface TestUtterance {
+    text: string;
+    expected: {
+        routedTo: "grammar" | "llm-translation" | "reasoning";
+        matchedFlow?: string | null;
+        extractedParams?: Record<string, unknown>;
+        execution?: {
+            shouldSucceed: boolean;
+            outputContains?: string[];
+            outputNotContains?: string[];
+            outputPattern?: string;
+        };
+        fallback?: {
+            shouldFallback: boolean;
+            fallbackReason?: string;
+            reasoningShouldFix?: boolean;
+        };
+        llmJudge?: { question: string; context?: string };
+    };
+}
+
+export interface PipelineTrace {
+    utterance: string;
+    grammarMatchAttempted: boolean;
+    grammarMatchResult: "match" | "no-match" | "rejected";
+    matchedAgent?: string;
+    matchedAction?: string;
+    extractedParams?: Record<string, unknown>;
+    llmTranslationAttempted: boolean;
+    llmTranslationResult?: unknown;
+    executionAttempted: boolean;
+    executionResult?: {
+        success: boolean;
+        output: string;
+        error?: string;
+    };
+    fallbackTriggered: boolean;
+    fallbackReason?: string;
+    reasoningInvoked: boolean;
+    totalTimeMs: number;
+}
+
+export interface EvaluationResult {
+    passed: boolean;
+    component:
+        | "grammar"
+        | "parameters"
+        | "execution"
+        | "fallback"
+        | "llm-judge";
+    expected: unknown;
+    actual: unknown;
+    message?: string;
+}
+
+export interface ScenarioResult {
+    scenarioId: string;
+    category: string;
+    description: string;
+    utterance: string;
+    passed: boolean;
+    evaluations: EvaluationResult[];
+    trace: PipelineTrace;
+    durationMs: number;
+}
+
+export interface CategorySummary {
+    total: number;
+    passed: number;
+    failed: number;
+    skipped: number;
+}
+
+export interface ComponentAccuracy {
+    accuracy: number;
+    total: number;
+    correct: number;
+}
+
+export interface Scorecard {
+    timestamp: string;
+    durationSeconds: number;
+    summary: CategorySummary;
+    byCategory: Record<string, CategorySummary>;
+    byComponent: Record<string, ComponentAccuracy>;
+    regressions: string[];
+    improvements: string[];
+}

--- a/ts/packages/agents/scriptflow/benchmark/results/.gitignore
+++ b/ts/packages/agents/scriptflow/benchmark/results/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/ts/packages/agents/scriptflow/benchmark/run-benchmark.mts
+++ b/ts/packages/agents/scriptflow/benchmark/run-benchmark.mts
@@ -1,0 +1,383 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+/**
+ * ScriptFlow Reliability Benchmark
+ *
+ * Usage:
+ *   npx tsx benchmark/run-benchmark.mts [options]
+ *
+ * Options:
+ *   --category <name>     Run only scenarios in this category
+ *   --scenario <id>       Run only this specific scenario
+ *   --no-llm-judge        Skip LLM-as-judge evaluations
+ *   --compare <path>      Compare results against a baseline scorecard.json
+ *   --dry-run             Load and validate scenarios without executing
+ */
+
+import { join, dirname } from "path";
+import { fileURLToPath } from "url";
+import { readFileSync, existsSync, rmSync } from "fs";
+import {
+    seedViaImport,
+    type SeedResult,
+} from "./harness/seedInstanceStorage.mjs";
+
+// Load .env from ts/ root manually (avoid dotenv dependency)
+const _thisDir = dirname(fileURLToPath(import.meta.url));
+const envPath = join(_thisDir, "..", "..", "..", "..", ".env");
+if (existsSync(envPath)) {
+    for (const line of readFileSync(envPath, "utf-8").split("\n")) {
+        const trimmed = line.trim();
+        if (!trimmed || trimmed.startsWith("#")) continue;
+        const eqIdx = trimmed.indexOf("=");
+        if (eqIdx < 0) continue;
+        const key = trimmed.substring(0, eqIdx).trim();
+        let val = trimmed.substring(eqIdx + 1).trim();
+        if (
+            (val.startsWith('"') && val.endsWith('"')) ||
+            (val.startsWith("'") && val.endsWith("'"))
+        ) {
+            val = val.slice(1, -1);
+        }
+        if (!process.env[key]) {
+            process.env[key] = val;
+        }
+    }
+}
+import {
+    BenchmarkRunner,
+    type BenchmarkOptions,
+    type DispatcherAdapter,
+} from "./harness/benchmarkRunner.mjs";
+import type { BenchmarkScenario } from "./harness/types.mjs";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+function parseArgs(): BenchmarkOptions & { dryRun: boolean } {
+    const args = process.argv.slice(2);
+    const options: BenchmarkOptions & { dryRun: boolean } = {
+        scenarioDir: join(__dirname, "scenarios"),
+        outputDir: join(__dirname, "results"),
+        benchmarkDir: __dirname,
+        dryRun: false,
+    };
+
+    for (let i = 0; i < args.length; i++) {
+        switch (args[i]) {
+            case "--category":
+                options.category = args[++i];
+                break;
+            case "--scenario":
+                options.scenarioId = args[++i];
+                break;
+            case "--no-llm-judge":
+                options.noLlmJudge = true;
+                break;
+            case "--compare":
+                options.compareBaseline = args[++i];
+                break;
+            case "--dry-run":
+                options.dryRun = true;
+                break;
+        }
+    }
+
+    return options;
+}
+
+async function createLiveDispatcher(
+    persistDir: string,
+): Promise<DispatcherAdapter> {
+    // Resolve dispatcher and provider via relative paths to avoid cyclic
+    // workspace dependencies (scriptflow -> defaultAgentProvider -> scriptflow)
+    const tsRoot = join(__dirname, "..", "..", "..", "..");
+    const dispatcherPath = join(
+        tsRoot,
+        "packages",
+        "dispatcher",
+        "dispatcher",
+        "dist",
+        "index.js",
+    );
+    const providerPath = join(
+        tsRoot,
+        "packages",
+        "defaultAgentProvider",
+        "dist",
+        "defaultAgentProviders.js",
+    );
+
+    const { createDispatcher } = await import(
+        /* webpackIgnore: true */ "file://" + dispatcherPath.replace(/\\/g, "/")
+    );
+    const { getDefaultAppAgentProviders } = await import(
+        /* webpackIgnore: true */ "file://" + providerPath.replace(/\\/g, "/")
+    );
+
+    const providers = getDefaultAppAgentProviders(undefined);
+
+    const nodeProvidersPath = join(
+        tsRoot,
+        "packages",
+        "dispatcher",
+        "nodeProviders",
+        "dist",
+        "index.js",
+    );
+    const { getFsStorageProvider } = await import(
+        /* webpackIgnore: true */ "file://" +
+            nodeProvidersPath.replace(/\\/g, "/")
+    );
+
+    const dispatcher = await createDispatcher("scriptflow-benchmark", {
+        appAgentProviders: providers,
+        agents: { actions: true, commands: true },
+        execution: { history: false },
+        collectCommandResult: true,
+        portBase: 9100,
+        persistDir,
+        storageProvider: getFsStorageProvider(),
+    });
+
+    let lastDisplayText = "";
+
+    return {
+        async processCommand(command: string): Promise<unknown> {
+            // Snapshot the current display log length so we can capture only
+            // entries produced by THIS command after it completes.
+            let seqBefore = 0;
+            try {
+                const before = await dispatcher.getDisplayHistory();
+                if (before.length > 0) {
+                    seqBefore = (before[before.length - 1] as any).seq ?? 0;
+                }
+            } catch {
+                /* ignore */
+            }
+
+            const result = await dispatcher.processCommand(command);
+
+            // Poll for display output. Script execution results arrive
+            // asynchronously through the agent RPC layer — processCommand
+            // resolves but display entries may still be in flight.
+            // Poll until the display log stabilizes (no new entries for 1s)
+            // or we hit a 15s timeout.
+            const pollStart = Date.now();
+            let prevCount = 0;
+            let stableAt = 0;
+            lastDisplayText = "";
+
+            while (Date.now() - pollStart < 15000) {
+                await new Promise((r) => setTimeout(r, 300));
+                try {
+                    const entries =
+                        await dispatcher.getDisplayHistory(seqBefore);
+                    if (entries.length > prevCount) {
+                        prevCount = entries.length;
+                        stableAt = Date.now();
+                    } else if (
+                        entries.length > 0 &&
+                        Date.now() - stableAt > 1000
+                    ) {
+                        // Stable for 1 second — capture and break
+                        break;
+                    }
+
+                    if (entries.length === 0 && Date.now() - pollStart > 2000) {
+                        break; // No entries at all after 2s — give up
+                    }
+                } catch {
+                    break;
+                }
+            }
+
+            // Final capture of all display entries
+            try {
+                const entries = await dispatcher.getDisplayHistory(seqBefore);
+                const textParts: string[] = [];
+                for (const entry of entries) {
+                    if (
+                        entry.type === "set-display" ||
+                        entry.type === "append-display"
+                    ) {
+                        const msg = (entry as any).message?.message;
+                        if (typeof msg === "string") {
+                            textParts.push(msg);
+                        } else if (Array.isArray(msg)) {
+                            for (const item of msg) {
+                                if (typeof item === "string") {
+                                    textParts.push(item);
+                                } else if (
+                                    item &&
+                                    typeof item === "object" &&
+                                    item.content
+                                ) {
+                                    textParts.push(String(item.content));
+                                }
+                            }
+                        }
+                    }
+                }
+                lastDisplayText = textParts.join("\n");
+            } catch {
+                lastDisplayText = "";
+            }
+            return result ?? null;
+        },
+        getDisplayText(): string {
+            return lastDisplayText;
+        },
+        async close(): Promise<void> {
+            await dispatcher.close();
+        },
+    };
+}
+
+function createStubDispatcher(): DispatcherAdapter {
+    return {
+        async processCommand(command: string): Promise<unknown> {
+            console.log(`  [DRY RUN] Would process: "${command}"`);
+            return { dryRun: true, command };
+        },
+        getDisplayText(): string {
+            return "";
+        },
+        async close(): Promise<void> {},
+    };
+}
+
+async function main() {
+    const options = parseArgs();
+
+    console.log("ScriptFlow Reliability Benchmark");
+    console.log("================================");
+
+    if (options.category) {
+        console.log(`Category filter: ${options.category}`);
+    }
+    if (options.scenarioId) {
+        console.log(`Scenario filter: ${options.scenarioId}`);
+    }
+    if (options.noLlmJudge) {
+        console.log("LLM judge: disabled");
+    }
+
+    // Validate scenario files exist
+    const scenarioFiles = [
+        "grammar-match.json",
+        "execution.json",
+        "llm-translation.json",
+        "fallback-chain.json",
+        "end-to-end.json",
+    ];
+
+    let totalScenarios = 0;
+    for (const file of scenarioFiles) {
+        const filePath = join(options.scenarioDir, file);
+        if (existsSync(filePath)) {
+            const scenarios: BenchmarkScenario[] = JSON.parse(
+                readFileSync(filePath, "utf-8"),
+            );
+            console.log(`  ${file}: ${scenarios.length} scenario(s)`);
+            totalScenarios += scenarios.length;
+        }
+    }
+    console.log(`  Total: ${totalScenarios} scenario(s)`);
+
+    if (options.dryRun) {
+        console.log("\nDry run mode - scenarios validated, not executed.");
+        const dispatcher = createStubDispatcher();
+        const runner = new BenchmarkRunner(dispatcher, options);
+        await runner.run();
+        return;
+    }
+
+    // Check if benchmark environment is set up
+    const benchmarkEnvDir = join(
+        process.env.TEMP ?? "",
+        "scriptflow-benchmark",
+    );
+    if (!existsSync(benchmarkEnvDir)) {
+        console.log(`\nBenchmark environment not found at ${benchmarkEnvDir}`);
+        console.log(
+            "Run: powershell -File benchmark/fixtures/Setup-BenchmarkEnv.ps1",
+        );
+        console.log(
+            "Or use --dry-run to validate scenarios without execution.",
+        );
+        process.exit(1);
+    }
+
+    const persistDir = join(
+        process.env.TEMP ?? "/tmp",
+        "scriptflow-benchmark-session",
+    );
+
+    // Clean previous session state so we start fresh
+    if (existsSync(persistDir)) {
+        rmSync(persistDir, { recursive: true, force: true });
+    }
+
+    // Phase 1: Import scripts via a temporary dispatcher.
+    // This runs the real import pipeline (LLM-based ScriptAnalyzer) and
+    // writes flows to instance storage. We then close this dispatcher.
+    const scriptsDir = join(
+        __dirname,
+        "..",
+        "test",
+        "import-scenarios",
+        "scripts",
+    );
+
+    let flowNameMap: Record<string, string> = {};
+    if (existsSync(scriptsDir)) {
+        try {
+            const seedResult = await seedViaImport(scriptsDir, persistDir, () =>
+                createLiveDispatcher(persistDir),
+            );
+            flowNameMap = seedResult.flowNameMap;
+            if (seedResult.failed > 0) {
+                console.log(`  Import errors: ${seedResult.errors.join("; ")}`);
+            }
+        } catch (err) {
+            console.error(`Failed to seed flows: ${err}`);
+        }
+    }
+
+    // Phase 2: Create a fresh dispatcher that loads the imported flows
+    // from instance storage at startup. This ensures grammar rules are
+    // registered via getDynamicGrammar() during agent initialization.
+    console.log("\nCreating dispatcher for benchmark run...");
+    let dispatcher: DispatcherAdapter;
+    try {
+        dispatcher = await createLiveDispatcher(persistDir);
+    } catch (err) {
+        console.error(`Failed to create dispatcher: ${err}`);
+        console.log(
+            "\nFalling back to dry-run mode. To run live tests, ensure TypeAgent is built.",
+        );
+        dispatcher = createStubDispatcher();
+    }
+
+    try {
+        const runner = new BenchmarkRunner(dispatcher, options, flowNameMap);
+        const scorecard = await runner.run();
+
+        const passRate =
+            scorecard.summary.total > 0
+                ? (
+                      (scorecard.summary.passed / scorecard.summary.total) *
+                      100
+                  ).toFixed(1)
+                : "0.0";
+        process.exit(parseFloat(passRate) >= 85 ? 0 : 1);
+    } finally {
+        await dispatcher.close();
+    }
+}
+
+main().catch((err) => {
+    console.error("Benchmark failed:", err);
+    process.exit(2);
+});

--- a/ts/packages/agents/scriptflow/benchmark/scenarios/end-to-end.json
+++ b/ts/packages/agents/scriptflow/benchmark/scenarios/end-to-end.json
@@ -1,0 +1,218 @@
+[
+  {
+    "id": "e2e-01",
+    "category": "end-to-end",
+    "description": "Import then match: import staleBranches.ps1 then match via grammar",
+    "setup": {
+      "requiredFlows": [],
+      "environmentSetup": "Setup-BenchmarkEnv"
+    },
+    "utterances": [
+      {
+        "text": "@scriptflow import ${SCRIPTFLOW_PKG}\\test\\import-scenarios\\scripts\\staleBranches.ps1",
+        "expected": {
+          "routedTo": "grammar",
+          "execution": {
+            "shouldSucceed": true,
+            "outputContains": ["Imported script flow"]
+          }
+        }
+      },
+      {
+        "text": "show stale branches",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "staleBranches",
+          "execution": {
+            "shouldSucceed": true
+          }
+        }
+      }
+    ]
+  },
+  {
+    "id": "e2e-02",
+    "category": "end-to-end",
+    "description": "Delete then re-import: delete findLargeFiles, import from .ps1, then match",
+    "setup": {
+      "requiredFlows": ["findLargeFiles"],
+      "environmentSetup": "Setup-BenchmarkEnv"
+    },
+    "utterances": [
+      {
+        "text": "delete script flow findLargeFiles",
+        "expected": {
+          "routedTo": "grammar",
+          "execution": {
+            "shouldSucceed": true,
+            "outputContains": ["Deleted"]
+          }
+        }
+      },
+      {
+        "text": "@scriptflow import ${SCRIPTFLOW_PKG}\\test\\import-scenarios\\scripts\\findLargeFiles.ps1",
+        "expected": {
+          "routedTo": "grammar",
+          "execution": {
+            "shouldSucceed": true,
+            "outputContains": ["Imported script flow"]
+          }
+        }
+      },
+      {
+        "text": "find large files",
+        "expected": {
+          "routedTo": "grammar",
+          "execution": { "shouldSucceed": true }
+        }
+      }
+    ]
+  },
+  {
+    "id": "e2e-03",
+    "category": "end-to-end",
+    "description": "Seed flows are immediately matchable after session start",
+    "setup": {
+      "requiredFlows": ["listFiles", "checkDiskSpace", "checkPorts"]
+    },
+    "utterances": [
+      {
+        "text": "list files in .",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "listFiles",
+          "execution": { "shouldSucceed": true }
+        }
+      },
+      {
+        "text": "check disk space",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "checkDiskSpace",
+          "execution": { "shouldSucceed": true }
+        }
+      },
+      {
+        "text": "show port listeners",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "checkPorts",
+          "execution": { "shouldSucceed": true }
+        }
+      }
+    ]
+  },
+  {
+    "id": "e2e-04",
+    "category": "end-to-end",
+    "description": "List flows shows all registered flows",
+    "setup": {
+      "requiredFlows": ["listFiles", "findLargeFiles", "checkDiskSpace"]
+    },
+    "utterances": [
+      {
+        "text": "list script flows",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "listScriptFlows",
+          "execution": {
+            "shouldSucceed": true,
+            "outputContains": ["listFiles", "findLargeFiles", "checkDiskSpace"]
+          }
+        }
+      }
+    ]
+  },
+  {
+    "id": "e2e-05",
+    "category": "end-to-end",
+    "description": "Check disk space execution produces valid system data",
+    "setup": { "requiredFlows": ["checkDiskSpace"] },
+    "utterances": [
+      {
+        "text": "check disk space",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "checkDiskSpace",
+          "execution": {
+            "shouldSucceed": true,
+            "outputContains": ["SizeGB"],
+            "outputPattern": "\\d+\\.\\d+"
+          },
+          "llmJudge": {
+            "question": "Does the output show a table of disk drives with their sizes, free space, and status (OK or LOW)?",
+            "context": "The system should report at least the C: drive with SizeGB, FreeGB, FreePct, and Status columns."
+          }
+        }
+      }
+    ]
+  },
+  {
+    "id": "e2e-06",
+    "category": "end-to-end",
+    "description": "Filter CSV with department filter produces correct subset",
+    "setup": {
+      "requiredFlows": ["filterCsv"],
+      "environmentSetup": "Setup-BenchmarkEnv"
+    },
+    "utterances": [
+      {
+        "text": "filter csv file ${BENCHMARK_DIR}\\csv\\employees.csv",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "filterCsv",
+          "execution": {
+            "shouldSucceed": true,
+            "outputContains": ["Processed:", "rows"],
+            "outputPattern": "25 rows -> 25 rows"
+          }
+        }
+      }
+    ]
+  },
+  {
+    "id": "e2e-07",
+    "category": "end-to-end",
+    "description": "Scan test logs produces accurate error count",
+    "setup": {
+      "requiredFlows": ["scanLogErrors"],
+      "environmentSetup": "Setup-BenchmarkEnv"
+    },
+    "utterances": [
+      {
+        "text": "log errors in ${BENCHMARK_DIR}\\logs",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "scanLogErrors",
+          "execution": {
+            "shouldSucceed": true,
+            "outputContains": ["ERROR", "WARN", "FATAL", "Summary by Severity"]
+          },
+          "llmJudge": {
+            "question": "Does the output show a summary of log errors by severity level including ERROR, WARN, and FATAL counts?",
+            "context": "The test logs contain 10 ERROR entries, 7 WARN entries, and 1 FATAL entry across two log files."
+          }
+        }
+      }
+    ]
+  },
+  {
+    "id": "e2e-08",
+    "category": "end-to-end",
+    "description": "Service health check with custom services",
+    "setup": { "requiredFlows": ["checkServiceHealth"] },
+    "utterances": [
+      {
+        "text": "service status for EventLog, WinRM, FakeService999",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "checkServiceHealth",
+          "execution": {
+            "shouldSucceed": true,
+            "outputContains": ["Running", "MISSING"]
+          }
+        }
+      }
+    ]
+  }
+]

--- a/ts/packages/agents/scriptflow/benchmark/scenarios/execution.json
+++ b/ts/packages/agents/scriptflow/benchmark/scenarios/execution.json
@@ -1,0 +1,248 @@
+[
+  {
+    "id": "ex-01",
+    "category": "execution",
+    "description": "Basic execution: list files in test directory",
+    "setup": {
+      "requiredFlows": ["listFiles"],
+      "environmentSetup": "Setup-BenchmarkEnv"
+    },
+    "utterances": [
+      {
+        "text": "list files in ${BENCHMARK_DIR}\\files",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "listFiles",
+          "execution": {
+            "shouldSucceed": true,
+            "outputContains": ["Name", "Length", "LastWriteTime"],
+            "outputNotContains": ["error", "Error"]
+          }
+        }
+      }
+    ]
+  },
+  {
+    "id": "ex-02",
+    "category": "execution",
+    "description": "Large file finder against Windows directory",
+    "setup": { "requiredFlows": ["findLargeFiles"] },
+    "utterances": [
+      {
+        "text": "find large files in C:\\Windows",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "findLargeFiles",
+          "execution": {
+            "shouldSucceed": true,
+            "outputContains": ["SizeMB"],
+            "outputPattern": "\\d+\\.\\d+\\s+\\d{4}-"
+          }
+        }
+      }
+    ]
+  },
+  {
+    "id": "ex-03",
+    "category": "execution",
+    "description": "Check disk space with defaults",
+    "setup": { "requiredFlows": ["checkDiskSpace"] },
+    "utterances": [
+      {
+        "text": "check disk space",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "checkDiskSpace",
+          "execution": {
+            "shouldSucceed": true,
+            "outputContains": ["SizeGB", "FreeGB"],
+            "outputPattern": "(Name|DeviceID)"
+          }
+        }
+      }
+    ]
+  },
+  {
+    "id": "ex-04",
+    "category": "execution",
+    "description": "Check service health with default services",
+    "setup": { "requiredFlows": ["checkServiceHealth"] },
+    "utterances": [
+      {
+        "text": "check service health",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "checkServiceHealth",
+          "execution": {
+            "shouldSucceed": true,
+            "outputContains": ["Name", "Status"],
+            "outputPattern": "(Running|Stopped)"
+          }
+        }
+      }
+    ]
+  },
+  {
+    "id": "ex-05",
+    "category": "execution",
+    "description": "Check common Windows ports",
+    "setup": { "requiredFlows": ["checkPorts"] },
+    "utterances": [
+      {
+        "text": "check port listeners on 135,445",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "checkPorts",
+          "execution": {
+            "shouldSucceed": true,
+            "outputPattern": "(Port|No listeners)"
+          }
+        }
+      }
+    ]
+  },
+  {
+    "id": "ex-06",
+    "category": "execution",
+    "description": "Scan test log files for errors",
+    "setup": {
+      "requiredFlows": ["scanLogErrors"],
+      "environmentSetup": "Setup-BenchmarkEnv"
+    },
+    "utterances": [
+      {
+        "text": "log errors in ${BENCHMARK_DIR}\\logs",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "scanLogErrors",
+          "execution": {
+            "shouldSucceed": true,
+            "outputContains": ["Scanning", "Summary by Severity"],
+            "outputPattern": "(ERROR|WARN|FATAL): \\d+ occurrence"
+          }
+        }
+      }
+    ]
+  },
+  {
+    "id": "ex-07",
+    "category": "execution",
+    "description": "Filter CSV by department",
+    "setup": {
+      "requiredFlows": ["filterCsv"],
+      "environmentSetup": "Setup-BenchmarkEnv"
+    },
+    "utterances": [
+      {
+        "text": "filter csv file ${BENCHMARK_DIR}\\csv\\employees.csv",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "filterCsv",
+          "execution": {
+            "shouldSucceed": true,
+            "outputContains": ["Processed:", "rows"],
+            "outputPattern": "\\d+ rows -> \\d+ rows"
+          }
+        }
+      }
+    ]
+  },
+  {
+    "id": "ex-08",
+    "category": "execution",
+    "description": "Error handling: non-existent path",
+    "setup": { "requiredFlows": ["listFiles"] },
+    "utterances": [
+      {
+        "text": "list files in C:\\NonExistent\\Path\\ThatDoesNotExist",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "listFiles",
+          "execution": {
+            "shouldSucceed": false
+          },
+          "fallback": {
+            "shouldFallback": true
+          }
+        }
+      }
+    ]
+  },
+  {
+    "id": "ex-09",
+    "category": "execution",
+    "description": "Empty result: check unlikely port",
+    "setup": { "requiredFlows": ["checkPorts"] },
+    "utterances": [
+      {
+        "text": "check port listeners on 59999",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "checkPorts",
+          "execution": {
+            "shouldSucceed": true,
+            "outputContains": ["No listeners"]
+          }
+        }
+      }
+    ]
+  },
+  {
+    "id": "ex-10",
+    "category": "execution",
+    "description": "Missing input file for CSV filter",
+    "setup": { "requiredFlows": ["filterCsv"] },
+    "utterances": [
+      {
+        "text": "filter csv file C:\\nonexistent\\fake.csv",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "filterCsv",
+          "execution": {
+            "shouldSucceed": false,
+            "outputContains": ["not found"]
+          }
+        }
+      }
+    ]
+  },
+  {
+    "id": "ex-11",
+    "category": "execution",
+    "description": "Missing service shows MISSING status",
+    "setup": { "requiredFlows": ["checkServiceHealth"] },
+    "utterances": [
+      {
+        "text": "service status for FakeService123",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "checkServiceHealth",
+          "execution": {
+            "shouldSucceed": true,
+            "outputContains": ["MISSING"]
+          }
+        }
+      }
+    ]
+  },
+  {
+    "id": "ex-12",
+    "category": "execution",
+    "description": "Relative path: list files in current directory",
+    "setup": { "requiredFlows": ["listFiles"] },
+    "utterances": [
+      {
+        "text": "list files in .",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "listFiles",
+          "extractedParams": { "path": "." },
+          "execution": {
+            "shouldSucceed": true,
+            "outputContains": ["Name"]
+          }
+        }
+      }
+    ]
+  }
+]

--- a/ts/packages/agents/scriptflow/benchmark/scenarios/fallback-chain.json
+++ b/ts/packages/agents/scriptflow/benchmark/scenarios/fallback-chain.json
@@ -1,0 +1,181 @@
+[
+  {
+    "id": "fb-01",
+    "category": "fallback-chain",
+    "description": "Path validation fail: list files in downloads and show safenet ones",
+    "setup": { "requiredFlows": ["listFiles"] },
+    "utterances": [
+      {
+        "text": "list files in downloads and show safenet ones",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "listFiles",
+          "fallback": {
+            "shouldFallback": true,
+            "fallbackReason": "path validation"
+          },
+          "llmJudge": {
+            "question": "Did the system recognize that the utterance contains both a path and a filter request, and handle them appropriately?"
+          }
+        }
+      }
+    ]
+  },
+  {
+    "id": "fb-02",
+    "category": "fallback-chain",
+    "description": "Script lacks feature: list files in C:\\temp sorted by date descending",
+    "setup": { "requiredFlows": ["listFiles"] },
+    "utterances": [
+      {
+        "text": "list files in C:\\temp sorted by date descending",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "listFiles",
+          "fallback": {
+            "shouldFallback": true
+          }
+        }
+      }
+    ]
+  },
+  {
+    "id": "fb-03",
+    "category": "fallback-chain",
+    "description": "Multi-step request: find large files and delete the oldest",
+    "setup": { "requiredFlows": ["findLargeFiles"] },
+    "utterances": [
+      {
+        "text": "find large files and delete the oldest",
+        "expected": {
+          "routedTo": "grammar",
+          "fallback": {
+            "shouldFallback": true
+          }
+        }
+      }
+    ]
+  },
+  {
+    "id": "fb-04",
+    "category": "fallback-chain",
+    "description": "No existing flow: show processes using more than 1GB memory",
+    "setup": { "requiredFlows": ["listFiles"] },
+    "utterances": [
+      {
+        "text": "show processes using more than 1GB memory",
+        "expected": {
+          "routedTo": "reasoning",
+          "matchedFlow": null
+        }
+      }
+    ]
+  },
+  {
+    "id": "fb-05",
+    "category": "fallback-chain",
+    "description": "Partial match + unsupported action: check disk space and email me if low",
+    "setup": { "requiredFlows": ["checkDiskSpace"] },
+    "utterances": [
+      {
+        "text": "check disk space and email me if low",
+        "expected": {
+          "routedTo": "grammar",
+          "fallback": {
+            "shouldFallback": true
+          }
+        }
+      }
+    ]
+  },
+  {
+    "id": "fb-06",
+    "category": "fallback-chain",
+    "description": "Cross-agent: scan logs for errors and create a JIRA ticket",
+    "setup": { "requiredFlows": ["scanLogErrors"] },
+    "utterances": [
+      {
+        "text": "scan logs for errors and create a JIRA ticket",
+        "expected": {
+          "routedTo": "grammar",
+          "fallback": {
+            "shouldFallback": true
+          }
+        }
+      }
+    ]
+  },
+  {
+    "id": "fb-07",
+    "category": "fallback-chain",
+    "description": "Env var handling: list files in $env:USERPROFILE\\Documents",
+    "setup": { "requiredFlows": ["listFiles"] },
+    "utterances": [
+      {
+        "text": "list files in $env:USERPROFILE\\Documents",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "listFiles",
+          "execution": {
+            "shouldSucceed": true,
+            "outputContains": ["Name"]
+          }
+        }
+      }
+    ]
+  },
+  {
+    "id": "fb-08",
+    "category": "fallback-chain",
+    "description": "Special char handling: filter csv with regex pattern [0-9]+",
+    "setup": { "requiredFlows": ["filterCsv"] },
+    "utterances": [
+      {
+        "text": "filter csv with regex pattern [0-9]+",
+        "expected": {
+          "routedTo": "llm-translation",
+          "matchedFlow": "filterCsv"
+        }
+      }
+    ]
+  },
+  {
+    "id": "fb-09",
+    "category": "fallback-chain",
+    "description": "No existing flow triggers reasoning: find files containing TODO in .ts files under src",
+    "setup": { "requiredFlows": ["listFiles"] },
+    "utterances": [
+      {
+        "text": "find files containing TODO in .ts files under src",
+        "expected": {
+          "routedTo": "reasoning",
+          "matchedFlow": null
+        }
+      }
+    ]
+  },
+  {
+    "id": "fb-10",
+    "category": "fallback-chain",
+    "description": "Empty dir execution: list files in empty test directory",
+    "setup": {
+      "requiredFlows": ["listFiles"],
+      "environmentSetup": "Setup-BenchmarkEnv"
+    },
+    "utterances": [
+      {
+        "text": "list files in ${BENCHMARK_DIR}\\empty-dir-that-does-not-exist",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "listFiles",
+          "execution": {
+            "shouldSucceed": false
+          },
+          "fallback": {
+            "shouldFallback": true
+          }
+        }
+      }
+    ]
+  }
+]

--- a/ts/packages/agents/scriptflow/benchmark/scenarios/grammar-match.json
+++ b/ts/packages/agents/scriptflow/benchmark/scenarios/grammar-match.json
@@ -1,0 +1,397 @@
+[
+  {
+    "id": "gm-01",
+    "category": "grammar-match",
+    "description": "Basic path capture: list files in C:\\temp",
+    "setup": { "requiredFlows": ["listFiles"] },
+    "utterances": [
+      {
+        "text": "list files in C:\\temp",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "listFiles",
+          "extractedParams": { "path": "C:\\temp" }
+        }
+      }
+    ]
+  },
+  {
+    "id": "gm-02",
+    "category": "grammar-match",
+    "description": "Optional words: list all the files in downloads",
+    "setup": { "requiredFlows": ["listFiles"] },
+    "utterances": [
+      {
+        "text": "list all the files in downloads",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "listFiles",
+          "extractedParams": { "path": "downloads" }
+        }
+      }
+    ]
+  },
+  {
+    "id": "gm-03",
+    "category": "grammar-match",
+    "description": "Terse alias: ls C:\\Users",
+    "setup": { "requiredFlows": ["listFiles"] },
+    "utterances": [
+      {
+        "text": "ls C:\\Users",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "listFiles",
+          "extractedParams": { "path": "C:\\Users" }
+        }
+      }
+    ]
+  },
+  {
+    "id": "gm-04",
+    "category": "grammar-match",
+    "description": "Verbose variant: show me the files in documents",
+    "setup": { "requiredFlows": ["listFiles"] },
+    "utterances": [
+      {
+        "text": "show me the files in documents",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "listFiles",
+          "extractedParams": { "path": "documents" }
+        }
+      }
+    ]
+  },
+  {
+    "id": "gm-05",
+    "category": "grammar-match",
+    "description": "Different flow: find large files in C:\\temp",
+    "setup": { "requiredFlows": ["findLargeFiles"] },
+    "utterances": [
+      {
+        "text": "find large files in C:\\temp",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "findLargeFiles",
+          "extractedParams": { "directory": "C:\\temp" }
+        }
+      }
+    ]
+  },
+  {
+    "id": "gm-06",
+    "category": "grammar-match",
+    "description": "Alias pattern: big files in downloads",
+    "setup": { "requiredFlows": ["findLargeFiles"] },
+    "utterances": [
+      {
+        "text": "big files downloads",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "findLargeFiles",
+          "extractedParams": { "directory": "downloads" }
+        }
+      }
+    ]
+  },
+  {
+    "id": "gm-07",
+    "category": "grammar-match",
+    "description": "Zero-parameter match: check disk space",
+    "setup": { "requiredFlows": ["checkDiskSpace"] },
+    "utterances": [
+      {
+        "text": "check disk space",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "checkDiskSpace",
+          "extractedParams": {}
+        }
+      }
+    ]
+  },
+  {
+    "id": "gm-08",
+    "category": "grammar-match",
+    "description": "Conversational phrasing: how much disk space is left",
+    "setup": { "requiredFlows": ["checkDiskSpace"] },
+    "utterances": [
+      {
+        "text": "how much disk space is left",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "checkDiskSpace",
+          "extractedParams": {}
+        }
+      }
+    ]
+  },
+  {
+    "id": "gm-09",
+    "category": "grammar-match",
+    "description": "Question form: are any drives running low",
+    "setup": { "requiredFlows": ["checkDiskSpace"] },
+    "utterances": [
+      {
+        "text": "are any drives running low",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "checkDiskSpace",
+          "extractedParams": {}
+        }
+      }
+    ]
+  },
+  {
+    "id": "gm-10",
+    "category": "grammar-match",
+    "description": "Different domain: check service health",
+    "setup": { "requiredFlows": ["checkServiceHealth"] },
+    "utterances": [
+      {
+        "text": "check service health",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "checkServiceHealth",
+          "extractedParams": {}
+        }
+      }
+    ]
+  },
+  {
+    "id": "gm-11",
+    "category": "grammar-match",
+    "description": "Question with param: what's listening on port 8080",
+    "setup": { "requiredFlows": ["checkPorts"] },
+    "utterances": [
+      {
+        "text": "what's listening on port 8080",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "checkPorts",
+          "extractedParams": { "ports": "8080" }
+        }
+      }
+    ]
+  },
+  {
+    "id": "gm-12",
+    "category": "grammar-match",
+    "description": "Multi-value param: check ports 80 and 443",
+    "setup": { "requiredFlows": ["checkPorts"] },
+    "utterances": [
+      {
+        "text": "check port listeners on 80,443",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "checkPorts",
+          "extractedParams": { "ports": "80,443" }
+        }
+      }
+    ]
+  },
+  {
+    "id": "gm-13",
+    "category": "grammar-match",
+    "description": "Log domain: scan logs for errors",
+    "setup": { "requiredFlows": ["scanLogErrors"] },
+    "utterances": [
+      {
+        "text": "scan logs for errors",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "scanLogErrors",
+          "extractedParams": {}
+        }
+      }
+    ]
+  },
+  {
+    "id": "gm-14",
+    "category": "grammar-match",
+    "description": "Path with extension: filter csv file C:\\data\\test.csv",
+    "setup": { "requiredFlows": ["filterCsv"] },
+    "utterances": [
+      {
+        "text": "filter csv file C:\\data\\test.csv",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "filterCsv",
+          "extractedParams": { "inputFile": "C:\\data\\test.csv" }
+        }
+      }
+    ]
+  },
+  {
+    "id": "gm-15",
+    "category": "grammar-match",
+    "description": "Optional param omitted: list files (no path)",
+    "setup": { "requiredFlows": ["listFiles"] },
+    "utterances": [
+      {
+        "text": "list files",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "listFiles",
+          "extractedParams": {}
+        }
+      }
+    ]
+  },
+  {
+    "id": "gm-16",
+    "category": "grammar-match",
+    "description": "Ultra-terse: disk space",
+    "setup": { "requiredFlows": ["checkDiskSpace"] },
+    "utterances": [
+      {
+        "text": "disk space",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "checkDiskSpace",
+          "extractedParams": {}
+        }
+      }
+    ]
+  },
+  {
+    "id": "gm-17",
+    "category": "grammar-match",
+    "description": "Param in middle: service status for WinRM, BITS",
+    "setup": { "requiredFlows": ["checkServiceHealth"] },
+    "utterances": [
+      {
+        "text": "service status for WinRM, BITS",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "checkServiceHealth",
+          "extractedParams": { "serviceList": "WinRM, BITS" }
+        }
+      }
+    ]
+  },
+  {
+    "id": "gm-18",
+    "category": "grammar-match",
+    "description": "Zero-param variant: show port listeners",
+    "setup": { "requiredFlows": ["checkPorts"] },
+    "utterances": [
+      {
+        "text": "show port listeners",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "checkPorts",
+          "extractedParams": {}
+        }
+      }
+    ]
+  },
+  {
+    "id": "gm-19",
+    "category": "grammar-match",
+    "description": "Conversational: who is using port 3000",
+    "setup": { "requiredFlows": ["checkPorts"] },
+    "utterances": [
+      {
+        "text": "who is using port 3000",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "checkPorts",
+          "extractedParams": { "ports": "3000" }
+        }
+      }
+    ]
+  },
+  {
+    "id": "gm-20",
+    "category": "grammar-match",
+    "description": "Path param in alias: log errors in C:\\Logs\\WebApp",
+    "setup": { "requiredFlows": ["scanLogErrors"] },
+    "utterances": [
+      {
+        "text": "log errors in C:\\Logs\\WebApp",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "scanLogErrors",
+          "extractedParams": { "logDir": "C:\\Logs\\WebApp" }
+        }
+      }
+    ]
+  },
+  {
+    "id": "gm-21",
+    "category": "grammar-match",
+    "description": "Negative: unrelated domain (music)",
+    "setup": { "requiredFlows": ["listFiles", "checkDiskSpace"] },
+    "utterances": [
+      {
+        "text": "play some music",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": null
+        }
+      }
+    ]
+  },
+  {
+    "id": "gm-22",
+    "category": "grammar-match",
+    "description": "Negative: unrelated domain (weather)",
+    "setup": { "requiredFlows": ["listFiles", "checkDiskSpace"] },
+    "utterances": [
+      {
+        "text": "what's the weather today",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": null
+        }
+      }
+    ]
+  },
+  {
+    "id": "gm-23",
+    "category": "grammar-match",
+    "description": "Negative: destructive verb should not match listFiles",
+    "setup": { "requiredFlows": ["listFiles"] },
+    "utterances": [
+      {
+        "text": "delete all files in temp",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": null
+        }
+      }
+    ]
+  },
+  {
+    "id": "gm-24",
+    "category": "grammar-match",
+    "description": "Compound request correctly rejected by grammar",
+    "setup": { "requiredFlows": ["listFiles"] },
+    "utterances": [
+      {
+        "text": "list files in downloads and show the big ones",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": null
+        }
+      }
+    ]
+  },
+  {
+    "id": "gm-25",
+    "category": "grammar-match",
+    "description": "Negative: meta question about scriptflow",
+    "setup": { "requiredFlows": ["listFiles"] },
+    "utterances": [
+      {
+        "text": "explain how scriptflow works",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": null
+        }
+      }
+    ]
+  }
+]

--- a/ts/packages/agents/scriptflow/benchmark/scenarios/llm-translation.json
+++ b/ts/packages/agents/scriptflow/benchmark/scenarios/llm-translation.json
@@ -1,0 +1,227 @@
+[
+  {
+    "id": "lt-01",
+    "category": "llm-translation",
+    "description": "Grammar over-capture: find files bigger than 50MB in D:\\data",
+    "setup": { "requiredFlows": ["findLargeFiles"] },
+    "utterances": [
+      {
+        "text": "find files bigger than 50MB in D:\\data",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "findLargeFiles"
+        }
+      }
+    ]
+  },
+  {
+    "id": "lt-02",
+    "category": "llm-translation",
+    "description": "Numeric extraction: show old branches older than 14 days",
+    "setup": { "requiredFlows": ["staleBranches"] },
+    "utterances": [
+      {
+        "text": "show old branches older than 14 days",
+        "expected": {
+          "routedTo": "llm-translation",
+          "matchedFlow": "staleBranches"
+        }
+      }
+    ]
+  },
+  {
+    "id": "lt-03",
+    "category": "llm-translation",
+    "description": "Enum param: show service dashboard as summary",
+    "setup": { "requiredFlows": ["checkServiceHealth"] },
+    "utterances": [
+      {
+        "text": "show service dashboard as summary",
+        "expected": {
+          "routedTo": "llm-translation",
+          "matchedFlow": "checkServiceHealth"
+        }
+      }
+    ]
+  },
+  {
+    "id": "lt-04",
+    "category": "llm-translation",
+    "description": "Multi-param: filter users.csv where status is active",
+    "setup": { "requiredFlows": ["filterCsv"] },
+    "utterances": [
+      {
+        "text": "filter users.csv where status is active",
+        "expected": {
+          "routedTo": "llm-translation",
+          "matchedFlow": "filterCsv"
+        }
+      }
+    ]
+  },
+  {
+    "id": "lt-05",
+    "category": "llm-translation",
+    "description": "Complex param: process csv, keep name and email columns",
+    "setup": { "requiredFlows": ["filterCsv"] },
+    "utterances": [
+      {
+        "text": "process csv, keep name and email columns",
+        "expected": {
+          "routedTo": "llm-translation",
+          "matchedFlow": "filterCsv"
+        }
+      }
+    ]
+  },
+  {
+    "id": "lt-06",
+    "category": "llm-translation",
+    "description": "Override default: check if any drive has less than 50GB free",
+    "setup": { "requiredFlows": ["checkDiskSpace"] },
+    "utterances": [
+      {
+        "text": "check if any drive has less than 50GB free",
+        "expected": {
+          "routedTo": "llm-translation",
+          "matchedFlow": "checkDiskSpace"
+        }
+      }
+    ]
+  },
+  {
+    "id": "lt-07",
+    "category": "llm-translation",
+    "description": "Grammar over-capture: list top 5 biggest files in C:\\Windows",
+    "setup": { "requiredFlows": ["findLargeFiles"] },
+    "utterances": [
+      {
+        "text": "list the top 5 biggest files in C:\\Windows",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "findLargeFiles"
+        }
+      }
+    ]
+  },
+  {
+    "id": "lt-08",
+    "category": "llm-translation",
+    "description": "Grammar over-capture: check ports 80, 443, and 8080",
+    "setup": { "requiredFlows": ["checkPorts"] },
+    "utterances": [
+      {
+        "text": "check ports 80, 443, and 8080",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "checkPorts"
+        }
+      }
+    ]
+  },
+  {
+    "id": "lt-09",
+    "category": "llm-translation",
+    "description": "Intent inference: what services are stopped",
+    "setup": { "requiredFlows": ["checkServiceHealth"] },
+    "utterances": [
+      {
+        "text": "what services are stopped",
+        "expected": {
+          "routedTo": "llm-translation",
+          "matchedFlow": "checkServiceHealth"
+        }
+      }
+    ]
+  },
+  {
+    "id": "lt-10",
+    "category": "llm-translation",
+    "description": "Grammar over-capture: find large files over 1GB",
+    "setup": { "requiredFlows": ["findLargeFiles"] },
+    "utterances": [
+      {
+        "text": "find large files over 1GB",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "findLargeFiles"
+        }
+      }
+    ]
+  },
+  {
+    "id": "lt-11",
+    "category": "llm-translation",
+    "description": "Boolean from NL: csv transform with no header",
+    "setup": { "requiredFlows": ["filterCsv"] },
+    "utterances": [
+      {
+        "text": "csv transform with no header",
+        "expected": {
+          "routedTo": "llm-translation",
+          "matchedFlow": "filterCsv"
+        }
+      }
+    ]
+  },
+  {
+    "id": "lt-12",
+    "category": "llm-translation",
+    "description": "Grammar over-capture: check if port 5432 is in use",
+    "setup": { "requiredFlows": ["checkPorts"] },
+    "utterances": [
+      {
+        "text": "check if port 5432 is in use",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "checkPorts"
+        }
+      }
+    ]
+  },
+  {
+    "id": "lt-13",
+    "category": "llm-translation",
+    "description": "Context path: stale branches in the TypeAgent repo",
+    "setup": { "requiredFlows": ["staleBranches"] },
+    "utterances": [
+      {
+        "text": "stale branches in the TypeAgent repo",
+        "expected": {
+          "routedTo": "llm-translation",
+          "matchedFlow": "staleBranches"
+        }
+      }
+    ]
+  },
+  {
+    "id": "lt-14",
+    "category": "llm-translation",
+    "description": "Modifier: list files sorted by size",
+    "setup": { "requiredFlows": ["listFiles"] },
+    "utterances": [
+      {
+        "text": "list files sorted by size",
+        "expected": {
+          "routedTo": "llm-translation",
+          "matchedFlow": "listFiles"
+        }
+      }
+    ]
+  },
+  {
+    "id": "lt-15",
+    "category": "llm-translation",
+    "description": "Temporal: scan yesterday's logs",
+    "setup": { "requiredFlows": ["scanLogErrors"] },
+    "utterances": [
+      {
+        "text": "scan yesterday's logs",
+        "expected": {
+          "routedTo": "llm-translation",
+          "matchedFlow": "scanLogErrors"
+        }
+      }
+    ]
+  }
+]

--- a/ts/packages/agents/scriptflow/package.json
+++ b/ts/packages/agents/scriptflow/package.json
@@ -20,6 +20,8 @@
   "scripts": {
     "agc": "agc -i ./src/scriptflowSchema.agr -o ./dist/scriptflowSchema.ag.json",
     "asc": "asc -i ./src/schema/scriptActions.mts -o ./dist/scriptflowSchema.pas.json -t ScriptFlowActions",
+    "benchmark": "npx tsx benchmark/run-benchmark.mts",
+    "benchmark:dry": "npx tsx benchmark/run-benchmark.mts --dry-run",
     "build": "concurrently npm:tsc npm:asc npm:agc",
     "clean": "rimraf --glob dist *.tsbuildinfo *.done.build.log",
     "compile": "node scripts/compileRecipes.mjs",


### PR DESCRIPTION
Adds a benchmark suite that measures ScriptFlow reliability across the full
  pipeline: grammar matching, LLM translation, parameter extraction, script
  execution, and fallback/self-repair. Runs 70 scenarios in 5 categories
  against a live TypeAgent dispatcher.

  Key components:
  - 5 scenario files (grammar-match, llm-translation, execution, fallback-chain, end-to-end)
  - Test harness with programmatic dispatcher creation, display log capture, and trace collection
  - Evaluators for grammar accuracy, parameter extraction, execution output, and fallback detection
  - Import-based flow seeding via @scriptflow import (tests real LLM analysis pipeline)
  - Fuzzy flow name mapping to handle LLM-generated action names
  - Scorecard reporter with regression comparison support
  - PowerShell fixture scripts for repeatable test environment setup

  Run with: pnpm run benchmark (live) or pnpm run benchmark:dry (validate only)