### PR TITLE
Change fix-dependabot-alerts schedule from weekly to daily

### DIFF
--- a/.github/workflows/fix-dependabot-alerts.yml
+++ b/.github/workflows/fix-dependabot-alerts.yml
@@ -14,8 +14,8 @@ name: fix-dependabot-alerts
 
 on:
   schedule:
-    # Run weekly on Monday at 9:00 UTC
-    - cron: "0 9 * * 1"
+    # Run daily at 9:00 UTC
+    - cron: "0 9 * * *"
   workflow_dispatch:
     inputs:
       dry-run:


### PR DESCRIPTION
Change the `fix-dependabot-alerts` workflow schedule from weekly (Mondays at 9:00 UTC) to daily (9:00 UTC) to catch and remediate security alerts sooner.