### PR TITLE
ci(fix-dependabot-alerts): unblock docs analysis, surface failures, track noPatch

### DIFF
--- a/.github/workflows/fix-dependabot-alerts.yml
+++ b/.github/workflows/fix-dependabot-alerts.yml
@@ -134,10 +134,16 @@ jobs:
             echo "=========================================="
             cd "$GITHUB_WORKSPACE/$WS_DIR"
 
-            # Install dependencies for this workspace
+            # Install dependencies for this workspace.
+            # The `ts` workspace was already installed in the "Install script
+            # dependencies (ts workspace)" step — re-running pnpm install here
+            # re-triggers postinstall scripts (e.g. better-sqlite3 copy/restore)
+            # which can segfault on the second pass. Skip the redundant install.
             echo "::group::Installing $WS_DIR dependencies"
             corepack enable
-            if ! pnpm install --frozen-lockfile 2>&1; then
+            if [ "$WS_DIR" = "ts" ]; then
+              echo "ts dependencies already installed in setup step; skipping redundant install"
+            elif ! pnpm install --frozen-lockfile 2>&1; then
               echo "::warning::Dependency install failed for $WS_DIR — skipping (analysis would be unreliable)"
               echo "::endgroup::"
               continue

--- a/.github/workflows/fix-dependabot-alerts.yml
+++ b/.github/workflows/fix-dependabot-alerts.yml
@@ -74,6 +74,18 @@ jobs:
           echo "---"
           gh api repos/${{ github.repository }}/dependabot/alerts?per_page=1 --jq 'length' || echo "API call failed with exit $?"
 
+      # Install ts/ dependencies once before the per-workspace loop.
+      # The fix-dependabot-alerts.mjs script lives under ts/tools/scripts/ and
+      # imports node modules (chalk, etc.) from ts/node_modules. Without this
+      # step, when the per-workspace loop processes a non-ts workspace first
+      # (e.g. docs/), Node fails with ERR_MODULE_NOT_FOUND for chalk and the
+      # workflow silently logs "No valid analysis for <ws> — skipping".
+      - name: Install script dependencies (ts workspace)
+        working-directory: ts
+        run: |
+          corepack enable
+          pnpm install --frozen-lockfile
+
       # ── Analyse and fix alerts across workspaces ──────────────────────
       #
       # Auto-discovers which workspaces have open alerts by querying the
@@ -94,8 +106,10 @@ jobs:
           ALL_ROLLED_BACK=""
           ALL_BLOCKED_PACKAGES=""
           ALL_NO_PATCH_PACKAGES=""
+          ALL_FAILED_WORKSPACES=""
           TOTAL_RESOLVED=0
           TOTAL_BLOCKED=0
+          TOTAL_NO_PATCH=0
           TOTAL_FAILED=0
 
           # Discover workspaces with open npm alerts from the Dependabot API
@@ -107,6 +121,7 @@ jobs:
             echo "No open npm Dependabot alerts found 🎉"
             echo "resolved=0" >> "$GITHUB_OUTPUT"
             echo "blocked=0" >> "$GITHUB_OUTPUT"
+            echo "no_patch=0" >> "$GITHUB_OUTPUT"
             echo "failed=0" >> "$GITHUB_OUTPUT"
             echo "changes=false" >> "$GITHUB_OUTPUT"
             exit 0
@@ -134,8 +149,19 @@ jobs:
             node "$SCRIPT" --dry-run --json --skip-install > /tmp/dep-analysis.json 2>/tmp/dep-analysis.log || true
 
             if ! jq -e '.summary' /tmp/dep-analysis.json > /dev/null 2>&1; then
-              echo "No valid analysis for $WS_DIR — skipping"
+              echo "::warning::No valid analysis for $WS_DIR — see log below"
               cat /tmp/dep-analysis.log || true
+              # Surface to job summary so the failure isn't silent across runs.
+              {
+                echo "### ⚠️ Analysis failed for \`$WS_DIR\`"
+                echo ""
+                echo '```'
+                tail -30 /tmp/dep-analysis.log 2>/dev/null || echo "(no log captured)"
+                echo '```'
+                echo ""
+              } >> "$GITHUB_STEP_SUMMARY"
+              # Track for the PR body / final summary.
+              ALL_FAILED_WORKSPACES="${ALL_FAILED_WORKSPACES:+$ALL_FAILED_WORKSPACES, }$WS_DIR"
               echo "::endgroup::"
               continue
             fi
