### PR TITLE
actionGrammar: runtime must-advance guard for nullable repeats

### DIFF
--- a/ts/packages/actionGrammar/src/grammarMatcher.ts
+++ b/ts/packages/actionGrammar/src/grammarMatcher.ts
@@ -170,6 +170,16 @@ type ParentMatchState = {
     valueIds: ValueIdNode | undefined | null; // null means we don't need any value
     parent: ParentMatchState | undefined;
     repeatPartIndex?: number | undefined; // defined for ()* / )+ - holds the part index to loop back to
+    // Input position captured AT ENTRY to the current repeat iteration's
+    // body.  Used by `finalizeNestedRule` to detect a zero-progress
+    // iteration of a `(...)*` / `(...)+` group whose body matched the
+    // empty string (e.g. `((foo)?)*`).  When `state.index ===
+    // repeatStartIndex` after the body completes, no input was consumed
+    // and re-entering would loop forever, so the CONTINUE frame is NOT
+    // pushed - the matcher commits to STOP for this branch.  Mirrors
+    // PCRE/V8 RegExp semantics for nullable-body repeats.  Only set
+    // when `repeatPartIndex !== undefined`.
+    repeatStartIndex?: number | undefined;
     spacingMode: CompiledSpacingMode; // parent rule's spacingMode, restored in MatchState on return from nested rule
 };
 
@@ -1238,21 +1248,58 @@ export function finalizeNestedRule(
         // suppresses the optional-skip push so we don't generate duplicate
         // "done" states.
         if (parent.repeatPartIndex !== undefined) {
-            // Build the CONTINUE alternative (re-enter the group).
-            const continueState: SnapshotState = {
-                ...forkMatchState(state),
-                partIndex: parent.repeatPartIndex,
-                suppressOptionalFork: true,
-            };
-            if (state.repeatPolicy === "greedy") {
-                // Live = continue (drill deeper); backtrack = stop
-                // (snapshot of state past the repeat).
-                const stopSnapshot = forkMatchState(state);
-                Object.assign(state, continueState);
-                pushBacktrack(state, stopSnapshot, "repeat");
+            // Must-advance guard: if this iteration consumed zero input
+            // (the body matched the empty string), do NOT push a
+            // CONTINUE frame - re-entering the group would loop
+            // forever absorbing zero input each time.  Mirrors PCRE/V8
+            // RegExp behavior for nullable-body repeats like `(a*)*`
+            // or `((foo)?)*`: at most one zero-length iteration, then
+            // commit to STOP.  `repeatStartIndex` is captured at the
+            // ITERATION's entry (not the original `*`/`+` entry), so
+            // each iteration is judged on its own progress.
+            //
+            // Design note: this matcher is a backtracking DFS over a
+            // LIFO snapshot stack (see `Backtrack` / `pushBacktrack`),
+            // not a true parse-forest builder - it has no GSS and no
+            // SPPF.  But because callers can request the default
+            // `"exhaustive"` policies, it will enumerate every viable
+            // parse rather than committing to the first, so a single
+            // input can yield multiple results.  For a nullable-body
+            // repeat the matcher therefore emits the single
+            // zero-length iteration as a distinct parse - a grammar
+            // like `((foo)?)*` on `""` produces TWO parses (zero
+            // outer iterations, and one ε-iteration of the body).
+            // The duplicate is harmless: downstream value-based
+            // deduplication in the dispatcher collapses any pair
+            // whose action values are equal.  The must-advance guard
+            // below is the standard PCRE / V8 RegExp semantics for
+            // nullable-body repeats - at most one zero-length
+            // iteration per repeat instance, then commit to STOP -
+            // and avoids the infinite-derivation pathology that
+            // GLR / Earley parsers instead solve via GSS
+            // deduplication or nullable-completer caching.
+            if (state.index !== parent.repeatStartIndex) {
+                // Build the CONTINUE alternative (re-enter the group).
+                const continueState: SnapshotState = {
+                    ...forkMatchState(state),
+                    partIndex: parent.repeatPartIndex,
+                    suppressOptionalFork: true,
+                };
+                if (state.repeatPolicy === "greedy") {
+                    // Live = continue (drill deeper); backtrack = stop
+                    // (snapshot of state past the repeat).
+                    const stopSnapshot = forkMatchState(state);
+                    Object.assign(state, continueState);
+                    pushBacktrack(state, stopSnapshot, "repeat");
+                } else {
+                    // Default / nonGreedy: live = stop; backtrack = continue.
+                    pushBacktrack(state, continueState, "repeat");
+                }
             } else {
-                // Default / nonGreedy: live = stop; backtrack = continue.
-                pushBacktrack(state, continueState, "repeat");
+                debugMatch(
+                    state,
+                    `Repeat body matched empty (zero-progress) - committing to STOP`,
+                );
             }
         }
 
@@ -1814,6 +1861,12 @@ export function matchState(state: MatchState, request: string) {
                     valueIds: state.valueIds,
                     parent: state.parent,
                     repeatPartIndex: part.repeat ? state.partIndex : undefined,
+                    // Capture the input position AT THIS ITERATION'S start so
+                    // `finalizeNestedRule` can detect a zero-progress
+                    // iteration of a nullable-body repeat (`((foo)?)*` etc.)
+                    // and refuse to push another CONTINUE frame.  See the
+                    // field doc on `ParentMatchState`.
+                    repeatStartIndex: part.repeat ? state.index : undefined,
                     spacingMode: state.spacingMode,
                 };
 

--- a/ts/packages/actionGrammar/test/grammarMatcherGroups.spec.ts
+++ b/ts/packages/actionGrammar/test/grammarMatcherGroups.spec.ts
@@ -235,5 +235,59 @@ describeForEachMatcher(
                 ]);
             });
         });
