### PR TITLE
Immediate Settings Refresh for Registry-Based Actions in autoShell

### DIFF
--- a/dotnet/autoShell.Tests/ActionDispatcherIntegrationTests.cs
+++ b/dotnet/autoShell.Tests/ActionDispatcherIntegrationTests.cs
@@ -5,6 +5,7 @@ using System.Text.Json;
 using autoShell.Logging;
 using autoShell.Services;
 using Moq;
+using static autoShell.Services.Interop.SpiConstants;
 
 namespace autoShell.Tests;
 
@@ -92,7 +93,7 @@ public class ActionDispatcherIntegrationTests
     {
         Dispatch("""{"actionName":"SetWallpaper","parameters":{"filePath":"C:\\wallpaper.jpg"}}""");
 
-        _systemParamsMock.Verify(s => s.SetParameter(0x0014, 0, @"C:\wallpaper.jpg", 3), Times.Once);
+        _systemParamsMock.Verify(s => s.SetParameter(SPI_SETDESKWALLPAPER, 0, @"C:\wallpaper.jpg", SPIF_UPDATEINIFILE_SENDCHANGE), Times.Once);
     }
 
     /// <summary>

--- a/dotnet/autoShell.Tests/HandlerRegistrationTests.cs
+++ b/dotnet/autoShell.Tests/HandlerRegistrationTests.cs
@@ -44,7 +44,7 @@ public class HandlerRegistrationTests
             new DisplaySettingsHandler(registryMock.Object, processMock.Object, brightnessMock.Object, loggerMock.Object),
             new PersonalizationSettingsHandler(registryMock.Object, processMock.Object),
             new MouseSettingsHandler(registryMock.Object, processMock.Object, systemParamsMock.Object, loggerMock.Object),
-            new AccessibilitySettingsHandler(registryMock.Object, processMock.Object),
+            new AccessibilitySettingsHandler(registryMock.Object, processMock.Object, systemParamsMock.Object),
             new PowerSettingsHandler(registryMock.Object, processMock.Object),
             new FileExplorerSettingsHandler(registryMock.Object),
             new PrivacySettingsHandler(registryMock.Object),

--- a/dotnet/autoShell.Tests/SettingsHandlerTests.cs
+++ b/dotnet/autoShell.Tests/SettingsHandlerTests.cs
@@ -8,6 +8,7 @@ using autoShell.Logging;
 using autoShell.Services;
 using Microsoft.Win32;
 using Moq;
+using static autoShell.Services.Interop.SpiConstants;
 
 namespace autoShell.Tests;
 
@@ -329,63 +330,56 @@ public class AccessibilitySettingsHandlerTests
 {
     private readonly Mock<IRegistryService> _registryMock = new();
     private readonly Mock<IProcessService> _processMock = new();
+    private readonly Mock<ISystemParametersService> _systemParamsMock = new();
     private readonly AccessibilitySettingsHandler _handler;
 
     public AccessibilitySettingsHandlerTests()
     {
-        _handler = new AccessibilitySettingsHandler(_registryMock.Object, _processMock.Object);
+        _handler = new AccessibilitySettingsHandler(_registryMock.Object, _processMock.Object, _systemParamsMock.Object);
     }
 
     /// <summary>
-    /// Verifies that enabling sticky keys sets the Flags registry value to "510".
+    /// Verifies that enabling sticky keys calls SystemParametersInfo(SPI_SETSTICKYKEYS).
     /// </summary>
     [Fact]
-    public void EnableStickyKeys_Enable_SetsFlags510()
+    public void EnableStickyKeys_Enable_CallsSetStickyKeys()
     {
         Handle("EnableStickyKeys", """{"enable":true}""");
 
-        _registryMock.Verify(r => r.SetValue(
-            @"Control Panel\Accessibility\StickyKeys",
-            "Flags", "510", RegistryValueKind.String), Times.Once);
+        _systemParamsMock.Verify(s => s.SetStickyKeys(true), Times.Once);
     }
 
     /// <summary>
-    /// Verifies that disabling sticky keys sets the Flags registry value to "506".
+    /// Verifies that disabling sticky keys calls SystemParametersInfo(SPI_SETSTICKYKEYS).
     /// </summary>
     [Fact]
-    public void EnableStickyKeys_Disable_SetsFlags506()
+    public void EnableStickyKeys_Disable_CallsSetStickyKeys()
     {
         Handle("EnableStickyKeys", """{"enable":false}""");
 
-        _registryMock.Verify(r => r.SetValue(
-            @"Control Panel\Accessibility\StickyKeys",
-            "Flags", "506", RegistryValueKind.String), Times.Once);
+        _systemParamsMock.Verify(s => s.SetStickyKeys(false), Times.Once);
     }
 
     /// <summary>
-    /// Verifies that enabling filter keys sets the Flags registry value to "2".
+    /// Verifies that enabling filter keys calls SystemParametersInfo(SPI_SETFILTERKEYS).
     /// </summary>
     [Fact]
-    public void EnableFilterKeysAction_Enable_SetsFlags2()
+    public void EnableFilterKeysAction_Enable_CallsSetFilterKeys()
     {
         Handle("EnableFilterKeysAction", """{"enable":true}""");
 
-        _registryMock.Verify(r => r.SetValue(
-            @"Control Panel\Accessibility\Keyboard Response",
-            "Flags", "2", RegistryValueKind.String), Times.Once);
+        _systemParamsMock.Verify(s => s.SetFilterKeys(true), Times.Once);
     }
 
     /// <summary>
-    /// Verifies that disabling filter keys sets the Flags registry value to "126".
+    /// Verifies that disabling filter keys calls SystemParametersInfo(SPI_SETFILTERKEYS).
     /// </summary>
     [Fact]
-    public void EnableFilterKeysAction_Disable_SetsFlags126()
+    public void EnableFilterKeysAction_Disable_CallsSetFilterKeys()
     {
         Handle("EnableFilterKeysAction", """{"enable":false}""");
 
-        _registryMock.Verify(r => r.SetValue(
-            @"Control Panel\Accessibility\Keyboard Response",
-            "Flags", "126", RegistryValueKind.String), Times.Once);
+        _systemParamsMock.Verify(s => s.SetFilterKeys(false), Times.Once);
     }
 
     /// <summary>
@@ -470,7 +464,7 @@ public class MouseSettingsHandlerTests
         Handle("MouseCursorSpeed", """{"speedLevel":10}""");
 
         _systemParamsMock.Verify(s => s.SetParameter(
-            0x0071, 0, 10, 3), Times.Once);
+            SPI_SETMOUSESPEED, 0, 10, SPIF_UPDATEINIFILE_SENDCHANGE), Times.Once);
     }
 
     /// <summary>
@@ -482,7 +476,7 @@ public class MouseSettingsHandlerTests
         Handle("MouseWheelScrollLines", """{"scrollLines":5}""");
 
         _systemParamsMock.Verify(s => s.SetParameter(
-            0x0069, 5, IntPtr.Zero, 3), Times.Once);
+            SPI_SETWHEELSCROLLLINES, 5, IntPtr.Zero, SPIF_UPDATEINIFILE_SENDCHANGE), Times.Once);
     }
 
     /// <summary>
@@ -493,9 +487,9 @@ public class MouseSettingsHandlerTests
     {
         Handle("EnhancePointerPrecision", """{"enable":true}""");
 
-        _systemParamsMock.Verify(s => s.GetParameter(3, 0, It.IsAny<int[]>(), 0), Times.Once);
+        _systemParamsMock.Verify(s => s.GetParameter(SPI_GETMOUSE, 0, It.IsAny<int[]>(), 0), Times.Once);
         _systemParamsMock.Verify(s => s.SetParameter(
-            4, 0, It.Is<int[]>(a => a[2] == 1), 3), Times.Once);
+            SPI_SETMOUSE, 0, It.Is<int[]>(a => a[2] == 1), SPIF_UPDATEINIFILE_SENDCHANGE), Times.Once);
     }
 
     /// <summary>
@@ -506,9 +500,9 @@ public class MouseSettingsHandlerTests
     {
         Handle("EnhancePointerPrecision", """{"enable":false}""");
 
-        _systemParamsMock.Verify(s => s.GetParameter(3, 0, It.IsAny<int[]>(), 0), Times.Once);
+        _systemParamsMock.Verify(s => s.GetParameter(SPI_GETMOUSE, 0, It.IsAny<int[]>(), 0), Times.Once);
         _systemParamsMock.Verify(s => s.SetParameter(
-            4, 0, It.Is<int[]>(a => a[2] == 0), 3), Times.Once);
+            SPI_SETMOUSE, 0, It.Is<int[]>(a => a[2] == 0), SPIF_UPDATEINIFILE_SENDCHANGE), Times.Once);
     }
 
     /// <summary>
@@ -571,7 +565,7 @@ public class MouseSettingsHandlerTests
         Handle("CursorTrail", """{"enable":true,"length":7}""");
 
         _systemParamsMock.Verify(s => s.SetParameter(
-            0x005D, 7, IntPtr.Zero, 3), Times.Once);
+            SPI_SETMOUSETRAILS, 7, IntPtr.Zero, SPIF_UPDATEINIFILE_SENDCHANGE), Times.Once);
     }
 
     /// <summary>
@@ -583,7 +577,7 @@ public class MouseSettingsHandlerTests
         Handle("CursorTrail", """{"enable":false}""");
 
         _systemParamsMock.Verify(s => s.SetParameter(
-            0x005D, 0, IntPtr.Zero, It.IsAny<int>()), Times.Once);
+            SPI_SETMOUSETRAILS, 0, IntPtr.Zero, It.IsAny<int>()), Times.Once);
     }
 
     /// <summary>
@@ -595,7 +589,7 @@ public class MouseSettingsHandlerTests
         Handle("CursorTrail", """{"enable":true,"length":0}""");
 
         _systemParamsMock.Verify(s => s.SetParameter(
-            0x005D, 2, IntPtr.Zero, It.IsAny<int>()), Times.Once);
+            SPI_SETMOUSETRAILS, 2, IntPtr.Zero, It.IsAny<int>()), Times.Once);
     }
 
     /// <summary>
