### PR TITLE
Add fluidBuild incremental configs for agc and asc tasks

### DIFF
--- a/ts/packages/agents/browser/package.json
+++ b/ts/packages/agents/browser/package.json
@@ -146,6 +146,32 @@
   },
   "fluidBuild": {
     "tasks": {
+      "agc": {
+        "dependsOn": [
+          "action-grammar-compiler#tsc"
+        ],
+        "files": {
+          "inputGlobs": [
+            "src/agent/browserSchema.agr"
+          ],
+          "outputGlobs": [
+            "dist/agent/browserSchema.ag.json"
+          ]
+        }
+      },
+      "asc": {
+        "dependsOn": [
+          "@typeagent/action-schema-compiler#tsc"
+        ],
+        "files": {
+          "inputGlobs": [
+            "src/agent/browserActionSchema.mts"
+          ],
+          "outputGlobs": [
+            "dist/agent/browserSchema.pas.json"
+          ]
+        }
+      },
       "build": {
         "dependsOn": [
           "^build",

--- a/ts/packages/agents/calendar/package.json
+++ b/ts/packages/agents/calendar/package.json
@@ -41,5 +41,35 @@
     "prettier": "^3.5.3",
     "rimraf": "^6.0.1",
     "typescript": "~5.4.5"
+  },
+  "fluidBuild": {
+    "tasks": {
+      "agc": {
+        "dependsOn": [
+          "action-grammar-compiler#tsc"
+        ],
+        "files": {
+          "inputGlobs": [
+            "src/calendarSchema.agr"
+          ],
+          "outputGlobs": [
+            "dist/calendarSchema.ag.json"
+          ]
+        }
+      },
+      "asc": {
+        "dependsOn": [
+          "@typeagent/action-schema-compiler#tsc"
+        ],
+        "files": {
+          "inputGlobs": [
+            "src/calendarActionsSchemaV3.ts"
+          ],
+          "outputGlobs": [
+            "dist/calendarSchema.pas.json"
+          ]
+        }
+      }
+    }
   }
 }

--- a/ts/packages/agents/code/package.json
+++ b/ts/packages/agents/code/package.json
@@ -49,5 +49,100 @@
     "prettier": "^3.5.3",
     "rimraf": "^6.0.1",
     "typescript": "~5.4.5"
+  },
+  "fluidBuild": {
+    "tasks": {
+      "asc": {
+        "dependsOn": [
+          "@typeagent/action-schema-compiler#tsc"
+        ],
+        "files": {
+          "inputGlobs": [
+            "src/codeActionsSchema.ts"
+          ],
+          "outputGlobs": [
+            "dist/codeSchema.pas.json"
+          ]
+        }
+      },
+      "asc:debug": {
+        "dependsOn": [
+          "@typeagent/action-schema-compiler#tsc"
+        ],
+        "files": {
+          "inputGlobs": [
+            "src/vscode/debugActionsSchema.ts"
+          ],
+          "outputGlobs": [
+            "dist/debugSchema.pas.json"
+          ]
+        }
+      },
+      "asc:display": {
+        "dependsOn": [
+          "@typeagent/action-schema-compiler#tsc"
+        ],
+        "files": {
+          "inputGlobs": [
+            "src/vscode/displayActionsSchema.ts"
+          ],
+          "outputGlobs": [
+            "dist/displaySchema.pas.json"
+          ]
+        }
+      },
+      "asc:editor": {
+        "dependsOn": [
+          "@typeagent/action-schema-compiler#tsc"
+        ],
+        "files": {
+          "inputGlobs": [
+            "src/vscode/editorCodeActionsSchema.ts"
+          ],
+          "outputGlobs": [
+            "dist/editorSchema.pas.json"
+          ]
+        }
+      },
+      "asc:extension": {
+        "dependsOn": [
+          "@typeagent/action-schema-compiler#tsc"
+        ],
+        "files": {
+          "inputGlobs": [
+            "src/vscode/extensionsActionsSchema.ts"
+          ],
+          "outputGlobs": [
+            "dist/extensionSchema.pas.json"
+          ]
+        }
+      },
+      "asc:general": {
+        "dependsOn": [
+          "@typeagent/action-schema-compiler#tsc"
+        ],
+        "files": {
+          "inputGlobs": [
+            "src/vscode/generalActionsSchema.ts"
+          ],
+          "outputGlobs": [
+            "dist/generalSchema.pas.json"
+          ]
+        }
+      },
+      "asc:workbench": {
+        "dependsOn": [
+          "@typeagent/action-schema-compiler#tsc"
+        ],
+        "files": {
+          "inputGlobs": [
+            "src/vscode/workbenchCommandActionsSchema.ts"
+          ],
+          "outputGlobs": [
+            "dist/workbenchSchema.pas.json"
+          ]
+        }
+      }
+    }
   }
 }

--- a/ts/packages/agents/email/package.json
+++ b/ts/packages/agents/email/package.json
@@ -41,5 +41,22 @@
     "prettier": "^3.5.3",
     "rimraf": "^6.0.1",
     "typescript": "~5.4.5"
