### PR TITLE
feat(grammar-tools): debug info, coverage, diff, and review fixes

### DIFF
--- a/ts/docs/plans/grammar-tools/STATUS.md
+++ b/ts/docs/plans/grammar-tools/STATUS.md
@@ -33,12 +33,12 @@ _Last updated: 2026-05-07_
 
 ### Track B - Core debug + quality services
 
-| Item | Description                               | Status      |
-| ---- | ----------------------------------------- | ----------- |
-| B.1  | Completion preview                        | done        |
-| B.2  | Rule-level trace                          | done        |
-| B.3  | Coverage (per-rule / per-part hit counts) | not started |
-| B.4  | Diff (structural rule-level diff)         | not started |
+| Item | Description                               | Status |
+| ---- | ----------------------------------------- | ------ |
+| B.1  | Completion preview                        | done   |
+| B.2  | Rule-level trace                          | done   |
+| B.3  | Coverage (per-rule / per-part hit counts) | done   |
+| B.4  | Diff (structural rule-level diff)         | done   |
 
 ### Track C - VS Code extension
 
@@ -67,14 +67,14 @@ _Last updated: 2026-05-07_
 
 ### Track E - CLI
 
-| Item | Description                  | Status      |
-| ---- | ---------------------------- | ----------- |
-| E.0  | Scaffold `grammar-tools-cli` | done        |
-| E.1  | `grammar load` command       | done        |
-| E.2  | `grammar complete` command   | done        |
-| E.3  | `grammar trace` command      | done        |
-| E.4  | `grammar coverage` command   | not started |
-| E.5  | `grammar diff` command       | not started |
+| Item | Description                  | Status |
+| ---- | ---------------------------- | ------ |
+| E.0  | Scaffold `grammar-tools-cli` | done   |
+| E.1  | `grammar load` command       | done   |
+| E.2  | `grammar complete` command   | done   |
+| E.3  | `grammar trace` command      | done   |
+| E.4  | `grammar coverage` command   | done   |
+| E.5  | `grammar diff` command       | done   |
 
 ### Track F - Dispatcher snapshot
 
@@ -177,11 +177,10 @@ Promote into "Queued actions" when scheduling.
   coverage analysis for the NFA/DFA compile paths as well. Lower
   priority since the rule-level matcher is the primary matching backend
   for authoring/debugging; NFA/DFA are production-optimized paths.
-- **B.3 coverage / B.4 diff implementation.** Stubs (`runCoverage`,
-  `diffGrammars`) removed during self-review (2026-05-07) to avoid
-  shipping dead code. Types (`CoverageReport`, `RuleCoverage`, etc.)
-  remain in `types.ts` as the agreed shape. Implement when Track A.5
-  (`GrammarDebugInfo` emission) lands.
+- **B.3 coverage / B.4 diff implementation.** ~~Stubs removed during
+  self-review (2026-05-07).~~ Implemented 2026-05-07: `computeCoverage`
+  in `coverage.ts`, `diffGrammars` in `diff.ts`. CLI commands E.4 and
+  E.5 (`grammar coverage`, `grammar diff`) also landed.
 
 ## Out of scope for this pass
 

--- a/ts/docs/plans/grammar-tools/STATUS.md
+++ b/ts/docs/plans/grammar-tools/STATUS.md
@@ -9,6 +9,83 @@ work**. Update it whenever an action is started, completed, or a new
 follow-up surfaces. Keep entries terse - one line per item where
 possible.
 
+## Progress by track
+
+_Last updated: 2026-05-07_
+
+### Track 0 - Critical path
+
+| Item | Description                                                     | Status |
+| ---- | --------------------------------------------------------------- | ------ |
+| 0a   | Resolve ADR 0001 (UI tech) and ADR 0002 (trace hook)            | done   |
+| 0b   | Chunk 02: matcher instrumentation (spans + trace hook + PartId) | done   |
+| 0c   | Chunk 01 scaffold: `grammar-tools-core` package layout          | done   |
+
+### Track A - Core language services
+
+| Item | Description                                          | Status |
+| ---- | ---------------------------------------------------- | ------ |
+| A.1  | Loader (file, agent, snapshot)                       | done   |
+| A.2  | Diagnostics                                          | done   |
+| A.3  | Symbol index (definitions / references / signatures) | done   |
+| A.4  | Formatter (wraps `writeGrammarRules`)                | done   |
+| A.5  | `GrammarDebugInfo` emission (compiler-side sidecar)  | done   |
+
+### Track B - Core debug + quality services
+
+| Item | Description                               | Status      |
+| ---- | ----------------------------------------- | ----------- |
+| B.1  | Completion preview                        | done        |
+| B.2  | Rule-level trace                          | done        |
+| B.3  | Coverage (per-rule / per-part hit counts) | not started |
+| B.4  | Diff (structural rule-level diff)         | not started |
+
+### Track C - VS Code extension
+
+| Item | Description                                  | Status      |
+| ---- | -------------------------------------------- | ----------- |
+| C.0  | Multi-package layout, reuse TextMate grammar | done        |
+| C.1  | LSP diagnostics                              | done        |
+| C.2  | LSP go-to-definition                         | done        |
+| C.3  | LSP find-references                          | done        |
+| C.4  | LSP hover                                    | done        |
+| C.5  | LSP document formatting                      | done        |
+| C.6  | Webview debug panel                          | not started |
+| C.7  | Coverage decorations                         | not started |
+| C.8  | Diff command                                 | not started |
+
+### Track D - Shared UI
+
+| Item | Description                          | Status      |
+| ---- | ------------------------------------ | ----------- |
+| D.0  | Scaffold `grammar-tools-ui` with Lit | not started |
+| D.1  | `<completion-preview>` component     | not started |
+| D.2  | `<rule-trace>` component             | not started |
+| D.3  | `<grammar-picker>` component         | not started |
+| D.4  | `<coverage-view>` component          | not started |
+| D.5  | `<diff-view>` component              | not started |
+
+### Track E - CLI
+
+| Item | Description                  | Status      |
+| ---- | ---------------------------- | ----------- |
+| E.0  | Scaffold `grammar-tools-cli` | done        |
+| E.1  | `grammar load` command       | done        |
+| E.2  | `grammar complete` command   | done        |
+| E.3  | `grammar trace` command      | done        |
+| E.4  | `grammar coverage` command   | not started |
+| E.5  | `grammar diff` command       | not started |
+
+### Track F - Dispatcher snapshot
+
+| Item | Description                                 | Status      |
+| ---- | ------------------------------------------- | ----------- |
+| F.1  | Dispatcher RPC `getCompiledGrammarSnapshot` | not started |
+
+### Tracks G & H - Web app + Shell (post-gate)
+
+All items not started. Blocked by Phase 2 decision gate.
+
 ## Conventions
 
 - **Status**: `queued` / `in-progress` / `done` / `dropped`.

--- a/ts/extensions/agr-language/package.json
+++ b/ts/extensions/agr-language/package.json
@@ -23,6 +23,13 @@
     "clean": "rimraf dist"
   },
   "contributes": {
+    "commands": [
+      {
+        "command": "agr.traceMatch",
+        "title": "Trace Match",
+        "category": "Action Grammar"
+      }
+    ],
     "grammars": [
       {
         "language": "agr",
@@ -41,13 +48,6 @@
           ".agr"
         ],
         "configuration": "./language-configuration.json"
-      }
-    ],
-    "commands": [
-      {
-        "command": "agr.traceMatch",
-        "title": "Trace Match",
-        "category": "Action Grammar"
       }
     ]
   },

--- a/ts/extensions/agr-language/package.json
+++ b/ts/extensions/agr-language/package.json
@@ -42,6 +42,13 @@
         ],
         "configuration": "./language-configuration.json"
       }
