### PR TITLE
fix: use App token for PR creation in dependabot workflow

### DIFF
--- a/.github/workflows/fix-dependabot-alerts.yml
+++ b/.github/workflows/fix-dependabot-alerts.yml
@@ -238,7 +238,7 @@ jobs:
       - name: Create pull request
         if: ${{ steps.fix.outputs.changes == 'true' && steps.build.outputs.build_ok == 'true' }}
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           BRANCH="automated/fix-dependabot-alerts-$(date +%Y%m%d)"
 


### PR DESCRIPTION
## Changes

Use the GitHub App token (instead of GITHUB_TOKEN) for the PR creation step.

## Why

The previous workflow run successfully fetched alerts, applied fixes (lodash, picomatch, undici), passed build and shell:package, but failed at PR creation with:

> GitHub Actions is not permitted to create or approve pull requests

This is because GITHUB_TOKEN is restricted from creating PRs by repo settings. Using the App token (which already has Pull requests: write permission) bypasses this restriction.

## Prerequisites

The GitHub App needs Pull requests: write and Contents: write permissions (in addition to the existing Dependabot alerts: read).