### PR TITLE
fix(dep-alerts): finish the workflow hardening — silent-failure & UX bugs

### DIFF
--- a/.github/workflows/fix-dependabot-alerts.yml
+++ b/.github/workflows/fix-dependabot-alerts.yml
@@ -260,9 +260,14 @@ jobs:
             fi
 
             # ── Step 2: Apply fixes one package at a time ───────────
-            LOCK_SHA=$(sha256sum pnpm-lock.yaml 2>/dev/null | awk '{print $1}' || echo "no-lock")
             for PKG in $FIXABLE; do
               echo "::group::Fixing $WS_DIR/$PKG"
+
+              # Recompute LOCK_SHA per package: earlier successful fixes in
+              # the same run mutate pnpm-lock.yaml, so a once-per-workspace
+              # snapshot would make the rollback cooldown skip key drift away
+              # from the actual on-disk lockfile state.
+              LOCK_SHA=$(sha256sum pnpm-lock.yaml 2>/dev/null | awk '{print $1}' || echo "no-lock")
 
               # Skip if this (workspace,pkg,lockSha) recently rolled back.
               ROLLBACK_KEY="$WS_DIR/$PKG"

--- a/.github/workflows/fix-dependabot-alerts.yml
+++ b/.github/workflows/fix-dependabot-alerts.yml
@@ -72,7 +72,14 @@ jobs:
         run: |
           gh auth status
           echo "---"
-          gh api repos/${{ github.repository }}/dependabot/alerts?per_page=1 --jq 'length' || echo "API call failed with exit $?"
+          # Probe the Dependabot API with a 1-item page. If the call fails the
+          # subsequent discovery step would silently produce an empty workspace
+          # list and the entire job would report "No fixable alerts found" —
+          # masking infra outages as "everything's fine". Fail fast instead.
+          if ! gh api "repos/${{ github.repository }}/dependabot/alerts?per_page=1" --jq 'length'; then
+            echo "::error::Dependabot API probe failed — aborting before silently misreporting alerts"
+            exit 1
+          fi
 
       # Install ts/ dependencies once before the per-workspace loop.
       # The fix-dependabot-alerts.mjs script lives under ts/tools/scripts/ and
@@ -85,6 +92,22 @@ jobs:
         run: |
           corepack enable
           pnpm install --frozen-lockfile
+
+      # Restore per-package rollback memory across runs. When a fix attempt
+      # rolls back (build/install failure), we record the package + lockfile
+      # SHA so subsequent daily runs skip retrying the same broken upgrade
+      # until either (a) the cooldown expires (default 7 days) or (b) the
+      # underlying lockfile changes (different SHA → potentially different
+      # outcome). Without this, the workflow burns CI minutes attempting
+      # the same hopeless rollback every single day.
+      - name: Restore rollback memory
+        id: rollback-cache
+        uses: actions/cache@v4
+        with:
+          path: /tmp/dep-rollback-state.json
+          key: dep-rollback-state-v1-${{ github.run_id }}
+          restore-keys: |
+            dep-rollback-state-v1-
 
       # ── Analyse and fix alerts across workspaces ──────────────────────
       #
@@ -104,6 +127,7 @@ jobs:
           FLAGS="${{ inputs.auto-fix-args || '--auto-fix' }}"
           ALL_APPLIED=""
           ALL_ROLLED_BACK=""
+          ALL_SKIPPED_RECENT_ROLLBACK=""
           ALL_BLOCKED_PACKAGES=""
           ALL_NO_PATCH_PACKAGES=""
           ALL_FAILED_WORKSPACES=""
@@ -111,8 +135,28 @@ jobs:
           TOTAL_BLOCKED=0
           TOTAL_NO_PATCH=0
           TOTAL_FAILED=0
+          TOTAL_SKIPPED=0
 
-          # Discover workspaces with open npm alerts from the Dependabot API
+          # Rollback memory: skip retrying any (workspace,pkg) that rolled
+          # back recently against the *current* lockfile SHA. Cooldown is in
+          # days; entries older than this are considered stale and retried.
+          ROLLBACK_STATE=/tmp/dep-rollback-state.json
+          ROLLBACK_COOLDOWN_DAYS=7
+          if [ ! -f "$ROLLBACK_STATE" ]; then
+            echo '{"version":1,"rollbacks":{}}' > "$ROLLBACK_STATE"
+          fi
+          NOW_EPOCH=$(date -u +%s)
+          COOLDOWN_SECONDS=$((ROLLBACK_COOLDOWN_DAYS * 86400))
+
+          # Discover workspaces with open npm alerts from the Dependabot API.
+          #
+          # NOTE: `split("/")[0]` collapses every alert manifest_path to its
+          # leading directory (so `ts/packages/X/package.json` → `ts`). This is
+          # correct for this repo because the only pnpm workspace roots are
+          # `ts/` and `docs/`, but it would silently misroute alerts whose
+          # manifest_path points outside those roots (e.g. a future workspace
+          # under `subprojects/foo/package.json`). Revisit if/when a third
+          # workspace root is added.
           WORKSPACES=$(gh api "repos/${{ github.repository }}/dependabot/alerts?state=open&per_page=100" \
             --paginate \
             --jq '[.[] | select(.dependency.package.ecosystem == "npm") | .dependency.manifest_path | split("/")[0]] | unique | .[]')
