### PR TITLE
Fix broken GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -51,6 +51,8 @@ jobs:
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
+        with:
+          package_json_file: docs/package.json
 
       - name: Get pnpm store directory
         id: pnpm-cache


### PR DESCRIPTION
The docs deployment has been failing on every push to `main` since February 2026. The last successful run (Jan 10) was a manual `workflow_dispatch` — all merge-queue-triggered runs fail immediately.

**Root cause:** The `check-user-permission` action rejects `github-merge-queue[bot]` (permission level `none`), even though pushes to `main` already require write access via branch protection. A secondary issue is that the error-handling step crashes because `working-directory: docs` is applied before `checkout` runs.

### Fixes
- [x] Remove redundant permission check that rejects the merge queue bot
- [x] Remove invalid `ref: pull_request.head.sha` (always empty on `push` events)
- [x] Remove stale `siteTestCode` branch trigger
- [x] Downgrade `contents` permission from `write` to `read`
- [x] Upgrade actions to v4 (`checkout`, `setup-node`, `cache`)
- [x] Upgrade `pnpm/action-setup` to v4 (auto-detects `packageManager` field)
- [x] Update Node.js from 18 to 22 (repo requires ≥20)
- [x] Scope cache key to `docs/pnpm-lock.yaml` instead of `**/pnpm-lock.yaml`
- [x] Add `id: deployment` to deploy step for environment URL output