### PR TITLE
Implement clientIO stubs on Shell

### DIFF
--- a/ts/packages/agentServer/docs/multi-client-interactions.md
+++ b/ts/packages/agentServer/docs/multi-client-interactions.md
@@ -167,13 +167,43 @@ interactionCancelled(interactionId): void {
 
 The abort reasons distinguish resolved vs. cancelled so the client can print the appropriate notice.
 
-## Shell Implementation Notes
+## Shell Implementation
 
-The Shell (`main.ts`) is not yet implemented (stubs in place). The same pattern applies: hold a `Map<interactionId, AbortController>` and call `abort()` from `interactionResolved`/`interactionCancelled`. The UI (modal dialog or inline card) should be dismissed programmatically and a toast shown if resolved by a remote client.
+The Shell (`main.ts`) implements the same `AbortController` pattern as the CLI. `registerClient()` holds a `Map<string, AbortController>` (called `activeInteractions`) scoped to the session. Each interaction is registered on `requestInteraction` and removed after the user responds or the interaction is dismissed.
+
+### `requestInteraction`
+
+Creates an `AbortController`, registers it in `activeInteractions`, and fires an async IIFE that calls `chatView.showInteractionQuestion()` (for `question`) or `chatView.proposeAction()` (for `proposeAction`). On success it calls `chatView.respondToInteraction(response)`. On abort it distinguishes known abort reasons (`{ kind: "resolved-by-other" }` / `"cancelled"`) from unexpected errors and logs the latter.
+
+`chatView.showInteractionQuestion()` renders the prompt inline in the chat scroll region using `ChoicePanel`. For binary `["Yes", "No"]` choices it reuses the same icon elements as the standalone `askYesNo()` path for visual consistency. All other choice sets render a numbered button panel. The method accepts an `AbortSignal` and dismisses the panel — appending a `[answered by another client]` or `[interaction cancelled]` inline notice — when the signal fires.
+
+### `interactionResolved` and `interactionCancelled`
+
+```typescript
+interactionResolved(interactionId): void {
+    const ac = activeInteractions.get(interactionId);
+    if (ac) {
+        activeInteractions.delete(interactionId);
+        ac.abort({ kind: "resolved-by-other" });
+    }
+},
+interactionCancelled(interactionId): void {
+    const ac = activeInteractions.get(interactionId);
+    if (ac) {
+        activeInteractions.delete(interactionId);
+        ac.abort("cancelled");
+    }
+},
+```
+
+### Standalone mode
+
+When the Shell runs its own dispatcher (not connected to an agent-server), `question()` is called directly on the renderer `ClientIO` — not via `requestInteraction`. In this path `showInteractionQuestion()` is called with `interactionId: ""` and no `AbortSignal`, since there are no other clients that could call `interactionResolved`/`interactionCancelled`.
+
+`popupQuestion` interactions (no `requestId`) use a synthesised `clientRequestId` with the `agent-interaction-` prefix, which triggers auto-creation of a standalone `MessageGroup` in the chat with no user bubble.
 
 ## Future Work
 
-- **Shell `question` support**: implement `requestInteraction` in `main.ts` using the same AbortController pattern as the CLI.
 - **`proposeAction` in CLI**: render the structured template editor inline in the terminal.
 - **Stable client identity**: allow a reconnecting client to reclaim its old `connectionId` so in-flight interactions are re-broadcast rather than orphaned (see `TODO` in `sharedDispatcher.ts` `join()`).
 - **Freeform text input**: add a `textInput` interaction type for open-ended questions where the agent needs a free-form string from the user (e.g. "What name should I use?"). This would follow the same broadcast-and-race pattern as `question`, with a `{ type: "textInput"; message: string; defaultValue?: string }` request and a `{ type: "textInput"; value: string }` response. A precedent exists in `typeagent/src/chat.ts` (`ChatUserInterface.getInput()`) and `knowledgeProcessor` which use this pattern outside the dispatcher layer.

--- a/ts/packages/shell/src/renderer/src/chat/chatView.ts
+++ b/ts/packages/shell/src/renderer/src/chat/chatView.ts
@@ -823,7 +823,8 @@ export class ChatView {
         const effectiveRequestId =
             requestId ??
             ({
-                requestId: `interaction-${interaction.interactionId}`,
+                requestId: "",
+                clientRequestId: `agent-interaction-${interaction.interactionId}`,
             } as RequestId);
 
         const agentMessage = this.ensureAgentMessage({
@@ -876,25 +877,6 @@ export class ChatView {
         }
 
         return new Promise<number>((resolve, reject) => {
-            const onAbort = () => {
-                choicePanel.remove();
-                // Append a dismissal notice inline in the message bubble.
-                const reason = signal?.reason;
-                const text =
-                    reason &&
-                    typeof reason === "object" &&
-                    reason.kind === "resolved-by-other"
-                        ? "answered by another client"
-                        : "interaction cancelled";
-                agentMessage.setMessage(`[${text}]`, source, "inline");
-                // signal is guaranteed non-null here: onAbort is only registered
-                // via signal?.addEventListener, so it can only fire when signal
-                // is defined.
-                reject(signal!.reason);
-            };
-
-            signal?.addEventListener("abort", onAbort, { once: true });
-
             // addChoicePanel removes the panel automatically on selection, but
             // we need the ChoicePanel reference for the abort path.  We capture
             // it by reaching into the ChoicePanel constructor directly here.
@@ -912,6 +894,31 @@ export class ChatView {
                     resolve(choice.value as number);
                 },
             );
+
+            const onAbort = () => {
+                choicePanel.remove();
+                // Append a dismissal notice inline in the message bubble.
+                const reason = signal?.reason;
+                const text =
+                    reason &&
+                    typeof reason === "object" &&
+                    reason.kind === "resolved-by-other"
+                        ? "answered by another client"
+                        : "interaction cancelled";
+                agentMessage.setMessage(`  [${text}]`, source, "inline");
+                // signal is guaranteed non-null here: onAbort is only registered
+                // when signal is defined (either via addEventListener or the
+                // already-aborted check below).
+                reject(signal!.reason);
+            };
+
+            if (signal?.aborted) {
+                // Signal was already aborted before we could register — dismiss
+                // the panel immediately rather than leaving it permanently open.
+                onAbort();
+            } else {
+                signal?.addEventListener("abort", onAbort, { once: true });
+            }
 
             this.updateScroll();
         });

--- a/ts/packages/shell/src/renderer/src/chat/chatView.ts
+++ b/ts/packages/shell/src/renderer/src/chat/chatView.ts
@@ -17,12 +17,13 @@ import {
     Dispatcher,
     IAgentMessage,
     NotifyExplainedData,
+    PendingInteractionRequest,
     RequestId,
     TemplateEditConfig,
 } from "agent-dispatcher";
 
 import { PartialCompletion } from "../partial";
-import { InputChoice } from "../choicePanel";
+import { ChoicePanel, InputChoice } from "../choicePanel";
 import { MessageGroup } from "./messageGroup";
 import { SettingsView } from "../settingsView";
 import { uint8ArrayToBase64 } from "@typeagent/common-utils";
@@ -141,7 +142,7 @@ export class ChatView {
         };
     }
 
-    private getDispatcher(): Dispatcher {
+    public getDispatcher(): Dispatcher {
         if (this._dispatcher === undefined) {
             throw new Error("Dispatcher is not initialized");
         }
@@ -783,6 +784,127 @@ export class ChatView {
         });
         this.updateScroll();
         return p;
+    }
+
+    /**
+     * Show an inline choice panel for a deferred interaction question.
+     *
+     * This is the unified entry point for both yes/no and multi-choice prompts
+     * arriving via the `requestInteraction` deferred-broadcast path (connected
+     * mode). The former `askYesNoWithContext` / `popupQuestion` distinction no
+     * longer exists at the protocol level — both arrive as a `"question"`
+     * interaction with an explicit `choices` array.
+     *
+     * For the binary `["Yes", "No"]` case we reuse the existing `askYesNo` UI.
+     * All other choice sets render a numbered button panel inline.
+     *
+     * @param interaction The full pending interaction request.
+     * @param signal      AbortSignal that dismisses the panel when another
+     *                    client answers or the server cancels the interaction.
+     */
+    public async showInteractionQuestion(
+        interaction: Extract<PendingInteractionRequest, { type: "question" }>,
+        signal?: AbortSignal,
+    ): Promise<number> {
+        const { requestId, message, choices, defaultId } = interaction;
+        const source = interaction.source ?? "";
+
+        const effectiveRequestId =
+            requestId ??
+            ({
+                requestId: `interaction-${interaction.interactionId}`,
+            } as RequestId);
+
+        const agentMessage = this.ensureAgentMessage({
+            message: "",
+            requestId: effectiveRequestId,
+            source,
+        });
+        if (agentMessage === undefined) {
+            throw new Error(
+                `Could not create agent message for interaction ${interaction.interactionId}`,
+            );
+        }
+        agentMessage.setMessage(message, source, "inline");
+
+        // Build InputChoice[] for all choices.  For the binary ["Yes","No"] case
+        // reuse the same icon elements that askYesNo() uses so the panel looks
+        // identical — but we keep the panel reference here so the AbortSignal
+        // can remove it when another client answers or the server cancels.
+        const isYesNo =
+            choices.length === 2 && choices[0] === "Yes" && choices[1] === "No";
+
+        const inputChoices: InputChoice[] = isYesNo
+            ? [
+                  {
+                      text: "Yes",
+                      element: iconCheckMarkCircle(),
+                      selectKey: ["Enter"],
+                      value: 0,
+                  },
+                  {
+                      text: "No",
+                      element: iconX(),
+                      selectKey: ["Delete"],
+                      value: 1,
+                  },
+              ]
+            : choices.map((label, index) => ({
+                  text: label,
+                  element: (() => {
+                      const span = document.createElement("span");
+                      span.textContent = String(index + 1);
+                      return span;
+                  })(),
+                  selectKey: [String(index + 1)],
+                  value: index,
+              }));
+
+        // Mark the default choice with an additional Enter key binding.
+        if (!isYesNo && defaultId !== undefined && inputChoices[defaultId]) {
+            inputChoices[defaultId].selectKey = [
+                ...(inputChoices[defaultId].selectKey ?? []),
+                "Enter",
+            ];
+        }
+
+        return new Promise<number>((resolve, reject) => {
+            const onAbort = () => {
+                choicePanel.remove();
+                // Append a dismissal notice inline in the message bubble.
+                const reason = signal?.reason;
+                const text =
+                    reason &&
+                    typeof reason === "object" &&
+                    reason.kind === "resolved-by-other"
+                        ? "answered by another client"
+                        : "interaction cancelled";
+                agentMessage.setMessage(`[${text}]`, source, "inline");
+                reject(signal!.reason);
+            };
+
+            signal?.addEventListener("abort", onAbort, { once: true });
+
+            // addChoicePanel removes the panel automatically on selection, but
+            // we need the ChoicePanel reference for the abort path.  We capture
+            // it by reaching into the ChoicePanel constructor directly here.
+            const choicePanel = new ChoicePanel(
+                agentMessage.getMessageDiv(),
+                inputChoices,
+                (choice: InputChoice) => {
+                    signal?.removeEventListener("abort", onAbort);
+                    choicePanel.remove();
+                    agentMessage.setMessage(
+                        `  ${choice.text}`,
+                        source,
+                        "inline",
+                    );
+                    resolve(choice.value as number);
+                },
+            );
+
+            this.updateScroll();
+        });
     }
 
     public showChoice(

--- a/ts/packages/shell/src/renderer/src/chat/chatView.ts
+++ b/ts/packages/shell/src/renderer/src/chat/chatView.ts
@@ -18,6 +18,7 @@ import {
     IAgentMessage,
     NotifyExplainedData,
     PendingInteractionRequest,
+    PendingInteractionResponse,
     RequestId,
     TemplateEditConfig,
 } from "agent-dispatcher";
@@ -142,7 +143,7 @@ export class ChatView {
         };
     }
 
-    public getDispatcher(): Dispatcher {
+    private getDispatcher(): Dispatcher {
         if (this._dispatcher === undefined) {
             throw new Error("Dispatcher is not initialized");
         }
@@ -787,6 +788,15 @@ export class ChatView {
     }
 
     /**
+     * Creates a numbered span element for use as a choice button label.
+     */
+    private static makeNumberSpan(n: number): HTMLSpanElement {
+        const span = document.createElement("span");
+        span.textContent = String(n);
+        return span;
+    }
+
+    /**
      * Show an inline choice panel for a deferred interaction question.
      *
      * This is the unified entry point for both yes/no and multi-choice prompts
@@ -795,8 +805,9 @@ export class ChatView {
      * longer exists at the protocol level — both arrive as a `"question"`
      * interaction with an explicit `choices` array.
      *
-     * For the binary `["Yes", "No"]` case we reuse the existing `askYesNo` UI.
-     * All other choice sets render a numbered button panel inline.
+     * For the binary `["Yes", "No"]` case we reuse the same icon elements as
+     * `askYesNo()` for visual consistency.  All other choice sets render a
+     * numbered button panel inline.
      *
      * @param interaction The full pending interaction request.
      * @param signal      AbortSignal that dismisses the panel when another
@@ -851,11 +862,7 @@ export class ChatView {
               ]
             : choices.map((label, index) => ({
                   text: label,
-                  element: (() => {
-                      const span = document.createElement("span");
-                      span.textContent = String(index + 1);
-                      return span;
-                  })(),
+                  element: ChatView.makeNumberSpan(index + 1),
                   selectKey: [String(index + 1)],
                   value: index,
               }));
@@ -880,6 +887,9 @@ export class ChatView {
                         ? "answered by another client"
                         : "interaction cancelled";
                 agentMessage.setMessage(`[${text}]`, source, "inline");
+                // signal is guaranteed non-null here: onAbort is only registered
+                // via signal?.addEventListener, so it can only fire when signal
+                // is defined.
                 reject(signal!.reason);
             };
 
@@ -975,6 +985,18 @@ export class ChatView {
             actionTemplates,
         );
     }
+
+    /**
+     * Forwards a client interaction response to the dispatcher.
+     * Delegates to `Dispatcher.respondToInteraction` while keeping the
+     * dispatcher reference private to ChatView.
+     */
+    public respondToInteraction(
+        response: PendingInteractionResponse,
+    ): Promise<void> {
+        return this.getDispatcher().respondToInteraction(response);
+    }
+
     public setVoiceMode(enabled: boolean): void {
         if (enabled) {
             document.body.classList.add("voice-mode");

--- a/ts/packages/shell/src/renderer/src/main.ts
+++ b/ts/packages/shell/src/renderer/src/main.ts
@@ -367,7 +367,16 @@ function registerClient(
                             value,
                         };
                     } else {
-                        const requestId = interaction.requestId!;
+                        const requestId = interaction.requestId;
+                        if (requestId === undefined) {
+                            console.error(
+                                `[requestInteraction] proposeAction interaction ${interaction.interactionId} has no requestId — skipping`,
+                            );
+                            activeInteractions.delete(
+                                interaction.interactionId,
+                            );
+                            return;
+                        }
                         const value = await chatView.proposeAction(
                             requestId,
                             interaction.actionTemplates,

--- a/ts/packages/shell/src/renderer/src/main.ts
+++ b/ts/packages/shell/src/renderer/src/main.ts
@@ -23,7 +23,12 @@ import { CameraView } from "./cameraView";
 import { createWebSocket, webapi } from "./webSocketAPI";
 import * as jose from "jose";
 import { AppAgentEvent } from "@typeagent/agent-sdk";
-import { ClientIO, Dispatcher, RequestId } from "agent-dispatcher";
+import {
+    ClientIO,
+    Dispatcher,
+    PendingInteractionResponse,
+    RequestId,
+} from "agent-dispatcher";
 import { swapContent } from "./setContent";
 import { remoteSearchMenuUIOnCompletion } from "./searchMenuUI/remoteSearchMenuUI";
 import { ChatInput } from "./chat/chatInput";
@@ -139,6 +144,10 @@ function registerClient(
     cameraView: CameraView,
     chatHistoryReady: Promise<void>,
 ) {
+    // Tracks open deferred interaction prompts so they can be dismissed when
+    // another client answers or the server cancels the interaction.
+    const activeInteractions = new Map<string, AbortController>();
+
     const clientIO: ClientIO = {
         clear: () => {
             chatView.clear();
@@ -193,21 +202,25 @@ function registerClient(
                 nextRefreshMs,
             );
         },
-        question: async (requestId, message, choices) => {
-            // For binary Yes/No with a known requestId, delegate to the existing chatView UI.
-            if (
-                requestId !== undefined &&
-                choices.length === 2 &&
-                choices[0] === "Yes" &&
-                choices[1] === "No"
-            ) {
-                const yes = await chatView.askYesNo(requestId, message, "");
-                return yes ? 0 : 1;
+        question: async (requestId, message, choices, defaultId) => {
+            if (requestId !== undefined) {
+                // Route through the unified interaction question UI which handles
+                // both binary Yes/No and arbitrary multi-choice prompts.
+                return chatView.showInteractionQuestion({
+                    interactionId: "",
+                    type: "question",
+                    requestId,
+                    source: "",
+                    timestamp: Date.now(),
+                    message,
+                    choices,
+                    defaultId,
+                });
             }
-            // General multi-choice and broadcast (no requestId) are not yet implemented
-            // in the Shell renderer — the main process handles those via dialog.showMessageBox.
+            // No requestId — main process should have handled this via
+            // dialog.showMessageBox before it reached the renderer.
             throw new Error(
-                "Main process should have handled multi-choice question",
+                "Main process should have handled question with no requestId",
             );
         },
         requestChoice: (
@@ -320,24 +333,64 @@ function registerClient(
         closeLocalView: async () => {
             throw new Error("Main process should have handled closeLocalView");
         },
-        requestInteraction: () => {
-            // TODO: Implement deferred interaction support for agent-server connect mode.
-            // When the shell connects to a SharedDispatcher, requestInteraction is pushed
-            // from the server. Without handling it, the server-side promise hangs for the
-            // full 10-minute timeout before resolving with the defaultId (question) or
-            // rejecting (proposeAction).
-            //
-            // The fix (Option A): on requestInteraction, dispatch into the existing
-            // chatView.askYesNo / chatView.proposeAction / dialog.showMessageBox UI (all
-            // already implemented for direct mode), await the result, then call
-            // dispatcher.respondToInteraction({ interactionId, type, value }). Hold a
-            // Map<interactionId, cancelFn> and dismiss open prompts on interactionCancelled.
+        requestInteraction: (interaction) => {
+            const ac = new AbortController();
+            activeInteractions.set(interaction.interactionId, ac);
+            (async () => {
+                let response: PendingInteractionResponse;
+                try {
+                    if (interaction.type === "question") {
+                        const value = await chatView.showInteractionQuestion(
+                            interaction,
+                            ac.signal,
+                        );
+                        response = {
+                            interactionId: interaction.interactionId,
+                            type: "question",
+                            value,
+                        };
+                    } else {
+                        const requestId = interaction.requestId!;
+                        const value = await chatView.proposeAction(
+                            requestId,
+                            interaction.actionTemplates,
+                            interaction.source,
+                        );
+                        response = {
+                            interactionId: interaction.interactionId,
+                            type: "proposeAction",
+                            value,
+                        };
+                    }
+                } catch {
+                    // Aborted by interactionResolved / interactionCancelled —
+                    // the UI has already been dismissed.
+                    activeInteractions.delete(interaction.interactionId);
+                    return;
+                }
+                activeInteractions.delete(interaction.interactionId);
+                try {
+                    await chatView
+                        .getDispatcher()
+                        .respondToInteraction(response);
+                } catch {
+                    // Interaction may have already timed out on the server.
+                }
+            })();
         },
-        interactionResolved: () => {
-            // Shell does not yet support deferred interactions
+        interactionResolved: (interactionId) => {
+            const ac = activeInteractions.get(interactionId);
+            if (ac) {
+                activeInteractions.delete(interactionId);
+                ac.abort({ kind: "resolved-by-other" });
+            }
         },
-        interactionCancelled: () => {
-            // Shell does not yet support deferred interactions
+        interactionCancelled: (interactionId) => {
+            const ac = activeInteractions.get(interactionId);
+            if (ac) {
+                activeInteractions.delete(interactionId);
+                ac.abort("cancelled");
+            }
         },
         takeAction: (_, action, data) => {
             // Android object gets injected on Android devices, otherwise unavailable
@@ -780,6 +833,11 @@ function registerClient(
     };
 
     getClientAPI().registerClient(client);
+
+    // Expose the clientIO object on window for integration tests so that tests
+    // can trigger requestInteraction / interactionResolved / interactionCancelled
+    // without requiring a live agent-server connection.
+    (window as any).__clientIO__ = clientIO;
 }
 
 function showNotifications(

--- a/ts/packages/shell/src/renderer/src/main.ts
+++ b/ts/packages/shell/src/renderer/src/main.ts
@@ -3,6 +3,15 @@
 
 /// <reference path="../../lib/lib.android.d.ts" />
 
+// Augment Window with the test hook exposed by registerClient() so that
+// Playwright tests can inject interactions without requiring a live
+// agent-server connection.
+declare global {
+    interface Window {
+        __clientIO__?: import("agent-dispatcher").ClientIO;
+    }
+}
+
 import {
     ClientAPI,
     NotifyCommands,
@@ -202,10 +211,18 @@ function registerClient(
                 nextRefreshMs,
             );
         },
+        // Called only in standalone mode (shell running its own dispatcher).
+        // In connected mode the SharedDispatcher implements question() by
+        // assigning an interactionId and broadcasting requestInteraction() to
+        // all connected clients — so the shell receives requestInteraction(),
+        // not question(), when attached to an agent-server.
         question: async (requestId, message, choices, defaultId) => {
             if (requestId !== undefined) {
                 // Route through the unified interaction question UI which handles
                 // both binary Yes/No and arbitrary multi-choice prompts.
+                // interactionId is left empty because this path has no
+                // server-assigned lifecycle — there are no other clients that
+                // could call interactionResolved/Cancelled for this prompt.
                 return chatView.showInteractionQuestion({
                     interactionId: "",
                     type: "question",
@@ -362,17 +379,27 @@ function registerClient(
                             value,
                         };
                     }
-                } catch {
-                    // Aborted by interactionResolved / interactionCancelled —
-                    // the UI has already been dismissed.
+                } catch (e) {
+                    // Expected: aborted by interactionResolved / interactionCancelled.
+                    // The abort reason is either { kind: "resolved-by-other" } or
+                    // the string "cancelled".  Anything else is unexpected and logged.
+                    const isKnownAbort =
+                        e === "cancelled" ||
+                        (e !== null &&
+                            typeof e === "object" &&
+                            (e as any).kind === "resolved-by-other");
+                    if (!isKnownAbort) {
+                        console.error(
+                            `[requestInteraction] unexpected error for ${interaction.interactionId}:`,
+                            e,
+                        );
+                    }
                     activeInteractions.delete(interaction.interactionId);
                     return;
                 }
                 activeInteractions.delete(interaction.interactionId);
                 try {
-                    await chatView
-                        .getDispatcher()
-                        .respondToInteraction(response);
+                    await chatView.respondToInteraction(response);
                 } catch {
                     // Interaction may have already timed out on the server.
                 }
@@ -837,7 +864,7 @@ function registerClient(
     // Expose the clientIO object on window for integration tests so that tests
     // can trigger requestInteraction / interactionResolved / interactionCancelled
     // without requiring a live agent-server connection.
-    (window as any).__clientIO__ = clientIO;
+    window.__clientIO__ = clientIO;
 }
 
 function showNotifications(

--- a/ts/packages/shell/src/renderer/src/messageContainer.ts
+++ b/ts/packages/shell/src/renderer/src/messageContainer.ts
@@ -270,6 +270,10 @@ export class MessageContainer {
         return this.messageDiv.innerText;
     }
 
+    public getMessageDiv() {
+        return this.messageDiv;
+    }
+
     public setMessage(
         content: DisplayContent,
         source: string,

--- a/ts/packages/shell/test/interactionUI.spec.ts
+++ b/ts/packages/shell/test/interactionUI.spec.ts
@@ -1,0 +1,210 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+/**
+ * Playwright integration tests for shell deferred-interaction UI.
+ *
+ * These tests exercise the `requestInteraction` / `interactionResolved` /
+ * `interactionCancelled` handlers that were implemented in main.ts to give the
+ * shell parity with the CLI's connected-mode interaction support.
+ *
+ * The tests use `window.__clientIO__` — exposed by registerClient() in main.ts
+ * — to simulate the server pushing interaction events without requiring a live
+ * agent-server connection.
+ *
+ * Background: when the shell connects to a SharedDispatcher (agent-server), the
+ * server broadcasts `requestInteraction` to every connected client.  The first
+ * client to call `respondToInteraction` wins; the server then broadcasts
+ * `interactionResolved` (or `interactionCancelled` on timeout) to tell the
+ * remaining clients to dismiss their open prompts.
+ *
+ * The unified `"question"` interaction type covers both yes/no and multi-choice
+ * prompts — the `askYesNoWithContext` / `popupQuestion` distinction only exists
+ * at the SessionContext helper layer, not in the protocol.
+ */
+
+import test, { expect, Page } from "@playwright/test";
+import { runTestCallback } from "./testHelper";
+
+// Annotate entire file as serial — interactions share renderer state.
+test.describe.configure({ mode: "serial" });
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/**
+ * Inject a `requestInteraction` call into the renderer via the test hook.
+ * Returns immediately (fire-and-forget, matching the real server behaviour).
+ */
+async function pushInteraction(
+    page: Page,
+    id: string,
+    choices: string[],
+    message = "Are you sure?",
+): Promise<void> {
+    await page.evaluate(
+        ({ id, choices, message }) => {
+            const clientIO = (window as any).__clientIO__;
+            if (!clientIO) throw new Error("__clientIO__ not exposed");
+            clientIO.requestInteraction({
+                interactionId: id,
+                type: "question",
+                message,
+                choices,
+                requestId: { requestId: `test-req-${id}` },
+                source: "test",
+                timestamp: Date.now(),
+            });
+        },
+        { id, choices, message },
+    );
+}
+
+/** Simulate the server telling this client that another client already answered. */
+async function resolveInteraction(page: Page, id: string): Promise<void> {
+    await page.evaluate((id) => {
+        (window as any).__clientIO__?.interactionResolved(id, 0);
+    }, id);
+}
+
+/** Simulate the server cancelling an interaction (e.g. timeout). */
+async function cancelInteraction(page: Page, id: string): Promise<void> {
+    await page.evaluate((id) => {
+        (window as any).__clientIO__?.interactionCancelled(id);
+    }, id);
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+test.describe("Shell deferred-interaction UI", () => {
+    test("binary yes/no question renders Yes and No buttons", async ({}) => {
+        await runTestCallback(async (page: Page) => {
+            await pushInteraction("int-yesno-1", ["Yes", "No"]);
+
+            // The Yes/No choice panel should appear inside the chat scroll region.
+            const choicePanel = page.locator(".choice-panel").first();
+            await choicePanel.waitFor({ state: "visible", timeout: 5000 });
+
+            // Both choice buttons should be present.
+            const buttons = choicePanel.locator(".choice-button");
+            await expect(buttons).toHaveCount(2);
+        });
+    });
+
+    test("multi-choice question renders all choice buttons", async ({}) => {
+        await runTestCallback(async (page: Page) => {
+            await pushInteraction("int-multi-1", ["Alpha", "Beta", "Gamma"]);
+
+            const choicePanel = page.locator(".choice-panel").last();
+            await choicePanel.waitFor({ state: "visible", timeout: 5000 });
+
+            const buttons = choicePanel.locator(".choice-button");
+            await expect(buttons).toHaveCount(3);
+        });
+    });
+
+    test("clicking a choice button dismisses the panel", async ({}) => {
+        await runTestCallback(async (page: Page) => {
+            await pushInteraction("int-click-1", ["Yes", "No"]);
+
+            const choicePanel = page.locator(".choice-panel").last();
+            await choicePanel.waitFor({ state: "visible", timeout: 5000 });
+
+            // Click the first choice button (Yes).
+            await choicePanel.locator(".choice-button").first().click();
+
+            // The panel should be removed from the DOM.
+            await choicePanel.waitFor({ state: "detached", timeout: 5000 });
+        });
+    });
+
+    test("interactionResolved dismisses the pending panel", async ({}) => {
+        await runTestCallback(async (page: Page) => {
+            await pushInteraction("int-resolved-1", ["Yes", "No"]);
+
+            const choicePanel = page.locator(".choice-panel").last();
+            await choicePanel.waitFor({ state: "visible", timeout: 5000 });
+
+            // Simulate another client answering.
+            await resolveInteraction(page, "int-resolved-1");
+
+            // The panel should disappear.
+            await choicePanel.waitFor({ state: "detached", timeout: 5000 });
+
+            // A dismissal notice should appear in the chat.
+            await expect(
+                page.locator("text=answered by another client").last(),
+            ).toBeVisible({ timeout: 5000 });
+        });
+    });
+
+    test("interactionCancelled dismisses the pending panel", async ({}) => {
+        await runTestCallback(async (page: Page) => {
+            await pushInteraction("int-cancel-1", ["Yes", "No"]);
+
+            const choicePanel = page.locator(".choice-panel").last();
+            await choicePanel.waitFor({ state: "visible", timeout: 5000 });
+
+            // Simulate the server cancelling (e.g. timeout).
+            await cancelInteraction(page, "int-cancel-1");
+
+            // The panel should disappear.
+            await choicePanel.waitFor({ state: "detached", timeout: 5000 });
+
+            // A cancellation notice should appear in the chat.
+            await expect(
+                page.locator("text=interaction cancelled").last(),
+            ).toBeVisible({ timeout: 5000 });
+        });
+    });
+
+    test("resolving an unknown interactionId is a no-op and does not throw", async ({}) => {
+        await runTestCallback(async (page: Page) => {
+            const result = await page.evaluate(() => {
+                try {
+                    (window as any).__clientIO__?.interactionResolved(
+                        "no-such-id",
+                        0,
+                    );
+                    return "ok";
+                } catch (e: any) {
+                    return `error: ${e.message}`;
+                }
+            });
+            expect(result).toBe("ok");
+        });
+    });
+
+    test("cancelling an unknown interactionId is a no-op and does not throw", async ({}) => {
+        await runTestCallback(async (page: Page) => {
+            const result = await page.evaluate(() => {
+                try {
+                    (window as any).__clientIO__?.interactionCancelled(
+                        "no-such-id",
+                    );
+                    return "ok";
+                } catch (e: any) {
+                    return `error: ${e.message}`;
+                }
+            });
+            expect(result).toBe("ok");
+        });
+    });
+
+    test("resolving one interaction does not affect a concurrent one", async ({}) => {
+        await runTestCallback(async (page: Page) => {
+            // Start two interactions simultaneously.
+            await pushInteraction("int-concurrent-A", ["Yes", "No"]);
+            await pushInteraction("int-concurrent-B", ["Yes", "No"]);
+
+            // Wait for both panels to appear.
+            const panels = page.locator(".choice-panel");
+            await expect(panels).toHaveCount(2, { timeout: 5000 });
+
+            // Resolve A (answered by another client).
+            await resolveInteraction(page, "int-concurrent-A");
+
+            // B should still be visible.
+            await expect(panels).toHaveCount(1, { timeout: 5000 });
+        });
+    });
+});

--- a/ts/packages/shell/test/interactionUI.spec.ts
+++ b/ts/packages/shell/test/interactionUI.spec.ts
@@ -50,7 +50,6 @@ async function pushInteraction(
                 type: "question",
                 message,
                 choices,
-                requestId: { requestId: `test-req-${id}` },
                 source: "test",
                 timestamp: Date.now(),
             });

--- a/ts/packages/shell/test/interactionUI.spec.ts
+++ b/ts/packages/shell/test/interactionUI.spec.ts
@@ -78,7 +78,7 @@ async function cancelInteraction(page: Page, id: string): Promise<void> {
 test.describe("Shell deferred-interaction UI", () => {
     test("binary yes/no question renders Yes and No buttons", async ({}) => {
         await runTestCallback(async (page: Page) => {
-            await pushInteraction("int-yesno-1", ["Yes", "No"]);
+            await pushInteraction(page, "int-yesno-1", ["Yes", "No"]);
 
             // The Yes/No choice panel should appear inside the chat scroll region.
             const choicePanel = page.locator(".choice-panel").first();
@@ -92,7 +92,11 @@ test.describe("Shell deferred-interaction UI", () => {
 
     test("multi-choice question renders all choice buttons", async ({}) => {
         await runTestCallback(async (page: Page) => {
-            await pushInteraction("int-multi-1", ["Alpha", "Beta", "Gamma"]);
+            await pushInteraction(page, "int-multi-1", [
+                "Alpha",
+                "Beta",
+                "Gamma",
+            ]);
 
             const choicePanel = page.locator(".choice-panel").last();
             await choicePanel.waitFor({ state: "visible", timeout: 5000 });
@@ -104,7 +108,7 @@ test.describe("Shell deferred-interaction UI", () => {
 
     test("clicking a choice button dismisses the panel", async ({}) => {
         await runTestCallback(async (page: Page) => {
-            await pushInteraction("int-click-1", ["Yes", "No"]);
+            await pushInteraction(page, "int-click-1", ["Yes", "No"]);
 
             const choicePanel = page.locator(".choice-panel").last();
             await choicePanel.waitFor({ state: "visible", timeout: 5000 });
@@ -119,7 +123,7 @@ test.describe("Shell deferred-interaction UI", () => {
 
     test("interactionResolved dismisses the pending panel", async ({}) => {
         await runTestCallback(async (page: Page) => {
-            await pushInteraction("int-resolved-1", ["Yes", "No"]);
+            await pushInteraction(page, "int-resolved-1", ["Yes", "No"]);
 
             const choicePanel = page.locator(".choice-panel").last();
             await choicePanel.waitFor({ state: "visible", timeout: 5000 });
@@ -139,7 +143,7 @@ test.describe("Shell deferred-interaction UI", () => {
 
     test("interactionCancelled dismisses the pending panel", async ({}) => {
         await runTestCallback(async (page: Page) => {
-            await pushInteraction("int-cancel-1", ["Yes", "No"]);
+            await pushInteraction(page, "int-cancel-1", ["Yes", "No"]);
 
             const choicePanel = page.locator(".choice-panel").last();
             await choicePanel.waitFor({ state: "visible", timeout: 5000 });
@@ -193,8 +197,8 @@ test.describe("Shell deferred-interaction UI", () => {
     test("resolving one interaction does not affect a concurrent one", async ({}) => {
         await runTestCallback(async (page: Page) => {
             // Start two interactions simultaneously.
-            await pushInteraction("int-concurrent-A", ["Yes", "No"]);
-            await pushInteraction("int-concurrent-B", ["Yes", "No"]);
+            await pushInteraction(page, "int-concurrent-A", ["Yes", "No"]);
+            await pushInteraction(page, "int-concurrent-B", ["Yes", "No"]);
 
             // Wait for both panels to appear.
             const panels = page.locator(".choice-panel");


### PR DESCRIPTION
<img width="1046" height="283" alt="image" src="https://github.com/user-attachments/assets/c04ca317-614b-4c3b-844b-b100c45eff7c" />
<img width="459" height="176" alt="image" src="https://github.com/user-attachments/assets/c4d577e4-6e4a-40f0-931e-57e78d5e3c91" />

  **When the shell is connected to an agent-server, agents can now ask the user questions and wait for a response — matching behavior that already existed in the CLI.** Previously, any agent-initiated prompt
  (yes/no confirmation, multi-choice question) would silently hang for 10 minutes before timing out, because the shell's handlers were unimplemented stubs.

  The shell now renders these prompts inline in the chat view using the existing choice panel UI, and correctly handles the multi-client case: if another connected client (e.g. the CLI) answers first, the
  shell dismisses its own panel and shows a "[answered by another client]" notice. Server-side cancellations (e.g. timeout) similarly dismiss the panel with an "[interaction cancelled]" notice. Both binary
  yes/no and arbitrary multi-choice questions are handled through a single unified code path, consistent with the protocol unification introduced in PR #2194.