### PR TITLE
Add missing fluidBuild configs and use copyfiles in completionUI

### DIFF
--- a/ts/packages/agentServer/server/package.json
+++ b/ts/packages/agentServer/server/package.json
@@ -24,7 +24,7 @@
     "!dist/test"
   ],
   "scripts": {
-    "build": "npm run tsc && node -e \"require('fs').writeFileSync('dist/.build-stamp', new Date().toISOString())\"",
+    "build": "npm run tsc",
     "clean": "rimraf --glob dist *.tsbuildinfo *.done.build.log",
     "prettier": "prettier --check . --ignore-path ../../../.prettierignore",
     "prettier:fix": "prettier --write . --ignore-path ../../../.prettierignore",

--- a/ts/packages/agents/github-cli/package.json
+++ b/ts/packages/agents/github-cli/package.json
@@ -37,5 +37,35 @@
     "jest": "^29.7.0",
     "rimraf": "^6.0.1",
     "typescript": "~5.4.5"
+  },
+  "fluidBuild": {
+    "tasks": {
+      "agc": {
+        "dependsOn": [
+          "action-grammar-compiler#tsc"
+        ],
+        "files": {
+          "inputGlobs": [
+            "src/github-cliSchema.agr"
+          ],
+          "outputGlobs": [
+            "dist/github-cliSchema.ag.json"
+          ]
+        }
+      },
+      "asc": {
+        "dependsOn": [
+          "@typeagent/action-schema-compiler#tsc"
+        ],
+        "files": {
+          "inputGlobs": [
+            "src/github-cliSchema.ts"
+          ],
+          "outputGlobs": [
+            "dist/github-cliSchema.pas.json"
+          ]
+        }
+      }
+    }
   }
 }

