### PR TITLE
Add ToggleMouseSonar and AdjustVolume desktop actions

### DIFF
--- a/dotnet/autoShell.Tests/AudioActionHandlerTests.cs
+++ b/dotnet/autoShell.Tests/AudioActionHandlerTests.cs
@@ -135,6 +135,80 @@ public class AudioActionHandlerTests
         _audioMock.Verify(a => a.SetMute(false), Times.Once);
     }
 
+    // --- AdjustVolume ---
+
+    /// <summary>
+    /// Verifies that AdjustVolume "up" increases volume by the specified amount.
+    /// </summary>
+    [Fact]
+    public void AdjustVolume_Up_IncreasesVolume()
+    {
+        _audioMock.Setup(a => a.GetVolume()).Returns(50);
+
+        var result = _handler.Handle("AdjustVolume", JsonDocument.Parse("""{"direction":"up","amount":15}""").RootElement);
+
+        Assert.True(result.Success);
+        _audioMock.Verify(a => a.SetVolume(65), Times.Once);
+    }
+
+    /// <summary>
+    /// Verifies that AdjustVolume "down" decreases volume by the specified amount.
+    /// </summary>
+    [Fact]
+    public void AdjustVolume_Down_DecreasesVolume()
+    {
+        _audioMock.Setup(a => a.GetVolume()).Returns(50);
+
+        var result = _handler.Handle("AdjustVolume", JsonDocument.Parse("""{"direction":"down","amount":20}""").RootElement);
+
+        Assert.True(result.Success);
+        _audioMock.Verify(a => a.SetVolume(30), Times.Once);
+    }
+
+    /// <summary>
+    /// Verifies that AdjustVolume defaults to 10% when amount is omitted.
+    /// </summary>
+    [Fact]
+    public void AdjustVolume_DefaultAmount_AdjustsBy10()
+    {
+        _audioMock.Setup(a => a.GetVolume()).Returns(40);
+
+        _handler.Handle("AdjustVolume", JsonDocument.Parse("""{"direction":"up"}""").RootElement);
+
+        _audioMock.Verify(a => a.SetVolume(50), Times.Once);
+    }
+
+    /// <summary>
+    /// Verifies that AdjustVolume clamps to 0-100 range.
+    /// </summary>
+    [Theory]
+    [InlineData("up", 95, 30, 100)]   // 95 + 30 = 125, clamped to 100
+    [InlineData("down", 10, 25, 0)]    // 10 - 25 = -15, clamped to 0
+    public void AdjustVolume_ClampsToRange(string direction, int current, int amount, int expected)
+    {
+        _audioMock.Setup(a => a.GetVolume()).Returns(current);
+
+        _handler.Handle("AdjustVolume", JsonDocument.Parse($$"""{"direction":"{{direction}}","amount":{{amount}}}""").RootElement);
+
+        _audioMock.Verify(a => a.SetVolume(expected), Times.Once);
+    }
+
+    /// <summary>
+    /// Verifies that AdjustVolume saves the current volume before adjusting.
+    /// </summary>
+    [Fact]
+    public void AdjustVolume_SavesCurrentVolume()
+    {
+        _audioMock.Setup(a => a.GetVolume()).Returns(60);
+
+        _handler.Handle("AdjustVolume", JsonDocument.Parse("""{"direction":"up","amount":10}""").RootElement);
+        _audioMock.Invocations.Clear();
+
+        _handler.Handle("RestoreVolume", JsonDocument.Parse("{}").RootElement);
+
+        _audioMock.Verify(a => a.SetVolume(60), Times.Once);
+    }
+
     // --- Unknown key ---
 
     /// <summary>

--- a/dotnet/autoShell.Tests/SettingsHandlerTests.cs
+++ b/dotnet/autoShell.Tests/SettingsHandlerTests.cs
@@ -621,6 +621,28 @@ public class MouseSettingsHandlerTests
         _systemParamsMock.Verify(s => s.SwapMouseButton(false), Times.Once);
     }
 
