### PR TITLE
Refactor grammarCompletion: two-phase B1/B2, extract helpers, simplify main loop

### DIFF
--- a/ts/docs/architecture/actionGrammar.md
+++ b/ts/docs/architecture/actionGrammar.md
@@ -447,15 +447,19 @@ are reported at `matchedPrefixLength=4`. The **caller** (shell trie or
 CLI) is responsible for filtering the completions against the remaining
 text `"mx"`. This applies equally to forward and backward directions.
 
-6. **Partial keyword detection in wildcards** (Category 2 backward only):
+6. **Partial keyword detection in wildcards** (Category 2, both directions):
    When a wildcard absorbs all remaining input and the next grammar part
-   is a keyword, `findPartialKeywordInWildcard()` checks whether the
-   wildcard text ends with a prefix of that keyword. For example, with
-   `play <song> by <artist>` and input `"play Never b"`, the wildcard
-   absorbs `"Never b"` but `"b"` is a prefix of `"by"`. Backward
-   completion offers `"by"` at the partial keyword position (after
-   `"Never "`), with `openWildcard=true`, instead of backing up to the
-   wildcard start. This handles multi-word keywords as well: for
+   is a keyword, Phase A defers the state (via `WildcardEoiDescriptor`)
+   to Phase B1, which calls `findPartialKeywordInWildcard()` to check
+   whether the wildcard text ends with a prefix of that keyword. For
+   example, with `play <song> by <artist>` and input `"play Never b"`,
+   the wildcard absorbs `"Never b"` but `"b"` is a prefix of `"by"`.
+   Phase B1 finds the partial keyword and (for backward) collects
+   `"by"` at the partial keyword position (after `"Never "`), with
+   `openWildcard=true`, instead of using the fallback wildcard-start
+   candidate from Phase A. For forward, Phase B1 records the partial
+   keyword anchor and Phase B2 uses it to emit the completion. This
+   handles multi-word keywords as well: for
    `play <song> played by <artist>` and input `"play Never played b"`,
    the function recognizes `"played b"` as a full match of the first
    keyword word plus a partial match of the second, and offers `"by"`.
@@ -508,25 +512,38 @@ To make backward non-lossy, the matcher uses **range candidates** —
 a single-pass approach that defers sibling-rule resolution to Phase B
 (the post-loop conversion step):
 
-1. **Main loop (backward):** For each state, `collectBackwardCandidate`
+1. **Phase A (main loop):** For each state, `collectBackwardCandidate`
    determines the backed-up position _P_ via `tryPartialStringMatch`
    or property completion. When a Category 2 state has a wildcard
-   preceding the next keyword part, the state also saves a
-   `RangeCandidate` recording the wildcard-start and next-part —
-   the wildcard's end position is flexible and will be resolved later.
-2. **Phase B (range candidate resolution):** After all rules have been
-   processed and `maxPrefixLength` is settled, range candidates are
-   evaluated. Each candidate checks whether `maxPrefixLength` falls
-   inside its valid range (`[wildcardStart+1, prefix.length]`) and
-   whether the wildcard text at that split is well-formed (via
+   preceding a non-string next part (wildcard/number), a
+   `RangeCandidate` is saved directly. When the next part is a string,
+   a lightweight `WildcardEoiDescriptor` is saved for Phase B1 instead
+   of running `findPartialKeywordInWildcard` inline. This applies to
+   both directions under the same condition.
+2. **Phase B1 (anchor resolution):** Runs
+   `findPartialKeywordInWildcard` on deferred `wildcardEoiDescriptors`.
+   For backward, a partial keyword found strictly inside the prefix is
+   collected as a fixed candidate (which may advance `maxPrefixLength`,
+   clearing weaker fallback candidates from Phase A); otherwise a range
+   candidate is created for Phase B2. For forward, the best partial
+   keyword anchor is recorded in `forwardPartialKeyword`; states
+   without a partial keyword are deferred to `forwardEoiCandidates`
+   for Phase B2.
+3. **Phase B2 (materialization):** Converts surviving candidates into
+   the final `completions[]` and `properties[]` arrays. Range
+   candidates are evaluated: each checks whether `maxPrefixLength`
+   falls inside its valid range (`[wildcardStart+1, prefix.length]`)
+   and whether the wildcard text at that split is well-formed (via
    `getWildcardStr`). If so, `tryPartialStringMatch` runs forward at
    `maxPrefixLength` to produce sibling completions — the same result
    the old two-pass re-invocation would have produced, but without a
-   second full traversal of the grammar.
+   second full traversal of the grammar. Phase B2 also handles forward
+   EOI candidate instantiation, trailing-separator advancement, and
+   global deduplication.
 
 **Correctness invariant — two-pass equivalence.** Let _P_ =
 `completion(input, backward).matchedPrefixLength`. The range-candidate
-resolution in Phase B must produce the same completions as
+resolution in Phase B2 must produce the same completions as
 `completion(input[0..P], forward)` — i.e., a single backward pass
 with range candidates is equivalent to the old two-pass approach
 (backward to find _P_, then forward at _P_ to collect siblings).
@@ -536,14 +553,14 @@ Range candidates are **skipped** when:
 
 - `backwardEmitted=false` — backward didn't back up (e.g., trailing
   separator committed the match), so the result already matches forward.
