### PR TITLE
Add --skip-install flag to fix OOM crash in Dependabot workflow

### DIFF
--- a/.github/workflows/fix-dependabot-alerts.yml
+++ b/.github/workflows/fix-dependabot-alerts.yml
@@ -80,7 +80,7 @@ jobs:
         run: |
           # ── Step 1: Discover fixable packages ───────────────────────
           echo "::group::Analysing alerts"
-          node tools/scripts/fix-dependabot-alerts.mjs --dry-run --json > /tmp/dep-analysis.json 2>/tmp/dep-analysis.log || true
+          node tools/scripts/fix-dependabot-alerts.mjs --dry-run --json --skip-install > /tmp/dep-analysis.json 2>/tmp/dep-analysis.log || true
 
           if ! jq -e '.summary' /tmp/dep-analysis.json > /dev/null 2>&1; then
             echo "::error::Script produced no valid JSON output"
@@ -147,6 +147,7 @@ jobs:
               esac
             done
             filtered_args+=("--auto-fix=$PKG")
+            filtered_args+=("--skip-install")
             echo "Running: fix-dependabot-alerts.mjs ${filtered_args[*]}"
             set +e
             node tools/scripts/fix-dependabot-alerts.mjs "${filtered_args[@]}" 2>&1

--- a/ts/tools/scripts/fix-dependabot-alerts.mjs
+++ b/ts/tools/scripts/fix-dependabot-alerts.mjs
@@ -30,6 +30,7 @@ const KNOWN_FLAG_PREFIXES = [
     "--show-chains",
     "--prune-overrides",
     "--skip-shell-check",
+    "--skip-install",
     "--json",
     "--verbose",
     "--help",
@@ -103,6 +104,7 @@ const SHOW_CHAINS =
 const SHOW_CHAINS_FULL = args.includes("--show-chains=full");
 const PRUNE_OVERRIDES = args.includes("--prune-overrides");
 const SKIP_SHELL_CHECK = args.includes("--skip-shell-check");
+const SKIP_INSTALL = args.includes("--skip-install");
 const JSON_OUTPUT = args.includes("--json");
 const VERBOSE = args.includes("--verbose");
 
@@ -132,6 +134,8 @@ Options:
                       check. By default, overrides for packages in the shell's
                       production dependency tree are blocked because
                       electron-builder validates exact version matches.
+  --skip-install      Skip the initial pnpm install --frozen-lockfile. Use when
+                      dependencies are already installed (e.g. in CI).
   --json              Output results as structured JSON (for CI integration)
   --verbose           Show detailed constraint analysis, advisory IDs, and
                       debug output
@@ -2912,8 +2916,10 @@ function emitJson(results) {
 async function main() {
     // Ensure node_modules matches the lockfile — pnpm why reads from the
     // installed virtual store, not the lockfile itself.
-    if (!JSON_OUTPUT) console.log("Running pnpm install --frozen-lockfile …");
-    runCmd("pnpm", ["install", "--frozen-lockfile"]);
+    if (!SKIP_INSTALL) {
+        if (!JSON_OUTPUT) console.log("Running pnpm install --frozen-lockfile …");
+        runCmd("pnpm", ["install", "--frozen-lockfile"]);
+    }
 
     if (PRUNE_OVERRIDES) {
         await pruneOverrides();


### PR DESCRIPTION
The Dependabot workflow fails because the script runs \pnpm install --frozen-lockfile\ at startup even though the workflow already installed dependencies. Running it again OOM-kills the runner (exit 139).

### Changes

- Add \--skip-install\ flag to skip the redundant \pnpm install\ when deps are already available
- Pass \--skip-install\ in both workflow invocations (dry-run and per-package fix)

### How to verify

Merge and re-run the \ix-dependabot-alerts\ workflow — it should now get past the install step and discover fixable packages.