+    /// <summary>
+    /// Verifies that ToggleMouseSonar enable writes "1" to the MouseSonar registry value.
+    /// </summary>
+    [Fact]
+    public void ToggleMouseSonar_Enable_SetsSonar1()
+    {
+        Handle("ToggleMouseSonar", """{"enable":true}""");
+
+        _registryMock.Verify(r => r.SetValue(@"Control Panel\Mouse", "MouseSonar", "1", RegistryValueKind.String), Times.Once);
+    }
+
+    /// <summary>
+    /// Verifies that ToggleMouseSonar disable writes "0" to the MouseSonar registry value.
+    /// </summary>
+    [Fact]
+    public void ToggleMouseSonar_Disable_SetsSonar0()
+    {
+        Handle("ToggleMouseSonar", """{"enable":false}""");
+
+        _registryMock.Verify(r => r.SetValue(@"Control Panel\Mouse", "MouseSonar", "0", RegistryValueKind.String), Times.Once);
+    }
+
     private void Handle(string key, string jsonValue)
     {
         _handler.Handle(key, JsonDocument.Parse(jsonValue).RootElement);

--- a/dotnet/autoShell/Handlers/AudioActionHandler.cs
+++ b/dotnet/autoShell/Handlers/AudioActionHandler.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System;
 using autoShell.Handlers.Generated;
 using autoShell.Services;
 
@@ -17,6 +18,7 @@ internal class AudioActionHandler : ActionHandlerBase
     public AudioActionHandler(IAudioService audio)
     {
         _audio = audio;
+        AddAction<AdjustVolumeParams>("AdjustVolume", HandleAdjustVolume);
         AddAction<MuteParams>("Mute", HandleMute);
         AddAction<RestoreVolumeParams>("RestoreVolume", HandleRestoreVolume);
         AddAction<VolumeParams>("Volume", HandleVolume);
@@ -27,6 +29,23 @@ internal class AudioActionHandler : ActionHandlerBase
         bool mute = p.On;
         _audio.SetMute(mute);
         return ActionResult.Ok($"Audio {(mute ? "muted" : "unmuted")}");
+    }
+
+    private ActionResult HandleAdjustVolume(AdjustVolumeParams p)
+    {
+        int current = _audio.GetVolume();
+        int amount = p.Amount is > 0 ? p.Amount.Value : 10;
+        int target = p.Direction.Equals("down", StringComparison.OrdinalIgnoreCase)
+            ? current - amount
+            : current + amount;
+        target = Math.Clamp(target, 0, 100);
+
+        if (current > 0)
+        {
+            _savedVolumePct = current;
+        }
+        _audio.SetVolume(target);
+        return ActionResult.Ok($"Volume adjusted from {current}% to {target}%");
     }
 
     private ActionResult HandleRestoreVolume(RestoreVolumeParams p)

--- a/dotnet/autoShell/Handlers/Settings/MouseSettingsHandler.cs
+++ b/dotnet/autoShell/Handlers/Settings/MouseSettingsHandler.cs
@@ -40,6 +40,9 @@ internal class MouseSettingsHandler : SettingsHandlerBase
         AddOpenSettingsAction("MousePointerCustomization", new OpenSettingsConfig("ms-settings:easeofaccess-mouse", "mouse settings"));
         AddOpenSettingsAction("EnableTouchPad", new OpenSettingsConfig("ms-settings:devices-touchpad", "touchpad settings"));
         AddOpenSettingsAction("TouchpadCursorSpeed", new OpenSettingsConfig("ms-settings:devices-touchpad", "touchpad settings"));
+        AddRegistryToggleAction("ToggleMouseSonar", new RegistryToggleConfig(
+            @"Control Panel\Mouse", "MouseSonar", "enable",
+            OnValue: "1", OffValue: "0", ValueKind: Microsoft.Win32.RegistryValueKind.String, DisplayName: "Mouse Sonar"));
         AddAction<CursorTrailParams>("CursorTrail", HandleMouseCursorTrail);
         AddAction<EnhancePointerPrecisionParams>("EnhancePointerPrecision", HandleEnhancePointerPrecision);
         AddAction<MouseCursorSpeedParams>("MouseCursorSpeed", HandleMouseCursorSpeed);

--- a/dotnet/autoShell/README.md
+++ b/dotnet/autoShell/README.md
@@ -109,6 +109,7 @@ Each command returns a JSON `ActionResult` on stdout:
 | `ToggleAirplaneMode` | `true`/`false` | Enables or disables Windows airplane mode |
 | `ToggleNotifications` | (none) | Toggles the Windows notification center |
 | `Volume` | `0-100` | Sets system volume percentage |
+| `AdjustVolume` | `{"direction": "up"/"down", "amount": 10}` | Adjusts volume relatively (default ±10%) |
 
 #### Settings Commands
 
@@ -165,6 +166,7 @@ Each command returns a JSON `ActionResult` on stdout:
 | `MousePointerCustomization` | (none) | Opens mouse pointer settings |
 | `MouseWheelScrollLines` | `{"scrollLines": 1-100}` | Sets mouse wheel scroll lines (default 3) |
 | `SetPrimaryMouseButton` | `{"primaryButton": "left"/"right"}` | Sets primary mouse button |
+| `ToggleMouseSonar` | `{"enable": true/false}` | Enables/disables "Find my pointer" Ctrl ring |
 | `TouchpadCursorSpeed` | (none) | Opens touchpad settings |
 
 ##### Privacy Settings

--- a/ts/packages/agents/desktop/src/actionsSchema.ts
+++ b/ts/packages/agents/desktop/src/actionsSchema.ts
@@ -9,6 +9,7 @@ export type DesktopActions =
     | MinimizeWindowAction
     | SwitchToWindowAction
     | SetVolumeAction
+    | AdjustVolumeAction
     | RestoreVolumeAction
     | MuteVolumeAction
     | SetWallpaperAction
@@ -93,6 +94,15 @@ export type SetVolumeAction = {
     actionName: "Volume";
     parameters: {
         targetVolume: number; // value between 0 and 100
+    };
+};
+
+// Adjusts system volume up or down by a relative amount
+export type AdjustVolumeAction = {
+    actionName: "AdjustVolume";
+    parameters: {
+        direction: "up" | "down"; // whether to increase or decrease volume
+        amount?: number; // percentage to adjust by (default 10)
     };
 };
 

--- a/ts/packages/agents/desktop/src/windows/inputActionsSchema.ts
+++ b/ts/packages/agents/desktop/src/windows/inputActionsSchema.ts
@@ -10,7 +10,8 @@ export type DesktopInputActions =
     | MousePointerCustomizationAction
     | CursorTrailAction
     | EnableTouchPadAction
-    | TouchpadCursorSpeedAction;
+    | TouchpadCursorSpeedAction
+    | ToggleMouseSonarAction;
 
 // Adjusts mouse cursor speed
 export type MouseCursorSpeedAction = {
@@ -84,5 +85,13 @@ export type TouchpadCursorSpeedAction = {
     actionName: "TouchpadCursorSpeed";
     parameters: {
         speed?: number;
+    };
+};
+
+// Enables or disables the "Find my pointer" sonar ring when pressing Ctrl
+export type ToggleMouseSonarAction = {
+    actionName: "ToggleMouseSonar";
+    parameters: {
+        enable: boolean;
     };
 };


### PR DESCRIPTION
This branch (based on `talzacc/action_json_schema`) demonstrates how easy it is to add new actions after the architecture refactoring in #2196. Two new actions are added, showcasing the two main patterns described in the [README](dotnet/autoShell/README.md#adding-a-new-action).

### ToggleMouseSonar — Option A: Registry Toggle

Enables/disables the Windows "Find my pointer" ring that appears when pressing Ctrl.

**Total lines added: 1** (in `MouseSettingsHandler.cs`)

```csharp
AddRegistryToggleAction("ToggleMouseSonar", new RegistryToggleConfig(
    @"Control Panel\Mouse", "MouseSonar", "enable",
    OnValue: "1", OffValue: "0", ValueKind: RegistryValueKind.String, DisplayName: "Mouse Sonar"));
```

No custom handler logic. The `AddRegistryToggleAction` helper does everything — reads the `enable` parameter, writes the registry value, returns an `ActionResult`.

### AdjustVolume — Option B: Typed Action with Custom Logic

Adjusts volume relatively ("turn it up a bit") instead of setting an absolute value.

**Steps:**
1. Define TS schema type in `actionsSchema.ts`
2. Add handler in `AudioActionHandler.cs` — reads current volume, applies delta, clamps 0–100, saves for restore

```typescript
export type AdjustVolumeAction = {
    actionName: "AdjustVolume";
    parameters: {
        direction: "up" | "down";
        amount?: number; // default 10
    };
};
```

The C# `AdjustVolumeParams` record is **automatically generated** by the Roslyn source generator from the `.pas.json` schema — no manual C# type definition needed.

### Test Coverage

- 6 new tests for `AdjustVolume` (up/down, default amount, clamping, volume save)
- 2 new tests for `ToggleMouseSonar` (enable/disable registry writes)