@@ -607,7 +601,7 @@ public class MouseSettingsHandlerTests
         Handle("CursorTrail", """{"enable":true,"length":99}""");
 
         _systemParamsMock.Verify(s => s.SetParameter(
-            0x005D, 12, IntPtr.Zero, It.IsAny<int>()), Times.Once);
+            SPI_SETMOUSETRAILS, 12, IntPtr.Zero, It.IsAny<int>()), Times.Once);
     }
 
     /// <summary>
@@ -622,25 +616,25 @@ public class MouseSettingsHandlerTests
     }
 
     /// <summary>
-    /// Verifies that ToggleMouseSonar enable writes "1" to the MouseSonar registry value.
+    /// Verifies that ToggleMouseSonar enable calls SystemParametersInfo with SPI_SETMOUSESONAR and value 1.
     /// </summary>
     [Fact]
     public void ToggleMouseSonar_Enable_SetsSonar1()
     {
         Handle("ToggleMouseSonar", """{"enable":true}""");
 
-        _registryMock.Verify(r => r.SetValue(@"Control Panel\Mouse", "MouseSonar", "1", RegistryValueKind.String), Times.Once);
+        _systemParamsMock.Verify(s => s.SetParameter(SPI_SETMOUSESONAR, 0, (IntPtr)1, SPIF_UPDATEINIFILE_SENDCHANGE), Times.Once);
     }
 
     /// <summary>
-    /// Verifies that ToggleMouseSonar disable writes "0" to the MouseSonar registry value.
+    /// Verifies that ToggleMouseSonar disable calls SystemParametersInfo with SPI_SETMOUSESONAR and value 0.
     /// </summary>
     [Fact]
     public void ToggleMouseSonar_Disable_SetsSonar0()
     {
         Handle("ToggleMouseSonar", """{"enable":false}""");
 
-        _registryMock.Verify(r => r.SetValue(@"Control Panel\Mouse", "MouseSonar", "0", RegistryValueKind.String), Times.Once);
+        _systemParamsMock.Verify(s => s.SetParameter(SPI_SETMOUSESONAR, 0, IntPtr.Zero, SPIF_UPDATEINIFILE_SENDCHANGE), Times.Once);
     }
 
     private void Handle(string key, string jsonValue)

--- a/dotnet/autoShell.Tests/ThemeActionHandlerTests.cs
+++ b/dotnet/autoShell.Tests/ThemeActionHandlerTests.cs
@@ -6,6 +6,7 @@ using autoShell.Handlers;
 using autoShell.Services;
 using Microsoft.Win32;
 using Moq;
+using static autoShell.Services.Interop.SpiConstants;
 
 namespace autoShell.Tests;
 
@@ -31,7 +32,7 @@ public class ThemeActionHandlerTests
         _handler.Handle("SetWallpaper", JsonDocument.Parse("""{"filePath":"C:\\wallpaper.jpg"}""").RootElement);
 
         _systemParamsMock.Verify(s => s.SetParameter(
-            0x0014, 0, @"C:\wallpaper.jpg", 3), Times.Once);
+            SPI_SETDESKWALLPAPER, 0, @"C:\wallpaper.jpg", SPIF_UPDATEINIFILE_SENDCHANGE), Times.Once);
     }
 
     /// <summary>

--- a/dotnet/autoShell/ActionDispatcher.cs
+++ b/dotnet/autoShell/ActionDispatcher.cs
@@ -83,7 +83,7 @@ internal class ActionDispatcher
             new DisplaySettingsHandler(registry, process, brightness, logger),
             new PersonalizationSettingsHandler(registry, process),
             new MouseSettingsHandler(registry, process, systemParams, logger),
-            new AccessibilitySettingsHandler(registry, process),
+            new AccessibilitySettingsHandler(registry, process, systemParams),
             new PowerSettingsHandler(registry, process),
             new FileExplorerSettingsHandler(registry),
             new PrivacySettingsHandler(registry),

--- a/dotnet/autoShell/Handlers/ActionHandlerBase.cs
+++ b/dotnet/autoShell/Handlers/ActionHandlerBase.cs
@@ -58,11 +58,9 @@ internal abstract class ActionHandlerBase : IActionHandler
             {
                 return ActionResult.Fail($"Invalid parameters for '{actionName}': {ex.Message}");
             }
-            if (typed == null)
-            {
-                return ActionResult.Fail($"Invalid parameters for '{actionName}': null parameters not allowed");
-            }
-            return handler(typed);
+            return typed == null
+                ? ActionResult.Fail($"Invalid parameters for '{actionName}': null parameters not allowed")
+                : handler(typed);
         });
     }
 

--- a/dotnet/autoShell/Handlers/DisplayActionHandler.cs
+++ b/dotnet/autoShell/Handlers/DisplayActionHandler.cs
@@ -63,8 +63,7 @@ internal class DisplayActionHandler : ActionHandlerBase
             }
 
             string result = _display.SetResolution((uint)width, (uint)height, refreshRate);
-            using var doc = JsonDocument.Parse(result);
-            return ActionResult.Ok($"Screen resolution set to {width}x{height}", doc.RootElement.Clone());
+            return ActionResult.Ok(result);
         }
         catch (Exception ex)
         {

--- a/dotnet/autoShell/Handlers/Settings/AccessibilitySettingsHandler.cs
+++ b/dotnet/autoShell/Handlers/Settings/AccessibilitySettingsHandler.cs
@@ -3,7 +3,6 @@
 
 using autoShell.Handlers.Generated;
 using autoShell.Services;
-using Microsoft.Win32;
 
 namespace autoShell.Handlers.Settings;
 
@@ -13,26 +12,38 @@ namespace autoShell.Handlers.Settings;
 internal class AccessibilitySettingsHandler : SettingsHandlerBase
 {
     private readonly IProcessService _process;
+    private readonly ISystemParametersService _systemParams;
 
     /// <summary>
     /// Registers registered actions for mono audio, filter keys, and sticky keys.
     /// Magnifier and Narrator require process start/kill and are handled as specialized actions.
     /// </summary>
-    public AccessibilitySettingsHandler(IRegistryService registry, IProcessService process)
+    public AccessibilitySettingsHandler(IRegistryService registry, IProcessService process, ISystemParametersService systemParams)
         : base(registry, process)
     {
         _process = process;
+        _systemParams = systemParams;
 
         AddRegistryToggleAction("MonoAudioToggle", new RegistryToggleConfig(
             @"Software\Microsoft\Multimedia\Audio", "AccessibilityMonoMixState", "enable", 1, 0));
-        AddRegistryToggleAction("EnableFilterKeysAction", new RegistryToggleConfig(
-            @"Control Panel\Accessibility\Keyboard Response", "Flags", "enable",
-            OnValue: "2", OffValue: "126", ValueKind: RegistryValueKind.String, DisplayName: "Filter Keys"));
-        AddRegistryToggleAction("EnableStickyKeys", new RegistryToggleConfig(
-            @"Control Panel\Accessibility\StickyKeys", "Flags", "enable",
-            OnValue: "510", OffValue: "506", ValueKind: RegistryValueKind.String, DisplayName: "Sticky Keys"));
+        AddAction<EnableFilterKeysActionParams>("EnableFilterKeysAction", HandleFilterKeys);
+        AddAction<EnableStickyKeysParams>("EnableStickyKeys", HandleStickyKeys);
         AddAction<EnableMagnifierParams>("EnableMagnifier", p => HandleToggleProcess(p.Enable ?? true, "magnify.exe", "Magnify", "Magnifier"));
         AddAction<EnableNarratorActionParams>("EnableNarratorAction", p => HandleToggleProcess(p.Enable ?? true, "narrator.exe", "Narrator", "Narrator"));
+    }
+
+    private ActionResult HandleFilterKeys(EnableFilterKeysActionParams p)
+    {
+        bool enable = p.Enable ?? true;
+        _systemParams.SetFilterKeys(enable);
+        return ActionResult.Ok($"Filter Keys {(enable ? "enabled" : "disabled")}");
+    }
+
+    private ActionResult HandleStickyKeys(EnableStickyKeysParams p)
+    {
+        bool enable = p.Enable;
+        _systemParams.SetStickyKeys(enable);
+        return ActionResult.Ok($"Sticky Keys {(enable ? "enabled" : "disabled")}");
     }
 
     private ActionResult HandleToggleProcess(bool enable, string exeName, string processName, string displayName)

--- a/dotnet/autoShell/Handlers/Settings/FileExplorerSettingsHandler.cs
+++ b/dotnet/autoShell/Handlers/Settings/FileExplorerSettingsHandler.cs
@@ -1,11 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System;
-using System.Runtime.InteropServices;
 using autoShell.Handlers.Generated;
 using autoShell.Services;
-using autoShell.Services.Interop;
 using Microsoft.Win32;
 
 namespace autoShell.Handlers.Settings;
@@ -13,14 +10,9 @@ namespace autoShell.Handlers.Settings;
 /// <summary>
 /// Handles File Explorer settings: file extensions and hidden/system files visibility.
 /// </summary>
-internal partial class FileExplorerSettingsHandler : SettingsHandlerBase
+internal class FileExplorerSettingsHandler : SettingsHandlerBase
 {
-    #region P/Invoke
     private const string ExplorerAdvanced = @"Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced";
-
-    [LibraryImport(NativeDlls.User32, EntryPoint = "SendNotifyMessageW")]
-    private static partial IntPtr SendNotifyMessage(IntPtr hWnd, uint msg, IntPtr wParam, IntPtr lParam);
-    #endregion P/Invoke
 
     /// <summary>
     /// Registers a registered action for showing file extensions (inverted toggle).
@@ -29,30 +21,9 @@ internal partial class FileExplorerSettingsHandler : SettingsHandlerBase
     public FileExplorerSettingsHandler(IRegistryService registry)
         : base(registry)
     {
-
         AddRegistryToggleAction("ShowFileExtensions", new RegistryToggleConfig(
             ExplorerAdvanced, "HideFileExt", "enable", OnValue: 0, OffValue: 1));
         AddAction<ShowHiddenAndSystemFilesParams>("ShowHiddenAndSystemFiles", HandleShowHiddenAndSystemFiles);
-    }
-
-    /// <inheritdoc/>
-    public override ActionResult Handle(string key, System.Text.Json.JsonElement parameters)
-    {
-        var result = base.Handle(key, parameters);
-        NotifySettingsChange();
-        return result;
-    }
-
-    private static void NotifySettingsChange()
-    {
-        try
-        {
-            SendNotifyMessage((IntPtr)0xffff, 0x001A, IntPtr.Zero, IntPtr.Zero);
-        }
-        catch (EntryPointNotFoundException)
-        {
-            // P/Invoke may not be available in all environments
-        }
     }
 
     private ActionResult HandleShowHiddenAndSystemFiles(ShowHiddenAndSystemFilesParams p)
@@ -62,6 +33,8 @@ internal partial class FileExplorerSettingsHandler : SettingsHandlerBase
         Registry.SetValue(ExplorerAdvanced, "Hidden", enable ? 1 : 2, RegistryValueKind.DWord);
         // Show protected operating system files
         Registry.SetValue(ExplorerAdvanced, "ShowSuperHidden", enable ? 1 : 0, RegistryValueKind.DWord);
+        Registry.BroadcastSettingChange();
+        Registry.NotifyShellChange();
         return ActionResult.Ok($"Hidden files {(enable ? "shown" : "hidden")}");
     }
 }

--- a/dotnet/autoShell/Handlers/Settings/FileExplorerSettingsHandler.cs
+++ b/dotnet/autoShell/Handlers/Settings/FileExplorerSettingsHandler.cs
@@ -22,7 +22,7 @@ internal class FileExplorerSettingsHandler : SettingsHandlerBase
         : base(registry)
     {
         AddRegistryToggleAction("ShowFileExtensions", new RegistryToggleConfig(
-            ExplorerAdvanced, "HideFileExt", "enable", OnValue: 0, OffValue: 1));
+            ExplorerAdvanced, "HideFileExt", "enable", OnValue: 0, OffValue: 1, NotifyShell: true));
         AddAction<ShowHiddenAndSystemFilesParams>("ShowHiddenAndSystemFiles", HandleShowHiddenAndSystemFiles);
     }
 

