### PR TITLE
Tighten spread evaluation error handling in NFA matcher

### DIFF
--- a/ts/packages/actionGrammar/src/grammarMatcher.ts
+++ b/ts/packages/actionGrammar/src/grammarMatcher.ts
@@ -437,15 +437,15 @@ function createValue(
                         partialValueId,
                         stat,
                     );
-                    if (inner != null && typeof inner === "object") {
-                        // Object.assign is the natural fit here: it copies
-                        // exactly the own enumerable string-keyed properties
-                        // we need, matching JS spread semantics.  Per-key
-                        // propertyName tracking is already handled by the
-                        // recursive createValue call above (which receives
-                        // the parent propertyName), so no per-key logic is
-                        // needed at the merge site.
+                    if (inner === undefined) {
+                        // Partial match — the spread argument's variable
+                        // hasn't been captured yet.  Skip silently.
+                    } else if (typeof inner === "object") {
                         Object.assign(obj, inner);
+                    } else {
+                        throw new Error(
+                            `Internal error: spread argument must produce an object, got ${typeof inner}`,
+                        );
                     }
                 } else if (elem.value === null) {
                     // Shorthand form: { k } means { k: k }


### PR DESCRIPTION
Follow-up to #2071 — tighten the spread element evaluation in `createValue()` (`grammarMatcher.ts`):

- **Distinguish partial-match skip from internal error**: Replace the loose `if (inner != null && typeof inner === "object")` guard with a three-way check:
  - `undefined` → partial match (spread argument not captured yet) — skip silently
  - `object` → merge via `Object.assign(obj, inner)`
  - anything else → throw an internal error (the compile-time validator guarantees spread arguments are object-typed, so this is a bug indicator)
- **Strict equality**: Use `=== undefined` instead of `== null` since `MatchedValue` never produces `null`