@@ -152,6 +178,7 @@ jobs:
 
             # Accumulate blocked/no-patch
             TOTAL_BLOCKED=$((TOTAL_BLOCKED + WS_BLOCKED))
+            TOTAL_NO_PATCH=$((TOTAL_NO_PATCH + WS_NO_PATCH))
             [ -n "$BLOCKED_PKGS" ] && ALL_BLOCKED_PACKAGES="${ALL_BLOCKED_PACKAGES:+$ALL_BLOCKED_PACKAGES, }$BLOCKED_PKGS"
             [ -n "$NO_PATCH_PKGS" ] && ALL_NO_PATCH_PACKAGES="${ALL_NO_PATCH_PACKAGES:+$ALL_NO_PATCH_PACKAGES, }$NO_PATCH_PKGS"
 
@@ -256,11 +283,13 @@ jobs:
           # ── Step 3: Report results ──────────────────────────────────
           echo "resolved=$TOTAL_RESOLVED" >> "$GITHUB_OUTPUT"
           echo "blocked=$TOTAL_BLOCKED" >> "$GITHUB_OUTPUT"
+          echo "no_patch=$TOTAL_NO_PATCH" >> "$GITHUB_OUTPUT"
           echo "failed=$TOTAL_FAILED" >> "$GITHUB_OUTPUT"
           echo "applied_packages=$ALL_APPLIED" >> "$GITHUB_OUTPUT"
           echo "rolled_back_packages=$ALL_ROLLED_BACK" >> "$GITHUB_OUTPUT"
           echo "blocked_packages=$ALL_BLOCKED_PACKAGES" >> "$GITHUB_OUTPUT"
           echo "no_patch_packages=$ALL_NO_PATCH_PACKAGES" >> "$GITHUB_OUTPUT"
+          echo "failed_workspaces=$ALL_FAILED_WORKSPACES" >> "$GITHUB_OUTPUT"
 
           cd "$GITHUB_WORKSPACE"
           if git diff --quiet; then
@@ -339,10 +368,13 @@ jobs:
           BODY="$BODY
           - **Applied ($RESOLVED):**$APPLIED
           - **Blocked ($BLOCKED):**${BLOCKED_PKGS:- (none)}
-          - **No patch available:**${NO_PATCH_PKGS:- (none)}
+          - **No patch available (${{ steps.fix.outputs.no_patch }}):**${NO_PATCH_PKGS:- (none)}
           - **Rolled back ($FAILED):**${ROLLED:- (none)}
+          - **Workspaces with analysis failures:**${{ steps.fix.outputs.failed_workspaces && format(' {0}', steps.fix.outputs.failed_workspaces) || ' (none)' }}
           - **Build:** ✅ Passed
           - **Shell packaging:** ${{ steps.shell.outputs.shell_ok == 'true' && '✅ Passed' || '⚠️ Skipped' }}