+
+        describe("Nullable repeat body (must-advance guard)", () => {
+            // These grammars have a repeat group whose body can match the
+            // empty string.  Without the runtime must-advance guard in
+            // grammarMatcher.finalizeNestedRule, the matcher would push an
+            // unbounded chain of zero-progress CONTINUE frames and hang.
+            // The guard short-circuits any iteration that consumed no
+            // input, so these tests must terminate (jest's 90s suite
+            // timeout would catch a regression).  Multiple distinct parse
+            // trees are expected for ambiguous inputs - we assert
+            // termination AND produce a small, exact set of parse trees.
+            // Expected parse counts (one `true` per distinct parse):
+            //   ((foo)?)*  on ""    -> 2 (zero-iters; one ε-iter)
+            //   ((foo)?)*  on "foo" -> 2 (one iter consuming "foo"; one
+            //                         iter consuming "foo" + a final
+            //                         ε-iter through the optional)
+            //   ((foo)?)+  on ""    -> 1 (`+` requires >=1 iteration; only
+            //                         the single ε-iter parse remains
+            //                         after the must-advance guard)
+            //   (<X>)*     on ""    -> 2 (zero-iters; one ε-iter via the
+            //                         nullable <X>)
+            it("((X)?)* on empty input has exactly 2 parses", () => {
+                const g = `<Start> = ((foo)?)* -> true;`;
+                const grammar = loadGrammarRules("test.grammar", g);
+                expect(testMatchGrammar(grammar, "")).toStrictEqual([
+                    true,
+                    true,
+                ]);
+            });
+            it("((X)?)* on 'foo' has exactly 2 parses", () => {
+                const g = `<Start> = ((foo)?)* -> true;`;
+                const grammar = loadGrammarRules("test.grammar", g);
+                expect(testMatchGrammar(grammar, "foo")).toStrictEqual([
+                    true,
+                    true,
+                ]);
+            });
+            it("((X)?)+ on empty input has exactly 1 parse", () => {
+                const g = `<Start> = ((foo)?)+ -> true;`;
+                const grammar = loadGrammarRules("test.grammar", g);
+                expect(testMatchGrammar(grammar, "")).toStrictEqual([true]);
+            });
+            it("(<X>)* with nullable <X> on empty input has exactly 2 parses", () => {
+                const g = `
+                    <Start> = (<X>)* -> true;
+                    <X> = (foo)?;
+                `;
+                const grammar = loadGrammarRules("test.grammar", g);
+                expect(testMatchGrammar(grammar, "")).toStrictEqual([
+                    true,
+                    true,
+                ]);
+            });
+        });
     },
 );

--- a/ts/packages/actionGrammar/test/grammarMatcherGroups.spec.ts
+++ b/ts/packages/actionGrammar/test/grammarMatcherGroups.spec.ts
@@ -288,6 +288,46 @@ describeForEachMatcher(
                     true,
                 ]);
             });
+
+            // Wildcard interaction: wildcards always advance index >= 1,
+            // so the must-advance guard never fires on a non-empty wildcard
+            // capture.  But when the wildcard is wrapped in an optional
+            // inside the repeat body, the body becomes nullable via the
+            // skipped-optional path, and the guard MUST fire to prevent
+            // an infinite chain of zero-progress iterations.
+            it("(($(w))?)* on empty input terminates", () => {
+                const g = `<Start> = (($(w))?)* -> true;`;
+                const grammar = loadGrammarRules("test.grammar", g);
+                // Body is fully nullable via the skipped optional.
+                // Must-advance guard short-circuits after the single
+                // ε-iteration: zero-iters + one ε-iter = 2 parses.
+                expect(testMatchGrammar(grammar, "")).toStrictEqual([
+                    true,
+                    true,
+                ]);
+            });
+            it("(($(w))?)* on non-empty input terminates", () => {
+                const g = `<Start> = (($(w))?)* -> true;`;
+                const grammar = loadGrammarRules("test.grammar", g);
+                // The wildcard can absorb the entire input in one
+                // iteration; the optional can also be skipped (body=ε).
+                // Must terminate with at least one parse (the wildcard
+                // capture); exact count depends on wildcard-length axis
+                // enumeration but must be finite and non-empty.
+                const results = testMatchGrammar(grammar, "hello");
+                expect(results.length).toBeGreaterThan(0);
+                expect(results.every((r) => r === true)).toBe(true);
+            });
+            it("((foo)? ($(w))?)* with two nullable parts terminates", () => {
+                // Body is two optional parts in sequence - fully nullable.
+                // Stresses the guard against multiple ε-paths through the
+                // body (skip both, skip first, skip second).
+                const g = `<Start> = ((foo)? ($(w))?)* -> true;`;
+                const grammar = loadGrammarRules("test.grammar", g);
+                const results = testMatchGrammar(grammar, "");
+                expect(results.length).toBeGreaterThan(0);
+                expect(results.every((r) => r === true)).toBe(true);
+            });
         });
     },
 );


### PR DESCRIPTION
Fixes infinite enumeration of empty CONTINUE frames when a repeat body can match without consuming input (e.g. `((foo)?)*`).

## Change

- Captures `repeatStartIndex` per iteration on the `ParentMatchState`.
- In `finalizeNestedRule`, skips re-pushing the CONTINUE frame when the body made zero progress (`state.index === parent.repeatStartIndex`).
- Mirrors PCRE / V8 RegExp semantics: at most one zero-length iteration per repeat instance, then commit to STOP.

## Tests

Adds tests in `grammarMatcherGroups.spec.ts` asserting exact parse counts for nullable-body repeat shapes (`((X)?)*`, `((X)?)+`, `(<X>)*` with nullable `<X>`).