### PR TITLE
fix(ts): avoid pnpm workspace bin link warnings before build

### DIFF
--- a/docs/content/setup/setup-WSL2.md
+++ b/docs/content/setup/setup-WSL2.md
@@ -17,6 +17,8 @@ This is a list of step-by-step instructions to set up a WSL2 environment from _s
     - `\. "$HOME/.nvm/nvm.sh"`
   - Install Node
     - `nvm install --lts`
+- Setup Node native module build tools:
+  - `sudo apt install -y make build-essential`
 - Clone and build:
   - `git clone https://github.com/microsoft/TypeAgent ~/src/TypeAgent` (Note: you can clone this to any location and does not have to be ~/src)
   - `cd ~/src/TypeAgent/ts`

--- a/ts/packages/actionGrammar/bin/generate-grammar.js
+++ b/ts/packages/actionGrammar/bin/generate-grammar.js
@@ -1,0 +1,19 @@
+#!/usr/bin/env node
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+
+import { existsSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const cliPath = path.resolve(__dirname, "../dist/generation/generate-grammar-cli.js");
+
+if (!existsSync(cliPath)) {
+    console.error("action-grammar has not been built yet.");
+    console.error("Run `pnpm -C ts/packages/actionGrammar build` or `pnpm -C ts run build` first.");
+    process.exit(1);
+}
+
+await import(cliPath);

--- a/ts/packages/actionGrammar/bin/generate-grammar.js
+++ b/ts/packages/actionGrammar/bin/generate-grammar.js
@@ -2,17 +2,21 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-
 import { existsSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import path from "node:path";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const cliPath = path.resolve(__dirname, "../dist/generation/generate-grammar-cli.js");
+const cliPath = path.resolve(
+    __dirname,
+    "../dist/generation/generate-grammar-cli.js",
+);
 
 if (!existsSync(cliPath)) {
     console.error("action-grammar has not been built yet.");
-    console.error("Run `pnpm -C ts/packages/actionGrammar build` or `pnpm -C ts run build` first.");
+    console.error(
+        "Run `pnpm -C ts/packages/actionGrammar build` or `pnpm -C ts run build` first.",
+    );
     process.exit(1);
 }
 

--- a/ts/packages/actionGrammar/bin/test-grammar.js
+++ b/ts/packages/actionGrammar/bin/test-grammar.js
@@ -1,0 +1,19 @@
+#!/usr/bin/env node
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+
+import { existsSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const cliPath = path.resolve(__dirname, "../dist/generation/test-grammar-cli.js");
+
+if (!existsSync(cliPath)) {
+    console.error("action-grammar has not been built yet.");
+    console.error("Run `pnpm -C ts/packages/actionGrammar build` or `pnpm -C ts run build` first.");
+    process.exit(1);
+}
+
+await import(cliPath);

--- a/ts/packages/actionGrammar/bin/test-grammar.js
+++ b/ts/packages/actionGrammar/bin/test-grammar.js
@@ -2,17 +2,21 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-
 import { existsSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import path from "node:path";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const cliPath = path.resolve(__dirname, "../dist/generation/test-grammar-cli.js");
+const cliPath = path.resolve(
+    __dirname,
+    "../dist/generation/test-grammar-cli.js",
+);
 
 if (!existsSync(cliPath)) {
     console.error("action-grammar has not been built yet.");
-    console.error("Run `pnpm -C ts/packages/actionGrammar build` or `pnpm -C ts run build` first.");
+    console.error(
+        "Run `pnpm -C ts/packages/actionGrammar build` or `pnpm -C ts run build` first.",
+    );
     process.exit(1);
 }
 

--- a/ts/packages/actionGrammar/package.json
+++ b/ts/packages/actionGrammar/package.json
@@ -19,8 +19,8 @@
     "./generation": "./dist/generation/index.js"
   },
   "bin": {
-    "generate-grammar": "./dist/generation/generate-grammar-cli.js",
-    "test-grammar": "./dist/generation/test-grammar-cli.js"
+    "generate-grammar": "./bin/generate-grammar.js",
+    "test-grammar": "./bin/test-grammar.js"
   },
   "files": [
     "dist",

--- a/ts/packages/coderWrapper/bin/coder-wrapper.js
+++ b/ts/packages/coderWrapper/bin/coder-wrapper.js
@@ -2,7 +2,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-
 import { existsSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import path from "node:path";
@@ -12,7 +11,9 @@ const cliPath = path.resolve(__dirname, "../dist/cli.js");
 
 if (!existsSync(cliPath)) {
     console.error("coder-wrapper has not been built yet.");
-    console.error("Run `pnpm -C ts/packages/coderWrapper build` or `pnpm -C ts run build` first.");
+    console.error(
+        "Run `pnpm -C ts/packages/coderWrapper build` or `pnpm -C ts run build` first.",
+    );
     process.exit(1);
 }
 

--- a/ts/packages/coderWrapper/bin/coder-wrapper.js
+++ b/ts/packages/coderWrapper/bin/coder-wrapper.js
@@ -1,0 +1,19 @@
+#!/usr/bin/env node
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+
+import { existsSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const cliPath = path.resolve(__dirname, "../dist/cli.js");
+
+if (!existsSync(cliPath)) {
+    console.error("coder-wrapper has not been built yet.");
+    console.error("Run `pnpm -C ts/packages/coderWrapper build` or `pnpm -C ts run build` first.");
+    process.exit(1);
+}
+
+await import(cliPath);

--- a/ts/packages/coderWrapper/package.json
+++ b/ts/packages/coderWrapper/package.json
@@ -17,7 +17,7 @@
   },
   "types": "./dist/index.d.ts",
   "bin": {
-    "coder-wrapper": "./dist/cli.js"
+    "coder-wrapper": "./bin/coder-wrapper.js"
   },
   "scripts": {
     "build": "npm run tsc",

--- a/ts/packages/kp/bin/kp-test.js
+++ b/ts/packages/kp/bin/kp-test.js
@@ -1,0 +1,19 @@
+#!/usr/bin/env node
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+
+import { existsSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const cliPath = path.resolve(__dirname, "../dist/testDriver.js");
+
+if (!existsSync(cliPath)) {
+    console.error("kp has not been built yet.");
+    console.error("Run `pnpm -C ts/packages/kp build` or `pnpm -C ts run build` first.");
+    process.exit(1);
+}
+
+await import(cliPath);

--- a/ts/packages/kp/bin/kp-test.js
+++ b/ts/packages/kp/bin/kp-test.js
@@ -2,7 +2,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-
 import { existsSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import path from "node:path";
@@ -12,7 +11,9 @@ const cliPath = path.resolve(__dirname, "../dist/testDriver.js");
 
 if (!existsSync(cliPath)) {
     console.error("kp has not been built yet.");
-    console.error("Run `pnpm -C ts/packages/kp build` or `pnpm -C ts run build` first.");
+    console.error(
+        "Run `pnpm -C ts/packages/kp build` or `pnpm -C ts run build` first.",
+    );
     process.exit(1);
 }
 

--- a/ts/packages/kp/package.json
+++ b/ts/packages/kp/package.json
@@ -17,7 +17,7 @@
   },
   "types": "./dist/index.d.ts",
   "bin": {
-    "kp-test": "./dist/testDriver.js"
+    "kp-test": "./bin/kp-test.js"
   },
   "files": [
     "dist",

--- a/ts/packages/security/mcpValidation/bin/mcp-plan-validation.js
+++ b/ts/packages/security/mcpValidation/bin/mcp-plan-validation.js
@@ -2,7 +2,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-
 import { existsSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import path from "node:path";
@@ -12,7 +11,9 @@ const cliPath = path.resolve(__dirname, "../dist/cli.js");
 
 if (!existsSync(cliPath)) {
     console.error("mcp-plan-validation has not been built yet.");
-    console.error("Run `pnpm -C ts/packages/security/mcpValidation build` or `pnpm -C ts run build` first.");
+    console.error(
+        "Run `pnpm -C ts/packages/security/mcpValidation build` or `pnpm -C ts run build` first.",
+    );
     process.exit(1);
 }
 

--- a/ts/packages/security/mcpValidation/bin/mcp-plan-validation.js
+++ b/ts/packages/security/mcpValidation/bin/mcp-plan-validation.js
@@ -1,0 +1,19 @@
+#!/usr/bin/env node
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+
+import { existsSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const cliPath = path.resolve(__dirname, "../dist/cli.js");
+
+if (!existsSync(cliPath)) {
+    console.error("mcp-plan-validation has not been built yet.");
+    console.error("Run `pnpm -C ts/packages/security/mcpValidation build` or `pnpm -C ts run build` first.");
+    process.exit(1);
+}
+
+await import(cliPath);

--- a/ts/packages/security/mcpValidation/package.json
+++ b/ts/packages/security/mcpValidation/package.json
@@ -25,7 +25,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "bin": {
-    "mcp-plan-validation": "dist/cli.js"
+    "mcp-plan-validation": "./bin/mcp-plan-validation.js"
   },
   "files": [
     "dist",


### PR DESCRIPTION
## Summary

### fix(ts): pnpm workspace bin link warnings
- Switch several workspace package `bin` entries from `dist/*` targets to checked-in shim entrypoints under `bin/`
- Add shim scripts for `action-grammar`, `mcp-plan-validation`, `coder-wrapper`, and `kp-test`
- Shims delegate to built `dist/*` files when present and print a clear build instruction if not yet built

### docs: WSL2 setup clarification
- Add "Setup Node native module build tools" step (`sudo apt install -y make build-essential`) before the clone/build steps

## Why
`pnpm i` creates executable symlinks during install. For workspace packages whose `bin` points directly to `dist/*` outputs, install warns when those compiled files don't exist yet (fresh clone before first build). The shims fix this by providing a stable, always-present entrypoint.

The WSL2 docs change makes clear that `make` and `build-essential` are required before running `pnpm i` / `pnpm run build`, preventing native module build failures.

## Validation
- Ran `pnpm i --ignore-scripts` in `ts` workspace — bin-link warnings no longer reproduced for these packages