### PR TITLE
Fix completion restore, session management, retry logging, and test improvements

### DIFF
--- a/ts/packages/shell/src/renderer/src/chat/chatView.ts
+++ b/ts/packages/shell/src/renderer/src/chat/chatView.ts
@@ -26,9 +26,6 @@ import { InputChoice } from "../choicePanel";
 import { MessageGroup } from "./messageGroup";
 import { SettingsView } from "../settingsView";
 import { uint8ArrayToBase64 } from "@typeagent/common-utils";
-import registerDebug from "debug";
-
-const debugPartial = registerDebug("typeagent:shell:partial");
 
 const DynamicDisplayMinRefreshIntervalMs = 15;
 
@@ -929,7 +926,6 @@ export class ChatView {
             isInput: boolean,
         ) => {
             if (this.partialCompletion) {
-                debugPartial(`Partial completion on change: ${isInput}`);
                 if (isInput) {
                     this.partialCompletion.update(true);
                 } else {

--- a/ts/packages/shell/src/renderer/src/chat/chatView.ts
+++ b/ts/packages/shell/src/renderer/src/chat/chatView.ts
@@ -26,6 +26,9 @@ import { InputChoice } from "../choicePanel";
 import { MessageGroup } from "./messageGroup";
 import { SettingsView } from "../settingsView";
 import { uint8ArrayToBase64 } from "@typeagent/common-utils";
+import registerDebug from "debug";
+
+const debugPartial = registerDebug("typeagent:shell:partial");
 
 const DynamicDisplayMinRefreshIntervalMs = 15;
 
@@ -926,7 +929,7 @@ export class ChatView {
             isInput: boolean,
         ) => {
             if (this.partialCompletion) {
-                console.log(`Partial completion on change: ${isInput}`);
+                debugPartial(`Partial completion on change: ${isInput}`);
                 if (isInput) {
                     this.partialCompletion.update(true);
                 } else {

--- a/ts/packages/shell/src/renderer/src/partial.ts
+++ b/ts/packages/shell/src/renderer/src/partial.ts
@@ -100,6 +100,12 @@ export class PartialCompletion {
                     this.searchMenu.updatePosition(state.prefix);
                 }
             } else {
+                // Reset trackers so that a future state with the same
+                // generation+prefix triggers a full render() instead of
+                // the lightweight updatePosition() (which no-ops when
+                // the menu is inactive).
+                this.lastGeneration = -1;
+                this.lastPrefix = "";
                 this.searchMenu.hide();
             }
         });

--- a/ts/packages/shell/src/renderer/src/partial.ts
+++ b/ts/packages/shell/src/renderer/src/partial.ts
@@ -16,6 +16,10 @@ import { ExpandableTextArea } from "./chat/expandableTextArea";
 const debug = registerDebug("typeagent:shell:partial");
 const debugError = registerDebug("typeagent:shell:partial:error");
 
+// Expose the debug factory so that Playwright tests (and developers in
+// DevTools) can call  __debug.enable('typeagent:*')  at runtime.
+(globalThis as any).__debug = registerDebug;
+
 function getLeafNode(node: Node, offset: number) {
     let curr = 0;
     let currNode: Node | undefined = node;
@@ -140,6 +144,7 @@ export class PartialCompletion {
         if (this.closed) {
             throw new Error("Using a closed PartialCompletion");
         }
+        debug(`update(contentChanged=${contentChanged})`);
         if (contentChanged) {
             // Normalize the input text to ensure selection at end is correct.
             this.input.getTextEntry().normalize();
@@ -167,6 +172,7 @@ export class PartialCompletion {
     }
 
     public hide() {
+        debug("hide");
         this.controller.hide();
     }
 

--- a/ts/packages/shell/src/renderer/src/partial.ts
+++ b/ts/packages/shell/src/renderer/src/partial.ts
@@ -61,6 +61,10 @@ export class PartialCompletion {
     // items) should be called on the SearchMenu.
     private lastGeneration: number = -1;
     private lastPrefix: string = "";
+    // Set when update(contentChanged=true) runs so the selectionchange
+    // handler can skip the redundant re-update that the browser fires
+    // after every content mutation.
+    private contentUpdated: boolean = false;
 
     private readonly cleanupEventListeners: () => void;
     constructor(
@@ -111,6 +115,10 @@ export class PartialCompletion {
         });
 
         const selectionChangeHandler = () => {
+            if (this.contentUpdated) {
+                this.contentUpdated = false;
+                return;
+            }
             debug("Partial completion update on selection changed");
             this.update(false);
         };
@@ -135,6 +143,9 @@ export class PartialCompletion {
         if (contentChanged) {
             // Normalize the input text to ensure selection at end is correct.
             this.input.getTextEntry().normalize();
+            // Suppress the selectionchange event that the browser fires
+            // after every content mutation — this update already covers it.
+            this.contentUpdated = true;
         }
         if (!this.isSelectionAtEnd(contentChanged)) {
             this.controller.hide();

--- a/ts/packages/shell/test/completionUpdate.spec.ts
+++ b/ts/packages/shell/test/completionUpdate.spec.ts
@@ -57,9 +57,10 @@ test.describe("Partial completion update suppression", () => {
             await input.focus();
 
             await mainWindow.keyboard.type("p", { delay: 0 });
-            await mainWindow.waitForTimeout(200);
 
-            expect(contentTrue.length).toBe(1);
+            await expect(async () => {
+                expect(contentTrue.length).toBe(1);
+            }).toPass({ timeout: 2000 });
             expect(contentFalse.length).toBe(0);
 
             await mainWindow.keyboard.press("Escape");
@@ -75,7 +76,16 @@ test.describe("Partial completion update suppression", () => {
 
             // Type first character and let it settle.
             await mainWindow.keyboard.type("p", { delay: 0 });
-            await mainWindow.waitForTimeout(200);
+
+            await expect(async () => {
+                expect(
+                    await mainWindow.evaluate(() =>
+                        document
+                            .querySelector("#phraseDiv")
+                            ?.textContent?.includes("p"),
+                    ),
+                ).toBe(true);
+            }).toPass({ timeout: 2000 });
 
             // Start collecting after the first keystroke has settled.
             const contentTrue = collectConsoleMessages(
@@ -88,9 +98,10 @@ test.describe("Partial completion update suppression", () => {
             );
 
             await mainWindow.keyboard.type("l", { delay: 0 });
-            await mainWindow.waitForTimeout(200);
 
-            expect(contentTrue.length).toBe(1);
+            await expect(async () => {
+                expect(contentTrue.length).toBe(1);
+            }).toPass({ timeout: 2000 });
             expect(contentFalse.length).toBe(0);
 
             await mainWindow.keyboard.press("Escape");
@@ -106,7 +117,16 @@ test.describe("Partial completion update suppression", () => {
 
             // Type two characters first.
             await mainWindow.keyboard.type("pl", { delay: 50 });
-            await mainWindow.waitForTimeout(200);
+
+            await expect(async () => {
+                expect(
+                    await mainWindow.evaluate(() =>
+                        document
+                            .querySelector("#phraseDiv")
+                            ?.textContent?.includes("pl"),
+                    ),
+                ).toBe(true);
+            }).toPass({ timeout: 2000 });
 
             // Start collecting after the initial typing has settled.
             const contentTrue = collectConsoleMessages(
@@ -119,9 +139,10 @@ test.describe("Partial completion update suppression", () => {
             );
 
             await mainWindow.keyboard.press("Backspace");
-            await mainWindow.waitForTimeout(200);
 
-            expect(contentTrue.length).toBe(1);
+            await expect(async () => {
+                expect(contentTrue.length).toBe(1);
+            }).toPass({ timeout: 2000 });
             expect(contentFalse.length).toBe(0);
 
             await mainWindow.keyboard.press("Escape");

--- a/ts/packages/shell/test/completionUpdate.spec.ts
+++ b/ts/packages/shell/test/completionUpdate.spec.ts
@@ -1,0 +1,130 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import test, { expect, Page } from "@playwright/test";
+import { runTestCallback } from "./testHelper";
+
+// Annotate entire file as serial.
+test.describe.configure({ mode: "serial" });
+
+const inputSelector = "#phraseDiv";
+
+/**
+ * Enables the `typeagent:shell:partial` debug namespace at runtime via
+ * the `__debug` factory exposed on globalThis by partial.ts.  Once
+ * enabled, all `debug(...)` calls in the module produce console.debug
+ * output that Playwright can intercept.
+ */
+async function enablePartialDebug(page: Page) {
+    await page.evaluate(() => {
+        const dbg = (window as any).__debug;
+        if (dbg && typeof dbg.enable === "function") {
+            dbg.enable("typeagent:shell:partial");
+        }
+    });
+}
+
+/**
+ * Collects console messages whose text includes a substring.
+ * Returns a live array that accumulates matches.
+ */
+function collectConsoleMessages(page: Page, substring: string) {
+    const messages: string[] = [];
+    page.on("console", (msg) => {
+        const text = msg.text();
+        if (text.includes(substring)) {
+            messages.push(text);
+        }
+    });
+    return messages;
+}
+
+test.describe("Partial completion update suppression", () => {
+    test("typing triggers exactly one update per keystroke", async () => {
+        await runTestCallback(async (mainWindow: Page) => {
+            await enablePartialDebug(mainWindow);
+
+            const contentTrue = collectConsoleMessages(
+                mainWindow,
+                "update(contentChanged=true)",
+            );
+            const contentFalse = collectConsoleMessages(
+                mainWindow,
+                "update(contentChanged=false)",
+            );
+
+            const input = mainWindow.locator(inputSelector);
+            await input.focus();
+
+            await mainWindow.keyboard.type("p", { delay: 0 });
+            await mainWindow.waitForTimeout(200);
+
+            expect(contentTrue.length).toBe(1);
+            expect(contentFalse.length).toBe(0);
+
+            await mainWindow.keyboard.press("Escape");
+        });
+    });
+
+    test("second keystroke also triggers exactly one update", async () => {
+        await runTestCallback(async (mainWindow: Page) => {
+            await enablePartialDebug(mainWindow);
+
+            const input = mainWindow.locator(inputSelector);
+            await input.focus();
+
+            // Type first character and let it settle.
+            await mainWindow.keyboard.type("p", { delay: 0 });
+            await mainWindow.waitForTimeout(200);
+
+            // Start collecting after the first keystroke has settled.
+            const contentTrue = collectConsoleMessages(
+                mainWindow,
+                "update(contentChanged=true)",
+            );
+            const contentFalse = collectConsoleMessages(
+                mainWindow,
+                "update(contentChanged=false)",
+            );
+
+            await mainWindow.keyboard.type("l", { delay: 0 });
+            await mainWindow.waitForTimeout(200);
+
+            expect(contentTrue.length).toBe(1);
+            expect(contentFalse.length).toBe(0);
+
+            await mainWindow.keyboard.press("Escape");
+        });
+    });
+
+    test("backspace triggers exactly one update", async () => {
+        await runTestCallback(async (mainWindow: Page) => {
+            await enablePartialDebug(mainWindow);
+
+            const input = mainWindow.locator(inputSelector);
+            await input.focus();
+
+            // Type two characters first.
+            await mainWindow.keyboard.type("pl", { delay: 50 });
+            await mainWindow.waitForTimeout(200);
+
+            // Start collecting after the initial typing has settled.
+            const contentTrue = collectConsoleMessages(
+                mainWindow,
+                "update(contentChanged=true)",
+            );
+            const contentFalse = collectConsoleMessages(
+                mainWindow,
+                "update(contentChanged=false)",
+            );
+
+            await mainWindow.keyboard.press("Backspace");
+            await mainWindow.waitForTimeout(200);
+
+            expect(contentTrue.length).toBe(1);
+            expect(contentFalse.length).toBe(0);
+
+            await mainWindow.keyboard.press("Escape");
+        });
+    });
+});

--- a/ts/packages/shell/test/partialCompletion/renderDispatch.spec.ts
+++ b/ts/packages/shell/test/partialCompletion/renderDispatch.spec.ts
@@ -51,6 +51,12 @@ function wireController(
                 menu.updatePosition(state.prefix);
             }
         } else {
+            // Reset trackers so that a future state with the same
+            // generation+prefix triggers a full render() instead of
+            // the lightweight updatePosition() (which no-ops when
+            // the menu is inactive).
+            lastGeneration = -1;
+            lastPrefix = "";
             menu.hide();
         }
     });
@@ -185,6 +191,45 @@ describe("render vs updatePosition dispatch", () => {
         // Diverge from anchor → re-fetch clears state → hide.
         controller.update("stop", "forward");
         expect(menu.hideCalls).toBeGreaterThan(hidesBefore);
+    });
+
+    test("backspace restores menu after accept-policy exhaustion", async () => {
+        // Scenario: "@shell s" shows completions, "@shell ss" exhausts
+        // the closed set (D4 ACCEPT hides menu), backspace to "@shell s"
+        // must re-show the menu via render().
+        const result = makeCompletionResult(["set", "status"], 7, {
+            separatorMode: "optionalSpace",
+            closedSet: true,
+            afterWildcard: "none",
+        });
+        const dispatcher = makeDispatcher(result);
+        const controller = createCompletionController(dispatcher);
+        const menu = new MockSearchMenu();
+        wireController(controller, menu);
+
+        // Initial fetch: "@shell " → items loaded.
+        controller.update("@shell ", "forward");
+        await Promise.resolve();
+
+        // Type "s" → prefix="s", trie has matches → render.
+        controller.update("@shell s", "forward");
+        expect(menu.renderCalls.length).toBeGreaterThan(0);
+        const rendersAfterS = menu.renderCalls.length;
+        const hidesAfterS = menu.hideCalls;
+
+        // Type "ss" → prefix="ss", no matches → D4 accept → hide.
+        controller.update("@shell ss", "forward");
+        expect(menu.hideCalls).toBeGreaterThan(hidesAfterS);
+
+        // Backspace to "s" → same generation+prefix as before the hide.
+        // Without the fix, this would call updatePosition() which no-ops
+        // because _active is false.  With the fix, trackers are reset on
+        // hide so this triggers a full render().
+        controller.update("@shell s", "backward");
+        expect(menu.renderCalls.length).toBeGreaterThan(rendersAfterS);
+        const lastRender = menu.renderCalls[menu.renderCalls.length - 1];
+        expect(lastRender.prefix).toBe("s");
+        expect(lastRender.items.length).toBeGreaterThan(0);
     });
 
     test("no redundant hide when state is already undefined", async () => {

--- a/ts/packages/shell/test/partialCompletion/renderDispatch.spec.ts
+++ b/ts/packages/shell/test/partialCompletion/renderDispatch.spec.ts
@@ -222,9 +222,8 @@ describe("render vs updatePosition dispatch", () => {
         expect(menu.hideCalls).toBeGreaterThan(hidesAfterS);
 
         // Backspace to "s" → same generation+prefix as before the hide.
-        // Without the fix, this would call updatePosition() which no-ops
-        // because _active is false.  With the fix, trackers are reset on
-        // hide so this triggers a full render().
+        // Tracker reset on hide ensures this triggers render(), not
+        // a no-op updatePosition().
         controller.update("@shell s", "backward");
         expect(menu.renderCalls.length).toBeGreaterThan(rendersAfterS);
         const lastRender = menu.renderCalls[menu.renderCalls.length - 1];


### PR DESCRIPTION
## Changes

- Improve robustness of webflow action discovery
- Add logging and per-attempt timeout to callWithRetry / embedding helpers
- Always-on retry logging + raise default fetch budget to 3 minutes
- Implement conversation (session) management in system agent
- Reasoning improvements
- Fix completion menu not restoring on backspace after exhaustion
- Suppress redundant selectionchange update and use debug trace
- Improve partial completion debug tracing and add update-suppression tests
- Replace waitForTimeout with expect().toPass() polling in Playwright tests