### PR TITLE
actionGrammar: opt-in tail RulesPart factoring

### DIFF
--- a/ts/docs/architecture/actionGrammar.md
+++ b/ts/docs/architecture/actionGrammar.md
@@ -540,14 +540,21 @@ below the failing fork still applies. Failure reasons:
 - **Cross-scope reference.** A suffix's value expression references
   a canonical name bound by the prefix. Nested rule scope is fresh
   in the matcher (entering a `RulesPart` resets `valueIds`), so the
-  suffix cannot see prefix bindings — bail out so each member emits
+  suffix cannot see prefix bindings - bail out so each member emits
   at the wrapper's level instead. (Recoverable by enabling
   `tailFactoring`; see below.)
-- **Mixed spacing.** Members disagree on `spacingMode`. The wrapper
-  rule has a single `spacingMode` that governs the prefix and the
-  prefix/suffix seam, and there is no value the wrapper can carry
-  that preserves every member's original prefix boundary semantics.
-  Factoring is refused at this fork.
+
+**Spacing-mode partitioning.** A wrapper rule has a single
+`spacingMode` that governs prefix-boundary semantics, so members
+with different spacing modes can never share a wrapper. Rather than
+bailing out at every mixed-spacing fork (which would miss legitimate
+factoring opportunities within each spacing group), `factorRules`
+partitions input rules by `spacingMode` and runs a separate trie per
+partition. Each partition emits its own factored output; the
+partitions are concatenated back in original-index order. As a
+result every member at every fork inside one trie is guaranteed to
+share the same `spacingMode` by construction, and `mixed-spacing`
+is never observed at the eligibility check.
 
 The earlier "binding shadow" guard is no longer needed: opaque
 canonicals allocated globally per `factorRules` call cannot
@@ -589,9 +596,10 @@ Tail wrappers carry a strict structural contract (validated by
 
 Tail wrappers are observably identical to the unfactored shape and
 also save one matcher frame push per fork. When `tailFactoring` is
-on, the factorer prefers tail wherever the contract is structurally
-satisfiable, falling back to the non-tail wrapper only when tail is
-unavailable (today: forks that hit `mixed-spacing`).
+on, the factorer prefers tail wherever the eligibility check
+succeeds; today every successful eligibility decision satisfies the
+tail contract, so the non-tail wrapper builder is only reached when
+`tailFactoring` is off.
 
 **NFA compatibility.** Tail RulesParts are understood only by the
 NFA-interpreter matcher (`grammarMatcher.ts`). The NFA compiler /

--- a/ts/docs/architecture/actionGrammar.md
+++ b/ts/docs/architecture/actionGrammar.md
@@ -541,11 +541,63 @@ below the failing fork still applies. Failure reasons:
   a canonical name bound by the prefix. Nested rule scope is fresh
   in the matcher (entering a `RulesPart` resets `valueIds`), so the
   suffix cannot see prefix bindings — bail out so each member emits
-  at the wrapper's level instead.
+  at the wrapper's level instead. (Recoverable by enabling
+  `tailFactoring`; see below.)
+- **Mixed spacing.** Members disagree on `spacingMode`. The wrapper
+  rule has a single `spacingMode` that governs the prefix and the
+  prefix/suffix seam, and there is no value the wrapper can carry
+  that preserves every member's original prefix boundary semantics.
+  Factoring is refused at this fork.
 
 The earlier "binding shadow" guard is no longer needed: opaque
 canonicals allocated globally per `factorRules` call cannot
 collide with each other.
+
+#### Pass 2b - Tail-call factoring (opt-in, NFA-incompatible)
+
+Some forks cannot be factored as a non-tail wrapper because each
+member's value expression references a prefix-bound canonical - for
+example the `playerSchema` shape
+
+```
+play <Inner> by   <Artist>     -> { kind: "by",   trackName, artist }
+play <Inner> from album <Album> -> { kind: "from", trackName, albumName }
+```
+
+where `trackName` is bound in the shared `play <Inner>` prefix and
+read by both members' value expressions. With Pass 2's non-tail
+wrapper this fork bails out (`cross-scope-ref`).
+
+Setting `optimizations.tailFactoring: true` (which requires
+`factorCommonPrefixes: true`) lets the factorer emit the suffix
+`RulesPart` as a **tail call** - a structurally-marked `RulesPart`
+the matcher enters without pushing a parent frame. The selected
+member's value flows up directly as the wrapper rule's value, and
+member value-exprs see the prefix's bindings through the inherited
+`valueIds` chain. No `__opt_factor_<n>` wrapper variable is
+synthesized.
+
+Tail wrappers carry a strict structural contract (validated by
+`validateTailRulesParts`):
+
+- This part is the **last** entry in its parent rule's `parts`.
+- The parent rule has `value === undefined`.
+- `repeat` / `optional` / `variable` are all forbidden.
+- `rules.length >= 2` (a single-member tail wrapper is equivalent
+  to inlining and the factorer never emits one).
+- Every member's `spacingMode` matches the parent rule's.
+
+Tail wrappers are observably identical to the unfactored shape and
+also save one matcher frame push per fork. When `tailFactoring` is
+on, the factorer prefers tail wherever the contract is structurally
+satisfiable, falling back to the non-tail wrapper only when tail is
+unavailable (today: forks that hit `mixed-spacing`).
+
+**NFA compatibility.** Tail RulesParts are understood only by the
+NFA-interpreter matcher (`grammarMatcher.ts`). The NFA compiler /
+DFA path (`nfaCompiler.ts`) explicitly throws on encountering one,
+so consumers that route through the NFA/DFA path must leave
+`tailFactoring` off.
 
 **No fixed-point loop.** Factoring is applied once per group of
 alternatives — the trie's grouping converges in a single pass and

--- a/ts/packages/actionGrammar/src/bench/benchUtil.ts
+++ b/ts/packages/actionGrammar/src/bench/benchUtil.ts
@@ -26,11 +26,27 @@ export const CONFIGS: { name: string; opts: LoadGrammarRulesOptions }[] = [
         opts: { optimizations: { factorCommonPrefixes: true } },
     },
     {
-        name: "both",
+        // Adds tailFactoring on top of factor.  Lets the factorer
+        // emit tail RulesParts at forks where members reference
+        // prefix-bound canonicals (today's `cross-scope-ref`
+        // bailouts), and prefers tail wrappers everywhere else
+        // (smaller AST, one fewer matcher frame push per fork).
+        name: "factor+tail",
+        opts: {
+            optimizations: {
+                factorCommonPrefixes: true,
+                tailFactoring: true,
+            },
+        },
+    },
+    {
+        // All passes enabled: inline + factor + tailFactoring.
+        name: "all",
         opts: {
             optimizations: {
                 inlineSingleAlternatives: true,
                 factorCommonPrefixes: true,
+                tailFactoring: true,
             },
         },
     },
@@ -80,9 +96,9 @@ export function runBenchmark(
 ): void {
     console.log(`\n=== ${label} ===`);
     console.log(
-        `| config    | RulesParts | match ms (${ITERATIONS}x) | speedup |`,
+        `| config      | RulesParts | match ms (${ITERATIONS}x) | speedup |`,
     );
-    console.log(`|-----------|-----------:|---------------:|--------:|`);
+    console.log(`|-------------|-----------:|---------------:|--------:|`);
     let baselineMs = 0;
     for (const cfg of CONFIGS) {
         const errors: string[] = [];
@@ -113,7 +129,7 @@ export function runBenchmark(
         if (cfg.name === "baseline") baselineMs = ms;
         const speedup = baselineMs > 0 ? baselineMs / ms : 1;
         console.log(
-            `| ${cfg.name.padEnd(9)} | ${String(partCount).padStart(10)} | ${ms.toFixed(1).padStart(14)} | ${colorSpeedup(speedup)} |`,
+            `| ${cfg.name.padEnd(11)} | ${String(partCount).padStart(10)} | ${ms.toFixed(1).padStart(14)} | ${colorSpeedup(speedup)} |`,
         );
     }
 }

--- a/ts/packages/actionGrammar/src/bench/grammarOptimizerSyntheticBenchmark.ts
+++ b/ts/packages/actionGrammar/src/bench/grammarOptimizerSyntheticBenchmark.ts
@@ -75,6 +75,32 @@ function buildCombined(width: number): string {
     );
 }
 