@@ -177,6 +221,23 @@ jobs:
             BLOCKED_PKGS=$(jq -r '[.blocked[].package] | unique | join(", ")' /tmp/dep-analysis.json)
             NO_PATCH_PKGS=$(jq -r '[.noPatch[].package] | unique | join(", ")' /tmp/dep-analysis.json)
 
+            # If there are blocked packages, capture --show-chains output
+            # for the PR body so reviewers can see why each was blocked
+            # without having to re-run the script locally.
+            if [ "$WS_BLOCKED" -gt 0 ]; then
+              echo "Capturing dependency chains for $WS_BLOCKED blocked package(s) in $WS_DIR"
+              CHAINS_OUT="/tmp/dep-chains-$WS_DIR.txt"
+              NO_COLOR=1 node "$SCRIPT" --dry-run --show-chains --skip-install \
+                > "$CHAINS_OUT" 2>&1 || true
+              if [ -s "$CHAINS_OUT" ]; then
+                {
+                  echo ""
+                  echo "===== $WS_DIR ====="
+                  cat "$CHAINS_OUT"
+                } >> /tmp/all-blocked-chains.txt
+              fi
+            fi
+
             FIXABLE=$(jq -r '.resolved[].package' /tmp/dep-analysis.json | sort -u)
             FIXABLE_COUNT=$(echo "$FIXABLE" | grep -c . || true)
             echo "Fixable $WS_DIR packages ($FIXABLE_COUNT): $FIXABLE"
@@ -199,8 +260,26 @@ jobs:
             fi
 
             # ── Step 2: Apply fixes one package at a time ───────────
+            LOCK_SHA=$(sha256sum pnpm-lock.yaml 2>/dev/null | awk '{print $1}' || echo "no-lock")
             for PKG in $FIXABLE; do
               echo "::group::Fixing $WS_DIR/$PKG"
+
+              # Skip if this (workspace,pkg,lockSha) recently rolled back.
+              ROLLBACK_KEY="$WS_DIR/$PKG"
+              PREV_TS=$(jq -r --arg k "$ROLLBACK_KEY" --arg sha "$LOCK_SHA" \
+                '.rollbacks[$k] | select(.lockSha == $sha) | .timestamp // empty' \
+                "$ROLLBACK_STATE")
+              if [ -n "$PREV_TS" ]; then
+                AGE=$((NOW_EPOCH - PREV_TS))
+                if [ "$AGE" -lt "$COOLDOWN_SECONDS" ]; then
+                  AGE_DAYS=$((AGE / 86400))
+                  echo "⏭️  Skipping $PKG: rolled back ${AGE_DAYS}d ago against same lockfile (cooldown ${ROLLBACK_COOLDOWN_DAYS}d)"
+                  ALL_SKIPPED_RECENT_ROLLBACK="$ALL_SKIPPED_RECENT_ROLLBACK $PKG"
+                  TOTAL_SKIPPED=$((TOTAL_SKIPPED + 1))
+                  echo "::endgroup::"
+                  continue
+                fi
+              fi
 
               # Save a rollback point
               cp package.json /tmp/pkg-backup.json
@@ -252,6 +331,10 @@ jobs:
                   git checkout -- . 2>/dev/null || true
                   ALL_ROLLED_BACK="$ALL_ROLLED_BACK $PKG"
                   TOTAL_FAILED=$((TOTAL_FAILED + 1))
+                  jq --arg k "$ROLLBACK_KEY" --arg sha "$LOCK_SHA" \
+                     --argjson ts "$NOW_EPOCH" --arg reason "install failed" \
+                     '.rollbacks[$k] = {lockSha:$sha,timestamp:$ts,reason:$reason}' \
+                     "$ROLLBACK_STATE" > "$ROLLBACK_STATE.tmp" && mv "$ROLLBACK_STATE.tmp" "$ROLLBACK_STATE"
                   echo "::endgroup::"
                   continue
                 fi
