### PR TITLE
actionGrammar: unified backtrack chain + per-axis match policies

### DIFF
--- a/ts/docs/architecture/actionGrammar.md
+++ b/ts/docs/architecture/actionGrammar.md
@@ -662,6 +662,84 @@ text `"mx"`. This applies equally to forward and backward directions.
    keyword word plus a partial match of the second, and offers `"by"`.
    The function honors `spacingMode` for inter-word separator matching.
 
+**Per-axis exploration policies (`GrammarMatchOptions` / `GrammarCompletionOptions`):**
+
+The matcher and completion both accept three independent
+policy options that control how each fork point in the grammar
+is explored:
+
+- `wildcardPolicy: "exhaustive" | "shortest"` — wildcard capture
+  length. `"exhaustive"` (default) emits a result for every viable
+  capture length; `"shortest"` commits to the shortest viable
+  capture along each path.
+- `optionalPolicy: "exhaustive" | "preferTake" | "preferSkip"` —
+  optional groups `(...)?`. Non-`exhaustive` values pick a side
+  first and skip enumerating the other when it succeeds (regex
+  `?` vs. `??`).
+- `repeatPolicy: "exhaustive" | "greedy" | "nonGreedy"` —
+  repetition `(...)*` / `(...)+` (regex `+` vs. `+?`).
+
+All three default to `"exhaustive"` so callers receive every valid
+parse. Non-exhaustive values are first-success commitments along
+that axis only; the other axes are still explored normally.
+
+**Why `wildcardPolicy: "shortest"` matters for completion.** By
+default, completion enumerates every wildcard-length alternative
+the matcher accumulates, surfacing candidates for every viable
+wildcard boundary. With ambiguous grammars this can produce
+spurious completions: for `play <name> by <artist>` and input
+`"play hello by world"`, the longest-wildcard alternative captures
+`name="hello by world"` and emits `"by"` as a fresh completion at
+the end of input — even though `"by"` is already the literal
+terminator matched at a shorter wildcard length.
+
+Under `wildcardPolicy: "shortest"`, completion stops enumerating
+wildcard alternatives for a state as soon as one alternative
+reaches end-of-meaningful-input. Two sub-cases qualify:
+
+1. **Clean finalize** — `matchState`/`finalizeState` consumed every
+   non-separator character (the exact-match success path, the
+   partial-clean path with only trailing separators, or a pending
+   end-of-rule wildcard that captured the tail).
+2. **Dirty partial with separator-only pending wildcard** — the
+   pending wildcard's start is at-or-past the last non-separator
+   character (e.g. `"play This Train by "` — `name="This Train"`,
+   literal `"by"` matched, `<artist>` pending at the trailing space).
+   `getWildcardStr` rejects the empty capture so `finalizeState`
+   returns false, but the rule has already reached end-of-input and
+   emitted a useful property completion. Extending the previous
+   wildcard further would only re-emit the just-matched literal as
+   a spurious completion.
+
+This is the policy the cache layer uses for grammar-driven
+completion (`grammarStore.ts`) — only the leftmost-shortest
+interpretation of each rule is needed to drive prefix and
+`afterWildcard` detection. The completion side honors the option
+with the broader end-of-input criterion above because completion
+emits useful candidates from partial attempts (not only from full
+successes as the matcher does).
+
+**Implementation: explicit-stack DFS with a unified backtrack chain.**
+
+Both `matchGrammar` and `matchGrammarCompletion` drive a single
+mutable `MatchState` that walks parts left-to-right; whenever a
+fork point is encountered (optional skip-vs-take, alternation,
+repeat continue-vs-stop, or wildcard length refinement) all-but-
+one branch are pushed onto `state.backtracks` — a LIFO
+linked list of `Backtrack` snapshots, each tagged with a
+`BacktrackOrigin` (`"wildcard" | "optional" | "alternation" |
+"repeat"`). `tryNextBacktrack` pops the most-recently-pushed
+frame (rightmost / deepest in DFS order) and restores it via
+`Object.assign`, replacing the live state in place. This is the
+explicit-stack DFS of the parse forest: left-to-right match,
+right-to-left (LIFO) backtrack.
+
+After every successful parse, `suppressBacktracksAfterSuccess`
+walks the entire chain and drops frames whose origin axis is
+non-exhaustive — for example, with `wildcardPolicy: "shortest"`
+it removes every `"wildcard"`-origin frame, including those owned
+by sibling alternation states deeper in the chain.
+
 **Why direction matters — reconsidering the last matched part:**
 
 The `direction` parameter (`"forward"` or `"backward"`) is provided by