--- a/ts/packages/agents/onboarding/package.json
+++ b/ts/packages/agents/onboarding/package.json
@@ -63,5 +63,217 @@
   },
   "engines": {
     "node": ">=20"
+  },
+  "fluidBuild": {
+    "tasks": {
+      "agc:main": {
+        "dependsOn": [
+          "action-grammar-compiler#tsc"
+        ],
+        "files": {
+          "inputGlobs": [
+            "src/onboardingSchema.agr"
+          ],
+          "outputGlobs": [
+            "dist/onboardingSchema.ag.json"
+          ]
+        }
+      },
+      "agc:discovery": {
+        "dependsOn": [
+          "action-grammar-compiler#tsc"
+        ],
+        "files": {
+          "inputGlobs": [
+            "src/discovery/discoverySchema.agr"
+          ],
+          "outputGlobs": [
+            "dist/discoverySchema.ag.json"
+          ]
+        }
+      },
+      "agc:grammargen": {
+        "dependsOn": [
+          "action-grammar-compiler#tsc"
+        ],
+        "files": {
+          "inputGlobs": [
+            "src/grammarGen/grammarGenSchema.agr"
+          ],
+          "outputGlobs": [
+            "dist/grammarGenSchema.ag.json"
+          ]
+        }
+      },
+      "agc:packaging": {
+        "dependsOn": [
+          "action-grammar-compiler#tsc"
+        ],
+        "files": {
+          "inputGlobs": [
+            "src/packaging/packagingSchema.agr"
+          ],
+          "outputGlobs": [
+            "dist/packagingSchema.ag.json"
+          ]
+        }
+      },
+      "agc:phrasegen": {
+        "dependsOn": [
+          "action-grammar-compiler#tsc"
+        ],
+        "files": {
+          "inputGlobs": [
+            "src/phraseGen/phraseGenSchema.agr"
+          ],
+          "outputGlobs": [
+            "dist/phraseGenSchema.ag.json"
+          ]
+        }
+      },
+      "agc:scaffolder": {
+        "dependsOn": [
+          "action-grammar-compiler#tsc"
+        ],
+        "files": {
+          "inputGlobs": [
+            "src/scaffolder/scaffolderSchema.agr"
+          ],
+          "outputGlobs": [
+            "dist/scaffolderSchema.ag.json"
+          ]
+        }
+      },
+      "agc:schemagen": {
+        "dependsOn": [
+          "action-grammar-compiler#tsc"
+        ],
+        "files": {
+          "inputGlobs": [
+            "src/schemaGen/schemaGenSchema.agr"
+          ],
+          "outputGlobs": [
+            "dist/schemaGenSchema.ag.json"
+          ]
+        }
+      },
+      "agc:testing": {
+        "dependsOn": [
+          "action-grammar-compiler#tsc"
+        ],
+        "files": {
+          "inputGlobs": [
+            "src/testing/testingSchema.agr"
+          ],
+          "outputGlobs": [
+            "dist/testingSchema.ag.json"
+          ]
+        }
+      },
+      "asc:main": {
+        "dependsOn": [
+          "@typeagent/action-schema-compiler#tsc"
+        ],
+        "files": {
+          "inputGlobs": [
+            "src/onboardingSchema.ts"
+          ],
+          "outputGlobs": [
+            "dist/onboardingSchema.pas.json"
+          ]
+        }
+      },
+      "asc:discovery": {
+        "dependsOn": [
+          "@typeagent/action-schema-compiler#tsc"
+        ],
+        "files": {
+          "inputGlobs": [
+            "src/discovery/discoverySchema.ts"
+          ],
+          "outputGlobs": [
+            "dist/discoverySchema.pas.json"
+          ]
+        }
+      },
+      "asc:grammargen": {
+        "dependsOn": [
+          "@typeagent/action-schema-compiler#tsc"
+        ],
+        "files": {
+          "inputGlobs": [
+            "src/grammarGen/grammarGenSchema.ts"
+          ],
+          "outputGlobs": [
+            "dist/grammarGenSchema.pas.json"
+          ]
+        }
+      },
+      "asc:packaging": {
+        "dependsOn": [
+          "@typeagent/action-schema-compiler#tsc"
+        ],
+        "files": {
+          "inputGlobs": [
+            "src/packaging/packagingSchema.ts"
+          ],
+          "outputGlobs": [
+            "dist/packagingSchema.pas.json"
+          ]
+        }
+      },
+      "asc:phrasegen": {
+        "dependsOn": [
+          "@typeagent/action-schema-compiler#tsc"
+        ],
+        "files": {
+          "inputGlobs": [
+            "src/phraseGen/phraseGenSchema.ts"
+          ],
+          "outputGlobs": [
+            "dist/phraseGenSchema.pas.json"
+          ]
+        }
+      },
+      "asc:scaffolder": {
+        "dependsOn": [
+          "@typeagent/action-schema-compiler#tsc"
+        ],
+        "files": {
+          "inputGlobs": [
+            "src/scaffolder/scaffolderSchema.ts"
+          ],
+          "outputGlobs": [
+            "dist/scaffolderSchema.pas.json"
+          ]
+        }
+      },
+      "asc:schemagen": {
+        "dependsOn": [
+          "@typeagent/action-schema-compiler#tsc"
+        ],
+        "files": {
+          "inputGlobs": [
+            "src/schemaGen/schemaGenSchema.ts"
+          ],
+          "outputGlobs": [
+            "dist/schemaGenSchema.pas.json"
+          ]
+        }
+      },
+      "asc:testing": {
+        "dependsOn": [
+          "@typeagent/action-schema-compiler#tsc"
+        ],
+        "files": {
+          "inputGlobs": [
+            "src/testing/testingSchema.ts"
+          ],
+          "outputGlobs": [
+            "dist/testingSchema.pas.json"
+          ]
+        }
+      }
+    }
   }
 }

--- a/ts/packages/agents/osNotifications/package.json
+++ b/ts/packages/agents/osNotifications/package.json
@@ -46,5 +46,35 @@
   },
   "engines": {
     "node": ">=20"
+  },
+  "fluidBuild": {
+    "tasks": {
+      "agc": {
+        "dependsOn": [
+          "action-grammar-compiler#tsc"
+        ],
+        "files": {
+          "inputGlobs": [
+            "src/osNotificationsSchema.agr"
+          ],
+          "outputGlobs": [
+            "dist/osNotificationsSchema.ag.json"
+          ]
+        }
+      },
+      "asc": {
+        "dependsOn": [
+          "@typeagent/action-schema-compiler#tsc"
+        ],
+        "files": {
+          "inputGlobs": [
+            "src/osNotificationsSchema.ts"
+          ],
+          "outputGlobs": [
+            "dist/osNotificationsSchema.pas.json"
+          ]
+        }
+      }
+    }
   }
 }