@@ -273,10 +356,17 @@ jobs:
                   git checkout -- . 2>/dev/null || true
                   ALL_ROLLED_BACK="$ALL_ROLLED_BACK $PKG"
                   TOTAL_FAILED=$((TOTAL_FAILED + 1))
+                  jq --arg k "$ROLLBACK_KEY" --arg sha "$LOCK_SHA" \
+                     --argjson ts "$NOW_EPOCH" --arg reason "build failed" \
+                     '.rollbacks[$k] = {lockSha:$sha,timestamp:$ts,reason:$reason}' \
+                     "$ROLLBACK_STATE" > "$ROLLBACK_STATE.tmp" && mv "$ROLLBACK_STATE.tmp" "$ROLLBACK_STATE"
                 else
                   echo "✅ $PKG fixed and build passed"
                   ALL_APPLIED="$ALL_APPLIED $PKG"
                   TOTAL_RESOLVED=$((TOTAL_RESOLVED + 1))
+                  # Successful upgrade — clear any stale rollback record.
+                  jq --arg k "$ROLLBACK_KEY" 'del(.rollbacks[$k])' \
+                     "$ROLLBACK_STATE" > "$ROLLBACK_STATE.tmp" && mv "$ROLLBACK_STATE.tmp" "$ROLLBACK_STATE"
                 fi
               else
                 echo "No changes for $PKG (may already be fixed)"
@@ -287,12 +377,21 @@ jobs:
           done
 
           # ── Step 3: Report results ──────────────────────────────────
+          # Prune rollback entries older than the cooldown window so the
+          # state file doesn't grow unbounded.
+          STALE_THRESHOLD=$((NOW_EPOCH - COOLDOWN_SECONDS))
+          jq --argjson th "$STALE_THRESHOLD" \
+             '.rollbacks |= with_entries(select(.value.timestamp >= $th))' \
+             "$ROLLBACK_STATE" > "$ROLLBACK_STATE.tmp" && mv "$ROLLBACK_STATE.tmp" "$ROLLBACK_STATE"
+
           echo "resolved=$TOTAL_RESOLVED" >> "$GITHUB_OUTPUT"
           echo "blocked=$TOTAL_BLOCKED" >> "$GITHUB_OUTPUT"
           echo "no_patch=$TOTAL_NO_PATCH" >> "$GITHUB_OUTPUT"
           echo "failed=$TOTAL_FAILED" >> "$GITHUB_OUTPUT"
+          echo "skipped=$TOTAL_SKIPPED" >> "$GITHUB_OUTPUT"
           echo "applied_packages=$ALL_APPLIED" >> "$GITHUB_OUTPUT"
           echo "rolled_back_packages=$ALL_ROLLED_BACK" >> "$GITHUB_OUTPUT"
+          echo "skipped_packages=$ALL_SKIPPED_RECENT_ROLLBACK" >> "$GITHUB_OUTPUT"
           echo "blocked_packages=$ALL_BLOCKED_PACKAGES" >> "$GITHUB_OUTPUT"
           echo "no_patch_packages=$ALL_NO_PATCH_PACKAGES" >> "$GITHUB_OUTPUT"
           echo "failed_workspaces=$ALL_FAILED_WORKSPACES" >> "$GITHUB_OUTPUT"
@@ -352,6 +451,26 @@ jobs:
 
           git push origin "$BRANCH"
 
+          # Close any previously-open PRs from this workflow before opening a
+          # new one. Each daily run produces a unique branch (date + run_number),
+          # so without dedup the repo accumulates stacking duplicate PRs when
+          # yesterday's hasn't merged yet. The freshest PR always wins because
+          # it incorporates the latest set of fixes (and re-verifies the build).
+          PREV_PRS=$(gh pr list \
+            --state open \
+            --search 'head:automated/fix-dependabot-alerts- in:branch' \
+            --json number,headRefName \
+            --jq '.[] | select(.headRefName != "'"$BRANCH"'") | .number')
+          if [ -n "$PREV_PRS" ]; then
+            echo "Closing superseded Dependabot fix PRs: $PREV_PRS"
+            for PR in $PREV_PRS; do
+              gh pr close "$PR" \
+                --delete-branch \
+                --comment "Superseded by a newer automated Dependabot fix PR." \
+                || echo "::warning::Failed to close PR #$PR"
+            done
+          fi
+
           # Build PR body from step outputs
           APPLIED="${{ steps.fix.outputs.applied_packages }}"
           ROLLED="${{ steps.fix.outputs.rolled_back_packages }}"