--- a/ts/packages/actionGrammar/src/grammarCompletion.ts
+++ b/ts/packages/actionGrammar/src/grammarCompletion.ts
@@ -9,6 +9,7 @@ import {
     type MatchState,
     type PendingWildcard,
     type SeparatorMode,
+    type GrammarMatchOptions,
     separatorRegExpStr,
     requiresSeparator,
     isBoundarySatisfied,
@@ -17,9 +18,12 @@ import {
     createValue,
     finalizeState,
     finalizeNestedRule,
-    matchState,
     initialMatchState,
     leadingSpacingMode,
+    matchState,
+    cloneMatchState,
+    suppressBacktracksAfterSuccess,
+    tryNextBacktrack,
 } from "./grammarMatcher.js";
 
 const debugCompletion = registerDebug("typeagent:grammar:completion");
@@ -376,7 +380,7 @@ function getGrammarCompletionProperty(
 ): GrammarCompletionProperty | undefined {
     const temp = { ...state };
 
-    while (finalizeNestedRule(temp, undefined, true)) {}
+    while (finalizeNestedRule(temp, true)) {}
     if (temp.valueIds === null) {
         // valueId would have been undefined
         throw new Error(
@@ -1154,6 +1158,7 @@ function collectCandidates(
     input: string,
     minPrefixLength: number | undefined,
     direction: "forward" | "backward" | undefined,
+    matchOptions: GrammarMatchOptions | undefined,
 ): CompletionContext {
     const ctx: CompletionContext = {
         input,
@@ -1165,22 +1170,32 @@ function collectCandidates(
         deferredShadowCandidates: [],
     };
 
-    // Seed the work-list with one MatchState per top-level grammar rule.
-    // matchState may push additional states (for nested rules, optional
-    // parts, wildcard extensions, repeat groups) during processing.
-    const pending = initialMatchState(grammar);
+    // Seed the live MatchState for rule 0; rules 1..N-1 are
+    // pre-pushed onto its `backtracks` chain by
+    // `initialMatchState`.  Each fork site (optional skip,
+    // nested-rule alternation, repeat continuation) pushes its
+    // alternative onto the live state's `backtracks` rather
+    // than a global work-list.
+    const state = initialMatchState(grammar, matchOptions);
+    if (state === undefined) {
+        return ctx;
+    }
 
-    while (pending.length > 0) {
-        const state = pending.pop()!;
+    const wildcardShortest = state.wildcardPolicy === "shortest";
 
-        // Attempt to greedily match as many grammar parts as possible
-        // against the prefix.  `matched` is true only when ALL parts in
-        // the rule (including nested rules) were satisfied.  matchState
-        // may also push new derivative states onto `pending` (e.g. for
-        // alternative nested rules, optional-skip paths, wildcard
-        // extensions, repeat iterations).
-        const matched = matchState(state, input, pending);
-
+    // Single-axis drain: process one match attempt, collect
+    // candidates per category, then advance to the next backtrack
+    // frame.  Wildcard refinements (origin "wildcard") and
+    // structural alternatives (origin "optional"/"alternation"/
+    // "repeat") share the same LIFO chain — see
+    // `pushBacktrack` / `tryNextBacktrack`.
+    //
+    // We process every attempt (success and failure), unlike the
+    // matcher which only emits results on success — a failed
+    // attempt is a partial match that produces completion
+    // candidates for the next expected part.
+    do {
+        const matched = matchState(state, input);
         // Save the pending wildcard before finalizeState clears it.
         // Needed for backward completion of wildcards at the end of a rule.
         const savedPendingWildcard: PendingWildcard | undefined =
@@ -1189,14 +1204,13 @@ function collectCandidates(
         // Snapshot the state BEFORE finalizeState mutates it.  When
         // backward backs up past a wildcard captured by finalizeState,
         // we need the pre-capture state so the property completion
-        // does not include the backed-up wildcard's value.
-        // Shallow copy is sufficient: finalizeState only reassigns
-        // primitive fields (pendingWildcard, index) and appends to the
-        // .values linked list.  The linked-list nodes themselves are
-        // immutable once created, so the snapshot and the mutated state
-        // share .values/.parent chains safely.
+        // does not include the backed-up wildcard's value.  Use
+        // `cloneMatchState` to drop `backtracks` — the live
+        // chain will be mutated by the next iteration.
         const preFinalizeState: MatchState | undefined =
-            savedPendingWildcard !== undefined ? { ...state } : undefined;
+            savedPendingWildcard !== undefined
+                ? cloneMatchState(state)
+                : undefined;
 
         // finalizeState does two things:
         //   1. If a wildcard is pending at the end, attempt to capture
@@ -1213,18 +1227,43 @@ function collectCandidates(
                     preFinalizeState,
                     savedPendingWildcard,
                 );
-                continue;
+            } else {
+                processCleanPartial(
+                    ctx,
+                    state,
+                    preFinalizeState,
+                    savedPendingWildcard,
+                );
             }
-            processCleanPartial(
-                ctx,
-                state,
-                preFinalizeState,
-                savedPendingWildcard,
-            );
+            // After a successful path through this state, drop
+            // backtrack frames whose origin axis is configured to
+            // commit on first success.  Under wildcardPolicy:
+            // "shortest", this ALSO drops "wildcard"-origin frames
+            // belonging to sibling states deeper in the chain —
+            // preventing the sibling-rescue spurious completion
+            // class of bug.
+            // See `suppressBacktracksAfterSuccess`.
+            suppressBacktracksAfterSuccess(state);
         } else {
             processDirtyPartial(ctx, state, matched);
+            // Even for a dirty partial, if the pending wildcard
+            // starts at-or-past the last non-separator character
+            // (capture region is separator-only), the state has
+            // reached end-of-meaningful-input and any longer-
+            // wildcard alternative would re-emit the just-matched
+            // literal terminator as a spurious completion.
+            // Suppress per-policy frames as if it were a clean
+            // success.
+            if (
+                wildcardShortest &&
+                savedPendingWildcard !== undefined &&
+                nextNonSeparatorIndex(input, savedPendingWildcard.start) ===
+                    input.length
+            ) {
+                suppressBacktracksAfterSuccess(state);
+            }
         }
-    }
+    } while (tryNextBacktrack(state));
 
     return ctx;
 }
@@ -1717,18 +1756,34 @@ function materializeCandidates(
     };
 }
 
+// Alias for `GrammarMatchOptions` from `grammarMatcher`.  Re-exported
+// here so completion callers don't need to reach across modules for
+// what is structurally the same option set, but kept as a distinct
+// type alias so the two surfaces can diverge without churning
+// callers.  Use this when a partial match against the full input is
+// sufficient and the caller does not need ambiguous wildcard
+// placements enumerated.
+export type GrammarCompletionOptions = GrammarMatchOptions;
+
 export function matchGrammarCompletion(
     grammar: Grammar,
     input: string,
     minPrefixLength?: number,
     direction?: "forward" | "backward",
+    options?: GrammarCompletionOptions,
 ): GrammarCompletionResult {
     debugCompletion(
         `Start completion for input ${direction ?? "forward"}: "${input}"`,
     );
 
     // Phase 1 (collect)
-    const ctx = collectCandidates(grammar, input, minPrefixLength, direction);
+    const ctx = collectCandidates(
+        grammar,
+        input,
+        minPrefixLength,
+        direction,
+        options,
+    );
     // Phase 2 (finalize): wildcard anchors, shadows, EOI
     finalizeCandidates(ctx);
     // Phase 3 (materialize): convert candidates to final completions/properties

--- a/ts/packages/actionGrammar/src/grammarMatcher.ts
+++ b/ts/packages/actionGrammar/src/grammarMatcher.ts
@@ -9,6 +9,7 @@ import escapeMatch from "regexp.escape";
 import {
     Grammar,
     GrammarPart,
+    GrammarRule,
     RulesPart,
     StringPart,
     StringPartRegExpEntry,
@@ -179,7 +180,184 @@ export type PendingWildcard = {
     readonly valueId: number | undefined;
 };
 
-export type MatchState = {
+// Per-axis exploration policies.  Each policy controls how the
+// matcher resolves an ambiguity along a single axis: what to do
+// when more than one parse is viable at a given fork point.
+//
+// All three default to `"exhaustive"` so callers receive every
+// valid parse.  The non-default values are first-success
+// commitments — the matcher picks one branch and abandons the
+// other(s) without enumerating them.
+
+/**
+ * Wildcard capture-length policy.
+ *
+ * Wildcards (`<name>`, `$(name)`) are inherently ambiguous: a
+ * wildcard followed by a literal can absorb any prefix of the
+ * remaining input that still leaves the literal matchable.  This
+ * policy decides whether to enumerate every viable length or
+ * commit to the shortest.
+ *
+ *   - `"exhaustive"` (default): emit a separate result for every
+ *     viable wildcard capture length.  Callers rank the results
+ *     (e.g. by `wildcardCharCount` or `matchedValueCount`).
+ *   - `"shortest"`: each traversal path commits to the shortest
+ *     viable wildcard capture; longer-wildcard alternatives for
+ *     that path are not enumerated.  Other axes (alternation,
+ *     optional, repeat) are still explored normally — only the
+ *     wildcard-length axis is collapsed.
+ */
+export type WildcardPolicy = "exhaustive" | "shortest";
+
+/**
+ * Optional-group take-vs-skip policy for `(...)?`.
+ *
+ *   - `"exhaustive"` (default): try both taking and skipping the
+ *     optional group; return all parses.
+ *   - `"preferTake"`: try take first; if it succeeds, do not
+ *     enumerate the skip alternative.  Equivalent to regex `?`.
+ *   - `"preferSkip"`: try skip first; if it succeeds, do not
+ *     enumerate the take alternative.  Equivalent to regex `??`.
+ */
+export type OptionalPolicy = "exhaustive" | "preferTake" | "preferSkip";
+
+/**
+ * Repetition-count policy for `(...)*` / `(...)+`.
+ *
+ *   - `"exhaustive"` (default): return all valid repetition counts.
+ *   - `"greedy"`: take the longest match first; if a parse
+ *     succeeds at that count, do not enumerate shorter counts.
+ *     Equivalent to regex `+`.
+ *   - `"nonGreedy"`: take the shortest valid match first; if a
+ *     parse succeeds at that count, do not enumerate longer
+ *     counts.  Equivalent to regex `+?`.
+ */
+export type RepeatPolicy = "exhaustive" | "greedy" | "nonGreedy";
+
+export type GrammarMatchOptions = {
+    /** See {@link WildcardPolicy}.  Defaults to `"exhaustive"`. */
+    wildcardPolicy?: WildcardPolicy;
+
+    /** See {@link OptionalPolicy}.  Defaults to `"exhaustive"`. */
+    optionalPolicy?: OptionalPolicy;
+
+    /** See {@link RepeatPolicy}.  Defaults to `"exhaustive"`. */
+    repeatPolicy?: RepeatPolicy;
+};
+
+// Origin tag carried on each Backtrack frame.  Used by
+// `suppressBacktracksAfterSuccess` to apply per-axis policy
+// (`wildcardPolicy` / `optionalPolicy` / `repeatPolicy`) when
+// pruning unexplored siblings after a successful parse.  The tag
+// does NOT affect drain order — that is purely LIFO push order.
+//
+// `"wildcard"` frames are pushed by `captureWildcard` to enable
+// extending a wildcard capture to a strictly longer length.
+// `"optional"`, `"alternation"`, and `"repeat"` frames are pushed
+// at structural fork points (skip-vs-take, alternation rules,
+// repeat continue-vs-stop).
+//
+// All four origins live on the SAME LIFO chain so a single drain
+// loop services every kind of backtrack uniformly.  Within a
+// single rule, a wildcard captured at part i lands BELOW any
+// frames pushed by parts > i, so DFS naturally exhausts (or
+// abandons) downstream alternatives before reconsidering the
+// upstream wildcard length.
+export type BacktrackOrigin =
+    | "wildcard"
+    | "optional"
+    | "alternation"
+    | "repeat";
+
+// Persistent linked-list of unexplored DFS branches (most recent
+// push at head).  Each frame snapshots a sibling parse path or a
+// wildcard refinement point.  Restoring a frame replaces the live
+// state via `Object.assign` (see `tryNextBacktrack`).
+//
+// This IS the explicit DFS stack: `matchState` walks parts
+// left-to-right mutating the live state in place; whenever a fork
+// is encountered, all-but-one branch are pushed here and
+// `tryNextBacktrack` pops them in right-to-left (LIFO) order
+// to backtrack.  Per-fork sibling ORDER (which branch goes live
+// vs. onto the stack) is policy-controlled (see
+// `optionalPolicy` / `repeatPolicy`).
+//
+// Single-owner invariant: only the live state may own frames;
+// `PendingMatchState` omits this field.
+//
+// Discriminated union by `origin`:
+//   - `"alternation"` frames are COMPRESSED: a single cursor frame
+//     represents all N-1 sibling alternatives at one fork point.
+//     Restoring the cursor overlays a per-rule override
+//     (`name/parts/value/spacingMode`) onto a shared `base`
+//     snapshot and advances `cursor`; the frame stays at the head
+//     of the chain until all alternatives have been restored, then
+//     unlinks.
+//   - The other three origins (`wildcard`/`optional`/`repeat`)
+//     each carry a full `SnapshotState` and unlink on restore.
+// See `pushBacktrack` / `pushAlternation` / `tryNextBacktrack`.
+type SingleBacktrack = {
+    readonly snapshot: SnapshotState;
+    readonly origin: "wildcard" | "optional" | "repeat";
+    readonly prev: Backtrack | undefined;
+};
+
+// Per-alternative state at one alternation fork point is fully
+// derivable from the rule itself (`parts`/`value`/`spacingMode`)
+// plus a debug `name` — nothing else differs across siblings.
+// The cursor frame stores a direct reference to the existing
+// `GrammarRule[]` (no copy) and a single `namePrefix` string;
+// `tryNextBacktrack` builds `namePrefix + "[" + cursor + "]"` and
+// reads `rules[cursor].parts/value/spacingMode` lazily on restore.
+// Eliminates per-alternative allocation entirely — N-way alternation
+// pushes 1 frame + 1 base snapshot regardless of N.
+type AlternationBacktrack = {
+    readonly origin: "alternation";
+    readonly base: SnapshotState;
+    readonly rules: ReadonlyArray<GrammarRule>;
+    readonly namePrefix: string; // debug name = `${namePrefix}[${cursor}]`
+    // Mutable cursor advanced by `tryNextBacktrack` on each restore;
+    // single-owner contract on the chain guarantees no other state
+    // observes intermediate values.  Starts at 1 (rule 0 is the
+    // live alternative); the frame unlinks once `cursor` reaches
+    // `rules.length`.
+    cursor: number;
+    readonly prev: Backtrack | undefined;
+};
+
+type Backtrack = SingleBacktrack | AlternationBacktrack;
+
+// Strict variant of `PendingMatchState` used as the snapshot payload
+// inside `Backtrack`.  The `-?` mapped modifier forces every
+// optional field to be a required own property so that
+// `Object.assign` in `tryNextBacktrack` reliably resets fields
+// that may have been assigned AFTER the snapshot was taken (e.g.
+// `values` after the captured wildcard is committed, or `parent`
+// after entering a nested rule).
+//
+// `captureSnapshot` returns this type, so adding a new field to
+// `PendingMatchState` without listing it in `captureSnapshot` is a
+// compile error.
+//
+// Audit points when adding a new MatchState field:
+//   1. `captureSnapshot` (this file) — must list the new field;
+//      this mapped type makes omitting it a compile error.
+//   2. `wildcardFrameSnapshot.spec.ts` — extend coverage if the
+//      field can be assigned AFTER a wildcard frame is pushed.
+type SnapshotState = { [K in keyof PendingMatchState]-?: PendingMatchState[K] };
+
+// Snapshot shape used as the payload of `Backtrack` frames
+// and as the return type of `forkMatchState` / `captureSnapshot`.
+// This is the base shape of a match state; the live `MatchState`
+// extends it with the mutating `backtracks` chain plus the
+// per-axis policy fields.
+//
+// Single-owner backtrack-chain invariant is enforced at the type
+// level: `PendingMatchState` has no `backtracks` field, so
+// snapshots cannot smuggle a parallel chain into a restored state.
+// Use `forkMatchState` (returns `SnapshotState`) at every push
+// site.
+export type PendingMatchState = {
     // Current context
     name: string; // For debugging
     parts: GrammarPart[];
@@ -194,7 +372,14 @@ export type MatchState = {
 
     nestedLevel: number; // for debugging
 
-    inRepeat?: boolean | undefined; // true when re-entering a repeat group after a successful match
+    // Single-use suppression flag for the optional-fork block in
+    // `matchState`.  Set on snapshots whose restore must skip the
+    // optional take/skip fork for the part at `partIndex` because
+    // the take/skip decision has already been made by the snapshot
+    // creator (repeat-continue re-entry, or a `preferSkip` take
+    // frame).  `matchState` clears it immediately after the fork
+    // block, so the flag never influences a subsequent part.
+    suppressOptionalFork?: boolean | undefined;
 
     spacingMode: CompiledSpacingMode; // active spacing mode for this rule
 
@@ -228,6 +413,291 @@ export type MatchState = {
           }
         | undefined;
 };
+
+export type MatchState = PendingMatchState & {
+    // Head of the linked-list stack of resumable backtrack frames
+    // (most recent first).  See `Backtrack` above.  Single
+    // chain covers both wildcard refinement (origin "wildcard")
+    // and structural alternatives (origin "optional" |
+    // "alternation" | "repeat").
+    //
+    // Mutation contract: external callers that clone a MatchState
+    // and expect it to remain stable across later matcher operations
+    // MUST drop this field on the clone.  Use `cloneMatchState`
+    // rather than spreading directly to enforce this at one site.
+    //
+    // Single-owner invariant: only the live state currently being
+    // driven by `matchGrammar`/`matchGrammarCompletion` may own
+    // frames.  States queued on a `PendingMatchState[]` work-list
+    // statically cannot — enforced by the `PendingMatchState` type
+    // (which omits this field).
+    backtracks?: Backtrack | undefined;
+
+    // Per-axis policies.  Set once at `initialMatchState` time and
+    // never changed.  Deliberately NOT in `PendingMatchState` /
+    // `SnapshotState` — `Object.assign` of a snapshot won't overwrite
+    // them, so they persist across `tryNextBacktrack` restores.
+    wildcardPolicy: WildcardPolicy;
+    optionalPolicy: OptionalPolicy;
+    repeatPolicy: RepeatPolicy;
+};
+
+// Explicit per-field copy of `state`.  Single source of truth
+// shared by every backtrack-frame push site (`captureWildcard`,
+// optional skip/take, alternation, repeat continue) and by the
+// public `cloneMatchState`.  Returns the strict `SnapshotState`
+// (every field required as an own property) so a missing field is
+// a compile error — the fork/clone helpers widen back to
+// `PendingMatchState`.
+function captureSnapshot(state: MatchState): SnapshotState {
+    return {
+        name: state.name,
+        parts: state.parts,
+        value: state.value,
+        partIndex: state.partIndex,
+        valueIds: state.valueIds,
+        nextValueId: state.nextValueId,
+        values: state.values,
+        parent: state.parent,
+        nestedLevel: state.nestedLevel,
+        suppressOptionalFork: state.suppressOptionalFork,
+        spacingMode: state.spacingMode,
+        index: state.index,
+        pendingWildcard: state.pendingWildcard,
+        lastMatchedPartInfo: state.lastMatchedPartInfo,
+    };
+}
+
+// Clone `state` into an independent MatchState that is safe to
+// retain across later matcher operations on the live state.  The
+// returned clone has no `backtracks` (live-state-only and
+// would be mutated by `tryNextBacktrack`); per-axis policies
+// are carried over (they are runtime constants).
+//
+// The result is typed as `MatchState`: `backtracks` is
+// optional on that type, so the clone is directly usable wherever
+// a MatchState is expected (e.g. read-only inspection, or as a
+// starting point for an independent matcher run).
+//
+// Use this for READ-ONLY views — e.g. the pre-finalize clone in
+// `grammarCompletion` that must survive subsequent matcher
+// mutation of the live state.  For fork sites (optional-skip,
+// nested-rule alternatives, repeat continuation, wildcard
+// extension) use `forkMatchState` instead — that returns a
+// `SnapshotState` with no policies, suitable for restoration via
+// `Object.assign` without disturbing the live state's policies.
+export function cloneMatchState(state: MatchState): MatchState {
+    // Single-allocation clone: drop only `backtracks` (live-state
+    // mutation surface) and keep everything else — including the
+    // three policy fields — by spreading once.
+    const { backtracks: _backtracks, ...rest } = state;
+    return rest;
+}
+
+// Fork a `state` into a sibling that is about to be pushed onto the
+// `backtracks` chain.  The return type omits `backtracks`
+// — only the live state retains ownership of the existing chain.
+// This makes the single-owner invariant a compile-time guarantee:
+// two siblings cannot independently pop the same chain.
+//
+// Behaviorally identical to `captureSnapshot` (and currently just
+// delegates to it).  Kept as a separate name so fork sites
+// (optional skip/take, alternation, repeat continue, wildcard
+// extension) read as "fork a sibling" rather than "snapshot for
+// internal use".  `captureSnapshot` stays private as the shared
+// per-field copy primitive used by `captureWildcard`,
+// `cloneMatchState`, and this function.
+export function forkMatchState(state: MatchState): SnapshotState {
+    return captureSnapshot(state);
+}
+
+// Push a single-snapshot backtrack frame onto the live state's chain.
+//
+// Used for:
+//   - structural forks at degree-2 fan-outs (origin "optional" /
+//     "repeat") — `alternative` is built via `forkMatchState` and
+//     mutated to reflect the alternative branch's choice.
+//   - wildcard refinement (origin "wildcard") — pushed by
+//     `captureWildcard` to enable extending the wildcard.
+//
+// Alternation uses `pushAlternation` instead — see that helper.
+//
+// Single-owner invariant: SnapshotState omits the `backtracks`
+// field, so the snapshot cannot smuggle a parallel chain in.  When
+// `tryNextBacktrack` restores via `Object.assign`, the live
+// state's `backtracks` is preserved (and explicitly advanced
+// to `frame.prev`).
+export function pushBacktrack(
+    state: MatchState,
+    alternative: SnapshotState,
+    origin: SingleBacktrack["origin"],
+) {
+    state.backtracks = {
+        snapshot: alternative,
+        origin,
+        prev: state.backtracks,
+    };
+}
+
+// Push a compressed alternation cursor frame.  Replaces the
+// historical pattern of pushing N-1 individual snapshots at one
+// alternation fork — the live state takes rule 0, and a single
+// cursor frame carries the shared `base` snapshot plus a direct
+// reference to the existing `GrammarRule[]` (no per-alternative
+// copy).  The debug name for `rules[i]` is built lazily as
+// `${namePrefix}[${i}]` inside `tryNextBacktrack`;
+// `parts`/`value`/`spacingMode` are read directly from `rules[i]`.
+//
+// Cursor starts at 1 (rule 0 is the live alternative) and advances
+// forward through `rules.length-1`, restoring the lowest-index
+// alternative first — matching the prior reverse-push order of one
+// frame per rule.  Caller must ensure `rules.length > 1`.
+//
+// `base` MUST be captured AFTER the live state has been set up for
+// rule 0 (the live alternative): every field other than the four
+// per-rule fields is identical across all alternatives at one fork
+// point, so reusing `base` for each restore is sound.  The shared
+// linked-list heads (`values`, `valueIds`, `parent`) are immutable,
+// so multiple restores from the same `base` cannot leak mutations
+// between alternatives.
+function pushAlternation(
+    state: MatchState,
+    base: SnapshotState,
+    rules: ReadonlyArray<GrammarRule>,
+    namePrefix: string,
+) {
+    state.backtracks = {
+        origin: "alternation",
+        base,
+        rules,
+        namePrefix,
+        cursor: 1,
+        prev: state.backtracks,
+    };
+}
+
+// Pop the most-recently-pushed (rightmost / deepest in DFS order)
+// unexplored sibling and restore it onto `state`, mutating in
+// place via `Object.assign`.  Returns true if a frame was
+// restored, false if the chain is empty.
+//
+// This is the backtrack step of the explicit-stack DFS: the live
+// state walks parts left-to-right; when its current path fails
+// (or yields a result that the caller wants more alternatives
+// after), this function rewinds to the most recent unexplored
+// branch and lets matching resume from there.
+//
+// Restoration semantics by origin:
+//   - `wildcard`: the snapshot has `pendingWildcard` set;
+//     re-running matchState extends the wildcard to a longer
+//     capture.
+//   - `optional` / `alternation` / `repeat`: the snapshot is a
+//     sibling parse path at a structural fork.
+//
+// Callers drive enumeration with the pattern:
+//
+//   do {
+//       const matched = matchState(state, request);
+//       // ...process attempt...
+//   } while (tryNextBacktrack(state));
+export function tryNextBacktrack(state: MatchState): boolean {
+    const frame = state.backtracks;
+    if (frame === undefined) {
+        return false;
+    }
+    if (frame.origin === "alternation") {
+        // Cursor frame: restore the shared base, then overlay the
+        // next per-rule fields read directly from `rules[cursor]`.
+        // The frame stays at the head of the chain until all
+        // alternatives have been consumed; new frames pushed during
+        // the restored alternative's matching sit on top of (and
+        // resolve before) this cursor.
+        const i = frame.cursor;
+        const rule = frame.rules[i];
+        Object.assign(state, frame.base);
+        state.name = `${frame.namePrefix}[${i}]`;
+        state.parts = rule.parts;
+        state.value = rule.value;
+        state.spacingMode = rule.spacingMode;
+        frame.cursor = i + 1;
+        if (frame.cursor >= frame.rules.length) {
+            // All alternatives restored — unlink the cursor.
+            state.backtracks = frame.prev;
+        }
+        debugMatch(state, `Restoring local backtrack (alternation)`);
+        return true;
+    }
+    // The snapshot omits `backtracks`, so Object.assign won't
+    // overwrite it — explicitly advance the head pointer to `prev`.
+    Object.assign(state, frame.snapshot);
+    state.backtracks = frame.prev;
+    debugMatch(
+        state,
+        frame.origin === "wildcard"
+            ? `Extending wildcard from frame`
+            : `Restoring local backtrack (${frame.origin})`,
+    );
+    return true;
+}
+
+// After a successful match, drop ALL backtrack frames in the chain
+// whose origin axis is configured to commit on first success —
+// the caller has said it doesn't want extra parses along that
+// axis once one has been found.
+//
+// Per-axis policy mapping:
+//   - origin "wildcard"  + wildcardPolicy === "shortest"
+//   - origin "optional"  + optionalPolicy !== "exhaustive"
+//   - origin "repeat"    + repeatPolicy   !== "exhaustive"
+//   - origin "alternation"                 — always retained
+//
+// Frames with non-suppressed origins are SKIPPED OVER (their own
+// `prev` is preserved through), so suppression walks the entire
+// chain rather than just the trailing prefix.  This is critical
+// for wildcard-axis suppression: a successful match in the live
+// state must invalidate wildcard refinements pushed by SIBLING
+// states (which sit deeper in the chain, below alternation
+// frames), not just the current state's own wildcards.
+export function suppressBacktracksAfterSuccess(state: MatchState) {
+    const wildcardSuppress = state.wildcardPolicy === "shortest";
+    const optionalSuppress = state.optionalPolicy !== "exhaustive";
+    const repeatSuppress = state.repeatPolicy !== "exhaustive";
+    if (!wildcardSuppress && !optionalSuppress && !repeatSuppress) {
+        return;
+    }
+    const isSuppressed = (origin: BacktrackOrigin): boolean => {
+        switch (origin) {
+            case "wildcard":
+                return wildcardSuppress;
+            case "optional":
+                return optionalSuppress;
+            case "repeat":
+                return repeatSuppress;
+            case "alternation":
+                return false;
+        }
+    };
+
+    // Skip suppressed frames at the head.
+    while (
+        state.backtracks !== undefined &&
+        isSuppressed(state.backtracks.origin)
+    ) {
+        state.backtracks = state.backtracks.prev;
+    }
+    // Walk the rest, splicing out any suppressed frame deeper in
+    // the chain.  Mutates `prev` pointers in place — the chain is
+    // single-owner, so no other state shares this view.
+    let kept = state.backtracks;
+    while (kept !== undefined) {
+        let next = kept.prev;
+        while (next !== undefined && isSuppressed(next.origin)) {
+            next = next.prev;
+        }
+        (kept as { prev: Backtrack | undefined }).prev = next;
+        kept = next;
+    }
+}
 
 type GrammarMatchStat = {
     matchedValueCount: number;
@@ -533,7 +1003,6 @@ function captureWildcard(
     request: string,
     wildcardEnd: number,
     newIndex: number,
-    pending: MatchState[] = [],
 ) {
     const { start: wildcardStart, valueId } = state.pendingWildcard!;
     const wildcardStr = getWildcardStr(
@@ -547,8 +1016,14 @@ function captureWildcard(
     }
     state.index = newIndex;
 
-    // Queue up longer wildcard match
-    pending.push({ ...state });
+    // Push a "wildcard"-origin backtrack so we can later resume
+    // scanning for a strictly longer wildcard capture (used by
+    // `tryNextBacktrack` on downstream failure, and on success
+    // in default mode).  The frame is taken BEFORE we clear
+    // pendingWildcard / commit the captured value so that restoring
+    // it puts the state back into the wildcard-scanning dispatch
+    // path with pendingWildcard still set.
+    pushBacktrack(state, captureSnapshot(state), "wildcard");
 
     // Update current state
     state.pendingWildcard = undefined;
@@ -559,7 +1034,7 @@ function captureWildcard(
 }
 
 function addValueId(
-    state: MatchState,
+    state: PendingMatchState,
     name: string | undefined,
     wildcardTypeName?: string,
 ) {
@@ -574,7 +1049,7 @@ function addValueId(
 }
 
 function addValueWithId(
-    state: MatchState,
+    state: PendingMatchState,
     valueId: number,
     matchedValue: MatchedValue,
     wildcard: boolean,
@@ -588,7 +1063,7 @@ function addValueWithId(
 }
 
 function addValue(
-    state: MatchState,
+    state: PendingMatchState,
     name: string | undefined,
     matchedValue: MatchedValue,
 ) {
@@ -672,7 +1147,7 @@ function finalizeMatch(
     state: MatchState,
     request: string,
     results: GrammarMatchResult[],
-) {
+): boolean {
     if (state.valueIds === null) {
         throw new Error(
             "Internal Error: state for finalizeMatch should not have valueIds be null",
@@ -680,7 +1155,7 @@ function finalizeMatch(
     }
 
     if (!finalizeState(state, request)) {
-        return;
+        return false;
     }
     debugMatch(
         state,
@@ -705,11 +1180,11 @@ function finalizeMatch(
         matchResult, // stats
     );
     results.push(matchResult);
+    return true;
 }
 
 export function finalizeNestedRule(
     state: MatchState,
-    pending?: MatchState[],
     partial: boolean = false,
 ) {
     const parent = state.parent;
@@ -759,14 +1234,26 @@ export function finalizeNestedRule(
         state.spacingMode = parent.spacingMode;
 
         // For repeat parts ()*  or )+: after each successful match, queue a state
-        // that tries to match the same group again.  inRepeat suppresses the
-        // optional-skip push so we don't generate duplicate "done" states.
-        if (parent.repeatPartIndex !== undefined && pending !== undefined) {
-            pending.push({
-                ...state,
+        // that tries to match the same group again.  suppressOptionalFork
+        // suppresses the optional-skip push so we don't generate duplicate
+        // "done" states.
+        if (parent.repeatPartIndex !== undefined) {
+            // Build the CONTINUE alternative (re-enter the group).
+            const continueState: SnapshotState = {
+                ...forkMatchState(state),
                 partIndex: parent.repeatPartIndex,
-                inRepeat: true,
-            });
+                suppressOptionalFork: true,
+            };
+            if (state.repeatPolicy === "greedy") {
+                // Live = continue (drill deeper); backtrack = stop
+                // (snapshot of state past the repeat).
+                const stopSnapshot = forkMatchState(state);
+                Object.assign(state, continueState);
+                pushBacktrack(state, stopSnapshot, "repeat");
+            } else {
+                // Default / nonGreedy: live = stop; backtrack = continue.
+                pushBacktrack(state, continueState, "repeat");
+            }
         }
 
         return true;
@@ -780,7 +1267,6 @@ function matchStringPartWithWildcard(
     request: string,
     part: StringPart,
     state: MatchState,
-    pending: MatchState[],
 ) {
     regExp.lastIndex = state.index;
     while (true) {
@@ -798,12 +1284,16 @@ function matchStringPartWithWildcard(
             continue;
         }
 
-        if (captureWildcard(state, request, wildcardEnd, newIndex, pending)) {
+        if (captureWildcard(state, request, wildcardEnd, newIndex)) {
             // If the StringPart has an explicit capture variable, write the
             // joined matched tokens into that named slot.  Otherwise fall
             // through to the implicit-default rule for single-part rules
             // without a value expression — same logic as the non-wildcard
-            // path in matchStringPartWithoutWildcard.
+            // path in matchStringPartWithoutWildcard.  Without this, a
+            // pending wildcard from a parent rule that leaks into a
+            // single-part child rule would bypass the default value
+            // assignment and cause "No value assign to variable" at
+            // finalizeNestedRule time.
             if (
                 state.valueIds !== null &&
                 (part.variable !== undefined || usesImplicitDefault(state))
@@ -955,20 +1445,37 @@ function buildStringPartRegExpStr(
 }
 
 /**
- * Get or create cached RegExp objects for a StringPart.  The cache key
- * is derived from (spacingMode, leadingIsNone) — for the same StringPart
- * and spacing configuration, the compiled regex is reused across calls.
+ * Get or create cached RegExp objects for a StringPart.  The cache
+ * has exactly 4 (`CompiledSpacingMode`) \u00d7 2 (`leadingIsNone`) = 8
+ * possible (spacingMode, leadingIsNone) keys, so it is stored as a
+ * fixed 8-slot sparse array indexed directly by
+ * `(modeIndex << 1) | leadingIsNone`.  This avoids the per-call
+ * template-string + `Map.get(string)` allocation incurred by the
+ * previous string-keyed Map on every match attempt.
  */
+// Maps each CompiledSpacingMode value to a 0..3 slot index used to
+// build the regex-cache key.  Order is fixed so cache keys remain
+// stable across matcher invocations.
+const spacingModeIndex: Record<"required" | "optional" | "none", number> = {
+    required: 0,
+    optional: 1,
+    none: 2,
+    // "auto" (undefined) handled separately as index 3.
+};
+
 function getStringPartRegExp(
     part: StringPart,
     spacingMode: CompiledSpacingMode,
     leadingIsNone: boolean,
 ): StringPartRegExpEntry {
-    const key = `${spacingMode ?? "auto"}:${leadingIsNone}`;
+    const modeIdx =
+        spacingMode === undefined ? 3 : spacingModeIndex[spacingMode];
+    const key = (modeIdx << 1) | (leadingIsNone ? 1 : 0);
     if (part.regexpCache === undefined) {
-        part.regexpCache = new Map();
+        // Sparse 8-slot array; unset slots remain `undefined`.
+        part.regexpCache = new Array(8);
     }
-    let entry = part.regexpCache.get(key);
+    let entry = part.regexpCache[key];
     if (entry === undefined) {
         const regExpStr = buildStringPartRegExpStr(
             part,
@@ -979,17 +1486,12 @@ function getStringPartRegExp(
             global: new RegExp(regExpStr, "iug"),
             sticky: new RegExp(regExpStr, "iuy"),
         };
-        part.regexpCache.set(key, entry);
+        part.regexpCache[key] = entry;
     }
     return entry;
 }
 
-function matchStringPart(
-    request: string,
-    state: MatchState,
-    part: StringPart,
-    pending: MatchState[],
-) {
+function matchStringPart(request: string, state: MatchState, part: StringPart) {
     debugMatch(
         state,
         `Checking string expr "${part.value.join(" ")}" with${state.pendingWildcard ? "" : "out"} wildcard`,
@@ -997,13 +1499,7 @@ function matchStringPart(
     const leadingIsNone = leadingSpacingMode(state) === "none";
     const entry = getStringPartRegExp(part, state.spacingMode, leadingIsNone);
     return state.pendingWildcard !== undefined
-        ? matchStringPartWithWildcard(
-              entry.global,
-              request,
-              part,
-              state,
-              pending,
-          )
+        ? matchStringPartWithWildcard(entry.global, request, part, state)
         : matchStringPartWithoutWildcard(entry.sticky, request, part, state);
 }
 
@@ -1016,7 +1512,6 @@ function matchVarNumberPartWithWildcard(
     request: string,
     state: MatchState,
     part: VarNumberPart,
-    pending: MatchState[],
 ) {
     const curr = state.index;
     const re =
@@ -1045,7 +1540,7 @@ function matchVarNumberPartWithWildcard(
             continue;
         }
 
-        if (captureWildcard(state, request, wildcardEnd, newIndex, pending)) {
+        if (captureWildcard(state, request, wildcardEnd, newIndex)) {
             debugMatch(
                 state,
                 `Matched number at ${wildcardEnd} to ${newIndex}`,
@@ -1124,14 +1619,13 @@ function matchVarNumberPart(
     request: string,
     state: MatchState,
     part: VarNumberPart,
-    pending: MatchState[],
 ) {
     debugMatch(
         state,
         `Checking number expr at with${state.pendingWildcard ? "" : "out"} wildcard`,
     );
     return state.pendingWildcard !== undefined
-        ? matchVarNumberPartWithWildcard(request, state, part, pending)
+        ? matchVarNumberPartWithWildcard(request, state, part)
         : matchVarNumberPartWithoutWildcard(request, state, part);
 }
 
@@ -1149,15 +1643,11 @@ function matchVarStringPart(state: MatchState, part: VarStringPart) {
     return true;
 }
 
-export function matchState(
-    state: MatchState,
-    request: string,
-    pending: MatchState[],
-) {
+export function matchState(state: MatchState, request: string) {
     while (true) {
         const { parts, partIndex } = state;
         if (partIndex >= parts.length) {
-            if (!finalizeNestedRule(state, pending)) {
+            if (!finalizeNestedRule(state)) {
                 // Finish matching this state.
                 return true;
             }
@@ -1187,25 +1677,56 @@ export function matchState(
             `matching type=${JSON.stringify(part.type)} pendingWildcard=${JSON.stringify(state.pendingWildcard)}`,
         );
 
-        if (part.optional && !state.inRepeat) {
-            // queue up skipping optional (suppressed when re-entering a repeat
-            // group to avoid duplicating already-queued "done" states)
-            const newState = { ...state, partIndex: state.partIndex + 1 };
+        // Consume the single-use suppression flag exactly once per
+        // part iteration: read it into a local and clear immediately.
+        // The flag's sole purpose is to gate the optional-fork block
+        // below; clearing here (before any early-continue path) makes
+        // it impossible for the flag to leak onto a subsequent part
+        // even if future code adds new branches inside the loop body.
+        const suppressOptionalFork = state.suppressOptionalFork;
+        state.suppressOptionalFork = undefined;
+
+        if (part.optional && !suppressOptionalFork) {
+            // Build the SKIP alternative (advance past the optional
+            // part, with `undefined` recorded for any variable).
+            const skipState: SnapshotState = {
+                ...forkMatchState(state),
+                partIndex: state.partIndex + 1,
+            };
             if (part.variable) {
-                addValue(newState, part.variable, undefined);
+                addValue(skipState, part.variable, undefined);
             }
-            pending.push(newState);
+            if (state.optionalPolicy === "preferSkip") {
+                // Live = skip; backtrack = take (snapshot of current
+                // state continues with the optional part).  The take
+                // snapshot is marked `suppressOptionalFork: true` so
+                // that on restore the optional-fork block at the top
+                // of this loop is suppressed — otherwise the same
+                // optional part would re-fork and we would push
+                // another take frame in an infinite loop.  The flag
+                // is consumed by the local capture above on the next
+                // iteration, so it cannot leak onto subsequent parts.
+                const takeSnapshot: SnapshotState = {
+                    ...forkMatchState(state),
+                    suppressOptionalFork: true,
+                };
+                Object.assign(state, skipState);
+                pushBacktrack(state, takeSnapshot, "optional");
+                continue;
+            }
+            // Default / preferTake: live = take; backtrack = skip.
+            pushBacktrack(state, skipState, "optional");
         }
 
         switch (part.type) {
             case "string":
-                if (!matchStringPart(request, state, part, pending)) {
+                if (!matchStringPart(request, state, part)) {
                     return false;
                 }
                 break;
 
             case "number":
-                if (!matchVarNumberPart(request, state, part, pending)) {
+                if (!matchVarNumberPart(request, state, part)) {
                     return false;
                 }
                 break;
@@ -1247,18 +1768,27 @@ export function matchState(
                 state.valueIds = requireValue ? undefined : null;
                 state.parent = parent;
                 state.nestedLevel++;
-                state.inRepeat = undefined; // entering nested rules, clear repeat flag
+                state.suppressOptionalFork = undefined; // entering nested rules, clear suppression flag
                 state.spacingMode = rules[0].spacingMode;
 
-                // queue up the other rules (backwards to search in the original order)
-                for (let i = rules.length - 1; i > 0; i--) {
-                    pending.push({
-                        ...state,
-                        name: getNestedStateName(state, part, i),
-                        parts: rules[i].parts,
-                        value: rules[i].value,
-                        spacingMode: rules[i].spacingMode,
-                    });
+                // Push a single compressed alternation cursor frame
+                // covering rules 1..N-1.  The shared `base` is the
+                // live state right after rule 0 setup — every
+                // alternative starts from the same fork-point
+                // context with only the four per-rule fields
+                // overlaid (read directly from `rules[i]` on
+                // restore).  The name prefix is computed once;
+                // `tryNextBacktrack` builds the per-rule debug name
+                // lazily as `${namePrefix}[${i}]`.
+                // `forkMatchState` enforces the single-owner
+                // invariant on the chain (the snapshot omits
+                // `backtracks`).
+                if (rules.length > 1) {
+                    const base = forkMatchState(state);
+                    const namePrefix = part.name
+                        ? `<${part.name}>`
+                        : getStateName(state);
+                    pushAlternation(state, base, rules, namePrefix);
                 }
                 // continue the loop (without incrementing partIndex)
                 continue;
@@ -1268,22 +1798,64 @@ export function matchState(
     }
 }
 
-export function initialMatchState(grammar: Grammar): MatchState[] {
-    return grammar.rules
-        .map((r, i) => ({
-            name: `<Start>[${i}]`,
-            parts: r.parts,
-            value: r.value,
-            partIndex: 0,
-            index: 0,
-            nextValueId: 0,
-            nestedLevel: 0,
-            spacingMode: r.spacingMode,
-        }))
-        .reverse();
+// Build the initial live MatchState for `matchGrammar` /
+// `matchGrammarCompletion`.  The returned state is initialized for
+// rule 0 (the live DFS path); rules 1..N-1 are pre-pushed onto
+// its `backtracks` chain as `"alternation"`-origin frames —
+// the same mechanism a nested-rule alternation uses.  Pushed in
+// reverse order so rule 1 is on top of the stack and gets
+// restored first by `tryNextBacktrack`, matching source
+// order.  Returns `undefined` for an empty grammar (no rules).
+export function initialMatchState(
+    grammar: Grammar,
+    options?: GrammarMatchOptions,
+): MatchState | undefined {
+    const rules = grammar.rules;
+    if (rules.length === 0) {
+        return undefined;
+    }
+    const wildcardPolicy = options?.wildcardPolicy ?? "exhaustive";
+    const optionalPolicy = options?.optionalPolicy ?? "exhaustive";
+    const repeatPolicy = options?.repeatPolicy ?? "exhaustive";
+
+    const state: MatchState = {
+        name: `<Start>[0]`,
+        parts: rules[0].parts,
+        value: rules[0].value,
+        partIndex: 0,
+        valueIds: undefined,
+        nextValueId: 0,
+        values: undefined,
+        parent: undefined,
+        nestedLevel: 0,
+        suppressOptionalFork: undefined,
+        spacingMode: rules[0].spacingMode,
+        index: 0,
+        pendingWildcard: undefined,
+        lastMatchedPartInfo: undefined,
+        wildcardPolicy,
+        optionalPolicy,
+        repeatPolicy,
+    };
+    // Top-level alternation: push a single compressed cursor frame
+    // covering rules 1..N-1.  The cursor advances forward (rule 1
+    // first, then rule 2, ...) — same source order as the prior
+    // reverse-push of one frame per rule.  `base` is rule-0's
+    // initial state; per-rule `parts/value/spacingMode` are read
+    // from `rules[i]` directly on restore, and the debug name is
+    // built lazily as `<Start>[i]`.
+    if (rules.length > 1) {
+        pushAlternation(state, forkMatchState(state), rules, "<Start>");
+    }
+    return state;
 }
 
 function debugMatch(state: MatchState, msg: string) {
+    if (state.nestedLevel < 0) {
+        throw new Error(
+            `Internal error: nestedLevel went negative (${state.nestedLevel}) at "${msg}"`,
+        );
+    }
     debugMatchRaw(
         `${" ".repeat(state.nestedLevel)}${getStateName(state)}: @${state.index}: ${msg}`,
     );
@@ -1296,16 +1868,29 @@ function getNestedStateName(state: MatchState, part: RulesPart, index: number) {
     return `${part.name ? `<${part.name}>` : getStateName(state)}[${index}]`;
 }
 
-export function matchGrammar(grammar: Grammar, request: string) {
-    const pending = initialMatchState(grammar);
+export function matchGrammar(
+    grammar: Grammar,
+    request: string,
+    options?: GrammarMatchOptions,
+) {
+    const state = initialMatchState(grammar, options);
     const results: GrammarMatchResult[] = [];
-    while (pending.length > 0) {
-        const state = pending.pop()!;
-        debugMatch(state, `resume state`);
-        if (matchState(state, request, pending)) {
-            finalizeMatch(state, request, results);
-        }
+    if (state === undefined) {
+        return results;
     }
+    // Explicit-stack DFS over the parse forest: `matchState` walks
+    // the live state's parts left-to-right; on success collect the
+    // result and prune any per-policy first-success frames; then
+    // pop the most-recently-pushed unexplored sibling and resume.
+    do {
+        debugMatch(state, `resume state`);
+        if (
+            matchState(state, request) &&
+            finalizeMatch(state, request, results)
+        ) {
+            suppressBacktracksAfterSuccess(state);
+        }
+    } while (tryNextBacktrack(state));
 
     return results;
 }

--- a/ts/packages/actionGrammar/src/grammarTypes.ts
+++ b/ts/packages/actionGrammar/src/grammarTypes.ts
@@ -192,12 +192,17 @@ export type StringPart = {
     variable?: string | undefined;
 
     /**
-     * Cache of compiled RegExp objects, keyed by
-     * `"${spacingMode ?? 'auto'}:${leadingIsNone}"`.
-     * Populated lazily by the matcher to avoid recompiling the same
-     * regex pattern on every match attempt.
+     * Cache of compiled RegExp objects.  There are exactly 4
+     * {@link CompiledSpacingMode} values \u00d7 2 leading-spacing
+     * variants = 8 possible (spacingMode, leadingIsNone) keys for
+     * a given StringPart, so the cache is a fixed 8-slot sparse
+     * tuple indexed directly by `(modeIndex << 1) | leadingIsNone`
+     * (see `getStringPartRegExp`).  Allocating an 8-slot array
+     * lazily avoids the per-call template-string + Map.get
+     * allocation that the previous string-keyed Map incurred on
+     * every match attempt.
      */
-    regexpCache?: Map<string, StringPartRegExpEntry>;
+    regexpCache?: Array<StringPartRegExpEntry | undefined>;
 };
 
 export type VarStringPart = {

--- a/ts/packages/actionGrammar/src/index.ts
+++ b/ts/packages/actionGrammar/src/index.ts
@@ -26,17 +26,21 @@ export type {
 // Writer / formatter
 export { writeGrammarRules } from "./grammarRuleWriter.js";
 
-export { matchGrammar, GrammarMatchResult } from "./grammarMatcher.js";
-export { needsSeparatorInAutoMode } from "./grammarMatcher.js";
+export { matchGrammar, needsSeparatorInAutoMode } from "./grammarMatcher.js";
+export type {
+    GrammarMatchResult,
+    GrammarMatchOptions,
+} from "./grammarMatcher.js";
 
 export {
     matchGrammarCompletion,
-    GrammarCompletionResult,
     spacingModeToSeparatorMode,
 } from "./grammarCompletion.js";
+export type { GrammarCompletionResult } from "./grammarCompletion.js";
 export type {
     AfterWildcard,
     GrammarCompletionGroup,
+    GrammarCompletionOptions,
     GrammarCompletionProperty,
 } from "./grammarCompletion.js";
 

--- a/ts/packages/actionGrammar/test/grammarCompletionShortestWildcard.spec.ts
+++ b/ts/packages/actionGrammar/test/grammarCompletionShortestWildcard.spec.ts
@@ -1,0 +1,291 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { matchGrammarCompletion } from "../src/grammarCompletion.js";
+import { loadGrammarRules } from "../src/grammarLoader.js";
+import { expectMetadata } from "./testUtils.js";
+
+// Tests for the `shortestWildcard` option on `matchGrammarCompletion`.
+//
+// Mirrors `GrammarMatchOptions.shortestWildcard` for the matcher: when
+// true, completion only explores the shortest-wildcard match for each
+// state.  Longer-wildcard alternatives — which under exhaustive
+// matching can surface "spurious" completions for keywords already
+// present inside the input — are suppressed.
+describe("Grammar Completion - shortestWildcard option", () => {
+    describe("wildcard followed by keyword terminator (full input)", () => {
+        // Grammar: `<x> hello world` where `hello world` is the keyword
+        // terminator.  Input "foo hello world" is ambiguous under
+        // exhaustive matching:
+        //   - shortest:  wildcard="foo",            terminator="hello world" ✔
+        //   - longest:   wildcard="foo hello world", terminator unmatched   ✔
+        // The longer-wildcard alternative leaves the keyword unmatched
+        // and emits a completion at P=15 (full input) instead of
+        // P=3 (back to the wildcard's end).
+        const g = `<Start> = $(x) hello\\ world -> x;`;
+        const grammar = loadGrammarRules("test.grammar", g);
+
+        it("exhaustive (default): matchedPrefixLength reflects longer-wildcard alternative (P=15)", () => {
+            const result = matchGrammarCompletion(grammar, "foo hello world");
+            expectMetadata(result, {
+                completions: ["hello world"],
+                matchedPrefixLength: 15,
+                separatorMode: "autoSpacePunctuation",
+                closedSet: true,
+                directionSensitive: true,
+                afterWildcard: "all",
+                properties: [],
+            });
+        });
+
+        it("shortestWildcard: matchedPrefixLength stays at shortest-wildcard match (P=3)", () => {
+            const result = matchGrammarCompletion(
+                grammar,
+                "foo hello world",
+                undefined,
+                undefined,
+                { wildcardPolicy: "shortest" },
+            );
+            // No longer-wildcard alternative is explored — completion
+            // anchors at the shortest match's wildcard end.
+            expectMetadata(result, {
+                completions: ["hello world"],
+                matchedPrefixLength: 3,
+                separatorMode: "autoSpacePunctuation",
+                closedSet: true,
+                directionSensitive: true,
+                afterWildcard: "all",
+                properties: [],
+            });
+        });
+    });
+
+    describe("two wildcards with keyword separator (full input)", () => {
+        // Grammar: `play <name> by <artist>`.  Input
+        // "play hello by world" is ambiguous:
+        //   - shortest:  name="hello",          artist="world"        ✔
+        //   - longest:   name="hello by world", artist unmatched       ✔
+        // Under exhaustive, the longer-wildcard alternative emits a
+        // spurious "by" completion at P=19 (full input).  Under
+        // shortest, only the shortest path is explored, leaving the
+        // result at the partial artist-completion path (P=13).
+        const g = `<Start> = play $(name) by $(artist) -> { name, artist };`;
+        const grammar = loadGrammarRules("test.grammar", g);
+
+        it("exhaustive (default): emits spurious 'by' completion from longer-wildcard alternative", () => {
+            const result = matchGrammarCompletion(
+                grammar,
+                "play hello by world",
+            );
+            expectMetadata(result, {
+                completions: ["by"],
+                matchedPrefixLength: 19,
+                separatorMode: "autoSpacePunctuation",
+                closedSet: true,
+                directionSensitive: true,
+                afterWildcard: "all",
+                properties: [],
+            });
+        });
+
+        it("shortestWildcard: only the shortest-match artist completion path is taken", () => {
+            const result = matchGrammarCompletion(
+                grammar,
+                "play hello by world",
+                undefined,
+                undefined,
+                { wildcardPolicy: "shortest" },
+            );
+            // Shortest path: name="hello", "by" matched, artist
+            // wildcard captured "world" — the partial-artist
+            // completion path emits at P=13 (after "by").
+            expectMetadata(result, {
+                completions: [],
+                matchedPrefixLength: 13,
+                closedSet: false,
+                directionSensitive: true,
+                afterWildcard: "none",
+                properties: [
+                    {
+                        match: { name: "hello" },
+                        propertyNames: ["artist"],
+                    },
+                ],
+            });
+        });
+    });
+
+    describe("partial input — both modes return same partial-match completion", () => {
+        // For inputs that don't fully consume to a successful match,
+        // shortestWildcard should not change behavior.  There's no
+        // successful full match to anchor "shortest" against, so the
+        // partial-match completion path is identical.
+        const g = `<Start> = play $(name) by $(artist) -> { name, artist };`;
+        const grammar = loadGrammarRules("test.grammar", g);
+
+        it("offers 'by' terminator after wildcard text (default and shortestWildcard match)", () => {
+            const def = matchGrammarCompletion(grammar, "play hello");
+            const shortest = matchGrammarCompletion(
+                grammar,
+                "play hello",
+                undefined,
+                undefined,
+                { wildcardPolicy: "shortest" },
+            );
+            expectMetadata(def, {
+                completions: ["by"],
+                matchedPrefixLength: 10,
+                afterWildcard: "all",
+            });
+            expect(shortest).toEqual(def);
+        });
+    });
+
+    describe("input ends with literal terminator + trailing separator", () => {
+        // Grammar: `play <name> by <artist>`.  Input
+        // "play This Train by " (note the trailing space).
+        // Under exhaustive, two interpretations are explored:
+        //   (1) name="This Train", literal "by" matches, artist
+        //       wildcard pending at the trailing space — emits
+        //       a property completion for `artist` at P=18.
+        //   (2) name="This Train by" (longer wildcard), literal
+        //       "by" doesn't match, finalizeState clean (only
+        //       trailing separator) — emits a spurious "by"
+        //       completion at P=19.
+        // shortestWildcard should suppress (2) because (1) has
+        // already consumed all meaningful (non-separator) input.
+        const g = `<Start> = play $(name) by $(artist) -> { name, artist };`;
+        const grammar = loadGrammarRules("test.grammar", g);
+
+        it("exhaustive (default): emits spurious 'by' completion from longer-wildcard alternative", () => {
+            const result = matchGrammarCompletion(
+                grammar,
+                "play This Train by ",
+            );
+            expectMetadata(result, {
+                completions: ["by"],
+                matchedPrefixLength: 18,
+                afterWildcard: "all",
+            });
+        });
+
+        it("shortestWildcard: only artist property completion is offered", () => {
+            const result = matchGrammarCompletion(
+                grammar,
+                "play This Train by ",
+                undefined,
+                undefined,
+                { wildcardPolicy: "shortest" },
+            );
+            // Shortest path: name="This Train", literal "by"
+            // matched, artist wildcard pending at trailing
+            // space — only the property completion for artist
+            // is emitted; the spurious "by" alternative is
+            // suppressed.
+            expectMetadata(result, {
+                completions: [],
+                matchedPrefixLength: 18,
+                closedSet: false,
+                directionSensitive: true,
+                afterWildcard: "none",
+                properties: [
+                    {
+                        match: { name: "This Train" },
+                        propertyNames: ["artist"],
+                    },
+                ],
+            });
+        });
+    });
+
+    describe("optional-skip sibling captures past literal terminator", () => {
+        // Multi-alternative rule with an optional `(the)?` between
+        // "from" and "album".  Input
+        // "play <track> by <artist> from album <album_partial>"
+        // produces three pending states:
+        //   - A1 (`play <track> by <artist>`): exact match — artist
+        //     wildcard captures "Wax Tailor from album", no completion.
+        //   - A3 (`play <track> by <artist> from (the)? album <album>`):
+        //     - "without the" branch: shorter track interpretation
+        //       reaches EOI with album wildcard pending — emits
+        //       property completion for album.
+        //     - "with the" branch: cannot match (no "the" in input);
+        //       finalizeState absorbs the rest into the track wildcard,
+        //       leaving partIndex at "from".  Without suppression,
+        //       Phase 2's findPartialKeywordInWildcard scans the
+        //       captured track text, finds the literal "from" inside,
+        //       and re-emits it as a spurious completion.
+        // shortestWildcard suppresses the "with the" sibling because
+        // its captured wildcard contains the next-part literal.
+        const g = `
+<Start> = play $(track) by $(artist) -> { track, artist }
+        | play $(track) from (the)? album $(album) -> { track, album }
+        | play $(track) by $(artist) from (the)? album $(album) -> { track, artist, album };
+`;
+        const grammar = loadGrammarRules("test.grammar", g);
+
+        it("shortestWildcard: no spurious 'from' completion", () => {
+            const result = matchGrammarCompletion(
+                grammar,
+                "play This Train by Wax Tailor from album ",
+                undefined,
+                undefined,
+                { wildcardPolicy: "shortest" },
+            );
+            // No string completions — only album property
+            // completions from the legitimate shorter-wildcard
+            // interpretations of A2 and A3.
+            expectMetadata(result, {
+                completions: [],
+                matchedPrefixLength: 40,
+                closedSet: false,
+                directionSensitive: true,
+                afterWildcard: "none",
+            });
+            // Two property entries (one per matching rule), both
+            // for `album`.
+            expect(result.properties).toHaveLength(2);
+            expect(
+                result.properties!.every((p) =>
+                    p.propertyNames.includes("album"),
+                ),
+            ).toBe(true);
+        });
+    });
+
+    describe("non-wildcard completion is unaffected by shortestWildcard", () => {
+        // Pure keyword grammar — no wildcards at all.  shortestWildcard
+        // should be a strict no-op since there are no wildcard frames
+        // to abandon.
+        const g = [
+            `<Start> = $(a:<A>) $(b:<B>) -> { a, b };`,
+            `<A> = first -> "a";`,
+            `<B> = second -> "b";`,
+        ].join("\n");
+        const grammar = loadGrammarRules("test.grammar", g);
+
+        it("default and shortestWildcard return identical results for empty input", () => {
+            const def = matchGrammarCompletion(grammar, "");
+            const shortest = matchGrammarCompletion(
+                grammar,
+                "",
+                undefined,
+                undefined,
+                { wildcardPolicy: "shortest" },
+            );
+            expect(shortest).toEqual(def);
+        });
+
+        it("default and shortestWildcard return identical results for partial input", () => {
+            const def = matchGrammarCompletion(grammar, "first");
+            const shortest = matchGrammarCompletion(
+                grammar,
+                "first",
+                undefined,
+                undefined,
+                { wildcardPolicy: "shortest" },
+            );
+            expect(shortest).toEqual(def);
+        });
+    });
+});

--- a/ts/packages/actionGrammar/test/optionalPolicyPreferSkipBacktrack.spec.ts
+++ b/ts/packages/actionGrammar/test/optionalPolicyPreferSkipBacktrack.spec.ts
@@ -1,0 +1,44 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { loadGrammarRules } from "../src/grammarLoader.js";
+import { matchGrammar } from "../src/grammarMatcher.js";
+
+// Regression: in `preferSkip` mode the matcher restores the take-frame
+// snapshot when the skip path fails, but the snapshot's `partIndex` is
+// unchanged and `suppressOptionalFork` is not set, so the optional-fork
+// block at the top of `matchState`'s loop fires again.  That re-pushes a
+// new take frame and re-enters the same skip path → infinite loop.
+//
+// The fix should mark the take snapshot as "already-decided" (via
+// `suppressOptionalFork: true`) so that on restore the optional-fork
+// block is suppressed and the part is matched directly.  The single-use
+// flag must then be cleared before the next part to avoid leaking
+// suppression onto unrelated downstream optionals.
+describe("optionalPolicy: preferSkip take-frame backtrack", () => {
+    it("does not infinite-loop when skip fails and take must be tried", () => {
+        const grammar = loadGrammarRules(
+            "test.grammar",
+            `<Start> = (please)? help -> true;`,
+        );
+        const results = matchGrammar(grammar, "please help", {
+            optionalPolicy: "preferSkip",
+        }).map((m) => m.match);
+        expect(results).toStrictEqual([true]);
+    }, 5000);
+
+    it("subsequent optional after a successful take is still considered", () => {
+        // Guards against a fix that sets `suppressOptionalFork` on the
+        // take snapshot but forgets to clear it after the optional-fork
+        // block — which would suppress the trailing optional and lose
+        // the (thanks) alternative.
+        const grammar = loadGrammarRules(
+            "test.grammar",
+            `<Start> = (please)? do it (thanks)? -> true;`,
+        );
+        const results = matchGrammar(grammar, "please do it thanks", {
+            optionalPolicy: "preferSkip",
+        }).map((m) => m.match);
+        expect(results).toStrictEqual([true]);
+    }, 5000);
+});

--- a/ts/packages/actionGrammar/test/policyCoverage.spec.ts
+++ b/ts/packages/actionGrammar/test/policyCoverage.spec.ts
@@ -1,0 +1,220 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { loadGrammarRules } from "../src/grammarLoader.js";
+import {
+    matchGrammar,
+    type GrammarMatchOptions,
+} from "../src/grammarMatcher.js";
+import type { Grammar } from "../src/grammarTypes.js";
+
+function match(
+    grammar: Grammar,
+    request: string,
+    options?: GrammarMatchOptions,
+): unknown[] {
+    return matchGrammar(grammar, request, options).map((m) => m.match);
+}
+
+// Coverage for the per-axis exploration policies on `GrammarMatchOptions`:
+//   - optionalPolicy: "exhaustive" | "preferTake" | "preferSkip"
+//   - repeatPolicy:   "exhaustive" | "greedy"     | "nonGreedy"
+//
+// Each non-default value is a "first-success commitment": once a parse
+// succeeds along that axis, sibling alternatives on the SAME axis must
+// be pruned.  The `preferSkip` regression (matcherInfiniteLoop on
+// take-frame restore) is covered separately in
+// `optionalPolicyPreferSkipBacktrack.spec.ts`.
+//
+// Tests use a 5-second per-test timeout: any policy bug that re-pushes
+// the same fork (as the original `preferSkip` defect did) would hang
+// the matcher and surface as a timeout rather than a wrong-answer.
+
+describe("optionalPolicy coverage", () => {
+    // Grammar: `(please)? help` — one optional prefix.
+    const g = `<Start> = (please)? help -> true;`;
+    let grammar: Grammar;
+    beforeAll(() => {
+        grammar = loadGrammarRules("test.grammar", g);
+    });
+
+    describe("exhaustive (default)", () => {
+        it("input with the optional present yields a single parse", () => {
+            // Skip path leaves "please help" to be matched as "help",
+            // which fails — only the take path succeeds.
+            expect(match(grammar, "please help")).toStrictEqual([true]);
+        });
+        it("input without the optional yields a single parse", () => {
+            expect(match(grammar, "help")).toStrictEqual([true]);
+        });
+    });
+
+    describe("preferTake", () => {
+        it("takes when the take path succeeds", () => {
+            expect(
+                match(grammar, "please help", { optionalPolicy: "preferTake" }),
+            ).toStrictEqual([true]);
+        });
+        it("falls back to skip when take fails", () => {
+            // `please` literal is absent, so the take path fails and
+            // the matcher restores the queued skip-frame.
+            expect(
+                match(grammar, "help", { optionalPolicy: "preferTake" }),
+            ).toStrictEqual([true]);
+        });
+    });
+
+    describe("preferSkip", () => {
+        it("falls back to take when skip fails", () => {
+            // The regression case from
+            // optionalPolicyPreferSkipBacktrack.spec.ts; included here
+            // for axis-completeness.
+            expect(
+                match(grammar, "please help", { optionalPolicy: "preferSkip" }),
+            ).toStrictEqual([true]);
+        }, 5000);
+        it("commits to skip when skip succeeds", () => {
+            expect(
+                match(grammar, "help", { optionalPolicy: "preferSkip" }),
+            ).toStrictEqual([true]);
+        }, 5000);
+    });
+
+    describe("downstream parts unaffected by the consumed flag", () => {
+        // Two optional groups; the suppression flag set on the take
+        // snapshot must not leak into the second optional.
+        const g2 = `<Start> = (please)? do (thanks)? -> true;`;
+        let grammar2: Grammar;
+        beforeAll(() => {
+            grammar2 = loadGrammarRules("test.grammar", g2);
+        });
+        for (const optionalPolicy of [
+            "exhaustive",
+            "preferTake",
+            "preferSkip",
+        ] as const) {
+            it(`(${optionalPolicy}) "please do thanks" matches`, () => {
+                expect(
+                    match(grammar2, "please do thanks", { optionalPolicy }),
+                ).toContain(true);
+            }, 5000);
+            it(`(${optionalPolicy}) "do" matches`, () => {
+                expect(match(grammar2, "do", { optionalPolicy })).toContain(
+                    true,
+                );
+            }, 5000);
+        }
+    });
+});
+
+describe("repeatPolicy coverage", () => {
+    // Grammar: `(a)+ $(x)` — repeat the `a` literal one-or-more times,
+    // then capture the rest of the input as a wildcard.
+    //
+    // Input "a a a" admits two valid splits (the third `a` cannot be
+    // both consumed by the repeat AND captured by the wildcard, since
+    // the wildcard requires at least one non-separator character):
+    //   - count=1, x="a a"
+    //   - count=2, x="a"
+    // count=3 fails (wildcard would be empty).
+    const g = `<Start> = (a)+ $(x) -> { x };`;
+    let grammar: Grammar;
+    beforeAll(() => {
+        grammar = loadGrammarRules("test.grammar", g);
+    });
+
+    describe("exhaustive (default)", () => {
+        it("returns every valid (count, x) split", () => {
+            const results = match(grammar, "a a a");
+            expect(results).toEqual(
+                expect.arrayContaining([{ x: "a a" }, { x: "a" }]),
+            );
+            expect(results).toHaveLength(2);
+        });
+    });
+
+    describe("greedy", () => {
+        it("commits to the longest viable repeat count", () => {
+            // count=2 is the longest count that still leaves a
+            // non-empty wildcard.
+            const results = match(grammar, "a a a", {
+                repeatPolicy: "greedy",
+            });
+            expect(results).toStrictEqual([{ x: "a" }]);
+        }, 5000);
+    });
+
+    describe("nonGreedy", () => {
+        it("commits to the shortest viable repeat count", () => {
+            // count=1 is the minimum required by `+`.
+            const results = match(grammar, "a a a", {
+                repeatPolicy: "nonGreedy",
+            });
+            expect(results).toStrictEqual([{ x: "a a" }]);
+        }, 5000);
+    });
+
+    describe("()* zero-or-more", () => {
+        // `*` admits count=0 as a valid alternative.  Grammar:
+        //   (a)* $(x)
+        // input "a a a" — count=0 ⇒ x="a a a"; count=1 ⇒ x="a a";
+        // count=2 ⇒ x="a"; count=3 fails (empty wildcard).
+        //
+        // NOTE: count=0 is NOT a repeat-origin fork — when the inner
+        // `( ... )?` skips, no nested rule is ever entered, so
+        // `finalizeNestedRule` is not called and no repeat-frame is
+        // pushed.  Consequently `repeatPolicy` does not influence
+        // the count=0 vs count≥1 split (that is governed by the
+        // OUTER optional fork via `optionalPolicy`).  The test
+        // documents this interaction.
+        const gStar = `<Start> = (a)* $(x) -> { x };`;
+        let grammarStar: Grammar;
+        beforeAll(() => {
+            grammarStar = loadGrammarRules("test.grammar", gStar);
+        });
+
+        it("exhaustive returns all counts from 0 upward", () => {
+            const results = match(grammarStar, "a a a");
+            expect(results).toEqual(
+                expect.arrayContaining([
+                    { x: "a a a" },
+                    { x: "a a" },
+                    { x: "a" },
+                ]),
+            );
+        });
+
+        it("greedy still allows count=0 fallback via the optional axis", () => {
+            // Greedy collapses the count≥1 branch to its longest
+            // valid count, but the count=0 alternative comes from
+            // the OUTER optional fork — `optionalPolicy` controls
+            // whether it is enumerated.  With optionalPolicy
+            // exhaustive (default) we still see count=0.
+            const results = match(grammarStar, "a a a", {
+                repeatPolicy: "greedy",
+            });
+            // Expect the count=0 result plus the greedy count≥1 pick.
+            expect(results).toEqual(
+                expect.arrayContaining([{ x: "a a a" }, { x: "a" }]),
+            );
+        }, 5000);
+
+        it("greedy + preferTake collapses to a single longest parse", () => {
+            // preferTake commits to entering the repeat (skipping
+            // count=0); greedy then commits to the longest count.
+            const results = match(grammarStar, "a a a", {
+                repeatPolicy: "greedy",
+                optionalPolicy: "preferTake",
+            });
+            expect(results).toStrictEqual([{ x: "a" }]);
+        }, 5000);
+
+        it("nonGreedy + preferTake collapses to count=1", () => {
+            const results = match(grammarStar, "a a a", {
+                repeatPolicy: "nonGreedy",
+                optionalPolicy: "preferTake",
+            });
+            expect(results).toStrictEqual([{ x: "a a" }]);
+        }, 5000);
+    });
+});

--- a/ts/packages/actionGrammar/test/shortestWildcard.spec.ts
+++ b/ts/packages/actionGrammar/test/shortestWildcard.spec.ts
@@ -1,0 +1,620 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { loadGrammarRules } from "../src/grammarLoader.js";
+import { matchGrammar } from "../src/grammarMatcher.js";
+import type { Grammar } from "../src/grammarTypes.js";
+
+function match(grammar: Grammar, request: string): unknown[] {
+    return matchGrammar(grammar, request).map((m) => m.match);
+}
+
+function matchShortest(grammar: Grammar, request: string): unknown[] {
+    return matchGrammar(grammar, request, {
+        wildcardPolicy: "shortest",
+    }).map((m) => m.match);
+}
+
+describe("shortestWildcard option", () => {
+    // ---------------------------------------------------------------
+    // Basic two-wildcard case (the motivating example)
+    // ---------------------------------------------------------------
+    describe("basic: two wildcards with ambiguous delimiter", () => {
+        const g = `<Start> = play $(track) by $(artist) -> { actionName: "playTrack", parameters: { track, artist }};`;
+        let grammar: Grammar;
+        beforeAll(() => {
+            grammar = loadGrammarRules("test.grammar", g);
+        });
+
+        it("exhaustive (default) returns multiple matches", () => {
+            const results = match(grammar, "play 5 by 5 by Math");
+            expect(results.length).toBeGreaterThan(1);
+        });
+
+        it("shortestWildcard returns single leftmost-shortest match", () => {
+            const results = matchShortest(grammar, "play 5 by 5 by Math");
+            expect(results).toHaveLength(1);
+            expect(results[0]).toStrictEqual({
+                actionName: "playTrack",
+                parameters: { track: "5", artist: "5 by Math" },
+            });
+        });
+
+        it("shortestWildcard with unambiguous input matches normally", () => {
+            const results = matchShortest(grammar, "play Stairway by Zeppelin");
+            expect(results).toHaveLength(1);
+            expect(results[0]).toStrictEqual({
+                actionName: "playTrack",
+                parameters: {
+                    track: "Stairway",
+                    artist: "Zeppelin",
+                },
+            });
+        });
+    });
+
+    // ---------------------------------------------------------------
+    // Backtracking: shortest wildcard leads to dead end
+    // ---------------------------------------------------------------
+    describe("backtracking when shortest wildcard fails", () => {
+        // $(a) captures the shortest string before "x", then "y" must follow.
+        // Input: "a x b x y" — shortest a="a" then expects "y" but sees "b",
+        // so must backtrack to a="a x b" to find "x y".
+        const g = `<Start> = $(a) x y -> { a };`;
+        let grammar: Grammar;
+        beforeAll(() => {
+            grammar = loadGrammarRules("test.grammar", g);
+        });
+
+        it("exhaustive returns the only valid match", () => {
+            const results = match(grammar, "a x b x y");
+            expect(results).toHaveLength(1);
+            expect(results[0]).toStrictEqual({ a: "a x b" });
+        });
+
+        it("shortestWildcard backtracks to find the valid match", () => {
+            const results = matchShortest(grammar, "a x b x y");
+            expect(results).toHaveLength(1);
+            expect(results[0]).toStrictEqual({ a: "a x b" });
+        });
+    });
+
+    // ---------------------------------------------------------------
+    // Multiple top-level rules: both should match independently
+    // ---------------------------------------------------------------
+    describe("multiple top-level rules are not pruned", () => {
+        const g = [
+            `<Start> = play $(track) by $(artist) -> { actionName: "playTrack", parameters: { track, artist }};`,
+            `<Start> = search $(query) by $(field) -> { actionName: "search", parameters: { query, field }};`,
+        ].join("\n");
+        let grammar: Grammar;
+        beforeAll(() => {
+            grammar = loadGrammarRules("test.grammar", g);
+        });
+
+        it("only one rule matches, shortestWildcard returns it", () => {
+            const results = matchShortest(grammar, "play 5 by 5 by Math");
+            expect(results).toHaveLength(1);
+            expect(results[0]).toStrictEqual({
+                actionName: "playTrack",
+                parameters: { track: "5", artist: "5 by Math" },
+            });
+        });
+
+        it("both rules match different inputs independently", () => {
+            const playResults = matchShortest(
+                grammar,
+                "play foo by bar by baz",
+            );
+            expect(playResults).toHaveLength(1);
+            expect((playResults[0] as any).actionName).toBe("playTrack");
+
+            const searchResults = matchShortest(
+                grammar,
+                "search foo by bar by baz",
+            );
+            expect(searchResults).toHaveLength(1);
+            expect((searchResults[0] as any).actionName).toBe("search");
+        });
+    });
+
+    // ---------------------------------------------------------------
+    // Nested alternatives: should NOT be pruned
+    // ---------------------------------------------------------------
+    describe("nested alternatives survive pruning", () => {
+        const g = [
+            `<Start> = $(a) <sep> $(b) -> { a, b };`,
+            `<sep> = by | from;`,
+        ].join("\n");
+        let grammar: Grammar;
+        beforeAll(() => {
+            grammar = loadGrammarRules("test.grammar", g);
+        });
+
+        it("exhaustive returns matches for both alternatives", () => {
+            // "track by something from artist" can match:
+            // - via "by": a="track", b="something from artist"
+            // - via "from": a="track by something", b="artist"
+            const results = match(grammar, "track by something from artist");
+            expect(results.length).toBeGreaterThanOrEqual(2);
+        });
+
+        it("shortestWildcard returns one match per alternative", () => {
+            // Both "by" and "from" alternatives should still be explored.
+            // For "by" alternative: a="track" (shortest before "by"), b="something from artist"
+            // For "from" alternative: a="track by something" (shortest before "from"), b="artist"
+            const results = matchShortest(
+                grammar,
+                "track by something from artist",
+            );
+            expect(results).toHaveLength(2);
+            // Find by-alternative result
+            const byResult = results.find(
+                (r: any) => r.a === "track" && r.b === "something from artist",
+            );
+            expect(byResult).toBeDefined();
+            // Find from-alternative result
+            const fromResult = results.find(
+                (r: any) => r.a === "track by something" && r.b === "artist",
+            );
+            expect(fromResult).toBeDefined();
+        });
+    });
+
+    // ---------------------------------------------------------------
+    // Single wildcard: no ambiguity, same result either way
+    // ---------------------------------------------------------------
+    describe("single wildcard: no difference", () => {
+        const g = `<Start> = play $(track) -> { track };`;
+        let grammar: Grammar;
+        beforeAll(() => {
+            grammar = loadGrammarRules("test.grammar", g);
+        });
+
+        it("exhaustive and shortestWildcard produce same result", () => {
+            const exhaustive = match(grammar, "play hello world");
+            const shortest = matchShortest(grammar, "play hello world");
+            expect(shortest).toStrictEqual(exhaustive);
+            expect(shortest).toHaveLength(1);
+            expect(shortest[0]).toStrictEqual({ track: "hello world" });
+        });
+    });
+
+    // ---------------------------------------------------------------
+    // Trailing wildcard: captures everything after the last literal
+    // ---------------------------------------------------------------
+    describe("trailing wildcard captures remainder", () => {
+        const g = `<Start> = find $(query) in $(location) -> { query, location };`;
+        let grammar: Grammar;
+        beforeAll(() => {
+            grammar = loadGrammarRules("test.grammar", g);
+        });
+
+        it("exhaustive with repeated delimiter", () => {
+            const results = match(grammar, "find books in the library in town");
+            expect(results.length).toBeGreaterThan(1);
+        });
+
+        it("shortestWildcard picks leftmost-shortest for first wildcard", () => {
+            const results = matchShortest(
+                grammar,
+                "find books in the library in town",
+            );
+            expect(results).toHaveLength(1);
+            expect(results[0]).toStrictEqual({
+                query: "books",
+                location: "the library in town",
+            });
+        });
+    });
+
+    // ---------------------------------------------------------------
+    // Three wildcards: each captures leftmost-shortest
+    // ---------------------------------------------------------------
+    describe("three wildcards: leftmost-shortest each", () => {
+        const g = `<Start> = $(a) x $(b) x $(c) -> { a, b, c };`;
+        let grammar: Grammar;
+        beforeAll(() => {
+            grammar = loadGrammarRules("test.grammar", g);
+        });
+
+        it("exhaustive returns multiple combinations", () => {
+            // "p x q x r x s" has "x" at positions 2, 6, 10
+            // Multiple ways to split across wildcards
+            const results = match(grammar, "p x q x r x s");
+            expect(results.length).toBeGreaterThan(1);
+        });
+
+        it("shortestWildcard returns one result with leftmost-shortest", () => {
+            const results = matchShortest(grammar, "p x q x r x s");
+            expect(results).toHaveLength(1);
+            // a="p" (shortest before first x)
+            // b="q" (shortest before second x)
+            // c="r x s" (remainder)
+            expect(results[0]).toStrictEqual({
+                a: "p",
+                b: "q",
+                c: "r x s",
+            });
+        });
+    });
+
+    // ---------------------------------------------------------------
+    // Optional parts are not pruned
+    // ---------------------------------------------------------------
+    describe("optional parts survive pruning", () => {
+        const g = `<Start> = play $(track) (by $(artist))? -> { actionName: "play", parameters: { track }};`;
+        let grammar: Grammar;
+        beforeAll(() => {
+            grammar = loadGrammarRules("test.grammar", g);
+        });
+
+        it("with optional present", () => {
+            const results = matchShortest(grammar, "play song by artist");
+            // Both "with optional" and "without optional" matches should remain
+            // since optional push is NOT tagged as wildcard expansion
+            expect(results.length).toBeGreaterThanOrEqual(1);
+        });
+
+        it("without optional part", () => {
+            const results = matchShortest(grammar, "play my song");
+            expect(results.length).toBeGreaterThanOrEqual(1);
+        });
+    });
+
+    // ---------------------------------------------------------------
+    // No match: should return empty in both modes
+    // ---------------------------------------------------------------
+    describe("no match returns empty", () => {
+        const g = `<Start> = play $(track) by $(artist) -> { track, artist };`;
+        let grammar: Grammar;
+        beforeAll(() => {
+            grammar = loadGrammarRules("test.grammar", g);
+        });
+
+        it("exhaustive returns empty", () => {
+            expect(match(grammar, "search something")).toStrictEqual([]);
+        });
+
+        it("shortestWildcard returns empty", () => {
+            expect(matchShortest(grammar, "search something")).toStrictEqual(
+                [],
+            );
+        });
+    });
+
+    // ---------------------------------------------------------------
+    // No wildcards at all: shortestWildcard has no effect
+    // ---------------------------------------------------------------
+    describe("no wildcards: flag has no effect", () => {
+        const g = `<Start> = hello world -> true;`;
+        let grammar: Grammar;
+        beforeAll(() => {
+            grammar = loadGrammarRules("test.grammar", g);
+        });
+
+        it("same result in both modes", () => {
+            expect(match(grammar, "hello world")).toStrictEqual([true]);
+            expect(matchShortest(grammar, "hello world")).toStrictEqual([true]);
+        });
+    });
+
+    // ---------------------------------------------------------------
+    // Wildcard with number part
+    // ---------------------------------------------------------------
+    describe("wildcard before number part", () => {
+        const g = `<Start> = $(label) $(count:number) items -> { label, count };`;
+        let grammar: Grammar;
+        beforeAll(() => {
+            grammar = loadGrammarRules("test.grammar", g);
+        });
+
+        it("exhaustive with ambiguous numbers", () => {
+            // "aisle 5 3 items" — wildcard "aisle" or "aisle 5"?
+            // (5 could be consumed by wildcard or by the number part)
+            const results = match(grammar, "aisle 5 3 items");
+            expect(results.length).toBeGreaterThanOrEqual(1);
+        });
+
+        it("shortestWildcard picks shortest label", () => {
+            const results = matchShortest(grammar, "aisle 5 3 items");
+            expect(results).toHaveLength(1);
+            // Two back-to-back wildcards: $(label) consumes up to
+            // the last number that can still satisfy $(count:number).
+            // The number matcher finds "3" as the last number before "items",
+            // so label="aisle 5", count=3.
+            expect(results[0]).toStrictEqual({
+                label: "aisle 5",
+                count: 3,
+            });
+        });
+    });
+
+    // ---------------------------------------------------------------
+    // Multiple top-level rules with wildcards — independent pruning
+    // ---------------------------------------------------------------
+    describe("independent pruning per top-level rule", () => {
+        const g = [
+            `<Start> = cmd $(a) x $(b) -> { action: "cmd", a, b };`,
+            `<Start> = run $(c) x $(d) -> { action: "run", c, d };`,
+        ].join("\n");
+        let grammar: Grammar;
+        beforeAll(() => {
+            grammar = loadGrammarRules("test.grammar", g);
+        });
+
+        it("exhaustive produces multiple per rule", () => {
+            const cmdResults = match(grammar, "cmd p x q x r");
+            const cmdMatches = cmdResults.filter(
+                (r: any) => r.action === "cmd",
+            );
+            expect(cmdMatches.length).toBeGreaterThan(1);
+        });
+
+        it("shortestWildcard gives one per matching rule", () => {
+            // Only "cmd" rule matches
+            const results = matchShortest(grammar, "cmd p x q x r");
+            expect(results).toHaveLength(1);
+            expect(results[0]).toStrictEqual({
+                action: "cmd",
+                a: "p",
+                b: "q x r",
+            });
+        });
+
+        it("both rules match different inputs independently", () => {
+            const cmdResults = matchShortest(grammar, "cmd p x q x r");
+            expect(cmdResults).toHaveLength(1);
+            expect((cmdResults[0] as any).action).toBe("cmd");
+
+            const runResults = matchShortest(grammar, "run p x q x r");
+            expect(runResults).toHaveLength(1);
+            expect((runResults[0] as any).action).toBe("run");
+        });
+    });
+
+    // ---------------------------------------------------------------
+    // Default (no options): same as before (exhaustive)
+    // ---------------------------------------------------------------
+    describe("default behavior unchanged (no options)", () => {
+        const g = `<Start> = $(a) x $(b) -> { a, b };`;
+        let grammar: Grammar;
+        beforeAll(() => {
+            grammar = loadGrammarRules("test.grammar", g);
+        });
+
+        it("returns all combinations when no options passed", () => {
+            const results = matchGrammar(grammar, "p x q x r");
+            expect(results.length).toBeGreaterThan(1);
+        });
+
+        it("returns all combinations when options is undefined", () => {
+            const results = matchGrammar(grammar, "p x q x r", undefined);
+            expect(results.length).toBeGreaterThan(1);
+        });
+
+        it("returns all combinations when shortestWildcard is false", () => {
+            const results = matchGrammar(grammar, "p x q x r", {
+                wildcardPolicy: "exhaustive",
+            });
+            expect(results.length).toBeGreaterThan(1);
+        });
+    });
+
+    // ---------------------------------------------------------------
+    // Nested rule alternatives with wildcards on both sides
+    // ---------------------------------------------------------------
+    describe("nested alternatives with multi-wildcard parent", () => {
+        const g = [
+            `<Start> = $(a) <delim> $(b) -> { a, b };`,
+            `<delim> = x | y;`,
+        ].join("\n");
+        let grammar: Grammar;
+        beforeAll(() => {
+            grammar = loadGrammarRules("test.grammar", g);
+        });
+
+        it("both alternatives explored, each with shortest wildcard", () => {
+            // "p x q y r" can match via "x" or "y"
+            // via "x": a="p" (shortest), b="q y r"
+            // via "y": a="p x q" (shortest before "y"), b="r"
+            const results = matchShortest(grammar, "p x q y r");
+            expect(results).toHaveLength(2);
+            const xResult = results.find(
+                (r: any) => r.a === "p" && r.b === "q y r",
+            );
+            expect(xResult).toBeDefined();
+            const yResult = results.find(
+                (r: any) => r.a === "p x q" && r.b === "r",
+            );
+            expect(yResult).toBeDefined();
+        });
+    });
+
+    // ---------------------------------------------------------------
+    // Nested alternatives: three choices, wildcard before each
+    // ---------------------------------------------------------------
+    describe("three nested alternatives each get shortest wildcards", () => {
+        const g = [
+            `<Start> = $(a) <kw> $(b) -> { a, b };`,
+            `<kw> = at | in | on;`,
+        ].join("\n");
+        let grammar: Grammar;
+        beforeAll(() => {
+            grammar = loadGrammarRules("test.grammar", g);
+        });
+
+        it("all three alternatives explored with ambiguous input", () => {
+            // "meet at noon in the park on tuesday"
+            // "at" alt: a="meet", b="noon in the park on tuesday"
+            // "in" alt: a="meet at noon", b="the park on tuesday"
+            // "on" alt: a="meet at noon in the park", b="tuesday"
+            const results = matchShortest(
+                grammar,
+                "meet at noon in the park on tuesday",
+            );
+            expect(results).toHaveLength(3);
+            expect(
+                results.find(
+                    (r: any) =>
+                        r.a === "meet" && r.b === "noon in the park on tuesday",
+                ),
+            ).toBeDefined();
+            expect(
+                results.find(
+                    (r: any) =>
+                        r.a === "meet at noon" && r.b === "the park on tuesday",
+                ),
+            ).toBeDefined();
+            // "on" is found inside "noon" — the matcher scans for substrings
+            expect(
+                results.find(
+                    (r: any) =>
+                        r.a === "meet at no" &&
+                        r.b === "in the park on tuesday",
+                ),
+            ).toBeDefined();
+        });
+    });
+
+    // ---------------------------------------------------------------
+    // Exact match (no ambiguity): works in both modes
+    // ---------------------------------------------------------------
+    describe("exact match with wildcards consumes all input", () => {
+        const g = `<Start> = $(a) plus $(b) -> { a, b };`;
+        let grammar: Grammar;
+        beforeAll(() => {
+            grammar = loadGrammarRules("test.grammar", g);
+        });
+
+        it("unique delimiter gives one result in both modes", () => {
+            const exhaustive = match(grammar, "foo plus bar");
+            const shortest = matchShortest(grammar, "foo plus bar");
+            expect(exhaustive).toHaveLength(1);
+            expect(shortest).toHaveLength(1);
+            expect(shortest[0]).toStrictEqual({ a: "foo", b: "bar" });
+        });
+    });
+
+    // ---------------------------------------------------------------
+    // Backtracking with nested alternative: dead end on one alternative,
+    // success on longer wildcard for another
+    // ---------------------------------------------------------------
+    describe("backtracking with nested alternatives", () => {
+        // <Start> = $(a) <kw> done
+        // <kw> = x | y
+        // Input: "foo x bar y done"
+        // "x" alt: a="foo" x, then expects "done" but sees "bar" -> dead end
+        //   backtrack: a="foo x bar y" x -> no more "x" -> fail
+        // "y" alt: a="foo x bar" y done -> success
+        const g = [`<Start> = $(a) <kw> done -> { a };`, `<kw> = x | y;`].join(
+            "\n",
+        );
+        let grammar: Grammar;
+        beforeAll(() => {
+            grammar = loadGrammarRules("test.grammar", g);
+        });
+
+        it("finds match via backtracking to correct alternative", () => {
+            const results = matchShortest(grammar, "foo x bar y done");
+            expect(results.length).toBeGreaterThanOrEqual(1);
+            // "y" alt with a="foo x bar" is the valid match
+            expect(results.find((r: any) => r.a === "foo x bar")).toBeDefined();
+        });
+    });
+
+    // ---------------------------------------------------------------
+    // Two top-level rules, both match: independent shortest per rule
+    // ---------------------------------------------------------------
+    describe("two top-level rules both matching same input", () => {
+        // Both rules can match "a x b x c"
+        const g = [
+            `<Start> = $(p) x $(q) -> { rule: "first", p, q };`,
+            `<Start> = $(r) x $(s) -> { rule: "second", r, s };`,
+        ].join("\n");
+        let grammar: Grammar;
+        beforeAll(() => {
+            grammar = loadGrammarRules("test.grammar", g);
+        });
+
+        it("both rules return one result each with shortest wildcards", () => {
+            const results = matchShortest(grammar, "a x b x c");
+            // Both rules match because they have the same structure.
+            // Each should return one result with leftmost-shortest.
+            expect(results).toHaveLength(2);
+            const first = results.find((r: any) => r.rule === "first");
+            const second = results.find((r: any) => r.rule === "second");
+            expect(first).toStrictEqual({ rule: "first", p: "a", q: "b x c" });
+            expect(second).toStrictEqual({
+                rule: "second",
+                r: "a",
+                s: "b x c",
+            });
+        });
+    });
+
+    // ---------------------------------------------------------------
+    // Repeat groups are not pruned
+    // ---------------------------------------------------------------
+    describe("repeat groups survive pruning", () => {
+        const g = `<Start> = (hello)+ world -> true;`;
+        let grammar: Grammar;
+        beforeAll(() => {
+            grammar = loadGrammarRules("test.grammar", g);
+        });
+
+        it("repeat still works in shortestWildcard mode", () => {
+            const exhaustive = match(grammar, "hello hello world");
+            const shortest = matchShortest(grammar, "hello hello world");
+            expect(exhaustive).toStrictEqual([true]);
+            expect(shortest).toStrictEqual([true]);
+        });
+    });
+
+    // ---------------------------------------------------------------
+    // Result uniqueness in default mode: each viable wildcard
+    // placement should be emitted exactly once.  Regression guard
+    // against the in-place extend-on-success loop in `matchGrammar`
+    // double-emitting paths that are also queued via `pending`.
+    // ---------------------------------------------------------------
+    describe("default mode emits no duplicate results", () => {
+        it("two wildcards with multiple anchors each", () => {
+            const g = `<Start> = $(a) x $(b) x end -> { a, b };`;
+            const grammar = loadGrammarRules("test.grammar", g);
+            // Input "a x b x c x end" admits these (a, b) splits:
+            //   ("a",         "b x c")
+            //   ("a x b",     "c")
+            const results = match(grammar, "a x b x c x end");
+            const serialized = results.map((r) => JSON.stringify(r));
+            expect(new Set(serialized).size).toBe(serialized.length);
+            expect(serialized.sort()).toStrictEqual(
+                [
+                    JSON.stringify({ a: "a", b: "b x c" }),
+                    JSON.stringify({ a: "a x b", b: "c" }),
+                ].sort(),
+            );
+        });
+
+        it("wildcard before a nested-rule with alternatives", () => {
+            // Sibling MatchStates spawned for nested-rule
+            // alternatives must not share ownership of the parent's
+            // wildcard-frame chain — otherwise each branch can
+            // independently extend to the same successful capture
+            // and double-emit the parse.  Single-owner enforcement
+            // happens via `cloneMatchState` at the spawn site.
+            const g = [
+                `<body> = foo bar | bar;`,
+                `<Start> = $(a) sep <body> -> { a };`,
+            ].join("\n");
+            const grammar = loadGrammarRules("test.grammar", g);
+            // Only one valid parse: a="a sep foo b" matched via
+            // the `bar` alternative.
+            const results = match(grammar, "a sep foo b sep bar");
+            const serialized = results.map((r) => JSON.stringify(r));
+            expect(new Set(serialized).size).toBe(serialized.length);
+            expect(serialized).toStrictEqual([
+                JSON.stringify({ a: "a sep foo b" }),
+            ]);
+        });
+    });
+});

--- a/ts/packages/actionGrammar/test/wildcardFrameInteractions.spec.ts
+++ b/ts/packages/actionGrammar/test/wildcardFrameInteractions.spec.ts
@@ -1,0 +1,268 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// Default-mode (`wildcardPolicy: "exhaustive"`) regression tests
+// for wildcard-length alternatives in `grammarMatcher`.
+//
+// Longer-wildcard alternatives live on the live state's unified
+// `backtracks` chain as `"wildcard"`-origin frames pushed by
+// `captureWildcard`.  Forked siblings (optional-skip, nested-rule
+// alternatives, repeat continuation) are produced by `forkMatchState`
+// which DROPS the chain on the fork — enforcing a single-owner
+// invariant on the backtrack chain.
+//
+// Correctness in default mode therefore depends on the live state
+// re-spawning a fresh sibling at EACH viable wildcard length: when
+// the matcher restores a `"wildcard"`-origin frame and re-runs
+// `matchState`, the part loop is expected to push a NEW optional-
+// skip / repeat backtrack at the new length.  These tests construct
+// inputs where the longer-wildcard parse exists but is reachable
+// only through that re-fork behavior.
+//
+// `wildcardFrameSnapshot.spec.ts` covers the snapshot-completeness
+// half of the same invariant for optional-skip and nested-rule alt.
+// This file extends coverage to the repeat-continuation re-spawn,
+// the consecutive-wildcard frame-stack discipline, and the
+// completion-side inner-loop refactor.
+
+import { matchGrammarCompletion } from "../src/grammarCompletion.js";
+import { loadGrammarRules } from "../src/grammarLoader.js";
+import { matchGrammar } from "../src/grammarMatcher.js";
+import type { Grammar } from "../src/grammarTypes.js";
+import { expectMetadata } from "./testUtils.js";
+
+function uniqueMatches(grammar: Grammar, request: string): string[] {
+    const results = matchGrammar(grammar, request).map((m) =>
+        JSON.stringify(m.match),
+    );
+    return Array.from(new Set(results)).sort();
+}
+
+function allMatches(grammar: Grammar, request: string): string[] {
+    return matchGrammar(grammar, request)
+        .map((m) => JSON.stringify(m.match))
+        .sort();
+}
+
+describe("wildcard-frame default-mode interactions", () => {
+    // -----------------------------------------------------------------
+    // Optional BEFORE wildcard — opt-skip is queued before the
+    // wildcard is encountered, so it gets a fresh frame chain
+    // naturally.  Both branches must surface independently.
+    // -----------------------------------------------------------------
+    describe("optional before wildcard: both branches enumerate independently", () => {
+        // Grammar: (foo)? $(x) bar
+        //
+        // Input: "foo p bar"
+        //
+        // Viable parses (both fully consume the input):
+        //   - opt taken: "foo" matched, x="p",      "bar" matched
+        //   - opt skip:  x="foo p",                 "bar" matched
+        const g = `<Start> = (foo)? $(x) bar -> { x };`;
+        let grammar: Grammar;
+        beforeAll(() => {
+            grammar = loadGrammarRules("test.grammar", g);
+        });
+
+        it("emits one match per branch with no duplicates", () => {
+            const all = allMatches(grammar, "foo p bar");
+            const unique = Array.from(new Set(all)).sort();
+            expect(all).toStrictEqual(unique);
+            expect(all).toStrictEqual(
+                [
+                    JSON.stringify({ x: "p" }),
+                    JSON.stringify({ x: "foo p" }),
+                ].sort(),
+            );
+        });
+    });
+
+    // -----------------------------------------------------------------
+    // Repeat AFTER wildcard: the only valid parse requires extending
+    // the wildcard past the first repeat occurrence and re-spawning
+    // the repeat continuation at the new wildcard length.
+    // -----------------------------------------------------------------
+    describe("repeat after wildcard: re-spawned per length", () => {
+        // Grammar: $(x) sep (more)+
+        //
+        // Input: "p sep more sep more"
+        //
+        // Viable parse:
+        //   - x="p sep more", (more)+ matches the trailing "more" ✓
+        //
+        // The shorter x="p" parse is partial: (more)+ matches the
+        // first "more", but trailing " sep more" remains so
+        // finalizeState rejects it.  The longer parse requires
+        // extending the wildcard frame and re-encountering the
+        // repeat group, which spawns a new continuation entry with
+        // an empty frame chain.
+        const g = `<Start> = $(x) sep (more)+ -> { x };`;
+        let grammar: Grammar;
+        beforeAll(() => {
+            grammar = loadGrammarRules("test.grammar", g);
+        });
+
+        it("longer-wildcard parse emerges via re-spawned repeat continuation", () => {
+            const unique = uniqueMatches(grammar, "p sep more sep more");
+            expect(unique).toStrictEqual([JSON.stringify({ x: "p sep more" })]);
+        });
+
+        it("no parse is double-emitted across repeat × wildcard length", () => {
+            const all = allMatches(grammar, "p sep more sep more");
+            const unique = Array.from(new Set(all)).sort();
+            expect(all).toStrictEqual(unique);
+        });
+    });
+
+    // -----------------------------------------------------------------
+    // Two consecutive wildcards: outer extension after inner has
+    // already pushed its own frame.  Verifies the linked-list stack
+    // discipline (most-recent first): inner extensions are exhausted
+    // before outer.
+    // -----------------------------------------------------------------
+    describe("two consecutive wildcards: stack discipline", () => {
+        // Grammar: $(a) x $(b) y
+        //
+        // Input: "p x q x r y"
+        //
+        // Viable (a, b) splits where "y" terminates b:
+        //   - a="p",     b="q x r"
+        //   - a="p x q", b="r"
+        //
+        // The longer-a parse requires extending the OUTER wildcard
+        // frame after the inner wildcard frames have been processed.
+        const g = `<Start> = $(a) x $(b) y -> { a, b };`;
+        let grammar: Grammar;
+        beforeAll(() => {
+            grammar = loadGrammarRules("test.grammar", g);
+        });
+
+        it("emits exactly the two valid splits, no duplicates", () => {
+            const all = allMatches(grammar, "p x q x r y");
+            const unique = Array.from(new Set(all)).sort();
+            expect(all).toStrictEqual(unique);
+            expect(all).toStrictEqual(
+                [
+                    JSON.stringify({ a: "p", b: "q x r" }),
+                    JSON.stringify({ a: "p x q", b: "r" }),
+                ].sort(),
+            );
+        });
+    });
+
+    // -----------------------------------------------------------------
+    // Wildcard before nested rule containing its own wildcard.
+    // Stresses snapshot completeness (parent / nestedLevel /
+    // spacingMode must reset on extend) AND the inner-frame /
+    // outer-frame stack discipline.
+    // -----------------------------------------------------------------
+    describe("wildcard before nested rule containing a wildcard", () => {
+        // Grammar:
+        //   <inner> = $(b) end -> b;
+        //   <Start> = $(a) sep $(i:<inner>) -> { a, i };
+        //
+        // Input: "p sep q end sep r end"
+        //
+        // Viable (a, i) splits — both wildcards must capture
+        // non-empty content AND the entire input must be consumed:
+        //   - a="p",           i="q end sep r" (inner b extends)
+        //   - a="p sep q end", i="r"           (outer a extends)
+        //
+        // The shorter-shorter split (a="p", i="q") is partial —
+        // " sep r end" remains unconsumed so finalizeState rejects.
+        // The two surviving parses each require a wildcard frame
+        // to be extended on a different axis (inner vs outer),
+        // exercising the linked-list stack discipline AND the
+        // snapshot reset of parent / nestedLevel / spacingMode
+        // when the OUTER frame is restored.
+        const g = [
+            `<inner> = $(b) end -> b;`,
+            `<Start> = $(a) sep $(i:<inner>) -> { a, i };`,
+        ].join("\n");
+        let grammar: Grammar;
+        beforeAll(() => {
+            grammar = loadGrammarRules("test.grammar", g);
+        });
+
+        it("emits both surviving parses with no duplicates", () => {
+            const all = allMatches(grammar, "p sep q end sep r end");
+            const unique = Array.from(new Set(all)).sort();
+            expect(all).toStrictEqual(unique);
+            expect(all).toStrictEqual(
+                [
+                    JSON.stringify({ a: "p", i: "q end sep r" }),
+                    JSON.stringify({ a: "p sep q end", i: "r" }),
+                ].sort(),
+            );
+        });
+    });
+
+    // -----------------------------------------------------------------
+    // Three wildcards in default mode: every viable (a, b, c) split
+    // must appear exactly once.  Regression guard against the
+    // in-place extend-on-success loop double-emitting paths.
+    // -----------------------------------------------------------------
+    describe("three wildcards: full enumeration without duplication", () => {
+        // Grammar: $(a) x $(b) x $(c) end
+        //
+        // Input: "p x q x r x s end"
+        //
+        // The terminal "end" anchors c; "x" delimits the three
+        // wildcards.  Viable (a, b, c) splits — each wildcard must
+        // capture at least one non-separator char:
+        //   - ("p",     "q",     "r x s")
+        //   - ("p",     "q x r", "s")
+        //   - ("p x q", "r",     "s")
+        const g = `<Start> = $(a) x $(b) x $(c) end -> { a, b, c };`;
+        let grammar: Grammar;
+        beforeAll(() => {
+            grammar = loadGrammarRules("test.grammar", g);
+        });
+
+        it("emits exactly the three splits with no duplicates", () => {
+            const all = allMatches(grammar, "p x q x r x s end");
+            const unique = Array.from(new Set(all)).sort();
+            expect(all).toStrictEqual(unique);
+            expect(all).toStrictEqual(
+                [
+                    JSON.stringify({ a: "p", b: "q", c: "r x s" }),
+                    JSON.stringify({ a: "p", b: "q x r", c: "s" }),
+                    JSON.stringify({ a: "p x q", b: "r", c: "s" }),
+                ].sort(),
+            );
+        });
+    });
+});
+
+// ---------------------------------------------------------------------
+// Default-mode completion: regression guard against the inner-loop
+// refactor in `collectCandidates`.  The previous design pushed each
+// longer-wildcard alternative as a new pending entry and processed
+// each via `matchState`; the new design drains every wildcard-extension
+// frame inline via `runStateWithExtensions`.  In default mode the
+// resulting candidate set must be unchanged.
+// ---------------------------------------------------------------------
+describe("grammar completion default-mode: candidate set preserved across wildcard extensions", () => {
+    // Grammar: play $(name) by $(artist)
+    //
+    // Input "play hello by world" is ambiguous — see
+    // grammarCompletionShortestWildcard.spec.ts for the full
+    // walkthrough.  In DEFAULT mode the longer-wildcard alternative
+    // must still surface its "by" completion at the full input
+    // length (P=19).  The refactored inner-loop must enumerate that
+    // alternative even though it is now processed inline against
+    // the same MatchState rather than as a clone in `pending`.
+    const g = `<Start> = play $(name) by $(artist) -> { name, artist };`;
+    const grammar = loadGrammarRules("test.grammar", g);
+
+    it("default mode still emits the longer-wildcard 'by' completion at P=19", () => {
+        const result = matchGrammarCompletion(grammar, "play hello by world");
+        // A regression in the inner extension loop would cause
+        // matchedPrefixLength to drop back to 13 (the shortest-
+        // wildcard partial-artist path).
+        expectMetadata(result, {
+            completions: ["by"],
+            matchedPrefixLength: 19,
+        });
+    });
+});

--- a/ts/packages/actionGrammar/test/wildcardFrameSnapshot.spec.ts
+++ b/ts/packages/actionGrammar/test/wildcardFrameSnapshot.spec.ts
@@ -1,0 +1,90 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// Regression tests for wildcard-frame snapshot completeness.
+//
+// `pushWildcardFrame` snapshots the current `MatchState` so that a
+// later `tryExtendWildcard` can `Object.assign` it back onto the live
+// state.  Several `MatchState` fields are optional (`values`,
+// `pendingWildcard`, `parent`, `suppressOptionalFork`, `lastMatchedPartInfo`) and
+// may be assigned AFTER the snapshot is taken — e.g. `addValueWithId`
+// commits the captured wildcard into `state.values` immediately after
+// the snapshot, and entering a nested rule sets `state.parent`.
+//
+// If the snapshot doesn't contain those fields as OWN properties
+// (because they were `undefined` at snapshot time and a plain spread
+// only copies own enumerable properties), `Object.assign` won't reset
+// them on extend — leaving stale post-snapshot state behind.  In
+// these cases that manifests as `state.nestedLevel` being decremented
+// below zero by `finalizeNestedRule` because a stale `parent` is
+// re-traversed.
+//
+// The cases below set up a scenario where the only valid parse
+// requires extending a wildcard AFTER the state has both committed
+// captured values and entered a nested rule.
+
+import { loadGrammarRules } from "../src/grammarLoader.js";
+import { matchGrammar } from "../src/grammarMatcher.js";
+import type { Grammar } from "../src/grammarTypes.js";
+
+function uniqueMatches(grammar: Grammar, request: string): string[] {
+    const results = matchGrammar(grammar, request).map((m) =>
+        JSON.stringify(m.match),
+    );
+    return Array.from(new Set(results)).sort();
+}
+
+describe("wildcard-frame snapshot completeness", () => {
+    describe("optional-skip path after wildcard capture", () => {
+        const g = `<Start> = $(x) end (opt)? tail -> { x };`;
+        let grammar: Grammar;
+        beforeAll(() => {
+            grammar = loadGrammarRules("test.grammar", g);
+        });
+
+        it("can extend wildcard cleanly via the skip-optional path", () => {
+            // Input: "a end b end tail"
+            // Viable parses:
+            //  - shortest x="a", with (opt)?: "opt" at "b" → fail
+            //  - shortest x="a", skip (opt)?: "tail" at "b" → fail
+            //  - longer x="a end b", with (opt)?: "opt" at "tail" → fail
+            //  - longer x="a end b", skip (opt)?: "tail" → MATCH
+            //
+            // The only valid parse requires extending the wildcard
+            // after at least one shorter capture has been committed
+            // and the alternative branches have been queued.
+            const unique = uniqueMatches(grammar, "a end b end tail");
+            expect(unique).toStrictEqual([JSON.stringify({ x: "a end b" })]);
+        });
+    });
+
+    describe("rules-part alternative after wildcard capture", () => {
+        // Use a sub-rule so the inner alternation's variables don't
+        // need to leak into <Start>'s value expression.
+        const g = `
+            <body> = foo bar | bar;
+            <Start> = $(x) end <body> -> { x };
+        `;
+        let grammar: Grammar;
+        beforeAll(() => {
+            grammar = loadGrammarRules("test.grammar", g);
+        });
+
+        it("can extend wildcard cleanly across nested-rule alternatives", () => {
+            // Input: "a end foo b end bar"
+            // Viable parses:
+            //  - alt1 "foo bar" with x="a":          "foo" ok, "bar" at "b" → fail
+            //  - alt2 "bar"     with x="a":          "bar" at "foo" → fail
+            //  - alt1 "foo bar" with x="a end foo b": remaining "bar" — "foo" fail
+            //  - alt2 "bar"     with x="a end foo b": "bar" at "bar" → MATCH
+            //
+            // The only valid parse requires extending the wildcard
+            // after the state has entered (and unwound from) a nested
+            // rule, then re-entered an alternative nested rule.
+            const unique = uniqueMatches(grammar, "a end foo b end bar");
+            expect(unique).toStrictEqual([
+                JSON.stringify({ x: "a end foo b" }),
+            ]);
+        });
+    });
+});

--- a/ts/packages/cache/src/cache/grammarStore.ts
+++ b/ts/packages/cache/src/cache/grammarStore.ts
@@ -393,11 +393,39 @@ export class GrammarStoreImpl implements GrammarStore {
                 }
             } else {
                 // simple grammar-based completions
+                //
+                // `wildcardPolicy: "shortest"` opts out of
+                // enumerating every wildcard-length alternative.
+                // Once any alternative has consumed all non-separator
+                // input (clean finalize, or a pending wildcard at a
+                // separator-only tail), longer-wildcard alternatives
+                // would surface the same completion candidates with
+                // strictly less informative prefix boundaries — and
+                // can re-emit literal terminators already matched at
+                // shorter wildcard lengths as spurious completions.
+                //
+                // User-visible behavior delta vs the prior exhaustive
+                // default: for ambiguous inputs that admit both a
+                // short-wildcard parse (with a downstream literal
+                // matched) and a long-wildcard parse (literal absorbed
+                // into the wildcard), the completion now anchors at
+                // the shorter parse and surfaces property-completion
+                // candidates for the unmatched downstream wildcard,
+                // instead of repeating the already-matched literal
+                // as a completion.  E.g. for grammar
+                // `play $(name) by $(artist)` and input
+                // "play hello by world", the completion now anchors
+                // at P=13 (after "by") and offers an `artist`
+                // property completion, rather than P=19 with "by"
+                // re-emitted as a literal completion.  See
+                // grammarCompletionShortestWildcard.spec.ts for the
+                // full behavioral matrix.
                 const partial = matchGrammarCompletion(
                     entry.grammar,
                     input,
                     matchedPrefixLength,
                     direction,
+                    { wildcardPolicy: "shortest" },
                 );
                 const partialPrefixLength = partial.matchedPrefixLength ?? 0;
                 if (partialPrefixLength !== matchedPrefixLength) {

--- a/ts/packages/security/mcpValidation/scripts/renderDocs.mjs
+++ b/ts/packages/security/mcpValidation/scripts/renderDocs.mjs
@@ -31,11 +31,15 @@ function parseArgs() {
         else if (a === "--title") opts.title = args[++i];
     }
     if (!opts.input) {
-        console.error("Usage: renderDocs.mjs --input <file.md> [--out <dir>] [--format html|pdf|both] [--title <title>]");
+        console.error(
+            "Usage: renderDocs.mjs --input <file.md> [--out <dir>] [--format html|pdf|both] [--title <title>]",
+        );
         process.exit(2);
     }
     if (!["html", "pdf", "both"].includes(opts.format)) {
-        console.error(`Unknown --format "${opts.format}". Use html, pdf, or both.`);
+        console.error(
+            `Unknown --format "${opts.format}". Use html, pdf, or both.`,
+        );
         process.exit(2);
     }
     return opts;
@@ -46,7 +50,12 @@ function which(name) {
     const cmd = isWin ? "where" : "which";
     const r = spawnSync(cmd, [name], { encoding: "utf-8" });
     if (r.status !== 0) return null;
-    return r.stdout.split(/\r?\n/).find((l) => l.trim().length > 0)?.trim() ?? null;
+    return (
+        r.stdout
+            .split(/\r?\n/)
+            .find((l) => l.trim().length > 0)
+            ?.trim() ?? null
+    );
 }
 
 function findPandoc() {
@@ -89,7 +98,9 @@ function findBrowser() {
 function run(cmd, args, opts = {}) {
     const r = spawnSync(cmd, args, { stdio: "inherit", ...opts });
     if (r.status !== 0) {
-        throw new Error(`${cmd} ${args.join(" ")} exited with code ${r.status}`);
+        throw new Error(
+            `${cmd} ${args.join(" ")} exited with code ${r.status}`,
+        );
     }
 }
 
@@ -107,12 +118,16 @@ function main() {
 
     const pandoc = findPandoc();
     if (!pandoc) {
-        console.error("pandoc not found on PATH. Install: winget install JohnMacFarlane.Pandoc");
+        console.error(
+            "pandoc not found on PATH. Install: winget install JohnMacFarlane.Pandoc",
+        );
         process.exit(1);
     }
     const mermaidFilter = findMermaidFilter();
     if (!mermaidFilter) {
-        console.error("mermaid-filter not found on PATH. Install: npm i -g @mermaid-js/mermaid-cli mermaid-filter");
+        console.error(
+            "mermaid-filter not found on PATH. Install: npm i -g @mermaid-js/mermaid-cli mermaid-filter",
+        );
         process.exit(1);
     }
 
@@ -128,11 +143,14 @@ function main() {
         console.log(`pandoc: ${inputAbs} → ${htmlOut}`);
         run(pandoc, [
             inputAbs,
-            "-o", htmlOut,
+            "-o",
+            htmlOut,
             "--standalone",
             "--embed-resources",
-            "--filter", mermaidFilter,
-            "--metadata", `title=${title}`,
+            "--filter",
+            mermaidFilter,
+            "--metadata",
+            `title=${title}`,
         ]);
     }
 

--- a/ts/packages/security/mcpValidation/testProject/index.html
+++ b/ts/packages/security/mcpValidation/testProject/index.html
@@ -2,7 +2,6 @@
 <!-- Copyright (c) Microsoft Corporation.
  Licensed under the MIT License. -->
 
-
 <html>
   <head>
     <title>Validation Testing</title>

--- a/ts/packages/security/validation/testProject/index.html
+++ b/ts/packages/security/validation/testProject/index.html
@@ -2,7 +2,6 @@
 <!-- Copyright (c) Microsoft Corporation.
  Licensed under the MIT License. -->
 
-
 <html>
   <head>
     <title>Validation Testing</title>


### PR DESCRIPTION
## Summary

Refactor of the `actionGrammar` matcher's backtracking machinery. Replaces the original "clone-into-pending" wildcard-extension scheme with an explicit-stack DFS over a single per-state linked list of resumable backtrack frames (`MatchState.backtracks`) covering wildcard refinement, optional take/skip, alternation, and repeat continue/stop. Generalizes the previous `shortestWildcard` boolean into three independent per-axis policies (`wildcardPolicy`, `optionalPolicy`, `repeatPolicy`) so callers can choose first-success commitment vs. exhaustive enumeration on each axis independently. Cache opts into `wildcardPolicy: "shortest"` for prefix completion.

## What changed

### `actionGrammar` — backtrack chain

- **Unified single-owner backtrack chain.** `MatchState.backtracks` is a single linked list of resumable DFS frames (most recent at head). One drain loop in `matchGrammar` / `matchGrammarCompletion` services every kind of fork uniformly.
- **`Backtrack` discriminated union.** Frames carry an `origin` tag — `"wildcard"`, `"optional"`, `"alternation"`, or `"repeat"` — used by `suppressBacktracksAfterSuccess` to apply per-axis first-success policy.
- **Compressed alternation frames.** N-way alternation now allocates **one** cursor frame + one shared base snapshot regardless of N (previously N-1 full snapshots). The cursor frame holds a direct `GrammarRule[]` reference and a `namePrefix`; `tryNextBacktrack` reads `parts/value/spacingMode` from `rules[cursor]` and builds the debug name lazily on restore. Used at both top-level and nested alternation sites.
- **Single-owner invariant, enforced at the type level.**
  - `PendingMatchState` is the base shape (snapshot payload).
  - `MatchState = PendingMatchState & { backtracks?, ...policies }` — only the live state may own frames.
  - `forkMatchState(state)` returns the strict `SnapshotState` (no `backtracks` field), so optional-skip / nested-rule alternatives / repeat-continue / wildcard-extend cannot leak frame ownership into siblings.
  - `captureSnapshot()` is the single source of truth; `SnapshotState`'s `[K]: -?` mapped modifier makes a missing field a compile error.
- **`cloneMatchState` helper.** Replaces the ad-hoc `{ ...state }` snapshot in `grammarCompletion`; carries policies forward and explicitly drops `backtracks` so external read-only views can outlive subsequent matcher mutation.

### `actionGrammar` — per-axis policies (`GrammarMatchOptions`)

Three independent commit-on-first-success axes; all default to `"exhaustive"`.

- **`wildcardPolicy: "exhaustive" | "shortest"`** — supersedes the old `shortestWildcard: boolean` option. `"shortest"` collapses only the wildcard-length axis; other axes still enumerate.
- **`optionalPolicy: "exhaustive" | "preferTake" | "preferSkip"`** — `(...)?` ordering analogous to regex `?` / `??`.
- **`repeatPolicy: "exhaustive" | "greedy" | "nonGreedy"`** — `(...)*` / `(...)+` ordering analogous to regex `+` / `+?`. Note: the count=0 alternative for `(...)*` is governed by `optionalPolicy`, not `repeatPolicy`, because skip never enters the nested rule.

Policies are runtime constants on the live `MatchState` (set once at `initialMatchState`) and survive `Object.assign`-based snapshot restore.

### `actionGrammar` — fixes

- **`shortestWildcard` partial-completion early-break.** The matcher previously suppressed longer-wildcard alternatives only on full exact-match success, so partial completions still re-emitted literal terminators already matched at shorter wildcard lengths (e.g. for `"play This Train by "` against `play <name> by <artist>`, `by` would be re-emitted). Now the break also fires when a pending wildcard sits at-or-past the last non-separator character.
- **`preferSkip` infinite loop.** A take-frame snapshot didn't suppress the optional fork on restore; when skip failed, the same optional re-forked another take frame indefinitely. Fix: tag the take snapshot with `suppressOptionalFork: true` and clear the flag immediately after the fork block so it cannot leak onto subsequent parts.
- **Rename `inRepeat` → `suppressOptionalFork`.** The flag is now set by both repeat-continue snapshots and `preferSkip` take frames; the new name describes its actual effect (gate the optional-fork block for one part visit).

### `cache`

- Opt into `wildcardPolicy: "shortest"` in `GrammarStoreImpl` partial-prefix completion. Updated rationale comment covers the partial-completion case as well.

### Docs

- `docs/architecture/actionGrammar.md` documents the per-axis policies and the unified backtrack chain.

### Tests (~1,250 lines added)

- `shortestWildcard.spec.ts`, `grammarCompletionShortestWildcard.spec.ts` — wildcard-axis option semantics across matcher and completion paths (incl. the `play This Train by ` regression).
- `optionalPolicyPreferSkipBacktrack.spec.ts` — regression test for the infinite loop plus a guard that the consumed flag does not suppress a downstream optional.
- `policyCoverage.spec.ts` — end-to-end coverage for every value of `optionalPolicy` and `repeatPolicy` and the `(...)* + repeatPolicy` interaction. Non-default-policy tests use a 5s per-test timeout so any future infinite-loop regression surfaces as a timeout rather than a silent hang.
- `wildcardFrameSnapshot.spec.ts` — regression for fields assigned after a snapshot is taken.
- `wildcardFrameInteractions.spec.ts` — default-mode parity coverage of the per-state frame mechanism.

## Verification

- `pnpm --filter action-grammar test` — passes.
- `pnpm --filter agent-cache test` — passes.

## Risk

Low. All changes are isolated to `actionGrammar` internals plus the cache opt-in. Default-mode behavior (matcher enumerates every alternative on every axis) is unchanged for all existing callers; `wildcardPolicy` / `optionalPolicy` / `repeatPolicy` are purely opt-in. The old `shortestWildcard` boolean option has been replaced by `wildcardPolicy: "shortest"` — only one in-tree caller (the cache) used it and is updated in this PR.
