### PR TITLE
fix: add gh auth debug step and use GITHUB_TOKEN directly

### DIFF
--- a/.github/workflows/fix-dependabot-alerts.yml
+++ b/.github/workflows/fix-dependabot-alerts.yml
@@ -5,10 +5,8 @@
 # fix-dependabot-alerts script, verifying the build for each fix,
 # and opening a pull request with the passing changes.
 #
-# REQUIRED: A repository secret named DEPENDABOT_PAT containing a
-# Personal Access Token (classic) with the `security_events` scope,
-# or a fine-grained token with "Dependabot alerts" read permission.
-# The default GITHUB_TOKEN cannot access the Dependabot alerts API.
+# Requires security-events: write permission for the GITHUB_TOKEN
+# to access the Dependabot alerts REST API.
 
 name: fix-dependabot-alerts
 
@@ -64,6 +62,14 @@ jobs:
         working-directory: ts
         run: pnpm install --frozen-lockfile --strict-peer-dependencies
 
+      - name: Verify gh authentication
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh auth status
+          echo "---"
+          gh api repos/${{ github.repository }}/dependabot/alerts?per_page=1 --jq 'length' || echo "API call failed with exit $?"
+
       # ── Analyse and fix alerts (bisect) ─────────────────────────────
       #
       # 1. Dry-run to discover fixable packages
@@ -74,9 +80,7 @@ jobs:
         id: fix
         working-directory: ts
         env:
-          # NOTE: GITHUB_TOKEN cannot access Dependabot alerts API (403).
-          # A PAT with security_events scope must be stored as DEPENDABOT_PAT.
-          GH_TOKEN: ${{ secrets.DEPENDABOT_PAT || secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # ── Step 1: Discover fixable packages ───────────────────────
           echo "::group::Analysing alerts"


### PR DESCRIPTION
## Changes

- Add **\Verify gh authentication\** step that runs \gh auth status\ and a test API call before the main script
- Remove \DEPENDABOT_PAT\ fallback — use \GITHUB_TOKEN\ directly with \security-events: write\
- Update header comment to reflect GITHUB_TOKEN approach

## Why

The previous run returned 403 on the Dependabot alerts API. This PR:
1. Adds diagnostics (\gh auth status\ + minimal API call) to confirm token wiring
2. Simplifies auth to rely solely on \GITHUB_TOKEN\ with the correct \security-events: write\ permission
3. Removes stale references to PAT-based authentication

## Testing

Merge and re-run the \ix-dependabot-alerts\ workflow. The new debug step will show:
- Whether \gh\ is authenticated
- Token scopes
- Whether the Dependabot API is accessible
