### PR TITLE
Reasoning Improvements

### DIFF
--- a/ts/docs/architecture/dispatcher.md
+++ b/ts/docs/architecture/dispatcher.md
@@ -349,6 +349,37 @@ entity references. Named entities (e.g., "that song", "the meeting") are
 looked up in conversation memory. Ambiguous references trigger a user
 clarification prompt via the `ClientIO` layer.
 
+Translated actions may also contain **entity placeholders** — explicit
+references the LLM emits as string values pointing back at entities
+provided in the prompt's history context. `resolveEntityPlaceholders()`
+in `pendingActions.ts` replaces them with the referenced values. Grammar:
+
+| Form                          | Example                       | Resolves to                                      |
+| ----------------------------- | ----------------------------- | ------------------------------------------------ |
+| Bare whole-value              | `${entity-0}`                 | `entity.name`                                    |
+| Embedded structured reference | `${entity-0}[Revenue]`        | `<entity.name>[Revenue]` (literal concatenation) |
+| Dotted path navigation        | `${entity-0.facets[0].value}` | Result of walking the path on the entity object  |
+
+Path navigation is controlled by the session config
+`translation.entity.pathNavigation` with four modes:
+
+| Mode                 | Behavior on a valid path                   | Behavior on miss                                                       |
+| -------------------- | ------------------------------------------ | ---------------------------------------------------------------------- |
+| `"off"`              | Not attempted — placeholder passes through | N/A                                                                    |
+| `"throw"` (default)  | Resolves and interpolates                  | Throws `Entity path did not resolve …`, surfaced to the reasoning loop |
+| `"fallback-to-name"` | Resolves and interpolates                  | Returns `entity.name` (same as the bare form)                          |
+| `"passthrough"`      | Resolves and interpolates                  | Leaves the literal `${entity-N.…}` placeholder intact                  |
+
+The `"throw"` default is intentional: a path miss is almost always an LLM
+mistake about the entity's shape (or a shape that changed under it), and
+the reasoning loop can retry with a corrected path. Silent fallbacks hide
+these mistakes as wrong-answer-looks-right failures downstream.
+
+When path navigation is enabled (any mode ≠ `"off"`), the translator
+system prompt includes a short line documenting the dotted syntax so the
+LLM knows it's an available form — see `createTypeAgentRequestPrompt()`
+in `chatHistoryPrompt.ts`.
+
 **Flow execution** — Some actions have registered flow definitions
 (multi-step recipes). When `getFlow(schemaName, actionName)` returns a
 flow, the `flowInterpreter` executes it step-by-step with parameter

--- a/ts/packages/agents/onboarding/src/schemaGen/schemaGenHandler.ts
+++ b/ts/packages/agents/onboarding/src/schemaGen/schemaGenHandler.ts
@@ -26,29 +26,39 @@ import { PhraseSet } from "../phraseGen/phraseGenHandler.js";
 // Shared schema authoring guidelines injected into every schema gen/refine prompt.
 const SCHEMA_GUIDELINES = `
 COMMENT STRUCTURE RULES:
-1. Action-level block (above the action type declaration): use only for a short "what it does" description and example user/agent phrase pairs. No rules or constraints here.
-2. Property-level comments (inside the parameters object, above each property declaration): ALL guidance lives here, co-located with the property it constrains. Do NOT put constraints at the action level.
-3. No inline end-of-line comments on property declarations. All commentary goes in the line(s) above the property.
+1. All commentary lives ABOVE the thing it applies to, on its own line(s). No inline end-of-line comments on property declarations.
+2. Action-level block (above the action type declaration): user/agent example pairs, IMPORTANT/NOTE rules, then a one-sentence "what it does" description directly above the type.
+3. Property-level comments (above each property): supplementary guidance and any IMPORTANT/NOTE rules, then a one-sentence identity line directly above the property.
 
-PROPERTY COMMENT ORDERING (top = least important, bottom = most important — the LLM reads top-to-bottom, so put the critical constraint last, immediately before the property):
-// General description of what this parameter is.
+THE IDENTITY LINE IS CLOSEST TO THE DECLARATION. Readers (human and LLM) always need the "what is this" answer first. Put the one-sentence identity line immediately above the type or property. Everything else — examples, IMPORTANT constraints, aliases, context — goes above that identity line. Broader context furthest away, specific rules closer.
+
+PROPERTY COMMENT ORDERING (top = broadest context, bottom = identity — the LLM reads top-to-bottom, then locks onto the identity line as it reaches the declaration):
 // Supplementary guidance / common aliases / optional tips.
 // NOTE: or IMPORTANT: The hard constraint the model must not violate.
+// One-sentence identity — what this parameter is.
 propertyName: type;
 
-CRITICAL CONSTRAINT FORMAT — embed a concrete WRONG/RIGHT example for any hard constraint; the WRONG case should be the exact failure mode you have observed:
-// The data range in A1 notation.
+CRITICAL CONSTRAINT FORMAT — embed a concrete WRONG/RIGHT example for any hard constraint; the WRONG case should be the exact failure mode you have observed. Put it ABOVE the identity line, not below:
 // NOTE: Must be a literal cell range — do NOT use named ranges or structured references.
 //   WRONG: "SalesData[ActualSales]"  ← structured table reference, will fail
 //   WRONG: "ActualSales"             ← column name, will fail
 //   RIGHT: "C1:C7"                  ← literal A1 range
+// The data range in A1 notation.
 dataRange: string;
 
+SCHEMA SHAPE — WORK WITH THE LLM'S INTENT, NOT AGAINST IT:
+When the LLM keeps picking the "wrong" action for a class of queries, the fix is almost always to widen the right action so it can absorb the intent, not to scold the LLM away from the wrong one. Anti-examples ("DO NOT use this for …") fight priors and rarely hold; positive parameters channel priors.
+
+- Shape the schema into the form the LLM wants to produce. Expand parameters along the direction the LLM is already reaching.
+- Where the action truly cannot deliver on a request, have the handler detect that deterministically and escalate to the reasoning loop — don't rely on the LLM to have read a prohibition.
+- Anti-examples are a last resort. Only add a "DO NOT use for" line when (1) you've already expanded the schema to absorb the intent where possible, and (2) the handler cannot detect the bad case at runtime. Most of the time, one of those two isn't met yet — so fix that first. An anti-example the LLM never reads is free entropy in the prompt.
+- Never lift sheet names, column names, cell ranges, or exact phrasing from real user queries or benchmark data into schema examples — doing so overfits the schema. Use generic placeholders (SalesData, Profit, Inventory, Category, Stock).
+
 BEST PRACTICES:
-- Enum-like properties: always define the type as an explicit union of string literals instead of \`string\`. The comment above the property should name the underlying API enum it maps to and explain the default value and why.
+- Enum-like properties: always define the type as an explicit union of string literals instead of \`string\`. The identity line should name the underlying API enum it maps to and explain the default value and why (supplementary context, if needed, goes above the identity line).
   Example:
-  // Label position relative to the data point. Maps to Office.js ChartDataLabelPosition enum.
   // Default is "BestFit" — Office.js automatically chooses the best placement.
+  // Label position relative to the data point. Maps to Office.js ChartDataLabelPosition enum.
   position?: "Top" | "Bottom" | "Center" | "InsideEnd" | "InsideBase" | "OutsideEnd" | "Left" | "Right" | "BestFit" | "Callout" | "None";
 `;
 

--- a/ts/packages/dispatcher/dispatcher/src/context/chatHistoryPrompt.ts
+++ b/ts/packages/dispatcher/dispatcher/src/context/chatHistoryPrompt.ts
@@ -2,9 +2,63 @@
 // Licensed under the MIT License.
 
 import { HistoryContext } from "agent-cache";
+import { Entity } from "@typeagent/agent-sdk";
 import { CachedImageWithDetails, TypeAgentJsonValidator } from "typechat-utils";
 import { PromptSection } from "typechat";
 import { getLocationString } from "./geolocation.js";