--- a/dotnet/autoShell/Handlers/Settings/MouseSettingsHandler.cs
+++ b/dotnet/autoShell/Handlers/Settings/MouseSettingsHandler.cs
@@ -5,6 +5,7 @@ using System;
 using autoShell.Handlers.Generated;
 using autoShell.Logging;
 using autoShell.Services;
+using static autoShell.Services.Interop.SpiConstants;
 
 namespace autoShell.Handlers.Settings;
 
@@ -14,15 +15,6 @@ namespace autoShell.Handlers.Settings;
 /// </summary>
 internal class MouseSettingsHandler : SettingsHandlerBase
 {
-    private const int SPI_GETMOUSE = 3;
-    private const int SPI_SETMOUSE = 4;
-    private const int SPI_SETMOUSESPEED = 0x0071;
-    private const int SPI_SETMOUSETRAILS = 0x005D;
-    private const int SPI_SETWHEELSCROLLLINES = 0x0069;
-    private const int SPIF_UPDATEINIFILE = 0x01;
-    private const int SPIF_SENDCHANGE = 0x02;
-    private const int SPIF_UPDATEINIFILE_SENDCHANGE = 3;
-
     private readonly ISystemParametersService _systemParams;
     private readonly ILogger _logger;
 
@@ -40,14 +32,19 @@ internal class MouseSettingsHandler : SettingsHandlerBase
         AddOpenSettingsAction("MousePointerCustomization", new OpenSettingsConfig("ms-settings:easeofaccess-mouse", "mouse settings"));
         AddOpenSettingsAction("EnableTouchPad", new OpenSettingsConfig("ms-settings:devices-touchpad", "touchpad settings"));
         AddOpenSettingsAction("TouchpadCursorSpeed", new OpenSettingsConfig("ms-settings:devices-touchpad", "touchpad settings"));
-        AddRegistryToggleAction("ToggleMouseSonar", new RegistryToggleConfig(
-            @"Control Panel\Mouse", "MouseSonar", "enable",
-            OnValue: "1", OffValue: "0", ValueKind: Microsoft.Win32.RegistryValueKind.String, DisplayName: "Mouse Sonar"));
+        AddAction<ToggleMouseSonarParams>("ToggleMouseSonar", HandleToggleMouseSonar);
         AddAction<CursorTrailParams>("CursorTrail", HandleMouseCursorTrail);
         AddAction<EnhancePointerPrecisionParams>("EnhancePointerPrecision", HandleEnhancePointerPrecision);
         AddAction<MouseCursorSpeedParams>("MouseCursorSpeed", HandleMouseCursorSpeed);
         AddAction<MouseWheelScrollLinesParams>("MouseWheelScrollLines", HandleMouseWheelScrollLines);
         AddAction<SetPrimaryMouseButtonParams>("SetPrimaryMouseButton", HandleSetPrimaryMouseButton);
+    }
+
+    private ActionResult HandleToggleMouseSonar(ToggleMouseSonarParams p)
+    {
+        bool enable = p.Enable;
+        _systemParams.SetParameter(SPI_SETMOUSESONAR, 0, (IntPtr)(enable ? 1 : 0), SPIF_UPDATEINIFILE_SENDCHANGE);
+        return ActionResult.Ok($"Mouse Sonar {(enable ? "enabled" : "disabled")}");
     }
 
     private ActionResult HandleEnhancePointerPrecision(EnhancePointerPrecisionParams p)

--- a/dotnet/autoShell/Handlers/Settings/PersonalizationSettingsHandler.cs
+++ b/dotnet/autoShell/Handlers/Settings/PersonalizationSettingsHandler.cs
@@ -22,9 +22,11 @@ internal class PersonalizationSettingsHandler : SettingsHandlerBase
     {
 
         AddRegistryToggleAction("ApplyColorToTitleBar", new RegistryToggleConfig(
-            @"Software\Microsoft\Windows\DWM", "ColorPrevalence", "enableColor", 1, 0));
+            @"Software\Microsoft\Windows\DWM", "ColorPrevalence", "enableColor", 1, 0,
+            BroadcastSetting: "ImmersiveColorSet"));
         AddRegistryToggleAction("EnableTransparency", new RegistryToggleConfig(
-            @"Software\Microsoft\Windows\CurrentVersion\Themes\Personalize", "EnableTransparency", "enable", 1, 0));
+            @"Software\Microsoft\Windows\CurrentVersion\Themes\Personalize", "EnableTransparency", "enable", 1, 0,
+            BroadcastSetting: "ImmersiveColorSet"));
         AddOpenSettingsAction("HighContrastTheme", new OpenSettingsConfig(
             "ms-settings:easeofaccess-highcontrast", "high contrast settings"));
         AddAction<SystemThemeModeParams>("SystemThemeMode", HandleSystemThemeMode);

--- a/dotnet/autoShell/Handlers/Settings/SettingsHandlerBase.cs
+++ b/dotnet/autoShell/Handlers/Settings/SettingsHandlerBase.cs
@@ -33,7 +33,8 @@ internal record RegistryToggleConfig(
     object OffValue,
     RegistryValueKind ValueKind = RegistryValueKind.DWord,
     bool UseLocalMachine = false,
-    string? DisplayName = null);
+    string? DisplayName = null,
+    string? BroadcastSetting = null);
 
 /// <summary>
 /// Configuration for a registry map action: reads a string parameter and maps it to a registry value.
@@ -141,6 +142,9 @@ internal abstract class SettingsHandlerBase : ActionHandlerBase
             {
                 Registry.SetValue(config.KeyPath, config.ValueName, value, config.ValueKind);
             }