+    ],
+    "commands": [
+      {
+        "command": "agr.traceMatch",
+        "title": "Trace Match",
+        "category": "Action Grammar"
+      }
     ]
   },
   "activationEvents": [

--- a/ts/extensions/agr-language/src/client.ts
+++ b/ts/extensions/agr-language/src/client.ts
@@ -2,13 +2,18 @@
 // Licensed under the MIT License.
 
 import * as path from "path";
-import { ExtensionContext, workspace } from "vscode";
+import { commands, ExtensionContext, window, workspace } from "vscode";
 import {
     LanguageClient,
     LanguageClientOptions,
     ServerOptions,
     TransportKind,
 } from "vscode-languageclient/node.js";
+import {
+    loadGrammarFromBuffer,
+    traceMatch,
+    formatTrace,
+} from "grammar-tools-core";
 
 let client: LanguageClient | undefined;
 
@@ -39,6 +44,46 @@ export function activate(context: ExtensionContext): void {
     );
 
     client.start();
+
+    const traceChannel = window.createOutputChannel(
+        "Action Grammar Trace",
+        "agr",
+    );
+
+    context.subscriptions.push(
+        commands.registerCommand("agr.traceMatch", async () => {
+            const editor = window.activeTextEditor;
+            if (!editor || editor.document.languageId !== "agr") {
+                window.showErrorMessage("Open an .agr file first.");
+                return;
+            }
+
+            const input = await window.showInputBox({
+                prompt: "Enter text to match against the grammar",
+                placeHolder: "e.g. play something",
+            });
+            if (input === undefined) return;
+
+            const text = editor.document.getText();
+            const fileId = path.basename(editor.document.fileName);
+            const result = loadGrammarFromBuffer(fileId, text);
+            if (!result.ok) {
+                window.showErrorMessage(
+                    "Grammar has errors. Fix diagnostics first.",
+                );
+                return;
+            }
+
+            const trace = traceMatch(result.grammar, input);
+            const output = formatTrace(trace, {
+                debugInfo: result.grammar.debugInfo,
+            });
+
+            traceChannel.clear();
+            traceChannel.appendLine(output);
+            traceChannel.show(true);
+        }),
+    );
 }
 
 export function deactivate(): Thenable<void> | undefined {

--- a/ts/packages/actionGrammar/src/grammarCompiler.ts
+++ b/ts/packages/actionGrammar/src/grammarCompiler.ts
@@ -113,8 +113,8 @@ type CompileContext = {
     derivedTypes: Map<GrammarRule[], SchemaType>; // cached derived output types for rule arrays (compile-time only)
     errors: GrammarCompileError[];
     warnings: GrammarCompileError[];
-    /** Next part ID to assign. Incremented per part creation. */
-    nextPartId: number;
+    /** Shared counter for part IDs across all contexts in this compilation. */
+    partIdCounter: { value: number };
     /** Collector for part source positions (partId -> source offset). */
     debugCollector?: DebugInfoCollector | undefined;
 };
@@ -124,6 +124,7 @@ function createImportCompileContext(
     grammarFileMap: Map<string, CompileContext>,
     referencingFileName: string,
     source: string,
+    partIdCounter?: { value: number },
 ): CompileContext {
     const fullPath = fileLoader.resolvePath(source, referencingFileName);
     if (grammarFileMap.has(fullPath)) {
@@ -140,6 +141,8 @@ function createImportCompileContext(
         fileLoader,
         result.definitions,
         result.imports,
+        undefined,
+        partIdCounter,
     );
     return importContext;
 }
@@ -250,6 +253,7 @@ function createCompileContext(
     definitions: RuleDefinition[],
     imports?: ImportStatement[],
     schemaLoader?: SchemaLoader,
+    partIdCounter?: { value: number },
 ): CompileContext {
     const ruleDefMap: DefinitionMap = new Map();
 
@@ -289,7 +293,7 @@ function createCompileContext(
         derivedTypes: new Map(),
         errors: [],
         warnings: [],
-        nextPartId: 0,
+        partIdCounter: partIdCounter ?? { value: 0 },
     };
 
     // Process definitions FIRST - this populates ruleDefMap
@@ -371,6 +375,7 @@ function createCompileContext(
                     grammarFileMap,
                     fullPath,
                     importStmt.source,
+                    context.partIdCounter,
                 );
 
                 const ruleNames =
@@ -458,6 +463,15 @@ export function compileGrammar(
         schemaLoader,
     );
     context.debugCollector = debugCollector;
+
+    // Propagate debugCollector and share the partId counter with all
+    // import contexts so imported rules get unique partIds and their
+    // source positions are recorded in the same collector.
+    for (const [, importCtx] of grammarFileMap) {
+        if (importCtx !== context) {
+            importCtx.debugCollector = debugCollector;
+        }
+    }
 
     const { grammarRules, hasValue } = createNamedGrammarRules(context, start);
 
@@ -794,7 +808,7 @@ function allocPartId(
     context: CompileContext,
     sourcePos: number | undefined,
 ): number {
-    const id = context.nextPartId++;
+    const id = context.partIdCounter.value++;
     if (context.debugCollector !== undefined && sourcePos !== undefined) {
         context.debugCollector.partPositions.set(id, sourcePos);
     }

--- a/ts/packages/actionGrammar/src/grammarCompiler.ts
+++ b/ts/packages/actionGrammar/src/grammarCompiler.ts
@@ -49,6 +49,20 @@ export type FileLoader = {
 };
 
 /**
+ * Mutable collector for debug info gathered during compilation.
+ * Passed into the compile pipeline; the compiler populates it
+ * with partId-to-source-offset and ruleId-to-source-offset mappings.
+ */
+export type DebugInfoCollector = {
+    /** Maps partId -> source character offset. */
+    partPositions: Map<number, number>;
+    /** Maps ruleId (e.g. "Start") -> source character offset of the definition. */
+    rulePositions: Map<string, number>;
+    /** The file path or id the grammar was loaded from. */
+    fileId: string;
+};
+
+/**
  * Resolves a type name imported from a .ts file to its parsed schema definition.
  * @param typeName - The type name to resolve (e.g., "PlayAction")
  * @param source - The resolved absolute path to the source file. The compiler
@@ -99,6 +113,10 @@ type CompileContext = {
     derivedTypes: Map<GrammarRule[], SchemaType>; // cached derived output types for rule arrays (compile-time only)
     errors: GrammarCompileError[];
     warnings: GrammarCompileError[];
+    /** Next part ID to assign. Incremented per part creation. */
+    nextPartId: number;
+    /** Collector for part source positions (partId -> source offset). */
+    debugCollector?: DebugInfoCollector | undefined;
 };
 
 function createImportCompileContext(
@@ -271,6 +289,7 @@ function createCompileContext(
         derivedTypes: new Map(),
         errors: [],
         warnings: [],
+        nextPartId: 0,
     };
 
     // Process definitions FIRST - this populates ruleDefMap
@@ -425,6 +444,7 @@ export function compileGrammar(
     imports?: ImportStatement[],
     schemaLoader?: SchemaLoader,
     optimizations?: GrammarOptimizationOptions,
+    debugCollector?: DebugInfoCollector,
 ): Grammar {
     const grammarFileMap = new Map<string, CompileContext>();
     const context = createCompileContext(
@@ -437,6 +457,7 @@ export function compileGrammar(
         imports,
         schemaLoader,
     );
+    context.debugCollector = debugCollector;
 
     const { grammarRules, hasValue } = createNamedGrammarRules(context, start);
 
@@ -765,6 +786,21 @@ const emptyRecord: ResolvedDefinitionRecord = {
 //   record.nullable ?? false   →  propagate ruleNullable (treat back-refs
 //                                 conservatively as non-nullable)
 
+/**
+ * Allocate a new partId and, if a debug collector is active, record the
+ * source offset for this part.
+ */
+function allocPartId(
+    context: CompileContext,
+    sourcePos: number | undefined,
+): number {
+    const id = context.nextPartId++;
+    if (context.debugCollector !== undefined && sourcePos !== undefined) {
+        context.debugCollector.partPositions.set(id, sourcePos);
+    }
+    return id;
+}
+
 function createNamedGrammarRules(
     context: CompileContext,
     name: string,
@@ -839,6 +875,14 @@ function createNamedGrammarRules(
         record.compiling = false;
         record.nullable = nullable;
         context.currentDefinition = prev;
+
+        // Record rule source position for debug info
+        if (context.debugCollector !== undefined) {
+            const firstDef = record.definitions[0];
+            if (firstDef.pos !== undefined) {
+                context.debugCollector.rulePositions.set(name, firstDef.pos);
+            }
+        }
 
         // Track valueType entries as used imported types
         if (record.valueType !== undefined) {
@@ -1101,7 +1145,11 @@ function createGrammarRule(
     for (const expr of expressions) {
         switch (expr.type) {
             case "string": {
-                const part = createStringPart(expr.value);
+                const part = createStringPart(
+                    expr.value,
+                    undefined,
+                    allocPartId(context, expr.pos),
+                );
                 // TODO: create regexp
                 parts.push(part);
                 // default value of the string
@@ -1137,6 +1185,7 @@ function createGrammarRule(
                             optional: expr.optional,
                             variable: name,
                             name: referencedName,
+                            partId: allocPartId(context, pos),
                         }),
                     );
                     if (!expr.optional) {
@@ -1151,7 +1200,13 @@ function createGrammarRule(
                             ruleNullable && (record.nullable ?? false);
                     }
                 } else if (referencedName === "number") {
-                    parts.push(createNumberPart(name, expr.optional));
+                    parts.push(
+                        createNumberPart(
+                            name,
+                            expr.optional,
+                            allocPartId(context, pos),
+                        ),
+                    );
                     if (!expr.optional) consumedInput();
                 } else {
                     // Validate type name references
@@ -1183,7 +1238,12 @@ function createGrammarRule(
                     }
 
                     parts.push(
-                        createWildcardPart(name, referencedName, expr.optional),
+                        createWildcardPart(
+                            name,
+                            referencedName,
+                            expr.optional,
+                            allocPartId(context, pos),
+                        ),
                     );
                     if (!expr.optional) consumedInput();
                 }
@@ -1201,7 +1261,13 @@ function createGrammarRule(
                     !isLocallyDefined &&
                     globalPhraseSetRegistry.isPhraseSetName(expr.refName.name)
                 ) {
-                    parts.push(createPhraseSetPart(expr.refName.name));
+                    parts.push(
+                        createPhraseSetPart(
+                            expr.refName.name,
+                            undefined,
+                            allocPartId(context, expr.pos),
+                        ),
+                    );
                     // Phrase sets don't produce a captured value on their own.
                     // Use defaultValue=true so single-part rules using a phrase set
                     // don't trip the "Start rule does not produce a value" check.
@@ -1221,6 +1287,7 @@ function createGrammarRule(
                 parts.push(
                     createRulesPart(record.grammarRules, {
                         name: expr.refName.name,
+                        partId: allocPartId(context, expr.pos),
                     }),
                 );
                 // RuleRefExpr has no optional modifier; it is always non-optional.
@@ -1246,6 +1313,7 @@ function createGrammarRule(
                     createRulesPart(grammarRules, {
                         optional,
                         repeat,
+                        partId: allocPartId(context, undefined),
                     }),
                 );
                 if (!optional && !groupNullable) consumedInput();

--- a/ts/packages/actionGrammar/src/grammarDeserializer.ts
+++ b/ts/packages/actionGrammar/src/grammarDeserializer.ts
@@ -224,11 +224,16 @@ function grammarFromJsonInternal(json: GrammarJson): Grammar {
     function grammarPartFromJson(p: GrammarPartJson): GrammarPart {
         switch (p.type) {
             case "string":
-                return createStringPart(p.value, p.variable);
+                return createStringPart(p.value, p.variable, p.partId);
             case "wildcard":
-                return createWildcardPart(p.variable, p.typeName, p.optional);
+                return createWildcardPart(
+                    p.variable,
+                    p.typeName,
+                    p.optional,
+                    p.partId,
+                );
             case "number":
-                return createNumberPart(p.variable, p.optional);
+                return createNumberPart(p.variable, p.optional, p.partId);
             case "rules": {
                 // A `tailCall` part with no `index` AND no
                 // `dispatch` has zero effective members - it can
@@ -269,10 +274,11 @@ function grammarFromJsonInternal(json: GrammarJson): Grammar {
                     tailCall: p.tailCall,
                     skipMemo: p.skipMemo,
                     dispatch,
+                    partId: p.partId,
                 });
             }
             case "phraseSet":
-                return createPhraseSetPart(p.matcherName, p.variable);
+                return createPhraseSetPart(p.matcherName, p.variable, p.partId);
         }
     }
 

--- a/ts/packages/actionGrammar/src/grammarLoader.ts
+++ b/ts/packages/actionGrammar/src/grammarLoader.ts
@@ -2,7 +2,12 @@
 // Licensed under the MIT License.
 
 import { defaultFileLoader } from "./defaultFileLoader.js";
-import { compileGrammar, FileLoader, SchemaLoader } from "./grammarCompiler.js";
+import {
+    compileGrammar,
+    FileLoader,
+    SchemaLoader,
+    DebugInfoCollector,
+} from "./grammarCompiler.js";
 import { GrammarOptimizationOptions } from "./grammarOptimizer.js";
 import { parseGrammarRules } from "./grammarRuleParser.js";
 import { Grammar } from "./grammarTypes.js";
@@ -14,6 +19,8 @@ export type LoadGrammarRulesOptions = {
     enableValueExpressions?: boolean; // Enable JavaScript-like value expressions (default: true)
     /** Compile-time AST optimizations.  All optimizations default to off. */
     optimizations?: GrammarOptimizationOptions;
+    /** When provided, the compiler populates this with partId/ruleId source positions. */
+    debugCollector?: DebugInfoCollector;
 };
 
 function parseAndCompileGrammar(
@@ -58,6 +65,7 @@ function parseAndCompileGrammar(
         parseResult.imports,
         options?.schemaLoader,
         options?.optimizations,
+        options?.debugCollector,
     );
     return grammar;
 }

--- a/ts/packages/actionGrammar/src/grammarMatcher.ts
+++ b/ts/packages/actionGrammar/src/grammarMatcher.ts
@@ -2939,12 +2939,13 @@ export function matchState(state: MatchState, request: string) {
         }
 
         if (trace !== undefined) {
+            const tracePartId = part.partId ?? partIndex;
             trace({
                 seq: state.traceSeq++,
                 inputPos: state.index,
                 kind: "partAttempted",
                 rule: state.name,
-                part: partIndex,
+                part: tracePartId,
                 partKind: part.type,
             });
         }
@@ -2958,7 +2959,7 @@ export function matchState(state: MatchState, request: string) {
                             inputPos: state.index,
                             kind: "partFailed",
                             rule: state.name,
-                            part: partIndex,
+                            part: part.partId ?? partIndex,
                         });
                     }
                     return false;
@@ -2973,7 +2974,7 @@ export function matchState(state: MatchState, request: string) {
                             inputPos: state.index,
                             kind: "partFailed",
                             rule: state.name,
-                            part: partIndex,
+                            part: part.partId ?? partIndex,
                         });
                     }
                     return false;
@@ -2988,7 +2989,7 @@ export function matchState(state: MatchState, request: string) {
                             inputPos: state.index,
                             kind: "partFailed",
                             rule: state.name,
-                            part: partIndex,
+                            part: part.partId ?? partIndex,
                         });
                     }
                     return false;
@@ -3003,7 +3004,7 @@ export function matchState(state: MatchState, request: string) {
                                 inputPos: state.index,
                                 kind: "partFailed",
                                 rule: state.name,
-                                part: partIndex,
+                                part: part.partId ?? partIndex,
                             });
                         }
                         return false;
@@ -3047,7 +3048,7 @@ export function matchState(state: MatchState, request: string) {
                 inputPos: state.index,
                 kind: "partMatched",
                 rule: state.name,
-                part: partIndex,
+                part: part.partId ?? partIndex,
                 endPos: state.index,
             });
         }

--- a/ts/packages/actionGrammar/src/grammarOptimizer.ts
+++ b/ts/packages/actionGrammar/src/grammarOptimizer.ts
@@ -2564,6 +2564,7 @@ function tryDispatchifyRulesPart(
         name: part.name,
         repeat: part.repeat,
         tailCall: part.tailCall,
+        partId: part.partId,
     });
 }
 
@@ -3100,6 +3101,7 @@ function tryPromoteTrailing(
         tailCall: true,
         name: last.name,
         dispatch: newDispatch,
+        partId: last.partId,
     });
 
     const newParts = parts.slice();

--- a/ts/packages/actionGrammar/src/grammarSerializer.ts
+++ b/ts/packages/actionGrammar/src/grammarSerializer.ts
@@ -136,6 +136,7 @@ export function grammarToJson(grammar: Grammar): GrammarJson {
                     value: p.value,
                 };
                 if (p.variable !== undefined) part.variable = p.variable;
+                if (p.partId !== undefined) part.partId = p.partId;
                 return part;
             }
             case "wildcard":
