### PR TITLE
Fix autoShell build with dotnet build

### DIFF
--- a/dotnet/autoShell/UIAutomation.cs
+++ b/dotnet/autoShell/UIAutomation.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading.Tasks;
+using UIAutomationClient = Interop.UIAutomationClient;
 
 namespace autoShell;
 

--- a/dotnet/autoShell/autoShell.csproj
+++ b/dotnet/autoShell/autoShell.csproj
@@ -10,17 +10,7 @@
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
   <ItemGroup>
-    <COMReference Include="UIAutomationClient">
-      <WrapperTool>tlbimp</WrapperTool>
-      <VersionMinor>0</VersionMinor>
-      <VersionMajor>1</VersionMajor>
-      <Guid>944de083-8fb8-45cf-bcb7-c477acb2f897</Guid>
-      <Lcid>0</Lcid>
-      <Isolated>false</Isolated>
-      <EmbedInteropTypes>true</EmbedInteropTypes>
-    </COMReference>
-  </ItemGroup>
-  <ItemGroup>
+    <PackageReference Include="Interop.UIAutomationClient" Version="10.19041.0" />
     <PackageReference Include="Microsoft-WindowsAPICodePack-Core" Version="1.1.5" />
     <PackageReference Include="Microsoft-WindowsAPICodePack-Shell" Version="1.1.5" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />


### PR DESCRIPTION
The autoShell project used a `<COMReference>` for `UIAutomationClient`, which only works with MSBuild. Running `dotnet build` fails with MSB4803.

  **Changes**

   - Replaced `<COMReference>` with the `Interop.UIAutomationClient`
  (https://www.nuget.org/packages/Interop.UIAutomationClient/) NuGet package (v10.19041.0)
   - Added a using alias in `UIAutomation.cs` to map the NuGet namespace

  **Testing**

   - Build passes with `dotnet build` (0 errors)
   - Runtime verified by sending `{"textSize": 100}` — UI Automation COM types resolve correctly