+  },
+  "fluidBuild": {
+    "tasks": {
+      "asc": {
+        "dependsOn": [
+          "@typeagent/action-schema-compiler#tsc"
+        ],
+        "files": {
+          "inputGlobs": [
+            "src/emailActionsSchema.ts"
+          ],
+          "outputGlobs": [
+            "dist/emailSchema.pas.json"
+          ]
+        }
+      }
+    }
   }
 }

--- a/ts/packages/agents/image/package.json
+++ b/ts/packages/agents/image/package.json
@@ -36,5 +36,22 @@
     "prettier": "^3.5.3",
     "rimraf": "^6.0.1",
     "typescript": "~5.4.5"
+  },
+  "fluidBuild": {
+    "tasks": {
+      "asc": {
+        "dependsOn": [
+          "@typeagent/action-schema-compiler#tsc"
+        ],
+        "files": {
+          "inputGlobs": [
+            "src/imageActionSchema.ts"
+          ],
+          "outputGlobs": [
+            "dist/imageSchema.pas.json"
+          ]
+        }
+      }
+    }
   }
 }

--- a/ts/packages/agents/list/package.json
+++ b/ts/packages/agents/list/package.json
@@ -35,5 +35,35 @@
     "prettier": "^3.5.3",
     "rimraf": "^6.0.1",
     "typescript": "~5.4.5"
+  },
+  "fluidBuild": {
+    "tasks": {
+      "agc": {
+        "dependsOn": [
+          "action-grammar-compiler#tsc"
+        ],
+        "files": {
+          "inputGlobs": [
+            "src/listSchema.agr"
+          ],
+          "outputGlobs": [
+            "dist/listSchema.ag.json"
+          ]
+        }
+      },
+      "asc": {
+        "dependsOn": [
+          "@typeagent/action-schema-compiler#tsc"
+        ],
+        "files": {
+          "inputGlobs": [
+            "src/listSchema.ts"
+          ],
+          "outputGlobs": [
+            "dist/listSchema.pas.json"
+          ]
+        }
+      }
+    }
   }
 }

--- a/ts/packages/agents/photo/package.json
+++ b/ts/packages/agents/photo/package.json
@@ -33,5 +33,22 @@
     "prettier": "^3.5.3",
     "rimraf": "^6.0.1",
     "typescript": "~5.4.5"
+  },
+  "fluidBuild": {
+    "tasks": {
+      "asc": {
+        "dependsOn": [
+          "@typeagent/action-schema-compiler#tsc"
+        ],
+        "files": {
+          "inputGlobs": [
+            "src/photoSchema.ts"
+          ],
+          "outputGlobs": [
+            "dist/photoSchema.pas.json"
+          ]
+        }
+      }
+    }
   }
 }

--- a/ts/packages/agents/playerLocal/package.json
+++ b/ts/packages/agents/playerLocal/package.json
@@ -42,5 +42,35 @@
     "jest": "^29.7.0",
     "rimraf": "^6.0.1",
     "typescript": "~5.4.5"
+  },
+  "fluidBuild": {
+    "tasks": {
+      "agc": {
+        "dependsOn": [
+          "action-grammar-compiler#tsc"
+        ],
+        "files": {
+          "inputGlobs": [
+            "src/agent/localPlayerSchema.agr"
+          ],
+          "outputGlobs": [
+            "dist/agent/localPlayerSchema.ag.json"
+          ]
+        }
+      },
+      "asc": {
+        "dependsOn": [
+          "@typeagent/action-schema-compiler#tsc"
+        ],
+        "files": {
+          "inputGlobs": [
+            "src/agent/localPlayerSchema.ts"
+          ],
+          "outputGlobs": [
+            "dist/agent/localPlayerSchema.pas.json"
+          ]
+        }
+      }
+    }
   }
 }

--- a/ts/packages/agents/video/package.json
+++ b/ts/packages/agents/video/package.json
@@ -36,5 +36,22 @@
     "prettier": "^3.5.3",
     "rimraf": "^6.0.1",
     "typescript": "~5.4.5"
+  },
+  "fluidBuild": {
+    "tasks": {
+      "asc": {
+        "dependsOn": [
+          "@typeagent/action-schema-compiler#tsc"
+        ],
+        "files": {
+          "inputGlobs": [
+            "src/videoActionSchema.ts"
+          ],
+          "outputGlobs": [
+            "dist/videoSchema.pas.json"
+          ]
+        }
+      }
+    }
   }
 }

--- a/ts/packages/agents/weather/package.json
+++ b/ts/packages/agents/weather/package.json
@@ -51,6 +51,19 @@
             "dist/weatherSchema.ag.json"
           ]
         }
+      },
+      "asc": {
+        "dependsOn": [
+          "@typeagent/action-schema-compiler#tsc"
+        ],
+        "files": {
+          "inputGlobs": [
+            "src/weatherSchema.ts"
+          ],
+          "outputGlobs": [
+            "dist/weatherSchema.pas.json"
+          ]
+        }
       }
     }
   }


### PR DESCRIPTION
Add inputGlobs/outputGlobs to fluidBuild.tasks for agc and asc across agent packages so fluid-build can skip these tasks when inputs are unchanged.

**Packages updated:**
- browser
- calendar
- code
- email
- image
- list
- photo
- playerLocal
- video
- weather