### PR TITLE
fix(dep-alerts): recover from pnpm update failures via override raise; surface pnpm stdout

### DIFF
--- a/ts/tools/scripts/fix-dependabot-alerts.mjs
+++ b/ts/tools/scripts/fix-dependabot-alerts.mjs
@@ -382,9 +382,18 @@ function runCmdAsync(cmd, cmdArgs, { nothrow, ...opts } = {}) {
                         );
                         resolve(null);
                     } else {
+                        // pnpm prints its actionable error context (e.g.
+                        // ERR_PNPM_OVERRIDE_NO_VERSIONS_MATCH) to stdout —
+                        // include both streams so callers can diagnose the
+                        // failure without re-running with verbose output.
+                        const detail =
+                            [stderr, stdout]
+                                .map((s) => (s || "").trim())
+                                .filter(Boolean)
+                                .join("\n") || error.message;
                         reject(
                             new Error(
-                                `Command failed: ${cmd} ${cmdArgs.join(" ")}\n${stderr || error.message}`,
+                                `Command failed: ${cmd} ${cmdArgs.join(" ")}\n${detail}`,
                             ),
                         );
                     }
@@ -2697,6 +2706,47 @@ async function executeResolutions(analyses) {
     }
 
     /**
+     * Try raising a stale `pnpm.overrides[pkg]` entry that allows the
+     * vulnerable version, then `pnpm install` and re-verify. Returns
+     *   { outcome: "ok" }     – raise + install + verify all succeeded
+     *   { outcome: "blocked", check } – raise applied but still unfixed
+     *   { outcome: "noop" }   – no stale override; nothing attempted
+     *   { outcome: "failed", error } – raise install threw
+     * Always restores package.json + lockfile if anything goes wrong.
+     */
+    async function tryRaiseStaleOverride(a) {
+        const existing = readExistingOverride(a.pkg);
+        if (!existing || !overrideAllowsVulnerable(existing, a.patched)) {
+            return { outcome: "noop" };
+        }
+        const newSpec = raiseOverrideSpec(existing, a.patched);
+        verbose(
+            `Stale override pnpm.overrides["${a.pkg}"] = "${existing}" allows vulnerable versions — raising to "${newSpec}"`,
+        );
+        const snap = snapshotRoot();
+        addOverrides(new Map([[a.pkg, newSpec]]));
+        let check;
+        try {
+            await runCmdAsync("pnpm", ["install"], { timeout: 180000 });
+            check = await verifyAllVersionsFixed(a.pkg, a.patched);
+        } catch (e) {
+            await restoreRoot(snap);
+            return { outcome: "failed", error: e, existing, newSpec };
+        }
+        if (check.ok) {
+            ok(
+                `Raised pnpm.overrides["${a.pkg}"] from "${existing}" to "${newSpec}" — all versions fixed: ${check.versions.join(", ")}`,
+            );
+            return { outcome: "ok" };
+        }
+        warn(
+            `Raised pnpm.overrides["${a.pkg}"] to "${newSpec}" but still unfixed: ${check.unfixed.join(", ")} — rolling back`,
+        );
+        await restoreRoot(snap);
+        return { outcome: "blocked", check, existing, newSpec };
+    }
+
+    /**
      * Run `pnpm update <pkg> -r` and verify all versions are fixed.
      * Returns "ok" | "blocked" | "failed".
      */