-- `openWildcard=true` — the backed-up position is at an ambiguous
-  wildcard boundary. Forward evaluation at the shorter input would
-  re-parse with fresh greedy wildcards that absorb different text,
-  producing an incorrect structural interpretation.
-- `partialKeywordBackup=true` — a multi-word keyword partial match
-  (via `findPartialKeywordInWildcard`) determined P. Forward can't
-  reconstruct the keyword-word boundary because the wildcard absorbs
-  the consumed words.
+- `openWildcard=true` **and** `partialKeywordBackup=false` — the
+  backed-up position is at an ambiguous wildcard boundary with no
+  partial keyword to pin it. Forward evaluation at the shorter input
+  would re-parse with fresh greedy wildcards that absorb different
+  text, producing an incorrect structural interpretation. (When
+  `partialKeywordBackup=true`, the keyword fragment pins the position
+  even though the wildcard boundary is open, so range candidates are
+  still processed.)
 
 This rule naturally handles three kinds of ambiguity:
 
@@ -664,12 +681,12 @@ more text, moving the boundary forward. The grammar matcher sets
 these positions. The table below explains _why_ the directions always
 differ at these boundaries.
 
-| Mode / Partial keyword?                          | Fwd = Bwd? | Why                                                               |
-| ------------------------------------------------ | ---------- | ----------------------------------------------------------------- |
-| non-`none` — no partial keyword                  | **No**     | Forward defers to Phase B; backward backs up to wildcard start    |
-| non-`none` — partial at Q < P                    | **No**     | Both find partial at Q, but backward can also back up — ambiguous |
-| non-`none` — partial at Q = P (full word at EOI) | **No**     | Forward uses it; backward rejects (Q < `state.index` required)    |
-| `none` — any                                     | **No**     | `couldBackUp` always true                                         |
+| Mode / Partial keyword?                          | Fwd = Bwd? | Why                                                                              |
+| ------------------------------------------------ | ---------- | -------------------------------------------------------------------------------- |
+| non-`none` — no partial keyword                  | **No**     | Forward defers to Phase B2; backward backs up to wildcard start                  |
+| non-`none` — partial at Q < P                    | **No**     | Both find partial at Q (via Phase B1), but backward can also back up — ambiguous |
+| non-`none` — partial at Q = P (full word at EOI) | **No**     | Forward uses it; backward rejects (Q < `state.index` required)                   |
+| `none` — any                                     | **No**     | `couldBackUp` always true                                                        |
 
 #### P inside a wildcard (no keyword boundary reached)
 

