### PR TITLE
Update AGR language extension syntax highlighting

### DIFF
--- a/ts/extensions/agr-language/language-configuration.json
+++ b/ts/extensions/agr-language/language-configuration.json
@@ -1,6 +1,7 @@
 {
   "comments": {
-    "lineComment": "//"
+    "lineComment": "//",
+    "blockComment": ["/*", "*/"]
   },
   "brackets": [
     ["{", "}"],

--- a/ts/extensions/agr-language/sample.agr
+++ b/ts/extensions/agr-language/sample.agr
@@ -4,15 +4,30 @@
 // Sample Action Grammar file demonstrating syntax highlighting
 // This file shows all the major syntax elements
 
-// Import syntax
+/* Block comment:
+   The grammar supports both line comments (//) and block comments.
+*/
+
+// ─── Import syntax ────────────────────────────────────────────────────────────
+
+// Named imports from .agr files
 import { Cardinal, TrackName, ArtistName } from "./base.agr";
+
+// Wildcard import from .agr files
 import * from "./shared.agr";
+
+// Imports from .ts schema files
 import { GreetAction, PlayAction, PauseAction } from "./schema.ts";
 
-// Simple rule definition
+// Source-less entity imports (no "from" clause — built-in entities)
+import { Ordinal, CalendarDate };
+
+// ─── Simple rule definition ───────────────────────────────────────────────────
+
 <Start> = <Greeting> | <Command>;
 
-// Rule with captures and value type annotation
+// ─── Rule with value type annotation ──────────────────────────────────────────
+
 <Greeting> : GreetAction =
     hello $(name:PersonName) -> {
         actionName: "greet",
@@ -22,7 +37,8 @@ import { GreetAction, PlayAction, PauseAction } from "./schema.ts";
     }
   | hi there -> { actionName: "greet" };
 
-// Rule with optional elements (union value type)
+// ─── Union value type annotation ──────────────────────────────────────────────
+
 <Command> : PlayAction | PauseAction =
     play (the)? $(track:TrackName)
     by $(artist:ArtistName) -> {
@@ -34,7 +50,25 @@ import { GreetAction, PlayAction, PauseAction } from "./schema.ts";
     }
   | pause (the)? music? -> { actionName: "pause" };
 
-// Rule with multiple patterns
+// ─── Exported rule ────────────────────────────────────────────────────────────
+
+export <PublicRule> = hello | goodbye;
+
+// ─── Spacing annotations ─────────────────────────────────────────────────────
+
+<Hashtag> [spacing=none] = \# $(tag:word) -> { actionName: "hashtag", parameters: { tag } };
+
+<SearchPhrase> [spacing=required] = search for $(query:string) -> {
+    actionName: "search",
+    parameters: { query }
+};
+
+<CJKMixed> [spacing=auto] = $(text:string) -> text;
+
+<Adjacent> [spacing=optional] = $(a:word) $(b:word) -> { a, b };
+
+// ─── Multiple patterns with bare results ─────────────────────────────────────
+
 <Volume> =
     (turn | set) (the)? volume to $(level:number) -> {
         actionName: "setVolume",
@@ -43,7 +77,7 @@ import { GreetAction, PlayAction, PauseAction } from "./schema.ts";
   | volume up -> { actionName: "volumeUp" }
   | volume down -> { actionName: "volumeDown" };
 
-// Bare -> results (non-object): string literal, number, or variable reference
+// Bare -> results: string literal, number, or variable reference
 <PromptSpec> = (
     ('ask me' | 'confirm' | 'please confirm') -> "true" |
     ("don't ask" | 'without asking' | 'skip') -> "false"
@@ -55,7 +89,8 @@ import { GreetAction, PlayAction, PauseAction } from "./schema.ts";
     'all' -> "all"
 );
 
-// Numeric patterns
+// ─── Numeric patterns ────────────────────────────────────────────────────────
+
 <Cardinal> =
     $(x:number)
   | one -> 1
@@ -64,14 +99,25 @@ import { GreetAction, PlayAction, PauseAction } from "./schema.ts";
   | four -> 4
   | five -> 5;
 
-// String type references
+// ─── Entity type captures ────────────────────────────────────────────────────
+
+<ScheduleEvent> =
+    schedule $(desc:string) on $(date:CalendarDate) -> {
+        actionName: "schedule",
+        parameters: { description: desc, date }
+    };
+
+<PlayNth> =
+    play (the)? $(n:Ordinal) (track | song)? -> {
+        actionName: "playFromQueue",
+        parameters: { trackNumber: n }
+    };
+
+// ─── Capture with rule references ─────────────────────────────────────────────
+
 <TrackName> = $(x:string);
 <ArtistName> = $(x:string);
 <PersonName> = $(x:string);
-
-// Complex nested rule
-<PlayCommand> =
-    <PlayTrack> | <PlayAlbum> | <PlayArtist>;
 
 <PlayTrack> =
     play track $(n:<Cardinal>) -> {
@@ -96,7 +142,83 @@ import { GreetAction, PlayAction, PauseAction } from "./schema.ts";
 
 <AlbumName> = $(x:string);
 
-// Operators demonstration
+// ─── Spread operator in values ────────────────────────────────────────────────
+
+<MergeAction> =
+    merge $(src:string) into $(dest:string) -> {
+        actionName: "merge",
+        parameters: { ...src, destination: dest }
+    };
+
+// ─── Escape sequences in string expressions ──────────────────────────────────
+
+<Status> = (what('s | is) | show) (playing | status)?
+    -> { actionName: "status" };
+
+<EscapeDemo> = hello\ world -> "hello world";
+
+// ─── Operators and grouping ──────────────────────────────────────────────────
+
 <Operators> =
     one? two* three+ four  // optional, zero-or-more, one-or-more
-  | (first | second | third)  // alternation with grouping;
+  | (first | second | third)  // alternation with grouping
+  | (item)+ // one-or-more group
+  | (prefix)* suffix; // zero-or-more group
+
+// ─── Optional capture quantifiers ────────────────────────────────────────────
+
+<ItemList> =
+    add $(item:word)+ to $(list:string) -> {
+        actionName: "addItems",
+        parameters: { items: [item], listName: list }
+    };
+
+// ─── Value expressions (enableExpressions mode) ──────────────────────────────
+
+// Ternary operator
+<Toggle> =
+    toggle $(flag:word) -> flag === "on" ? true : false;
+
+// Logical and nullish coalescing operators
+<Fallback> =
+    set $(key:word) to $(val:string) -> {
+        actionName: "set",
+        parameters: {
+            key,
+            value: val ?? "default",
+            enabled: val !== "" && val !== "off"
+        }
+    };
+
+// Arithmetic and comparison in values
+<Repeat> =
+    repeat $(n:number) times -> {
+        actionName: "repeat",
+        parameters: {
+            count: n,
+            doubled: n * 2,
+            isMany: n > 5 || n === 0
+        }
+    };
+
+// Member access and optional chaining
+<Lookup> =
+    lookup $(obj:word) -> obj.value?.name;
+
+// Template literals
+<Greet> =
+    greet $(name:string) -> `Hello, ${name}!`;
+
+// Unary operators
+<Negate> =
+    negate $(x:number) -> -x;
+
+<Check> =
+    check $(val:word) -> !val ? "empty" : typeof val;
+
+// Method calls and computed access
+<Transform> =
+    transform $(data:word) -> data.items[0]?.toString();
+
+/* End of sample — this block comment demonstrates
+   that multi-line block comments are highlighted. */

--- a/ts/extensions/agr-language/syntaxes/agr.tmLanguage.json
+++ b/ts/extensions/agr-language/syntaxes/agr.tmLanguage.json
@@ -3,6 +3,7 @@
   "patterns": [
     { "include": "#comments" },
     { "include": "#import-statement" },
+    { "include": "#export-rule-definition" },
     { "include": "#rule-definition" }
   ],
   "repository": {
@@ -11,15 +12,23 @@
         {
           "name": "comment.line.double-slash.agr",
           "match": "//.*$"
+        },
+        {
+          "name": "comment.block.agr",
+          "begin": "/\\*",
+          "end": "\\*/",
+          "captures": {
+            "0": { "name": "punctuation.definition.comment.agr" }
+          }
         }
       ]
     },
     "import-statement": {
       "patterns": [
         {
-          "comment": "Named import: import { RuleA, RuleB } from './path.agr';",
+          "comment": "Import statement: import { names } from './path'; or import * from './path'; or import { Entity };",
           "begin": "^\\s*(import)\\b",
-          "end": "(;)|(?=$|//)",
+          "end": "(;)|(?=$)",
           "beginCaptures": {
             "1": { "name": "keyword.control.import.agr" }
           },
@@ -27,13 +36,27 @@
             "1": { "name": "punctuation.terminator.statement.agr" }
           },
           "patterns": [
+            { "include": "#comments" },
             {
-              "match": "(\\{)([^}]*)(\\})",
-              "captures": {
-                "1": { "name": "punctuation.definition.import-list.begin.agr" },
-                "2": { "name": "variable.other.agr" },
-                "3": { "name": "punctuation.definition.import-list.end.agr" }
-              }
+              "begin": "(\\{)",
+              "end": "(\\})",
+              "beginCaptures": {
+                "1": { "name": "punctuation.definition.import-list.begin.agr" }
+              },
+              "endCaptures": {
+                "1": { "name": "punctuation.definition.import-list.end.agr" }
+              },
+              "patterns": [
+                { "include": "#comments" },
+                {
+                  "name": "variable.other.import.agr",
+                  "match": "[A-Za-z_][A-Za-z0-9_]*"
+                },
+                {
+                  "name": "punctuation.separator.comma.agr",
+                  "match": ","
+                }
+              ]
             },
             {
               "name": "keyword.operator.wildcard.agr",
@@ -48,21 +71,82 @@
         }
       ]
     },
+    "export-rule-definition": {
+      "comment": "Exported rule definition: export <Name> ... = ... ;",
+      "begin": "^\\s*(export)\\s+(?=<)",
+      "end": "(;)",
+      "beginCaptures": {
+        "1": { "name": "keyword.control.export.agr" }
+      },
+      "endCaptures": {
+        "1": { "name": "punctuation.terminator.statement.agr" }
+      },
+      "patterns": [{ "include": "#rule-header" }, { "include": "#rule-body" }]
+    },
     "rule-definition": {
       "patterns": [
         {
-          "begin": "^\\s*(<)([A-Za-z_][A-Za-z0-9_]*)(>)\\s*(=)",
+          "comment": "Rule definition: <Name> [annotation]? : Type? = ... ;",
+          "begin": "^\\s*(?=<[A-Za-z_])",
           "end": "(;)",
-          "beginCaptures": {
-            "1": { "name": "punctuation.definition.rule-name.begin.agr" },
-            "2": { "name": "entity.name.type.rule.agr" },
-            "3": { "name": "punctuation.definition.rule-name.end.agr" },
-            "4": { "name": "keyword.operator.assignment.agr" }
-          },
           "endCaptures": {
             "1": { "name": "punctuation.terminator.statement.agr" }
           },
-          "patterns": [{ "include": "#rule-body" }]
+          "patterns": [
+            { "include": "#rule-header" },
+            { "include": "#rule-body" }
+          ]
+        }
+      ]
+    },
+    "rule-header": {
+      "comment": "Rule header: <Name> [spacing=mode]? : Type (| Type)* =",
+      "patterns": [
+        { "include": "#comments" },
+        {
+          "comment": "Rule name in definition position",
+          "match": "(<)([A-Za-z_][A-Za-z0-9_]*)(>)",
+          "captures": {
+            "1": { "name": "punctuation.definition.rule-name.begin.agr" },
+            "2": { "name": "entity.name.type.rule.agr" },
+            "3": { "name": "punctuation.definition.rule-name.end.agr" }
+          }
+        },
+        { "include": "#spacing-annotation" },
+        { "include": "#value-type-annotation" },
+        {
+          "name": "keyword.operator.assignment.agr",
+          "match": "="
+        }
+      ]
+    },
+    "spacing-annotation": {
+      "comment": "Spacing annotation: [spacing=required|optional|auto|none]",
+      "match": "(\\[)(spacing)(=)(required|optional|auto|none)(\\])",
+      "captures": {
+        "1": { "name": "punctuation.definition.annotation.begin.agr" },
+        "2": { "name": "entity.other.attribute-name.agr" },
+        "3": { "name": "keyword.operator.assignment.agr" },
+        "4": { "name": "support.constant.spacing-mode.agr" },
+        "5": { "name": "punctuation.definition.annotation.end.agr" }
+      }
+    },
+    "value-type-annotation": {
+      "comment": "Value type annotation: : TypeName (| TypeName)*",
+      "begin": "(:)\\s*(?=[A-Za-z_])",
+      "end": "(?==)",
+      "beginCaptures": {
+        "1": { "name": "punctuation.separator.type-annotation.agr" }
+      },
+      "patterns": [
+        { "include": "#comments" },
+        {
+          "name": "entity.name.type.value-type.agr",
+          "match": "[A-Za-z_][A-Za-z0-9_]*"
+        },
+        {
+          "name": "keyword.operator.alternation.agr",
+          "match": "\\|"
         }
       ]
     },
@@ -73,7 +157,7 @@
         { "include": "#action-bare" },
         { "include": "#capture" },
         { "include": "#rule-reference" },
-        { "include": "#string-literal" },
+        { "include": "#escape-sequence" },
         { "include": "#operators" },
         { "include": "#keywords" }
       ]
@@ -81,23 +165,42 @@
     "capture": {
       "patterns": [
         {
-          "match": "(\\$)(\\()([A-Za-z_][A-Za-z0-9_]*)(:)([A-Za-z_<>][A-Za-z0-9_<>]*)(\\))",
+          "comment": "Typed capture with rule reference: $(var:<RuleName>)",
+          "match": "(\\$)(\\()([A-Za-z_][A-Za-z0-9_]*)(:)(<)([A-Za-z_][A-Za-z0-9_]*)(>)(\\))(\\?)?",
           "captures": {
             "1": { "name": "keyword.operator.capture.agr" },
             "2": { "name": "punctuation.definition.capture.begin.agr" },
-            "3": { "name": "variable.other.agr" },
+            "3": { "name": "variable.other.capture.agr" },
             "4": { "name": "punctuation.separator.type.agr" },
-            "5": { "name": "entity.name.type.agr" },
-            "6": { "name": "punctuation.definition.capture.end.agr" }
+            "5": { "name": "punctuation.definition.rule-reference.begin.agr" },
+            "6": { "name": "entity.name.type.rule-reference.agr" },
+            "7": { "name": "punctuation.definition.rule-reference.end.agr" },
+            "8": { "name": "punctuation.definition.capture.end.agr" },
+            "9": { "name": "keyword.operator.optional.agr" }
           }
         },
         {
-          "match": "(\\$)(\\()([A-Za-z_][A-Za-z0-9_]*)(\\))",
+          "comment": "Typed capture: $(var:Type) with optional quantifier",
+          "match": "(\\$)(\\()([A-Za-z_][A-Za-z0-9_]*)(:)([A-Za-z_][A-Za-z0-9_]*)(\\))([?*+])?",
           "captures": {
             "1": { "name": "keyword.operator.capture.agr" },
             "2": { "name": "punctuation.definition.capture.begin.agr" },
-            "3": { "name": "variable.other.agr" },
-            "4": { "name": "punctuation.definition.capture.end.agr" }
+            "3": { "name": "variable.other.capture.agr" },
+            "4": { "name": "punctuation.separator.type.agr" },
+            "5": { "name": "entity.name.type.agr" },
+            "6": { "name": "punctuation.definition.capture.end.agr" },
+            "7": { "name": "keyword.operator.quantifier.agr" }
+          }
+        },
+        {
+          "comment": "Untyped capture: $(var) with optional quantifier",
+          "match": "(\\$)(\\()([A-Za-z_][A-Za-z0-9_]*)(\\))([?*+])?",
+          "captures": {
+            "1": { "name": "keyword.operator.capture.agr" },
+            "2": { "name": "punctuation.definition.capture.begin.agr" },
+            "3": { "name": "variable.other.capture.agr" },
+            "4": { "name": "punctuation.definition.capture.end.agr" },
+            "5": { "name": "keyword.operator.quantifier.agr" }
           }
         }
       ]
@@ -105,11 +208,12 @@
     "rule-reference": {
       "patterns": [
         {
-          "match": "(<)([A-Za-z_][A-Za-z0-9_]*)(>)",
+          "match": "(<)([A-Za-z_][A-Za-z0-9_]*)(>)([?*+])?",
           "captures": {
             "1": { "name": "punctuation.definition.rule-reference.begin.agr" },
             "2": { "name": "entity.name.type.rule-reference.agr" },
-            "3": { "name": "punctuation.definition.rule-reference.end.agr" }
+            "3": { "name": "punctuation.definition.rule-reference.end.agr" },
+            "4": { "name": "keyword.operator.quantifier.agr" }
           }
         }
       ]
@@ -120,55 +224,273 @@
           "name": "string.quoted.double.agr",
           "begin": "\"",
           "end": "\"",
-          "patterns": [
-            {
-              "name": "constant.character.escape.agr",
-              "match": "\\\\."
-            }
-          ]
+          "patterns": [{ "include": "#string-escape" }]
         },
         {
           "name": "string.quoted.single.agr",
           "begin": "(?<!\\w)'",
           "end": "'",
-          "patterns": [
-            {
-              "name": "constant.character.escape.agr",
-              "match": "\\\\."
-            }
-          ]
+          "patterns": [{ "include": "#string-escape" }]
         }
       ]
     },
+    "string-escape": {
+      "patterns": [
+        {
+          "name": "constant.character.escape.unicode-codepoint.agr",
+          "match": "\\\\u\\{[0-9A-Fa-f]+\\}"
+        },
+        {
+          "name": "constant.character.escape.unicode.agr",
+          "match": "\\\\u[0-9A-Fa-f]{4}"
+        },
+        {
+          "name": "constant.character.escape.hex.agr",
+          "match": "\\\\x[0-9A-Fa-f]{2}"
+        },
+        {
+          "name": "constant.character.escape.agr",
+          "match": "\\\\[0nrvtbf'\"\\\\]"
+        },
+        {
+          "name": "constant.character.escape.agr",
+          "match": "\\\\."
+        }
+      ]
+    },
+    "escape-sequence": {
+      "comment": "Escape sequences in bare string expressions (outside quotes)",
+      "name": "constant.character.escape.agr",
+      "match": "\\\\."
+    },
     "action-object": {
-      "comment": "Object action result: -> { ... } — embedded JavaScript content",
+      "comment": "Object action result: -> { ... } with nested AGR value syntax",
       "begin": "(->)\\s*(\\{)",
-      "end": "\\}",
+      "end": "(\\})",
       "beginCaptures": {
         "1": { "name": "keyword.operator.arrow.agr" },
         "2": { "name": "punctuation.definition.action.begin.agr" }
       },
       "endCaptures": {
-        "0": { "name": "punctuation.definition.action.end.agr" }
+        "1": { "name": "punctuation.definition.action.end.agr" }
       },
-      "contentName": "meta.embedded.block.javascript",
-      "patterns": [{ "include": "source.js" }]
+      "contentName": "meta.action-value.agr",
+      "patterns": [{ "include": "#value-body" }]
+    },
+    "action-array": {
+      "comment": "Array action result: -> [ ... ]",
+      "begin": "(->)\\s*(\\[)",
+      "end": "(\\])",
+      "beginCaptures": {
+        "1": { "name": "keyword.operator.arrow.agr" },
+        "2": { "name": "punctuation.definition.array.begin.agr" }
+      },
+      "endCaptures": {
+        "1": { "name": "punctuation.definition.array.end.agr" }
+      },
+      "contentName": "meta.action-value.agr",
+      "patterns": [{ "include": "#value-body" }]
     },
     "action-bare": {
-      "comment": "Bare action result: -> value  where value is string, number, or identifier. End is non-consuming so | or ; is available to the parent rule scope.",
+      "comment": "Bare action result: -> expression (value expression with operators)",
       "begin": "(->)\\s*",
-      "end": "(?=[|;])",
+      "end": "(?=[|;)}\\]])",
       "beginCaptures": {
         "1": { "name": "keyword.operator.arrow.agr" }
       },
+      "patterns": [{ "include": "#value-expression" }]
+    },
+    "value-body": {
+      "comment": "Shared patterns for value positions (inside objects and arrays)",
       "patterns": [
+        { "include": "#comments" },
         { "include": "#string-literal" },
-        { "include": "#keywords" },
+        { "include": "#template-literal" },
+        { "include": "#value-object" },
+        { "include": "#value-array" },
+        { "include": "#spread-operator" },
+        { "include": "#numeric-literal" },
+        { "include": "#value-keywords" },
+        { "include": "#value-operators" },
+        {
+          "name": "punctuation.separator.comma.agr",
+          "match": ","
+        },
+        {
+          "name": "punctuation.separator.colon.agr",
+          "match": ":"
+        },
+        {
+          "name": "variable.other.property.agr",
+          "match": "[A-Za-z_][A-Za-z0-9_]*(?=\\s*:)"
+        },
         {
           "name": "variable.other.agr",
           "match": "[A-Za-z_][A-Za-z0-9_]*"
         }
       ]
+    },
+    "value-expression": {
+      "comment": "Patterns for full value expressions (after ->), including operators, ternary, template literals, calls, member access",
+      "patterns": [
+        { "include": "#comments" },
+        { "include": "#string-literal" },
+        { "include": "#template-literal" },
+        { "include": "#value-object" },
+        { "include": "#value-array" },
+        { "include": "#spread-operator" },
+        { "include": "#numeric-literal" },
+        { "include": "#value-keywords" },
+        { "include": "#value-operators" },
+        { "include": "#value-paren-group" },
+        {
+          "name": "punctuation.separator.comma.agr",
+          "match": ","
+        },
+        {
+          "name": "variable.other.agr",
+          "match": "[A-Za-z_][A-Za-z0-9_]*"
+        }
+      ]
+    },
+    "value-paren-group": {
+      "comment": "Grouped expression or function call arguments: (expr, ...)",
+      "begin": "(\\()",
+      "end": "(\\))",
+      "beginCaptures": {
+        "1": { "name": "punctuation.definition.expression.begin.agr" }
+      },
+      "endCaptures": {
+        "1": { "name": "punctuation.definition.expression.end.agr" }
+      },
+      "patterns": [{ "include": "#value-expression" }]
+    },
+    "value-operators": {
+      "comment": "Operators in value expression context. Order matters: longer matches first.",
+      "patterns": [
+        {
+          "name": "keyword.operator.comparison.agr",
+          "match": "===|!=="
+        },
+        {
+          "name": "keyword.operator.relational.agr",
+          "match": "<=|>="
+        },
+        {
+          "name": "keyword.operator.nullish-coalescing.agr",
+          "match": "\\?\\?"
+        },
+        {
+          "name": "keyword.operator.optional-chaining.agr",
+          "match": "\\?\\."
+        },
+        {
+          "name": "keyword.operator.logical.agr",
+          "match": "\\|\\||&&"
+        },
+        {
+          "name": "keyword.operator.typeof.agr",
+          "match": "\\btypeof\\b"
+        },
+        {
+          "name": "keyword.operator.ternary.agr",
+          "match": "\\?"
+        },
+        {
+          "name": "keyword.operator.logical-not.agr",
+          "match": "!"
+        },
+        {
+          "name": "keyword.operator.arithmetic.agr",
+          "match": "[+\\-*/%]"
+        },
+        {
+          "name": "keyword.operator.member-access.agr",
+          "match": "\\."
+        }
+      ]
+    },
+    "template-literal": {
+      "comment": "Template literals: `text ${expr} text`",
+      "name": "string.template.agr",
+      "begin": "`",
+      "end": "`",
+      "patterns": [
+        {
+          "comment": "Template expression: ${expr}",
+          "begin": "(\\$\\{)",
+          "end": "(\\})",
+          "beginCaptures": {
+            "1": {
+              "name": "punctuation.definition.template-expression.begin.agr"
+            }
+          },
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.definition.template-expression.end.agr"
+            }
+          },
+          "contentName": "meta.template-expression.agr",
+          "patterns": [{ "include": "#value-expression" }]
+        },
+        { "include": "#string-escape" }
+      ]
+    },
+    "value-object": {
+      "comment": "Nested object literal: { ... }",
+      "begin": "(\\{)",
+      "end": "(\\})",
+      "beginCaptures": {
+        "1": { "name": "punctuation.definition.object.begin.agr" }
+      },
+      "endCaptures": {
+        "1": { "name": "punctuation.definition.object.end.agr" }
+      },
+      "patterns": [{ "include": "#value-body" }]
+    },
+    "value-array": {
+      "comment": "Array literal: [ ... ]",
+      "begin": "(\\[)",
+      "end": "(\\])",
+      "beginCaptures": {
+        "1": { "name": "punctuation.definition.array.begin.agr" }
+      },
+      "endCaptures": {
+        "1": { "name": "punctuation.definition.array.end.agr" }
+      },
+      "patterns": [{ "include": "#value-body" }]
+    },
+    "spread-operator": {
+      "name": "keyword.operator.spread.agr",
+      "match": "\\.\\.\\."
+    },
+    "numeric-literal": {
+      "patterns": [
+        {
+          "name": "constant.numeric.hex.agr",
+          "match": "\\b0[xX][0-9A-Fa-f]+\\b"
+        },
+        {
+          "name": "constant.numeric.float.agr",
+          "match": "-?\\b\\d+\\.\\d+([eE][+-]?\\d+)?\\b"
+        },
+        {
+          "name": "constant.numeric.exponential.agr",
+          "match": "-?\\b\\d+[eE][+-]?\\d+\\b"
+        },
+        {
+          "name": "constant.numeric.infinity.agr",
+          "match": "-?\\bInfinity\\b"
+        },
+        {
+          "name": "constant.numeric.integer.agr",
+          "match": "-?\\b\\d+\\b"
+        }
+      ]
+    },
+    "value-keywords": {
+      "name": "constant.language.agr",
+      "match": "\\b(true|false|null|undefined)\\b"
     },
     "operators": {
       "patterns": [
@@ -178,15 +500,23 @@
         },
         {
           "name": "keyword.operator.optional.agr",
-          "match": "\\?"
+          "match": "\\)\\?"
         },
         {
           "name": "keyword.operator.zero-or-more.agr",
-          "match": "\\*"
+          "match": "\\)\\*"
         },
         {
           "name": "keyword.operator.one-or-more.agr",
-          "match": "\\+"
+          "match": "\\)\\+"
+        },
+        {
+          "name": "punctuation.definition.group.begin.agr",
+          "match": "\\("
+        },
+        {
+          "name": "punctuation.definition.group.end.agr",
+          "match": "\\)"
         }
       ]
     },
@@ -196,10 +526,7 @@
           "name": "constant.language.agr",
           "match": "\\b(true|false|null|undefined)\\b"
         },
