### PR TITLE
fix: use GitHub App token for Dependabot alerts API

### DIFF
--- a/.github/workflows/fix-dependabot-alerts.yml
+++ b/.github/workflows/fix-dependabot-alerts.yml
@@ -34,7 +34,6 @@ concurrency:
 permissions:
   contents: write
   pull-requests: write
-  security-events: write
 
 env:
   ELECTRON_CACHE: ${{ github.workspace }}/.cache/electron


### PR DESCRIPTION
## Changes

- Add **actions/create-github-app-token@v1** step to mint a short-lived token from a GitHub App
- Use the App token (instead of GITHUB_TOKEN) for all Dependabot API calls
- Keep GITHUB_TOKEN for PR creation (which only needs repo write access)
- Remove unnecessary security-events permission

## Why

GITHUB_TOKEN returns HTTP 403 on the Dependabot alerts REST API. This is a known limitation — the endpoint does not support GITHUB_TOKEN.

A GitHub App with **Dependabot alerts: read** permission provides the required access.

## Prerequisites

Before merging, ensure these are configured:
- **Repo variable** DEPENDABOT_APP_ID — the numeric App ID
- **Repo secret** DEPENDABOT_APP_PRIVATE_KEY — the App's private key (.pem)
- The App must be installed on the microsoft/TypeAgent repo with Dependabot alerts read permission