### PR TITLE
Fix CLI conversation commands

### DIFF
--- a/ts/packages/cli/src/commands/connect.ts
+++ b/ts/packages/cli/src/commands/connect.ts
@@ -19,7 +19,6 @@ import type { ConversationCommandContext } from "../conversationCommands.js";
 import {
     connectAgentServer,
     ensureAgentServer,
-    ensureAndConnectConversation,
     AgentServerConnection,
 } from "@typeagent/agent-server-client";
 import { getStatusSummary } from "@typeagent/dispatcher-types/helpers/status";
@@ -272,43 +271,47 @@ export default class Connect extends Command {
                 //   3. default: find-or-create the "CLI" conversation
                 const result =
                     persistedConversationId !== undefined
-                        ? await ensureAndConnectConversation(
-                              clientIO,
-                              flags.port,
-                              { conversationId: persistedConversationId },
-                              onDisconnect,
-                              flags.hidden,
-                              flags.idleTimeout,
-                          )
-                              .then((s) => ({
-                                  conversation: s,
-                                  connection: undefined as
-                                      | AgentServerConnection
-                                      | undefined,
-                              }))
-                              .catch(async (err: any) => {
-                                  if (
-                                      isDefaultConversation &&
-                                      typeof err?.message === "string" &&
-                                      err.message.startsWith(
-                                          "Conversation not found:",
-                                      )
-                                  ) {
-                                      console.log(
-                                          `The last used conversation no longer exists on the server.`,
-                                      );
-                                      const join = await promptYesNo(
-                                          `Join the default '${CLI_CONVERSATION_NAME}' conversation?`,
-                                      );
-                                      if (!join) {
-                                          clearLastConversationId();
-                                          return null;
-                                      }
+                        ? await (async () => {
+                              await ensureAgentServer(
+                                  flags.port,
+                                  flags.hidden,
+                                  flags.idleTimeout,
+                              );
+                              const conn = await connectAgentServer(
+                                  url,
+                                  onDisconnect,
+                              );
+                              const conv = await conn.joinConversation(
+                                  clientIO,
+                                  { conversationId: persistedConversationId },
+                              );
+                              conv.dispatcher.close = async () => {
+                                  await conn.close();
+                              };
+                              return { conversation: conv, connection: conn };
+                          })().catch(async (err: any) => {
+                              if (
+                                  isDefaultConversation &&
+                                  typeof err?.message === "string" &&
+                                  err.message.startsWith(
+                                      "Conversation not found:",
+                                  )
+                              ) {
+                                  console.log(
+                                      `The last used conversation no longer exists on the server.`,
+                                  );
+                                  const join = await promptYesNo(
+                                      `Join the default '${CLI_CONVERSATION_NAME}' conversation?`,
+                                  );
+                                  if (!join) {
                                       clearLastConversationId();
-                                      return connectToCliConversation();
+                                      return null;
                                   }
-                                  throw err;
-                              })
+                                  clearLastConversationId();
+                                  return connectToCliConversation();
+                              }
+                              throw err;
+                          })
                         : await connectToCliConversation();
 
                 if (result === null) {
@@ -336,10 +339,8 @@ export default class Connect extends Command {
             await replayDisplayHistory(activeDispatcher, clientIO, activeName);
 
             // Set up ConversationCommandContext for @conversation commands.
-            // Only available when the AgentServerConnection is accessible
-            // (connectToCliConversation / connectToEphemeralConversation paths).
-            // The ensureAndConnectConversation path (--session / --resume flags)
-            // does not expose the connection, so convCtx stays undefined there.
+            // Available on all connection paths since each path now exposes the
+            // AgentServerConnection.
             let convCtx: ConversationCommandContext | undefined;
             if (connection !== undefined) {
                 convCtx = {

--- a/ts/packages/cli/src/enhancedConsole.ts
+++ b/ts/packages/cli/src/enhancedConsole.ts
@@ -33,6 +33,7 @@ import type { CompletionController } from "agent-dispatcher/helpers/completion";
 import chalk from "chalk";
 import fs from "fs";
 import path from "path";
+import os from "os";
 import { EnhancedSpinner, ANSI, getDisplayWidth } from "interactive-app";
 import { createInterface } from "readline/promises";
 import readline from "readline";
@@ -1886,10 +1887,15 @@ export async function processCommandsEnhanced<T>(
     dispatcherForCancel?: Dispatcher,
 ) {
     const fs = await import("node:fs");
+    const historyFile = path.join(
+        os.homedir(),
+        ".typeagent",
+        "command_history.json",
+    );
     let history: string[] = [];
-    if (fs.existsSync("command_history.json")) {
+    if (fs.existsSync(historyFile)) {
         const hh = JSON.parse(
-            fs.readFileSync("command_history.json", { encoding: "utf-8" }),
+            fs.readFileSync(historyFile, { encoding: "utf-8" }),
         );
         history = hh.commands;
     }
@@ -2033,10 +2039,7 @@ export async function processCommandsEnhanced<T>(
         console.log("");
 
         // save command history
-        fs.writeFileSync(
-            "command_history.json",
-            JSON.stringify({ commands: history }),
-        );
+        fs.writeFileSync(historyFile, JSON.stringify({ commands: history }));
     }
 }
 

--- a/ts/packages/cli/src/enhancedConsole.ts
+++ b/ts/packages/cli/src/enhancedConsole.ts
@@ -1239,6 +1239,7 @@ async function questionWithCompletion(
         let savedInput = ""; // Saves current input when navigating history
         let filterStartIndex = -1; // Where filtering begins (render-cache)
         let completionPrefix = ""; // Fixed prefix before completions (render-cache)
+        let slashCompletionsDismissed = false; // Set by Escape; cleared when input changes
         const stdin = process.stdin;
         const stdout = process.stdout;
 
@@ -1264,7 +1265,7 @@ async function questionWithCompletion(
         const render = () => {
             // Recompute completions from controller state each frame.
             if (controller) {
-                if (isSlashCommand(input)) {
+                if (isSlashCommand(input) && !slashCompletionsDismissed) {
                     filteredCompletions = getSlashCompletions(input);
                     filterStartIndex = 0;
                     completionPrefix = "";
@@ -1407,6 +1408,7 @@ async function questionWithCompletion(
                         historyIndex--;
                         input = history[historyIndex];
                         cursorPos = input.length;
+                        slashCompletionsDismissed = false;
                         render();
                     }
                     return;
@@ -1424,6 +1426,7 @@ async function questionWithCompletion(
                                 ? savedInput
                                 : history[historyIndex];
                         cursorPos = input.length;
+                        slashCompletionsDismissed = false;
                         render();
                     }
                     return;
@@ -1447,7 +1450,13 @@ async function questionWithCompletion(
 
             if (data === "\x1b") {
                 if (controller && filteredCompletions.length > 0) {
-                    controller.dismiss(input, "forward");
+                    if (isSlashCommand(input)) {
+                        // Slash completions are recomputed every render; use a
+                        // flag to suppress them until the input changes.
+                        slashCompletionsDismissed = true;
+                    } else {
+                        controller.dismiss(input, "forward");
+                    }
                 } else {
                     // Esc with no completions — clear input.
                     // Also hide the controller in case a fetch is in-flight
@@ -1456,6 +1465,7 @@ async function questionWithCompletion(
                     input = "";
                     cursorPos = 0;
                     historyIndex = history.length;
+                    slashCompletionsDismissed = false;
                 }
                 render();
                 return;
@@ -1540,6 +1550,7 @@ async function questionWithCompletion(
                             : "") +
                         completion;
                     cursorPos = input.length; // Move cursor to end
+                    slashCompletionsDismissed = false;
                     if (controller) {
                         controller.accept();
                     }
@@ -1551,6 +1562,7 @@ async function questionWithCompletion(
                     input =
                         input.slice(0, cursorPos - 1) + input.slice(cursorPos);
                     cursorPos--;
+                    slashCompletionsDismissed = false;
                     if (controller) {
                         controller.update(input, "backward");
                     }
@@ -1561,6 +1573,7 @@ async function questionWithCompletion(
                 input =
                     input.slice(0, cursorPos) + data + input.slice(cursorPos);
                 cursorPos++;
+                slashCompletionsDismissed = false;
                 if (controller) {
                     controller.update(input, "forward");
                 }

--- a/ts/packages/dispatcher/dispatcher/src/helpers/console.ts
+++ b/ts/packages/dispatcher/dispatcher/src/helpers/console.ts
@@ -19,6 +19,8 @@ import chalk from "chalk";
 import stringWidth from "string-width";
 import { createInterface } from "readline/promises";
 import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
 import readline from "readline";
 import open from "open";
 import { convert } from "html-to-text";
@@ -544,9 +546,14 @@ export async function processCommands<T>(
     inputs?: string[],
 ) {
     let history: string[] = [];
-    if (fs.existsSync("command_history.json")) {
+    const historyFile = path.join(
+        os.homedir(),
+        ".typeagent",
+        "command_history.json",
+    );
+    if (fs.existsSync(historyFile)) {
         const hh = JSON.parse(
-            fs.readFileSync("command_history.json", { encoding: "utf-8" }),
+            fs.readFileSync(historyFile, { encoding: "utf-8" }),
         );
         history = hh.commands;
     }
@@ -589,7 +596,7 @@ export async function processCommands<T>(
 
         // save command history
         fs.writeFileSync(
-            "command_history.json",
+            historyFile,
             JSON.stringify({ commands: (rl as any).history }),
         );
     }

--- a/ts/packages/interactiveApp/src/interactiveApp.ts
+++ b/ts/packages/interactiveApp/src/interactiveApp.ts
@@ -6,6 +6,7 @@ import { InteractiveIo, getInteractiveIO } from "./InteractiveIo.js";
 import { exit } from "process";
 import readline from "readline";
 import path from "path";
+import os from "os";
 
 /**
  * Handler of command line inputs
@@ -111,6 +112,11 @@ export async function runConsole(
  * An Interactive App. You can inherit from this, but typically you just call RunConsole
  */
 class InteractiveApp {
+    static readonly historyFile = path.join(
+        os.homedir(),
+        ".typeagent",
+        "command_history.json",
+    );
     public settings: InteractiveAppSettings;
     private _stdio: InteractiveIo;
     private lineReader: readline.promises.Interface;
@@ -122,9 +128,11 @@ class InteractiveApp {
         this.lineReader = this._stdio.readline;
         this.lineReader.setPrompt(this.settings.prompt!);
 
-        if (fs.existsSync("command_history.json")) {
+        if (fs.existsSync(InteractiveApp.historyFile)) {
             const history = JSON.parse(
-                fs.readFileSync("command_history.json", { encoding: "utf-8" }),
+                fs.readFileSync(InteractiveApp.historyFile, {
+                    encoding: "utf-8",
+                }),
             );
 
             (this.lineReader as any).history = history.commands;
@@ -201,7 +209,7 @@ class InteractiveApp {
                 .on("close", () => {
                     this.lineReader.close();
                     fs.writeFileSync(
-                        "command_history.json",
+                        InteractiveApp.historyFile,
                         JSON.stringify({
                             commands: (this.lineReader as any).history,
                         }),


### PR DESCRIPTION
CLI @conversation command was recently broken, this PR fixes the capability that was lost when the agent server connection was accidentally dropped on joining. It also replaces the relative path for the command history with an absolute one set to the os profile's .typagent directory