### PR TITLE
Fix instance storage usage by passing in baseDir to dispatcher creation

### DIFF
--- a/ts/packages/agentServer/server/src/conversationManager.ts
+++ b/ts/packages/agentServer/server/src/conversationManager.ts
@@ -266,6 +266,7 @@ export async function createConversationManager(
                     createSharedDispatcher(hostName, {
                         ...baseOptions,
                         persistDir,
+                        instanceDir: baseDir,
                         persistSession: true,
                     }),
                 )


### PR DESCRIPTION
Previously, the instanceDir was accidentally ommitted during dispatcher creation, so it would fallback to persistDir and save storage on a per-conversation basis instead of global.