@@ -2719,36 +2769,17 @@ async function executeResolutions(analyses) {
             // remaining vulnerability gate is a stale override (e.g. an
             // earlier security bump that has since been superseded by a new
             // advisory) get classified as blocked.
-            const existing = readExistingOverride(a.pkg);
-            if (existing && overrideAllowsVulnerable(existing, a.patched)) {
-                const newSpec = raiseOverrideSpec(existing, a.patched);
-                verbose(
-                    `Stale override pnpm.overrides["${a.pkg}"] = "${existing}" allows ${check.unfixed.join(", ")} — raising to "${newSpec}"`,
+            const raised = await tryRaiseStaleOverride(a);
+            if (raised.outcome === "ok") return "ok";
+            if (raised.outcome === "failed") {
+                fail(
+                    `Override raise install failed for ${a.pkg}: ${raised.error.message}`,
                 );
-                // Snapshot before mutating so we can roll back cleanly if the
-                // raise doesn't actually fix the vulnerability.
-                const snap = snapshotRoot();
-                addOverrides(new Map([[a.pkg, newSpec]]));
-                try {
-                    await runCmdAsync("pnpm", ["install"], { timeout: 180000 });
-                    check = await verifyAllVersionsFixed(a.pkg, a.patched);
-                } catch (e) {
-                    await restoreRoot(snap);
-                    throw e;
-                }
-                if (check.ok) {
-                    ok(
-                        `Raised pnpm.overrides["${a.pkg}"] from "${existing}" to "${newSpec}" — all versions fixed: ${check.versions.join(", ")}`,
-                    );
-                    return "ok";
-                }
-                // Re-verify still failed — undo the override + lockfile
-                // changes so this package's blocked outcome doesn't leak
-                // into the next package's analysis.
-                warn(
-                    `Raised pnpm.overrides["${a.pkg}"] to "${newSpec}" but still unfixed: ${check.unfixed.join(", ")} — rolling back`,
-                );
-                await restoreRoot(snap);
+                a.error = raised.error.message;
+                return "failed";
+            }
+            if (raised.outcome === "blocked") {
+                check = raised.check;
             }
 
             warn(
@@ -2759,6 +2790,21 @@ async function executeResolutions(analyses) {
             );
             return "blocked";
         } catch (e) {
+            // pnpm update threw — most often a stale `pnpm.overrides[pkg]`
+            // entry whose lower bound now excludes any non-vulnerable version
+            // makes pnpm refuse to resolve the install entirely. Try the
+            // same override-raise recovery path before giving up.
+            const raised = await tryRaiseStaleOverride(a);
+            if (raised.outcome === "ok") return "ok";
+            if (raised.outcome === "blocked") {
+                a.blockingReasons.push(
+                    `pnpm update threw and raised override still leaves unfixed versions: ${raised.check.unfixed.join(", ")}`,
+                );
+                return "blocked";
+            }
+            // Either no stale override was found (noop) or the raised
+            // install also threw (failed) — surface the original update
+            // error since that's the actionable signal.
             fail(`pnpm update failed for ${a.pkg}: ${e.message}`);
             a.error = e.message;
             return "failed";


### PR DESCRIPTION
# fix(dep-alerts): recover from `pnpm update` failures via override raise; surface pnpm stdout

Two follow-ups discovered watching the first scheduled run after PR
#2312 landed. liquidjs is still in `docs/`, but the workflow couldn't
fix it because:

```
[1/1] liquidjs (high) — 10.25.0 → need ≥10.25.5
   Fix: pnpm update liquidjs -r
   ✗ pnpm update failed for liquidjs: Command failed: pnpm install
```

That's all we got — the bare wrapper string, no actionable detail.

## Two changes

### 1. `runCmdAsync` includes both `stdout` and `stderr` in rejection

pnpm prints its actionable error context — `ERR_PNPM_OVERRIDE_NO_VERSIONS_MATCH`,
peer-dep mismatches, lockfile resolution conflicts — to **stdout**, not
stderr. The previous rejection used `stderr || error.message`, so when
stderr was empty the diagnostic payload was lost.

Now the rejection joins whichever streams are non-empty, falling back
to `error.message` only when neither stream produced output. With this
change the same failure would have been self-diagnosing — the workflow
log would have shown the real pnpm error instead of `Command failed:
pnpm install`.

### 2. `runUpdateAndVerify` attempts override raise on update *failure*

PR #2310 added stale-`pnpm.overrides` raising, but only on the
*blocked* outcome (update succeeded but versions stayed unfixed). The
exact same stale override can also make `pnpm update` *throw* — when
the existing override's lower bound now excludes any non-vulnerable
version, pnpm refuses to resolve the install at all and we returned
`"failed"` without trying the raise.

Extract the raise+install+verify path into `tryRaiseStaleOverride()`
and call it from both:
- the blocked path (existing behavior)
- the new catch path (B10 — when update throws)

If no stale override exists, or the raise install itself throws, the
original update error is surfaced unchanged. So this strictly expands
recovery; nothing previously diagnosable becomes more opaque.

## Canonical repro

`docs/package.json` has `pnpm.overrides.liquidjs: ">=10.22.0"`. The new
advisory needs `>=10.25.5`. The `>=10.22.0` ceiling matches `10.25.0`
(the vulnerable version) but pnpm's resolver gets wedged when an
intermediate dep's spec disagrees. With this PR the script:

1. tries `pnpm update liquidjs -r` → throws.
2. catches, sees stale override `>=10.22.0`, raises to `>=10.22.0 >=10.25.5`
   via `raiseOverrideSpec` from #2310.
3. reinstalls + verifies → expected to succeed.

If verify still fails, the original update error is surfaced and the
package is rolled back via `restoreRoot`.

## Validation

- `node --check` passes.
- No new public surface; the helper is internal to the planner closure.
- E2E validation will happen on the next scheduled run after merge.