+
+            Registry.BroadcastSettingChange(config.BroadcastSetting);
+            Registry.NotifyShellChange();
         }
         catch (Exception ex) when (ex is UnauthorizedAccessException or SecurityException or IOException)
         {
@@ -162,6 +166,8 @@ internal abstract class SettingsHandlerBase : ActionHandlerBase
         try
         {
             Registry.SetValue(config.KeyPath, config.ValueName, regValue, config.ValueKind);
+            Registry.BroadcastSettingChange();
+            Registry.NotifyShellChange();
         }
         catch (Exception ex) when (ex is UnauthorizedAccessException or SecurityException or IOException)
         {

--- a/dotnet/autoShell/Handlers/Settings/SettingsHandlerBase.cs
+++ b/dotnet/autoShell/Handlers/Settings/SettingsHandlerBase.cs
@@ -25,6 +25,8 @@ namespace autoShell.Handlers.Settings;
 /// <param name="ValueKind">The registry data type (default DWord).</param>
 /// <param name="UseLocalMachine">If true, writes to HKLM instead of HKCU (default false).</param>
 /// <param name="DisplayName">Human-readable name for log messages.</param>
+/// <param name="BroadcastSetting">If set, broadcasts WM_SETTINGCHANGE with this string after writing.</param>
+/// <param name="NotifyShell">If true, calls SHChangeNotify to refresh Explorer views after writing (default false).</param>
 internal record RegistryToggleConfig(
     string KeyPath,
     string ValueName,
@@ -34,7 +36,8 @@ internal record RegistryToggleConfig(
     RegistryValueKind ValueKind = RegistryValueKind.DWord,
     bool UseLocalMachine = false,
     string? DisplayName = null,
-    string? BroadcastSetting = null);
+    string? BroadcastSetting = null,
+    bool NotifyShell = false);
 
 /// <summary>
 /// Configuration for a registry map action: reads a string parameter and maps it to a registry value.
@@ -46,6 +49,7 @@ internal record RegistryToggleConfig(
 /// <param name="DefaultValue">Value used when the parameter doesn't match any key in the map.</param>
 /// <param name="ValueKind">The registry data type (default DWord).</param>
 /// <param name="DisplayName">Human-readable name for log messages.</param>
+/// <param name="NotifyShell">If true, calls SHChangeNotify to refresh Explorer views after writing (default false).</param>
 internal record RegistryMapConfig(
     string KeyPath,
     string ValueName,
@@ -53,7 +57,8 @@ internal record RegistryMapConfig(
     Dictionary<string, object> ValueMap,
     object DefaultValue,
     RegistryValueKind ValueKind = RegistryValueKind.DWord,
-    string? DisplayName = null);
+    string? DisplayName = null,
+    bool NotifyShell = false);
 
 /// <summary>
 /// Configuration for an action that opens a Windows Settings page.
@@ -144,7 +149,10 @@ internal abstract class SettingsHandlerBase : ActionHandlerBase
             }
 
             Registry.BroadcastSettingChange(config.BroadcastSetting);
-            Registry.NotifyShellChange();
+            if (config.NotifyShell)
+            {
+                Registry.NotifyShellChange();
+            }
         }
         catch (Exception ex) when (ex is UnauthorizedAccessException or SecurityException or IOException)
         {
@@ -167,7 +175,10 @@ internal abstract class SettingsHandlerBase : ActionHandlerBase
         {
             Registry.SetValue(config.KeyPath, config.ValueName, regValue, config.ValueKind);
             Registry.BroadcastSettingChange();
-            Registry.NotifyShellChange();
+            if (config.NotifyShell)
+            {
+                Registry.NotifyShellChange();
+            }
         }
         catch (Exception ex) when (ex is UnauthorizedAccessException or SecurityException or IOException)
         {

--- a/dotnet/autoShell/Handlers/Settings/TaskbarSettingsHandler.cs
+++ b/dotnet/autoShell/Handlers/Settings/TaskbarSettingsHandler.cs
@@ -1,12 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System;
 using System.Collections.Generic;
-using System.Runtime.InteropServices;
 using autoShell.Handlers.Generated;
 using autoShell.Services;
-using autoShell.Services.Interop;
 using Microsoft.Win32;
 
 namespace autoShell.Handlers.Settings;
@@ -15,15 +12,10 @@ namespace autoShell.Handlers.Settings;
 /// Handles taskbar settings: auto-hide, clock seconds, multi-monitor, badges, task view,
 /// alignment, and widgets visibility.
 /// </summary>
-internal partial class TaskbarSettingsHandler : SettingsHandlerBase
+internal class TaskbarSettingsHandler : SettingsHandlerBase
 {
-    #region P/Invoke
     private const string StuckRects3 = @"Software\Microsoft\Windows\CurrentVersion\Explorer\StuckRects3";
     private const string ExplorerAdvanced = @"Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced";
-
-    [LibraryImport(NativeDlls.User32, EntryPoint = "SendNotifyMessageW")]
-    private static partial IntPtr SendNotifyMessage(IntPtr hWnd, uint msg, IntPtr wParam, IntPtr lParam);
-    #endregion P/Invoke
 
     /// <summary>
     /// Registers registered actions for clock seconds, multi-monitor taskbar, badges, task view,
@@ -45,26 +37,6 @@ internal partial class TaskbarSettingsHandler : SettingsHandlerBase
         AddAction<AutoHideTaskbarParams>("AutoHideTaskbar", HandleAutoHideTaskbar);
     }
 
-    /// <inheritdoc/>
-    public override ActionResult Handle(string key, System.Text.Json.JsonElement parameters)
-    {
-        var result = base.Handle(key, parameters);
-        NotifySettingsChange();
-        return result;
-    }
-
-    private static void NotifySettingsChange()
-    {
-        try
-        {
-            SendNotifyMessage((IntPtr)0xffff, 0x001A, IntPtr.Zero, IntPtr.Zero);
-        }
-        catch (EntryPointNotFoundException)
-        {
-            // P/Invoke may not be available in all environments
-        }
-    }
-
     private ActionResult HandleAutoHideTaskbar(AutoHideTaskbarParams p)
     {
         bool hide = p.HideWhenNotUsing;
@@ -83,6 +55,8 @@ internal partial class TaskbarSettingsHandler : SettingsHandlerBase
             }
 
             Registry.SetValue(StuckRects3, "Settings", settings, RegistryValueKind.Binary);
+            Registry.SetTaskbarAutoHideState(hide);
+
             return ActionResult.Ok($"Taskbar auto-hide {(hide ? "enabled" : "disabled")}");
         }
 

--- a/dotnet/autoShell/Handlers/Settings/TaskbarSettingsHandler.cs
+++ b/dotnet/autoShell/Handlers/Settings/TaskbarSettingsHandler.cs
@@ -26,14 +26,14 @@ internal class TaskbarSettingsHandler : SettingsHandlerBase
         : base(registry, process)
     {
 
-        AddRegistryToggleAction("DisplaySecondsInSystrayClock", new RegistryToggleConfig(ExplorerAdvanced, "ShowSecondsInSystemClock", "enable", 1, 0));
-        AddRegistryToggleAction("DisplayTaskbarOnAllMonitors", new RegistryToggleConfig(ExplorerAdvanced, "MMTaskbarEnabled", "enable", 1, 0));
-        AddRegistryToggleAction("ShowBadgesOnTaskbar", new RegistryToggleConfig(ExplorerAdvanced, "TaskbarBadges", "enableBadging", 1, 0));
-        AddRegistryToggleAction("TaskViewVisibility", new RegistryToggleConfig(ExplorerAdvanced, "ShowTaskViewButton", "visibility", 1, 0));
+        AddRegistryToggleAction("DisplaySecondsInSystrayClock", new RegistryToggleConfig(ExplorerAdvanced, "ShowSecondsInSystemClock", "enable", 1, 0, NotifyShell: true));
+        AddRegistryToggleAction("DisplayTaskbarOnAllMonitors", new RegistryToggleConfig(ExplorerAdvanced, "MMTaskbarEnabled", "enable", 1, 0, NotifyShell: true));
+        AddRegistryToggleAction("ShowBadgesOnTaskbar", new RegistryToggleConfig(ExplorerAdvanced, "TaskbarBadges", "enableBadging", 1, 0, NotifyShell: true));
+        AddRegistryToggleAction("TaskViewVisibility", new RegistryToggleConfig(ExplorerAdvanced, "ShowTaskViewButton", "visibility", 1, 0, NotifyShell: true));
         AddRegistryMapAction("TaskbarAlignment", new RegistryMapConfig(ExplorerAdvanced, "TaskbarAl", "alignment",
-            new Dictionary<string, object> { ["left"] = 0, ["center"] = 1 }, DefaultValue: 1));
+            new Dictionary<string, object> { ["left"] = 0, ["center"] = 1 }, DefaultValue: 1, NotifyShell: true));
         AddRegistryMapAction("ToggleWidgetsButtonVisibility", new RegistryMapConfig(ExplorerAdvanced, "TaskbarDa", "visibility",
-            new Dictionary<string, object> { ["show"] = 1 }, DefaultValue: 0));
+            new Dictionary<string, object> { ["show"] = 1 }, DefaultValue: 0, NotifyShell: true));
         AddAction<AutoHideTaskbarParams>("AutoHideTaskbar", HandleAutoHideTaskbar);
     }
 

--- a/dotnet/autoShell/Handlers/ThemeActionHandler.cs
+++ b/dotnet/autoShell/Handlers/ThemeActionHandler.cs
@@ -4,12 +4,11 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Runtime.InteropServices;
 using System.Text.Json;
 using autoShell.Handlers.Generated;
 using autoShell.Services;
-using autoShell.Services.Interop;
 using Microsoft.Win32;
+using static autoShell.Services.Interop.SpiConstants;
 
 namespace autoShell.Handlers;
 
@@ -18,26 +17,8 @@ namespace autoShell.Handlers;
 /// Contains all Windows theme management logic including discovery, application,
 /// and light/dark mode toggling.
 /// </summary>