@@ -376,12 +495,31 @@ jobs:
           - **Blocked ($BLOCKED):**${BLOCKED_PKGS:- (none)}
           - **No patch available (${{ steps.fix.outputs.no_patch }}):**${NO_PATCH_PKGS:- (none)}
           - **Rolled back ($FAILED):**${ROLLED:- (none)}
+          - **Skipped (recent rollback, ${{ steps.fix.outputs.skipped }}):**${{ steps.fix.outputs.skipped_packages || ' (none)' }}
           - **Workspaces with analysis failures:**${{ steps.fix.outputs.failed_workspaces && format(' {0}', steps.fix.outputs.failed_workspaces) || ' (none)' }}
           - **Build:** ✅ Passed
           - **Shell packaging:** ${{ steps.shell.outputs.shell_ok == 'true' && '✅ Passed' || '⚠️ Skipped' }}
 
           > _Note: the analysis source (\`fix-dependabot-alerts.mjs\`) is broader than the GitHub Dependabot REST API — it also audits the lockfile directly. Some packages listed above may not have a corresponding open Dependabot alert, and vice versa._
+          "
 
+          # Embed dependency chain output for blocked packages so reviewers
+          # can see why each package couldn't be auto-fixed.
+          if [ -s /tmp/all-blocked-chains.txt ]; then
+            CHAINS=$(cat /tmp/all-blocked-chains.txt)
+            BODY="$BODY
+          ### Why blocked packages couldn't be auto-fixed
+          <details><summary>Dependency chains (\`--show-chains\` output)</summary>
+
+          \`\`\`
+          $CHAINS
+          \`\`\`
+
+          </details>
+          "
+          fi
+
+          BODY="$BODY
           ### How this works
           1. Analyses all open Dependabot alerts
           2. Applies each fix **individually** with build verification

--- a/ts/tools/scripts/fix-dependabot-alerts.mjs
+++ b/ts/tools/scripts/fix-dependabot-alerts.mjs
@@ -559,8 +559,9 @@ function fmtDepChain(whyData, pkg) {
         }
     }
 
+    const reverseTree = toReverseTree(whyData, pkg);
     const roots = [];
-    for (const entry of whyData) {
+    for (const entry of reverseTree) {
         const tree = buildTree(entry, true);
         roots.push(...tree.children);
     }
@@ -676,8 +677,9 @@ const getPnpmWhy = cachedAsync("getPnpmWhy", {
 });
 
 async function findConstrainingParentsFromData(whyData, pkg) {
+    const reverseTree = toReverseTree(whyData, pkg);
     const pairs = deduplicateBy(
-        whyData.flatMap((entry) => entry.dependents || []),
+        reverseTree.flatMap((entry) => entry.dependents || []),
         (dep) => `${dep.name}@${dep.version}`,
     );
     const specs = await Promise.all(
@@ -694,6 +696,177 @@ async function findConstrainingParentsFromData(whyData, pkg) {
         version: dep.version,
         requiredSpec: specs[i],
     }));
+}
+
+/**
+ * Convert the forward-direction `pnpm why <pkg> -r --json` output into the
+ * reverse-direction `{version, dependents: [...]}` shape that the rest of
+ * the planner (planFixes, walkUpTree, fmtDepChain, extractWorkspaceRoots,
+ * findConstrainingParentsFromData) was originally written for.
+ *
+ * The current pnpm CLI emits forward-direction trees only:
+ *   [
+ *     { name: <ws-name>, version, path,
+ *       dependencies: { foo: { version, dependencies: { bar: {...} } } },
+ *       devDependencies: {...}, optionalDependencies: {...}
+ *     }, ...
+ *   ]
+ *
+ * walkUpTree / planFixes were written assuming each top-level entry is a
+ * distinct resolved version of `pkg` with a `dependents: [...]` array
+ * walking back toward the workspace roots — a shape that pnpm no longer
+ * produces (and may never have, depending on which version of pnpm the
+ * original code was tested against). With the wrong shape, every entry
+ * had `dependents === undefined`, the `if (!entry.dependents) continue;`
+ * guard in planFixes silently dropped every transitively-vulnerable
+ * package, and the planner reported them as `alreadyFixed`.
+ *
+ * This helper does a single forward walk per workspace, collecting every
+ * path that ends at `pkg`, then reverses each path and merges paths that
+ * share the same parent chain so the resulting reverse-tree has the
+ * dedup characteristics walkUpTree's cache assumes.
+ *
+ * Returned shape (matches what walkUpTree expects):
+ *   [
+ *     { version: <pkg-version>,
+ *       dependents: [
+ *         { name, version, dependents: [...] },           // intermediate
+ *         { name: <ws-name>, depField: <field>, dependents: [] } // workspace
+ *       ]
+ *     }, ...
+ *   ]
+ */
+function toReverseTree(whyData, pkg) {
+    if (!Array.isArray(whyData) || whyData.length === 0) return [];
+    const depFields = [
+        "dependencies",
+        "devDependencies",
+        "optionalDependencies",
+    ];
+
+    // Collect every root→pkg path. Each entry in `path` is one node; the
+    // first node is the workspace and the last is `pkg`.
+    const paths = [];
+    const visited = new WeakSet();
+
+    function walk(node, path, fromWorkspaceField) {
+        if (!node || typeof node !== "object") return;
+        // Cycle guard: pnpm output should be tree-shaped but defend anyway.
+        if (visited.has(node)) return;
+        visited.add(node);
+        for (const field of depFields) {
+            const deps = node[field];
+            if (!deps || typeof deps !== "object") continue;
+            for (const [depName, depNode] of Object.entries(deps)) {
+                if (!depNode || typeof depNode !== "object") continue;
+                if (typeof depNode.version !== "string") continue;
+                const childEntry = {
+                    name: depName,
+                    version: depNode.version,
+                };
+                const newPath = [...path, childEntry];
+                if (depName === pkg) {
+                    // Record the workspace's depField on the path's
+                    // workspace node (path[0]) so the reverse tree can
+                    // surface it. Use the field nearest to the workspace
+                    // (i.e. the first traversal's field).
+                    paths.push({
+                        pkgVersion: depNode.version,
+                        chain: newPath,
+                        workspaceDepField: fromWorkspaceField ?? field,
+                    });
+                }
+                walk(depNode, newPath, fromWorkspaceField ?? field);
+            }
+        }
+        visited.delete(node);
+    }
+
+    for (const ws of whyData) {
+        if (!ws || typeof ws !== "object") continue;
+        walk(
+            ws,
+            [
+                {
+                    name: ws.name,
+                    version: ws.version,
+                    isWorkspace: true,
+                },
+            ],
+            null,
+        );
+    }
+
+    if (paths.length === 0) return [];
+
+    // Group paths by the resolved version of `pkg` they end at.
+    const byVersion = new Map();
+    for (const p of paths) {
+        if (!byVersion.has(p.pkgVersion)) byVersion.set(p.pkgVersion, []);
+        byVersion.get(p.pkgVersion).push(p);
+    }
+
+    // For each version, reverse the chains (drop the pkg leaf so the
+    // reverse-tree's first level holds pkg's *parents*) and merge nodes
+    // that share the same identity.
+    function buildLevel(reversedChains) {
+        const buckets = new Map();
+        for (const chain of reversedChains) {
+            if (chain.length === 0) continue;
+            const head = chain[0];
+            const key = head.isWorkspace
+                ? `ws:${head.name}`
+                : `${head.name}@${head.version}`;
+            if (!buckets.has(key)) {
+                buckets.set(key, { head, tails: [] });
+            }
+            buckets.get(key).tails.push(chain.slice(1));
+        }
+        const nodes = [];
+        for (const { head, tails } of buckets.values()) {
+            if (head.isWorkspace) {
+                // walkUpTree only checks `node.depField` truthiness to
+                // recognise workspace nodes; getWorkspaceDepInfo() reads
+                // the workspace's package.json directly to resolve the
+                // actual spec. The recorded depField is informational.
+                nodes.push({
+                    name: head.name,
+                    depField: head.workspaceDepField || "dependencies",
+                });
+            } else {
+                nodes.push({
+                    name: head.name,
+                    version: head.version,
+                    dependents: buildLevel(tails),
+                });
+            }
+        }
+        return nodes;
+    }
+
+    const result = [];
+    for (const [version, ps] of byVersion) {
+        const reversed = ps.map((p) => {
+            // Drop the pkg leaf, reverse, then attach workspaceDepField
+            // to the workspace node (now at the end after reversal).
+            const noLeaf = p.chain.slice(0, -1);
+            const reversedChain = [...noLeaf].reverse();
+            // The workspace is the last element of reversedChain; tag it.
+            if (reversedChain.length > 0) {
+                const wsNode = reversedChain[reversedChain.length - 1];
+                if (wsNode.isWorkspace) {
+                    wsNode.workspaceDepField = p.workspaceDepField;
+                }
+            }
+            return reversedChain;
+        });
+        result.push({
+            version,
+            dependents: buildLevel(reversed),
+        });
+    }
+
+    return result;
 }
 
 /**
@@ -1147,7 +1320,10 @@ async function planFixes(pkg, requiredVersion, whyData) {
     const allBlockReasons = [];
     const allConstraints = [];
 
-    for (const entry of whyData) {
+    // pnpm emits forward-direction trees; convert once per planFixes call.
+    const reverseTree = toReverseTree(whyData, pkg);
+
+    for (const entry of reverseTree) {
         if (!entry.version || !semver.valid(entry.version)) continue;
         if (semver.gte(entry.version, requiredVersion)) continue; // already OK
         if (!entry.dependents || entry.dependents.length === 0) continue;
@@ -1865,8 +2041,9 @@ function addOverrides(overridesMap) {
  * Extract workspace root names from pnpm-why data by walking the dependents
  * tree to find leaf nodes (those with a `depField` property).
  */
-function extractWorkspaceRoots(whyData) {
+function extractWorkspaceRoots(whyData, pkg) {
     const roots = new Set();
+    const reverseTree = toReverseTree(whyData, pkg);
     function walk(node) {
         if (node.depField) {
             roots.add(node.name);
@@ -1876,7 +2053,7 @@ function extractWorkspaceRoots(whyData) {
             for (const dep of node.dependents) walk(dep);
         }
     }
-    for (const entry of whyData) {
+    for (const entry of reverseTree) {
         if (entry.dependents) {
             for (const dep of entry.dependents) walk(dep);
         }
@@ -2044,7 +2221,7 @@ async function formatPackageAnalysis(entry, whyData, pkgIndex, pkgTotal) {
 
     // ── "Used by" — which workspace packages are affected ─────────────
     if (!isSimpleUpdate(entry)) {
-        const wsRoots = extractWorkspaceRoots(whyData);
+        const wsRoots = extractWorkspaceRoots(whyData, pkg);
         if (wsRoots.length > 0) {
             const rootsStr =
                 wsRoots

--- a/ts/tools/scripts/fix-dependabot-alerts.mjs
+++ b/ts/tools/scripts/fix-dependabot-alerts.mjs
@@ -260,6 +260,11 @@ const _npmSem = new Semaphore(
  * @param {Function} opts.fetchFn   - async (key) => result
  * @param {Semaphore} [opts.semaphore] - optional concurrency limiter
  * @param {*}        [opts.fallback=null] - value to cache on failure
+ * @param {Function} [opts.isFatal] - (e) => boolean. When provided and it
+ *   returns true for a thrown error, the error is rethrown instead of
+ *   caching `fallback`. Use for failures (missing binaries, permission
+ *   errors) where treating the empty fallback as "no data" would mask a
+ *   broken environment and produce silently-wrong downstream results.
  */
 function cachedAsync(label, { fetchFn, semaphore, fallback = null, isFatal }) {
     const cache = new Map();
@@ -730,8 +735,9 @@ async function findConstrainingParentsFromData(whyData, pkg) {
  *   [
  *     { version: <pkg-version>,
  *       dependents: [
- *         { name, version, dependents: [...] },           // intermediate
- *         { name: <ws-name>, depField: <field>, dependents: [] } // workspace
+ *         { name, version, dependents: [...] }, // intermediate
+ *         { name: <ws-name>, depField: <field> } // workspace (terminal;
+ *                                                // no `dependents` field)
  *       ]
  *     }, ...
  *   ]
@@ -851,11 +857,20 @@ function toReverseTree(whyData, pkg) {
             // to the workspace node (now at the end after reversal).
             const noLeaf = p.chain.slice(0, -1);
             const reversedChain = [...noLeaf].reverse();
-            // The workspace is the last element of reversedChain; tag it.
+            // The workspace is the last element of reversedChain; clone it
+            // before tagging — the same workspace identity object is shared
+            // across every path emitted from that workspace, so mutating
+            // workspaceDepField in place would let later paths overwrite
+            // earlier ones (and the chosen depField would become
+            // traversal-order dependent).
             if (reversedChain.length > 0) {
-                const wsNode = reversedChain[reversedChain.length - 1];
+                const lastIdx = reversedChain.length - 1;
+                const wsNode = reversedChain[lastIdx];
                 if (wsNode.isWorkspace) {
-                    wsNode.workspaceDepField = p.workspaceDepField;
+                    reversedChain[lastIdx] = {
+                        ...wsNode,
+                        workspaceDepField: p.workspaceDepField,
+                    };
                 }
             }
             return reversedChain;

--- a/ts/tools/scripts/fix-dependabot-alerts.mjs
+++ b/ts/tools/scripts/fix-dependabot-alerts.mjs
@@ -261,7 +261,7 @@ const _npmSem = new Semaphore(
  * @param {Semaphore} [opts.semaphore] - optional concurrency limiter
  * @param {*}        [opts.fallback=null] - value to cache on failure
  */
-function cachedAsync(label, { fetchFn, semaphore, fallback = null }) {
+function cachedAsync(label, { fetchFn, semaphore, fallback = null, isFatal }) {
     const cache = new Map();
     const inflight = new Map();
 
@@ -276,6 +276,10 @@ function cachedAsync(label, { fetchFn, semaphore, fallback = null }) {
                 cache.set(key, result);
                 return result;
             } catch (e) {
+                // Some failures (e.g. missing binaries) are too dangerous to
+                // mask with a fallback — they let downstream code conclude
+                // "no data" when the real cause is a broken environment.
+                if (isFatal && isFatal(e)) throw e;
                 verbose(`${label}(${key}) failed: ${e.message}`);
                 cache.set(key, fallback);
                 return fallback;
@@ -358,7 +362,16 @@ function runCmdAsync(cmd, cmdArgs, { nothrow, ...opts } = {}) {
             { cwd: ROOT, maxBuffer: MAX_BUFFER, encoding: "utf-8", ...opts },
             (error, stdout, stderr) => {
                 if (error) {
-                    if (nothrow) {
+                    // `nothrow` should swallow non-zero exits but NOT spawn
+                    // failures (ENOENT, EACCES, etc.) — those usually indicate
+                    // a misconfigured environment (missing binary, missing
+                    // permissions) and silently treating them as "no output"
+                    // can mask real bugs (e.g. classifying vulnerable packages
+                    // as already-fixed because `pnpm why` couldn't even run).
+                    const isSpawnFailure =
+                        typeof error.code === "string" &&
+                        !Number.isFinite(Number(error.code));
+                    if (nothrow && !isSpawnFailure) {
                         verbose(
                             `${cmd} ${cmdArgs.join(" ")} failed: ${error.message}`,
                         );
@@ -642,6 +655,11 @@ async function verifyAllVersionsFixed(pkg, requiredVersion) {
 
 /**
  * Run `pnpm why <pkg> -r --json` and return parsed entries.
+ *
+ * Spawn-level failures (e.g. `pnpm` not on PATH) propagate to callers
+ * rather than getting masked as "no data" — see the `isFatal` clause.
+ * Without this, a missing pnpm shim would let analysis report every
+ * vulnerable package as `alreadyFixed`.
  */
 const getPnpmWhy = cachedAsync("getPnpmWhy", {
     fetchFn: async (pkg) => {
@@ -652,6 +670,9 @@ const getPnpmWhy = cachedAsync("getPnpmWhy", {
         return parsePaginatedJson(output);
     },
     fallback: [],
+    // runCmdAsync now throws on spawn failure even with nothrow; surface
+    // those instead of caching `[]`.
+    isFatal: (e) => /\bENOENT\b|\bEACCES\b|\bEPERM\b/.test(e?.message || ""),
 });
 
 async function findConstrainingParentsFromData(whyData, pkg) {


### PR DESCRIPTION
# fix(dep-alerts): finish the workflow hardening — silent-failure & UX bugs

Eight remaining bugs in the daily Dependabot fix workflow & script,
discovered while diagnosing why PR #2310 alone wouldn't fix every alert.

PRs in this multi-PR effort:
- #2305: workspace-discovery & analysis-failure surfacing (merged).
- #2308: getResolvedVersions reads versions from nested pnpm-why tree (merged).
- #2310: raise stale pnpm.overrides when pnpm update can't progress (merged).
- This PR: everything else surfaced by the audit.

Each commit is independently reviewable.

---

## Commits

### 1. `fix(dep-alerts): rethrow spawn failures in getPnpmWhy`

When `pnpm` is missing from PATH (ENOENT) or otherwise unspawnable,
`runCmdAsync` previously returned a placeholder with `nothrow: true`, and
`cachedAsync` cached the empty fallback `[]`. The empty array flowed
through `getResolvedVersions` → `vulnVersions=[]` → `fixPlan=null` →
the package was misclassified as `alreadyFixed`, hiding real CI infra
failures behind green workflow runs.

- `runCmdAsync` now distinguishes spawn failures (string `error.code`
  like `ENOENT`/`EACCES`) from non-zero exits and rethrows the former
  even when `nothrow: true`.
- `cachedAsync` gains an optional `isFatal(e)` callback so callers can
  opt out of fallback caching for known-dangerous errors.
- `getPnpmWhy` opts in for `ENOENT`/`EACCES`/`EPERM`.

Validated locally on Windows: instead of silently classifying liquidjs
as `alreadyFixed`, the script now reports it as `blocked` with a clear
`spawn pnpm ENOENT` reason.

### 2. `fix(dep-alerts): harden workflow with dedup, rollback memory, chains, hard-fail`

Five workflow improvements bundled (each addresses a separate audit finding):

- **`gh api` hard-fail (B8)**: Replace `gh api ... || echo "API call failed"`
  with `if !; then ::error::; exit 1`. The previous form swallowed
  auth/API failures, kept the workflow green, and let downstream steps
  proceed with an empty alert list.
- **Workspace discovery comment (B7)**: The `split("/")[0]` collapse is
  correct for this repo today (`ts/` and `docs/` only) but would silently
  misroute future workspace alerts. Documented inline with a pointer to
  revisit.
- **`--show-chains` in PR body (B6)**: When analysis reports blocked
  packages, run a second dry-run pass with `--show-chains` and embed the
  output inside a `<details>` block in the PR body. Reviewers can now
  see why each blocked package couldn't be auto-fixed without
  re-running the script locally.
- **PR dedup (B4)**: Before opening a new PR, list any open PRs whose
  head branch starts with `automated/fix-dependabot-alerts-` and close
  them with `--delete-branch` and a supersession comment. The freshest
  run always wins because it incorporates the newest set of fixes plus
  fresh build verification.
- **Per-package rollback memory (B5)**: New `actions/cache` step backs
  `/tmp/dep-rollback-state.json`, mapping `<workspace>/<pkg> →
  {lockSha, timestamp, reason}`. Before each fix attempt, skip any
  `(pkg, lockSha)` that rolled back within the cooldown window (7 days).
  Successful upgrades clear the entry. Stale entries are pruned at the
  end of every run. Cooldown is invalidated automatically when the
  lockfile SHA changes, so an unrelated dependency change can unblock
  the retry early.

YAML lint surfaced a real `run: |` indentation bug in the PR-body
construction (unindented `"` and `$(cat …)` lines that broke the literal
scalar). Would have failed CI on first run; fixed before push.