--- a/ts/packages/agents/visualStudio/package.json
+++ b/ts/packages/agents/visualStudio/package.json
@@ -34,5 +34,35 @@
     "concurrently": "^9.1.2",
     "rimraf": "^6.0.1",
     "typescript": "~5.4.5"
+  },
+  "fluidBuild": {
+    "tasks": {
+      "agc": {
+        "dependsOn": [
+          "action-grammar-compiler#tsc"
+        ],
+        "files": {
+          "inputGlobs": [
+            "src/visualStudioSchema.agr"
+          ],
+          "outputGlobs": [
+            "dist/visualStudioSchema.ag.json"
+          ]
+        }
+      },
+      "asc": {
+        "dependsOn": [
+          "@typeagent/action-schema-compiler#tsc"
+        ],
+        "files": {
+          "inputGlobs": [
+            "src/visualStudioSchema.ts"
+          ],
+          "outputGlobs": [
+            "dist/visualStudioSchema.pas.json"
+          ]
+        }
+      }
+    }
   }
 }

--- a/ts/packages/agents/windowsClock/package.json
+++ b/ts/packages/agents/windowsClock/package.json
@@ -34,5 +34,22 @@
   },
   "engines": {
     "node": ">=20"
+  },
+  "fluidBuild": {
+    "tasks": {
+      "asc:main": {
+        "dependsOn": [
+          "@typeagent/action-schema-compiler#tsc"
+        ],
+        "files": {
+          "inputGlobs": [
+            "src/windowsClockSchema.ts"
+          ],
+          "outputGlobs": [
+            "dist/windowsClockSchema.pas.json"
+          ]
+        }
+      }
+    }
   }
 }

--- a/ts/packages/completionUI/package.json
+++ b/ts/packages/completionUI/package.json
@@ -21,13 +21,14 @@
   "scripts": {
     "build": "npm run tsc && npm run copy:css",
     "clean": "rimraf --glob dist *.tsbuildinfo *.done.build.log",
-    "copy:css": "node -e \"require('fs').mkdirSync('dist',{recursive:true});require('fs').copyFileSync('src/styles.css','dist/styles.css')\"",
+    "copy:css": "copyfiles -u 1 \"src/styles.css\" dist",
     "prettier": "prettier --check . --ignore-path ../../.prettierignore",
     "prettier:fix": "prettier --write . --ignore-path ../../.prettierignore",
     "tsc": "tsc -b"
   },
   "dependencies": {},
   "devDependencies": {
+    "copyfiles": "^2.4.1",
     "prettier": "^3.5.3",
     "rimraf": "^6.0.1",
     "typescript": "~5.4.5"

--- a/ts/packages/mcp/thoughts/package.json
+++ b/ts/packages/mcp/thoughts/package.json
@@ -43,6 +43,6 @@
   "devDependencies": {
     "@types/node": "^20.11.19",
     "rimraf": "^6.0.1",
-    "typescript": "^5.5.4"
+    "typescript": "~5.4.5"
   }
 }

--- a/ts/packages/security/mcpValidation/package.json
+++ b/ts/packages/security/mcpValidation/package.json
@@ -65,6 +65,6 @@
     "@types/node": "^20.11.19",
     "rimraf": "^6.0.1",
     "tsx": "^4.21.0",
-    "typescript": "^5.5.4"
+    "typescript": "~5.4.5"
   }
 }

--- a/ts/packages/security/validation/package.json
+++ b/ts/packages/security/validation/package.json
@@ -29,6 +29,6 @@
   "devDependencies": {
     "@types/node": "^20.11.19",
     "rimraf": "^6.0.1",
-    "typescript": "^5.5.4"
+    "typescript": "~5.4.5"
   }
 }

--- a/ts/pnpm-lock.yaml
+++ b/ts/pnpm-lock.yaml
@@ -3671,6 +3671,9 @@ importers:
 
   packages/completionUI:
     devDependencies:
+      copyfiles:
+        specifier: ^2.4.1
+        version: 2.4.1
       prettier:
         specifier: ^3.5.3
         version: 3.5.3
