### PR TITLE
Update default session resume behavior for agent server

### DIFF
--- a/ts/docs/architecture/agentServerSessions.md
+++ b/ts/docs/architecture/agentServerSessions.md
@@ -18,7 +18,7 @@ As we begin making a larger shift towards a client-server model with the agent s
 - **Rename** a session.
 - **Delete** a session and its persisted data.
 - Sessions are identified by a **GUID** and carry a human-readable **name** and **client count** so clients can make informed join decisions.
-- Clients specify an **optional session ID** at `joinSession()` time; omitting it resumes the most recently active session, or auto-creates a default session if none exist.
+- Clients specify an **optional session ID** at `joinSession()` time; omitting it connects to the default session, or auto-creates one if none exist. The server always resolves to `"default"` rather than the most recently active session because in a multi-client environment, "most recently active" is a server-wide concept — a CLI user spinning up independently should not be silently dropped into an active Shell session. Clients that want last-used behavior should remember their last session ID locally and pass it explicitly.
 - Session isolation is **client-enforced** for now — the server provides the signals, clients decide the policy.
 
 ## Non-Goals
@@ -87,8 +87,7 @@ A `sessions.json` file lives at `persistDir/server-sessions/sessions.json` and i
       "name": "workout playlist setup",
       "createdAt": "2026-04-01T10:00:00Z"
     }
-  ],
-  "lastActiveSessionId": "a1b2c3d4-..."
+  ]
 }
 ```
 
@@ -108,7 +107,7 @@ type DispatcherConnectOptions = {
   clientType?: "shell" | "extension";
 
   // Session management (new)
-  sessionId?: string; // Join a specific session by UUID. If omitted → resumes most recently active session.
+  sessionId?: string; // Join a specific session by UUID. If omitted → connects to the default session.
 };
 ```
 
@@ -189,12 +188,11 @@ Client calls joinSession({ sessionId?, clientType, filter })
   │   ├─ Yes → look up sessions.json
   │   │   ├─ Found → load SharedDispatcher for this session (lazy init if not in memory pool)
   │   │   └─ Not found → return error: "Session not found"
-  │   └─ No → resolve most recently active session
-  │       ├─ lastActiveSessionId set and valid → use it
+  │   └─ No → connect to the default session
+  │       ├─ Session named "default" exists → use it
   │       └─ No sessions exist → auto-create session named "default"
   │
   ├─ Register client in session's SharedDispatcher routing table
-  ├─ Update lastActiveSessionId in sessions.json
   └─ Return JoinSessionResult { connectionId, sessionId }
 ```
 
@@ -227,7 +225,7 @@ SessionInfo[]
 1. Close all active client dispatcher handles for the session.
 2. Shut down and evict the session's `SharedDispatcher` from the in-memory pool.
 3. Remove `persistDir/server-sessions/<sessionId>/` from disk (recursive delete, best-effort).
-4. Remove the entry from `sessions.json` and update `lastActiveSessionId` if needed.
+4. Remove the entry from `sessions.json`.
 
 > **Note:** Any connected client can call `deleteSession` on any session, including sessions they are not currently connected to. The calling client's session-namespaced channels are cleaned up immediately; other clients connected to the deleted session have their dispatcher handles closed when `SharedDispatcher.close()` is called. Server-side authorization is out of scope for v1 (see Open Questions).
 
@@ -242,11 +240,11 @@ The CLI implements the full session management surface described in this documen
 #### `connect` — join a session
 
 ```bash
-agent-cli connect                        # resume most recently active session
+agent-cli connect                        # connect to the default session
 agent-cli connect --session <id>         # resume a specific session by ID
 ```
 
-`connect.ts` passes `{ sessionId: flags.session }` to `ensureAndConnectSession()` when `--session` is provided; omitting the flag calls `joinSession()` without a session ID, letting the server resolve the most recently active session (or auto-create `"default"`).
+`connect.ts` passes `{ sessionId: flags.session }` to `ensureAndConnectSession()` when `--session` is provided; omitting the flag calls `joinSession()` without a session ID, letting the server connect to the default session (or auto-create `"default"` if none exist).
 
 #### `sessions` topic — session CRUD
 
@@ -269,7 +267,7 @@ Session management only applies when the Shell is running in **connected mode** 
 
 When connected to the agentServer:
 
-- On startup, Shell calls `listSessions()` and presents a session picker (or auto-resumes the most recently active session).
+- On startup, Shell calls `listSessions()` and presents a session picker (or auto-connects to the default session).
 - A session management panel allows listing, switching, renaming, and deleting sessions.
 - When resuming a session, the Shell loads chat history from the server via `getDisplayHistory()` (which already exists on the `Dispatcher` interface and works per-session since each session has its own `DisplayLog` instance) rather than its local HTML file. How this history is rendered in the Shell UI is an open question — see Open Questions item 2.
 

--- a/ts/packages/agentServer/README.md
+++ b/ts/packages/agentServer/README.md
@@ -91,11 +91,10 @@ Client calls joinSession({ sessionId?, clientType, filter })
   │   ├─ Yes → look up sessions.json
   │   │   ├─ Found → load SharedDispatcher (lazy init if not in memory)
   │   │   └─ Not found → error: "Session not found"
-  │   └─ No → resume most recently active session
+  │   └─ No → connect to the default session
   │       └─ No sessions exist → auto-create session named "default"
   │
   ├─ Register client in session's SharedDispatcher routing table
-  ├─ Update lastActiveSessionId in sessions.json
   └─ Return { connectionId, sessionId }
 ```
 

