### PR TITLE
Implement CLI in-conversation session management

### DIFF
--- a/ts/packages/agentServer/server/src/sessionManager.ts
+++ b/ts/packages/agentServer/server/src/sessionManager.ts
@@ -396,6 +396,15 @@ export async function createSessionManager(
             if (record.sharedDispatcher === undefined) {
                 return; // Session not active
             }
+
+            // Notify remaining clients before this client leaves
+            if (record.sharedDispatcher.clientCount > 1) {
+                record.sharedDispatcher.broadcastSystemMessage(
+                    `[A client has left this conversation. You remain connected to '${record.name}'.]`,
+                    connectionId,
+                );
+            }
+
             await record.sharedDispatcher.leave(connectionId);
             debugSession(
                 `Client ${connectionId} left session "${record.name}" (${sessionId}), clients: ${record.sharedDispatcher.clientCount}`,

--- a/ts/packages/agentServer/server/src/sessionManager.ts
+++ b/ts/packages/agentServer/server/src/sessionManager.ts
@@ -394,6 +394,9 @@ export async function createSessionManager(
                 throw new Error(`Session not found: ${sessionId}`);
             }
             if (record.sharedDispatcher === undefined) {
+                debugSession(
+                    `leaveSession: dispatcher not active for session "${record.name}" (${sessionId}), ignoring connectionId ${connectionId}`,
+                );
                 return; // Session not active
             }
 

--- a/ts/packages/agentServer/server/src/sharedDispatcher.ts
+++ b/ts/packages/agentServer/server/src/sharedDispatcher.ts
@@ -415,6 +415,32 @@ export async function createSharedDispatcher(
                 );
             });
         },
