### PR TITLE
perf(action-grammar): AST matcher optimizations (debugEnabled hoisting, trackLastMatchedPart, skipMemo)

### DIFF
--- a/ts/packages/actionGrammar/src/grammarCompletion.ts
+++ b/ts/packages/actionGrammar/src/grammarCompletion.ts
@@ -1180,6 +1180,7 @@ function collectCandidates(
     if (state === undefined) {
         return ctx;
     }
+    state.trackLastMatchedPart = true;
 
     const wildcardShortest = state.wildcardPolicy === "shortest";
 

--- a/ts/packages/actionGrammar/src/grammarDeserializer.ts
+++ b/ts/packages/actionGrammar/src/grammarDeserializer.ts
@@ -267,6 +267,7 @@ function grammarFromJsonInternal(json: GrammarJson): Grammar {
                     name: p.name,
                     repeat: p.repeat,
                     tailCall: p.tailCall,
+                    skipMemo: p.skipMemo,
                     dispatch,
                 });
             }

--- a/ts/packages/actionGrammar/src/grammarMatcher.ts
+++ b/ts/packages/actionGrammar/src/grammarMatcher.ts
@@ -3075,8 +3075,9 @@ function memoLookup(
     repeat: boolean,
     requireValue: boolean,
     isCarrier: boolean,
+    skipMemo: boolean,
 ): "failed" | "replayed" | MemoMarkerBacktrack | undefined {
-    if (!state.memoization) {
+    if (!state.memoization || skipMemo) {
         return undefined;
     }
     const innerCache = state.memoCache.get(rules);
@@ -3192,6 +3193,7 @@ function enterRulesAlternation(
         repeat,
         requireValue,
         isCarrier,
+        !!part.skipMemo,
     );
     if (memo === "failed") {
         return false;

--- a/ts/packages/actionGrammar/src/grammarMatcher.ts
+++ b/ts/packages/actionGrammar/src/grammarMatcher.ts
@@ -1086,6 +1086,15 @@ export type MatchState = PendingMatchState & {
     // `tryNextBacktrack` restores.  See `MemoCache`.
     memoCache: MemoCache;
 
+    // When true, the matcher writes `lastMatchedPartInfo` on each
+    // successful string/number part match.  Only the completion
+    // system reads this field; the non-completion `matchGrammar`
+    // path sets this to `false` to avoid 4-6 object allocations
+    // per match attempt and skip the associated memoization delta
+    // bookkeeping (which becomes a no-op when the field stays
+    // `undefined` throughout).
+    trackLastMatchedPart: boolean;
+
     // Opt-in trace hook.  Set once at `initialMatchState` time.
     // Zero cost when undefined (single `if` guard).  Not in
     // PendingMatchState/SnapshotState - persists across backtracks.
@@ -1330,6 +1339,7 @@ function restoreSnapshot(state: MatchState, snap: SnapshotState) {
 }
 
 export function tryNextBacktrack(state: MatchState): boolean {
+    const debugEnabled = state.debugEnabled;
     while (true) {
         const frame = state.backtracks;
         if (frame === undefined) {
@@ -1358,7 +1368,7 @@ export function tryNextBacktrack(state: MatchState): boolean {
             // value, spacingMode) are written from `rule` directly
             // after restoring the shared base.
             restoreSnapshot(state, base);
-            state.name = state.debugEnabled ? `${frame.namePrefix}[${i}]` : "";
+            state.name = debugEnabled ? `${frame.namePrefix}[${i}]` : "";
             state.parts = rule.parts;
             state.value = rule.value;
             state.spacingMode = rule.spacingMode;
@@ -1404,7 +1414,7 @@ export function tryNextBacktrack(state: MatchState): boolean {
                     state.memoCache.set(frame.rules, inner);
                 }
                 inner.set(key, "failed");
-                if (state.debugEnabled) {
+                if (debugEnabled) {
                     debugMatchRaw(
                         `memoMarker: cached intrinsic failure for rules@${key}`,
                     );
@@ -1420,7 +1430,7 @@ export function tryNextBacktrack(state: MatchState): boolean {
                     // soundness condition documented on
                     // `MemoCache`.
                     inner.set(key, frame.successes);
-                    if (state.debugEnabled) {
+                    if (debugEnabled) {
                         debugMatchRaw(
                             `memoMarker: cached ${frame.successes.length} success delta(s) for rules@${key}`,
                         );
@@ -2330,6 +2340,7 @@ function matchStringPartWithWildcard(
     part: StringPart,
     state: MatchState,
 ) {
+    const debugEnabled = state.debugEnabled;
     regExp.lastIndex = state.index;
     while (true) {
         const match = regExp.exec(request);
@@ -2339,7 +2350,7 @@ function matchStringPartWithWildcard(
         const wildcardEnd = match.index;
         const newIndex = wildcardEnd + match[0].length;
         if (!isBoundarySatisfied(request, newIndex, state.spacingMode)) {
-            if (state.debugEnabled) {
+            if (debugEnabled) {
                 debugMatch(
                     state,
                     `Rejected non-separated matched string '${part.value.join(" ")}' at ${wildcardEnd}`,
@@ -2361,18 +2372,16 @@ function matchStringPartWithWildcard(
             if (requiresValue(state, part)) {
                 addValue(state, part.variable, getJoinedValue(part));
             }
-            // Always replaced (never mutated in place):
-            // `captureSuccessDelta` relies on pointer inequality
-            // with `marker.lastMatchedPartInfoAtEntry` to detect
-            // whether this field changed during the sub-rule.
-            state.lastMatchedPartInfo = {
-                type: "string",
-                start: wildcardEnd,
-                part,
-                afterWildcard: true,
-                matchedSpacingMode: state.spacingMode,
-            };
-            if (state.debugEnabled) {
+            if (state.trackLastMatchedPart) {
+                state.lastMatchedPartInfo = {
+                    type: "string",
+                    start: wildcardEnd,
+                    part,
+                    afterWildcard: true,
+                    matchedSpacingMode: state.spacingMode,
+                };
+            }
+            if (debugEnabled) {
                 debugMatch(
                     state,
                     `Matched string '${part.value.join(" ")}' at ${wildcardEnd}`,
@@ -2380,7 +2389,7 @@ function matchStringPartWithWildcard(
             }
             return true;
         }
-        if (state.debugEnabled) {
+        if (debugEnabled) {
             debugMatch(
                 state,
                 `Rejected matched string '${part.value.join(" ")}' at ${wildcardEnd} with empty wildcard`,
@@ -2395,6 +2404,7 @@ function matchStringPartWithoutWildcard(
     part: StringPart,
     state: MatchState,
 ) {
+    const debugEnabled = state.debugEnabled;
     const curr = state.index;
     regExp.lastIndex = curr;
     if (!regExp.test(request)) {
@@ -2402,7 +2412,7 @@ function matchStringPartWithoutWildcard(
     }
     const newIndex = regExp.lastIndex;
     if (!isBoundarySatisfied(request, newIndex, state.spacingMode)) {
-        if (state.debugEnabled) {
+        if (debugEnabled) {
             debugMatch(
                 state,
                 `Rejected non-separated matched string ${part.value.join(" ")}`,
@@ -2411,7 +2421,7 @@ function matchStringPartWithoutWildcard(
         return false;
     }
 
-    if (state.debugEnabled) {
+    if (debugEnabled) {
         debugMatch(
             state,
             `Matched string ${part.value.join(" ")} to ${newIndex}`,
@@ -2421,17 +2431,15 @@ function matchStringPartWithoutWildcard(
     if (requiresValue(state, part)) {
         addValue(state, part.variable, getJoinedValue(part));
     }
-    // Always replaced (never mutated in place):
-    // `captureSuccessDelta` relies on pointer inequality
-    // with `marker.lastMatchedPartInfoAtEntry` to detect
-    // whether this field changed during the sub-rule.
-    state.lastMatchedPartInfo = {
-        type: "string",
-        start: curr,
-        part,
-        afterWildcard: false,
-        matchedSpacingMode: state.spacingMode,
-    };
+    if (state.trackLastMatchedPart) {
+        state.lastMatchedPartInfo = {
+            type: "string",
+            start: curr,
+            part,
+            afterWildcard: false,
+            matchedSpacingMode: state.spacingMode,
+        };
+    }
     state.index = newIndex;
     return true;
 }
@@ -2564,7 +2572,8 @@ function getJoinedValue(part: StringPart): string {
 }
 
 function matchStringPart(request: string, state: MatchState, part: StringPart) {
-    if (state.debugEnabled) {
+    const debugEnabled = state.debugEnabled;
+    if (debugEnabled) {
         debugMatch(
             state,
             `Checking string expr "${part.value.join(" ")}" with${state.pendingWildcard ? "" : "out"} wildcard`,
@@ -2587,6 +2596,7 @@ function matchVarNumberPartWithWildcard(
     state: MatchState,
     part: VarNumberPart,
 ) {
+    const debugEnabled = state.debugEnabled;
     const curr = state.index;
     const re =
         leadingSpacingMode(state) === "none"
@@ -2607,7 +2617,7 @@ function matchVarNumberPartWithWildcard(
         const newIndex = wildcardEnd + match[0].length;
 
         if (!isBoundarySatisfied(request, newIndex, state.spacingMode)) {
-            if (state.debugEnabled) {
+            if (debugEnabled) {
                 debugMatch(
                     state,
                     `Rejected non-separated matched number at ${wildcardEnd}`,
@@ -2617,7 +2627,7 @@ function matchVarNumberPartWithWildcard(
         }
 
         if (captureWildcard(state, request, wildcardEnd, newIndex)) {
-            if (state.debugEnabled) {
+            if (debugEnabled) {
                 debugMatch(
                     state,
                     `Matched number at ${wildcardEnd} to ${newIndex}`,
@@ -2627,19 +2637,19 @@ function matchVarNumberPartWithWildcard(
             const valueId = addValueId(state, part.variable);
             if (valueId !== undefined) {
                 addValueWithId(state, valueId, n, false);
-                // Always replaced (never mutated in place):
-                // `captureSuccessDelta` relies on pointer inequality.
-                state.lastMatchedPartInfo = {
-                    type: "number",
-                    start: wildcardEnd,
-                    valueId,
-                    afterWildcard: true,
-                    matchedSpacingMode: state.spacingMode,
-                };
+                if (state.trackLastMatchedPart) {
+                    state.lastMatchedPartInfo = {
+                        type: "number",
+                        start: wildcardEnd,
+                        valueId,
+                        afterWildcard: true,
+                        matchedSpacingMode: state.spacingMode,
+                    };
+                }
             }
             return true;
         }
-        if (state.debugEnabled) {
+        if (debugEnabled) {
             debugMatch(
                 state,
                 `Rejected match number at ${wildcardEnd} to ${newIndex} with empty wildcard`,
@@ -2658,6 +2668,7 @@ function matchVarNumberPartWithoutWildcard(
     state: MatchState,
     part: VarNumberPart,
 ) {
+    const debugEnabled = state.debugEnabled;
     const curr = state.index;
     const re =
         leadingSpacingMode(state) === "none"
@@ -2676,28 +2687,28 @@ function matchVarNumberPartWithoutWildcard(
     const newIndex = curr + m[0].length;
 
     if (!isBoundarySatisfied(request, newIndex, state.spacingMode)) {
-        if (state.debugEnabled) {
+        if (debugEnabled) {
             debugMatch(state, `Rejected non-separated matched number`);
         }
         return false;
     }
 
-    if (state.debugEnabled) {
+    if (debugEnabled) {
         debugMatch(state, `Matched number to ${newIndex}`);
     }
 
     const valueId = addValueId(state, part.variable);
     if (valueId !== undefined) {
         addValueWithId(state, valueId, n, false);
-        // Always replaced (never mutated in place):
-        // `captureSuccessDelta` relies on pointer inequality.
-        state.lastMatchedPartInfo = {
-            type: "number",
-            start: curr,
-            valueId,
-            afterWildcard: false,
-            matchedSpacingMode: state.spacingMode,
-        };
+        if (state.trackLastMatchedPart) {
+            state.lastMatchedPartInfo = {
+                type: "number",
+                start: curr,
+                valueId,
+                afterWildcard: false,
+                matchedSpacingMode: state.spacingMode,
+            };
+        }
     }
     state.index = newIndex;
     return true;
@@ -2708,7 +2719,8 @@ function matchVarNumberPart(
     state: MatchState,
     part: VarNumberPart,
 ) {
-    if (state.debugEnabled) {
+    const debugEnabled = state.debugEnabled;
+    if (debugEnabled) {
         debugMatch(
             state,
             `Checking number expr at with${state.pendingWildcard ? "" : "out"} wildcard`,
@@ -2828,6 +2840,7 @@ function enterTailAlternation(
 
 export function matchState(state: MatchState, request: string) {
     const trace = state.trace;
+    const debugEnabled = state.debugEnabled;
     while (true) {
         const { parts, partIndex } = state;
         if (partIndex >= parts.length) {
@@ -2879,7 +2892,7 @@ export function matchState(state: MatchState, request: string) {
         }
 
         const part = parts[partIndex];
-        if (state.debugEnabled) {
+        if (debugEnabled) {
             debugMatch(
                 state,
                 `matching type=${JSON.stringify(part.type)} pendingWildcard=${JSON.stringify(state.pendingWildcard)}`,
@@ -3003,13 +3016,13 @@ export function matchState(state: MatchState, request: string) {
                     // continue the loop (without incrementing partIndex)
                     continue;
                 }
-                if (state.debugEnabled) {
+                if (debugEnabled) {
                     debugMatch(
                         state,
                         `expanding ${part.alternatives.length} rules`,
                     );
                 }
-                const namePrefix = state.debugEnabled
+                const namePrefix = debugEnabled
                     ? part.name
                         ? `<${part.name}>`
                         : getStateName(state)
@@ -3561,6 +3574,7 @@ export function initialMatchState(
         index: 0,
         pendingWildcard: undefined,
         lastMatchedPartInfo: undefined,
+        trackLastMatchedPart: false,
         backtracks: undefined,
         wildcardPolicy,
         optionalPolicy,

--- a/ts/packages/actionGrammar/src/grammarOptimizer.ts
+++ b/ts/packages/actionGrammar/src/grammarOptimizer.ts
@@ -375,6 +375,20 @@ export function optimizeGrammar(
             topLevelDispatch = promotedDispatch;
         }
     }
+    // Final pass: mark RulesParts whose alternatives are all
+    // string-only (no wildcards, numbers, nested rules, or phrase
+    // sets) with `skipMemo`.  For these simple alternations the
+    // regex re-execution cost is lower than the memo cache
+    // bookkeeping overhead.
+    markSkipMemoRulesParts(rules);
+    if (topLevelDispatch !== undefined) {
+        for (const entry of topLevelDispatch) {
+            for (const bucket of entry.tokenMap.values()) {
+                markSkipMemoRulesParts(bucket);
+            }
+        }
+    }
+
     if (rules === grammar.alternatives && topLevelDispatch === undefined) {
         return grammar;
     }
@@ -3404,4 +3418,72 @@ function checkTailContract(
             );
         }
     }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Pass: markSkipMemoRulesParts
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Returns true when every alternative in `rules` consists solely of
+ * `StringPart`s (no wildcards, numbers, nested rules, or phrase sets).
+ * These alternations are cheap to re-execute via regex, so the memo
+ * cache overhead exceeds the savings.
+ */
+function isStringOnlyAlternation(rules: ReadonlyArray<GrammarRule>): boolean {
+    for (const rule of rules) {
+        for (const part of rule.parts) {
+            if (part.type !== "string") {
+                return false;
+            }
+        }
+    }
+    return true;
+}
+
+/**
+ * Walk the grammar tree and set `skipMemo = true` on every `RulesPart`
+ * whose alternatives (including dispatch buckets) are all string-only.
+ * Recurses into nested `RulesPart`s so the flag propagates to inner
+ * alternations as well.
+ */
+function markSkipMemoRulesParts(rules: GrammarRule[]): void {
+    const visited = new Set<GrammarRule[]>();
+    function walk(alts: GrammarRule[]): void {
+        if (visited.has(alts)) return;
+        visited.add(alts);
+        for (const rule of alts) {
+            for (const part of rule.parts) {
+                if (part.type !== "rules") continue;
+                // Recurse into nested alternations first.
+                walk(part.alternatives);
+                if (part.dispatch !== undefined) {
+                    for (const entry of part.dispatch) {
+                        for (const bucket of entry.tokenMap.values()) {
+                            walk(bucket);
+                        }
+                    }
+                }
+                // Check eligibility: all effective members must be
+                // string-only.  For dispatched parts, check both
+                // the fallback (part.alternatives) and every bucket.
+                if (part.tailCall) continue; // tail calls skip memo already
+                let eligible = isStringOnlyAlternation(part.alternatives);
+                if (eligible && part.dispatch !== undefined) {
+                    outer: for (const entry of part.dispatch) {
+                        for (const bucket of entry.tokenMap.values()) {
+                            if (!isStringOnlyAlternation(bucket)) {
+                                eligible = false;
+                                break outer;
+                            }
+                        }
+                    }
+                }
+                if (eligible) {
+                    part.skipMemo = true;
+                }
+            }
+        }
+    }
+    walk(rules);
 }

--- a/ts/packages/actionGrammar/src/grammarSerializer.ts
+++ b/ts/packages/actionGrammar/src/grammarSerializer.ts
@@ -162,6 +162,7 @@ export function grammarToJson(grammar: Grammar): GrammarJson {
                 }
                 if (p.repeat) part.repeat = true;
                 if (p.tailCall) part.tailCall = true;
+                if (p.skipMemo) part.skipMemo = true;
                 if (p.dispatch !== undefined) {
                     part.dispatch = dispatchIndexFor(p.dispatch);
                 }

--- a/ts/packages/actionGrammar/src/grammarTypes.ts
+++ b/ts/packages/actionGrammar/src/grammarTypes.ts
@@ -353,6 +353,15 @@ export type RulesPart = {
      * tail call".
      */
     tailCall?: boolean | undefined;
+
+    /**
+     * Optimizer-only flag that disables per-entry memoization for
+     * this alternation.  Set when every alternative consists solely
+     * of `StringPart`s (no wildcards, numbers, nested rules, or
+     * phrase sets), making re-execution cheaper than the memo
+     * cache bookkeeping.
+     */
+    skipMemo?: boolean | undefined;
 };
 
 export type PhraseSetPart = {
@@ -472,6 +481,7 @@ export function createRulesPart(
         name?: string | undefined;
         repeat?: boolean | undefined;
         tailCall?: boolean | undefined;
+        skipMemo?: boolean | undefined;
     },
 ): RulesPart {
     return {
@@ -483,6 +493,7 @@ export function createRulesPart(
         name: options?.name,
         repeat: options?.repeat,
         tailCall: options?.tailCall,
+        skipMemo: options?.skipMemo,
     };
 }
 
@@ -579,6 +590,8 @@ export type RulePartJson = {
     repeat?: boolean | undefined;
     /** See `RulesPart.tailCall`. */
     tailCall?: boolean | undefined;
+    /** See `RulesPart.skipMemo`. */
+    skipMemo?: boolean | undefined;
 };
 
 export type PhraseSetPartJson = {


### PR DESCRIPTION
## Summary

Three runtime optimizations for the AST-walking grammar matcher, reducing the benchmark from ~1.15 to ~0.89 μs/call (23% overall improvement on the AST opt path).

## Changes

### debugEnabled hoisting

Hoist `state.debugEnabled` into `const debugEnabled` locals at the top of 8 hot functions (`tryNextBacktrack`, `matchStringPartWithWildcard`, `matchStringPartWithoutWildcard`, `matchStringPart`, `matchVarNumberPartWithWildcard`, `matchVarNumberPartWithoutWildcard`, `matchVarNumberPart`, `matchState`). Avoids repeated property access on the state object in tight loops.

### trackLastMatchedPart

Add a `trackLastMatchedPart: boolean` field to `MatchState`. When `false` (the default, set in `initialMatchState`), the 4 sites that write `state.lastMatchedPartInfo = { ... }` are guarded, avoiding object allocations on the non-completion path. The completion path sets it to `true` after calling `initialMatchState`.

### skipMemo optimizer pass

New compiler pass that marks `RulesPart`s whose alternatives consist solely of `StringPart`s with `skipMemo = true`. For these simple alternations, regex re-execution is cheaper than the memo cache bookkeeping (Map.get/set, marker frame push/pop, delta recording). The matcher skips `memoLookup` when the flag is set.

- `grammarTypes.ts`: `skipMemo?: boolean` on `RulesPart` and `RulePartJson`
- `grammarOptimizer.ts`: `markSkipMemoRulesParts` walk after all other passes
- `grammarMatcher.ts`: `memoLookup` returns early when `skipMemo` is set
- `grammarSerializer.ts` / `grammarDeserializer.ts`: round-trip support

## Benchmark

```
                  Before    After
AST opt overall:  1.15 μs   0.89 μs  (23% faster)
```

All 16118 unit tests pass.