+
+export type EntityPromptShape = "facets" | "flat" | "facets-with-schema";
+
+// Renders a single Entity into the JSON-serializable shape the LLM will see.
+// "facets" and "facets-with-schema" produce identical JSON; they differ only in
+// whether the reasoning system prompt includes the Entity TS type block (handled
+// separately at the system-prompt assembly site).
+export function serializeEntityForPrompt(
+    entity: Entity,
+    shape: EntityPromptShape,
+    i: number,
+): Record<string, unknown> {
+    const id = `\${entity-${i}}`;
+    if (shape === "flat") {
+        const properties: Record<string, unknown> = {};
+        let duplicate = false;
+        for (const f of entity.facets ?? []) {
+            if (f.name in properties) {
+                duplicate = true;
+            }
+            properties[f.name] = f.value;
+        }
+        if (duplicate) {
+            // Last-write-wins on duplicate facet names. Surface via debug so we can tell
+            // whether the flat shape is silently losing data in practice.
+            // eslint-disable-next-line no-console
+            console.warn(
+                `serializeEntityForPrompt: duplicate facet name in entity '${entity.name}' — last-write-wins`,
+            );
+        }
+        const out: Record<string, unknown> = {
+            id,
+            name: entity.name,
+            type: entity.type,
+        };
+        if (entity.uniqueId) {
+            out.uniqueId = entity.uniqueId;
+        }
+        if (Object.keys(properties).length > 0) {
+            out.properties = properties;
+        }
+        return out;
+    }
+    const out: Record<string, unknown> = {
+        id,
+        name: entity.name,
+        type: entity.type,
+    };
+    if (entity.facets && entity.facets.length > 0) {
+        out.facets = entity.facets;
+    }
+    return out;
+}
 
 export function createTypeAgentRequestPrompt(
     validator: TypeAgentJsonValidator<object>,
@@ -12,6 +66,13 @@ export function createTypeAgentRequestPrompt(
     history: HistoryContext | undefined,
     attachments: CachedImageWithDetails[] | undefined,
     context: boolean = true, // set to false to totally remove any context information (e.g. today's date), not just history
+    entityPromptShape: EntityPromptShape = "facets",
+    // When the dispatcher's entity path-navigation feature is enabled (any mode
+    // other than "off"), include a short prompt line telling the LLM it may
+    // reference entity subfields via dotted paths. When "off" (the default),
+    // the prompt is unchanged — we don't advertise a feature the resolver
+    // won't honor.
+    entityPathNavigationEnabled: boolean = false,
 ) {
     if (attachments !== undefined && attachments?.length > 0) {
         if (request.length == 0) {
@@ -62,17 +123,13 @@ export function createTypeAgentRequestPrompt(
                     );
                     prompts.push(
                         JSON.stringify(
-                            promptEntities.map((entity, i) => {
-                                const e: Record<string, unknown> = {
-                                    id: `\${entity-${i}}`,
-                                    name: entity.name,
-                                    type: entity.type,
-                                };
-                                if (entity.facets && entity.facets.length > 0) {
-                                    e.facets = entity.facets;
-                                }
-                                return e;
-                            }),
+                            promptEntities.map((entity, i) =>
+                                serializeEntityForPrompt(
+                                    entity,
+                                    entityPromptShape,
+                                    i,
+                                ),
+                            ),
                             undefined,
                             2,
                         ),
@@ -122,6 +179,11 @@ export function createTypeAgentRequestPrompt(
             "Determine the entities implicitly referred in the current user request based on the recent chat history.",
             "If parameter value refers to an entity, use entities' id as parameter values when referring to entities instead of the entities' name. Do not use entity ids that do not exist in the chat history.",
             "Entity facets provide structured properties about the entity. Use facet values directly when filling action parameters — prefer them over guessing or calling additional lookup actions.",
+            ...(entityPathNavigationEnabled
+                ? [
+                      "To reference a subfield of an entity — such as a specific facet value — you may append a dotted path to the entity id, e.g. `${entity-0.facets[0].value}` or `${entity-0.name}`. The path is walked against the entity object you see above. If you are unsure the path exists, inline the literal value from the entity instead.",
+                  ]
+                : []),
             "If there are multiple possible resolution, choose the most likely resolution based on conversation context, bias toward the newest.",
             "Avoid clarifying unless absolutely necessary. Infer the user's intent based on conversation context.",
             `Based primarily on the current user request with references and pronouns resolved with recent entities in the chat history, but considering the context of the whole chat history, the following is the current user request translated into a JSON object with 2 spaces of indentation and no properties with the value undefined:`,

--- a/ts/packages/dispatcher/dispatcher/src/context/dispatcher/handlers/requestCommandHandler.ts
+++ b/ts/packages/dispatcher/dispatcher/src/context/dispatcher/handlers/requestCommandHandler.ts
@@ -387,7 +387,8 @@ export class RequestCommandHandler implements CommandHandler {
                 "record ",
             ];
             const lowerRequest = request.trimStart().toLowerCase();
-            const forceReasoningEnv = process.env.CLAUDE_FORCE_REASONING === "1";
+            const forceReasoningEnv =
+                process.env.CLAUDE_FORCE_REASONING === "1";
             if (
                 !systemContext.noReasoning &&
                 (forceReasoningEnv ||

--- a/ts/packages/dispatcher/dispatcher/src/context/dispatcher/handlers/requestCommandHandler.ts
+++ b/ts/packages/dispatcher/dispatcher/src/context/dispatcher/handlers/requestCommandHandler.ts
@@ -387,9 +387,11 @@ export class RequestCommandHandler implements CommandHandler {
                 "record ",
             ];
             const lowerRequest = request.trimStart().toLowerCase();
+            const forceReasoningEnv = process.env.CLAUDE_FORCE_REASONING === "1";
             if (
                 !systemContext.noReasoning &&
-                REASONING_PREFIXES.some((p) => lowerRequest.startsWith(p))
+                (forceReasoningEnv ||
+                    REASONING_PREFIXES.some((p) => lowerRequest.startsWith(p)))
             ) {
                 await executeReasoning(request, context, { engine: "claude" });
                 return;
@@ -503,6 +505,13 @@ export class RequestCommandHandler implements CommandHandler {
                             );
                             await executeReasoning(augmentedRequest, context, {
                                 engine: "claude",
+                                fallbackContext: {
+                                    failedSchema:
+                                        failedAction.action.schemaName,
+                                    failedAction:
+                                        failedAction.action.actionName,
+                                    error,
+                                },
                             });
                         } catch (e: any) {
                             debugRequest(

--- a/ts/packages/dispatcher/dispatcher/src/context/session.ts
+++ b/ts/packages/dispatcher/dispatcher/src/context/session.ts
@@ -126,6 +126,28 @@ export type DispatcherConfig = {
             resolve: boolean; // resolve entities in the request
             clarify: boolean; // clarify entity names when multiple entities match
             filter: boolean;
+            // Path-navigation resolution for entity placeholders in action
+            // parameters. Extends the `${entity-N}` form with dotted property
+            // access — `${entity-0.facets[0].value}` — by walking the entity
+            // object. Four modes:
+            //  • "off":              current behavior — only the bare regex form is
+            //                        resolved; anything else passes through as a
+            //                        literal string.
+            //  • "throw":            attempt path navigation; throw a descriptive
+            //                        error if the path does not resolve. Strictest —
+            //                        feeds a named error into the reasoning loop.
+            //  • "fallback-to-name": attempt path navigation; if the path misses,
+            //                        resolve the bare form (entity.name) instead.
+            //  • "passthrough":      attempt path navigation; if the path misses,
+            //                        leave the literal placeholder untouched
+            //                        (equivalent to "off" for that specific miss).
+            // Shape-agnostic: if the entity schema grows a new field, the LLM's
+            // path guess resolves automatically — no code change here.
+            pathNavigation:
+                | "off"
+                | "throw"
+                | "fallback-to-name"
+                | "passthrough";
         };
     };
 
@@ -139,6 +161,11 @@ export type DispatcherConfig = {
             legacy: boolean; // use legacy memory behavior
         };
         reasoning: "claude" | "copilot" | "none";
+        // Controls how Entity objects are rendered into LLM prompts (translation + reasoning context).
+        // "facets" (default): current shape `{id, name, type, facets: [{name, value}, ...]}`.
+        // "flat": collapse facets into a `properties` object — `{id, name, type, uniqueId?, properties: {...}}`.
+        // "facets-with-schema": same JSON as "facets", but the Entity/EntityFacet TS type is appended to the reasoning system prompt.
+        entityPromptShape: "facets" | "flat" | "facets-with-schema";
     };
     explainer: {
         enabled: boolean;
@@ -222,6 +249,13 @@ const defaultSessionConfig: SessionConfig = {
             resolve: true,
             filter: true,
             clarify: false, // TODO: enable when it is ready.
+            // Default "throw": path navigation is ON, and unresolvable paths
+            // fail fast with a descriptive error. This matches the project
+            // pattern of making the reasoning loop — not silent fallbacks —
+            // handle LLM mistakes. Set to "off" to restore pre-feature
+            // behavior, "fallback-to-name" to recover via entity.name on
+            // miss, or "passthrough" to leave the literal placeholder.
+            pathNavigation: "throw",
         },
     },
     execution: {
@@ -233,6 +267,10 @@ const defaultSessionConfig: SessionConfig = {
             legacy: true, // use the new memory behavior
         },
         reasoning: "none",
+        // Default set based on the entity-shape experiment (bench-results/entity-shape-experiment.md):
+        // appending the Entity TS type to the reasoning system prompt produced 4 consistent
+        // gains / 0 consistent regressions on a 20-test sample (median of 3 runs).
+        entityPromptShape: "facets-with-schema",
     },
     explainer: {
         enabled: true,

--- a/ts/packages/dispatcher/dispatcher/src/context/system/handlers/configCommandHandlers.ts
+++ b/ts/packages/dispatcher/dispatcher/src/context/system/handlers/configCommandHandlers.ts
@@ -1494,6 +1494,40 @@ class ConfigExecutionScriptReuseCommandHandler implements CommandHandler {
     }
 }
 
+class ConfigExecutionEntityPromptShapeCommandHandler
+    implements CommandHandler
+{
+    public readonly description =
+        "Shape used when serializing Entity objects into LLM prompts";
+    public readonly parameters = {
+        args: {
+            shape: {
+                description:
+                    "'facets' (default, name+value array), 'flat' (collapse facets into a properties object), or 'facets-with-schema' (facets + append the Entity TS type to the reasoning system prompt)",
+                type: "string" as const,
+                enum: ["facets", "flat", "facets-with-schema"],
+            },
+        },
+    } as const;
+
+    async run(
+        context: ActionContext<CommandHandlerContext>,
+        params: ParsedCommandParams<typeof this.parameters>,
+    ) {
+        const shape = params.args.shape as
+            | "facets"
+            | "flat"
+            | "facets-with-schema";
+
+        await changeContextConfig(
+            { execution: { entityPromptShape: shape } },
+            context,
+        );
+
+        return displayResult(`Entity prompt shape: ${shape}`, context);
+    }
+}
+
 const configExecutionCommandHandlers: CommandHandlerTable = {
     description: "Execution configuration",
     commands: {
@@ -1509,6 +1543,8 @@ const configExecutionCommandHandlers: CommandHandlerTable = {
         reasoning: new ConfigExecutionReasoningCommandHandler(),
         planReuse: new ConfigExecutionPlanReuseCommandHandler(),
         scriptReuse: new ConfigExecutionScriptReuseCommandHandler(),
+        entityPromptShape:
+            new ConfigExecutionEntityPromptShapeCommandHandler(),
     },
 };
 

--- a/ts/packages/dispatcher/dispatcher/src/context/system/handlers/configCommandHandlers.ts
+++ b/ts/packages/dispatcher/dispatcher/src/context/system/handlers/configCommandHandlers.ts
@@ -1494,9 +1494,7 @@ class ConfigExecutionScriptReuseCommandHandler implements CommandHandler {
     }
 }
 
-class ConfigExecutionEntityPromptShapeCommandHandler
-    implements CommandHandler
-{
+class ConfigExecutionEntityPromptShapeCommandHandler implements CommandHandler {
     public readonly description =
         "Shape used when serializing Entity objects into LLM prompts";
     public readonly parameters = {
@@ -1543,8 +1541,7 @@ const configExecutionCommandHandlers: CommandHandlerTable = {
         reasoning: new ConfigExecutionReasoningCommandHandler(),
         planReuse: new ConfigExecutionPlanReuseCommandHandler(),
         scriptReuse: new ConfigExecutionScriptReuseCommandHandler(),
-        entityPromptShape:
-            new ConfigExecutionEntityPromptShapeCommandHandler(),
+        entityPromptShape: new ConfigExecutionEntityPromptShapeCommandHandler(),
     },
 };
 

--- a/ts/packages/dispatcher/dispatcher/src/execute/pendingActions.ts
+++ b/ts/packages/dispatcher/dispatcher/src/execute/pendingActions.ts
@@ -205,19 +205,99 @@ type ParameterEntityResolverOptions = {
     resolve: boolean;
     clarify: boolean;
     filter: boolean;
+    // Read at the dispatcher via session config translation.entity.pathNavigation.
+    // Existing call sites that omit this field keep the pre-existing "off"
+    // behavior — no path navigation, literal placeholders pass through.
+    pathNavigation?: EntityPathNavigationMode;
 };
+
+/**
+ * Path-navigation mode for entity placeholders. See `translation.entity.pathNavigation`
+ * in session.ts for the semantics of each mode.
+ */
+export type EntityPathNavigationMode =
+    | "off"
+    | "throw"
+    | "fallback-to-name"
+    | "passthrough";
+
+/**
+ * Walk a dotted + bracketed path on `root` and return the value at the leaf,
+ * or `undefined` if any step misses. The path grammar accepts:
+ *   .identifier        — property access
+ *   [integer]          — array index
+ *   .identifier[N]     — combined
+ * Returns `{ ok: true, value }` on success or `{ ok: false, at }` on miss,
+ * where `at` is the path prefix that failed (for error messages).
+ */
+function walkEntityPath(
+    root: unknown,
+    path: string,
+): { ok: true; value: unknown } | { ok: false; at: string } {
+    if (path === "") return { ok: true, value: root };
+    // Tokenize the path into steps. Each step is either ".name" or "[index]".
+    const stepRe = /\.([A-Za-z_][A-Za-z0-9_]*)|\[(\d+)\]/g;
+    let cur: unknown = root;
+    let consumedEnd = 0;
+    let lastConsumed = "";
+    let m: RegExpExecArray | null;
+    // Path should begin with either "." or "[" — any other leading char is a
+    // syntactic miss we surface the same way as an unresolved path.
+    if (path[0] !== "." && path[0] !== "[") {
+        return { ok: false, at: "" };
+    }
+    while ((m = stepRe.exec(path)) !== null) {
+        if (m.index !== consumedEnd) {
+            // Unparseable segment between the last match and the next.
+            return { ok: false, at: lastConsumed };
+        }
+        consumedEnd = m.index + m[0].length;
+        lastConsumed += m[0];
+        if (cur === null || cur === undefined) {
+            return { ok: false, at: lastConsumed };
+        }
+        if (m[1] !== undefined) {
+            // .property
+            cur = (cur as Record<string, unknown>)[m[1]];
+        } else {
+            // [index]
+            const idx = Number(m[2]);
+            if (!Array.isArray(cur)) {
+                return { ok: false, at: lastConsumed };
+            }
+            cur = cur[idx];
+        }
+        if (cur === undefined) {
+            return { ok: false, at: lastConsumed };
+        }
+    }
+    if (consumedEnd !== path.length) {
+        // Trailing garbage — path not fully consumed by the step grammar.
+        return { ok: false, at: lastConsumed };
+    }
+    return { ok: true, value: cur };
+}
 
 /**
  * Replace all ${entity-N} placeholders in `value` using the provided map.
  * Handles both whole-value refs ("${entity-1}") and embedded structured refs
  * ("${entity-1}[Column]", "${entity-0}[A],${entity-0}[B]").
- * Throws if any placeholder has no corresponding entry in the map.
+ *
+ * When `mode` is not "off", the extended form `${entity-N<path>}` is also
+ * recognized (e.g. `${entity-0.facets[0].value}`). The path is walked against
+ * the PromptEntity object; see `EntityPathNavigationMode` for miss semantics.
+ *
+ * Throws if any bare `${entity-N}` placeholder has no corresponding entry in
+ * the map, regardless of mode.
  */
 export function resolveEntityPlaceholders(
     value: string,
     promptEntityMap: Map<string, PromptEntity> | undefined,
+    mode: EntityPathNavigationMode = "off",
 ): string {
-    return value.replace(/\$\{entity-(\d+)\}/g, (match) => {
+    // Match the bare form first: ${entity-N} with nothing else inside the
+    // braces. This is the existing, always-supported grammar.
+    const bareResolved = value.replace(/\$\{entity-(\d+)\}/g, (match) => {
         const entity = promptEntityMap?.get(match);
         if (entity === undefined) {
             throw new Error(
@@ -226,6 +306,55 @@ export function resolveEntityPlaceholders(
         }
         return entity.name;
     });
+    if (mode === "off") {
+        return bareResolved;
+    }
+    // Extended form: ${entity-N<path>} where <path> is ".prop" / "[idx]" / etc.
+    // Anything that doesn't parse as a clean step chain is treated as a miss.
+    return bareResolved.replace(
+        /\$\{entity-(\d+)([^}]*)\}/g,
+        (match, idx: string, path: string) => {
+            const key = `\${entity-${idx}}`;
+            const entity = promptEntityMap?.get(key);
+            if (entity === undefined) {
+                throw new Error(
+                    `Entity reference not found: ${key} in "${value}"`,
+                );
+            }
+            const walk = walkEntityPath(entity, path);
+            if (walk.ok) {
+                // Navigable values are coerced to string. Object/array leaves
+                // become JSON — the LLM occasionally navigates one level too
+                // shallow and we'd rather surface "[object Object]"-avoiding
+                // output than throw on every non-primitive leaf.
+                const v = walk.value;
+                if (v === null) return "";
+                if (typeof v === "string") return v;
+                if (typeof v === "number" || typeof v === "boolean")
+                    return String(v);
+                try {
+                    return JSON.stringify(v);
+                } catch {
+                    return String(v);
+                }
+            }
+            // Path miss — honor the configured mode.
+            if (mode === "throw") {
+                throw new Error(
+                    `Entity path did not resolve: ${match} in "${value}". ` +
+                        `Navigation failed at "${key}${walk.at}". ` +
+                        `Inspect the entity you were handed in context and use a path ` +
+                        `that matches its actual shape, or inline the literal value.`,
+                );
+            }
+            if (mode === "fallback-to-name") {
+                return entity.name;
+            }
+            // "passthrough": leave the original placeholder untouched, which
+            // matches what "off" would have produced for the same input.
+            return match;
+        },
+    );
 }
 
 function toPromptEntityMap(entities: PromptEntity[] | undefined) {
@@ -678,6 +807,7 @@ function createParameterEntityResolver(
                 const resolved = resolveEntityPlaceholders(
                     value,
                     promptEntityMap,
+                    options?.pathNavigation ?? "off",
                 );
                 obj[key] = resolved;
                 // Return entity metadata only when the whole value was a single bare ref.

--- a/ts/packages/dispatcher/dispatcher/src/reasoning/claude.ts
+++ b/ts/packages/dispatcher/dispatcher/src/reasoning/claude.ts
@@ -15,6 +15,7 @@ import {
     SdkMcpToolDefinition,
 } from "@anthropic-ai/claude-agent-sdk";
 import registerDebug from "debug";
+import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { z } from "zod/v4";
@@ -23,6 +24,8 @@ import {
     composeActionSchema,
     createActionSchemaJsonValidator,
 } from "../translation/actionSchemaJsonTranslator.js";
+import { serializeEntityForPrompt } from "../context/chatHistoryPrompt.js";
+import { Entity } from "@typeagent/agent-sdk";
 import { TypeAgentJsonValidator } from "typechat-utils";
 import { executeAction } from "../execute/actionHandlers.js";
 import { nullClientIO } from "../context/interactiveIO.js";
@@ -37,6 +40,10 @@ import {
     formatThinkingDisplay as sharedFormatThinkingDisplay,
 } from "./reasoningLoopBase.js";
 const debug = registerDebug("typeagent:dispatcher:reasoning:messages");
+// Separate channel for MCP tool invocations (discover_actions / execute_action)
+// so call counts can be traced without enabling the full messages channel.
+// Enable with DEBUG=typeagent:dispatcher:reasoning:mcp (or :* for everything).
+const debugMcp = registerDebug("typeagent:dispatcher:reasoning:mcp");
 
 const model = "claude-opus-4-6";
 
@@ -147,12 +154,21 @@ function buildPromptWithContext(
         if (fallbackContext.error) {
             lines.push(`Error: ${fallbackContext.error}`);
         }
-        lines.push(
-            "You MUST use scriptflow actions (discover_actions, listScriptFlows, executeScriptFlow, createScriptFlow, editScriptFlow, deleteScriptFlow) to handle this request. Do NOT use the Bash tool for operations that scriptflow can handle.",
-        );
-        if (fallbackContext.failedFlowName) {
+        const isScriptflowFailure =
+            fallbackContext.failedSchema?.startsWith("scriptflow") === true ||
+            fallbackContext.failedFlowName !== undefined;
+        if (isScriptflowFailure) {
             lines.push(
-                `IMPORTANT: The flow '${fallbackContext.failedFlowName}' failed. Use editScriptFlow to fix its script rather than creating a duplicate flow. Only create a new flow if the existing one's parameters/grammar are fundamentally wrong.`,
+                "You MUST use scriptflow actions (discover_actions, listScriptFlows, executeScriptFlow, createScriptFlow, editScriptFlow, deleteScriptFlow) to handle this request. Do NOT use the Bash tool for operations that scriptflow can handle.",
+            );
+            if (fallbackContext.failedFlowName) {
+                lines.push(
+                    `IMPORTANT: The flow '${fallbackContext.failedFlowName}' failed. Use editScriptFlow to fix its script rather than creating a duplicate flow. Only create a new flow if the existing one's parameters/grammar are fundamentally wrong.`,
+                );
+            }
+        } else {
+            lines.push(
+                "IMPORTANT: Do NOT re-invoke the failed action with substantively the same parameters — that attempt already failed. Complete the user's original request using a different approach: a different action, different parameters, or a sequence of typed actions.",
             );
         }
         parts.push(lines.join("\n"));
@@ -254,6 +270,7 @@ function getClaudeOptions(
         ].join("\n"),
         inputSchema: discoverSchema,
         handler: async (args) => {
+            debugMcp(`discover_actions schema=${args.schemaName}`);
             const validator = getValidator(args.schemaName);
             if (!validator) {
                 throw new Error(`Invalid schema name '${args.schemaName}'`);
@@ -285,6 +302,9 @@ function getClaudeOptions(
         ].join("\n"),
         inputSchema: executeSchema,
         handler: async (args) => {
+            debugMcp(
+                `execute_action schema=${args.schemaName} action=${args.action?.actionName}`,
+            );
             const validator = getValidator(args.schemaName);
             if (!validator) {
                 throw new Error(`Invalid schema name '${args.schemaName}'`);
@@ -300,6 +320,9 @@ function getClaudeOptions(
             }
             const validationResult = validator.validate(actionJson);
             if (!validationResult.success) {
+                debugMcp(
+                    `execute_action validation failed: ${validationResult.message}`,
+                );
                 // For unknown action names, include the schema text so the model
                 // can self-correct without an extra discover_actions round trip.
                 if (
@@ -319,6 +342,7 @@ function getClaudeOptions(
             }
 
             const result: IAgentMessage[] = [];
+            const savedClientIO = systemContext.clientIO;
             const capturingClientIO: ClientIO = {
                 ...nullClientIO,
                 setDisplay: (message) => {
@@ -329,8 +353,15 @@ function getClaudeOptions(
                         result.push(message);
                     }
                 },
+                // Diagnostic data emitted by handlers running inside the
+                // reasoning loop should still reach the outer collector.
+                // Without this override the default nullClientIO drops it
+                // silently, breaking any external consumer that inspects
+                // handler-emitted diagnostics.
+                appendDiagnosticData: (requestId, data) => {
+                    savedClientIO.appendDiagnosticData(requestId, data);
+                },
             };
-            const savedClientIO = systemContext.clientIO;
             systemContext.isInsideReasoningLoop = true;
             try {
                 systemContext.clientIO = capturingClientIO;
@@ -355,6 +386,26 @@ function getClaudeOptions(
     };
 
     const sessionId = getSessionId(context);
+
+    // Experimental override: if CLAUDE_CUSTOM_PROMPT_FILE is set, read that file
+    // each call and use its contents as the ENTIRE system prompt (bypassing
+    // claude_code preset and config.promptAppend). Used by prompt-variation
+    // benchmark experiments.
+    const overrideFile = process.env.CLAUDE_CUSTOM_PROMPT_FILE;
+    let customSystemPrompt: string | undefined;
+    if (overrideFile) {
+        try {
+            customSystemPrompt = fs.readFileSync(overrideFile, "utf8");
+            debug(
+                `[prompt-override] Using custom system prompt from ${overrideFile} (${customSystemPrompt.length} chars)`,
+            );
+        } catch (err) {
+            debug(
+                `[prompt-override] Failed to read ${overrideFile}: ${(err as Error).message}`,
+            );
+        }
+    }
+
     const claudeOptions: Options = {
         model,
         permissionMode: "acceptEdits",
@@ -365,7 +416,8 @@ function getClaudeOptions(
         settingSources: [],
         maxTurns: 20,
         thinking: { type: "adaptive" },
-        systemPrompt: {
+        effort: "max",
+        systemPrompt: customSystemPrompt ?? {
             type: "preset",
             preset: "claude_code",
             append: [
@@ -379,6 +431,26 @@ function getClaudeOptions(
                 "When the user asks about agent capabilities, use discover_actions first.",
                 "When the user asks to perform an action, discover the schema then execute_action.",
                 "",
+                ...(config.execution.entityPromptShape ===
+                "facets-with-schema"
+                    ? [
+                          "# Entity Schema",
+                          "",
+                          "Entities in the [Context Entities] block follow this TypeScript shape:",
+                          "",
+                          "```typescript",
+                          "interface Entity {",
+                          "    name: string;",
+                          "    type: string[];",
+                          "    uniqueId?: string;",
+                          "    facets?: { name: string; value: string | number | boolean | object | any[] }[];",
+                          "}",
+                          "```",
+                          "",
+                          "Read `facets[].name` as the property key and `facets[].value` as the value. Prefer values from facets over re-reading the underlying source. `uniqueId` can be used to reference an entity in follow-up turns.",
+                          "",
+                      ]
+                    : []),
                 ...(config.promptAppend
                     ? [
                           "# TypeAgent Configuration/Context",
@@ -394,6 +466,8 @@ function getClaudeOptions(
                 "When information is ambiguous or missing, make a reasonable safe default choice and proceed.",
                 "Prefer non-destructive defaults: add rather than replace, use conservative values.",
                 "Only stop if you are truly unable to proceed — in that case, emit a clear error message explaining what is missing.",
+                "",
+                "ACTIONS, NOT DESCRIPTIONS: a request to modify state is only complete when you have actually executed an action that modifies it. Writing code or pseudo-code in a markdown response is NOT execution. If an action exists that performs the change, call it — do not describe the change in text and stop. Never finish a turn with only a text-only explanation when the task required a modification.",
                 "",
                 "# File Placement Policy",
                 "",
@@ -730,6 +804,34 @@ function generateRequestId(): string {
     return `req-${Date.now()}-${Math.random().toString(36).substring(2, 9)}`;
 }
 
+// Default reasoning-loop timeout. Override with TYPEAGENT_REASONING_TIMEOUT_MS.
+const DEFAULT_REASONING_TIMEOUT_MS = 20 * 60 * 1000;
+
+// Pull schemaName + actionName out of a Claude SDK tool_use input when the tool
+// is one of the MCP action-executor tools. Leaves both undefined for other tools
+// so the emitted reasoningStep stays small and well-typed.
+function extractActionInfo(
+    toolName: string,
+    input: unknown,
+): { schemaName?: string; actionName?: string } {
+    const inp = input as Record<string, unknown> | undefined;
+    if (!inp) return {};
+    const out: { schemaName?: string; actionName?: string } = {};
+    if (toolName.endsWith("execute_action")) {
+        if (typeof inp.schemaName === "string") out.schemaName = inp.schemaName;
+        const actionRaw = inp.action as Record<string, unknown> | undefined;
+        if (typeof actionRaw?.actionName === "string") {
+            out.actionName = actionRaw.actionName;
+        }
+        return out;
+    }
+    if (toolName.endsWith("discover_actions")) {
+        if (typeof inp.schemaName === "string") out.schemaName = inp.schemaName;
+        return out;
+    }
+    return out;
+}
+
 /**
  * Execute reasoning action without planning (standard mode)
  */
@@ -737,6 +839,7 @@ async function executeReasoningWithoutPlanning(
     originalRequest: string,
     context: ActionContext<CommandHandlerContext>,
     fallbackContext?: ReasoningFallbackContext,
+    abortSignal?: AbortSignal,
 ): Promise<any> {
     // Display initial message
     context.actionIO.appendDisplay("Thinking...", "temporary");
@@ -752,10 +855,13 @@ async function executeReasoningWithoutPlanning(
     });
 
     let finalResult: string | undefined = undefined;
+    let toolUseCount = 0;
+    let reasoningStepCount = 0;
+    const toolUseIdToName = new Map<string, string>();
 
     // Process streaming response
     for await (const message of queryInstance) {
-        context.abortSignal?.throwIfAborted();
+        (abortSignal ?? context.abortSignal)?.throwIfAborted();
         debug(message);
         // Capture session ID from first message for future resume
         if ("session_id" in message && !getSessionId(context)) {
@@ -774,6 +880,23 @@ async function executeReasoningWithoutPlanning(
                         "block",
                     );
                 } else if (content.type === "tool_use") {
+                    toolUseCount++;
+                    reasoningStepCount++;
+                    toolUseIdToName.set(content.id, content.name);
+                    const actionInfo = extractActionInfo(
+                        content.name,
+                        content.input,
+                    );
+                    context.actionIO.appendDiagnosticData({
+                        type: "reasoningStep",
+                        phase: "toolCall",
+                        stepNumber: reasoningStepCount,
+                        toolUseId: content.id,
+                        toolName: content.name,
+                        ...actionInfo,
+                        parameters: content.input,
+                        timestamp: new Date().toISOString(),
+                    });
                     context.actionIO.appendDisplay(
                         {
                             type: "markdown",
@@ -813,6 +936,18 @@ async function executeReasoningWithoutPlanning(
                         } else if (typeof block.content === "string") {
                             content = block.content;
                         }
+                        const toolName = toolUseIdToName.get(
+                            block.tool_use_id,
+                        );
+                        context.actionIO.appendDiagnosticData({
+                            type: "reasoningStep",
+                            phase: "toolResult",
+                            toolUseId: block.tool_use_id,
+                            ...(toolName !== undefined ? { toolName } : {}),
+                            isError,
+                            result: content,
+                            timestamp: new Date().toISOString(),
+                        });
                         context.actionIO.appendDisplay(
                             {
                                 type: "markdown",
@@ -841,6 +976,16 @@ async function executeReasoningWithoutPlanning(
         }
     }
 
+    // A success result with zero tool calls means the model replied with text
+    // only (e.g. described the change in prose) without executing anything.
+    // Nothing was actually modified — surface as a failure instead of letting
+    // the text be reported as a successful action.
+    if (finalResult && toolUseCount === 0) {
+        throw new Error(
+            "Reasoning completed with no tool calls — the model produced a text-only response and did not execute any action. No state was modified.",
+        );
+    }
+
     return finalResult ? createActionResultNoDisplay(finalResult) : undefined;
 }
 
@@ -851,6 +996,7 @@ async function executeReasoningWithTracing(
     originalRequest: string,
     context: ActionContext<CommandHandlerContext>,
     fallbackContext?: ReasoningFallbackContext,
+    abortSignal?: AbortSignal,
 ): Promise<any> {
     const systemContext = context.sessionContext.agentContext;
     const storage = context.sessionContext.sessionStorage;
@@ -858,7 +1004,12 @@ async function executeReasoningWithTracing(
     if (!storage) {
         // No session storage available - fallback to standard reasoning
         debug("No sessionStorage available, using standard reasoning");
-        return executeReasoningWithoutPlanning(originalRequest, context);
+        return executeReasoningWithoutPlanning(
+            originalRequest,
+            context,
+            undefined,
+            abortSignal,
+        );
     }
 
     const requestId = generateRequestId();
@@ -888,11 +1039,13 @@ async function executeReasoningWithTracing(
         });
 
         let finalResult: string | undefined = undefined;
+        let toolUseCount = 0;
+        let reasoningStepCount = 0;
         const toolUseIdToName = new Map<string, string>();
 
         // Process streaming response with tracing
         for await (const message of queryInstance) {
-            context.abortSignal?.throwIfAborted();
+            (abortSignal ?? context.abortSignal)?.throwIfAborted();
             debug(message);
             // Capture session ID from first message for future resume
             if ("session_id" in message && !getSessionId(context)) {
@@ -911,10 +1064,27 @@ async function executeReasoningWithTracing(
                             content: content.text,
                         });
                     } else if (content.type === "tool_use") {
+                        toolUseCount++;
+                        reasoningStepCount++;
                         // Track tool_use_id → name for matching results
                         toolUseIdToName.set(content.id, content.name);
                         // Record tool call for tracing
                         tracer.recordToolCall(content.name, content.input);
+
+                        const actionInfo = extractActionInfo(
+                            content.name,
+                            content.input,
+                        );
+                        context.actionIO.appendDiagnosticData({
+                            type: "reasoningStep",
+                            phase: "toolCall",
+                            stepNumber: reasoningStepCount,
+                            toolUseId: content.id,
+                            toolName: content.name,
+                            ...actionInfo,
+                            parameters: content.input,
+                            timestamp: new Date().toISOString(),
+                        });
 
                         context.actionIO.appendDisplay(
                             {
@@ -967,6 +1137,16 @@ async function executeReasoningWithTracing(
                                 isError ? content : undefined,
                             );
 
+                            context.actionIO.appendDiagnosticData({
+                                type: "reasoningStep",
+                                phase: "toolResult",
+                                toolUseId: block.tool_use_id,
+                                toolName,
+                                isError,
+                                result: content,
+                                timestamp: new Date().toISOString(),
+                            });
+
                             context.actionIO.appendDisplay(
                                 {
                                     type: "markdown",
@@ -995,6 +1175,15 @@ async function executeReasoningWithTracing(
                     throw new Error(errorMessage);
                 }
             }
+        }
+
+        // A success result with zero tool calls means the model replied with
+        // text only (e.g. described the change in prose) without executing
+        // anything. Nothing was actually modified — surface as a failure.
+        if (finalResult && toolUseCount === 0) {
+            throw new Error(
+                "Reasoning completed with no tool calls — the model produced a text-only response and did not execute any action. No state was modified.",
+            );
         }
 
         // Mark trace as successful
@@ -1143,23 +1332,56 @@ export async function executeReasoningAction(
     if (attemptedAction !== undefined || contextEntities !== undefined) {
         const parts: string[] = [request, ""];
         if (attemptedAction !== undefined) {
+            const hasError =
+                attemptedAction &&
+                typeof attemptedAction === "object" &&
+                typeof (attemptedAction as any).error === "string";
+            const headline = hasError
+                ? "A previous action attempt failed. The failed action (and its error) are shown below:"
+                : "The translator produced this action (intercepted for inspection before execution):";
+            const followUp = hasError
+                ? "Do not retry the failed action as-is — diagnose the error, inspect the " +
+                  "relevant state to understand the actual shape, then complete the user's " +
+                  "original request using whichever available tools are appropriate."
+                : "Use the parameters above as your starting point. Inspect the relevant " +
+                  "state to verify they are correct, then execute the same action (or a " +
+                  "corrected variant) to satisfy the user's request.";
             parts.push(
                 "[Attempted Action]",
-                "The translator produced this action (intercepted for workbook inspection before execution):",
+                headline,
                 "```json",
                 JSON.stringify(attemptedAction, null, 2),
                 "```",
-                "Use the formula and address above as your starting point. Inspect the workbook " +
-                    "to verify they are correct, then call execute_action(setFormula) with the " +
-                    "confirmed (or corrected) parameters.",
+                followUp,
                 "",
             );
         }
         if (contextEntities !== undefined) {
+            // Producers serialize Entity[] in the canonical {name, type,
+            // facets} shape. Re-render here per the configured prompt shape
+            // so all variants flow through one transform point.
+            const shape = config.execution.entityPromptShape;
+            const rendered = Array.isArray(contextEntities)
+                ? contextEntities.map((raw: unknown, i: number) => {
+                      if (
+                          raw !== null &&
+                          typeof raw === "object" &&
+                          typeof (raw as any).name === "string" &&
+                          Array.isArray((raw as any).type)
+                      ) {
+                          return serializeEntityForPrompt(
+                              raw as Entity,
+                              shape,
+                              i,
+                          );
+                      }
+                      return raw;
+                  })
+                : contextEntities;
             parts.push(
                 "[Context Entities]",
                 "```json",
-                JSON.stringify(contextEntities, null, 2),
+                JSON.stringify(rendered, null, 2),
                 "```",
                 "",
             );
@@ -1167,9 +1389,27 @@ export async function executeReasoningAction(
         enrichedRequest = parts.join("\n");
     }
 
+    // Build a fallbackContext from the attemptedAction when an agent
+    // intercepted and redirected the request. This lets
+    // buildPromptWithContext emit the appropriate re-invocation guidance.
+    const fallbackContext: ReasoningFallbackContext | undefined =
+        attemptedAction &&
+        typeof attemptedAction === "object" &&
+        typeof (attemptedAction as any).schemaName === "string" &&
+        typeof (attemptedAction as any).actionName === "string"
+            ? {
+                  failedSchema: (attemptedAction as any).schemaName,
+                  failedAction: (attemptedAction as any).actionName,
+                  ...(typeof (attemptedAction as any).error === "string"
+                      ? { error: (attemptedAction as any).error }
+                      : {}),
+              }
+            : undefined;
+
     return executeReasoning(enrichedRequest, context, {
         planReuseEnabled: planReuseEnabled || scriptReuseEnabled,
         engine: "claude",
+        ...(fallbackContext ? { fallbackContext } : {}),
     });
 }
 
@@ -1477,6 +1717,53 @@ export interface ReasoningFallbackContext {
     error?: string | undefined;
 }
 
+/**
+ * Run `fn` with a per-test reasoning timeout.
+ *
+ * The timeout is taken from `TYPEAGENT_REASONING_TIMEOUT_MS` (milliseconds) and
+ * defaults to 10 minutes. Set it to `0` to disable the timeout entirely.
+ *
+ * The returned AbortSignal is aborted on timeout OR when `context.abortSignal`
+ * is aborted externally. Inner reasoning loops check the signal on every
+ * streamed message, so long-running loops exit promptly on timeout.
+ */
+async function runWithReasoningTimeout<T>(
+    context: ActionContext<CommandHandlerContext>,
+    fn: (signal: AbortSignal) => Promise<T>,
+): Promise<T> {
+    const raw = process.env.TYPEAGENT_REASONING_TIMEOUT_MS;
+    const parsed = raw !== undefined ? Number(raw) : NaN;
+    const timeoutMs = Number.isFinite(parsed) && parsed >= 0
+        ? parsed
+        : DEFAULT_REASONING_TIMEOUT_MS;
+
+    const controller = new AbortController();
+    const externalSignal = context.abortSignal;
+    const onExternalAbort = () => controller.abort(externalSignal?.reason);
+
+    if (externalSignal) {
+        if (externalSignal.aborted) controller.abort(externalSignal.reason);
+        else externalSignal.addEventListener("abort", onExternalAbort, { once: true });
+    }
+
+    const timer = timeoutMs > 0
+        ? setTimeout(() => {
+              controller.abort(
+                  new Error(
+                      `Reasoning exceeded timeout of ${timeoutMs} ms (set TYPEAGENT_REASONING_TIMEOUT_MS to change).`,
+                  ),
+              );
+          }, timeoutMs)
+        : undefined;
+
+    try {
+        return await fn(controller.signal);
+    } finally {
+        if (timer !== undefined) clearTimeout(timer);
+        externalSignal?.removeEventListener?.("abort", onExternalAbort);
+    }
+}
+
 export async function executeReasoning(
     request: string,
     context: ActionContext<CommandHandlerContext>,
@@ -1492,14 +1779,21 @@ export async function executeReasoning(
     }
     const planReuseEnabled = options?.planReuseEnabled ?? false;
     const fallbackContext = options?.fallbackContext;
-    if (!planReuseEnabled) {
-        return executeReasoningWithoutPlanning(
+    return runWithReasoningTimeout(context, (signal) => {
+        if (!planReuseEnabled) {
+            return executeReasoningWithoutPlanning(
+                request,
+                context,
+                fallbackContext,
+                signal,
+            );
+        }
+        // Trace capture + auto recipe generation
+        return executeReasoningWithTracing(
             request,
             context,
             fallbackContext,
+            signal,
         );
-    }
-
-    // Trace capture + auto recipe generation
-    return executeReasoningWithTracing(request, context, fallbackContext);
+    });
 }

--- a/ts/packages/dispatcher/dispatcher/src/reasoning/claude.ts
+++ b/ts/packages/dispatcher/dispatcher/src/reasoning/claude.ts
@@ -431,8 +431,7 @@ function getClaudeOptions(
                 "When the user asks about agent capabilities, use discover_actions first.",
                 "When the user asks to perform an action, discover the schema then execute_action.",
                 "",
-                ...(config.execution.entityPromptShape ===
-                "facets-with-schema"
+                ...(config.execution.entityPromptShape === "facets-with-schema"
                     ? [
                           "# Entity Schema",
                           "",
@@ -936,9 +935,7 @@ async function executeReasoningWithoutPlanning(
                         } else if (typeof block.content === "string") {
                             content = block.content;
                         }
-                        const toolName = toolUseIdToName.get(
-                            block.tool_use_id,
-                        );
+                        const toolName = toolUseIdToName.get(block.tool_use_id);
                         context.actionIO.appendDiagnosticData({
                             type: "reasoningStep",
                             phase: "toolResult",
@@ -1733,9 +1730,10 @@ async function runWithReasoningTimeout<T>(
 ): Promise<T> {
     const raw = process.env.TYPEAGENT_REASONING_TIMEOUT_MS;
     const parsed = raw !== undefined ? Number(raw) : NaN;
-    const timeoutMs = Number.isFinite(parsed) && parsed >= 0
-        ? parsed
-        : DEFAULT_REASONING_TIMEOUT_MS;
+    const timeoutMs =
+        Number.isFinite(parsed) && parsed >= 0
+            ? parsed
+            : DEFAULT_REASONING_TIMEOUT_MS;
 
     const controller = new AbortController();
     const externalSignal = context.abortSignal;
@@ -1743,18 +1741,22 @@ async function runWithReasoningTimeout<T>(
 
     if (externalSignal) {
         if (externalSignal.aborted) controller.abort(externalSignal.reason);
-        else externalSignal.addEventListener("abort", onExternalAbort, { once: true });
+        else
+            externalSignal.addEventListener("abort", onExternalAbort, {
+                once: true,
+            });
     }
 
-    const timer = timeoutMs > 0
-        ? setTimeout(() => {
-              controller.abort(
-                  new Error(
-                      `Reasoning exceeded timeout of ${timeoutMs} ms (set TYPEAGENT_REASONING_TIMEOUT_MS to change).`,
-                  ),
-              );
-          }, timeoutMs)
-        : undefined;
+    const timer =
+        timeoutMs > 0
+            ? setTimeout(() => {
+                  controller.abort(
+                      new Error(
+                          `Reasoning exceeded timeout of ${timeoutMs} ms (set TYPEAGENT_REASONING_TIMEOUT_MS to change).`,
+                      ),
+                  );
+              }, timeoutMs)
+            : undefined;
 
     try {
         return await fn(controller.signal);

--- a/ts/packages/dispatcher/dispatcher/src/reasoning/claudeSDKAdapter.ts
+++ b/ts/packages/dispatcher/dispatcher/src/reasoning/claudeSDKAdapter.ts
@@ -155,6 +155,9 @@ class ClaudeReasoningSession implements ReasoningSession {
             mcpServers: {
                 [MCP_SERVER_NAME]: mcpServer,
             },
+            ...(this.config.resumeSessionId
+                ? { resume: this.config.resumeSessionId }
+                : {}),
             ...this.baseOptions,
         };
     }

--- a/ts/packages/dispatcher/dispatcher/src/reasoning/reasoningLoopBase.ts
+++ b/ts/packages/dispatcher/dispatcher/src/reasoning/reasoningLoopBase.ts
@@ -32,9 +32,9 @@ export interface ReasoningLoopConfig {
     onToolResult?: (tool: string, result: unknown, isError: boolean) => void;
     onText?: (text: string) => void;
     /**
-     * When set, the adapter resumes the prior session with this id rather than
-     * starting a fresh conversation. Used by the VBA-to-typed-actions subagent
-     * to carry parent/sub-agent dialogue across iterations.
+     * When set, the adapter resumes the prior session with this id rather
+     * than starting a fresh conversation. Useful for subagents that need to
+     * carry parent/sub-agent dialogue across iterations.
      */
     resumeSessionId?: string;
 }

--- a/ts/packages/dispatcher/dispatcher/src/reasoning/reasoningLoopBase.ts
+++ b/ts/packages/dispatcher/dispatcher/src/reasoning/reasoningLoopBase.ts
@@ -31,6 +31,12 @@ export interface ReasoningLoopConfig {
     onToolCall?: (tool: string, args: unknown) => void;
     onToolResult?: (tool: string, result: unknown, isError: boolean) => void;
     onText?: (text: string) => void;
+    /**
+     * When set, the adapter resumes the prior session with this id rather than
+     * starting a fresh conversation. Used by the VBA-to-typed-actions subagent
+     * to carry parent/sub-agent dialogue across iterations.
+     */
+    resumeSessionId?: string;
 }
 
 export interface ReasoningTraceCollectorInterface {

--- a/ts/packages/dispatcher/dispatcher/src/translation/agentTranslators.ts
+++ b/ts/packages/dispatcher/dispatcher/src/translation/agentTranslators.ts
@@ -19,7 +19,10 @@ import {
     MultipleActionOptions,
 } from "./multipleActionSchema.js";
 import { HistoryContext, ParamObjectType } from "agent-cache";
-import { createTypeAgentRequestPrompt } from "../context/chatHistoryPrompt.js";
+import {
+    createTypeAgentRequestPrompt,
+    EntityPromptShape,
+} from "../context/chatHistoryPrompt.js";
 import {
     composeActionSchema,
     ComposeSchemaOptions,
@@ -373,6 +376,8 @@ export function loadAgentJsonTranslator<
     generateOptions?: GenerateSchemaOptions | null, // null means not generated
     model?: string,
     promptLogger?: PromptLogger,
+    entityPromptShape: EntityPromptShape = "facets",
+    entityPathNavigationEnabled: boolean = false,
 ): TypeAgentTranslator<T> {
     const validator = createTypeAgentValidator<T>(
         actionConfigs,
@@ -383,10 +388,16 @@ export function loadAgentJsonTranslator<
     );
     // Collect schema name mapping.
     const schemaNameMap = collectSchemaName(actionConfigs, provider);
-    return createTypeAgentTranslator<T>(validator, schemaNameMap, {
-        model,
-        promptLogger,
-    });
+    return createTypeAgentTranslator<T>(
+        validator,
+        schemaNameMap,
+        {
+            model,
+            promptLogger,
+        },
+        entityPromptShape,
+        entityPathNavigationEnabled,
+    );
 }
 
 function createTypeAgentTranslator<
@@ -395,6 +406,8 @@ function createTypeAgentTranslator<
     validator: TypeAgentJsonValidator<T>,
     schemaNameMap: Map<string, string>,
     options: JsonTranslatorOptions<T>,
+    entityPromptShape: EntityPromptShape = "facets",
+    entityPathNavigationEnabled: boolean = false,
 ): TypeAgentTranslator<T> {
     const translator = createJsonTranslatorWithValidator<T>(
         validator.getTypeName().toLowerCase(),
@@ -436,6 +449,9 @@ function createTypeAgentTranslator<
                 request,
                 history,
                 attachments,
+                true,
+                entityPromptShape,
+                entityPathNavigationEnabled,
             );
 
             return streamingTranslator.translate(
@@ -454,6 +470,8 @@ function createTypeAgentTranslator<
                 undefined,
                 undefined,
                 false,
+                entityPromptShape,
+                entityPathNavigationEnabled,
             );
             return altTranslator.translate(requestPrompt);
         },
@@ -476,6 +494,8 @@ export function createTypeAgentTranslatorForSelectedActions<
     options?: ComposeSchemaOptions,
     model?: string,
     promptLogger?: PromptLogger,
+    entityPromptShape: EntityPromptShape = "facets",
+    entityPathNavigationEnabled: boolean = false,
 ) {
     const validator = createActionSchemaJsonValidator<T>(
         composeSelectedActionSchema(
@@ -493,10 +513,16 @@ export function createTypeAgentTranslatorForSelectedActions<
         definitions,
         actionConfig,
     );
-    return createTypeAgentTranslator<T>(validator, schemaNameMap, {
-        model,
-        promptLogger,
-    });
+    return createTypeAgentTranslator<T>(
+        validator,
+        schemaNameMap,
+        {
+            model,
+            promptLogger,
+        },
+        entityPromptShape,
+        entityPathNavigationEnabled,
+    );
 }
 
 // For CLI, replicate the behavior of loadAgentJsonTranslator to get the schema

--- a/ts/packages/dispatcher/dispatcher/src/translation/translateRequest.ts
+++ b/ts/packages/dispatcher/dispatcher/src/translation/translateRequest.ts
@@ -121,7 +121,8 @@ export function getTranslatorForSchema(
         debugTranslate(`Using cached translator for '${translatorName}'`);
         return translator;
     }
-    const config = context.session.getConfig().translation;
+    const sessionConfig = context.session.getConfig();
+    const config = sessionConfig.translation;
     const { actionConfigs, switchActionConfigs } = getTranslationActionConfigs(
         context.agents,
         activeSchemas,
@@ -157,6 +158,8 @@ export function getTranslatorForSchema(
         generateOptions,
         config.model,
         context.promptLogger,
+        sessionConfig.execution.entityPromptShape,
+        sessionConfig.translation.entity.pathNavigation !== "off",
     );
     if (!activityContext) {
         context.translatorCache.set(translatorName, newTranslator);
@@ -191,7 +194,8 @@ async function getTranslatorForSelectedActions(
     if (nearestNeighbors === undefined) {
         return undefined;
     }
-    const config = context.session.getConfig().translation;
+    const sessionConfig = context.session.getConfig();
+    const config = sessionConfig.translation;
     const { actionConfigs, switchActionConfigs } = getTranslationActionConfigs(
         context.agents,
         activeSchemas,
@@ -210,6 +214,8 @@ async function getTranslatorForSelectedActions(
         },
         config.model,
         context.promptLogger,
+        sessionConfig.execution.entityPromptShape,
+        sessionConfig.translation.entity.pathNavigation !== "off",
     );
 }
 

--- a/ts/packages/dispatcher/dispatcher/test/entityResolution.spec.ts
+++ b/ts/packages/dispatcher/dispatcher/test/entityResolution.spec.ts
@@ -17,6 +17,34 @@ function makeMap(entries: Array<[string, string]>): Map<string, PromptEntity> {
     );
 }
 
+// Richer entity shape for path-navigation tests — mirrors a real PromptEntity
+// with facets and a uniqueId so dotted paths have something to walk.
+function makeRichMap(): Map<string, PromptEntity> {
+    return new Map<string, PromptEntity>([
+        [
+            "${entity-0}",
+            {
+                name: "Sheet1",
+                type: ["worksheet", "active"],
+                uniqueId: "worksheet:Sheet1",
+                facets: [
+                    { name: "usedRange", value: "A1:A7" },
+                    { name: "author", value: "R. Gruen" },
+                ],
+                sourceAppAgentName: "excel",
+            },
+        ],
+        [
+            "${entity-1}",
+            {
+                name: "Budget",
+                type: ["table"],
+                sourceAppAgentName: "excel",
+            },
+        ],
+    ]);
+}
+
 describe("resolveEntityPlaceholders", () => {
     const map = makeMap([
         ["${entity-0}", "SalesData"],
@@ -68,5 +96,141 @@ describe("resolveEntityPlaceholders", () => {
         expect(() =>
             resolveEntityPlaceholders("${entity-0}", undefined),
         ).toThrow("Entity reference not found: ${entity-0}");
+    });
+});
+
+describe("resolveEntityPlaceholders — path navigation", () => {
+    const rich = makeRichMap();
+
+    describe('mode "off"', () => {
+        it("passes dotted paths through untouched (legacy behavior)", () => {
+            expect(
+                resolveEntityPlaceholders(
+                    "${entity-0.facets[0].value}",
+                    rich,
+                    "off",
+                ),
+            ).toBe("${entity-0.facets[0].value}");
+        });
+
+        it("still resolves bare forms when mode is off", () => {
+            expect(resolveEntityPlaceholders("${entity-0}", rich, "off")).toBe(
+                "Sheet1",
+            );
+        });
+    });
+
+    describe('mode "throw"', () => {
+        it("resolves a valid facet path to a scalar value", () => {
+            expect(
+                resolveEntityPlaceholders(
+                    "${entity-0.facets[0].value}",
+                    rich,
+                    "throw",
+                ),
+            ).toBe("A1:A7");
+        });
+
+        it("resolves a direct scalar property", () => {
+            expect(
+                resolveEntityPlaceholders(
+                    "${entity-0.uniqueId}",
+                    rich,
+                    "throw",
+                ),
+            ).toBe("worksheet:Sheet1");
+        });
+
+        it("resolves an embedded path in a longer string", () => {
+            expect(
+                resolveEntityPlaceholders(
+                    "range=${entity-0.facets[0].value} in ${entity-0.name}",
+                    rich,
+                    "throw",
+                ),
+            ).toBe("range=A1:A7 in Sheet1");
+        });
+
+        it("JSON-encodes object/array leaves", () => {
+            // facets is an array of objects — walking to it without indexing
+            // should surface JSON rather than "[object Object]".
+            expect(
+                resolveEntityPlaceholders("${entity-0.facets}", rich, "throw"),
+            ).toMatch(/^\[\{"name":"usedRange"/);
+        });
+
+        it("throws on a missing property path with a descriptive error", () => {
+            expect(() =>
+                resolveEntityPlaceholders(
+                    "${entity-0.nonexistent.field}",
+                    rich,
+                    "throw",
+                ),
+            ).toThrow(/Entity path did not resolve/);
+        });
+
+        it("throws on an out-of-bounds array index", () => {
+            expect(() =>
+                resolveEntityPlaceholders(
+                    "${entity-0.facets[99].value}",
+                    rich,
+                    "throw",
+                ),
+            ).toThrow(/Entity path did not resolve/);
+        });
+
+        it("throws on malformed path syntax", () => {
+            expect(() =>
+                resolveEntityPlaceholders(
+                    "${entity-0 bad path}",
+                    rich,
+                    "throw",
+                ),
+            ).toThrow(/Entity path did not resolve/);
+        });
+    });
+
+    describe('mode "fallback-to-name"', () => {
+        it("returns the entity name on path miss", () => {
+            expect(
+                resolveEntityPlaceholders(
+                    "${entity-0.nonexistent}",
+                    rich,
+                    "fallback-to-name",
+                ),
+            ).toBe("Sheet1");
+        });
+
+        it("still resolves valid paths", () => {
+            expect(
+                resolveEntityPlaceholders(
+                    "${entity-0.facets[1].value}",
+                    rich,
+                    "fallback-to-name",
+                ),
+            ).toBe("R. Gruen");
+        });
+    });
+
+    describe('mode "passthrough"', () => {
+        it("leaves the literal placeholder on path miss", () => {
+            expect(
+                resolveEntityPlaceholders(
+                    "${entity-0.nonexistent}",
+                    rich,
+                    "passthrough",
+                ),
+            ).toBe("${entity-0.nonexistent}");
+        });
+
+        it("still resolves valid paths", () => {
+            expect(
+                resolveEntityPlaceholders(
+                    "${entity-0.facets[0].value}",
+                    rich,
+                    "passthrough",
+                ),
+            ).toBe("A1:A7");
+        });
     });
 });

--- a/ts/packages/typeagent/src/async.ts
+++ b/ts/packages/typeagent/src/async.ts
@@ -35,8 +35,7 @@ export async function callWithRetry<T = any>(
         } catch (e: any) {
             const elapsed = Date.now() - attemptStart;
             const msg =
-                e?.message ??
-                (typeof e === "string" ? e : JSON.stringify(e));
+                e?.message ?? (typeof e === "string" ? e : JSON.stringify(e));
             if (
                 retryCount >= retryMaxAttempts ||
                 (shouldAbort && shouldAbort(e))
@@ -69,7 +68,9 @@ async function withTimeout<T>(p: Promise<T>, ms: number): Promise<T> {
                 timer = setTimeout(
                     () =>
                         reject(
-                            new Error(`callWithRetry attempt timed out after ${ms}ms`),
+                            new Error(
+                                `callWithRetry attempt timed out after ${ms}ms`,
+                            ),
                         ),
                     ms,
                 );

--- a/ts/packages/typeagent/src/async.ts
+++ b/ts/packages/typeagent/src/async.ts
@@ -35,7 +35,8 @@ export async function callWithRetry<T = any>(
         } catch (e: any) {
             const elapsed = Date.now() - attemptStart;
             const msg =
-                e?.message ?? (typeof e === "string" ? e : JSON.stringify(e));
+                e?.message ??
+                (typeof e === "string" ? e : JSON.stringify(e));
             if (
                 retryCount >= retryMaxAttempts ||
                 (shouldAbort && shouldAbort(e))
@@ -68,9 +69,7 @@ async function withTimeout<T>(p: Promise<T>, ms: number): Promise<T> {
                 timer = setTimeout(
                     () =>
                         reject(
-                            new Error(
-                                `callWithRetry attempt timed out after ${ms}ms`,
-                            ),
+                            new Error(`callWithRetry attempt timed out after ${ms}ms`),
                         ),
                     ms,
                 );


### PR DESCRIPTION
**Key changes:**

### Entity Placeholder Resolution and Path Navigation

* Introduced support for entity placeholders with dotted path navigation (e.g., `${entity-0.facets[0].value}`) in action parameters, allowing the LLM to reference nested entity properties. The behavior is configurable via the new `translation.entity.pathNavigation` session config with four modes: `"off"`, `"throw"`, `"fallback-to-name"`, and `"passthrough"`; default is `"throw"` for strict error handling. Documentation and prompt instructions have been updated accordingly. [[1]](diffhunk://#diff-922e7df9ebde8da9a60fbfaf7486b22910f4e6f378f366f91c31f1fe00b2774eR352-R382) [[2]](diffhunk://#diff-5637f94f6ede3217a94cd99add0a1d9d00509c0662634ef9dc1d49cc9c658cc8R129-R150) [[3]](diffhunk://#diff-5637f94f6ede3217a94cd99add0a1d9d00509c0662634ef9dc1d49cc9c658cc8R252-R258)

### Entity Serialization and Prompt Shape Configuration

* Added `entityPromptShape` configuration (with options `"facets"`, `"flat"`, and `"facets-with-schema"`) to control how `Entity` objects are serialized into LLM prompts. Serialization logic and prompt assembly have been refactored to support these shapes, and a new system command handler allows runtime adjustment of this setting. Default is now `"facets-with-schema"` based on experiment results. [[1]](diffhunk://#diff-ee92ecc75ee8bc6d84ce9d4222fe533b2d7c4214a45695479fdf54a3b77c29f8R5-R75) [[2]](diffhunk://#diff-ee92ecc75ee8bc6d84ce9d4222fe533b2d7c4214a45695479fdf54a3b77c29f8L65-R132) [[3]](diffhunk://#diff-ee92ecc75ee8bc6d84ce9d4222fe533b2d7c4214a45695479fdf54a3b77c29f8R182-R186) [[4]](diffhunk://#diff-5637f94f6ede3217a94cd99add0a1d9d00509c0662634ef9dc1d49cc9c658cc8R164-R168) [[5]](diffhunk://#diff-5637f94f6ede3217a94cd99add0a1d9d00509c0662634ef9dc1d49cc9c658cc8R270-R273) [[6]](diffhunk://#diff-cc46b192698c0e479bf706075d2fc08a58a39b1f350a13dcdf6f28d25d753730R1497-R1528) [[7]](diffhunk://#diff-cc46b192698c0e479bf706075d2fc08a58a39b1f350a13dcdf6f28d25d753730R1544)

### Schema Authoring Guidelines

* Revised schema authoring guidelines to clarify comment structure, emphasize the placement of identity lines, discourage anti-examples unless necessary, and improve guidance on shaping schemas to match LLM intent.

### Reasoning Invocation Controls

* Added support for forcing reasoning invocation via an environment variable (`CLAUDE_FORCE_REASONING`), and expanded fallback context information in reasoning error handling to aid debugging and error recovery. [[1]](diffhunk://#diff-ed3d233f0943c7004056abfc1ca99dccfe103243b2b95adaba814f67a436ef61R390-R395) [[2]](diffhunk://#diff-ed3d233f0943c7004056abfc1ca99dccfe103243b2b95adaba814f67a436ef61R509-R515)

---

These changes collectively enhance the flexibility, transparency, and reliability of entity handling in the dispatcher, and provide better tools for prompt engineering and debugging.