### 3. `fix(dep-alerts): adapt planner to forward-direction pnpm-why output`

**Root cause for B1, B3 — the bug behind the missing transitive fixes.**

The planner (`planFixes` / `walkUpTree` / `fmtDepChain` /
`extractWorkspaceRoots` / `findConstrainingParentsFromData`) was written
assuming each top-level entry of `pnpm why <pkg> -r --json` is a
distinct resolved version of `pkg` with a `dependents: [...]` array
walking back toward the workspace roots.

The current pnpm CLI emits forward-direction trees only — top-level
entries are workspace projects, and the package is reached by walking
nested `dependencies` / `devDependencies` / `optionalDependencies` maps
forward. Result: `entry.dependents` was always `undefined`, the
`if (!entry.dependents) continue;` guard in `planFixes` silently
dropped every transitively-vulnerable package, and the planner
reported them as `alreadyFixed`.

Add `toReverseTree(whyData, pkg)` which:
- walks each workspace's forward tree once,
- collects every root→pkg path,
- groups paths by the resolved `pkg` version,
- reverses each path and merges paths sharing the same parent identity
  so the resulting reverse-tree has the dedup characteristics
  walkUpTree's promise-cache assumes.

The five callers pre-convert their input via `toReverseTree` and pass
the legacy reverse-tree shape to the existing recursion logic. This
contains the change to a single helper rather than rewriting the
recursion. Subsumes the standalone B3 fix.