+/**
+ * Cross-scope-ref fork: N alternatives that share a prefix capturing
+ * `$(item:string)` and each alternative's value expression references
+ * that prefix-bound capture.  Without `tailFactoring`, the factorer
+ * bails out at this fork (`cross-scope-ref`) and emits each member
+ * as a separate full rule - losing prefix factoring entirely.  With
+ * `tailFactoring`, the factorer emits a tail RulesPart and the prefix
+ * is shared.  This is the motivating case the player grammar hits in
+ * the wild.
+ *
+ *   <Choice> = act on $(item:string) by $(name0:string) -> { kind: "by0", item, name0 }
+ *            | act on $(item:string) by $(name1:string) -> { kind: "by1", item, name1 }
+ *            | …
+ */
+function buildCrossScopeRefFork(width: number): string {
+    const alts: string[] = [];
+    for (let i = 0; i < width; i++) {
+        const slot = `name${i}`;
+        const tag = `by${i}`;
+        alts.push(
+            `act on $(item:string) by ${i} $(${slot}:string) -> { kind: "${tag}", item, ${slot} }`,
+        );
+    }
+    return `<Start> = <Choice>;\n<Choice> = ${alts.join("\n         | ")};`;
+}
+
 function main(): void {
     runBenchmark(
         `pass-through chain (depth=8)`,
@@ -117,6 +143,34 @@ function main(): void {
             "perform the action with item valuea0",
             "perform the action with item valuek0",
             "perform the action with item nothere",
+            "noise",
+        ],
+    );
+
+    runBenchmark(
+        `cross-scope-ref fork (width=10)`,
+        "synthetic.grammar",
+        buildCrossScopeRefFork(10),
+        [
+            "act on widget by 0 alice",
+            "act on widget by 5 bob",
+            "act on widget by 9 carol",
+            "act on widget by 3 dave",
+            "act on widget by 11 eve",
+            "no match here",
+        ],
+    );
+
+    runBenchmark(
+        `cross-scope-ref fork (width=30)`,
+        "synthetic.grammar",
+        buildCrossScopeRefFork(30),
+        [
+            "act on widget by 0 alice",
+            "act on widget by 15 bob",
+            "act on widget by 29 carol",
+            "act on widget by 7 dave",
+            "act on widget by 99 eve",
             "noise",
         ],
     );

--- a/ts/packages/actionGrammar/src/grammarCompiler.ts
+++ b/ts/packages/actionGrammar/src/grammarCompiler.ts
@@ -519,7 +519,7 @@ export function compileGrammar(
     // Skip optimizations when there were errors — the AST may be partial
     // and optimization invariants may not hold.
     if (errors.length === 0 && optimizations !== undefined) {
-        return optimizeGrammar(grammar, optimizations);
+        return optimizeGrammar(grammar, optimizations, warnings);
     }
     return grammar;
 }

--- a/ts/packages/actionGrammar/src/grammarDeserializer.ts
+++ b/ts/packages/actionGrammar/src/grammarDeserializer.ts
@@ -13,7 +13,7 @@ import {
 } from "./grammarTypes.js";
 import { validateTailRulesParts } from "./grammarOptimizer.js";
 
-export function grammarFromJson(json: GrammarJson): Grammar {
+function grammarFromJsonInternal(json: GrammarJson): Grammar {
     const start = json[0];
     const indexToRules: Map<number, GrammarRule[]> = new Map();
     function grammarRuleFromJson(r: GrammarRuleJson, json: GrammarJson) {
@@ -70,17 +70,22 @@ export function grammarFromJson(json: GrammarJson): Grammar {
 
 /**
  * Deserialize a `GrammarJson` and validate the structural contract on
- * any tail `RulesPart` it carries.  Untrusted JSON inputs (cached
- * grammars, hand-crafted test fixtures) should prefer this entry
- * point so contract violations surface as a clear `Error` at load
- * time rather than as confusing match failures or NFA-compile
- * crashes downstream.
+ * any tail `RulesPart` it carries.  Cost is dominated by tree size,
+ * not the presence of tail parts, so validation is on by default for
+ * every load - cached/untrusted JSON surfaces contract violations as
+ * a clear `Error` at load time rather than as confusing match
+ * failures or NFA-compile crashes downstream.
  *
- * Validation is a single recursive walk; cost is dominated by tree
- * size, not the presence of tail parts.
+ * Trusted producers (the in-process compiler emitting JSON it just
+ * built) can opt out by passing `validate: false` to skip the walk.
  */
-export function grammarFromJsonValidated(json: GrammarJson): Grammar {
-    const grammar = grammarFromJson(json);
-    validateTailRulesParts(grammar.rules);
+export function grammarFromJson(
+    json: GrammarJson,
+    options?: { validate?: boolean },
+): Grammar {
+    const grammar = grammarFromJsonInternal(json);
+    if (options?.validate !== false) {
+        validateTailRulesParts(grammar.rules);
+    }
     return grammar;
 }

--- a/ts/packages/actionGrammar/src/grammarDeserializer.ts
+++ b/ts/packages/actionGrammar/src/grammarDeserializer.ts
@@ -11,6 +11,7 @@ import {
     PhraseSetPart,
     RulesPart,
 } from "./grammarTypes.js";
+import { validateTailRulesParts } from "./grammarOptimizer.js";
 
 export function grammarFromJson(json: GrammarJson): Grammar {
     const start = json[0];
@@ -48,7 +49,7 @@ export function grammarFromJson(json: GrammarJson): Grammar {
                     optional: p.optional,
                 };
                 if (p.repeat) part.repeat = true;
-                if (p.tail) part.tail = true;
+                if (p.tailCall) part.tailCall = true;
                 return part;
             }
             case "phraseSet": {
@@ -65,4 +66,21 @@ export function grammarFromJson(json: GrammarJson): Grammar {
     return {
         rules: start.map((r) => grammarRuleFromJson(r, json)),
     };
+}
+
+/**
+ * Deserialize a `GrammarJson` and validate the structural contract on
+ * any tail `RulesPart` it carries.  Untrusted JSON inputs (cached
+ * grammars, hand-crafted test fixtures) should prefer this entry
+ * point so contract violations surface as a clear `Error` at load
+ * time rather than as confusing match failures or NFA-compile
+ * crashes downstream.
+ *
+ * Validation is a single recursive walk; cost is dominated by tree
+ * size, not the presence of tail parts.
+ */
+export function grammarFromJsonValidated(json: GrammarJson): Grammar {
+    const grammar = grammarFromJson(json);
+    validateTailRulesParts(grammar.rules);
+    return grammar;
 }

--- a/ts/packages/actionGrammar/src/grammarDeserializer.ts
+++ b/ts/packages/actionGrammar/src/grammarDeserializer.ts
@@ -48,6 +48,7 @@ export function grammarFromJson(json: GrammarJson): Grammar {
                     optional: p.optional,
                 };
                 if (p.repeat) part.repeat = true;
+                if (p.tail) part.tail = true;
                 return part;
             }
             case "phraseSet": {

--- a/ts/packages/actionGrammar/src/grammarMatcher.ts
+++ b/ts/packages/actionGrammar/src/grammarMatcher.ts
@@ -1740,6 +1740,50 @@ export function matchState(state: MatchState, request: string) {
                 const rules = part.rules;
                 debugMatch(state, `expanding ${rules.length} rules`);
 
+                if (part.tail) {
+                    // Tail RulesPart: true tail call.  No parent frame
+                    // is pushed — `state.parent` keeps pointing at
+                    // whatever ancestor frame was already current.
+                    // When the selected member finishes, finalize pops
+                    // straight to that ancestor with the member's
+                    // value/valueIds in place.
+                    //
+                    // Structural contract (validated upstream): this
+                    // is the last part of the parent rule, the parent
+                    // has no value of its own, and `repeat`/`optional`/
+                    // `variable` are all forbidden — so there is
+                    // nothing left in the parent for a parent frame to
+                    // resume to, no value to synthesize at parent
+                    // finalize, and no captured wrapper variable to
+                    // bind.
+                    //
+                    // Scope: do NOT reset `state.valueIds` — the
+                    // child's bindings cons onto the parent's
+                    // persistent linked list, so member value-exprs
+                    // resolve prefix-bound canonicals naturally
+                    // through `createValue`.  Backtracking across
+                    // sibling alts comes for free because the
+                    // alternation cursor frame snapshots `valueIds`
+                    // before any member binds, automatically
+                    // discarding anything an abandoned branch added.
+                    state.name = getNestedStateName(state, part, 0);
+                    state.parts = rules[0].parts;
+                    state.value = rules[0].value;
+                    state.partIndex = 0;
+                    state.suppressOptionalFork = undefined;
+                    state.spacingMode = rules[0].spacingMode;
+
+                    if (rules.length > 1) {
+                        const base = forkMatchState(state);
+                        const namePrefix = part.name
+                            ? `<${part.name}>`
+                            : getStateName(state);
+                        pushAlternation(state, base, rules, namePrefix);
+                    }
+                    // continue the loop (without incrementing partIndex)
+                    continue;
+                }
+
                 // Save the current state to be restored after finishing the nested rule.
                 const parent: ParentMatchState = {
                     name: state.name,

--- a/ts/packages/actionGrammar/src/grammarMatcher.ts
+++ b/ts/packages/actionGrammar/src/grammarMatcher.ts
@@ -1696,7 +1696,13 @@ function enterTailRulesPart(state: MatchState, part: RulesPart): void {
     state.value = rules[0].value;
     state.partIndex = 0;
     state.suppressOptionalFork = undefined;
-    // state.spacingMode unchanged - contract guarantees member matches.
+    // Mirror the non-tail RulesPart entry path and the backtrack
+    // restore in `tryNextBacktrack` (which overlays
+    // `rule.spacingMode` per restored alternative).  The assertion
+    // above guarantees this is a no-op when the contract holds; on
+    // a contract violation it keeps rule 0's behavior consistent
+    // with rule i's after backtrack.
+    state.spacingMode = rules[0].spacingMode;
 
     // `forkMatchState` snapshots `valueIds` (and every other field) at
     // this fork point; restoring on backtrack rewinds anything an

--- a/ts/packages/actionGrammar/src/grammarMatcher.ts
+++ b/ts/packages/actionGrammar/src/grammarMatcher.ts
@@ -1670,27 +1670,13 @@ function matchVarStringPart(state: MatchState, part: VarStringPart) {
 // are automatically discarded on restore.
 function enterTailRulesPart(state: MatchState, part: RulesPart): void {
     const rules = part.rules;
-    // Defensive: validateGrammar should have caught any contract
-    // violation upstream, but a misbehaving caller / future change
-    // could still hand us a malformed tail part.  The assertions are
-    // cheap and catch problems at the offending site rather than
-    // letting state corruption surface as a confusing match failure.
-    if (rules.length < 2) {
-        throw new Error(
-            `Internal: tail RulesPart requires rules.length >= 2 (got ${rules.length})`,
-        );
-    }
-    if (part.repeat || part.optional || part.variable !== undefined) {
-        throw new Error(
-            "Internal: tail RulesPart cannot have repeat/optional/variable",
-        );
-    }
-    if (rules[0].spacingMode !== state.spacingMode) {
-        throw new Error(
-            "Internal: tail RulesPart member spacingMode must match parent's",
-        );
-    }
-
+    // Structural contract is enforced by `validateTailRulesParts`,
+    // which runs at JSON load time (default in `grammarFromJson`) and
+    // at the end of `optimizeGrammar` when `tailFactoring` is on.
+    // No runtime asserts here on the hot path - the cases this code
+    // would otherwise check (rules.length >= 2, no
+    // repeat/optional/variable, member spacingMode matches parent's)
+    // are caught at construction time at the offending site.
     state.name = getNestedStateName(state, part, 0);
     state.parts = rules[0].parts;
     state.value = rules[0].value;
@@ -1698,10 +1684,13 @@ function enterTailRulesPart(state: MatchState, part: RulesPart): void {
     state.suppressOptionalFork = undefined;
     // Mirror the non-tail RulesPart entry path and the backtrack
     // restore in `tryNextBacktrack` (which overlays
-    // `rule.spacingMode` per restored alternative).  The assertion
-    // above guarantees this is a no-op when the contract holds; on
-    // a contract violation it keeps rule 0's behavior consistent
-    // with rule i's after backtrack.
+    // `rule.spacingMode` per restored alternative).  By contract,
+    // member spacingMode equals the parent rule's spacingMode and
+    // `state.spacingMode` is already the parent rule's mode at this
+    // point (the tail RulesPart is the last part of the parent),
+    // so this assignment is a no-op when the contract holds.  Kept
+    // explicit to mirror the non-tail entry path and the backtrack
+    // restore.
     state.spacingMode = rules[0].spacingMode;
 
     // `forkMatchState` snapshots `valueIds` (and every other field) at

--- a/ts/packages/actionGrammar/src/grammarMatcher.ts
+++ b/ts/packages/actionGrammar/src/grammarMatcher.ts
@@ -121,8 +121,8 @@ export function isBoundarySatisfied(
             // the outer boundary.  For top-level "none" rules, leading
             // whitespace is rejected (via leadingSpacingMode) and trailing
             // content is rejected (via finalizeState).  For nested rules,
-            // the nearest ancestor with a flex-space boundary — or the
-            // top-level rule if none — controls leading/trailing spacing
+            // the nearest ancestor with a flex-space boundary - or the
+            // top-level rule if none - controls leading/trailing spacing
             // around the nested match (see leadingSpacingMode).  The
             // boundary check itself always passes.
             return true;
@@ -169,7 +169,7 @@ type ParentMatchState = {
     variable: string | undefined;
     valueIds: ValueIdNode | undefined | null; // null means we don't need any value
     parent: ParentMatchState | undefined;
-    repeatPartIndex?: number | undefined; // defined for ()* / )+ — holds the part index to loop back to
+    repeatPartIndex?: number | undefined; // defined for ()* / )+ - holds the part index to loop back to
     spacingMode: CompiledSpacingMode; // parent rule's spacingMode, restored in MatchState on return from nested rule
 };
 
@@ -186,7 +186,7 @@ export type PendingWildcard = {
 //
 // All three default to `"exhaustive"` so callers receive every
 // valid parse.  The non-default values are first-success
-// commitments — the matcher picks one branch and abandons the
+// commitments - the matcher picks one branch and abandons the
 // other(s) without enumerating them.
 
 /**
@@ -204,7 +204,7 @@ export type PendingWildcard = {
  *   - `"shortest"`: each traversal path commits to the shortest
  *     viable wildcard capture; longer-wildcard alternatives for
  *     that path are not enumerated.  Other axes (alternation,
- *     optional, repeat) are still explored normally — only the
+ *     optional, repeat) are still explored normally - only the
  *     wildcard-length axis is collapsed.
  */
 export type WildcardPolicy = "exhaustive" | "shortest";
@@ -249,7 +249,7 @@ export type GrammarMatchOptions = {
 // `suppressBacktracksAfterSuccess` to apply per-axis policy
 // (`wildcardPolicy` / `optionalPolicy` / `repeatPolicy`) when
 // pruning unexplored siblings after a successful parse.  The tag
-// does NOT affect drain order — that is purely LIFO push order.
+// does NOT affect drain order - that is purely LIFO push order.
 //
 // `"wildcard"` frames are pushed by `captureWildcard` to enable
 // extending a wildcard capture to a strictly longer length.
@@ -304,12 +304,12 @@ type SingleBacktrack = {
 
 // Per-alternative state at one alternation fork point is fully
 // derivable from the rule itself (`parts`/`value`/`spacingMode`)
-// plus a debug `name` — nothing else differs across siblings.
+// plus a debug `name` - nothing else differs across siblings.
 // The cursor frame stores a direct reference to the existing
 // `GrammarRule[]` (no copy) and a single `namePrefix` string;
 // `tryNextBacktrack` builds `namePrefix + "[" + cursor + "]"` and
 // reads `rules[cursor].parts/value/spacingMode` lazily on restore.
-// Eliminates per-alternative allocation entirely — N-way alternation
+// Eliminates per-alternative allocation entirely - N-way alternation
 // pushes 1 frame + 1 base snapshot regardless of N.
 type AlternationBacktrack = {
     readonly origin: "alternation";
@@ -340,9 +340,9 @@ type Backtrack = SingleBacktrack | AlternationBacktrack;
 // compile error.
 //
 // Audit points when adding a new MatchState field:
-//   1. `captureSnapshot` (this file) — must list the new field;
+//   1. `captureSnapshot` (this file) - must list the new field;
 //      this mapped type makes omitting it a compile error.
-//   2. `wildcardFrameSnapshot.spec.ts` — extend coverage if the
+//   2. `wildcardFrameSnapshot.spec.ts` - extend coverage if the
 //      field can be assigned AFTER a wildcard frame is pushed.
 type SnapshotState = { [K in keyof PendingMatchState]-?: PendingMatchState[K] };
 
@@ -392,7 +392,7 @@ export type PendingMatchState = {
     //
     // `afterWildcard` indicates the part was matched via wildcard
     // scanning (matchStringPartWithWildcard / matchVarNumberPartWithWildcard)
-    // — i.e., a wildcard preceded this part and the part's position
+    // - i.e., a wildcard preceded this part and the part's position
     // was determined by scanning forward through the wildcard region.
     // When backward backs up to such a part, the position is ambiguous
     // (see afterWildcard on GrammarCompletionResult in grammarCompletion.ts).
@@ -429,13 +429,13 @@ export type MatchState = PendingMatchState & {
     // Single-owner invariant: only the live state currently being
     // driven by `matchGrammar`/`matchGrammarCompletion` may own
     // frames.  States queued on a `PendingMatchState[]` work-list
-    // statically cannot — enforced by the `PendingMatchState` type
+    // statically cannot - enforced by the `PendingMatchState` type
     // (which omits this field).
     backtracks?: Backtrack | undefined;
 
     // Per-axis policies.  Set once at `initialMatchState` time and
     // never changed.  Deliberately NOT in `PendingMatchState` /
-    // `SnapshotState` — `Object.assign` of a snapshot won't overwrite
+    // `SnapshotState` - `Object.assign` of a snapshot won't overwrite
     // them, so they persist across `tryNextBacktrack` restores.
     wildcardPolicy: WildcardPolicy;
     optionalPolicy: OptionalPolicy;
@@ -447,7 +447,7 @@ export type MatchState = PendingMatchState & {
 // optional skip/take, alternation, repeat continue) and by the
 // public `cloneMatchState`.  Returns the strict `SnapshotState`
 // (every field required as an own property) so a missing field is
-// a compile error — the fork/clone helpers widen back to
+// a compile error - the fork/clone helpers widen back to
 // `PendingMatchState`.
 function captureSnapshot(state: MatchState): SnapshotState {
     return {
@@ -479,24 +479,24 @@ function captureSnapshot(state: MatchState): SnapshotState {
 // a MatchState is expected (e.g. read-only inspection, or as a
 // starting point for an independent matcher run).
 //
-// Use this for READ-ONLY views — e.g. the pre-finalize clone in
+// Use this for READ-ONLY views - e.g. the pre-finalize clone in
 // `grammarCompletion` that must survive subsequent matcher
 // mutation of the live state.  For fork sites (optional-skip,
 // nested-rule alternatives, repeat continuation, wildcard
-// extension) use `forkMatchState` instead — that returns a
+// extension) use `forkMatchState` instead - that returns a
 // `SnapshotState` with no policies, suitable for restoration via
 // `Object.assign` without disturbing the live state's policies.
 export function cloneMatchState(state: MatchState): MatchState {
     // Single-allocation clone: drop only `backtracks` (live-state
-    // mutation surface) and keep everything else — including the
-    // three policy fields — by spreading once.
+    // mutation surface) and keep everything else - including the
+    // three policy fields - by spreading once.
     const { backtracks: _backtracks, ...rest } = state;
     return rest;
 }
 
 // Fork a `state` into a sibling that is about to be pushed onto the
 // `backtracks` chain.  The return type omits `backtracks`
-// — only the live state retains ownership of the existing chain.
+// - only the live state retains ownership of the existing chain.
 // This makes the single-owner invariant a compile-time guarantee:
 // two siblings cannot independently pop the same chain.
 //
@@ -515,12 +515,12 @@ export function forkMatchState(state: MatchState): SnapshotState {
 //
 // Used for:
 //   - structural forks at degree-2 fan-outs (origin "optional" /
-//     "repeat") — `alternative` is built via `forkMatchState` and
+//     "repeat") - `alternative` is built via `forkMatchState` and
 //     mutated to reflect the alternative branch's choice.
-//   - wildcard refinement (origin "wildcard") — pushed by
+//   - wildcard refinement (origin "wildcard") - pushed by
 //     `captureWildcard` to enable extending the wildcard.
 //
-// Alternation uses `pushAlternation` instead — see that helper.
+// Alternation uses `pushAlternation` instead - see that helper.
 //
 // Single-owner invariant: SnapshotState omits the `backtracks`
 // field, so the snapshot cannot smuggle a parallel chain in.  When
@@ -541,7 +541,7 @@ export function pushBacktrack(
 
 // Push a compressed alternation cursor frame.  Replaces the
 // historical pattern of pushing N-1 individual snapshots at one
-// alternation fork — the live state takes rule 0, and a single
+// alternation fork - the live state takes rule 0, and a single
 // cursor frame carries the shared `base` snapshot plus a direct
 // reference to the existing `GrammarRule[]` (no per-alternative
 // copy).  The debug name for `rules[i]` is built lazily as
@@ -550,7 +550,7 @@ export function pushBacktrack(
 //
 // Cursor starts at 1 (rule 0 is the live alternative) and advances
 // forward through `rules.length-1`, restoring the lowest-index
-// alternative first — matching the prior reverse-push order of one
+// alternative first - matching the prior reverse-push order of one
 // frame per rule.  Caller must ensure `rules.length > 1`.
 //
 // `base` MUST be captured AFTER the live state has been set up for
@@ -621,14 +621,14 @@ export function tryNextBacktrack(state: MatchState): boolean {
         state.spacingMode = rule.spacingMode;
         frame.cursor = i + 1;
         if (frame.cursor >= frame.rules.length) {
-            // All alternatives restored — unlink the cursor.
+            // All alternatives restored - unlink the cursor.
             state.backtracks = frame.prev;
         }
         debugMatch(state, `Restoring local backtrack (alternation)`);
         return true;
     }
     // The snapshot omits `backtracks`, so Object.assign won't
-    // overwrite it — explicitly advance the head pointer to `prev`.
+    // overwrite it - explicitly advance the head pointer to `prev`.
     Object.assign(state, frame.snapshot);
     state.backtracks = frame.prev;
     debugMatch(
@@ -641,7 +641,7 @@ export function tryNextBacktrack(state: MatchState): boolean {
 }
 
 // After a successful match, drop ALL backtrack frames in the chain
-// whose origin axis is configured to commit on first success —
+// whose origin axis is configured to commit on first success -
 // the caller has said it doesn't want extra parses along that
 // axis once one has been found.
 //
@@ -649,7 +649,7 @@ export function tryNextBacktrack(state: MatchState): boolean {
 //   - origin "wildcard"  + wildcardPolicy === "shortest"
 //   - origin "optional"  + optionalPolicy !== "exhaustive"
 //   - origin "repeat"    + repeatPolicy   !== "exhaustive"
-//   - origin "alternation"                 — always retained
+//   - origin "alternation"                 - always retained
 //
 // Frames with non-suppressed origins are SKIPPED OVER (their own
 // `prev` is preserved through), so suppression walks the entire
@@ -686,7 +686,7 @@ export function suppressBacktracksAfterSuccess(state: MatchState) {
         state.backtracks = state.backtracks.prev;
     }
     // Walk the rest, splicing out any suppressed frame deeper in
-    // the chain.  Mutates `prev` pointers in place — the chain is
+    // the chain.  Mutates `prev` pointers in place - the chain is
     // single-owner, so no other state shares this view.
     let kept = state.backtracks;
     while (kept !== undefined) {
@@ -867,7 +867,7 @@ export function createValue(
                         stat,
                     );
                     if (inner === undefined) {
-                        // Partial match — the spread argument's variable
+                        // Partial match - the spread argument's variable
                         // hasn't been captured yet.  Skip silently.
                     } else if (typeof inner === "object") {
                         Object.assign(obj, inner);
@@ -954,7 +954,7 @@ export function createValue(
         default: {
             // Expression node (binaryExpression, unaryExpression, etc.).
             // All expression node types are handled by evaluateValueExpr,
-            // which throws on unknown types — no silent fallthrough risk.
+            // which throws on unknown types - no silent fallthrough risk.
             // The evalBase callback routes base nodes (literal, variable,
             // object, array) back through createValue so variable resolution
             // and wildcard extraction work correctly.
@@ -976,7 +976,7 @@ export function createValue(
 // Extract and trim a wildcard capture from `request[start..end)`.  In the
 // default spacing modes the result is stripped of leading/trailing separators
 // (whitespace and punctuation).  Returns `undefined` when the capture is empty
-// or consists *entirely* of separator characters — e.g. a lone " " — so that
+// or consists *entirely* of separator characters - e.g. a lone " " - so that
 // the matcher rejects wildcard slots that contain no meaningful content.
 // In "none" mode no trimming is performed; only a truly zero-length capture
 // is rejected.
@@ -1113,7 +1113,7 @@ export function finalizeState(state: MatchState, request: string) {
         }
     }
     if (state.index < request.length) {
-        // In "none" mode the match must be exact — no trailing content
+        // In "none" mode the match must be exact - no trailing content
         // is tolerated.  This applies to the top-level rule's spacing
         // mode (by the time finalizeState runs, nested rules have been
         // unwound and the spacing mode has been restored to the
@@ -1288,7 +1288,7 @@ function matchStringPartWithWildcard(
             // If the StringPart has an explicit capture variable, write the
             // joined matched tokens into that named slot.  Otherwise fall
             // through to the implicit-default rule for single-part rules
-            // without a value expression — same logic as the non-wildcard
+            // without a value expression - same logic as the non-wildcard
             // path in matchStringPartWithoutWildcard.  Without this, a
             // pending wildcard from a parent rule that leaks into a
             // single-part child rule would bypass the default value
@@ -1347,7 +1347,7 @@ function matchStringPartWithoutWildcard(
         state.valueIds !== null &&
         (part.variable !== undefined || usesImplicitDefault(state))
     ) {
-        // Explicit capture variable on the StringPart — write the joined
+        // Explicit capture variable on the StringPart - write the joined
         // matched tokens into that named slot.  Otherwise fall through to
         // the implicit-default rule for single-part rules without a value
         // expression.
@@ -1368,7 +1368,7 @@ function matchStringPartWithoutWildcard(
 // ([\s\p{P}]*?) for a part at the current position.
 //
 // For subsequent parts within a rule (partIndex > 0), the rule's own
-// spacingMode applies — there is a flex-space boundary between the
+// spacingMode applies - there is a flex-space boundary between the
 // previous part and this one.
 //
 // For the first part of a nested rule (partIndex === 0, parent exists),
@@ -1376,7 +1376,7 @@ function matchStringPartWithoutWildcard(
 // a flex-space boundary before the rule reference (parent.partIndex > 1
 // means the rule ref was not the first part).  That ancestor's spacing
 // mode controls the separator.  If no ancestor has a preceding
-// flex-space, we've reached the top-level rule — its spacing mode
+// flex-space, we've reached the top-level rule - its spacing mode
 // determines the leading/trailing behavior (all modes except "none"
 // allow leading whitespace at the top level).
 export function leadingSpacingMode(state: MatchState): CompiledSpacingMode {
@@ -1387,7 +1387,7 @@ export function leadingSpacingMode(state: MatchState): CompiledSpacingMode {
     while (parent !== undefined) {
         if (parent.partIndex > 1) {
             // The rule reference had a preceding part in this ancestor
-            // — use this ancestor's spacing mode for the flex-space.
+            // - use this ancestor's spacing mode for the flex-space.
             return parent.spacingMode;
         }
         if (parent.parent === undefined) {
@@ -1419,7 +1419,7 @@ function buildStringPartRegExpStr(
     const regexpSegments: string[] = [escaped[0]];
     for (let i = 1; i < escaped.length; i++) {
         // In "none" mode flex-space positions must match exactly zero
-        // characters — tokens are directly adjacent.  Any literal spaces
+        // characters - tokens are directly adjacent.  Any literal spaces
         // (e.g. from "\ ") are already part of the segment text and will
         // be matched by the regex itself.
         const sep =
@@ -1643,6 +1643,69 @@ function matchVarStringPart(state: MatchState, part: VarStringPart) {
     return true;
 }
 
+// Enter a tail `RulesPart` (true tail call).  No parent frame is
+// pushed - `state.parent` keeps pointing at whatever ancestor frame
+// was already current.  When the selected member finishes, finalize
+// pops straight to that ancestor with the member's value/valueIds in
+// place.
+//
+// Structural contract (enforced by `validateGrammar` and asserted
+// here): `tailCall` requires `rules.length >= 2`, the part is the
+// last in its parent's `parts`, the parent has no value of its own,
+// and `repeat`/`optional`/`variable` are all forbidden.  So there is
+// nothing left in the parent for a parent frame to resume to, no
+// value to synthesize at parent finalize, and no captured wrapper
+// variable to bind.  The contract also requires every member's
+// `spacingMode` to equal the parent's - `forkMatchState` (used to
+// snapshot the alternation base) doesn't capture `spacingMode` per
+// member, so disagreement here would silently corrupt state.
+//
+// Scope: do NOT reset `state.valueIds` - the child's bindings cons
+// onto the parent's persistent linked list, so member value-exprs
+// resolve prefix-bound canonicals naturally through `createValue`.
+// Backtracking across sibling alts comes for free because
+// `pushAlternation` captures the alternation base via
+// `forkMatchState`, which snapshots `valueIds` (see
+// `captureSnapshot`) before any member binds - abandoned branches
+// are automatically discarded on restore.
+function enterTailRulesPart(state: MatchState, part: RulesPart): void {
+    const rules = part.rules;
+    // Defensive: validateGrammar should have caught any contract
+    // violation upstream, but a misbehaving caller / future change
+    // could still hand us a malformed tail part.  The assertions are
+    // cheap and catch problems at the offending site rather than
+    // letting state corruption surface as a confusing match failure.
+    if (rules.length < 2) {
+        throw new Error(
+            `Internal: tail RulesPart requires rules.length >= 2 (got ${rules.length})`,
+        );
+    }
+    if (part.repeat || part.optional || part.variable !== undefined) {
+        throw new Error(
+            "Internal: tail RulesPart cannot have repeat/optional/variable",
+        );
+    }
+    if (rules[0].spacingMode !== state.spacingMode) {
+        throw new Error(
+            "Internal: tail RulesPart member spacingMode must match parent's",
+        );
+    }
+
+    state.name = getNestedStateName(state, part, 0);
+    state.parts = rules[0].parts;
+    state.value = rules[0].value;
+    state.partIndex = 0;
+    state.suppressOptionalFork = undefined;
+    // state.spacingMode unchanged - contract guarantees member matches.
+
+    // `forkMatchState` snapshots `valueIds` (and every other field) at
+    // this fork point; restoring on backtrack rewinds anything an
+    // abandoned member added to the chain.
+    const base = forkMatchState(state);
+    const namePrefix = part.name ? `<${part.name}>` : getStateName(state);
+    pushAlternation(state, base, rules, namePrefix);
+}
+
 export function matchState(state: MatchState, request: string) {
     while (true) {
         const { parts, partIndex } = state;
@@ -1657,7 +1720,7 @@ export function matchState(state: MatchState, request: string) {
             // parent still has parts remaining.  If the parent is also
             // exhausted, skip the check here: the loop will call
             // finalizeNestedRule again and the check will fire once we
-            // reach an ancestor that actually has a following part — using
+            // reach an ancestor that actually has a following part - using
             // that ancestor's mode instead of an intermediate pass-through
             // rule's mode.
             if (
@@ -1701,7 +1764,7 @@ export function matchState(state: MatchState, request: string) {
                 // state continues with the optional part).  The take
                 // snapshot is marked `suppressOptionalFork: true` so
                 // that on restore the optional-fork block at the top
-                // of this loop is suppressed — otherwise the same
+                // of this loop is suppressed - otherwise the same
                 // optional part would re-fork and we would push
                 // another take frame in an infinite loop.  The flag
                 // is consumed by the local capture above on the next
@@ -1740,46 +1803,8 @@ export function matchState(state: MatchState, request: string) {
                 const rules = part.rules;
                 debugMatch(state, `expanding ${rules.length} rules`);
 
-                if (part.tail) {
-                    // Tail RulesPart: true tail call.  No parent frame
-                    // is pushed — `state.parent` keeps pointing at
-                    // whatever ancestor frame was already current.
-                    // When the selected member finishes, finalize pops
-                    // straight to that ancestor with the member's
-                    // value/valueIds in place.
-                    //
-                    // Structural contract (validated upstream): this
-                    // is the last part of the parent rule, the parent
-                    // has no value of its own, and `repeat`/`optional`/
-                    // `variable` are all forbidden — so there is
-                    // nothing left in the parent for a parent frame to
-                    // resume to, no value to synthesize at parent
-                    // finalize, and no captured wrapper variable to
-                    // bind.
-                    //
-                    // Scope: do NOT reset `state.valueIds` — the
-                    // child's bindings cons onto the parent's
-                    // persistent linked list, so member value-exprs
-                    // resolve prefix-bound canonicals naturally
-                    // through `createValue`.  Backtracking across
-                    // sibling alts comes for free because the
-                    // alternation cursor frame snapshots `valueIds`
-                    // before any member binds, automatically
-                    // discarding anything an abandoned branch added.
-                    state.name = getNestedStateName(state, part, 0);
-                    state.parts = rules[0].parts;
-                    state.value = rules[0].value;
-                    state.partIndex = 0;
-                    state.suppressOptionalFork = undefined;
-                    state.spacingMode = rules[0].spacingMode;
-
-                    if (rules.length > 1) {
-                        const base = forkMatchState(state);
-                        const namePrefix = part.name
-                            ? `<${part.name}>`
-                            : getStateName(state);
-                        pushAlternation(state, base, rules, namePrefix);
-                    }
+                if (part.tailCall) {
+                    enterTailRulesPart(state, part);
                     // continue the loop (without incrementing partIndex)
                     continue;
                 }
@@ -1817,7 +1842,7 @@ export function matchState(state: MatchState, request: string) {
 
                 // Push a single compressed alternation cursor frame
                 // covering rules 1..N-1.  The shared `base` is the
-                // live state right after rule 0 setup — every
+                // live state right after rule 0 setup - every
                 // alternative starts from the same fork-point
                 // context with only the four per-rule fields
                 // overlaid (read directly from `rules[i]` on
@@ -1845,7 +1870,7 @@ export function matchState(state: MatchState, request: string) {
 // Build the initial live MatchState for `matchGrammar` /
 // `matchGrammarCompletion`.  The returned state is initialized for
 // rule 0 (the live DFS path); rules 1..N-1 are pre-pushed onto
-// its `backtracks` chain as `"alternation"`-origin frames —
+// its `backtracks` chain as `"alternation"`-origin frames -
 // the same mechanism a nested-rule alternation uses.  Pushed in
 // reverse order so rule 1 is on top of the stack and gets
 // restored first by `tryNextBacktrack`, matching source
@@ -1883,7 +1908,7 @@ export function initialMatchState(
     };
     // Top-level alternation: push a single compressed cursor frame
     // covering rules 1..N-1.  The cursor advances forward (rule 1
-    // first, then rule 2, ...) — same source order as the prior
+    // first, then rule 2, ...) - same source order as the prior
     // reverse-push of one frame per rule.  `base` is rule-0's
     // initial state; per-rule `parts/value/spacingMode` are read
     // from `rules[i]` directly on restore, and the debug name is

--- a/ts/packages/actionGrammar/src/grammarOptimizer.ts
+++ b/ts/packages/actionGrammar/src/grammarOptimizer.ts
@@ -40,7 +40,7 @@ export type GrammarOptimizationOptions = {
 
     /**
      * Behavior when the inliner reaches an internal invariant violation
-     * (a bound `RulesPart` whose child has no binding-friendly part —
+     * (a bound `RulesPart` whose child has no binding-friendly part -
      * see `tryInlineRulesPart`).  This indicates either a compiler bug
      * upstream or a future change to `hasValue` semantics.
      *
@@ -59,7 +59,7 @@ export type GrammarOptimizationOptions = {
      * the wrapper rule's value).  Tail wrappers are observably
      * identical to the unfactored shape, produce a smaller AST (no
      * synthesized wrapper-binding variable, no `factoredAlt.value`
-     * indirection), and save one matcher frame push per fork — so
+     * indirection), and save one matcher frame push per fork - so
      * tail is preferred whenever it can be emitted.
      *
      * The non-tail wrapper is used only as a fallback at forks where
@@ -71,7 +71,7 @@ export type GrammarOptimizationOptions = {
      * and emits each member as a separate full rule.
      *
      * Without this flag set, the factorer never emits tail RulesParts
-     * — preserving today's matcher semantics for every consumer.
+     * - preserving today's matcher semantics for every consumer.
      *
      * Currently only the NFA-interpreter matcher (`grammarMatcher.ts`)
      * understands tail RulesParts.  The NFA compiler / DFA path does
@@ -82,7 +82,7 @@ export type GrammarOptimizationOptions = {
 
 /**
  * Recommended preset enabling all optimizations.  Use this when callers
- * want every safe pass on without naming each flag individually \u2014 future
+ * want every safe pass on without naming each flag individually - future
  * passes added here will be picked up automatically.
  *
  * Caveat: enabling `factorCommonPrefixes` destroys the 1:1
@@ -97,7 +97,7 @@ export const recommendedOptimizations: GrammarOptimizationOptions = {
 
 /**
  * Run enabled optimization passes against the compiled grammar AST.
- * The returned grammar is semantically equivalent to the input — only the
+ * The returned grammar is semantically equivalent to the input - only the
  * shape of the parts/rules tree changes.
  *
  * The optimizer is intentionally conservative: when in doubt about an
@@ -114,13 +114,20 @@ export function optimizeGrammar(
     const inlineConfig: InlineConfig = {
         onInvariantViolation: options.onInvariantViolation ?? "debug",
     };
+    if (options.tailFactoring && !options.factorCommonPrefixes) {
+        // tailFactoring is a sub-mode of the prefix-factoring pass;
+        // setting it without enabling the parent pass is almost
+        // certainly a configuration mistake.  Log so it surfaces in
+        // debug traces rather than silently being a no-op.
+        debug(
+            "tailFactoring is set but factorCommonPrefixes is not - tailFactoring has no effect",
+        );
+    }
     if (options.inlineSingleAlternatives) {
         rules = inlineSingleAlternativeRules(rules, inlineConfig);
     }
     if (options.factorCommonPrefixes) {
-        rules = factorCommonPrefixes(rules, {
-            tailFactoring: !!options.tailFactoring,
-        });
+        rules = factorCommonPrefixes(rules, !!options.tailFactoring);
         if (options.inlineSingleAlternatives) {
             // Factoring never emits a single-alternative wrapper itself
             // (factorRulesPart only wraps when members.length >= 2), but
@@ -280,13 +287,13 @@ type TryInlineResult = {
     valueSubstitution?: InlineValueSubstitution;
     /**
      * When set, the parent rule had no value expression of its own and
-     * this inlining synthesizes one — copying what the matcher would
+     * this inlining synthesizes one - copying what the matcher would
      * have computed via its default-value rule (i.e. the captured child
      * rule's value).  At most one assignment is possible per parent
      * rule: the matcher's default-value rule requires exactly one
      * variable on the parent, so two inlinings each producing a
      * valueAssignment would mean the parent originally had two
-     * variables and `hasValue=false` — a grammar the compiler
+     * variables and `hasValue=false` - a grammar the compiler
      * rejects (or warns about).
      */
     valueAssignment?: CompiledValueNode;
@@ -333,7 +340,7 @@ function inlineParts(
         // Refuse to inline a RulesPart whose body is shared by more than
         // one reference: inlining duplicates the child's parts at the
         // call site, but the original array is still referenced from the
-        // other call sites — net effect is N copies in the serialized
+        // other call sites - net effect is N copies in the serialized
         // grammar instead of 1 dedup'd entry.  Reference counts come
         // from the *input* AST; the rewritten array shares identity with
         // it via the memo when no nested change occurred, and otherwise
@@ -355,7 +362,7 @@ function inlineParts(
                 // valueAssignment is only produced when the parent had
                 // no value of its own and the matcher's default-value
                 // rule would have used child.value as the parent's
-                // result — see TryInlineResult.valueAssignment for why
+                // result - see TryInlineResult.valueAssignment for why
                 // this can fire at most once per parent rule.
                 valueAssignment = replacement.valueAssignment;
             }
@@ -394,18 +401,20 @@ function tryInlineRulesPart(
     }
     // Past this point, `part.rules.length === 1`.  Tail RulesParts have
     // a structural contract requiring `rules.length >= 2` (see
-    // `RulesPart.tail` doc) — reaching here with `tail` set is a real
-    // invariant violation rather than a routine "skip" case (a
-    // multi-member tail RulesPart from the factorer's second-pass AST
-    // would have been refused by the length check above).  Honor the
-    // configured policy: throw on the strict path, log + bail on the
-    // permissive path.
-    if (part.tail) {
+    // `RulesPart.tailCall` doc), so the factorer never produces a
+    // single-member tail RulesPart - today this branch is dead and
+    // serves only as a future-proofing assertion.  It would become
+    // reachable if a future change relaxed the >=2 invariant
+    // (e.g. allowed a single-member tail wrapper as a structural
+    // marker).  Honor the configured policy: throw on the strict
+    // path, log + bail on the permissive path.
+    /* istanbul ignore if -- @preserve: dead-by-construction defense */
+    if (part.tailCall) {
         const msg = `Internal: single-member tail RulesPart violates the rules.length>=2 contract (variable='${part.variable ?? "<none>"}')`;
         if (config.onInvariantViolation === "throw") {
             throw new Error(msg);
         }
-        debug(`${msg} — refusing to inline (onInvariantViolation=debug)`);
+        debug(`${msg} - refusing to inline (onInvariantViolation=debug)`);
         return undefined;
     }
     const child = part.rules[0];
@@ -417,7 +426,7 @@ function tryInlineRulesPart(
     // *between* its own parts.  When inlined, those boundaries are
     // governed by the parent's spacing mode.  Require exact equality:
     // `undefined` (auto) is a distinct mode at the matcher level, not
-    // a synonym for "inherit from parent" — inlining a child with
+    // a synonym for "inherit from parent" - inlining a child with
     // `undefined` into a parent with `"required"` would change boundary
     // behavior at e.g. digit↔Latin transitions where auto resolves to
     // `optionalSpacePunctuation` but required is always
@@ -434,7 +443,7 @@ function tryInlineRulesPart(
     //
     //   (Hoist)        parent has no value of its own and exactly one
     //                  part (this RulesPart).  Synthesize a value
-    //                  assignment from child.value onto the parent —
+    //                  assignment from child.value onto the parent -
     //                  this is what the matcher's single-part
     //                  default-value rule would have computed at
     //                  runtime.
@@ -447,7 +456,7 @@ function tryInlineRulesPart(
     //   (Drop)         child.value is unobservable: inline child.parts
     //                  and forget the value.
     //
-    // The Substitute and Drop cases share the same parts handling —
+    // The Substitute and Drop cases share the same parts handling -
     // child's top-level bindings are α-renamed (so they can't collide
     // with parent's other parts) and the renamed child.value is
     // either folded into parent.value (Substitute) or discarded
@@ -459,7 +468,7 @@ function tryInlineRulesPart(
         // they can't collide with any other top-level bindings the
         // parent already has, and apply the same remap to child.value.
         // Skipped when parent has only this RulesPart as its single
-        // part — there are no siblings to collide with.
+        // part - there are no siblings to collide with.
         const { parts: renamedParts, value: renamedValue } =
             parentRule.parts.length === 1
                 ? { parts: child.parts, value: child.value }
@@ -467,7 +476,7 @@ function tryInlineRulesPart(
 
         // (Hoist) Parent has no value of its own and the matcher
         // would have computed the parent's value via its
-        // default-value rule using `child.value` — either because
+        // default-value rule using `child.value` - either because
         // parent has a single part (this RulesPart) or because
         // parent's only variable is `part.variable` (which captured
         // child.value at runtime).  Synthesize that assignment
@@ -483,7 +492,7 @@ function tryInlineRulesPart(
         }
 
         // (Substitute) parent captures via `part.variable` AND has
-        // its own value expression — fold the renamed child.value
+        // its own value expression - fold the renamed child.value
         // into it.  When parent.value doesn't reference
         // `part.variable` the substitution is a no-op walk and we
         // get the same result as the drop case.
@@ -510,7 +519,7 @@ function tryInlineRulesPart(
     // a child with no explicit value:
     //
     //   - Single-part child: the lone part contributes the value (any
-    //     type — string / phraseSet via implicit text, wildcard /
+    //     type - string / phraseSet via implicit text, wildcard /
     //     number / rules via their captured value).  All five types
     //     qualify.
     //
@@ -521,7 +530,7 @@ function tryInlineRulesPart(
     //     string / phraseSet qualify only when bound (`cp.variable !==
     //     undefined`).  An unbound rules / string / phraseSet
     //     contributes nothing to the value at runtime, so it isn't a
-    //     binding target — and counting it would produce false
+    //     binding target - and counting it would produce false
     //     ambiguity rejections (e.g. child = `<X> $(n:string)` with
     //     `<X>` unbound: only the wildcard is the real contributor).
     //
@@ -567,7 +576,7 @@ function tryInlineRulesPart(
             if (config.onInvariantViolation === "throw") {
                 throw new Error(msg);
             }
-            debug(`${msg} — refusing to inline (onInvariantViolation=debug)`);
+            debug(`${msg} - refusing to inline (onInvariantViolation=debug)`);
             return undefined;
         }
         const bindingCp = child.parts[bindingIdx];
@@ -597,25 +606,21 @@ function tryInlineRulesPart(
  * treats inner `RulesPart` alternatives (each is queued as its own
  * `MatchState` and produces its own result), so factoring is semantically
  * safe.  This intentionally destroys the 1:1 correspondence between
- * top-level rule indices and the original source — that mapping must be
+ * top-level rule indices and the original source - that mapping must be
  * recovered via separate metadata if needed downstream.
  *
  * Uses an identity memo over `GrammarRule[]` arrays so shared named
  * rules (multiple `RulesPart`s pointing at the same array) still share
- * after the pass — see `inlineSingleAlternativeRules` for rationale.
+ * after the pass - see `inlineSingleAlternativeRules` for rationale.
  */
 /** Per-invocation configuration for `factorCommonPrefixes`. */
-export type FactorConfig = {
-    tailFactoring: boolean;
-};
-
 export function factorCommonPrefixes(
     rules: GrammarRule[],
-    config: FactorConfig = { tailFactoring: false },
+    tailFactoring: boolean = false,
 ): GrammarRule[] {
     const counter = { factored: 0 };
     const memo: RulesArrayMemo = new Map();
-    let result = factorRulesArray(rules, counter, memo, config);
+    let result = factorRulesArray(rules, counter, memo, tailFactoring);
 
     // Top-level factoring: the matcher treats top-level alternatives the
     // same way it treats inner `RulesPart` alternatives (each is queued
@@ -623,7 +628,7 @@ export function factorCommonPrefixes(
     // trie-based factoring applies.  Newly synthesized suffix
     // `RulesPart`s produced here are not themselves re-walked, matching
     // the existing behavior for nested factoring.
-    result = factorRules(result, counter, config);
+    result = factorRules(result, counter, tailFactoring);
 
     if (counter.factored > 0) {
         debug(`factored ${counter.factored} common prefix groups`);
@@ -635,7 +640,7 @@ function factorRulesArray(
     rules: GrammarRule[],
     counter: { factored: number },
     memo: RulesArrayMemo,
-    config: FactorConfig,
+    tailFactoring: boolean,
 ): GrammarRule[] {
     const cached = memo.get(rules);
     if (cached !== undefined) return cached;
@@ -644,7 +649,7 @@ function factorRulesArray(
     // (see inlineRulesArray for rationale).
     let next: GrammarRule[] | undefined;
     for (let i = 0; i < rules.length; i++) {
-        const r = factorRule(rules[i], counter, memo, config);
+        const r = factorRule(rules[i], counter, memo, tailFactoring);
         if (next !== undefined) {
             next.push(r);
         } else if (r !== rules[i]) {
@@ -661,9 +666,14 @@ function factorRule(
     rule: GrammarRule,
     counter: { factored: number },
     memo: RulesArrayMemo,
-    config: FactorConfig,
+    tailFactoring: boolean,
 ): GrammarRule {
-    const { parts, changed } = factorParts(rule.parts, counter, memo, config);
+    const { parts, changed } = factorParts(
+        rule.parts,
+        counter,
+        memo,
+        tailFactoring,
+    );
     if (!changed) return rule;
     return { ...rule, parts };
 }
@@ -672,7 +682,7 @@ function factorParts(
     parts: GrammarPart[],
     counter: { factored: number },
     memo: RulesArrayMemo,
-    config: FactorConfig,
+    tailFactoring: boolean,
 ): { parts: GrammarPart[]; changed: boolean } {
     // Single-pass: only allocate `out` once an element actually changes
     // (mirrors `factorRulesArray` / `inlineRulesArray`).
@@ -685,11 +695,16 @@ function factorParts(
         }
         // Recurse into nested rules first, preserving shared-array
         // identity via memo.
-        const recursedRules = factorRulesArray(p.rules, counter, memo, config);
+        const recursedRules = factorRulesArray(
+            p.rules,
+            counter,
+            memo,
+            tailFactoring,
+        );
         const recursed: RulesPart =
             recursedRules !== p.rules ? { ...p, rules: recursedRules } : p;
 
-        const working = factorRulesPart(recursed, counter, config);
+        const working = factorRulesPart(recursed, counter, tailFactoring);
         if (out !== undefined) {
             out.push(working);
         } else if (working !== p) {
@@ -712,14 +727,14 @@ function factorParts(
 function factorRulesPart(
     part: RulesPart,
     counter: { factored: number },
-    config: FactorConfig,
+    tailFactoring: boolean,
 ): RulesPart {
     if (part.repeat || part.optional) {
         // Repeat/optional change the matcher's loop-back semantics; leave
         // such groups untouched to stay safe.
         return part;
     }
-    const factored = factorRules(part.rules, counter, config);
+    const factored = factorRules(part.rules, counter, tailFactoring);
     if (factored === part.rules) return part;
     return { ...part, rules: factored };
 }
@@ -737,7 +752,7 @@ function factorRulesPart(
  *     "play" edge but branch at "song"/"album");
  *   - VarStringPart, VarNumberPart, RulesPart, PhraseSetPart each yield
  *     one edge.  RulesPart edges key by `rules` array identity so that
- *     two `<RuleName>` references share the same edge — preserving the
+ *     two `<RuleName>` references share the same edge - preserving the
  *     dedup invariant `grammarSerializer.ts` relies on.
  *
  * Variables on wildcard/number/rules edges are carried by the first
@@ -749,7 +764,7 @@ function factorRulesPart(
  * are path-compressed back into a flat parts array (with adjacent
  * StringParts re-merged), and multi-member nodes become wrapper
  * `RulesPart`s.  Per-fork eligibility checks are applied at each wrapper
- * site; failure causes a *local* bailout — the would-be members are
+ * site; failure causes a *local* bailout - the would-be members are
  * emitted as separate full rules with the canonical prefix prepended,
  * losing factoring at that fork only (factoring above and below the
  * fork still applies).
@@ -759,7 +774,7 @@ function factorRulesPart(
 function factorRules(
     rules: GrammarRule[],
     counter: { factored: number },
-    config: FactorConfig,
+    tailFactoring: boolean,
 ): GrammarRule[] {
     if (rules.length < 2) return rules;
 
@@ -767,7 +782,7 @@ function factorRules(
         nextCanonicalId: 0,
         rulesArrayIds: new WeakMap(),
         nextRulesArrayId: 0,
-        config,
+        tailFactoring,
     };
     const root: TrieRoot = { children: new Map(), terminals: [] };
     for (let i = 0; i < rules.length; i++) {
@@ -818,7 +833,7 @@ function factorRules(
 // `local` field), `insertRuleIntoTrie` matches steps against existing
 // edges and either reuses an edge (recording `local → canonical` in
 // the per-rule remap) or allocates a new edge with a fresh canonical.
-// Every inserter — *including the lead* — records its remap; the lead
+// Every inserter - *including the lead* - records its remap; the lead
 // is no longer an exception because its local also differs from the
 // canonical.
 
@@ -839,7 +854,7 @@ type TrieStep =
           repeat: boolean;
           name: string | undefined;
           local: string | undefined;
-          tail: boolean;
+          tailCall: boolean;
       }
     | {
           kind: "phraseSet";
@@ -869,7 +884,7 @@ type TrieEdge =
           name: string | undefined;
           /** undefined iff every inserter at this edge was unbound. */
           canonical: string | undefined;
-          tail: boolean;
+          tailCall: boolean;
       }
     | {
           kind: "phraseSet";
@@ -895,7 +910,7 @@ type Terminal = {
  * for `<RuleName>` references).
  *
  * Scope is one `RulesPart` because canonicals never escape the wrapper
- * rule we're about to emit — a fresh BuildState per invocation is
+ * rule we're about to emit - a fresh BuildState per invocation is
  * enough to guarantee within-RulesPart uniqueness.  Distinct from
  * `RenameState` (which scopes per-parent-rule and produces
  * `__opt_inline_<n>` names for the inliner pass).
@@ -904,7 +919,7 @@ type BuildState = {
     nextCanonicalId: number;
     rulesArrayIds: WeakMap<GrammarRule[], number>;
     nextRulesArrayId: number;
-    config: FactorConfig;
+    tailFactoring: boolean;
 };
 
 function freshCanonical(state: BuildState): string {
@@ -932,12 +947,12 @@ function rulesArrayId(state: BuildState, rules: GrammarRule[]): number {
 
 /**
  * Compute a primitive merge key for a trie step.  Two steps with
- * the same key share a child node at insertion time — the same
+ * the same key share a child node at insertion time - the same
  * pairing `edgeKeyMatches` performs by walking sibling edges, but
  * O(1) via a `Map<string, TrieNode>` lookup.  For variable-bearing
  * kinds the variable *name* is omitted (names are remapped); for
  * `rules` edges the binding presence (bound vs. unbound) is encoded
- * so they don't merge — mirrors the parity check in `edgeKeyMatches`.
+ * so they don't merge - mirrors the parity check in `edgeKeyMatches`.
  */
 function stepMergeKey(step: TrieStep, state: BuildState): string {
     // Use JSON.stringify for any field that could contain unrestricted text
@@ -946,7 +961,7 @@ function stepMergeKey(step: TrieStep, state: BuildState): string {
     //
     // Note: tokens are encoded as a JSON array, so atomic-bound vs.
     // exploded-unbound StringPart encodings stay on separate edges by
-    // construction — `JSON.stringify(["foo"])` ≠ `JSON.stringify(["fo","o"])`,
+    // construction - `JSON.stringify(["foo"])` ≠ `JSON.stringify(["fo","o"])`,
     // and the `local` parity bit further guarantees bound and unbound
     // single-token forms also never collide.
     switch (step.kind) {
@@ -957,8 +972,11 @@ function stepMergeKey(step: TrieStep, state: BuildState): string {
         case "number":
             return `n:${step.optional ? 1 : 0}`;
         case "rules": {
+            // Two otherwise-identical edges with different `tailCall`
+            // must NOT merge: their matcher entry semantics differ
+            // (tail call skips parent-frame push, see RulesPart.tailCall).
             const id = rulesArrayId(state, step.rules);
-            return `r:${id}:${step.optional ? 1 : 0}:${step.repeat ? 1 : 0}:${step.local !== undefined ? 1 : 0}:${step.tail ? 1 : 0}`;
+            return `r:${id}:${step.optional ? 1 : 0}:${step.repeat ? 1 : 0}:${step.local !== undefined ? 1 : 0}:${step.tailCall ? 1 : 0}`;
         }
         case "phraseSet":
             return `p:${JSON.stringify(step.matcherName)}:${step.local !== undefined ? 1 : 0}`;
@@ -967,7 +985,7 @@ function stepMergeKey(step: TrieStep, state: BuildState): string {
 
 /**
  * Root of the trie.  Distinct from `TrieNode` so that `edge` can be
- * required on every non-root node — eliminating non-null assertions in
+ * required on every non-root node - eliminating non-null assertions in
  * the insertion and emission code.  Terminals on the root represent
  * empty-parts input rules (rare but legal).
  *
@@ -1045,7 +1063,7 @@ function insertRuleIntoTrie(
  * Unbound StringParts explode into one step per token so that adjacent
  * alternatives can factor on a shared prefix substring.  Bound
  * StringParts emit a single atomic step containing the full token
- * sequence — splitting would break the binding parity (the matcher
+ * sequence - splitting would break the binding parity (the matcher
  * captures the whole joined text into the slot, so the binding can't
  * be moved to the last token alone without changing semantics) and
  * would also leak the binding-presence bit into intermediate edges,
@@ -1053,9 +1071,9 @@ function insertRuleIntoTrie(
  *
  * TODO: bound StringParts that share a token prefix (e.g.
  * `[good, morning]` and `[good, evening]`, both bound) currently
- * cannot factor.  The same trick `compileStringPart` uses — emit
+ * cannot factor.  The same trick `compileStringPart` uses - emit
  * sub-token transitions for the shared prefix and write the slot
- * only on the final transition — would let the trie share the
+ * only on the final transition - would let the trie share the
  * `good` edge if we tracked "binding emitted on last sub-step
  * only" parity.  Not yet worth the complexity.
  */
@@ -1102,7 +1120,7 @@ function* partsToEdgeSteps(parts: GrammarPart[]): Generator<TrieStep> {
                     repeat: !!p.repeat,
                     name: p.name,
                     local: p.variable,
-                    tail: !!p.tail,
+                    tailCall: !!p.tailCall,
                 };
                 break;
             case "phraseSet":
@@ -1161,7 +1179,7 @@ function stepToEdge(step: TrieStep, buildState: BuildState): TrieEdge {
                     step.local !== undefined
                         ? freshCanonical(buildState)
                         : undefined,
-                tail: step.tail,
+                tailCall: step.tailCall,
             };
     }
 }
@@ -1223,7 +1241,7 @@ function edgeToPart(edge: TrieEdge): GrammarPart {
             if (edge.optional) out.optional = true;
             if (edge.repeat) out.repeat = true;
             if (edge.name !== undefined) out.name = edge.name;
-            if (edge.tail) out.tail = true;
+            if (edge.tailCall) out.tailCall = true;
             return out;
         }
         case "phraseSet": {
@@ -1241,7 +1259,7 @@ function edgeToPart(edge: TrieEdge): GrammarPart {
  * Append `part` to `prefix` in place, folding when both ends are
  * StringParts (i.e. merging `last.value` and `part.value` into one
  * `StringPart`).  Mutating in place keeps path-compression linear in
- * chain depth — returning a fresh array on every step would be
+ * chain depth - returning a fresh array on every step would be
  * O(depth²).
  */
 function appendPartInPlace(prefix: GrammarPart[], part: GrammarPart): void {
@@ -1311,7 +1329,7 @@ function emitFromNode(
     buildState: BuildState,
 ): GrammarRule[] {
     // Path-compress: walk down single-child / no-terminal chain, but
-    // stop *before* entering a node that would itself be a fork — that
+    // stop *before* entering a node that would itself be a fork - that
     // way the fork's edge becomes the first part of each emitted member
     // (avoiding empty-parts members at the fork, which would defeat
     // factoring via the wholeConsumed-with-value check below).
@@ -1353,9 +1371,9 @@ function emitFromNode(
     // Multi-member fork: try to wrap; bail out if any check fails.
     const eligibility = checkFactoringEligible(
         members,
-        buildState.config.tailFactoring,
+        buildState.tailFactoring,
     );
-    if (eligibility.reason !== undefined) {
+    if (!eligibility.ok) {
         debug(
             `factor bailout (${eligibility.reason}) at fork with ${members.length} members; emitting unfactored`,
         );
@@ -1365,20 +1383,27 @@ function emitFromNode(
         }));
     }
     state.didFactor = true;
-    return [buildWrapperRule(prefix, members, buildState, eligibility.tail)];
+    return [
+        eligibility.tail
+            ? buildTailWrapper(prefix, members)
+            : buildNonTailWrapper(prefix, members, buildState),
+    ];
 }
 
 /**
- * Per-fork eligibility result.  When `reason` is defined the caller
- * must bail out (emit each member as a separate full rule).  When
- * `reason` is undefined, `tail` indicates whether the wrapper's suffix
- * `RulesPart` should be emitted as a tail call (skipping parent-frame
- * push so member value-exprs can resolve prefix-bound canonicals).
+ * Per-fork eligibility result.  When `ok` is `false` the caller must
+ * bail out (emit each member as a separate full rule).  When `ok` is
+ * `true`, `tail` indicates whether the wrapper's suffix `RulesPart`
+ * should be emitted as a tail call (skipping parent-frame push so
+ * member value-exprs can resolve prefix-bound canonicals).
+ *
+ * Modeled as a discriminated union so callers cannot read `tail`
+ * without first checking `ok` - the wrapper builders only run on the
+ * `ok: true` branch by construction.
  */
-type FactorEligibility = {
-    reason: string | undefined;
-    tail: boolean;
-};
+type FactorEligibility =
+    | { ok: false; reason: string }
+    | { ok: true; tail: boolean };
 
 /**
  * Per-fork eligibility checks (lifted from the previous implementation).
@@ -1394,13 +1419,13 @@ function checkFactoringEligible(
     // resolver throws ("missing value for default") because the
     // empty-parts rule has nothing to default from.
     if (members.some((m) => m.parts.length === 0)) {
-        return { reason: "whole-consumed", tail: false };
+        return { ok: false, reason: "whole-consumed" };
     }
     const valuePresence = members.map((m) => m.value !== undefined);
     const allHaveValue = valuePresence.every((v) => v);
     const noneHaveValue = valuePresence.every((v) => !v);
     if (!allHaveValue && !noneHaveValue) {
-        return { reason: "mixed-value-presence", tail: false };
+        return { ok: false, reason: "mixed-value-presence" };
     }
     if (noneHaveValue) {
         // The matcher synthesizes an implicit text-concatenation
@@ -1408,26 +1433,26 @@ function checkFactoringEligible(
         // is a StringPart (`matchStringPartWithoutWildcard` fast
         // path).  After factoring, the wrapper rule becomes
         // `[prefix..., suffixRulesPart]` with parts.length >= 2 and
-        // no value expression — the implicit default no longer
+        // no value expression - the implicit default no longer
         // fires and `createValue` throws "missing value for default"
         // at finalize time.  Without a wrapper variable to
         // synthesize a value into, factoring at this fork breaks
         // matcher behavior whenever the parent rule relied on the
         // implicit default.  Bail out unconditionally.
-        return { reason: "no-value-implicit-default", tail: false };
+        return { ok: false, reason: "no-value-implicit-default" };
     }
 
     // Cross-scope-ref classification.  Nested rule scope is normally
     // fresh at the matcher level (entering a `RulesPart` resets
     // `valueIds`).  When members are lifted into a wrapper rule's
     // (non-tail) `suffixRulesPart`, each member's value can only see
-    // variables bound in its own `parts` — bindings in the wrapper's
+    // variables bound in its own `parts` - bindings in the wrapper's
     // prefix are not visible.
     //
     // Tail-RulesPart entry skips the parent-frame push and inherits
     // the parent's `valueIds` chain, so member value-exprs *can*
     // resolve prefix-bound canonicals.  `needsTail` records whether
-    // any member's value-expr references a prefix-bound canonical —
+    // any member's value-expr references a prefix-bound canonical -
     // i.e. whether the non-tail wrapper would change observable
     // behavior at this fork.
     let needsTail = false;
@@ -1447,7 +1472,7 @@ function checkFactoringEligible(
     // non-tail.  The wrapper rule has a single `spacingMode` that
     // governs boundary semantics for the prefix parts (and the
     // prefix/suffix seam); before factoring, each member's own
-    // `spacingMode` governed boundaries across its full parts —
+    // `spacingMode` governed boundaries across its full parts -
     // including the prefix portion.  When members disagree on
     // `spacingMode` there is no single value the wrapper can carry
     // that preserves every member's original prefix semantics, so we
@@ -1455,7 +1480,7 @@ function checkFactoringEligible(
     const firstSpacing = members[0].spacingMode;
     const uniformSpacing = members.every((m) => m.spacingMode === firstSpacing);
     if (!uniformSpacing) {
-        return { reason: "mixed-spacing", tail: false };
+        return { ok: false, reason: "mixed-spacing" };
     }
 
     // Policy: prefer tail when enabled.  Tail wrapper is observably
@@ -1466,7 +1491,7 @@ function checkFactoringEligible(
     // and saves one matcher frame push per fork.  Fall back to the
     // non-tail wrapper only when tail is disabled.
     if (tailFactoringEnabled) {
-        return { reason: undefined, tail: true };
+        return { ok: true, tail: true };
     }
 
     // Tail disabled.  The non-tail wrapper is only safe when no
@@ -1474,47 +1499,57 @@ function checkFactoringEligible(
     // resolve to a different scope after lifting).  When needsTail is
     // true we have to bail out.
     if (needsTail) {
-        return { reason: "cross-scope-ref", tail: false };
+        return { ok: false, reason: "cross-scope-ref" };
     }
-    return { reason: undefined, tail: false };
+    return { ok: true, tail: false };
 }
 
-function buildWrapperRule(
+/**
+ * Build a tail-call wrapper rule: the suffix `RulesPart` runs in the
+ * wrapper rule's own scope (no parent-frame push), so the member's
+ * value flows up directly as the wrapper rule's value - no
+ * synthesized wrapper-binding variable, no `factoredAlt.value`.
+ *
+ * Caller (`emitFromNode`) only reaches this with `members.length >= 2`
+ * (the length===1 short-circuit returns earlier), upholding the
+ * `RulesPart.tailCall` >= 2-rules invariant by construction.
+ */
+function buildTailWrapper(
+    prefix: GrammarPart[],
+    members: GrammarRule[],
+): GrammarRule {
+    const suffixRulesPart: RulesPart = {
+        type: "rules",
+        rules: members,
+        tailCall: true,
+    };
+    const factoredAlt: GrammarRule = {
+        parts: [...prefix, suffixRulesPart],
+    };
+    // Uniform spacing across members is guaranteed by
+    // `checkFactoringEligible` (mixed-spacing forks bail out before
+    // reaching here), so any member's spacingMode represents the whole
+    // group's.
+    const firstSpacing = members[0].spacingMode;
+    if (firstSpacing !== undefined) {
+        factoredAlt.spacingMode = firstSpacing;
+    }
+    return factoredAlt;
+}
+
+/**
+ * Build a non-tail wrapper rule: each member's value is captured into
+ * a synthesized opaque wrapper-binding variable, and the wrapper rule
+ * forwards that binding as its own value.  Used when `tailFactoring`
+ * is disabled and the fork doesn't need cross-scope reference
+ * resolution (otherwise the factorer would have bailed out with
+ * `cross-scope-ref`).
+ */
+function buildNonTailWrapper(
     prefix: GrammarPart[],
     members: GrammarRule[],
     buildState: BuildState,
-    tail: boolean,
 ): GrammarRule {
-    if (tail) {
-        // Tail wrapper: the suffix `RulesPart` runs in the wrapper
-        // rule's own scope (no parent-frame push), so the member's
-        // value flows up directly as the wrapper rule's value — no
-        // synthesized wrapper-binding variable, no `factoredAlt.value`.
-        //
-        // `emitFromNode` only reaches this branch with members.length
-        // >= 2 (the length===1 short-circuit returns earlier), so the
-        // RulesPart.tail >= 2-rules invariant is upheld here by
-        // construction.  Defensive assertion catches future callers
-        // that bypass the short-circuit.
-        if (members.length < 2) {
-            throw new Error(
-                `Internal: tail wrapper requires >= 2 members (got ${members.length})`,
-            );
-        }
-        const suffixRulesPart: RulesPart = {
-            type: "rules",
-            rules: members,
-            tail: true,
-        };
-        const factoredAlt: GrammarRule = {
-            parts: [...prefix, suffixRulesPart],
-        };
-        const firstSpacing = members[0].spacingMode;
-        if (firstSpacing !== undefined) {
-            factoredAlt.spacingMode = firstSpacing;
-        }
-        return factoredAlt;
-    }
     const suffixRulesPart: RulesPart = { type: "rules", rules: members };
     const factoredAlt: GrammarRule = {
         parts: [...prefix, suffixRulesPart],
@@ -1522,7 +1557,7 @@ function buildWrapperRule(
     if (members.some((m) => m.value !== undefined)) {
         // Opaque counter-based name shares `BuildState.nextCanonicalId`
         // with `freshCanonical`, so it can never collide with any
-        // canonical edge binding in this `factorRules` invocation — no
+        // canonical edge binding in this `factorRules` invocation - no
         // reserved-set scan needed.
         const gen = freshWrapperBinding(buildState);
         suffixRulesPart.variable = gen;
@@ -1530,8 +1565,8 @@ function buildWrapperRule(
     }
     // Uniform spacing across members is guaranteed by
     // `checkFactoringEligible` (mixed-spacing forks bail out before
-    // reaching the wrapper builder), so any member's spacingMode
-    // represents the whole group's.
+    // reaching here), so any member's spacingMode represents the whole
+    // group's.
     const firstSpacing = members[0].spacingMode;
     if (firstSpacing !== undefined) {
         factoredAlt.spacingMode = firstSpacing;
@@ -1739,4 +1774,76 @@ function substituteValueVariables(
         case "templateLiteral":
             return { ...node, expressions: node.expressions.map(sub) };
     }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Structural validation: RulesPart.tailCall contract
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Walk every rule in `rules` and verify that any `RulesPart` carrying
+ * `tailCall: true` satisfies the contract documented on
+ * `RulesPart.tailCall`:
+ *
+ *   - last entry in its parent rule's `parts`
+ *   - parent rule has no `value` of its own
+ *   - `repeat` / `optional` / `variable` all unset
+ *   - `rules.length >= 2`
+ *   - every member's `spacingMode` matches the parent rule's
+ *
+ * Throws on the first violation with a message identifying the
+ * offending rule.  Cheap to run; intended to be called after loading
+ * a serialized grammar from JSON (where the bytes are not produced by
+ * a trusted in-process compiler) and from tests.
+ *
+ * Members are recursed into so that nested tail RulesParts are also
+ * validated.
+ */
+export function validateTailRulesParts(rules: GrammarRule[]): void {
+    const visited = new WeakSet<GrammarRule[]>();
+    const visitRules = (rs: GrammarRule[]): void => {
+        if (visited.has(rs)) return;
+        visited.add(rs);
+        for (const r of rs) {
+            visitRule(r);
+        }
+    };
+    const visitRule = (rule: GrammarRule): void => {
+        const parts = rule.parts;
+        for (let i = 0; i < parts.length; i++) {
+            const p = parts[i];
+            if (p.type !== "rules") continue;
+            if (p.tailCall) {
+                if (i !== parts.length - 1) {
+                    throw new Error(
+                        `Invalid tail RulesPart: must be the last part of its parent rule (name='${p.name ?? "<unnamed>"}')`,
+                    );
+                }
+                if (rule.value !== undefined) {
+                    throw new Error(
+                        `Invalid tail RulesPart: parent rule must have no value of its own (name='${p.name ?? "<unnamed>"}')`,
+                    );
+                }
+                if (p.repeat || p.optional || p.variable !== undefined) {
+                    throw new Error(
+                        `Invalid tail RulesPart: repeat/optional/variable are forbidden (name='${p.name ?? "<unnamed>"}')`,
+                    );
+                }
+                if (p.rules.length < 2) {
+                    throw new Error(
+                        `Invalid tail RulesPart: requires rules.length >= 2 (got ${p.rules.length}, name='${p.name ?? "<unnamed>"}')`,
+                    );
+                }
+                for (const m of p.rules) {
+                    if (m.spacingMode !== rule.spacingMode) {
+                        throw new Error(
+                            `Invalid tail RulesPart: every member's spacingMode must match the parent rule's (name='${p.name ?? "<unnamed>"}')`,
+                        );
+                    }
+                }
+            }
+            visitRules(p.rules);
+        }
+    };
+    visitRules(rules);
 }

--- a/ts/packages/actionGrammar/src/grammarOptimizer.ts
+++ b/ts/packages/actionGrammar/src/grammarOptimizer.ts
@@ -144,7 +144,10 @@ export function optimizeGrammar(
             // site rather than as confusing match failures or
             // runtime throws deep in `enterTailRulesPart`.  Honors
             // `onInvariantViolation`: throw on the strict path,
-            // demote to warning + debug log on the permissive path.
+            // demote to warning + debug log on the permissive path
+            // and discard the optimized output (return the input
+            // grammar unchanged) so callers get a known-good AST
+            // rather than a contract-violating one.
             try {
                 validateTailRulesParts(rules);
             } catch (e) {
@@ -152,8 +155,9 @@ export function optimizeGrammar(
                 if (inlineConfig.onInvariantViolation === "throw") {
                     throw new Error(msg);
                 }
-                debug(msg);
+                debug(`${msg} - discarding optimized output`);
                 warnings?.push(msg);
+                return grammar;
             }
         }
     }

--- a/ts/packages/actionGrammar/src/grammarOptimizer.ts
+++ b/ts/packages/actionGrammar/src/grammarOptimizer.ts
@@ -1420,8 +1420,13 @@ function emitFromNode(
     state.didFactor = true;
     return [
         eligibility.tail
-            ? buildTailWrapper(prefix, members)
-            : buildNonTailWrapper(prefix, members, buildState),
+            ? buildTailWrapper(prefix, members, partitionSpacing)
+            : buildNonTailWrapper(
+                  prefix,
+                  members,
+                  buildState,
+                  partitionSpacing,
+              ),
     ];
 }
 
@@ -1537,6 +1542,7 @@ function checkFactoringEligible(
 function buildTailWrapper(
     prefix: GrammarPart[],
     members: GrammarRule[],
+    partitionSpacing: CompiledSpacingMode | undefined,
 ): GrammarRule {
     const suffixRulesPart: RulesPart = {
         type: "rules",
@@ -1546,12 +1552,8 @@ function buildTailWrapper(
     const factoredAlt: GrammarRule = {
         parts: [...prefix, suffixRulesPart],
     };
-    // Members all share the partition's spacingMode (set by
-    // `terminalToRule` from the partition `factorRules` is processing),
-    // so any member's value represents the whole group's.
-    const firstSpacing = members[0].spacingMode;
-    if (firstSpacing !== undefined) {
-        factoredAlt.spacingMode = firstSpacing;
+    if (partitionSpacing !== undefined) {
+        factoredAlt.spacingMode = partitionSpacing;
     }
     return factoredAlt;
 }
@@ -1568,6 +1570,7 @@ function buildNonTailWrapper(
     prefix: GrammarPart[],
     members: GrammarRule[],
     buildState: BuildState,
+    partitionSpacing: CompiledSpacingMode | undefined,
 ): GrammarRule {
     const suffixRulesPart: RulesPart = { type: "rules", rules: members };
     const factoredAlt: GrammarRule = {
@@ -1582,12 +1585,8 @@ function buildNonTailWrapper(
         suffixRulesPart.variable = gen;
         factoredAlt.value = { type: "variable", name: gen };
     }
-    // Members all share the partition's spacingMode (set by
-    // `terminalToRule` from the partition `factorRules` is processing),
-    // so any member's value represents the whole group's.
-    const firstSpacing = members[0].spacingMode;
-    if (firstSpacing !== undefined) {
-        factoredAlt.spacingMode = firstSpacing;
+    if (partitionSpacing !== undefined) {
+        factoredAlt.spacingMode = partitionSpacing;
     }
     return factoredAlt;
 }

--- a/ts/packages/actionGrammar/src/grammarOptimizer.ts
+++ b/ts/packages/actionGrammar/src/grammarOptimizer.ts
@@ -51,6 +51,33 @@ export type GrammarOptimizationOptions = {
      *   regressions immediately.
      */
     onInvariantViolation?: "debug" | "throw";
+
+    /**
+     * Opt-in: when factoring a common prefix, emit the suffix
+     * `RulesPart` as a *tail* call wherever structurally possible
+     * (skip parent-frame push; member's value flows up directly as
+     * the wrapper rule's value).  Tail wrappers are observably
+     * identical to the unfactored shape, produce a smaller AST (no
+     * synthesized wrapper-binding variable, no `factoredAlt.value`
+     * indirection), and save one matcher frame push per fork — so
+     * tail is preferred whenever it can be emitted.
+     *
+     * The non-tail wrapper is used only as a fallback at forks where
+     * tail is structurally unavailable (currently: members with
+     * heterogeneous `spacingMode`).  Forks whose member value
+     * expressions reference prefix-bound canonicals can *only* be
+     * factored as tail; if tail is unavailable at such a fork the
+     * factorer bails out (`cross-scope-ref` / `tail-mixed-spacing`)
+     * and emits each member as a separate full rule.
+     *
+     * Without this flag set, the factorer never emits tail RulesParts
+     * — preserving today's matcher semantics for every consumer.
+     *
+     * Currently only the NFA-interpreter matcher (`grammarMatcher.ts`)
+     * understands tail RulesParts.  The NFA compiler / DFA path does
+     * not, and will throw if it encounters one.
+     */
+    tailFactoring?: boolean;
 };
 
 /**
@@ -91,7 +118,9 @@ export function optimizeGrammar(
         rules = inlineSingleAlternativeRules(rules, inlineConfig);
     }
     if (options.factorCommonPrefixes) {
-        rules = factorCommonPrefixes(rules);
+        rules = factorCommonPrefixes(rules, {
+            tailFactoring: !!options.tailFactoring,
+        });
         if (options.inlineSingleAlternatives) {
             // Factoring never emits a single-alternative wrapper itself
             // (factorRulesPart only wraps when members.length >= 2), but
@@ -363,6 +392,22 @@ function tryInlineRulesPart(
     if (part.rules.length !== 1) {
         return undefined;
     }
+    // Past this point, `part.rules.length === 1`.  Tail RulesParts have
+    // a structural contract requiring `rules.length >= 2` (see
+    // `RulesPart.tail` doc) — reaching here with `tail` set is a real
+    // invariant violation rather than a routine "skip" case (a
+    // multi-member tail RulesPart from the factorer's second-pass AST
+    // would have been refused by the length check above).  Honor the
+    // configured policy: throw on the strict path, log + bail on the
+    // permissive path.
+    if (part.tail) {
+        const msg = `Internal: single-member tail RulesPart violates the rules.length>=2 contract (variable='${part.variable ?? "<none>"}')`;
+        if (config.onInvariantViolation === "throw") {
+            throw new Error(msg);
+        }
+        debug(`${msg} — refusing to inline (onInvariantViolation=debug)`);
+        return undefined;
+    }
     const child = part.rules[0];
     if (child.parts.length === 0) {
         return undefined;
@@ -559,10 +604,18 @@ function tryInlineRulesPart(
  * rules (multiple `RulesPart`s pointing at the same array) still share
  * after the pass — see `inlineSingleAlternativeRules` for rationale.
  */
-export function factorCommonPrefixes(rules: GrammarRule[]): GrammarRule[] {
+/** Per-invocation configuration for `factorCommonPrefixes`. */
+export type FactorConfig = {
+    tailFactoring: boolean;
+};
+
+export function factorCommonPrefixes(
+    rules: GrammarRule[],
+    config: FactorConfig = { tailFactoring: false },
+): GrammarRule[] {
     const counter = { factored: 0 };
     const memo: RulesArrayMemo = new Map();
-    let result = factorRulesArray(rules, counter, memo);
+    let result = factorRulesArray(rules, counter, memo, config);
 
     // Top-level factoring: the matcher treats top-level alternatives the
     // same way it treats inner `RulesPart` alternatives (each is queued
@@ -570,7 +623,7 @@ export function factorCommonPrefixes(rules: GrammarRule[]): GrammarRule[] {
     // trie-based factoring applies.  Newly synthesized suffix
     // `RulesPart`s produced here are not themselves re-walked, matching
     // the existing behavior for nested factoring.
-    result = factorRules(result, counter);
+    result = factorRules(result, counter, config);
 
     if (counter.factored > 0) {
         debug(`factored ${counter.factored} common prefix groups`);
@@ -582,6 +635,7 @@ function factorRulesArray(
     rules: GrammarRule[],
     counter: { factored: number },
     memo: RulesArrayMemo,
+    config: FactorConfig,
 ): GrammarRule[] {
     const cached = memo.get(rules);
     if (cached !== undefined) return cached;
@@ -590,7 +644,7 @@ function factorRulesArray(
     // (see inlineRulesArray for rationale).
     let next: GrammarRule[] | undefined;
     for (let i = 0; i < rules.length; i++) {
-        const r = factorRule(rules[i], counter, memo);
+        const r = factorRule(rules[i], counter, memo, config);
         if (next !== undefined) {
             next.push(r);
         } else if (r !== rules[i]) {
@@ -607,8 +661,9 @@ function factorRule(
     rule: GrammarRule,
     counter: { factored: number },
     memo: RulesArrayMemo,
+    config: FactorConfig,
 ): GrammarRule {
-    const { parts, changed } = factorParts(rule.parts, counter, memo);
+    const { parts, changed } = factorParts(rule.parts, counter, memo, config);
     if (!changed) return rule;
     return { ...rule, parts };
 }
@@ -617,6 +672,7 @@ function factorParts(
     parts: GrammarPart[],
     counter: { factored: number },
     memo: RulesArrayMemo,
+    config: FactorConfig,
 ): { parts: GrammarPart[]; changed: boolean } {
     // Single-pass: only allocate `out` once an element actually changes
     // (mirrors `factorRulesArray` / `inlineRulesArray`).
@@ -629,11 +685,11 @@ function factorParts(
         }
         // Recurse into nested rules first, preserving shared-array
         // identity via memo.
-        const recursedRules = factorRulesArray(p.rules, counter, memo);
+        const recursedRules = factorRulesArray(p.rules, counter, memo, config);
         const recursed: RulesPart =
             recursedRules !== p.rules ? { ...p, rules: recursedRules } : p;
 
-        const working = factorRulesPart(recursed, counter);
+        const working = factorRulesPart(recursed, counter, config);
         if (out !== undefined) {
             out.push(working);
         } else if (working !== p) {
@@ -656,13 +712,14 @@ function factorParts(
 function factorRulesPart(
     part: RulesPart,
     counter: { factored: number },
+    config: FactorConfig,
 ): RulesPart {
     if (part.repeat || part.optional) {
         // Repeat/optional change the matcher's loop-back semantics; leave
         // such groups untouched to stay safe.
         return part;
     }
-    const factored = factorRules(part.rules, counter);
+    const factored = factorRules(part.rules, counter, config);
     if (factored === part.rules) return part;
     return { ...part, rules: factored };
 }
@@ -702,6 +759,7 @@ function factorRulesPart(
 function factorRules(
     rules: GrammarRule[],
     counter: { factored: number },
+    config: FactorConfig,
 ): GrammarRule[] {
     if (rules.length < 2) return rules;
 
@@ -709,6 +767,7 @@ function factorRules(
         nextCanonicalId: 0,
         rulesArrayIds: new WeakMap(),
         nextRulesArrayId: 0,
+        config,
     };
     const root: TrieRoot = { children: new Map(), terminals: [] };
     for (let i = 0; i < rules.length; i++) {
@@ -780,6 +839,7 @@ type TrieStep =
           repeat: boolean;
           name: string | undefined;
           local: string | undefined;
+          tail: boolean;
       }
     | {
           kind: "phraseSet";
@@ -809,6 +869,7 @@ type TrieEdge =
           name: string | undefined;
           /** undefined iff every inserter at this edge was unbound. */
           canonical: string | undefined;
+          tail: boolean;
       }
     | {
           kind: "phraseSet";
@@ -843,6 +904,7 @@ type BuildState = {
     nextCanonicalId: number;
     rulesArrayIds: WeakMap<GrammarRule[], number>;
     nextRulesArrayId: number;
+    config: FactorConfig;
 };
 
 function freshCanonical(state: BuildState): string {
@@ -896,7 +958,7 @@ function stepMergeKey(step: TrieStep, state: BuildState): string {
             return `n:${step.optional ? 1 : 0}`;
         case "rules": {
             const id = rulesArrayId(state, step.rules);
-            return `r:${id}:${step.optional ? 1 : 0}:${step.repeat ? 1 : 0}:${step.local !== undefined ? 1 : 0}`;
+            return `r:${id}:${step.optional ? 1 : 0}:${step.repeat ? 1 : 0}:${step.local !== undefined ? 1 : 0}:${step.tail ? 1 : 0}`;
         }
         case "phraseSet":
             return `p:${JSON.stringify(step.matcherName)}:${step.local !== undefined ? 1 : 0}`;
@@ -1040,6 +1102,7 @@ function* partsToEdgeSteps(parts: GrammarPart[]): Generator<TrieStep> {
                     repeat: !!p.repeat,
                     name: p.name,
                     local: p.variable,
+                    tail: !!p.tail,
                 };
                 break;
             case "phraseSet":
@@ -1098,6 +1161,7 @@ function stepToEdge(step: TrieStep, buildState: BuildState): TrieEdge {
                     step.local !== undefined
                         ? freshCanonical(buildState)
                         : undefined,
+                tail: step.tail,
             };
     }
 }
@@ -1159,6 +1223,7 @@ function edgeToPart(edge: TrieEdge): GrammarPart {
             if (edge.optional) out.optional = true;
             if (edge.repeat) out.repeat = true;
             if (edge.name !== undefined) out.name = edge.name;
+            if (edge.tail) out.tail = true;
             return out;
         }
         case "phraseSet": {
@@ -1286,21 +1351,42 @@ function emitFromNode(
     }
 
     // Multi-member fork: try to wrap; bail out if any check fails.
-    if (checkFactoringEligible(members) !== undefined) {
+    const eligibility = checkFactoringEligible(
+        members,
+        buildState.config.tailFactoring,
+    );
+    if (eligibility.reason !== undefined) {
+        debug(
+            `factor bailout (${eligibility.reason}) at fork with ${members.length} members; emitting unfactored`,
+        );
         return members.map((m) => ({
             ...m,
             parts: concatParts(prefix, m.parts),
         }));
     }
     state.didFactor = true;
-    return [buildWrapperRule(prefix, members, buildState)];
+    return [buildWrapperRule(prefix, members, buildState, eligibility.tail)];
 }
 
 /**
- * Per-fork eligibility checks (lifted from the previous implementation).
- * Returns `undefined` when factoring is safe, or a short reason string.
+ * Per-fork eligibility result.  When `reason` is defined the caller
+ * must bail out (emit each member as a separate full rule).  When
+ * `reason` is undefined, `tail` indicates whether the wrapper's suffix
+ * `RulesPart` should be emitted as a tail call (skipping parent-frame
+ * push so member value-exprs can resolve prefix-bound canonicals).
  */
-function checkFactoringEligible(members: GrammarRule[]): string | undefined {
+type FactorEligibility = {
+    reason: string | undefined;
+    tail: boolean;
+};
+
+/**
+ * Per-fork eligibility checks (lifted from the previous implementation).
+ */
+function checkFactoringEligible(
+    members: GrammarRule[],
+    tailFactoringEnabled: boolean,
+): FactorEligibility {
     // Empty-parts members never compose cleanly inside a wrapped
     // RulesPart: with a value, the matcher would have to treat
     // `{parts:[], value: V}` as a degenerate match (today's algorithm
@@ -1308,13 +1394,13 @@ function checkFactoringEligible(members: GrammarRule[]): string | undefined {
     // resolver throws ("missing value for default") because the
     // empty-parts rule has nothing to default from.
     if (members.some((m) => m.parts.length === 0)) {
-        return "whole-consumed";
+        return { reason: "whole-consumed", tail: false };
     }
     const valuePresence = members.map((m) => m.value !== undefined);
     const allHaveValue = valuePresence.every((v) => v);
     const noneHaveValue = valuePresence.every((v) => !v);
     if (!allHaveValue && !noneHaveValue) {
-        return "mixed-value-presence";
+        return { reason: "mixed-value-presence", tail: false };
     }
     if (noneHaveValue) {
         // The matcher synthesizes an implicit text-concatenation
@@ -1328,43 +1414,107 @@ function checkFactoringEligible(members: GrammarRule[]): string | undefined {
         // synthesize a value into, factoring at this fork breaks
         // matcher behavior whenever the parent rule relied on the
         // implicit default.  Bail out unconditionally.
-        return "no-value-implicit-default";
+        return { reason: "no-value-implicit-default", tail: false };
     }
-    // Cross-scope-ref: nested rule scope is fresh at the matcher level
-    // (entering a `RulesPart` resets `valueIds`).  When members are
-    // lifted into a wrapper rule's `suffixRulesPart`, each member
-    // becomes an isolated inner rule whose value can only see
+
+    // Cross-scope-ref classification.  Nested rule scope is normally
+    // fresh at the matcher level (entering a `RulesPart` resets
+    // `valueIds`).  When members are lifted into a wrapper rule's
+    // (non-tail) `suffixRulesPart`, each member's value can only see
     // variables bound in its own `parts` — bindings in the wrapper's
-    // prefix, *or* in any ancestor's prefix that has already been
-    // incorporated upstream, are no longer visible.
+    // prefix are not visible.
     //
-    // We therefore require every variable referenced by a member's
-    // value to appear in that member's own top-level part bindings.
-    // This subsumes the simpler "member references prefix binding"
-    // check, and additionally catches the case where a deeper bailout
-    // dragged ancestor-prefix canonical references into a member that
-    // doesn't bind them (the bailout-then-factor scenario in
-    // playerSchema's `play <TrackPhrase> by <ArtistName> [...]`).
-    //
-    // Binding-shadow (a member's own binding colliding with a prefix
-    // binding) is not reachable: canonicals are opaque `__opt_v_<n>`
-    // names allocated globally per `factorRulesPart` call, so two
-    // distinct edges always get distinct canonicals.
+    // Tail-RulesPart entry skips the parent-frame push and inherits
+    // the parent's `valueIds` chain, so member value-exprs *can*
+    // resolve prefix-bound canonicals.  `needsTail` records whether
+    // any member's value-expr references a prefix-bound canonical —
+    // i.e. whether the non-tail wrapper would change observable
+    // behavior at this fork.
+    let needsTail = false;
     for (const m of members) {
         if (m.value === undefined) continue;
         const memberBindings = collectVariableNames(m.parts);
         for (const v of collectVariableReferences(m.value)) {
-            if (!memberBindings.has(v)) return "cross-scope-ref";
+            if (!memberBindings.has(v)) {
+                needsTail = true;
+                break;
+            }
         }
+        if (needsTail) break;
     }
-    return undefined;
+
+    // Spacing-mode uniformity is required for *any* wrapper, tail or
+    // non-tail.  The wrapper rule has a single `spacingMode` that
+    // governs boundary semantics for the prefix parts (and the
+    // prefix/suffix seam); before factoring, each member's own
+    // `spacingMode` governed boundaries across its full parts —
+    // including the prefix portion.  When members disagree on
+    // `spacingMode` there is no single value the wrapper can carry
+    // that preserves every member's original prefix semantics, so we
+    // refuse to factor at this fork.
+    const firstSpacing = members[0].spacingMode;
+    const uniformSpacing = members.every((m) => m.spacingMode === firstSpacing);
+    if (!uniformSpacing) {
+        return { reason: "mixed-spacing", tail: false };
+    }
+
+    // Policy: prefer tail when enabled.  Tail wrapper is observably
+    // identical to the unfactored shape for both needsTail and
+    // !needsTail forks (the inherited `valueIds` chain is unread when
+    // !needsTail), produces a smaller AST (no synthesized
+    // `__opt_factor_<n>` binding, no `factoredAlt.value` indirection),
+    // and saves one matcher frame push per fork.  Fall back to the
+    // non-tail wrapper only when tail is disabled.
+    if (tailFactoringEnabled) {
+        return { reason: undefined, tail: true };
+    }
+
+    // Tail disabled.  The non-tail wrapper is only safe when no
+    // member references a prefix-bound canonical (would silently
+    // resolve to a different scope after lifting).  When needsTail is
+    // true we have to bail out.
+    if (needsTail) {
+        return { reason: "cross-scope-ref", tail: false };
+    }
+    return { reason: undefined, tail: false };
 }
 
 function buildWrapperRule(
     prefix: GrammarPart[],
     members: GrammarRule[],
     buildState: BuildState,
+    tail: boolean,
 ): GrammarRule {
+    if (tail) {
+        // Tail wrapper: the suffix `RulesPart` runs in the wrapper
+        // rule's own scope (no parent-frame push), so the member's
+        // value flows up directly as the wrapper rule's value — no
+        // synthesized wrapper-binding variable, no `factoredAlt.value`.
+        //
+        // `emitFromNode` only reaches this branch with members.length
+        // >= 2 (the length===1 short-circuit returns earlier), so the
+        // RulesPart.tail >= 2-rules invariant is upheld here by
+        // construction.  Defensive assertion catches future callers
+        // that bypass the short-circuit.
+        if (members.length < 2) {
+            throw new Error(
+                `Internal: tail wrapper requires >= 2 members (got ${members.length})`,
+            );
+        }
+        const suffixRulesPart: RulesPart = {
+            type: "rules",
+            rules: members,
+            tail: true,
+        };
+        const factoredAlt: GrammarRule = {
+            parts: [...prefix, suffixRulesPart],
+        };
+        const firstSpacing = members[0].spacingMode;
+        if (firstSpacing !== undefined) {
+            factoredAlt.spacingMode = firstSpacing;
+        }
+        return factoredAlt;
+    }
     const suffixRulesPart: RulesPart = { type: "rules", rules: members };
     const factoredAlt: GrammarRule = {
         parts: [...prefix, suffixRulesPart],
@@ -1378,11 +1528,12 @@ function buildWrapperRule(
         suffixRulesPart.variable = gen;
         factoredAlt.value = { type: "variable", name: gen };
     }
+    // Uniform spacing across members is guaranteed by
+    // `checkFactoringEligible` (mixed-spacing forks bail out before
+    // reaching the wrapper builder), so any member's spacingMode
+    // represents the whole group's.
     const firstSpacing = members[0].spacingMode;
-    if (
-        firstSpacing !== undefined &&
-        members.every((m) => m.spacingMode === firstSpacing)
-    ) {
+    if (firstSpacing !== undefined) {
         factoredAlt.spacingMode = firstSpacing;
     }
     return factoredAlt;

--- a/ts/packages/actionGrammar/src/grammarOptimizer.ts
+++ b/ts/packages/actionGrammar/src/grammarOptimizer.ts
@@ -809,7 +809,7 @@ function factorRules(
     const state: EmitState = { didFactor: false };
     const items: { idx: number; rules: GrammarRule[] }[] = [];
 
-    for (const partition of partitions.values()) {
+    for (const [partitionSpacing, partition] of partitions) {
         if (partition.length === 1) {
             // Solo partition - nothing to factor against; pass the
             // rule through at its original index.
@@ -823,7 +823,7 @@ function factorRules(
         for (const c of root.children.values()) {
             items.push({
                 idx: c.firstIdx,
-                rules: emitFromNode(c, state, buildState),
+                rules: emitFromNode(c, state, buildState, partitionSpacing),
             });
         }
     }
@@ -926,7 +926,6 @@ type TrieEdge =
 type Terminal = {
     idx: number;
     value: CompiledValueNode | undefined;
-    spacingMode: CompiledSpacingMode | undefined;
     /** local→canonical variable rename accumulated along the path. */
     remap: Map<string, string>;
 };
@@ -1082,7 +1081,6 @@ function insertRuleIntoTrie(
     terminals.push({
         idx,
         value: rule.value,
-        spacingMode: rule.spacingMode,
         remap,
     });
 }
@@ -1334,14 +1332,17 @@ function concatParts(a: GrammarPart[], b: GrammarPart[]): GrammarPart[] {
     return [...a, ...b];
 }
 
-function terminalToRule(t: Terminal): GrammarRule {
+function terminalToRule(
+    t: Terminal,
+    partitionSpacing: CompiledSpacingMode | undefined,
+): GrammarRule {
     let value = t.value;
     if (value !== undefined && t.remap.size > 0) {
         value = remapValueVariables(value, t.remap);
     }
     const out: GrammarRule = { parts: [] };
     if (value !== undefined) out.value = value;
-    if (t.spacingMode !== undefined) out.spacingMode = t.spacingMode;
+    if (partitionSpacing !== undefined) out.spacingMode = partitionSpacing;
     return out;
 }
 
@@ -1357,6 +1358,7 @@ function emitFromNode(
     node: TrieNode,
     state: EmitState,
     buildState: BuildState,
+    partitionSpacing: CompiledSpacingMode | undefined,
 ): GrammarRule[] {
     // Path-compress: walk down single-child / no-terminal chain, but
     // stop *before* entering a node that would itself be a fork - that
@@ -1378,12 +1380,15 @@ function emitFromNode(
     // plus each child's emitted subtree (in original insertion order).
     const items: { idx: number; rules: GrammarRule[] }[] = [];
     for (const t of current.terminals) {
-        items.push({ idx: t.idx, rules: [terminalToRule(t)] });
+        items.push({
+            idx: t.idx,
+            rules: [terminalToRule(t, partitionSpacing)],
+        });
     }
     for (const c of current.children.values()) {
         items.push({
             idx: c.firstIdx,
-            rules: emitFromNode(c, state, buildState),
+            rules: emitFromNode(c, state, buildState, partitionSpacing),
         });
     }
     items.sort((a, b) => a.idx - b.idx);
@@ -1498,21 +1503,6 @@ function checkFactoringEligible(
         if (needsTail) break;
     }
 
-    // Spacing-mode uniformity is required for *any* wrapper, tail or
-    // non-tail.  The wrapper rule has a single `spacingMode` that
-    // governs boundary semantics for the prefix parts (and the
-    // prefix/suffix seam).  `factorRules` partitions input rules by
-    // `spacingMode` and runs a separate trie per partition, so
-    // every member at every fork in one trie is guaranteed to share
-    // the same spacingMode by construction.  The check here is
-    // defensive against a future caller that bypasses partitioning.
-    /* istanbul ignore if -- @preserve: dead-by-construction defense */
-    if (!members.every((m) => m.spacingMode === members[0].spacingMode)) {
-        throw new Error(
-            "Internal: factorRules should partition members by spacingMode before reaching checkFactoringEligible",
-        );
-    }
-
     // Policy: prefer tail when enabled.  Tail wrapper is observably
     // identical to the unfactored shape for both needsTail and
     // !needsTail forks (the inherited `valueIds` chain is unread when
@@ -1556,10 +1546,9 @@ function buildTailWrapper(
     const factoredAlt: GrammarRule = {
         parts: [...prefix, suffixRulesPart],
     };
-    // Uniform spacing across members is guaranteed by
-    // `checkFactoringEligible` (mixed-spacing forks bail out before
-    // reaching here), so any member's spacingMode represents the whole
-    // group's.
+    // Members all share the partition's spacingMode (set by
+    // `terminalToRule` from the partition `factorRules` is processing),
+    // so any member's value represents the whole group's.
     const firstSpacing = members[0].spacingMode;
     if (firstSpacing !== undefined) {
         factoredAlt.spacingMode = firstSpacing;
@@ -1593,10 +1582,9 @@ function buildNonTailWrapper(
         suffixRulesPart.variable = gen;
         factoredAlt.value = { type: "variable", name: gen };
     }
-    // Uniform spacing across members is guaranteed by
-    // `checkFactoringEligible` (mixed-spacing forks bail out before
-    // reaching here), so any member's spacingMode represents the whole
-    // group's.
+    // Members all share the partition's spacingMode (set by
+    // `terminalToRule` from the partition `factorRules` is processing),
+    // so any member's value represents the whole group's.
     const firstSpacing = members[0].spacingMode;
     if (firstSpacing !== undefined) {
         factoredAlt.spacingMode = firstSpacing;

--- a/ts/packages/actionGrammar/src/grammarOptimizer.ts
+++ b/ts/packages/actionGrammar/src/grammarOptimizer.ts
@@ -82,14 +82,21 @@ export type GrammarOptimizationOptions = {
  * want every safe pass on without naming each flag individually - future
  * passes added here will be picked up automatically.
  *
- * Caveat: enabling `factorCommonPrefixes` destroys the 1:1
- * correspondence between top-level rule indices and the original
- * source.  Callers that need that mapping for diagnostics must capture
- * it before optimization runs.
+ * Caveats:
+ *   - Enabling `factorCommonPrefixes` destroys the 1:1 correspondence
+ *     between top-level rule indices and the original source.  Callers
+ *     that need that mapping for diagnostics must capture it before
+ *     optimization runs.
+ *   - Enabling `tailFactoring` produces `RulesPart.tailCall` nodes that
+ *     only the AST-walking matcher (`grammarMatcher.ts`) understands.
+ *     Callers that route the compiled grammar through the NFA compiler
+ *     / DFA path must not use this preset (or must override
+ *     `tailFactoring: false`).
  */
 export const recommendedOptimizations: GrammarOptimizationOptions = {
     inlineSingleAlternatives: true,
     factorCommonPrefixes: true,
+    tailFactoring: true,
 };
 
 /**

--- a/ts/packages/actionGrammar/src/grammarOptimizer.ts
+++ b/ts/packages/actionGrammar/src/grammarOptimizer.ts
@@ -62,13 +62,10 @@ export type GrammarOptimizationOptions = {
      * indirection), and save one matcher frame push per fork - so
      * tail is preferred whenever it can be emitted.
      *
-     * The non-tail wrapper is used only as a fallback at forks where
-     * tail is structurally unavailable (currently: members with
-     * heterogeneous `spacingMode`).  Forks whose member value
-     * expressions reference prefix-bound canonicals can *only* be
-     * factored as tail; if tail is unavailable at such a fork the
-     * factorer bails out (`cross-scope-ref` / `tail-mixed-spacing`)
-     * and emits each member as a separate full rule.
+     * Forks whose member value expressions reference prefix-bound
+     * canonicals can *only* be factored as tail; with this flag off
+     * the factorer bails out at such forks (`cross-scope-ref`) and
+     * emits each member as a separate full rule.
      *
      * Without this flag set, the factorer never emits tail RulesParts
      * - preserving today's matcher semantics for every consumer.
@@ -778,24 +775,57 @@ function factorRules(
 ): GrammarRule[] {
     if (rules.length < 2) return rules;
 
+    // Partition by `spacingMode`.  A wrapper rule has a single
+    // `spacingMode` that governs prefix-boundary semantics, so two
+    // members with different spacingModes can never share a wrapper.
+    // Rather than bail out at every mixed-spacing fork (which would
+    // miss legitimate factoring opportunities within each spacing
+    // group), build a separate trie per spacingMode and concatenate
+    // the per-partition output back in original-index order.
+    //
+    // Map iteration is insertion order; partitions are visited in
+    // first-occurrence order, but the final flatten sorts by `idx`
+    // so source ordering is preserved across partitions.
+    const partitions = new Map<
+        CompiledSpacingMode,
+        { idx: number; rule: GrammarRule }[]
+    >();
+    for (let i = 0; i < rules.length; i++) {
+        const r = rules[i];
+        let p = partitions.get(r.spacingMode);
+        if (p === undefined) {
+            p = [];
+            partitions.set(r.spacingMode, p);
+        }
+        p.push({ idx: i, rule: r });
+    }
+
     const buildState: BuildState = {
         nextCanonicalId: 0,
         rulesArrayIds: new WeakMap(),
         nextRulesArrayId: 0,
         tailFactoring,
     };
-    const root: TrieRoot = { children: new Map(), terminals: [] };
-    for (let i = 0; i < rules.length; i++) {
-        insertRuleIntoTrie(root, rules[i], i, buildState);
-    }
-
     const state: EmitState = { didFactor: false };
     const items: { idx: number; rules: GrammarRule[] }[] = [];
-    for (const c of root.children.values()) {
-        items.push({
-            idx: c.firstIdx,
-            rules: emitFromNode(c, state, buildState),
-        });
+
+    for (const partition of partitions.values()) {
+        if (partition.length === 1) {
+            // Solo partition - nothing to factor against; pass the
+            // rule through at its original index.
+            items.push({ idx: partition[0].idx, rules: [partition[0].rule] });
+            continue;
+        }
+        const root: TrieRoot = { children: new Map(), terminals: [] };
+        for (const { idx, rule } of partition) {
+            insertRuleIntoTrie(root, rule, idx, buildState);
+        }
+        for (const c of root.children.values()) {
+            items.push({
+                idx: c.firstIdx,
+                rules: emitFromNode(c, state, buildState),
+            });
+        }
     }
     items.sort((a, b) => a.idx - b.idx);
     const newRules: GrammarRule[] = items.flatMap((it) => it.rules);
@@ -1471,16 +1501,16 @@ function checkFactoringEligible(
     // Spacing-mode uniformity is required for *any* wrapper, tail or
     // non-tail.  The wrapper rule has a single `spacingMode` that
     // governs boundary semantics for the prefix parts (and the
-    // prefix/suffix seam); before factoring, each member's own
-    // `spacingMode` governed boundaries across its full parts -
-    // including the prefix portion.  When members disagree on
-    // `spacingMode` there is no single value the wrapper can carry
-    // that preserves every member's original prefix semantics, so we
-    // refuse to factor at this fork.
-    const firstSpacing = members[0].spacingMode;
-    const uniformSpacing = members.every((m) => m.spacingMode === firstSpacing);
-    if (!uniformSpacing) {
-        return { ok: false, reason: "mixed-spacing" };
+    // prefix/suffix seam).  `factorRules` partitions input rules by
+    // `spacingMode` and runs a separate trie per partition, so
+    // every member at every fork in one trie is guaranteed to share
+    // the same spacingMode by construction.  The check here is
+    // defensive against a future caller that bypasses partitioning.
+    /* istanbul ignore if -- @preserve: dead-by-construction defense */
+    if (!members.every((m) => m.spacingMode === members[0].spacingMode)) {
+        throw new Error(
+            "Internal: factorRules should partition members by spacingMode before reaching checkFactoringEligible",
+        );
     }
 
     // Policy: prefer tail when enabled.  Tail wrapper is observably

--- a/ts/packages/actionGrammar/src/grammarOptimizer.ts
+++ b/ts/packages/actionGrammar/src/grammarOptimizer.ts
@@ -103,6 +103,7 @@ export const recommendedOptimizations: GrammarOptimizationOptions = {
 export function optimizeGrammar(
     grammar: Grammar,
     options: GrammarOptimizationOptions | undefined,
+    warnings?: string[],
 ): Grammar {
     if (!options) {
         return grammar;
@@ -114,11 +115,13 @@ export function optimizeGrammar(
     if (options.tailFactoring && !options.factorCommonPrefixes) {
         // tailFactoring is a sub-mode of the prefix-factoring pass;
         // setting it without enabling the parent pass is almost
-        // certainly a configuration mistake.  Log so it surfaces in
-        // debug traces rather than silently being a no-op.
-        debug(
-            "tailFactoring is set but factorCommonPrefixes is not - tailFactoring has no effect",
-        );
+        // certainly a configuration mistake.  Surface via the caller's
+        // warnings array (and log via debug) so it doesn't silently
+        // become a no-op.
+        const msg =
+            "tailFactoring is set but factorCommonPrefixes is not - tailFactoring has no effect";
+        debug(msg);
+        warnings?.push(msg);
     }
     if (options.inlineSingleAlternatives) {
         rules = inlineSingleAlternativeRules(rules, inlineConfig);
@@ -133,6 +136,25 @@ export function optimizeGrammar(
             // Pass 1 in their pre-factored shape.  Re-run the inliner so
             // those collapse.
             rules = inlineSingleAlternativeRules(rules, inlineConfig);
+        }
+        if (options.tailFactoring) {
+            // Self-validate: any tail RulesPart the factorer emitted
+            // must satisfy the structural contract.  Catches
+            // regressions in the wrapper builders at the offending
+            // site rather than as confusing match failures or
+            // runtime throws deep in `enterTailRulesPart`.  Honors
+            // `onInvariantViolation`: throw on the strict path,
+            // demote to warning + debug log on the permissive path.
+            try {
+                validateTailRulesParts(rules);
+            } catch (e) {
+                const msg = `Optimizer self-check failed: ${(e as Error).message}`;
+                if (inlineConfig.onInvariantViolation === "throw") {
+                    throw new Error(msg);
+                }
+                debug(msg);
+                warnings?.push(msg);
+            }
         }
     }
     if (rules === grammar.rules) {
@@ -1535,9 +1557,12 @@ function checkFactoringEligible(
  * value flows up directly as the wrapper rule's value - no
  * synthesized wrapper-binding variable, no `factoredAlt.value`.
  *
- * Caller (`emitFromNode`) only reaches this with `members.length >= 2`
- * (the length===1 short-circuit returns earlier), upholding the
- * `RulesPart.tailCall` >= 2-rules invariant by construction.
+ * Invariant - `members.length >= 2`.  `emitFromNode` short-circuits
+ * the single-member case before reaching the wrapper builders
+ * (`if (members.length === 1) return [...]`), so this builder is
+ * only ever called at multi-member forks.  This upholds the
+ * `RulesPart.tailCall` `rules.length >= 2` contract by construction;
+ * `validateTailRulesParts` re-checks it post-emit.
  */
 function buildTailWrapper(
     prefix: GrammarPart[],
@@ -1561,10 +1586,18 @@ function buildTailWrapper(
 /**
  * Build a non-tail wrapper rule: each member's value is captured into
  * a synthesized opaque wrapper-binding variable, and the wrapper rule
- * forwards that binding as its own value.  Used when `tailFactoring`
- * is disabled and the fork doesn't need cross-scope reference
- * resolution (otherwise the factorer would have bailed out with
- * `cross-scope-ref`).
+ * forwards that binding as its own value.
+ *
+ * **Reachability:** today this builder is only reached when
+ * `tailFactoring` is OFF.  When `tailFactoring` is on, the
+ * eligibility check unconditionally returns `tail: true` for every
+ * passing fork (the tail wrapper is observably identical to the
+ * non-tail wrapper for both `needsTail` and `!needsTail` shapes,
+ * produces a smaller AST, and saves a frame push), so this branch
+ * is dead on the tail-factoring path.  Kept as the legacy emit
+ * path: callers that route through the NFA/DFA matcher must leave
+ * `tailFactoring` off, and they still benefit from prefix factoring
+ * via this builder for the `!needsTail` case.
  */
 function buildNonTailWrapper(
     prefix: GrammarPart[],

--- a/ts/packages/actionGrammar/src/grammarSerializer.ts
+++ b/ts/packages/actionGrammar/src/grammarSerializer.ts
@@ -48,7 +48,7 @@ export function grammarToJson(grammar: Grammar): GrammarJson {
                     optional: p.optional,
                 };
                 if (p.repeat) part.repeat = true;
-                if (p.tail) part.tail = true;
+                if (p.tailCall) part.tailCall = true;
                 return part;
             }
             case "phraseSet": {

--- a/ts/packages/actionGrammar/src/grammarSerializer.ts
+++ b/ts/packages/actionGrammar/src/grammarSerializer.ts
@@ -48,6 +48,7 @@ export function grammarToJson(grammar: Grammar): GrammarJson {
                     optional: p.optional,
                 };
                 if (p.repeat) part.repeat = true;
+                if (p.tail) part.tail = true;
                 return part;
             }
             case "phraseSet": {

--- a/ts/packages/actionGrammar/src/grammarTypes.ts
+++ b/ts/packages/actionGrammar/src/grammarTypes.ts
@@ -228,6 +228,35 @@ export type RulesPart = {
     variable?: string | undefined;
     optional?: boolean | undefined;
     repeat?: boolean | undefined; // Kleene star: zero or more occurrences
+
+    /**
+     * Optimizer-only flag marking this `RulesPart` as a true *tail call*.
+     * When set, the matcher does not push a parent frame on entry — the
+     * selected member's value flows up directly as the containing
+     * (parent) rule's value, and the child's bindings cons onto the
+     * parent's `valueIds` chain (so member value-exprs see prefix
+     * bindings).
+     *
+     * Required structural constraints, validated by the compiler:
+     *   - This part is the LAST entry in its containing rule's `parts`.
+     *   - The containing rule has `value === undefined`.
+     *   - `repeat`, `optional`, and `variable` are all forbidden here.
+     *   - `rules.length >= 2`.  A single-rule tail `RulesPart` is
+     *     pointless: the lone member's value would just flow up to
+     *     the parent, which is equivalent to inlining the member's
+     *     parts directly into the parent (since tail already shares
+     *     scope with the parent).  The factorer only emits tail
+     *     wrappers at multi-member forks.
+     *   - Each member rule individually produces a value (explicit
+     *     `value` or implicit-default-eligible).
+     *   - `spacingMode` of every member equals the containing rule's
+     *     spacingMode (boundary semantics must match — see the
+     *     equivalent check in the inliner).
+     *
+     * Not exposed in `.agr` source syntax; introduced only by the
+     * factorer's prefix-factoring pass.
+     */
+    tail?: boolean | undefined;
 };
 
 export type PhraseSetPart = {
@@ -335,6 +364,8 @@ export type RulePartJson = {
     variable?: string | undefined;
     optional?: boolean | undefined;
     repeat?: boolean | undefined;
+    /** See `RulesPart.tail`. */
+    tail?: boolean | undefined;
 };
 
 export type PhraseSetPartJson = {

--- a/ts/packages/actionGrammar/src/grammarTypes.ts
+++ b/ts/packages/actionGrammar/src/grammarTypes.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 /**
- * SpacingMode after compilation — "auto" is folded to undefined so it never
+ * SpacingMode after compilation - "auto" is folded to undefined so it never
  * appears in compiled grammar output (.ag.json) or at match time.
  */
 export type CompiledSpacingMode = "required" | "optional" | "none" | undefined;
@@ -157,7 +157,7 @@ export type CompiledValueExprNode =
     | CompiledSpreadValueExprNode
     | CompiledTemplateLiteralValueExprNode;
 
-/** ValueNode without comment annotations — used in compiled grammar output (.ag.json). */
+/** ValueNode without comment annotations - used in compiled grammar output (.ag.json). */
 export type CompiledValueNode =
     | CompiledLiteralValueNode
     | CompiledVariableValueNode
@@ -182,7 +182,7 @@ export type StringPart = {
     /**
      * Optional capture variable.  When set, the matcher writes the
      * joined matched tokens (`value.join(" ")`) into the slot/value
-     * named by this variable — same string the implicit-default path
+     * named by this variable - same string the implicit-default path
      * computes for a single-StringPart rule with no value expression,
      * just routed to a named slot instead of the anonymous default.
      *
@@ -231,13 +231,14 @@ export type RulesPart = {
 
     /**
      * Optimizer-only flag marking this `RulesPart` as a true *tail call*.
-     * When set, the matcher does not push a parent frame on entry — the
+     * When set, the matcher does not push a parent frame on entry - the
      * selected member's value flows up directly as the containing
      * (parent) rule's value, and the child's bindings cons onto the
      * parent's `valueIds` chain (so member value-exprs see prefix
      * bindings).
      *
-     * Required structural constraints, validated by the compiler:
+     * Required structural constraints, validated by
+     * `validateGrammar`:
      *   - This part is the LAST entry in its containing rule's `parts`.
      *   - The containing rule has `value === undefined`.
      *   - `repeat`, `optional`, and `variable` are all forbidden here.
@@ -250,13 +251,16 @@ export type RulesPart = {
      *   - Each member rule individually produces a value (explicit
      *     `value` or implicit-default-eligible).
      *   - `spacingMode` of every member equals the containing rule's
-     *     spacingMode (boundary semantics must match — see the
+     *     spacingMode (boundary semantics must match - see the
      *     equivalent check in the inliner).
      *
      * Not exposed in `.agr` source syntax; introduced only by the
-     * factorer's prefix-factoring pass.
+     * factorer's prefix-factoring pass.  Named `tailCall` (not just
+     * `tail`) so it doesn't read as "this part is at the end of the
+     * parts list" - the flag means "matcher should treat this as a
+     * tail call".
      */
-    tail?: boolean | undefined;
+    tailCall?: boolean | undefined;
 };
 
 export type PhraseSetPart = {
@@ -289,7 +293,7 @@ export type GrammarPart =
  *
  * - wildcard / number: source-level captures (`$(name:string)`, `$(n:number)`).
  * - rules:             nested rule capture (`$(x:<Inner>)`).
- * - string / phraseSet: optimizer-introduced captures only — no `.agr` source syntax.
+ * - string / phraseSet: optimizer-introduced captures only - no `.agr` source syntax.
  */
 export type CaptureBearingPart =
     | VarStringPart
@@ -340,7 +344,7 @@ export type Grammar = {
 export type StringPartJson = {
     type: "string";
     value: string[];
-    /** Optional capture variable — see `StringPart.variable`. */
+    /** Optional capture variable - see `StringPart.variable`. */
     variable?: string | undefined;
 };
 
@@ -364,14 +368,14 @@ export type RulePartJson = {
     variable?: string | undefined;
     optional?: boolean | undefined;
     repeat?: boolean | undefined;
-    /** See `RulesPart.tail`. */
-    tail?: boolean | undefined;
+    /** See `RulesPart.tailCall`. */
+    tailCall?: boolean | undefined;
 };
 
 export type PhraseSetPartJson = {
     type: "phraseSet";
     matcherName: string;
-    /** Optional capture variable — see `PhraseSetPart.variable`. */
+    /** Optional capture variable - see `PhraseSetPart.variable`. */
     variable?: string | undefined;
 };
 

--- a/ts/packages/actionGrammar/src/nfaCompiler.ts
+++ b/ts/packages/actionGrammar/src/nfaCompiler.ts
@@ -1194,6 +1194,12 @@ function compileRulesPart(
     checkedVariables?: Set<string>,
     overrideVariableName?: string,
 ): number {
+    if (part.tail) {
+        throw new Error(
+            "compileRulesPart: tail RulesParts are not supported by the NFA compiler. " +
+                "Disable `tailFactoring` in the grammar optimizer for NFA/DFA paths.",
+        );
+    }
     if (part.rules.length === 0) {
         // Empty rules - epsilon transition
         builder.addEpsilonTransition(fromState, toState);
@@ -1266,6 +1272,12 @@ function compileRulesPartWithSlots(
     toState: number,
     context: RuleCompilationContext,
 ): number {
+    if (part.tail) {
+        throw new Error(
+            "compileRulesPartWithSlots: tail RulesParts are not supported by the NFA compiler. " +
+                "Disable `tailFactoring` in the grammar optimizer for NFA/DFA paths.",
+        );
+    }
     if (part.rules.length === 0) {
         // Empty rules - epsilon transition
         builder.addEpsilonTransition(fromState, toState);

--- a/ts/packages/actionGrammar/src/nfaCompiler.ts
+++ b/ts/packages/actionGrammar/src/nfaCompiler.ts
@@ -1194,9 +1194,10 @@ function compileRulesPart(
     checkedVariables?: Set<string>,
     overrideVariableName?: string,
 ): number {
-    if (part.tail) {
+    if (part.tailCall) {
         throw new Error(
-            "compileRulesPart: tail RulesParts are not supported by the NFA compiler. " +
+            `compileRulesPart: tail RulesParts are not supported by the NFA compiler ` +
+                `(part.name='${part.name ?? "<unnamed>"}'). ` +
                 "Disable `tailFactoring` in the grammar optimizer for NFA/DFA paths.",
         );
     }
@@ -1272,9 +1273,10 @@ function compileRulesPartWithSlots(
     toState: number,
     context: RuleCompilationContext,
 ): number {
-    if (part.tail) {
+    if (part.tailCall) {
         throw new Error(
-            "compileRulesPartWithSlots: tail RulesParts are not supported by the NFA compiler. " +
+            `compileRulesPartWithSlots: tail RulesParts are not supported by the NFA compiler ` +
+                `(part.name='${part.name ?? "<unnamed>"}'). ` +
                 "Disable `tailFactoring` in the grammar optimizer for NFA/DFA paths.",
         );
     }

--- a/ts/packages/actionGrammar/test/grammarOptimizerFactoring.spec.ts
+++ b/ts/packages/actionGrammar/test/grammarOptimizerFactoring.spec.ts
@@ -798,18 +798,17 @@ describe("Grammar Optimizer - Wrapper rule spacingMode propagation", () => {
         }
     });
 
-    it("refuses to factor when members disagree on spacingMode", () => {
-        // Members with differing spacingMode have no single boundary
-        // semantics the wrapper rule could carry that preserves every
-        // member's original prefix matching, so the factorer bails out
-        // at this fork and emits the alternatives unfactored.
+    it("partitions by spacingMode so mismatched groups don't share a wrapper", () => {
+        // Members with differing spacingMode can't share a single
+        // wrapper rule.  `factorRules` partitions by spacingMode and
+        // factors each partition independently; with only one rule
+        // per partition here, no factoring happens, and both
+        // top-level rules survive with their original spacingMode.
         const text = `<Start> [spacing=required] = play hello -> 1;
 <Start> [spacing=optional] = play world -> 2;`;
         const optimized = loadGrammarRules("t.grammar", text, {
             optimizations: { factorCommonPrefixes: true },
         });
-        // No factoring → both top-level rules survive with their
-        // original spacingMode intact.
         expect(optimized.rules.length).toBe(2);
         expect(optimized.rules[0].spacingMode).toBe("required");
         expect(optimized.rules[1].spacingMode).toBe("optional");
@@ -822,6 +821,44 @@ describe("Grammar Optimizer - Wrapper rule spacingMode propagation", () => {
             "play world",
             "playhello",
             "playworld",
+        ]) {
+            expect(match(optimized, input)).toStrictEqual(
+                match(baseline, input),
+            );
+        }
+    });
+
+    it("factors within each spacingMode partition independently", () => {
+        // Two rules per spacing mode that share a prefix.  With
+        // partitioning, each spacing group factors on its own and
+        // produces its own wrapper rule carrying the partition's
+        // spacingMode.  Without partitioning the whole fork would
+        // bail out (mixed-spacing) and lose all factoring.
+        const text = `<Start> [spacing=required] = play song -> "rs";
+<Start> [spacing=required] = play album -> "ra";
+<Start> [spacing=optional] = play track -> "ot";
+<Start> [spacing=optional] = play list -> "ol";`;
+        const optimized = loadGrammarRules("t.grammar", text, {
+            optimizations: { factorCommonPrefixes: true },
+        });
+        // One wrapper per spacing group: 2 top-level rules total.
+        expect(optimized.rules.length).toBe(2);
+        const spacingModes = optimized.rules.map((r) => r.spacingMode).sort();
+        expect(spacingModes).toStrictEqual(["optional", "required"]);
+        // Each wrapper has the shared `play` prefix factored out.
+        for (const r of optimized.rules) {
+            expect(r.parts.length).toBeGreaterThanOrEqual(2);
+            expect(r.parts[0].type).toBe("string");
+        }
+
+        const baseline = loadGrammarRules("t.grammar", text);
+        for (const input of [
+            "play song",
+            "play album",
+            "play track",
+            "play list",
+            "playsong",
+            "playtrack",
         ]) {
             expect(match(optimized, input)).toStrictEqual(
                 match(baseline, input),

--- a/ts/packages/actionGrammar/test/grammarOptimizerFactoring.spec.ts
+++ b/ts/packages/actionGrammar/test/grammarOptimizerFactoring.spec.ts
@@ -798,16 +798,35 @@ describe("Grammar Optimizer - Wrapper rule spacingMode propagation", () => {
         }
     });
 
-    it("does not set wrapper spacingMode when members disagree", () => {
-        // Members with differing spacingMode → wrapper stays default
-        // (auto / undefined).
+    it("refuses to factor when members disagree on spacingMode", () => {
+        // Members with differing spacingMode have no single boundary
+        // semantics the wrapper rule could carry that preserves every
+        // member's original prefix matching, so the factorer bails out
+        // at this fork and emits the alternatives unfactored.
         const text = `<Start> [spacing=required] = play hello -> 1;
 <Start> [spacing=optional] = play world -> 2;`;
         const optimized = loadGrammarRules("t.grammar", text, {
             optimizations: { factorCommonPrefixes: true },
         });
-        expect(optimized.rules.length).toBe(1);
-        expect(optimized.rules[0].spacingMode).toBeUndefined();
+        // No factoring → both top-level rules survive with their
+        // original spacingMode intact.
+        expect(optimized.rules.length).toBe(2);
+        expect(optimized.rules[0].spacingMode).toBe("required");
+        expect(optimized.rules[1].spacingMode).toBe("optional");
+
+        // Behavior is identical to the unoptimized grammar across
+        // representative inputs (with and without inter-token spacing).
+        const baseline = loadGrammarRules("t.grammar", text);
+        for (const input of [
+            "play hello",
+            "play world",
+            "playhello",
+            "playworld",
+        ]) {
+            expect(match(optimized, input)).toStrictEqual(
+                match(baseline, input),
+            );
+        }
     });
 });
 

--- a/ts/packages/actionGrammar/test/grammarOptimizerTailFactoring.spec.ts
+++ b/ts/packages/actionGrammar/test/grammarOptimizerTailFactoring.spec.ts
@@ -1,0 +1,114 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { loadGrammarRules } from "../src/grammarLoader.js";
+import { matchGrammar } from "../src/grammarMatcher.js";
+import { GrammarPart, GrammarRule, RulesPart } from "../src/grammarTypes.js";
+
+function match(grammar: ReturnType<typeof loadGrammarRules>, request: string) {
+    return matchGrammar(grammar, request).map((m) => m.match);
+}
+
+function findAllRulesParts(rules: GrammarRule[]): RulesPart[] {
+    const out: RulesPart[] = [];
+    const visit = (parts: GrammarPart[]) => {
+        for (const p of parts) {
+            if (p.type === "rules") {
+                out.push(p);
+                for (const r of p.rules) visit(r.parts);
+            }
+        }
+    };
+    for (const r of rules) visit(r.parts);
+    return out;
+}
+
+describe("Grammar Optimizer - tail RulesPart factoring (opt-in)", () => {
+    // Without the opt-in, the cross-scope-ref bailout still fires and
+    // no tail RulesPart is emitted — matcher results stay correct.
+    it("does not emit tail wrappers without the tailFactoring flag", () => {
+        const text = `<Start> = <Play>;
+<Inner> = $(trackName:string) -> trackName | the $(trackName:string) -> trackName;
+<Play> = play $(trackName:<Inner>) by $(artist:string) -> { kind: "by", trackName, artist }
+       | play $(trackName:<Inner>) from album $(albumName:string) -> { kind: "from", trackName, albumName };`;
+        const optimized = loadGrammarRules("t.grammar", text, {
+            optimizations: { factorCommonPrefixes: true },
+        });
+        const tailParts = findAllRulesParts(optimized.rules).filter(
+            (rp) => rp.tail,
+        );
+        expect(tailParts).toHaveLength(0);
+    });
+
+    // The motivating case: shared `play <Inner> by <ArtistName>` /
+    // `play <Inner> from album <AlbumName>` prefix factoring previously
+    // bailed via cross-scope-ref because each member's value references
+    // the prefix-bound `trackName`.  With tailFactoring enabled, we
+    // emit a tail RulesPart and the matcher still returns the same
+    // results.
+    it("emits a tail wrapper for the playerSchema-shaped grammar", () => {
+        const text = `<Start> = <Play>;
+<Inner> = $(trackName:string) -> trackName | the $(trackName:string) -> trackName;
+<Play> = play $(trackName:<Inner>) by $(artist:string) -> { kind: "by", trackName, artist }
+       | play $(trackName:<Inner>) from album $(albumName:string) -> { kind: "from", trackName, albumName };`;
+        const baseline = loadGrammarRules("t.grammar", text);
+        const optimized = loadGrammarRules("t.grammar", text, {
+            optimizations: {
+                factorCommonPrefixes: true,
+                tailFactoring: true,
+            },
+        });
+
+        const tailParts = findAllRulesParts(optimized.rules).filter(
+            (rp) => rp.tail,
+        );
+        expect(tailParts.length).toBeGreaterThanOrEqual(1);
+        for (const tp of tailParts) {
+            expect(tp.variable).toBeUndefined();
+            expect(tp.optional).toBeFalsy();
+            expect(tp.repeat).toBeFalsy();
+        }
+
+        for (const input of [
+            "play hello by alice",
+            "play the world by bob",
+            "play hello from album unity",
+            "play the world from album greatest",
+        ]) {
+            expect(match(optimized, input)).toStrictEqual(
+                match(baseline, input),
+            );
+        }
+        expect(match(optimized, "play hello by alice")).toStrictEqual([
+            { kind: "by", trackName: "hello", artist: "alice" },
+        ]);
+        expect(match(optimized, "play hello from album unity")).toStrictEqual([
+            { kind: "from", trackName: "hello", albumName: "unity" },
+        ]);
+    });
+
+    // Backtracking discipline: when one branch consumes input that
+    // doesn't validate, the matcher must restore valueIds so a sibling
+    // alt can rebind the same canonical without bleed-through.
+    it("backtracks correctly across tail siblings", () => {
+        const text = `<Start> = <X>;
+<Tail> = a $(v:string) -> { branch: "a", v }
+       | b $(v:string) -> { branch: "b", v };
+<X> = pre $(prefix:string) <Tail>;`;
+        const optimized = loadGrammarRules("t.grammar", text, {
+            optimizations: {
+                factorCommonPrefixes: true,
+                tailFactoring: true,
+            },
+        });
+        // With distinct member binding names but no prefix reference,
+        // the cross-scope check would not need tail; this test pins
+        // matcher behavior under tail-factoring stays sane regardless.
+        const baseline = loadGrammarRules("t.grammar", text);
+        for (const input of ["pre hello a world", "pre hello b world"]) {
+            expect(match(optimized, input)).toStrictEqual(
+                match(baseline, input),
+            );
+        }
+    });
+});

--- a/ts/packages/actionGrammar/test/grammarOptimizerTailFactoring.spec.ts
+++ b/ts/packages/actionGrammar/test/grammarOptimizerTailFactoring.spec.ts
@@ -1,9 +1,20 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+import {
+    grammarFromJson,
+    grammarFromJsonValidated,
+} from "../src/grammarDeserializer.js";
 import { loadGrammarRules } from "../src/grammarLoader.js";
 import { matchGrammar } from "../src/grammarMatcher.js";
-import { GrammarPart, GrammarRule, RulesPart } from "../src/grammarTypes.js";
+import { validateTailRulesParts } from "../src/grammarOptimizer.js";
+import { grammarToJson } from "../src/grammarSerializer.js";
+import {
+    Grammar,
+    GrammarPart,
+    GrammarRule,
+    RulesPart,
+} from "../src/grammarTypes.js";
 
 function match(grammar: ReturnType<typeof loadGrammarRules>, request: string) {
     return matchGrammar(grammar, request).map((m) => m.match);
@@ -11,11 +22,15 @@ function match(grammar: ReturnType<typeof loadGrammarRules>, request: string) {
 
 function findAllRulesParts(rules: GrammarRule[]): RulesPart[] {
     const out: RulesPart[] = [];
+    const visited = new WeakSet<GrammarRule[]>();
     const visit = (parts: GrammarPart[]) => {
         for (const p of parts) {
             if (p.type === "rules") {
                 out.push(p);
-                for (const r of p.rules) visit(r.parts);
+                if (!visited.has(p.rules)) {
+                    visited.add(p.rules);
+                    for (const r of p.rules) visit(r.parts);
+                }
             }
         }
     };
@@ -23,19 +38,20 @@ function findAllRulesParts(rules: GrammarRule[]): RulesPart[] {
     return out;
 }
 
-describe("Grammar Optimizer - tail RulesPart factoring (opt-in)", () => {
-    // Without the opt-in, the cross-scope-ref bailout still fires and
-    // no tail RulesPart is emitted — matcher results stay correct.
-    it("does not emit tail wrappers without the tailFactoring flag", () => {
-        const text = `<Start> = <Play>;
+const PLAYER_SCHEMA = `<Start> = <Play>;
 <Inner> = $(trackName:string) -> trackName | the $(trackName:string) -> trackName;
 <Play> = play $(trackName:<Inner>) by $(artist:string) -> { kind: "by", trackName, artist }
        | play $(trackName:<Inner>) from album $(albumName:string) -> { kind: "from", trackName, albumName };`;
-        const optimized = loadGrammarRules("t.grammar", text, {
+
+describe("Grammar Optimizer - tail RulesPart factoring (opt-in)", () => {
+    // Without the opt-in, the cross-scope-ref bailout still fires and
+    // no tail RulesPart is emitted - matcher results stay correct.
+    it("does not emit tail wrappers without the tailFactoring flag", () => {
+        const optimized = loadGrammarRules("t.grammar", PLAYER_SCHEMA, {
             optimizations: { factorCommonPrefixes: true },
         });
         const tailParts = findAllRulesParts(optimized.rules).filter(
-            (rp) => rp.tail,
+            (rp) => rp.tailCall,
         );
         expect(tailParts).toHaveLength(0);
     });
@@ -47,12 +63,8 @@ describe("Grammar Optimizer - tail RulesPart factoring (opt-in)", () => {
     // emit a tail RulesPart and the matcher still returns the same
     // results.
     it("emits a tail wrapper for the playerSchema-shaped grammar", () => {
-        const text = `<Start> = <Play>;
-<Inner> = $(trackName:string) -> trackName | the $(trackName:string) -> trackName;
-<Play> = play $(trackName:<Inner>) by $(artist:string) -> { kind: "by", trackName, artist }
-       | play $(trackName:<Inner>) from album $(albumName:string) -> { kind: "from", trackName, albumName };`;
-        const baseline = loadGrammarRules("t.grammar", text);
-        const optimized = loadGrammarRules("t.grammar", text, {
+        const baseline = loadGrammarRules("t.grammar", PLAYER_SCHEMA);
+        const optimized = loadGrammarRules("t.grammar", PLAYER_SCHEMA, {
             optimizations: {
                 factorCommonPrefixes: true,
                 tailFactoring: true,
@@ -60,13 +72,14 @@ describe("Grammar Optimizer - tail RulesPart factoring (opt-in)", () => {
         });
 
         const tailParts = findAllRulesParts(optimized.rules).filter(
-            (rp) => rp.tail,
+            (rp) => rp.tailCall,
         );
         expect(tailParts.length).toBeGreaterThanOrEqual(1);
         for (const tp of tailParts) {
             expect(tp.variable).toBeUndefined();
             expect(tp.optional).toBeFalsy();
             expect(tp.repeat).toBeFalsy();
+            expect(tp.rules.length).toBeGreaterThanOrEqual(2);
         }
 
         for (const input of [
@@ -87,28 +100,276 @@ describe("Grammar Optimizer - tail RulesPart factoring (opt-in)", () => {
         ]);
     });
 
-    // Backtracking discipline: when one branch consumes input that
-    // doesn't validate, the matcher must restore valueIds so a sibling
-    // alt can rebind the same canonical without bleed-through.
-    it("backtracks correctly across tail siblings", () => {
-        const text = `<Start> = <X>;
-<Tail> = a $(v:string) -> { branch: "a", v }
-       | b $(v:string) -> { branch: "b", v };
-<X> = pre $(prefix:string) <Tail>;`;
+    // Force a cross-scope-ref scenario: every member's value-expr
+    // references a prefix-bound canonical (`prefix`).  Without
+    // tailFactoring this fork bails out (cross-scope-ref); with
+    // tailFactoring we emit a tail wrapper and the matcher must
+    // backtrack correctly between sibling tail alts when the live
+    // alternative consumes input but eventually fails.
+    it("backtracks across tail siblings when prefix is referenced", () => {
+        const text = `<Start> = pre $(prefix:string) a $(v:string) -> { branch: "a", prefix, v }
+       | pre $(prefix:string) b $(v:string) -> { branch: "b", prefix, v };`;
+        const baseline = loadGrammarRules("t.grammar", text);
         const optimized = loadGrammarRules("t.grammar", text, {
             optimizations: {
                 factorCommonPrefixes: true,
                 tailFactoring: true,
             },
         });
-        // With distinct member binding names but no prefix reference,
-        // the cross-scope check would not need tail; this test pins
-        // matcher behavior under tail-factoring stays sane regardless.
-        const baseline = loadGrammarRules("t.grammar", text);
+        const tailParts = findAllRulesParts(optimized.rules).filter(
+            (rp) => rp.tailCall,
+        );
+        expect(tailParts.length).toBeGreaterThanOrEqual(1);
         for (const input of ["pre hello a world", "pre hello b world"]) {
             expect(match(optimized, input)).toStrictEqual(
                 match(baseline, input),
             );
         }
+    });
+
+    // Round-trip serialization: a tail-factored grammar must survive
+    // grammarToJson → grammarFromJson without losing the tailCall
+    // flag, and the deserialized form must match identically to the
+    // baseline.
+    it("round-trips tail RulesPart through grammarToJson / grammarFromJson", () => {
+        const baseline = loadGrammarRules("t.grammar", PLAYER_SCHEMA);
+        const optimized = loadGrammarRules("t.grammar", PLAYER_SCHEMA, {
+            optimizations: {
+                factorCommonPrefixes: true,
+                tailFactoring: true,
+            },
+        });
+        const json = grammarToJson(optimized);
+        const reloaded = grammarFromJsonValidated(json);
+
+        const reloadedTailParts = findAllRulesParts(reloaded.rules).filter(
+            (rp) => rp.tailCall,
+        );
+        expect(reloadedTailParts.length).toBeGreaterThanOrEqual(1);
+
+        for (const input of [
+            "play hello by alice",
+            "play the world by bob",
+            "play hello from album unity",
+        ]) {
+            expect(match(reloaded, input)).toStrictEqual(
+                match(baseline, input),
+            );
+        }
+    });
+
+    // Behavior-equivalence sweep: a representative set of inputs must
+    // match identically against the optimized (tail-factored) and
+    // unoptimized grammars.  Pins observable transparency of the
+    // optimization for the playerSchema shape.
+    it("baseline-equivalence sweep over representative inputs", () => {
+        const baseline = loadGrammarRules("t.grammar", PLAYER_SCHEMA);
+        const optimized = loadGrammarRules("t.grammar", PLAYER_SCHEMA, {
+            optimizations: {
+                factorCommonPrefixes: true,
+                tailFactoring: true,
+            },
+        });
+        const inputs = [
+            "play foo by bar",
+            "play the foo by bar",
+            "play foo from album bar",
+            "play the foo from album bar",
+            // Negative inputs - both should reject.
+            "play",
+            "play foo",
+            "play foo by",
+            "stop foo by bar",
+            "playby",
+            "play foo by bar from album baz",
+        ];
+        for (const input of inputs) {
+            expect(match(optimized, input)).toStrictEqual(
+                match(baseline, input),
+            );
+        }
+    });
+
+    // Nested tail factoring: a tail RulesPart member that itself
+    // contains a fork eligible for tail factoring.  Validates the
+    // factorer recurses through tail wrappers and the matcher handles
+    // nested tail-call entries correctly.
+    it("supports nested tail RulesParts", () => {
+        const text = `<Start> = a $(p:string) b $(q:string) -> { v: "ab", p, q }
+       | a $(p:string) c $(q:string) -> { v: "ac", p, q }
+       | a $(p:string) d $(q:string) -> { v: "ad", p, q };`;
+        const baseline = loadGrammarRules("t.grammar", text);
+        const optimized = loadGrammarRules("t.grammar", text, {
+            optimizations: {
+                factorCommonPrefixes: true,
+                tailFactoring: true,
+            },
+        });
+        const tailParts = findAllRulesParts(optimized.rules).filter(
+            (rp) => rp.tailCall,
+        );
+        expect(tailParts.length).toBeGreaterThanOrEqual(1);
+        // Validator should accept the optimized AST.
+        expect(() => validateTailRulesParts(optimized.rules)).not.toThrow();
+
+        for (const input of [
+            "a x b y",
+            "a x c y",
+            "a x d y",
+            "a x e y", // negative
+        ]) {
+            expect(match(optimized, input)).toStrictEqual(
+                match(baseline, input),
+            );
+        }
+    });
+});
+
+describe("validateTailRulesParts", () => {
+    function buildBadGrammar(
+        mutate: (rule: GrammarRule, tail: RulesPart) => void,
+    ): Grammar {
+        const baseline = loadGrammarRules("t.grammar", PLAYER_SCHEMA, {
+            optimizations: {
+                factorCommonPrefixes: true,
+                tailFactoring: true,
+            },
+        });
+        // Find any tail RulesPart and its parent rule, then apply the
+        // caller's mutation.
+        const findTail = (
+            rules: GrammarRule[],
+        ): { rule: GrammarRule; part: RulesPart } | undefined => {
+            const visited = new WeakSet<GrammarRule[]>();
+            const recur = (
+                rs: GrammarRule[],
+            ): { rule: GrammarRule; part: RulesPart } | undefined => {
+                if (visited.has(rs)) return undefined;
+                visited.add(rs);
+                for (const r of rs) {
+                    for (const p of r.parts) {
+                        if (p.type !== "rules") continue;
+                        if (p.tailCall) return { rule: r, part: p };
+                        const inner = recur(p.rules);
+                        if (inner) return inner;
+                    }
+                }
+                return undefined;
+            };
+            return recur(rules);
+        };
+        const found = findTail(baseline.rules);
+        if (!found) throw new Error("test setup: no tail RulesPart found");
+        mutate(found.rule, found.part);
+        return baseline;
+    }
+
+    it("accepts a well-formed tail-factored grammar", () => {
+        const optimized = loadGrammarRules("t.grammar", PLAYER_SCHEMA, {
+            optimizations: {
+                factorCommonPrefixes: true,
+                tailFactoring: true,
+            },
+        });
+        expect(() => validateTailRulesParts(optimized.rules)).not.toThrow();
+    });
+
+    it("rejects single-member tail RulesPart", () => {
+        const bad = buildBadGrammar((_rule, tail) => {
+            tail.rules = [tail.rules[0]];
+        });
+        expect(() => validateTailRulesParts(bad.rules)).toThrow(
+            /rules\.length >= 2/,
+        );
+    });
+
+    it("rejects tail RulesPart with variable", () => {
+        const bad = buildBadGrammar((_rule, tail) => {
+            tail.variable = "x";
+        });
+        expect(() => validateTailRulesParts(bad.rules)).toThrow(
+            /repeat\/optional\/variable/,
+        );
+    });
+
+    it("rejects tail RulesPart not at the end of parent's parts", () => {
+        const bad = buildBadGrammar((rule, _tail) => {
+            // Append a sentinel string part so the tail is no longer
+            // last.
+            rule.parts.push({ type: "string", value: ["xyz"] });
+        });
+        expect(() => validateTailRulesParts(bad.rules)).toThrow(
+            /must be the last part/,
+        );
+    });
+
+    it("rejects tail RulesPart when parent has its own value", () => {
+        const bad = buildBadGrammar((rule, _tail) => {
+            rule.value = { type: "literal", value: "fixed" };
+        });
+        expect(() => validateTailRulesParts(bad.rules)).toThrow(
+            /no value of its own/,
+        );
+    });
+
+    it("rejects tail RulesPart with mismatched member spacingMode", () => {
+        const bad = buildBadGrammar((_rule, tail) => {
+            tail.rules = tail.rules.map((m, i) =>
+                i === 0 ? { ...m, spacingMode: "required" as const } : m,
+            );
+        });
+        expect(() => validateTailRulesParts(bad.rules)).toThrow(
+            /spacingMode must match/,
+        );
+    });
+
+    // grammarFromJsonValidated should surface the validation error
+    // at load time rather than at match time.
+    it("grammarFromJsonValidated catches a malformed tail in cached JSON", () => {
+        const optimized = loadGrammarRules("t.grammar", PLAYER_SCHEMA, {
+            optimizations: {
+                factorCommonPrefixes: true,
+                tailFactoring: true,
+            },
+        });
+        const json = grammarToJson(optimized);
+        // Mutate the JSON to break the >=2 invariant.
+        for (const ruleSet of json) {
+            for (const rule of ruleSet) {
+                for (const p of rule.parts) {
+                    if (p.type === "rules" && p.tailCall) {
+                        // Force the referenced rules array to have
+                        // length 1 by replacing the index target with
+                        // a single-rule array.
+                        json[p.index] = [json[p.index][0]];
+                    }
+                }
+            }
+        }
+        // Permissive load still works (cached path), but validated
+        // load throws.
+        expect(() => grammarFromJson(json)).not.toThrow();
+        expect(() => grammarFromJsonValidated(json)).toThrow(
+            /rules\.length >= 2/,
+        );
+    });
+});
+
+describe("Grammar Optimizer - tailFactoring + NFA compatibility", () => {
+    // The NFA compiler refuses tail RulesParts.  Verify that a
+    // tail-factored grammar fed to the NFA path produces a clear
+    // error rather than silent miscompilation.  Loaded lazily so
+    // tests above don't pull in the NFA module unnecessarily.
+    it("NFA compile of a tail-factored grammar throws a descriptive error", async () => {
+        const { compileGrammarToNFA } = await import("../src/nfaCompiler.js");
+        const optimized = loadGrammarRules("t.grammar", PLAYER_SCHEMA, {
+            optimizations: {
+                factorCommonPrefixes: true,
+                tailFactoring: true,
+            },
+        });
+        expect(() => compileGrammarToNFA(optimized)).toThrow(
+            /tail RulesParts are not supported by the NFA compiler/,
+        );
     });
 });

--- a/ts/packages/actionGrammar/test/grammarOptimizerTailFactoring.spec.ts
+++ b/ts/packages/actionGrammar/test/grammarOptimizerTailFactoring.spec.ts
@@ -1,10 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import {
-    grammarFromJson,
-    grammarFromJsonValidated,
-} from "../src/grammarDeserializer.js";
+import { grammarFromJson } from "../src/grammarDeserializer.js";
 import { loadGrammarRules } from "../src/grammarLoader.js";
 import { matchGrammar } from "../src/grammarMatcher.js";
 import { validateTailRulesParts } from "../src/grammarOptimizer.js";
@@ -140,7 +137,7 @@ describe("Grammar Optimizer - tail RulesPart factoring (opt-in)", () => {
             },
         });
         const json = grammarToJson(optimized);
-        const reloaded = grammarFromJsonValidated(json);
+        const reloaded = grammarFromJson(json);
 
         const reloadedTailParts = findAllRulesParts(reloaded.rules).filter(
             (rp) => rp.tailCall,
@@ -190,11 +187,14 @@ describe("Grammar Optimizer - tail RulesPart factoring (opt-in)", () => {
         }
     });
 
-    // Nested tail factoring: a tail RulesPart member that itself
-    // contains a fork eligible for tail factoring.  Validates the
-    // factorer recurses through tail wrappers and the matcher handles
-    // nested tail-call entries correctly.
-    it("supports nested tail RulesParts", () => {
+    // Strengthened from a `tailParts.length >= 1` smoke check to
+    // assert the exact factored shape: three input alternatives
+    // sharing a `a $(p:string)` prefix collapse into a SINGLE tail
+    // wrapper whose prefix is the shared parts and whose suffix
+    // RulesPart has one member per original alt.  A regression that
+    // failed to factor (or that emitted multiple wrappers per fork)
+    // would change either count.
+    it("collapses three prefix-sharing alts into a single tail wrapper", () => {
         const text = `<Start> = a $(p:string) b $(q:string) -> { v: "ab", p, q }
        | a $(p:string) c $(q:string) -> { v: "ac", p, q }
        | a $(p:string) d $(q:string) -> { v: "ad", p, q };`;
@@ -205,11 +205,21 @@ describe("Grammar Optimizer - tail RulesPart factoring (opt-in)", () => {
                 tailFactoring: true,
             },
         });
+        // Top-level: one wrapper rule (was three before factoring).
+        expect(optimized.rules.length).toBe(1);
         const tailParts = findAllRulesParts(optimized.rules).filter(
             (rp) => rp.tailCall,
         );
-        expect(tailParts.length).toBeGreaterThanOrEqual(1);
-        // Validator should accept the optimized AST.
+        // Exactly one tail wrapper at this fork.
+        expect(tailParts.length).toBe(1);
+        // The single tail wrapper holds all three original alternatives.
+        expect(tailParts[0].rules.length).toBe(3);
+        // The wrapper rule itself ends in the tail RulesPart (last
+        // part), per `RulesPart.tailCall` contract.
+        const wrapper = optimized.rules[0];
+        expect(wrapper.parts[wrapper.parts.length - 1]).toBe(tailParts[0]);
+        expect(wrapper.parts.length).toBeGreaterThan(1); // prefix exists
+        // Validator should accept the factored AST.
         expect(() => validateTailRulesParts(optimized.rules)).not.toThrow();
 
         for (const input of [
@@ -346,12 +356,10 @@ describe("validateTailRulesParts", () => {
                 }
             }
         }
-        // Permissive load still works (cached path), but validated
-        // load throws.
-        expect(() => grammarFromJson(json)).not.toThrow();
-        expect(() => grammarFromJsonValidated(json)).toThrow(
-            /rules\.length >= 2/,
-        );
+        // Permissive (validate: false) load still works (cached path),
+        // but the default load throws.
+        expect(() => grammarFromJson(json, { validate: false })).not.toThrow();
+        expect(() => grammarFromJson(json)).toThrow(/rules\.length >= 2/);
     });
 });
 


### PR DESCRIPTION
## Overview

Adds an opt-in **tail-call factoring** sub-mode to the actionGrammar prefix-factoring optimizer.  Previously, when the factorer found a common prefix shared across alternatives but at least one of those alternatives had a value expression that referenced a prefix-bound variable, it had to bail out and emit each member as a separate full rule (`cross-scope-ref`) - because the synthesized wrapper `RulesPart` opens a fresh scope and prefix bindings are not visible inside it.

This PR introduces a second wrapper shape - a *tail* `RulesPart` - that the AST-walking matcher enters without pushing a new frame.  The member's `valueIds` chain inherits the wrapper's, so prefix-bound canonicals resolve, and the member's value flows up directly as the wrapper rule's value with no synthesized indirection.

## Motivation

Two wins, both observable on real grammars:

1. **More factoring opportunities.**  Forks that previously bailed out with `cross-scope-ref` now factor cleanly, eliminating duplicated prefix matching.
2. **Smaller, faster AST even for forks that already factored.**  Tail wrappers drop the synthesized `__opt_factor_<n>` binding and the `factoredAlt.value` indirection that the non-tail wrapper needs, and save one matcher frame push per fork at runtime.

A synthetic benchmark (`grammarOptimizerSyntheticBenchmark.ts`) is added to track the impact.

## Design

### `RulesPart.tailCall` flag
A new optional `tailCall: true` field on `RulesPart`.  When set, the matcher enters the part as a tail call: no parent-frame push, the parent's `valueIds` chain is inherited, and the member's computed value becomes the parent rule's value.  Carries a strict structural contract:

- last entry in its parent rule's `parts`
- parent rule has no `value` of its own
- `repeat` / `optional` / `variable` all unset
- `rules.length >= 2`
- every member's `spacingMode` matches the parent rule's

### Opt-in flag
A new `tailFactoring?: boolean` option on `GrammarOptimizationOptions`.  Off by default - the legacy non-tail wrapper remains the only emit shape until a caller opts in, and existing consumers see no behavior change.  When on, the factorer prefers tail wrappers at every passing fork (they're observably identical to the unfactored shape and strictly better than the non-tail wrapper).

### Matcher support
Only the AST-walking matcher (`grammarMatcher.ts`) understands tail RulesParts.  The NFA compiler / DFA path throws if it encounters one - callers that route through that path must leave `tailFactoring` off.

### Safety nets
Tail RulesParts are observably equivalent to unfactored alternatives only when the contract holds, so a contract violation could silently produce wrong matches.  Three layers of defense:

- **Construction-time validation** (`validateTailRulesParts`): walks the AST and throws on any contract violation.  Run as a self-check by the optimizer right after emit.
- **Deserializer validation**: `grammarFromJson` validates by default for any cached `.ag.json` loaded from disk, since serialized bytes are not produced by a trusted in-process compiler.  Trusted producers (round-trip tests) can opt out via `{ validate: false }`.
- **Permissive failure mode**: on the `onInvariantViolation: "debug"` path, an optimizer self-check failure logs a warning and discards the optimized output (returns the input grammar unchanged), so callers always get a known-good AST rather than a contract-violating one.

### Other changes pulled in along the way
- Partition `factorRules` by `spacingMode` so mixed-spacing forks no longer block all factoring - each spacing group factors independently.
- Per-fork eligibility result modeled as a discriminated union (`FactorEligibility`) so callers can't read `tail` without first checking `ok`.
- Forward-compatibility hazard documented on `RulePartJson.tailCall`: older deserializers that silently drop the flag will produce wrong matches, so the field is part of the wire-format contract.
- Bench harness extended to measure factor-only vs. factor+tail.

## Validation

- 14 new tests in `grammarOptimizerTailFactoring.spec.ts` covering eligibility, structural-shape assertions, validator behavior, and end-to-end matching parity vs. unfactored.
- Existing prefix-factoring tests extended for the partition-by-spacingMode and discriminated-union changes.
- Full workspace: 2728 unit tests pass (3 skipped); 98-project build green.
