### PR TITLE
Reduce latency on action discovery

### DIFF
--- a/ts/packages/agents/browser/src/agent/discovery/actionHandler.mts
+++ b/ts/packages/agents/browser/src/agent/discovery/actionHandler.mts
@@ -134,9 +134,7 @@ async function handleFindUserActions(
     debugPerf(
         `getCandidateUserActions LLM: ${Date.now() - candidateStart}ms, success=${response.success}`,
     );
-    debugPerf(
-        `handleFindUserActions total: ${Date.now() - totalStart}ms`,
-    );
+    debugPerf(`handleFindUserActions total: ${Date.now() - totalStart}ms`);
 
     if (!response.success) {
         debug("Discovery LLM call failed: %s", response.message);

--- a/ts/packages/agents/browser/src/agent/discovery/translator.mts
+++ b/ts/packages/agents/browser/src/agent/discovery/translator.mts
@@ -305,9 +305,7 @@ export class SchemaDiscoveryAgent<T extends object> {
             (sum, s: any) => sum + (s.text?.length || 0),
             0,
         );
-        debugPerf(
-            `  [getCandidateUserActions] prompt: ${promptChars} chars`,
-        );
+        debugPerf(`  [getCandidateUserActions] prompt: ${promptChars} chars`);
         const llmStart = Date.now();
         const response = await bootstrapTranslator.translate("", [
             {

--- a/ts/packages/cli/src/enhancedConsole.ts
+++ b/ts/packages/cli/src/enhancedConsole.ts
@@ -1278,14 +1278,15 @@ async function questionWithCompletion(
                 // into the normal terminal flow so it appears in scrollback.
                 cleanup();
                 const width = process.stdout.columns || 80;
-                const styledInput = chalk.cyanBright(message) + input;
+                const inputDisplay = `❯ ${input}`;
+                const visibleLen = getDisplayWidth(inputDisplay);
+                const pad = Math.max(0, width - visibleLen);
                 stdout.write(
-                    styledInput +
-                        "\n" +
-                        ANSI.dim +
-                        "─".repeat(width) +
-                        ANSI.reset +
-                        "\n",
+                    "\n" +
+                        chalk.bgGray.white.bold(
+                            inputDisplay + " ".repeat(pad),
+                        ) +
+                        "\n\n",
                 );
                 resolve(input);
             } else if (code === 9) {
@@ -1780,5 +1781,5 @@ function getNextInput(
  * Returns a clean prompt regardless of status text
  */
 export function getEnhancedConsolePrompt(_text: string): string {
-    return `${getVerboseIndicator()}> `;
+    return `${getVerboseIndicator()}❯ `;
 }


### PR DESCRIPTION
- Update prompts to reduce action discovery latency. Removed page summarization call and took discovery from 40 seconds to 10s.
- Fix CLI bug that would overwrite last 3 rows of content near the input section