-        {
-          "name": "constant.numeric.agr",
-          "match": "\\b\\d+\\b"
-        }
+        { "include": "#numeric-literal" }
       ]
     }
   }

--- a/ts/packages/actionGrammar/src/grammarRuleParser.ts
+++ b/ts/packages/actionGrammar/src/grammarRuleParser.ts
@@ -87,9 +87,12 @@ const debugParse = registerDebug("typeagent:grammar:parse");
  *   <RuleRefExpr> ::= <RuleName>
  *   <GroupExpr> ::= "(" <Rules> ( ")" | ")?" | ")*" | ")+" )
  *
- *   <Value> = BooleanValue | NumberValue | StringValue | ObjectValue | ArrayValue | VarReference
+ *   // ── Value (basic mode: enableExpressions=false) ──────────────────────────
+ *   <Value> = <BooleanValue> | <NumberValue> | <StringValue>
+ *           | <ObjectValue> | <ArrayValue> | <VarReference>
  *   <ArrayValue> = "[" (<Value> ("," <Value>)* ","?)? "]"
- *   <ObjectValue> = "{" (<ObjectProperty> ("," <ObjectProperty>)* ","?)? "}"
+ *   <ObjectValue> = "{" (<ObjectElement> ("," <ObjectElement>)* ","?)? "}"
+ *   <ObjectElement> = <ObjectProperty> | <SpreadElement>
  *   <ObjectProperty> = <ObjectPropertyFull> | <ObjectPropertyShort>
  *   <ObjectPropertyFull> = <ObjectPropertyName> ":" <Value>
  *   <ObjectPropertyShort> = <VarReference>