-internal partial class ThemeActionHandler : ActionHandlerBase
+internal class ThemeActionHandler : ActionHandlerBase
 {
-    #region P/Invoke
-
-    private const int SPI_SETDESKWALLPAPER = 0x0014;
-    private const int SPIF_UPDATEINIFILE_SENDCHANGE = 3;
-    private const uint LOAD_LIBRARY_AS_DATAFILE = 0x00000002;
-
-    [LibraryImport(NativeDlls.Kernel32, SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]
-    private static partial IntPtr LoadLibraryEx(string lpFileName, IntPtr hFile, uint dwFlags);
-
-    [LibraryImport(NativeDlls.Kernel32, SetLastError = true)]
-    [return: MarshalAs(UnmanagedType.Bool)]
-    private static partial bool FreeLibrary(IntPtr hModule);
-
-    [LibraryImport(NativeDlls.User32, StringMarshalling = StringMarshalling.Utf16)]
-    private static partial int LoadString(IntPtr hInstance, uint uID, [Out] char[] lpBuffer, int nBufferMax);
-
-    #endregion P/Invoke
-
     private readonly IRegistryService _registry;
     private readonly IProcessService _process;
     private readonly ISystemParametersService _systemParams;
@@ -314,7 +295,7 @@ internal partial class ThemeActionHandler : ActionHandlerBase
     /// <summary>
     /// Parses the display name from a .theme file.
     /// </summary>
-    private static string GetThemeDisplayName(string themeFilePath)
+    private string GetThemeDisplayName(string themeFilePath)
     {
         try
         {
@@ -377,7 +358,7 @@ internal partial class ThemeActionHandler : ActionHandlerBase
     /// <summary>
     /// Resolves a localized string resource reference.
     /// </summary>
-    private static string ResolveLocalizedString(string localizedString)
+    private string ResolveLocalizedString(string localizedString)
     {
         try
         {
@@ -391,22 +372,10 @@ internal partial class ThemeActionHandler : ActionHandlerBase
                 string resourceIdStr = resourcePath[(commaIndex + 1)..];
                 if (int.TryParse(resourceIdStr, out int resourceId))
                 {
-                    char[] buffer = new char[256];
-                    IntPtr hModule = LoadLibraryEx(dllPath, IntPtr.Zero, LOAD_LIBRARY_AS_DATAFILE);
-                    if (hModule != IntPtr.Zero)
+                    string resolved = _systemParams.LoadStringResource(dllPath, resourceId);
+                    if (resolved != null)
                     {
-                        try
-                        {
-                            int result = LoadString(hModule, (uint)Math.Abs(resourceId), buffer, buffer.Length);
-                            if (result > 0)
-                            {
-                                return new string(buffer, 0, result);
-                            }
-                        }
-                        finally
-                        {
-                            FreeLibrary(hModule);
-                        }
+                        return resolved;
                     }
                 }
             }

--- a/dotnet/autoShell/JsonOptions.cs
+++ b/dotnet/autoShell/JsonOptions.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Text.Json;
+
+namespace autoShell;
+
+/// <summary>
+/// Shared JSON serialization options for consistent output formatting.
+/// </summary>
+internal static class JsonOptions
+{
+    /// <summary>
+    /// Serializes with camelCase property names to match TypeScript conventions.
+    /// </summary>
+    public static readonly JsonSerializerOptions CamelCase = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+    };
+}

--- a/dotnet/autoShell/Services/IRegistryService.cs
+++ b/dotnet/autoShell/Services/IRegistryService.cs
@@ -39,4 +39,16 @@ internal interface IRegistryService
     /// </summary>
     /// <param name="setting">The setting name to broadcast (e.g., "ImmersiveColorSet"), or null for a generic notification.</param>
     void BroadcastSettingChange(string setting = null);
+
+    /// <summary>
+    /// Notifies the shell that file associations or Explorer settings have changed,
+    /// causing open Explorer windows to refresh immediately.
+    /// </summary>
+    void NotifyShellChange();
+
+    /// <summary>
+    /// Notifies the taskbar to update its auto-hide state immediately.
+    /// </summary>
+    /// <param name="autoHide">True to enable auto-hide, false to disable.</param>
+    void SetTaskbarAutoHideState(bool autoHide);
 }

--- a/dotnet/autoShell/Services/ISystemParametersService.cs
+++ b/dotnet/autoShell/Services/ISystemParametersService.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#nullable enable
+
 using System;
 
 namespace autoShell.Services;
@@ -51,4 +53,23 @@ internal interface ISystemParametersService
     /// </summary>
     /// <param name="swap">If true, swaps the buttons; if false, restores default.</param>
     bool SwapMouseButton(bool swap);
+
+    /// <summary>
+    /// Enables or disables Filter Keys via SystemParametersInfo(SPI_SETFILTERKEYS).
+    /// </summary>
+    bool SetFilterKeys(bool enable);
+
+    /// <summary>
+    /// Enables or disables Sticky Keys via SystemParametersInfo(SPI_SETSTICKYKEYS).
+    /// </summary>
+    bool SetStickyKeys(bool enable);
+
+    /// <summary>
+    /// Loads a string resource from a native DLL by resource ID.
+    /// Used to resolve localized display names (e.g., theme names from themeui.dll).
+    /// </summary>
+    /// <param name="dllPath">Full path to the DLL containing the string resource.</param>
+    /// <param name="resourceId">The resource ID of the string to load.</param>
+    /// <returns>The loaded string, or null if the resource could not be found.</returns>
+    string? LoadStringResource(string dllPath, int resourceId);
 }

--- a/dotnet/autoShell/Services/Interop/NativeDlls.cs
+++ b/dotnet/autoShell/Services/Interop/NativeDlls.cs
@@ -10,5 +10,6 @@ internal static class NativeDlls
 {
     public const string User32 = "user32.dll";
     public const string Kernel32 = "kernel32.dll";
+    public const string Shell32 = "shell32.dll";
     public const string WlanApi = "wlanapi.dll";
 }

--- a/dotnet/autoShell/Services/Interop/SpiConstants.cs
+++ b/dotnet/autoShell/Services/Interop/SpiConstants.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace autoShell.Services.Interop;
+
+/// <summary>
+/// Win32 SystemParametersInfo (SPI) constants and flags.
+/// Shared between handlers and tests to avoid duplicated magic numbers.
+/// </summary>
+internal static class SpiConstants
+{
+    // Flags
+    public const int SPIF_UPDATEINIFILE = 0x01;
+    public const int SPIF_SENDCHANGE = 0x02;
+    public const int SPIF_UPDATEINIFILE_SENDCHANGE = SPIF_UPDATEINIFILE | SPIF_SENDCHANGE;
+
+    // Mouse
+    public const int SPI_GETMOUSE = 0x0003;
+    public const int SPI_SETMOUSE = 0x0004;
+    public const int SPI_SETDESKWALLPAPER = 0x0014;
+    public const int SPI_SETMOUSETRAILS = 0x005D;
+    public const int SPI_SETWHEELSCROLLLINES = 0x0069;
+    public const int SPI_SETMOUSESPEED = 0x0071;
+    public const int SPI_SETMOUSESONAR = 0x101D;
+
+    // Accessibility
+    public const int SPI_GETFILTERKEYS = 0x0032;
+    public const int SPI_SETFILTERKEYS = 0x0033;
+    public const int SPI_GETSTICKYKEYS = 0x003A;
+    public const int SPI_SETSTICKYKEYS = 0x003B;
+}

--- a/dotnet/autoShell/Services/WindowsDisplayService.cs
+++ b/dotnet/autoShell/Services/WindowsDisplayService.cs
@@ -113,7 +113,7 @@ internal class WindowsDisplayService : IDisplayService
             .ThenByDescending(r => r.RefreshRate)
             .ToList();
 
-        return JsonSerializer.Serialize(uniqueResolutions);
+        return JsonSerializer.Serialize(uniqueResolutions, JsonOptions.CamelCase);
     }
 
     /// <inheritdoc/>

--- a/dotnet/autoShell/Services/WindowsNetworkService.cs
+++ b/dotnet/autoShell/Services/WindowsNetworkService.cs
@@ -394,7 +394,7 @@ internal class WindowsNetworkService : INetworkService
                 .OrderByDescending(n => ((dynamic)n).SignalQuality)
                 .ToList();
 
-            return JsonSerializer.Serialize(uniqueNetworks);
+            return JsonSerializer.Serialize(uniqueNetworks, JsonOptions.CamelCase);
         }
         catch (Exception ex)
         {

--- a/dotnet/autoShell/Services/WindowsRegistryService.cs
+++ b/dotnet/autoShell/Services/WindowsRegistryService.cs
@@ -50,8 +50,56 @@ internal class WindowsRegistryService : IRegistryService
             out _);
     }
 
+    /// <inheritdoc/>
+    public void NotifyShellChange()
+    {
+        const int SHCNE_ASSOCCHANGED = 0x08000000;
+        const int SHCNF_IDLIST = 0x0000;
+        SHChangeNotify(SHCNE_ASSOCCHANGED, SHCNF_IDLIST, IntPtr.Zero, IntPtr.Zero);
+    }
+
+    /// <inheritdoc/>
+    public void SetTaskbarAutoHideState(bool autoHide)
+    {
+        const int ABM_SETSTATE = 0x0000000A;
+        const int ABS_AUTOHIDE = 0x0001;
+        const int ABS_ALWAYSONTOP = 0x0002;
+
+        IntPtr taskbarHwnd = FindWindow("Shell_TrayWnd", null);
+        if (taskbarHwnd != IntPtr.Zero)
+        {
+            var abd = new APPBARDATA
+            {
+                cbSize = Marshal.SizeOf<APPBARDATA>(),
+                hWnd = taskbarHwnd,
+                lParam = (IntPtr)(autoHide ? ABS_AUTOHIDE : ABS_ALWAYSONTOP)
+            };
+            SHAppBarMessage(ABM_SETSTATE, ref abd);
+        }
+    }
+
     [DllImport(NativeDlls.User32, CharSet = CharSet.Auto, SetLastError = true)]
     private static extern IntPtr SendMessageTimeout(
         IntPtr hWnd, uint Msg, IntPtr wParam, string lParam,
         uint fuFlags, uint uTimeout, out IntPtr lpdwResult);
+
+    [DllImport(NativeDlls.Shell32, CharSet = CharSet.Auto)]
+    private static extern void SHChangeNotify(int wEventId, int uFlags, IntPtr dwItem1, IntPtr dwItem2);
+
+    [DllImport(NativeDlls.User32, CharSet = CharSet.Unicode, SetLastError = true)]
+    private static extern IntPtr FindWindow(string lpClassName, string lpWindowName);
+
+    [DllImport(NativeDlls.Shell32)]
+    private static extern IntPtr SHAppBarMessage(int dwMessage, ref APPBARDATA pData);
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct APPBARDATA
+    {
+        public int cbSize;
+        public IntPtr hWnd;
+        public uint uCallbackMessage;
+        public uint uEdge;
+        public int left, top, right, bottom;
+        public IntPtr lParam;
+    }
 }

--- a/dotnet/autoShell/Services/WindowsRegistryService.cs
+++ b/dotnet/autoShell/Services/WindowsRegistryService.cs
@@ -72,7 +72,7 @@ internal class WindowsRegistryService : IRegistryService
             {
                 cbSize = Marshal.SizeOf<APPBARDATA>(),
                 hWnd = taskbarHwnd,
-                lParam = (IntPtr)(autoHide ? ABS_AUTOHIDE : ABS_ALWAYSONTOP)
+                lParam = (IntPtr)(autoHide ? (ABS_AUTOHIDE | ABS_ALWAYSONTOP) : ABS_ALWAYSONTOP)
             };
             SHAppBarMessage(ABM_SETSTATE, ref abd);
         }

