### PR TITLE
actionGrammar: variable capture on string/phraseSet + factor pass + inliner correctness

### DIFF
--- a/ts/packages/actionGrammar/src/grammarDeserializer.ts
+++ b/ts/packages/actionGrammar/src/grammarDeserializer.ts
@@ -8,6 +8,8 @@ import {
     GrammarPartJson,
     GrammarRule,
     GrammarRuleJson,
+    PhraseSetPart,
+    RulesPart,
 } from "./grammarTypes.js";
 
 export function grammarFromJson(json: GrammarJson): Grammar {
@@ -38,7 +40,7 @@ export function grammarFromJson(json: GrammarJson): Grammar {
                         rules.push(grammarRuleFromJson(r, json));
                     }
                 }
-                const part: import("./grammarTypes.js").RulesPart = {
+                const part: RulesPart = {
                     type: "rules",
                     name: p.name,
                     rules,
@@ -48,8 +50,14 @@ export function grammarFromJson(json: GrammarJson): Grammar {
                 if (p.repeat) part.repeat = true;
                 return part;
             }
-            case "phraseSet":
-                return { type: "phraseSet", matcherName: p.matcherName };
+            case "phraseSet": {
+                const part: PhraseSetPart = {
+                    type: "phraseSet",
+                    matcherName: p.matcherName,
+                };
+                if (p.variable !== undefined) part.variable = p.variable;
+                return part;
+            }
         }
     }
 