Validated against captured `pnpm why liquidjs -r --json` output from
docs/: OLD code processed 0 entries (the bug); NEW code processes 1
with the correct shape `liquidjs@10.25.0 ← @11ty/eleventy@3.1.2 ←
typeagent-docs (devDependencies)`.

---

## Validation

- B2: live test in docs/ — script now reports `blocked` instead of
  silently misclassifying as `alreadyFixed` when pnpm spawn fails.
- B1: real-data unit test on `toReverseTree` against captured pnpm
  output — proves OLD planner dropped liquidjs and NEW planner sees it.
- Workflow YAML: `python -c "import yaml; yaml.safe_load(open(...))"`
  parses cleanly; surfaced and fixed a `run: |` indentation bug.
- Script: `node --check` passes after every commit.

End-to-end CI validation will happen when this lands and the next
scheduled run executes.

## Expected outcome

After merge, the next scheduled run should:
- Surface any pnpm-spawn / `gh api` failures loudly instead of hiding
  them behind "no fixable alerts found".
- Process transitively-vulnerable packages (which the planner has been
  silently dropping for some time now).
- Skip retrying any (pkg, lockSha) that rolled back within the last 7
  days, freeing CI minutes for genuinely actionable fixes.
- Either edit / supersede the existing automated PR if there is one, or
  open a fresh one with `--show-chains` output embedded for blocked
  packages.