--- a/dotnet/autoShell/Services/WindowsSystemParametersService.cs
+++ b/dotnet/autoShell/Services/WindowsSystemParametersService.cs
@@ -71,7 +71,11 @@ internal partial class WindowsSystemParametersService : ISystemParametersService
         try
         {
             Marshal.StructureToPtr(fk, ptr, false);
-            SystemParametersInfo(SPI_GETFILTERKEYS, cbSize, ptr, 0);
+            if (!SystemParametersInfo(SPI_GETFILTERKEYS, cbSize, ptr, 0))
+            {
+                return false;
+            }
+
             fk = Marshal.PtrToStructure<FilterKeysNative>(ptr);
 
             if (enable)
@@ -103,7 +107,11 @@ internal partial class WindowsSystemParametersService : ISystemParametersService
         try
         {
             Marshal.StructureToPtr(sk, ptr, false);
-            SystemParametersInfo(SPI_GETSTICKYKEYS, cbSize, ptr, 0);
+            if (!SystemParametersInfo(SPI_GETSTICKYKEYS, cbSize, ptr, 0))
+            {
+                return false;
+            }
+
             sk = Marshal.PtrToStructure<StickyKeysNative>(ptr);
 
             if (enable)
@@ -126,14 +134,14 @@ internal partial class WindowsSystemParametersService : ISystemParametersService
 
     private const uint LOAD_LIBRARY_AS_DATAFILE = 0x00000002;
 
-    [LibraryImport(NativeDlls.Kernel32, SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]
+    [LibraryImport(NativeDlls.Kernel32, EntryPoint = "LoadLibraryExW", SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]
     private static partial IntPtr LoadLibraryEx(string lpFileName, IntPtr hFile, uint dwFlags);
 
     [LibraryImport(NativeDlls.Kernel32, SetLastError = true)]
     [return: MarshalAs(UnmanagedType.Bool)]
     private static partial bool FreeLibrary(IntPtr hModule);
 
-    [LibraryImport(NativeDlls.User32, StringMarshalling = StringMarshalling.Utf16)]
+    [LibraryImport(NativeDlls.User32, EntryPoint = "LoadStringW", StringMarshalling = StringMarshalling.Utf16)]
     private static partial int LoadStringNative(IntPtr hInstance, uint uID, [Out] char[] lpBuffer, int nBufferMax);
 
     /// <inheritdoc/>

--- a/dotnet/autoShell/Services/WindowsSystemParametersService.cs
+++ b/dotnet/autoShell/Services/WindowsSystemParametersService.cs
@@ -1,9 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#nullable enable
+
 using System;
 using System.Runtime.InteropServices;
 using autoShell.Services.Interop;
+using static autoShell.Services.Interop.SpiConstants;
 
 namespace autoShell.Services;
 
@@ -55,5 +58,120 @@ internal partial class WindowsSystemParametersService : ISystemParametersService
     public bool SwapMouseButton(bool swap)
     {
         return SwapMouseButtonNative(swap ? 1 : 0);
+    }
+
+    /// <inheritdoc/>
+    public bool SetFilterKeys(bool enable)
+    {
+        const int FKF_FILTERKEYSON = 0x00000001;
+
+        int cbSize = Marshal.SizeOf<FilterKeysNative>();
+        var fk = new FilterKeysNative { cbSize = cbSize };
+        IntPtr ptr = Marshal.AllocHGlobal(cbSize);
+        try
+        {
+            Marshal.StructureToPtr(fk, ptr, false);
+            SystemParametersInfo(SPI_GETFILTERKEYS, cbSize, ptr, 0);
+            fk = Marshal.PtrToStructure<FilterKeysNative>(ptr);
+
+            if (enable)
+            {
+                fk.dwFlags |= FKF_FILTERKEYSON;
+            }
+            else
+            {
+                fk.dwFlags &= ~FKF_FILTERKEYSON;
+            }
+
+            Marshal.StructureToPtr(fk, ptr, false);
+            return SystemParametersInfo(SPI_SETFILTERKEYS, cbSize, ptr, SPIF_UPDATEINIFILE_SENDCHANGE);
+        }
+        finally
+        {
+            Marshal.FreeHGlobal(ptr);
+        }
+    }
+
+    /// <inheritdoc/>
+    public bool SetStickyKeys(bool enable)
+    {
+        const int SKF_STICKYKEYSON = 0x00000001;
+
+        int cbSize = Marshal.SizeOf<StickyKeysNative>();
+        var sk = new StickyKeysNative { cbSize = cbSize };
+        IntPtr ptr = Marshal.AllocHGlobal(cbSize);
+        try
+        {
+            Marshal.StructureToPtr(sk, ptr, false);
+            SystemParametersInfo(SPI_GETSTICKYKEYS, cbSize, ptr, 0);
+            sk = Marshal.PtrToStructure<StickyKeysNative>(ptr);
+
+            if (enable)
+            {
+                sk.dwFlags |= SKF_STICKYKEYSON;
+            }
+            else
+            {
+                sk.dwFlags &= ~SKF_STICKYKEYSON;
+            }
+
+            Marshal.StructureToPtr(sk, ptr, false);
+            return SystemParametersInfo(SPI_SETSTICKYKEYS, cbSize, ptr, SPIF_UPDATEINIFILE_SENDCHANGE);
+        }
+        finally
+        {
+            Marshal.FreeHGlobal(ptr);
+        }
+    }
+
+    private const uint LOAD_LIBRARY_AS_DATAFILE = 0x00000002;
+
+    [LibraryImport(NativeDlls.Kernel32, SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]
+    private static partial IntPtr LoadLibraryEx(string lpFileName, IntPtr hFile, uint dwFlags);
+
+    [LibraryImport(NativeDlls.Kernel32, SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static partial bool FreeLibrary(IntPtr hModule);
+
+    [LibraryImport(NativeDlls.User32, StringMarshalling = StringMarshalling.Utf16)]
+    private static partial int LoadStringNative(IntPtr hInstance, uint uID, [Out] char[] lpBuffer, int nBufferMax);
+
+    /// <inheritdoc/>
+    public string? LoadStringResource(string dllPath, int resourceId)
+    {
+        IntPtr hModule = LoadLibraryEx(dllPath, IntPtr.Zero, LOAD_LIBRARY_AS_DATAFILE);
+        if (hModule == IntPtr.Zero)
+        {
+            return null;
+        }
+
+        try
+        {
+            char[] buffer = new char[256];
+            int result = LoadStringNative(hModule, (uint)Math.Abs(resourceId), buffer, buffer.Length);
+            return result > 0 ? new string(buffer, 0, result) : null;
+        }
+        finally
+        {
+            FreeLibrary(hModule);
+        }
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct FilterKeysNative
+    {
+        public int cbSize;
+        public int dwFlags;
+        public int iWaitMSec;
+        public int iDelayMSec;
+        public int iRepeatMSec;
+        public int iBounceMSec;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct StickyKeysNative
+    {
+        public int cbSize;
+        public int dwFlags;
     }
 }

--- a/ts/packages/agents/desktop/src/actionHandler.ts
+++ b/ts/packages/agents/desktop/src/actionHandler.ts
@@ -56,7 +56,23 @@ async function executeDesktopAction(
         action.schemaName, // Pass schema name for disambiguation
     );
     if (result.success) {
-        return createActionResult(result.message);
+        const displayText = formatResultDisplay(result.message, result.data);
+        return createActionResult(displayText);
     }
     return { error: result.message };
+}
+
+function formatResultDisplay(message: string, data?: unknown): string {
+    if (data === undefined || data === null) {
+        return message;
+    }
+    if (Array.isArray(data)) {
+        return data.length > 0
+            ? `${message}:\n${data.map((item) => `  - ${item}`).join("\n")}`
+            : message;
+    }
+    if (typeof data === "object") {
+        return `${message}:\n${JSON.stringify(data, null, 2)}`;
+    }
+    return `${message}: ${data}`;
 }

--- a/ts/packages/agents/desktop/src/actionHandler.ts
+++ b/ts/packages/agents/desktop/src/actionHandler.ts
@@ -98,13 +98,13 @@ function defaultItemFormatter(item: unknown): string {
 const itemFormatters: Record<string, (item: unknown) => string> = {
     ListWifiNetworks: (item) => {
         const n = item as Record<string, unknown>;
-        const signal = n.SignalQuality ?? n.signalQuality ?? "?";
-        const secured = (n.Secured ?? n.secured) ? "🔒" : "🔓";
-        const connected = (n.Connected ?? n.connected) ? " (connected)" : "";
-        return `${n.SSID ?? n.ssid ?? n.Ssid} — ${signal}% ${secured}${connected}`;
+        const signal = n.signalQuality ?? "?";
+        const secured = n.secured ? "🔒" : "🔓";
+        const connected = n.connected ? " (connected)" : "";
+        return `${n.ssid} — ${signal}% ${secured}${connected}`;
     },
     ListResolutions: (item) => {
         const r = item as Record<string, unknown>;
-        return `${r.Width ?? r.width}x${r.Height ?? r.height} @ ${r.RefreshRate ?? r.refreshRate}Hz`;
+        return `${r.width}x${r.height} @ ${r.refreshRate}Hz`;
     },
 };

--- a/ts/packages/agents/desktop/src/actionHandler.ts
+++ b/ts/packages/agents/desktop/src/actionHandler.ts
@@ -98,13 +98,13 @@ function defaultItemFormatter(item: unknown): string {
 const itemFormatters: Record<string, (item: unknown) => string> = {
     ListWifiNetworks: (item) => {
         const n = item as Record<string, unknown>;
-        const signal = n.signalQuality ?? "?";
-        const secured = n.secured ? "🔒" : "🔓";
-        const connected = n.connected ? " (connected)" : "";
-        return `${n.ssid} — ${signal}% ${secured}${connected}`;
+        const signal = n.SignalQuality ?? n.signalQuality ?? "?";
+        const secured = (n.Secured ?? n.secured) ? "🔒" : "🔓";
+        const connected = (n.Connected ?? n.connected) ? " (connected)" : "";
+        return `${n.SSID ?? n.ssid ?? n.Ssid} — ${signal}% ${secured}${connected}`;
     },
     ListResolutions: (item) => {
         const r = item as Record<string, unknown>;
-        return `${r.width}x${r.height} @ ${r.refreshRate}Hz`;
+        return `${r.Width ?? r.width}x${r.Height ?? r.height} @ ${r.RefreshRate ?? r.refreshRate}Hz`;
     },
 };

--- a/ts/packages/agents/desktop/src/actionHandler.ts
+++ b/ts/packages/agents/desktop/src/actionHandler.ts
@@ -70,16 +70,33 @@ function formatResultDisplay(message: string, data?: unknown): string {
         if (data.length === 0) {
             return message;
         }
-        const lines = data.map((item) => {
-            if (typeof item === "object" && item !== null) {
-                return `  - ${Object.values(item).join(", ")}`;
-            }
-            return `  - ${item}`;
-        });
+        const lines = data.map((item) => `  - ${formatItem(item)}`);
         return `${message}:\n${lines.join("\n")}`;
     }
     if (typeof data === "object") {
         return `${message}:\n${JSON.stringify(data, null, 2)}`;
     }
     return `${message}: ${data}`;
+}
+
+function formatItem(item: unknown): string {
+    if (typeof item !== "object" || item === null) {
+        return String(item);
+    }
+    const obj = item as Record<string, unknown>;
+
+    // WiFi network: { Ssid, SignalQuality, Secured, Connected }
+    if ("Ssid" in obj) {
+        const signal = obj.SignalQuality ?? "?";
+        const secured = obj.Secured ? "🔒" : "🔓";
+        const connected = obj.Connected ? " (connected)" : "";
+        return `${obj.Ssid} — ${signal}% ${secured}${connected}`;
+    }
+
+    // Display resolution: { Width, Height, BitsPerPixel, RefreshRate }
+    if ("Width" in obj && "Height" in obj && "RefreshRate" in obj) {
+        return `${obj.Width}x${obj.Height} @ ${obj.RefreshRate}Hz`;
+    }
+
+    return Object.values(obj).join(", ");
 }

--- a/ts/packages/agents/desktop/src/actionHandler.ts
+++ b/ts/packages/agents/desktop/src/actionHandler.ts
@@ -56,13 +56,21 @@ async function executeDesktopAction(
         action.schemaName, // Pass schema name for disambiguation
     );
     if (result.success) {
-        const displayText = formatResultDisplay(result.message, result.data);
+        const displayText = formatResultDisplay(
+            action.actionName,
+            result.message,
+            result.data,
+        );
         return createActionResult(displayText);
     }
     return { error: result.message };
 }
 
-function formatResultDisplay(message: string, data?: unknown): string {
+function formatResultDisplay(
+    actionName: string,
+    message: string,
+    data?: unknown,
+): string {
     if (data === undefined || data === null) {
         return message;
     }
@@ -70,7 +78,8 @@ function formatResultDisplay(message: string, data?: unknown): string {
         if (data.length === 0) {
             return message;
         }
-        const lines = data.map((item) => `  - ${formatItem(item)}`);
+        const formatter = itemFormatters[actionName] ?? defaultItemFormatter;
+        const lines = data.map((item) => `  - ${formatter(item)}`);
         return `${message}:\n${lines.join("\n")}`;
     }
     if (typeof data === "object") {
@@ -79,28 +88,23 @@ function formatResultDisplay(message: string, data?: unknown): string {
     return `${message}: ${data}`;
 }
 
-function formatItem(item: unknown): string {
+function defaultItemFormatter(item: unknown): string {
     if (typeof item !== "object" || item === null) {
         return String(item);
     }
-    const obj = item as Record<string, unknown>;
-
-    // WiFi network: { ssid, signalQuality, secured, connected }
-    if ("ssid" in obj || "Ssid" in obj) {
-        const ssid = obj.ssid ?? obj.Ssid;
-        const signal = obj.signalQuality ?? obj.SignalQuality ?? "?";
-        const secured = (obj.secured ?? obj.Secured) ? "🔒" : "🔓";
-        const connected = (obj.connected ?? obj.Connected) ? " (connected)" : "";
-        return `${ssid} — ${signal}% ${secured}${connected}`;
-    }
-
-    // Display resolution: { width, height, bitsPerPixel, refreshRate }
-    if (("width" in obj || "Width" in obj) && ("refreshRate" in obj || "RefreshRate" in obj)) {
-        const w = obj.width ?? obj.Width;
-        const h = obj.height ?? obj.Height;
-        const hz = obj.refreshRate ?? obj.RefreshRate;
-        return `${w}x${h} @ ${hz}Hz`;
-    }
-
-    return Object.values(obj).join(", ");
+    return Object.values(item).join(", ");
 }
+
+const itemFormatters: Record<string, (item: unknown) => string> = {
+    ListWifiNetworks: (item) => {
+        const n = item as Record<string, unknown>;
+        const signal = n.signalQuality ?? "?";
+        const secured = n.secured ? "🔒" : "🔓";
+        const connected = n.connected ? " (connected)" : "";
+        return `${n.ssid} — ${signal}% ${secured}${connected}`;
+    },
+    ListResolutions: (item) => {
+        const r = item as Record<string, unknown>;
+        return `${r.width}x${r.height} @ ${r.refreshRate}Hz`;
+    },
+};

--- a/ts/packages/agents/desktop/src/actionHandler.ts
+++ b/ts/packages/agents/desktop/src/actionHandler.ts
@@ -85,17 +85,21 @@ function formatItem(item: unknown): string {
     }
     const obj = item as Record<string, unknown>;
 
-    // WiFi network: { Ssid, SignalQuality, Secured, Connected }
-    if ("Ssid" in obj) {
-        const signal = obj.SignalQuality ?? "?";
-        const secured = obj.Secured ? "🔒" : "🔓";
-        const connected = obj.Connected ? " (connected)" : "";
-        return `${obj.Ssid} — ${signal}% ${secured}${connected}`;
+    // WiFi network: { ssid, signalQuality, secured, connected }
+    if ("ssid" in obj || "Ssid" in obj) {
+        const ssid = obj.ssid ?? obj.Ssid;
+        const signal = obj.signalQuality ?? obj.SignalQuality ?? "?";
+        const secured = (obj.secured ?? obj.Secured) ? "🔒" : "🔓";
+        const connected = (obj.connected ?? obj.Connected) ? " (connected)" : "";
+        return `${ssid} — ${signal}% ${secured}${connected}`;
     }
 
-    // Display resolution: { Width, Height, BitsPerPixel, RefreshRate }
-    if ("Width" in obj && "Height" in obj && "RefreshRate" in obj) {
-        return `${obj.Width}x${obj.Height} @ ${obj.RefreshRate}Hz`;
+    // Display resolution: { width, height, bitsPerPixel, refreshRate }
+    if (("width" in obj || "Width" in obj) && ("refreshRate" in obj || "RefreshRate" in obj)) {
+        const w = obj.width ?? obj.Width;
+        const h = obj.height ?? obj.Height;
+        const hz = obj.refreshRate ?? obj.RefreshRate;
+        return `${w}x${h} @ ${hz}Hz`;
     }
 
     return Object.values(obj).join(", ");

--- a/ts/packages/agents/desktop/src/actionHandler.ts
+++ b/ts/packages/agents/desktop/src/actionHandler.ts
@@ -67,9 +67,16 @@ function formatResultDisplay(message: string, data?: unknown): string {
         return message;
     }
     if (Array.isArray(data)) {
-        return data.length > 0
-            ? `${message}:\n${data.map((item) => `  - ${item}`).join("\n")}`
-            : message;
+        if (data.length === 0) {
+            return message;
+        }
+        const lines = data.map((item) => {
+            if (typeof item === "object" && item !== null) {
+                return `  - ${Object.values(item).join(", ")}`;
+            }
+            return `  - ${item}`;
+        });
+        return `${message}:\n${lines.join("\n")}`;
     }
     if (typeof data === "object") {
         return `${message}:\n${JSON.stringify(data, null, 2)}`;

--- a/ts/packages/agents/desktop/src/actionsSchema.ts
+++ b/ts/packages/agents/desktop/src/actionsSchema.ts
@@ -15,6 +15,7 @@ export type DesktopActions =
     | SetWallpaperAction
     | ChangeThemeModeAction
     | ApplyThemeAction
+    | ListThemesAction
     | ConnectWifiAction
     | DisconnectWifiAction
     | ToggleAirplaneModeAction
@@ -139,6 +140,12 @@ export type ApplyThemeAction = {
     parameters: {
         filePath: string; // The theme name or file path to apply (use "previous" to revert)
     };
+};
+
+// Lists all installed Windows themes
+export type ListThemesAction = {
+    actionName: "ListThemes";
+    parameters: {};
 };
 
 export type ConnectWifiAction = {

--- a/ts/packages/agents/desktop/src/actionsSchema.ts
+++ b/ts/packages/agents/desktop/src/actionsSchema.ts
@@ -134,11 +134,11 @@ export type ChangeThemeModeAction = {
     };
 };
 
-// Applies a Windows theme by name or file path
+// Applies a Windows theme by name (e.g. "Captured Motion", "Glow", "Sunrise") or file path. Use this when the user wants to switch to a specific named theme.
 export type ApplyThemeAction = {
     actionName: "ApplyTheme";
     parameters: {
-        filePath: string; // The theme name or file path to apply (use "previous" to revert)
+        filePath: string; // The theme name or .theme file path to apply (use "previous" to revert)
     };
 };
 

--- a/ts/packages/agents/desktop/src/actionsSchema.ts
+++ b/ts/packages/agents/desktop/src/actionsSchema.ts
@@ -18,6 +18,7 @@ export type DesktopActions =
     | ListThemesAction
     | ConnectWifiAction
     | DisconnectWifiAction
+    | ListWifiNetworksAction
     | ToggleAirplaneModeAction
     | CreateDesktopAction
     | MoveWindowToDesktopAction
@@ -162,6 +163,12 @@ export type DisconnectWifiAction = {
     parameters: {
         // No parameters required
     };
+};
+
+// Lists available WiFi networks
+export type ListWifiNetworksAction = {
+    actionName: "ListWifiNetworks";
+    parameters: {};
 };
 
 export type ToggleAirplaneModeAction = {

--- a/ts/packages/agents/desktop/src/desktopSchema.agr
+++ b/ts/packages/agents/desktop/src/desktopSchema.agr
@@ -90,6 +90,11 @@ import { DesktopActions } from "./actionsSchema.ts";
               | switch to dark (mode)? -> { actionName: "SetThemeMode", parameters: { mode: "dark" } }
               | switch to light (mode)? -> { actionName: "SetThemeMode", parameters: { mode: "light" } };
 
+// ===== List Themes =====
+<ListThemes> = list (my)? (desktop)? themes -> { actionName: "ListThemes", parameters: {} }
+               | show (available)? themes -> { actionName: "ListThemes", parameters: {} }
+               | what themes (do I have|are installed|are available)? -> { actionName: "ListThemes", parameters: {} };
+
 // ===== WiFi Control =====
 <WifiControl> = connect to $(ssid:wildcard) wifi -> { actionName: "ConnectWifi", parameters: { ssid } }
                 | connect to wifi $(ssid:wildcard) -> { actionName: "ConnectWifi", parameters: { ssid } }

--- a/ts/packages/agents/desktop/src/desktopSchema.agr
+++ b/ts/packages/agents/desktop/src/desktopSchema.agr
@@ -99,6 +99,9 @@ import { DesktopActions } from "./actionsSchema.ts";
 <WifiControl> = connect to $(ssid:wildcard) wifi -> { actionName: "ConnectWifi", parameters: { ssid } }
                 | connect to wifi $(ssid:wildcard) -> { actionName: "ConnectWifi", parameters: { ssid } }
                 | disconnect (from)? wifi -> { actionName: "DisconnectWifi", parameters: {} }
+                | list (available)? wifi networks -> { actionName: "ListWifiNetworks", parameters: {} }
+                | show (available)? wifi networks -> { actionName: "ListWifiNetworks", parameters: {} }
+                | what wifi networks (are available|can I see)? -> { actionName: "ListWifiNetworks", parameters: {} }
                 | enable airplane mode -> { actionName: "ToggleAirplaneMode", parameters: { enable: true } }
                 | disable airplane mode -> { actionName: "ToggleAirplaneMode", parameters: { enable: false } }
                 | turn on airplane mode -> { actionName: "ToggleAirplaneMode", parameters: { enable: true } }

--- a/ts/packages/agents/desktop/src/windows/displayActionsSchema.ts
+++ b/ts/packages/agents/desktop/src/windows/displayActionsSchema.ts
@@ -7,6 +7,7 @@ export type DesktopDisplayActions =
     | DisplayScalingAction
     | AdjustScreenOrientationAction
     | RotationLockAction
+    | ListResolutionsAction
     | DisplayResolutionAndAspectRatioAction;
 
 // Enables or disables blue light filter schedule (Night Light)
@@ -48,6 +49,12 @@ export type RotationLockAction = {
     parameters: {
         enable?: boolean;
     };
+};
+
+// Lists available display resolutions for the current monitor
+export type ListResolutionsAction = {
+    actionName: "ListResolutions";
+    parameters: {};
 };
 
 // Opens display settings to adjust resolution and aspect ratio

--- a/ts/packages/agents/desktop/src/windows/displayActionsSchema.ts
+++ b/ts/packages/agents/desktop/src/windows/displayActionsSchema.ts
@@ -6,7 +6,8 @@ export type DesktopDisplayActions =
     | AdjustColorTemperatureAction
     | DisplayScalingAction
     | AdjustScreenOrientationAction
-    | RotationLockAction;
+    | RotationLockAction
+    | DisplayResolutionAndAspectRatioAction;
 
 // Enables or disables blue light filter schedule (Night Light)
 export type EnableBlueLightFilterScheduleAction = {
@@ -47,4 +48,10 @@ export type RotationLockAction = {
     parameters: {
         enable?: boolean;
     };
+};
+
+// Opens display settings to adjust resolution and aspect ratio
+export type DisplayResolutionAndAspectRatioAction = {
+    actionName: "DisplayResolutionAndAspectRatio";
+    parameters: {};
 };

--- a/ts/packages/agents/desktop/src/windows/displaySchema.agr
+++ b/ts/packages/agents/desktop/src/windows/displaySchema.agr
@@ -11,6 +11,7 @@ import { DesktopDisplayActions } from "./displayActionsSchema.ts";
           | <DisplayScaling>
           | <AdjustScreenOrientation>
           | <RotationLock>
+          | <ListResolutions>
           | <DisplayResolution>;
 
 <EnableBlueLightFilter> =
@@ -44,6 +45,11 @@ import { DesktopDisplayActions } from "./displayActionsSchema.ts";
   | unlock (screen)? rotation -> { actionName: "RotationLock", parameters: { enable: false } }
   | enable rotation lock -> { actionName: "RotationLock", parameters: { enable: true } }
   | disable rotation lock -> { actionName: "RotationLock", parameters: { enable: false } };
+
+<ListResolutions> =
+    list (display|screen|available)? resolutions -> { actionName: "ListResolutions", parameters: {} }
+  | show (display|screen|available)? resolutions -> { actionName: "ListResolutions", parameters: {} }
+  | what resolutions (are available|are supported|can I use)? -> { actionName: "ListResolutions", parameters: {} };
 
 <DisplayResolution> =
     change (display|screen)? resolution -> { actionName: "DisplayResolutionAndAspectRatio", parameters: {} }

--- a/ts/packages/agents/desktop/src/windows/displaySchema.agr
+++ b/ts/packages/agents/desktop/src/windows/displaySchema.agr
@@ -10,7 +10,8 @@ import { DesktopDisplayActions } from "./displayActionsSchema.ts";
           | <AdjustColorTemperature>
           | <DisplayScaling>
           | <AdjustScreenOrientation>
-          | <RotationLock>;
+          | <RotationLock>
+          | <DisplayResolution>;
 
 <EnableBlueLightFilter> =
     enable night light -> { actionName: "EnableBlueLightFilterSchedule", parameters: { schedule: "sunset to sunrise", nightLightScheduleDisabled: false } }
@@ -43,3 +44,9 @@ import { DesktopDisplayActions } from "./displayActionsSchema.ts";
   | unlock (screen)? rotation -> { actionName: "RotationLock", parameters: { enable: false } }
   | enable rotation lock -> { actionName: "RotationLock", parameters: { enable: true } }
   | disable rotation lock -> { actionName: "RotationLock", parameters: { enable: false } };
+
+<DisplayResolution> =
+    change (display|screen)? resolution -> { actionName: "DisplayResolutionAndAspectRatio", parameters: {} }
+  | adjust (display|screen)? resolution -> { actionName: "DisplayResolutionAndAspectRatio", parameters: {} }
+  | change aspect ratio -> { actionName: "DisplayResolutionAndAspectRatio", parameters: {} }
+  | open display settings -> { actionName: "DisplayResolutionAndAspectRatio", parameters: {} };

--- a/ts/packages/agents/desktop/src/windows/personalizationActionsSchema.ts
+++ b/ts/packages/agents/desktop/src/windows/personalizationActionsSchema.ts
@@ -23,13 +23,13 @@ export type ApplyColorToTitleBarAction = {
     };
 };
 
-// Enables high contrast theme
+// Opens the high contrast accessibility settings page. Only use when the user explicitly asks for high contrast settings.
 export type HighContrastThemeAction = {
     actionName: "HighContrastTheme";
     parameters: {};
 };
 
-// Sets the system-wide theme mode (affects apps, taskbar, and Start menu)
+// Sets the system-wide theme mode to light or dark (affects apps, taskbar, and Start menu). Only for light/dark mode, not for named themes.
 export type SystemThemeModeAction = {
     actionName: "SystemThemeMode";
     parameters: {


### PR DESCRIPTION
## Problem

Registry-based settings weren't taking effect until sign-out/restart. Actions returning data (themes, resolutions, WiFi) displayed only a success message, hiding the actual results.

## Changes

### Settings Refresh
- **SPI-based actions** (Mouse Sonar, FilterKeys, StickyKeys): replaced registry writes with `SystemParametersInfo` calls
- **DWM settings** (title bar color, transparency): broadcast `WM_SETTINGCHANGE` with `"ImmersiveColorSet"`
- **Taskbar auto-hide**: added `SHAppBarMessage(ABM_SETSTATE)` with proper `ABS_ALWAYSONTOP` preservation
- **Explorer settings**: `NotifyShellChange()` gated behind opt-in `NotifyShell` config property (FileExplorer + Taskbar only)
- **Config-driven actions**: `BroadcastSettingChange()` called after every registry write; `BroadcastSetting` property for targeted broadcasts

### P/Invoke Safety
- All P/Invoke moved behind mockable interfaces (`IRegistryService`, `ISystemParametersService`)
- No handler contains P/Invoke — unit tests never touch the real machine
- `SpiConstants.cs`: shared constants, no more magic numbers in handlers or tests
- `LibraryImport` EntryPoints fixed (`LoadLibraryExW`, `LoadStringW`)
- `SetFilterKeys`/`SetStickyKeys` check GET return value before SET

### Action Data Display
- `actionHandler.ts`: new `formatResultDisplay()` surfaces `data` payload from autoShell responses
- Per-action formatters: WiFi → `MyNetwork — 85% 🔒`, resolutions → `1920x1080 @ 60Hz`
- `JsonOptions.CamelCase`: C# services serialize with camelCase to match TS conventions
- Fixed `SetResolution` JSON parse error (was parsing plain text as JSON)

### Missing Schemas
Added TS schemas + grammar rules for: `ListThemes`, `ListWifiNetworks`, `ListResolutions`, `DisplayResolutionAndAspectRatio`. Improved schema comments to disambiguate `ApplyTheme` vs `HighContrastTheme` vs `SystemThemeMode`.

## Testing
- 228 unit tests pass
- Manually verified all settings apply immediately