+        broadcastSystemMessage(
+            message: string,
+            excludeConnectionId?: string,
+        ): void {
+            const agentMessage = {
+                message: {
+                    type: "text" as const,
+                    content: message,
+                    kind: "status" as const,
+                },
+                requestId: { requestId: "system" },
+                source: "system",
+            };
+            for (const [connectionId, clientRecord] of clients) {
+                if (connectionId === excludeConnectionId) {
+                    continue;
+                }
+                try {
+                    clientRecord.clientIO.appendDisplay(agentMessage, "block");
+                } catch (error) {
+                    debugClientIOError(
+                        `ClientIO error on broadcastSystemMessage for client ${connectionId}: ${error}`,
+                    );
+                }
+            }
+        },
         async leave(connectionId: string) {
             const dispatcher = dispatchers.get(connectionId);
             if (dispatcher) {
@@ -455,6 +481,7 @@ export type SharedDispatcher = {
         filter: boolean,
     ): PendingInteractionRequest[];
     leave(connectionId: string): Promise<void>;
+    broadcastSystemMessage(message: string, excludeConnectionId?: string): void;
     closeAllClients(): Promise<void>;
     close(): Promise<void>;
 };

--- a/ts/packages/agentServer/server/src/sharedDispatcher.ts
+++ b/ts/packages/agentServer/server/src/sharedDispatcher.ts
@@ -444,6 +444,11 @@ export async function createSharedDispatcher(
         async leave(connectionId: string) {
             const dispatcher = dispatchers.get(connectionId);
             if (dispatcher) {
+                // Remove from clients synchronously so clientCount reflects the
+                // post-leave state before any async close work completes.
+                // The close callback also calls clients.delete, but that is
+                // idempotent so the double-delete is harmless.
+                clients.delete(connectionId);
                 await dispatcher.close();
             }
         },

--- a/ts/packages/cli/README.md
+++ b/ts/packages/cli/README.md
@@ -165,12 +165,15 @@ agent-cli connect --resume               # resume the last used session
 agent-cli connect --session <id>         # connect to a specific session by ID
 agent-cli connect --port <port>          # connect to a server on a non-default port (default: 8999)
 agent-cli connect --hidden               # start the server hidden (no visible window)
+agent-cli connect --memory               # use an ephemeral session (deleted on exit)
 ```
 
 - By default, `connect` targets a session named `"CLI"`. If no such session exists on the server it is created automatically.
 - Pass `--resume` / `-r` to instead resume the last used session (persisted client-side in `~/.typeagent/cli-state.json`). If that session no longer exists, you will be prompted to join the `"CLI"` session.
 - Pass `--session` / `-s <id>` to connect to any specific session by its UUID. Takes priority over `--resume` if both are provided.
+- Pass `--memory` to use an ephemeral session that is created fresh and automatically deleted when you exit. Cannot be combined with `--session` or `--resume`.
 - The server is started automatically if it is not already running. By default it starts in a visible window; pass `--hidden` to suppress the window.
+- On connect (and on every conversation switch), the session name is printed after any replayed history, just below the `─── now ─────` separator.
 
 ### `@conversation` Commands (Connect Mode)
 
@@ -188,12 +191,19 @@ Example:
 
 ```
 [player]🤖> @conversation new music-chat
-Created conversation 'music-chat'. Switch to 'music-chat' now? [y/N] y
+Created conversation 'music-chat'.
+Switch to 'music-chat' now? [y/N] y
+─── now ──────────────────────────────────────────────────────────────────────
+Connected to conversation 'music-chat'.
 [player]🤖> @conversation list
-  ▸ music-chat
-    CLI
+
+Conversations:
+  NAME            CREATED           CLIENTS
+  ──────────────────────────────────────────────────────
+▸ music-chat      2026-01-15 10:01  1  (current)
+  CLI             2026-01-14 09:00  0
 [player]🤖> @conversation rename playlist-session
-Renamed to 'playlist-session'.
+Renamed current conversation to 'playlist-session'.
 ```
 
 When multiple clients are connected and one switches conversations, the remaining clients in the old conversation see a status message:

--- a/ts/packages/cli/README.md
+++ b/ts/packages/cli/README.md
@@ -172,6 +172,36 @@ agent-cli connect --hidden               # start the server hidden (no visible w
 - Pass `--session` / `-s <id>` to connect to any specific session by its UUID. Takes priority over `--resume` if both are provided.
 - The server is started automatically if it is not already running. By default it starts in a visible window; pass `--hidden` to suppress the window.
 
+### `@conversation` Commands (Connect Mode)
+
+While in connect mode, you can manage conversations interactively using `@conversation` commands. These commands use conversation names (not UUIDs) everywhere.
+
+| Command                          | Description                                                          |
+| -------------------------------- | -------------------------------------------------------------------- |
+| `@conversation new <name>`       | Create a new conversation. Prompts to switch to it after creation.   |
+| `@conversation switch <name>`    | Switch to an existing conversation by name (case-insensitive).       |
+| `@conversation list [<filter>]`  | List all conversations. The current conversation is marked with `▸`. |
+| `@conversation rename <newName>` | Rename the current conversation.                                     |
+| `@conversation delete <name>`    | Delete a conversation by name (prompts for confirmation).            |
+
+Example:
+
+```
+[player]🤖> @conversation new music-chat
+Created conversation 'music-chat'. Switch to 'music-chat' now? [y/N] y
+[player]🤖> @conversation list
+  ▸ music-chat
+    CLI
+[player]🤖> @conversation rename playlist-session
+Renamed to 'playlist-session'.
+```
+
+When multiple clients are connected and one switches conversations, the remaining clients in the old conversation see a status message:
+
+```
+[A client has left this conversation. You remain connected to 'playlist-session'.]
+```
+
 ### `agent-cli server`
 
 `agent-cli server` provides commands to manage the agent server process.

--- a/ts/packages/cli/src/commands/connect.ts
+++ b/ts/packages/cli/src/commands/connect.ts
@@ -14,8 +14,11 @@ import {
     replayDisplayHistory,
     withEnhancedConsoleClientIO,
 } from "../enhancedConsole.js";
-import { isSlashCommand, getSlashCompletions } from "../slashCommands.js";
-import { setConversationCommandContext } from "../slashCommands.js";
+import {
+    isSlashCommand,
+    getSlashCompletions,
+    setConversationCommandContext,
+} from "../slashCommands.js";
 import type { ConversationCommandContext } from "../conversationCommands.js";
 import {
     connectAgentServer,
@@ -356,13 +359,14 @@ export default class Connect extends Command {
             if (!isEphemeral) {
                 saveLastSessionId(activeSessionId);
             }
-            console.log(`Connected to session '${activeName}'.`);
             bindDispatcher(activeDispatcher);
-            await replayDisplayHistory(activeDispatcher, clientIO);
+            await replayDisplayHistory(activeDispatcher, clientIO, activeName);
 
             // Set up ConversationCommandContext for @conversation commands.
-            // Only available when we have a connection (non-ephemeral or
-            // ephemeral — both have a connection object at this point).
+            // Only available when the AgentServerConnection is accessible
+            // (connectToCliSession / connectToEphemeralSession paths).
+            // The ensureAndConnectSession path (--session / --resume flags)
+            // does not expose the connection, so convCtx stays undefined there.
             let convCtx: ConversationCommandContext | undefined;
             if (connection !== undefined) {
                 convCtx = {
@@ -370,7 +374,8 @@ export default class Connect extends Command {
                     getCurrentSessionId: () => activeSessionId,
                     getCurrentSessionName: () => activeName,
                     switchSession: async (newSessionId: string) => {
-                        await connection.leaveSession(activeSessionId);
+                        // Join the new session first so that if it fails we
+                        // haven't already left the old one (avoids stranded state).
                         const newSession = await connection.joinSession(
                             clientIO,
                             { sessionId: newSessionId },
@@ -378,6 +383,7 @@ export default class Connect extends Command {
                         newSession.dispatcher.close = async () => {
                             await connection.close();
                         };
+                        await connection.leaveSession(activeSessionId);
                         activeDispatcher = newSession.dispatcher;
                         activeSessionId = newSession.sessionId;
                         activeName = newSession.name;
@@ -385,7 +391,11 @@ export default class Connect extends Command {
                         if (!isEphemeral) {
                             saveLastSessionId(activeSessionId);
                         }
-                        await replayDisplayHistory(activeDispatcher, clientIO);
+                        await replayDisplayHistory(
+                            activeDispatcher,
+                            clientIO,
+                            activeName,
+                        );
                         return newSession;
                     },
                 };

--- a/ts/packages/cli/src/commands/connect.ts
+++ b/ts/packages/cli/src/commands/connect.ts
@@ -15,6 +15,8 @@ import {
     withEnhancedConsoleClientIO,
 } from "../enhancedConsole.js";
 import { isSlashCommand, getSlashCompletions } from "../slashCommands.js";
+import { setConversationCommandContext } from "../slashCommands.js";
+import type { ConversationCommandContext } from "../conversationCommands.js";
 import {
     connectAgentServer,
     ensureAgentServer,
@@ -340,39 +342,85 @@ export default class Connect extends Command {
                 connection = result.connection;
             }
 
-            const { dispatcher, name, sessionId: connectedSessionId } = session;
+            const {
+                dispatcher: initialDispatcher,
+                name: initialName,
+                sessionId: initialSessionId,
+            } = session;
+
+            // Mutable session state — updated by switchSession callback
+            let activeDispatcher = initialDispatcher;
+            let activeSessionId = initialSessionId;
+            let activeName = initialName;
+
             if (!isEphemeral) {
-                saveLastSessionId(connectedSessionId);
+                saveLastSessionId(activeSessionId);
             }
-            console.log(`Connected to session '${name}'.`);
-            bindDispatcher(dispatcher);
-            await replayDisplayHistory(dispatcher, clientIO);
+            console.log(`Connected to session '${activeName}'.`);
+            bindDispatcher(activeDispatcher);
+            await replayDisplayHistory(activeDispatcher, clientIO);
+
+            // Set up ConversationCommandContext for @conversation commands.
+            // Only available when we have a connection (non-ephemeral or
+            // ephemeral — both have a connection object at this point).
+            let convCtx: ConversationCommandContext | undefined;
+            if (connection !== undefined) {
+                convCtx = {
+                    connection,
+                    getCurrentSessionId: () => activeSessionId,
+                    getCurrentSessionName: () => activeName,
+                    switchSession: async (newSessionId: string) => {
+                        await connection.leaveSession(activeSessionId);
+                        const newSession = await connection.joinSession(
+                            clientIO,
+                            { sessionId: newSessionId },
+                        );
+                        newSession.dispatcher.close = async () => {
+                            await connection.close();
+                        };
+                        activeDispatcher = newSession.dispatcher;
+                        activeSessionId = newSession.sessionId;
+                        activeName = newSession.name;
+                        bindDispatcher(activeDispatcher);
+                        if (!isEphemeral) {
+                            saveLastSessionId(activeSessionId);
+                        }
+                        await replayDisplayHistory(activeDispatcher, clientIO);
+                        return newSession;
+                    },
+                };
+                setConversationCommandContext(convCtx);
+            }
+
             try {
                 let processed = false;
                 if (flags.request) {
-                    await dispatcher.processCommand(flags.request);
+                    await activeDispatcher.processCommand(flags.request);
                     processed = true;
                 }
                 if (args.input) {
-                    await dispatcher.processCommand(`@run ${args.input}`);
+                    await activeDispatcher.processCommand(`@run ${args.input}`);
                     processed = true;
                 }
                 if (processed && flags.exit) {
                     return;
                 }
                 await processCommandsEnhanced(
-                    async (dispatcher: Dispatcher) =>
+                    async (_dispatcher: Dispatcher) =>
                         getEnhancedConsolePrompt(
-                            getStatusSummary(await dispatcher.getStatus(), {
-                                showPrimaryName: false,
-                            }),
+                            getStatusSummary(
+                                await activeDispatcher.getStatus(),
+                                { showPrimaryName: false },
+                            ),
                         ),
-                    (command: string, dispatcher: Dispatcher) =>
-                        dispatcher.processCommand(command),
-                    dispatcher,
+                    async (command: string, _dispatcher: Dispatcher) => {
+                        return activeDispatcher.processCommand(command);
+                    },
+                    activeDispatcher,
                     undefined,
-                    (line: string) => getCompletionsData(line, dispatcher),
-                    dispatcher,
+                    (line: string) =>
+                        getCompletionsData(line, activeDispatcher),
+                    activeDispatcher,
                 );
             } finally {
                 if (
@@ -385,8 +433,8 @@ export default class Connect extends Command {
                         // Best effort cleanup of ephemeral session
                     }
                 }
-                if (dispatcher) {
-                    await dispatcher.close();
+                if (activeDispatcher) {
+                    await activeDispatcher.close();
                 }
             }
         });

--- a/ts/packages/cli/src/conversationCommands.ts
+++ b/ts/packages/cli/src/conversationCommands.ts
@@ -113,7 +113,6 @@ async function handleSwitch(
     }
     await ctx.switchSession(target.sessionId);
 }
-}
 
 async function handleList(
     ctx: ConversationCommandContext,

--- a/ts/packages/cli/src/conversationCommands.ts
+++ b/ts/packages/cli/src/conversationCommands.ts
@@ -89,20 +89,12 @@ async function handleNew(
         console.log(chalk.yellow("Usage: @conversation new <name>"));
         return;
     }
-    await ctx.connection.createSession(name);
+    const created = await ctx.connection.createSession(name);
     console.log(`Created conversation '${chalk.green(name)}'.`);
     const switchNow = await promptYesNo(`Switch to '${name}' now?`);
     if (switchNow) {
-        const all = await ctx.connection.listSessions();
-        const target = all.find(
-            (s) => s.name.toLowerCase() === name.toLowerCase(),
-        );
-        if (target !== undefined) {
-            console.log(
-                `Switched to conversation '${chalk.green(target.name)}'.`,
-            );
-            await ctx.switchSession(target.sessionId);
-        }
+        await ctx.switchSession(created.sessionId);
+        console.log(`Switched to conversation '${chalk.green(name)}'.`);
     }
 }
 
@@ -120,8 +112,8 @@ async function handleSwitch(
         console.log(chalk.yellow(`Already in conversation '${target.name}'.`));
         return;
     }
-    console.log(`Switched to conversation '${chalk.green(target.name)}'.`);
     await ctx.switchSession(target.sessionId);
+    console.log(`Switched to conversation '${chalk.green(target.name)}'.`);
 }
 
 async function handleList(
@@ -280,5 +272,9 @@ export async function handleConversationCommand(
         return;
     }
 
-    await handler(ctx, subArgs);
+    try {
+        await handler(ctx, subArgs);
+    } catch (err: any) {
+        console.log(chalk.red(`Error: ${err?.message ?? String(err)}`));
+    }
 }

--- a/ts/packages/cli/src/conversationCommands.ts
+++ b/ts/packages/cli/src/conversationCommands.ts
@@ -94,7 +94,6 @@ async function handleNew(
     const switchNow = await promptYesNo(`Switch to '${name}' now?`);
     if (switchNow) {
         await ctx.switchSession(created.sessionId);
-        console.log(`Switched to conversation '${chalk.green(name)}'.`);
     }
 }
 
@@ -113,7 +112,7 @@ async function handleSwitch(
         return;
     }
     await ctx.switchSession(target.sessionId);
-    console.log(`Switched to conversation '${chalk.green(target.name)}'.`);
+}
 }
 
 async function handleList(

--- a/ts/packages/cli/src/conversationCommands.ts
+++ b/ts/packages/cli/src/conversationCommands.ts
@@ -1,0 +1,284 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import chalk from "chalk";
+import * as readline from "readline";
+import type {
+    AgentServerConnection,
+    SessionDispatcher,
+    SessionInfo,
+} from "@typeagent/agent-server-client";
+
+/**
+ * Context required by conversation commands. Created in connect.ts after
+ * the agent server connection is established.
+ */
+export type ConversationCommandContext = {
+    connection: AgentServerConnection;
+    getCurrentSessionId: () => string;
+    getCurrentSessionName: () => string;
+    switchSession: (sessionId: string) => Promise<SessionDispatcher>;
+};
+
+// ── Name resolution ────────────────────────────────────────────────────
+
+/**
+ * Resolve a conversation name to a single SessionInfo using
+ * case-insensitive exact matching.
+ */
+async function resolveByName(
+    connection: AgentServerConnection,
+    name: string,
+): Promise<SessionInfo> {
+    const all = await connection.listSessions();
+    const matches = all.filter(
+        (s) => s.name.toLowerCase() === name.toLowerCase(),
+    );
+    if (matches.length === 0) {
+        throw new Error(
+            `No conversation named '${name}' found. Use @conversation list to see all.`,
+        );
+    }
+    if (matches.length > 1) {
+        throw new Error(
+            `Multiple conversations named '${name}' found. Use @conversation list to see all.`,
+        );
+    }
+    return matches[0];
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────
+
+function promptYesNo(question: string): Promise<boolean> {
+    const rl = readline.createInterface({
+        input: process.stdin,
+        output: process.stdout,
+    });
+    return new Promise((resolve) => {
+        rl.question(`${question} [y/N] `, (answer) => {
+            rl.close();
+            resolve(answer.trim().toLowerCase() === "y");
+        });
+    });
+}
+
+/**
+ * Parse the argument string, respecting double-quoted names.
+ * Returns the trimmed argument (without surrounding quotes).
+ */
+function parseNameArg(args: string): string {
+    const trimmed = args.trim();
+    if (
+        trimmed.startsWith('"') &&
+        trimmed.endsWith('"') &&
+        trimmed.length > 1
+    ) {
+        return trimmed.slice(1, -1);
+    }
+    return trimmed;
+}
+
+// ── Subcommand handlers ────────────────────────────────────────────────
+
+async function handleNew(
+    ctx: ConversationCommandContext,
+    args: string,
+): Promise<void> {
+    const name = parseNameArg(args);
+    if (!name) {
+        console.log(chalk.yellow("Usage: @conversation new <name>"));
+        return;
+    }
+    await ctx.connection.createSession(name);
+    console.log(`Created conversation '${chalk.green(name)}'.`);
+    const switchNow = await promptYesNo(`Switch to '${name}' now?`);
+    if (switchNow) {
+        const all = await ctx.connection.listSessions();
+        const target = all.find(
+            (s) => s.name.toLowerCase() === name.toLowerCase(),
+        );
+        if (target !== undefined) {
+            console.log(
+                `Switched to conversation '${chalk.green(target.name)}'.`,
+            );
+            await ctx.switchSession(target.sessionId);
+        }
+    }
+}
+
+async function handleSwitch(
+    ctx: ConversationCommandContext,
+    args: string,
+): Promise<void> {
+    const name = parseNameArg(args);
+    if (!name) {
+        console.log(chalk.yellow("Usage: @conversation switch <name>"));
+        return;
+    }
+    const target = await resolveByName(ctx.connection, name);
+    if (target.sessionId === ctx.getCurrentSessionId()) {
+        console.log(chalk.yellow(`Already in conversation '${target.name}'.`));
+        return;
+    }
+    console.log(`Switched to conversation '${chalk.green(target.name)}'.`);
+    await ctx.switchSession(target.sessionId);
+}
+
+async function handleList(
+    ctx: ConversationCommandContext,
+    args: string,
+): Promise<void> {
+    const filter = args.trim() || undefined;
+    const sessions = await ctx.connection.listSessions(filter);
+    if (sessions.length === 0) {
+        console.log(chalk.dim("No conversations found."));
+        return;
+    }
+
+    // Sort by creation date, most recent first
+    sessions.sort(
+        (a, b) =>
+            new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+    );
+
+    const currentId = ctx.getCurrentSessionId();
+
+    // Calculate column widths
+    const nameWidth = Math.max(4, ...sessions.map((s) => s.name.length));
+    const header =
+        "  " + "NAME".padEnd(nameWidth + 2) + "CREATED".padEnd(22) + "CLIENTS";
+    const divider =
+        "  " + "─".repeat(nameWidth + 2) + "─".repeat(22) + "───────";
+
+    console.log(chalk.bold("\nConversations:"));
+    console.log(chalk.dim(header));
+    console.log(chalk.dim(divider));
+
+    for (const s of sessions) {
+        const isCurrent = s.sessionId === currentId;
+        const marker = isCurrent ? "▸ " : "  ";
+        const created = new Date(s.createdAt)
+            .toISOString()
+            .replace("T", " ")
+            .substring(0, 16);
+        const suffix = isCurrent ? "  (current)" : "";
+        const line =
+            marker +
+            s.name.padEnd(nameWidth + 2) +
+            created.padEnd(22) +
+            String(s.clientCount) +
+            suffix;
+        console.log(isCurrent ? chalk.green(line) : line);
+    }
+    console.log("");
+}
+
+async function handleRename(
+    ctx: ConversationCommandContext,
+    args: string,
+): Promise<void> {
+    const newName = parseNameArg(args);
+    if (!newName) {
+        console.log(chalk.yellow("Usage: @conversation rename <newName>"));
+        return;
+    }
+    await ctx.connection.renameSession(ctx.getCurrentSessionId(), newName);
+    console.log(`Renamed current conversation to '${chalk.green(newName)}'.`);
+}
+
+async function handleDelete(
+    ctx: ConversationCommandContext,
+    args: string,
+): Promise<void> {
+    const name = parseNameArg(args);
+    if (!name) {
+        console.log(chalk.yellow("Usage: @conversation delete <name>"));
+        return;
+    }
+    const target = await resolveByName(ctx.connection, name);
+    if (target.sessionId === ctx.getCurrentSessionId()) {
+        console.log(
+            chalk.red(
+                "Cannot delete the active conversation. Switch to another conversation first.",
+            ),
+        );
+        return;
+    }
+    const confirmed = await promptYesNo(
+        `Delete conversation '${target.name}'?`,
+    );
+    if (!confirmed) {
+        console.log(chalk.dim("Cancelled."));
+        return;
+    }
+    await ctx.connection.deleteSession(target.sessionId);
+    console.log(`Deleted conversation '${chalk.green(target.name)}'.`);
+}
+
+// ── Help text ──────────────────────────────────────────────────────────
+
+function printHelp(): void {
+    console.log(chalk.bold("\n@conversation commands:"));
+    const cmds: [string, string][] = [
+        ["new <name>", "Create a new conversation"],
+        ["switch <name>", "Switch to a conversation by name"],
+        ["list [<filter>]", "List all conversations"],
+        ["rename <newName>", "Rename the current conversation"],
+        ["delete <name>", "Delete a conversation by name"],
+    ];
+    for (const [usage, desc] of cmds) {
+        console.log(
+            `  ${chalk.cyanBright(("@conversation " + usage).padEnd(38))} ${chalk.dim(desc)}`,
+        );
+    }
+    console.log("");
+}
+
+// ── Main entry point ───────────────────────────────────────────────────
+
+const subcommands: Record<
+    string,
+    (ctx: ConversationCommandContext, args: string) => Promise<void>
+> = {
+    new: handleNew,
+    switch: handleSwitch,
+    list: handleList,
+    rename: handleRename,
+    delete: handleDelete,
+};
+
+/**
+ * Handle a conversation command. Called from the slash command system.
+ *
+ * @param ctx - The conversation command context (connection, session state, switch callback)
+ * @param args - Everything after "conversation", e.g. "list" or "switch myChat"
+ */
+export async function handleConversationCommand(
+    ctx: ConversationCommandContext,
+    args: string,
+): Promise<void> {
+    const trimmed = args.trim();
+    if (!trimmed) {
+        printHelp();
+        return;
+    }
+
+    const spaceIdx = trimmed.indexOf(" ");
+    const sub =
+        spaceIdx === -1
+            ? trimmed.toLowerCase()
+            : trimmed.substring(0, spaceIdx).toLowerCase();
+    const subArgs = spaceIdx === -1 ? "" : trimmed.substring(spaceIdx + 1);
+
+    const handler = subcommands[sub];
+    if (!handler) {
+        console.log(
+            chalk.yellow(
+                `Unknown subcommand '${sub}'. Available: new, switch, list, rename, delete`,
+            ),
+        );
+        return;
+    }
+
+    await handler(ctx, subArgs);
+}

--- a/ts/packages/cli/src/enhancedConsole.ts
+++ b/ts/packages/cli/src/enhancedConsole.ts
@@ -2011,9 +2011,15 @@ export function getEnhancedConsolePrompt(_text: string): string {
 export async function replayDisplayHistory(
     dispatcher: Dispatcher,
     clientIO: ClientIO,
+    sessionName?: string,
 ): Promise<void> {
     const entries = await dispatcher.getDisplayHistory();
     if (entries.length === 0) {
+        if (sessionName !== undefined) {
+            console.log(
+                chalk.dim(`Connected to conversation '${sessionName}'.`),
+            );
+        }
         return;
     }
 
@@ -2084,4 +2090,7 @@ export async function replayDisplayHistory(
     process.stdout.write(
         chalk.dim("─── now " + "─".repeat(Math.max(0, width - 8))) + "\n",
     );
+    if (sessionName !== undefined) {
+        console.log(chalk.dim(`Connected to conversation '${sessionName}'.`));
+    }
 }

--- a/ts/packages/cli/src/slashCommands.ts
+++ b/ts/packages/cli/src/slashCommands.ts
@@ -171,7 +171,24 @@ export function isSlashCommand(input: string): boolean {
     );
 }
 
+const conversationSubcommands = ["new", "switch", "list", "rename", "delete"];
+
 export function getSlashCompletions(input: string): string[] {
+    // Handle @conversation <partial-subcommand> completions
+    if (input.startsWith("@conversation")) {
+        const after = input.slice("@conversation".length);
+        // "@conversation" with no space yet — offer all subcommands
+        if (after === "") {
+            return conversationSubcommands.map((s) => `@conversation ${s}`);
+        }
+        if (after.startsWith(" ")) {
+            const partial = after.slice(1).toLowerCase();
+            return conversationSubcommands
+                .filter((s) => s.startsWith(partial))
+                .map((s) => `@conversation ${s}`);
+        }
+        return [];
+    }
     const prefix = input.substring(1).toLowerCase();
     return slashCommands
         .filter((cmd) => cmd.name.startsWith(prefix))

--- a/ts/packages/cli/src/slashCommands.ts
+++ b/ts/packages/cli/src/slashCommands.ts
@@ -3,6 +3,8 @@
 
 import registerDebug from "debug";
 import chalk from "chalk";
+import type { ConversationCommandContext } from "./conversationCommands.js";
+import { handleConversationCommand } from "./conversationCommands.js";
 
 export type SlashCommandHandler = (
     args: string,
@@ -26,6 +28,16 @@ export function isVerboseEnabled(): boolean {
 export function enableVerboseFromFlag(namespaces: string): void {
     verboseEnabled = true;
     activeNamespaces = namespaces;
+}
+
+// Late-binding context for conversation commands.
+// Set from connect.ts after the AgentServerConnection is established.
+let conversationContext: ConversationCommandContext | undefined;
+
+export function setConversationCommandContext(
+    ctx: ConversationCommandContext,
+): void {
+    conversationContext = ctx;
 }
 
 export function getVerboseIndicator(): string {
@@ -65,7 +77,7 @@ const slashCommands: SlashCommand[] = [
             console.log(chalk.bold("\nSlash Commands:"));
             for (const cmd of slashCommands) {
                 console.log(
-                    `  ${chalk.cyanBright("/" + cmd.name.padEnd(12))} ${chalk.dim(cmd.description)}`,
+                    `  ${chalk.cyanBright("/" + cmd.name.padEnd(16))} ${chalk.dim(cmd.description)}`,
                 );
             }
             console.log("");
@@ -122,6 +134,21 @@ const slashCommands: SlashCommand[] = [
         },
     },
     {
+        name: "conversation",
+        description: "Manage conversations (new, switch, list, rename, delete)",
+        handler: async (args) => {
+            if (conversationContext === undefined) {
+                console.log(
+                    chalk.red(
+                        "Conversation commands are not available (no server connection).",
+                    ),
+                );
+                return;
+            }
+            return handleConversationCommand(conversationContext, args);
+        },
+    },
+    {
         name: "exit",
         description: "Exit the CLI",
         handler: async () => {
@@ -137,7 +164,11 @@ for (const cmd of slashCommands) {
 }
 
 export function isSlashCommand(input: string): boolean {
-    return input.startsWith("/");
+    return (
+        input.startsWith("/") ||
+        input.startsWith("@conversation ") ||
+        input === "@conversation"
+    );
 }
 
 export function getSlashCompletions(input: string): string[] {
@@ -157,7 +188,14 @@ export async function handleSlashCommand(
     input: string,
     processCommand: (command: string) => Promise<any>,
 ): Promise<SlashCommandResult> {
-    const trimmed = input.substring(1).trim();
+    // Rewrite @conversation to /conversation so it routes through the
+    // slash command system (avoids the spinner path in processCommandsEnhanced)
+    let normalized = input;
+    if (input.startsWith("@conversation")) {
+        normalized = "/conversation" + input.substring("@conversation".length);
+    }
+
+    const trimmed = normalized.substring(1).trim();
     const spaceIdx = trimmed.indexOf(" ");
     const name =
         spaceIdx === -1

--- a/ts/packages/cli/test/conversationCommands.spec.ts
+++ b/ts/packages/cli/test/conversationCommands.spec.ts
@@ -13,6 +13,10 @@
  *
  * The tests mock AgentServerConnection methods and readline to verify
  * routing, argument validation, and interactive confirmation flows.
+ *
+ * Because the module under test (conversationCommands.ts) imports `readline`
+ * and `chalk` which are ESM-only, we use `jest.unstable_mockModule` to mock
+ * readline *before* the dynamic import of the module under test.
  */
 
 import {
@@ -23,16 +27,34 @@ import {
     afterEach,
     jest,
 } from "@jest/globals";
-import * as readline from "readline";
 import type {
     AgentServerConnection,
     SessionDispatcher,
     SessionInfo,
 } from "@typeagent/agent-server-client";
-import {
-    handleConversationCommand,
-    type ConversationCommandContext,
-} from "../src/conversationCommands.js";
+
+// ── readline mock (must be installed before importing the module under test) ─
+
+type QuestionCallback = (answer: string) => void;
+
+let questionCallbacks: QuestionCallback[];
+
+jest.unstable_mockModule("readline", () => ({
+    createInterface: jest.fn(() => ({
+        question: jest.fn((_prompt: string, cb: QuestionCallback) => {
+            questionCallbacks.push(cb);
+        }),
+        close: jest.fn(),
+    })),
+}));
+
+// ── Dynamic import of the module under test (after the mock is installed) ──
+
+const { handleConversationCommand } = await import(
+    "../src/conversationCommands.js"
+);
+type ConversationCommandContext =
+    import("../src/conversationCommands.js").ConversationCommandContext;
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -48,61 +70,34 @@ function makeSession(
 }
 
 /** Build mock AgentServerConnection with jest.fn() stubs. */
-function makeConnection(): jest.Mocked<
-    Pick<
-        AgentServerConnection,
-        "listSessions" | "createSession" | "renameSession" | "deleteSession"
-    >
-> &
-    AgentServerConnection {
+function makeConnection() {
     return {
         listSessions: jest.fn<AgentServerConnection["listSessions"]>(),
         createSession: jest.fn<AgentServerConnection["createSession"]>(),
         renameSession: jest.fn<AgentServerConnection["renameSession"]>(),
         deleteSession: jest.fn<AgentServerConnection["deleteSession"]>(),
-        // Unused stubs
+        // Unused stubs required by the interface
         joinSession: jest.fn(),
         leaveSession: jest.fn(),
         close: jest.fn(),
-    } as unknown as jest.Mocked<
-        Pick<
-            AgentServerConnection,
-            "listSessions" | "createSession" | "renameSession" | "deleteSession"
-        >
-    > &
-        AgentServerConnection;
-}
-
-type FakeRl = {
-    question: jest.Mock;
-    close: jest.Mock;
-};
-
-let fakeRl: FakeRl;
-let createInterfaceSpy: ReturnType<typeof jest.spyOn>;
-
-/**
- * Install a spy on readline.createInterface that returns a fake rl object.
- * Call `answerPrompt(text)` to simulate the user typing a response.
- */
-function installReadlineSpy() {
-    fakeRl = {
-        question: jest.fn(),
-        close: jest.fn(),
+    } as unknown as AgentServerConnection & {
+        listSessions: jest.Mock;
+        createSession: jest.Mock;
+        renameSession: jest.Mock;
+        deleteSession: jest.Mock;
     };
-    createInterfaceSpy = jest
-        .spyOn(readline, "createInterface")
-        .mockReturnValue(fakeRl as unknown as readline.Interface);
 }
 
 /** Simulate the user answering the outstanding readline question. */
 function answerPrompt(answer: string) {
-    const calls = fakeRl.question.mock.calls;
-    expect(calls.length).toBeGreaterThan(0);
-    // rl.question(prompt, callback) — invoke the callback
-    const lastCall = calls[calls.length - 1];
-    const callback = lastCall[1] as (answer: string) => void;
-    callback(answer);
+    expect(questionCallbacks.length).toBeGreaterThan(0);
+    const cb = questionCallbacks.shift()!;
+    cb(answer);
+}
+
+/** Wait for microtasks + setImmediate so async code can progress. */
+function flushAsync() {
+    return new Promise<void>((resolve) => setImmediate(resolve));
 }
 
 // ── Spying on console.log ──────────────────────────────────────────────────
@@ -117,18 +112,17 @@ function capturedLog(): string {
 // ── Setup / teardown ───────────────────────────────────────────────────────
 
 beforeEach(() => {
+    questionCallbacks = [];
     logOutput = [];
     logSpy = jest
         .spyOn(console, "log")
         .mockImplementation((...args: unknown[]) => {
             logOutput.push(args.map(String).join(" "));
         });
-    installReadlineSpy();
 });
 
 afterEach(() => {
     logSpy.mockRestore();
-    createInterfaceSpy.mockRestore();
 });
 
 // ── Context factory ────────────────────────────────────────────────────────
@@ -187,17 +181,14 @@ describe("@conversation new", () => {
 
     it("creates session and does NOT switch when user answers 'n'", async () => {
         const ctx = makeCtx();
-        (ctx.connection.createSession as jest.Mock).mockResolvedValue(
+        ctx.connection.createSession.mockResolvedValue(
             makeSession({ sessionId: "new-id", name: "MyChat" }),
         );
-        (ctx.connection.listSessions as jest.Mock).mockResolvedValue([
-            makeSession({ sessionId: "new-id", name: "MyChat" }),
-        ]);
 
         const promise = handleConversationCommand(ctx, "new MyChat");
 
-        // Wait for the readline question to be called
-        await new Promise<void>((r) => setImmediate(r));
+        // Wait for the readline question callback to be queued
+        await flushAsync();
         answerPrompt("n");
         await promise;
 
@@ -208,66 +199,37 @@ describe("@conversation new", () => {
 
     it("creates session and switches when user answers 'y'", async () => {
         const ctx = makeCtx();
-        (ctx.connection.createSession as jest.Mock).mockResolvedValue(
+        ctx.connection.createSession.mockResolvedValue(
             makeSession({ sessionId: "new-id", name: "MyChat" }),
         );
-        (ctx.connection.listSessions as jest.Mock).mockResolvedValue([
-            makeSession({ sessionId: "new-id", name: "MyChat" }),
-        ]);
 
         const promise = handleConversationCommand(ctx, "new MyChat");
 
-        await new Promise<void>((r) => setImmediate(r));
+        await flushAsync();
         answerPrompt("y");
         await promise;
 
         expect(ctx.connection.createSession).toHaveBeenCalledWith("MyChat");
+        // switchSession called with the sessionId from createSession's return value
         expect(ctx.switchSession).toHaveBeenCalledWith("new-id");
         expect(capturedLog()).toContain("Switched to conversation");
     });
 
     it("handles quoted name argument", async () => {
         const ctx = makeCtx();
-        (ctx.connection.createSession as jest.Mock).mockResolvedValue(
-            makeSession({
-                sessionId: "new-id",
-                name: "My Chat Room",
-            }),
+        ctx.connection.createSession.mockResolvedValue(
+            makeSession({ sessionId: "new-id", name: "My Chat Room" }),
         );
-        (ctx.connection.listSessions as jest.Mock).mockResolvedValue([
-            makeSession({
-                sessionId: "new-id",
-                name: "My Chat Room",
-            }),
-        ]);
 
         const promise = handleConversationCommand(ctx, 'new "My Chat Room"');
 
-        await new Promise<void>((r) => setImmediate(r));
+        await flushAsync();
         answerPrompt("n");
         await promise;
 
         expect(ctx.connection.createSession).toHaveBeenCalledWith(
             "My Chat Room",
         );
-    });
-
-    it("does not switch if the created session is not found in listSessions", async () => {
-        const ctx = makeCtx();
-        (ctx.connection.createSession as jest.Mock).mockResolvedValue(
-            makeSession({ sessionId: "new-id", name: "Ephemeral" }),
-        );
-        // listSessions returns empty — session disappeared
-        (ctx.connection.listSessions as jest.Mock).mockResolvedValue([]);
-
-        const promise = handleConversationCommand(ctx, "new Ephemeral");
-
-        await new Promise<void>((r) => setImmediate(r));
-        answerPrompt("y");
-        await promise;
-
-        // Even though user said yes, there is no target to switch to
-        expect(ctx.switchSession).not.toHaveBeenCalled();
     });
 });
 
@@ -279,24 +241,22 @@ describe("@conversation switch", () => {
         expect(capturedLog()).toContain("@conversation switch");
     });
 
-    it("throws/prints error when name is not found", async () => {
+    it("prints error when name is not found", async () => {
         const ctx = makeCtx();
-        (ctx.connection.listSessions as jest.Mock).mockResolvedValue([]);
+        ctx.connection.listSessions.mockResolvedValue([]);
 
-        await expect(
-            handleConversationCommand(ctx, "switch ghost"),
-        ).rejects.toThrow("No conversation named 'ghost' found");
+        await handleConversationCommand(ctx, "switch ghost");
+
+        expect(capturedLog()).toContain("No conversation named 'ghost' found");
+        expect(ctx.switchSession).not.toHaveBeenCalled();
     });
 
     it("prints message when already in that session", async () => {
         const ctx = makeCtx({
             getCurrentSessionId: () => "already-here",
         });
-        (ctx.connection.listSessions as jest.Mock).mockResolvedValue([
-            makeSession({
-                sessionId: "already-here",
-                name: "Current",
-            }),
+        ctx.connection.listSessions.mockResolvedValue([
+            makeSession({ sessionId: "already-here", name: "Current" }),
         ]);
 
         await handleConversationCommand(ctx, "switch Current");
@@ -309,11 +269,8 @@ describe("@conversation switch", () => {
         const ctx = makeCtx({
             getCurrentSessionId: () => "old-id",
         });
-        (ctx.connection.listSessions as jest.Mock).mockResolvedValue([
-            makeSession({
-                sessionId: "target-id",
-                name: "MyChat",
-            }),
+        ctx.connection.listSessions.mockResolvedValue([
+            makeSession({ sessionId: "target-id", name: "MyChat" }),
         ]);
 
         await handleConversationCommand(ctx, "switch mychat");
@@ -322,34 +279,37 @@ describe("@conversation switch", () => {
         expect(capturedLog()).toContain("Switched to conversation");
     });
 
-    it("throws error when multiple sessions match", async () => {
+    it("prints error when multiple sessions match", async () => {
         const ctx = makeCtx();
-        (ctx.connection.listSessions as jest.Mock).mockResolvedValue([
+        ctx.connection.listSessions.mockResolvedValue([
             makeSession({ sessionId: "id-1", name: "dup" }),
             makeSession({ sessionId: "id-2", name: "Dup" }),
         ]);
 
-        await expect(
-            handleConversationCommand(ctx, "switch dup"),
-        ).rejects.toThrow("Multiple conversations named 'dup' found");
+        await handleConversationCommand(ctx, "switch dup");
+
+        expect(capturedLog()).toContain(
+            "Multiple conversations named 'dup' found",
+        );
+        expect(ctx.switchSession).not.toHaveBeenCalled();
     });
 });
 
 describe("@conversation list", () => {
     it("prints 'No conversations found.' for empty list", async () => {
         const ctx = makeCtx();
-        (ctx.connection.listSessions as jest.Mock).mockResolvedValue([]);
+        ctx.connection.listSessions.mockResolvedValue([]);
 
         await handleConversationCommand(ctx, "list");
 
         expect(capturedLog()).toContain("No conversations found.");
     });
 
-    it("shows single session with current marker '▸'", async () => {
+    it("shows single session with current marker", async () => {
         const ctx = makeCtx({
             getCurrentSessionId: () => "sess-1",
         });
-        (ctx.connection.listSessions as jest.Mock).mockResolvedValue([
+        ctx.connection.listSessions.mockResolvedValue([
             makeSession({
                 sessionId: "sess-1",
                 name: "OnlySession",
@@ -370,7 +330,7 @@ describe("@conversation list", () => {
         const ctx = makeCtx({
             getCurrentSessionId: () => "sess-2",
         });
-        (ctx.connection.listSessions as jest.Mock).mockResolvedValue([
+        ctx.connection.listSessions.mockResolvedValue([
             makeSession({
                 sessionId: "sess-1",
                 name: "Older",
@@ -395,7 +355,7 @@ describe("@conversation list", () => {
 
         const output = capturedLog();
 
-        // Newest should appear before Older in the output
+        // Newest should appear before Older in the output (descending sort)
         const newestIdx = output.indexOf("Newest");
         const middleIdx = output.indexOf("Middle");
         const olderIdx = output.indexOf("Older");
@@ -403,7 +363,6 @@ describe("@conversation list", () => {
         expect(middleIdx).toBeLessThan(olderIdx);
 
         // "▸" appears on the current session line (Middle)
-        // The current marker line also contains "(current)"
         const lines = output.split("\n");
         const currentLine = lines.find((l) => l.includes("Middle"));
         expect(currentLine).toBeDefined();
@@ -420,7 +379,7 @@ describe("@conversation list", () => {
 
     it("passes filter to listSessions", async () => {
         const ctx = makeCtx();
-        (ctx.connection.listSessions as jest.Mock).mockResolvedValue([]);
+        ctx.connection.listSessions.mockResolvedValue([]);
 
         await handleConversationCommand(ctx, "list myFilter");
 
@@ -429,7 +388,7 @@ describe("@conversation list", () => {
 
     it("passes undefined filter when no filter given", async () => {
         const ctx = makeCtx();
-        (ctx.connection.listSessions as jest.Mock).mockResolvedValue([]);
+        ctx.connection.listSessions.mockResolvedValue([]);
 
         await handleConversationCommand(ctx, "list");
 
@@ -440,7 +399,7 @@ describe("@conversation list", () => {
         const ctx = makeCtx({
             getCurrentSessionId: () => "sess-1",
         });
-        (ctx.connection.listSessions as jest.Mock).mockResolvedValue([
+        ctx.connection.listSessions.mockResolvedValue([
             makeSession({
                 sessionId: "sess-1",
                 name: "Chat",
@@ -467,9 +426,7 @@ describe("@conversation rename", () => {
         const ctx = makeCtx({
             getCurrentSessionId: () => "my-session-id",
         });
-        (ctx.connection.renameSession as jest.Mock).mockResolvedValue(
-            undefined,
-        );
+        ctx.connection.renameSession.mockResolvedValue(undefined);
 
         await handleConversationCommand(ctx, "rename NewName");
 
@@ -485,9 +442,7 @@ describe("@conversation rename", () => {
         const ctx = makeCtx({
             getCurrentSessionId: () => "my-session-id",
         });
-        (ctx.connection.renameSession as jest.Mock).mockResolvedValue(
-            undefined,
-        );
+        ctx.connection.renameSession.mockResolvedValue(undefined);
 
         await handleConversationCommand(ctx, 'rename "New Name With Spaces"');
 
@@ -510,11 +465,8 @@ describe("@conversation delete", () => {
         const ctx = makeCtx({
             getCurrentSessionId: () => "current-id",
         });
-        (ctx.connection.listSessions as jest.Mock).mockResolvedValue([
-            makeSession({
-                sessionId: "current-id",
-                name: "ActiveChat",
-            }),
+        ctx.connection.listSessions.mockResolvedValue([
+            makeSession({ sessionId: "current-id", name: "ActiveChat" }),
         ]);
 
         await handleConversationCommand(ctx, "delete ActiveChat");
@@ -529,16 +481,13 @@ describe("@conversation delete", () => {
         const ctx = makeCtx({
             getCurrentSessionId: () => "other-id",
         });
-        (ctx.connection.listSessions as jest.Mock).mockResolvedValue([
-            makeSession({
-                sessionId: "target-id",
-                name: "OldChat",
-            }),
+        ctx.connection.listSessions.mockResolvedValue([
+            makeSession({ sessionId: "target-id", name: "OldChat" }),
         ]);
 
         const promise = handleConversationCommand(ctx, "delete OldChat");
 
-        await new Promise<void>((r) => setImmediate(r));
+        await flushAsync();
         answerPrompt("n");
         await promise;
 
@@ -550,19 +499,14 @@ describe("@conversation delete", () => {
         const ctx = makeCtx({
             getCurrentSessionId: () => "other-id",
         });
-        (ctx.connection.listSessions as jest.Mock).mockResolvedValue([
-            makeSession({
-                sessionId: "target-id",
-                name: "OldChat",
-            }),
+        ctx.connection.listSessions.mockResolvedValue([
+            makeSession({ sessionId: "target-id", name: "OldChat" }),
         ]);
-        (ctx.connection.deleteSession as jest.Mock).mockResolvedValue(
-            undefined,
-        );
+        ctx.connection.deleteSession.mockResolvedValue(undefined);
 
         const promise = handleConversationCommand(ctx, "delete OldChat");
 
-        await new Promise<void>((r) => setImmediate(r));
+        await flushAsync();
         answerPrompt("y");
         await promise;
 
@@ -570,14 +514,15 @@ describe("@conversation delete", () => {
         expect(capturedLog()).toContain("Deleted conversation");
     });
 
-    it("throws error when session name is not found", async () => {
+    it("prints error when session name is not found", async () => {
         const ctx = makeCtx({
             getCurrentSessionId: () => "other-id",
         });
-        (ctx.connection.listSessions as jest.Mock).mockResolvedValue([]);
+        ctx.connection.listSessions.mockResolvedValue([]);
 
-        await expect(
-            handleConversationCommand(ctx, "delete ghost"),
-        ).rejects.toThrow("No conversation named 'ghost' found");
+        await handleConversationCommand(ctx, "delete ghost");
+
+        expect(capturedLog()).toContain("No conversation named 'ghost' found");
+        expect(ctx.connection.deleteSession).not.toHaveBeenCalled();
     });
 });

--- a/ts/packages/cli/test/conversationCommands.spec.ts
+++ b/ts/packages/cli/test/conversationCommands.spec.ts
@@ -212,7 +212,6 @@ describe("@conversation new", () => {
         expect(ctx.connection.createSession).toHaveBeenCalledWith("MyChat");
         // switchSession called with the sessionId from createSession's return value
         expect(ctx.switchSession).toHaveBeenCalledWith("new-id");
-        expect(capturedLog()).toContain("Switched to conversation");
     });
 
     it("handles quoted name argument", async () => {
@@ -276,7 +275,6 @@ describe("@conversation switch", () => {
         await handleConversationCommand(ctx, "switch mychat");
 
         expect(ctx.switchSession).toHaveBeenCalledWith("target-id");
-        expect(capturedLog()).toContain("Switched to conversation");
     });
 
     it("prints error when multiple sessions match", async () => {

--- a/ts/packages/cli/test/conversationCommands.spec.ts
+++ b/ts/packages/cli/test/conversationCommands.spec.ts
@@ -1,0 +1,583 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+/**
+ * Tests for the @conversation command handler in conversationCommands.ts.
+ *
+ * Subcommands:
+ *   new <name>      — create a session, optionally switch to it
+ *   switch <name>   — switch to a named session
+ *   list [filter]   — list sessions with current marker
+ *   rename <name>   — rename the current session
+ *   delete <name>   — delete a session after confirmation
+ *
+ * The tests mock AgentServerConnection methods and readline to verify
+ * routing, argument validation, and interactive confirmation flows.
+ */
+
+import {
+    describe,
+    it,
+    expect,
+    beforeEach,
+    afterEach,
+    jest,
+} from "@jest/globals";
+import * as readline from "readline";
+import type {
+    AgentServerConnection,
+    SessionDispatcher,
+    SessionInfo,
+} from "@typeagent/agent-server-client";
+import {
+    handleConversationCommand,
+    type ConversationCommandContext,
+} from "../src/conversationCommands.js";
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+/** Minimal SessionInfo factory. */
+function makeSession(
+    overrides: Partial<SessionInfo> & { sessionId: string; name: string },
+): SessionInfo {
+    return {
+        clientCount: 1,
+        createdAt: new Date().toISOString(),
+        ...overrides,
+    };
+}
+
+/** Build mock AgentServerConnection with jest.fn() stubs. */
+function makeConnection(): jest.Mocked<
+    Pick<
+        AgentServerConnection,
+        "listSessions" | "createSession" | "renameSession" | "deleteSession"
+    >
+> &
+    AgentServerConnection {
+    return {
+        listSessions: jest.fn<AgentServerConnection["listSessions"]>(),
+        createSession: jest.fn<AgentServerConnection["createSession"]>(),
+        renameSession: jest.fn<AgentServerConnection["renameSession"]>(),
+        deleteSession: jest.fn<AgentServerConnection["deleteSession"]>(),
+        // Unused stubs
+        joinSession: jest.fn(),
+        leaveSession: jest.fn(),
+        close: jest.fn(),
+    } as unknown as jest.Mocked<
+        Pick<
+            AgentServerConnection,
+            "listSessions" | "createSession" | "renameSession" | "deleteSession"
+        >
+    > &
+        AgentServerConnection;
+}
+
+type FakeRl = {
+    question: jest.Mock;
+    close: jest.Mock;
+};
+
+let fakeRl: FakeRl;
+let createInterfaceSpy: ReturnType<typeof jest.spyOn>;
+
+/**
+ * Install a spy on readline.createInterface that returns a fake rl object.
+ * Call `answerPrompt(text)` to simulate the user typing a response.
+ */
+function installReadlineSpy() {
+    fakeRl = {
+        question: jest.fn(),
+        close: jest.fn(),
+    };
+    createInterfaceSpy = jest
+        .spyOn(readline, "createInterface")
+        .mockReturnValue(fakeRl as unknown as readline.Interface);
+}
+
+/** Simulate the user answering the outstanding readline question. */
+function answerPrompt(answer: string) {
+    const calls = fakeRl.question.mock.calls;
+    expect(calls.length).toBeGreaterThan(0);
+    // rl.question(prompt, callback) — invoke the callback
+    const lastCall = calls[calls.length - 1];
+    const callback = lastCall[1] as (answer: string) => void;
+    callback(answer);
+}
+
+// ── Spying on console.log ──────────────────────────────────────────────────
+
+let logSpy: ReturnType<typeof jest.spyOn>;
+let logOutput: string[];
+
+function capturedLog(): string {
+    return logOutput.join("\n");
+}
+
+// ── Setup / teardown ───────────────────────────────────────────────────────
+
+beforeEach(() => {
+    logOutput = [];
+    logSpy = jest
+        .spyOn(console, "log")
+        .mockImplementation((...args: unknown[]) => {
+            logOutput.push(args.map(String).join(" "));
+        });
+    installReadlineSpy();
+});
+
+afterEach(() => {
+    logSpy.mockRestore();
+    createInterfaceSpy.mockRestore();
+});
+
+// ── Context factory ────────────────────────────────────────────────────────
+
+function makeCtx(
+    overrides: Partial<ConversationCommandContext> = {},
+): ConversationCommandContext & {
+    connection: ReturnType<typeof makeConnection>;
+    switchSession: jest.Mock;
+} {
+    const connection = makeConnection();
+    const switchSession =
+        jest.fn<(sessionId: string) => Promise<SessionDispatcher>>();
+    return {
+        connection,
+        getCurrentSessionId: () => "current-id",
+        getCurrentSessionName: () => "Current Session",
+        switchSession,
+        ...overrides,
+    } as ConversationCommandContext & {
+        connection: ReturnType<typeof makeConnection>;
+        switchSession: jest.Mock;
+    };
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+describe("handleConversationCommand — routing", () => {
+    it("prints help when args are empty", async () => {
+        const ctx = makeCtx();
+        await handleConversationCommand(ctx, "");
+        expect(capturedLog()).toContain("@conversation commands:");
+    });
+
+    it("prints help when args are whitespace-only", async () => {
+        const ctx = makeCtx();
+        await handleConversationCommand(ctx, "   ");
+        expect(capturedLog()).toContain("@conversation commands:");
+    });
+
+    it("prints error for unknown subcommand", async () => {
+        const ctx = makeCtx();
+        await handleConversationCommand(ctx, "foobar");
+        expect(capturedLog()).toContain("Unknown subcommand");
+        expect(capturedLog()).toContain("foobar");
+    });
+});
+
+describe("@conversation new", () => {
+    it("prints usage when name is missing", async () => {
+        const ctx = makeCtx();
+        await handleConversationCommand(ctx, "new");
+        expect(capturedLog()).toContain("Usage");
+        expect(capturedLog()).toContain("@conversation new");
+    });
+
+    it("creates session and does NOT switch when user answers 'n'", async () => {
+        const ctx = makeCtx();
+        (ctx.connection.createSession as jest.Mock).mockResolvedValue(
+            makeSession({ sessionId: "new-id", name: "MyChat" }),
+        );
+        (ctx.connection.listSessions as jest.Mock).mockResolvedValue([
+            makeSession({ sessionId: "new-id", name: "MyChat" }),
+        ]);
+
+        const promise = handleConversationCommand(ctx, "new MyChat");
+
+        // Wait for the readline question to be called
+        await new Promise<void>((r) => setImmediate(r));
+        answerPrompt("n");
+        await promise;
+
+        expect(ctx.connection.createSession).toHaveBeenCalledWith("MyChat");
+        expect(capturedLog()).toContain("Created conversation");
+        expect(ctx.switchSession).not.toHaveBeenCalled();
+    });
+
+    it("creates session and switches when user answers 'y'", async () => {
+        const ctx = makeCtx();
+        (ctx.connection.createSession as jest.Mock).mockResolvedValue(
+            makeSession({ sessionId: "new-id", name: "MyChat" }),
+        );
+        (ctx.connection.listSessions as jest.Mock).mockResolvedValue([
+            makeSession({ sessionId: "new-id", name: "MyChat" }),
+        ]);
+
+        const promise = handleConversationCommand(ctx, "new MyChat");
+
+        await new Promise<void>((r) => setImmediate(r));
+        answerPrompt("y");
+        await promise;
+
+        expect(ctx.connection.createSession).toHaveBeenCalledWith("MyChat");
+        expect(ctx.switchSession).toHaveBeenCalledWith("new-id");
+        expect(capturedLog()).toContain("Switched to conversation");
+    });
+
+    it("handles quoted name argument", async () => {
+        const ctx = makeCtx();
+        (ctx.connection.createSession as jest.Mock).mockResolvedValue(
+            makeSession({
+                sessionId: "new-id",
+                name: "My Chat Room",
+            }),
+        );
+        (ctx.connection.listSessions as jest.Mock).mockResolvedValue([
+            makeSession({
+                sessionId: "new-id",
+                name: "My Chat Room",
+            }),
+        ]);
+
+        const promise = handleConversationCommand(ctx, 'new "My Chat Room"');
+
+        await new Promise<void>((r) => setImmediate(r));
+        answerPrompt("n");
+        await promise;
+
+        expect(ctx.connection.createSession).toHaveBeenCalledWith(
+            "My Chat Room",
+        );
+    });
+
+    it("does not switch if the created session is not found in listSessions", async () => {
+        const ctx = makeCtx();
+        (ctx.connection.createSession as jest.Mock).mockResolvedValue(
+            makeSession({ sessionId: "new-id", name: "Ephemeral" }),
+        );
+        // listSessions returns empty — session disappeared
+        (ctx.connection.listSessions as jest.Mock).mockResolvedValue([]);
+
+        const promise = handleConversationCommand(ctx, "new Ephemeral");
+
+        await new Promise<void>((r) => setImmediate(r));
+        answerPrompt("y");
+        await promise;
+
+        // Even though user said yes, there is no target to switch to
+        expect(ctx.switchSession).not.toHaveBeenCalled();
+    });
+});
+
+describe("@conversation switch", () => {
+    it("prints usage when name is missing", async () => {
+        const ctx = makeCtx();
+        await handleConversationCommand(ctx, "switch");
+        expect(capturedLog()).toContain("Usage");
+        expect(capturedLog()).toContain("@conversation switch");
+    });
+
+    it("throws/prints error when name is not found", async () => {
+        const ctx = makeCtx();
+        (ctx.connection.listSessions as jest.Mock).mockResolvedValue([]);
+
+        await expect(
+            handleConversationCommand(ctx, "switch ghost"),
+        ).rejects.toThrow("No conversation named 'ghost' found");
+    });
+
+    it("prints message when already in that session", async () => {
+        const ctx = makeCtx({
+            getCurrentSessionId: () => "already-here",
+        });
+        (ctx.connection.listSessions as jest.Mock).mockResolvedValue([
+            makeSession({
+                sessionId: "already-here",
+                name: "Current",
+            }),
+        ]);
+
+        await handleConversationCommand(ctx, "switch Current");
+
+        expect(capturedLog()).toContain("Already in conversation");
+        expect(ctx.switchSession).not.toHaveBeenCalled();
+    });
+
+    it("resolves case-insensitively and switches", async () => {
+        const ctx = makeCtx({
+            getCurrentSessionId: () => "old-id",
+        });
+        (ctx.connection.listSessions as jest.Mock).mockResolvedValue([
+            makeSession({
+                sessionId: "target-id",
+                name: "MyChat",
+            }),
+        ]);
+
+        await handleConversationCommand(ctx, "switch mychat");
+
+        expect(ctx.switchSession).toHaveBeenCalledWith("target-id");
+        expect(capturedLog()).toContain("Switched to conversation");
+    });
+
+    it("throws error when multiple sessions match", async () => {
+        const ctx = makeCtx();
+        (ctx.connection.listSessions as jest.Mock).mockResolvedValue([
+            makeSession({ sessionId: "id-1", name: "dup" }),
+            makeSession({ sessionId: "id-2", name: "Dup" }),
+        ]);
+
+        await expect(
+            handleConversationCommand(ctx, "switch dup"),
+        ).rejects.toThrow("Multiple conversations named 'dup' found");
+    });
+});
+
+describe("@conversation list", () => {
+    it("prints 'No conversations found.' for empty list", async () => {
+        const ctx = makeCtx();
+        (ctx.connection.listSessions as jest.Mock).mockResolvedValue([]);
+
+        await handleConversationCommand(ctx, "list");
+
+        expect(capturedLog()).toContain("No conversations found.");
+    });
+
+    it("shows single session with current marker '▸'", async () => {
+        const ctx = makeCtx({
+            getCurrentSessionId: () => "sess-1",
+        });
+        (ctx.connection.listSessions as jest.Mock).mockResolvedValue([
+            makeSession({
+                sessionId: "sess-1",
+                name: "OnlySession",
+                clientCount: 2,
+                createdAt: "2026-01-15T10:00:00.000Z",
+            }),
+        ]);
+
+        await handleConversationCommand(ctx, "list");
+
+        const output = capturedLog();
+        expect(output).toContain("▸");
+        expect(output).toContain("OnlySession");
+        expect(output).toContain("(current)");
+    });
+
+    it("shows multiple sessions sorted by createdAt descending, current marked", async () => {
+        const ctx = makeCtx({
+            getCurrentSessionId: () => "sess-2",
+        });
+        (ctx.connection.listSessions as jest.Mock).mockResolvedValue([
+            makeSession({
+                sessionId: "sess-1",
+                name: "Older",
+                clientCount: 1,
+                createdAt: "2026-01-01T00:00:00.000Z",
+            }),
+            makeSession({
+                sessionId: "sess-2",
+                name: "Middle",
+                clientCount: 3,
+                createdAt: "2026-02-01T00:00:00.000Z",
+            }),
+            makeSession({
+                sessionId: "sess-3",
+                name: "Newest",
+                clientCount: 0,
+                createdAt: "2026-03-01T00:00:00.000Z",
+            }),
+        ]);
+
+        await handleConversationCommand(ctx, "list");
+
+        const output = capturedLog();
+
+        // Newest should appear before Older in the output
+        const newestIdx = output.indexOf("Newest");
+        const middleIdx = output.indexOf("Middle");
+        const olderIdx = output.indexOf("Older");
+        expect(newestIdx).toBeLessThan(middleIdx);
+        expect(middleIdx).toBeLessThan(olderIdx);
+
+        // "▸" appears on the current session line (Middle)
+        // The current marker line also contains "(current)"
+        const lines = output.split("\n");
+        const currentLine = lines.find((l) => l.includes("Middle"));
+        expect(currentLine).toBeDefined();
+        expect(currentLine).toContain("▸");
+        expect(currentLine).toContain("(current)");
+
+        // Non-current session lines should NOT have "▸"
+        const newestLine = lines.find(
+            (l) => l.includes("Newest") && !l.includes("NAME"),
+        );
+        expect(newestLine).toBeDefined();
+        expect(newestLine).not.toContain("▸");
+    });
+
+    it("passes filter to listSessions", async () => {
+        const ctx = makeCtx();
+        (ctx.connection.listSessions as jest.Mock).mockResolvedValue([]);
+
+        await handleConversationCommand(ctx, "list myFilter");
+
+        expect(ctx.connection.listSessions).toHaveBeenCalledWith("myFilter");
+    });
+
+    it("passes undefined filter when no filter given", async () => {
+        const ctx = makeCtx();
+        (ctx.connection.listSessions as jest.Mock).mockResolvedValue([]);
+
+        await handleConversationCommand(ctx, "list");
+
+        expect(ctx.connection.listSessions).toHaveBeenCalledWith(undefined);
+    });
+
+    it("displays clientCount for each session", async () => {
+        const ctx = makeCtx({
+            getCurrentSessionId: () => "sess-1",
+        });
+        (ctx.connection.listSessions as jest.Mock).mockResolvedValue([
+            makeSession({
+                sessionId: "sess-1",
+                name: "Chat",
+                clientCount: 5,
+                createdAt: "2026-01-15T10:00:00.000Z",
+            }),
+        ]);
+
+        await handleConversationCommand(ctx, "list");
+
+        expect(capturedLog()).toContain("5");
+    });
+});
+
+describe("@conversation rename", () => {
+    it("prints usage when name is missing", async () => {
+        const ctx = makeCtx();
+        await handleConversationCommand(ctx, "rename");
+        expect(capturedLog()).toContain("Usage");
+        expect(capturedLog()).toContain("@conversation rename");
+    });
+
+    it("calls renameSession with current session ID and new name", async () => {
+        const ctx = makeCtx({
+            getCurrentSessionId: () => "my-session-id",
+        });
+        (ctx.connection.renameSession as jest.Mock).mockResolvedValue(
+            undefined,
+        );
+
+        await handleConversationCommand(ctx, "rename NewName");
+
+        expect(ctx.connection.renameSession).toHaveBeenCalledWith(
+            "my-session-id",
+            "NewName",
+        );
+        expect(capturedLog()).toContain("Renamed current conversation");
+        expect(capturedLog()).toContain("NewName");
+    });
+
+    it("handles quoted new name", async () => {
+        const ctx = makeCtx({
+            getCurrentSessionId: () => "my-session-id",
+        });
+        (ctx.connection.renameSession as jest.Mock).mockResolvedValue(
+            undefined,
+        );
+
+        await handleConversationCommand(ctx, 'rename "New Name With Spaces"');
+
+        expect(ctx.connection.renameSession).toHaveBeenCalledWith(
+            "my-session-id",
+            "New Name With Spaces",
+        );
+    });
+});
+
+describe("@conversation delete", () => {
+    it("prints usage when name is missing", async () => {
+        const ctx = makeCtx();
+        await handleConversationCommand(ctx, "delete");
+        expect(capturedLog()).toContain("Usage");
+        expect(capturedLog()).toContain("@conversation delete");
+    });
+
+    it("prints error when trying to delete the current session", async () => {
+        const ctx = makeCtx({
+            getCurrentSessionId: () => "current-id",
+        });
+        (ctx.connection.listSessions as jest.Mock).mockResolvedValue([
+            makeSession({
+                sessionId: "current-id",
+                name: "ActiveChat",
+            }),
+        ]);
+
+        await handleConversationCommand(ctx, "delete ActiveChat");
+
+        expect(capturedLog()).toContain(
+            "Cannot delete the active conversation",
+        );
+        expect(ctx.connection.deleteSession).not.toHaveBeenCalled();
+    });
+
+    it("does not delete when user cancels confirmation", async () => {
+        const ctx = makeCtx({
+            getCurrentSessionId: () => "other-id",
+        });
+        (ctx.connection.listSessions as jest.Mock).mockResolvedValue([
+            makeSession({
+                sessionId: "target-id",
+                name: "OldChat",
+            }),
+        ]);
+
+        const promise = handleConversationCommand(ctx, "delete OldChat");
+
+        await new Promise<void>((r) => setImmediate(r));
+        answerPrompt("n");
+        await promise;
+
+        expect(capturedLog()).toContain("Cancelled");
+        expect(ctx.connection.deleteSession).not.toHaveBeenCalled();
+    });
+
+    it("deletes when user confirms", async () => {
+        const ctx = makeCtx({
+            getCurrentSessionId: () => "other-id",
+        });
+        (ctx.connection.listSessions as jest.Mock).mockResolvedValue([
+            makeSession({
+                sessionId: "target-id",
+                name: "OldChat",
+            }),
+        ]);
+        (ctx.connection.deleteSession as jest.Mock).mockResolvedValue(
+            undefined,
+        );
+
+        const promise = handleConversationCommand(ctx, "delete OldChat");
+
+        await new Promise<void>((r) => setImmediate(r));
+        answerPrompt("y");
+        await promise;
+
+        expect(ctx.connection.deleteSession).toHaveBeenCalledWith("target-id");
+        expect(capturedLog()).toContain("Deleted conversation");
+    });
+
+    it("throws error when session name is not found", async () => {
+        const ctx = makeCtx({
+            getCurrentSessionId: () => "other-id",
+        });
+        (ctx.connection.listSessions as jest.Mock).mockResolvedValue([]);
+
+        await expect(
+            handleConversationCommand(ctx, "delete ghost"),
+        ).rejects.toThrow("No conversation named 'ghost' found");
+    });
+});


### PR DESCRIPTION
**In-Conversation Session Management (@conversation commands)**
Adds a @conversation command family to the TypeAgent CLI that lets users create, list, switch between, rename, and delete named conversation sessions — all without leaving the interactive REPL. Previously, sessions were only selectable at startup.

**Changes**:

**New @conversation commands** ([ts/packages/cli/src/conversationCommands.ts](vscode-webview://1o48rp7rdr60cpilngp5dms8tvlq1h8f0158a5o23usnfvp78ej7/ts/packages/cli/src/conversationCommands.ts)) — five subcommands:

**new <name>** — create a conversation and optionally switch to it
**switch <name>** — hot-swap the active session mid-REPL
**list [filter]** — tabular view of all sessions with current marker
**rename <newName>** — rename the current session in-place
**delete <name>** — delete a non-active session with confirmation

Conversation command example
<img width="706" height="564" alt="image" src="https://github.com/user-attachments/assets/c10ea2b3-34f5-410d-b647-8de8bf067393" />

Multi-client experience
<img width="1653" height="331" alt="image" src="https://github.com/user-attachments/assets/492706c6-7b0c-4ac6-bce1-6d4c2148371a" />
