### PR TITLE
Add shell packaging guard and automation workflow for Dependabot remediation

### DIFF
--- a/.github/workflows/fix-dependabot-alerts.yml
+++ b/.github/workflows/fix-dependabot-alerts.yml
@@ -123,13 +123,23 @@ jobs:
             cp package.json /tmp/pkg-backup.json
             cp pnpm-lock.yaml /tmp/lock-backup.yaml 2>/dev/null || true
 
-            # Apply fix for this specific package
-            read -r -a fix_args <<< "$FLAGS"
-            last_index=$((${#fix_args[@]} - 1))
-            fix_args[$last_index]="${fix_args[$last_index]}=$PKG"
-            echo "Running: fix-dependabot-alerts.mjs ${fix_args[*]}"
+            # Apply fix for this specific package — always use --auto-fix=$PKG
+            # regardless of other flags, so each package is targeted individually
+            read -r -a extra_args <<< "$FLAGS"
+            filtered_args=()
+            for arg in "${extra_args[@]}"; do
+              case "$arg" in
+                --auto-fix|--auto-fix=*)
+                  ;;
+                *)
+                  filtered_args+=("$arg")
+                  ;;
+              esac
+            done
+            filtered_args+=("--auto-fix=$PKG")
+            echo "Running: fix-dependabot-alerts.mjs ${filtered_args[*]}"
             set +e
-            node tools/scripts/fix-dependabot-alerts.mjs "${fix_args[@]}" 2>&1
+            node tools/scripts/fix-dependabot-alerts.mjs "${filtered_args[@]}" 2>&1
             fix_exit=$?
             set -e
 

--- a/ts/tools/scripts/fix-dependabot-alerts.mjs
+++ b/ts/tools/scripts/fix-dependabot-alerts.mjs
@@ -1634,7 +1634,8 @@ function getShellProductionDeps() {
             warn(
                 "Could not resolve shell production deps — shell packaging post-check will still validate",
             );
-            return new Set();
+            _cache.shellProdDeps = new Set();
+            return _cache.shellProdDeps;
         }
         const deps = new Set();
         const parsed = parsePaginatedJson(output);
@@ -1656,7 +1657,8 @@ function getShellProductionDeps() {
         warn(
             "Could not resolve shell production deps — shell packaging post-check will still validate",
         );
-        return new Set();
+        _cache.shellProdDeps = new Set();
+        return _cache.shellProdDeps;
     }
 }
 
@@ -1703,8 +1705,8 @@ async function verifyShellPackaging() {
                 "--filter",
                 SHELL_WORKSPACE,
                 "--prod",
-                deployDir,
                 "--ignore-scripts",
+                deployDir,
             ],
             { timeout: 300000 },
         );


### PR DESCRIPTION
### Problem

The `fix-dependabot-alerts.mjs` script can apply pnpm overrides that break `shell:package` — electron-builder's `traversalNodeModulesCollector` validates that installed versions exactly match declared dependency ranges, which pnpm overrides silently violate. There's also no automation to run the script and create PRs.

### Changes

**Shell packaging guard** (`ts/tools/scripts/fix-dependabot-alerts.mjs`)

- **Pre-check**: Resolves the shell workspace's production dependency tree via `pnpm ls --prod` and blocks overrides for packages found in it
- **Post-check**: After applying overrides, runs `pnpm deploy --prod` + `electron-builder install-app-deps` to validate compatibility; automatically rolls back offending overrides if the check fails
- `--skip-shell-check` flag to bypass both checks when needed
- JSON output now includes `inShellBundle` field per package

**GitHub Action** (`.github/workflows/fix-dependabot-alerts.yml`)

- Scheduled weekly (Monday 9:00 UTC) with manual dispatch
- **Bisect strategy**: applies each fix individually with a build check after each — rolls back failures, keeps passing fixes
- Final `shell:package` verification before PR creation
- Auto-creates PR with summary of applied/rolled-back/blocked packages
- Supports `dry-run` and custom flags via workflow inputs

### Testing

- Verified `--dry-run` correctly identifies shell-bundle packages (`lodash-es`, `underscore`, `qs`, `undici`, `brace-expansion`, `@xmldom/xmldom`) and blocks their overrides
- Confirmed safe packages (`node-forge`, `picomatch`, `serialize-javascript`, `vite`) are not blocked
- Script syntax check passes
