### PR TITLE
Fix Dependabot workflow: use security-events write permission

### DIFF
--- a/.github/workflows/fix-dependabot-alerts.yml
+++ b/.github/workflows/fix-dependabot-alerts.yml
@@ -34,7 +34,7 @@ concurrency:
 permissions:
   contents: write
   pull-requests: write
-  security-events: read
+  security-events: write
 
 env:
   ELECTRON_CACHE: ${{ github.workspace }}/.cache/electron


### PR DESCRIPTION
The Dependabot alerts REST API returns 403 with \security-events: read\. Changing to \security-events: write\ may unlock access for the \GITHUB_TOKEN\.

### Change

\\\yaml
permissions:
  security-events: write  # was: read
\\\

### How to verify

Merge and re-run the \ix-dependabot-alerts\ workflow. If it gets past the 403, we don't need a GitHub App.