### PR TITLE
test(dispatcher): widen selectFromPartitions wall-time threshold to 120ms

### DIFF
--- a/ts/packages/dispatcher/dispatcher/test/unknownSwitcher.spec.ts
+++ b/ts/packages/dispatcher/dispatcher/test/unknownSwitcher.spec.ts
@@ -151,7 +151,7 @@ describe("selectFromPartitions", () => {
         expect(spread).toBeLessThan(10);
 
         // Parallel: total time should be close to one delay (not 3×)
-        expect(elapsed).toBeLessThan(80);
+        expect(elapsed).toBeLessThan(120);
     });
 
     test("error from a partition is propagated in order", async () => {


### PR DESCRIPTION
# test(dispatcher): widen `selectFromPartitions` wall-time threshold to 120ms

The "all partitions run in parallel" test asserts `elapsed < 80ms` for
3 partitions × 20ms delays. PR #2296 (May 6) added per-partition
`AbortSignal` plumbing through `selectFromPartitions`, adding a few ms
of overhead per partition and pushing wall-time past 80ms on shared CI
runners.

## Evidence

| Date | Run | Wall-time |
|---|---|---|
| May 7 18:30 | [25514597765](https://github.com/microsoft/TypeAgent/actions/runs/25514597765) | 108ms |
| Today, merge queue | [25578868557](https://github.com/microsoft/TypeAgent/actions/runs/25578868557) | 86ms |
| Today, merge queue | [25580652506](https://github.com/microsoft/TypeAgent/actions/runs/25580652506) | 86ms |

PR #2296 merged **May 6**. Failures start **May 7**. Pre-#2296 runs
back weeks: all green. The 86ms reading repeating exactly across runs
suggests the new abort-plumbing overhead landed deterministically just
above the old threshold.

## Fix

Bump the assertion from `< 80ms` to `< 120ms`. That absorbs the
observed overhead (108ms worst case) with a small margin while keeping
the spread check and a meaningful upper bound — a serial-await
regression on these 20ms delays would still take ≥60ms minimum and
combined with the spread check this remains a useful guard.

```diff
-expect(elapsed).toBeLessThan(80);
+expect(elapsed).toBeLessThan(120);
```
