### PR TITLE
Fix PowerShell benchmark isolation mode and browser agent init error

### DIFF
--- a/ts/packages/agents/browser/src/agent/browserActionHandler.mts
+++ b/ts/packages/agents/browser/src/agent/browserActionHandler.mts
@@ -2181,6 +2181,13 @@ async function createViewServiceHost(
     const port = context.agentContext.localHostPort;
     const sessionDir = await getSessionFolderPath(context);
 
+    if (!sessionDir) {
+        debug(
+            "Session directory not available, skipping view service host creation",
+        );
+        return undefined;
+    }
+
     const timeoutPromise = new Promise<undefined>((_resolve, reject) => {
         timeoutHandle = setTimeout(
             () => reject(new Error("Browser views service creation timed out")),
@@ -2198,7 +2205,7 @@ async function createViewServiceHost(
                     ),
                 );
 
-                const folderPath = path.join(sessionDir!, "files");
+                const folderPath = path.join(sessionDir, "files");
 
                 fs.mkdirSync(folderPath, { recursive: true });
 

--- a/ts/packages/agents/powershell/benchmark/BASELINE-2026-04-30.md
+++ b/ts/packages/agents/powershell/benchmark/BASELINE-2026-04-30.md
@@ -1,0 +1,80 @@
+# PowerShell Dispatcher Benchmark - Baseline Results
+
+**Date:** 2026-04-30
+**Test Environment:** Windows, TypeAgent dispatcher with grammar-based routing
+
+## Summary
+
+| Test Mode                            | Pass Rate | Passed | Total |
+| ------------------------------------ | --------- | ------ | ----- |
+| **Competition Mode** (all agents)    | **85.7%** | 30     | 35    |
+| **Isolation Mode** (PowerShell only) | **0%**    | 0      | 125   |
+
+## Competition Mode Results (grammar-competition)
+
+### Passed Tests (30/35)
+
+| Category           | Utterances                                                           | Status                       |
+| ------------------ | -------------------------------------------------------------------- | ---------------------------- |
+| Network ping       | `ping google.com`                                                    | PASS                         |
+| File search        | `grep error in logs`, `find TODO in src`                             | PASS                         |
+| Processes          | `show running processes`, `kill notepad`                             | PASS                         |
+| Start process      | `start notepad`, `launch calculator`, `run cmd`                      | PASS                         |
+| System info        | `show system information`, `show disk usage`, `show uptime`          | PASS                         |
+| Services           | `list all services`, `restart service spooler`                       | PASS                         |
+| Network utils      | `ipconfig`, `netstat`, `nslookup google.com`                         | PASS                         |
+| Archives           | `zip logs`, `unzip backup.zip`                                       | PASS                         |
+| Data ops           | `read csv data.csv`, `convert data.csv to json`                      | PASS                         |
+| Unix aliases       | `cat readme.md`, `rm temp.txt`, `cp file.txt backup.txt`, `ps`, `df` | PASS                         |
+| Negative: music    | `play some music`, `play shake it off`                               | PASS (correctly NOT matched) |
+| Negative: calendar | `schedule a meeting for tomorrow`, `what's on my calendar`           | PASS                         |
+| Negative: email    | `send an email to john`                                              | PASS                         |
+
+### Failed Tests (5/35)
+
+| Utterance                 | Expected                  | Actual                         | Root Cause                                                            |
+| ------------------------- | ------------------------- | ------------------------------ | --------------------------------------------------------------------- |
+| `list files in downloads` | `listFiles`               | `listFiles`                    | **Test data bug**: Expected `findLargeFiles` due to flow name mapping |
+| `show files in documents` | `listFiles`               | `listFiles`                    | **Test data bug**: Same as above                                      |
+| `ls`                      | `listFiles`               | `listFiles`                    | **Test data bug**: Same as above                                      |
+| `mv old.txt new.txt`      | `moveFile` / `powershell` | `readFile` / `utility`         | **Grammar gap**: `mv` alias not properly mapped                       |
+| `check my inbox`          | not powershell            | `serviceStatus` / `powershell` | **Disambiguation issue**: "check" is too broad                        |
+
+### Analysis
+
+1. **3 false failures** - Test data expects `findLargeFiles` but correct action is `listFiles`
+2. **1 grammar gap** - `mv` command not routing to `moveFile` action
+3. **1 disambiguation issue** - "check my inbox" incorrectly matches PowerShell's `serviceStatus`
+
+**Corrected pass rate:** 33/35 = **94.3%** (excluding test data bugs)
+
+## Isolation Mode Results (grammar-subschemas)
+
+### Status: All 125 tests failed
+
+The grammar IS matching correctly (logs show `powershell.listFiles - Result: ACCEPTED`), but evaluation fails because:
+
+- **Isolation mode schema format:** `powershell.listFiles`
+- **Expected sub-schema format:** `powershell-files` with action `listFiles`
+
+This is a **configuration issue** with how the dispatcher loads schemas in isolation mode, not a grammar problem.
+
+## Component Accuracy (Competition Mode)
+
+| Component        | Accuracy      |
+| ---------------- | ------------- |
+| Grammar matching | 91.4% (64/70) |
+
+## Test Artifacts
+
+Results written to: `benchmark/results/2026-04-30T1650/`
+
+- `scorecard.json` - Machine-readable results
+- `details.md` - Full test details with traces
+
+## Recommendations
+
+1. **Fix test data** - Update `grammar-competition.json` to expect `listFiles` instead of `findLargeFiles`
+2. **Fix isolation mode** - Update dispatcher config to properly load sub-schemas
+3. **Add `mv` grammar pattern** - Ensure move command routes correctly
+4. **Improve "check" disambiguation** - Make `serviceStatus` grammar more specific

--- a/ts/packages/agents/powershell/benchmark/BASELINE-2026-05-04.md
+++ b/ts/packages/agents/powershell/benchmark/BASELINE-2026-05-04.md
@@ -1,0 +1,137 @@
+# PowerShell Dispatcher Benchmark - Results
+
+**Date:** 2026-05-04
+**Test Environment:** Windows, TypeAgent dispatcher with grammar-based routing
+
+## Summary
+
+| Test Mode                                        | Pass Rate | Passed | Total |
+| ------------------------------------------------ | --------- | ------ | ----- |
+| **Competition Mode** (all agents)                | **91.4%** | 32     | 35    |
+| **Isolation Mode** (PowerShell only, no samples) | **92.0%** | 115    | 125   |
+
+## Fixes Applied Since Last Baseline
+
+### 1. Schema Name Configuration (Critical)
+
+**File:** `benchmark/run-benchmark.mts`
+
+Schema names changed from short form to fully qualified form:
+
+```typescript
+// Before (broken)
+schemas: ["powershell", "powershell-files", "powershell-processes", ...]
+
+// After (working)
+schemas: ["powershell", "powershell.powershell-files", "powershell.powershell-processes", ...]
+```
+
+### 2. Browser Agent Initialization Error
+
+**File:** `packages/agents/browser/src/agent/browserActionHandler.mts`
+
+Added null check for `sessionDir` in `createViewServiceHost` to prevent TypeError when session directory is unavailable.
+
+### 3. Sample Flow Control
+
+**Files:** `benchmark/run-benchmark.mts`, `src/actionHandler.mts`
+
+Added `--no-samples` CLI flag and `TYPEAGENT_NO_SAMPLES` environment variable to disable sample recipe seeding during benchmark runs, allowing namespace schema grammars to be tested in isolation.
+
+## Competition Mode Results (grammar-competition)
+
+**Pass Rate:** 91.4% (32/35)
+
+### Failed Tests (3/35)
+
+| Utterance            | Expected                  | Actual          | Root Cause                   |
+| -------------------- | ------------------------- | --------------- | ---------------------------- |
+| `mv old.txt new.txt` | `moveFile` / `powershell` | Other agent     | Grammar pattern gap          |
+| `check my inbox`     | not powershell            | `serviceStatus` | "check" is too broad         |
+| Various              | Test data issues          | -               | Flow name mapping mismatches |
+
+## Isolation Mode Results (grammar-subschemas)
+
+**Pass Rate:** 92.0% (115/125)
+
+### Component Accuracy
+
+| Component            | Accuracy  | Details         |
+| -------------------- | --------- | --------------- |
+| Grammar matching     | **97.6%** | 122/125 correct |
+| Parameter extraction | **90.8%** | 109/120 correct |
+
+### Passed Tests by Namespace
+
+| Namespace                   | Pass Rate    | Notes                           |
+| --------------------------- | ------------ | ------------------------------- |
+| Files (listFiles)           | 80% (4/5)    | 1 parameter extraction issue    |
+| Files (readFile)            | 100% (5/5)   | All patterns working            |
+| Files (writeFile)           | 100% grammar | Parameter quote handling issues |
+| Files (copyFile)            | 100% (3/3)   | All patterns working            |
+| Files (moveFile)            | 100% (3/3)   | All patterns working            |
+| Files (deleteFile)          | 100% (3/3)   | All patterns working            |
+| Files (testPath)            | 100% (3/3)   | All patterns working            |
+| Files (findText)            | 67% (2/3)    | 1 pattern/path split issue      |
+| Files (newItem)             | 100% (4/4)   | All patterns working            |
+| Processes (list/stop/start) | 92%          | 2 grammar mismatches            |
+| System                      | 100% (16/16) | All patterns working            |
+| Services                    | 100% (15/15) | All patterns working            |
+| Network                     | 92%          | 2 minor issues                  |
+| Data                        | 100% (10/10) | All patterns working            |
+| Archives                    | 88% (7/8)    | 1 parameter extraction issue    |
+
+### Failed Tests (10/125)
+
+| Scenario    | Utterance                         | Issue Type | Details                                 |
+| ----------- | --------------------------------- | ---------- | --------------------------------------- |
+| gs-files-01 | "show me the files in documents"  | Parameter  | Path captured extra words               |
+| gs-files-03 | "write 'hello world' to test.txt" | Parameter  | Quote handling                          |
+| gs-files-03 | "save 'test data' to output.txt"  | Parameter  | Quote handling                          |
+| gs-files-03 | "append 'new line' to log.txt"    | Parameter  | Quote handling                          |
+| gs-files-08 | "grep TODO src"                   | Parameter  | Pattern/path split                      |
+| gs-proc-02  | "show top 5 memory hogs"          | Grammar    | Matched `listFiles` not `processMemory` |
+| gs-proc-03  | "show top 10 cpu hogs"            | Grammar    | Matched `listFiles` not `processCpu`    |
+| gs-net-04   | "show my ip address"              | Grammar    | Matched `listFiles` not `ipConfig`      |
+| gs-net-05   | "resolve gmail.com MX"            | Parameter  | Type suffix not parsed                  |
+| gs-arch-02  | "extract archive.zip to output"   | Parameter  | Path extraction issue                   |
+
+### Root Cause Analysis
+
+1. **Grammar Conflicts (3 failures):** Phrases like "show top 5" and "show my" match the broad `listFiles` pattern before more specific patterns
+2. **Greedy Wildcards (4 failures):** Wildcard captures consume more tokens than intended
+3. **Quote Handling (3 failures):** Content parameters include surrounding quotes that tests expect stripped
+
+## Test Artifacts
+
+Results written to: `benchmark/results/2026-05-04T1728/`
+
+- `scorecard.json` - Machine-readable results
+- `details.md` - Full test details with traces
+
+## Recommendations
+
+### High Priority
+
+1. **Add specificity to memory/cpu patterns** - Ensure "show top N memory/cpu" routes to process namespace
+2. **Fix "show my" grammar conflict** - "show my ip" should match `ipConfig` not `listFiles`
+
+### Medium Priority
+
+3. **Improve wildcard boundaries** - Add stop words to prevent greedy matching
+4. **Handle quoted content** - Strip quotes from content parameters in grammar
+
+### Low Priority
+
+5. **DNS type parsing** - Support "resolve X MX" syntax with type parameter
+6. **Archive path extraction** - Improve "extract X to Y" pattern
+
+## Comparison with Previous Baseline
+
+| Metric           | 2026-04-30 | 2026-05-04 | Change |
+| ---------------- | ---------- | ---------- | ------ |
+| Competition Mode | 85.7%      | 91.4%      | +5.7%  |
+| Isolation Mode   | 0%         | 92.0%      | +92.0% |
+| Grammar Accuracy | 91.4%      | 97.6%      | +6.2%  |
+
+The isolation mode is now functional and achieves comparable accuracy to competition mode, validating that namespace schema grammars work correctly when properly configured.

--- a/ts/packages/agents/powershell/benchmark/harness/benchmarkRunner.mts
+++ b/ts/packages/agents/powershell/benchmark/harness/benchmarkRunner.mts
@@ -131,6 +131,8 @@ export class BenchmarkRunner {
     private loadScenarios(): BenchmarkScenario[] {
         const scenarioFiles = [
             "grammar-match.json",
+            "grammar-subschemas.json",
+            "grammar-competition.json",
             "execution.json",
             "llm-translation.json",
             "fallback-chain.json",
@@ -243,13 +245,18 @@ export class BenchmarkRunner {
             }
 
             // Resolve canonical flow names to actual LLM-generated names
+            // ONLY for non-grammar scenarios - grammar tests use built-in action names
+            const isGrammarTest = scenario.category.startsWith("grammar");
             const resolvedUtterance = {
                 ...utterance,
                 expected: {
                     ...utterance.expected,
-                    matchedFlow: utterance.expected.matchedFlow
-                        ? this.resolveFlowName(utterance.expected.matchedFlow)
-                        : utterance.expected.matchedFlow,
+                    matchedFlow:
+                        utterance.expected.matchedFlow && !isGrammarTest
+                            ? this.resolveFlowName(
+                                  utterance.expected.matchedFlow,
+                              )
+                            : utterance.expected.matchedFlow,
                 },
             };
 

--- a/ts/packages/agents/powershell/benchmark/harness/evaluators/grammarEvaluator.mts
+++ b/ts/packages/agents/powershell/benchmark/harness/evaluators/grammarEvaluator.mts
@@ -47,6 +47,38 @@ export function evaluateGrammarMatch(
         }
     }
 
+    // Check if the right agent was matched (for competition testing)
+    if (expected.matchedAgent !== undefined) {
+        const actualAgent = extractAgentName(commandResult, trace);
+        if (expected.matchedAgent === null) {
+            // Negative test: should NOT match powershell
+            results.push({
+                passed: actualAgent !== "powershell",
+                component: "grammar",
+                expected: "not powershell",
+                actual: actualAgent ?? "no match",
+                message:
+                    actualAgent === "powershell"
+                        ? `Expected non-powershell match but matched powershell`
+                        : undefined,
+            });
+        } else {
+            results.push({
+                passed:
+                    actualAgent?.toLowerCase() ===
+                    expected.matchedAgent.toLowerCase(),
+                component: "grammar",
+                expected: `agent: ${expected.matchedAgent}`,
+                actual: `agent: ${actualAgent ?? "no match"}`,
+                message:
+                    actualAgent?.toLowerCase() !==
+                    expected.matchedAgent.toLowerCase()
+                        ? `Expected agent '${expected.matchedAgent}' but got '${actualAgent ?? "no match"}'`
+                        : undefined,
+            });
+        }
+    }
+
     // Check extracted parameters
     if (
         expected.extractedParams &&
@@ -96,6 +128,24 @@ export function evaluateGrammarMatch(
     return results;
 }
 
+function extractAgentName(
+    commandResult: unknown,
+    trace: PipelineTrace,
+): string | null {
+    if (trace.matchedAgent) return trace.matchedAgent;
+    const result = commandResult as any;
+
+    const firstAction = result?.actions?.[0];
+    if (firstAction?.schemaName) {
+        // Extract base agent name from schema (e.g., "powershell-files" -> "powershell")
+        const schemaName = firstAction.schemaName as string;
+        if (schemaName.startsWith("powershell")) return "powershell";
+        return schemaName.split("-")[0];
+    }
+
+    return null;
+}
+
 function extractFlowName(
     commandResult: unknown,
     trace: PipelineTrace,
@@ -108,7 +158,11 @@ function extractFlowName(
     const firstAction = result?.actions?.[0];
     if (firstAction) {
         // Per-flow action types: actionName IS the flow name
-        if (firstAction.schemaName === "powershell") {
+        // Handle both monolithic "powershell" and sub-schemas "powershell-*"
+        if (
+            firstAction.schemaName === "powershell" ||
+            firstAction.schemaName?.startsWith("powershell-")
+        ) {
             return firstAction.actionName;
         }
         // Legacy: executePowerShellFlow with flowName param

--- a/ts/packages/agents/powershell/benchmark/harness/types.mts
+++ b/ts/packages/agents/powershell/benchmark/harness/types.mts
@@ -5,13 +5,17 @@ export interface BenchmarkScenario {
     id: string;
     category:
         | "grammar-match"
+        | "grammar-subschemas"
+        | "grammar-competition"
         | "llm-translation"
         | "execution"
         | "fallback-chain"
         | "end-to-end";
     description: string;
     setup: {
-        requiredFlows: string[];
+        requiredFlows?: string[];
+        requiredSchemas?: string[];
+        allAgents?: boolean;
         environmentSetup?: string;
         configOverrides?: Record<string, unknown>;
     };
@@ -24,6 +28,7 @@ export interface TestUtterance {
     expected: {
         routedTo: "grammar" | "llm-translation" | "reasoning";
         matchedFlow?: string | null;
+        matchedAgent?: string | null;
         extractedParams?: Record<string, unknown>;
         execution?: {
             shouldSucceed: boolean;

--- a/ts/packages/agents/powershell/benchmark/run-benchmark.mts
+++ b/ts/packages/agents/powershell/benchmark/run-benchmark.mts
@@ -54,13 +54,23 @@ import type { BenchmarkScenario } from "./harness/types.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
-function parseArgs(): BenchmarkOptions & { dryRun: boolean } {
+function parseArgs(): BenchmarkOptions & {
+    dryRun: boolean;
+    allAgents: boolean;
+    noSamples: boolean;
+} {
     const args = process.argv.slice(2);
-    const options: BenchmarkOptions & { dryRun: boolean } = {
+    const options: BenchmarkOptions & {
+        dryRun: boolean;
+        allAgents: boolean;
+        noSamples: boolean;
+    } = {
         scenarioDir: join(__dirname, "scenarios"),
         outputDir: join(__dirname, "results"),
         benchmarkDir: __dirname,
         dryRun: false,
+        allAgents: false,
+        noSamples: false,
     };
 
     for (let i = 0; i < args.length; i++) {
@@ -80,6 +90,12 @@ function parseArgs(): BenchmarkOptions & { dryRun: boolean } {
             case "--dry-run":
                 options.dryRun = true;
                 break;
+            case "--all-agents":
+                options.allAgents = true;
+                break;
+            case "--no-samples":
+                options.noSamples = true;
+                break;
         }
     }
 
@@ -88,6 +104,8 @@ function parseArgs(): BenchmarkOptions & { dryRun: boolean } {
 
 async function createLiveDispatcher(
     persistDir: string,
+    allAgents: boolean = false,
+    noSamples: boolean = false,
 ): Promise<DispatcherAdapter> {
     // Resolve dispatcher and provider via relative paths to avoid cyclic
     // workspace dependencies (powershell -> defaultAgentProvider -> powershell)
@@ -130,9 +148,31 @@ async function createLiveDispatcher(
             nodeProvidersPath.replace(/\\/g, "/")
     );
 
+    // When noSamples is true, set env var to prevent sample flow seeding
+    // during agent initialization. This allows namespace schema grammars
+    // to be tested without competition from sample flows.
+    if (noSamples) {
+        process.env.TYPEAGENT_NO_SAMPLES = "1";
+    }
+
     const dispatcher = await createDispatcher("powershell-benchmark", {
         appAgentProviders: providers,
-        agents: { actions: true, commands: true },
+        agents: allAgents
+            ? { actions: true, commands: true }
+            : {
+                  schemas: [
+                      "powershell",
+                      "powershell.powershell-files",
+                      "powershell.powershell-processes",
+                      "powershell.powershell-system",
+                      "powershell.powershell-services",
+                      "powershell.powershell-network",
+                      "powershell.powershell-data",
+                      "powershell.powershell-archives",
+                  ],
+                  actions: true,
+                  commands: ["dispatcher"],
+              },
         execution: { history: false },
         collectCommandResult: true,
         persistDir,
@@ -261,6 +301,14 @@ async function main() {
     if (options.noLlmJudge) {
         console.log("LLM judge: disabled");
     }
+    if (options.allAgents) {
+        console.log("Agent mode: ALL agents (competition testing)");
+    } else {
+        console.log("Agent mode: PowerShell only (isolation testing)");
+    }
+    if (options.noSamples) {
+        console.log("Sample flows: disabled (namespace schemas only)");
+    }
 
     // Validate scenario files exist
     const scenarioFiles = [
@@ -333,7 +381,11 @@ async function main() {
     if (existsSync(scriptsDir)) {
         try {
             const seedResult = await seedViaImport(scriptsDir, persistDir, () =>
-                createLiveDispatcher(persistDir),
+                createLiveDispatcher(
+                    persistDir,
+                    options.allAgents,
+                    options.noSamples,
+                ),
             );
             flowNameMap = seedResult.flowNameMap;
             if (seedResult.failed > 0) {
@@ -350,7 +402,11 @@ async function main() {
     console.log("\nCreating dispatcher for benchmark run...");
     let dispatcher: DispatcherAdapter;
     try {
-        dispatcher = await createLiveDispatcher(persistDir);
+        dispatcher = await createLiveDispatcher(
+            persistDir,
+            options.allAgents,
+            options.noSamples,
+        );
     } catch (err) {
         console.error(`Failed to create dispatcher: ${err}`);
         console.log(

--- a/ts/packages/agents/powershell/benchmark/scenarios/grammar-competition.json
+++ b/ts/packages/agents/powershell/benchmark/scenarios/grammar-competition.json
@@ -1,0 +1,394 @@
+[
+  {
+    "id": "gc-01",
+    "category": "grammar-competition",
+    "description": "Competition: 'ping' should route to powershell, not player",
+    "setup": { "allAgents": true },
+    "utterances": [
+      {
+        "text": "ping google.com",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "testConnection",
+          "matchedAgent": "powershell"
+        }
+      }
+    ]
+  },
+  {
+    "id": "gc-02",
+    "category": "grammar-competition",
+    "description": "Competition: file operations should stay in powershell",
+    "setup": { "allAgents": true },
+    "utterances": [
+      {
+        "text": "list files in downloads",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "listFiles",
+          "matchedAgent": "powershell"
+        }
+      },
+      {
+        "text": "show files in documents",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "listFiles",
+          "matchedAgent": "powershell"
+        }
+      }
+    ]
+  },
+  {
+    "id": "gc-03",
+    "category": "grammar-competition",
+    "description": "Competition: 'search' may conflict with browser - use grep instead",
+    "setup": { "allAgents": true },
+    "utterances": [
+      {
+        "text": "grep error in logs",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "findText",
+          "matchedAgent": "powershell"
+        }
+      },
+      {
+        "text": "find TODO in src",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "findText",
+          "matchedAgent": "powershell"
+        }
+      }
+    ]
+  },
+  {
+    "id": "gc-04",
+    "category": "grammar-competition",
+    "description": "Competition: process commands should not conflict with player",
+    "setup": { "allAgents": true },
+    "utterances": [
+      {
+        "text": "show running processes",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "listProcesses",
+          "matchedAgent": "powershell"
+        }
+      },
+      {
+        "text": "kill notepad",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "stopProcess",
+          "matchedAgent": "powershell"
+        }
+      }
+    ]
+  },
+  {
+    "id": "gc-05",
+    "category": "grammar-competition",
+    "description": "Competition: 'start' may conflict with player - context matters",
+    "setup": { "allAgents": true },
+    "utterances": [
+      {
+        "text": "start notepad",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "startProcess",
+          "matchedAgent": "powershell"
+        }
+      },
+      {
+        "text": "launch calculator",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "startProcess",
+          "matchedAgent": "powershell"
+        }
+      },
+      {
+        "text": "run cmd",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "startProcess",
+          "matchedAgent": "powershell"
+        }
+      }
+    ]
+  },
+  {
+    "id": "gc-06",
+    "category": "grammar-competition",
+    "description": "Competition: system info should stay in powershell",
+    "setup": { "allAgents": true },
+    "utterances": [
+      {
+        "text": "show system information",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "systemInfo",
+          "matchedAgent": "powershell"
+        }
+      },
+      {
+        "text": "show disk usage",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "diskUsage",
+          "matchedAgent": "powershell"
+        }
+      },
+      {
+        "text": "show uptime",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "uptime",
+          "matchedAgent": "powershell"
+        }
+      }
+    ]
+  },
+  {
+    "id": "gc-07",
+    "category": "grammar-competition",
+    "description": "Competition: service commands are powershell-specific",
+    "setup": { "allAgents": true },
+    "utterances": [
+      {
+        "text": "list all services",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "listServices",
+          "matchedAgent": "powershell"
+        }
+      },
+      {
+        "text": "restart service spooler",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "restartService",
+          "matchedAgent": "powershell"
+        }
+      }
+    ]
+  },
+  {
+    "id": "gc-08",
+    "category": "grammar-competition",
+    "description": "Competition: network commands should stay in powershell",
+    "setup": { "allAgents": true },
+    "utterances": [
+      {
+        "text": "ipconfig",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "ipConfig",
+          "matchedAgent": "powershell"
+        }
+      },
+      {
+        "text": "netstat",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "portListeners",
+          "matchedAgent": "powershell"
+        }
+      },
+      {
+        "text": "nslookup google.com",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "dnsLookup",
+          "matchedAgent": "powershell"
+        }
+      }
+    ]
+  },
+  {
+    "id": "gc-09",
+    "category": "grammar-competition",
+    "description": "Competition: zip/unzip should stay in powershell",
+    "setup": { "allAgents": true },
+    "utterances": [
+      {
+        "text": "zip logs",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "compress",
+          "matchedAgent": "powershell"
+        }
+      },
+      {
+        "text": "unzip backup.zip",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "expand",
+          "matchedAgent": "powershell"
+        }
+      }
+    ]
+  },
+  {
+    "id": "gc-10",
+    "category": "grammar-competition",
+    "description": "Competition: csv/json data operations should stay in powershell",
+    "setup": { "allAgents": true },
+    "utterances": [
+      {
+        "text": "read csv data.csv",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "readCsv",
+          "matchedAgent": "powershell"
+        }
+      },
+      {
+        "text": "convert data.csv to json",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "convertFormat",
+          "matchedAgent": "powershell"
+        }
+      }
+    ]
+  },
+  {
+    "id": "gc-11",
+    "category": "grammar-competition",
+    "description": "Competition: Unix-like aliases should route to powershell",
+    "setup": { "allAgents": true },
+    "utterances": [
+      {
+        "text": "ls",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "listFiles",
+          "matchedAgent": "powershell"
+        }
+      },
+      {
+        "text": "cat readme.md",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "readFile",
+          "matchedAgent": "powershell"
+        }
+      },
+      {
+        "text": "rm temp.txt",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "deleteFile",
+          "matchedAgent": "powershell"
+        }
+      },
+      {
+        "text": "cp file.txt backup.txt",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "copyFile",
+          "matchedAgent": "powershell"
+        }
+      },
+      {
+        "text": "mv old.txt new.txt",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "moveFile",
+          "matchedAgent": "powershell"
+        }
+      },
+      {
+        "text": "ps",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "listProcesses",
+          "matchedAgent": "powershell"
+        }
+      },
+      {
+        "text": "df",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "diskUsage",
+          "matchedAgent": "powershell"
+        }
+      }
+    ]
+  },
+  {
+    "id": "gc-neg-01",
+    "category": "grammar-competition",
+    "description": "Competition Negative: music commands should NOT match powershell",
+    "setup": { "allAgents": true },
+    "utterances": [
+      {
+        "text": "play some music",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": null,
+          "matchedAgent": null
+        }
+      },
+      {
+        "text": "play shake it off",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": null,
+          "matchedAgent": null
+        }
+      }
+    ]
+  },
+  {
+    "id": "gc-neg-02",
+    "category": "grammar-competition",
+    "description": "Competition Negative: calendar commands should NOT match powershell",
+    "setup": { "allAgents": true },
+    "utterances": [
+      {
+        "text": "schedule a meeting for tomorrow",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": null,
+          "matchedAgent": null
+        }
+      },
+      {
+        "text": "what's on my calendar",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": null,
+          "matchedAgent": null
+        }
+      }
+    ]
+  },
+  {
+    "id": "gc-neg-03",
+    "category": "grammar-competition",
+    "description": "Competition Negative: email commands should NOT match powershell",
+    "setup": { "allAgents": true },
+    "utterances": [
+      {
+        "text": "send an email to john",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": null,
+          "matchedAgent": null
+        }
+      },
+      {
+        "text": "check my inbox",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": null,
+          "matchedAgent": null
+        }
+      }
+    ]
+  }
+]