@@ -98,6 +101,61 @@ const debugParse = registerDebug("typeagent:grammar:parse");
  *   <NumberValue> = <NumberLiteral>
  *   <StringValue> = <StringLiteral>
  *   <VarReference> = <VarName>
+ *
+ *   // ── Value expressions (enableExpressions=true) ───────────────────────────
+ *   // When enableExpressions is true, the <Value> position (after "->")
+ *   // supports full JavaScript-like expressions with operator precedence.
+ *   // In this mode <Value> is replaced by <ValueExpr>.
+ *   //
+ *   // Operator precedence (lowest → highest):
+ *   //   1. Ternary              ? :
+ *   //   2. Nullish coalescing   ??    (cannot mix with || && without parens)
+ *   //   3. Logical OR           ||
+ *   //   4. Logical AND          &&
+ *   //   5. Equality             === !==
+ *   //   6. Comparison           < > <= >=
+ *   //   7. Additive             + -
+ *   //   8. Multiplicative       * / %
+ *   //   9. Unary                - ! typeof
+ *   //  10. Postfix              . ?. [] ?.[] ?.()
+ *   //  11. Primary              literals, identifiers, objects, arrays,
+ *   //                           template literals, (expr), ...expr
+ *   //
+ *   <ValueExpr> ::= <TernaryExpr>
+ *   <TernaryExpr> ::= <ShortCircuitExpr> ( "?" <TernaryExpr> ":" <TernaryExpr> )?
+ *
+ *   <ShortCircuitExpr> ::= <NullishExpr> | <LogicalExpr>
+ *   // Nullish and logical families cannot be mixed without parentheses.
+ *   <NullishExpr> ::= <EqualityExpr> ( "??" <EqualityExpr> )*
+ *   <LogicalExpr> ::= <LogicalAndExpr> ( "||" <LogicalAndExpr> )*
+ *   <LogicalAndExpr> ::= <EqualityExpr> ( "&&" <EqualityExpr> )*
+ *
+ *   <EqualityExpr> ::= <ComparisonExpr> ( ("===" | "!==") <ComparisonExpr> )*
+ *   <ComparisonExpr> ::= <AdditiveExpr> ( ("<" | ">" | "<=" | ">=") <AdditiveExpr> )*
+ *   <AdditiveExpr> ::= <MultiplicativeExpr> ( ("+" | "-") <MultiplicativeExpr> )*
+ *   <MultiplicativeExpr> ::= <UnaryExpr> ( ("*" | "/" | "%") <UnaryExpr> )*
+ *   <UnaryExpr> ::= ("-" | "!" | "typeof") <UnaryExpr> | <PostfixExpr>
+ *
+ *   <PostfixExpr> ::= <PrimaryExpr> <PostfixOp>*
+ *   <PostfixOp> ::= "." <Identifier> ( "(" <ArgList> ")" )?    // member access / method call
+ *                  | "?." <Identifier> ( "(" <ArgList> ")" )?   // optional member / method
+ *                  | "?." "[" <ValueExpr> "]"                   // optional computed access
+ *                  | "?." "(" <ArgList> ")"                     // optional call
+ *                  | "[" <ValueExpr> "]"                        // computed member access
+ *
+ *   <PrimaryExpr> ::= <SpreadElement>
+ *                    | <TemplateLiteral>
+ *                    | "(" <ValueExpr> ")"              // grouped expression
+ *                    | <ObjectValue>
+ *                    | <ArrayValue>
+ *                    | <StringLiteral>
+ *                    | <BooleanValue>
+ *                    | <Identifier>                     // variable reference
+ *                    | <NumberLiteral>
+ *
+ *   <SpreadElement> ::= "..." <ValueExpr>
+ *   <TemplateLiteral> ::= "`" ( <TemplateChars> | "${" <ValueExpr> "}" )* "`"
+ *   <ArgList> ::= <ValueExpr> ( "," <ValueExpr> )*
  *
  *   <VarName> = <Identifier>
  *   <TypeName> = <Identifier>