--- a/ts/packages/actionGrammar/src/grammarCompletion.ts
+++ b/ts/packages/actionGrammar/src/grammarCompletion.ts
@@ -449,12 +449,11 @@ function tryPartialStringMatch(
  *      - Wildcard / number → property completion (handled elsewhere).
  *
  *    **Wildcard-at-EOI deferral:** when a pending wildcard absorbed all
- *    input to end-of-string, forward string-part candidates are *not*
- *    processed inline.  Instead they are saved to `forwardEoiCandidates`
- *    and instantiated in Phase B at the appropriate anchor position
- *    (partial keyword position or `prefix.length`).  This prevents
- *    wildcard-at-EOI states from pushing `maxPrefixLength` past
- *    more-meaningful candidates.  See the Phase B EOI block.
+ *    input to end-of-string, string-part candidates are *not* processed
+ *    inline.  Instead, lightweight `WildcardEoiDescriptor`s are saved
+ *    for Phase B1 to resolve via `findPartialKeywordInWildcard`.  This
+ *    prevents wildcard-at-EOI states from pushing `maxPrefixLength`
+ *    past more-meaningful candidates.  See the Phase B1/B2 blocks.
  *
  * 3. **Partial match, NOT finalized** — either:
  *      a. A pending wildcard could not be finalized (trailing text is only
@@ -531,15 +530,27 @@ type RangeCandidate =
           spacingMode: CompiledSpacingMode;
       };
 
-// Forward partial keyword anchor: when
+// Lightweight descriptor for wildcard-at-EOI states whose
+// partial keyword scan is deferred to Phase B1.  Phase A pushes
+// one descriptor per wildcard-at-EOI string state (both forward
+// and backward).  Phase B1 runs findPartialKeywordInWildcard on
+// each descriptor, resolving it into either a partial keyword
+// anchor or a deferred candidate for Phase B2.
+type WildcardEoiDescriptor = {
+    wildcardStart: number;
+    nextPart: StringPart;
+    spacingMode: CompiledSpacingMode;
+};
+
+// Forward partial keyword anchor: populated by Phase B1 when
 // findPartialKeywordInWildcard finds a partial keyword at
-// position P < state.index inside a wildcard-at-EOI state,
-// the result is saved here.  Phase B uses position to anchor
-// and completionWord to emit the completion (tryPartialStringMatch
-// at the anchor position cannot reproduce multi-word keyword
-// results — e.g. for keyword ["played","by"], the partial
-// keyword "by" is found at position 18 from candidateStart=11,
-// but tryPartialStringMatch at 18 returns "played" instead).
+// position P inside a wildcard-at-EOI state.  Phase B2 uses
+// position to anchor and completionWord to emit the completion
+// (tryPartialStringMatch at the anchor position cannot reproduce
+// multi-word keyword results — e.g. for keyword ["played","by"],
+// the partial keyword "by" is found at position 18 from
+// candidateStart=11, but tryPartialStringMatch at 18 returns
+// "played" instead).
 type ForwardPartialKeywordCandidate = {
     position: number;
     completionWord: string;
@@ -611,33 +622,21 @@ export function matchGrammarCompletion(
     //     a flexible position.  Processed in Phase B only under
     //     the same conditions the old retrigger required.
     //
-    // Phase B also handles:
-    //  • Forward EOI candidate instantiation at the appropriate
-    //    anchor (partial keyword position or prefix.length).
-    //  • Global string deduplication via Set.
-    //  • Range candidate gating (only under retrigger conditions).
-    //  • Trailing-separator advancement (forward only).
+    // Phase B is split into two sub-phases:
+    //  B1 — Anchor resolution: runs findPartialKeywordInWildcard
+    //    on deferred wildcardEoiDescriptors, populating
+    //    forwardPartialKeyword / forwardEoiCandidates (forward) or
+    //    fixedCandidates / rangeCandidates (backward).
+    //  B2 — Materialization: converts surviving candidates into
+    //    the final completions[] and properties[] arrays.
+    //    Also handles EOI instantiation, range candidates,
+    //    trailing-separator advancement, and deduplication.
     const fixedCandidates: FixedCandidate[] = [];
     const rangeCandidates: RangeCandidate[] = [];
-    // Forward partial keyword: see ForwardPartialKeywordCandidate.
-    let forwardPartialKeyword: ForwardPartialKeywordCandidate | undefined;
-    // Forward EOI candidates: when a wildcard absorbed all input
-    // (state.index >= prefix.length) and the next part is a string,
-    // the candidate is deferred here instead of being processed
-    // inline.  States where findPartialKeywordInWildcard found a
-    // partial keyword are NOT added here (tryPartialStringMatch
-    // at the anchor can't reproduce multi-word results); only
-    // the anchor position is saved in forwardPartialKeyword.
-    //
-    // Phase B fires when this array is non-empty OR
-    // forwardPartialKeyword is set, and instantiates candidates at
-    // the appropriate anchor:
-    //   - partial keyword position (if one exists)
-    //   - prefix.length (otherwise)
-    // Only "wildcardString" items are added/consumed; the broader
-    // RangeCandidate type is kept for structural uniformity with
-    // rangeCandidates.
-    const forwardEoiCandidates: RangeCandidate[] = [];
+    // Wildcard-at-EOI descriptors: Phase A pushes one descriptor
+    // per wildcard-at-EOI string state (both directions).  Phase
+    // B1 processes them via findPartialKeywordInWildcard.
+    const wildcardEoiDescriptors: WildcardEoiDescriptor[] = [];
 
     // Track the furthest point the grammar consumed across all
     // states (including exact matches).  This tells the caller where
@@ -646,10 +645,11 @@ export function matchGrammarCompletion(
     let maxPrefixLength = minPrefixLength ?? 0;
 
     // Whether backward actually collected a backed-up candidate (via
-    // collectBackwardCandidate or findPartialKeywordInWildcard).  When
-    // false, backward fell through to forward behavior — range
-    // candidate processing and the trailing-separator-advancement
-    // guard are skipped so the result is identical to forward.
+    // collectBackwardCandidate in Phase A or partial keyword resolution
+    // in Phase B1).  When false, backward fell through to forward
+    // behavior — range candidate processing and the trailing-separator-
+    // advancement guard are skipped so the result is identical to
+    // forward.
     let backwardEmitted = false;
 
     // Helper: update maxPrefixLength.  When it increases, all previously
@@ -705,6 +705,34 @@ export function matchGrammarCompletion(
             openWildcard: candidateOpenWildcard,
             partialKeywordBackup: candidatePartialKeywordBackup,
         });
+    }
+
+    // Helper: try partial string match and collect the result as a
+    // string candidate.  Used by Category 2 forward and Category 3b.
+    // Returns true if a candidate was collected.
+    function tryCollectStringCompletion(
+        state: MatchState,
+        part: StringPart,
+        candidateOpenWildcard: boolean = false,
+    ): void {
+        const partial = tryPartialStringMatch(
+            part,
+            prefix,
+            state.index,
+            state.spacingMode,
+            direction,
+        );
+        if (partial !== undefined) {
+            collectStringCandidate(
+                state,
+                partial.consumedLength,
+                partial.remainingText,
+                candidateOpenWildcard,
+            );
+            if (partial.couldBackUp && direction === "backward") {
+                backwardEmitted = true;
+            }
+        }
     }
 
     // Helper: backward completion — back up to the last matched item
@@ -807,14 +835,6 @@ export function matchGrammarCompletion(
         // It returns true when the state is "clean" — all input was
         // consumed (or only trailing separators remain).
         if (finalizeState(state, prefix)) {
-            // Would backward produce different results than forward?
-            // True when the prefix was fully consumed and there is a
-            // matched part (string/number) or wildcard to back up to.
-            const hasPartToReconsider =
-                state.index >= prefix.length &&
-                (savedPendingWildcard?.valueId !== undefined ||
-                    state.lastMatchedPartInfo !== undefined);
-
             // --- Category 1: Exact match ---
             // All parts matched AND prefix was fully consumed.
             // Back up to the last matched term (string keyword,
@@ -846,170 +866,70 @@ export function matchGrammarCompletion(
             // That next part is what we offer as a completion.
             const nextPart = state.parts[state.partIndex];
 
-            // Track whether findPartialKeywordInWildcard produced a
-            // result that forward would also use (position strictly
-            // inside the wildcard, i.e. < state.index).  When both
-            // directions agree, the state is not direction-sensitive.
-            // When the partial keyword position equals state.index
-            // (the wildcard absorbed a complete first keyword word),
-            // forward uses it but backward falls through to
-            // collectBackwardCandidate, so the directions differ.
+            // Wildcard-at-EOI with a string next part: defer the
+            // partial keyword scan to Phase B1.  This applies to
+            // both directions under the same condition.
+            const deferredToEoi =
+                savedPendingWildcard?.valueId !== undefined &&
+                state.index >= prefix.length &&
+                nextPart.type === "string";
+            if (deferredToEoi) {
+                wildcardEoiDescriptors.push({
+                    wildcardStart: savedPendingWildcard.start,
+                    nextPart,
+                    spacingMode: state.spacingMode,
+                });
+            }
+
+            // Would backward produce different results than forward?
+            // True when the prefix was fully consumed and there is a
+            // matched part (string/number) or wildcard to back up to.
+            const hasPartToReconsider =
+                state.index >= prefix.length &&
+                (savedPendingWildcard?.valueId !== undefined ||
+                    state.lastMatchedPartInfo !== undefined);
 
             if (direction === "backward" && hasPartToReconsider) {
-                // When a wildcard absorbed text ending with a partial
-                // keyword prefix (e.g. "Never b" where "b" prefixes
-                // "by"), offer the keyword at the partial keyword
-                // position instead of backing up to the wildcard start.
-                // The partial keyword position has a higher
-                // matchedPrefixLength and is more useful to the user.
-                let partialKeywordForThisState = false;
+                // Backward: collect a fallback candidate (backs up
+                // to the wildcard start or last matched part).  If
+                // a partial keyword exists inside the wildcard, Phase
+                // B1 will find it and may clear this fallback in
+                // favor of a higher-position candidate.
+                backwardEmitted =
+                    tryCollectBackwardCandidate(
+                        preFinalizeState ?? state,
+                        savedPendingWildcard,
+                    ) || backwardEmitted;
+                // Range candidates for non-string next parts
+                // (wildcard/number) — these don't involve partial
+                // keyword scans so they're pushed directly.
                 if (
                     savedPendingWildcard?.valueId !== undefined &&
-                    nextPart.type === "string"
+                    (nextPart.type === "wildcard" || nextPart.type === "number")
                 ) {
-                    const partialResult = findPartialKeywordInWildcard(
-                        prefix,
-                        savedPendingWildcard.start,
-                        nextPart,
-                        state.spacingMode,
-                    );
-                    if (
-                        partialResult !== undefined &&
-                        partialResult.position < state.index
-                    ) {
-                        collectStringCandidate(
-                            state,
-                            partialResult.position,
-                            partialResult.completionWord,
-                            /* openWildcard */ true,
-                            /* partialKeywordBackup */ true,
-                        );
-                        backwardEmitted = true;
-                        partialKeywordForThisState = true;
-                    } else {
-                        backwardEmitted =
-                            tryCollectBackwardCandidate(
-                                preFinalizeState ?? state,
-                                savedPendingWildcard,
-                            ) || backwardEmitted;
-                    }
-                } else {
-                    backwardEmitted =
-                        tryCollectBackwardCandidate(
-                            preFinalizeState ?? state,
-                            savedPendingWildcard,
-                        ) || backwardEmitted;
-                }
-                // Save a range candidate for the wildcard-nextPart
-                // split — the wildcard end is flexible and may match
-                // the final maxPrefixLength determined by other rules.
-                // Skip only for the state where
-                // findPartialKeywordInWildcard already found the
-                // optimal position — other alternatives still need
-                // their range candidates so Phase B can contribute
-                // their keywords at the settled maxPrefixLength.
-                if (
-                    savedPendingWildcard?.valueId !== undefined &&
-                    !partialKeywordForThisState
-                ) {
-                    if (nextPart.type === "string") {
-                        rangeCandidates.push({
-                            kind: "wildcardString",
-                            wildcardStart: savedPendingWildcard.start,
-                            nextPart,
-                            spacingMode: state.spacingMode,
-                        });
-                    } else if (
-                        nextPart.type === "wildcard" ||
-                        nextPart.type === "number"
-                    ) {
-                        // preFinalizeState is always defined here:
-                        // the guard `savedPendingWildcard?.valueId !== undefined`
-                        // implies `savedPendingWildcard !== undefined`, which is
-                        // the same condition that created preFinalizeState.
-                        rangeCandidates.push({
-                            kind: "wildcardProperty",
-                            wildcardStart: savedPendingWildcard.start,
-                            valueId: savedPendingWildcard.valueId,
-                            state: preFinalizeState!,
-                            spacingMode: state.spacingMode,
-                        });
-                    }
+                    // preFinalizeState is always defined here:
+                    // the guard `savedPendingWildcard?.valueId !== undefined`
+                    // implies `savedPendingWildcard !== undefined`, which is
+                    // the same condition that created preFinalizeState.
+                    rangeCandidates.push({
+                        kind: "wildcardProperty",
+                        wildcardStart: savedPendingWildcard.start,
+                        valueId: savedPendingWildcard.valueId,
+                        state: preFinalizeState!,
+                        spacingMode: state.spacingMode,
+                    });
                 }
             } else {
                 debugCompletion(
                     `Completing ${nextPart.type} part ${state.name}`,
                 );
-                if (nextPart.type === "string") {
-                    if (
-                        savedPendingWildcard?.valueId !== undefined &&
-                        state.index >= prefix.length
-                    ) {
-                        // Wildcard absorbed all input to EOI.
-                        // Check for a partial keyword to determine
-                        // the Phase B anchor, then defer.
-                        const partialResult = findPartialKeywordInWildcard(
-                            prefix,
-                            savedPendingWildcard.start,
-                            nextPart,
-                            state.spacingMode,
-                        );
-                        let partialKeywordForThisState = false;
-                        if (
-                            partialResult !== undefined &&
-                            partialResult.position <= state.index
-                        ) {
-                            if (
-                                forwardPartialKeyword === undefined ||
-                                partialResult.position >
-                                    forwardPartialKeyword.position
-                            ) {
-                                forwardPartialKeyword = {
-                                    position: partialResult.position,
-                                    completionWord:
-                                        partialResult.completionWord,
-                                    spacingMode: state.spacingMode,
-                                };
-                            }
-                            partialKeywordForThisState = true;
-                        }
-                        // Defer to Phase B.  Skip when
-                        // findPartialKeywordInWildcard resolved
-                        // this state — Phase B adds the correct
-                        // multi-word completionWord explicitly;
-                        // tryPartialStringMatch at the anchor
-                        // can't reproduce it.
-                        if (!partialKeywordForThisState) {
-                            forwardEoiCandidates.push({
-                                kind: "wildcardString",
-                                wildcardStart: savedPendingWildcard.start,
-                                nextPart,
-                                spacingMode: state.spacingMode,
-                            });
-                        }
-                    } else {
-                        const partial = tryPartialStringMatch(
-                            nextPart,
-                            prefix,
-                            state.index,
-                            state.spacingMode,
-                            direction,
-                        );
-                        if (partial !== undefined) {
-                            collectStringCandidate(
-                                state,
-                                partial.consumedLength,
-                                partial.remainingText,
-                                savedPendingWildcard?.valueId !== undefined,
-                            );
-                            if (partial.couldBackUp) {
-                                if (direction === "backward") {
-                                    backwardEmitted = true;
-                                }
-                            }
-                        }
-                    }
-                } else {
+                if (nextPart.type === "string" && !deferredToEoi) {
+                    tryCollectStringCompletion(
+                        state,
+                        nextPart,
+                        savedPendingWildcard?.valueId !== undefined,
+                    );
+                } else if (nextPart.type !== "string") {
                     debugCompletion(
                         `No completion for ${nextPart.type} part (handled by Category 3a or matchState expansion)`,
                     );
@@ -1084,31 +1004,106 @@ export function matchGrammarCompletion(
                     currentPart !== undefined &&
                     currentPart.type === "string"
                 ) {
-                    const partial = tryPartialStringMatch(
-                        currentPart,
-                        prefix,
-                        state.index,
-                        state.spacingMode,
-                        direction,
-                    );
-                    if (partial !== undefined) {
-                        collectStringCandidate(
-                            state,
-                            partial.consumedLength,
-                            partial.remainingText,
-                        );
-                        if (partial.couldBackUp) {
-                            if (direction === "backward") {
-                                backwardEmitted = true;
-                            }
-                        }
-                    }
+                    tryCollectStringCompletion(state, currentPart);
                 }
             }
         }
     }
 
-    // --- Phase B: Convert candidates to final completions/properties ---
+    // --- Phase B1: Resolve partial keyword anchors ---
+    //
+    // wildcardEoiDescriptors contains all wildcard-at-EOI string
+    // states from both directions.  findPartialKeywordInWildcard
+    // is called here (not in Phase A) so that the scan is decoupled
+    // from candidate discovery.
+    //
+    // For each descriptor, B1 either:
+    //   - Finds a partial keyword → records the best anchor for
+    //     forward (forwardPartialKeyword), or collects a fixed
+    //     candidate for backward.
+    //   - Does not find a partial keyword → defers to Phase B2 via
+    //     forwardEoiCandidates (forward) or rangeCandidates
+    //     (backward).
+
+    // Forward partial keyword: see ForwardPartialKeywordCandidate.
+    let forwardPartialKeyword: ForwardPartialKeywordCandidate | undefined;
+    // Forward EOI candidates: wildcard-at-EOI string states where
+    // B1 did NOT find a partial keyword.  B2 instantiates them at
+    // the appropriate anchor:
+    //   - partial keyword position (if one exists from other states)
+    //   - prefix.length (otherwise)
+    // Only "wildcardString" items are added/consumed; the broader
+    // RangeCandidate type is kept for structural uniformity with
+    // rangeCandidates.
+    const forwardEoiCandidates: RangeCandidate[] = [];
+
+    for (const desc of wildcardEoiDescriptors) {
+        const partialResult = findPartialKeywordInWildcard(
+            prefix,
+            desc.wildcardStart,
+            desc.nextPart,
+            desc.spacingMode,
+        );
+        if (direction === "backward") {
+            if (
+                partialResult !== undefined &&
+                partialResult.position < prefix.length
+            ) {
+                // Partial keyword found strictly inside the prefix.
+                // Collect as a fixed candidate (may advance
+                // maxPrefixLength, clearing weaker fallback
+                // candidates from Phase A).
+                updateMaxPrefixLength(partialResult.position);
+                if (partialResult.position === maxPrefixLength) {
+                    fixedCandidates.push({
+                        kind: "string",
+                        completionText: partialResult.completionWord,
+                        spacingMode: desc.spacingMode,
+                        openWildcard: true,
+                        partialKeywordBackup: true,
+                    });
+                }
+                backwardEmitted = true;
+            } else {
+                // No useful partial keyword — create range
+                // candidate for Phase B2.
+                rangeCandidates.push({
+                    kind: "wildcardString",
+                    wildcardStart: desc.wildcardStart,
+                    nextPart: desc.nextPart,
+                    spacingMode: desc.spacingMode,
+                });
+            }
+        } else {
+            // Forward direction.
+            if (partialResult !== undefined) {
+                // Partial keyword found — update best anchor.
+                // Don't push to forwardEoiCandidates:
+                // tryPartialStringMatch at the anchor can't
+                // reproduce multi-word keyword results.
+                if (
+                    forwardPartialKeyword === undefined ||
+                    partialResult.position > forwardPartialKeyword.position
+                ) {
+                    forwardPartialKeyword = {
+                        position: partialResult.position,
+                        completionWord: partialResult.completionWord,
+                        spacingMode: desc.spacingMode,
+                    };
+                }
+            } else {
+                // No partial keyword — defer to Phase B2.
+                forwardEoiCandidates.push({
+                    kind: "wildcardString",
+                    wildcardStart: desc.wildcardStart,
+                    nextPart: desc.nextPart,
+                    spacingMode: desc.spacingMode,
+                });
+            }
+        }
+    }
+
+    // --- Phase B2: Convert candidates to final completions/properties ---
     //
     // Fixed candidates are converted directly — they are already
     // guaranteed to be at maxPrefixLength (candidates at shorter
@@ -1276,15 +1271,16 @@ export function matchGrammarCompletion(
     // Forward EOI candidate instantiation and partial keyword recovery.
     //
     // Category 2 wildcard-at-EOI string candidates are deferred
-    // during Phase A (forwardEoiCandidates).  The wildcard boundary
-    // is ambiguous, so Phase A never pushes maxPrefixLength for
-    // them; Phase B decides the final anchor.
+    // during Phase A (via wildcardEoiDescriptors) and resolved by
+    // Phase B1 into forwardPartialKeyword / forwardEoiCandidates.
+    // The wildcard boundary is ambiguous, so Phase A never pushes
+    // maxPrefixLength for them; Phase B1/B2 decides the final anchor.
     //
-    // Phase B operates in one of three modes:
+    // Phase B2 operates in one of three modes:
     //
     //   Clear + anchor at partial keyword position P:
-    //     findPartialKeywordInWildcard found a partial keyword at
-    //     P < prefix.length.  Reset everything and anchor there.
+    //     Phase B1 found a partial keyword at P < prefix.length.
+    //     Reset everything and anchor there.
     //
     //   Clear + anchor at prefix.length (displace):
     //     maxPrefixLength < prefix.length means only weaker

--- a/ts/packages/actionGrammar/src/grammarCompletion.ts
+++ b/ts/packages/actionGrammar/src/grammarCompletion.ts
@@ -692,7 +692,8 @@ export function matchGrammarCompletion(
     // literal string completion candidate.  Updates maxPrefixLength;
     // skips if position is below max.  Used by Category 2 forward,
     // Category 3b, and backward candidate collection.  Returns true
-    // if a candidate was collected.
+    // if a partial match was found (the candidate may still be
+    // discarded by the maxPrefixLength filter).
     function tryCollectStringCandidate(
         state: MatchState,
         part: StringPart,
@@ -1026,10 +1027,10 @@ export function matchGrammarCompletion(
     // the appropriate anchor:
     //   - partial keyword position (if one exists from other states)
     //   - prefix.length (otherwise)
-    // Only "wildcardString" items are added/consumed; the broader
-    // RangeCandidate type is kept for structural uniformity with
-    // rangeCandidates.
-    const forwardEoiCandidates: RangeCandidate[] = [];
+    const forwardEoiCandidates: Extract<
+        RangeCandidate,
+        { kind: "wildcardString" }
+    >[] = [];
 
     for (const desc of wildcardEoiDescriptors) {
         const partialResult = findPartialKeywordInWildcard(
@@ -1041,6 +1042,9 @@ export function matchGrammarCompletion(
         if (direction === "backward") {
             if (
                 partialResult !== undefined &&
+                // Equivalent to the old `< state.index`: deferredToEoi
+                // guarantees state.index >= prefix.length, and
+                // state.index never exceeds prefix.length.
                 partialResult.position < prefix.length
             ) {
                 // Partial keyword found strictly inside the prefix.
@@ -1349,7 +1353,6 @@ export function matchGrammarCompletion(
 
         // Instantiate deferred EOI candidates at the anchor.
         for (const c of forwardEoiCandidates) {
-            if (c.kind !== "wildcardString") continue;
             if (anchor <= c.wildcardStart) continue;
             if (
                 getWildcardStr(

--- a/ts/packages/actionGrammar/src/grammarCompletion.ts
+++ b/ts/packages/actionGrammar/src/grammarCompletion.ts
@@ -167,11 +167,13 @@ function matchKeywordWordsFrom(
 // the partial keyword starts (i.e. the first non-separator character after
 // the last separator), or undefined if no partial keyword is found.
 //
-// Used in both directions:
-//   - Forward Category 2: determines the Phase B anchor position for
-//     deferred wildcard-at-EOI candidates (see forwardPartialKeyword).
-//   - Backward Category 2: offers the keyword at the partial keyword
-//     position instead of backing up to the wildcard start.
+// Used in both directions (called from Phase B1, not inline in
+// Phase A):
+//   - Forward: determines the Phase B1 anchor position for deferred
+//     wildcard-at-EOI candidates (see forwardPartialKeyword).
+//   - Backward: collects a fixed candidate at the partial keyword
+//     position, which may advance maxPrefixLength and clear weaker
+//     fallback candidates from Phase A.
 //
 // Handles both single-word and multi-word keyword parts.  For a keyword
 // like ["played", "by"], the function recognizes:
@@ -686,53 +688,42 @@ export function matchGrammarCompletion(
         });
     }
 
-    // Helper: collect a literal string completion candidate at a
-    // given prefix position.  Updates maxPrefixLength; skips if
-    // position is below max.  Converted in Phase B.
-    function collectStringCandidate(
-        state: MatchState,
-        candidatePrefixLength: number,
-        completionText: string,
-        candidateOpenWildcard: boolean = false,
-        candidatePartialKeywordBackup: boolean = false,
-    ): void {
-        updateMaxPrefixLength(candidatePrefixLength);
-        if (candidatePrefixLength !== maxPrefixLength) return;
-        fixedCandidates.push({
-            kind: "string",
-            completionText,
-            spacingMode: state.spacingMode,
-            openWildcard: candidateOpenWildcard,
-            partialKeywordBackup: candidatePartialKeywordBackup,
-        });
-    }
-
     // Helper: try partial string match and collect the result as a
-    // string candidate.  Used by Category 2 forward and Category 3b.
-    // Returns true if a candidate was collected.
-    function tryCollectStringCompletion(
+    // literal string completion candidate.  Updates maxPrefixLength;
+    // skips if position is below max.  Used by Category 2 forward,
+    // Category 3b, and backward candidate collection.  Returns true
+    // if a candidate was collected.
+    function tryCollectStringCandidate(
         state: MatchState,
         part: StringPart,
-        candidateOpenWildcard: boolean = false,
-    ): void {
+        candidateOpenWildcard: boolean,
+        startIndex: number,
+        dir: "forward" | "backward" | undefined,
+    ): boolean {
         const partial = tryPartialStringMatch(
             part,
             prefix,
-            state.index,
+            startIndex,
             state.spacingMode,
-            direction,
+            dir,
         );
         if (partial !== undefined) {
-            collectStringCandidate(
-                state,
-                partial.consumedLength,
-                partial.remainingText,
-                candidateOpenWildcard,
-            );
-            if (partial.couldBackUp && direction === "backward") {
+            updateMaxPrefixLength(partial.consumedLength);
+            if (partial.consumedLength === maxPrefixLength) {
+                fixedCandidates.push({
+                    kind: "string",
+                    completionText: partial.remainingText,
+                    spacingMode: state.spacingMode,
+                    openWildcard: candidateOpenWildcard,
+                    partialKeywordBackup: false,
+                });
+            }
+            if (partial.couldBackUp && dir === "backward") {
                 backwardEmitted = true;
             }
+            return true;
         }
+        return false;
     }
 
     // Helper: backward completion — back up to the last matched item
@@ -765,20 +756,15 @@ export function matchGrammarCompletion(
         } else if (state.lastMatchedPartInfo !== undefined) {
             const info = state.lastMatchedPartInfo;
             if (info.type === "string") {
-                const backResult = tryPartialStringMatch(
-                    info.part,
-                    prefix,
-                    info.start,
-                    state.spacingMode,
-                    "backward",
-                );
-                if (backResult !== undefined) {
-                    collectStringCandidate(
+                if (
+                    tryCollectStringCandidate(
                         state,
-                        backResult.consumedLength,
-                        backResult.remainingText,
+                        info.part,
                         info.afterWildcard,
-                    );
+                        info.start,
+                        "backward",
+                    )
+                ) {
                     return true;
                 } else {
                     updateMaxPrefixLength(state.index);
@@ -924,10 +910,12 @@ export function matchGrammarCompletion(
                     `Completing ${nextPart.type} part ${state.name}`,
                 );
                 if (nextPart.type === "string" && !deferredToEoi) {
-                    tryCollectStringCompletion(
+                    tryCollectStringCandidate(
                         state,
                         nextPart,
                         savedPendingWildcard?.valueId !== undefined,
+                        state.index,
+                        direction,
                     );
                 } else if (nextPart.type !== "string") {
                     debugCompletion(
@@ -1004,7 +992,13 @@ export function matchGrammarCompletion(
                     currentPart !== undefined &&
                     currentPart.type === "string"
                 ) {
-                    tryCollectStringCompletion(state, currentPart);
+                    tryCollectStringCandidate(
+                        state,
+                        currentPart,
+                        false,
+                        state.index,
+                        direction,
+                    );
                 }
             }
         }


### PR DESCRIPTION
## Summary

Refactors `matchGrammarCompletion` in `grammarCompletion.ts` to improve readability and maintainability. All 2101 tests pass with no behavior changes.

### Changes

**Commit 1 — Phase B1/B2 extraction:**
- Introduces `WildcardEoiDescriptor` type to defer wildcard-at-EOI states from Phase A to a new Phase B1.
- Phase B1 runs `findPartialKeywordInWildcard` on all deferred descriptors in one loop (previously duplicated inline in forward and backward branches).
- Phase B2 materializes surviving candidates into final completions/properties.
- Removes ~100 lines from the main loop by consolidating the `findPartialKeywordInWildcard` logic.

**Commit 2 — `tryCollectStringCandidate` helper:**
- Merges `collectStringCandidate` + inline `tryPartialStringMatch` calls into a single `tryCollectStringCandidate` helper that handles partial matching, candidate collection, and `backwardEmitted` tracking.
- Updates docs/architecture/actionGrammar.md to reflect Phase B1/B2 terminology.

**Commit 3 — Polish:**
- Fix `tryCollectStringCandidate` comment: returns true when a partial match is found, not when a candidate is collected.
- Narrow `forwardEoiCandidates` type to `Extract<RangeCandidate, { kind: "wildcardString" }>[]`, removing the runtime kind guard.
- Add inline note explaining Phase B1 backward condition equivalence (`< prefix.length` vs old `< state.index`).

### Testing

All 2101 unit tests pass. No new tests needed (behavior-preserving refactor).