--- a/ts/packages/agents/powershell/benchmark/scenarios/grammar-subschemas.json
+++ b/ts/packages/agents/powershell/benchmark/scenarios/grammar-subschemas.json
@@ -1,0 +1,1315 @@
+[
+  {
+    "id": "gs-files-01",
+    "category": "grammar-subschemas",
+    "description": "Files: listFiles - multiple phrasings",
+    "setup": { "requiredSchemas": ["powershell-files"] },
+    "utterances": [
+      {
+        "text": "list files in downloads",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "listFiles",
+          "extractedParams": { "path": "downloads" }
+        }
+      },
+      {
+        "text": "show me the files in documents",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "listFiles",
+          "extractedParams": { "path": "documents" }
+        }
+      },
+      {
+        "text": "what's in C:\\temp",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "listFiles",
+          "extractedParams": { "path": "C:\\temp" }
+        }
+      },
+      {
+        "text": "dir C:\\Users",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "listFiles",
+          "extractedParams": { "path": "C:\\Users" }
+        }
+      },
+      {
+        "text": "display all the files",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "listFiles",
+          "extractedParams": {}
+        }
+      }
+    ]
+  },
+  {
+    "id": "gs-files-02",
+    "category": "grammar-subschemas",
+    "description": "Files: readFile - multiple phrasings",
+    "setup": { "requiredSchemas": ["powershell-files"] },
+    "utterances": [
+      {
+        "text": "read config.json",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "readFile",
+          "extractedParams": { "path": "config.json" }
+        }
+      },
+      {
+        "text": "show the contents of readme.md",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "readFile",
+          "extractedParams": { "path": "readme.md" }
+        }
+      },
+      {
+        "text": "cat package.json",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "readFile",
+          "extractedParams": { "path": "package.json" }
+        }
+      },
+      {
+        "text": "show last 20 lines of app.log",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "readFile",
+          "extractedParams": { "path": "app.log", "tail": 20 }
+        }
+      },
+      {
+        "text": "display file settings.xml",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "readFile",
+          "extractedParams": { "path": "settings.xml" }
+        }
+      }
+    ]
+  },
+  {
+    "id": "gs-files-03",
+    "category": "grammar-subschemas",
+    "description": "Files: writeFile - multiple phrasings",
+    "setup": { "requiredSchemas": ["powershell-files"] },
+    "utterances": [
+      {
+        "text": "write 'hello world' to test.txt",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "writeFile",
+          "extractedParams": { "content": "'hello world'", "path": "test.txt" }
+        }
+      },
+      {
+        "text": "save 'test data' to output.txt",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "writeFile",
+          "extractedParams": { "content": "'test data'", "path": "output.txt" }
+        }
+      },
+      {
+        "text": "append 'new line' to log.txt",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "writeFile",
+          "extractedParams": {
+            "content": "'new line'",
+            "path": "log.txt",
+            "append": true
+          }
+        }
+      }
+    ]
+  },
+  {
+    "id": "gs-files-04",
+    "category": "grammar-subschemas",
+    "description": "Files: copyFile - multiple phrasings",
+    "setup": { "requiredSchemas": ["powershell-files"] },
+    "utterances": [
+      {
+        "text": "copy report.pdf to backup",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "copyFile",
+          "extractedParams": { "source": "report.pdf", "destination": "backup" }
+        }
+      },
+      {
+        "text": "cp config.json config.backup.json",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "copyFile",
+          "extractedParams": {
+            "source": "config.json",
+            "destination": "config.backup.json"
+          }
+        }
+      },
+      {
+        "text": "duplicate document.docx to archives",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "copyFile",
+          "extractedParams": {
+            "source": "document.docx",
+            "destination": "archives"
+          }
+        }
+      }
+    ]
+  },
+  {
+    "id": "gs-files-05",
+    "category": "grammar-subschemas",
+    "description": "Files: moveFile - multiple phrasings",
+    "setup": { "requiredSchemas": ["powershell-files"] },
+    "utterances": [
+      {
+        "text": "move old.txt to archive",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "moveFile",
+          "extractedParams": { "source": "old.txt", "destination": "archive" }
+        }
+      },
+      {
+        "text": "rename document.docx to final.docx",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "moveFile",
+          "extractedParams": {
+            "source": "document.docx",
+            "destination": "final.docx"
+          }
+        }
+      },
+      {
+        "text": "mv temp.log logs",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "moveFile",
+          "extractedParams": { "source": "temp.log", "destination": "logs" }
+        }
+      }
+    ]
+  },
+  {
+    "id": "gs-files-06",
+    "category": "grammar-subschemas",
+    "description": "Files: deleteFile - multiple phrasings",
+    "setup": { "requiredSchemas": ["powershell-files"] },
+    "utterances": [
+      {
+        "text": "delete temp.txt",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "deleteFile",
+          "extractedParams": { "path": "temp.txt" }
+        }
+      },
+      {
+        "text": "remove old-backup",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "deleteFile",
+          "extractedParams": { "path": "old-backup" }
+        }
+      },
+      {
+        "text": "rm debug.log",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "deleteFile",
+          "extractedParams": { "path": "debug.log" }
+        }
+      }
+    ]
+  },
+  {
+    "id": "gs-files-07",
+    "category": "grammar-subschemas",
+    "description": "Files: testPath - multiple phrasings",
+    "setup": { "requiredSchemas": ["powershell-files"] },
+    "utterances": [
+      {
+        "text": "check if config.json exists",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "testPath",
+          "extractedParams": { "path": "config.json" }
+        }
+      },
+      {
+        "text": "does backup.zip exist",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "testPath",
+          "extractedParams": { "path": "backup.zip" }
+        }
+      },
+      {
+        "text": "is there a file named settings.json",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "testPath",
+          "extractedParams": { "path": "settings.json" }
+        }
+      }
+    ]
+  },
+  {
+    "id": "gs-files-08",
+    "category": "grammar-subschemas",
+    "description": "Files: findText - multiple phrasings",
+    "setup": { "requiredSchemas": ["powershell-files"] },
+    "utterances": [
+      {
+        "text": "find error in logs",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "findText",
+          "extractedParams": { "pattern": "error", "path": "logs" }
+        }
+      },
+      {
+        "text": "grep TODO src",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "findText",
+          "extractedParams": { "pattern": "TODO", "path": "src" }
+        }
+      },
+      {
+        "text": "search for password in config",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "findText",
+          "extractedParams": { "pattern": "password", "path": "config" }
+        }
+      }
+    ]
+  },
+  {
+    "id": "gs-files-09",
+    "category": "grammar-subschemas",
+    "description": "Files: newItem - multiple phrasings",
+    "setup": { "requiredSchemas": ["powershell-files"] },
+    "utterances": [
+      {
+        "text": "create a new file notes.txt",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "newItem",
+          "extractedParams": { "path": "notes.txt", "itemType": "file" }
+        }
+      },
+      {
+        "text": "make a directory backups",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "newItem",
+          "extractedParams": { "path": "backups", "itemType": "directory" }
+        }
+      },
+      {
+        "text": "mkdir logs",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "newItem",
+          "extractedParams": { "path": "logs", "itemType": "directory" }
+        }
+      },
+      {
+        "text": "touch placeholder.txt",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "newItem",
+          "extractedParams": { "path": "placeholder.txt", "itemType": "file" }
+        }
+      }
+    ]
+  },
+  {
+    "id": "gs-proc-01",
+    "category": "grammar-subschemas",
+    "description": "Processes: listProcesses - multiple phrasings",
+    "setup": { "requiredSchemas": ["powershell-processes"] },
+    "utterances": [
+      {
+        "text": "show running processes",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "listProcesses",
+          "extractedParams": {}
+        }
+      },
+      {
+        "text": "list processes named chrome",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "listProcesses",
+          "extractedParams": { "name": "chrome" }
+        }
+      },
+      {
+        "text": "ps notepad",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "listProcesses",
+          "extractedParams": { "name": "notepad" }
+        }
+      },
+      {
+        "text": "what processes are running",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "listProcesses",
+          "extractedParams": {}
+        }
+      }
+    ]
+  },
+  {
+    "id": "gs-proc-02",
+    "category": "grammar-subschemas",
+    "description": "Processes: processMemory - multiple phrasings",
+    "setup": { "requiredSchemas": ["powershell-processes"] },
+    "utterances": [
+      {
+        "text": "what's using the most memory",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "processMemory",
+          "extractedParams": {}
+        }
+      },
+      {
+        "text": "show top 5 memory hogs",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "processMemory",
+          "extractedParams": { "topN": 5 }
+        }
+      },
+      {
+        "text": "memory usage by process",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "processMemory",
+          "extractedParams": {}
+        }
+      }
+    ]
+  },
+  {
+    "id": "gs-proc-03",
+    "category": "grammar-subschemas",
+    "description": "Processes: processCpu - multiple phrasings",
+    "setup": { "requiredSchemas": ["powershell-processes"] },
+    "utterances": [
+      {
+        "text": "what's using the most cpu",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "processCpu",
+          "extractedParams": {}
+        }
+      },
+      {
+        "text": "show top 10 cpu hogs",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "processCpu",
+          "extractedParams": { "topN": 10 }
+        }
+      },
+      {
+        "text": "cpu usage by process",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "processCpu",
+          "extractedParams": {}
+        }
+      }
+    ]
+  },
+  {
+    "id": "gs-proc-04",
+    "category": "grammar-subschemas",
+    "description": "Processes: stopProcess - multiple phrasings",
+    "setup": { "requiredSchemas": ["powershell-processes"] },
+    "utterances": [
+      {
+        "text": "kill notepad",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "stopProcess",
+          "extractedParams": { "name": "notepad" }
+        }
+      },
+      {
+        "text": "stop process chrome",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "stopProcess",
+          "extractedParams": { "name": "chrome" }
+        }
+      },
+      {
+        "text": "kill process id 1234",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "stopProcess",
+          "extractedParams": { "id": 1234 }
+        }
+      }
+    ]
+  },
+  {
+    "id": "gs-proc-05",
+    "category": "grammar-subschemas",
+    "description": "Processes: startProcess - multiple phrasings",
+    "setup": { "requiredSchemas": ["powershell-processes"] },
+    "utterances": [
+      {
+        "text": "start notepad",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "startProcess",
+          "extractedParams": { "path": "notepad" }
+        }
+      },
+      {
+        "text": "launch calculator",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "startProcess",
+          "extractedParams": { "path": "calculator" }
+        }
+      },
+      {
+        "text": "run cmd",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "startProcess",
+          "extractedParams": { "path": "cmd" }
+        }
+      },
+      {
+        "text": "open explorer",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "startProcess",
+          "extractedParams": { "path": "explorer" }
+        }
+      }
+    ]
+  },
+  {
+    "id": "gs-sys-01",
+    "category": "grammar-subschemas",
+    "description": "System: systemInfo - multiple phrasings",
+    "setup": { "requiredSchemas": ["powershell-system"] },
+    "utterances": [
+      {
+        "text": "show system information",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "systemInfo",
+          "extractedParams": {}
+        }
+      },
+      {
+        "text": "get computer info",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "systemInfo",
+          "extractedParams": {}
+        }
+      },
+      {
+        "text": "about this pc",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "systemInfo",
+          "extractedParams": {}
+        }
+      },
+      {
+        "text": "system details",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "systemInfo",
+          "extractedParams": {}
+        }
+      }
+    ]
+  },
+  {
+    "id": "gs-sys-02",
+    "category": "grammar-subschemas",
+    "description": "System: diskUsage - multiple phrasings",
+    "setup": { "requiredSchemas": ["powershell-system"] },
+    "utterances": [
+      {
+        "text": "show disk usage",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "diskUsage",
+          "extractedParams": {}
+        }
+      },
+      {
+        "text": "how much free space",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "diskUsage",
+          "extractedParams": {}
+        }
+      },
+      {
+        "text": "drive capacity",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "diskUsage",
+          "extractedParams": {}
+        }
+      },
+      {
+        "text": "df",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "diskUsage",
+          "extractedParams": {}
+        }
+      }
+    ]
+  },
+  {
+    "id": "gs-sys-03",
+    "category": "grammar-subschemas",
+    "description": "System: hotFixes - multiple phrasings",
+    "setup": { "requiredSchemas": ["powershell-system"] },
+    "utterances": [
+      {
+        "text": "show installed hotfixes",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "hotFixes",
+          "extractedParams": {}
+        }
+      },
+      {
+        "text": "list updates",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "hotFixes",
+          "extractedParams": {}
+        }
+      },
+      {
+        "text": "what updates are installed",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "hotFixes",
+          "extractedParams": {}
+        }
+      },
+      {
+        "text": "windows updates",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "hotFixes",
+          "extractedParams": {}
+        }
+      }
+    ]
+  },
+  {
+    "id": "gs-sys-04",
+    "category": "grammar-subschemas",
+    "description": "System: uptime - multiple phrasings",
+    "setup": { "requiredSchemas": ["powershell-system"] },
+    "utterances": [
+      {
+        "text": "show uptime",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "uptime",
+          "extractedParams": {}
+        }
+      },
+      {
+        "text": "how long has the computer been running",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "uptime",
+          "extractedParams": {}
+        }
+      },
+      {
+        "text": "when did the system boot",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "uptime",
+          "extractedParams": {}
+        }
+      },
+      {
+        "text": "uptime",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "uptime",
+          "extractedParams": {}
+        }
+      }
+    ]
+  },
+  {
+    "id": "gs-sys-05",
+    "category": "grammar-subschemas",
+    "description": "System: envVars - multiple phrasings",
+    "setup": { "requiredSchemas": ["powershell-system"] },
+    "utterances": [
+      {
+        "text": "show environment variables",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "envVars",
+          "extractedParams": {}
+        }
+      },
+      {
+        "text": "get env var JAVA_HOME",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "envVars",
+          "extractedParams": { "name": "JAVA_HOME" }
+        }
+      },
+      {
+        "text": "what is the path variable",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "envVars",
+          "extractedParams": { "name": "PATH" }
+        }
+      },
+      {
+        "text": "list env vars",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "envVars",
+          "extractedParams": {}
+        }
+      }
+    ]
+  },
+  {
+    "id": "gs-svc-01",
+    "category": "grammar-subschemas",
+    "description": "Services: listServices - multiple phrasings",
+    "setup": { "requiredSchemas": ["powershell-services"] },
+    "utterances": [
+      {
+        "text": "list all services",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "listServices",
+          "extractedParams": {}
+        }
+      },
+      {
+        "text": "show running services",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "listServices",
+          "extractedParams": { "status": "running" }
+        }
+      },
+      {
+        "text": "what services are running",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "listServices",
+          "extractedParams": { "status": "running" }
+        }
+      },
+      {
+        "text": "show windows services",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "listServices",
+          "extractedParams": {}
+        }
+      }
+    ]
+  },
+  {
+    "id": "gs-svc-02",
+    "category": "grammar-subschemas",
+    "description": "Services: serviceStatus - multiple phrasings",
+    "setup": { "requiredSchemas": ["powershell-services"] },
+    "utterances": [
+      {
+        "text": "is spooler running",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "serviceStatus",
+          "extractedParams": { "name": "spooler" }
+        }
+      },
+      {
+        "text": "check service wuauserv",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "serviceStatus",
+          "extractedParams": { "name": "wuauserv" }
+        }
+      },
+      {
+        "text": "status of AudioSrv service",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "serviceStatus",
+          "extractedParams": { "name": "AudioSrv" }
+        }
+      }
+    ]
+  },
+  {
+    "id": "gs-svc-03",
+    "category": "grammar-subschemas",
+    "description": "Services: startService - multiple phrasings",
+    "setup": { "requiredSchemas": ["powershell-services"] },
+    "utterances": [
+      {
+        "text": "start service spooler",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "startService",
+          "extractedParams": { "name": "spooler" }
+        }
+      },
+      {
+        "text": "enable wuauserv service",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "startService",
+          "extractedParams": { "name": "wuauserv" }
+        }
+      },
+      {
+        "text": "turn on AudioSrv",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "startService",
+          "extractedParams": { "name": "AudioSrv" }
+        }
+      }
+    ]
+  },
+  {
+    "id": "gs-svc-04",
+    "category": "grammar-subschemas",
+    "description": "Services: stopService - multiple phrasings",
+    "setup": { "requiredSchemas": ["powershell-services"] },
+    "utterances": [
+      {
+        "text": "stop service spooler",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "stopService",
+          "extractedParams": { "name": "spooler" }
+        }
+      },
+      {
+        "text": "disable wuauserv service",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "stopService",
+          "extractedParams": { "name": "wuauserv" }
+        }
+      },
+      {
+        "text": "turn off AudioSrv",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "stopService",
+          "extractedParams": { "name": "AudioSrv" }
+        }
+      }
+    ]
+  },
+  {
+    "id": "gs-svc-05",
+    "category": "grammar-subschemas",
+    "description": "Services: restartService - multiple phrasings",
+    "setup": { "requiredSchemas": ["powershell-services"] },
+    "utterances": [
+      {
+        "text": "restart service spooler",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "restartService",
+          "extractedParams": { "name": "spooler" }
+        }
+      },
+      {
+        "text": "bounce wuauserv service",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "restartService",
+          "extractedParams": { "name": "wuauserv" }
+        }
+      },
+      {
+        "text": "cycle AudioSrv",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "restartService",
+          "extractedParams": { "name": "AudioSrv" }
+        }
+      }
+    ]
+  },
+  {
+    "id": "gs-net-01",
+    "category": "grammar-subschemas",
+    "description": "Network: testConnection - multiple phrasings",
+    "setup": { "requiredSchemas": ["powershell-network"] },
+    "utterances": [
+      {
+        "text": "ping google.com",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "testConnection",
+          "extractedParams": { "computerName": "google.com" }
+        }
+      },
+      {
+        "text": "test connection to 192.168.1.1",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "testConnection",
+          "extractedParams": { "computerName": "192.168.1.1" }
+        }
+      },
+      {
+        "text": "is github.com reachable",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "testConnection",
+          "extractedParams": { "computerName": "github.com" }
+        }
+      },
+      {
+        "text": "ping localhost port 8080",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "testConnection",
+          "extractedParams": { "computerName": "localhost", "port": 8080 }
+        }
+      }
+    ]
+  },
+  {
+    "id": "gs-net-02",
+    "category": "grammar-subschemas",
+    "description": "Network: portListeners - multiple phrasings",
+    "setup": { "requiredSchemas": ["powershell-network"] },
+    "utterances": [
+      {
+        "text": "what's listening on port 80",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "portListeners",
+          "extractedParams": { "port": 80 }
+        }
+      },
+      {
+        "text": "show open ports",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "portListeners",
+          "extractedParams": {}
+        }
+      },
+      {
+        "text": "list port listeners",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "portListeners",
+          "extractedParams": {}
+        }
+      },
+      {
+        "text": "which process is using port 3000",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "portListeners",
+          "extractedParams": { "port": 3000 }
+        }
+      },
+      {
+        "text": "netstat",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "portListeners",
+          "extractedParams": {}
+        }
+      }
+    ]
+  },
+  {
+    "id": "gs-net-03",
+    "category": "grammar-subschemas",
+    "description": "Network: networkAdapters - multiple phrasings",
+    "setup": { "requiredSchemas": ["powershell-network"] },
+    "utterances": [
+      {
+        "text": "show network adapters",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "networkAdapters",
+          "extractedParams": {}
+        }
+      },
+      {
+        "text": "list interfaces",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "networkAdapters",
+          "extractedParams": {}
+        }
+      },
+      {
+        "text": "get adapter Ethernet",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "networkAdapters",
+          "extractedParams": { "name": "Ethernet" }
+        }
+      }
+    ]
+  },
+  {
+    "id": "gs-net-04",
+    "category": "grammar-subschemas",
+    "description": "Network: ipConfig - multiple phrasings",
+    "setup": { "requiredSchemas": ["powershell-network"] },
+    "utterances": [
+      {
+        "text": "show my ip address",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "ipConfig",
+          "extractedParams": {}
+        }
+      },
+      {
+        "text": "ipconfig",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "ipConfig",
+          "extractedParams": {}
+        }
+      },
+      {
+        "text": "what's my ip",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "ipConfig",
+          "extractedParams": {}
+        }
+      },
+      {
+        "text": "get ip config",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "ipConfig",
+          "extractedParams": {}
+        }
+      }
+    ]
+  },
+  {
+    "id": "gs-net-05",
+    "category": "grammar-subschemas",
+    "description": "Network: dnsLookup - multiple phrasings",
+    "setup": { "requiredSchemas": ["powershell-network"] },
+    "utterances": [
+      {
+        "text": "lookup microsoft.com",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "dnsLookup",
+          "extractedParams": { "name": "microsoft.com" }
+        }
+      },
+      {
+        "text": "nslookup google.com",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "dnsLookup",
+          "extractedParams": { "name": "google.com" }
+        }
+      },
+      {
+        "text": "dns lookup for github.com",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "dnsLookup",
+          "extractedParams": { "name": "github.com" }
+        }
+      },
+      {
+        "text": "resolve gmail.com MX",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "dnsLookup",
+          "extractedParams": { "name": "gmail.com", "type": "MX" }
+        }
+      }
+    ]
+  },
+  {
+    "id": "gs-data-01",
+    "category": "grammar-subschemas",
+    "description": "Data: readJson - multiple phrasings",
+    "setup": { "requiredSchemas": ["powershell-data"] },
+    "utterances": [
+      {
+        "text": "read json from config.json",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "readJson",
+          "extractedParams": { "path": "config.json" }
+        }
+      },
+      {
+        "text": "parse json settings.json",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "readJson",
+          "extractedParams": { "path": "settings.json" }
+        }
+      },
+      {
+        "text": "show json file package.json",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "readJson",
+          "extractedParams": { "path": "package.json" }
+        }
+      }
+    ]
+  },
+  {
+    "id": "gs-data-02",
+    "category": "grammar-subschemas",
+    "description": "Data: readCsv - multiple phrasings",
+    "setup": { "requiredSchemas": ["powershell-data"] },
+    "utterances": [
+      {
+        "text": "read csv data.csv",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "readCsv",
+          "extractedParams": { "path": "data.csv" }
+        }
+      },
+      {
+        "text": "import csv users.csv",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "readCsv",
+          "extractedParams": { "path": "users.csv" }
+        }
+      },
+      {
+        "text": "show csv file sales.csv",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "readCsv",
+          "extractedParams": { "path": "sales.csv" }
+        }
+      },
+      {
+        "text": "load records.csv as csv",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "readCsv",
+          "extractedParams": { "path": "records.csv" }
+        }
+      }
+    ]
+  },
+  {
+    "id": "gs-data-03",
+    "category": "grammar-subschemas",
+    "description": "Data: filterCsv - multiple phrasings",
+    "setup": { "requiredSchemas": ["powershell-data"] },
+    "utterances": [
+      {
+        "text": "filter csv sales.csv where region equals West",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "filterCsv",
+          "extractedParams": {
+            "path": "sales.csv",
+            "column": "region",
+            "pattern": "West"
+          }
+        }
+      },
+      {
+        "text": "find in csv users.csv where status is active",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "filterCsv",
+          "extractedParams": {
+            "path": "users.csv",
+            "column": "status",
+            "pattern": "active"
+          }
+        }
+      }
+    ]
+  },
+  {
+    "id": "gs-data-04",
+    "category": "grammar-subschemas",
+    "description": "Data: convertFormat - multiple phrasings",
+    "setup": { "requiredSchemas": ["powershell-data"] },
+    "utterances": [
+      {
+        "text": "convert data.csv to json",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "convertFormat",
+          "extractedParams": { "input": "data.csv", "format": "json" }
+        }
+      },
+      {
+        "text": "convert config.json to xml",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "convertFormat",
+          "extractedParams": { "input": "config.json", "format": "xml" }
+        }
+      },
+      {
+        "text": "convert report.json to csv",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "convertFormat",
+          "extractedParams": { "input": "report.json", "format": "csv" }
+        }
+      }
+    ]
+  },
+  {
+    "id": "gs-arch-01",
+    "category": "grammar-subschemas",
+    "description": "Archives: compress - multiple phrasings",
+    "setup": { "requiredSchemas": ["powershell-archives"] },
+    "utterances": [
+      {
+        "text": "zip logs to backup.zip",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "compress",
+          "extractedParams": {
+            "sourcePath": "logs",
+            "destinationPath": "backup.zip"
+          }
+        }
+      },
+      {
+        "text": "compress src as archive.zip",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "compress",
+          "extractedParams": {
+            "sourcePath": "src",
+            "destinationPath": "archive.zip"
+          }
+        }
+      },
+      {
+        "text": "create a zip of documents",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "compress",
+          "extractedParams": { "sourcePath": "documents" }
+        }
+      },
+      {
+        "text": "zip reports",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "compress",
+          "extractedParams": { "sourcePath": "reports" }
+        }
+      }
+    ]
+  },
+  {
+    "id": "gs-arch-02",
+    "category": "grammar-subschemas",
+    "description": "Archives: expand - multiple phrasings",
+    "setup": { "requiredSchemas": ["powershell-archives"] },
+    "utterances": [
+      {
+        "text": "unzip backup.zip",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "expand",
+          "extractedParams": { "archivePath": "backup.zip" }
+        }
+      },
+      {
+        "text": "extract archive.zip to output",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "expand",
+          "extractedParams": {
+            "archivePath": "archive.zip",
+            "destinationPath": "output"
+          }
+        }
+      },
+      {
+        "text": "expand package.zip in downloads",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "expand",
+          "extractedParams": {
+            "archivePath": "package.zip",
+            "destinationPath": "downloads"
+          }
+        }
+      },
+      {
+        "text": "open archive release.zip",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "expand",
+          "extractedParams": { "archivePath": "release.zip" }
+        }
+      }
+    ]
+  }
+]

--- a/ts/packages/agents/powershell/src/actionHandler.mts
+++ b/ts/packages/agents/powershell/src/actionHandler.mts
@@ -988,7 +988,14 @@ export function instantiate(): AppAgent {
             agentContext.store = store;
             _agentStore = store;
 
-            await seedSampleFlows(store);
+            // Skip sample seeding if TYPEAGENT_NO_SAMPLES env var is set
+            if (!process.env.TYPEAGENT_NO_SAMPLES) {
+                await seedSampleFlows(store);
+            } else {
+                debug(
+                    "Sample seeding disabled by TYPEAGENT_NO_SAMPLES env var",
+                );
+            }
             // Dynamic grammar rules are written to grammar/dynamic.agr by the store.
             // The dispatcher reads this file after updateAgentContext completes
             // and registers the rules in its own grammar system.


### PR DESCRIPTION
- Browser agent: Add null check for sessionDir to prevent TypeError when session folder is unavailable.

- PowerShell benchmark: Enable isolation mode testing by using fully qualified schema names and adding --no-samples flag to disable sample flow competition. Pass rate improved from 0% to 92%.