### PR TITLE
Consolidate directionSensitive docs between completion.md and actionGrammar.md

### DIFF
--- a/ts/docs/architecture/actionGrammar.md
+++ b/ts/docs/architecture/actionGrammar.md
@@ -817,13 +817,6 @@ already covers this case.
   titles, contact names). When the grammar offers only keyword completions
   (no wildcards), `properties` is empty.
 
-  `properties` is a grammar-matcher concept. At the dispatcher layer,
-  `properties` entries have been consumed via `getActionCompletion()`
-  and `closedSet` is determined by `computeClosedSet()` independently —
-  so the grammar-matcher invariant `closedSet=false ↔ properties non-empty`
-  does not hold at the dispatcher level (e.g., free-form text has
-  `closedSet=false` with no `properties`).
-
 - `separatorMode` — determined by the grammar rule's `[spacing=...]`
   annotation (see [Spacing modes](#spacing-modes) above). Special cases:
   - When `matchedPrefixLength=0` (nothing consumed), `separatorMode` is
@@ -842,11 +835,11 @@ already covers this case.
   (no entity/wildcard values).
 - `directionSensitive` — `true` when `completion(input[0..P], backward)`
   would differ from `completion(input[0..P], forward)`, where P =
-  `matchedPrefixLength`. See "Why direction matters" and "When
-  direction does _not_ matter" above. True whenever something was
-  matched beyond the caller's floor (`P > minPrefixLength`) or the
-  wildcard boundary is ambiguous (`openWildcard`). False only when
-  nothing was matched.
+  `matchedPrefixLength`. True whenever `P > 0` (something was matched
+  that backward can back up to). False only when nothing was matched
+  (`P = 0`). See "Why direction matters", "Forward/backward equivalence
+  analysis", and the decision tree earlier in this document for the
+  full rationale.
 - `openWildcard` is `true` when the matched position sits at an ambiguous
   wildcard boundary — see `completion.md` [`openWildcard`] for the full
   definition (definite vs. ambiguous positions, persistence semantics,

--- a/ts/docs/architecture/completion.md
+++ b/ts/docs/architecture/completion.md
@@ -542,64 +542,25 @@ direction if this flag is `true`." When it is `false`, the shell skips
 the re-fetch entirely (trigger A4 does not fire), reusing the cached
 result regardless of whether the user is now typing or backspacing.
 
-**The rule:** The grammar matcher sets `directionSensitive=true`
-whenever backward completion has something to reconsider — i.e., a
-word, keyword, wildcard, or number was fully matched (the position is
-always uncommitted because trailing separators are not consumed).
-Forward offers what comes _next_; backward
-backs up to re-offer the last thing the user passed. If those two
-results differ, `directionSensitive=true`.
+The grammar matcher determines `directionSensitive` based on the
+matched prefix position — see `actionGrammar.md` § "Forward/backward
+equivalence analysis" for the decision tree, position-by-position
+analysis, and the Option A/B design trade-off.
 
-This arises at three kinds of structural ambiguity: wildcard-keyword
-boundary forks, multi-word keyword boundaries, and alternation-prefix
-overlaps. See `actionGrammar.md` "Why direction matters" for detailed
-examples and the Option A/B design trade-off.
+**Examples:** The table below shows `directionSensitive` across layers.
+The interesting cases are where `false` appears despite a non-zero
+`startIndex` — the position is unambiguous so direction doesn't matter.
 
-**When `directionSensitive=false`:** Nothing was fully matched
-(partial/dirty) — P = 0.
+| Layer      | Input               | `directionSensitive` | Why                                                                                      |
+| ---------- | ------------------- | -------------------- | ---------------------------------------------------------------------------------------- |
+| Dispatcher | `@player --level`   | `true`               | Flag exactly matched; backward re-offers flag alternatives (case 2a-ii)                  |
+| Dispatcher | `@player --level `  | `false`              | Trailing space commits the flag; position unambiguous (case 2b)                          |
+| Dispatcher | `@player --level 5` | `false`              | Editing free-form value; trailing whitespace determines state, not direction (case 2a-i) |
+| Dispatcher | `@play`             | `true`               | `play` matches subcommand but `player` also exists; backward reconsiders                 |
 
-The flag is correct under the cross-query invariant definition:
-`directionSensitive=true` if and only if
-`completion(input[0..P], "backward")` differs from the forward result.
-For `openWildcard` positions, truncating to `input[0..P]` removes the
-content that established the anchor, so backward on the truncated input
-always diverges — even when both directions happen to agree on the
-original (longer) input. See invariant #7.
-
-`minPrefixLength` is not consulted: it is a caller-supplied lower
-bound for the search, not a property of the result.
-
-**Decision tree** (evaluated once after all candidates are collected):
-
-```
-P = 0      → false (nothing matched; backward has nothing to reconsider)
-P > 0      → true  (something was matched — backward can back up)
-```
-
-See the "Forward/backward equivalence analysis" section in
-`actionGrammar.md` for the full position-by-position analysis.
-
-**Examples:** The table below shows `directionSensitive` for various
-inputs. The general pattern: `true` when anything was matched beyond
-the floor; `false` only when partial/dirty or exact match with no
-remaining completions.
-
-| Rule                   | Input          | `directionSensitive` | Why                                                           |
-| ---------------------- | -------------- | -------------------- | ------------------------------------------------------------- |
-| `play <song> by <a>`   | `play`         | `true`               | `"play"` fully matched, backward can reconsider               |
-| `play <song> by <a>`   | `play `        | `true`               | Trailing space not consumed; P stays at `"play"` boundary     |
-| `play <song> by <a>`   | `play Never`   | `true`               | `"Never"` in wildcard, keyword `"by"` next; no trailing space |
-| `play <song> by <a>`   | `play Never b` | `true`               | `openWildcard=true` — wildcard boundary ambiguous             |
-| `play <song> by <a>`   | `pla`          | `false`              | Only partial match (Category 3b) — nothing to back up to      |
-| `play music`           | `play`         | `true`               | `"play"` fully matched, no trailing space                     |
-| `play music`           | `play `        | `true`               | Trailing space not consumed; P stays at `"play"` boundary     |
-| `play music`           | `play music `  | `true`               | Cat 1 strips trailing space; P=4, completions=["music"]       |
-| `(play \| player) now` | `play`         | `true`               | Backward: `["play","player"]` at mpl=0; forward: `["now"]`    |
-| `(play \| player) now` | `play `        | `true`               | Trailing space not consumed; P stays at `"play"` boundary     |
-
-The dispatcher may additionally set `directionSensitive=true` at the
-command level — for example, when a subcommand name is both a valid
-complete command and a prefix of a longer one.
+For grammar-level examples (the `P = 0 → false`, `P > 0 → true` rule,
+equivalence analysis tables, and the Option A/B design trade-off), see
+`actionGrammar.md` § "Forward/backward equivalence analysis".
 
 Merge rule: OR across sources (sensitive if _any_ source is sensitive).
 
@@ -749,11 +710,17 @@ Automatically checked by the `withInvariantChecks` wrapper in
 _Impact:_ Completions inserted at wrong position in the input.
 
 **#2 — `closedSet` ↔ `properties` consistency** (grammar matcher layer
-only — see `actionGrammar.md` [properties](#metadata-produced) for scope).
+only).
 `closedSet=false` ↔ `properties` is non-empty.
 _Impact:_ False `true` → shell uses "accept" policy and never re-fetches —
 user misses entity completions. False `false` → unnecessary re-fetches
 (perf cost, no visible bug).
+_Scope:_ This invariant applies only at the grammar matcher layer.
+At the dispatcher layer, `properties` entries have been consumed via
+`getActionCompletion()` and `closedSet` is determined by
+`computeClosedSet()` independently — so the grammar-matcher biconditional
+does not hold (e.g., free-form text has `closedSet=false` with no
+`properties`).
 
 **#3 — Truncated-forward idempotency.**
 When `matchedPrefixLength < prefix.length`:

--- a/ts/packages/actionGrammar/src/grammarCompletion.ts
+++ b/ts/packages/actionGrammar/src/grammarCompletion.ts
@@ -295,8 +295,16 @@ export type GrammarCompletionResult = {
     // completion(input[0..P], "forward"), where P = matchedPrefixLength.
     // When false, the caller can skip re-fetching on direction change.
     //
-    // True whenever P > 0 — something was matched.  False only when
-    // nothing was matched (P = 0).
+    // In this implementation, computed as `P > 0`.  P is always
+    // placed at a part or sub-part (word) boundary by
+    // updateMaxPrefixLength, so P > 0 guarantees a preceding
+    // part exists for backward to back up to.
+    // Re-invoking at input[0..P]:
+    //   - Forward: re-matches up to P, stays at or near P.
+    //   - Backward: backs up to the preceding part, producing
+    //     matchedPrefixLength < P.
+    // When P = 0 no part boundary was crossed and both
+    // directions are identical.
     directionSensitive: boolean;
     // True when the completion's `matchedPrefixLength` position is
     // *ambiguous* — it could shift forward as the user types more.
@@ -449,9 +457,10 @@ function tryPartialStringMatch(
  * one of three categories:
  *
  * 1. **Exact match** — the prefix satisfies every part in the rule.
- *    No completion is needed, but `maxPrefixLength` is updated to
- *    the full input length so that completion candidates from shorter
- *    partial matches are eagerly discarded (via `updateMaxPrefixLength`).
+ *    The function backs up to the last matched term (keyword, wildcard,
+ *    or number) and offers it as a completion — `maxPrefixLength` is set
+ *    to the backed-up position so that candidates from shorter partial
+ *    matches are eagerly discarded (via `updateMaxPrefixLength`).
  *
  * 2. **Partial match, finalized** — the prefix was consumed (possibly with
  *    trailing separators) but the rule still has remaining parts.
@@ -781,8 +790,12 @@ function tryCollectBackwardCandidate(
 // --- Category 1: Exact match ---
 // All parts matched AND prefix was fully consumed.
 // Back up to the last matched term (string keyword,
-// number, or wildcard).  Both directions get the same
-// result — no direction-specific handling needed.
+// number, or wildcard).  The processing is direction-
+// agnostic — this function always backs up, producing
+// the same candidate regardless of ctx.direction.
+// (The caller re-invoking at input[0..P] will see
+// different results for forward vs backward, but that
+// difference is handled by the re-invocation, not here.)
 function processExactMatch(
     ctx: CompletionContext,
     state: MatchState,
@@ -794,8 +807,10 @@ function processExactMatch(
         state.lastMatchedPartInfo !== undefined ||
         savedPendingWildcard?.valueId !== undefined
     ) {
-        // Category 1 is direction-agnostic — both
-        // directions back up identically.
+        // Category 1 processing is direction-agnostic:
+        // always back up to the last matched term.
+        // (Forward vs backward divergence occurs when
+        // the caller re-invokes at input[0..P].)
         // Ignore trailing separators: in an exact
         // match, trailing whitespace/punctuation
         // carries no structural meaning — all parts
@@ -853,9 +868,11 @@ function processCleanPartial(
         });
     }
 
-    // Would backward produce different results than forward?
-    // True when the prefix was fully consumed and there is a
-    // matched part (string/number) or wildcard to back up to.
+    // Does this state have a matched part that backward could
+    // reconsider?  True when the prefix was fully consumed and
+    // there is a matched part (string/number) or wildcard to
+    // back up to.  (Per-state condition, not the final output
+    // directionSensitive — that is computed after all states.)
     const hasPartToReconsider =
         state.index >= prefix.length &&
         (savedPendingWildcard?.valueId !== undefined ||
@@ -1533,15 +1550,10 @@ function materializeCandidates(
         }
     }
 
-    // Compute directionSensitive.
-    //
-    // True whenever P > 0 — something was matched and backward at
-    // input[0..P] can reconsider it.  minPrefixLength is not
-    // consulted: it is a caller-supplied lower bound for the search,
-    // not a property of the result.  Category 1 exact matches with
-    // trailing separators are handled by stripping the trailing text
-    // before backing up, so the backup always succeeds and P lands
-    // at the backed-up keyword position (not at prefix.length).
+    // See the directionSensitive field comment on
+    // GrammarCompletionResult for why P > 0 is correct.
+    // minPrefixLength (caller-supplied search lower bound) is
+    // not consulted — it constrains the search, not the result.
     const directionSensitive = ctx.maxPrefixLength > 0;
 
     return {


### PR DESCRIPTION
- Move grammar implementation detail (decision tree, P>0 rule) from completion.md to actionGrammar.md; completion.md now cross-references
- Fix actionGrammar.md metadata bullet: P>minPrefixLength → P>0
- Replace grammar-only examples in completion.md with dispatcher examples that illustrate cross-layer nuance (trailing space, free-form values)
- Move properties dispatcher caveat to completion.md invariant #2
- Update grammarCompletion.ts comment to clarify P>0 is an implementation choice