### PR TITLE
Harden agent process shutdown and type the control channel

### DIFF
--- a/ts/packages/agentRpc/src/common.ts
+++ b/ts/packages/agentRpc/src/common.ts
@@ -6,17 +6,17 @@ import registerDebug from "debug";
 type MessageHandler<T> = (message: Partial<T>) => void;
 type DisconnectHandler = () => void;
 
-export type SharedRpcChannel<T = any> = {
-    on(event: "message", cb: MessageHandler<T>): void;
+export type SharedRpcChannel<InT = any, OutT = any> = {
+    on(event: "message", cb: MessageHandler<InT>): void;
     on(event: "disconnect", cb: DisconnectHandler): void;
-    off(event: "message", cb: MessageHandler<T>): void;
+    off(event: "message", cb: MessageHandler<InT>): void;
     off(event: "disconnect", cb: DisconnectHandler): void;
-    send(message: T, cb?: (err: Error | null) => void): void;
+    send(message: OutT, cb?: (err: Error | null) => void): void;
 };
 
 // Compatible with ChildProcess | NodeJS.Process
-export type RpcChannel<T = any> = SharedRpcChannel<T> & {
-    once(event: "message", cb: MessageHandler<T>): void;
+export type RpcChannel<InT = any, OutT = any> = SharedRpcChannel<InT, OutT> & {
+    once(event: "message", cb: MessageHandler<InT>): void;
     once(event: "disconnect", cb: DisconnectHandler): void;
 };
 
@@ -33,7 +33,7 @@ type ChannelData = {
 export type ChannelProvider = {
     on(event: "disconnect", cb: DisconnectHandler): void;
     off(event: "disconnect", cb: DisconnectHandler): void;
-    createChannel<T = any>(name: string): RpcChannel<T>;
+    createChannel<InT = any, OutT = any>(name: string): RpcChannel<InT, OutT>;
     deleteChannel(name: string): void;
 };
 

--- a/ts/packages/agentRpc/src/server.ts
+++ b/ts/packages/agentRpc/src/server.ts
@@ -673,3 +673,5 @@ export function createAgentRpcServer(
 export type AgentInterfaceFunctionName =
     | keyof AgentInvokeFunctions
     | keyof AgentCallFunctions;
+
+export type AgentControlMessage = "exit";

--- a/ts/packages/dispatcher/nodeProviders/src/agentProvider/npmAgentProvider.ts
+++ b/ts/packages/dispatcher/nodeProviders/src/agentProvider/npmAgentProvider.ts
@@ -214,7 +214,9 @@ export function createNpmAppAgentProvider(
             }
             if (--agent.count === 0) {
                 moduleAgents.delete(appAgentName);
-                await agent.close?.();
+                if (agent.close) {
+                    await agent.close();
+                }
             }
         },
         setTraceNamespaces(namespaces: string) {

--- a/ts/packages/dispatcher/nodeProviders/src/agentProvider/npmAgentProvider.ts
+++ b/ts/packages/dispatcher/nodeProviders/src/agentProvider/npmAgentProvider.ts
@@ -213,8 +213,8 @@ export function createNpmAppAgentProvider(
                 throw new Error(`Invalid app agent: ${appAgentName}`);
             }
             if (--agent.count === 0) {
-                agent.process?.kill();
                 moduleAgents.delete(appAgentName);
+                await agent.close?.();
             }
         },
         setTraceNamespaces(namespaces: string) {

--- a/ts/packages/dispatcher/nodeProviders/src/agentProvider/process/agentProcess.ts
+++ b/ts/packages/dispatcher/nodeProviders/src/agentProvider/process/agentProcess.ts
@@ -3,7 +3,10 @@
 
 import registerDebug from "debug";
 import { AppAgent } from "@typeagent/agent-sdk";
-import { createAgentRpcServer } from "@typeagent/agent-rpc/server";
+import {
+    AgentInterfaceFunctionName,
+    createAgentRpcServer,
+} from "@typeagent/agent-rpc/server";
 import { createChannelProvider } from "@typeagent/agent-rpc/channel";
 import { createRequire } from "node:module";
 
@@ -47,7 +50,7 @@ if (typeof module.instantiate !== "function") {
 }
 
 //=================================================================
-// Instantiate agent and  Create agent RPC server
+// Instantiate agent and create agent RPC server
 //=================================================================
 const agent: AppAgent = module.instantiate();
 const channelProvider = createChannelProvider(
@@ -60,7 +63,18 @@ const { agentInterface } = createAgentRpcServer(
     channelProvider,
 );
 
-channelProvider.createChannel("initialize").send(agentInterface);
+const controlChannel = channelProvider.createChannel<
+    string,
+    AgentInterfaceFunctionName[]
+>("control");
+
+controlChannel.on("message", () => {
+    debug(
+        `Parent process requested exit, exiting '${agentName}': ${modulePath}`,
+    );
+    process.exit(0);
+});
+controlChannel.send(agentInterface);
 
 //=================================================================
 // Set up debug trace coordination

--- a/ts/packages/dispatcher/nodeProviders/src/agentProvider/process/agentProcess.ts
+++ b/ts/packages/dispatcher/nodeProviders/src/agentProvider/process/agentProcess.ts
@@ -39,6 +39,11 @@ process.on("disconnect", () => {
     process.exit(-1);
 });
 
+process.on("SIGTERM", () => {
+    debug(`SIGTERM received, exiting '${agentName}': ${modulePath}`);
+    process.exit(-2);
+});
+
 //=================================================================
 // Load the module.
 //=================================================================

--- a/ts/packages/dispatcher/nodeProviders/src/agentProvider/process/agentProcess.ts
+++ b/ts/packages/dispatcher/nodeProviders/src/agentProvider/process/agentProcess.ts
@@ -4,6 +4,7 @@
 import registerDebug from "debug";
 import { AppAgent } from "@typeagent/agent-sdk";
 import {
+    AgentControlMessage,
     AgentInterfaceFunctionName,
     createAgentRpcServer,
 } from "@typeagent/agent-rpc/server";
@@ -69,7 +70,7 @@ const { agentInterface } = createAgentRpcServer(
 );
 
 const controlChannel = channelProvider.createChannel<
-    string,
+    AgentControlMessage,
     AgentInterfaceFunctionName[]
 >("control");
 

--- a/ts/packages/dispatcher/nodeProviders/src/agentProvider/process/agentProcessShim.ts
+++ b/ts/packages/dispatcher/nodeProviders/src/agentProvider/process/agentProcessShim.ts
@@ -7,7 +7,10 @@ import { AppAgent } from "@typeagent/agent-sdk";
 import { createAgentRpcClient } from "@typeagent/agent-rpc/client";
 import { createChannelProvider } from "@typeagent/agent-rpc/channel";
 import { fileURLToPath } from "url";
-import { AgentInterfaceFunctionName } from "@typeagent/agent-rpc/server";
+import {
+    AgentControlMessage,
+    AgentInterfaceFunctionName,
+} from "@typeagent/agent-rpc/server";
 
 export type AgentProcess = {
     appAgent: AppAgent;
@@ -64,7 +67,10 @@ export async function createAgentProcess(
         agentProcess,
     );
     const traceChannel = channelProvider.createChannel("trace");
-    const channel = channelProvider.createChannel("control");
+    const channel = channelProvider.createChannel<
+        AgentInterfaceFunctionName[],
+        AgentControlMessage
+    >("control");
     const agentInterface = await new Promise<AgentInterfaceFunctionName[]>(
         (resolve, reject) => {
             channel.once("message", (message: any) => {
@@ -86,12 +92,18 @@ export async function createAgentProcess(
                 return;
             }
             await new Promise<void>((resolve) => {
-                agentProcess.once("exit", resolve);
+                let timer: NodeJS.Timeout | undefined;
+                agentProcess.once("exit", () => {
+                    if (timer !== undefined) {
+                        clearTimeout(timer);
+                    }
+                    resolve();
+                });
 
                 // Ask the child to exit gracefully via the control channel.
                 // If it doesn't exit within 1s, fall back to disconnect/kill.
                 if (agentProcess.connected) {
-                    const timer = setTimeout(() => {
+                    timer = setTimeout(() => {
                         if (agentProcess.exitCode !== null) {
                             return;
                         }
@@ -102,7 +114,13 @@ export async function createAgentProcess(
                         }
                     }, 1000);
                     timer.unref();
-                    channel.send("exit");
+                    try {
+                        channel.send("exit");
+                    } catch {
+                        // IPC channel may have closed between the
+                        // connected check and the send; the exit
+                        // event will still fire.
+                    }
                 } else {
                     agentProcess.kill();
                 }

--- a/ts/packages/dispatcher/nodeProviders/src/agentProvider/process/agentProcessShim.ts
+++ b/ts/packages/dispatcher/nodeProviders/src/agentProvider/process/agentProcessShim.ts
@@ -12,7 +12,7 @@ import { AgentInterfaceFunctionName } from "@typeagent/agent-rpc/server";
 export type AgentProcess = {
     appAgent: AppAgent;
     count: number;
-    process?: child_process.ChildProcess;
+    close?: () => Promise<void>;
     trace?: (namespaces: string) => void;
 };
 
@@ -64,18 +64,7 @@ export async function createAgentProcess(
         agentProcess,
     );
     const traceChannel = channelProvider.createChannel("trace");
-    return {
-        process: agentProcess,
-        trace: (namespaces: string) => {
-            traceChannel.send(namespaces);
-        },
-        appAgent: await initializeAgentRpcClient(agentName, channelProvider),
-        count: 1,
-    };
-}
-
-async function initializeAgentRpcClient(name: string, channelProvider: any) {
-    const channel = channelProvider.createChannel("initialize");
+    const channel = channelProvider.createChannel("control");
     const agentInterface = await new Promise<AgentInterfaceFunctionName[]>(
         (resolve, reject) => {
             channel.once("message", (message: any) => {
@@ -91,5 +80,42 @@ async function initializeAgentRpcClient(name: string, channelProvider: any) {
             });
         },
     );
-    return createAgentRpcClient(name, channelProvider, agentInterface);
+    return {
+        close: async () => {
+            if (agentProcess.exitCode !== null) {
+                return;
+            }
+            await new Promise<void>((resolve) => {
+                agentProcess.once("exit", resolve);
+
+                // Ask the child to exit gracefully via the control channel.
+                // If it doesn't exit within 1s, fall back to disconnect/kill.
+                if (agentProcess.connected) {
+                    const timer = setTimeout(() => {
+                        if (agentProcess.exitCode !== null) {
+                            return;
+                        }
+                        if (agentProcess.connected) {
+                            agentProcess.disconnect();
+                        } else {
+                            agentProcess.kill();
+                        }
+                    }, 1000);
+                    timer.unref();
+                    channel.send("exit");
+                } else {
+                    agentProcess.kill();
+                }
+            });
+        },
+        trace: (namespaces: string) => {
+            traceChannel.send(namespaces);
+        },
+        appAgent: await createAgentRpcClient(
+            agentName,
+            channelProvider,
+            agentInterface,
+        ),
+        count: 1,
+    };
 }


### PR DESCRIPTION
## Summary

Fixes agent child processes not exiting cleanly when the dispatcher closes. Hardens the shutdown sequence and adds proper typing to the IPC control channel.

## Changes

### Graceful shutdown via typed control channel
- Replaced the `initialize` IPC channel with a typed `control` channel that carries both initialization messages and shutdown commands (`AgentControlMessage = "exit"`)
- Added `InT`/`OutT` type parameters to `SharedRpcChannel`, `RpcChannel`, and `ChannelProvider.createChannel` for type-safe bidirectional messaging
- Exported `AgentControlMessage` type from `@typeagent/agent-rpc/server`

### Agent process lifecycle improvements
- **agentProcessShim.ts**: Replaced `process.kill()` with a graceful shutdown sequence:
  1. Send `"exit"` over the control channel
  2. Wait up to 1 second for the child to exit
  3. Fall back to `disconnect()` or `kill()` if the child doesn't respond
- **agentProcess.ts**: Added `SIGTERM` handler so the child process exits cleanly on signal
- **agentProcess.ts**: Added listener on the control channel for the `"exit"` message from the parent
- **npmAgentProvider.ts**: Changed from `agent.process?.kill()` to `await agent.close()` for proper async cleanup; removed direct `process` reference from `AgentProcess` type in favor of an async `close()` method