### PR TITLE
actionGrammar: V8 hidden class optimization via factory functions

### DIFF
--- a/ts/packages/actionGrammar/src/grammarCompiler.ts
+++ b/ts/packages/actionGrammar/src/grammarCompiler.ts
@@ -5,11 +5,14 @@ import {
     Grammar,
     GrammarPart,
     GrammarRule,
-    RulesPart,
-    StringPart,
     CompiledSpacingMode,
     CompiledValueNode,
     CompiledObjectElement,
+    createStringPart,
+    createWildcardPart,
+    createNumberPart,
+    createRulesPart,
+    createPhraseSetPart,
 } from "./grammarTypes.js";
 import {
     Rule,
@@ -1098,10 +1101,7 @@ function createGrammarRule(
     for (const expr of expressions) {
         switch (expr.type) {
             case "string": {
-                const part: StringPart = {
-                    type: "string",
-                    value: expr.value,
-                };
+                const part = createStringPart(expr.value);
                 // TODO: create regexp
                 parts.push(part);
                 // default value of the string
@@ -1132,13 +1132,13 @@ function createGrammarRule(
                         name,
                         currentEpr,
                     );
-                    parts.push({
-                        type: "rules",
-                        alternatives: record.grammarRules,
-                        variable: name,
-                        name: referencedName,
-                        optional: expr.optional,
-                    });
+                    parts.push(
+                        createRulesPart(record.grammarRules, {
+                            optional: expr.optional,
+                            variable: name,
+                            name: referencedName,
+                        }),
+                    );
                     if (!expr.optional) {
                         // === false: only clear when *definitely* non-nullable.
                         // undefined (back-ref still compiling) leaves epr intact
@@ -1151,11 +1151,7 @@ function createGrammarRule(
                             ruleNullable && (record.nullable ?? false);
                     }
                 } else if (referencedName === "number") {
-                    parts.push({
-                        type: "number",
-                        variable: name,
-                        optional: expr.optional,
-                    });
+                    parts.push(createNumberPart(name, expr.optional));
                     if (!expr.optional) consumedInput();
                 } else {
                     // Validate type name references
@@ -1186,12 +1182,9 @@ function createGrammarRule(
                         }
                     }
 
-                    parts.push({
-                        type: "wildcard",
-                        variable: name,
-                        optional: expr.optional,
-                        typeName: referencedName,
-                    });
+                    parts.push(
+                        createWildcardPart(name, referencedName, expr.optional),
+                    );
                     if (!expr.optional) consumedInput();
                 }
                 break;
@@ -1208,10 +1201,7 @@ function createGrammarRule(
                     !isLocallyDefined &&
                     globalPhraseSetRegistry.isPhraseSetName(expr.refName.name)
                 ) {
-                    parts.push({
-                        type: "phraseSet",
-                        matcherName: expr.refName.name,
-                    });
+                    parts.push(createPhraseSetPart(expr.refName.name));
                     // Phrase sets don't produce a captured value on their own.
                     // Use defaultValue=true so single-part rules using a phrase set
                     // don't trip the "Start rule does not produce a value" check.
@@ -1228,11 +1218,11 @@ function createGrammarRule(
                 );
                 // default value of the rule reference
                 defaultValue = record.hasValue;
-                parts.push({
-                    type: "rules",
-                    alternatives: record.grammarRules,
-                    name: expr.refName.name,
-                });
+                parts.push(
+                    createRulesPart(record.grammarRules, {
+                        name: expr.refName.name,
+                    }),
+                );
                 // RuleRefExpr has no optional modifier; it is always non-optional.
                 // === false: only clear when *definitely* non-nullable (same
                 // asymmetry as the variable ruleRef case above).
@@ -1252,13 +1242,12 @@ function createGrammarRule(
                     nullable: groupNullable,
                 } = createGrammarRules(context, rules, currentEpr, spacingMode);
                 defaultValue = groupHasValue;
-                const rulesPart: RulesPart = {
-                    type: "rules",
-                    alternatives: grammarRules,
-                    optional,
-                };
-                if (repeat) rulesPart.repeat = true;
-                parts.push(rulesPart);
+                parts.push(
+                    createRulesPart(grammarRules, {
+                        optional,
+                        repeat,
+                    }),
+                );
                 if (!optional && !groupNullable) consumedInput();
                 break;
             }

--- a/ts/packages/actionGrammar/src/grammarDeserializer.ts
+++ b/ts/packages/actionGrammar/src/grammarDeserializer.ts
@@ -10,8 +10,11 @@ import {
     GrammarPartJson,
     GrammarRule,
     GrammarRuleJson,
-    PhraseSetPart,
-    RulesPart,
+    createStringPart,
+    createWildcardPart,
+    createNumberPart,
+    createRulesPart,
+    createPhraseSetPart,
 } from "./grammarTypes.js";
 import { validateTailRulesParts } from "./grammarOptimizer.js";
 import registerDebug from "debug";
@@ -221,9 +224,11 @@ function grammarFromJsonInternal(json: GrammarJson): Grammar {
     function grammarPartFromJson(p: GrammarPartJson): GrammarPart {
         switch (p.type) {
             case "string":
+                return createStringPart(p.value, p.variable);
             case "wildcard":
+                return createWildcardPart(p.variable, p.typeName, p.optional);
             case "number":
-                return p;
+                return createNumberPart(p.variable, p.optional);
             case "rules": {
                 // A `tailCall` part with no `index` AND no
                 // `dispatch` has zero effective members - it can
@@ -246,34 +251,27 @@ function grammarFromJsonInternal(json: GrammarJson): Grammar {
                 }
                 const rules =
                     p.index === undefined ? emptyRules : rulesFor(p.index);
-                const part: RulesPart = {
-                    type: "rules",
-                    name: p.name,
-                    alternatives: rules,
-                    variable: p.variable,
-                    optional: p.optional,
-                };
-                if (p.repeat) part.repeat = true;
-                if (p.tailCall) part.tailCall = true;
+                let dispatch: DispatchModeBucket[] | undefined;
                 if (p.dispatch !== undefined) {
                     const tag = `dispatched RulesPart (name='${p.name ?? "<unnamed>"}')`;
-                    part.dispatch = dispatchFor(
+                    dispatch = dispatchFor(
                         p.dispatch,
                         rules.length,
                         `RulesPart name='${p.name ?? "<unnamed>"}'`,
                         tag,
                     );
                 }
-                return part;
+                return createRulesPart(rules, {
+                    optional: p.optional,
+                    variable: p.variable,
+                    name: p.name,
+                    repeat: p.repeat,
+                    tailCall: p.tailCall,
+                    dispatch,
+                });
             }
-            case "phraseSet": {
-                const part: PhraseSetPart = {
-                    type: "phraseSet",
-                    matcherName: p.matcherName,
-                };
-                if (p.variable !== undefined) part.variable = p.variable;
-                return part;
-            }
+            case "phraseSet":
+                return createPhraseSetPart(p.matcherName, p.variable);
         }
     }
 

--- a/ts/packages/actionGrammar/src/grammarMatcher.ts
+++ b/ts/packages/actionGrammar/src/grammarMatcher.ts
@@ -2266,24 +2266,7 @@ export function finalizeNestedRule(
                     // Live = continue (drill deeper); backtrack = stop
                     // (snapshot of state past the repeat).
                     const stopSnapshot = forkMatchState(state);
-                    // Restore continue state via explicit field writes.
-                    state.name = continueState.name;
-                    state.parts = continueState.parts;
-                    state.value = continueState.value;
-                    state.partIndex = continueState.partIndex;
-                    state.valueIds = continueState.valueIds;
-                    state.nextValueId = continueState.nextValueId;
-                    state.values = continueState.values;
-                    state.parent = continueState.parent;
-                    state.nestedLevel = continueState.nestedLevel;
-                    state.suppressOptionalFork =
-                        continueState.suppressOptionalFork;
-                    state.leadingSpacingMode = continueState.leadingSpacingMode;
-                    state.spacingMode = continueState.spacingMode;
-                    state.index = continueState.index;
-                    state.pendingWildcard = continueState.pendingWildcard;
-                    state.lastMatchedPartInfo =
-                        continueState.lastMatchedPartInfo;
+                    restoreSnapshot(state, continueState);
                     pushBacktrack(state, stopSnapshot, "repeat");
                 } else {
                     // Default / nonGreedy: live = stop; backtrack = continue.
@@ -2895,23 +2878,7 @@ export function matchState(state: MatchState, request: string) {
                 // iteration, so it cannot leak onto subsequent parts.
                 const takeSnapshot = forkMatchState(state);
                 takeSnapshot.suppressOptionalFork = true;
-                // Restore skip state via explicit field writes
-                // instead of Object.assign.
-                state.name = skipState.name;
-                state.parts = skipState.parts;
-                state.value = skipState.value;
-                state.partIndex = skipState.partIndex;
-                state.valueIds = skipState.valueIds;
-                state.nextValueId = skipState.nextValueId;
-                state.values = skipState.values;
-                state.parent = skipState.parent;
-                state.nestedLevel = skipState.nestedLevel;
-                state.suppressOptionalFork = skipState.suppressOptionalFork;
-                state.leadingSpacingMode = skipState.leadingSpacingMode;
-                state.spacingMode = skipState.spacingMode;
-                state.index = skipState.index;
-                state.pendingWildcard = skipState.pendingWildcard;
-                state.lastMatchedPartInfo = skipState.lastMatchedPartInfo;
+                restoreSnapshot(state, skipState);
                 pushBacktrack(state, takeSnapshot, "optional");
                 continue;
             }

--- a/ts/packages/actionGrammar/src/grammarMatcher.ts
+++ b/ts/packages/actionGrammar/src/grammarMatcher.ts
@@ -344,7 +344,7 @@ export type BacktrackOrigin =
 // Persistent linked-list of unexplored DFS branches (most recent
 // push at head).  Each frame snapshots a sibling parse path or a
 // wildcard refinement point.  Restoring a frame replaces the live
-// state via `Object.assign` (see `tryNextBacktrack`).
+// state via `restoreSnapshot` (see `tryNextBacktrack`).
 //
 // This IS the explicit DFS stack: `matchState` walks parts
 // left-to-right mutating the live state in place; whenever a fork
@@ -900,7 +900,7 @@ type MemoMarkerBacktrack = {
 // previous N-1 per-delta linked-list frames: it holds the full
 // `SuccessDelta[]` array and an advancing `cursor` index (starts
 // at 1; delta 0 was applied live).  On each `tryNextBacktrack`
-// pop the cursor `Object.assign`s `snapshot` (the pre-entry outer
+// pop the cursor `restoreSnapshot`s `snapshot` (the pre-entry outer
 // state) and invokes `applyDelta(deltas[cursor])`.  The frame
 // stays at the chain head until all deltas have been consumed;
 // new frames pushed during the restored delta's suffix sit on top
@@ -927,7 +927,7 @@ type MemoReplayBacktrack = {
 // Strict variant of `PendingMatchState` used as the snapshot payload
 // inside `Backtrack`.  The `-?` mapped modifier forces every
 // optional field to be a required own property so that
-// `Object.assign` in `tryNextBacktrack` reliably resets fields
+// `restoreSnapshot` in `tryNextBacktrack` reliably resets fields
 // that may have been assigned AFTER the snapshot was taken (e.g.
 // `values` after the captured wildcard is committed, or `parent`
 // after entering a nested rule).
@@ -1044,7 +1044,7 @@ export type MatchState = PendingMatchState & {
 
     // Per-axis policies.  Set once at `initialMatchState` time and
     // never changed.  Deliberately NOT in `PendingMatchState` /
-    // `SnapshotState` - `Object.assign` of a snapshot won't overwrite
+    // `SnapshotState` - `restoreSnapshot` of a snapshot won't overwrite
     // them, so they persist across `tryNextBacktrack` restores.
     wildcardPolicy: WildcardPolicy;
     optionalPolicy: OptionalPolicy;
@@ -1123,7 +1123,7 @@ function captureSnapshot(state: MatchState): SnapshotState {
 // nested-rule alternatives, repeat continuation, wildcard
 // extension) use `forkMatchState` instead - that returns a
 // `SnapshotState` with no policies, suitable for restoration via
-// `Object.assign` without disturbing the live state's policies.
+// `restoreSnapshot` without disturbing the live state's policies.
 export function cloneMatchState(state: MatchState): MatchState {
     // Single-allocation clone: drop only `backtracks` (live-state
     // mutation surface) and keep everything else - including the
@@ -1162,7 +1162,7 @@ export function forkMatchState(state: MatchState): SnapshotState {
 //
 // Single-owner invariant: SnapshotState omits the `backtracks`
 // field, so the snapshot cannot smuggle a parallel chain in.  When
-// `tryNextBacktrack` restores via `Object.assign`, the live
+// `tryNextBacktrack` restores via `restoreSnapshot`, the live
 // state's `backtracks` is preserved (and explicitly advanced
 // to `frame.prev`).
 export function pushBacktrack(
@@ -1271,7 +1271,7 @@ function pushMemoMarker(
 
 // Pop the most-recently-pushed (rightmost / deepest in DFS order)
 // unexplored sibling and restore it onto `state`, mutating in
-// place via `Object.assign`.  Returns true if a frame was
+// place via `restoreSnapshot`.  Returns true if a frame was
 // restored, false if the chain is empty.
 //
 // This is the backtrack step of the explicit-stack DFS: the live
@@ -1331,12 +1331,10 @@ export function tryNextBacktrack(state: MatchState): boolean {
             const i = frame.cursor;
             const rule = frame.rules[i];
             const base = frame.base;
-            // Explicit field writes instead of Object.assign:
-            // V8 emits monomorphic inline caches for direct
-            // property stores, which are faster than the generic
-            // Object.assign path.  The 4 per-rule fields (name,
-            // parts, value, spacingMode) are written from `rule`
-            // directly after restoring the shared base.
+            // restoreSnapshot replaces the 15 PendingMatchState
+            // fields, then the 4 per-rule fields (name, parts,
+            // value, spacingMode) are written from `rule` directly
+            // after restoring the shared base.
             restoreSnapshot(state, base);
             state.name = state.debugEnabled ? `${frame.namePrefix}[${i}]` : "";
             state.parts = rule.parts;

--- a/ts/packages/actionGrammar/src/grammarMatcher.ts
+++ b/ts/packages/actionGrammar/src/grammarMatcher.ts
@@ -16,6 +16,7 @@ import {
     VarNumberPart,
     VarStringPart,
     DispatchModeBucket,
+    createRulesPart,
 } from "./grammarTypes.js";
 import { wordBoundaryScriptRe } from "./spacingScripts.js";
 import {
@@ -368,9 +369,9 @@ export type BacktrackOrigin =
 //     each carry a full `SnapshotState` and unlink on restore.
 // See `pushBacktrack` / `pushAlternation` / `tryNextBacktrack`.
 type SingleBacktrack = {
-    readonly snapshot: SnapshotState;
     readonly origin: "wildcard" | "optional" | "repeat";
     readonly prev: Backtrack | undefined;
+    readonly snapshot: SnapshotState;
 };
 
 // Per-alternative state at one alternation fork point is fully
@@ -384,6 +385,7 @@ type SingleBacktrack = {
 // pushes 1 frame + 1 base snapshot regardless of N.
 type AlternationBacktrack = {
     readonly origin: "alternation";
+    readonly prev: Backtrack | undefined;
     readonly base: SnapshotState;
     readonly rules: ReadonlyArray<GrammarRule>;
     readonly namePrefix: string; // debug name = `${namePrefix}[${cursor}]`
@@ -393,7 +395,6 @@ type AlternationBacktrack = {
     // live alternative); the frame unlinks once `cursor` reaches
     // `rules.length`.
     cursor: number;
-    readonly prev: Backtrack | undefined;
 };
 
 type Backtrack =
@@ -838,6 +839,7 @@ function applyDelta(state: MatchState, delta: SuccessDelta) {
 // chain; only the live state observes its mutation.
 type MemoMarkerBacktrack = {
     readonly origin: "memoMarker";
+    readonly prev: Backtrack | undefined;
     readonly rules: ReadonlyArray<GrammarRule>;
     readonly index: number;
     readonly leading: CompiledSpacingMode;
@@ -891,7 +893,6 @@ type MemoMarkerBacktrack = {
     // `"failed"`).  Captured for observation in Phase 1; replay
     // is wired in Phase 2.
     readonly successes: SuccessDelta[];
-    readonly prev: Backtrack | undefined;
 };
 
 // Replay cursor for SUCCESS memoization.  See the `"memoReplay"`
@@ -906,6 +907,7 @@ type MemoMarkerBacktrack = {
 // and resolve before the next cursor advance.
 type MemoReplayBacktrack = {
     readonly origin: "memoReplay";
+    readonly prev: Backtrack | undefined;
     readonly snapshot: SnapshotState;
     readonly deltas: SuccessDelta[];
     // Mutable cursor advanced by `tryNextBacktrack` on each
@@ -920,7 +922,6 @@ type MemoReplayBacktrack = {
     // fail identically.  Lossless: only provably-doomed
     // branches are pruned.
     readonly failedSuffixKeys: Set<number>;
-    readonly prev: Backtrack | undefined;
 };
 
 // Strict variant of `PendingMatchState` used as the snapshot payload
@@ -1049,6 +1050,13 @@ export type MatchState = PendingMatchState & {
     optionalPolicy: OptionalPolicy;
     repeatPolicy: RepeatPolicy;
 
+    // Cached copy of `debugMatchRaw.enabled`.  The `debug` package
+    // implements `.enabled` as a getter that re-evaluates on every
+    // access; caching here avoids ~29 getter calls per match.
+    // Set once at `initialMatchState` time; same lifecycle as the
+    // other policy fields.
+    debugEnabled: boolean;
+
     // When false, `enterRulesAlternation` skips the memo marker
     // push entirely - no failure caching, no success capture, no
     // replay.  See `memoization` on `GrammarMatchOptions`.
@@ -1163,9 +1171,9 @@ export function pushBacktrack(
     origin: SingleBacktrack["origin"],
 ) {
     state.backtracks = {
-        snapshot: alternative,
         origin,
         prev: state.backtracks,
+        snapshot: alternative,
     };
 }
 
@@ -1198,12 +1206,67 @@ function pushAlternation(
 ) {
     state.backtracks = {
         origin: "alternation",
+        prev: state.backtracks,
         base,
         rules,
         namePrefix,
         cursor: 1,
-        prev: state.backtracks,
     };
+}
+
+// Push a memo-replay cursor frame covering `deltas[1..N-1]`.
+// Delta 0 is applied live by the caller; the cursor advances
+// forward through the remaining deltas on each `tryNextBacktrack`
+// pop (same pattern as the alternation cursor).
+function pushMemoReplay(
+    state: MatchState,
+    snapshot: SnapshotState,
+    deltas: SuccessDelta[],
+    failedSuffixKeys: Set<number>,
+) {
+    state.backtracks = {
+        origin: "memoReplay",
+        prev: state.backtracks,
+        snapshot,
+        deltas,
+        cursor: 1,
+        failedSuffixKeys,
+    };
+}
+
+// Push a memo-marker sentinel frame for failure (and optionally
+// success) memoization.  Pushed BEFORE the alternation cursor so
+// the cursor sits on top; when all body frames drain the marker
+// becomes head and `tryNextBacktrack` pops it, populating the
+// failure cache if no member ever flipped `anyMemberFinalized`.
+function pushMemoMarker(
+    state: MatchState,
+    rules: ReadonlyArray<GrammarRule>,
+    leading: CompiledSpacingMode,
+    pendingWildcardActive: boolean,
+    carrier: boolean,
+    requireValue: boolean,
+    noSuccessCache: boolean,
+): MemoMarkerBacktrack {
+    const marker: MemoMarkerBacktrack = {
+        origin: "memoMarker",
+        prev: state.backtracks,
+        rules,
+        index: state.index,
+        leading,
+        pendingWildcardActive,
+        anyMemberFinalized: false,
+        valuesAtEntry: state.values,
+        valueIdsAtEntry: state.valueIds,
+        nextValueIdAtEntry: state.nextValueId,
+        lastMatchedPartInfoAtEntry: state.lastMatchedPartInfo,
+        carrier,
+        requireValue,
+        noSuccessCache,
+        successes: [],
+    };
+    state.backtracks = marker;
+    return marker;
 }
 
 // Pop the most-recently-pushed (rightmost / deepest in DFS order)
@@ -1230,6 +1293,28 @@ function pushAlternation(
 //       const matched = matchState(state, request);
 //       // ...process attempt...
 //   } while (tryNextBacktrack(state));
+// Restore all `PendingMatchState` fields from a snapshot onto the
+// live state.  Shared by `tryNextBacktrack` (memoReplay, single,
+// and alternation branches) to avoid duplicating the 15-field
+// write block.
+function restoreSnapshot(state: MatchState, snap: SnapshotState) {
+    state.name = snap.name;
+    state.parts = snap.parts;
+    state.value = snap.value;
+    state.partIndex = snap.partIndex;
+    state.valueIds = snap.valueIds;
+    state.nextValueId = snap.nextValueId;
+    state.values = snap.values;
+    state.parent = snap.parent;
+    state.nestedLevel = snap.nestedLevel;
+    state.suppressOptionalFork = snap.suppressOptionalFork;
+    state.leadingSpacingMode = snap.leadingSpacingMode;
+    state.spacingMode = snap.spacingMode;
+    state.index = snap.index;
+    state.pendingWildcard = snap.pendingWildcard;
+    state.lastMatchedPartInfo = snap.lastMatchedPartInfo;
+}
+
 export function tryNextBacktrack(state: MatchState): boolean {
     while (true) {
         const frame = state.backtracks;
@@ -1245,8 +1330,15 @@ export function tryNextBacktrack(state: MatchState): boolean {
             // resolve before) this cursor.
             const i = frame.cursor;
             const rule = frame.rules[i];
-            Object.assign(state, frame.base);
-            state.name = `${frame.namePrefix}[${i}]`;
+            const base = frame.base;
+            // Explicit field writes instead of Object.assign:
+            // V8 emits monomorphic inline caches for direct
+            // property stores, which are faster than the generic
+            // Object.assign path.  The 4 per-rule fields (name,
+            // parts, value, spacingMode) are written from `rule`
+            // directly after restoring the shared base.
+            restoreSnapshot(state, base);
+            state.name = state.debugEnabled ? `${frame.namePrefix}[${i}]` : "";
             state.parts = rule.parts;
             state.value = rule.value;
             state.spacingMode = rule.spacingMode;
@@ -1283,7 +1375,7 @@ export function tryNextBacktrack(state: MatchState): boolean {
                     state.memoCache.set(frame.rules, inner);
                 }
                 inner.set(key, "failed");
-                if (debugMatchRaw.enabled) {
+                if (state.debugEnabled) {
                     debugMatchRaw(
                         `memoMarker: cached intrinsic failure for rules@${key}`,
                     );
@@ -1299,7 +1391,7 @@ export function tryNextBacktrack(state: MatchState): boolean {
                     // soundness condition documented on
                     // `MemoCache`.
                     inner.set(key, frame.successes);
-                    if (debugMatchRaw.enabled) {
+                    if (state.debugEnabled) {
                         debugMatchRaw(
                             `memoMarker: cached ${frame.successes.length} success delta(s) for rules@${key}`,
                         );
@@ -1334,7 +1426,8 @@ export function tryNextBacktrack(state: MatchState): boolean {
             // at head until fully consumed.  New frames pushed
             // during this delta's suffix sit on top and resolve
             // before the next cursor advance.
-            Object.assign(state, frame.snapshot);
+            const snap = frame.snapshot;
+            restoreSnapshot(state, snap);
             if (frame.cursor >= deltas.length) {
                 // Last delta: unlink the cursor frame.
                 state.backtracks = frame.prev;
@@ -1345,9 +1438,10 @@ export function tryNextBacktrack(state: MatchState): boolean {
             debugMatch(state, `Restoring memoReplay cursor [${i}]`);
             return true;
         }
-        // The snapshot omits `backtracks`, so Object.assign won't
-        // overwrite it - explicitly advance the head pointer to `prev`.
-        Object.assign(state, frame.snapshot);
+        // Explicit per-field restore: the snapshot omits
+        // `backtracks`, so we advance the head pointer separately.
+        const snap = frame.snapshot;
+        restoreSnapshot(state, snap);
         state.backtracks = frame.prev;
         debugMatch(
             state,
@@ -2048,7 +2142,7 @@ function finalizeMatch(
     if (!finalizeState(state, request)) {
         return false;
     }
-    if (debugMatchRaw.enabled) {
+    if (state.debugEnabled) {
         debugMatch(
             state,
             `Matched at end of input. Matched ids: ${JSON.stringify(state.valueIds)}, values: ${JSON.stringify(state.values)}'`,
@@ -2164,16 +2258,32 @@ export function finalizeNestedRule(
             // deduplication or nullable-completer caching.
             if (state.index !== parent.repeatStartIndex) {
                 // Build the CONTINUE alternative (re-enter the group).
-                const continueState: SnapshotState = {
-                    ...forkMatchState(state),
-                    partIndex: parent.repeatPartIndex,
-                    suppressOptionalFork: true,
-                };
+                // Mutate fields directly instead of spreading.
+                const continueState = forkMatchState(state);
+                continueState.partIndex = parent.repeatPartIndex;
+                continueState.suppressOptionalFork = true;
                 if (state.repeatPolicy === "greedy") {
                     // Live = continue (drill deeper); backtrack = stop
                     // (snapshot of state past the repeat).
                     const stopSnapshot = forkMatchState(state);
-                    Object.assign(state, continueState);
+                    // Restore continue state via explicit field writes.
+                    state.name = continueState.name;
+                    state.parts = continueState.parts;
+                    state.value = continueState.value;
+                    state.partIndex = continueState.partIndex;
+                    state.valueIds = continueState.valueIds;
+                    state.nextValueId = continueState.nextValueId;
+                    state.values = continueState.values;
+                    state.parent = continueState.parent;
+                    state.nestedLevel = continueState.nestedLevel;
+                    state.suppressOptionalFork =
+                        continueState.suppressOptionalFork;
+                    state.leadingSpacingMode = continueState.leadingSpacingMode;
+                    state.spacingMode = continueState.spacingMode;
+                    state.index = continueState.index;
+                    state.pendingWildcard = continueState.pendingWildcard;
+                    state.lastMatchedPartInfo =
+                        continueState.lastMatchedPartInfo;
                     pushBacktrack(state, stopSnapshot, "repeat");
                 } else {
                     // Default / nonGreedy: live = stop; backtrack = continue.
@@ -2208,7 +2318,7 @@ function matchStringPartWithWildcard(
         const wildcardEnd = match.index;
         const newIndex = wildcardEnd + match[0].length;
         if (!isBoundarySatisfied(request, newIndex, state.spacingMode)) {
-            if (debugMatchRaw.enabled) {
+            if (state.debugEnabled) {
                 debugMatch(
                     state,
                     `Rejected non-separated matched string '${part.value.join(" ")}' at ${wildcardEnd}`,
@@ -2228,7 +2338,7 @@ function matchStringPartWithWildcard(
             // assignment and cause "No value assign to variable" at
             // finalizeNestedRule time.
             if (requiresValue(state, part)) {
-                addValue(state, part.variable, part.value.join(" "));
+                addValue(state, part.variable, getJoinedValue(part));
             }
             // Always replaced (never mutated in place):
             // `captureSuccessDelta` relies on pointer inequality
@@ -2241,7 +2351,7 @@ function matchStringPartWithWildcard(
                 afterWildcard: true,
                 matchedSpacingMode: state.spacingMode,
             };
-            if (debugMatchRaw.enabled) {
+            if (state.debugEnabled) {
                 debugMatch(
                     state,
                     `Matched string '${part.value.join(" ")}' at ${wildcardEnd}`,
@@ -2249,7 +2359,7 @@ function matchStringPartWithWildcard(
             }
             return true;
         }
-        if (debugMatchRaw.enabled) {
+        if (state.debugEnabled) {
             debugMatch(
                 state,
                 `Rejected matched string '${part.value.join(" ")}' at ${wildcardEnd} with empty wildcard`,
@@ -2271,7 +2381,7 @@ function matchStringPartWithoutWildcard(
     }
     const newIndex = regExp.lastIndex;
     if (!isBoundarySatisfied(request, newIndex, state.spacingMode)) {
-        if (debugMatchRaw.enabled) {
+        if (state.debugEnabled) {
             debugMatch(
                 state,
                 `Rejected non-separated matched string ${part.value.join(" ")}`,
@@ -2280,7 +2390,7 @@ function matchStringPartWithoutWildcard(
         return false;
     }
 
-    if (debugMatchRaw.enabled) {
+    if (state.debugEnabled) {
         debugMatch(
             state,
             `Matched string ${part.value.join(" ")} to ${newIndex}`,
@@ -2288,7 +2398,7 @@ function matchStringPartWithoutWildcard(
     }
 
     if (requiresValue(state, part)) {
-        addValue(state, part.variable, part.value.join(" "));
+        addValue(state, part.variable, getJoinedValue(part));
     }
     // Always replaced (never mutated in place):
     // `captureSuccessDelta` relies on pointer inequality
@@ -2419,8 +2529,21 @@ function getStringPartRegExp(
     return entry;
 }
 
+// Lazily compute and cache the joined string for a StringPart.
+// `part.value` is immutable after grammar construction, so the
+// cached result is safe to reuse.  Avoids calling
+// `Array.prototype.join` on every successful match.
+function getJoinedValue(part: StringPart): string {
+    let joined = part.joinedCache;
+    if (joined === undefined) {
+        joined = part.value.join(" ");
+        part.joinedCache = joined;
+    }
+    return joined;
+}
+
 function matchStringPart(request: string, state: MatchState, part: StringPart) {
-    if (debugMatchRaw.enabled) {
+    if (state.debugEnabled) {
         debugMatch(
             state,
             `Checking string expr "${part.value.join(" ")}" with${state.pendingWildcard ? "" : "out"} wildcard`,
@@ -2463,7 +2586,7 @@ function matchVarNumberPartWithWildcard(
         const newIndex = wildcardEnd + match[0].length;
 
         if (!isBoundarySatisfied(request, newIndex, state.spacingMode)) {
-            if (debugMatchRaw.enabled) {
+            if (state.debugEnabled) {
                 debugMatch(
                     state,
                     `Rejected non-separated matched number at ${wildcardEnd}`,
@@ -2473,7 +2596,7 @@ function matchVarNumberPartWithWildcard(
         }
 
         if (captureWildcard(state, request, wildcardEnd, newIndex)) {
-            if (debugMatchRaw.enabled) {
+            if (state.debugEnabled) {
                 debugMatch(
                     state,
                     `Matched number at ${wildcardEnd} to ${newIndex}`,
@@ -2495,7 +2618,7 @@ function matchVarNumberPartWithWildcard(
             }
             return true;
         }
-        if (debugMatchRaw.enabled) {
+        if (state.debugEnabled) {
             debugMatch(
                 state,
                 `Rejected match number at ${wildcardEnd} to ${newIndex} with empty wildcard`,
@@ -2532,13 +2655,13 @@ function matchVarNumberPartWithoutWildcard(
     const newIndex = curr + m[0].length;
 
     if (!isBoundarySatisfied(request, newIndex, state.spacingMode)) {
-        if (debugMatchRaw.enabled) {
+        if (state.debugEnabled) {
             debugMatch(state, `Rejected non-separated matched number`);
         }
         return false;
     }
 
-    if (debugMatchRaw.enabled) {
+    if (state.debugEnabled) {
         debugMatch(state, `Matched number to ${newIndex}`);
     }
 
@@ -2564,7 +2687,7 @@ function matchVarNumberPart(
     state: MatchState,
     part: VarNumberPart,
 ) {
-    if (debugMatchRaw.enabled) {
+    if (state.debugEnabled) {
         debugMatch(
             state,
             `Checking number expr at with${state.pendingWildcard ? "" : "out"} wildcard`,
@@ -2622,7 +2745,11 @@ function enterTailRulesPart(state: MatchState, part: RulesPart): void {
     // would otherwise check (rules.length >= 2, no
     // repeat/optional/variable, member spacingMode matches parent's)
     // are caught at construction time at the offending site.
-    const namePrefix = part.name ? `<${part.name}>` : getStateName(state);
+    const namePrefix = state.debugEnabled
+        ? part.name
+            ? `<${part.name}>`
+            : getStateName(state)
+        : "";
     enterTailAlternation(state, part, part.alternatives, namePrefix);
 }
 
@@ -2645,7 +2772,7 @@ function enterTailAlternation(
     namePrefix: string,
 ): void {
     state.leadingSpacingMode = leadingSpacingMode(state);
-    state.name = getNestedStateName(state, part, 0);
+    state.name = state.debugEnabled ? getNestedStateName(state, part, 0) : "";
     state.parts = rules[0].parts;
     state.value = rules[0].value;
     state.partIndex = 0;
@@ -2730,7 +2857,7 @@ export function matchState(state: MatchState, request: string) {
         }
 
         const part = parts[partIndex];
-        if (debugMatchRaw.enabled) {
+        if (state.debugEnabled) {
             debugMatch(
                 state,
                 `matching type=${JSON.stringify(part.type)} pendingWildcard=${JSON.stringify(state.pendingWildcard)}`,
@@ -2749,10 +2876,10 @@ export function matchState(state: MatchState, request: string) {
         if (part.optional && !suppressOptionalFork) {
             // Build the SKIP alternative (advance past the optional
             // part, with `undefined` recorded for any variable).
-            const skipState: SnapshotState = {
-                ...forkMatchState(state),
-                partIndex: state.partIndex + 1,
-            };
+            // Mutate partIndex directly instead of spreading a new
+            // object: avoids a second allocation per optional part.
+            const skipState = forkMatchState(state);
+            skipState.partIndex = state.partIndex + 1;
             if (part.variable) {
                 addValue(skipState, part.variable, undefined);
             }
@@ -2766,11 +2893,25 @@ export function matchState(state: MatchState, request: string) {
                 // another take frame in an infinite loop.  The flag
                 // is consumed by the local capture above on the next
                 // iteration, so it cannot leak onto subsequent parts.
-                const takeSnapshot: SnapshotState = {
-                    ...forkMatchState(state),
-                    suppressOptionalFork: true,
-                };
-                Object.assign(state, skipState);
+                const takeSnapshot = forkMatchState(state);
+                takeSnapshot.suppressOptionalFork = true;
+                // Restore skip state via explicit field writes
+                // instead of Object.assign.
+                state.name = skipState.name;
+                state.parts = skipState.parts;
+                state.value = skipState.value;
+                state.partIndex = skipState.partIndex;
+                state.valueIds = skipState.valueIds;
+                state.nextValueId = skipState.nextValueId;
+                state.values = skipState.values;
+                state.parent = skipState.parent;
+                state.nestedLevel = skipState.nestedLevel;
+                state.suppressOptionalFork = skipState.suppressOptionalFork;
+                state.leadingSpacingMode = skipState.leadingSpacingMode;
+                state.spacingMode = skipState.spacingMode;
+                state.index = skipState.index;
+                state.pendingWildcard = skipState.pendingWildcard;
+                state.lastMatchedPartInfo = skipState.lastMatchedPartInfo;
                 pushBacktrack(state, takeSnapshot, "optional");
                 continue;
             }
@@ -2809,15 +2950,17 @@ export function matchState(state: MatchState, request: string) {
                     // continue the loop (without incrementing partIndex)
                     continue;
                 }
-                if (debugMatchRaw.enabled) {
+                if (state.debugEnabled) {
                     debugMatch(
                         state,
                         `expanding ${part.alternatives.length} rules`,
                     );
                 }
-                const namePrefix = part.name
-                    ? `<${part.name}>`
-                    : getStateName(state);
+                const namePrefix = state.debugEnabled
+                    ? part.name
+                        ? `<${part.name}>`
+                        : getStateName(state)
+                    : "";
                 if (
                     !enterRulesAlternation(
                         state,
@@ -2871,7 +3014,7 @@ function memoLookup(
         ),
     );
     if (cached === "failed") {
-        if (debugMatchRaw.enabled) {
+        if (state.debugEnabled) {
             debugMatchRaw(
                 `memoMarker: cache hit for rules@${state.index}|${childLeadingSpacingMode}|${pendingWildcardActive ? 1 : 0}|${requireValue ? 1 : 0}|${isCarrier ? 1 : 0} - short-circuit`,
             );
@@ -2900,19 +3043,12 @@ function memoLookup(
         // cursor).  One frame instead of N-1 saves ~80 bytes per
         // delta in the pathological case.
         if (cached.length > 1) {
-            state.backtracks = {
-                origin: "memoReplay",
-                snapshot: baseSnapshot,
-                deltas: cached,
-                cursor: 1,
-                failedSuffixKeys,
-                prev: state.backtracks,
-            };
+            pushMemoReplay(state, baseSnapshot, cached, failedSuffixKeys);
         }
         applyDelta(state, cached[0]);
         state.lastReplayBatch = failedSuffixKeys;
         state.lastReplaySuffixKey = suffixStateKey(cached[0]);
-        if (debugMatchRaw.enabled) {
+        if (state.debugEnabled) {
             debugMatchRaw(
                 `memoReplay: cache hit for rules@${state.index - cached[0].endOffset}|${childLeadingSpacingMode}|0 - replaying ${cached.length} delta(s)`,
             );
@@ -2929,25 +3065,15 @@ function memoLookup(
     // flipped its flag.
     const noSuccessCache =
         repeat || pendingWildcardActive || state.valueIds === null;
-    const marker: MemoMarkerBacktrack = {
-        origin: "memoMarker",
+    return pushMemoMarker(
+        state,
         rules,
-        index: state.index,
-        leading: childLeadingSpacingMode,
+        childLeadingSpacingMode,
         pendingWildcardActive,
-        anyMemberFinalized: false,
-        valuesAtEntry: state.values,
-        valueIdsAtEntry: state.valueIds,
-        nextValueIdAtEntry: state.nextValueId,
-        lastMatchedPartInfoAtEntry: state.lastMatchedPartInfo,
-        carrier: isCarrier,
+        isCarrier,
         requireValue,
         noSuccessCache,
-        successes: [],
-        prev: state.backtracks,
-    };
-    state.backtracks = marker;
-    return marker;
+    );
 }
 
 /**
@@ -3028,7 +3154,7 @@ function enterRulesAlternation(
     // Note: `requireValue` was computed above for the cache key.
 
     // Update the current state to consider the first nested rule.
-    state.name = `${namePrefix}[0]`;
+    state.name = state.debugEnabled ? `${namePrefix}[0]` : "";
     state.parts = rules[0].parts;
     state.value = rules[0].value;
     state.partIndex = 0;
@@ -3156,9 +3282,11 @@ function enterDispatchPart(
             debugMatch(state, `dispatch: pending-wildcard fallback empty`);
             return false;
         }
-        const namePrefix = part.name
-            ? `<${part.name}>`
-            : `${getStateName(state)}<dispatch>`;
+        const namePrefix = state.debugEnabled
+            ? part.name
+                ? `<${part.name}>`
+                : `${getStateName(state)}<dispatch>`
+            : "";
         if (part.tailCall) {
             enterTailAlternation(state, part, all, namePrefix);
             // Tail calls always succeed: they replace the current
@@ -3228,9 +3356,11 @@ function enterDispatchPart(
         );
     }
 
-    const namePrefix = part.name
-        ? `<${part.name}>`
-        : `${getStateName(state)}<dispatch>`;
+    const namePrefix = state.debugEnabled
+        ? part.name
+            ? `<${part.name}>`
+            : `${getStateName(state)}<dispatch>`
+        : "";
     if (part.tailCall) {
         enterTailAlternation(state, part, effective, namePrefix);
         // Tail calls always succeed: they replace the current
@@ -3261,11 +3391,9 @@ const topLevelDispatchCacheParts = new WeakMap<Grammar, RulesPart>();
 function getTopLevelDispatchCachePart(grammar: Grammar): RulesPart {
     let p = topLevelDispatchCacheParts.get(grammar);
     if (p === undefined) {
-        p = {
-            type: "rules",
-            alternatives: grammar.alternatives,
+        p = createRulesPart(grammar.alternatives, {
             dispatch: grammar.dispatch,
-        };
+        });
         topLevelDispatchCacheParts.set(grammar, p);
     }
     return p;
@@ -3276,6 +3404,9 @@ export function initialMatchState(
     request: string,
     options?: GrammarMatchOptions,
 ): MatchState | undefined {
+    // Read the debug flag once from the getter; stored on the state
+    // so every downstream function reads a plain boolean field.
+    const debugEnabled = debugMatchRaw.enabled;
     const wildcardPolicy = options?.wildcardPolicy ?? "exhaustive";
     const optionalPolicy = options?.optionalPolicy ?? "exhaustive";
     const repeatPolicy = options?.repeatPolicy ?? "exhaustive";
@@ -3343,7 +3474,7 @@ export function initialMatchState(
     }
 
     const state: MatchState = {
-        name: `<Start>[0]`,
+        name: debugEnabled ? `<Start>[0]` : "",
         parts: effective[0].parts,
         value: effective[0].value,
         partIndex: 0,
@@ -3358,10 +3489,14 @@ export function initialMatchState(
         index: 0,
         pendingWildcard: undefined,
         lastMatchedPartInfo: undefined,
+        backtracks: undefined,
         wildcardPolicy,
         optionalPolicy,
         repeatPolicy,
+        debugEnabled,
         memoization,
+        lastReplayBatch: undefined,
+        lastReplaySuffixKey: undefined,
         // Per-call memoization cache: empty at start, populated
         // as sub-rule entries complete (with intrinsic-failure or
         // success-delta records).  See `MemoCache` and the
@@ -3376,13 +3511,18 @@ export function initialMatchState(
     // from `effective[i]` directly on restore, and the debug name is
     // built lazily as `<Start>[i]`.
     if (effective.length > 1) {
-        pushAlternation(state, forkMatchState(state), effective, "<Start>");
+        pushAlternation(
+            state,
+            forkMatchState(state),
+            effective,
+            debugEnabled ? "<Start>" : "",
+        );
     }
     return state;
 }
 
 function debugMatch(state: MatchState, msg: string) {
-    if (!debugMatchRaw.enabled) return;
+    if (!state.debugEnabled) return;
     if (state.nestedLevel < 0) {
         throw new Error(
             `Internal error: nestedLevel went negative (${state.nestedLevel}) at "${msg}"`,

--- a/ts/packages/actionGrammar/src/grammarOptimizer.ts
+++ b/ts/packages/actionGrammar/src/grammarOptimizer.ts
@@ -12,9 +12,12 @@ import {
     GrammarPart,
     GrammarRule,
     isCaptureBearingPart,
-    PhraseSetPart,
     RulesPart,
-    StringPart,
+    createStringPart,
+    createWildcardPart,
+    createNumberPart,
+    createRulesPart,
+    createPhraseSetPart,
 } from "./grammarTypes.js";
 import { leadingWordBoundaryScriptPrefix } from "./spacingScripts.js";
 import { leadingNonSeparatorRun } from "./grammarMatcher.js";
@@ -1667,47 +1670,26 @@ function recordStepRemap(
 
 function edgeToPart(edge: TrieEdge): GrammarPart {
     switch (edge.kind) {
-        case "string": {
-            const out: StringPart = { type: "string", value: edge.tokens };
-            if (edge.canonical !== undefined) out.variable = edge.canonical;
-            return out;
-        }
-        case "wildcard": {
-            const out: GrammarPart = {
-                type: "wildcard",
-                typeName: edge.typeName,
+        case "string":
+            return createStringPart(edge.tokens, edge.canonical);
+        case "wildcard":
+            return createWildcardPart(
+                edge.canonical,
+                edge.typeName,
+                edge.optional,
+            );
+        case "number":
+            return createNumberPart(edge.canonical, edge.optional);
+        case "rules":
+            return createRulesPart(edge.rules, {
+                optional: edge.optional,
                 variable: edge.canonical,
-            };
-            if (edge.optional) out.optional = true;
-            return out;
-        }
-        case "number": {
-            const out: GrammarPart = {
-                type: "number",
-                variable: edge.canonical,
-            };
-            if (edge.optional) out.optional = true;
-            return out;
-        }
-        case "rules": {
-            const out: RulesPart = { type: "rules", alternatives: edge.rules };
-            if (edge.canonical !== undefined) {
-                out.variable = edge.canonical;
-            }
-            if (edge.optional) out.optional = true;
-            if (edge.repeat) out.repeat = true;
-            if (edge.name !== undefined) out.name = edge.name;
-            if (edge.tailCall) out.tailCall = true;
-            return out;
-        }
-        case "phraseSet": {
-            const out: PhraseSetPart = {
-                type: "phraseSet",
-                matcherName: edge.matcherName,
-            };
-            if (edge.canonical !== undefined) out.variable = edge.canonical;
-            return out;
-        }
+                repeat: edge.repeat,
+                name: edge.name,
+                tailCall: edge.tailCall,
+            });
+        case "phraseSet":
+            return createPhraseSetPart(edge.matcherName, edge.canonical);
     }
 }
 
@@ -1730,10 +1712,10 @@ function appendPartInPlace(prefix: GrammarPart[], part: GrammarPart): void {
         last.variable === undefined &&
         part.variable === undefined
     ) {
-        prefix[prefix.length - 1] = {
-            type: "string",
-            value: [...last.value, ...part.value],
-        };
+        prefix[prefix.length - 1] = createStringPart([
+            ...last.value,
+            ...part.value,
+        ]);
         return;
     }
     prefix.push(part);
@@ -1751,10 +1733,7 @@ function concatParts(a: GrammarPart[], b: GrammarPart[]): GrammarPart[] {
         last.variable === undefined &&
         first.variable === undefined
     ) {
-        const merged: GrammarPart = {
-            type: "string",
-            value: [...last.value, ...first.value],
-        };
+        const merged = createStringPart([...last.value, ...first.value]);
         return [...a.slice(0, a.length - 1), merged, ...b.slice(1)];
     }
     return [...a, ...b];
@@ -1982,11 +1961,9 @@ function buildTailWrapper(
     members: GrammarRule[],
     partitionSpacing: CompiledSpacingMode | undefined,
 ): GrammarRule {
-    const suffixRulesPart: RulesPart = {
-        type: "rules",
-        alternatives: members,
+    const suffixRulesPart = createRulesPart(members, {
         tailCall: true,
-    };
+    });
     const factoredAlt: GrammarRule = {
         parts: [...prefix, suffixRulesPart],
     };
@@ -2018,7 +1995,7 @@ function buildNonTailWrapper(
     buildState: BuildState,
     partitionSpacing: CompiledSpacingMode | undefined,
 ): GrammarRule {
-    const suffixRulesPart: RulesPart = { type: "rules", alternatives: members };
+    const suffixRulesPart = createRulesPart(members);
     const factoredAlt: GrammarRule = {
         parts: [...prefix, suffixRulesPart],
     };
@@ -2566,17 +2543,14 @@ function tryDispatchifyRulesPart(
     }
     if (payload === null) return undefined;
 
-    const out: RulesPart = {
-        type: "rules",
-        alternatives: payload.alternatives,
+    return createRulesPart(payload.alternatives, {
+        optional: part.optional,
+        variable: part.variable,
         dispatch: payload.dispatch,
-    };
-    if (part.name !== undefined) out.name = part.name;
-    if (part.variable !== undefined) out.variable = part.variable;
-    if (part.optional) out.optional = true;
-    if (part.repeat) out.repeat = true;
-    if (part.tailCall) out.tailCall = true;
-    return out;
+        name: part.name,
+        repeat: part.repeat,
+        tailCall: part.tailCall,
+    });
 }
 
 /**
@@ -2807,10 +2781,7 @@ function dispatchifyAlternations(rules: GrammarRule[]): {
     };
     if (result.length >= 2) {
         const dispatched = tryDispatchifyRulesPart(
-            {
-                type: "rules",
-                alternatives: result,
-            },
+            createRulesPart(result),
             dispatchMemo,
         );
         if (dispatched?.dispatch !== undefined) {
@@ -3111,13 +3082,11 @@ function tryPromoteTrailing(
 
     // Build the rewritten last part: drop variable / repeat /
     // optional (already verified absent), set tailCall.
-    const newLast: RulesPart = {
-        type: "rules",
-        alternatives: newAlternatives,
+    const newLast = createRulesPart(newAlternatives, {
         tailCall: true,
-    };
-    if (last.name !== undefined) newLast.name = last.name;
-    if (newDispatch !== undefined) newLast.dispatch = newDispatch;
+        name: last.name,
+        dispatch: newDispatch,
+    });
 
     const newParts = parts.slice();
     newParts[newParts.length - 1] = newLast;

--- a/ts/packages/actionGrammar/src/grammarSerializer.ts
+++ b/ts/packages/actionGrammar/src/grammarSerializer.ts
@@ -152,8 +152,8 @@ export function grammarToJson(grammar: Grammar): GrammarJson {
                 // both an `[]` pool slot and a per-site `index`
                 // field for that case.
                 const part: RulePartJson = {
-                    name: p.name,
                     type: "rules",
+                    name: p.name,
                     variable: p.variable,
                     optional: p.optional,
                 };

--- a/ts/packages/actionGrammar/src/grammarSerializer.ts
+++ b/ts/packages/actionGrammar/src/grammarSerializer.ts
@@ -152,8 +152,8 @@ export function grammarToJson(grammar: Grammar): GrammarJson {
                 // both an `[]` pool slot and a per-site `index`
                 // field for that case.
                 const part: RulePartJson = {
-                    type: "rules",
                     name: p.name,
+                    type: "rules",
                     variable: p.variable,
                     optional: p.optional,
                 };

--- a/ts/packages/actionGrammar/src/grammarTypes.ts
+++ b/ts/packages/actionGrammar/src/grammarTypes.ts
@@ -202,14 +202,14 @@ export type StringPart = {
      * allocation that the previous string-keyed Map incurred on
      * every match attempt.
      */
-    regexpCache?: Array<StringPartRegExpEntry | undefined>;
+    regexpCache?: Array<StringPartRegExpEntry | undefined> | undefined;
 
     /**
      * Cached result of `value.join(" ")`.  Populated lazily by
      * `getJoinedValue` in the matcher to avoid repeated
      * `Array.prototype.join` calls on every successful match.
      */
-    joinedCache?: string;
+    joinedCache?: string | undefined;
 };
 
 export type VarStringPart = {
@@ -434,6 +434,8 @@ export function createStringPart(
         optional: undefined,
         variable,
         value,
+        regexpCache: undefined,
+        joinedCache: undefined,
     };
 }
 

--- a/ts/packages/actionGrammar/src/grammarTypes.ts
+++ b/ts/packages/actionGrammar/src/grammarTypes.ts
@@ -177,8 +177,7 @@ export type StringPartRegExpEntry = {
 
 export type StringPart = {
     type: "string";
-    value: string[];
-    optional?: undefined; // TODO: support optional string parts
+    optional: undefined; // TODO: support optional string parts
     /**
      * Optional capture variable.  When set, the matcher writes the
      * joined matched tokens (`value.join(" ")`) into the slot/value
@@ -189,7 +188,8 @@ export type StringPart = {
      * Currently introduced only by the optimizer's inliner pass; not
      * exposed in `.agr` source syntax.
      */
-    variable?: string | undefined;
+    variable: string | undefined;
+    value: string[];
 
     /**
      * Cache of compiled RegExp objects.  There are exactly 4
@@ -203,20 +203,27 @@ export type StringPart = {
      * every match attempt.
      */
     regexpCache?: Array<StringPartRegExpEntry | undefined>;
+
+    /**
+     * Cached result of `value.join(" ")`.  Populated lazily by
+     * `getJoinedValue` in the matcher to avoid repeated
+     * `Array.prototype.join` calls on every successful match.
+     */
+    joinedCache?: string;
 };
 
 export type VarStringPart = {
     type: "wildcard";
+    optional: boolean | undefined;
     variable: string;
-    optional?: boolean | undefined;
 
     typeName: string; // Not needed at runtime?
 };
 
 export type VarNumberPart = {
     type: "number";
+    optional: boolean | undefined;
     variable: string;
-    optional?: boolean | undefined;
 };
 
 /**
@@ -248,6 +255,8 @@ export type DispatchModeBucket = {
  */
 export type RulesPart = {
     type: "rules";
+    optional: boolean | undefined;
+    variable: string | undefined;
 
     alternatives: GrammarRule[];
     /**
@@ -309,8 +318,6 @@ export type RulesPart = {
     dispatch?: DispatchModeBucket[] | undefined;
     name?: string | undefined; // For debugging
 
-    variable?: string | undefined;
-    optional?: boolean | undefined;
     repeat?: boolean | undefined; // Kleene star: zero or more occurrences
 
     /**
@@ -350,8 +357,7 @@ export type RulesPart = {
 
 export type PhraseSetPart = {
     type: "phraseSet";
-    /** Name of the phrase-set matcher (e.g. "Polite", "Greeting") */
-    matcherName: string;
+    optional: undefined;
     /**
      * Optional capture variable.  When set, the matcher writes the
      * actual matched phrase (its tokens joined with a single space)
@@ -360,8 +366,9 @@ export type PhraseSetPart = {
      * Currently introduced only by the optimizer's inliner pass; not
      * exposed in `.agr` source syntax.
      */
-    variable?: string | undefined;
-    optional?: undefined;
+    variable: string | undefined;
+    /** Name of the phrase-set matcher (e.g. "Polite", "Greeting") */
+    matcherName: string;
 };
 
 export type GrammarPart =
@@ -411,6 +418,84 @@ export function isCaptureBearingPart(
 export function getCapturedVariableName(part: GrammarPart): string | undefined {
     return isCaptureBearingPart(part) ? part.variable : undefined;
 }
+
+// ── GrammarPart factory functions ────────────────────────────────────────
+//
+// Single creation point for each GrammarPart kind.  Guarantees V8 sees
+// a single hidden class per kind (identical field order, all fields
+// always present).  Optional fields default to `undefined`.
+
+export function createStringPart(
+    value: string[],
+    variable?: string,
+): StringPart {
+    return {
+        type: "string",
+        optional: undefined,
+        variable: variable ?? undefined,
+        value,
+    };
+}
+
+export function createWildcardPart(
+    variable: string,
+    typeName: string,
+    optional?: boolean,
+): VarStringPart {
+    return {
+        type: "wildcard",
+        optional: optional,
+        variable,
+        typeName,
+    };
+}
+
+export function createNumberPart(
+    variable: string,
+    optional?: boolean,
+): VarNumberPart {
+    return {
+        type: "number",
+        optional: optional,
+        variable,
+    };
+}
+
+export function createRulesPart(
+    alternatives: GrammarRule[],
+    options?: {
+        optional?: boolean | undefined;
+        variable?: string | undefined;
+        dispatch?: DispatchModeBucket[] | undefined;
+        name?: string | undefined;
+        repeat?: boolean | undefined;
+        tailCall?: boolean | undefined;
+    },
+): RulesPart {
+    return {
+        type: "rules",
+        optional: options?.optional,
+        variable: options?.variable,
+        alternatives,
+        dispatch: options?.dispatch,
+        name: options?.name,
+        repeat: options?.repeat,
+        tailCall: options?.tailCall,
+    };
+}
+
+export function createPhraseSetPart(
+    matcherName: string,
+    variable?: string,
+): PhraseSetPart {
+    return {
+        type: "phraseSet",
+        optional: undefined,
+        variable: variable ?? undefined,
+        matcherName,
+    };
+}
+
 export type GrammarRule = {
     parts: GrammarPart[];
     value?: CompiledValueNode | undefined;

--- a/ts/packages/actionGrammar/src/grammarTypes.ts
+++ b/ts/packages/actionGrammar/src/grammarTypes.ts
@@ -432,7 +432,7 @@ export function createStringPart(
     return {
         type: "string",
         optional: undefined,
-        variable: variable ?? undefined,
+        variable,
         value,
     };
 }
@@ -491,7 +491,7 @@ export function createPhraseSetPart(
     return {
         type: "phraseSet",
         optional: undefined,
-        variable: variable ?? undefined,
+        variable,
         matcherName,
     };
 }

--- a/ts/packages/actionGrammar/src/nfaCompiler.ts
+++ b/ts/packages/actionGrammar/src/nfaCompiler.ts
@@ -12,6 +12,7 @@ import {
     PhraseSetPart,
     CompiledSpacingMode,
     getCapturedVariableName,
+    createRulesPart,
 } from "./grammarTypes.js";
 import { NFA, NFABuilder } from "./nfa.js";
 import {
@@ -340,16 +341,13 @@ function stripDispatch(part: RulesPart): RulesPart {
         }
     }
     for (const r of part.alternatives) expanded.push(r);
-    const rulesPart: RulesPart = {
-        type: "rules",
-        alternatives: expanded,
-        name: part.name,
+    return createRulesPart(expanded, {
+        optional: part.optional,
         variable: part.variable,
-    };
-    if (part.optional) rulesPart.optional = true;
-    if (part.repeat) rulesPart.repeat = true;
-    if (part.tailCall) rulesPart.tailCall = true;
-    return rulesPart;
+        name: part.name,
+        repeat: part.repeat,
+        tailCall: part.tailCall,
+    });
 }
 
 /**

--- a/ts/packages/actionGrammar/test/agentGrammarRegistry.spec.ts
+++ b/ts/packages/actionGrammar/test/agentGrammarRegistry.spec.ts
@@ -6,7 +6,8 @@ import {
     AgentGrammar,
 } from "../src/agentGrammarRegistry.js";
 import { registerBuiltInEntities } from "../src/builtInEntities.js";
-import { Grammar,
+import {
+    Grammar,
     createStringPart,
     createWildcardPart,
 } from "../src/grammarTypes.js";

--- a/ts/packages/actionGrammar/test/agentGrammarRegistry.spec.ts
+++ b/ts/packages/actionGrammar/test/agentGrammarRegistry.spec.ts
@@ -6,7 +6,10 @@ import {
     AgentGrammar,
 } from "../src/agentGrammarRegistry.js";
 import { registerBuiltInEntities } from "../src/builtInEntities.js";
-import { Grammar } from "../src/grammarTypes.js";
+import { Grammar,
+    createStringPart,
+    createWildcardPart,
+} from "../src/grammarTypes.js";
 import { compileGrammarToNFA } from "../src/nfaCompiler.js";
 
 describe("Agent Grammar Registry", () => {
@@ -20,12 +23,8 @@ describe("Agent Grammar Registry", () => {
                 alternatives: [
                     {
                         parts: [
-                            { type: "string", value: ["play"] },
-                            {
-                                type: "wildcard",
-                                variable: "track",
-                                typeName: "string",
-                            },
+                            createStringPart(["play"]),
+                            createWildcardPart("track", "string"),
                         ],
                         value: {
                             type: "object",
@@ -53,7 +52,7 @@ describe("Agent Grammar Registry", () => {
             const baseGrammar: Grammar = {
                 alternatives: [
                     {
-                        parts: [{ type: "string", value: ["pause"] }],
+                        parts: [createStringPart(["pause"])],
                     },
                 ],
             };
@@ -87,7 +86,7 @@ describe("Agent Grammar Registry", () => {
             const baseGrammar: Grammar = {
                 alternatives: [
                     {
-                        parts: [{ type: "string", value: ["test"] }],
+                        parts: [createStringPart(["test"])],
                     },
                 ],
             };
@@ -116,7 +115,7 @@ describe("Agent Grammar Registry", () => {
             const baseGrammar: Grammar = {
                 alternatives: [
                     {
-                        parts: [{ type: "string", value: ["test"] }],
+                        parts: [createStringPart(["test"])],
                     },
                 ],
                 entities: ["Ordinal"],
@@ -149,7 +148,7 @@ describe("Agent Grammar Registry", () => {
             const grammar: Grammar = {
                 alternatives: [
                     {
-                        parts: [{ type: "string", value: ["test"] }],
+                        parts: [createStringPart(["test"])],
                     },
                 ],
             };
@@ -167,7 +166,7 @@ describe("Agent Grammar Registry", () => {
             const baseGrammar: Grammar = {
                 alternatives: [
                     {
-                        parts: [{ type: "string", value: ["pause"] }],
+                        parts: [createStringPart(["pause"])],
                     },
                 ],
             };
@@ -257,7 +256,7 @@ describe("Agent Grammar Registry", () => {
             const grammar: Grammar = {
                 alternatives: [
                     {
-                        parts: [{ type: "string", value: ["play"] }],
+                        parts: [createStringPart(["play"])],
                     },
                 ],
             };
@@ -296,7 +295,7 @@ describe("Agent Grammar Registry", () => {
             const grammar: Grammar = {
                 alternatives: [
                     {
-                        parts: [{ type: "string", value: ["test"] }],
+                        parts: [createStringPart(["test"])],
                     },
                 ],
             };
@@ -313,7 +312,7 @@ describe("Agent Grammar Registry", () => {
             const baseGrammar: Grammar = {
                 alternatives: [
                     {
-                        parts: [{ type: "string", value: ["pause"] }],
+                        parts: [createStringPart(["pause"])],
                     },
                 ],
             };
@@ -350,12 +349,8 @@ describe("Agent Grammar Registry", () => {
                 alternatives: [
                     {
                         parts: [
-                            { type: "string", value: ["play"] },
-                            {
-                                type: "wildcard",
-                                variable: "track",
-                                typeName: "string",
-                            },
+                            createStringPart(["play"]),
+                            createWildcardPart("track", "string"),
                         ],
                         value: {
                             type: "object",
@@ -377,12 +372,8 @@ describe("Agent Grammar Registry", () => {
                 alternatives: [
                     {
                         parts: [
-                            { type: "string", value: ["schedule"] },
-                            {
-                                type: "wildcard",
-                                variable: "event",
-                                typeName: "string",
-                            },
+                            createStringPart(["schedule"]),
+                            createWildcardPart("event", "string"),
                         ],
                         value: {
                             type: "object",
@@ -423,14 +414,14 @@ describe("Agent Grammar Registry", () => {
             registry.registerAgent("player", {
                 alternatives: [
                     {
-                        parts: [{ type: "string", value: ["play"] }],
+                        parts: [createStringPart(["play"])],
                     },
                 ],
             });
             registry.registerAgent("calendar", {
                 alternatives: [
                     {
-                        parts: [{ type: "string", value: ["schedule"] }],
+                        parts: [createStringPart(["schedule"])],
                     },
                 ],
             });
@@ -449,7 +440,7 @@ describe("Agent Grammar Registry", () => {
             registry.registerAgent("player", {
                 alternatives: [
                     {
-                        parts: [{ type: "string", value: ["play"] }],
+                        parts: [createStringPart(["play"])],
                     },
                 ],
             });
@@ -464,14 +455,14 @@ describe("Agent Grammar Registry", () => {
             registry.registerAgent("player", {
                 alternatives: [
                     {
-                        parts: [{ type: "string", value: ["play"] }],
+                        parts: [createStringPart(["play"])],
                     },
                 ],
             });
             registry.registerAgent("calendar", {
                 alternatives: [
                     {
-                        parts: [{ type: "string", value: ["schedule"] }],
+                        parts: [createStringPart(["schedule"])],
                     },
                 ],
             });
@@ -486,14 +477,14 @@ describe("Agent Grammar Registry", () => {
             registry.registerAgent("agent1", {
                 alternatives: [
                     {
-                        parts: [{ type: "string", value: ["test1"] }],
+                        parts: [createStringPart(["test1"])],
                     },
                 ],
             });
             registry.registerAgent("agent2", {
                 alternatives: [
                     {
-                        parts: [{ type: "string", value: ["test2"] }],
+                        parts: [createStringPart(["test2"])],
                     },
                 ],
             });

--- a/ts/packages/actionGrammar/test/dfa.spec.ts
+++ b/ts/packages/actionGrammar/test/dfa.spec.ts
@@ -1,3 +1,4 @@
+import { createStringPart, createWildcardPart } from "../src/grammarTypes.js";
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
@@ -27,8 +28,8 @@ describe("DFA Compilation", () => {
             alternatives: [
                 {
                     parts: [
-                        { type: "string", value: ["play"] },
-                        { type: "string", value: ["music"] },
+                        createStringPart(["play"]),
+                        createStringPart(["music"]),
                     ],
                     value: {
                         type: "object",
@@ -58,8 +59,8 @@ describe("DFA Compilation", () => {
             alternatives: [
                 {
                     parts: [
-                        { type: "string", value: ["play"] },
-                        { type: "string", value: ["music"] },
+                        createStringPart(["play"]),
+                        createStringPart(["music"]),
                     ],
                     value: {
                         type: "object",
@@ -91,13 +92,8 @@ describe("DFA Compilation", () => {
             alternatives: [
                 {
                     parts: [
-                        { type: "string", value: ["play"] },
-                        {
-                            type: "wildcard",
-                            variable: "track",
-                            typeName: "string",
-                            optional: false,
-                        },
+                        createStringPart(["play"]),
+                        createWildcardPart("track", "string"),
                     ],
                     value: {
                         type: "object",
@@ -115,8 +111,8 @@ describe("DFA Compilation", () => {
                 },
                 {
                     parts: [
-                        { type: "string", value: ["play"] },
-                        { type: "string", value: ["music"] },
+                        createStringPart(["play"]),
+                        createStringPart(["music"]),
                     ],
                     value: {
                         type: "object",
@@ -148,20 +144,20 @@ describe("DFA Compilation", () => {
             alternatives: [
                 {
                     parts: [
-                        { type: "string", value: ["play"] },
-                        { type: "string", value: ["music"] },
+                        createStringPart(["play"]),
+                        createStringPart(["music"]),
                     ],
                     value: { type: "literal", value: "play-music" },
                 },
                 {
                     parts: [
-                        { type: "string", value: ["play"] },
-                        { type: "string", value: ["song"] },
+                        createStringPart(["play"]),
+                        createStringPart(["song"]),
                     ],
                     value: { type: "literal", value: "play-song" },
                 },
                 {
-                    parts: [{ type: "string", value: ["pause"] }],
+                    parts: [createStringPart(["pause"])],
                     value: { type: "literal", value: "pause" },
                 },
             ],
@@ -189,13 +185,8 @@ describe("DFA Compilation", () => {
             alternatives: [
                 {
                     parts: [
-                        { type: "string", value: ["play"] },
-                        {
-                            type: "wildcard",
-                            variable: "track",
-                            typeName: "string",
-                            optional: false,
-                        },
+                        createStringPart(["play"]),
+                        createWildcardPart("track", "string"),
                     ],
                     value: {
                         type: "object",
@@ -226,13 +217,8 @@ describe("DFA Compilation", () => {
             alternatives: [
                 {
                     parts: [
-                        { type: "string", value: ["play"] },
-                        {
-                            type: "wildcard",
-                            variable: "track",
-                            typeName: "string",
-                            optional: false,
-                        },
+                        createStringPart(["play"]),
+                        createWildcardPart("track", "string"),
                     ],
                     value: {
                         type: "object",
@@ -247,13 +233,8 @@ describe("DFA Compilation", () => {
                 },
                 {
                     parts: [
-                        { type: "string", value: ["play"] },
-                        {
-                            type: "wildcard",
-                            variable: "n",
-                            typeName: "number",
-                            optional: false,
-                        },
+                        createStringPart(["play"]),
+                        createWildcardPart("n", "number"),
                     ],
                     value: {
                         type: "object",
@@ -285,8 +266,8 @@ describe("DFA Compilation", () => {
             alternatives: [
                 {
                     parts: [
-                        { type: "string", value: ["play"] },
-                        { type: "string", value: ["music"] },
+                        createStringPart(["play"]),
+                        createStringPart(["music"]),
                     ],
                     value: { type: "literal", value: "play-music" },
                 },
@@ -313,13 +294,8 @@ describe("DFA Compilation", () => {
             alternatives: [
                 {
                     parts: [
-                        { type: "string", value: ["play"] },
-                        {
-                            type: "wildcard",
-                            variable: "track",
-                            typeName: "string",
-                            optional: false,
-                        },
+                        createStringPart(["play"]),
+                        createWildcardPart("track", "string"),
                     ],
                     value: {
                         type: "object",
@@ -339,13 +315,8 @@ describe("DFA Compilation", () => {
                 },
                 {
                     parts: [
-                        { type: "string", value: ["play"] },
-                        {
-                            type: "wildcard",
-                            variable: "id",
-                            typeName: "number",
-                            optional: false,
-                        },
+                        createStringPart(["play"]),
+                        createWildcardPart("id", "number"),
                     ],
                     value: {
                         type: "object",
@@ -385,20 +356,10 @@ describe("DFA Compilation", () => {
             alternatives: [
                 {
                     parts: [
-                        { type: "string", value: ["play"] },
-                        {
-                            type: "wildcard",
-                            variable: "track",
-                            typeName: "string",
-                            optional: false,
-                        },
-                        { type: "string", value: ["by"] },
-                        {
-                            type: "wildcard",
-                            variable: "artist",
-                            typeName: "string",
-                            optional: false,
-                        },
+                        createStringPart(["play"]),
+                        createWildcardPart("track", "string"),
+                        createStringPart(["by"]),
+                        createWildcardPart("artist", "string"),
                     ],
                     value: {
                         type: "object",
@@ -447,13 +408,8 @@ describe("DFA Compilation", () => {
             alternatives: [
                 {
                     parts: [
-                        { type: "string", value: ["play"] },
-                        {
-                            type: "wildcard",
-                            variable: "track",
-                            typeName: "string",
-                            optional: false,
-                        },
+                        createStringPart(["play"]),
+                        createWildcardPart("track", "string"),
                     ],
                     value: {
                         type: "object",
@@ -468,13 +424,8 @@ describe("DFA Compilation", () => {
                 },
                 {
                     parts: [
-                        { type: "string", value: ["play"] },
-                        {
-                            type: "wildcard",
-                            variable: "id",
-                            typeName: "number",
-                            optional: false,
-                        },
+                        createStringPart(["play"]),
+                        createWildcardPart("id", "number"),
                     ],
                     value: {
                         type: "object",
@@ -489,8 +440,8 @@ describe("DFA Compilation", () => {
                 },
                 {
                     parts: [
-                        { type: "string", value: ["play"] },
-                        { type: "string", value: ["music"] },
+                        createStringPart(["play"]),
+                        createStringPart(["music"]),
                     ],
                     value: { type: "literal", value: "play-music" },
                 },
@@ -524,19 +475,9 @@ describe("DFA Compilation", () => {
             alternatives: [
                 {
                     parts: [
-                        { type: "string", value: ["play"] },
-                        {
-                            type: "wildcard",
-                            variable: "x",
-                            typeName: "string",
-                            optional: false,
-                        },
-                        {
-                            type: "wildcard",
-                            variable: "y",
-                            typeName: "string",
-                            optional: false,
-                        },
+                        createStringPart(["play"]),
+                        createWildcardPart("x", "string"),
+                        createWildcardPart("y", "string"),
                     ],
                     value: {
                         type: "object",
@@ -564,14 +505,9 @@ describe("DFA Compilation", () => {
                 },
                 {
                     parts: [
-                        { type: "string", value: ["play"] },
-                        { type: "string", value: ["track"] },
-                        {
-                            type: "wildcard",
-                            variable: "name",
-                            typeName: "string",
-                            optional: false,
-                        },
+                        createStringPart(["play"]),
+                        createStringPart(["track"]),
+                        createWildcardPart("name", "string"),
                     ],
                     value: {
                         type: "object",
@@ -618,13 +554,8 @@ describe("DFA Compilation", () => {
             alternatives: [
                 {
                     parts: [
-                        { type: "string", value: ["play"] },
-                        {
-                            type: "wildcard",
-                            variable: "track", // SAME NAME
-                            typeName: "string",
-                            optional: false,
-                        },
+                        createStringPart(["play"]),
+                        createWildcardPart("track", "string"), // SAME NAME
                     ],
                     value: {
                         type: "object",
@@ -644,13 +575,8 @@ describe("DFA Compilation", () => {
                 },
                 {
                     parts: [
-                        { type: "string", value: ["play"] },
-                        {
-                            type: "wildcard",
-                            variable: "track", // SAME NAME
-                            typeName: "number",
-                            optional: false,
-                        },
+                        createStringPart(["play"]),
+                        createWildcardPart("track", "number"), // SAME NAME
                     ],
                     value: {
                         type: "object",
@@ -695,8 +621,8 @@ describe("DFA Compilation", () => {
                 {
                     // Rule 0
                     parts: [
-                        { type: "string", value: ["play"] },
-                        { type: "string", value: ["music"] },
+                        createStringPart(["play"]),
+                        createStringPart(["music"]),
                     ],
                     value: {
                         type: "object",
@@ -711,7 +637,7 @@ describe("DFA Compilation", () => {
                 },
                 {
                     // Rule 1
-                    parts: [{ type: "string", value: ["pause"] }],
+                    parts: [createStringPart(["pause"])],
                     value: {
                         type: "object",
                         value: [
@@ -726,13 +652,8 @@ describe("DFA Compilation", () => {
                 {
                     // Rule 2
                     parts: [
-                        { type: "string", value: ["play"] },
-                        {
-                            type: "wildcard",
-                            variable: "track",
-                            typeName: "string",
-                            optional: false,
-                        },
+                        createStringPart(["play"]),
+                        createWildcardPart("track", "string"),
                     ],
                     value: {
                         type: "object",
@@ -773,8 +694,8 @@ describe("DFA Compilation", () => {
                 {
                     // Rule 0
                     parts: [
-                        { type: "string", value: ["play"] },
-                        { type: "string", value: ["music"] },
+                        createStringPart(["play"]),
+                        createStringPart(["music"]),
                     ],
                     value: {
                         type: "object",
@@ -790,8 +711,8 @@ describe("DFA Compilation", () => {
                 {
                     // Rule 1
                     parts: [
-                        { type: "string", value: ["play"] },
-                        { type: "string", value: ["song"] },
+                        createStringPart(["play"]),
+                        createStringPart(["song"]),
                     ],
                     value: {
                         type: "object",
@@ -828,13 +749,8 @@ describe("DFA Compilation", () => {
                 {
                     // Rule 0 - lower priority (wildcard)
                     parts: [
-                        { type: "string", value: ["play"] },
-                        {
-                            type: "wildcard",
-                            variable: "track",
-                            typeName: "string",
-                            optional: false,
-                        },
+                        createStringPart(["play"]),
+                        createWildcardPart("track", "string"),
                     ],
                     value: {
                         type: "object",
@@ -853,8 +769,8 @@ describe("DFA Compilation", () => {
                 {
                     // Rule 1 - higher priority (more fixed strings)
                     parts: [
-                        { type: "string", value: ["play"] },
-                        { type: "string", value: ["music"] },
+                        createStringPart(["play"]),
+                        createStringPart(["music"]),
                     ],
                     value: {
                         type: "object",
@@ -889,10 +805,10 @@ describe("DFA Compilation", () => {
                 {
                     // play the first track
                     parts: [
-                        { type: "string", value: ["play"] },
-                        { type: "string", value: ["the"] },
-                        { type: "string", value: ["first"] },
-                        { type: "string", value: ["track"] },
+                        createStringPart(["play"]),
+                        createStringPart(["the"]),
+                        createStringPart(["first"]),
+                        createStringPart(["track"]),
                     ],
                     value: {
                         type: "object",
@@ -911,14 +827,9 @@ describe("DFA Compilation", () => {
                 {
                     // play track #5
                     parts: [
-                        { type: "string", value: ["play"] },
-                        { type: "string", value: ["track"] },
-                        {
-                            type: "wildcard",
-                            variable: "n",
-                            typeName: "number",
-                            optional: false,
-                        },
+                        createStringPart(["play"]),
+                        createStringPart(["track"]),
+                        createWildcardPart("n", "number"),
                     ],
                     value: {
                         type: "object",
@@ -937,20 +848,10 @@ describe("DFA Compilation", () => {
                 {
                     // play <trackName> by <artist>
                     parts: [
-                        { type: "string", value: ["play"] },
-                        {
-                            type: "wildcard",
-                            variable: "trackName",
-                            typeName: "string",
-                            optional: false,
-                        },
-                        { type: "string", value: ["by"] },
-                        {
-                            type: "wildcard",
-                            variable: "artist",
-                            typeName: "string",
-                            optional: false,
-                        },
+                        createStringPart(["play"]),
+                        createWildcardPart("trackName", "string"),
+                        createStringPart(["by"]),
+                        createWildcardPart("artist", "string"),
                     ],
                     value: {
                         type: "object",
@@ -988,20 +889,10 @@ describe("DFA Compilation", () => {
                 {
                     // play <trackName> by <artist>
                     parts: [
-                        { type: "string", value: ["play"] },
-                        {
-                            type: "wildcard",
-                            variable: "trackName",
-                            typeName: "string",
-                            optional: false,
-                        },
-                        { type: "string", value: ["by"] },
-                        {
-                            type: "wildcard",
-                            variable: "artist",
-                            typeName: "string",
-                            optional: false,
-                        },
+                        createStringPart(["play"]),
+                        createWildcardPart("trackName", "string"),
+                        createStringPart(["by"]),
+                        createWildcardPart("artist", "string"),
                     ],
                     value: {
                         type: "object",
@@ -1017,21 +908,11 @@ describe("DFA Compilation", () => {
                 {
                     // play <trackName> from album <album>
                     parts: [
-                        { type: "string", value: ["play"] },
-                        {
-                            type: "wildcard",
-                            variable: "trackName",
-                            typeName: "string",
-                            optional: false,
-                        },
-                        { type: "string", value: ["from"] },
-                        { type: "string", value: ["album"] },
-                        {
-                            type: "wildcard",
-                            variable: "albumName",
-                            typeName: "string",
-                            optional: false,
-                        },
+                        createStringPart(["play"]),
+                        createWildcardPart("trackName", "string"),
+                        createStringPart(["from"]),
+                        createStringPart(["album"]),
+                        createWildcardPart("albumName", "string"),
                     ],
                     value: {
                         type: "object",
@@ -1071,20 +952,10 @@ describe("DFA Compilation", () => {
             alternatives: [
                 {
                     parts: [
-                        { type: "string", value: ["play"] },
-                        {
-                            type: "wildcard",
-                            variable: "trackName",
-                            typeName: "string",
-                            optional: false,
-                        },
-                        { type: "string", value: ["by"] },
-                        {
-                            type: "wildcard",
-                            variable: "artist",
-                            typeName: "ArtistName",
-                            optional: false,
-                        },
+                        createStringPart(["play"]),
+                        createWildcardPart("trackName", "string"),
+                        createStringPart(["by"]),
+                        createWildcardPart("artist", "ArtistName"),
                     ],
                     value: {
                         type: "object",
@@ -1150,13 +1021,8 @@ describe("DFA Compilation", () => {
                 {
                     // play <artist>
                     parts: [
-                        { type: "string", value: ["play"] },
-                        {
-                            type: "wildcard",
-                            variable: "artist",
-                            typeName: "ArtistName",
-                            optional: false,
-                        },
+                        createStringPart(["play"]),
+                        createWildcardPart("artist", "ArtistName"),
                     ],
                     value: {
                         type: "object",
@@ -1172,13 +1038,8 @@ describe("DFA Compilation", () => {
                 {
                     // play <track>
                     parts: [
-                        { type: "string", value: ["play"] },
-                        {
-                            type: "wildcard",
-                            variable: "track",
-                            typeName: "TrackName",
-                            optional: false,
-                        },
+                        createStringPart(["play"]),
+                        createWildcardPart("track", "TrackName"),
                     ],
                     value: {
                         type: "object",
@@ -1194,13 +1055,8 @@ describe("DFA Compilation", () => {
                 {
                     // play <album>
                     parts: [
-                        { type: "string", value: ["play"] },
-                        {
-                            type: "wildcard",
-                            variable: "album",
-                            typeName: "AlbumName",
-                            optional: false,
-                        },
+                        createStringPart(["play"]),
+                        createWildcardPart("album", "AlbumName"),
                     ],
                     value: {
                         type: "object",

--- a/ts/packages/actionGrammar/test/dfa.spec.ts
+++ b/ts/packages/actionGrammar/test/dfa.spec.ts
@@ -1,6 +1,7 @@
-import { createStringPart, createWildcardPart } from "../src/grammarTypes.js";
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+
+import { createStringPart, createWildcardPart } from "../src/grammarTypes.js";
 
 /**
  * Tests for DFA compilation and matching

--- a/ts/packages/actionGrammar/test/dfaAST.spec.ts
+++ b/ts/packages/actionGrammar/test/dfaAST.spec.ts
@@ -1,6 +1,7 @@
-import { createStringPart, createWildcardPart } from "../src/grammarTypes.js";
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+
+import { createStringPart, createWildcardPart } from "../src/grammarTypes.js";
 
 /**
  * Tests for AST-based DFA matching (matchDFAToAST + evaluateMatchAST)

--- a/ts/packages/actionGrammar/test/dfaAST.spec.ts
+++ b/ts/packages/actionGrammar/test/dfaAST.spec.ts
@@ -1,3 +1,4 @@
+import { createStringPart, createWildcardPart } from "../src/grammarTypes.js";
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
@@ -36,8 +37,8 @@ describe("DFA AST Matching", () => {
                 alternatives: [
                     {
                         parts: [
-                            { type: "string", value: ["play"] },
-                            { type: "string", value: ["music"] },
+                            createStringPart(["play"]),
+                            createStringPart(["music"]),
                         ],
                         value: {
                             type: "object",
@@ -78,8 +79,8 @@ describe("DFA AST Matching", () => {
                 alternatives: [
                     {
                         parts: [
-                            { type: "string", value: ["play"] },
-                            { type: "string", value: ["music"] },
+                            createStringPart(["play"]),
+                            createStringPart(["music"]),
                         ],
                         value: { type: "literal", value: "playMusic" },
                     },
@@ -97,8 +98,8 @@ describe("DFA AST Matching", () => {
                 alternatives: [
                     {
                         parts: [
-                            { type: "string", value: ["play"] },
-                            { type: "string", value: ["music"] },
+                            createStringPart(["play"]),
+                            createStringPart(["music"]),
                         ],
                         value: { type: "literal", value: "playMusic" },
                     },
@@ -118,12 +119,8 @@ describe("DFA AST Matching", () => {
                 alternatives: [
                     {
                         parts: [
-                            { type: "string", value: ["play"] },
-                            {
-                                type: "wildcard",
-                                variable: "track",
-                                typeName: "string",
-                            },
+                            createStringPart(["play"]),
+                            createWildcardPart("track", "string"),
                         ],
                         value: {
                             type: "object",
@@ -161,12 +158,8 @@ describe("DFA AST Matching", () => {
                 alternatives: [
                     {
                         parts: [
-                            { type: "string", value: ["play"] },
-                            {
-                                type: "wildcard",
-                                variable: "track",
-                                typeName: "string",
-                            },
+                            createStringPart(["play"]),
+                            createWildcardPart("track", "string"),
                         ],
                         value: {
                             type: "object",
@@ -198,18 +191,10 @@ describe("DFA AST Matching", () => {
                 alternatives: [
                     {
                         parts: [
-                            { type: "string", value: ["play"] },
-                            {
-                                type: "wildcard",
-                                variable: "track",
-                                typeName: "string",
-                            },
-                            { type: "string", value: ["by"] },
-                            {
-                                type: "wildcard",
-                                variable: "artist",
-                                typeName: "string",
-                            },
+                            createStringPart(["play"]),
+                            createWildcardPart("track", "string"),
+                            createStringPart(["by"]),
+                            createWildcardPart("artist", "string"),
                         ],
                         value: {
                             type: "object",
@@ -264,18 +249,10 @@ describe("DFA AST Matching", () => {
                 alternatives: [
                     {
                         parts: [
-                            { type: "string", value: ["play"] },
-                            {
-                                type: "wildcard",
-                                variable: "track",
-                                typeName: "string",
-                            },
-                            { type: "string", value: ["by"] },
-                            {
-                                type: "wildcard",
-                                variable: "artist",
-                                typeName: "string",
-                            },
+                            createStringPart(["play"]),
+                            createWildcardPart("track", "string"),
+                            createStringPart(["by"]),
+                            createWildcardPart("artist", "string"),
                         ],
                         value: {
                             type: "object",
@@ -338,18 +315,10 @@ describe("DFA AST Matching", () => {
                 alternatives: [
                     {
                         parts: [
-                            { type: "string", value: ["play"] },
-                            {
-                                type: "wildcard",
-                                variable: "track",
-                                typeName: "string",
-                            },
-                            { type: "string", value: ["on"] },
-                            {
-                                type: "wildcard",
-                                variable: "device",
-                                typeName: "string",
-                            },
+                            createStringPart(["play"]),
+                            createWildcardPart("track", "string"),
+                            createStringPart(["on"]),
+                            createWildcardPart("device", "string"),
                         ],
                         value: {
                             type: "object",
@@ -393,12 +362,8 @@ describe("DFA AST Matching", () => {
                 alternatives: [
                     {
                         parts: [
-                            { type: "string", value: ["play"] },
-                            {
-                                type: "wildcard",
-                                variable: "track",
-                                typeName: "string",
-                            },
+                            createStringPart(["play"]),
+                            createWildcardPart("track", "string"),
                         ],
                         value: {
                             type: "object",
@@ -432,18 +397,10 @@ describe("DFA AST Matching", () => {
                 alternatives: [
                     {
                         parts: [
-                            { type: "string", value: ["play"] },
-                            {
-                                type: "wildcard",
-                                variable: "track",
-                                typeName: "string",
-                            },
-                            { type: "string", value: ["by"] },
-                            {
-                                type: "wildcard",
-                                variable: "artist",
-                                typeName: "string",
-                            },
+                            createStringPart(["play"]),
+                            createWildcardPart("track", "string"),
+                            createStringPart(["by"]),
+                            createWildcardPart("artist", "string"),
                         ],
                         value: {
                             type: "object",
@@ -483,18 +440,10 @@ describe("DFA AST Matching", () => {
                 alternatives: [
                     {
                         parts: [
-                            { type: "string", value: ["play"] },
-                            {
-                                type: "wildcard",
-                                variable: "track",
-                                typeName: "string",
-                            },
-                            { type: "string", value: ["by"] },
-                            {
-                                type: "wildcard",
-                                variable: "artist",
-                                typeName: "string",
-                            },
+                            createStringPart(["play"]),
+                            createWildcardPart("track", "string"),
+                            createStringPart(["by"]),
+                            createWildcardPart("artist", "string"),
                         ],
                         value: {
                             type: "object",
@@ -535,7 +484,7 @@ describe("DFA AST Matching", () => {
             const grammar: Grammar = {
                 alternatives: [
                     {
-                        parts: [{ type: "string", value: ["pause"] }],
+                        parts: [createStringPart(["pause"])],
                         value: {
                             type: "object",
                             value: [
@@ -566,8 +515,8 @@ describe("DFA AST Matching", () => {
                 alternatives: [
                     {
                         parts: [
-                            { type: "string", value: ["play"] },
-                            { type: "string", value: ["music"] },
+                            createStringPart(["play"]),
+                            createStringPart(["music"]),
                         ],
                         value: {
                             type: "object",
@@ -585,8 +534,8 @@ describe("DFA AST Matching", () => {
                     },
                     {
                         parts: [
-                            { type: "string", value: ["stop"] },
-                            { type: "string", value: ["music"] },
+                            createStringPart(["stop"]),
+                            createStringPart(["music"]),
                         ],
                         value: {
                             type: "object",
@@ -627,18 +576,10 @@ describe("DFA AST Matching", () => {
                 alternatives: [
                     {
                         parts: [
-                            { type: "string", value: ["play"] },
-                            {
-                                type: "wildcard",
-                                variable: "artist",
-                                typeName: "string",
-                            },
-                            { type: "string", value: ["'s"] },
-                            {
-                                type: "wildcard",
-                                variable: "track",
-                                typeName: "string",
-                            },
+                            createStringPart(["play"]),
+                            createWildcardPart("artist", "string"),
+                            createStringPart(["'s"]),
+                            createWildcardPart("track", "string"),
                         ],
                         value: {
                             type: "object",
@@ -681,9 +622,9 @@ describe("DFA AST Matching", () => {
                 alternatives: [
                     {
                         parts: [
-                            { type: "string", value: ["play"] },
-                            { type: "string", value: ["the"] },
-                            { type: "string", value: ["music"] },
+                            createStringPart(["play"]),
+                            createStringPart(["the"]),
+                            createStringPart(["music"]),
                         ],
                         value: { type: "literal", value: "playTheMusic" },
                     },
@@ -703,12 +644,8 @@ describe("DFA AST Matching", () => {
                 alternatives: [
                     {
                         parts: [
-                            { type: "string", value: ["play"] },
-                            {
-                                type: "wildcard",
-                                variable: "track",
-                                typeName: "string",
-                            },
+                            createStringPart(["play"]),
+                            createWildcardPart("track", "string"),
                         ],
                         value: {
                             type: "object",
@@ -735,8 +672,8 @@ describe("DFA AST Matching", () => {
                 alternatives: [
                     {
                         parts: [
-                            { type: "string", value: ["play"] },
-                            { type: "string", value: ["music"] },
+                            createStringPart(["play"]),
+                            createStringPart(["music"]),
                         ],
                         value: {
                             type: "literal",
@@ -758,7 +695,7 @@ describe("DFA AST Matching", () => {
             const grammar: Grammar = {
                 alternatives: [
                     {
-                        parts: [{ type: "string", value: ["play"] }],
+                        parts: [createStringPart(["play"])],
                     },
                 ],
             };

--- a/ts/packages/actionGrammar/test/dynamicGrammarLoader.spec.ts
+++ b/ts/packages/actionGrammar/test/dynamicGrammarLoader.spec.ts
@@ -1,7 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { Grammar } from "../src/grammarTypes.js";
+import { Grammar,
+    createStringPart,
+    createWildcardPart,
+} from "../src/grammarTypes.js";
 import { compileGrammarToNFA } from "../src/nfaCompiler.js";
 import { matchNFA } from "../src/nfaInterpreter.js";
 import {
@@ -165,7 +168,7 @@ describe("Dynamic Grammar Loader", () => {
             const existingGrammar: Grammar = {
                 alternatives: [
                     {
-                        parts: [{ type: "string", value: ["pause"] }],
+                        parts: [createStringPart(["pause"])],
                     },
                 ],
             };
@@ -204,12 +207,8 @@ describe("Dynamic Grammar Loader", () => {
                 alternatives: [
                     {
                         parts: [
-                            { type: "string", value: ["play"] },
-                            {
-                                type: "wildcard",
-                                variable: "track",
-                                typeName: "string",
-                            },
+                            createStringPart(["play"]),
+                            createWildcardPart("track", "string"),
                         ],
                         value: {
                             type: "object",
@@ -259,7 +258,7 @@ describe("Dynamic Grammar Loader", () => {
             const initialGrammar: Grammar = {
                 alternatives: [
                     {
-                        parts: [{ type: "string", value: ["pause"] }],
+                        parts: [createStringPart(["pause"])],
                     },
                 ],
             };
@@ -299,7 +298,7 @@ describe("Dynamic Grammar Loader", () => {
             const initialGrammar: Grammar = {
                 alternatives: [
                     {
-                        parts: [{ type: "string", value: ["pause"] }],
+                        parts: [createStringPart(["pause"])],
                     },
                 ],
             };
@@ -355,7 +354,7 @@ describe("Dynamic Grammar Loader", () => {
             const initialGrammar: Grammar = {
                 alternatives: [
                     {
-                        parts: [{ type: "string", value: ["pause"] }],
+                        parts: [createStringPart(["pause"])],
                     },
                 ],
             };

--- a/ts/packages/actionGrammar/test/dynamicGrammarLoader.spec.ts
+++ b/ts/packages/actionGrammar/test/dynamicGrammarLoader.spec.ts
@@ -1,7 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { Grammar,
+import {
+    Grammar,
     createStringPart,
     createWildcardPart,
 } from "../src/grammarTypes.js";

--- a/ts/packages/actionGrammar/test/grammarOptimizerDispatch.spec.ts
+++ b/ts/packages/actionGrammar/test/grammarOptimizerDispatch.spec.ts
@@ -19,7 +19,9 @@
 
 import { loadGrammarRules } from "../src/grammarLoader.js";
 import { matchGrammar } from "../src/grammarMatcher.js";
-import { GrammarRule, RulesPart } from "../src/grammarTypes.js";
+import { GrammarRule, RulesPart,
+    createStringPart,
+} from "../src/grammarTypes.js";
 import { grammarToJson } from "../src/grammarSerializer.js";
 import { grammarFromJson } from "../src/grammarDeserializer.js";
 import {
@@ -947,7 +949,9 @@ describe("Grammar Optimizer - dispatchifyAlternations", () => {
 describe("Grammar Optimizer - non-canonical DispatchPart shapes", () => {
     function buildRule(token: string, value: string): GrammarRule {
         return {
-            parts: [{ type: "string", value: [token] }],
+            parts: [
+                createStringPart([token]),
+            ],
             value: { type: "literal", value },
         };
     }
@@ -959,6 +963,8 @@ describe("Grammar Optimizer - non-canonical DispatchPart shapes", () => {
         const ruleB = buildRule("beta", "b");
         const dispatch: RulesPart = {
             type: "rules",
+            optional: undefined,
+            variable: undefined,
             dispatch: [],
             alternatives: [ruleA, ruleB],
         };
@@ -981,11 +987,15 @@ describe("Grammar Optimizer - non-canonical DispatchPart shapes", () => {
         // peek hit yields the bucket, miss yields no alternatives.
         const ruleA = buildRule("alpha", "a1");
         const ruleA2: GrammarRule = {
-            parts: [{ type: "string", value: ["alpha", "two"] }],
+            parts: [
+                createStringPart(["alpha", "two"]),
+            ],
             value: { type: "literal", value: "a2" },
         };
         const dispatch: RulesPart = {
             type: "rules",
+            optional: undefined,
+            variable: undefined,
             alternatives: [],
             dispatch: [
                 {
@@ -1015,6 +1025,8 @@ describe("Grammar Optimizer - non-canonical DispatchPart shapes", () => {
         // nothing.
         const dispatch: RulesPart = {
             type: "rules",
+            optional: undefined,
+            variable: undefined,
             alternatives: [],
             dispatch: [],
         };
@@ -1033,6 +1045,8 @@ describe("Grammar Optimizer - non-canonical DispatchPart shapes", () => {
         const ruleA = buildRule("alpha", "a");
         const dispatch: RulesPart = {
             type: "rules",
+            optional: undefined,
+            variable: undefined,
             alternatives: [],
             dispatch: [
                 {

--- a/ts/packages/actionGrammar/test/grammarOptimizerDispatch.spec.ts
+++ b/ts/packages/actionGrammar/test/grammarOptimizerDispatch.spec.ts
@@ -19,7 +19,9 @@
 
 import { loadGrammarRules } from "../src/grammarLoader.js";
 import { matchGrammar } from "../src/grammarMatcher.js";
-import { GrammarRule, RulesPart,
+import {
+    GrammarRule,
+    RulesPart,
     createStringPart,
 } from "../src/grammarTypes.js";
 import { grammarToJson } from "../src/grammarSerializer.js";
@@ -949,9 +951,7 @@ describe("Grammar Optimizer - dispatchifyAlternations", () => {
 describe("Grammar Optimizer - non-canonical DispatchPart shapes", () => {
     function buildRule(token: string, value: string): GrammarRule {
         return {
-            parts: [
-                createStringPart([token]),
-            ],
+            parts: [createStringPart([token])],
             value: { type: "literal", value },
         };
     }
@@ -987,9 +987,7 @@ describe("Grammar Optimizer - non-canonical DispatchPart shapes", () => {
         // peek hit yields the bucket, miss yields no alternatives.
         const ruleA = buildRule("alpha", "a1");
         const ruleA2: GrammarRule = {
-            parts: [
-                createStringPart(["alpha", "two"]),
-            ],
+            parts: [createStringPart(["alpha", "two"])],
             value: { type: "literal", value: "a2" },
         };
         const dispatch: RulesPart = {

--- a/ts/packages/actionGrammar/test/grammarOptimizerDispatchMultiKey.spec.ts
+++ b/ts/packages/actionGrammar/test/grammarOptimizerDispatchMultiKey.spec.ts
@@ -29,7 +29,10 @@
 
 import { loadGrammarRules } from "../src/grammarLoader.js";
 import { optimizeGrammar } from "../src/grammarOptimizer.js";
-import { Grammar, GrammarRule, RulesPart,
+import {
+    Grammar,
+    GrammarRule,
+    RulesPart,
     createStringPart,
 } from "../src/grammarTypes.js";
 import {

--- a/ts/packages/actionGrammar/test/grammarOptimizerDispatchMultiKey.spec.ts
+++ b/ts/packages/actionGrammar/test/grammarOptimizerDispatchMultiKey.spec.ts
@@ -29,7 +29,9 @@
 
 import { loadGrammarRules } from "../src/grammarLoader.js";
 import { optimizeGrammar } from "../src/grammarOptimizer.js";
-import { Grammar, GrammarRule, RulesPart } from "../src/grammarTypes.js";
+import { Grammar, GrammarRule, RulesPart,
+    createStringPart,
+} from "../src/grammarTypes.js";
 import {
     findDispatchPart,
     getDispatchAllTokenMap,
@@ -245,15 +247,16 @@ describe("Grammar Optimizer - multi-key dispatch classifier", () => {
         const cyclingAlts: GrammarRule[] = [];
         const recursivePart: RulesPart = {
             type: "rules",
+            variable: undefined,
             alternatives: cyclingAlts,
             optional: true,
         };
         cyclingAlts.push({
-            parts: [recursivePart, { type: "string", value: ["alpha"] }],
+            parts: [recursivePart, createStringPart(["alpha"])],
             value: { type: "literal", value: "a" },
         });
         cyclingAlts.push({
-            parts: [{ type: "string", value: ["beta"] }],
+            parts: [createStringPart(["beta"])],
             value: { type: "literal", value: "b" },
         });
         const grammar: Grammar = { alternatives: cyclingAlts };

--- a/ts/packages/actionGrammar/test/grammarOptimizerDispatchTail.spec.ts
+++ b/ts/packages/actionGrammar/test/grammarOptimizerDispatchTail.spec.ts
@@ -24,7 +24,9 @@ import { grammarFromJson } from "../src/grammarDeserializer.js";
 import { loadGrammarRules } from "../src/grammarLoader.js";
 import { validateTailRulesParts } from "../src/grammarOptimizer.js";
 import { grammarToJson } from "../src/grammarSerializer.js";
-import { Grammar, GrammarRule, RulesPart } from "../src/grammarTypes.js";
+import { Grammar, GrammarRule, RulesPart,
+    createStringPart,
+} from "../src/grammarTypes.js";
 import { getDispatchEffectiveMembers } from "../src/dispatchHelpers.js";
 import {
     DispatchedRulesPart,
@@ -160,15 +162,17 @@ describe("Grammar Optimizer - DispatchPart with tailCall", () => {
 
         function buildBaseline(): Grammar {
             const memberA: GrammarRule = {
-                parts: [{ type: "string", value: ["alpha"] }],
+                parts: [createStringPart(["alpha"])],
                 value: { type: "literal", value: "a" },
             };
             const memberB: GrammarRule = {
-                parts: [{ type: "string", value: ["beta"] }],
+                parts: [createStringPart(["beta"])],
                 value: { type: "literal", value: "b" },
             };
             const dispatch: RulesPart = {
                 type: "rules",
+                optional: undefined,
+                variable: undefined,
                 alternatives: [],
                 dispatch: [
                     {
@@ -193,10 +197,7 @@ describe("Grammar Optimizer - DispatchPart with tailCall", () => {
 
         it("rejects when not the last part of the parent rule", () => {
             const g = buildBaseline();
-            g.alternatives[0].parts.push({
-                type: "string",
-                value: ["trailer"],
-            });
+            g.alternatives[0].parts.push(createStringPart(["trailer"]));
             expect(() => validateTailRulesParts(g.alternatives)).toThrow(
                 /must be the last part/,
             );

--- a/ts/packages/actionGrammar/test/grammarOptimizerDispatchTail.spec.ts
+++ b/ts/packages/actionGrammar/test/grammarOptimizerDispatchTail.spec.ts
@@ -24,7 +24,10 @@ import { grammarFromJson } from "../src/grammarDeserializer.js";
 import { loadGrammarRules } from "../src/grammarLoader.js";
 import { validateTailRulesParts } from "../src/grammarOptimizer.js";
 import { grammarToJson } from "../src/grammarSerializer.js";
-import { Grammar, GrammarRule, RulesPart,
+import {
+    Grammar,
+    GrammarRule,
+    RulesPart,
     createStringPart,
 } from "../src/grammarTypes.js";
 import { getDispatchEffectiveMembers } from "../src/dispatchHelpers.js";

--- a/ts/packages/actionGrammar/test/grammarOptimizerIntegration.spec.ts
+++ b/ts/packages/actionGrammar/test/grammarOptimizerIntegration.spec.ts
@@ -21,7 +21,9 @@ import {
 } from "../src/grammarLoader.js";
 import { matchGrammar } from "../src/grammarMatcher.js";
 import { optimizeGrammar } from "../src/grammarOptimizer.js";
-import { Grammar, GrammarPart, GrammarRule } from "../src/grammarTypes.js";
+import { Grammar, GrammarPart, GrammarRule,
+    createStringPart,
+} from "../src/grammarTypes.js";
 
 function countRulesParts(rules: GrammarRule[]): number {
     let n = 0;
@@ -43,7 +45,7 @@ function countRulesParts(rules: GrammarRule[]): number {
 describe("Grammar Optimizer - Public API entry points", () => {
     it("optimizeGrammar returns the input grammar unchanged when options is undefined", () => {
         const grammar: Grammar = {
-            alternatives: [{ parts: [{ type: "string", value: ["hello"] }] }],
+            alternatives: [{ parts: [createStringPart(["hello"])] }],
         };
         const result = optimizeGrammar(grammar, undefined);
         // Same object identity — early return, no copy.
@@ -52,7 +54,7 @@ describe("Grammar Optimizer - Public API entry points", () => {
 
     it("optimizeGrammar returns the input grammar unchanged when no flags are set", () => {
         const grammar: Grammar = {
-            alternatives: [{ parts: [{ type: "string", value: ["hello"] }] }],
+            alternatives: [{ parts: [createStringPart(["hello"])] }],
         };
         // Both flags off → both passes skipped → returns same identity.
         const result = optimizeGrammar(grammar, {});

--- a/ts/packages/actionGrammar/test/grammarOptimizerIntegration.spec.ts
+++ b/ts/packages/actionGrammar/test/grammarOptimizerIntegration.spec.ts
@@ -21,7 +21,10 @@ import {
 } from "../src/grammarLoader.js";
 import { matchGrammar } from "../src/grammarMatcher.js";
 import { optimizeGrammar } from "../src/grammarOptimizer.js";
-import { Grammar, GrammarPart, GrammarRule,
+import {
+    Grammar,
+    GrammarPart,
+    GrammarRule,
     createStringPart,
 } from "../src/grammarTypes.js";
 

--- a/ts/packages/actionGrammar/test/grammarOptimizerTailFactoring.spec.ts
+++ b/ts/packages/actionGrammar/test/grammarOptimizerTailFactoring.spec.ts
@@ -6,7 +6,9 @@ import { loadGrammarRules } from "../src/grammarLoader.js";
 import { matchGrammar } from "../src/grammarMatcher.js";
 import { validateTailRulesParts } from "../src/grammarOptimizer.js";
 import { grammarToJson } from "../src/grammarSerializer.js";
-import { Grammar, GrammarRule, RulesPart } from "../src/grammarTypes.js";
+import { Grammar, GrammarRule, RulesPart,
+    createStringPart,
+} from "../src/grammarTypes.js";
 import { findAllRulesParts } from "./testUtils.js";
 
 function match(grammar: ReturnType<typeof loadGrammarRules>, request: string) {
@@ -288,7 +290,7 @@ describe("validateTailRulesParts", () => {
         const bad = buildBadGrammar((rule, _tail) => {
             // Append a sentinel string part so the tail is no longer
             // last.
-            rule.parts.push({ type: "string", value: ["xyz"] });
+            rule.parts.push(createStringPart(["xyz"]));
         });
         expect(() => validateTailRulesParts(bad.alternatives)).toThrow(
             /must be the last part/,
@@ -536,9 +538,9 @@ describe("leadingSpacingMode propagation through tail-call entries", () => {
                 // 0: Start
                 {
                     parts: [
-                        { type: "string", value: ["do"] },
+                        createStringPart(["do"]),
                         { type: "rules", index: 1, variable: "x" },
-                        { type: "string", value: ["end"] },
+                        createStringPart(["end"]),
                     ],
                     value: { type: "variable", name: "x" },
                     spacingMode: "required",
@@ -550,13 +552,13 @@ describe("leadingSpacingMode propagation through tail-call entries", () => {
                 },
                 // 2: Tail member "bar"
                 {
-                    parts: [{ type: "string", value: ["bar"] }],
+                    parts: [createStringPart(["bar"])],
                     value: { type: "literal", value: "b" },
                     spacingMode: "none",
                 },
                 // 3: Tail member "baz"
                 {
-                    parts: [{ type: "string", value: ["baz"] }],
+                    parts: [createStringPart(["baz"])],
                     value: { type: "literal", value: "z" },
                     spacingMode: "none",
                 },

--- a/ts/packages/actionGrammar/test/grammarOptimizerTailFactoring.spec.ts
+++ b/ts/packages/actionGrammar/test/grammarOptimizerTailFactoring.spec.ts
@@ -6,7 +6,10 @@ import { loadGrammarRules } from "../src/grammarLoader.js";
 import { matchGrammar } from "../src/grammarMatcher.js";
 import { validateTailRulesParts } from "../src/grammarOptimizer.js";
 import { grammarToJson } from "../src/grammarSerializer.js";
-import { Grammar, GrammarRule, RulesPart,
+import {
+    Grammar,
+    GrammarRule,
+    RulesPart,
     createStringPart,
 } from "../src/grammarTypes.js";
 import { findAllRulesParts } from "./testUtils.js";

--- a/ts/packages/actionGrammar/test/nfa.spec.ts
+++ b/ts/packages/actionGrammar/test/nfa.spec.ts
@@ -1,7 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { Grammar,
+import {
+    Grammar,
     createNumberPart,
     createStringPart,
     createWildcardPart,
@@ -60,9 +61,7 @@ describe("NFA Infrastructure", () => {
             const grammar: Grammar = {
                 alternatives: [
                     {
-                        parts: [
-                            createStringPart(["hello"]),
-                        ],
+                        parts: [createStringPart(["hello"])],
                     },
                 ],
             };
@@ -78,14 +77,10 @@ describe("NFA Infrastructure", () => {
             const grammar: Grammar = {
                 alternatives: [
                     {
-                        parts: [
-                            createStringPart(["hello"]),
-                        ],
+                        parts: [createStringPart(["hello"])],
                     },
                     {
-                        parts: [
-                            createStringPart(["hi"]),
-                        ],
+                        parts: [createStringPart(["hi"])],
                     },
                 ],
             };
@@ -199,14 +194,10 @@ describe("NFA Infrastructure", () => {
                                 variable: undefined,
                                 alternatives: [
                                     {
-                                        parts: [
-                                            createStringPart(["um"]),
-                                        ],
+                                        parts: [createStringPart(["um"])],
                                     },
                                     {
-                                        parts: [
-                                            createStringPart(["uh"]),
-                                        ],
+                                        parts: [createStringPart(["uh"])],
                                     },
                                 ],
                                 repeat: true,
@@ -240,9 +231,7 @@ describe("NFA Infrastructure", () => {
                                 variable: undefined,
                                 alternatives: [
                                     {
-                                        parts: [
-                                            createStringPart(["word"]),
-                                        ],
+                                        parts: [createStringPart(["word"])],
                                     },
                                 ],
                                 repeat: true,
@@ -331,9 +320,7 @@ describe("NFA Infrastructure", () => {
             const grammar: Grammar = {
                 alternatives: [
                     {
-                        parts: [
-                            createNumberPart("count"),
-                        ],
+                        parts: [createNumberPart("count")],
                         value: {
                             type: "object",
                             value: [
@@ -405,9 +392,7 @@ describe("NFA Infrastructure", () => {
             const grammar: Grammar = {
                 alternatives: [
                     {
-                        parts: [
-                            createStringPart(["hello"]),
-                        ],
+                        parts: [createStringPart(["hello"])],
                     },
                 ],
             };

--- a/ts/packages/actionGrammar/test/nfa.spec.ts
+++ b/ts/packages/actionGrammar/test/nfa.spec.ts
@@ -1,7 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { Grammar } from "../src/grammarTypes.js";
+import { Grammar,
+    createNumberPart,
+    createStringPart,
+    createWildcardPart,
+} from "../src/grammarTypes.js";
 import { compileGrammarToNFA } from "../src/nfaCompiler.js";
 import { matchNFA, printNFA, printMatchResult } from "../src/nfaInterpreter.js";
 import { NFABuilder, combineNFAs } from "../src/nfa.js";
@@ -57,10 +61,7 @@ describe("NFA Infrastructure", () => {
                 alternatives: [
                     {
                         parts: [
-                            {
-                                type: "string",
-                                value: ["hello"],
-                            },
+                            createStringPart(["hello"]),
                         ],
                     },
                 ],
@@ -78,18 +79,12 @@ describe("NFA Infrastructure", () => {
                 alternatives: [
                     {
                         parts: [
-                            {
-                                type: "string",
-                                value: ["hello"],
-                            },
+                            createStringPart(["hello"]),
                         ],
                     },
                     {
                         parts: [
-                            {
-                                type: "string",
-                                value: ["hi"],
-                            },
+                            createStringPart(["hi"]),
                         ],
                     },
                 ],
@@ -110,14 +105,8 @@ describe("NFA Infrastructure", () => {
                 alternatives: [
                     {
                         parts: [
-                            {
-                                type: "string",
-                                value: ["hello"],
-                            },
-                            {
-                                type: "string",
-                                value: ["world"],
-                            },
+                            createStringPart(["hello"]),
+                            createStringPart(["world"]),
                         ],
                         value: { type: "literal", value: "hello-world" },
                     },
@@ -139,15 +128,8 @@ describe("NFA Infrastructure", () => {
                 alternatives: [
                     {
                         parts: [
-                            {
-                                type: "string",
-                                value: ["hello"],
-                            },
-                            {
-                                type: "wildcard",
-                                variable: "name",
-                                typeName: "string",
-                            },
+                            createStringPart(["hello"]),
+                            createWildcardPart("name", "string"),
                         ],
                         value: {
                             type: "object",
@@ -176,16 +158,8 @@ describe("NFA Infrastructure", () => {
                 alternatives: [
                     {
                         parts: [
-                            {
-                                type: "string",
-                                value: ["hello"],
-                            },
-                            {
-                                type: "wildcard",
-                                variable: "name",
-                                typeName: "string",
-                                optional: true,
-                            },
+                            createStringPart(["hello"]),
+                            createWildcardPart("name", "string", true),
                         ],
                         value: {
                             type: "object",
@@ -221,28 +195,28 @@ describe("NFA Infrastructure", () => {
                         parts: [
                             {
                                 type: "rules",
+                                optional: true,
+                                variable: undefined,
                                 alternatives: [
                                     {
                                         parts: [
-                                            { type: "string", value: ["um"] },
+                                            createStringPart(["um"]),
                                         ],
                                     },
                                     {
                                         parts: [
-                                            { type: "string", value: ["uh"] },
+                                            createStringPart(["uh"]),
                                         ],
                                     },
                                 ],
-                                optional: true,
                                 repeat: true,
                             },
-                            { type: "string", value: ["help"] },
+                            createStringPart(["help"]),
                         ],
                         value: { type: "literal", value: true },
                     },
                 ],
             };
-
             const nfa = compileGrammarToNFA(grammar, "kleene-star");
             // zero repetitions
             expect(matchNFA(nfa, ["help"]).matched).toBe(true);
@@ -262,17 +236,19 @@ describe("NFA Infrastructure", () => {
                         parts: [
                             {
                                 type: "rules",
+                                optional: undefined,
+                                variable: undefined,
                                 alternatives: [
                                     {
                                         parts: [
-                                            { type: "string", value: ["word"] },
+                                            createStringPart(["word"]),
                                         ],
                                     },
                                 ],
                                 repeat: true,
                                 // optional is intentionally absent → must match at least once
                             },
-                            { type: "string", value: ["end"] },
+                            createStringPart(["end"]),
                         ],
                         value: { type: "literal", value: true },
                     },
@@ -356,10 +332,7 @@ describe("NFA Infrastructure", () => {
                 alternatives: [
                     {
                         parts: [
-                            {
-                                type: "number",
-                                variable: "count",
-                            },
+                            createNumberPart("count"),
                         ],
                         value: {
                             type: "object",
@@ -433,10 +406,7 @@ describe("NFA Infrastructure", () => {
                 alternatives: [
                     {
                         parts: [
-                            {
-                                type: "string",
-                                value: ["hello"],
-                            },
+                            createStringPart(["hello"]),
                         ],
                     },
                 ],

--- a/ts/packages/actionGrammar/test/nfaDfaStringPhraseSetVariable.spec.ts
+++ b/ts/packages/actionGrammar/test/nfaDfaStringPhraseSetVariable.spec.ts
@@ -28,6 +28,11 @@ import { matchDFAWithSplitting } from "../src/dfaMatcher.js";
 import { grammarToJson } from "../src/grammarSerializer.js";
 import { grammarFromJson } from "../src/grammarDeserializer.js";
 import type { Grammar } from "../src/grammarTypes.js";
+import {
+    createStringPart,
+    createWildcardPart,
+    createPhraseSetPart,
+} from "../src/grammarTypes.js";
 
 function bestNfaActionValue(grammar: Grammar, request: string): unknown {
     const nfa = compileGrammarToNFA(grammar, "test.grammar");
@@ -61,13 +66,7 @@ describe("StringPart variable capture", () => {
     const grammar: Grammar = {
         alternatives: [
             {
-                parts: [
-                    {
-                        type: "string",
-                        value: ["hello"],
-                        variable: "greeting",
-                    },
-                ],
+                parts: [createStringPart(["hello"], "greeting")],
                 value: { type: "variable", name: "greeting" },
             },
         ],
@@ -91,13 +90,7 @@ describe("StringPart variable capture", () => {
     const multiTokenGrammar: Grammar = {
         alternatives: [
             {
-                parts: [
-                    {
-                        type: "string",
-                        value: ["good", "morning"],
-                        variable: "greeting",
-                    },
-                ],
+                parts: [createStringPart(["good", "morning"], "greeting")],
                 value: { type: "variable", name: "greeting" },
             },
         ],
@@ -127,16 +120,8 @@ describe("StringPart variable capture", () => {
         alternatives: [
             {
                 parts: [
-                    {
-                        type: "string",
-                        value: ["greet"],
-                        variable: "verb",
-                    },
-                    {
-                        type: "wildcard",
-                        typeName: "string",
-                        variable: "name",
-                    },
+                    createStringPart(["greet"], "verb"),
+                    createWildcardPart("name", "string"),
                 ],
                 value: {
                     type: "object",
@@ -185,12 +170,8 @@ describe("PhraseSetPart variable capture", () => {
         alternatives: [
             {
                 parts: [
-                    {
-                        type: "phraseSet",
-                        matcherName: "Polite",
-                        variable: "opener",
-                    },
-                    { type: "string", value: ["go"] },
+                    createPhraseSetPart("Polite", "opener"),
+                    createStringPart(["go"]),
                 ],
                 value: {
                     type: "object",
@@ -231,13 +212,7 @@ describe("Serialization round-trip preserves variable", () => {
         const grammar: Grammar = {
             alternatives: [
                 {
-                    parts: [
-                        {
-                            type: "string",
-                            value: ["hi"],
-                            variable: "v",
-                        },
-                    ],
+                    parts: [createStringPart(["hi"], "v")],
                     value: { type: "variable", name: "v" },
                 },
             ],
@@ -254,12 +229,8 @@ describe("Serialization round-trip preserves variable", () => {
             alternatives: [
                 {
                     parts: [
-                        {
-                            type: "phraseSet",
-                            matcherName: "Polite",
-                            variable: "v",
-                        },
-                        { type: "string", value: ["go"] },
+                        createPhraseSetPart("Polite", "v"),
+                        createStringPart(["go"]),
                     ],
                     value: { type: "variable", name: "v" },
                 },

--- a/ts/packages/actionGrammar/test/nfaPriority.spec.ts
+++ b/ts/packages/actionGrammar/test/nfaPriority.spec.ts
@@ -13,8 +13,7 @@
  */
 
 import { compileGrammarToNFA, matchNFA, Grammar } from "../src/index.js";
-import { createStringPart ,
-    createWildcardPart} from "../src/grammarTypes.js";
+import { createStringPart, createWildcardPart } from "../src/grammarTypes.js";
 
 describe("NFA Priority System", () => {
     test("Rule 1: No unchecked wildcards beats rules with unchecked wildcards", () => {
@@ -523,9 +522,7 @@ describe("NFA Priority System", () => {
                             variable: undefined,
                             alternatives: [
                                 {
-                                    parts: [
-                                        createStringPart(["please"]),
-                                    ],
+                                    parts: [createStringPart(["please"])],
                                 },
                             ],
                         },

--- a/ts/packages/actionGrammar/test/nfaPriority.spec.ts
+++ b/ts/packages/actionGrammar/test/nfaPriority.spec.ts
@@ -13,6 +13,8 @@
  */
 
 import { compileGrammarToNFA, matchNFA, Grammar } from "../src/index.js";
+import { createStringPart ,
+    createWildcardPart} from "../src/grammarTypes.js";
 
 describe("NFA Priority System", () => {
     test("Rule 1: No unchecked wildcards beats rules with unchecked wildcards", () => {
@@ -22,13 +24,8 @@ describe("NFA Priority System", () => {
             alternatives: [
                 {
                     parts: [
-                        { type: "string", value: ["play"] },
-                        {
-                            type: "wildcard",
-                            variable: "track",
-                            typeName: "string",
-                            optional: false,
-                        },
+                        createStringPart(["play"]),
+                        createWildcardPart("track", "string"),
                     ],
                     value: {
                         type: "object",
@@ -46,8 +43,8 @@ describe("NFA Priority System", () => {
                 },
                 {
                     parts: [
-                        { type: "string", value: ["play"] },
-                        { type: "string", value: ["music"] },
+                        createStringPart(["play"]),
+                        createStringPart(["music"]),
                     ],
                     value: {
                         type: "object",
@@ -79,13 +76,8 @@ describe("NFA Priority System", () => {
             alternatives: [
                 {
                     parts: [
-                        { type: "string", value: ["play"] },
-                        {
-                            type: "wildcard",
-                            variable: "track",
-                            typeName: "string",
-                            optional: false,
-                        },
+                        createStringPart(["play"]),
+                        createWildcardPart("track", "string"),
                     ],
                     value: {
                         type: "object",
@@ -100,14 +92,9 @@ describe("NFA Priority System", () => {
                 },
                 {
                     parts: [
-                        { type: "string", value: ["play"] },
-                        { type: "string", value: ["track"] },
-                        {
-                            type: "wildcard",
-                            variable: "name",
-                            typeName: "string",
-                            optional: false,
-                        },
+                        createStringPart(["play"]),
+                        createStringPart(["track"]),
+                        createWildcardPart("name", "string"),
                     ],
                     value: {
                         type: "object",
@@ -138,13 +125,8 @@ describe("NFA Priority System", () => {
             alternatives: [
                 {
                     parts: [
-                        { type: "string", value: ["play"] },
-                        {
-                            type: "wildcard",
-                            variable: "track",
-                            typeName: "number",
-                            optional: false,
-                        },
+                        createStringPart(["play"]),
+                        createWildcardPart("track", "number"),
                     ],
                     value: {
                         type: "object",
@@ -159,20 +141,10 @@ describe("NFA Priority System", () => {
                 },
                 {
                     parts: [
-                        { type: "string", value: ["play"] },
-                        {
-                            type: "wildcard",
-                            variable: "track",
-                            typeName: "number",
-                            optional: false,
-                        },
-                        { type: "string", value: ["by"] },
-                        {
-                            type: "wildcard",
-                            variable: "artist",
-                            typeName: "number",
-                            optional: false,
-                        },
+                        createStringPart(["play"]),
+                        createWildcardPart("track", "number"),
+                        createStringPart(["by"]),
+                        createWildcardPart("artist", "number"),
                     ],
                     value: {
                         type: "object",
@@ -204,20 +176,10 @@ describe("NFA Priority System", () => {
             alternatives: [
                 {
                     parts: [
-                        { type: "string", value: ["play"] },
-                        {
-                            type: "wildcard",
-                            variable: "track",
-                            typeName: "string",
-                            optional: false,
-                        },
-                        { type: "string", value: ["by"] },
-                        {
-                            type: "wildcard",
-                            variable: "artist",
-                            typeName: "string",
-                            optional: false,
-                        },
+                        createStringPart(["play"]),
+                        createWildcardPart("track", "string"),
+                        createStringPart(["by"]),
+                        createWildcardPart("artist", "string"),
                     ],
                     value: {
                         type: "object",
@@ -232,13 +194,8 @@ describe("NFA Priority System", () => {
                 },
                 {
                     parts: [
-                        { type: "string", value: ["play"] },
-                        {
-                            type: "wildcard",
-                            variable: "track",
-                            typeName: "string",
-                            optional: false,
-                        },
+                        createStringPart(["play"]),
+                        createWildcardPart("track", "string"),
                     ],
                     value: {
                         type: "object",
@@ -270,25 +227,10 @@ describe("NFA Priority System", () => {
             alternatives: [
                 {
                     parts: [
-                        { type: "string", value: ["play"] },
-                        {
-                            type: "wildcard",
-                            variable: "x",
-                            typeName: "string",
-                            optional: false,
-                        },
-                        {
-                            type: "wildcard",
-                            variable: "y",
-                            typeName: "string",
-                            optional: false,
-                        },
-                        {
-                            type: "wildcard",
-                            variable: "z",
-                            typeName: "string",
-                            optional: false,
-                        },
+                        createStringPart(["play"]),
+                        createWildcardPart("x", "string"),
+                        createWildcardPart("y", "string"),
+                        createWildcardPart("z", "string"),
                     ],
                     value: {
                         type: "object",
@@ -306,9 +248,9 @@ describe("NFA Priority System", () => {
                 },
                 {
                     parts: [
-                        { type: "string", value: ["play"] },
-                        { type: "string", value: ["music"] },
-                        { type: "string", value: ["now"] },
+                        createStringPart(["play"]),
+                        createStringPart(["music"]),
+                        createStringPart(["now"]),
                     ],
                     value: {
                         type: "object",
@@ -340,13 +282,8 @@ describe("NFA Priority System", () => {
             alternatives: [
                 {
                     parts: [
-                        { type: "string", value: ["play"] },
-                        {
-                            type: "wildcard",
-                            variable: "song",
-                            typeName: "string",
-                            optional: false,
-                        },
+                        createStringPart(["play"]),
+                        createWildcardPart("song", "string"),
                     ],
                     value: {
                         type: "object",
@@ -361,13 +298,8 @@ describe("NFA Priority System", () => {
                 },
                 {
                     parts: [
-                        { type: "string", value: ["play"] },
-                        {
-                            type: "wildcard",
-                            variable: "track",
-                            typeName: "string",
-                            optional: false,
-                        },
+                        createStringPart(["play"]),
+                        createWildcardPart("track", "string"),
                     ],
                     value: {
                         type: "object",
@@ -400,13 +332,8 @@ describe("NFA Priority System", () => {
             alternatives: [
                 {
                     parts: [
-                        { type: "string", value: ["play"] },
-                        {
-                            type: "wildcard",
-                            variable: "track",
-                            typeName: "string",
-                            optional: false,
-                        },
+                        createStringPart(["play"]),
+                        createWildcardPart("track", "string"),
                     ],
                     value: {
                         type: "object",
@@ -421,13 +348,8 @@ describe("NFA Priority System", () => {
                 },
                 {
                     parts: [
-                        { type: "string", value: ["play"] },
-                        {
-                            type: "wildcard",
-                            variable: "n",
-                            typeName: "number",
-                            optional: false,
-                        },
+                        createStringPart(["play"]),
+                        createWildcardPart("n", "number"),
                     ],
                     value: {
                         type: "object",
@@ -459,19 +381,9 @@ describe("NFA Priority System", () => {
                 // Lowest priority: 1 fixed + 2 unchecked wildcards
                 {
                     parts: [
-                        { type: "string", value: ["play"] },
-                        {
-                            type: "wildcard",
-                            variable: "a",
-                            typeName: "string",
-                            optional: false,
-                        },
-                        {
-                            type: "wildcard",
-                            variable: "b",
-                            typeName: "string",
-                            optional: false,
-                        },
+                        createStringPart(["play"]),
+                        createWildcardPart("a", "string"),
+                        createWildcardPart("b", "string"),
                     ],
                     value: {
                         type: "object",
@@ -487,13 +399,8 @@ describe("NFA Priority System", () => {
                 // Mid priority: 1 fixed + 1 unchecked wildcard
                 {
                     parts: [
-                        { type: "string", value: ["play"] },
-                        {
-                            type: "wildcard",
-                            variable: "track",
-                            typeName: "string",
-                            optional: false,
-                        },
+                        createStringPart(["play"]),
+                        createWildcardPart("track", "string"),
                     ],
                     value: {
                         type: "object",
@@ -509,13 +416,8 @@ describe("NFA Priority System", () => {
                 // High priority: 1 fixed + 1 checked wildcard
                 {
                     parts: [
-                        { type: "string", value: ["play"] },
-                        {
-                            type: "wildcard",
-                            variable: "n",
-                            typeName: "number",
-                            optional: false,
-                        },
+                        createStringPart(["play"]),
+                        createWildcardPart("n", "number"),
                     ],
                     value: {
                         type: "object",
@@ -531,8 +433,8 @@ describe("NFA Priority System", () => {
                 // Highest priority: 2 fixed strings
                 {
                     parts: [
-                        { type: "string", value: ["play"] },
-                        { type: "string", value: ["music"] },
+                        createStringPart(["play"]),
+                        createStringPart(["music"]),
                     ],
                     value: {
                         type: "object",
@@ -564,13 +466,8 @@ describe("NFA Priority System", () => {
             alternatives: [
                 {
                     parts: [
-                        { type: "string", value: ["play"] },
-                        {
-                            type: "wildcard",
-                            variable: "track",
-                            typeName: "string",
-                            optional: false,
-                        },
+                        createStringPart(["play"]),
+                        createWildcardPart("track", "string"),
                     ],
                     value: {
                         type: "object",
@@ -585,13 +482,8 @@ describe("NFA Priority System", () => {
                 },
                 {
                     parts: [
-                        { type: "string", value: ["play"] },
-                        {
-                            type: "wildcard",
-                            variable: "song",
-                            typeName: "string",
-                            optional: false,
-                        },
+                        createStringPart(["play"]),
+                        createWildcardPart("song", "string"),
                     ],
                     value: {
                         type: "object",
@@ -624,19 +516,20 @@ describe("NFA Priority System", () => {
             alternatives: [
                 {
                     parts: [
-                        { type: "string", value: ["play"] },
+                        createStringPart(["play"]),
                         {
                             type: "rules",
                             optional: true,
+                            variable: undefined,
                             alternatives: [
                                 {
                                     parts: [
-                                        { type: "string", value: ["please"] },
+                                        createStringPart(["please"]),
                                     ],
                                 },
                             ],
                         },
-                        { type: "string", value: ["music"] },
+                        createStringPart(["music"]),
                     ],
                     value: {
                         type: "object",
@@ -651,8 +544,8 @@ describe("NFA Priority System", () => {
                 },
                 {
                     parts: [
-                        { type: "string", value: ["play"] },
-                        { type: "string", value: ["music"] },
+                        createStringPart(["play"]),
+                        createStringPart(["music"]),
                     ],
                     value: {
                         type: "object",
@@ -688,20 +581,10 @@ describe("NFA Priority System", () => {
             alternatives: [
                 {
                     parts: [
-                        { type: "string", value: ["play"] },
-                        {
-                            type: "wildcard",
-                            variable: "a",
-                            typeName: "string",
-                            optional: false,
-                        },
-                        { type: "string", value: ["by"] },
-                        {
-                            type: "wildcard",
-                            variable: "b",
-                            typeName: "string",
-                            optional: false,
-                        },
+                        createStringPart(["play"]),
+                        createWildcardPart("a", "string"),
+                        createStringPart(["by"]),
+                        createWildcardPart("b", "string"),
                     ],
                     value: {
                         type: "object",
@@ -719,20 +602,10 @@ describe("NFA Priority System", () => {
                 },
                 {
                     parts: [
-                        { type: "string", value: ["play"] },
-                        {
-                            type: "wildcard",
-                            variable: "track",
-                            typeName: "string",
-                            optional: false,
-                        },
-                        { type: "string", value: ["by"] },
-                        {
-                            type: "wildcard",
-                            variable: "artist",
-                            typeName: "number",
-                            optional: false,
-                        },
+                        createStringPart(["play"]),
+                        createWildcardPart("track", "string"),
+                        createStringPart(["by"]),
+                        createWildcardPart("artist", "number"),
                     ],
                     value: {
                         type: "object",

--- a/ts/packages/actionGrammar/test/spacingMode.spec.ts
+++ b/ts/packages/actionGrammar/test/spacingMode.spec.ts
@@ -18,7 +18,8 @@
  *                      no over-splitting of contractions in required rules.
  */
 
-import { Grammar,
+import {
+    Grammar,
     createStringPart,
     createWildcardPart,
 } from "../src/grammarTypes.js";
@@ -41,10 +42,7 @@ describe("flex-space — two-segment compound (hip hop)", () => {
     const grammar: Grammar = {
         alternatives: [
             {
-                parts: [
-                    createStringPart(["hip"]),
-                    createStringPart(["hop"]),
-                ],
+                parts: [createStringPart(["hip"]), createStringPart(["hop"])],
                 value: { type: "literal", value: "hiphop" },
             },
         ],
@@ -89,10 +87,7 @@ describe("flex-space — case-insensitive normalisation", () => {
     const grammar: Grammar = {
         alternatives: [
             {
-                parts: [
-                    createStringPart(["Hip"]),
-                    createStringPart(["Hop"]),
-                ],
+                parts: [createStringPart(["Hip"]), createStringPart(["Hop"])],
                 value: { type: "literal", value: "matched" },
             },
         ],
@@ -199,9 +194,7 @@ describe("two-pass matching — literal contraction wins over wildcard + suffix"
         alternatives: [
             // Literal rule — expects "don't" as one token
             {
-                parts: [
-                    createStringPart(["don't"]),
-                ],
+                parts: [createStringPart(["don't"])],
                 value: { type: "literal", value: "matched-literal" },
             },
             // Wildcard + suffix rule — "'t" registered as split candidate
@@ -251,23 +244,17 @@ describe("spacing=auto (undefined) — CJK token pre-splitting", () => {
 
     // The <color> alternatives as inline rules
     const yellowRule = {
-        parts: [
-            createStringPart(["黃色"]),
-        ],
+        parts: [createStringPart(["黃色"])],
         value: { type: "literal" as const, value: "yellow" },
         spacingMode: undefined as undefined, // auto
     };
     const blueRule = {
-        parts: [
-            createStringPart(["藍色"]),
-        ],
+        parts: [createStringPart(["藍色"])],
         value: { type: "literal" as const, value: "blue" },
         spacingMode: undefined as undefined,
     };
     const greenRule = {
-        parts: [
-            createStringPart(["綠色"]),
-        ],
+        parts: [createStringPart(["綠色"])],
         value: { type: "literal" as const, value: "green" },
         spacingMode: undefined as undefined,
     };
@@ -337,10 +324,7 @@ describe("spacing=auto — Latin token NOT registered as split candidate", () =>
     const grammar: Grammar = {
         alternatives: [
             {
-                parts: [
-                    createStringPart(["play"]),
-                    createStringPart(["'s"]),
-                ],
+                parts: [createStringPart(["play"]), createStringPart(["'s"])],
                 spacingMode: undefined, // auto
                 value: { type: "literal", value: "matched" },
             },
@@ -402,10 +386,7 @@ describe("flex-space — German two-morpheme compound (Fahrrad = bicycle)", () =
     const grammar: Grammar = {
         alternatives: [
             {
-                parts: [
-                    createStringPart(["Fahr"]),
-                    createStringPart(["rad"]),
-                ],
+                parts: [createStringPart(["Fahr"]), createStringPart(["rad"])],
                 value: { type: "literal", value: "bicycle" },
             },
         ],
@@ -546,17 +527,11 @@ describe("flex-space — Swahili noun-class prefix (kitabu / vitabu = book / boo
     const grammar: Grammar = {
         alternatives: [
             {
-                parts: [
-                    createStringPart(["ki"]),
-                    createStringPart(["tabu"]),
-                ],
+                parts: [createStringPart(["ki"]), createStringPart(["tabu"])],
                 value: { type: "literal", value: "book" },
             },
             {
-                parts: [
-                    createStringPart(["vi"]),
-                    createStringPart(["tabu"]),
-                ],
+                parts: [createStringPart(["vi"]), createStringPart(["tabu"])],
                 value: { type: "literal", value: "books" },
             },
         ],
@@ -628,19 +603,13 @@ describe("flex-space — Swahili <Tense> rule reference: fused and spaced forms 
                         name: "Tense",
                         alternatives: [
                             {
-                                parts: [
-                                    createStringPart(["li"]),
-                                ],
+                                parts: [createStringPart(["li"])],
                             },
                             {
-                                parts: [
-                                    createStringPart(["na"]),
-                                ],
+                                parts: [createStringPart(["na"])],
                             },
                             {
-                                parts: [
-                                    createStringPart(["ta"]),
-                                ],
+                                parts: [createStringPart(["ta"])],
                             },
                         ],
                     },

--- a/ts/packages/actionGrammar/test/spacingMode.spec.ts
+++ b/ts/packages/actionGrammar/test/spacingMode.spec.ts
@@ -18,7 +18,10 @@
  *                      no over-splitting of contractions in required rules.
  */
 
-import { Grammar } from "../src/grammarTypes.js";
+import { Grammar,
+    createStringPart,
+    createWildcardPart,
+} from "../src/grammarTypes.js";
 import { compileGrammarToNFA } from "../src/nfaCompiler.js";
 import { matchGrammarWithNFA } from "../src/nfaMatcher.js";
 
@@ -39,8 +42,8 @@ describe("flex-space — two-segment compound (hip hop)", () => {
         alternatives: [
             {
                 parts: [
-                    { type: "string", value: ["hip"] },
-                    { type: "string", value: ["hop"] },
+                    createStringPart(["hip"]),
+                    createStringPart(["hop"]),
                 ],
                 value: { type: "literal", value: "hiphop" },
             },
@@ -87,8 +90,8 @@ describe("flex-space — case-insensitive normalisation", () => {
         alternatives: [
             {
                 parts: [
-                    { type: "string", value: ["Hip"] },
-                    { type: "string", value: ["Hop"] },
+                    createStringPart(["Hip"]),
+                    createStringPart(["Hop"]),
                 ],
                 value: { type: "literal", value: "matched" },
             },
@@ -115,12 +118,8 @@ describe("auto split candidates — apostrophe morpheme splitting", () => {
         alternatives: [
             {
                 parts: [
-                    {
-                        type: "wildcard",
-                        variable: "artist",
-                        typeName: "wildcard",
-                    },
-                    { type: "string", value: ["'s"] },
+                    createWildcardPart("artist", "wildcard"),
+                    createStringPart(["'s"]),
                 ],
                 value: { type: "variable", name: "artist" },
             },
@@ -162,8 +161,8 @@ describe("auto split candidates — contraction splitting", () => {
         alternatives: [
             {
                 parts: [
-                    { type: "wildcard", variable: "v", typeName: "wildcard" },
-                    { type: "string", value: ["'t"] },
+                    createWildcardPart("v", "wildcard"),
+                    createStringPart(["'t"]),
                 ],
                 value: { type: "variable", name: "v" },
             },
@@ -200,14 +199,16 @@ describe("two-pass matching — literal contraction wins over wildcard + suffix"
         alternatives: [
             // Literal rule — expects "don't" as one token
             {
-                parts: [{ type: "string", value: ["don't"] }],
+                parts: [
+                    createStringPart(["don't"]),
+                ],
                 value: { type: "literal", value: "matched-literal" },
             },
             // Wildcard + suffix rule — "'t" registered as split candidate
             {
                 parts: [
-                    { type: "wildcard", variable: "v", typeName: "wildcard" },
-                    { type: "string", value: ["'t"] },
+                    createWildcardPart("v", "wildcard"),
+                    createStringPart(["'t"]),
                 ],
                 value: { type: "variable", name: "v" },
             },
@@ -250,17 +251,23 @@ describe("spacing=auto (undefined) — CJK token pre-splitting", () => {
 
     // The <color> alternatives as inline rules
     const yellowRule = {
-        parts: [{ type: "string" as const, value: ["黃色"] }],
+        parts: [
+            createStringPart(["黃色"]),
+        ],
         value: { type: "literal" as const, value: "yellow" },
         spacingMode: undefined as undefined, // auto
     };
     const blueRule = {
-        parts: [{ type: "string" as const, value: ["藍色"] }],
+        parts: [
+            createStringPart(["藍色"]),
+        ],
         value: { type: "literal" as const, value: "blue" },
         spacingMode: undefined as undefined,
     };
     const greenRule = {
-        parts: [{ type: "string" as const, value: ["綠色"] }],
+        parts: [
+            createStringPart(["綠色"]),
+        ],
         value: { type: "literal" as const, value: "green" },
         spacingMode: undefined as undefined,
     };
@@ -271,10 +278,11 @@ describe("spacing=auto (undefined) — CJK token pre-splitting", () => {
                 parts: [
                     {
                         type: "rules",
-                        alternatives: [yellowRule, blueRule, greenRule],
+                        optional: undefined,
                         variable: "color",
+                        alternatives: [yellowRule, blueRule, greenRule],
                     },
-                    { type: "string", value: ["汽車"] },
+                    createStringPart(["汽車"]),
                 ],
                 spacingMode: undefined, // auto
                 value: { type: "variable", name: "color" },
@@ -330,8 +338,8 @@ describe("spacing=auto — Latin token NOT registered as split candidate", () =>
         alternatives: [
             {
                 parts: [
-                    { type: "string", value: ["play"] },
-                    { type: "string", value: ["'s"] },
+                    createStringPart(["play"]),
+                    createStringPart(["'s"]),
                 ],
                 spacingMode: undefined, // auto
                 value: { type: "literal", value: "matched" },
@@ -357,9 +365,9 @@ describe("flex-space — three-segment English compound (rock and roll)", () => 
         alternatives: [
             {
                 parts: [
-                    { type: "string", value: ["rock"] },
-                    { type: "string", value: ["and"] },
-                    { type: "string", value: ["roll"] },
+                    createStringPart(["rock"]),
+                    createStringPart(["and"]),
+                    createStringPart(["roll"]),
                 ],
                 value: { type: "literal", value: "genre" },
             },
@@ -395,8 +403,8 @@ describe("flex-space — German two-morpheme compound (Fahrrad = bicycle)", () =
         alternatives: [
             {
                 parts: [
-                    { type: "string", value: ["Fahr"] },
-                    { type: "string", value: ["rad"] },
+                    createStringPart(["Fahr"]),
+                    createStringPart(["rad"]),
                 ],
                 value: { type: "literal", value: "bicycle" },
             },
@@ -426,9 +434,9 @@ describe("flex-space — German three-morpheme compound (Kraftfahrzeug = motor v
         alternatives: [
             {
                 parts: [
-                    { type: "string", value: ["Kraft"] },
-                    { type: "string", value: ["Fahr"] },
-                    { type: "string", value: ["Zeug"] },
+                    createStringPart(["Kraft"]),
+                    createStringPart(["Fahr"]),
+                    createStringPart(["Zeug"]),
                 ],
                 value: { type: "literal", value: "motor vehicle" },
             },
@@ -472,10 +480,10 @@ describe("flex-space — German four-morpheme compound (Donaudampfschifffahrt)",
         alternatives: [
             {
                 parts: [
-                    { type: "string", value: ["Donau"] },
-                    { type: "string", value: ["Dampf"] },
-                    { type: "string", value: ["Schiff"] },
-                    { type: "string", value: ["Fahrt"] },
+                    createStringPart(["Donau"]),
+                    createStringPart(["Dampf"]),
+                    createStringPart(["Schiff"]),
+                    createStringPart(["Fahrt"]),
                 ],
                 value: { type: "literal", value: "danube-steamship-voyage" },
             },
@@ -539,15 +547,15 @@ describe("flex-space — Swahili noun-class prefix (kitabu / vitabu = book / boo
         alternatives: [
             {
                 parts: [
-                    { type: "string", value: ["ki"] },
-                    { type: "string", value: ["tabu"] },
+                    createStringPart(["ki"]),
+                    createStringPart(["tabu"]),
                 ],
                 value: { type: "literal", value: "book" },
             },
             {
                 parts: [
-                    { type: "string", value: ["vi"] },
-                    { type: "string", value: ["tabu"] },
+                    createStringPart(["vi"]),
+                    createStringPart(["tabu"]),
                 ],
                 value: { type: "literal", value: "books" },
             },
@@ -612,23 +620,31 @@ describe("flex-space — Swahili <Tense> rule reference: fused and spaced forms 
         alternatives: [
             {
                 parts: [
-                    { type: "string", value: ["ni"] },
+                    createStringPart(["ni"]),
                     {
                         type: "rules",
+                        optional: undefined,
+                        variable: undefined,
                         name: "Tense",
                         alternatives: [
                             {
-                                parts: [{ type: "string", value: ["li"] }],
+                                parts: [
+                                    createStringPart(["li"]),
+                                ],
                             },
                             {
-                                parts: [{ type: "string", value: ["na"] }],
+                                parts: [
+                                    createStringPart(["na"]),
+                                ],
                             },
                             {
-                                parts: [{ type: "string", value: ["ta"] }],
+                                parts: [
+                                    createStringPart(["ta"]),
+                                ],
                             },
                         ],
                     },
-                    { type: "string", value: ["soma"] },
+                    createStringPart(["soma"]),
                 ],
                 // No spacingMode="none" — NFA has separate "ni"/"na"/"soma"
                 // token transitions, so both spaced and fused input works.
@@ -713,25 +729,25 @@ describe("flex-space — Swahili subject-agreement: person variation (ninasoma /
         alternatives: [
             {
                 parts: [
-                    { type: "string", value: ["ni"] },
-                    { type: "string", value: ["na"] },
-                    { type: "string", value: ["soma"] },
+                    createStringPart(["ni"]),
+                    createStringPart(["na"]),
+                    createStringPart(["soma"]),
                 ],
                 value: { type: "literal", value: "I am reading" },
             },
             {
                 parts: [
-                    { type: "string", value: ["u"] },
-                    { type: "string", value: ["na"] },
-                    { type: "string", value: ["soma"] },
+                    createStringPart(["u"]),
+                    createStringPart(["na"]),
+                    createStringPart(["soma"]),
                 ],
                 value: { type: "literal", value: "you are reading" },
             },
             {
                 parts: [
-                    { type: "string", value: ["a"] },
-                    { type: "string", value: ["na"] },
-                    { type: "string", value: ["soma"] },
+                    createStringPart(["a"]),
+                    createStringPart(["na"]),
+                    createStringPart(["soma"]),
                 ],
                 value: { type: "literal", value: "he/she is reading" },
             },

--- a/ts/packages/actionGrammar/test/wildcardLengthVariations.spec.ts
+++ b/ts/packages/actionGrammar/test/wildcardLengthVariations.spec.ts
@@ -1,3 +1,4 @@
+import { createStringPart, createWildcardPart } from "../src/grammarTypes.js";
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
@@ -22,13 +23,9 @@ describe("Wildcard Length Variations - NFA", () => {
             alternatives: [
                 {
                     parts: [
-                        { type: "string", value: ["show"] },
-                        {
-                            type: "wildcard",
-                            variable: "location",
-                            typeName: "string",
-                        },
-                        { type: "string", value: ["weather"] },
+                        createStringPart(["show"]),
+                        createWildcardPart("location", "string"),
+                        createStringPart(["weather"]),
                     ],
                     value: {
                         type: "object",
@@ -56,13 +53,9 @@ describe("Wildcard Length Variations - NFA", () => {
             alternatives: [
                 {
                     parts: [
-                        { type: "string", value: ["show"] },
-                        {
-                            type: "wildcard",
-                            variable: "location",
-                            typeName: "string",
-                        },
-                        { type: "string", value: ["weather"] },
+                        createStringPart(["show"]),
+                        createWildcardPart("location", "string"),
+                        createStringPart(["weather"]),
                     ],
                     value: {
                         type: "object",
@@ -90,13 +83,9 @@ describe("Wildcard Length Variations - NFA", () => {
             alternatives: [
                 {
                     parts: [
-                        { type: "string", value: ["show"] },
-                        {
-                            type: "wildcard",
-                            variable: "location",
-                            typeName: "string",
-                        },
-                        { type: "string", value: ["weather"] },
+                        createStringPart(["show"]),
+                        createWildcardPart("location", "string"),
+                        createStringPart(["weather"]),
                     ],
                     value: {
                         type: "object",
@@ -130,13 +119,9 @@ describe("Wildcard Length Variations - NFA", () => {
             alternatives: [
                 {
                     parts: [
-                        { type: "string", value: ["show"] },
-                        {
-                            type: "wildcard",
-                            variable: "location",
-                            typeName: "string",
-                        },
-                        { type: "string", value: ["weather"] },
+                        createStringPart(["show"]),
+                        createWildcardPart("location", "string"),
+                        createStringPart(["weather"]),
                     ],
                     value: {
                         type: "object",
@@ -171,12 +156,8 @@ describe("Wildcard Length Variations - NFA", () => {
             alternatives: [
                 {
                     parts: [
-                        { type: "string", value: ["show"] },
-                        {
-                            type: "wildcard",
-                            variable: "location",
-                            typeName: "string",
-                        },
+                        createStringPart(["show"]),
+                        createWildcardPart("location", "string"),
                     ],
                     value: {
                         type: "object",
@@ -214,18 +195,10 @@ describe("Wildcard Length Variations - NFA", () => {
             alternatives: [
                 {
                     parts: [
-                        { type: "string", value: ["play"] },
-                        {
-                            type: "wildcard",
-                            variable: "track",
-                            typeName: "string",
-                        },
-                        { type: "string", value: ["by"] },
-                        {
-                            type: "wildcard",
-                            variable: "artist",
-                            typeName: "string",
-                        },
+                        createStringPart(["play"]),
+                        createWildcardPart("track", "string"),
+                        createStringPart(["by"]),
+                        createWildcardPart("artist", "string"),
                     ],
                     value: {
                         type: "object",
@@ -265,18 +238,10 @@ describe("Wildcard Length Variations - NFA", () => {
             alternatives: [
                 {
                     parts: [
-                        { type: "string", value: ["play"] },
-                        {
-                            type: "wildcard",
-                            variable: "track",
-                            typeName: "string",
-                        },
-                        { type: "string", value: ["by"] },
-                        {
-                            type: "wildcard",
-                            variable: "artist",
-                            typeName: "string",
-                        },
+                        createStringPart(["play"]),
+                        createWildcardPart("track", "string"),
+                        createStringPart(["by"]),
+                        createWildcardPart("artist", "string"),
                     ],
                     value: {
                         type: "object",
@@ -318,18 +283,10 @@ describe("Wildcard Length Variations - NFA", () => {
             alternatives: [
                 {
                     parts: [
-                        { type: "string", value: ["play"] },
-                        {
-                            type: "wildcard",
-                            variable: "track",
-                            typeName: "string",
-                        },
-                        { type: "string", value: ["by"] },
-                        {
-                            type: "wildcard",
-                            variable: "artist",
-                            typeName: "string",
-                        },
+                        createStringPart(["play"]),
+                        createWildcardPart("track", "string"),
+                        createStringPart(["by"]),
+                        createWildcardPart("artist", "string"),
                     ],
                     value: {
                         type: "object",
@@ -371,24 +328,12 @@ describe("Wildcard Length Variations - NFA", () => {
             alternatives: [
                 {
                     parts: [
-                        { type: "string", value: ["move"] },
-                        {
-                            type: "wildcard",
-                            variable: "item",
-                            typeName: "string",
-                        },
-                        { type: "string", value: ["from"] },
-                        {
-                            type: "wildcard",
-                            variable: "source",
-                            typeName: "string",
-                        },
-                        { type: "string", value: ["to"] },
-                        {
-                            type: "wildcard",
-                            variable: "dest",
-                            typeName: "string",
-                        },
+                        createStringPart(["move"]),
+                        createWildcardPart("item", "string"),
+                        createStringPart(["from"]),
+                        createWildcardPart("source", "string"),
+                        createStringPart(["to"]),
+                        createWildcardPart("dest", "string"),
                     ],
                     value: {
                         type: "object",
@@ -439,12 +384,8 @@ describe("Wildcard Length Variations - NFA", () => {
             alternatives: [
                 {
                     parts: [
-                        {
-                            type: "wildcard",
-                            variable: "location",
-                            typeName: "string",
-                        },
-                        { type: "string", value: ["weather", "forecast"] },
+                        createWildcardPart("location", "string"),
+                        createStringPart(["weather", "forecast"]),
                     ],
                     value: {
                         type: "object",
@@ -478,12 +419,8 @@ describe("Wildcard Length Variations - NFA", () => {
             alternatives: [
                 {
                     parts: [
-                        {
-                            type: "wildcard",
-                            variable: "item",
-                            typeName: "string",
-                        },
-                        { type: "string", value: ["is", "ready"] },
+                        createWildcardPart("item", "string"),
+                        createStringPart(["is", "ready"]),
                     ],
                     value: {
                         type: "object",
@@ -520,12 +457,8 @@ describe("Wildcard Length Variations - NFA", () => {
             alternatives: [
                 {
                     parts: [
-                        { type: "string", value: ["search", "for"] },
-                        {
-                            type: "wildcard",
-                            variable: "query",
-                            typeName: "string",
-                        },
+                        createStringPart(["search", "for"]),
+                        createWildcardPart("query", "string"),
                     ],
                     value: {
                         type: "object",
@@ -566,30 +499,14 @@ describe("Wildcard Length Variations - NFA", () => {
             alternatives: [
                 {
                     parts: [
-                        { type: "string", value: ["copy"] },
-                        {
-                            type: "wildcard",
-                            variable: "file",
-                            typeName: "string",
-                        },
-                        { type: "string", value: ["from"] },
-                        {
-                            type: "wildcard",
-                            variable: "source",
-                            typeName: "string",
-                        },
-                        { type: "string", value: ["to"] },
-                        {
-                            type: "wildcard",
-                            variable: "dest",
-                            typeName: "string",
-                        },
-                        { type: "string", value: ["using"] },
-                        {
-                            type: "wildcard",
-                            variable: "method",
-                            typeName: "string",
-                        },
+                        createStringPart(["copy"]),
+                        createWildcardPart("file", "string"),
+                        createStringPart(["from"]),
+                        createWildcardPart("source", "string"),
+                        createStringPart(["to"]),
+                        createWildcardPart("dest", "string"),
+                        createStringPart(["using"]),
+                        createWildcardPart("method", "string"),
                     ],
                     value: {
                         type: "object",
@@ -651,13 +568,9 @@ describe("Wildcard Length Variations - DFA", () => {
             alternatives: [
                 {
                     parts: [
-                        { type: "string", value: ["show"] },
-                        {
-                            type: "wildcard",
-                            variable: "location",
-                            typeName: "string",
-                        },
-                        { type: "string", value: ["weather"] },
+                        createStringPart(["show"]),
+                        createWildcardPart("location", "string"),
+                        createStringPart(["weather"]),
                     ],
                     value: {
                         type: "object",
@@ -686,13 +599,9 @@ describe("Wildcard Length Variations - DFA", () => {
             alternatives: [
                 {
                     parts: [
-                        { type: "string", value: ["show"] },
-                        {
-                            type: "wildcard",
-                            variable: "location",
-                            typeName: "string",
-                        },
-                        { type: "string", value: ["weather"] },
+                        createStringPart(["show"]),
+                        createWildcardPart("location", "string"),
+                        createStringPart(["weather"]),
                     ],
                     value: {
                         type: "object",
@@ -721,13 +630,9 @@ describe("Wildcard Length Variations - DFA", () => {
             alternatives: [
                 {
                     parts: [
-                        { type: "string", value: ["show"] },
-                        {
-                            type: "wildcard",
-                            variable: "location",
-                            typeName: "string",
-                        },
-                        { type: "string", value: ["weather"] },
+                        createStringPart(["show"]),
+                        createWildcardPart("location", "string"),
+                        createStringPart(["weather"]),
                     ],
                     value: {
                         type: "object",
@@ -762,12 +667,8 @@ describe("Wildcard Length Variations - DFA", () => {
             alternatives: [
                 {
                     parts: [
-                        { type: "string", value: ["show"] },
-                        {
-                            type: "wildcard",
-                            variable: "location",
-                            typeName: "string",
-                        },
+                        createStringPart(["show"]),
+                        createWildcardPart("location", "string"),
                     ],
                     value: {
                         type: "object",
@@ -806,18 +707,10 @@ describe("Wildcard Length Variations - DFA", () => {
             alternatives: [
                 {
                     parts: [
-                        { type: "string", value: ["play"] },
-                        {
-                            type: "wildcard",
-                            variable: "track",
-                            typeName: "string",
-                        },
-                        { type: "string", value: ["by"] },
-                        {
-                            type: "wildcard",
-                            variable: "artist",
-                            typeName: "string",
-                        },
+                        createStringPart(["play"]),
+                        createWildcardPart("track", "string"),
+                        createStringPart(["by"]),
+                        createWildcardPart("artist", "string"),
                     ],
                     value: {
                         type: "object",
@@ -860,24 +753,12 @@ describe("Wildcard Length Variations - DFA", () => {
             alternatives: [
                 {
                     parts: [
-                        { type: "string", value: ["move"] },
-                        {
-                            type: "wildcard",
-                            variable: "item",
-                            typeName: "string",
-                        },
-                        { type: "string", value: ["from"] },
-                        {
-                            type: "wildcard",
-                            variable: "source",
-                            typeName: "string",
-                        },
-                        { type: "string", value: ["to"] },
-                        {
-                            type: "wildcard",
-                            variable: "dest",
-                            typeName: "string",
-                        },
+                        createStringPart(["move"]),
+                        createWildcardPart("item", "string"),
+                        createStringPart(["from"]),
+                        createWildcardPart("source", "string"),
+                        createStringPart(["to"]),
+                        createWildcardPart("dest", "string"),
                     ],
                     value: {
                         type: "object",
@@ -929,12 +810,8 @@ describe("Wildcard Length Variations - DFA", () => {
             alternatives: [
                 {
                     parts: [
-                        { type: "string", value: ["search", "for"] },
-                        {
-                            type: "wildcard",
-                            variable: "query",
-                            typeName: "string",
-                        },
+                        createStringPart(["search", "for"]),
+                        createWildcardPart("query", "string"),
                     ],
                     value: {
                         type: "object",
@@ -976,30 +853,14 @@ describe("Wildcard Length Variations - DFA", () => {
             alternatives: [
                 {
                     parts: [
-                        { type: "string", value: ["copy"] },
-                        {
-                            type: "wildcard",
-                            variable: "file",
-                            typeName: "string",
-                        },
-                        { type: "string", value: ["from"] },
-                        {
-                            type: "wildcard",
-                            variable: "source",
-                            typeName: "string",
-                        },
-                        { type: "string", value: ["to"] },
-                        {
-                            type: "wildcard",
-                            variable: "dest",
-                            typeName: "string",
-                        },
-                        { type: "string", value: ["using"] },
-                        {
-                            type: "wildcard",
-                            variable: "method",
-                            typeName: "string",
-                        },
+                        createStringPart(["copy"]),
+                        createWildcardPart("file", "string"),
+                        createStringPart(["from"]),
+                        createWildcardPart("source", "string"),
+                        createStringPart(["to"]),
+                        createWildcardPart("dest", "string"),
+                        createStringPart(["using"]),
+                        createWildcardPart("method", "string"),
                     ],
                     value: {
                         type: "object",

--- a/ts/packages/actionGrammar/test/wildcardLengthVariations.spec.ts
+++ b/ts/packages/actionGrammar/test/wildcardLengthVariations.spec.ts
@@ -1,6 +1,7 @@
-import { createStringPart, createWildcardPart } from "../src/grammarTypes.js";
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+
+import { createStringPart, createWildcardPart } from "../src/grammarTypes.js";
 
 /**
  * Tests for wildcard matching with varying token lengths

--- a/ts/packages/actionGrammar/test/wildcardLoop.spec.ts
+++ b/ts/packages/actionGrammar/test/wildcardLoop.spec.ts
@@ -3,7 +3,10 @@
 
 import { compileGrammarToNFA } from "../src/nfaCompiler.js";
 import { matchNFA } from "../src/nfaInterpreter.js";
-import { Grammar } from "../src/grammarTypes.js";
+import { Grammar,
+    createStringPart,
+    createWildcardPart,
+} from "../src/grammarTypes.js";
 
 describe("Wildcard Loop Behavior", () => {
     it("should match single-token wildcard", () => {
@@ -13,13 +16,9 @@ describe("Wildcard Loop Behavior", () => {
             alternatives: [
                 {
                     parts: [
-                        { type: "string", value: ["show"] },
-                        {
-                            type: "wildcard",
-                            variable: "location",
-                            typeName: "string",
-                        },
-                        { type: "string", value: ["weather"] },
+                        createStringPart(["show"]),
+                        createWildcardPart("location", "string"),
+                        createStringPart(["weather"]),
                     ],
                     value: {
                         type: "object",
@@ -50,13 +49,9 @@ describe("Wildcard Loop Behavior", () => {
             alternatives: [
                 {
                     parts: [
-                        { type: "string", value: ["show"] },
-                        {
-                            type: "wildcard",
-                            variable: "location",
-                            typeName: "string",
-                        },
-                        { type: "string", value: ["weather"] },
+                        createStringPart(["show"]),
+                        createWildcardPart("location", "string"),
+                        createStringPart(["weather"]),
                     ],
                     value: {
                         type: "object",
@@ -87,18 +82,10 @@ describe("Wildcard Loop Behavior", () => {
             alternatives: [
                 {
                     parts: [
-                        { type: "string", value: ["play"] },
-                        {
-                            type: "wildcard",
-                            variable: "track",
-                            typeName: "string",
-                        },
-                        { type: "string", value: ["by"] },
-                        {
-                            type: "wildcard",
-                            variable: "artist",
-                            typeName: "string",
-                        },
+                        createStringPart(["play"]),
+                        createWildcardPart("track", "string"),
+                        createStringPart(["by"]),
+                        createWildcardPart("artist", "string"),
                     ],
                     value: {
                         type: "object",
@@ -135,12 +122,8 @@ describe("Wildcard Loop Behavior", () => {
             alternatives: [
                 {
                     parts: [
-                        { type: "string", value: ["show"] },
-                        {
-                            type: "wildcard",
-                            variable: "location",
-                            typeName: "string",
-                        },
+                        createStringPart(["show"]),
+                        createWildcardPart("location", "string"),
                     ],
                     value: {
                         type: "object",

--- a/ts/packages/actionGrammar/test/wildcardLoop.spec.ts
+++ b/ts/packages/actionGrammar/test/wildcardLoop.spec.ts
@@ -3,7 +3,8 @@
 
 import { compileGrammarToNFA } from "../src/nfaCompiler.js";
 import { matchNFA } from "../src/nfaInterpreter.js";
-import { Grammar,
+import {
+    Grammar,
     createStringPart,
     createWildcardPart,
 } from "../src/grammarTypes.js";


### PR DESCRIPTION
## Summary

Introduce factory functions for all `GrammarPart` and `Backtrack` frame types in the actionGrammar package. This ensures V8 sees a single monomorphic hidden class per type (objects created via the same function with properties in the same order share one shape), eliminating megamorphic inline-cache misses on hot-path property accesses.

## Changes

- **Factory functions** (`createStringPart`, `createWildcardPart`, `createNumberPart`, `createRulesPart`, `createPhraseSetPart`, `pushMemoMarker`, `pushMemoReplay`) replace all inline object literals across src/ and test/
- **`restoreSnapshot`** helper centralizes the 15-field state restore (was duplicated inline in greedy-repeat and optional-preferSkip paths)
- **StringPart shape stability**: `regexpCache` and `joinedCache` initialized as `undefined` at construction time to avoid hidden class transitions on first lazy population
- **Comment hygiene**: all stale `Object.assign` references updated to `restoreSnapshot`

## Results

- Net **-342 lines** (22 files changed) in the initial commit
- **16,103 tests pass** (70 suites, 3 skipped)
- Benchmark: **1.02-1.05 μs/call** (no regression vs baseline)
- No serialization format changes (field order preserved)

## Commits

1. `actionGrammar: factory functions for GrammarPart and Backtrack types` - main refactoring
2. `review: use restoreSnapshot for inline restores, drop redundant ?? undefined` - review fixes
3. `review P3: stabilize StringPart hidden class, fix stale comments` - shape stability + comment cleanup