### PR TITLE
Improve exportGrammar: caching, value expression support, and NFA environment fix

### DIFF
--- a/ts/docs/architecture/actionGrammar.md
+++ b/ts/docs/architecture/actionGrammar.md
@@ -908,7 +908,7 @@ type-checked at compile time. Every expression node has a statically-known
 type — there is no `any` escape hatch. This section documents the design
 principles and restrictions.
 
-Enable expressions via `enableExpressions: true` in
+Enable expressions via `enableValueExpressions: true` in
 `LoadGrammarRulesOptions` when your grammar rules need computed values
 (arithmetic, conditionals, method calls) in the `->` position.
 

--- a/ts/extensions/agr-language/sample.agr
+++ b/ts/extensions/agr-language/sample.agr
@@ -173,7 +173,7 @@ export <PublicRule> = hello | goodbye;
         parameters: { items: [item], listName: list }
     };
 
-// ─── Value expressions (enableExpressions mode) ──────────────────────────────
+// ─── Value expressions (enableValueExpressions mode) ─────────────────────────
 
 // Ternary operator
 <Toggle> =

--- a/ts/packages/actionGrammar/src/grammarLoader.ts
+++ b/ts/packages/actionGrammar/src/grammarLoader.ts
@@ -10,7 +10,7 @@ export type LoadGrammarRulesOptions = {
     start?: string; // Optional start symbol (default: "Start")
     startValueRequired?: boolean; // Whether the start rule must produce a value (default: true)
     schemaLoader?: SchemaLoader; // Optional loader for resolving .ts type imports
-    enableExpressions?: boolean; // Enable JavaScript-like value expressions (default: false)
+    enableValueExpressions?: boolean; // Enable JavaScript-like value expressions (default: false)
 };
 
 function parseAndCompileGrammar(
@@ -35,12 +35,12 @@ function parseAndCompileGrammar(
 
     const start = options?.start ?? "Start";
     const startValueRequired = options?.startValueRequired ?? true;
-    const enableExpressions = options?.enableExpressions ?? false;
+    const enableValueExpressions = options?.enableValueExpressions ?? false;
     const parseResult = parseGrammarRules(
         displayPath,
         content,
         undefined,
-        enableExpressions,
+        enableValueExpressions,
     );
     const grammar = compileGrammar(
         displayPath,

--- a/ts/packages/actionGrammar/src/grammarMatcher.ts
+++ b/ts/packages/actionGrammar/src/grammarMatcher.ts
@@ -834,6 +834,20 @@ function matchStringPartWithWildcard(
         }
 
         if (captureWildcard(state, request, wildcardEnd, newIndex, pending)) {
+            // Assign default string value for single-part rules without
+            // an explicit value expression — same logic as the non-wildcard
+            // path in matchStringPartWithoutWildcard.  Without this, a
+            // pending wildcard from a parent rule that leaks into a
+            // single-part child rule would bypass the default value
+            // assignment and cause "No value assign to variable" at
+            // finalizeNestedRule time.
+            if (
+                state.value === undefined &&
+                state.parts.length === 1 &&
+                state.valueIds !== null
+            ) {
+                addValue(state, undefined, part.value.join(" "));
+            }
             state.lastMatchedPartInfo = {
                 type: "string",
                 start: wildcardEnd,

--- a/ts/packages/actionGrammar/src/grammarRuleParser.ts
+++ b/ts/packages/actionGrammar/src/grammarRuleParser.ts
@@ -87,7 +87,7 @@ const debugParse = registerDebug("typeagent:grammar:parse");
  *   <RuleRefExpr> ::= <RuleName>
  *   <GroupExpr> ::= "(" <Rules> ( ")" | ")?" | ")*" | ")+" )
  *
- *   // ── Value (basic mode: enableExpressions=false) ──────────────────────────
+ *   // ── Value (basic mode: enableValueExpressions=false) ──────────────────────────
  *   <Value> = <BooleanValue> | <NumberValue> | <StringValue>
  *           | <ObjectValue> | <ArrayValue> | <VarReference>
  *   <ArrayValue> = "[" (<Value> ("," <Value>)* ","?)? "]"
@@ -102,8 +102,8 @@ const debugParse = registerDebug("typeagent:grammar:parse");
  *   <StringValue> = <StringLiteral>
  *   <VarReference> = <VarName>
  *
- *   // ── Value expressions (enableExpressions=true) ───────────────────────────
- *   // When enableExpressions is true, the <Value> position (after "->")
+ *   // ── Value expressions (enableValueExpressions=true) ───────────────────────────
+ *   // When enableValueExpressions is true, the <Value> position (after "->")
  *   // supports full JavaScript-like expressions with operator precedence.
  *   // In this mode <Value> is replaced by <ValueExpr>.
  *   //
@@ -181,13 +181,13 @@ export function parseGrammarRules(
     /** Whether to track source positions on value nodes (default: true). */
     position?: boolean,
     /** Enable JavaScript-like value expressions in the `->` position (default: false). */
-    enableExpressions: boolean = false,
+    enableValueExpressions: boolean = false,
 ): GrammarParseResult {
     const parser = new GrammarRuleParser(
         fileName,
         content,
         position ?? true,
-        enableExpressions,
+        enableValueExpressions,
     );
     const result = parser.parse();
     debugParse(JSON.stringify(result, undefined, 2));
@@ -430,7 +430,7 @@ class GrammarRuleParser implements ValueExprParserContext {
         private readonly fileName: string,
         readonly content: string,
         private readonly position: boolean = true,
-        private readonly enableExpressions: boolean = false,
+        private readonly enableValueExpressions: boolean = false,
     ) {}
 
     private get pos(): number | undefined {
@@ -905,7 +905,7 @@ class GrammarRuleParser implements ValueExprParserContext {
     }
 
     private parseValue(): ValueNode {
-        if (this.enableExpressions) {
+        if (this.enableValueExpressions) {
             return parseValueExpr(this);
         }
         return this.parseSimpleValue();

--- a/ts/packages/actionGrammar/src/grammarValueExprParser.ts
+++ b/ts/packages/actionGrammar/src/grammarValueExprParser.ts
@@ -130,7 +130,7 @@ export interface ValueExprParserContext {
 
 /**
  * Parse a value expression.
- * Entry point called from GrammarRuleParser.parseValue() when enableExpressions is true.
+ * Entry point called from GrammarRuleParser.parseValue() when enableValueExpressions is true.
  */
 export function parseValueExpr(ctx: ValueExprParserContext): ValueNode {
     return parseTernary(ctx);

--- a/ts/packages/actionGrammar/src/nfaCompiler.ts
+++ b/ts/packages/actionGrammar/src/nfaCompiler.ts
@@ -479,9 +479,11 @@ export function compileGrammarToNFA(grammar: Grammar, name?: string): NFA {
 
         // Create slot map for this rule FIRST (needed to compile value expression)
         const slotMap = createRuleSlotMap(rule);
-        if (slotMap.size > 0) {
-            builder.setStateSlotInfo(ruleEntry, slotMap.size, slotMap);
-        }
+        // Always set slot info for Start rules — even rules with no variables
+        // need an environment so that nested sub-rules (e.g. optional groups
+        // normalized into passthrough wrappers) can correctly pop back to the
+        // Start rule's environment/actionValue on exit.
+        builder.setStateSlotInfo(ruleEntry, slotMap.size, slotMap);
 
         // Create type map for type conversion during evaluation
         const typeMap = createRuleTypeMap(rule);

--- a/ts/packages/actionGrammar/src/nfaInterpreter.ts
+++ b/ts/packages/actionGrammar/src/nfaInterpreter.ts
@@ -306,11 +306,14 @@ function seedQueue(
                     `    Environment slots: ${JSON.stringify(state.environment.slots)}`,
                 );
             }
-            if (state.actionValue && state.environment) {
+            if (state.actionValue) {
+                // Use the existing environment, or create an empty one for
+                // literal-only values that don't reference any variables.
+                const env = state.environment ?? createEnvironment(0);
                 try {
                     evaluatedActionValue = evaluateExpression(
                         state.actionValue,
-                        state.environment,
+                        env,
                     );
                     debugNFA(
                         `  Evaluated actionValue: ${JSON.stringify(evaluatedActionValue)}`,
@@ -788,7 +791,7 @@ function epsilonClosure(
             // This is a rule entry with an action value - use it
             currentActionValue = nfaState.actionValue;
         } else if (nfaState.actionValue !== undefined && !state.environment) {
-            // Legacy: top-level rule entry without environment (backwards compatibility)
+            // Top-level rule entry without environment (backwards compatibility)
             currentActionValue = nfaState.actionValue;
         }
         // Otherwise keep the current actionValue (we're inside the same rule)

--- a/ts/packages/actionGrammar/test/grammarMatcherGroups.spec.ts
+++ b/ts/packages/actionGrammar/test/grammarMatcherGroups.spec.ts
@@ -95,5 +95,64 @@ describeForEachMatcher(
                 ]);
             });
         });
+
+        describe("Wildcard leaking into captured nested rule", () => {
+            it("wildcard sibling does not prevent default value in following captured rule", () => {
+                // Regression: when the wildcard alternative $(wc)->wc in
+                // <Genre> is explored, the pending wildcard leaks into
+                // <Suffix>.  matchStringPartWithWildcard must assign the
+                // default string value for single-part rules (just like the
+                // non-wildcard path) to avoid "No value assign to variable".
+                const g = `
+                    <Start> = $(v0:<Genre>) $(v1:<Suffix>)
+                            -> { genre: v0, suffix: v1 };
+                    <Genre> = rock -> "rock"
+                            | pop -> "pop"
+                            | $(wc) -> wc;
+                    <Suffix> = tunes;
+                `;
+                const grammar = loadGrammarRules("test.grammar", g);
+
+                // Literal genre — may match via both literal and wildcard
+                // paths; verify at least one result is correct.
+                const rockResults = testMatchGrammar(grammar, "rock tunes");
+                expect(rockResults).toContainEqual({
+                    genre: "rock",
+                    suffix: "tunes",
+                });
+
+                // Unknown genre — wildcard path, wc captures "metal",
+                // then <Suffix> must still produce its default value.
+                expect(testMatchGrammar(grammar, "metal tunes")).toStrictEqual([
+                    { genre: "metal", suffix: "tunes" },
+                ]);
+            });
+
+            it("wildcard with preceding literal and trailing captured rule", () => {
+                // Same pattern but with a non-captured literal part before
+                // the wildcard rule, matching the exportGrammar output shape.
+                const g = `
+                    <Start> = play $(v0:<Genre>) $(v1:<Suffix>)
+                            -> { genre: v0, suffix: v1 };
+                    <Genre> = rock -> "rock"
+                            | $(wc) -> wc;
+                    <Suffix> = tunes;
+                `;
+                const grammar = loadGrammarRules("test.grammar", g);
+
+                const rockResults = testMatchGrammar(
+                    grammar,
+                    "play rock tunes",
+                );
+                expect(rockResults).toContainEqual({
+                    genre: "rock",
+                    suffix: "tunes",
+                });
+
+                expect(
+                    testMatchGrammar(grammar, "play metal tunes"),
+                ).toStrictEqual([{ genre: "metal", suffix: "tunes" }]);
+            });
+        });
     },
 );

--- a/ts/packages/actionGrammar/test/grammarValueExprTypeChecking.spec.ts
+++ b/ts/packages/actionGrammar/test/grammarValueExprTypeChecking.spec.ts
@@ -21,7 +21,7 @@ const exprLoader: SchemaLoader = (typeName) =>
     typeName === "ExprAction" ? ExprActionDef : undefined;
 const exprOpts = {
     schemaLoader: exprLoader,
-    enableExpressions: true,
+    enableValueExpressions: true,
 };
 
 describe("expression type inference", () => {
@@ -344,7 +344,7 @@ describe("expression type inference", () => {
         const errors: string[] = [];
         loadGrammarRulesNoThrow("test", grammarText, errors, undefined, {
             schemaLoader: arrayLoader,
-            enableExpressions: true,
+            enableValueExpressions: true,
         });
         expect(errors.length).toBeGreaterThan(0);
         expect(errors[0]).toContain("filter");
@@ -458,7 +458,7 @@ describe("expression type inference", () => {
         const errors: string[] = [];
         loadGrammarRulesNoThrow("test", grammarText, errors, undefined, {
             schemaLoader: arrayLoader,
-            enableExpressions: true,
+            enableValueExpressions: true,
         });
         expect(errors.length).toBe(0);
     });
@@ -485,7 +485,7 @@ describe("expression type inference", () => {
         const errors: string[] = [];
         loadGrammarRulesNoThrow("test", grammarText, errors, undefined, {
             schemaLoader: arrayLoader,
-            enableExpressions: true,
+            enableValueExpressions: true,
         });
         expect(errors.length).toBe(0);
     });
@@ -1169,7 +1169,7 @@ describe("operator type restrictions", () => {
         const warnings: string[] = [];
         loadGrammarRulesNoThrow("test", grammarText, errors, warnings, {
             schemaLoader: optLoader,
-            enableExpressions: true,
+            enableValueExpressions: true,
         });
         expect(errors.length).toBe(0);
         // name is string | undefined, so ?. is legitimate
@@ -1233,7 +1233,7 @@ describe("expression structural conformance", () => {
         const errors: string[] = [];
         loadGrammarRulesNoThrow("test", grammarText, errors, undefined, {
             schemaLoader: loader,
-            enableExpressions: true,
+            enableValueExpressions: true,
         });
         expect(errors.length).toBe(1);
         expect(errors[0]).toContain("number");
@@ -1262,7 +1262,7 @@ describe("expression structural conformance", () => {
         const errors: string[] = [];
         loadGrammarRulesNoThrow("test", grammarText, errors, undefined, {
             schemaLoader: loader,
-            enableExpressions: true,
+            enableValueExpressions: true,
         });
         expect(errors.length).toBe(0);
     });
@@ -1398,7 +1398,7 @@ describe("expression structural conformance", () => {
         const errors: string[] = [];
         loadGrammarRulesNoThrow("test", grammarText, errors, undefined, {
             schemaLoader: loader,
-            enableExpressions: true,
+            enableValueExpressions: true,
         });
         expect(errors.length).toBe(0);
     });

--- a/ts/packages/actionGrammar/test/grammarValueExpressions.spec.ts
+++ b/ts/packages/actionGrammar/test/grammarValueExpressions.spec.ts
@@ -7,14 +7,21 @@ import { writeGrammarRules } from "../src/grammarRuleWriter.js";
 import { evaluateValueExpr } from "../src/grammarValueExprEvaluator.js";
 import { describeForEachMatcher } from "./testUtils.js";
 
-const enableExpressions = true;
+const enableValueExpressions = true;
 
 function loadWithExpressions(grammar: string) {
-    return loadGrammarRules("test.grammar", grammar, { enableExpressions });
+    return loadGrammarRules("test.grammar", grammar, {
+        enableValueExpressions,
+    });
 }
 
 function parseWithExpressions(grammar: string) {
-    return parseGrammarRules("test.agr", grammar, false, enableExpressions);
+    return parseGrammarRules(
+        "test.agr",
+        grammar,
+        false,
+        enableValueExpressions,
+    );
 }
 
 // ── Parser Tests ──────────────────────────────────────────────────────────────
@@ -489,7 +496,7 @@ describe("Value Expression Parser", () => {
                 "test.agr",
                 `<Start> = hello -> -3;`,
                 false,
-                false, // enableExpressions = false
+                false, // enableValueExpressions = false
             );
             const value = r.definitions[0].rules[0].value!;
             expect(value).toEqual({ type: "literal", value: -3 });

--- a/ts/packages/actionGrammar/test/grammarValueStringUnion.spec.ts
+++ b/ts/packages/actionGrammar/test/grammarValueStringUnion.spec.ts
@@ -26,7 +26,7 @@ describe("string literal type inference", () => {
         typeName === "ExprAction" ? ExprActionDef : undefined;
     const exprOpts = {
         schemaLoader: exprLoader,
-        enableExpressions: true,
+        enableValueExpressions: true,
     };
 
     it("literal + variable string is valid", () => {
@@ -204,7 +204,7 @@ describe("string literal type inference", () => {
         const errors: string[] = [];
         loadGrammarRulesNoThrow("test", grammarText, errors, undefined, {
             schemaLoader: arrayLoader,
-            enableExpressions: true,
+            enableValueExpressions: true,
         });
         expect(errors.length).toBe(0);
     });
@@ -664,7 +664,7 @@ describe("Cross-field string-union assignments", () => {
         const errors: string[] = [];
         loadGrammarRulesNoThrow("test", grammarText, errors, undefined, {
             schemaLoader: exprLoader,
-            enableExpressions: true,
+            enableValueExpressions: true,
         });
         expect(errors.length).toBe(0);
     });

--- a/ts/packages/cache/src/grammar/exportGrammar.ts
+++ b/ts/packages/cache/src/grammar/exportGrammar.ts
@@ -37,7 +37,9 @@ const MAX_MULTI_PART_COMBINATIONS = 1000;
 const noTransformSentinel: MatchedValueTranslator = {
     transform: () => undefined,
     transformConflicts: () => undefined,
-    parse: () => undefined as any,
+    parse: () => {
+        throw new Error("noTransformSentinel.parse must never be called");
+    },
 };
 type State = {
     definitions: Set<RuleDefinition>;
@@ -47,7 +49,10 @@ type State = {
     >;
     ruleNameNextIds: Map<string, number>;
 };
-export async function convertConstructionFileToGrammar(fileName: string) {
+export async function convertConstructionFileToGrammar(
+    fileName: string,
+    options?: ConvertConstructionsOptions,
+) {
     const cache = await loadConstructionCacheFile(fileName);
     if (cache === undefined) {
         throw new Error(`Construction cache file '${fileName}' is empty.`);
@@ -58,6 +63,7 @@ export async function convertConstructionFileToGrammar(fileName: string) {
         matchSetRuleDefinitions: new Map(),
         ruleNameNextIds: new Map(),
     };
+    const enableValueExpressions = options?.enableValueExpressions ?? false;
     const namespaces = cache.getConstructionNamespaces();
     for (const ns of namespaces) {
         const constructions = cache.getConstructionNamespace(ns);
@@ -66,7 +72,11 @@ export async function convertConstructionFileToGrammar(fileName: string) {
                 `No constructions found for namespace '${ns}' in file '${fileName}'.`,
             );
         }
-        convertConstructions(state, constructions.constructions);
+        convertConstructions(
+            state,
+            constructions.constructions,
+            enableValueExpressions,
+        );
     }
     return writeGrammarRules({
         definitions: Array.from(state.definitions),
@@ -74,20 +84,41 @@ export async function convertConstructionFileToGrammar(fileName: string) {
     });
 }
 
-export function convertConstructionsToGrammar(constructions: Construction[]) {
+export type ConvertConstructionsOptions = {
+    /**
+     * Enable value expressions (memberExpression, literal-only rules) in the
+     * generated grammar. When false (the default), constructions that require
+     * these features are silently skipped so the output is safe for the NFA
+     * matcher. Set to true when the consumer supports full value expressions.
+     */
+    enableValueExpressions?: boolean;
+};
+
+export function convertConstructionsToGrammar(
+    constructions: Construction[],
+    options?: ConvertConstructionsOptions,
+) {
     const state: State = {
         definitions: new Set(),
         matchSetRuleDefinitions: new Map(),
         ruleNameNextIds: new Map(),
     };
-    convertConstructions(state, constructions);
+    convertConstructions(
+        state,
+        constructions,
+        options?.enableValueExpressions ?? false,
+    );
     return writeGrammarRules({
         definitions: Array.from(state.definitions),
         imports: [],
     });
 }
 
-function convertConstructions(state: State, constructions: Construction[]) {
+function convertConstructions(
+    state: State,
+    constructions: Construction[],
+    enableValueExpressions: boolean,
+) {
     // Cache translators by transformNamespaces identity so that constructions
     // sharing the same transformNamespaces reuse the same translator object,
     // enabling MatchSet rule deduplication in the cache.
@@ -103,7 +134,12 @@ function convertConstructions(state: State, constructions: Construction[]) {
             );
             translatorCache.set(construction.transformNamespaces, translator);
         }
-        convertConstruction(state, construction, translator);
+        convertConstruction(
+            state,
+            construction,
+            translator,
+            enableValueExpressions,
+        );
     }
 }
 
@@ -213,7 +249,7 @@ function matchSetCacheKey(
     const base = matchSet.unmergedUid;
     const ti = transformInfo ? toTransformInfoKey(transformInfo) : "";
     const wm = wildcardMode ?? 0;
-    return `${base}|${ti}|${wm}`;
+    return `${base}\0${ti}\0${wm}`;
 }
 
 /**
@@ -226,6 +262,18 @@ function getMultiTransformMatchSetRuleDefinition(
     translator: MatchedValueTranslator,
     transformInfos: readonly TransformInfo[],
 ): RuleDefinition | undefined {
+    // Cache using the same two-level scheme as getMatchSetRuleDefinition:
+    // translator → string key → RuleDefinition.
+    const tiKeys = transformInfos.map(toTransformInfoKey).sort().join(",");
+    const cacheKey = `${matchSet.unmergedUid}\0multi\0${tiKeys}`;
+    let translatorCache = state.matchSetRuleDefinitions.get(translator);
+    if (translatorCache !== undefined) {
+        const existing = translatorCache.get(cacheKey);
+        if (existing !== undefined) {
+            return existing;
+        }
+    }
+
     const rules: Rule[] = [];
     for (const match of matchSet.matches) {
         const properties: {
@@ -265,17 +313,33 @@ function getMultiTransformMatchSetRuleDefinition(
         return undefined;
     }
 
-    return {
+    const ruleDef: RuleDefinition = {
         definitionName: { name: getNextRuleName(state, matchSet.name) },
         rules,
     };
+    if (translatorCache === undefined) {
+        translatorCache = new Map();
+        state.matchSetRuleDefinitions.set(translator, translatorCache);
+    }
+    translatorCache.set(cacheKey, ruleDef);
+    return ruleDef;
 }
 
 function convertConstruction(
     state: State,
     construction: Construction,
     translator: MatchedValueTranslator,
-): undefined {
+    enableValueExpressions: boolean,
+): void {
+    // Skip constructions with multi-transform parts when value expressions
+    // are disabled — they require memberExpression which the NFA cannot evaluate.
+    const hasMultiTransform = construction.parts.some(
+        (p) => isMatchPart(p) && (p.transformInfos?.length ?? 0) > 1,
+    );
+    if (!enableValueExpressions && hasMultiTransform) {
+        return;
+    }
+
     // Handle multi-part transforms using cross-product enumeration when
     // any transform in the construction spans multiple parts.
     if (
@@ -419,16 +483,26 @@ function convertParts(
         let variableName: string | undefined;
         let transformInfo: TransformInfo | undefined;
         if (transformInfos !== undefined) {
-            const variableId = nextVariableId++;
-            variableName = `v${variableId}`;
-
             if (transformInfos.length === 1) {
                 // Single transform — use direct variable reference
                 transformInfo = transformInfos[0];
                 const propertyName =
                     getPropertyNameFromTransformInfo(transformInfo);
-                propertyVariables.set(propertyName, variableId);
+                // If a prior multi-transform part already claimed this
+                // property, don't capture it again — emit the matchSet
+                // as uncaptured to avoid duplicate tokens and conflicting
+                // value entries.
+                if (propertyValueOverrides.has(propertyName)) {
+                    variableName = undefined;
+                    transformInfo = undefined;
+                } else {
+                    const variableId = nextVariableId++;
+                    variableName = `v${variableId}`;
+                    propertyVariables.set(propertyName, variableId);
+                }
             } else {
+                const variableId = nextVariableId++;
+                variableName = `v${variableId}`;
                 // Multi-transform — the MatchSet rule returns an object,
                 // and each property is accessed via member expressions.
                 for (const ti of transformInfos) {
@@ -623,9 +697,8 @@ function convertToValueNode(entry: any, leafValues: ValueNode[]): ValueNode {
     throw new Error(`Internal error: invalid value node entry: ${entry}`);
 }
 
-function multiPartGroupKey(ti: TransformInfo): string {
-    return `${ti.namespace}::${ti.actionIndex ?? ""}::${ti.transformName}`;
-}
+// Use toTransformInfoKey for grouping multi-part transforms.
+const multiPartGroupKey = toTransformInfoKey;
 
 /**
  * Handle constructions with multi-part transforms (partCount > 1) by
@@ -636,7 +709,7 @@ function convertMultiPartConstruction(
     state: State,
     construction: Construction,
     translator: MatchedValueTranslator,
-): undefined {
+): void {
     const groups = new Map<string, MultiPartGroup>();
     const multiPartPartIndices = new Set<number>();
 
@@ -692,15 +765,18 @@ function convertMultiPartConstruction(
     const groupCombos = new Map<string, ValidCombo[]>();
 
     for (const [key, group] of groups) {
-        const crossProduct = computeCrossProduct(
-            group.matchSets.map((ms) => [...ms.matches]),
+        const matchArrays = group.matchSets.map((ms) => [...ms.matches]);
+        const totalCombinations = matchArrays.reduce(
+            (acc, a) => acc * a.length,
+            1,
         );
-        if (crossProduct.length > MAX_MULTI_PART_COMBINATIONS) {
+        if (totalCombinations > MAX_MULTI_PART_COMBINATIONS) {
             debugError(
                 "Too many multi-part combinations, skipping construction",
             );
             return undefined;
         }
+        const crossProduct = computeCrossProduct(matchArrays);
         const validCombos: ValidCombo[] = [];
         for (const combo of crossProduct) {
             const v = translator.transform(group.transformInfo, combo);
@@ -735,14 +811,18 @@ function convertMultiPartConstruction(
     // Cross product across groups (when a construction has multiple
     // independent multi-part properties).
     const allGroupKeys = [...groupCombos.keys()];
+    const totalGroupCombinations = allGroupKeys.reduce(
+        (acc, k) => acc * groupCombos.get(k)!.length,
+        1,
+    );
+    if (totalGroupCombinations > MAX_MULTI_PART_COMBINATIONS) {
+        debugError("Too many cross-group combinations, skipping");
+        return undefined;
+    }
     const groupCrossProduct = computeGroupCrossProduct(
         allGroupKeys,
         groupCombos,
     );
-    if (groupCrossProduct.length > MAX_MULTI_PART_COMBINATIONS) {
-        debugError("Too many cross-group combinations, skipping");
-        return undefined;
-    }
 
     // For each overall combination, produce a Start rule alternative.
     const startRules: Rule[] = [];
@@ -888,7 +968,7 @@ function decomposeMultiPartGroups(
     groups: Map<string, MultiPartGroup>,
     groupCombos: Map<string, ValidCombo[]>,
     multiPartPartIndices: Set<number>,
-): undefined {
+): void {
     // Compute each group's span and create a composite rule.
     type GroupSpan = {
         key: string;

--- a/ts/packages/cache/src/indexGrammar.ts
+++ b/ts/packages/cache/src/indexGrammar.ts
@@ -5,3 +5,4 @@ export {
     convertConstructionsToGrammar,
     convertConstructionFileToGrammar,
 } from "./grammar/exportGrammar.js";
+export type { ConvertConstructionsOptions } from "./grammar/exportGrammar.js";

--- a/ts/packages/cache/test/exportGrammar.spec.ts
+++ b/ts/packages/cache/test/exportGrammar.spec.ts
@@ -401,6 +401,57 @@ describe("exportGrammar equivalence", () => {
             );
             expect(grammarResults[0].match).toEqual(constructionAction);
         });
+
+        it("wildcard fallback followed by non-transformed captured part", () => {
+            // Regression test: when a wildcard-enabled part's $(wc) alternative
+            // is explored by the tree matcher, the pending wildcard leaks into
+            // the next captured rule.  matchStringPartWithWildcard must assign
+            // the default string value for single-part rules just like the
+            // non-wildcard path does, otherwise finalizeNestedRule throws
+            // "No value assign to variable".
+            const construction = Construction.create(
+                [
+                    createMatchPart(["play"], "command", {
+                        wildcardMode: WildcardMode.Disabled,
+                    }),
+                    createMatchPart(["rock", "pop", "jazz"], "genre", {
+                        transformInfos: [makeTransformInfo("parameters.genre")],
+                        wildcardMode: WildcardMode.Enabled,
+                    }),
+                    createMatchPart(["tunes"], "music", {
+                        wildcardMode: WildcardMode.Disabled,
+                    }),
+                ],
+                makeTransforms([
+                    ["parameters.genre", "rock", "rock"],
+                    ["parameters.genre", "pop", "pop"],
+                    ["parameters.genre", "jazz", "jazz"],
+                ]),
+                undefined,
+                [
+                    {
+                        paramName: "fullActionName",
+                        paramValue: "player.playGenre",
+                    },
+                ],
+            );
+
+            // Known genre — should match via literal alternative
+            expectEquivalent(construction, "play rock tunes");
+            expectEquivalent(construction, "play pop tunes");
+
+            // Unknown genre — wildcard fallback path
+            const { constructionResults, grammarResults } = matchBoth(
+                construction,
+                "play metal tunes",
+            );
+            expect(constructionResults.length).toBeGreaterThan(0);
+            expect(grammarResults.length).toBeGreaterThan(0);
+            const constructionAction = toJsonActions(
+                constructionResults[0].match.actions,
+            );
+            expect(grammarResults[0].match).toEqual(constructionAction);
+        });
     });
 
     describe("multi-part transforms (Option A)", () => {
@@ -1021,6 +1072,105 @@ describe("exportGrammar equivalence", () => {
             // decomposition was not possible).
             const grammarText = convertConstructionsToGrammar([construction]);
             expect(grammarText).not.toMatch(/<multiPart_\d+>/);
+        });
+    });
+
+    describe("multi-transform parts (#7)", () => {
+        function matchBothExpr(construction: Construction, request: string) {
+            const constructionResults = construction.match(
+                request,
+                defaultConfig,
+            );
+            const grammarText = convertConstructionsToGrammar([construction], {
+                enableValueExpressions: true,
+            });
+            let grammarResults: { match: unknown }[] = [];
+            if (grammarText !== "") {
+                const grammar = loadGrammarRules("test", grammarText, {
+                    enableValueExpressions: true,
+                });
+                grammarResults = matchGrammar(grammar, request);
+            }
+            return { constructionResults, grammarResults, grammarText };
+        }
+
+        it("handles a single part with multiple transforms", () => {
+            // A single MatchPart that maps the same text to two different
+            // properties (e.g., "rock" → genre="rock" and category="music").
+            const construction = Construction.create(
+                [
+                    createMatchPart(["rock", "pop"], "genre", {
+                        transformInfos: [
+                            makeTransformInfo("genre"),
+                            makeTransformInfo("category"),
+                        ],
+                    }),
+                ],
+                makeTransforms([
+                    ["genre", "rock", "rock"],
+                    ["genre", "pop", "pop"],
+                    ["category", "rock", "music"],
+                    ["category", "pop", "music"],
+                ]),
+                undefined,
+                [
+                    {
+                        paramName: "fullActionName",
+                        paramValue: "player.setGenre",
+                    },
+                ],
+            );
+
+            // Verify both properties are present in the result.
+            const { grammarResults } = matchBothExpr(construction, "rock");
+            expect(grammarResults.length).toBeGreaterThan(0);
+            expect((grammarResults[0].match as any).genre).toBe("rock");
+            expect((grammarResults[0].match as any).category).toBe("music");
+            expect((grammarResults[0].match as any).fullActionName).toBe(
+                "player.setGenre",
+            );
+
+            // Also verify "pop"
+            const { grammarResults: gr2 } = matchBothExpr(construction, "pop");
+            expect(gr2.length).toBeGreaterThan(0);
+            expect((gr2[0].match as any).genre).toBe("pop");
+            expect((gr2[0].match as any).category).toBe("music");
+        });
+
+        it("skips matches where any transform fails in multi-transform", () => {
+            // "rock" has both transforms, "jazz" only has genre — should be
+            // skipped from the multi-transform rule.
+            const construction = Construction.create(
+                [
+                    createMatchPart(["rock", "jazz"], "genre", {
+                        transformInfos: [
+                            makeTransformInfo("genre"),
+                            makeTransformInfo("category"),
+                        ],
+                    }),
+                ],
+                makeTransforms([
+                    ["genre", "rock", "rock"],
+                    ["genre", "jazz", "jazz"],
+                    ["category", "rock", "music"],
+                    // no category entry for "jazz"
+                ]),
+                undefined,
+                [
+                    {
+                        paramName: "fullActionName",
+                        paramValue: "player.setGenre",
+                    },
+                ],
+            );
+
+            // "rock" should match — both transforms succeed.
+            const { grammarResults: gr1 } = matchBothExpr(construction, "rock");
+            expect(gr1.length).toBeGreaterThan(0);
+
+            // "jazz" should not match in grammar — category transform fails.
+            const { grammarResults: gr2 } = matchBothExpr(construction, "jazz");
+            expect(gr2.length).toBe(0);
         });
     });
 });


### PR DESCRIPTION
## Summary

Enhances the construction-to-grammar export pipeline with caching, value expression controls, and fixes both the NFA interpreter and tree-based grammar matcher to correctly handle edge cases.

### Changes

**Value expression support (`enableValueExpressions` option):**
- Rename `enableExpressions` → `enableValueExpressions` across grammar loader, parser, and all tests for clarity
- Add `ConvertConstructionsOptions` with `enableValueExpressions` flag to `convertConstructionsToGrammar` and `convertConstructionFileToGrammar`
- Skip multi-transform constructions when value expressions are disabled (they require `memberExpression`)
- Avoid duplicate property captures when a multi-transform part already claimed a property

**NFA environment fix (compiler + interpreter):**
- Always create NFA environment for Start rules, even when the rule has no variables — nested sub-rules (e.g. optional groups normalized into passthrough wrappers) need an environment to correctly pop back to the Start rule's actionValue on exit
- Allow the NFA interpreter to evaluate literal-only value expressions by creating an empty environment when none exists
- Remove the now-unnecessary workaround in `exportGrammar` that skipped constructions with no variable captures

**Tree-based matcher fix (`matchStringPartWithWildcard`):**
- Assign default string value for single-part rules in the wildcard path — matching the non-wildcard path in `matchStringPartWithoutWildcard`
- Fixes "No value assign to variable" error when a wildcard from a parent rule (e.g. `$(wc) -> wc` alternative) leaks into a captured child rule that has a single string part without an explicit `->` value

**Caching & deduplication:**
- Cache translators by `transformNamespaces` identity so constructions sharing the same namespaces reuse the same translator object, enabling MatchSet rule deduplication
- Use a sentinel translator for non-transformed rules so they are always shared regardless of construction's `transformNamespaces`

**Other improvements:**
- Handle `ParsePart` (number/percentage parser) in grammar export
- Add wildcard fallback alternatives for wildcard-enabled parts
- Skip individual failed transforms instead of failing entire rule definition

**Tests:**
- Extend equivalence tests comparing construction matcher vs. grammar matcher
- Add wildcard-to-nested-rule interaction tests in `grammarMatcherGroups.spec.ts`
- Cover: literals, alternatives, transforms, wildcards, multi-part, multi-transform, optional parts, implicit parameters, ParsePart, and edge cases