### PR TITLE
feat(grammar-tools): cross-file import support for AGR language server

### DIFF
--- a/ts/extensions/agr-language/src/debugPanel.ts
+++ b/ts/extensions/agr-language/src/debugPanel.ts
@@ -262,6 +262,9 @@ class DebugPanelInstance implements Disposable {
                       partRules: [
                           ...result.grammar.debugInfo.partRules.entries(),
                       ],
+                      filePaths: [
+                          ...result.grammar.debugInfo.filePaths.entries(),
+                      ],
                   }
                 : undefined,
             files: result.grammar.files,

--- a/ts/extensions/agr-language/src/server.ts
+++ b/ts/extensions/agr-language/src/server.ts
@@ -21,6 +21,9 @@ import {
     Position,
 } from "vscode-languageserver/node.js";
 import { TextDocument } from "vscode-languageserver-textdocument";
+import * as path from "node:path";
+import * as fs from "node:fs";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import {
     loadGrammarFromBuffer,
     getSymbolIndex,
@@ -29,6 +32,7 @@ import {
     type LoadResult,
     type SymbolIndex,
     type Diagnostic,
+    type FileLoader,
 } from "grammar-tools-core";
 
 // ---------------------------------------------------------------------------
@@ -67,8 +71,31 @@ function validateDocument(doc: TextDocument): void {
     const text = doc.getText();
     const uri = doc.uri;
 
+    // Build a FileLoader if the document is on disk, so imports resolve.
+    // The loader intercepts reads for the current file to use the
+    // in-memory buffer (which may differ from disk).
+    let fileLoader: FileLoader | undefined;
+    let id: string;
+    if (uri.startsWith("file://")) {
+        const filePath = fileURLToPath(uri);
+        id = filePath;
+        fileLoader = {
+            resolvePath: (name: string, ref?: string) =>
+                ref
+                    ? path.resolve(path.dirname(ref), name)
+                    : path.resolve(path.dirname(filePath), name),
+            readContent: (fullPath: string) => {
+                if (fullPath === filePath) return text;
+                return fs.readFileSync(fullPath, "utf-8");
+            },
+            displayPath: (fullPath: string) => fullPath,
+        };
+    } else {
+        id = uriToId(uri);
+    }
+
     // Parse and cache
-    const result = loadGrammarFromBuffer(uriToId(uri), text);
+    const result = loadGrammarFromBuffer(id, text, fileLoader);
     grammarCache.set(uri, result);
     symbolCache.delete(uri); // invalidate
 
@@ -116,7 +143,7 @@ connection.onDefinition((params: DefinitionParams) => {
 
     const word = symbolAtPosition(
         index,
-        uriToId(params.textDocument.uri),
+        getFileId(params.textDocument.uri),
         params.position.line,
         params.position.character,
     );
@@ -146,7 +173,7 @@ connection.onReferences((params: ReferenceParams) => {
 
     const word = symbolAtPosition(
         index,
-        uriToId(params.textDocument.uri),
+        getFileId(params.textDocument.uri),
         params.position.line,
         params.position.character,
     );
@@ -194,7 +221,7 @@ connection.onHover((params: HoverParams) => {
 
     const word = symbolAtPosition(
         index,
-        uriToId(params.textDocument.uri),
+        getFileId(params.textDocument.uri),
         params.position.line,
         params.position.character,
     );
@@ -285,6 +312,18 @@ function getIndex(uri: string): SymbolIndex | null {
     return index;
 }
 
+/**
+ * Return the file ID used for symbol lookups in the current document.
+ * For file:// URIs with a FileLoader, this is the absolute path (matching
+ * the root SourceFile.id). Otherwise, just the filename.
+ */
+function getFileId(uri: string): string {
+    if (uri.startsWith("file://")) {
+        return fileURLToPath(uri);
+    }
+    return uriToId(uri);
+}
+
 function uriToId(uri: string): string {
     // Extract filename from URI for use as grammar ID
     const lastSlash = uri.lastIndexOf("/");
@@ -292,7 +331,15 @@ function uriToId(uri: string): string {
 }
 
 function fileIdToUri(fileId: string, contextUri: string): string {
-    // If fileId matches the filename part of contextUri, return contextUri
+    // Try to resolve via debugInfo.filePaths first
+    const result = grammarCache.get(contextUri);
+    if (result?.ok && result.grammar.debugInfo?.filePaths) {
+        const resolvedPath = result.grammar.debugInfo.filePaths.get(fileId);
+        if (resolvedPath) {
+            return pathToFileURL(resolvedPath).toString();
+        }
+    }
+    // Fallback: if fileId matches the filename part of contextUri, return contextUri
     const contextFile = uriToId(contextUri);
     if (fileId === contextFile) return contextUri;
     // Resolve relative to the context URI, encoding the fileId for URI safety

--- a/ts/extensions/agr-language/webview/webviewBackend.ts
+++ b/ts/extensions/agr-language/webview/webviewBackend.ts
@@ -57,6 +57,7 @@ export interface SerializedLoadResult {
         rules: Array<[RuleId, SourceLocation]>;
         parts: Array<[PartId, SourceLocation]>;
         partRules: Array<[PartId, RuleId]>;
+        filePaths?: Array<[string, string]>;
     };
     files?: readonly SourceFile[];
     source: GrammarSource;
@@ -106,6 +107,7 @@ export function hydrateLoadResult(raw: SerializedLoadResult): LoadResult {
               rules: new Map(raw.debugInfo.rules),
               parts: new Map(raw.debugInfo.parts),
               partRules: new Map(raw.debugInfo.partRules),
+              filePaths: new Map(raw.debugInfo.filePaths ?? []),
           }
         : undefined;
 

--- a/ts/packages/actionGrammar/src/grammarCompiler.ts
+++ b/ts/packages/actionGrammar/src/grammarCompiler.ts
@@ -71,6 +71,8 @@ export type DebugInfoCollector = {
     partRules: Map<number, string>;
     /** Source texts keyed by fileId (displayPath), for offset-to-line conversion. */
     fileContents: Map<string, string>;
+    /** Maps fileId (displayPath) -> resolved absolute path on disk. */
+    filePaths: Map<string, string>;
 };
 
 /**
@@ -490,8 +492,9 @@ export function compileGrammar(
 
     // Register all file contents so buildDebugInfo can resolve per-file offsets.
     if (debugCollector !== undefined) {
-        for (const [, ctx] of grammarFileMap) {
+        for (const [fullPath, ctx] of grammarFileMap) {
             debugCollector.fileContents.set(ctx.displayPath, ctx.content);
+            debugCollector.filePaths.set(ctx.displayPath, fullPath);
         }
     }
 

--- a/ts/packages/actionGrammar/test/partId.spec.ts
+++ b/ts/packages/actionGrammar/test/partId.spec.ts
@@ -3,6 +3,7 @@
 
 import { loadGrammarRules } from "../src/grammarLoader.js";
 import type { DebugInfoCollector } from "../src/grammarCompiler.js";
+import { defaultFileLoader } from "../src/defaultFileLoader.js";
 import { matchGrammar } from "../src/grammarMatcher.js";
 import { grammarToJson } from "../src/grammarSerializer.js";
 import { grammarFromJson } from "../src/grammarDeserializer.js";
@@ -14,6 +15,7 @@ function makeCollector(): DebugInfoCollector {
         rulePositions: new Map(),
         partRules: new Map(),
         fileContents: new Map(),
+        filePaths: new Map(),
     };
 }
 
@@ -133,6 +135,62 @@ describe("partId in trace events", () => {
             if ("part" in e) {
                 expect(validPartIds.has(e.part)).toBe(true);
             }
+        }
+    });
+});
+
+describe("filePaths in DebugInfoCollector", () => {
+    function getTestFileLoader(grammarFiles: Record<string, string>) {
+        const fileMap = new Map(
+            Object.keys(grammarFiles).map((key) => [
+                defaultFileLoader.resolvePath(key),
+                key,
+            ]),
+        );
+        return {
+            ...defaultFileLoader,
+            readContent: (fullPath: string) => {
+                const fileKey = fileMap.get(fullPath);
+                const content = fileKey ? grammarFiles[fileKey] : undefined;
+                if (content === undefined) {
+                    throw new Error(`File not found: ${fullPath}`);
+                }
+                return content;
+            },
+        };
+    }
+
+    it("records filePaths for single-file grammar", () => {
+        const source = `<Start> = hello -> true;`;
+        const collector = makeCollector();
+        loadGrammarRules("test.agr", source, { debugCollector: collector });
+
+        // fileContents should have the source
+        expect(collector.fileContents.size).toBeGreaterThan(0);
+    });
+
+    it("records filePaths for multi-file grammar with imports", () => {
+        const grammarFiles: Record<string, string> = {
+            "helper.agr": `export <Greeting> = (hello | hi) -> "greeting";`,
+            "main.agr": `
+                import { Greeting } from "./helper.agr";
+                <Start> = $(g:<Greeting>) world -> { g, target: "world" };
+            `,
+        };
+
+        const collector = makeCollector();
+        const loader = getTestFileLoader(grammarFiles);
+        loadGrammarRules("main.agr", loader, { debugCollector: collector });
+
+        // Both files should appear in fileContents
+        expect(collector.fileContents.size).toBeGreaterThanOrEqual(2);
+
+        // filePaths should map displayPath -> resolved full path for each file
+        expect(collector.filePaths.size).toBeGreaterThanOrEqual(2);
+
+        // Each filePaths key should also exist in fileContents
+        for (const displayPath of collector.filePaths.keys()) {
+            expect(collector.fileContents.has(displayPath)).toBe(true);
         }
     });
 });

--- a/ts/packages/grammarTools/core/src/index.ts
+++ b/ts/packages/grammarTools/core/src/index.ts
@@ -74,6 +74,7 @@ export {
 
 // Services
 export { loadGrammarFromFile, loadGrammarFromBuffer } from "./loader.js";
+export type { FileLoader } from "action-grammar";
 export {
     getSymbolIndex,
     offsetToPosition,

--- a/ts/packages/grammarTools/core/src/loader.ts
+++ b/ts/packages/grammarTools/core/src/loader.ts
@@ -54,8 +54,21 @@ export async function loadGrammarFromFile(
 
 /**
  * Load a grammar from an in-memory text buffer.
+ * If a `fileLoader` is provided, `import ... from "./other.agr"` statements
+ * in the buffer will be resolved via the loader.  The `id` is used as the
+ * file identity for import path resolution.
  */
-export function loadGrammarFromBuffer(id: string, text: string): LoadResult {
+export function loadGrammarFromBuffer(
+    id: string,
+    text: string,
+    fileLoader?: FileLoader,
+): LoadResult {
+    if (fileLoader) {
+        return loadFromFileLoader(id, text, id, fileLoader, {
+            kind: "buffer",
+            id,
+        });
+    }
     return loadFromText(text, { kind: "buffer", id });
 }
 
@@ -90,6 +103,7 @@ function makeCollector(fileId: string, text: string): DebugInfoCollector {
         rulePositions: new Map(),
         partRules: new Map(),
         fileContents: new Map([[fileId, text]]),
+        filePaths: new Map(),
     };
 }
 
@@ -105,11 +119,21 @@ function buildLoadResult(
     if (grammar && errors.length === 0) {
         const identifiers = buildIdentifierIndex(grammar);
         const debugInfo = buildDebugInfo(collector);
+
+        // Build file list: root file + any imported files from the collector
+        const rootId = file.id;
+        const files: SourceFile[] = [file];
+        for (const [fileId, fileText] of collector.fileContents) {
+            if (fileId !== rootId) {
+                files.push({ id: fileId, text: fileText, imported: true });
+            }
+        }
+
         const loaded: LoadedGrammar = {
             source,
             grammar,
             debugInfo,
-            files: [file],
+            files,
             identifiers,
         };
         const diagnostics: Diagnostic[] | undefined =
@@ -344,5 +368,11 @@ function buildDebugInfo(collector: DebugInfoCollector): GrammarDebugInfo {
     );
     const grammarHash = `${totalLen}:${fileKeys}:${collector.partPositions.size}:${collector.rulePositions.size}`;
 
-    return { grammarHash, rules, parts, partRules: collector.partRules };
+    return {
+        grammarHash,
+        rules,
+        parts,
+        partRules: collector.partRules,
+        filePaths: collector.filePaths,
+    };
 }

--- a/ts/packages/grammarTools/core/src/types.ts
+++ b/ts/packages/grammarTools/core/src/types.ts
@@ -56,6 +56,7 @@ export interface SourceFile {
     readonly id: string;
     readonly text: string;
     readonly synthetic?: boolean;
+    readonly imported?: boolean;
 }
 
 export interface GrammarDebugInfo {
@@ -64,6 +65,8 @@ export interface GrammarDebugInfo {
     readonly parts: ReadonlyMap<PartId, SourceLocation>;
     /** Maps partId -> owning ruleId (recorded at compile time). */
     readonly partRules: ReadonlyMap<PartId, RuleId>;
+    /** Maps fileId (displayPath) -> resolved absolute path on disk. */
+    readonly filePaths: ReadonlyMap<string, string>;
 }
 
 export interface GrammarIdentifierIndex {

--- a/ts/packages/grammarTools/core/test/loader.spec.ts
+++ b/ts/packages/grammarTools/core/test/loader.spec.ts
@@ -1,7 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { loadGrammarFromBuffer, loadGrammarFromFile } from "../src/index.js";
+import {
+    loadGrammarFromBuffer,
+    loadGrammarFromFile,
+    type FileLoader,
+} from "../src/index.js";
+import { defaultFileLoader } from "action-grammar";
 
 describe("loader", () => {
     it("loads a simple grammar from a buffer", () => {
@@ -188,5 +193,86 @@ describe("loader", () => {
         expect(() => loadGrammarFromSnapshot({ grammar: {} })).toThrow(
             /not yet implemented/,
         );
+    });
+});
+
+describe("loadGrammarFromBuffer with FileLoader (imports)", () => {
+    function getTestFileLoader(
+        grammarFiles: Record<string, string>,
+    ): FileLoader {
+        const fileMap = new Map(
+            Object.keys(grammarFiles).map((key) => [
+                defaultFileLoader.resolvePath(key),
+                key,
+            ]),
+        );
+        return {
+            ...defaultFileLoader,
+            readContent: (fullPath: string) => {
+                const fileKey = fileMap.get(fullPath);
+                const content = fileKey ? grammarFiles[fileKey] : undefined;
+                if (content === undefined) {
+                    throw new Error(`File not found: ${fullPath}`);
+                }
+                return content;
+            },
+        };
+    }
+
+    const helperSource = `export <Greeting> = (hello | hi) -> "greeting";`;
+    const mainSource = `
+        import { Greeting } from "./helper.agr";
+        <Start> = $(g:<Greeting>) world -> { g, target: "world" };
+    `;
+
+    it("resolves imports when FileLoader is provided", () => {
+        const loader = getTestFileLoader({
+            "main.agr": mainSource,
+            "helper.agr": helperSource,
+        });
+        const result = loadGrammarFromBuffer("main.agr", mainSource, loader);
+        expect(result.ok).toBe(true);
+    });
+
+    it("includes imported files in LoadedGrammar.files", () => {
+        const loader = getTestFileLoader({
+            "main.agr": mainSource,
+            "helper.agr": helperSource,
+        });
+        const result = loadGrammarFromBuffer("main.agr", mainSource, loader);
+        expect(result.ok).toBe(true);
+        if (!result.ok) return;
+
+        const files = result.grammar.files!;
+        expect(files.length).toBeGreaterThanOrEqual(2);
+
+        // Root file should not be marked as imported
+        const root = files.find((f) => !f.imported);
+        expect(root).toBeDefined();
+
+        // Imported file should be marked as imported
+        const imported = files.filter((f) => f.imported);
+        expect(imported.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it("populates debugInfo.filePaths for multi-file grammars", () => {
+        const loader = getTestFileLoader({
+            "main.agr": mainSource,
+            "helper.agr": helperSource,
+        });
+        const result = loadGrammarFromBuffer("main.agr", mainSource, loader);
+        expect(result.ok).toBe(true);
+        if (!result.ok) return;
+
+        const dbg = result.grammar.debugInfo;
+        expect(dbg).toBeDefined();
+        expect(dbg!.filePaths.size).toBeGreaterThanOrEqual(2);
+    });
+
+    it("fails gracefully without FileLoader (no import resolution)", () => {
+        // Without a FileLoader, imports cannot be resolved; the grammar
+        // still loads but the imported rules are unresolved (error).
+        const result = loadGrammarFromBuffer("main.agr", mainSource);
+        expect(result.ok).toBe(false);
     });
 });

--- a/ts/packages/grammarTools/core/test/symbols.spec.ts
+++ b/ts/packages/grammarTools/core/test/symbols.spec.ts
@@ -1,7 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { loadGrammarFromBuffer, getSymbolIndex } from "../src/index.js";
+import {
+    loadGrammarFromBuffer,
+    getSymbolIndex,
+    symbolAtPosition,
+    type FileLoader,
+} from "../src/index.js";
+import { defaultFileLoader } from "action-grammar";
 
 describe("symbols", () => {
     const source = [
@@ -56,5 +62,138 @@ describe("symbols", () => {
         expect(song).toBeDefined();
         expect(song!.location.fileId).toBe("test.agr");
         expect(song!.location.range.start.line).toBe(2); // third line, 0-based
+    });
+});
+
+describe("symbolAtPosition", () => {
+    const source = [
+        '<Start> = play $(song:<Song>) -> { action: "play", song };',
+        "<Song> = $(name:string);",
+    ].join("\n");
+
+    it("returns rule ID when cursor is on a definition", () => {
+        const result = loadGrammarFromBuffer("test.agr", source);
+        expect(result.ok).toBe(true);
+        if (!result.ok) return;
+
+        const index = getSymbolIndex(result.grammar);
+        // <Start> definition is at line 0, starting at character 0
+        const id = symbolAtPosition(index, "test.agr", 0, 1);
+        expect(id).toBe("Start");
+    });
+
+    it("returns rule ID when cursor is on a reference", () => {
+        const result = loadGrammarFromBuffer("test.agr", source);
+        expect(result.ok).toBe(true);
+        if (!result.ok) return;
+
+        const index = getSymbolIndex(result.grammar);
+        // <Song> reference is inside $(song:<Song>) on line 0
+        // Find where the reference actually is by checking refs
+        const refs = index.references("Song");
+        expect(refs.length).toBeGreaterThan(0);
+        const ref = refs[0];
+        const id = symbolAtPosition(
+            index,
+            ref.fileId,
+            ref.range.start.line,
+            ref.range.start.character + 1,
+        );
+        expect(id).toBe("Song");
+    });
+
+    it("returns null when cursor is not on a symbol", () => {
+        const result = loadGrammarFromBuffer("test.agr", source);
+        expect(result.ok).toBe(true);
+        if (!result.ok) return;
+
+        const index = getSymbolIndex(result.grammar);
+        // Line 1 far past the end of content
+        const id = symbolAtPosition(index, "test.agr", 1, 50);
+        expect(id).toBeNull();
+    });
+
+    it("returns null for non-existent file", () => {
+        const result = loadGrammarFromBuffer("test.agr", source);
+        expect(result.ok).toBe(true);
+        if (!result.ok) return;
+
+        const index = getSymbolIndex(result.grammar);
+        const id = symbolAtPosition(index, "other.agr", 0, 1);
+        expect(id).toBeNull();
+    });
+});
+
+describe("cross-file symbols", () => {
+    function getTestFileLoader(
+        grammarFiles: Record<string, string>,
+    ): FileLoader {
+        const fileMap = new Map(
+            Object.keys(grammarFiles).map((key) => [
+                defaultFileLoader.resolvePath(key),
+                key,
+            ]),
+        );
+        return {
+            ...defaultFileLoader,
+            readContent: (fullPath: string) => {
+                const fileKey = fileMap.get(fullPath);
+                const content = fileKey ? grammarFiles[fileKey] : undefined;
+                if (content === undefined) {
+                    throw new Error(`File not found: ${fullPath}`);
+                }
+                return content;
+            },
+        };
+    }
+
+    const helperSource = `export <Greeting> = (hello | hi) -> "greeting";`;
+    const mainSource = `import { Greeting } from "./helper.agr";\n<Start> = <Greeting> world -> true;`;
+
+    it("indexes definitions from imported files", () => {
+        const loader = getTestFileLoader({
+            "main.agr": mainSource,
+            "helper.agr": helperSource,
+        });
+        const result = loadGrammarFromBuffer("main.agr", mainSource, loader);
+        expect(result.ok).toBe(true);
+        if (!result.ok) return;
+
+        const index = getSymbolIndex(result.grammar);
+        expect(index.byId.has("Start")).toBe(true);
+        expect(index.byId.has("Greeting")).toBe(true);
+    });
+
+    it("imported definition has correct fileId", () => {
+        const loader = getTestFileLoader({
+            "main.agr": mainSource,
+            "helper.agr": helperSource,
+        });
+        const result = loadGrammarFromBuffer("main.agr", mainSource, loader);
+        expect(result.ok).toBe(true);
+        if (!result.ok) return;
+
+        const index = getSymbolIndex(result.grammar);
+        const greeting = index.byId.get("Greeting");
+        expect(greeting).toBeDefined();
+        // The imported rule's fileId should differ from the main file
+        const start = index.byId.get("Start");
+        expect(start).toBeDefined();
+        expect(greeting!.location.fileId).not.toBe(start!.location.fileId);
+    });
+
+    it("collects cross-file references", () => {
+        const loader = getTestFileLoader({
+            "main.agr": mainSource,
+            "helper.agr": helperSource,
+        });
+        const result = loadGrammarFromBuffer("main.agr", mainSource, loader);
+        expect(result.ok).toBe(true);
+        if (!result.ok) return;
+
+        const index = getSymbolIndex(result.grammar);
+        const refs = index.references("Greeting");
+        // <Greeting> is referenced in main.agr (import + rule body)
+        expect(refs.length).toBeGreaterThan(0);
     });
 });

--- a/ts/packages/grammarTools/ui/src/fixture/fixtureBackend.ts
+++ b/ts/packages/grammarTools/ui/src/fixture/fixtureBackend.ts
@@ -136,6 +136,7 @@ const fixtureGrammar: LoadedGrammar = {
         ]),
         parts: new Map(),
         partRules: new Map(),
+        filePaths: new Map(),
     },
     files: [
         {


### PR DESCRIPTION
Add cross-file import support to the AGR language server so that go-to-definition, find-references, and hover work across `.agr` file imports.

## Changes

### Core (`action-grammar`, `grammar-tools-core`)
- Add `filePaths: Map<string, string>` to `DebugInfoCollector` - maps display paths to resolved absolute paths
- Add `filePaths` to `GrammarDebugInfo` type
- Propagate all imported files (with `imported: true` flag) through `LoadedGrammar.files`
- Support optional `FileLoader` parameter in `loadGrammarFromBuffer` for resolving imports

### Language Server (`agr-language`)
- Use absolute file paths as file IDs (via `fileURLToPath`)
- Create a `FileLoader` that intercepts the current document buffer while loading imports from disk
- Resolve cross-file references using `debugInfo.filePaths` for URI mapping

### Tests
- `partId.spec.ts`: tests for `filePaths` population in single and multi-file grammars
- `loader.spec.ts`: tests for `loadGrammarFromBuffer` with `FileLoader`
- `symbols.spec.ts`: tests for `symbolAtPosition` and cross-file symbol resolution