### PR DESCRIPTION
## Summary

Updates the VS Code AGR language extension to support all current grammar features with proper syntax coloring.

### Syntax highlighting additions

- **Block comments** (`/* ... */`) — previously only line comments were supported
- **`export` keyword** — for exported rule definitions
- **`[spacing=...]` annotations** — `required`, `optional`, `auto`, `none` with distinct scopes
- **Value type annotations** — `: TypeName | TypeName` after rule names
- **Source-less entity imports** — `import { Ordinal, CalendarDate };` (no `from` clause)
- **Value expression operators** — `===`, `!==`, `??`, `?.`, `||`, `&&`, ternary `? :`, `typeof`, arithmetic, member access
- **Template literals** — `\`text \${expr} text\`` with recursive expression highlighting inside `\${}`
- **Spread operator** — `...` in value positions
- **Capture quantifiers** — `?`, `*`, `+` on captures and rule references
- **Grouped expressions** — `(expr)` and function call arguments in value context

### Bug fixes

- **Single-quote handling** — Apostrophes in expression context (e.g. `what('s | is)`) are now treated as literal characters, not string delimiters. Previously this broke all highlighting from that point onward.
- **Action object values** — Replaced embedded `source.js` grammar with native AGR value syntax for correct highlighting of AGR-specific constructs.

### Other changes

- **language-configuration.json** — Added `blockComment` support for `/* */` toggle
- **grammarRuleParser.ts** — Added comprehensive BNF for value expressions to the parser documentation comment
- **sample.agr** — Updated with examples demonstrating all new features

### Files changed

- `extensions/agr-language/syntaxes/agr.tmLanguage.json`
- `extensions/agr-language/language-configuration.json`
- `extensions/agr-language/sample.agr`
- `packages/actionGrammar/src/grammarRuleParser.ts`