### PR TITLE
Refactor matchGrammarCompletion: extract phases and category handlers

### DIFF
--- a/ts/packages/actionGrammar/src/grammarCompletion.ts
+++ b/ts/packages/actionGrammar/src/grammarCompletion.ts
@@ -639,21 +639,6 @@ type CompletionContext = {
     wildcardEoiDescriptors: WildcardEoiDescriptor[];
 };
 
-function createCompletionContext(
-    prefix: string,
-    minPrefixLength: number | undefined,
-    direction: "forward" | "backward" | undefined,
-): CompletionContext {
-    return {
-        prefix,
-        direction,
-        maxPrefixLength: minPrefixLength ?? 0,
-        fixedCandidates: [],
-        rangeCandidates: [],
-        wildcardEoiDescriptors: [],
-    };
-}
-
 // Update maxPrefixLength.  When it increases, all previously
 // accumulated fixed-point candidates from shorter matches are
 // irrelevant — clear them.
@@ -1035,8 +1020,20 @@ function processDirtyPartial(
 //    couldn't be finalized, or trailing text didn't match any part.
 //
 // See matchGrammarCompletion JSDoc for full category descriptions.
-function collectCandidates(ctx: CompletionContext, grammar: Grammar): void {
-    const { prefix } = ctx;
+function collectCandidates(
+    grammar: Grammar,
+    prefix: string,
+    minPrefixLength: number | undefined,
+    direction: "forward" | "backward" | undefined,
+): CompletionContext {
+    const ctx: CompletionContext = {
+        prefix,
+        direction,
+        maxPrefixLength: minPrefixLength ?? 0,
+        fixedCandidates: [],
+        rangeCandidates: [],
+        wildcardEoiDescriptors: [],
+    };
 
     // Seed the work-list with one MatchState per top-level grammar rule.
     // matchState may push additional states (for nested rules, optional
@@ -1098,6 +1095,7 @@ function collectCandidates(ctx: CompletionContext, grammar: Grammar): void {
             processDirtyPartial(ctx, state, matched);
         }
     }
+    return ctx;
 }
 
 // --- Phase B1: Resolve partial keyword anchors ---
@@ -1567,12 +1565,14 @@ export function matchGrammarCompletion(
         `Start completion for prefix ${direction ?? "forward"}: "${prefix}"`,
     );
 
-    const ctx = createCompletionContext(prefix, minPrefixLength, direction);
-
-    collectCandidates(ctx, grammar); // Phase A
+    // Phase A
+    const ctx = collectCandidates(grammar, prefix, minPrefixLength, direction);
+    // Phase B1
     const { forwardPartialKeyword, forwardEoiCandidates } =
-        resolveWildcardAnchors(ctx); // Phase B1
-    const result = materializeCandidates( // Phase B2
+        resolveWildcardAnchors(ctx);
+
+    // Phase B2
+    const result = materializeCandidates(
         ctx,
         forwardPartialKeyword,
         forwardEoiCandidates,


### PR DESCRIPTION
## Summary

Refactor the ~870-line `matchGrammarCompletion` function in `grammarCompletion.ts` into standalone module-scope functions, eliminating all closure variables.

## Changes

- **`CompletionContext`** — plain object holding mutable state shared across phases (prefix, direction, maxPrefixLength, candidates).
- **`createCompletionContext()`** — factory function.
- **`updateMaxPrefixLength()`** — advances max and clears stale candidates.
- **`collectPropertyCandidate()`** — collects property completion candidates.
- **`tryCollectStringCandidate()`** — partial string match + candidate collect.
- **`tryCollectBackwardCandidate()`** — backward backup to last matched item.
- **`collectCandidates()`** (Phase A) — main loop over grammar states, dispatches to category handlers.
- **`processExactMatch()`** — Category 1: backs up to last matched term.
- **`processCleanPartial()`** — Category 2: defers EOI descriptors, collects forward/backward candidates.
- **`processDirtyPartial()`** — Category 3: handles unfinalizable wildcards (3a) and trailing text (3b).
- **`resolveWildcardAnchors()`** (Phase B1) — resolves wildcard-at-EOI partial keyword anchors.
- **`materializeCandidates()`** (Phase B2) — converts candidates into final completions[], properties[], and metadata.
- **`matchGrammarCompletion()`** — thin orchestrator calling the above.

## Verification

- Public API and behavior unchanged
- All 431 completion tests pass (6 test suites)
- Build succeeds with no errors
- Single file changed: `packages/actionGrammar/src/grammarCompletion.ts`