### PR TITLE
Fix completion spacing at nested rule boundaries

### DIFF
--- a/ts/packages/actionGrammar/src/grammarCompletion.ts
+++ b/ts/packages/actionGrammar/src/grammarCompletion.ts
@@ -65,7 +65,7 @@ function matchWordsGreedily(
     text: string,
     startIndex: number,
     spacingMode: CompiledSpacingMode,
-    noLeadingSeparator: boolean = false,
+    suppressLeadingSeparator: boolean = false,
 ): { matchedWords: number; endIndex: number; prevEndIndex: number } {
     let index = startIndex;
     let prevIndex = startIndex;
@@ -75,13 +75,37 @@ function matchWordsGreedily(
         const word = words[k];
         const escaped = escapeMatch(word);
 
+        // Separator logic has two independent dimensions:
+        //
+        //   k === 0 (first word):
+        //     Governed by the *caller*, not spacingMode.  The caller
+        //     decides whether the leading separator (between the match
+        //     start position and the first keyword word) is allowed:
+        //       suppressLeadingSeparator=true  → bare word, no prefix
+        //         (used when leadingSpacingMode() returns "none")
+        //       suppressLeadingSeparator=false → [sep]*? lazy optional
+        //         prefix that skips any leading whitespace/punctuation.
+        //         The lazy quantifier matches zero-width when the
+        //         keyword starts immediately, so this is "allow but
+        //         don't require" leading whitespace.
+        //     Note: spacingMode is intentionally NOT consulted for
+        //     k=0.  Even when spacingMode is "none", callers like
+        //     matchKeywordWordsFrom (wildcard scanning) need the
+        //     optional leading separator to find keyword candidates
+        //     at separator-delimited positions within wildcard text.
+        //
+        //   k > 0 (subsequent words):
+        //     Governed by the rule's spacingMode:
+        //       "none"  → bare word, no inter-word separator
+        //       other   → separator required or optional per
+        //                 requiresSeparator() for the character pair
         let regExpStr: string;
-        if (k === 0 && noLeadingSeparator) {
+        if (k === 0) {
+            regExpStr = suppressLeadingSeparator
+                ? escaped
+                : `[${separatorRegExpStr}]*?${escaped}`;
+        } else if (spacingMode === "none") {
             regExpStr = escaped;
-        } else if (spacingMode === "none" && k > 0) {
-            regExpStr = escaped;
-        } else if (k === 0) {
-            regExpStr = `[${separatorRegExpStr}]*?${escaped}`;
         } else {
             const sep = requiresSeparator(
                 words[k - 1].at(-1)!,
@@ -392,7 +416,7 @@ function tryPartialStringMatch(
     spacingMode: CompiledSpacingMode,
     direction?: "forward" | "backward",
     effectivePrefixEnd?: number,
-    noLeadingSeparator: boolean = false,
+    suppressLeadingSeparator: boolean = false,
 ):
     | {
           consumedLength: number;
@@ -408,7 +432,7 @@ function tryPartialStringMatch(
         input,
         startIndex,
         spacingMode,
-        noLeadingSeparator,
+        suppressLeadingSeparator,
     );
 
     // Direction matters when at least one word fully matched and no
@@ -784,7 +808,7 @@ function tryCollectBackwardCandidate(
                 tryCollectStringCandidate(
                     ctx,
                     leadingSpacingMode(state),
-                    info.spacingMode,
+                    info.matchedSpacingMode,
                     info.part,
                     info.afterWildcard,
                     info.start,

--- a/ts/packages/actionGrammar/src/grammarMatcher.ts
+++ b/ts/packages/actionGrammar/src/grammarMatcher.ts
@@ -260,14 +260,14 @@ export type MatchState = {
               readonly start: number;
               readonly part: StringPart;
               readonly afterWildcard: boolean;
-              readonly spacingMode: CompiledSpacingMode;
+              readonly matchedSpacingMode: CompiledSpacingMode;
           }
         | {
               readonly type: "number";
               readonly start: number;
               readonly valueId: number;
               readonly afterWildcard: boolean;
-              readonly spacingMode: CompiledSpacingMode;
+              readonly matchedSpacingMode: CompiledSpacingMode;
           }
         | undefined;
 };
@@ -842,7 +842,7 @@ function matchStringPartWithWildcard(
                 start: wildcardEnd,
                 part,
                 afterWildcard: true,
-                spacingMode: state.spacingMode,
+                matchedSpacingMode: state.spacingMode,
             };
             debugMatch(
                 state,
@@ -894,7 +894,7 @@ function matchStringPartWithoutWildcard(
         start: curr,
         part,
         afterWildcard: false,
-        spacingMode: state.spacingMode,
+        matchedSpacingMode: state.spacingMode,
     };
     state.index = newIndex;
     return true;
@@ -1039,7 +1039,7 @@ function matchVarNumberPartWithWildcard(
                     start: wildcardEnd,
                     valueId,
                     afterWildcard: true,
-                    spacingMode: state.spacingMode,
+                    matchedSpacingMode: state.spacingMode,
                 };
             }
             return true;
@@ -1093,7 +1093,7 @@ function matchVarNumberPartWithoutWildcard(
             start: curr,
             valueId,
             afterWildcard: false,
-            spacingMode: state.spacingMode,
+            matchedSpacingMode: state.spacingMode,
         };
     }
     state.index = newIndex;

--- a/ts/packages/actionGrammar/test/grammarCompletionSpacingNested.spec.ts
+++ b/ts/packages/actionGrammar/test/grammarCompletionSpacingNested.spec.ts
@@ -112,8 +112,9 @@ describeForEachCompletion(
                 const result = matchGrammarCompletion(grammar, "play ");
                 // "play " → "play" matched, trailing separator consumed.
                 // Next is <Track> whose first part is "ab".  Leading
-                // separator mode = parent's auto (Latin→Latin requires
-                // space).  But we already have a trailing separator.
+                // separator mode = parent's auto mode (compiles to
+                // spacePunctuation; Latin→Latin requires space).
+                // But we already have a trailing separator.
                 expectMetadata(result, {
                     completions: ["ab"],
                     matchedPrefixLength: 4,
@@ -146,8 +147,8 @@ describeForEachCompletion(
             it("exact match 'play abcd' backs up to last word (Category 1)", () => {
                 // "play abcd" → full match.  Category 1 exact match backs
                 // up to the last matched part.  The backup uses the nested
-                // rule's spacingMode (saved on lastMatchedPartInfo) so that
-                // the inter-word "none" mode is preserved across
+                // rule's spacingMode (saved as matchedSpacingMode on
+                // lastMatchedPartInfo) so that the inter-word "none" mode is preserved across
                 // finalizeNestedRule's parent-state restoration.
                 const result = matchGrammarCompletion(grammar, "play abcd");
                 expectMetadata(result, {
@@ -412,6 +413,130 @@ describeForEachCompletion(
                     closedSet: true,
                     directionSensitive: true,
                     afterWildcard: "none",
+                    properties: [],
+                });
+            });
+        });
+
+        // ================================================================
+        // Section 9: Wildcard + keyword in spacing=none
+        //
+        // matchKeywordWordsFrom calls matchWordsGreedily without
+        // suppressLeadingSeparator.  When the rule uses spacing=none,
+        // the k=0 branch falls through to the optional leading
+        // separator regex ([\\s\\p{P}]*?).  Because the quantifier is
+        // lazy, it matches zero-width when the keyword immediately
+        // follows — so for callers that don't set
+        // suppressLeadingSeparator, behavior is equivalent to no
+        // separator in practice.
+        // ================================================================
+
+        describe("wildcard + keyword in spacing=none", () => {
+            const g = `
+                <Start> [spacing=none] = $(x:wildcard) done -> { x };
+            `;
+            const grammar = loadGrammarRules("test.grammar", g);
+
+            it("offers 'done' after wildcard input", () => {
+                const result = matchGrammarCompletion(grammar, "abc");
+                // "abc" is consumed by the wildcard.  "done" is the
+                // next keyword.  In spacing=none, the keyword must
+                // abut the wildcard content with no separator.
+                expectMetadata(result, {
+                    completions: ["done"],
+                    matchedPrefixLength: 3,
+                    separatorMode: "none",
+                    closedSet: true,
+                    directionSensitive: true,
+                    afterWildcard: "all",
+                    properties: [],
+                });
+            });
+
+            it("partial keyword abutting wildcard matches in none mode", () => {
+                // "abcdo" → wildcard absorbs "abc", "do" partially
+                // matches "done" with no separator (spacing=none).
+                const result = matchGrammarCompletion(grammar, "abcdo");
+                expectMetadata(result, {
+                    completions: ["done"],
+                    matchedPrefixLength: 3,
+                    separatorMode: "none",
+                    closedSet: true,
+                    directionSensitive: true,
+                    afterWildcard: "all",
+                    properties: [],
+                });
+            });
+
+            it("wildcard absorbs spurious space in none mode (space not a separator)", () => {
+                // "abc do" — in spacing=none, the space is part of the
+                // wildcard content.  The wildcard scanning still finds
+                // "do" as a partial match of "done".
+                // matchedPrefixLength=3 reflects the wildcard end before
+                // the keyword candidate start.
+                const result = matchGrammarCompletion(grammar, "abc do");
+                expectMetadata(result, {
+                    completions: ["done"],
+                    matchedPrefixLength: 3,
+                    separatorMode: "none",
+                    closedSet: true,
+                    directionSensitive: true,
+                    afterWildcard: "all",
+                    properties: [],
+                });
+            });
+        });
+
+        // ================================================================
+        // Section 10: Deferred EOI/wildcard-string path with mixed modes
+        //
+        // When a wildcard is followed by a string part in a nested rule
+        // with mixed spacing modes, the deferred wildcard-string
+        // candidate path (post-processing) should still work correctly.
+        // ================================================================
+
+        describe("wildcard + string in nested rule with mixed spacing modes", () => {
+            // Use matching spacing modes (both none) so backward's
+            // path-dependent spacingMode matches forward's.
+            const g = `
+                <Inner> [spacing=none] = $(x:wildcard) done -> { x };
+                <Start> = play $(y:<Inner>) -> y;
+            `;
+            const grammar = loadGrammarRules("test.grammar", g);
+
+            it("offers 'done' after wildcard in nested none-mode rule", () => {
+                // "play something" → "play" matched in <Start> (auto),
+                // then " something" enters <Inner>.  The wildcard
+                // absorbs "something", and "done" is the next keyword.
+                const result = matchGrammarCompletion(
+                    grammar,
+                    "play something",
+                );
+                expectMetadata(result, {
+                    completions: ["done"],
+                    matchedPrefixLength: 14,
+                    separatorMode: "none",
+                    closedSet: true,
+                    directionSensitive: true,
+                    afterWildcard: "all",
+                    properties: [],
+                });
+            });
+
+            it("partial keyword in nested none-mode rule after wildcard", () => {
+                // "play somethingdo" → wildcard absorbs "something",
+                // "do" partially matches "done" (no separator, none mode).
+                const result = matchGrammarCompletion(
+                    grammar,
+                    "play somethingdo",
+                );
+                expectMetadata(result, {
+                    completions: ["done"],
+                    matchedPrefixLength: 14,
+                    separatorMode: "none",
+                    closedSet: true,
+                    directionSensitive: true,
+                    afterWildcard: "all",
                     properties: [],
                 });
             });


### PR DESCRIPTION
## Summary

Fix completion `separatorMode` reporting when grammar rules with different spacing modes are nested. The separator between the matched prefix and the first completion word at a nested-rule boundary should be governed by the **parent's** spacing mode (`leadingSpacingMode`), not the nested rule's own `spacingMode`.

## Problem

When a parent rule uses `spacing=none` and nests a child rule with auto/required spacing (or vice versa), the completion system incorrectly reported the child rule's spacing mode as the `separatorMode`. This caused the shell/caller to insert incorrect separators between the matched prefix and completion text at nested rule boundaries.

## Changes

### grammarMatcher.ts
- Export `leadingSpacingMode()` so the completion module can use it.
- Record `matchedSpacingMode` on `lastMatchedPartInfo` — captures the spacing mode that was active when a string/number part was matched, so that backward completion (Category 1 exact-match backup) preserves the correct inter-word spacing mode even after `finalizeNestedRule` restores the parent state.

### grammarCompletion.ts
- **`matchWordsGreedily`**: Add `suppressLeadingSeparator` parameter. When `leadingSpacingMode()` returns `"none"`, the first word regex omits the optional leading separator prefix — preventing it from skipping across a boundary that should have no separator.
- **`tryCollectStringCandidate`**: Accept separate `leadingMode` and `interWordMode` parameters instead of a single `MatchState`. The leading mode (from `leadingSpacingMode()`) governs the first-word separator; the inter-word mode governs subsequent words within the same keyword.
- **`collectPropertyCandidate`**: Use `leadingSpacingMode(state)` for the candidate's spacing mode, so property completions at nested boundaries report the parent's mode.
- All call sites updated to pass `leadingSpacingMode(state)` and `state.spacingMode` separately.

### New tests: grammarCompletionSpacingNested.spec.ts (545 lines, 20 tests)
Comprehensive coverage of mixed-spacing nested rule completion:
1. Parent `spacing=none`, nested auto
2. Parent auto, nested `spacing=none`
3. Parent `spacing=optional`, nested `spacing=required`
4. Deep pass-through chains (3 and 4 levels)
5. Property completion at nested boundaries
6. Backward completion at nested boundaries
7. Alternation with different spacing modes
8. Wildcard + keyword in `spacing=none`
9. Wildcard + string in nested rules with mixed modes