### PR TITLE
Suppress selectionchange echo in completion pipeline

### DIFF
--- a/ts/packages/dispatcher/dispatcher/src/helpers/completion/session.ts
+++ b/ts/packages/dispatcher/dispatcher/src/helpers/completion/session.ts
@@ -247,7 +247,7 @@ export class PartialCompletionSession implements CompletionController {
     ): void {
         // Deduplicate: if the input and direction haven't changed and
         // the session is already active or pending, there is no new
-        // work to do.  The shell's lastControllerInput guard prevents
+        // work to do.  The shell's previousInput guard prevents
         // selectionchange echoes from reaching here, so direction is
         // safe to compare.
         if (

--- a/ts/packages/dispatcher/dispatcher/src/helpers/completion/session.ts
+++ b/ts/packages/dispatcher/dispatcher/src/helpers/completion/session.ts
@@ -245,6 +245,20 @@ export class PartialCompletionSession implements CompletionController {
         input: string,
         direction: CompletionDirection = "forward",
     ): void {
+        // Deduplicate: if the input and direction haven't changed and
+        // the session is already active or pending, there is no new
+        // work to do.  The shell's lastControllerInput guard prevents
+        // selectionchange echoes from reaching here, so direction is
+        // safe to compare.
+        if (
+            input === this.lastInput &&
+            direction === this.lastDirection &&
+            (this.completionState !== undefined ||
+                this.completionP !== undefined)
+        ) {
+            debug(`update skipped: input unchanged ('${input}')`);
+            return;
+        }
         this.lastInput = input;
         this.lastDirection = direction;
         if (this.reuseSession(input, direction)) {

--- a/ts/packages/shell/src/renderer/src/partial.ts
+++ b/ts/packages/shell/src/renderer/src/partial.ts
@@ -139,6 +139,7 @@ export class PartialCompletion {
         if (this.closed) {
             throw new Error("Using a closed PartialCompletion");
         }
+        debug(`update entry: contentChanged=${contentChanged}`);
         if (contentChanged) {
             // Normalize the input text to ensure selection at end is correct.
             this.input.getTextEntry().normalize();
@@ -162,7 +163,7 @@ export class PartialCompletion {
             return;
         }
         debug(
-            `Partial completion input: '${input}: ${contentChanged ? "content changed" : "selection changed"}'`,
+            `Partial completion input: '${input}' (${contentChanged ? "content changed" : "selection changed"})`,
         );
 
         // Only use "backward" when the user is genuinely backspacing:

--- a/ts/packages/shell/src/renderer/src/partial.ts
+++ b/ts/packages/shell/src/renderer/src/partial.ts
@@ -65,10 +65,6 @@ export class PartialCompletion {
     // items) should be called on the SearchMenu.
     private lastGeneration: number = -1;
     private lastPrefix: string = "";
-    // Set when update(contentChanged=true) runs so the selectionchange
-    // handler can skip the redundant re-update that the browser fires
-    // after every content mutation.
-    private contentUpdated: boolean = false;
 
     private readonly cleanupEventListeners: () => void;
     constructor(
@@ -96,6 +92,9 @@ export class PartialCompletion {
         // pass them directly to avoid a redundant trie query in render().
         this.controller.setOnUpdate(() => {
             const state = this.controller.getCompletionState();
+            debug(
+                `onUpdate: ${state ? `prefix='${state.prefix}' items=${state.items.length}` : "hidden"}`,
+            );
             if (state) {
                 if (
                     state.generation !== this.lastGeneration ||
@@ -119,10 +118,6 @@ export class PartialCompletion {
         });
 
         const selectionChangeHandler = () => {
-            if (this.contentUpdated) {
-                this.contentUpdated = false;
-                return;
-            }
             debug("Partial completion update on selection changed");
             this.update(false);
         };
@@ -144,20 +139,31 @@ export class PartialCompletion {
         if (this.closed) {
             throw new Error("Using a closed PartialCompletion");
         }
-        debug(`update(contentChanged=${contentChanged})`);
         if (contentChanged) {
             // Normalize the input text to ensure selection at end is correct.
             this.input.getTextEntry().normalize();
-            // Suppress the selectionchange event that the browser fires
-            // after every content mutation — this update already covers it.
-            this.contentUpdated = true;
         }
         if (!this.isSelectionAtEnd(contentChanged)) {
+            this.previousInput = "";
             this.controller.hide();
+            debug("update: selection not at end, hiding");
             return;
         }
         const input = this.getCurrentInputForCompletion();
-        debug(`Partial completion input: '${input}'`);
+
+        // Skip if input hasn't changed since the last call we forwarded
+        // to the controller.  This prevents selectionchange echoes from
+        // recomputing direction against the already-mutated previousInput
+        // (which would flip "backward" to "forward").
+        // Reset to "" on hide (cursor moved away) so re-focus always
+        // re-activates the controller.
+        if (input === this.previousInput) {
+            debug(`update skipped: input unchanged ('${input}')`);
+            return;
+        }
+        debug(
+            `Partial completion input: '${input}: ${contentChanged ? "content changed" : "selection changed"}'`,
+        );
 
         // Only use "backward" when the user is genuinely backspacing:
         // the new input must be a strict prefix of the previous input.

--- a/ts/packages/shell/test/completionUpdate.spec.ts
+++ b/ts/packages/shell/test/completionUpdate.spec.ts
@@ -48,9 +48,17 @@ test.describe("Partial completion update suppression", () => {
                 mainWindow,
                 "content changed",
             );
-            const onUpdateCalls = collectConsoleMessages(
+            const updateEntries = collectConsoleMessages(
                 mainWindow,
-                "onUpdate:",
+                "update entry:",
+            );
+            const updateSkipped = collectConsoleMessages(
+                mainWindow,
+                "update skipped:",
+            );
+            const updateHidden = collectConsoleMessages(
+                mainWindow,
+                "selection not at end",
             );
 
             const input = mainWindow.locator(inputSelector);
@@ -65,9 +73,13 @@ test.describe("Partial completion update suppression", () => {
             // Wait a beat for any straggling selectionchange echoes.
             await mainWindow.waitForTimeout(500);
 
-            // The controller should have fired onUpdate at most once
-            // for this keystroke (the dedup guard suppresses echoes).
-            expect(onUpdateCalls.length).toBeLessThanOrEqual(1);
+            // Every update() call must either be the content-change
+            // path, deduped by the previousInput guard, or hidden
+            // because selection moved away from the end.  No call
+            // may slip through to recompute direction.
+            expect(updateEntries.length).toBe(
+                contentTrue.length + updateSkipped.length + updateHidden.length,
+            );
 
             await mainWindow.keyboard.press("Escape");
         });
@@ -98,9 +110,17 @@ test.describe("Partial completion update suppression", () => {
                 mainWindow,
                 "content changed",
             );
-            const onUpdateCalls = collectConsoleMessages(
+            const updateEntries = collectConsoleMessages(
                 mainWindow,
-                "onUpdate:",
+                "update entry:",
+            );
+            const updateSkipped = collectConsoleMessages(
+                mainWindow,
+                "update skipped:",
+            );
+            const updateHidden = collectConsoleMessages(
+                mainWindow,
+                "selection not at end",
             );
 
             await mainWindow.keyboard.type("l", { delay: 0 });
@@ -112,9 +132,11 @@ test.describe("Partial completion update suppression", () => {
             // Wait a beat for any straggling selectionchange echoes.
             await mainWindow.waitForTimeout(500);
 
-            // The controller should have fired onUpdate at most once
-            // for this keystroke.
-            expect(onUpdateCalls.length).toBeLessThanOrEqual(1);
+            // Every update() call must either be the content-change
+            // path, deduped by the previousInput guard, or hidden.
+            expect(updateEntries.length).toBe(
+                contentTrue.length + updateSkipped.length + updateHidden.length,
+            );
 
             await mainWindow.keyboard.press("Escape");
         });
@@ -145,9 +167,17 @@ test.describe("Partial completion update suppression", () => {
                 mainWindow,
                 "content changed",
             );
-            const onUpdateCalls = collectConsoleMessages(
+            const updateEntries = collectConsoleMessages(
                 mainWindow,
-                "onUpdate:",
+                "update entry:",
+            );
+            const updateSkipped = collectConsoleMessages(
+                mainWindow,
+                "update skipped:",
+            );
+            const updateHidden = collectConsoleMessages(
+                mainWindow,
+                "selection not at end",
             );
 
             await mainWindow.keyboard.press("Backspace");
@@ -159,9 +189,11 @@ test.describe("Partial completion update suppression", () => {
             // Wait a beat for any straggling selectionchange echoes.
             await mainWindow.waitForTimeout(500);
 
-            // The controller should have fired onUpdate at most once
-            // for this keystroke.
-            expect(onUpdateCalls.length).toBeLessThanOrEqual(1);
+            // Every update() call must either be the content-change
+            // path, deduped by the previousInput guard, or hidden.
+            expect(updateEntries.length).toBe(
+                contentTrue.length + updateSkipped.length + updateHidden.length,
+            );
 
             await mainWindow.keyboard.press("Escape");
         });

--- a/ts/packages/shell/test/completionUpdate.spec.ts
+++ b/ts/packages/shell/test/completionUpdate.spec.ts
@@ -40,17 +40,17 @@ function collectConsoleMessages(page: Page, substring: string) {
 }
 
 test.describe("Partial completion update suppression", () => {
-    test("typing triggers exactly one update per keystroke", async () => {
+    test("typing triggers exactly one content-change update per keystroke", async () => {
         await runTestCallback(async (mainWindow: Page) => {
             await enablePartialDebug(mainWindow);
 
             const contentTrue = collectConsoleMessages(
                 mainWindow,
-                "update(contentChanged=true)",
+                "content changed",
             );
-            const contentFalse = collectConsoleMessages(
+            const onUpdateCalls = collectConsoleMessages(
                 mainWindow,
-                "update(contentChanged=false)",
+                "onUpdate:",
             );
 
             const input = mainWindow.locator(inputSelector);
@@ -61,13 +61,19 @@ test.describe("Partial completion update suppression", () => {
             await expect(async () => {
                 expect(contentTrue.length).toBe(1);
             }).toPass({ timeout: 2000 });
-            expect(contentFalse.length).toBe(0);
+
+            // Wait a beat for any straggling selectionchange echoes.
+            await mainWindow.waitForTimeout(500);
+
+            // The controller should have fired onUpdate at most once
+            // for this keystroke (the dedup guard suppresses echoes).
+            expect(onUpdateCalls.length).toBeLessThanOrEqual(1);
 
             await mainWindow.keyboard.press("Escape");
         });
     });
 
-    test("second keystroke also triggers exactly one update", async () => {
+    test("second keystroke also triggers exactly one content-change update", async () => {
         await runTestCallback(async (mainWindow: Page) => {
             await enablePartialDebug(mainWindow);
 
@@ -90,11 +96,11 @@ test.describe("Partial completion update suppression", () => {
             // Start collecting after the first keystroke has settled.
             const contentTrue = collectConsoleMessages(
                 mainWindow,
-                "update(contentChanged=true)",
+                "content changed",
             );
-            const contentFalse = collectConsoleMessages(
+            const onUpdateCalls = collectConsoleMessages(
                 mainWindow,
-                "update(contentChanged=false)",
+                "onUpdate:",
             );
 
             await mainWindow.keyboard.type("l", { delay: 0 });
@@ -102,13 +108,19 @@ test.describe("Partial completion update suppression", () => {
             await expect(async () => {
                 expect(contentTrue.length).toBe(1);
             }).toPass({ timeout: 2000 });
-            expect(contentFalse.length).toBe(0);
+
+            // Wait a beat for any straggling selectionchange echoes.
+            await mainWindow.waitForTimeout(500);
+
+            // The controller should have fired onUpdate at most once
+            // for this keystroke.
+            expect(onUpdateCalls.length).toBeLessThanOrEqual(1);
 
             await mainWindow.keyboard.press("Escape");
         });
     });
 
-    test("backspace triggers exactly one update", async () => {
+    test("backspace triggers exactly one content-change update", async () => {
         await runTestCallback(async (mainWindow: Page) => {
             await enablePartialDebug(mainWindow);
 
@@ -131,11 +143,11 @@ test.describe("Partial completion update suppression", () => {
             // Start collecting after the initial typing has settled.
             const contentTrue = collectConsoleMessages(
                 mainWindow,
-                "update(contentChanged=true)",
+                "content changed",
             );
-            const contentFalse = collectConsoleMessages(
+            const onUpdateCalls = collectConsoleMessages(
                 mainWindow,
-                "update(contentChanged=false)",
+                "onUpdate:",
             );
 
             await mainWindow.keyboard.press("Backspace");
@@ -143,7 +155,13 @@ test.describe("Partial completion update suppression", () => {
             await expect(async () => {
                 expect(contentTrue.length).toBe(1);
             }).toPass({ timeout: 2000 });
-            expect(contentFalse.length).toBe(0);
+
+            // Wait a beat for any straggling selectionchange echoes.
+            await mainWindow.waitForTimeout(500);
+
+            // The controller should have fired onUpdate at most once
+            // for this keystroke.
+            expect(onUpdateCalls.length).toBeLessThanOrEqual(1);
 
             await mainWindow.keyboard.press("Escape");
         });

--- a/ts/packages/shell/test/partialCompletion/renderDispatch.spec.ts
+++ b/ts/packages/shell/test/partialCompletion/renderDispatch.spec.ts
@@ -86,7 +86,29 @@ describe("render vs updatePosition dispatch", () => {
         expect(menu.updatePositionCalls.length).toBe(0);
     });
 
-    test("same generation + same prefix calls updatePosition", async () => {
+    test("same input + direction is deduplicated (no callback)", async () => {
+        const result = makeCompletionResult(["song", "shuffle"], 4, {
+            separatorMode: "optionalSpace",
+        });
+        const dispatcher = makeDispatcher(result);
+        const controller = createCompletionController(dispatcher);
+        const menu = new MockSearchMenu();
+        wireController(controller, menu);
+
+        controller.update("play", "forward");
+        await Promise.resolve();
+
+        const rendersBefore = menu.renderCalls.length;
+        const updatePosBefore = menu.updatePositionCalls.length;
+
+        // Same input, same direction — controller skips entirely.
+        controller.update("play", "forward");
+
+        expect(menu.renderCalls.length).toBe(rendersBefore);
+        expect(menu.updatePositionCalls.length).toBe(updatePosBefore);
+    });
+
+    test("same input + different direction calls updatePosition", async () => {
         const result = makeCompletionResult(["song", "shuffle"], 4, {
             separatorMode: "optionalSpace",
         });
@@ -100,8 +122,8 @@ describe("render vs updatePosition dispatch", () => {
 
         const rendersBefore = menu.renderCalls.length;
 
-        // Same input — same generation, same prefix.
-        controller.update("play", "forward");
+        // Same input, different direction — passes dedup, reuse triggers updatePosition.
+        controller.update("play", "backward");
 
         expect(menu.renderCalls.length).toBe(rendersBefore);
         expect(menu.updatePositionCalls.length).toBe(1);


### PR DESCRIPTION
Suppresses redundant `update()` calls in the shell partial completion pipeline that were caused by `selectionchange` events firing after every content mutation, and adds a matching dedup guard in the dispatcher's `PartialCompletionSession`.

## Changes

- **shell/src/renderer/src/partial.ts**: Replace the `contentUpdated` flag (which suppressed the next selectionchange after a content mutation) with a `previousInput`-based guard. This correctly skips selectionchange echoes without flipping the computed direction (`backward` → `forward`) when the input string hasn't actually changed. Reset on hide so re-focus re-activates the controller.
- **dispatcher/src/helpers/completion/session.ts**: Mirror the dedup at the controller level — skip if `input` and `direction` match the last call and a session is already active or pending.
- Updated debug strings (`update entry:`, `content changed`, `update skipped:`, `selection not at end`) for clearer tracing.
- Tests updated to assert the invariant: every `update()` entry is accounted for as a content-change, a dedup skip, or a hide.
- Added `renderDispatch` test for the new "same input + different direction" path.

## Commits

- Suppress selectionchange echo in completion pipeline
- Address review feedback on selectionchange dedup