### PR TITLE
Restore RemoteSearchMenuUI for Electron overlay search menu

### DIFF
--- a/ts/packages/shell/src/renderer/src/search.ts
+++ b/ts/packages/shell/src/renderer/src/search.ts
@@ -1,9 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+import { isElectron } from "./main";
 import { SearchMenuBase } from "./searchMenuBase";
 import { InlineSearchMenuUI } from "./searchMenuUI/inlineSearchMenuUI";
 import { LocalSearchMenuUI } from "./searchMenuUI/localSearchMenuUI";
+import { RemoteSearchMenuUI } from "./searchMenuUI/remoteSearchMenuUI";
 import {
     SearchMenuItem,
     SearchMenuPosition,
@@ -29,7 +31,9 @@ export class SearchMenu extends SearchMenuBase {
         if (this.searchMenuUI === undefined) {
             this.searchMenuUI = this.inline
                 ? new InlineSearchMenuUI(this.onCompletion, this.textEntry!)
-                : new LocalSearchMenuUI(this.onCompletion);
+                : isElectron()
+                  ? new RemoteSearchMenuUI(this.onCompletion)
+                  : new LocalSearchMenuUI(this.onCompletion);
         }
         this.searchMenuUI.update({ position, prefix, items });
     }


### PR DESCRIPTION
## Summary

Restore `RemoteSearchMenuUI` usage in Electron so the completion menu renders in a separate `WebContentsView` that can overlay beyond the chat view bounds.

When PR #1933 added inline ghost text completions, it replaced the `RemoteSearchMenuUI`/`LocalSearchMenuUI` branching with `InlineSearchMenuUI`/`LocalSearchMenuUI`, leaving `RemoteSearchMenuUI` as dead code. The remote search menu infrastructure (IPC handlers, `electronSearchMenuUI.ts`, `searchMenuView.ts`, preload bindings) was never removed and remains fully intact.

## Changes

- **`packages/shell/src/renderer/src/search.ts`**: When not in inline mode, use `RemoteSearchMenuUI` in Electron (via `isElectron()` check) and fall back to `LocalSearchMenuUI` in non-Electron environments. This matches the original behavior before #1933.