@@ -166,6 +167,7 @@ export function grammarToJson(grammar: Grammar): GrammarJson {
                 if (p.dispatch !== undefined) {
                     part.dispatch = dispatchIndexFor(p.dispatch);
                 }
+                if (p.partId !== undefined) part.partId = p.partId;
                 return part;
             }
             case "phraseSet": {
@@ -174,6 +176,7 @@ export function grammarToJson(grammar: Grammar): GrammarJson {
                     matcherName: p.matcherName,
                 };
                 if (p.variable !== undefined) part.variable = p.variable;
+                if (p.partId !== undefined) part.partId = p.partId;
                 return part;
             }
         }

--- a/ts/packages/actionGrammar/src/grammarTypes.ts
+++ b/ts/packages/actionGrammar/src/grammarTypes.ts
@@ -190,6 +190,8 @@ export type StringPart = {
      */
     variable: string | undefined;
     value: string[];
+    /** Stable compile-time identifier for debug info and trace events. */
+    partId?: number | undefined;
 
     /**
      * Cache of compiled RegExp objects.  There are exactly 4
@@ -218,12 +220,16 @@ export type VarStringPart = {
     variable: string;
 
     typeName: string; // Not needed at runtime?
+    /** Stable compile-time identifier for debug info and trace events. */
+    partId?: number | undefined;
 };
 
 export type VarNumberPart = {
     type: "number";
     optional: boolean | undefined;
     variable: string;
+    /** Stable compile-time identifier for debug info and trace events. */
+    partId?: number | undefined;
 };
 
 /**
@@ -362,6 +368,8 @@ export type RulesPart = {
      * cache bookkeeping.
      */
     skipMemo?: boolean | undefined;
+    /** Stable compile-time identifier for debug info and trace events. */
+    partId?: number | undefined;
 };
 
 export type PhraseSetPart = {
@@ -378,6 +386,8 @@ export type PhraseSetPart = {
     variable: string | undefined;
     /** Name of the phrase-set matcher (e.g. "Polite", "Greeting") */
     matcherName: string;
+    /** Stable compile-time identifier for debug info and trace events. */
+    partId?: number | undefined;
 };
 
 export type GrammarPart =
@@ -437,12 +447,14 @@ export function getCapturedVariableName(part: GrammarPart): string | undefined {
 export function createStringPart(
     value: string[],
     variable?: string,
+    partId?: number,
 ): StringPart {
     return {
         type: "string",
         optional: undefined,
         variable,
         value,
+        partId,
         regexpCache: undefined,
         joinedCache: undefined,
     };
@@ -452,23 +464,27 @@ export function createWildcardPart(
     variable: string,
     typeName: string,
     optional?: boolean,
+    partId?: number,
 ): VarStringPart {
     return {
         type: "wildcard",
         optional: optional,
         variable,
         typeName,
+        partId,
     };
 }
 
 export function createNumberPart(
     variable: string,
     optional?: boolean,
+    partId?: number,
 ): VarNumberPart {
     return {
         type: "number",
         optional: optional,
         variable,
+        partId,
     };
 }
 
@@ -482,6 +498,7 @@ export function createRulesPart(
         repeat?: boolean | undefined;
         tailCall?: boolean | undefined;
         skipMemo?: boolean | undefined;
+        partId?: number | undefined;
     },
 ): RulesPart {
     return {
@@ -494,18 +511,21 @@ export function createRulesPart(
         repeat: options?.repeat,
         tailCall: options?.tailCall,
         skipMemo: options?.skipMemo,
+        partId: options?.partId,
     };
 }
 
 export function createPhraseSetPart(
     matcherName: string,
     variable?: string,
+    partId?: number,
 ): PhraseSetPart {
     return {
         type: "phraseSet",
         optional: undefined,
         variable,
         matcherName,
+        partId,
     };
 }
 
@@ -542,6 +562,8 @@ export type StringPartJson = {
     value: string[];
     /** Optional capture variable - see `StringPart.variable`. */
     variable?: string | undefined;
+    /** Stable compile-time identifier - see `StringPart.partId`. */
+    partId?: number | undefined;
 };
 
 export type VarStringPartJson = {
@@ -549,12 +571,16 @@ export type VarStringPartJson = {
     variable: string;
     typeName: string;
     optional?: boolean | undefined;
+    /** Stable compile-time identifier - see `VarStringPart.partId`. */
+    partId?: number | undefined;
 };
 
 export type VarNumberPartJson = {
     type: "number";
     variable: string;
     optional?: boolean | undefined;
+    /** Stable compile-time identifier - see `VarNumberPart.partId`. */
+    partId?: number | undefined;
 };
 
 export type RulePartJson = {
@@ -592,6 +618,8 @@ export type RulePartJson = {
     tailCall?: boolean | undefined;
     /** See `RulesPart.skipMemo`. */
     skipMemo?: boolean | undefined;
+    /** Stable compile-time identifier - see `RulesPart.partId`. */
+    partId?: number | undefined;
 };
 
 export type PhraseSetPartJson = {
@@ -599,6 +627,8 @@ export type PhraseSetPartJson = {
     matcherName: string;
     /** Optional capture variable - see `PhraseSetPart.variable`. */
     variable?: string | undefined;
+    /** Stable compile-time identifier - see `PhraseSetPart.partId`. */
+    partId?: number | undefined;
 };
 
 export type GrammarPartJson =

--- a/ts/packages/actionGrammar/src/index.ts
+++ b/ts/packages/actionGrammar/src/index.ts
@@ -4,6 +4,8 @@
 export type {
     GrammarJson,
     Grammar,
+    GrammarRule,
+    GrammarPart,
     CompiledSpacingMode,
 } from "./grammarTypes.js";
 export { grammarFromJson } from "./grammarDeserializer.js";

--- a/ts/packages/actionGrammar/src/index.ts
+++ b/ts/packages/actionGrammar/src/index.ts
@@ -12,7 +12,12 @@ export { loadGrammarRules, loadGrammarRulesNoThrow } from "./grammarLoader.js";
 export type { LoadGrammarRulesOptions } from "./grammarLoader.js";
 export type { GrammarOptimizationOptions } from "./grammarOptimizer.js";
 export { recommendedOptimizations } from "./grammarOptimizer.js";
-export type { SchemaLoader, DebugInfoCollector } from "./grammarCompiler.js";
+export type {
+    SchemaLoader,
+    DebugInfoCollector,
+    FileLoader,
+} from "./grammarCompiler.js";
+export { defaultFileLoader } from "./defaultFileLoader.js";
 
 // Parser (for tooling — formatter, linters, etc.)
 export { parseGrammarRules } from "./grammarRuleParser.js";

--- a/ts/packages/actionGrammar/src/index.ts
+++ b/ts/packages/actionGrammar/src/index.ts
@@ -12,7 +12,7 @@ export { loadGrammarRules, loadGrammarRulesNoThrow } from "./grammarLoader.js";
 export type { LoadGrammarRulesOptions } from "./grammarLoader.js";
 export type { GrammarOptimizationOptions } from "./grammarOptimizer.js";
 export { recommendedOptimizations } from "./grammarOptimizer.js";
-export type { SchemaLoader } from "./grammarCompiler.js";
+export type { SchemaLoader, DebugInfoCollector } from "./grammarCompiler.js";
 
 // Parser (for tooling — formatter, linters, etc.)
 export { parseGrammarRules } from "./grammarRuleParser.js";

--- a/ts/packages/actionGrammar/src/traceEvents.ts
+++ b/ts/packages/actionGrammar/src/traceEvents.ts
@@ -9,11 +9,9 @@ export type RuleId = string;
 
 /**
  * Stable identifier for a part within a rule. Compile-time integer
- * assigned on the source AST at parse time and propagated through
- * every optimizer pass.
- *
- * Not yet assigned by the parser (chunk 02 part 2); until then,
- * trace events use the runtime part index as a stand-in.
+ * assigned during grammar compilation and propagated through
+ * every optimizer pass. Falls back to the runtime part index when
+ * the grammar was loaded without debug info.
  */
 export type PartId = number;
 

--- a/ts/packages/actionGrammar/test/partId.spec.ts
+++ b/ts/packages/actionGrammar/test/partId.spec.ts
@@ -1,0 +1,137 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { loadGrammarRules } from "../src/grammarLoader.js";
+import type { DebugInfoCollector } from "../src/grammarCompiler.js";
+import { matchGrammar } from "../src/grammarMatcher.js";
+import { grammarToJson } from "../src/grammarSerializer.js";
+import { grammarFromJson } from "../src/grammarDeserializer.js";
+import type { TraceEvent } from "../src/traceEvents.js";
+
+function makeCollector(): DebugInfoCollector {
+    return {
+        partPositions: new Map(),
+        rulePositions: new Map(),
+        fileId: "test.agr",
+    };
+}
+
+describe("partId assignment", () => {
+    it("assigns sequential partIds during compilation", () => {
+        const source = `<Start> = hello world -> true;
+<Start> = goodbye friend -> false;`;
+        const collector = makeCollector();
+        const grammar = loadGrammarRules("test", source, {
+            debugCollector: collector,
+        });
+
+        // Every part in the grammar should have a partId
+        const partIds = new Set<number>();
+        for (const rule of grammar.alternatives) {
+            for (const part of rule.parts) {
+                expect(part.partId).toBeDefined();
+                expect(typeof part.partId).toBe("number");
+                partIds.add(part.partId!);
+            }
+        }
+        // All partIds should be unique
+        expect(partIds.size).toBeGreaterThan(0);
+
+        // Collector should have recorded positions for all partIds
+        for (const id of partIds) {
+            expect(collector.partPositions.has(id)).toBe(true);
+        }
+    });
+
+    it("records rule positions in debug collector", () => {
+        const source = `<Start> = hello -> true;
+<Action> = play -> "play";`;
+        const collector = makeCollector();
+        loadGrammarRules("test", source, { debugCollector: collector });
+
+        expect(collector.rulePositions.size).toBeGreaterThan(0);
+        // Rule positions should be valid offsets into the source
+        for (const offset of collector.rulePositions.values()) {
+            expect(offset).toBeGreaterThanOrEqual(0);
+            expect(offset).toBeLessThan(source.length);
+        }
+    });
+
+    it("part positions point to valid source offsets", () => {
+        const source = `<Start> = play $(song:string) -> { action: "play", song };`;
+        const collector = makeCollector();
+        loadGrammarRules("test", source, { debugCollector: collector });
+
+        for (const offset of collector.partPositions.values()) {
+            expect(offset).toBeGreaterThanOrEqual(0);
+            expect(offset).toBeLessThan(source.length);
+        }
+    });
+});
+
+describe("partId serialization round-trip", () => {
+    it("preserves partIds through JSON serialization", () => {
+        const source = `<Start> = play $(song:string) -> { action: "play", song };
+<Start> = pause -> { action: "pause" };`;
+        const collector = makeCollector();
+        const grammar = loadGrammarRules("test", source, {
+            debugCollector: collector,
+        });
+
+        // Serialize and deserialize
+        const json = grammarToJson(grammar);
+        const restored = grammarFromJson(json);
+
+        // Verify partIds survived the round-trip
+        for (let r = 0; r < grammar.alternatives.length; r++) {
+            const origRule = grammar.alternatives[r];
+            const restoredRule = restored.alternatives[r];
+            expect(restoredRule.parts.length).toBe(origRule.parts.length);
+            for (let p = 0; p < origRule.parts.length; p++) {
+                expect(restoredRule.parts[p].partId).toBe(
+                    origRule.parts[p].partId,
+                );
+            }
+        }
+    });
+});
+
+describe("partId in trace events", () => {
+    it("trace events use partId instead of raw index", () => {
+        const source = `<Start> = hello world -> true;`;
+        const collector = makeCollector();
+        const grammar = loadGrammarRules("test", source, {
+            debugCollector: collector,
+        });
+
+        const events: TraceEvent[] = [];
+        matchGrammar(grammar, "hello world", {
+            trace: (e) => events.push(e),
+        });
+
+        const partEvents = events.filter(
+            (e) =>
+                e.kind === "partAttempted" ||
+                e.kind === "partMatched" ||
+                e.kind === "partFailed",
+        );
+        expect(partEvents.length).toBeGreaterThan(0);
+
+        // Collect the actual partIds from the grammar
+        const validPartIds = new Set<number>();
+        for (const rule of grammar.alternatives) {
+            for (const part of rule.parts) {
+                if (part.partId !== undefined) {
+                    validPartIds.add(part.partId);
+                }
+            }
+        }
+
+        // Each part event's "part" field should be a valid partId
+        for (const e of partEvents) {
+            if ("part" in e) {
+                expect(validPartIds.has(e.part)).toBe(true);
+            }
+        }
+    });
+});

--- a/ts/packages/grammarTools/cli/src/cli.ts
+++ b/ts/packages/grammarTools/cli/src/cli.ts
@@ -6,6 +6,8 @@ import { loadGrammarFromFile } from "grammar-tools-core";
 import { previewCompletion } from "grammar-tools-core";
 import { format } from "grammar-tools-core";
 import { traceMatch, formatTrace } from "grammar-tools-core";
+import { computeCoverage } from "grammar-tools-core";
+import { diffGrammars } from "grammar-tools-core";
 import * as fs from "fs";
 import * as path from "path";
 
@@ -20,11 +22,13 @@ function usage(): void {
             "grammar-tools - Grammar exploration CLI",
             "",
             "Usage:",
-            "  grammar-tools load <file.agr>            Load and validate a grammar file",
-            "  grammar-tools complete <file> <input>    Preview completions for input",
-            "  grammar-tools format <file.agr>          Format a grammar file",
-            "  grammar-tools trace <file> <input>       Trace matcher execution on input",
-            "  grammar-tools help                       Show this help",
+            "  grammar-tools load <file.agr>              Load and validate a grammar file",
+            "  grammar-tools complete <file> <input>      Preview completions for input",
+            "  grammar-tools format <file.agr>            Format a grammar file",
+            "  grammar-tools trace <file> <input>         Trace matcher execution on input",
+            "  grammar-tools coverage <file> <corpus>     Run coverage against a corpus file",
+            "  grammar-tools diff <a.agr> <b.agr>        Diff two grammar files",
+            "  grammar-tools help                         Show this help",
             "",
             "Options:",
             "  --json    Output as JSON (machine-readable)",
@@ -184,6 +188,155 @@ async function main(): Promise<void> {
                         debugInfo: result.grammar.debugInfo,
                     }),
                 );
+            }
+            break;
+        }
+        case "coverage": {
+            const file = positionals[1];
+            const corpusFile = positionals[2];
+            if (!file || !corpusFile) {
+                console.error(
+                    "Usage: grammar-tools coverage <file.agr> <corpus.txt>",
+                );
+                process.exit(1);
+            }
+            const result = await loadGrammarFromFile(path.resolve(file));
+            if (!result.ok) {
+                if (jsonFlag) {
+                    console.log(
+                        JSON.stringify(
+                            {
+                                ok: false,
+                                diagnostics: result.diagnostics,
+                            },
+                            null,
+                            2,
+                        ),
+                    );
+                } else {
+                    console.error("Failed to load grammar:");
+                    for (const d of result.diagnostics) {
+                        console.error(`  ${d.severity}: ${d.message}`);
+                    }
+                }
+                process.exit(1);
+            }
+            let corpusText: string;
+            try {
+                corpusText = fs.readFileSync(path.resolve(corpusFile), "utf-8");
+            } catch (e: unknown) {
+                const msg = e instanceof Error ? e.message : String(e);
+                console.error(`Error reading corpus: ${msg}`);
+                process.exit(1);
+            }
+            const inputs = corpusText
+                .split("\n")
+                .map((l) => l.trim())
+                .filter((l) => l.length > 0 && !l.startsWith("#"));
+            const report = computeCoverage(result.grammar, inputs);
+            if (jsonFlag) {
+                console.log(JSON.stringify(report, null, 2));
+            } else {
+                console.log(
+                    `Coverage: ${report.totals.ruleHits}/${report.totals.rules} rules, ` +
+                        `${report.totals.partHits}/${report.totals.parts} parts`,
+                );
+                for (const r of report.perRule) {
+                    const marker = r.hits > 0 ? "+" : "-";
+                    console.log(`  ${marker} ${r.id} (${r.hits} hits)`);
+                }
+                if (report.unmatchedInputs.length > 0) {
+                    console.log(
+                        `\nUnmatched inputs (${report.unmatchedInputs.length}):`,
+                    );
+                    for (const u of report.unmatchedInputs) {
+                        console.log(`  ? ${u.input}`);
+                    }
+                }
+            }
+            break;
+        }
+        case "diff": {
+            const fileA = positionals[1];
+            const fileB = positionals[2];
+            if (!fileA || !fileB) {
+                console.error("Usage: grammar-tools diff <a.agr> <b.agr>");
+                process.exit(1);
+            }
+            const resultA = await loadGrammarFromFile(path.resolve(fileA));
+            if (!resultA.ok) {
+                if (jsonFlag) {
+                    console.log(
+                        JSON.stringify(
+                            {
+                                ok: false,
+                                file: fileA,
+                                diagnostics: resultA.diagnostics,
+                            },
+                            null,
+                            2,
+                        ),
+                    );
+                } else {
+                    console.error(`Failed to load ${fileA}:`);
+                    for (const d of resultA.diagnostics) {
+                        console.error(`  ${d.severity}: ${d.message}`);
+                    }
+                }
+                process.exit(1);
+            }
+            const resultB = await loadGrammarFromFile(path.resolve(fileB));
+            if (!resultB.ok) {
+                if (jsonFlag) {
+                    console.log(
+                        JSON.stringify(
+                            {
+                                ok: false,
+                                file: fileB,
+                                diagnostics: resultB.diagnostics,
+                            },
+                            null,
+                            2,
+                        ),
+                    );
+                } else {
+                    console.error(`Failed to load ${fileB}:`);
+                    for (const d of resultB.diagnostics) {
+                        console.error(`  ${d.severity}: ${d.message}`);
+                    }
+                }
+                process.exit(1);
+            }
+            const diff = diffGrammars(resultA.grammar, resultB.grammar);
+            if (jsonFlag) {
+                console.log(JSON.stringify(diff, null, 2));
+            } else {
+                if (
+                    diff.added.length === 0 &&
+                    diff.removed.length === 0 &&
+                    diff.changed.length === 0
+                ) {
+                    console.log("No differences.");
+                } else {
+                    if (diff.added.length > 0) {
+                        console.log("Added rules:");
+                        for (const r of diff.added) {
+                            console.log(`  + ${r}`);
+                        }
+                    }
+                    if (diff.removed.length > 0) {
+                        console.log("Removed rules:");
+                        for (const r of diff.removed) {
+                            console.log(`  - ${r}`);
+                        }
+                    }
+                    if (diff.changed.length > 0) {
+                        console.log("Changed rules:");
+                        for (const c of diff.changed) {
+                            console.log(`  ~ ${c.rule} (${c.reason})`);
+                        }
+                    }
+                }
             }
             break;
         }

--- a/ts/packages/grammarTools/cli/src/cli.ts
+++ b/ts/packages/grammarTools/cli/src/cli.ts
@@ -179,7 +179,11 @@ async function main(): Promise<void> {
                     ),
                 );
             } else {
-                console.log(formatTrace(trace));
+                console.log(
+                    formatTrace(trace, {
+                        debugInfo: result.grammar.debugInfo,
+                    }),
+                );
             }
             break;
         }

