### PR TITLE
Fix type validator inconsistencies and improve variable error reporting

### DIFF
--- a/ts/packages/actionGrammar/src/grammarCompiler.ts
+++ b/ts/packages/actionGrammar/src/grammarCompiler.ts
@@ -708,7 +708,18 @@ function createNamedGrammarRules(
             }
 
             // Collect all leaf value nodes from the rule tree,
-            // including those in sub-rules referenced via RulesPart
+            // including those in sub-rules referenced via RulesPart.
+            //
+            // Why per-leaf instead of deriving the whole rule's type and doing
+            // a single isTypeAssignable check?  Semantically equivalent, but
+            // per-leaf validation yields much better diagnostics:
+            //   1. Source positions — each leaf carries a pos, so errors point
+            //      to the specific -> expression, not just the rule name.
+            //   2. Structural detail — object leaves get field-level messages
+            //      (missing required property, extraneous property, type mismatch).
+            //   3. Per-alternative isolation — if one of N alternatives is wrong,
+            //      the error identifies that alternative rather than failing the
+            //      whole union.
             const leafValues = collectLeafValues(
                 record.grammarRules,
                 context.valuePositions,
@@ -775,7 +786,6 @@ function createNamedGrammarRules(
                                 leaf.value,
                                 expectedType,
                                 varTypes,
-                                context.resolvedTypes,
                                 "",
                                 leafExprTypes.get(leaf.value),
                             );

--- a/ts/packages/actionGrammar/src/grammarValueTypeValidator.ts
+++ b/ts/packages/actionGrammar/src/grammarValueTypeValidator.ts
@@ -10,7 +10,6 @@ import type {
 } from "./grammarTypes.js";
 import type {
     SchemaType,
-    SchemaTypeDefinition,
     SchemaTypeReference,
     ActionParamObject as SchemaTypeObject,
     SchemaObjectField,
@@ -646,6 +645,11 @@ function deriveValueTypeImpl(
                 case "number":
                     return SchemaCreator.number();
                 case "boolean":
+                    // TODO: return SchemaCreator.true_() / SchemaCreator.false_()
+                    // to preserve literal precision (matching how string literals
+                    // return string-union).  Currently not possible because
+                    // actionSchema doesn't maintain boolean or number literal
+                    // types — SchemaCreator has no true_/false_ factory.
                     return SchemaCreator.boolean();
                 default:
                     throw new Error(
@@ -777,7 +781,7 @@ function deriveValueTypeImpl(
                     return SchemaCreator.number();
                 case "+":
                     // Operand type constraints checked in pass 2
-                    if (isStringType(leftType) || isStringType(rightType)) {
+                    if (isStringType(leftType) && isStringType(rightType)) {
                         return SchemaCreator.string();
                     }
                     if (
@@ -1038,6 +1042,14 @@ function grammarTypeToSchemaType(grammarType: string): SchemaType {
  * via fixed-point iteration (producing a plain type like `string`) or via
  * the type-reference approach (producing `A = string | A`).  Both
  * representations validate identically.
+ *
+ * NOTE: This is a shallow type-discriminant check.  For object and array
+ * types it only verifies that both sides share the same discriminant
+ * ("object" or "array") — it does NOT compare fields or element types.
+ * Structural validation for objects lives in `validateInferredObjectType`
+ * / `validateInferredAgainstExpected`, which produce per-field error
+ * messages.  Callers that need structural depth must use those functions
+ * instead of relying solely on this one.
  */
 function isTypeAssignable(
     inferred: SchemaType,
@@ -1048,10 +1060,15 @@ function isTypeAssignable(
     // Coinductive cycle detection for recursive type-references.
     // If we've already started checking this ref, assume assignable —
     // the concrete (non-self-referencing) union members determine the
-    // real answer.
+    // real answer.  Guards both sides symmetrically so that recursive
+    // expected types (e.g. A = string | A) also terminate.
     if (inferred.type === "type-reference") {
         if (visited.has(inferred.name)) return true;
         visited.add(inferred.name);
+    }
+    if (expected.type === "type-reference") {
+        if (visited.has(expected.name)) return true;
+        visited.add(expected.name);
     }
     const resolvedInferred = resolveType(inferred);
     const resolvedExpected = resolveType(expected);
@@ -1818,13 +1835,18 @@ export function validateVariableType(
     if (variableType === ANY_TYPE) return [];
     const resolved = resolveType(expectedType);
     if (resolved.type === "any") return [];
-    if (!isTypeAssignable(variableType, resolved)) {
-        const resolvedVar = resolveType(variableType);
-        return [
-            `Value expected ${formatSchemaType(resolved)}, but variable '${variableName}' produces ${formatSchemaType(resolvedVar)}`,
-        ];
-    }
-    return [];
+    // Use structural validation so object fields and array element types
+    // are checked, not just the type discriminant.
+    const errors = validateInferredAgainstExpected(variableType, resolved, "");
+    if (errors.length === 0) return errors;
+    // Prefix with variable context so the error identifies which variable failed.
+    // Top-level errors start with "Value " — replace with the variable name.
+    // Nested errors ("Field '...'", "Missing ...") get the variable as context.
+    return errors.map((e) =>
+        e.startsWith("Value ")
+            ? `Variable '$${variableName}' ${e.slice(6)}`
+            : `Variable '$${variableName}': ${e}`,
+    );
 }
 
 /**
@@ -1838,7 +1860,6 @@ export function validateVariableType(
  * @param value - The compiled value node from a grammar rule's -> expression
  * @param expectedType - The expected schema type from the declared value type
  * @param variableTypes - Map from variable name to its captured type name
- * @param resolvedTypes - Map from type name to its parsed schema definition
  * @param path - Current property path for error messages
  * @param inferredExprType - Pre-computed expression type from validateExprTypes
  */
@@ -1846,7 +1867,6 @@ export function validateValueType(
     value: CompiledValueNode,
     expectedType: SchemaType,
     variableTypes: Map<string, SchemaType>,
-    resolvedTypes: Map<string, SchemaTypeDefinition>,
     path: string = "",
     inferredExprType?: SchemaType,
 ): string[] {
@@ -1864,22 +1884,9 @@ export function validateValueType(
         if (exprType === undefined) return [];
         const resolved = resolveType(expectedType);
         if (resolved.type === "any") return [];
-        if (resolved.type === "type-union") {
-            for (const memberType of resolved.types) {
-                const memberResolved = resolveType(memberType);
-                if (
-                    memberResolved.type === "any" ||
-                    isTypeAssignable(exprType, memberResolved)
-                )
-                    return [];
-            }
-            return [
-                `${fieldName(path)} expression produces ${exprType.type}, which does not match any union type member`,
-            ];
-        }
         if (!isTypeAssignable(exprType, resolved)) {
             return [
-                `${fieldName(path)} expected ${resolved.type}, got ${exprType.type} expression`,
+                `${fieldName(path)} expected ${formatSchemaType(resolved)}, got ${formatSchemaType(exprType)} expression`,
             ];
         }
         return [];
@@ -1899,7 +1906,6 @@ export function validateValueType(
                     value,
                     memberType,
                     variableTypes,
-                    resolvedTypes,
                     path,
                 );
                 if (errors.length === 0) {
@@ -1911,20 +1917,13 @@ export function validateValueType(
         }
 
         case "object":
-            return validateObjectValue(
-                value,
-                resolved,
-                variableTypes,
-                resolvedTypes,
-                path,
-            );
+            return validateObjectValue(value, resolved, variableTypes, path);
 
         case "array":
             return validateArrayValue(
                 value,
                 resolved.elementType,
                 variableTypes,
-                resolvedTypes,
                 path,
             );
 
@@ -1980,7 +1979,6 @@ function validateObjectValue(
     value: CompiledValueNode,
     expected: SchemaTypeObject,
     variableTypes: Map<string, SchemaType>,
-    resolvedTypes: Map<string, SchemaTypeDefinition>,
     path: string,
 ): string[] {
     if (value.type === "variable") {
@@ -1988,7 +1986,6 @@ function validateObjectValue(
         return validateVariableAgainstSchema(
             value.name,
             variableTypes,
-            resolvedTypes,
             expected,
             path,
         );
@@ -2177,14 +2174,12 @@ function validateArrayValue(
     value: CompiledValueNode,
     elementType: SchemaType,
     variableTypes: Map<string, SchemaType>,
-    resolvedTypes: Map<string, SchemaTypeDefinition>,
     path: string,
 ): string[] {
     if (value.type === "variable") {
         return validateVariableAgainstSchema(
             value.name,
             variableTypes,
-            resolvedTypes,
             SchemaCreator.array(elementType),
             path,
         );
@@ -2204,7 +2199,6 @@ function validateArrayValue(
                 arrValue.value[i],
                 elementType,
                 variableTypes,
-                resolvedTypes,
                 fullPath(path, String(i)),
             ),
         );
@@ -2333,7 +2327,6 @@ function validateStringUnionValue(
 function validateVariableAgainstSchema(
     varName: string,
     variableTypes: Map<string, SchemaType>,
-    resolvedTypes: Map<string, SchemaTypeDefinition>,
     expectedType: SchemaType,
     path: string,
 ): string[] {
@@ -2341,16 +2334,9 @@ function validateVariableAgainstSchema(
     if (varType === undefined || varType === ANY_TYPE) {
         return []; // Unknown — skip
     }
-    // Check if the variable's inferred type is assignable to the expected
-    // type.  isTypeAssignable handles recursive type-references via
-    // coinductive reasoning, so both plain types and recursive aliases
-    // validate correctly.
-    if (!isTypeAssignable(varType, expectedType)) {
-        const resolved = resolveType(expectedType);
-        const resolvedVar = resolveType(varType);
-        return [
-            `${fieldName(path)} expected ${resolved.type}, but variable '${varName}' produces ${resolvedVar.type}`,
-        ];
-    }
-    return [];
+    // Use structural validation so object fields and array element types
+    // are checked, not just the type discriminant.
+    const resolved = resolveType(expectedType);
+    if (resolved.type === "any") return [];
+    return validateInferredAgainstExpected(varType, resolved, path);
 }

--- a/ts/packages/actionGrammar/test/grammarValueTypeValidation.spec.ts
+++ b/ts/packages/actionGrammar/test/grammarValueTypeValidation.spec.ts
@@ -382,6 +382,62 @@ describe("Value type validation", () => {
         });
         // string doesn't conform to PauseAction — expect a type error
         expect(errors.length).toBe(1);
+        expect(errors[0]).toContain("Variable '$x'");
+    });
+
+    it("implicit variable error includes variable name for type mismatch", () => {
+        const NumActionDef = SchemaCreator.intf(
+            "NumAction",
+            SchemaCreator.obj({
+                actionName: SchemaCreator.field(SchemaCreator.string("count")),
+                value: SchemaCreator.field(SchemaCreator.number()),
+            }),
+            undefined,
+            true,
+        );
+        const loader: SchemaLoader = (typeName) =>
+            typeName === "NumAction" ? NumActionDef : undefined;
+
+        // Variable captures string, but declared type expects { actionName, value: number }
+        const grammarText = `
+            import { NumAction } from "schema.ts";
+            <Start> : NumAction = <Wrapper>;
+            <Wrapper> = $(myVar:string);
+        `;
+        const errors: string[] = [];
+        loadGrammarRulesNoThrow("test", grammarText, errors, undefined, {
+            schemaLoader: loader,
+        });
+        expect(errors.length).toBe(1);
+        expect(errors[0]).toContain("Variable '$myVar'");
+    });
+
+    it("implicit variable with object type reports nested field errors with variable context", () => {
+        const ItemDef = SchemaCreator.intf(
+            "Item",
+            SchemaCreator.obj({
+                name: SchemaCreator.field(SchemaCreator.string()),
+                count: SchemaCreator.field(SchemaCreator.number()),
+            }),
+            undefined,
+            true,
+        );
+        const loader: SchemaLoader = (typeName) =>
+            typeName === "Item" ? ItemDef : undefined;
+
+        // Sub-rule produces { name: string, count: string } but Item expects count: number
+        const grammarText = `
+            import { Item } from "schema.ts";
+            <Start> : Item = <Sub>;
+            <Sub> = $(n:string) $(c:string) -> { name: n, count: c };
+        `;
+        const errors: string[] = [];
+        loadGrammarRulesNoThrow("test", grammarText, errors, undefined, {
+            schemaLoader: loader,
+        });
+        expect(errors.length).toBe(1);
+        expect(errors[0]).toContain("count");
+        expect(errors[0]).toContain("expected number");
     });
 
     it("error in passthrough sub-rule of mixed alternatives", () => {


### PR DESCRIPTION
## Changes

- **Fix `+` operator pass1/pass2 consistency**: Changed `||` to `&&` in the `+` case of `deriveValueTypeImpl` so pass 1 type inference matches pass 2 validation semantics — both operands must be strings to infer `string`.

- **Use `formatSchemaType()` in error messages**: Replaced raw `.type` discriminant strings with `formatSchemaType()` for richer, human-readable type descriptions (e.g. `string | number` instead of `type-union`). Removed the redundant union-iteration branch in `validateValueType` that duplicated logic already handled by `isTypeAssignable`.

- **Pre-resolve expected type in `validateVariableAgainstSchema`**: Resolve the expected type and short-circuit on `any` before calling into structural validation.

- **Add symmetric coinductive guard for type-reference cycles**: The `isTypeAssignable` visited-set now guards both `inferred` and `expected` type-references, preventing infinite recursion when the expected type is self-recursive (e.g. `A = string | A`).

- **Replace shallow `isTypeAssignable` with structural `validateInferredAgainstExpected`**: Both `validateVariableType` and `validateVariableAgainstSchema` now use structural validation so object fields and array element types are checked, not just the top-level type discriminant.

- **Remove dead `resolvedTypes` parameter**: Eliminated the unused `resolvedTypes: Map<string, SchemaTypeDefinition>` parameter from `validateValueType`, `validateObjectValue`, `validateArrayValue`, and `validateVariableAgainstSchema`.

- **Include variable name in validation error messages**: Errors now report which variable caused the mismatch (e.g. `Variable '$myVar' expected number, got string`).

- **Add tests for variable name error reporting**: Three new test cases verify that variable names appear in error messages for direct type mismatches, implicit variable mismatches, and nested field errors.

- **Add TODO for boolean literal type precision**: Documented a future improvement to return `true`/`false` literal types from boolean constants (blocked on `actionSchema` lacking boolean literal factories).