### PR TITLE
fix(dep-alerts): extract package versions from nested pnpm-why tree

### DIFF
--- a/ts/tools/scripts/fix-dependabot-alerts.mjs
+++ b/ts/tools/scripts/fix-dependabot-alerts.mjs
@@ -576,14 +576,44 @@ async function getLatestVersion(pkg) {
 }
 
 /**
- * Extract unique sorted versions from pnpm-why data.
+ * Extract unique sorted resolved versions of a specific package from
+ * `pnpm why <pkg> -r --json` output.
+ *
+ * The output is an array of workspace-project entries, each with its own
+ * `name`/`version` (the workspace's version, NOT the queried package's
+ * version) and a nested `dependencies`/`devDependencies`/`optionalDependencies`
+ * tree. Each node in those trees keyed by a package name carries the
+ * `version` we actually want.
+ *
+ * Earlier this function read `e.version` off the top-level entries, which
+ * always returned the workspace project's own version (e.g. `1.0.0`) and
+ * caused `verifyAllVersionsFixed` to incorrectly conclude that updates had
+ * left vulnerable versions in place.
  */
-function getResolvedVersions(whyData) {
-    return [
-        ...new Set(
-            whyData.map((e) => e.version).filter((v) => v && semver.valid(v)),
-        ),
-    ].sort(semver.compare);
+function getResolvedVersions(whyData, pkg) {
+    const versions = new Set();
+    const depKeys = ["dependencies", "devDependencies", "optionalDependencies"];
+
+    function walk(node) {
+        if (!node || typeof node !== "object") return;
+        for (const key of depKeys) {
+            const deps = node[key];
+            if (!deps || typeof deps !== "object") continue;
+            for (const [depName, depNode] of Object.entries(deps)) {
+                if (!depNode || typeof depNode !== "object") continue;
+                if (depName === pkg && typeof depNode.version === "string") {
+                    versions.add(depNode.version);
+                }
+                walk(depNode);
+            }
+        }
+    }
+
+    for (const entry of whyData) walk(entry);
+
+    return [...versions]
+        .filter((v) => semver.valid(v))
+        .sort(semver.compare);
 }
 
 /**
@@ -605,7 +635,7 @@ async function verifyAllVersionsFixed(pkg, requiredVersion) {
     }
     getPnpmWhy.cache.delete(pkg);
     getPnpmWhy.inflight.delete(pkg);
-    const versions = getResolvedVersions(await getPnpmWhy(pkg));
+    const versions = getResolvedVersions(await getPnpmWhy(pkg), pkg);
     const unfixed = versions.filter((v) => semver.lt(v, requiredVersion));
     return { ok: unfixed.length === 0, versions, unfixed };
 }
@@ -1952,7 +1982,7 @@ async function formatPackageAnalysis(entry, whyData, pkgIndex, pkgTotal) {
 
     // ── Line 1: Identity ─────────────────────────────────────────────────
     if (!patched) {
-        const noPatchVersions = getResolvedVersions(whyData);
+        const noPatchVersions = getResolvedVersions(whyData, pkg);
         const installedStr =
             noPatchVersions.length > 0
                 ? noPatchVersions.map((v) => clr.versionBad(v)).join(", ")
@@ -1971,7 +2001,7 @@ async function formatPackageAnalysis(entry, whyData, pkgIndex, pkgTotal) {
     }
 
     // For strategies that need action: show version gap
-    const uniqueVersions = getResolvedVersions(whyData);
+    const uniqueVersions = getResolvedVersions(whyData, pkg);
     const vulnVersions = uniqueVersions.filter((v) => semver.lt(v, patched));
     const versionGap = vulnVersions
         .map((v) => clr.versionBad(`\u2717 ${v}`))
@@ -2277,13 +2307,13 @@ async function analyzeVulnerabilities(byPackage) {
                     }
 
                     if (!patched) {
-                        const noPatchVersions = getResolvedVersions(whyData);
+                        const noPatchVersions = getResolvedVersions(whyData, pkg);
                         e.currentVersion =
                             noPatchVersions.length > 0
                                 ? noPatchVersions[0]
                                 : null;
                     } else {
-                        const uniqueVersions = getResolvedVersions(whyData);
+                        const uniqueVersions = getResolvedVersions(whyData, pkg);
                         const vulnVersions = uniqueVersions.filter((v) =>
                             semver.lt(v, patched),
                         );


### PR DESCRIPTION
## Summary

`getResolvedVersions` in `ts/tools/scripts/fix-dependabot-alerts.mjs` was reading `e.version` off the top-level `pnpm why <pkg> -r --json` entries. Those top-level entries are **workspace projects** — their `version` field is the workspace's own version (e.g. `typeagent-docs@1.0.0`), not the queried package's version. The actual package versions live nested inside each entry's `dependencies` / `devDependencies` / `optionalDependencies` trees, keyed by package name.

## Impact

This caused `verifyAllVersionsFixed` to always see the workspace's own version after running `pnpm update <pkg> -r`, decide the update was incomplete, push a `blockingReasons` entry, and exit non-zero — so the daily `fix-dependabot-alerts.yml` workflow created **no PR**, even when it had successfully updated the lockfile.

### Repro (run 25523292442 against `docs/`)

`
[1/1] 📦 liquidjs (high) — ✗ 1.0.0 → need ≥10.25.5
   Fix: pnpm update liquidjs -r
⚠  pnpm update left unfixed versions of liquidjs: 1.0.0 (need >=10.25.5)
   liquidjs: pnpm update left unfixed versions: 1.0.0
…
##[warning]Script failed for liquidjs in docs (exit 1) with no file changes
`

The lockfile only contains `liquidjs@10.25.0` — the `1.0.0` is `typeagent-docs`'s own `package.json` version, leaking out of the workspace project entry.

## Fix

Recursively walk `dependencies` / `devDependencies` / `optionalDependencies` of every workspace entry; collect `version` strings from any node keyed by the queried package name. Threaded the package name through the five existing call sites (`verifyAllVersionsFixed`, `formatPackageAnalysis` ×2, the analysis pass ×2).

## Verification

Against `docs/` locally:

`
NEW versions: [ '10.25.0' ]
OLD (buggy) versions: [ '1.0.0' ]
`

So once this lands, the daily workflow run will be able to bump `liquidjs` in `docs/` and clear Dependabot alerts #320, #321, #322 (3 high-severity, including ReDoS GHSA-56p5-8mhr-2fph).

## Stacking with #2305

This is a separate fix from #2305 (workflow-side improvements: surfacing analysis failures, `ts` install-once, `noPatch` row in summary). PR #2305 unblocks `docs` analysis from being silently dropped; this PR unblocks the resulting fix from being silently rolled back. **Both must merge** for the workflow to clear any alert end-to-end.

## Out of scope

- `findConstrainingParentsFromData` walks `entry.dependents` which is also not a top-level field in `pnpm why` output. Suspect-but-untriaged; left for a follow-up.
- The original F6 follow-up (`alreadyFixed` misclassification when `pnpm why` returns no data) is unchanged.