--- a/ts/packages/grammarTools/cli/test/cli.spec.ts
+++ b/ts/packages/grammarTools/cli/test/cli.spec.ts
@@ -29,6 +29,8 @@ describe("grammar-tools CLI", () => {
     let tmpDir: string;
     let validFile: string;
     let invalidFile: string;
+    let corpusFile: string;
+    let validFileB: string;
 
     beforeAll(() => {
         tmpDir = mkdtempSync(join(tmpdir(), "grammar-tools-test-"));
@@ -39,12 +41,21 @@ describe("grammar-tools CLI", () => {
         );
         invalidFile = join(tmpDir, "bad.agr");
         writeFileSync(invalidFile, "this is not valid <<<");
+        corpusFile = join(tmpDir, "corpus.txt");
+        writeFileSync(corpusFile, `play something\npause\nxyz nothing\n`);
+        validFileB = join(tmpDir, "test-b.agr");
+        writeFileSync(
+            validFileB,
+            `<Start> = play $(song:string) -> { action: "play", song };\n<Start> = stop -> { action: "stop" };\n`,
+        );
     });
 
     afterAll(() => {
         try {
             unlinkSync(validFile);
             unlinkSync(invalidFile);
+            unlinkSync(corpusFile);
+            unlinkSync(validFileB);
         } catch {
             // ignore cleanup errors
         }
@@ -218,6 +229,71 @@ describe("grammar-tools CLI", () => {
         const result = JSON.parse(stdout);
         expect(result.ok).toBe(false);
         expect(result.diagnostics).toBeDefined();
+    });
+
+    // ---------------------------------------------------------------
+    // coverage
+    // ---------------------------------------------------------------
+
+    it("coverage: outputs summary", async () => {
+        const { stdout, code } = await run(["coverage", validFile, corpusFile]);
+        expect(code).toBe(0);
+        expect(stdout).toContain("Coverage:");
+    });
+
+    it("coverage --json: returns JSON report", async () => {
+        const { stdout, code } = await run([
+            "coverage",
+            validFile,
+            corpusFile,
+            "--json",
+        ]);
+        expect(code).toBe(0);
+        const report = JSON.parse(stdout);
+        expect(report.totals).toBeDefined();
+        expect(report.perRule).toBeInstanceOf(Array);
+        expect(report.unmatchedInputs).toBeInstanceOf(Array);
+        expect(report.unmatchedInputs.length).toBeGreaterThan(0);
+    });
+
+    it("coverage: errors on missing args", async () => {
+        const { code } = await run(["coverage"]);
+        expect(code).not.toBe(0);
+    });
+
+    // ---------------------------------------------------------------
+    // diff
+    // ---------------------------------------------------------------
+
+    it("diff: outputs changes", async () => {
+        const { stdout, code } = await run(["diff", validFile, validFileB]);
+        expect(code).toBe(0);
+        expect(stdout).toContain("Changed rules:");
+    });
+
+    it("diff --json: returns JSON diff", async () => {
+        const { stdout, code } = await run([
+            "diff",
+            validFile,
+            validFileB,
+            "--json",
+        ]);
+        expect(code).toBe(0);
+        const diff = JSON.parse(stdout);
+        expect(diff.added).toBeInstanceOf(Array);
+        expect(diff.removed).toBeInstanceOf(Array);
+        expect(diff.changed).toBeInstanceOf(Array);
+    });
+
+    it("diff: shows no differences for identical files", async () => {
+        const { stdout, code } = await run(["diff", validFile, validFile]);
+        expect(code).toBe(0);
+        expect(stdout).toContain("No differences.");
+    });
+
+    it("diff: errors on missing args", async () => {
+        const { code } = await run(["diff"]);
+        expect(code).not.toBe(0);
     });
 
     // ---------------------------------------------------------------

--- a/ts/packages/grammarTools/core/src/coverage.ts
+++ b/ts/packages/grammarTools/core/src/coverage.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import { matchGrammar } from "action-grammar";
-import type { TraceCallback, TraceEvent } from "action-grammar";
+import type { TraceCallback, TraceEvent, GrammarPart } from "action-grammar";
 import type {
     LoadedGrammar,
     CoverageReport,
@@ -28,8 +28,10 @@ export function computeCoverage(
     }
     const debugInfo = g.debugInfo;
 
-    // Build a mapping from PartId -> owning RuleId using source positions.
-    const partOwner = buildPartOwnerMap(debugInfo);
+    // Build a mapping from PartId -> owning RuleId by walking the
+    // compiled grammar AST. This is reliable for nested and optimized
+    // grammars (unlike source-offset heuristics).
+    const partOwner = buildPartOwnerMap(g);
 
     // Accumulators
     const partHits = new Map<PartId, number>();
@@ -70,7 +72,7 @@ export function computeCoverage(
             }
         }
 
-        // Rule hit count = sum of part hits (or count of matched parts)
+        // Rule hit count = sum of part hits
         const ruleHitCount = parts.reduce((sum, p) => sum + p.hits, 0);
 
         perRule.push({ id: ruleId, location, hits: ruleHitCount, parts });
@@ -99,33 +101,71 @@ export function computeCoverage(
 }
 
 /**
- * Map each PartId to its owning RuleId by comparing source offsets.
- * A part belongs to the rule whose source offset is the largest
- * offset <= the part's offset.
+ * Walk the compiled grammar AST and map each part's `partId` to the
+ * rule name (RuleId) it was compiled from, using the debugInfo's rule
+ * map to identify which top-level alternatives belong to which rule.
+ *
+ * For parts without a `partId` (optimizer-synthesized wrappers), or
+ * for partIds not present in `debugInfo.parts`, the part is silently
+ * excluded from coverage - this is expected for optimized grammars.
  */
-function buildPartOwnerMap(debugInfo: GrammarDebugInfo): Map<PartId, RuleId> {
-    // Sort rules by source offset (ascending)
-    const sortedRules: Array<{ id: RuleId; offset: number }> = [];
-    for (const [id, loc] of debugInfo.rules) {
-        sortedRules.push({ id, offset: loc.range.start.offset });
-    }
-    sortedRules.sort((a, b) => a.offset - b.offset);
-
+function buildPartOwnerMap(g: LoadedGrammar): Map<PartId, RuleId> {
     const result = new Map<PartId, RuleId>();
-    for (const [partId, partLoc] of debugInfo.parts) {
-        const partOffset = partLoc.range.start.offset;
-        // Find the rule with the largest offset <= partOffset
-        let owner: RuleId | undefined;
-        for (const rule of sortedRules) {
-            if (rule.offset <= partOffset) {
-                owner = rule.id;
-            } else {
-                break;
+    const debugInfo = g.debugInfo!;
+
+    // For each rule in debugInfo, find which parts belong to it
+    // by walking all parts in the grammar and checking debugInfo.
+    // We use the rule positions from debugInfo (source offsets) to
+    // determine ownership: a part belongs to the rule whose source
+    // range it falls within. But since we have the grammar AST, we
+    // can walk it and use the partIds directly.
+    //
+    // Strategy: walk all alternatives, collect partIds, and assign
+    // each to the closest preceding rule in source order.
+    const sortedRules = [...debugInfo.rules.entries()].sort(
+        (a, b) => a[1].range.start.offset - b[1].range.start.offset,
+    );
+
+    // Collect all partIds from the grammar AST
+    for (const alt of g.grammar.alternatives) {
+        collectPartIds(alt.parts, result, sortedRules, debugInfo);
+    }
+
+    return result;
+}
+
+/**
+ * Recursively collect partIds from a parts array and nested RulesParts.
+ */
+function collectPartIds(
+    parts: readonly GrammarPart[],
+    result: Map<PartId, RuleId>,
+    sortedRules: Array<[RuleId, { range: { start: { offset: number } } }]>,
+    debugInfo: GrammarDebugInfo,
+): void {
+    for (const part of parts) {
+        const partId = part.partId;
+        if (partId !== undefined && debugInfo.parts.has(partId)) {
+            // Find the owning rule using the part's source position
+            const partLoc = debugInfo.parts.get(partId)!;
+            const partOffset = partLoc.range.start.offset;
+            let owner: RuleId | undefined;
+            for (const [ruleId, ruleLoc] of sortedRules) {
+                if (ruleLoc.range.start.offset <= partOffset) {
+                    owner = ruleId;
+                } else {
+                    break;
+                }
+            }
+            if (owner !== undefined) {
+                result.set(partId, owner);
             }
         }
-        if (owner !== undefined) {
-            result.set(partId, owner);
+        // Recurse into nested RulesParts
+        if (part.type === "rules") {
+            for (const rule of part.alternatives) {
+                collectPartIds(rule.parts, result, sortedRules, debugInfo);
+            }
         }
     }
-    return result;
 }

--- a/ts/packages/grammarTools/core/src/coverage.ts
+++ b/ts/packages/grammarTools/core/src/coverage.ts
@@ -1,0 +1,131 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { matchGrammar } from "action-grammar";
+import type { TraceCallback, TraceEvent } from "action-grammar";
+import type {
+    LoadedGrammar,
+    CoverageReport,
+    RuleCoverage,
+    PartCoverage,
+    GrammarDebugInfo,
+    RuleId,
+    PartId,
+} from "./types.js";
+import { MissingDebugInfoError, hasDebugInfo } from "./types.js";
+
+/**
+ * Run a corpus of inputs against a grammar and return per-rule /
+ * per-part hit counts. Requires `debugInfo` on the grammar; throws
+ * `MissingDebugInfoError` otherwise.
+ */
+export function computeCoverage(
+    g: LoadedGrammar,
+    inputs: readonly string[],
+): CoverageReport {
+    if (!hasDebugInfo(g)) {
+        throw new MissingDebugInfoError(g.source);
+    }
+    const debugInfo = g.debugInfo;
+
+    // Build a mapping from PartId -> owning RuleId using source positions.
+    const partOwner = buildPartOwnerMap(debugInfo);
+
+    // Accumulators
+    const partHits = new Map<PartId, number>();
+    const unmatchedInputs: Array<{ input: string; reason?: string }> = [];
+
+    for (const input of inputs) {
+        const events: TraceEvent[] = [];
+        const trace: TraceCallback = (event) => {
+            events.push(event);
+        };
+        const results = matchGrammar(g.grammar, input, { trace });
+
+        if (results.length === 0) {
+            unmatchedInputs.push({ input });
+            continue;
+        }
+
+        // Count part hits from partMatched events
+        for (const event of events) {
+            if (event.kind === "partMatched") {
+                partHits.set(event.part, (partHits.get(event.part) ?? 0) + 1);
+            }
+        }
+    }
+
+    // Build per-rule coverage entries from debugInfo
+    const perRule: RuleCoverage[] = [];
+    for (const [ruleId, location] of debugInfo.rules) {
+        // Collect parts belonging to this rule
+        const parts: PartCoverage[] = [];
+        for (const [partId, partLoc] of debugInfo.parts) {
+            if (partOwner.get(partId) === ruleId) {
+                parts.push({
+                    id: partId,
+                    location: partLoc,
+                    hits: partHits.get(partId) ?? 0,
+                });
+            }
+        }
+
+        // Rule hit count = sum of part hits (or count of matched parts)
+        const ruleHitCount = parts.reduce((sum, p) => sum + p.hits, 0);
+
+        perRule.push({ id: ruleId, location, hits: ruleHitCount, parts });
+    }
+
+    // Totals
+    const totalRules = perRule.length;
+    const totalParts = perRule.reduce((sum, r) => sum + r.parts.length, 0);
+    const totalRuleHits = perRule.filter((r) => r.hits > 0).length;
+    const totalPartHits = perRule.reduce(
+        (sum, r) => sum + r.parts.filter((p) => p.hits > 0).length,
+        0,
+    );
+
+    return {
+        grammarHash: debugInfo.grammarHash,
+        totals: {
+            rules: totalRules,
+            parts: totalParts,
+            ruleHits: totalRuleHits,
+            partHits: totalPartHits,
+        },
+        perRule,
+        unmatchedInputs,
+    };
+}
+
+/**
+ * Map each PartId to its owning RuleId by comparing source offsets.
+ * A part belongs to the rule whose source offset is the largest
+ * offset <= the part's offset.
+ */
+function buildPartOwnerMap(debugInfo: GrammarDebugInfo): Map<PartId, RuleId> {
+    // Sort rules by source offset (ascending)
+    const sortedRules: Array<{ id: RuleId; offset: number }> = [];
+    for (const [id, loc] of debugInfo.rules) {
+        sortedRules.push({ id, offset: loc.range.start.offset });
+    }
+    sortedRules.sort((a, b) => a.offset - b.offset);
+
+    const result = new Map<PartId, RuleId>();
+    for (const [partId, partLoc] of debugInfo.parts) {
+        const partOffset = partLoc.range.start.offset;
+        // Find the rule with the largest offset <= partOffset
+        let owner: RuleId | undefined;
+        for (const rule of sortedRules) {
+            if (rule.offset <= partOffset) {
+                owner = rule.id;
+            } else {
+                break;
+            }
+        }
+        if (owner !== undefined) {
+            result.set(partId, owner);
+        }
+    }
+    return result;
+}

--- a/ts/packages/grammarTools/core/src/diff.ts
+++ b/ts/packages/grammarTools/core/src/diff.ts
@@ -9,7 +9,7 @@ import type {
     RuleChange,
     RuleId,
 } from "./types.js";
-import { MissingSourceError, hasSource } from "./types.js";
+import { MissingSourceError, hasSource, GrammarToolsError } from "./types.js";
 
 /**
  * Compute a structural rule-level diff between two grammars.
@@ -17,7 +17,7 @@ import { MissingSourceError, hasSource } from "./types.js";
  * includes the canonical text of both versions.
  *
  * Requires source files on both grammars (throws MissingSourceError
- * otherwise).
+ * otherwise). Throws GrammarToolsError if source files cannot be parsed.
  */
 export function diffGrammars(
     before: LoadedGrammar,
@@ -58,13 +58,7 @@ export function diffGrammars(
         if (beforeText !== afterText) {
             changed.push({
                 rule: name,
-                reason: classifyChange(
-                    beforeRules,
-                    afterRules,
-                    name,
-                    beforeText,
-                    afterText,
-                ),
+                reason: classifyChange(beforeText, afterText),
                 before: beforeText,
                 after: afterText,
             });
@@ -80,7 +74,7 @@ export function diffGrammars(
 
 /**
  * Parse source files and collect each rule's canonical text, keyed by
- * rule name.
+ * rule name. Throws GrammarToolsError if any source file fails to parse.
  */
 function collectRules(g: LoadedGrammar): Map<RuleId, string> {
     const rules = new Map<RuleId, string>();
@@ -88,8 +82,12 @@ function collectRules(g: LoadedGrammar): Map<RuleId, string> {
         let parsed;
         try {
             parsed = parseGrammarRules(file.id, file.text);
-        } catch {
-            continue; // skip unparseable files
+        } catch (e: unknown) {
+            const msg = e instanceof Error ? e.message : String(e);
+            throw new GrammarToolsError(
+                "PARSE_ERROR",
+                `Failed to parse source file '${file.id}' for diff: ${msg}`,
+            );
         }
         for (const def of parsed.definitions) {
             const name = def.definitionName.name;
@@ -102,11 +100,10 @@ function collectRules(g: LoadedGrammar): Map<RuleId, string> {
 }
 
 /**
- * Serialize a single rule definition to its canonical text form.
+ * Serialize a single rule definition to its canonical text form
+ * using writeGrammarRules to ensure deterministic output.
  */
 function serializeSingleRule(def: RuleDefinition): string {
-    // Create a minimal parse result with just this one definition
-    // and use writeGrammarRules to get canonical text
     const singleResult = {
         imports: [],
         definitions: [def],
@@ -126,9 +123,6 @@ function serializeSingleRule(def: RuleDefinition): string {
  * "value" = only the value expression changed.
  */
 function classifyChange(
-    _beforeRules: Map<RuleId, string>,
-    _afterRules: Map<RuleId, string>,
-    _name: RuleId,
     beforeText: string,
     afterText: string,
 ): "signature" | "body" | "value" {

--- a/ts/packages/grammarTools/core/src/diff.ts
+++ b/ts/packages/grammarTools/core/src/diff.ts
@@ -1,0 +1,166 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { parseGrammarRules, writeGrammarRules } from "action-grammar";
+import type { RuleDefinition } from "action-grammar";
+import type {
+    LoadedGrammar,
+    GrammarDiff,
+    RuleChange,
+    RuleId,
+} from "./types.js";
+import { MissingSourceError, hasSource } from "./types.js";
+
+/**
+ * Compute a structural rule-level diff between two grammars.
+ * Reports rules added, removed, or changed. For changed rules,
+ * includes the canonical text of both versions.
+ *
+ * Requires source files on both grammars (throws MissingSourceError
+ * otherwise).
+ */
+export function diffGrammars(
+    before: LoadedGrammar,
+    after: LoadedGrammar,
+): GrammarDiff {
+    if (!hasSource(before)) {
+        throw new MissingSourceError(before.source);
+    }
+    if (!hasSource(after)) {
+        throw new MissingSourceError(after.source);
+    }
+
+    const beforeRules = collectRules(before);
+    const afterRules = collectRules(after);
+
+    const added: RuleId[] = [];
+    const removed: RuleId[] = [];
+    const changed: RuleChange[] = [];
+
+    // Rules in after but not in before: added
+    for (const name of afterRules.keys()) {
+        if (!beforeRules.has(name)) {
+            added.push(name);
+        }
+    }
+
+    // Rules in before but not in after: removed
+    for (const name of beforeRules.keys()) {
+        if (!afterRules.has(name)) {
+            removed.push(name);
+        }
+    }
+
+    // Rules in both: check for changes
+    for (const [name, beforeText] of beforeRules) {
+        const afterText = afterRules.get(name);
+        if (afterText === undefined) continue; // already in removed
+        if (beforeText !== afterText) {
+            changed.push({
+                rule: name,
+                reason: classifyChange(
+                    beforeRules,
+                    afterRules,
+                    name,
+                    beforeText,
+                    afterText,
+                ),
+                before: beforeText,
+                after: afterText,
+            });
+        }
+    }
+
+    return { added, removed, changed };
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse source files and collect each rule's canonical text, keyed by
+ * rule name.
+ */
+function collectRules(g: LoadedGrammar): Map<RuleId, string> {
+    const rules = new Map<RuleId, string>();
+    for (const file of g.files!) {
+        let parsed;
+        try {
+            parsed = parseGrammarRules(file.id, file.text);
+        } catch {
+            continue; // skip unparseable files
+        }
+        for (const def of parsed.definitions) {
+            const name = def.definitionName.name;
+            // Serialize this single rule to canonical text
+            const canonical = serializeSingleRule(def);
+            rules.set(name, canonical);
+        }
+    }
+    return rules;
+}
+
+/**
+ * Serialize a single rule definition to its canonical text form.
+ */
+function serializeSingleRule(def: RuleDefinition): string {
+    // Create a minimal parse result with just this one definition
+    // and use writeGrammarRules to get canonical text
+    const singleResult = {
+        imports: [],
+        definitions: [def],
+    };
+    try {
+        return writeGrammarRules(singleResult).trim();
+    } catch {
+        // Fallback: use the definition name
+        return `<${def.definitionName.name}> = (serialization failed)`;
+    }
+}
+
+/**
+ * Classify whether a change is to the signature or body of a rule.
+ * "signature" = the rule name/type/spacing changed but not the body.
+ * "body" = the rule alternatives changed.
+ * "value" = only the value expression changed.
+ */
+function classifyChange(
+    _beforeRules: Map<RuleId, string>,
+    _afterRules: Map<RuleId, string>,
+    _name: RuleId,
+    beforeText: string,
+    afterText: string,
+): "signature" | "body" | "value" {
+    // Extract the part before "=" as signature
+    const beforeSig = beforeText.split("=")[0]?.trim() ?? "";
+    const afterSig = afterText.split("=")[0]?.trim() ?? "";
+
+    if (beforeSig !== afterSig) {
+        return "signature";
+    }
+
+    // Check if only the value expression differs
+    // Value expressions appear after "->" in rule alternatives
+    const beforeBody = stripValues(beforeText);
+    const afterBody = stripValues(afterText);
+    if (beforeBody === afterBody) {
+        return "value";
+    }
+
+    return "body";
+}
+
+/**
+ * Strip value expressions (everything after "->") from rule text
+ * for body comparison.
+ */
+function stripValues(text: string): string {
+    return text
+        .split("\n")
+        .map((line) => {
+            const arrowIdx = line.indexOf("->");
+            return arrowIdx >= 0 ? line.substring(0, arrowIdx).trimEnd() : line;
+        })
+        .join("\n");
+}

--- a/ts/packages/grammarTools/core/src/formatTrace.ts
+++ b/ts/packages/grammarTools/core/src/formatTrace.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import type { TraceEvent } from "action-grammar";
-import type { MatchTrace } from "./types.js";
+import type { GrammarDebugInfo, MatchTrace, SourceLocation } from "./types.js";
 
 export interface FormatTraceOptions {
     /** Include the input string and result summary header. Default: true. */
@@ -13,6 +13,13 @@ export interface FormatTraceOptions {
     showPos?: boolean;
     /** Max width for input excerpts. Default: 20. */
     excerptWidth?: number;
+    /** Debug info for resolving partId/rule to source locations. */
+    debugInfo?: GrammarDebugInfo | undefined;
+    /**
+     * Append source locations to part and rule events.
+     * Default: true when `debugInfo` is provided, false otherwise.
+     */
+    showSourceLocations?: boolean;
 }
 
 /**
@@ -27,6 +34,9 @@ export function formatTrace(
     const showSeq = options?.showSeq ?? false;
     const showPos = options?.showPos ?? true;
     const excerptWidth = options?.excerptWidth ?? 20;
+    const debugInfo = options?.debugInfo;
+    const showSourceLocations =
+        options?.showSourceLocations ?? debugInfo !== undefined;
 
     const lines: string[] = [];
     if (showHeader) {
@@ -69,6 +79,7 @@ export function formatTrace(
                 showSeq,
                 showPos,
                 excerptWidth,
+                debugInfo: showSourceLocations ? debugInfo : undefined,
             }),
         );
     }
@@ -81,21 +92,31 @@ function formatEvent(
     input: string,
     depth: number,
     lastAttemptPos: number,
-    opts: { showSeq: boolean; showPos: boolean; excerptWidth: number },
+    opts: {
+        showSeq: boolean;
+        showPos: boolean;
+        excerptWidth: number;
+        debugInfo: GrammarDebugInfo | undefined;
+    },
 ): string {
     const indent = "  ".repeat(depth);
     const pos = opts.showPos ? ` @${event.inputPos}` : "";
     const seq = opts.showSeq ? `[${event.seq}] ` : "";
+    const dbg = opts.debugInfo;
 
     switch (event.kind) {
-        case "ruleEntered":
-            return `${seq}${indent}\u25b6 ${event.rule}${pos}`;
+        case "ruleEntered": {
+            const src = dbg ? locStr(dbg.rules.get(event.rule)) : "";
+            return `${seq}${indent}\u25b6 ${event.rule}${pos}${src}`;
+        }
         case "ruleExited": {
             const icon = event.result === "matched" ? "\u2713" : "\u2717";
             return `${seq}${indent}${icon} ${event.rule} ${event.result}${pos}`;
         }
-        case "partAttempted":
-            return `${seq}${indent}  \u251c try ${event.partKind}[${event.part}]${pos}`;
+        case "partAttempted": {
+            const src = dbg ? locStr(dbg.parts.get(event.part)) : "";
+            return `${seq}${indent}  \u251c try ${event.partKind}[${event.part}]${pos}${src}`;
+        }
         case "partMatched": {
             const span = excerpt(
                 input,
@@ -129,4 +150,15 @@ function excerpt(
     const slice = input.slice(start, end);
     if (slice.length <= maxWidth) return slice;
     return slice.slice(0, maxWidth - 1) + "\u2026";
+}
+
+/**
+ * Format a SourceLocation as a short " (file:line:col)" suffix.
+ * Returns empty string when loc is undefined.
+ */
+function locStr(loc: SourceLocation | undefined): string {
+    if (!loc) return "";
+    const line = loc.range.start.line + 1; // 0-based → 1-based
+    const col = loc.range.start.character + 1;
+    return ` (${loc.displayPath}:${line}:${col})`;
 }

--- a/ts/packages/grammarTools/core/src/index.ts
+++ b/ts/packages/grammarTools/core/src/index.ts
@@ -46,6 +46,14 @@ export type {
     PartFailedEvent,
     BacktrackEvent,
     MatchTrace,
+    // Coverage
+    PartCoverage,
+    RuleCoverage,
+    CoverageReport,
+    // Diff
+    DiffChangeReason,
+    RuleChange,
+    GrammarDiff,
     // Snapshot
     GrammarSnapshot,
 } from "./types.js";
@@ -67,3 +75,5 @@ export { previewCompletion } from "./completion.js";
 export { traceMatch } from "./trace.js";
 export { formatTrace } from "./formatTrace.js";
 export type { FormatTraceOptions } from "./formatTrace.js";
+export { computeCoverage } from "./coverage.js";
+export { diffGrammars } from "./diff.js";

--- a/ts/packages/grammarTools/core/src/loader.ts
+++ b/ts/packages/grammarTools/core/src/loader.ts
@@ -2,14 +2,16 @@
 // Licensed under the MIT License.
 
 import { loadGrammarRulesNoThrow } from "action-grammar";
-import type { Grammar } from "action-grammar";
+import type { Grammar, DebugInfoCollector } from "action-grammar";
 import type {
     GrammarIdentifierIndex,
+    GrammarDebugInfo,
     GrammarSource,
     LoadedGrammar,
     LoadResult,
     GrammarSnapshot,
     SourceFile,
+    SourceLocation,
     Diagnostic,
     SourceRange,
 } from "./types.js";
@@ -59,18 +61,26 @@ function loadFromText(text: string, source: GrammarSource): LoadResult {
     const file: SourceFile = { id: sourceId(source), text };
     const errors: string[] = [];
     const warnings: string[] = [];
+    const collector: DebugInfoCollector = {
+        partPositions: new Map(),
+        rulePositions: new Map(),
+        fileId: sourceId(source),
+    };
     const grammar = loadGrammarRulesNoThrow(
         sourceId(source),
         text,
         errors,
         warnings,
+        { debugCollector: collector },
     );
 
     if (grammar && errors.length === 0) {
         const identifiers = buildIdentifierIndex(grammar);
+        const debugInfo = buildDebugInfo(collector, text, sourceId(source));
         const loaded: LoadedGrammar = {
             source,
             grammar,
+            debugInfo,
             files: [file],
             identifiers,
         };
@@ -181,4 +191,68 @@ function positionToOffset(
         offset++;
     }
     return offset + character;
+}
+
+/**
+ * Convert a character offset in `text` to a line/character position.
+ */
+function offsetToPosition(
+    text: string,
+    offset: number,
+): { line: number; character: number } {
+    let line = 0;
+    let lineStart = 0;
+    for (let i = 0; i < offset && i < text.length; i++) {
+        if (text[i] === "\n") {
+            line++;
+            lineStart = i + 1;
+        } else if (text[i] === "\r") {
+            line++;
+            if (i + 1 < text.length && text[i + 1] === "\n") {
+                i++; // skip \n in \r\n
+            }
+            lineStart = i + 1;
+        }
+    }
+    return { line, character: offset - lineStart };
+}
+
+/**
+ * Build a `GrammarDebugInfo` from the raw offsets collected during compilation.
+ */
+function buildDebugInfo(
+    collector: DebugInfoCollector,
+    text: string,
+    fileId: string,
+): GrammarDebugInfo {
+    const rules = new Map<string, SourceLocation>();
+    for (const [ruleId, offset] of collector.rulePositions) {
+        const start = offsetToPosition(text, offset);
+        rules.set(ruleId, {
+            fileId,
+            displayPath: fileId,
+            range: {
+                start: { ...start, offset },
+                end: { ...start, offset },
+            },
+        });
+    }
+
+    const parts = new Map<number, SourceLocation>();
+    for (const [partId, offset] of collector.partPositions) {
+        const start = offsetToPosition(text, offset);
+        parts.set(partId, {
+            fileId,
+            displayPath: fileId,
+            range: {
+                start: { ...start, offset },
+                end: { ...start, offset },
+            },
+        });
+    }
+
+    // Simple hash: length + first/last chars + part count
+    const grammarHash = `${text.length}:${collector.partPositions.size}:${collector.rulePositions.size}`;
+
+    return { grammarHash, rules, parts };
 }

--- a/ts/packages/grammarTools/core/src/loader.ts
+++ b/ts/packages/grammarTools/core/src/loader.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import { loadGrammarRulesNoThrow } from "action-grammar";
-import type { Grammar, DebugInfoCollector } from "action-grammar";
+import type { Grammar, DebugInfoCollector, FileLoader } from "action-grammar";
 import type {
     GrammarIdentifierIndex,
     GrammarDebugInfo,
@@ -18,11 +18,38 @@ import type {
 
 /**
  * Load a grammar from a file path on disk.
+ * Supports .agr file imports (import ... from "./other.agr").
  */
-export async function loadGrammarFromFile(path: string): Promise<LoadResult> {
+export async function loadGrammarFromFile(
+    filePath: string,
+): Promise<LoadResult> {
+    const nodePath = await import("path");
+    const nodeFs = await import("fs");
     const { readFile } = await import("fs/promises");
-    const text = await readFile(path, "utf-8");
-    return loadFromText(text, { kind: "file", path });
+
+    const resolvedPath = nodePath.resolve(filePath);
+    const text = await readFile(resolvedPath, "utf-8");
+    const displayPath = nodePath.relative(process.cwd(), resolvedPath);
+
+    const fileLoader: FileLoader = {
+        resolvePath: (name: string, ref?: string) =>
+            ref
+                ? nodePath.resolve(nodePath.dirname(ref), name)
+                : nodePath.resolve(name),
+        readContent: (fullPath: string) => {
+            if (!nodeFs.existsSync(fullPath)) {
+                throw new Error(`File not found: ${fullPath}`);
+            }
+            return nodeFs.readFileSync(fullPath, "utf-8");
+        },
+        displayPath: (fullPath: string) =>
+            nodePath.relative(process.cwd(), fullPath),
+    };
+
+    return loadFromFileLoader(resolvedPath, text, displayPath, fileLoader, {
+        kind: "file",
+        path: filePath,
+    });
 }
 
 /**
@@ -77,6 +104,75 @@ function loadFromText(text: string, source: GrammarSource): LoadResult {
     if (grammar && errors.length === 0) {
         const identifiers = buildIdentifierIndex(grammar);
         const debugInfo = buildDebugInfo(collector, text, sourceId(source));
+        const loaded: LoadedGrammar = {
+            source,
+            grammar,
+            debugInfo,
+            files: [file],
+            identifiers,
+        };
+        const diagnostics: Diagnostic[] | undefined =
+            warnings.length > 0
+                ? warnings.map((message) => ({
+                      range: extractRange(message, text),
+                      severity: "warning" as const,
+                      message,
+                      source: "grammar-tools-core" as const,
+                  }))
+                : undefined;
+        if (diagnostics) {
+            return { ok: true, grammar: loaded, diagnostics };
+        }
+        return { ok: true, grammar: loaded };
+    }
+
+    const diagnostics: Diagnostic[] = [
+        ...errors.map((message) => ({
+            range: extractRange(message, text),
+            severity: "error" as const,
+            message,
+            source: "grammar-tools-core" as const,
+        })),
+        ...warnings.map((message) => ({
+            range: extractRange(message, text),
+            severity: "warning" as const,
+            message,
+            source: "grammar-tools-core" as const,
+        })),
+    ];
+    return { ok: false, diagnostics, files: [file] };
+}
+
+/**
+ * Load a grammar using a FileLoader so the compiler can resolve
+ * `import ... from "./other.agr"` statements.
+ */
+function loadFromFileLoader(
+    fullPath: string,
+    text: string,
+    displayPath: string,
+    fileLoader: FileLoader,
+    source: GrammarSource,
+): LoadResult {
+    const file: SourceFile = { id: sourceId(source), text };
+    const errors: string[] = [];
+    const warnings: string[] = [];
+    const collector: DebugInfoCollector = {
+        partPositions: new Map(),
+        rulePositions: new Map(),
+        fileId: displayPath,
+    };
+    const grammar = loadGrammarRulesNoThrow(
+        fullPath,
+        fileLoader,
+        errors,
+        warnings,
+        { debugCollector: collector },
+    );
+
+    if (grammar && errors.length === 0) {
+        const identifiers = buildIdentifierIndex(grammar);
+        const debugInfo = buildDebugInfo(collector, text, displayPath);
         const loaded: LoadedGrammar = {
             source,
             grammar,

--- a/ts/packages/grammarTools/core/test/coverage.spec.ts
+++ b/ts/packages/grammarTools/core/test/coverage.spec.ts
@@ -114,4 +114,71 @@ describe("computeCoverage", () => {
         expect(report.totals.partHits).toBe(0);
         expect(report.unmatchedInputs).toHaveLength(0);
     });
+
+    it("tracks coverage across nested rule references", () => {
+        const nested = `<Start> = do $(x:<Action>) -> x;
+<Action> = play $(song:string) -> { action: "play", song };
+<Action> = pause -> { action: "pause" };`;
+
+        const result = loadGrammarFromBuffer("test.agr", nested);
+        expect(result.ok).toBe(true);
+        if (!result.ok) return;
+
+        const report = computeCoverage(result.grammar, ["do play something"]);
+
+        // Both Start and Action should have hits
+        const startRule = report.perRule.find((r) => r.id === "Start");
+        const actionRule = report.perRule.find((r) => r.id === "Action");
+        expect(startRule).toBeDefined();
+        expect(actionRule).toBeDefined();
+        if (startRule) expect(startRule.hits).toBeGreaterThan(0);
+        if (actionRule) expect(actionRule.hits).toBeGreaterThan(0);
+    });
+
+    it("assigns parts to the correct owning rule", () => {
+        const multiRule = `<Start> = play $(song:string) -> { action: "play", song };
+<Start> = do $(x:<Other>) -> x;
+<Other> = pause -> { action: "pause" };
+<Other> = stop -> { action: "stop" };`;
+
+        const result = loadGrammarFromBuffer("test.agr", multiRule);
+        expect(result.ok).toBe(true);
+        if (!result.ok) return;
+
+        const report = computeCoverage(result.grammar, ["play something"]);
+
+        // Check that there are per-rule entries for both Start and Other
+        const ruleNames = report.perRule.map((r) => r.id);
+        expect(ruleNames).toContain("Start");
+        expect(ruleNames).toContain("Other");
+
+        // Start should have hits, Other should not
+        const startHits = report.perRule
+            .filter((r) => r.id === "Start")
+            .reduce((sum, r) => sum + r.hits, 0);
+        const otherHits = report.perRule
+            .filter((r) => r.id === "Other")
+            .reduce((sum, r) => sum + r.hits, 0);
+        expect(startHits).toBeGreaterThan(0);
+        expect(otherHits).toBe(0);
+    });
+
+    it("reports correct totals for repeated inputs", () => {
+        const result = loadGrammarFromBuffer("test.agr", source);
+        expect(result.ok).toBe(true);
+        if (!result.ok) return;
+
+        const report = computeCoverage(result.grammar, [
+            "play a",
+            "play b",
+            "play c",
+            "pause",
+            "stop",
+        ]);
+
+        // All 5 inputs should match
+        expect(report.unmatchedInputs).toHaveLength(0);
+        // All rules should be hit
+        expect(report.perRule.every((r) => r.hits > 0)).toBe(true);
+    });
 });

--- a/ts/packages/grammarTools/core/test/coverage.spec.ts
+++ b/ts/packages/grammarTools/core/test/coverage.spec.ts
@@ -1,0 +1,117 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import {
+    computeCoverage,
+    loadGrammarFromBuffer,
+    MissingDebugInfoError,
+} from "../src/index.js";
+import type { LoadedGrammar } from "../src/index.js";
+
+describe("computeCoverage", () => {
+    const source = `<Start> = play $(song:string) -> { action: "play", song };
+<Start> = pause -> { action: "pause" };
+<Start> = stop -> { action: "stop" };`;
+
+    it("counts rule hits for matching inputs", () => {
+        const result = loadGrammarFromBuffer("test.agr", source);
+        expect(result.ok).toBe(true);
+        if (!result.ok) return;
+
+        const report = computeCoverage(result.grammar, [
+            "play something",
+            "play another thing",
+            "pause",
+        ]);
+
+        expect(report.totals.rules).toBeGreaterThan(0);
+        expect(report.totals.ruleHits).toBeGreaterThan(0);
+        expect(report.unmatchedInputs).toHaveLength(0);
+    });
+
+    it("reports unmatched inputs", () => {
+        const result = loadGrammarFromBuffer("test.agr", source);
+        expect(result.ok).toBe(true);
+        if (!result.ok) return;
+
+        const report = computeCoverage(result.grammar, [
+            "play something",
+            "xyz nothing matches this",
+        ]);
+
+        expect(report.unmatchedInputs).toHaveLength(1);
+        expect(report.unmatchedInputs[0].input).toBe(
+            "xyz nothing matches this",
+        );
+    });
+
+    it("returns zero hits for rules with no matching inputs", () => {
+        const multiRule = `<Start> = play $(song:string) -> { action: "play", song };
+<Start> = do $(x:<Action>) -> x;
+<Action> = pause -> { action: "pause" };
+<Unused> = something weird -> { action: "weird" };`;
+
+        const result = loadGrammarFromBuffer("test.agr", multiRule);
+        expect(result.ok).toBe(true);
+        if (!result.ok) return;
+
+        // Only match "play" inputs - "Unused" should have zero hits
+        const report = computeCoverage(result.grammar, ["play something"]);
+
+        const zeroRules = report.perRule.filter((r) => r.hits === 0);
+        expect(zeroRules.length).toBeGreaterThan(0);
+    });
+
+    it("includes grammarHash from debugInfo", () => {
+        const result = loadGrammarFromBuffer("test.agr", source);
+        expect(result.ok).toBe(true);
+        if (!result.ok) return;
+
+        const report = computeCoverage(result.grammar, ["pause"]);
+        expect(report.grammarHash).toBeTruthy();
+        expect(typeof report.grammarHash).toBe("string");
+    });
+
+    it("part hit counts increase with more matching inputs", () => {
+        const result = loadGrammarFromBuffer("test.agr", source);
+        expect(result.ok).toBe(true);
+        if (!result.ok) return;
+
+        const report1 = computeCoverage(result.grammar, ["pause"]);
+        const report2 = computeCoverage(result.grammar, [
+            "pause",
+            "pause",
+            "pause",
+        ]);
+
+        expect(report2.totals.partHits).toBeGreaterThanOrEqual(
+            report1.totals.partHits,
+        );
+    });
+
+    it("throws MissingDebugInfoError when debugInfo is absent", () => {
+        const result = loadGrammarFromBuffer("test.agr", source);
+        expect(result.ok).toBe(true);
+        if (!result.ok) return;
+
+        // Strip debugInfo to simulate a grammar without it
+        const { debugInfo: _, ...rest } = result.grammar;
+        const stripped = rest as LoadedGrammar;
+
+        expect(() => computeCoverage(stripped, ["pause"])).toThrow(
+            MissingDebugInfoError,
+        );
+    });
+
+    it("handles empty corpus", () => {
+        const result = loadGrammarFromBuffer("test.agr", source);
+        expect(result.ok).toBe(true);
+        if (!result.ok) return;
+
+        const report = computeCoverage(result.grammar, []);
+
+        expect(report.totals.ruleHits).toBe(0);
+        expect(report.totals.partHits).toBe(0);
+        expect(report.unmatchedInputs).toHaveLength(0);
+    });
+});

--- a/ts/packages/grammarTools/core/test/diff.spec.ts
+++ b/ts/packages/grammarTools/core/test/diff.spec.ts
@@ -1,0 +1,141 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import {
+    diffGrammars,
+    loadGrammarFromBuffer,
+    MissingSourceError,
+} from "../src/index.js";
+import type { LoadedGrammar } from "../src/index.js";
+
+describe("diffGrammars", () => {
+    it("detects no differences for identical grammars", () => {
+        const source = `<Start> = play -> "play";
+<Start> = pause -> "pause";`;
+
+        const a = loadGrammarFromBuffer("a.agr", source);
+        const b = loadGrammarFromBuffer("b.agr", source);
+        expect(a.ok).toBe(true);
+        expect(b.ok).toBe(true);
+        if (!a.ok || !b.ok) return;
+
+        const diff = diffGrammars(a.grammar, b.grammar);
+        expect(diff.added).toHaveLength(0);
+        expect(diff.removed).toHaveLength(0);
+        expect(diff.changed).toHaveLength(0);
+    });
+
+    it("detects added rules", () => {
+        const sourceA = `<Start> = play -> "play";`;
+        const sourceB = `<Start> = play -> "play";
+<Other> = stop -> "stop";`;
+
+        const a = loadGrammarFromBuffer("a.agr", sourceA);
+        const b = loadGrammarFromBuffer("b.agr", sourceB);
+        expect(a.ok).toBe(true);
+        expect(b.ok).toBe(true);
+        if (!a.ok || !b.ok) return;
+
+        const diff = diffGrammars(a.grammar, b.grammar);
+        expect(diff.added).toContain("Other");
+        expect(diff.removed).toHaveLength(0);
+    });
+
+    it("detects removed rules", () => {
+        const sourceA = `<Start> = play -> "play";
+<Other> = stop -> "stop";`;
+        const sourceB = `<Start> = play -> "play";`;
+
+        const a = loadGrammarFromBuffer("a.agr", sourceA);
+        const b = loadGrammarFromBuffer("b.agr", sourceB);
+        expect(a.ok).toBe(true);
+        expect(b.ok).toBe(true);
+        if (!a.ok || !b.ok) return;
+
+        const diff = diffGrammars(a.grammar, b.grammar);
+        expect(diff.removed).toContain("Other");
+        expect(diff.added).toHaveLength(0);
+    });
+
+    it("detects changed rules", () => {
+        const sourceA = `<Start> = play -> "play";`;
+        const sourceB = `<Start> = pause -> "pause";`;
+
+        const a = loadGrammarFromBuffer("a.agr", sourceA);
+        const b = loadGrammarFromBuffer("b.agr", sourceB);
+        expect(a.ok).toBe(true);
+        expect(b.ok).toBe(true);
+        if (!a.ok || !b.ok) return;
+
+        const diff = diffGrammars(a.grammar, b.grammar);
+        expect(diff.changed).toHaveLength(1);
+        expect(diff.changed[0].rule).toBe("Start");
+    });
+
+    it("changed rules include before and after text", () => {
+        const sourceA = `<Start> = play -> "play";`;
+        const sourceB = `<Start> = pause -> "pause";`;
+
+        const a = loadGrammarFromBuffer("a.agr", sourceA);
+        const b = loadGrammarFromBuffer("b.agr", sourceB);
+        expect(a.ok).toBe(true);
+        expect(b.ok).toBe(true);
+        if (!a.ok || !b.ok) return;
+
+        const diff = diffGrammars(a.grammar, b.grammar);
+        expect(diff.changed[0].before).toBeTruthy();
+        expect(diff.changed[0].after).toBeTruthy();
+        expect(diff.changed[0].before).not.toBe(diff.changed[0].after);
+    });
+
+    it("classifies body changes as 'body'", () => {
+        const sourceA = `<Start> = play -> "play";`;
+        const sourceB = `<Start> = pause -> "pause";`;
+
+        const a = loadGrammarFromBuffer("a.agr", sourceA);
+        const b = loadGrammarFromBuffer("b.agr", sourceB);
+        expect(a.ok).toBe(true);
+        expect(b.ok).toBe(true);
+        if (!a.ok || !b.ok) return;
+
+        const diff = diffGrammars(a.grammar, b.grammar);
+        expect(diff.changed[0].reason).toBe("body");
+    });
+
+    it("throws MissingSourceError when source is absent", () => {
+        const result = loadGrammarFromBuffer(
+            "test.agr",
+            `<Start> = play -> "play";`,
+        );
+        expect(result.ok).toBe(true);
+        if (!result.ok) return;
+
+        // Strip source files
+        const { files: _, ...rest } = result.grammar;
+        const stripped = rest as LoadedGrammar;
+
+        expect(() => diffGrammars(stripped, result.grammar)).toThrow(
+            MissingSourceError,
+        );
+    });
+
+    it("handles multiple changes at once", () => {
+        const sourceA = `<Start> = play -> "play";
+<Action> = stop -> "stop";
+<Old> = go -> "go";`;
+        const sourceB = `<Start> = play -> "play";
+<Action> = halt -> "halt";
+<New> = run -> "run";`;
+
+        const a = loadGrammarFromBuffer("a.agr", sourceA);
+        const b = loadGrammarFromBuffer("b.agr", sourceB);
+        expect(a.ok).toBe(true);
+        expect(b.ok).toBe(true);
+        if (!a.ok || !b.ok) return;
+
+        const diff = diffGrammars(a.grammar, b.grammar);
+        expect(diff.added).toContain("New");
+        expect(diff.removed).toContain("Old");
+        expect(diff.changed.some((c) => c.rule === "Action")).toBe(true);
+    });
+});

--- a/ts/packages/grammarTools/core/test/diff.spec.ts
+++ b/ts/packages/grammarTools/core/test/diff.spec.ts
@@ -5,6 +5,7 @@ import {
     diffGrammars,
     loadGrammarFromBuffer,
     MissingSourceError,
+    GrammarToolsError,
 } from "../src/index.js";
 import type { LoadedGrammar } from "../src/index.js";
 
@@ -137,5 +138,42 @@ describe("diffGrammars", () => {
         expect(diff.added).toContain("New");
         expect(diff.removed).toContain("Old");
         expect(diff.changed.some((c) => c.rule === "Action")).toBe(true);
+    });
+
+    it("treats whitespace-only differences as no change", () => {
+        // Same grammar with different whitespace in source
+        const sourceA = `<Start> = play -> "play";`;
+        const sourceB = `<Start>  =  play  ->  "play" ;`;
+
+        const a = loadGrammarFromBuffer("a.agr", sourceA);
+        const b = loadGrammarFromBuffer("b.agr", sourceB);
+        expect(a.ok).toBe(true);
+        expect(b.ok).toBe(true);
+        if (!a.ok || !b.ok) return;
+
+        // Canonical serialization should normalize whitespace
+        const diff = diffGrammars(a.grammar, b.grammar);
+        expect(diff.changed).toHaveLength(0);
+        expect(diff.added).toHaveLength(0);
+        expect(diff.removed).toHaveLength(0);
+    });
+
+    it("throws GrammarToolsError on unparseable source", () => {
+        const valid = loadGrammarFromBuffer(
+            "a.agr",
+            `<Start> = play -> "play";`,
+        );
+        expect(valid.ok).toBe(true);
+        if (!valid.ok) return;
+
+        // Create a grammar with corrupted source text
+        const corrupted: LoadedGrammar = {
+            ...valid.grammar,
+            files: [{ id: "bad.agr", text: "<<< not valid grammar %%%" }],
+        };
+
+        expect(() => diffGrammars(corrupted, valid.grammar)).toThrow(
+            GrammarToolsError,
+        );
     });
 });

--- a/ts/packages/grammarTools/core/test/formatTrace.spec.ts
+++ b/ts/packages/grammarTools/core/test/formatTrace.spec.ts
@@ -135,4 +135,49 @@ describe("formatTrace", () => {
         expect(output).not.toContain("input:");
         expect(output).toMatch(/\[\d+\]/);
     });
+
+    // ---------------------------------------------------------------
+    // Source location annotations
+    // ---------------------------------------------------------------
+
+    it("shows source locations when debugInfo is provided", () => {
+        const g = load();
+        const trace = traceMatch(g, "pause");
+        const output = formatTrace(trace, { debugInfo: g.debugInfo });
+        // Should contain file:line:col annotations
+        expect(output).toContain("(test.agr:");
+    });
+
+    it("omits source locations when debugInfo is absent", () => {
+        const trace = traceMatch(load(), "pause");
+        const output = formatTrace(trace);
+        // Should not contain file references
+        expect(output).not.toContain("(test.agr:");
+    });
+
+    it("respects showSourceLocations: false even with debugInfo", () => {
+        const g = load();
+        const trace = traceMatch(g, "pause");
+        const output = formatTrace(trace, {
+            debugInfo: g.debugInfo,
+            showSourceLocations: false,
+        });
+        expect(output).not.toContain("(test.agr:");
+    });
+
+    it("source locations have 1-based line numbers", () => {
+        const g = load();
+        const trace = traceMatch(g, "pause");
+        const output = formatTrace(trace, { debugInfo: g.debugInfo });
+        // Extract all (file:line:col) annotations
+        const locs = [...output.matchAll(/\(test\.agr:(\d+):(\d+)\)/g)];
+        expect(locs.length).toBeGreaterThan(0);
+        for (const m of locs) {
+            const line = parseInt(m[1], 10);
+            const col = parseInt(m[2], 10);
+            // 1-based, so both should be >= 1
+            expect(line).toBeGreaterThanOrEqual(1);
+            expect(col).toBeGreaterThanOrEqual(1);
+        }
+    });
 });

--- a/ts/packages/grammarTools/core/test/loader.spec.ts
+++ b/ts/packages/grammarTools/core/test/loader.spec.ts
@@ -109,6 +109,60 @@ describe("loader", () => {
     });
 
     // ---------------------------------------------------------------
+    // GrammarDebugInfo
+    // ---------------------------------------------------------------
+
+    it("populates debugInfo with part and rule positions", () => {
+        const source = `<Start> = hello world -> true;
+<Start> = goodbye -> false;`;
+        const result = loadGrammarFromBuffer("debug.agr", source);
+        expect(result.ok).toBe(true);
+        if (result.ok) {
+            const dbg = result.grammar.debugInfo;
+            expect(dbg).toBeDefined();
+            expect(dbg!.rules.size).toBeGreaterThan(0);
+            expect(dbg!.parts.size).toBeGreaterThan(0);
+            // Every source location should have valid line/character
+            for (const loc of dbg!.parts.values()) {
+                expect(loc.range.start.line).toBeGreaterThanOrEqual(0);
+                expect(loc.range.start.character).toBeGreaterThanOrEqual(0);
+                expect(loc.range.start.offset).toBeGreaterThanOrEqual(0);
+            }
+            for (const loc of dbg!.rules.values()) {
+                expect(loc.range.start.line).toBeGreaterThanOrEqual(0);
+                expect(loc.range.start.character).toBeGreaterThanOrEqual(0);
+            }
+        }
+    });
+
+    it("debugInfo part positions point to correct source offsets", () => {
+        const source = `<Start> = play $(song:string) -> { action: "play", song };`;
+        const result = loadGrammarFromBuffer("pos.agr", source);
+        expect(result.ok).toBe(true);
+        if (result.ok) {
+            const dbg = result.grammar.debugInfo;
+            expect(dbg).toBeDefined();
+            // At least one part should reference a position in the source
+            for (const loc of dbg!.parts.values()) {
+                expect(loc.range.start.offset).toBeLessThan(source.length);
+                expect(loc.fileId).toBe("pos.agr");
+            }
+        }
+    });
+
+    it("debugInfo grammarHash is populated", () => {
+        const source = `<Start> = hello -> true;`;
+        const result = loadGrammarFromBuffer("hash.agr", source);
+        expect(result.ok).toBe(true);
+        if (result.ok) {
+            expect(result.grammar.debugInfo!.grammarHash).toBeDefined();
+            expect(
+                result.grammar.debugInfo!.grammarHash.length,
+            ).toBeGreaterThan(0);
+        }
+    });
+
+    // ---------------------------------------------------------------
     // File I/O (loadGrammarFromFile)
     // ---------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Add compile-time debug info (source positions for rules and parts) to the action-grammar compiler, then build coverage and diff services on top of it in grammar-tools-core.

## Changes

### action-grammar (compiler)

- **A.5 GrammarDebugInfo**: Assign monotonic `partId` to every `GrammarPart` during compilation. Emit `DebugInfoCollector` with `partPositions` and `rulePositions` maps.
- **Shared counters**: `partIdCounter` is shared across import contexts to prevent ID collisions in multi-file grammars.
- **Debug propagation**: `debugCollector` is propagated to import contexts so imported rules get debug info.
- **Exports**: `GrammarPart` and `GrammarRule` types are now re-exported from the public API.

### grammar-tools-core

- **B.3 Coverage** (`coverage.ts`): `computeCoverage()` runs a corpus against a grammar via the trace hook, then maps part hits back to source rules using the debug info. Walks the grammar AST to build the part-owner map.
- **B.4 Diff** (`diff.ts`): `diffGrammars()` computes structural rule-level diffs between two grammars. Uses `writeGrammarRules` for canonical serialization. Throws `GrammarToolsError` on parse failures instead of silently skipping.
- **Loader**: `loadGrammarFromFile` supports `.agr` file imports via `FileLoader`.
- **Trace**: `formatTrace()` shows source locations when debug info is available.

### grammar-tools-cli

- `coverage` and `diff` commands wired up with `--json` support.

### grammar-tools-vscode (extension)

- Debug info surfaced in trace output.

### Docs

- `STATUS.md` progress-by-track table added.

## Testing

- 67 tests in grammar-tools-core (coverage, diff, loader, trace, completion, symbols, formatTrace)
- 28 CLI integration tests
- 16,131 action-grammar tests pass (including compiler changes)
- New tests cover: nested rule references, part ownership, repeated inputs, whitespace-invariant diff, parse error propagation
