### PR TITLE
fix(dep-alerts): use --no-frozen-lockfile when raising stale overrides

### DIFF
--- a/ts/tools/scripts/fix-dependabot-alerts.mjs
+++ b/ts/tools/scripts/fix-dependabot-alerts.mjs
@@ -2727,7 +2727,15 @@ async function executeResolutions(analyses) {
         addOverrides(new Map([[a.pkg, newSpec]]));
         let check;
         try {
-            await runCmdAsync("pnpm", ["install"], { timeout: 180000 });
+            // Use --no-frozen-lockfile because we just mutated
+            // pnpm.overrides; in CI (CI=true) pnpm install defaults to
+            // --frozen-lockfile and will refuse to proceed with
+            // ERR_PNPM_LOCKFILE_CONFIG_MISMATCH because the new override
+            // doesn't match what's recorded in pnpm-lock.yaml. Updating
+            // the lockfile is exactly the intent of the raise.
+            await runCmdAsync("pnpm", ["install", "--no-frozen-lockfile"], {
+                timeout: 180000,
+            });
             check = await verifyAllVersionsFixed(a.pkg, a.patched);
         } catch (e) {
             await restoreRoot(snap);


### PR DESCRIPTION
# fix(dep-alerts): use `--no-frozen-lockfile` when raising stale overrides

The override-raise install in `tryRaiseStaleOverride` mutates
`pnpm.overrides` immediately before `pnpm install`. In CI (`CI=true`)
pnpm defaults to `--frozen-lockfile` and refuses to proceed with
`ERR_PNPM_LOCKFILE_CONFIG_MISMATCH` because the new override doesn't
match the value baked into `pnpm-lock.yaml`. Updating the lockfile is
exactly the intent of the raise, so explicitly opt out of frozen mode.

## Where this came from

Workflow run [25583251721](https://github.com/microsoft/TypeAgent/actions/runs/25583251721)
(manual dispatch on main, after PR #2313 landed). The B11 change in
#2313 made `runCmdAsync` surface pnpm's stdout in failure messages,
which finally exposed the real reason liquidjs couldn't be auto-fixed:

```
✗ Override raise install failed for liquidjs: Command failed: pnpm install
ERR_PNPM_LOCKFILE_CONFIG_MISMATCH
Cannot proceed with the frozen installation. The current "overrides"
configuration doesn't match the value found in the lockfile
Update your lockfile using "pnpm install --no-frozen-lockfile"
```

The error literally tells us the fix; this PR applies it.

## Scope

Single one-line change in `tryRaiseStaleOverride`:

```diff
-await runCmdAsync("pnpm", ["install"], { timeout: 180000 });
+await runCmdAsync("pnpm", ["install", "--no-frozen-lockfile"], {
+    timeout: 180000,
+});
```

I deliberately didn't propagate `--no-frozen-lockfile` to the other
`pnpm install` callsites in this script — they run *after* `pnpm
update` (which already updates the lockfile), so frozen mode is the
correct behavior there (it would catch unexpected drift).

## Validation

- `node --check` passes.
- E2E will be observable on the next workflow run after merge: liquidjs
  should either fix successfully (override raised to `>=10.22.0
  >=10.25.5`) or surface a different actionable error rather than the
  frozen-lockfile rejection.
