### PR TITLE
Move entity tracking from parser to compiler

### DIFF
--- a/ts/packages/actionGrammar/src/grammarCompiler.ts
+++ b/ts/packages/actionGrammar/src/grammarCompiler.ts
@@ -356,17 +356,24 @@ export function compileGrammar(
         );
     }
 
-    // Collect all imported .ts types used as variable types across all contexts
-    const usedImportedTypes = new Set<string>();
+    // TODO: Find a better way to discover entities instead of deriving them
+    // from import statements.
+    // Collect entity names from two sources:
+    // 1. Source-less imports: import { Ordinal, Cardinal };
+    // 2. Imported .ts types used as variable types across all contexts
+    const allEntities = new Set<string>();
+    for (const name of context.importedTypeNames.keys()) {
+        allEntities.add(name);
+    }
     for (const [, compileContext] of context.grammarFileMap) {
         for (const t of compileContext.usedImportedTypes) {
-            usedImportedTypes.add(t);
+            allEntities.add(t);
         }
     }
 
     const grammar: Grammar = { rules: grammarRules };
-    if (usedImportedTypes.size > 0) {
-        grammar.entities = Array.from(usedImportedTypes);
+    if (allEntities.size > 0) {
+        grammar.entities = Array.from(allEntities);
     }
     return grammar;
 }

--- a/ts/packages/actionGrammar/src/grammarLoader.ts
+++ b/ts/packages/actionGrammar/src/grammarLoader.ts
@@ -55,17 +55,6 @@ function parseAndCompileGrammar(
         parseResult.imports,
         options?.schemaLoader,
     );
-    if (errors.length === 0) {
-        // Merge entity names from source-less imports (parseResult.entities)
-        // with entity names discovered by the compiler (grammar.entities,
-        // which contains imported .ts types used as variable types).
-        const allEntities = grammar.entities
-            ? [...parseResult.entities, ...grammar.entities]
-            : parseResult.entities;
-        if (allEntities.length > 0) {
-            grammar.entities = allEntities;
-        }
-    }
     return grammar;
 }
 

--- a/ts/packages/actionGrammar/src/grammarRuleParser.ts
+++ b/ts/packages/actionGrammar/src/grammarRuleParser.ts
@@ -316,7 +316,6 @@ export type ImportStatement = {
 
 // Grammar Parse Result (includes imports)
 export type GrammarParseResult = {
-    entities: string[]; // Entity types this grammar depends on (derived from source-less imports)
     imports: ImportStatement[]; // Import statements (includes source-less entity imports)
     definitions: RuleDefinition[];
     leadingComments?: Comment[] | undefined; // comments at top of file before first item
@@ -1459,15 +1458,7 @@ class GrammarRuleParser implements ValueExprParserContext {
                 "Expected rule definition or 'import' statement",
             );
         }
-        // Derive entity names from source-less imports
-        const entities: string[] = [];
-        for (const imp of imports) {
-            if (imp.source === undefined && imp.names !== "*") {
-                entities.push(...imp.names.map((n) => n.name));
-            }
-        }
         return {
-            entities,
             imports,
             definitions,
             leadingComments,

--- a/ts/packages/cache/src/grammar/exportGrammar.ts
+++ b/ts/packages/cache/src/grammar/exportGrammar.ts
@@ -55,7 +55,6 @@ export async function convertConstructionFileToGrammar(fileName: string) {
     return writeGrammarRules({
         definitions: Array.from(state.definitions),
         imports: [],
-        entities: [],
     });
 }
 
@@ -69,7 +68,6 @@ export function convertConstructionsToGrammar(constructions: Construction[]) {
     return writeGrammarRules({
         definitions: Array.from(state.definitions),
         imports: [],
-        entities: [],
     });
 }
 


### PR DESCRIPTION
Source-less import entity names were tracked in both the parser (`parseResult.entities`) and the compiler (`grammar.entities`) from different sources, then merged in the loader. Since the compiler already receives the import statements and populates `importedTypeNames`, it can include source-less import entities directly in `grammar.entities`.

### Changes
- Remove `entities` field from `GrammarParseResult`
- Collect source-less import entities in `compileGrammar`
- Remove merge logic from `grammarLoader`
- Add TODO for better entity discovery mechanism

### Testing
All 2089 actionGrammar tests pass. Full build succeeds.