--- a/ts/packages/agentServer/protocol/README.md
+++ b/ts/packages/agentServer/protocol/README.md
@@ -37,11 +37,11 @@ getClientIOChannelName(sessionId: string): string // "clientio:<sessionId>"
 
 **`DispatcherConnectOptions`** — options passed to `joinSession`:
 
-| Field        | Type      | Description                                                                       |
-| ------------ | --------- | --------------------------------------------------------------------------------- |
-| `sessionId`  | `string`  | Join a specific session by UUID. Omit to resume the most recently active session. |
-| `clientType` | `string`  | Identifies the client (`"shell"`, `"extension"`, etc.)                            |
-| `filter`     | `boolean` | If true, only receive ClientIO messages for this connection's requests            |
+| Field        | Type      | Description                                                              |
+| ------------ | --------- | ------------------------------------------------------------------------ |
+| `sessionId`  | `string`  | Join a specific session by UUID. Omit to connect to the default session. |
+| `clientType` | `string`  | Identifies the client (`"shell"`, `"extension"`, etc.)                   |
+| `filter`     | `boolean` | If true, only receive ClientIO messages for this connection's requests   |
 
 ## RPC methods
 

--- a/ts/packages/agentServer/protocol/src/protocol.ts
+++ b/ts/packages/agentServer/protocol/src/protocol.ts
@@ -4,7 +4,7 @@
 export type DispatcherConnectOptions = {
     filter?: boolean; // filter to message for own request. Default is false (no filtering)
     clientType?: "shell" | "extension"; // identifies the connecting client type
-    sessionId?: string; // join a specific session by UUID. If omitted, joins the most recently active session.
+    sessionId?: string; // join a specific session by UUID. If omitted, connects to the default session.
 };
 
 export type SessionInfo = {

--- a/ts/packages/agentServer/server/README.md
+++ b/ts/packages/agentServer/server/README.md
@@ -48,7 +48,6 @@ Maintains a pool of per-session `SharedDispatcher` instances. Key behaviors:
 - **Persistence:** session metadata stored in `~/.typeagent/server-sessions/sessions.json`; each session's data in `~/.typeagent/server-sessions/<sessionId>/`
 - **Lazy init:** each session's `SharedDispatcher` is created on first `joinSession()` and torn down after 5 minutes of inactivity
 - **Auto-create:** if no session exists and no `sessionId` is provided, a `"default"` session is created automatically
-- **Last active tracking:** `lastActiveSessionId` is updated on each join so the most recently used session is resumed by default
 
 ### `sharedDispatcher.ts` — Routing layer
 

--- a/ts/packages/agentServer/server/src/server.ts
+++ b/ts/packages/agentServer/server/src/server.ts
@@ -63,7 +63,7 @@ async function main() {
     // Pre-initialize the default session dispatcher before accepting clients,
     // so the first joinSession call is fast and concurrent joinSession calls
     // don't race to initialize the same dispatcher.
-    await sessionManager.prewarmMostRecentSession();
+    await sessionManager.prewarmDefaultSession();
 
     const wss = await createWebSocketChannelServer(
         { port: 8999 },

--- a/ts/packages/agentServer/server/src/sessionManager.ts
+++ b/ts/packages/agentServer/server/src/sessionManager.ts
@@ -40,22 +40,21 @@ type SessionRecord = {
 
 type PersistedMetadata = {
     sessions: SessionMetadata[];
-    lastActiveSessionId: string | undefined;
 };
 
 export type SessionManager = {
     createSession(name: string): Promise<SessionInfo>;
     /**
-     * Resolve a session ID. If undefined, returns the most recently active
-     * session, creating a default one if none exist.
+     * Resolve a session ID. If undefined, returns the default session,
+     * creating one if none exist.
      */
     resolveSessionId(sessionId: string | undefined): Promise<string>;
     /**
-     * Pre-initialize the most recently active session's dispatcher so it is
-     * ready before the first client connects. If no sessions exist, a "default"
-     * session is created. Safe to call multiple times.
+     * Pre-initialize the default session's dispatcher so it is ready before
+     * the first client connects. If no sessions exist, a "default" session is
+     * created. Safe to call multiple times.
      */
-    prewarmMostRecentSession(): Promise<void>;
+    prewarmDefaultSession(): Promise<void>;
     joinSession(
         sessionId: string,
         clientIO: ClientIO,
@@ -79,7 +78,6 @@ export async function createSessionManager(
     await fs.promises.mkdir(sessionsDir, { recursive: true });
 
     const sessions = new Map<string, SessionRecord>();
-    let lastActiveSessionId: string | undefined;
 
     // Load persisted metadata
     await loadMetadata();
@@ -100,7 +98,6 @@ export async function createSessionManager(
                     idleTimer: undefined,
                 });
             }
-            lastActiveSessionId = persisted.lastActiveSessionId;
             debugSession(`Loaded ${sessions.size} session(s) from metadata`);
         } catch (e: any) {
             if (e?.code === "ENOENT") {
@@ -138,7 +135,6 @@ export async function createSessionManager(
         }
         const persisted: PersistedMetadata = {
             sessions: entries,
-            lastActiveSessionId,
         };
         await fs.promises.writeFile(
             tmpPath,
@@ -225,16 +221,19 @@ export async function createSessionManager(
         const record = sessions.get(sessionId);
         if (record) {
             record.lastActiveAt = Date.now();
-            lastActiveSessionId = sessionId;
         }
     }
 
-    function getMostRecentSessionId(): string | undefined {
-        // Prefer explicitly tracked last active session
-        if (lastActiveSessionId && sessions.has(lastActiveSessionId)) {
-            return lastActiveSessionId;
+    function getDefaultSessionId(): string | undefined {
+        for (const [id, record] of sessions) {
+            if (record.name === "default") {
+                return id;
+            }
         }
-        // Fall back to any existing session
+        return undefined;
+    }
+
+    function getAnySessionId(): string | undefined {
         for (const id of sessions.keys()) {
             return id;
         }
@@ -264,7 +263,6 @@ export async function createSessionManager(
                 idleTimer: undefined,
             };
             sessions.set(sessionId, record);
-            lastActiveSessionId = sessionId;
             await saveMetadata();
             debugSession(`Session created: "${name}" (${sessionId})`);
             return {
@@ -282,7 +280,8 @@ export async function createSessionManager(
                 }
                 return sessionId;
             }
-            const resolved = getMostRecentSessionId();
+            // Prefer the session named "default"; fall back to any existing session
+            const resolved = getDefaultSessionId() ?? getAnySessionId();
             if (resolved !== undefined) {
                 return resolved;
             }
@@ -291,7 +290,7 @@ export async function createSessionManager(
             return info.sessionId;
         },
 
-        async prewarmMostRecentSession(): Promise<void> {
+        async prewarmDefaultSession(): Promise<void> {
             const sessionId = await manager.resolveSessionId(undefined);
             const record = sessions.get(sessionId)!;
             cancelIdleTimer(record);
@@ -404,11 +403,6 @@ export async function createSessionManager(
             }
 
             sessions.delete(sessionId);
-
-            // Update last active if we just deleted it
-            if (lastActiveSessionId === sessionId) {
-                lastActiveSessionId = getMostRecentSessionId();
-            }
 
             // Remove persist directory
             const persistDir = getSessionPersistDir(sessionId);

--- a/ts/packages/cli/README.md
+++ b/ts/packages/cli/README.md
@@ -141,12 +141,12 @@ There are 3 command under `agent-cli run`:
 `agent-cli connect` starts the interactive agent in connected mode, attaching to a running (or auto-started) agent server.
 
 ```bash
-agent-cli connect                        # resume most recently active session
+agent-cli connect                        # connect to the default session
 agent-cli connect --session <id>         # resume a specific session by ID
 agent-cli connect --port <port>          # connect to a server on a non-default port (default: 8999)
 ```
 
-- If `--session <id>` is omitted, the server resumes the most recently active session, or auto-creates a session named `"default"` if none exist.
+- If `--session <id>` is omitted, the server connects to the default session, or auto-creates a session named `"default"` if none exist.
 - The server is started automatically if it is not already running.
 
 ### `agent-cli sessions`

--- a/ts/packages/cli/src/commands/connect.ts
+++ b/ts/packages/cli/src/commands/connect.ts
@@ -67,7 +67,7 @@ async function getCompletionsData(
 
 export default class Connect extends Command {
     static description =
-        "Connect to the agent server in interactive mode. Resumes the most recently active session, or specify --session <id> to join a specific one.";
+        "Connect to the agent server in interactive mode. Connects to the default session, or specify --session <id> to join a specific one.";
     static flags = {
         request: Flags.string({
             description:
@@ -85,7 +85,7 @@ export default class Connect extends Command {
         }),
         session: Flags.string({
             description:
-                "Session ID to join. Omit to resume the most recently active session.",
+                "Session ID to join. Omit to connect to the default session.",
             required: false,
         }),
         verbose: Flags.string({


### PR DESCRIPTION
AgentServer should connect users to the default global session when no session ID is specified, rather than arbitrarily joining the last-used session, which may be isolated to another client. Session persistence should be handled client-side.