@@ -4455,8 +4458,8 @@ importers:
         specifier: ^6.0.1
         version: 6.0.1
       typescript:
-        specifier: ^5.5.4
-        version: 5.9.3
+        specifier: ~5.4.5
+        version: 5.4.5
 
   packages/memory/conversation:
     dependencies:
@@ -4800,8 +4803,8 @@ importers:
         specifier: ^4.21.0
         version: 4.21.0
       typescript:
-        specifier: ^5.5.4
-        version: 5.9.3
+        specifier: ~5.4.5
+        version: 5.4.5
 
   packages/security/validation:
     dependencies:
@@ -4816,8 +4819,8 @@ importers:
         specifier: ^6.0.1
         version: 6.0.1
       typescript:
-        specifier: ^5.5.4
-        version: 5.9.3
+        specifier: ~5.4.5
+        version: 5.4.5
 
   packages/shell:
     dependencies:
@@ -12886,9 +12889,6 @@ packages:
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
-  nan@2.26.2:
-    resolution: {integrity: sha512-0tTvBTYkt3tdGw22nrAy50x7gpbGCCFH3AFcyS5WiUu7Eu4vWlri1woE6qHBSfy11vksDqkiwjOnlR7WV8G1Hw==}
-
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
@@ -14833,11 +14833,6 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  typescript@5.9.3:
-    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
-    engines: {node: '>=14.17'}
-    hasBin: true
-
   typical@4.0.0:
     resolution: {integrity: sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw==}
     engines: {node: '>=8'}
@@ -14980,9 +14975,6 @@ packages:
   user-home@2.0.0:
     resolution: {integrity: sha512-KMWqdlOcjCYdtIJpicDSFBQ8nFwS2i9sslAd6f4+CBGcU4gist2REnr2fxj2YocvJFxSF3ZOHLYLVZnUxv4BZQ==}
     engines: {node: '>=0.10.0'}
-
-  usocket@0.3.0:
-    resolution: {integrity: sha512-V/H02RNiaOCJZuPoKont/y12VJaImC6C5xW7OzPFjYu9qnig0yv9hyp9E7Wqjm6d8yZuZouH3NAfDATVMgh2SQ==}
 
   utf8-byte-length@1.0.4:
     resolution: {integrity: sha512-4+wkEYLBbWxqTahEsWrhxepcoVOJ+1z5PGIjPZxRkytcdSUaNjIjBM7Xn8E+pdSuV7SzvWovBFA54FO0JSoqhA==}
@@ -22230,10 +22222,7 @@ snapshots:
       jsbi: 2.0.5
       long: 4.0.0
       safe-buffer: 5.2.1
-      usocket: 0.3.0
       xml2js: 0.4.23
-    transitivePeerDependencies:
-      - supports-color
 
   debug@2.6.9:
     dependencies:
@@ -25923,8 +25912,6 @@ snapshots:
       object-assign: 4.1.1
       thenify-all: 1.6.0
 
-  nan@2.26.2: {}
-
   nanoid@3.3.11: {}
 
   nanoid@5.1.5: {}
@@ -28309,8 +28296,6 @@ snapshots:
 
   typescript@5.4.5: {}
 
-  typescript@5.9.3: {}
-
   typical@4.0.0: {}
 
   typical@7.3.0: {}
@@ -28446,14 +28431,6 @@ snapshots:
   user-home@2.0.0:
     dependencies:
       os-homedir: 1.0.2
-
-  usocket@0.3.0:
-    dependencies:
-      bindings: 1.5.0
-      nan: 2.26.2
-      node-gyp: 12.2.0
-    transitivePeerDependencies:
-      - supports-color
 
   utf8-byte-length@1.0.4: {}
 


### PR DESCRIPTION
## Summary

Incremental build improvements:

- **Add missing `fluidBuild` task configs** for `agc`/`asc` in five agent packages that were missing them:
  - `github-cli`
  - `osNotifications`
  - `visualStudio`
  - `onboarding` (8 agc + 8 asc variant tasks)
  - `windowsClock` (asc:main only)

- **Replace inline `node -e` script** with `copyfiles` in `completionUI` for CSS copying

- **Remove build-stamp** from `agentServer/server` build script