### PR TITLE
fix: use unique branch name for dependabot workflow runs

### DIFF
--- a/.github/workflows/fix-dependabot-alerts.yml
+++ b/.github/workflows/fix-dependabot-alerts.yml
@@ -240,7 +240,7 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
-          BRANCH="automated/fix-dependabot-alerts-$(date +%Y%m%d)"
+          BRANCH="automated/fix-dependabot-alerts-$(date +%Y%m%d)-${{ github.run_number }}"
 
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"


### PR DESCRIPTION
## Changes

Appends github.run_number to the automated PR branch name to make it unique per run.

## Why

Re-running the workflow on the same day fails because the branch already exists from a previous run:

> ! [rejected] automated/fix-dependabot-alerts-20260407 -> ... (non-fast-forward)

Now each run creates a unique branch like automated/fix-dependabot-alerts-20260407-8.