--- a/ts/packages/actionGrammar/src/grammarMatcher.ts
+++ b/ts/packages/actionGrammar/src/grammarMatcher.ts
@@ -600,12 +600,9 @@ function addValue(
 
 // True when this rule/state would synthesize its result from the lone
 // captured value of its single part (no explicit value expression and
-// exactly one part).  Both parameters are read; pass either a MatchState
-// or ParentMatchState.
-function usesImplicitDefault(s: {
-    value: CompiledValueNode | undefined;
-    parts: GrammarPart[];
-}): boolean {
+// exactly one part).  Pass either a MatchState or ParentMatchState.
+type ImplicitDefaultCarrier = Pick<MatchState, "value" | "parts">;
+function usesImplicitDefault(s: ImplicitDefaultCarrier): boolean {
     return s.value === undefined && s.parts.length === 1;
 }
 

--- a/ts/packages/actionGrammar/src/grammarMatcher.ts
+++ b/ts/packages/actionGrammar/src/grammarMatcher.ts
@@ -600,7 +600,7 @@ function addValue(
 
 // True when this rule/state would synthesize its result from the lone
 // captured value of its single part (no explicit value expression and
-// exactly one part).  Pass either a MatchState or ParentMatchState.
+// exactly one part).
 type ImplicitDefaultCarrier = Pick<MatchState, "value" | "parts">;
 function usesImplicitDefault(s: ImplicitDefaultCarrier): boolean {
     return s.value === undefined && s.parts.length === 1;

--- a/ts/packages/actionGrammar/src/grammarMatcher.ts
+++ b/ts/packages/actionGrammar/src/grammarMatcher.ts
@@ -598,6 +598,17 @@ function addValue(
     }
 }
 
+// True when this rule/state would synthesize its result from the lone
+// captured value of its single part (no explicit value expression and
+// exactly one part).  Both parameters are read; pass either a MatchState
+// or ParentMatchState.
+function usesImplicitDefault(s: {
+    value: CompiledValueNode | undefined;
+    parts: GrammarPart[];
+}): boolean {
+    return s.value === undefined && s.parts.length === 1;
+}
+
 export function nextNonSeparatorIndex(request: string, index: number) {
     if (request.length <= index) {
         return request.length;
@@ -717,9 +728,7 @@ export function finalizeNestedRule(
         if (
             // Only process values if the parent rule is tracking values
             parent.valueIds !== null &&
-            (parent.variable !== undefined ||
-                parent.value !== undefined ||
-                parent.parts.length !== 1)
+            (parent.variable !== undefined || !usesImplicitDefault(parent))
         ) {
             state.value = parent.value;
             state.valueIds = parent.valueIds;
@@ -793,19 +802,16 @@ function matchStringPartWithWildcard(
         }
 
         if (captureWildcard(state, request, wildcardEnd, newIndex, pending)) {
-            // Assign default string value for single-part rules without
-            // an explicit value expression — same logic as the non-wildcard
-            // path in matchStringPartWithoutWildcard.  Without this, a
-            // pending wildcard from a parent rule that leaks into a
-            // single-part child rule would bypass the default value
-            // assignment and cause "No value assign to variable" at
-            // finalizeNestedRule time.
+            // If the StringPart has an explicit capture variable, write the
+            // joined matched tokens into that named slot.  Otherwise fall
+            // through to the implicit-default rule for single-part rules
+            // without a value expression — same logic as the non-wildcard
+            // path in matchStringPartWithoutWildcard.
             if (
-                state.value === undefined &&
-                state.parts.length === 1 &&
-                state.valueIds !== null
+                state.valueIds !== null &&
+                (part.variable !== undefined || usesImplicitDefault(state))
             ) {
-                addValue(state, undefined, part.value.join(" "));
+                addValue(state, part.variable, part.value.join(" "));
             }
             state.lastMatchedPartInfo = {
                 type: "string",
@@ -851,12 +857,14 @@ function matchStringPartWithoutWildcard(
     debugMatch(state, `Matched string ${part.value.join(" ")} to ${newIndex}`);
 
     if (
-        state.value === undefined &&
-        state.parts.length === 1 &&
-        state.valueIds !== null
+        state.valueIds !== null &&
+        (part.variable !== undefined || usesImplicitDefault(state))
     ) {
-        // default string part value
-        addValue(state, undefined, part.value.join(" "));
+        // Explicit capture variable on the StringPart — write the joined
+        // matched tokens into that named slot.  Otherwise fall through to
+        // the implicit-default rule for single-part rules without a value
+        // expression.
+        addValue(state, part.variable, part.value.join(" "));
     }
     state.lastMatchedPartInfo = {
         type: "string",
@@ -1232,8 +1240,7 @@ export function matchState(
                 // - the current rule has not explicit value and only has one part (default)
                 const requireValue =
                     state.valueIds !== null &&
-                    (part.variable !== undefined ||
-                        (state.value === undefined && parts.length === 1));
+                    (part.variable !== undefined || usesImplicitDefault(state));
 
                 // Update the current state to consider the first nested rule.
                 state.name = getNestedStateName(state, part, 0);

--- a/ts/packages/actionGrammar/src/grammarOptimizer.ts
+++ b/ts/packages/actionGrammar/src/grammarOptimizer.ts
@@ -9,7 +9,9 @@ import {
     Grammar,
     GrammarPart,
     GrammarRule,
+    PhraseSetPart,
     RulesPart,
+    StringPart,
 } from "./grammarTypes.js";
 
 const debug = registerDebug("typeagent:grammar:opt");
@@ -471,7 +473,7 @@ function tryInlineRulesPart(
             bindingIdx = i;
         }
         if (bindingIdx === -1) {
-            // Unreachable: we're past the `child.value !== undefined`
+            // Invariant: we're past the `child.value !== undefined`
             // branch, so child has no explicit value, and parent binds
             // it via `part.variable`.  The compiler enforces
             // `child.hasValue === true` at any bound rule reference
@@ -481,21 +483,14 @@ function tryInlineRulesPart(
             // (some top-level part is variable-bearing → friendly in
             // the multi-part branch) or `parts.length === 1 &&
             // defaultValue` (single-part → any type is friendly).
-            // Either way at least one friendly part exists.  Trace
-            // and bail out conservatively if the invariant is ever
-            // violated (e.g. a future compiler change loosens
-            // hasValue).
-            debug(
-                `tryInlineRulesPart: no binding-friendly part in child of bound RulesPart (variable='${part.variable}'); refusing to inline`,
+            // Either way at least one friendly part exists.  Throw
+            // loudly if a future compiler change ever loosens
+            // hasValue and reaches this point.
+            throw new Error(
+                `Internal: bound RulesPart child has no binding-friendly part (variable='${part.variable}')`,
             );
-            return undefined;
         }
-        const bindingCp = child.parts[bindingIdx] as Extract<
-            GrammarPart,
-            {
-                type: "wildcard" | "number" | "rules" | "string" | "phraseSet";
-            }
-        >;
+        const bindingCp = child.parts[bindingIdx];
         const newParts = child.parts.slice();
         newParts[bindingIdx] = { ...bindingCp, variable: part.variable };
         // No duplicate-name guard here: if the parent already had two
@@ -848,11 +843,14 @@ function rulesArrayId(state: BuildState, rules: GrammarRule[]): number {
  * so they don't merge — mirrors the parity check in `edgeKeyMatches`.
  */
 function stepMergeKey(step: TrieStep, state: BuildState): string {
+    // Use JSON.stringify for any field that could contain unrestricted text
+    // (token values, matcher names) so that delimiters / colons / quotes
+    // inside the field can't collide with the key's structural separators.
     switch (step.kind) {
         case "string":
-            return `s:${step.tokens.join(" ")}:${step.local !== undefined ? 1 : 0}`;
+            return `s:${JSON.stringify(step.tokens)}:${step.local !== undefined ? 1 : 0}`;
         case "wildcard":
-            return `w:${step.typeName}:${step.optional ? 1 : 0}`;
+            return `w:${JSON.stringify(step.typeName)}:${step.optional ? 1 : 0}`;
         case "number":
             return `n:${step.optional ? 1 : 0}`;
         case "rules": {
@@ -860,7 +858,7 @@ function stepMergeKey(step: TrieStep, state: BuildState): string {
             return `r:${id}:${step.optional ? 1 : 0}:${step.repeat ? 1 : 0}:${step.local !== undefined ? 1 : 0}`;
         }
         case "phraseSet":
-            return `p:${step.matcherName}:${step.local !== undefined ? 1 : 0}`;
+            return `p:${JSON.stringify(step.matcherName)}:${step.local !== undefined ? 1 : 0}`;
     }
 }
 
@@ -949,6 +947,14 @@ function insertRuleIntoTrie(
  * be moved to the last token alone without changing semantics) and
  * would also leak the binding-presence bit into intermediate edges,
  * preventing legitimate factoring with unbound prefix tokens.
+ *
+ * TODO: bound StringParts that share a token prefix (e.g.
+ * `[good, morning]` and `[good, evening]`, both bound) currently
+ * cannot factor.  The same trick `compileStringPart` uses — emit
+ * sub-token transitions for the shared prefix and write the slot
+ * only on the final transition — would let the trie share the
+ * `good` edge if we tracked "binding emitted on last sub-step
+ * only" parity.  Not yet worth the complexity.
  */
 function* partsToEdgeSteps(parts: GrammarPart[]): Generator<TrieStep> {
     for (const p of parts) {
@@ -1083,10 +1089,8 @@ function recordStepRemap(
 function edgeToPart(edge: TrieEdge): GrammarPart {
     switch (edge.kind) {
         case "string": {
-            const out: GrammarPart = { type: "string", value: edge.tokens };
-            if (edge.canonical !== undefined) {
-                (out as { variable?: string }).variable = edge.canonical;
-            }
+            const out: StringPart = { type: "string", value: edge.tokens };
+            if (edge.canonical !== undefined) out.variable = edge.canonical;
             return out;
         }
         case "wildcard": {
@@ -1117,13 +1121,11 @@ function edgeToPart(edge: TrieEdge): GrammarPart {
             return out;
         }
         case "phraseSet": {
-            const out: GrammarPart = {
+            const out: PhraseSetPart = {
                 type: "phraseSet",
                 matcherName: edge.matcherName,
             };
-            if (edge.canonical !== undefined) {
-                (out as { variable?: string }).variable = edge.canonical;
-            }
+            if (edge.canonical !== undefined) out.variable = edge.canonical;
             return out;
         }
     }

--- a/ts/packages/actionGrammar/src/grammarOptimizer.ts
+++ b/ts/packages/actionGrammar/src/grammarOptimizer.ts
@@ -425,43 +425,85 @@ function tryInlineRulesPart(
     }
 
     // If the parent expects to capture this RulesPart into a variable, the
-    // child rule must provide exactly one binding-friendly part to take
-    // the variable name; otherwise we'd silently drop the binding.
-    // Multiple variable-bearing parts would mean child relied on an
-    // explicit value expression (which the no-value branch rules out)
-    // or violated the matcher's default-value contract; either way we
-    // can't safely re-target the parent's binding.  Other parts in
-    // child (string / phraseSet literals) come along unchanged.
+    // child must expose exactly one binding-friendly top-level part to take
+    // the parent's variable name; otherwise we'd silently drop the binding.
+    //
+    // "Binding-friendly" mirrors the matcher's implicit-default rule for
+    // a child with no explicit value:
+    //
+    //   - Single-part child: the lone part contributes the value (any
+    //     type — string / phraseSet via implicit text, wildcard /
+    //     number / rules via their captured value).  All five types
+    //     qualify.
+    //
+    //   - Multi-part child: the matcher requires exactly *one*
+    //     variable-bearing part (else its createValue throws
+    //     "missing/multiple values for default" at finalize time).
+    //     wildcard and number always carry a variable; rules /
+    //     string / phraseSet qualify only when bound (`cp.variable !==
+    //     undefined`).  An unbound rules / string / phraseSet
+    //     contributes nothing to the value at runtime, so it isn't a
+    //     binding target — and counting it would produce false
+    //     ambiguity rejections (e.g. child = `<X> $(n:string)` with
+    //     `<X>` unbound: only the wildcard is the real contributor).
+    //
+    // Multiple binding-friendly parts in the same child means child
+    // relied on an explicit value expression (which the no-value
+    // branch already rules out) or violated the matcher's
+    // default-value contract; either way we can't safely re-target
+    // the parent's binding.
     if (part.variable !== undefined) {
+        const isSinglePart = child.parts.length === 1;
         let bindingIdx = -1;
-        let bindingCp:
-            | Extract<GrammarPart, { type: "wildcard" | "number" | "rules" }>
-            | undefined;
         for (let i = 0; i < child.parts.length; i++) {
             const cp = child.parts[i];
-            if (
+            const friendly =
                 cp.type === "wildcard" ||
                 cp.type === "number" ||
-                cp.type === "rules"
-            ) {
-                if (bindingIdx !== -1) {
-                    return undefined;
-                }
-                bindingIdx = i;
-                bindingCp = cp;
+                ((cp.type === "rules" ||
+                    cp.type === "string" ||
+                    cp.type === "phraseSet") &&
+                    (isSinglePart || cp.variable !== undefined));
+            if (!friendly) continue;
+            if (bindingIdx !== -1) {
+                return undefined;
             }
+            bindingIdx = i;
         }
-        if (bindingCp === undefined) {
+        if (bindingIdx === -1) {
+            // Unreachable: we're past the `child.value !== undefined`
+            // branch, so child has no explicit value, and parent binds
+            // it via `part.variable`.  The compiler enforces
+            // `child.hasValue === true` at any bound rule reference
+            // (grammarCompiler "Referenced rule does not produce a
+            // value for variable" check); for a value-less child,
+            // hasValue=true requires either `variableCount === 1`
+            // (some top-level part is variable-bearing → friendly in
+            // the multi-part branch) or `parts.length === 1 &&
+            // defaultValue` (single-part → any type is friendly).
+            // Either way at least one friendly part exists.  Trace
+            // and bail out conservatively if the invariant is ever
+            // violated (e.g. a future compiler change loosens
+            // hasValue).
+            debug(
+                `tryInlineRulesPart: no binding-friendly part in child of bound RulesPart (variable='${part.variable}'); refusing to inline`,
+            );
             return undefined;
         }
+        const bindingCp = child.parts[bindingIdx] as Extract<
+            GrammarPart,
+            {
+                type: "wildcard" | "number" | "rules" | "string" | "phraseSet";
+            }
+        >;
         const newParts = child.parts.slice();
         newParts[bindingIdx] = { ...bindingCp, variable: part.variable };
         // No duplicate-name guard here: if the parent already had two
         // top-level parts bound to `part.variable` (the RulesPart and
         // some sibling), that collision predates inlining and the
         // matcher's behavior on it is unchanged when we replace the
-        // RulesPart with a wildcard/number/rules part bound to the
-        // same name.
+        // RulesPart with a wildcard/number/rules/string/phraseSet part
+        // bound to the same name.
         return { parts: newParts };
     }
 
@@ -692,7 +734,13 @@ function factorRules(
 // canonical.
 
 type TrieStep =
-    | { kind: "string"; token: string }
+    | {
+          kind: "string";
+          /** Single token for unbound (per-token explosion); full token
+           * sequence for bound (atomic, never split). */
+          tokens: string[];
+          local: string | undefined;
+      }
     | { kind: "wildcard"; typeName: string; optional: boolean; local: string }
     | { kind: "number"; optional: boolean; local: string }
     | {
@@ -703,10 +751,19 @@ type TrieStep =
           name: string | undefined;
           local: string | undefined;
       }
-    | { kind: "phraseSet"; matcherName: string };
+    | {
+          kind: "phraseSet";
+          matcherName: string;
+          local: string | undefined;
+      };
 
 type TrieEdge =
-    | { kind: "string"; token: string }
+    | {
+          kind: "string";
+          tokens: string[];
+          /** undefined iff every inserter at this edge was unbound. */
+          canonical: string | undefined;
+      }
     | {
           kind: "wildcard";
           typeName: string;
@@ -723,7 +780,12 @@ type TrieEdge =
           /** undefined iff every inserter at this edge was unbound. */
           canonical: string | undefined;
       }
-    | { kind: "phraseSet"; matcherName: string };
+    | {
+          kind: "phraseSet";
+          matcherName: string;
+          /** undefined iff every inserter at this edge was unbound. */
+          canonical: string | undefined;
+      };
 
 type Terminal = {
     idx: number;
@@ -788,7 +850,7 @@ function rulesArrayId(state: BuildState, rules: GrammarRule[]): number {
 function stepMergeKey(step: TrieStep, state: BuildState): string {
     switch (step.kind) {
         case "string":
-            return `s:${step.token}`;
+            return `s:${step.tokens.join(" ")}:${step.local !== undefined ? 1 : 0}`;
         case "wildcard":
             return `w:${step.typeName}:${step.optional ? 1 : 0}`;
         case "number":
@@ -798,7 +860,7 @@ function stepMergeKey(step: TrieStep, state: BuildState): string {
             return `r:${id}:${step.optional ? 1 : 0}:${step.repeat ? 1 : 0}:${step.local !== undefined ? 1 : 0}`;
         }
         case "phraseSet":
-            return `p:${step.matcherName}`;
+            return `p:${step.matcherName}:${step.local !== undefined ? 1 : 0}`;
     }
 }
 
@@ -876,12 +938,37 @@ function insertRuleIntoTrie(
     });
 }
 
-/** Yield each rule.parts as a sequence of trie steps (StringPart explodes). */
+/**
+ * Yield each rule.parts as a sequence of trie steps.
+ *
+ * Unbound StringParts explode into one step per token so that adjacent
+ * alternatives can factor on a shared prefix substring.  Bound
+ * StringParts emit a single atomic step containing the full token
+ * sequence — splitting would break the binding parity (the matcher
+ * captures the whole joined text into the slot, so the binding can't
+ * be moved to the last token alone without changing semantics) and
+ * would also leak the binding-presence bit into intermediate edges,
+ * preventing legitimate factoring with unbound prefix tokens.
+ */
 function* partsToEdgeSteps(parts: GrammarPart[]): Generator<TrieStep> {
     for (const p of parts) {
         switch (p.type) {
             case "string":
-                for (const tok of p.value) yield { kind: "string", token: tok };
+                if (p.variable !== undefined) {
+                    yield {
+                        kind: "string",
+                        tokens: p.value,
+                        local: p.variable,
+                    };
+                } else {
+                    for (const tok of p.value) {
+                        yield {
+                            kind: "string",
+                            tokens: [tok],
+                            local: undefined,
+                        };
+                    }
+                }
                 break;
             case "wildcard":
                 yield {
@@ -909,7 +996,11 @@ function* partsToEdgeSteps(parts: GrammarPart[]): Generator<TrieStep> {
                 };
                 break;
             case "phraseSet":
-                yield { kind: "phraseSet", matcherName: p.matcherName };
+                yield {
+                    kind: "phraseSet",
+                    matcherName: p.matcherName,
+                    local: p.variable,
+                };
                 break;
         }
     }
@@ -919,8 +1010,23 @@ function* partsToEdgeSteps(parts: GrammarPart[]): Generator<TrieStep> {
 function stepToEdge(step: TrieStep, buildState: BuildState): TrieEdge {
     switch (step.kind) {
         case "string":
+            return {
+                kind: "string",
+                tokens: step.tokens,
+                canonical:
+                    step.local !== undefined
+                        ? freshCanonical(buildState)
+                        : undefined,
+            };
         case "phraseSet":
-            return step;
+            return {
+                kind: "phraseSet",
+                matcherName: step.matcherName,
+                canonical:
+                    step.local !== undefined
+                        ? freshCanonical(buildState)
+                        : undefined,
+            };
         case "wildcard":
             return {
                 kind: "wildcard",
@@ -960,7 +1066,6 @@ function recordStepRemap(
     step: TrieStep,
     remap: Map<string, string>,
 ): void {
-    if (edge.kind === "string" || edge.kind === "phraseSet") return;
     const local = (step as { local: string | undefined }).local;
     const canonical = edge.canonical;
     if (local === undefined || canonical === undefined) return;
@@ -977,8 +1082,13 @@ function recordStepRemap(
 
 function edgeToPart(edge: TrieEdge): GrammarPart {
     switch (edge.kind) {
-        case "string":
-            return { type: "string", value: [edge.token] };
+        case "string": {
+            const out: GrammarPart = { type: "string", value: edge.tokens };
+            if (edge.canonical !== undefined) {
+                (out as { variable?: string }).variable = edge.canonical;
+            }
+            return out;
+        }
         case "wildcard": {
             const out: GrammarPart = {
                 type: "wildcard",
@@ -1006,8 +1116,16 @@ function edgeToPart(edge: TrieEdge): GrammarPart {
             if (edge.name !== undefined) out.name = edge.name;
             return out;
         }
-        case "phraseSet":
-            return { type: "phraseSet", matcherName: edge.matcherName };
+        case "phraseSet": {
+            const out: GrammarPart = {
+                type: "phraseSet",
+                matcherName: edge.matcherName,
+            };
+            if (edge.canonical !== undefined) {
+                (out as { variable?: string }).variable = edge.canonical;
+            }
+            return out;
+        }
     }
 }
 
@@ -1024,7 +1142,12 @@ function appendPartInPlace(prefix: GrammarPart[], part: GrammarPart): void {
         return;
     }
     const last = prefix[prefix.length - 1];
-    if (last.type === "string" && part.type === "string") {
+    if (
+        last.type === "string" &&
+        part.type === "string" &&
+        last.variable === undefined &&
+        part.variable === undefined
+    ) {
         prefix[prefix.length - 1] = {
             type: "string",
             value: [...last.value, ...part.value],
@@ -1040,7 +1163,12 @@ function concatParts(a: GrammarPart[], b: GrammarPart[]): GrammarPart[] {
     if (b.length === 0) return a.slice();
     const last = a[a.length - 1];
     const first = b[0];
-    if (last.type === "string" && first.type === "string") {
+    if (
+        last.type === "string" &&
+        first.type === "string" &&
+        last.variable === undefined &&
+        first.variable === undefined
+    ) {
         const merged: GrammarPart = {
             type: "string",
             value: [...last.value, ...first.value],
@@ -1225,7 +1353,9 @@ function collectVariableNames(parts: GrammarPart[]): Set<string> {
         if (
             (p.type === "wildcard" ||
                 p.type === "number" ||
-                p.type === "rules") &&
+                p.type === "rules" ||
+                p.type === "string" ||
+                p.type === "phraseSet") &&
             p.variable !== undefined
         ) {
             out.add(p.variable);
@@ -1256,7 +1386,9 @@ function renameAllChildBindings(
         if (
             (p.type !== "wildcard" &&
                 p.type !== "number" &&
-                p.type !== "rules") ||
+                p.type !== "rules" &&
+                p.type !== "string" &&
+                p.type !== "phraseSet") ||
             p.variable === undefined
         ) {
             if (outParts !== undefined) outParts.push(p);

--- a/ts/packages/actionGrammar/src/grammarOptimizer.ts
+++ b/ts/packages/actionGrammar/src/grammarOptimizer.ts
@@ -6,9 +6,11 @@ import {
     CompiledObjectElement,
     CompiledSpacingMode,
     CompiledValueNode,
+    getCapturedVariableName,
     Grammar,
     GrammarPart,
     GrammarRule,
+    isCaptureBearingPart,
     PhraseSetPart,
     RulesPart,
     StringPart,
@@ -35,6 +37,20 @@ export type GrammarOptimizationOptions = {
      * rule by index) must capture it before this pass runs.
      */
     factorCommonPrefixes?: boolean;
+
+    /**
+     * Behavior when the inliner reaches an internal invariant violation
+     * (a bound `RulesPart` whose child has no binding-friendly part —
+     * see `tryInlineRulesPart`).  This indicates either a compiler bug
+     * upstream or a future change to `hasValue` semantics.
+     *
+     * - `"debug"` (default): log via `debug` and refuse the inlining
+     *   (returns `undefined`, leaving the AST unchanged at this site).
+     *   Safe for production.
+     * - `"throw"`: throw an `Error`.  Useful in tests / CI to surface
+     *   regressions immediately.
+     */
+    onInvariantViolation?: "debug" | "throw";
 };
 
 /**
@@ -68,8 +84,11 @@ export function optimizeGrammar(
         return grammar;
     }
     let rules = grammar.rules;
+    const inlineConfig: InlineConfig = {
+        onInvariantViolation: options.onInvariantViolation ?? "debug",
+    };
     if (options.inlineSingleAlternatives) {
-        rules = inlineSingleAlternativeRules(rules);
+        rules = inlineSingleAlternativeRules(rules, inlineConfig);
     }
     if (options.factorCommonPrefixes) {
         rules = factorCommonPrefixes(rules);
@@ -80,7 +99,7 @@ export function optimizeGrammar(
             // single-alternative RulesParts that were not visible to
             // Pass 1 in their pre-factored shape.  Re-run the inliner so
             // those collapse.
-            rules = inlineSingleAlternativeRules(rules);
+            rules = inlineSingleAlternativeRules(rules, inlineConfig);
         }
     }
     if (rules === grammar.rules) {
@@ -103,8 +122,14 @@ export function optimizeGrammar(
  * after the pass.  Preserves the dedup invariant that
  * `grammarSerializer.ts` relies on (`rulesToIndex.get(p.rules)`).
  */
+/** Configuration for a single inline pass. */
+type InlineConfig = {
+    onInvariantViolation: "debug" | "throw";
+};
+
 export function inlineSingleAlternativeRules(
     rules: GrammarRule[],
+    config: InlineConfig = { onInvariantViolation: "debug" },
 ): GrammarRule[] {
     const counter = { inlined: 0 };
     const memo: RulesArrayMemo = new Map();
@@ -114,7 +139,7 @@ export function inlineSingleAlternativeRules(
     // call site and bloat the serialized grammar (the serializer dedups
     // by array identity).
     const refCounts = countRulesArrayRefs(rules);
-    const result = inlineRulesArray(rules, counter, memo, refCounts);
+    const result = inlineRulesArray(rules, counter, memo, refCounts, config);
     if (counter.inlined > 0) {
         debug(`inlined ${counter.inlined} single-alternative RulesParts`);
     }
@@ -152,6 +177,7 @@ function inlineRulesArray(
     counter: { inlined: number },
     memo: RulesArrayMemo,
     refCounts: Map<GrammarRule[], number>,
+    config: InlineConfig,
 ): GrammarRule[] {
     const cached = memo.get(rules);
     if (cached !== undefined) return cached;
@@ -162,7 +188,7 @@ function inlineRulesArray(
     // walk when no rule in this array is rewritten.
     let next: GrammarRule[] | undefined;
     for (let i = 0; i < rules.length; i++) {
-        const r = inlineRule(rules[i], counter, memo, refCounts);
+        const r = inlineRule(rules[i], counter, memo, refCounts, config);
         if (next !== undefined) {
             next.push(r);
         } else if (r !== rules[i]) {
@@ -180,6 +206,7 @@ function inlineRule(
     counter: { inlined: number },
     memo: RulesArrayMemo,
     refCounts: Map<GrammarRule[], number>,
+    config: InlineConfig,
 ): GrammarRule {
     // Per-parent-rule counter for opaque α-rename names.  Shared
     // across every `tryInlineRulesPart` call for this rule so two
@@ -192,6 +219,7 @@ function inlineRule(
         memo,
         refCounts,
         renameState,
+        config,
     );
     if (!changed) {
         return rule;
@@ -245,6 +273,7 @@ function inlineParts(
     memo: RulesArrayMemo,
     refCounts: Map<GrammarRule[], number>,
     renameState: RenameState,
+    config: InlineConfig,
 ): {
     parts: GrammarPart[];
     changed: boolean;
@@ -267,6 +296,7 @@ function inlineParts(
             counter,
             memo,
             refCounts,
+            config,
         );
         const rewritten: RulesPart =
             inlinedRules !== p.rules ? { ...p, rules: inlinedRules } : p;
@@ -282,7 +312,7 @@ function inlineParts(
         const shared = (refCounts.get(p.rules) ?? 1) > 1;
         const replacement = shared
             ? undefined
-            : tryInlineRulesPart(rewritten, parentRule, renameState);
+            : tryInlineRulesPart(rewritten, parentRule, renameState, config);
         if (replacement !== undefined) {
             counter.inlined++;
             changed = true;
@@ -325,6 +355,7 @@ function tryInlineRulesPart(
     part: RulesPart,
     parentRule: GrammarRule,
     renameState: RenameState,
+    config: InlineConfig,
 ): TryInlineResult | undefined {
     if (part.repeat || part.optional) {
         return undefined;
@@ -483,12 +514,16 @@ function tryInlineRulesPart(
             // (some top-level part is variable-bearing → friendly in
             // the multi-part branch) or `parts.length === 1 &&
             // defaultValue` (single-part → any type is friendly).
-            // Either way at least one friendly part exists.  Throw
-            // loudly if a future compiler change ever loosens
-            // hasValue and reaches this point.
-            throw new Error(
-                `Internal: bound RulesPart child has no binding-friendly part (variable='${part.variable}')`,
-            );
+            // Either way at least one friendly part exists.  If a
+            // future compiler change ever loosens hasValue and reaches
+            // this point, the configured policy decides whether to
+            // throw (tests / CI) or just bail out and log (production).
+            const msg = `Internal: bound RulesPart child has no binding-friendly part (variable='${part.variable}')`;
+            if (config.onInvariantViolation === "throw") {
+                throw new Error(msg);
+            }
+            debug(`${msg} — refusing to inline (onInvariantViolation=debug)`);
+            return undefined;
         }
         const bindingCp = child.parts[bindingIdx];
         const newParts = child.parts.slice();
@@ -846,6 +881,12 @@ function stepMergeKey(step: TrieStep, state: BuildState): string {
     // Use JSON.stringify for any field that could contain unrestricted text
     // (token values, matcher names) so that delimiters / colons / quotes
     // inside the field can't collide with the key's structural separators.
+    //
+    // Note: tokens are encoded as a JSON array, so atomic-bound vs.
+    // exploded-unbound StringPart encodings stay on separate edges by
+    // construction — `JSON.stringify(["foo"])` ≠ `JSON.stringify(["fo","o"])`,
+    // and the `local` parity bit further guarantees bound and unbound
+    // single-token forms also never collide.
     switch (step.kind) {
         case "string":
             return `s:${JSON.stringify(step.tokens)}:${step.local !== undefined ? 1 : 0}`;
@@ -1352,15 +1393,9 @@ function buildWrapperRule(
 function collectVariableNames(parts: GrammarPart[]): Set<string> {
     const out = new Set<string>();
     for (const p of parts) {
-        if (
-            (p.type === "wildcard" ||
-                p.type === "number" ||
-                p.type === "rules" ||
-                p.type === "string" ||
-                p.type === "phraseSet") &&
-            p.variable !== undefined
-        ) {
-            out.add(p.variable);
+        const v = getCapturedVariableName(p);
+        if (v !== undefined) {
+            out.add(v);
         }
     }
     return out;
@@ -1385,14 +1420,7 @@ function renameAllChildBindings(
     let outParts: GrammarPart[] | undefined;
     for (let i = 0; i < parts.length; i++) {
         const p = parts[i];
-        if (
-            (p.type !== "wildcard" &&
-                p.type !== "number" &&
-                p.type !== "rules" &&
-                p.type !== "string" &&
-                p.type !== "phraseSet") ||
-            p.variable === undefined
-        ) {
+        if (!isCaptureBearingPart(p) || p.variable === undefined) {
             if (outParts !== undefined) outParts.push(p);
             continue;
         }

--- a/ts/packages/actionGrammar/src/grammarSerializer.ts
+++ b/ts/packages/actionGrammar/src/grammarSerializer.ts
@@ -9,6 +9,9 @@ import {
     GrammarRule,
     GrammarRuleJson,
     GrammarRulesJson,
+    PhraseSetPartJson,
+    RulePartJson,
+    StringPartJson,
 } from "./grammarTypes.js";
 
 export function grammarToJson(grammar: Grammar): GrammarJson {
@@ -18,8 +21,14 @@ export function grammarToJson(grammar: Grammar): GrammarJson {
 
     function grammarPartToJson(p: GrammarPart): GrammarPartJson {
         switch (p.type) {
-            case "string":
-                return { type: "string", value: p.value };
+            case "string": {
+                const part: StringPartJson = {
+                    type: "string",
+                    value: p.value,
+                };
+                if (p.variable !== undefined) part.variable = p.variable;
+                return part;
+            }
             case "wildcard":
             case "number":
                 return p;
@@ -31,7 +40,7 @@ export function grammarToJson(grammar: Grammar): GrammarJson {
                     json[index] = p.rules.map(grammarRuleToJson);
                 }
 
-                const part: import("./grammarTypes.js").RulePartJson = {
+                const part: RulePartJson = {
                     name: p.name,
                     type: "rules",
                     index,
@@ -41,8 +50,14 @@ export function grammarToJson(grammar: Grammar): GrammarJson {
                 if (p.repeat) part.repeat = true;
                 return part;
             }
-            case "phraseSet":
-                return { type: "phraseSet", matcherName: p.matcherName };
+            case "phraseSet": {
+                const part: PhraseSetPartJson = {
+                    type: "phraseSet",
+                    matcherName: p.matcherName,
+                };
+                if (p.variable !== undefined) part.variable = p.variable;
+                return part;
+            }
         }
     }
 

--- a/ts/packages/actionGrammar/src/grammarTypes.ts
+++ b/ts/packages/actionGrammar/src/grammarTypes.ts
@@ -179,7 +179,17 @@ export type StringPart = {
     type: "string";
     value: string[];
     optional?: undefined; // TODO: support optional string parts
-    variable?: undefined;
+    /**
+     * Optional capture variable.  When set, the matcher writes the
+     * joined matched tokens (`value.join(" ")`) into the slot/value
+     * named by this variable — same string the implicit-default path
+     * computes for a single-StringPart rule with no value expression,
+     * just routed to a named slot instead of the anonymous default.
+     *
+     * Currently introduced only by the optimizer's inliner pass; not
+     * exposed in `.agr` source syntax.
+     */
+    variable?: string | undefined;
 
     /**
      * Cache of compiled RegExp objects, keyed by
@@ -219,7 +229,15 @@ export type PhraseSetPart = {
     type: "phraseSet";
     /** Name of the phrase-set matcher (e.g. "Polite", "Greeting") */
     matcherName: string;
-    variable?: undefined;
+    /**
+     * Optional capture variable.  When set, the matcher writes the
+     * actual matched phrase (its tokens joined with a single space)
+     * into the slot/value named by this variable.
+     *
+     * Currently introduced only by the optimizer's inliner pass; not
+     * exposed in `.agr` source syntax.
+     */
+    variable?: string | undefined;
     optional?: undefined;
 };
 
@@ -247,6 +265,8 @@ export type Grammar = {
 export type StringPartJson = {
     type: "string";
     value: string[];
+    /** Optional capture variable — see `StringPart.variable`. */
+    variable?: string | undefined;
 };
 
 export type VarStringPartJson = {
@@ -274,6 +294,8 @@ export type RulePartJson = {
 export type PhraseSetPartJson = {
     type: "phraseSet";
     matcherName: string;
+    /** Optional capture variable — see `PhraseSetPart.variable`. */
+    variable?: string | undefined;
 };
 
 export type GrammarPartJson =

--- a/ts/packages/actionGrammar/src/grammarTypes.ts
+++ b/ts/packages/actionGrammar/src/grammarTypes.ts
@@ -247,6 +247,47 @@ export type GrammarPart =
     | VarNumberPart
     | RulesPart
     | PhraseSetPart;
+
+/**
+ * GrammarPart kinds that can carry an optional capture `variable`.
+ * Centralized so adding a future capture-bearing part type only needs
+ * one edit here plus the predicate / accessor below.
+ *
+ * - wildcard / number: source-level captures (`$(name:string)`, `$(n:number)`).
+ * - rules:             nested rule capture (`$(x:<Inner>)`).
+ * - string / phraseSet: optimizer-introduced captures only — no `.agr` source syntax.
+ */
+export type CaptureBearingPart =
+    | VarStringPart
+    | VarNumberPart
+    | RulesPart
+    | StringPart
+    | PhraseSetPart;
+
+/** Type guard: does this part kind support a capture `variable`? */
+export function isCaptureBearingPart(
+    part: GrammarPart,
+): part is CaptureBearingPart {
+    switch (part.type) {
+        case "wildcard":
+        case "number":
+        case "rules":
+        case "string":
+        case "phraseSet":
+            return true;
+        default:
+            return false;
+    }
+}
+
+/**
+ * Return the capture-variable name for any GrammarPart kind that
+ * supports one.  Returns `undefined` when the part either doesn't
+ * support captures or carries no binding.
+ */
+export function getCapturedVariableName(part: GrammarPart): string | undefined {
+    return isCaptureBearingPart(part) ? part.variable : undefined;
+}
 export type GrammarRule = {
     parts: GrammarPart[];
     value?: CompiledValueNode | undefined;

--- a/ts/packages/actionGrammar/src/nfa.ts
+++ b/ts/packages/actionGrammar/src/nfa.ts
@@ -44,12 +44,14 @@ export interface NFATransition {
     slotIndex?: number | undefined;
     // If true, append to existing value (for multi-word wildcards)
     appendToSlot?: boolean | undefined;
-    // For token / phraseSet transitions: when set together with slotIndex,
-    // overrides the matched value written to the slot.  Used for StringPart
-    // captures so the slot receives the joined fixed string (`value.join(" ")`)
-    // rather than the single normalized token from the consumed transition.
-    // PhraseSet captures don't set this — the matcher writes the joined matched
-    // phrase tokens at runtime (the matched phrase varies per input).
+    // For token transitions only: when set together with slotIndex,
+    // overrides the matched value written to the slot.  Used for
+    // StringPart captures so the slot receives the joined fixed string
+    // (`value.join(" ")`) rather than the single normalized token from
+    // the consumed transition.  PhraseSet transitions don't carry this
+    // (no parameter on `addPhraseSetTransition`); for phraseSet
+    // captures the matcher writes the joined matched phrase tokens at
+    // runtime (the matched phrase varies per input).
     slotValue?: string | undefined;
 
     // For epsilon transitions exiting nested rules:
@@ -205,13 +207,16 @@ export class NFABuilder {
         slotIndex?: number,
         slotValue?: string,
     ): void {
-        this.addTransition(from, to, "token", tokens);
+        const state = this.states[from];
+        if (!state) {
+            throw new Error(`State ${from} does not exist`);
+        }
+        const trans: NFATransition = { type: "token", to, tokens };
         if (slotIndex !== undefined) {
-            const state = this.states[from];
-            const trans = state.transitions[state.transitions.length - 1];
             trans.slotIndex = slotIndex;
             if (slotValue !== undefined) trans.slotValue = slotValue;
         }
+        state.transitions.push(trans);
     }
 
     addEpsilonTransition(from: number, to: number): void {

--- a/ts/packages/actionGrammar/src/nfa.ts
+++ b/ts/packages/actionGrammar/src/nfa.ts
@@ -180,6 +180,7 @@ export class NFABuilder {
         appendToSlot?: boolean,
         actionName?: string,
         propertyPath?: string,
+        slotValue?: string,
     ): void {
         const state = this.states[from];
         if (!state) {
@@ -197,6 +198,7 @@ export class NFABuilder {
         };
         if (actionName) trans.actionName = actionName;
         if (propertyPath) trans.propertyPath = propertyPath;
+        if (slotValue !== undefined) trans.slotValue = slotValue;
         state.transitions.push(trans);
     }
 
@@ -207,16 +209,25 @@ export class NFABuilder {
         slotIndex?: number,
         slotValue?: string,
     ): void {
-        const state = this.states[from];
-        if (!state) {
-            throw new Error(`State ${from} does not exist`);
-        }
-        const trans: NFATransition = { type: "token", to, tokens };
-        if (slotIndex !== undefined) {
-            trans.slotIndex = slotIndex;
-            if (slotValue !== undefined) trans.slotValue = slotValue;
-        }
-        state.transitions.push(trans);
+        // Route through addTransition so token transitions have the
+        // same property shape as wildcard / epsilon transitions
+        // (variable / typeName / checked / appendToSlot keys present
+        // as `undefined`).  Avoids divergence in any consumer that
+        // fingerprints transitions by `Object.keys`.
+        this.addTransition(
+            from,
+            to,
+            "token",
+            tokens,
+            undefined, // variable
+            undefined, // typeName
+            undefined, // checked
+            slotIndex,
+            undefined, // appendToSlot
+            undefined, // actionName
+            undefined, // propertyPath
+            slotValue,
+        );
     }
 
     addEpsilonTransition(from: number, to: number): void {

--- a/ts/packages/actionGrammar/src/nfa.ts
+++ b/ts/packages/actionGrammar/src/nfa.ts
@@ -44,6 +44,13 @@ export interface NFATransition {
     slotIndex?: number | undefined;
     // If true, append to existing value (for multi-word wildcards)
     appendToSlot?: boolean | undefined;
+    // For token / phraseSet transitions: when set together with slotIndex,
+    // overrides the matched value written to the slot.  Used for StringPart
+    // captures so the slot receives the joined fixed string (`value.join(" ")`)
+    // rather than the single normalized token from the consumed transition.
+    // PhraseSet captures don't set this — the matcher writes the joined matched
+    // phrase tokens at runtime (the matched phrase varies per input).
+    slotValue?: string | undefined;
 
     // For epsilon transitions exiting nested rules:
     // When true, evaluate the current rule's actionValue and write to parent slot
@@ -191,8 +198,20 @@ export class NFABuilder {
         state.transitions.push(trans);
     }
 
-    addTokenTransition(from: number, to: number, tokens: string[]): void {
+    addTokenTransition(
+        from: number,
+        to: number,
+        tokens: string[],
+        slotIndex?: number,
+        slotValue?: string,
+    ): void {
         this.addTransition(from, to, "token", tokens);
+        if (slotIndex !== undefined) {
+            const state = this.states[from];
+            const trans = state.transitions[state.transitions.length - 1];
+            trans.slotIndex = slotIndex;
+            if (slotValue !== undefined) trans.slotValue = slotValue;
+        }
     }
 
     addEpsilonTransition(from: number, to: number): void {
@@ -240,12 +259,15 @@ export class NFABuilder {
         from: number,
         to: number,
         matcherName: string,
+        slotIndex?: number,
     ): void {
         const state = this.states[from];
         if (!state) {
             throw new Error(`State ${from} does not exist`);
         }
-        state.transitions.push({ type: "phraseSet", matcherName, to });
+        const trans: NFATransition = { type: "phraseSet", matcherName, to };
+        if (slotIndex !== undefined) trans.slotIndex = slotIndex;
+        state.transitions.push(trans);
     }
 
     addWildcardTransition(

--- a/ts/packages/actionGrammar/src/nfaCompiler.ts
+++ b/ts/packages/actionGrammar/src/nfaCompiler.ts
@@ -348,7 +348,14 @@ function collectVariables(rule: GrammarRule): string[] {
                 break;
             case "string":
             case "phraseSet":
-                // No variables in string or phraseSet parts
+                // Optimizer-introduced capture: parent rule binds the matched
+                // literal text (string) or matched phrase (phraseSet) to a
+                // named slot.  Source-syntax bindings on these part types are
+                // not yet supported.
+                if (part.variable && !seen.has(part.variable)) {
+                    seen.add(part.variable);
+                    variables.push(part.variable);
+                }
                 break;
         }
     }
@@ -404,8 +411,18 @@ function createRuleTypeMap(rule: GrammarRule): Map<string, string> {
                 }
                 break;
             case "string":
+                // Optimizer-introduced capture binds the joined literal
+                // tokens (a string) to the named slot.
+                if (part.variable) {
+                    typeMap.set(part.variable, "string");
+                }
+                break;
             case "phraseSet":
-                // No variables
+                // Optimizer-introduced capture binds the matched phrase
+                // (a string of joined matched tokens) to the named slot.
+                if (part.variable) {
+                    typeMap.set(part.variable, "string");
+                }
                 break;
         }
     }
@@ -701,6 +718,9 @@ function compilePartWithSlots(
                 toState,
                 context.spacingMode,
                 context.splitCandidatesCollector,
+                part.variable !== undefined
+                    ? context.slotMap.get(part.variable)
+                    : undefined,
             );
 
         case "wildcard":
@@ -732,7 +752,13 @@ function compilePartWithSlots(
             );
 
         case "phraseSet":
-            return compilePhraseSetPart(builder, part, fromState, toState);
+            return compilePhraseSetPart(
+                builder,
+                part,
+                fromState,
+                toState,
+                context,
+            );
 
         default:
             throw new Error(`Unknown part type: ${(part as any).type}`);
@@ -749,14 +775,28 @@ function compilePartWithSlots(
  *
  * PhraseSetParts are always non-optional at this level; optionality is handled
  * by the enclosing RulesPart (e.g., from "(<Polite>)?").
+ *
+ * When `part.variable` is set (an optimizer-introduced capture), the matched
+ * phrase tokens are written as a joined string into the named slot.  See
+ * `tryTransition` in `nfaInterpreter.ts` for the runtime side.
  */
 function compilePhraseSetPart(
     builder: NFABuilder,
     part: PhraseSetPart,
     fromState: number,
     toState: number,
+    context?: RuleCompilationContext,
 ): number {
-    builder.addPhraseSetTransition(fromState, toState, part.matcherName);
+    const slotIndex =
+        part.variable !== undefined && context !== undefined
+            ? context.slotMap.get(part.variable)
+            : undefined;
+    builder.addPhraseSetTransition(
+        fromState,
+        toState,
+        part.matcherName,
+        slotIndex,
+    );
     return toState;
 }
 
@@ -777,6 +817,15 @@ function compileStringPart(
     toState: number,
     spacingMode?: CompiledSpacingMode,
     splitCandidatesCollector?: Set<string>,
+    /**
+     * Optional slot to write the joined StringPart value into.  When set
+     * (an optimizer-introduced capture), the slot receives
+     * `part.value.join(" ")` on the FINAL emitted transition — a single
+     * write per StringPart, regardless of how many sub-token transitions
+     * the chain emits.  See `tryTransition` in `nfaInterpreter.ts` for the
+     * runtime side (slotValue overrides the consumed token).
+     */
+    captureSlotIndex?: number,
 ): number {
     // Normalize grammar tokens (lowercase + strip trailing punctuation) so they
     // compare correctly against the normalized input tokens from tokenizeRequest().
@@ -790,12 +839,24 @@ function compileStringPart(
         return toState;
     }
 
+    // The captured slot value is the joined ORIGINAL StringPart tokens (not
+    // the normalized ones); this matches what `grammarMatcher.ts` writes via
+    // `addValue(state, part.variable, part.value.join(" "))`.
+    const captureSlotValue =
+        captureSlotIndex !== undefined ? part.value.join(" ") : undefined;
+
     // spacing=none: concatenate all segments into a single fused token.
     // The grammar author expects the input to contain no spaces between these
     // segments, so we emit one token transition for the concatenated form.
     if (spacingMode === "none") {
         const fused = normalized.join("");
-        builder.addTokenTransition(fromState, toState, [fused]);
+        builder.addTokenTransition(
+            fromState,
+            toState,
+            [fused],
+            captureSlotIndex,
+            captureSlotValue,
+        );
         return toState;
     }
 
@@ -812,18 +873,37 @@ function compileStringPart(
 
     // Emit individual token transitions (same as before for required/optional/auto).
     if (normalized.length === 1) {
-        builder.addTokenTransition(fromState, toState, normalized);
+        builder.addTokenTransition(
+            fromState,
+            toState,
+            normalized,
+            captureSlotIndex,
+            captureSlotValue,
+        );
         return toState;
     }
 
     // For multiple tokens, create a sequence chain
     // Each token must match in order: state1 --token1--> state2 --token2--> ... --> toState
+    // The capture slot (if any) is written only on the final transition so the
+    // joined StringPart value is recorded once — same single-write semantics as
+    // grammarMatcher.ts's `addValue` for a multi-token literal.
     let currentState = fromState;
     for (let i = 0; i < normalized.length; i++) {
         const token = normalized[i];
         const isLast = i === normalized.length - 1;
         const nextState = isLast ? toState : builder.createState(false);
-        builder.addTokenTransition(currentState, nextState, [token]);
+        if (isLast) {
+            builder.addTokenTransition(
+                currentState,
+                nextState,
+                [token],
+                captureSlotIndex,
+                captureSlotValue,
+            );
+        } else {
+            builder.addTokenTransition(currentState, nextState, [token]);
+        }
         currentState = nextState;
     }
     return toState;

--- a/ts/packages/actionGrammar/src/nfaCompiler.ts
+++ b/ts/packages/actionGrammar/src/nfaCompiler.ts
@@ -313,6 +313,25 @@ function isSingleVariableRule(rule: GrammarRule): { variable: string } | false {
 }
 
 /**
+ * Return the capture-variable name for any GrammarPart kind that
+ * supports one (wildcard / number / rules / string / phraseSet — the
+ * last two carry an optimizer-introduced binding).  Centralized so
+ * that adding a future capture-bearing part type only needs one edit.
+ */
+function getCapturedVariableName(part: GrammarPart): string | undefined {
+    switch (part.type) {
+        case "wildcard":
+        case "number":
+        case "rules":
+        case "string":
+        case "phraseSet":
+            return part.variable;
+        default:
+            return undefined;
+    }
+}
+
+/**
  * Collect all variable names from a rule's parts
  * Returns them in order of appearance
  *
@@ -329,39 +348,16 @@ function collectVariables(rule: GrammarRule): string[] {
         return variables;
     }
 
-    function collectFromPart(part: GrammarPart): void {
-        switch (part.type) {
-            case "wildcard":
-            case "number":
-                if (part.variable && !seen.has(part.variable)) {
-                    seen.add(part.variable);
-                    variables.push(part.variable);
-                }
-                break;
-            case "rules":
-                // For nested rules, if the RulesPart has a variable, that's what gets captured
-                if (part.variable && !seen.has(part.variable)) {
-                    seen.add(part.variable);
-                    variables.push(part.variable);
-                }
-                // Don't recurse into nested rule's inner variables - they use their own slots
-                break;
-            case "string":
-            case "phraseSet":
-                // Optimizer-introduced capture: parent rule binds the matched
-                // literal text (string) or matched phrase (phraseSet) to a
-                // named slot.  Source-syntax bindings on these part types are
-                // not yet supported.
-                if (part.variable && !seen.has(part.variable)) {
-                    seen.add(part.variable);
-                    variables.push(part.variable);
-                }
-                break;
-        }
-    }
-
     for (const part of rule.parts) {
-        collectFromPart(part);
+        // For nested rules, only the RulesPart's own variable is captured
+        // here — the matcher writes the nested rule's value into that slot.
+        // We don't recurse into the nested rule's inner parts; they live
+        // in their own slot maps.
+        const v = getCapturedVariableName(part);
+        if (v && !seen.has(v)) {
+            seen.add(v);
+            variables.push(v);
+        }
     }
 
     return variables;

--- a/ts/packages/actionGrammar/src/nfaCompiler.ts
+++ b/ts/packages/actionGrammar/src/nfaCompiler.ts
@@ -11,6 +11,7 @@ import {
     RulesPart,
     PhraseSetPart,
     CompiledSpacingMode,
+    getCapturedVariableName,
 } from "./grammarTypes.js";
 import { NFA, NFABuilder } from "./nfa.js";
 import {
@@ -310,25 +311,6 @@ function isSingleVariableRule(rule: GrammarRule): { variable: string } | false {
         }
     }
     return false;
-}
-
-/**
- * Return the capture-variable name for any GrammarPart kind that
- * supports one (wildcard / number / rules / string / phraseSet — the
- * last two carry an optimizer-introduced binding).  Centralized so
- * that adding a future capture-bearing part type only needs one edit.
- */
-function getCapturedVariableName(part: GrammarPart): string | undefined {
-    switch (part.type) {
-        case "wildcard":
-        case "number":
-        case "rules":
-        case "string":
-        case "phraseSet":
-            return part.variable;
-        default:
-            return undefined;
-    }
 }
 
 /**
@@ -657,6 +639,18 @@ function compilePart(
     checkedVariables?: Set<string>,
     overrideVariableName?: string,
 ): number {
+    // Deprecated path has no slot context, so optimizer-introduced
+    // captures on string / phraseSet parts (which require a slot to
+    // write into) cannot be honored.  Reject loudly rather than silently
+    // dropping the binding and producing a wrong action result.
+    if (
+        (part.type === "string" || part.type === "phraseSet") &&
+        part.variable !== undefined
+    ) {
+        throw new Error(
+            `compilePart (deprecated, no slot context) cannot honor capture variable '${part.variable}' on ${part.type}Part — caller must use compilePartWithSlots`,
+        );
+    }
     switch (part.type) {
         case "string":
             return compileStringPart(builder, part, fromState, toState);
@@ -686,7 +680,12 @@ function compilePart(
             );
 
         case "phraseSet":
-            return compilePhraseSetPart(builder, part, fromState, toState);
+            return compilePhraseSetPartNoSlots(
+                builder,
+                part,
+                fromState,
+                toState,
+            );
 
         default:
             throw new Error(`Unknown part type: ${(part as any).type}`);
@@ -748,7 +747,7 @@ function compilePartWithSlots(
             );
 
         case "phraseSet":
-            return compilePhraseSetPart(
+            return compilePhraseSetPartWithSlots(
                 builder,
                 part,
                 fromState,
@@ -772,19 +771,34 @@ function compilePartWithSlots(
  * PhraseSetParts are always non-optional at this level; optionality is handled
  * by the enclosing RulesPart (e.g., from "(<Polite>)?").
  *
- * When `part.variable` is set (an optimizer-introduced capture), the matched
- * phrase tokens are written as a joined string into the named slot.  See
- * `tryTransition` in `nfaInterpreter.ts` for the runtime side.
+ * Two callers exist:
+ *  - `compilePhraseSetPartNoSlots` for the deprecated, slot-less compile
+ *    path (rejects optimizer-introduced captures upstream — see
+ *    `compilePart`).
+ *  - `compilePhraseSetPartWithSlots` for the slot-aware path; when
+ *    `part.variable` is set the matched phrase tokens are written as a
+ *    joined string into the named slot.  See `tryTransition` in
+ *    `nfaInterpreter.ts` for the runtime side.
  */
-function compilePhraseSetPart(
+function compilePhraseSetPartNoSlots(
     builder: NFABuilder,
     part: PhraseSetPart,
     fromState: number,
     toState: number,
-    context?: RuleCompilationContext,
+): number {
+    builder.addPhraseSetTransition(fromState, toState, part.matcherName);
+    return toState;
+}
+
+function compilePhraseSetPartWithSlots(
+    builder: NFABuilder,
+    part: PhraseSetPart,
+    fromState: number,
+    toState: number,
+    context: RuleCompilationContext,
 ): number {
     const slotIndex =
-        part.variable !== undefined && context !== undefined
+        part.variable !== undefined
             ? context.slotMap.get(part.variable)
             : undefined;
     builder.addPhraseSetTransition(

--- a/ts/packages/actionGrammar/src/nfaInterpreter.ts
+++ b/ts/packages/actionGrammar/src/nfaInterpreter.ts
@@ -176,6 +176,20 @@ function matchNFACore(
         let newState: NFAExecutionState | undefined;
         if (trans.type === "phraseSet" && matchedPhrase) {
             // PhraseSet: build result state directly (phrase was validated in seedQueue)
+            let environment = state.environment;
+            if (trans.slotIndex !== undefined && state.environment) {
+                // PhraseSet capture: write the actual matched phrase tokens
+                // joined with single spaces into the named slot.  Unlike
+                // StringPart, the matched phrase varies per input so the
+                // value can't be precomputed into trans.slotValue.
+                environment = cloneEnvironment(state.environment);
+                setSlotValue(
+                    environment,
+                    trans.slotIndex,
+                    matchedPhrase.join(" "),
+                    false,
+                );
+            }
             newState = {
                 stateId: trans.to,
                 tokenIndex: state.tokenIndex + 1,
@@ -186,7 +200,7 @@ function matchNFACore(
                 uncheckedWildcardCount: state.uncheckedWildcardCount,
                 ruleIndex: state.ruleIndex,
                 actionValue: state.actionValue,
-                environment: state.environment,
+                environment,
                 slotMap: state.slotMap,
                 skipCount:
                     matchedPhrase.length > 1
@@ -432,6 +446,20 @@ function tryTransition(
             // Match specific token(s); normalize input token so that
             // case and trailing punctuation don't prevent a match
             if (trans.tokens && trans.tokens.includes(normalizeToken(token))) {
+                let environment = currentState.environment;
+                if (trans.slotIndex !== undefined && currentState.environment) {
+                    // StringPart capture: the slot receives the
+                    // pre-computed joined StringPart text (slotValue),
+                    // not the consumed normalized token.  See
+                    // `compileStringPart` in `nfaCompiler.ts`.
+                    environment = cloneEnvironment(currentState.environment);
+                    setSlotValue(
+                        environment,
+                        trans.slotIndex,
+                        trans.slotValue ?? token,
+                        false,
+                    );
+                }
                 return {
                     stateId: trans.to,
                     tokenIndex: tokenIndex + 1,
@@ -441,7 +469,7 @@ function tryTransition(
                     uncheckedWildcardCount: currentState.uncheckedWildcardCount,
                     ruleIndex: currentState.ruleIndex,
                     actionValue: currentState.actionValue,
-                    environment: currentState.environment,
+                    environment,
                     slotMap: currentState.slotMap,
                 };
             }

--- a/ts/packages/actionGrammar/src/nfaInterpreter.ts
+++ b/ts/packages/actionGrammar/src/nfaInterpreter.ts
@@ -117,6 +117,38 @@ export function matchNFA(
 }
 
 /**
+ * Apply the optimizer-introduced StringPart / PhraseSetPart capture (if
+ * any) for a transition: when `trans.slotIndex` is set, clone the
+ * thread's environment and write `value` into the slot.  Returns the
+ * (possibly cloned) environment to install on the successor state.
+ *
+ * Centralises the small asymmetry between the two capture paths:
+ *
+ *   - StringPart (token transition, see `tryTransition`): the matcher
+ *     prefers the precomputed `trans.slotValue` (joined fixed-string
+ *     literal) but falls back to the consumed `token` if absent.
+ *   - PhraseSet (phraseSet transition, see `matchNFACore`): the matcher
+ *     joins the actual matched phrase tokens at runtime — no
+ *     `trans.slotValue` because the matched text varies per input.
+ *
+ * The caller computes the appropriate `value`; this helper just wraps
+ * the env-clone + setSlotValue handshake so future transition kinds
+ * with capture can reuse it.
+ */
+function applySlotCapture(
+    env: Environment | undefined,
+    slotIndex: number | undefined,
+    value: string,
+): Environment | undefined {
+    if (slotIndex === undefined || env === undefined) {
+        return env;
+    }
+    const cloned = cloneEnvironment(env);
+    setSlotValue(cloned, slotIndex, value, false);
+    return cloned;
+}
+
+/**
  * Core NFA matching loop — shared by matchNFA and matchNFAWithIndex.
  *
  * Uses a work queue of (transition, threadState) pairs.  Only transitions
@@ -175,21 +207,16 @@ function matchNFACore(
         // Apply the transition to produce a new thread state
         let newState: NFAExecutionState | undefined;
         if (trans.type === "phraseSet" && matchedPhrase) {
-            // PhraseSet: build result state directly (phrase was validated in seedQueue)
-            let environment = state.environment;
-            if (trans.slotIndex !== undefined && state.environment) {
-                // PhraseSet capture: write the actual matched phrase tokens
-                // joined with single spaces into the named slot.  Unlike
-                // StringPart, the matched phrase varies per input so the
-                // value can't be precomputed into trans.slotValue.
-                environment = cloneEnvironment(state.environment);
-                setSlotValue(
-                    environment,
-                    trans.slotIndex,
-                    matchedPhrase.join(" "),
-                    false,
-                );
-            }
+            // PhraseSet: build result state directly (phrase was validated in seedQueue).
+            // PhraseSet capture: write the actual matched phrase tokens
+            // joined with single spaces into the named slot.  Unlike
+            // StringPart, the matched phrase varies per input so the
+            // value can't be precomputed into trans.slotValue.
+            const environment = applySlotCapture(
+                state.environment,
+                trans.slotIndex,
+                matchedPhrase.join(" "),
+            );
             newState = {
                 stateId: trans.to,
                 tokenIndex: state.tokenIndex + 1,
@@ -446,20 +473,15 @@ function tryTransition(
             // Match specific token(s); normalize input token so that
             // case and trailing punctuation don't prevent a match
             if (trans.tokens && trans.tokens.includes(normalizeToken(token))) {
-                let environment = currentState.environment;
-                if (trans.slotIndex !== undefined && currentState.environment) {
-                    // StringPart capture: the slot receives the
-                    // pre-computed joined StringPart text (slotValue),
-                    // not the consumed normalized token.  See
-                    // `compileStringPart` in `nfaCompiler.ts`.
-                    environment = cloneEnvironment(currentState.environment);
-                    setSlotValue(
-                        environment,
-                        trans.slotIndex,
-                        trans.slotValue ?? token,
-                        false,
-                    );
-                }
+                // StringPart capture: the slot receives the
+                // pre-computed joined StringPart text (slotValue),
+                // not the consumed normalized token.  See
+                // `compileStringPart` in `nfaCompiler.ts`.
+                const environment = applySlotCapture(
+                    currentState.environment,
+                    trans.slotIndex,
+                    trans.slotValue ?? token,
+                );
                 return {
                     stateId: trans.to,
                     tokenIndex: tokenIndex + 1,

--- a/ts/packages/actionGrammar/test/grammarOptimizerFactoring.spec.ts
+++ b/ts/packages/actionGrammar/test/grammarOptimizerFactoring.spec.ts
@@ -810,3 +810,155 @@ describe("Grammar Optimizer - Wrapper rule spacingMode propagation", () => {
         expect(optimized.rules[0].spacingMode).toBeUndefined();
     });
 });
+
+// ── Stage 3: factor pass for bound StringPart / PhraseSetPart ─────────
+//
+// Bound string/phraseSet edges in the trie carry a parity bit
+// (bound vs. unbound) and an opaque canonical when bound, so:
+//   - two unbound `play` tokens still merge into one prefix edge.
+//   - two bound `$(x:hello)` parts on different alternatives merge
+//     into one canonical edge with each alternative remapping its
+//     own local onto the shared canonical.
+//   - bound and unbound parts with the same token never merge
+//     (different parity).
+
+describe("Grammar Optimizer - bound StringPart / PhraseSetPart factoring", () => {
+    it("factors a shared bound multi-token StringPart prefix when members don't reference it", () => {
+        // Each alt has its own wrapper (refCount=1) so Stage 2
+        // collapses it into a bound StringPart "good morning".
+        // Member values are constants — no cross-scope-ref blocker —
+        // so Stage 3's atomic bound-string trie edge merges the
+        // prefix into one canonical edge in the wrapper.
+        const text = `<Start> = $(g:<G1>) world -> "w"
+        | $(g:<G2>) friend -> "f";
+<G1> = good morning;
+<G2> = good morning;`;
+        const baseline = loadGrammarRules("t.grammar", text);
+        const optimized = loadGrammarRules("t.grammar", text, {
+            optimizations: {
+                inlineSingleAlternatives: true,
+                factorCommonPrefixes: true,
+            },
+        });
+        // Top-level alternative count drops (factored under wrapper).
+        expect(optimized.rules.length).toBeLessThan(baseline.rules.length);
+        for (const input of ["good morning world", "good morning friend"]) {
+            expect(match(optimized, input)).toStrictEqual(
+                match(baseline, input),
+            );
+        }
+        expect(match(optimized, "good morning world")).toStrictEqual(["w"]);
+        expect(match(optimized, "good morning friend")).toStrictEqual(["f"]);
+    });
+
+    it("preserves match correctness when bound prefix is referenced (factoring may bail)", () => {
+        // Stage 3 enables trie-level merging of the bound prefix,
+        // but the existing cross-scope-ref eligibility check bails
+        // out at the fork because each member's value references
+        // the now-prefix-bound `g`.  This test guarantees the
+        // bailout path stays correct (no garbled match results).
+        const text = `<Start> = $(g:<G1>) world -> { g: g, w: 1 }
+        | $(g:<G2>) friend -> { g: g, w: 2 };
+<G1> = good morning;
+<G2> = good morning;`;
+        const baseline = loadGrammarRules("t.grammar", text);
+        const optimized = loadGrammarRules("t.grammar", text, {
+            optimizations: {
+                inlineSingleAlternatives: true,
+                factorCommonPrefixes: true,
+            },
+        });
+        for (const input of ["good morning world", "good morning friend"]) {
+            expect(match(optimized, input)).toStrictEqual(
+                match(baseline, input),
+            );
+        }
+        expect(match(optimized, "good morning world")).toStrictEqual([
+            { g: "good morning", w: 1 },
+        ]);
+    });
+
+    it("factors a shared bound PhraseSetPart prefix when members don't reference it", () => {
+        // Built-in phrase sets cannot be bound directly via .agr
+        // syntax (the parser treats `$(o:<Polite>)` as a sub-rule
+        // reference), so we use distinct wrapper rules around
+        // <Polite> and rely on the Stage 2 inliner to retarget
+        // the outer variable onto the bound PhraseSetPart.  Member
+        // values don't reference `o`, so the cross-scope-ref check
+        // passes and Stage 3 produces a single canonical phraseSet
+        // edge in the wrapper prefix.
+        const text = `<Start> = $(o:<W1>) play -> "p"
+        | $(o:<W2>) stop -> "s";
+<W1> = <Polite>;
+<W2> = <Polite>;`;
+        const baseline = loadGrammarRules("t.grammar", text);
+        const optimized = loadGrammarRules("t.grammar", text, {
+            optimizations: {
+                inlineSingleAlternatives: true,
+                factorCommonPrefixes: true,
+            },
+        });
+        expect(optimized.rules.length).toBeLessThan(baseline.rules.length);
+        // Structural check: only one phraseSet edge remains, and
+        // it's bound to a fresh canonical.
+        const phraseSetParts: GrammarPart[] = [];
+        const collect = (parts: GrammarPart[]) => {
+            for (const p of parts) {
+                if (p.type === "phraseSet") phraseSetParts.push(p);
+                else if (p.type === "rules") {
+                    for (const r of p.rules) collect(r.parts);
+                }
+            }
+        };
+        for (const r of optimized.rules) collect(r.parts);
+        expect(phraseSetParts.length).toBe(1);
+        expect((phraseSetParts[0] as { variable?: string }).variable).toMatch(
+            /^__opt_v_/,
+        );
+    });
+
+    it("does not merge bound and unbound StringParts with the same token", () => {
+        // After inlining, alt 1 has bound StringPart "play"; alt 2's
+        // literal "play" stays unbound.  Parity check keeps them on
+        // separate trie edges.
+        const text = `<Start> = $(p:<P>) hello -> { p: p }
+        | play world -> "world";
+<P> = play;`;
+        const baseline = loadGrammarRules("t.grammar", text);
+        const optimized = loadGrammarRules("t.grammar", text, {
+            optimizations: {
+                inlineSingleAlternatives: true,
+                factorCommonPrefixes: true,
+            },
+        });
+        for (const input of ["play hello", "play world"]) {
+            expect(match(optimized, input)).toStrictEqual(
+                match(baseline, input),
+            );
+        }
+    });
+
+    it("still factors unbound common prefix when one alt has a trailing bound StringPart", () => {
+        // Stage 3's atomic bound-StringPart edge sits AFTER the
+        // shared "play" prefix in alt 1, so it doesn't block the
+        // unbound "play" tokens from factoring across alts.
+        const text = `<Start> = play $(g:<Greeting>) -> { g: g }
+        | play song -> "song";
+<Greeting> = good morning;`;
+        const baseline = loadGrammarRules("t.grammar", text);
+        const optimized = loadGrammarRules("t.grammar", text, {
+            optimizations: {
+                inlineSingleAlternatives: true,
+                factorCommonPrefixes: true,
+            },
+        });
+        // Sanity: shared "play" prefix factored.
+        expect(optimized.rules.length).toBe(1);
+        expect(match(optimized, "play good morning")).toStrictEqual(
+            match(baseline, "play good morning"),
+        );
+        expect(match(optimized, "play song")).toStrictEqual(
+            match(baseline, "play song"),
+        );
+    });
+});

--- a/ts/packages/actionGrammar/test/grammarOptimizerInline.spec.ts
+++ b/ts/packages/actionGrammar/test/grammarOptimizerInline.spec.ts
@@ -409,28 +409,28 @@ describe("Grammar Optimizer - Inline single-alternative RulesPart", () => {
         ]);
     });
 
-    // ── default-value behaviors not handled by the propagate branch ─────
+    // ── Stage 2: implicit-default literal capture handled in propagate branch ──
     //
-    // The matcher's `defaultValue` flag also fires for single-part
-    // rules whose only part is a string literal or phraseSet — the
-    // matcher returns the literal text as the rule's value.  Neither
-    // string nor phraseSet parts can carry a `variable`, so the
-    // optimizer's propagate branch refuses to inline these.  Verify
-    // that the wrapper stays in place AND that the value still flows.
+    // The matcher's `defaultValue` flag fires for single-part rules
+    // whose only part is a string literal or phraseSet — the matcher
+    // returns the literal text as the rule's value.  Stage 2 made
+    // string and phraseSet parts variable-capable, so the propagate
+    // branch can now retarget the parent's variable onto the single
+    // literal part directly, collapsing the wrapper.
 
-    it("leaves single string-literal child nested when parent captures via variable", () => {
-        // `<Inner> = hello;` produces "hello" as its value; parent's
-        // `t` binds to that.  Inlining would require putting `t` onto
-        // the string part — which the type system forbids — so the
-        // optimizer must leave the wrapper rule alone.
+    it("inlines single string-literal child by injecting parent's variable onto the StringPart", () => {
+        // Parent's `t` binds the wrapped <Inner>; <Inner> is a single
+        // StringPart "hello".  Stage 2: the propagate branch injects
+        // `variable: "t"` onto the StringPart and inlines.  The
+        // matcher writes "hello" to the `t` slot at runtime.
         const text = `<Start> = play $(t:<Inner>) -> { what: t };
 <Inner> = hello;`;
         const baseline = loadGrammarRules("t.grammar", text);
         const optimized = loadGrammarRules("t.grammar", text, {
             optimizations: { inlineSingleAlternatives: true },
         });
-        // Wrapper stays — same rules-part count.
-        expect(countRulesParts(optimized.rules)).toBe(
+        // Wrapper collapsed.
+        expect(countRulesParts(optimized.rules)).toBeLessThan(
             countRulesParts(baseline.rules),
         );
         expect(match(optimized, "play hello")).toStrictEqual(
@@ -441,18 +441,18 @@ describe("Grammar Optimizer - Inline single-alternative RulesPart", () => {
         ]);
     });
 
-    it("leaves multi-string-literal child nested when parent captures via variable", () => {
-        // `<Greeting> = hello world;` is a single-part rule (the two
-        // tokens compile into one StringPart).  Same situation as the
-        // single-token case: matcher returns the matched text as the
-        // value, but it can't be propagated onto the StringPart.
+    it("inlines multi-token string-literal child by injecting parent's variable onto the StringPart", () => {
+        // <Greeting> = hello world; is a single-part rule (the two
+        // tokens compile into one StringPart).  Same as the
+        // single-token case: injection + inline; matcher writes the
+        // joined text to the `x` slot.
         const text = `<Start> = $(x:<Greeting>) -> x;
 <Greeting> = hello world;`;
         const baseline = loadGrammarRules("t.grammar", text);
         const optimized = loadGrammarRules("t.grammar", text, {
             optimizations: { inlineSingleAlternatives: true },
         });
-        expect(countRulesParts(optimized.rules)).toBe(
+        expect(countRulesParts(optimized.rules)).toBeLessThan(
             countRulesParts(baseline.rules),
         );
         expect(match(optimized, "hello world")).toStrictEqual(
@@ -619,5 +619,82 @@ describe("Grammar Optimizer - Inline single-alternative RulesPart", () => {
         expect(match(baseline, "play the hello")).toStrictEqual([
             { what: { who: "hello" } },
         ]);
+    });
+
+    // Stage 2: bound PhraseSetPart inlining.
+    // The propagate branch now accepts a single PhraseSetPart child
+    // as binding-friendly via the implicit-default fallback — the
+    // matcher writes the matched phrase tokens to the named slot.
+    // (The single-StringPart cases are covered by the two
+    // implicit-default tests above.)
+    it("inlines a single-PhraseSetPart child and retargets parent's variable", () => {
+        // <Polite> is intercepted by the grammar compiler and becomes
+        // a PhraseSetPart, so <Wrap> = <Polite>; is a single-PhraseSetPart
+        // child rule with no value.  matchGrammar (the interpreter)
+        // doesn't handle phraseSet, so we only assert structural
+        // collapse here; runtime capture is covered in
+        // grammarMatcherStringPhraseSetVariable.spec.ts.
+        const text = `<Start> = $(o:<Wrap>) go -> { opener: o };
+<Wrap> = <Polite>;`;
+        const baseline = loadGrammarRules("t.grammar", text);
+        const optimized = loadGrammarRules("t.grammar", text, {
+            optimizations: { inlineSingleAlternatives: true },
+        });
+        expect(countRulesParts(optimized.rules)).toBeLessThan(
+            countRulesParts(baseline.rules),
+        );
+        const phraseSetPart = optimized.rules[0].parts.find(
+            (p) => p.type === "phraseSet",
+        );
+        expect(phraseSetPart).toBeDefined();
+        expect((phraseSetPart as { variable?: string }).variable).toBe("o");
+    });
+
+    it("retargets parent's variable onto a bound PhraseSetPart in a multi-part child", () => {
+        // After Stage 1 inlines <Wrap> into <Outer>, the latter
+        // becomes `please <PhraseSet:Polite,var=p>` — an unbound
+        // literal "please" plus a bound PhraseSetPart.  When the
+        // inliner then visits `$(o:<Outer>)`, the bound phraseSet is
+        // the lone value contributor at runtime; the binding-friendly
+        // check must recognize it (treating the unbound "please" as
+        // non-friendly) so that parent's `o` retargets onto the
+        // phraseSet rather than failing with false ambiguity.
+        const text = `<Start> = $(o:<Outer>) go -> { opener: o };
+<Outer> = please $(p:<Wrap>);
+<Wrap> = <Polite>;`;
+        const baseline = loadGrammarRules("t.grammar", text);
+        const optimized = loadGrammarRules("t.grammar", text, {
+            optimizations: { inlineSingleAlternatives: true },
+        });
+        // <Wrap> wrapper collapsed; "please" + bound phraseSet sit
+        // directly in the start rule.
+        expect(countRulesParts(optimized.rules)).toBeLessThan(
+            countRulesParts(baseline.rules),
+        );
+        const collect = (parts: GrammarPart[], out: GrammarPart[]) => {
+            for (const p of parts) {
+                out.push(p);
+                if (p.type === "rules") {
+                    for (const r of p.rules) collect(r.parts, out);
+                }
+            }
+        };
+        const all: GrammarPart[] = [];
+        for (const r of optimized.rules) collect(r.parts, all);
+        const phraseSetPart = all.find((p) => p.type === "phraseSet");
+        expect(phraseSetPart).toBeDefined();
+        // Parent's `o` retargeted onto the bound phraseSet — the same
+        // user-named variable wins because the inliner doesn't
+        // α-rename the binding it injects.
+        expect((phraseSetPart as { variable?: string }).variable).toBe("o");
+        // The literal "please" comes along unchanged (no variable).
+        const stringPart = all.find(
+            (p) =>
+                p.type === "string" &&
+                Array.isArray(p.value) &&
+                p.value.includes("please"),
+        );
+        expect(stringPart).toBeDefined();
+        expect((stringPart as { variable?: string }).variable).toBeUndefined();
     });
 });

--- a/ts/packages/actionGrammar/test/nfaDfaStringPhraseSetVariable.spec.ts
+++ b/ts/packages/actionGrammar/test/nfaDfaStringPhraseSetVariable.spec.ts
@@ -1,0 +1,261 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+/**
+ * Stage 1 foundation tests for StringPart / PhraseSetPart variable capture.
+ *
+ * These bindings have no source syntax — they're produced only by the
+ * optimizer's inliner pass.  Tests construct grammars manually to exercise
+ * the matcher / NFA / DFA capture paths in isolation, before any optimizer
+ * code emits these forms.
+ *
+ * Coverage:
+ *   - matchGrammar (interpreter): StringPart capture (single + multi-token)
+ *   - matchGrammarWithNFA: StringPart and PhraseSetPart capture
+ *   - matchDFAWithSplitting: StringPart and PhraseSetPart capture (delegates
+ *     to matchNFA via dfa.sourceNFA)
+ *   - JSON round-trip: variable preserved through serialize/deserialize
+ *
+ * grammarMatcher.ts has no PhraseSetPart match path — phraseSet capture is
+ * exercised only against the NFA / DFA matchers.
+ */
+
+import { matchGrammar } from "../src/grammarMatcher.js";
+import { compileGrammarToNFA } from "../src/nfaCompiler.js";
+import { matchGrammarWithNFA, tokenizeRequest } from "../src/nfaMatcher.js";
+import { compileNFAToDFA } from "../src/dfaCompiler.js";
+import { matchDFAWithSplitting } from "../src/dfaMatcher.js";
+import { grammarToJson } from "../src/grammarSerializer.js";
+import { grammarFromJson } from "../src/grammarDeserializer.js";
+import type { Grammar } from "../src/grammarTypes.js";
+
+function bestNfaActionValue(grammar: Grammar, request: string): unknown {
+    const nfa = compileGrammarToNFA(grammar, "test.grammar");
+    const results = matchGrammarWithNFA(grammar, nfa, request);
+    return results[0]?.match;
+}
+
+function bestDfaActionValue(grammar: Grammar, request: string): unknown {
+    const nfa = compileGrammarToNFA(grammar, "test.grammar");
+    const dfa = compileNFAToDFA(nfa, "test.grammar");
+    const tokens = tokenizeRequest(request);
+    const result = matchDFAWithSplitting(dfa, tokens);
+    return result.matched ? result.actionValue : undefined;
+}
+
+describe("StringPart variable capture", () => {
+    // <Start> = "hello" -> { greeting: <captured "hello"> }
+    const grammar: Grammar = {
+        rules: [
+            {
+                parts: [
+                    {
+                        type: "string",
+                        value: ["hello"],
+                        variable: "greeting",
+                    },
+                ],
+                value: { type: "variable", name: "greeting" },
+            },
+        ],
+    };
+
+    it("interpreter: single-token StringPart binds joined value", () => {
+        const matches = matchGrammar(grammar, "hello");
+        expect(matches?.map((m) => m.match)).toStrictEqual(["hello"]);
+    });
+
+    it("NFA: single-token StringPart binds joined value", () => {
+        expect(bestNfaActionValue(grammar, "hello")).toBe("hello");
+    });
+
+    it("DFA: single-token StringPart binds joined value", () => {
+        expect(bestDfaActionValue(grammar, "hello")).toBe("hello");
+    });
+
+    // Multi-token StringPart should write the joined fixed string,
+    // once, on the final transition of the chain.
+    const multiTokenGrammar: Grammar = {
+        rules: [
+            {
+                parts: [
+                    {
+                        type: "string",
+                        value: ["good", "morning"],
+                        variable: "greeting",
+                    },
+                ],
+                value: { type: "variable", name: "greeting" },
+            },
+        ],
+    };
+
+    it("interpreter: multi-token StringPart binds joined value", () => {
+        const matches = matchGrammar(multiTokenGrammar, "good morning");
+        expect(matches?.map((m) => m.match)).toStrictEqual(["good morning"]);
+    });
+
+    it("NFA: multi-token StringPart binds joined value", () => {
+        expect(bestNfaActionValue(multiTokenGrammar, "good morning")).toBe(
+            "good morning",
+        );
+    });
+
+    it("DFA: multi-token StringPart binds joined value", () => {
+        expect(bestDfaActionValue(multiTokenGrammar, "good morning")).toBe(
+            "good morning",
+        );
+    });
+
+    // Mixed multi-part rule: the StringPart capture coexists with a
+    // wildcard capture in the same parent rule.  The value expression
+    // references both.
+    const mixedGrammar: Grammar = {
+        rules: [
+            {
+                parts: [
+                    {
+                        type: "string",
+                        value: ["greet"],
+                        variable: "verb",
+                    },
+                    {
+                        type: "wildcard",
+                        typeName: "string",
+                        variable: "name",
+                    },
+                ],
+                value: {
+                    type: "object",
+                    value: [
+                        {
+                            type: "property",
+                            key: "verb",
+                            value: { type: "variable", name: "verb" },
+                        },
+                        {
+                            type: "property",
+                            key: "name",
+                            value: { type: "variable", name: "name" },
+                        },
+                    ],
+                },
+            },
+        ],
+    };
+
+    it("interpreter: StringPart capture coexists with wildcard capture", () => {
+        const matches = matchGrammar(mixedGrammar, "greet alice");
+        expect(matches?.map((m) => m.match)).toStrictEqual([
+            { verb: "greet", name: "alice" },
+        ]);
+    });
+
+    it("NFA: StringPart capture coexists with wildcard capture", () => {
+        expect(bestNfaActionValue(mixedGrammar, "greet alice")).toStrictEqual({
+            verb: "greet",
+            name: "alice",
+        });
+    });
+
+    it("DFA: StringPart capture coexists with wildcard capture", () => {
+        expect(bestDfaActionValue(mixedGrammar, "greet alice")).toStrictEqual({
+            verb: "greet",
+            name: "alice",
+        });
+    });
+});
+
+describe("PhraseSetPart variable capture", () => {
+    // <Start> = <Polite> "go" -> { opener: <captured polite phrase>, action: "go" }
+    const grammar: Grammar = {
+        rules: [
+            {
+                parts: [
+                    {
+                        type: "phraseSet",
+                        matcherName: "Polite",
+                        variable: "opener",
+                    },
+                    { type: "string", value: ["go"] },
+                ],
+                value: {
+                    type: "object",
+                    value: [
+                        {
+                            type: "property",
+                            key: "opener",
+                            value: { type: "variable", name: "opener" },
+                        },
+                    ],
+                },
+            },
+        ],
+    };
+
+    it("NFA: PhraseSetPart binds matched phrase tokens joined", () => {
+        // "Polite" set includes "please", "could you", "would you", etc.
+        expect(bestNfaActionValue(grammar, "please go")).toStrictEqual({
+            opener: "please",
+        });
+        expect(bestNfaActionValue(grammar, "could you go")).toStrictEqual({
+            opener: "could you",
+        });
+    });
+
+    it("DFA: PhraseSetPart binds matched phrase tokens joined", () => {
+        expect(bestDfaActionValue(grammar, "please go")).toStrictEqual({
+            opener: "please",
+        });
+        expect(bestDfaActionValue(grammar, "could you go")).toStrictEqual({
+            opener: "could you",
+        });
+    });
+});
+
+describe("Serialization round-trip preserves variable", () => {
+    it("StringPart variable survives JSON round-trip", () => {
+        const grammar: Grammar = {
+            rules: [
+                {
+                    parts: [
+                        {
+                            type: "string",
+                            value: ["hi"],
+                            variable: "v",
+                        },
+                    ],
+                    value: { type: "variable", name: "v" },
+                },
+            ],
+        };
+        const json = grammarToJson(grammar);
+        const restored = grammarFromJson(json);
+        const part = restored.rules[0].parts[0];
+        expect(part.type).toBe("string");
+        expect((part as { variable?: string }).variable).toBe("v");
+    });
+
+    it("PhraseSetPart variable survives JSON round-trip", () => {
+        const grammar: Grammar = {
+            rules: [
+                {
+                    parts: [
+                        {
+                            type: "phraseSet",
+                            matcherName: "Polite",
+                            variable: "v",
+                        },
+                        { type: "string", value: ["go"] },
+                    ],
+                    value: { type: "variable", name: "v" },
+                },
+            ],
+        };
+        const json = grammarToJson(grammar);
+        const restored = grammarFromJson(json);
+        const part = restored.rules[0].parts[0];
+        expect(part.type).toBe("phraseSet");
+        expect((part as { variable?: string }).variable).toBe("v");
+    });
+});

--- a/ts/packages/actionGrammar/test/nfaDfaStringPhraseSetVariable.spec.ts
+++ b/ts/packages/actionGrammar/test/nfaDfaStringPhraseSetVariable.spec.ts
@@ -32,7 +32,20 @@ import type { Grammar } from "../src/grammarTypes.js";
 function bestNfaActionValue(grammar: Grammar, request: string): unknown {
     const nfa = compileGrammarToNFA(grammar, "test.grammar");
     const results = matchGrammarWithNFA(grammar, nfa, request);
-    return results[0]?.match;
+    // Each test grammar here has exactly one rule, so any successful
+    // match must have produced the same action value regardless of
+    // result ordering.  Return the first match (or undefined when the
+    // grammar didn't match).  Asserting via the set of all matches
+    // would be more robust against future ordering changes — but with
+    // a single-rule grammar there's at most one distinct value.
+    if (results.length === 0) return undefined;
+    const distinct = new Set(results.map((r) => JSON.stringify(r.match)));
+    if (distinct.size > 1) {
+        throw new Error(
+            `Expected a single distinct action value, got ${distinct.size}: ${[...distinct].join(", ")}`,
+        );
+    }
+    return results[0].match;
 }
 
 function bestDfaActionValue(grammar: Grammar, request: string): unknown {


### PR DESCRIPTION
## actionGrammar: variable capture on string/phraseSet + factor pass + inliner correctness

Extends variable-capture support to `StringPart` and `PhraseSetPart` across the NFA/DFA matchers, propagates it through the prefix-factoring optimizer, and fixes an inliner false-ambiguity bug uncovered by the new bound-string/phraseSet edges.

### Matcher / compiler

- Stage 1–3: variable capture works on `StringPart` and `PhraseSetPart` in the NFA/DFA matchers and through the prefix-factoring optimizer (atomic bound-string edges, parity bits in merge keys).
- `nfaCompiler`: split `compilePhraseSetPart` into `...NoSlots` / `...WithSlots` (mirrors the rule compile split). Reject optimizer-introduced `StringPart`/`PhraseSetPart` captures on the deprecated slot-less `compilePart` path so they fail loudly instead of silently dropping the binding.
- `nfa.addTokenTransition`: build the transition directly (mirrors `addPhraseSetTransition`) and route through `addTransition` so token transitions carry the same property shape (`variable` / `typeName` / `checked` / `appendToSlot`) as wildcard / epsilon.
- `nfaInterpreter`: extract `applySlotCapture`; both the phraseSet (`matchNFACore`) and token (`tryTransition`) capture sites use it.
- `grammarMatcher.usesImplicitDefault`: extracted helper, collapses redundant if/else branches into single `addValue` calls; introduces `ImplicitDefaultCarrier = Pick<MatchState, 'value' | 'parts'>`.

### Inliner correctness fix

`tryInlineRulesPart` now mirrors the matcher's implicit-default contract:

- single-part child: any type qualifies
- multi-part child: only variable-bearing parts (wildcard/number always; rules/string/phraseSet only when bound)

Fixes false-ambiguity rejection on multi-part children with an unbound rules/string sibling, and enables retargeting onto a bound `phraseSet`/`string` buried in a multi-part child after Stage 2.

### Optimizer hygiene

- `stepMergeKey`: `JSON.stringify` token/matcher fields to prevent delimiter collisions in the trie merge key.
- Centralize `CaptureBearingPart` / `isCaptureBearingPart` / `getCapturedVariableName` in `grammarTypes.ts`; replaces four duplicated `wildcard|number|rules|string|phraseSet` predicates across `grammarOptimizer.ts` and `nfaCompiler.ts`.
- `edgeToPart`: import `StringPart`/`PhraseSetPart` directly, removes `(out as { variable?: string })` escape-hatch casts.
- `GrammarOptimizationOptions.onInvariantViolation` (`'debug'` default | `'throw'`): the bound-`RulesPart`-with-no-binding-friendly-part case now logs and bails out in production; tests can opt into `'throw'` to surface regressions.

### Serializer / tests

- Serializer/deserializer: replace dynamic imports with named imports; add back-compat note for the new optional `StringPart.variable` / `PhraseSetPart.variable` fields.
- Rename `grammarMatcherStringPhraseSetVariable.spec.ts` → `nfaDfaStringPhraseSetVariable.spec.ts` to reflect NFA/DFA scope.
- New factor-pass tests for Stage 3 and an inliner test covering the bound-`phraseSet`-in-multi-part case.
- `bestNfaActionValue` test helper now verifies all results carry the same action value (resilient to NFA result ordering changes).

All 2636 actionGrammar unit tests pass.
