### PR TITLE
Fix multiple bugs: XSS, operator precedence, event listener loss, rac…

### DIFF
--- a/ts/packages/agents/video/src/videoActionHandler.ts
+++ b/ts/packages/agents/video/src/videoActionHandler.ts
@@ -198,7 +198,7 @@ function createVideoPlaceHolder(
                     container.innerText = "❌ Failed to retrieve video content.";
                 }
             } else {
-                container.innerHTML = "<div>❌ Video generation failed: " + statusData.failure_reason ?? "" + "</div>";
+                container.innerHTML = "<div>❌ Video generation failed: " + (statusData.failure_reason ?? "") + "</div>";
                 console.log(JSON.stringify(statusData, null, 2));
             }
         }

--- a/ts/packages/shell/src/main/browserViewManager.ts
+++ b/ts/packages/shell/src/main/browserViewManager.ts
@@ -196,8 +196,20 @@ export class BrowserViewManager {
                 // only show the error if it's for the page the user was asking
                 // it's possible some other resource failed to load (image, script, etc.)
                 if (validatedURL === options.url) {
+                    const safeUrl = options.url
+                        .replace(/&/g, "&amp;")
+                        .replace(/</g, "&lt;")
+                        .replace(/>/g, "&gt;")
+                        .replace(/"/g, "&quot;")
+                        .replace(/'/g, "&#39;");
+                    const safeDesc = errorDesc
+                        .replace(/&/g, "&amp;")
+                        .replace(/</g, "&lt;")
+                        .replace(/>/g, "&gt;")
+                        .replace(/"/g, "&quot;")
+                        .replace(/'/g, "&#39;");
                     webContentsView.webContents.executeJavaScript(
-                        `document.body.innerHTML = "There was an error loading '${options.url}'.<br />Error Details: <br />${errorCode} - ${errorDesc}"`,
+                        `document.body.innerHTML = "There was an error loading '${safeUrl}'.<br />Error Details: <br />${errorCode} - ${safeDesc}"`,
                     );
                 }
             },
@@ -261,9 +273,21 @@ export class BrowserViewManager {
                             `Error loading URL ${webContentsView.webContents.getURL()} in tab ${tabId}:`,
                             err,
                         );
-
+                        const safeUrl = webContentsView.webContents
+                            .getURL()
+                            .replace(/&/g, "&amp;")
+                            .replace(/</g, "&lt;")
+                            .replace(/>/g, "&gt;")
+                            .replace(/"/g, "&quot;")
+                            .replace(/'/g, "&#39;");
+                        const safeErr = String(err)
+                            .replace(/&/g, "&amp;")
+                            .replace(/</g, "&lt;")
+                            .replace(/>/g, "&gt;")
+                            .replace(/"/g, "&quot;")
+                            .replace(/'/g, "&#39;");
                         webContentsView.webContents.executeJavaScript(
-                            `document.body.innerHTML = "There was an error loading '${webContentsView.webContents.getURL()}'.<br />: ${err}"`,
+                            `document.body.innerHTML = "There was an error loading '${safeUrl}'.<br />: ${safeErr}"`,
                         );
                     });
             } else {
@@ -274,8 +298,21 @@ export class BrowserViewManager {
                             `Error loading URL ${webContentsView.webContents.getURL()} in tab ${tabId}:`,
                             err,
                         );
+                        const safeUrl = webContentsView.webContents
+                            .getURL()
+                            .replace(/&/g, "&amp;")
+                            .replace(/</g, "&lt;")
+                            .replace(/>/g, "&gt;")
+                            .replace(/"/g, "&quot;")
+                            .replace(/'/g, "&#39;");
+                        const safeErr = String(err)
+                            .replace(/&/g, "&amp;")
+                            .replace(/</g, "&lt;")
+                            .replace(/>/g, "&gt;")
+                            .replace(/"/g, "&quot;")
+                            .replace(/'/g, "&#39;");
                         webContentsView.webContents.executeJavaScript(
-                            `document.body.innerHTML = "There was an error loading '${webContentsView.webContents.getURL()}'.<br />: ${err}"`,
+                            `document.body.innerHTML = "There was an error loading '${safeUrl}'.<br />: ${safeErr}"`,
                         );
                     });
             }

--- a/ts/packages/shell/src/renderer/src/setContent.ts
+++ b/ts/packages/shell/src/renderer/src/setContent.ts
@@ -294,12 +294,16 @@ export function setContent(
             ${css}
             </head>
             <body style="height: auto; overflow: hidden; background: transparent;">${message}</body></html>`;
+        }).catch((err) => {
+            console.error(`Failed to load CSS for iframe: ${err}`);
+            iframe.srcdoc = `<html>
+            <body style="height: auto; overflow: hidden; background: transparent;">${message}</body></html>`;
         });
 
         contentElm.appendChild(iframe);
     } else {
         // vanilla, sanitized HTML only
-        contentElm.innerHTML += contentHtml;
+        contentElm.insertAdjacentHTML("beforeend", contentHtml);
 
         // Add click handlers for all links to open in browser tabs
         const allLinks = contentElm.querySelectorAll("a[href]");

--- a/ts/packages/shell/src/renderer/src/webSocketAPI.ts
+++ b/ts/packages/shell/src/renderer/src/webSocketAPI.ts
@@ -99,6 +99,7 @@ export async function createWebSocket(autoReconnect: boolean = true) {
     const endpoint = `${protocol}://${url.hostname}${port}`;
 
     return new Promise<WebSocket | undefined>((resolve) => {
+        let reconnecting = false;
         console.log(`opening web socket to ${endpoint} `);
         const webSocket = new WebSocket(endpoint);
 
@@ -162,8 +163,14 @@ export async function createWebSocket(autoReconnect: boolean = true) {
             resolve(undefined);
 
             // reconnect?
-            if (autoReconnect) {
-                createWebSocket().then((ws) => (globalThis.ws = ws));
+            if (autoReconnect && !reconnecting) {
+                reconnecting = true;
+                createWebSocket().then((ws) => {
+                    if (ws) {
+                        globalThis.ws = ws;
+                    }
+                    reconnecting = false;
+                });
             } else {
                 clientIOChannel.notifyDisconnected();
                 dispatcherChannel.notifyDisconnected();


### PR DESCRIPTION
…e condition

- Fix XSS in browserViewManager.ts: HTML-escape URLs and error messages before interpolating into innerHTML via executeJavaScript (3 locations)
- Fix operator precedence bug in videoActionHandler.ts: `+` has higher precedence than `??`, making `failure_reason ?? ""` dead code. Added parentheses to correct the logic
- Fix unhandled promise rejection in setContent.ts: added .catch() handler for CSS loading in iframe so content is still shown on fetch failure
- Fix event listener loss in setContent.ts: replaced `innerHTML +=` with `insertAdjacentHTML("beforeend")` to avoid destroying existing DOM nodes and their event listeners
- Fix race condition in webSocketAPI.ts: added `reconnecting` flag to prevent multiple concurrent reconnection attempts on rapid socket closes