+
+          > _Note: the analysis source (\`fix-dependabot-alerts.mjs\`) is broader than the GitHub Dependabot REST API — it also audits the lockfile directly. Some packages listed above may not have a corresponding open Dependabot alert, and vice versa._
 
           ### How this works
           1. Analyses all open Dependabot alerts
@@ -372,6 +404,7 @@ jobs:
           echo "|--------|-------|" >> "$GITHUB_STEP_SUMMARY"
           echo "| Applied | ${{ steps.fix.outputs.resolved || '0' }} |" >> "$GITHUB_STEP_SUMMARY"
           echo "| Blocked | ${{ steps.fix.outputs.blocked || '0' }} |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| No patch available | ${{ steps.fix.outputs.no_patch || '0' }} |" >> "$GITHUB_STEP_SUMMARY"
           echo "| Rolled back | ${{ steps.fix.outputs.failed || '0' }} |" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           if [ -n "${{ steps.fix.outputs.applied_packages }}" ]; then
@@ -379,6 +412,9 @@ jobs:
           fi
           if [ -n "${{ steps.fix.outputs.rolled_back_packages }}" ]; then
             echo "**Rolled back:**${{ steps.fix.outputs.rolled_back_packages }}" >> "$GITHUB_STEP_SUMMARY"
+          fi
+          if [ -n "${{ steps.fix.outputs.failed_workspaces }}" ]; then
+            echo "**⚠️ Analysis failed for workspaces:** ${{ steps.fix.outputs.failed_workspaces }}" >> "$GITHUB_STEP_SUMMARY"
           fi
           echo "" >> "$GITHUB_STEP_SUMMARY"
           if [ "${{ steps.fix.outputs.changes }}" == "true" ]; then


### PR DESCRIPTION
## What

Three fixes + one PR-body clarification to the daily `fix-dependabot-alerts` workflow.

## Why

While auditing why so many alerts have been "blocked" for months, I found that **the docs workspace has been silently failing analysis on every run**. CI log:

```
Processing workspace: docs
##[group]Analysing docs alerts
No valid analysis for docs — skipping
Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'chalk' imported from
  /home/runner/work/TypeAgent/TypeAgent/ts/tools/scripts/fix-dependabot-alerts.mjs
```

The script lives at `ts/tools/scripts/fix-dependabot-alerts.mjs` and imports `chalk` from `ts/node_modules`. The workflow currently does `pnpm install` only inside each iterated workspace. When `docs` is processed before `ts`, `ts/node_modules` is empty, the import crashes, and the workflow swallows the error as "No valid analysis — skipping" with no surfacing in the job summary or PR body.

This has been dropping **3 fixable Dependabot alerts** in `docs/` (`liquidjs` GHSA-56p5-8mhr-2fph high + 2 others). The lockfile has `liquidjs@10.25.0`; the patched version is `≥10.25.5`; `docs/package.json` declares `"liquidjs": ">=10.22.0"`. A plain `pnpm update liquidjs` clears all three — the script just never got there.

## Changes

All in `.github/workflows/fix-dependabot-alerts.yml`:

- **F1: Install `ts/` deps once before the per-workspace loop.** Adds a single `pnpm install --frozen-lockfile` step in `ts/` so the script's own dependencies are always present, regardless of which workspace is being analysed. This is the actual fix for the bug above.
- **F2: Surface analysis failures.** When `jq -e '.summary'` fails, echo the tail of the error log into `$GITHUB_STEP_SUMMARY` and track failed workspaces, then list them in the PR body. Removes the class of "silent workspace failure" bug.
- **F3: Track `TOTAL_NO_PATCH` separately from `TOTAL_BLOCKED`.** "No patch available" (no upstream fix yet) and "blocked" (fix exists but couldn't apply, e.g. the shell-bundle override gate) need to be distinguished for triage. Adds a row to the summary table and a line to the PR body. The `noPatch` count was already produced by the script per workspace; we just weren't aggregating it.
- **F8: Note in PR body.** One sentence explaining that the script audits the lockfile directly and may flag packages that aren't in the open Dependabot REST alerts (and vice versa), to prevent reviewer confusion when triaging.

## Expected impact

- **Next nightly run should clear the 3 `liquidjs` alerts** in `docs/`. (Subject to the script's normal build-verification rollback.)
- All other alert categories unchanged — this PR doesn't touch the `--auto-fix` / shell-bundle gate / parent-update logic.
- Future workspace analysis breakage will be visible immediately in the job summary instead of being silent.

## Verification

- Reproduced the `chalk` ENOENT locally (Windows PowerShell, no `pnpm` on PATH for the analysis test) and confirmed the error path.
- Manually ran `node ../ts/tools/scripts/fix-dependabot-alerts.mjs --dry-run --json` against `docs/` after installing `ts/` deps; analysis succeeded and detected `liquidjs`.
- YAML validated with `yaml.safe_load`.

## Out of scope (filed mentally as follow-ups)

- F4: dedupe daily PRs against an existing open one (state-machine work, separate PR).
- F5: embed `--show-chains=full` output in PR body for blocked packages.
- F6: script-side bug — when `pnpm why` returns no data, the script currently classifies a package as `alreadyFixed` instead of `failed`. Different file, different test surface, separate PR.
- F7: per-package rollback memory.
