### PR TITLE
Workflow engine: structured output, validation passes, onError recovery, and dependency-aware branching

### DIFF
--- a/ts/examples/workflow/cli/package.json
+++ b/ts/examples/workflow/cli/package.json
@@ -26,6 +26,7 @@
     "tsc": "tsc -b"
   },
   "dependencies": {
+    "dotenv": "^17.4.2",
     "workflow-engine": "workspace:*",
     "workflow-model": "workspace:*"
   },

--- a/ts/examples/workflow/cli/src/cli.ts
+++ b/ts/examples/workflow/cli/src/cli.ts
@@ -67,7 +67,14 @@ async function cmdRun(
     mode?: "dry-run" | "allow-all",
 ): Promise<void> {
     const ir = loadIR(file);
-    const input = inputJson ? JSON.parse(inputJson) : {};
+    let input: Record<string, unknown> = {};
+    if (inputJson) {
+        try {
+            input = JSON.parse(inputJson);
+        } catch (e) {
+            fail(`Invalid JSON in --input: ${(e as Error).message}`);
+        }
+    }
     const engine = makeEngine();
 
     engine.on((event) => {
@@ -253,7 +260,13 @@ switch (command) {
         if (!file) fail(usage);
         loadEnvFiles(args);
         const inputIdx = args.indexOf("--input");
-        const inputJson = inputIdx >= 0 ? args[inputIdx + 1] : undefined;
+        let inputJson: string | undefined;
+        if (inputIdx >= 0) {
+            inputJson = args[inputIdx + 1];
+            if (!inputJson || inputJson.startsWith("--")) {
+                fail("--input requires a JSON value argument");
+            }
+        }
         const mode = args.includes("--dry-run")
             ? "dry-run"
             : args.includes("--allow-all")

--- a/ts/examples/workflow/cli/src/cli.ts
+++ b/ts/examples/workflow/cli/src/cli.ts
@@ -5,6 +5,7 @@
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { createInterface } from "node:readline";
+import dotenv from "dotenv";
 import {
     WorkflowIR,
     TaskPolicy,
@@ -20,11 +21,13 @@ import {
 } from "workflow-engine";
 
 const usage = `Usage:
-  workflow run <file.json> [--input <json>] [--dry-run | --allow-all]   Run a workflow
-  workflow validate <file.json>                                        Validate a workflow
-  workflow list-tasks                                                  List registered tasks
+  workflow run <file.json> [--input <json>] [--env <file>] [--dry-run | --allow-all]   Run a workflow
+  workflow validate <file.json>                                                        Validate a workflow
+  workflow list-tasks                                                                  List registered tasks
 
 Options:
+  --env <file>  Load environment variables from the given dotenv file before
+                running. Can be specified multiple times.
   --dry-run     Deny all side-effecting tasks (shell, network, file, LLM)
                 without prompting. Useful for testing workflow structure.
   --allow-all   Allow all tasks without prompting. Use for scripted/CI runs
@@ -226,10 +229,27 @@ function cmdListTasks(): void {
 const args = process.argv.slice(2);
 const command = args[0];
 
+/** Collect all --env <file> arguments and load them in order. */
+function loadEnvFiles(argv: string[]): void {
+    for (let i = 0; i < argv.length; i++) {
+        if (argv[i] === "--env" && i + 1 < argv.length) {
+            const envPath = resolve(argv[i + 1]);
+            const result = dotenv.config({ path: envPath });
+            if (result.error) {
+                fail(
+                    `Failed to load env file ${envPath}: ${result.error.message}`,
+                );
+            }
+            console.error(`[env] Loaded ${envPath}`);
+        }
+    }
+}
+
 switch (command) {
     case "run": {
         const file = args[1];
         if (!file) fail(usage);
+        loadEnvFiles(args);
         const inputIdx = args.indexOf("--input");
         const inputJson = inputIdx >= 0 ? args[inputIdx + 1] : undefined;
         const mode = args.includes("--dry-run")

--- a/ts/examples/workflow/cli/src/cli.ts
+++ b/ts/examples/workflow/cli/src/cli.ts
@@ -236,11 +236,13 @@ function loadEnvFiles(argv: string[]): void {
             const envPath = resolve(argv[i + 1]);
             const result = dotenv.config({ path: envPath });
             if (result.error) {
+                // fail() calls process.exit and never returns.
                 fail(
                     `Failed to load env file ${envPath}: ${result.error.message}`,
                 );
+            } else {
+                console.error(`[env] Loaded ${envPath}`);
             }
-            console.error(`[env] Loaded ${envPath}`);
         }
     }
 }

--- a/ts/examples/workflow/engine/src/ajv.ts
+++ b/ts/examples/workflow/engine/src/ajv.ts
@@ -1,0 +1,10 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import AjvModule from "ajv";
+
+const AjvConstructor = (AjvModule as any).default ?? AjvModule;
+
+export function createAjv() {
+    return new AjvConstructor({ strict: false });
+}

--- a/ts/examples/workflow/engine/src/builtinTasks.ts
+++ b/ts/examples/workflow/engine/src/builtinTasks.ts
@@ -15,8 +15,39 @@ import { execFile } from "node:child_process";
 import { readFile, writeFile, mkdir, stat } from "node:fs/promises";
 import { dirname, resolve, relative, isAbsolute } from "node:path";
 import { homedir, tmpdir } from "node:os";
-import { TaskDefinition } from "workflow-model";
+import { JSONSchema, TaskDefinition } from "workflow-model";
 import { openai } from "aiclient";
+
+/**
+ * Recursively enforce OpenAI structured output requirements on a schema:
+ * - `additionalProperties: false` on every object
+ * - `required` must list every key in `properties`
+ * Returns a deep copy; the original schema is not mutated.
+ */
+function sealObjects(schema: JSONSchema): JSONSchema {
+    const copy = { ...schema };
+    if (copy.type === "object" || copy.properties) {
+        copy.additionalProperties = false;
+        if (copy.properties) {
+            const sealed: Record<string, JSONSchema> = {};
+            for (const [key, sub] of Object.entries(copy.properties)) {
+                if (typeof sub !== "boolean") {
+                    sealed[key] = sealObjects(sub);
+                }
+            }
+            copy.properties = sealed;
+            copy.required = Object.keys(sealed);
+        }
+    }
+    if (
+        copy.items &&
+        typeof copy.items !== "boolean" &&
+        !Array.isArray(copy.items)
+    ) {
+        copy.items = sealObjects(copy.items);
+    }
+    return copy;
+}
 
 export const intAdd: TaskDefinition<
     { a: number; b: number },
@@ -338,7 +369,10 @@ export const llmGenerateJson: TaskDefinition<
                 ? {
                       name: "response",
                       strict: true as const,
-                      schema: valueSchema as Record<string, unknown>,
+                      schema: sealObjects(valueSchema) as Record<
+                          string,
+                          unknown
+                      >,
                   }
                 : undefined;
         const result = await model.complete(

--- a/ts/examples/workflow/engine/src/builtinTasks.ts
+++ b/ts/examples/workflow/engine/src/builtinTasks.ts
@@ -296,6 +296,76 @@ export const llmGenerate: TaskDefinition<
     },
 };
 
+export const llmGenerateJson: TaskDefinition<
+    { prompt: string; endpoint?: string },
+    { value: unknown }
+> = {
+    name: "llm.generateJson",
+    sideEffects: true,
+    inputSchema: {
+        type: "object",
+        required: ["prompt"],
+        properties: {
+            prompt: { type: "string" },
+            endpoint: { type: "string" },
+        },
+    },
+    outputSchema: {
+        type: "object",
+        required: ["value"],
+        properties: { value: {} },
+    },
+    async execute(input, ctx) {
+        ctx?.signal?.throwIfAborted();
+        let model;
+        try {
+            model = openai.createJsonChatModel(input.endpoint);
+        } catch (err) {
+            return {
+                kind: "fail",
+                error: {
+                    message: err instanceof Error ? err.message : String(err),
+                },
+            };
+        }
+        // Derive structured output schema from the node's outputSchema if
+        // it declares a "value" property with a non-opaque schema.
+        const valueSchema = ctx.outputSchema?.properties?.value;
+        const jsonSchema =
+            valueSchema &&
+            typeof valueSchema !== "boolean" &&
+            Object.keys(valueSchema).length > 0
+                ? {
+                      name: "response",
+                      strict: true as const,
+                      schema: valueSchema as Record<string, unknown>,
+                  }
+                : undefined;
+        const result = await model.complete(
+            input.prompt,
+            undefined,
+            jsonSchema,
+        );
+        if (!result.success) {
+            return {
+                kind: "fail",
+                error: { message: result.message },
+            };
+        }
+        try {
+            const value = JSON.parse(result.data);
+            return { kind: "ok", output: { value } };
+        } catch (parseErr) {
+            return {
+                kind: "fail",
+                error: {
+                    message: `Failed to parse LLM JSON response: ${parseErr instanceof Error ? parseErr.message : String(parseErr)}`,
+                },
+            };
+        }
+    },
+};
+
 // ---- Utility tasks ----
 
 export const textTemplate: TaskDefinition<
@@ -647,6 +717,7 @@ export const allBuiltinTasks: TaskDefinition[] = [
     boolToLabel,
     shellExec,
     llmGenerate,
+    llmGenerateJson,
     httpGet,
     fileRead,
     fileWrite,

--- a/ts/examples/workflow/engine/src/builtinTasks.ts
+++ b/ts/examples/workflow/engine/src/builtinTasks.ts
@@ -12,7 +12,7 @@
  */
 
 import { execFile } from "node:child_process";
-import { readFile, writeFile, mkdir, stat } from "node:fs/promises";
+import { readFile, writeFile, mkdir } from "node:fs/promises";
 import { dirname, resolve, relative, isAbsolute } from "node:path";
 import { homedir, tmpdir } from "node:os";
 import { JSONSchema, TaskDefinition } from "workflow-model";
@@ -137,6 +137,14 @@ export const listElementAt: TaskDefinition<
         properties: { element: {} },
     },
     async execute(input) {
+        if (input.index < 0 || input.index >= input.list.length) {
+            return {
+                kind: "fail",
+                error: {
+                    message: `Index ${input.index} out of bounds for list of length ${input.list.length}`,
+                },
+            };
+        }
         return { kind: "ok", output: { element: input.list[input.index] } };
     },
 };
@@ -463,7 +471,7 @@ export const stringJoin: TaskDefinition<
 };
 
 export const stringSplit: TaskDefinition<
-    { text: string; delimiter: string },
+    { text: string; delimiter: string; keepEmpty?: boolean },
     { list: string[] }
 > = {
     name: "string.split",
@@ -474,6 +482,11 @@ export const stringSplit: TaskDefinition<
         properties: {
             text: { type: "string" },
             delimiter: { type: "string" },
+            keepEmpty: {
+                type: "boolean",
+                description:
+                    "Keep empty strings in the result (default: false).",
+            },
         },
     },
     outputSchema: {
@@ -482,10 +495,13 @@ export const stringSplit: TaskDefinition<
         properties: { list: { type: "array", items: { type: "string" } } },
     },
     async execute(input) {
-        const list = input.text
-            .split(input.delimiter)
-            .filter((s) => s.length > 0);
-        return { kind: "ok", output: { list } };
+        const list = input.text.split(input.delimiter);
+        return {
+            kind: "ok",
+            output: {
+                list: input.keepEmpty ? list : list.filter((s) => s.length > 0),
+            },
+        };
     },
 };
 
@@ -535,7 +551,7 @@ export const httpGet: TaskDefinition<
                 hostname === "[::1]" ||
                 hostname?.startsWith("10.") ||
                 hostname?.startsWith("192.168.") ||
-                hostname?.startsWith("172.16.") ||
+                /^172\.(1[6-9]|2\d|3[01])\./.test(hostname ?? "") ||
                 hostname?.endsWith(".internal") ||
                 parsed.protocol === "file:"
             ) {
@@ -683,16 +699,15 @@ export const fileRead: TaskDefinition<
         const maxBytes = input.maxBytes ?? DEFAULT_MAX_FILE_READ_BYTES;
         try {
             const safePath = validateFilePath(input.path);
-            const info = await stat(safePath);
-            if (info.size > maxBytes) {
+            const content = await readFile(safePath, "utf8");
+            if (Buffer.byteLength(content, "utf8") > maxBytes) {
                 return {
                     kind: "fail",
                     error: {
-                        message: `File is ${info.size} bytes, exceeding the ${maxBytes} byte limit`,
+                        message: `File exceeds the ${maxBytes} byte limit`,
                     },
                 };
             }
-            const content = await readFile(safePath, "utf8");
             return { kind: "ok", output: { content } };
         } catch (err) {
             return {

--- a/ts/examples/workflow/engine/src/builtinTasks.ts
+++ b/ts/examples/workflow/engine/src/builtinTasks.ts
@@ -46,6 +46,11 @@ function sealObjects(schema: JSONSchema): JSONSchema {
     ) {
         copy.items = sealObjects(copy.items);
     }
+    for (const kw of ["oneOf", "anyOf", "allOf"] as const) {
+        if (Array.isArray(copy[kw])) {
+            copy[kw] = (copy[kw] as JSONSchema[]).map(sealObjects);
+        }
+    }
     return copy;
 }
 

--- a/ts/examples/workflow/engine/src/runner.ts
+++ b/ts/examples/workflow/engine/src/runner.ts
@@ -217,6 +217,11 @@ export interface RunOptions {
      * - allowedHosts: if set, only these hostnames are permitted in http.get
      */
     constraints?: TaskConstraints;
+    /**
+     * Skip structural validation before running. Use only in tests that
+     * intentionally exercise invalid IRs for error-path coverage.
+     */
+    skipValidation?: boolean;
 }
 
 export interface RunResult {
@@ -284,16 +289,20 @@ export class WorkflowEngine {
                 : rawTimeout;
 
         // Validate
-        const validation = validateWorkflowIR(ir, this.registry.all());
-        if (!validation.valid) {
-            const msgs = validation.errors.map(
-                (e) => `${e.path}: ${e.message}`,
-            );
-            return {
-                runId: "",
-                success: false,
-                error: { message: `Validation failed:\n${msgs.join("\n")}` },
-            };
+        if (!options?.skipValidation) {
+            const validation = validateWorkflowIR(ir, this.registry.all());
+            if (!validation.valid) {
+                const msgs = validation.errors.map(
+                    (e) => `${e.path}: ${e.message}`,
+                );
+                return {
+                    runId: "",
+                    success: false,
+                    error: {
+                        message: `Validation failed:\n${msgs.join("\n")}`,
+                    },
+                };
+            }
         }
 
         const runId = `run-${randomUUID()}`;

--- a/ts/examples/workflow/engine/src/runner.ts
+++ b/ts/examples/workflow/engine/src/runner.ts
@@ -3,7 +3,6 @@
 
 import { randomUUID } from "node:crypto";
 import Debug from "debug";
-import AjvModule from "ajv";
 import {
     WorkflowIR,
     WorkflowNode,
@@ -21,10 +20,9 @@ import {
 } from "workflow-model";
 import { TaskRegistry } from "./taskRegistry.js";
 import { WorkflowEvent, WorkflowEventListener } from "./events.js";
+import { createAjv } from "./ajv.js";
 
 const debug = Debug("typeagent:workflow:engine");
-
-const AjvConstructor = (AjvModule as any).default ?? AjvModule;
 
 // ---- Scope context ----
 
@@ -235,7 +233,7 @@ export interface RunResult {
 
 export class WorkflowEngine {
     private listeners: WorkflowEventListener[] = [];
-    private ajv = new AjvConstructor({ strict: false });
+    private ajv = createAjv();
     private validatorCache = new Map<
         string,
         ReturnType<typeof this.ajv.compile>
@@ -648,27 +646,35 @@ export class WorkflowEngine {
 
             let result: TaskResult;
             if (effectiveTimeout !== undefined) {
-                let timeoutId: ReturnType<typeof setTimeout>;
-                let completed = false;
-                const timeout = new Promise<never>((_, reject) => {
-                    timeoutId = setTimeout(() => {
-                        if (!completed) {
-                            taskAbortController!.abort("Task timed out");
-                            reject(
-                                new EngineError(
-                                    `Task "${node.task}" at "${nodeId}" timed out after ${effectiveTimeout}ms`,
-                                ),
-                            );
-                        }
-                    }, effectiveTimeout);
+                const timeoutSignal = AbortSignal.timeout(effectiveTimeout);
+                const onParentAbort = () =>
+                    taskAbortController!.abort(signal.reason);
+                const onTimeoutAbort = () =>
+                    taskAbortController!.abort("Task timed out");
+                signal.addEventListener("abort", onParentAbort, {
+                    once: true,
                 });
-                result = await Promise.race([
-                    task.execute(resolvedInput, ctx).then((r) => {
-                        completed = true;
-                        return r;
-                    }),
-                    timeout,
-                ]).finally(() => clearTimeout(timeoutId));
+                timeoutSignal.addEventListener("abort", onTimeoutAbort, {
+                    once: true,
+                });
+                try {
+                    result = await task.execute(resolvedInput, ctx);
+                } catch (e) {
+                    if (timeoutSignal.aborted) {
+                        throw new EngineError(
+                            `Task "${node.task}" at "${nodeId}" timed out after ${effectiveTimeout}ms`,
+                        );
+                    }
+                    throw e;
+                } finally {
+                    signal.removeEventListener("abort", onParentAbort);
+                    timeoutSignal.removeEventListener("abort", onTimeoutAbort);
+                }
+                if (timeoutSignal.aborted) {
+                    throw new EngineError(
+                        `Task "${node.task}" at "${nodeId}" timed out after ${effectiveTimeout}ms`,
+                    );
+                }
             } else {
                 result = await task.execute(resolvedInput, ctx);
             }

--- a/ts/examples/workflow/engine/src/runner.ts
+++ b/ts/examples/workflow/engine/src/runner.ts
@@ -10,6 +10,7 @@ import {
     Template,
     TaskNode,
     LoopNode,
+    JSONSchema,
     TaskContext,
     TaskConstraints,
     TaskResult,
@@ -237,7 +238,7 @@ export class WorkflowEngine {
      * Keyed by JSON.stringify of the schema to handle structurally
      * identical schemas from parsed JSON (no reference identity).
      */
-    private getValidator(schema: Record<string, unknown>) {
+    private getValidator(schema: JSONSchema) {
         const key = JSON.stringify(schema);
         let v = this.validatorCache.get(key);
         if (!v) {
@@ -578,6 +579,9 @@ export class WorkflowEngine {
                 scopePath: [...scopePath],
                 signal: taskSignal,
                 ...(constraints ? { constraints } : {}),
+                ...(node.outputSchema
+                    ? { outputSchema: node.outputSchema }
+                    : {}),
             };
 
             let result: TaskResult;

--- a/ts/examples/workflow/engine/src/runner.ts
+++ b/ts/examples/workflow/engine/src/runner.ts
@@ -171,7 +171,12 @@ class TaskFailure extends Error {
 // ---- Scope exit ----
 
 type ScopeExit =
-    | { kind: "terminal" }
+    | {
+          kind: "terminal";
+          errorHandled?:
+              | { message: string; nodeId: string | undefined }
+              | undefined;
+      }
     | { kind: "sentinel"; sentinel: "@iterate" | "@exit" };
 
 // ---- Public types ----
@@ -346,7 +351,7 @@ export class WorkflowEngine {
         });
 
         try {
-            await this.executeScope(
+            const exit = await this.executeScope(
                 ir.nodes,
                 ir.entry,
                 scope,
@@ -359,7 +364,34 @@ export class WorkflowEngine {
                 constraints,
             );
 
-            const output = resolveTemplate(ir.output, scope);
+            let output: unknown;
+            try {
+                output = resolveTemplate(ir.output, scope);
+            } catch (resolveErr) {
+                // Output resolution failed. If we went through an error
+                // recovery path (e.g. cleanup), report the original error
+                // instead of the confusing "unresolved reference" message.
+                if (exit.kind === "terminal" && exit.errorHandled) {
+                    const { message, nodeId } = exit.errorHandled;
+                    debug(
+                        "run %s failed (error handled, output unresolvable): %s",
+                        runId,
+                        message,
+                    );
+                    this.emit({
+                        type: "runFailed",
+                        runId,
+                        error: { message },
+                        timestamp: Date.now(),
+                    });
+                    return {
+                        runId,
+                        success: false,
+                        error: { message, nodeId },
+                    };
+                }
+                throw resolveErr;
+            }
 
             debug("run %s completed", runId);
 
@@ -401,6 +433,11 @@ export class WorkflowEngine {
         let currentId: string | undefined = entryId;
         let pendingError:
             | { error: Record<string, unknown>; trigger: unknown }
+            | undefined;
+        // Track the first error that was handled via onError so the caller
+        // knows this scope completed through an error-recovery path.
+        let handledError:
+            | { message: string; nodeId: string | undefined }
             | undefined;
 
         while (currentId) {
@@ -444,6 +481,12 @@ export class WorkflowEngine {
                         signal,
                         (err, trigger) => {
                             pendingError = { error: err, trigger };
+                            if (!handledError) {
+                                handledError = {
+                                    message: err["message"] as string,
+                                    nodeId: err["node"] as string | undefined,
+                                };
+                            }
                         },
                         policy,
                         approve,
@@ -483,6 +526,12 @@ export class WorkflowEngine {
                         signal,
                         (err, trigger) => {
                             pendingError = { error: err, trigger };
+                            if (!handledError) {
+                                handledError = {
+                                    message: err["message"] as string,
+                                    nodeId: err["node"] as string | undefined,
+                                };
+                            }
                         },
                         policy,
                         approve,
@@ -493,7 +542,9 @@ export class WorkflowEngine {
             }
         }
 
-        return { kind: "terminal" };
+        return handledError
+            ? { kind: "terminal", errorHandled: handledError }
+            : { kind: "terminal" };
     }
 
     private async executeTask(
@@ -556,9 +607,11 @@ export class WorkflowEngine {
             debug("task %s (%s) executing", nodeId, node.task);
 
             // Build per-task signal with optional timeout.
+            // Node-level timeoutMs overrides the global default.
+            const effectiveTimeout = node.timeoutMs ?? taskTimeoutMs;
             let taskSignal = signal;
             let taskAbortController: AbortController | undefined;
-            if (taskTimeoutMs !== undefined) {
+            if (effectiveTimeout !== undefined) {
                 taskAbortController = new AbortController();
                 // Propagate parent signal
                 if (signal.aborted) {
@@ -585,7 +638,7 @@ export class WorkflowEngine {
             };
 
             let result: TaskResult;
-            if (taskTimeoutMs !== undefined) {
+            if (effectiveTimeout !== undefined) {
                 let timeoutId: ReturnType<typeof setTimeout>;
                 let completed = false;
                 const timeout = new Promise<never>((_, reject) => {
@@ -594,11 +647,11 @@ export class WorkflowEngine {
                             taskAbortController!.abort("Task timed out");
                             reject(
                                 new EngineError(
-                                    `Task "${node.task}" at "${nodeId}" timed out after ${taskTimeoutMs}ms`,
+                                    `Task "${node.task}" at "${nodeId}" timed out after ${effectiveTimeout}ms`,
                                 ),
                             );
                         }
-                    }, taskTimeoutMs);
+                    }, effectiveTimeout);
                 });
                 result = await Promise.race([
                     task.execute(resolvedInput, ctx).then((r) => {

--- a/ts/examples/workflow/engine/src/taskRegistry.ts
+++ b/ts/examples/workflow/engine/src/taskRegistry.ts
@@ -1,17 +1,15 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import AjvModule from "ajv";
 import { TaskDefinition } from "workflow-model";
-
-const AjvConstructor = (AjvModule as any).default ?? AjvModule;
+import { createAjv } from "./ajv.js";
 
 /**
  * In-memory registry for task definitions.
  */
 export class TaskRegistry {
     private tasks = new Map<string, TaskDefinition>();
-    private ajv = new AjvConstructor({ strict: false });
+    private ajv = createAjv();
 
     register(task: TaskDefinition): void {
         if (this.tasks.has(task.name)) {

--- a/ts/examples/workflow/engine/src/taskRegistry.ts
+++ b/ts/examples/workflow/engine/src/taskRegistry.ts
@@ -18,7 +18,7 @@ export class TaskRegistry {
             throw new Error(`Task "${task.name}" is already registered.`);
         }
         try {
-            this.ajv.compile(task.inputSchema as object);
+            this.ajv.compile(task.inputSchema);
         } catch (e: unknown) {
             const msg = e instanceof Error ? e.message : String(e);
             throw new Error(
@@ -26,7 +26,7 @@ export class TaskRegistry {
             );
         }
         try {
-            this.ajv.compile(task.outputSchema as object);
+            this.ajv.compile(task.outputSchema);
         } catch (e: unknown) {
             const msg = e instanceof Error ? e.message : String(e);
             throw new Error(

--- a/ts/examples/workflow/engine/test/engine.spec.ts
+++ b/ts/examples/workflow/engine/test/engine.spec.ts
@@ -3064,7 +3064,9 @@ describe("WorkflowEngine (IR v1)", () => {
                                 },
                             },
                         },
-                        iterateState: {},
+                        iterateState: {
+                            i: { $from: "state", name: "i" } as Template,
+                        },
                         output: null as Template,
                         outputSchema: { type: "null" },
                         maxIterations: 1,
@@ -4333,7 +4335,7 @@ describe("WorkflowEngine (IR v1)", () => {
                             properties: { result: { type: "integer" } },
                         },
                         inputs: { a: 1 as Template, b: 2 as Template },
-                        bind: "answer",
+                        bind: "firstAnswer",
                         next: "second",
                     },
                     second: {
@@ -6013,7 +6015,10 @@ describe("WorkflowEngine (IR v1)", () => {
                 } as Template,
             };
 
-            const result = await eng.run(ir, { input: {} });
+            const result = await eng.run(ir, {
+                input: {},
+                skipValidation: true,
+            });
             expect(result.success).toBe(false);
             // Should report the *original* error, not "unresolved reference"
             expect(result.error?.message).toContain("the original problem");
@@ -6158,7 +6163,10 @@ describe("WorkflowEngine (IR v1)", () => {
                 } as Template,
             };
 
-            const result = await eng.run(ir, { input: {} });
+            const result = await eng.run(ir, {
+                input: {},
+                skipValidation: true,
+            });
             expect(result.success).toBe(false);
             expect(result.error?.nodeId).toBe("doWork");
         });

--- a/ts/examples/workflow/engine/test/engine.spec.ts
+++ b/ts/examples/workflow/engine/test/engine.spec.ts
@@ -5334,8 +5334,8 @@ describe("WorkflowEngine (IR v1)", () => {
 
             const result = await engine.run(ir, { input: {} });
             expect(result.success).toBe(false);
-            expect(result.error?.message).toContain("unresolved");
             expect(result.error?.message).toContain("doesNotExist");
+            expect(result.error?.message).toContain("no node");
         });
     });
 
@@ -5945,6 +5945,222 @@ describe("WorkflowEngine (IR v1)", () => {
             expect(result.error?.message).toContain(
                 "not in the allowed hosts list",
             );
+        });
+    });
+
+    describe("onError cleanup-then-fail", () => {
+        it("reports original error when cleanup path leaves output unresolvable", async () => {
+            const failTask: TaskDefinition = {
+                name: "test.fail",
+                sideEffects: false,
+                inputSchema: { type: "object" },
+                outputSchema: { type: "object" },
+                async execute() {
+                    return {
+                        kind: "fail" as const,
+                        error: { message: "the original problem" },
+                    };
+                },
+            };
+            const cleanupTask: TaskDefinition = {
+                name: "test.cleanup",
+                sideEffects: false,
+                inputSchema: { type: "object" },
+                outputSchema: { type: "object" },
+                async execute() {
+                    return { kind: "ok" as const, output: { cleaned: true } };
+                },
+            };
+
+            const reg = makeRegistry(
+                ...standardLibraryTasks,
+                failTask,
+                cleanupTask,
+            );
+            const eng = new WorkflowEngine(reg);
+
+            // step fails -> cleanup runs (binds "cleanupResult")
+            // but output references "happyResult" which was never bound
+            const ir: WorkflowIR = {
+                kind: "workflow",
+                name: "cleanupFail",
+                version: "1",
+                inputSchema: { type: "object" },
+                outputSchema: { type: "object" },
+                nodes: {
+                    step: {
+                        kind: "task",
+                        task: "test.fail",
+                        inputSchema: { type: "object" },
+                        outputSchema: { type: "object" },
+                        inputs: {},
+                        onError: "cleanup",
+                        bind: "happyResult",
+                    },
+                    cleanup: {
+                        kind: "task",
+                        task: "test.cleanup",
+                        inputSchema: { type: "object" },
+                        outputSchema: { type: "object" },
+                        inputs: {},
+                        bind: "cleanupResult",
+                    },
+                },
+                entry: "step",
+                output: {
+                    $from: "scope",
+                    name: "happyResult",
+                } as Template,
+            };
+
+            const result = await eng.run(ir, { input: {} });
+            expect(result.success).toBe(false);
+            // Should report the *original* error, not "unresolved reference"
+            expect(result.error?.message).toContain("the original problem");
+        });
+
+        it("succeeds when onError handler produces a valid output", async () => {
+            const failTask: TaskDefinition = {
+                name: "test.fail",
+                sideEffects: false,
+                inputSchema: { type: "object" },
+                outputSchema: { type: "object" },
+                async execute() {
+                    return {
+                        kind: "fail" as const,
+                        error: { message: "step failed" },
+                    };
+                },
+            };
+            const recoverTask: TaskDefinition = {
+                name: "test.recover",
+                sideEffects: false,
+                inputSchema: { type: "object" },
+                outputSchema: { type: "object" },
+                async execute(input: any) {
+                    return {
+                        kind: "ok" as const,
+                        output: {
+                            fallback: true,
+                            reason: input.error?.message,
+                        },
+                    };
+                },
+            };
+
+            const reg = makeRegistry(
+                ...standardLibraryTasks,
+                failTask,
+                recoverTask,
+            );
+            const eng = new WorkflowEngine(reg);
+
+            // step fails -> recover runs and binds "result"
+            // output references "result", which IS bound by the recovery node
+            const ir: WorkflowIR = {
+                kind: "workflow",
+                name: "recoverSuccess",
+                version: "1",
+                inputSchema: { type: "object" },
+                outputSchema: { type: "object" },
+                nodes: {
+                    step: {
+                        kind: "task",
+                        task: "test.fail",
+                        inputSchema: { type: "object" },
+                        outputSchema: { type: "object" },
+                        inputs: {},
+                        onError: "recover",
+                    },
+                    recover: {
+                        kind: "task",
+                        task: "test.recover",
+                        inputSchema: { type: "object" },
+                        outputSchema: { type: "object" },
+                        inputs: {
+                            error: {
+                                $from: "input",
+                                name: "error",
+                            } as Template,
+                        },
+                        bind: "result",
+                    },
+                },
+                entry: "step",
+                output: { $from: "scope", name: "result" } as Template,
+            };
+
+            const result = await eng.run(ir, { input: {} });
+            expect(result.success).toBe(true);
+            expect((result.output as any).fallback).toBe(true);
+            expect((result.output as any).reason).toBe("step failed");
+        });
+
+        it("reports original error with nodeId from the failing task", async () => {
+            const failTask: TaskDefinition = {
+                name: "test.fail",
+                sideEffects: false,
+                inputSchema: { type: "object" },
+                outputSchema: { type: "object" },
+                async execute() {
+                    return {
+                        kind: "fail" as const,
+                        error: { message: "boom" },
+                    };
+                },
+            };
+            const noopTask: TaskDefinition = {
+                name: "test.noop",
+                sideEffects: false,
+                inputSchema: { type: "object" },
+                outputSchema: { type: "object" },
+                async execute() {
+                    return { kind: "ok" as const, output: {} };
+                },
+            };
+
+            const reg = makeRegistry(
+                ...standardLibraryTasks,
+                failTask,
+                noopTask,
+            );
+            const eng = new WorkflowEngine(reg);
+
+            const ir: WorkflowIR = {
+                kind: "workflow",
+                name: "nodeIdCheck",
+                version: "1",
+                inputSchema: { type: "object" },
+                outputSchema: { type: "object" },
+                nodes: {
+                    doWork: {
+                        kind: "task",
+                        task: "test.fail",
+                        inputSchema: { type: "object" },
+                        outputSchema: { type: "object" },
+                        inputs: {},
+                        onError: "cleanup",
+                        bind: "workOutput",
+                    },
+                    cleanup: {
+                        kind: "task",
+                        task: "test.noop",
+                        inputSchema: { type: "object" },
+                        outputSchema: { type: "object" },
+                        inputs: {},
+                        bind: "cleanedUp",
+                    },
+                },
+                entry: "doWork",
+                output: {
+                    $from: "scope",
+                    name: "workOutput",
+                } as Template,
+            };
+
+            const result = await eng.run(ir, { input: {} });
+            expect(result.success).toBe(false);
+            expect(result.error?.nodeId).toBe("doWork");
         });
     });
 });

--- a/ts/examples/workflow/engine/test/engine.spec.ts
+++ b/ts/examples/workflow/engine/test/engine.spec.ts
@@ -5167,13 +5167,14 @@ describe("WorkflowEngine (IR v1)", () => {
                 nodes: {
                     producer: {
                         kind: "task",
-                        task: "int.add",
+                        task: "bool.toLabel",
                         inputSchema: {
                             type: "object",
-                            required: ["a", "b"],
+                            required: ["value", "ifTrue", "ifFalse"],
                             properties: {
-                                a: { type: "integer" },
-                                b: { type: "integer" },
+                                value: { type: "boolean" },
+                                ifTrue: { type: "string" },
+                                ifFalse: { type: "string" },
                             },
                         },
                         outputSchema: {
@@ -5181,7 +5182,11 @@ describe("WorkflowEngine (IR v1)", () => {
                             required: ["label"],
                             properties: { label: { type: "string" } },
                         },
-                        inputs: { a: 1 as Template, b: 2 as Template },
+                        inputs: {
+                            value: true as Template,
+                            ifTrue: "yes" as Template,
+                            ifFalse: "no" as Template,
+                        },
                         next: "consumer",
                         bind: "data",
                     },
@@ -5216,7 +5221,7 @@ describe("WorkflowEngine (IR v1)", () => {
                 output: { $from: "scope", name: "final" } as Template,
             };
 
-            const tasks = new Map(standardLibraryTasks.map((t) => [t.name, t]));
+            const tasks = new Map(allBuiltinTasks.map((t) => [t.name, t]));
             const validation = validateWorkflowIR(ir, tasks);
             expect(validation.valid).toBe(false);
             expect(validation.errors[0].message).toContain("type mismatch");
@@ -5737,6 +5742,7 @@ describe("WorkflowEngine (IR v1)", () => {
                         },
                         outputSchema: {
                             type: "object",
+                            required: ["stdout", "stderr", "exitCode"],
                             properties: {
                                 stdout: { type: "string" },
                                 stderr: { type: "string" },
@@ -5817,6 +5823,7 @@ describe("WorkflowEngine (IR v1)", () => {
                         },
                         outputSchema: {
                             type: "object",
+                            required: ["stdout", "stderr", "exitCode"],
                             properties: {
                                 stdout: { type: "string" },
                                 stderr: { type: "string" },
@@ -5863,6 +5870,7 @@ describe("WorkflowEngine (IR v1)", () => {
                         },
                         outputSchema: {
                             type: "object",
+                            required: ["body", "status"],
                             properties: {
                                 body: { type: "string" },
                                 status: { type: "integer" },
@@ -5911,6 +5919,7 @@ describe("WorkflowEngine (IR v1)", () => {
                         },
                         outputSchema: {
                             type: "object",
+                            required: ["body", "status"],
                             properties: {
                                 body: { type: "string" },
                                 status: { type: "integer" },

--- a/ts/examples/workflow/engine/test/engine.spec.ts
+++ b/ts/examples/workflow/engine/test/engine.spec.ts
@@ -206,11 +206,7 @@ function makeA4IR(): WorkflowIR {
                 maxCommits: { type: "integer", minimum: 1 },
             },
         },
-        outputSchema: {
-            type: "object",
-            required: ["brief"],
-            properties: { brief: { type: "string" } },
-        },
+        outputSchema: { type: "string" },
         constants: {
             one: { schema: { type: "integer" }, value: 1 },
         },
@@ -2782,7 +2778,7 @@ describe("WorkflowEngine (IR v1)", () => {
                 name: "badLoopState",
                 version: "1",
                 inputSchema: { type: "object" },
-                outputSchema: { type: "object" },
+                outputSchema: { type: "integer" },
                 nodes: {
                     loop: {
                         kind: "loop",
@@ -3771,7 +3767,7 @@ describe("WorkflowEngine (IR v1)", () => {
                 name: "loopAbortTest",
                 version: "1",
                 inputSchema: { type: "object" },
-                outputSchema: { type: "object" },
+                outputSchema: { type: "integer" },
                 nodes: {
                     loop: {
                         kind: "loop",
@@ -3861,7 +3857,7 @@ describe("WorkflowEngine (IR v1)", () => {
                 name: "maxIterTest",
                 version: "1",
                 inputSchema: { type: "object" },
-                outputSchema: { type: "object" },
+                outputSchema: { type: "integer" },
                 nodes: {
                     loop: {
                         kind: "loop",
@@ -3949,7 +3945,7 @@ describe("WorkflowEngine (IR v1)", () => {
                 name: "loopConstantTest",
                 version: "1",
                 inputSchema: { type: "object" },
-                outputSchema: { type: "object" },
+                outputSchema: { type: "integer" },
                 constants: {
                     step: {
                         schema: { type: "integer" },
@@ -5237,7 +5233,7 @@ describe("WorkflowEngine (IR v1)", () => {
                 name: "noSentinel",
                 version: "1",
                 inputSchema: { type: "object" },
-                outputSchema: { type: "object" },
+                outputSchema: { type: "integer" },
                 nodes: {
                     loop: {
                         kind: "loop",

--- a/ts/examples/workflow/model/package.json
+++ b/ts/examples/workflow/model/package.json
@@ -28,6 +28,7 @@
   },
   "devDependencies": {
     "@types/jest": "^29.5.7",
+    "@types/json-schema": "^7.0.15",
     "jest": "^29.7.0",
     "prettier": "^3.5.3",
     "rimraf": "^6.0.1",

--- a/ts/examples/workflow/model/src/ir.ts
+++ b/ts/examples/workflow/model/src/ir.ts
@@ -40,6 +40,7 @@ export interface TaskNode {
     next?: string;
     onError?: string;
     bind?: string;
+    timeoutMs?: number;
 }
 
 export interface BranchNode {
@@ -71,6 +72,7 @@ export interface LoopNode {
     next?: string;
     onError?: string;
     bind?: string;
+    timeoutMs?: number;
 }
 
 export type WorkflowNode = TaskNode | BranchNode | LoopNode;

--- a/ts/examples/workflow/model/src/ir.ts
+++ b/ts/examples/workflow/model/src/ir.ts
@@ -8,8 +8,10 @@
  * document (parsed JSON), validates it structurally, then executes it.
  */
 
-/** Permissive JSON Schema type (passed directly to ajv). */
-export type JSONSchema = Record<string, unknown>;
+import type { JSONSchema7 } from "json-schema";
+
+/** JSON Schema Draft 7 type, re-exported from @types/json-schema. */
+export type JSONSchema = JSONSchema7;
 
 /**
  * Template: any JSON value the engine evaluates recursively.

--- a/ts/examples/workflow/model/src/taskDefinition.ts
+++ b/ts/examples/workflow/model/src/taskDefinition.ts
@@ -34,6 +34,9 @@ export interface TaskContext {
      * Task implementations should check these to enforce caller restrictions.
      */
     constraints?: TaskConstraints;
+
+    /** The node's declared output schema, if any. */
+    outputSchema?: JSONSchema;
 }
 
 /**

--- a/ts/examples/workflow/model/src/validate.ts
+++ b/ts/examples/workflow/model/src/validate.ts
@@ -205,35 +205,47 @@ function detectCycles(cfg: ScopeCFG): string[][] {
     }
 
     const cycles: string[][] = [];
-    const stack: string[] = [];
 
-    function dfs(u: string): void {
-        color.set(u, GRAY);
-        stack.push(u);
-        const succs = cfg.edges.get(u);
-        if (succs) {
-            for (const v of succs) {
+    function dfsIterative(start: string): void {
+        const stack: { node: string; iter: IterableIterator<string> }[] = [];
+        const path: string[] = [];
+
+        color.set(start, GRAY);
+        path.push(start);
+        const startSuccs = cfg.edges.get(start) ?? new Set<string>();
+        stack.push({ node: start, iter: startSuccs.values() });
+
+        while (stack.length > 0) {
+            const frame = stack[stack.length - 1];
+            const next = frame.iter.next();
+            if (next.done) {
+                color.set(frame.node, BLACK);
+                path.pop();
+                stack.pop();
+            } else {
+                const v = next.value;
                 const c = color.get(v);
                 if (c === GRAY) {
-                    // Back edge: extract cycle from stack
-                    const idx = stack.indexOf(v);
-                    cycles.push(stack.slice(idx));
+                    // Back edge: extract cycle from path
+                    const idx = path.indexOf(v);
+                    cycles.push(path.slice(idx));
                 } else if (c === WHITE) {
-                    dfs(v);
+                    color.set(v, GRAY);
+                    path.push(v);
+                    const vSuccs = cfg.edges.get(v) ?? new Set<string>();
+                    stack.push({ node: v, iter: vSuccs.values() });
                 }
             }
         }
-        stack.pop();
-        color.set(u, BLACK);
     }
 
     // Start from entry, then visit any unreached nodes
     if (color.has(cfg.entry)) {
-        dfs(cfg.entry);
+        dfsIterative(cfg.entry);
     }
     for (const id of cfg.edges.keys()) {
         if (color.get(id) === WHITE) {
-            dfs(id);
+            dfsIterative(id);
         }
     }
 
@@ -307,20 +319,30 @@ function checkTermination(cfg: ScopeCFG, insideLoop: boolean): Set<string> {
  * The entry node maps to itself.
  */
 function computeImmediateDominators(cfg: ScopeCFG): Map<string, string> {
-    // Compute reverse postorder via DFS from entry
+    // Compute reverse postorder via iterative DFS from entry
     const rpo: string[] = [];
     const visited = new Set<string>();
-    function dfs(u: string): void {
-        visited.add(u);
-        const succs = cfg.edges.get(u);
-        if (succs) {
-            for (const v of succs) {
-                if (!visited.has(v)) dfs(v);
+    {
+        const stack: {
+            node: string;
+            iter: IterableIterator<string>;
+        }[] = [];
+        visited.add(cfg.entry);
+        const entrySuccs = cfg.edges.get(cfg.entry) ?? new Set<string>();
+        stack.push({ node: cfg.entry, iter: entrySuccs.values() });
+        while (stack.length > 0) {
+            const frame = stack[stack.length - 1];
+            const next = frame.iter.next();
+            if (next.done) {
+                rpo.push(frame.node);
+                stack.pop();
+            } else if (!visited.has(next.value)) {
+                visited.add(next.value);
+                const vSuccs = cfg.edges.get(next.value) ?? new Set<string>();
+                stack.push({ node: next.value, iter: vSuccs.values() });
             }
         }
-        rpo.push(u);
     }
-    dfs(cfg.entry);
     rpo.reverse();
 
     // Map node -> rpo index for O(1) lookup
@@ -464,7 +486,7 @@ function buildOnErrorSplits(
             // Success side: nodes dominated by the next target (if any),
             // excluding nodes on the error side.
             let successSide = new Set<string>();
-            const nextTarget = node.kind === "task" ? node.next : node.next;
+            const nextTarget = node.next;
             if (
                 nextTarget &&
                 nextTarget !== "@iterate" &&
@@ -540,9 +562,7 @@ function isBindingCoveredAtNode(
         const hasSuccessBinder = binderList.some((b) =>
             split.successSide.has(b),
         );
-        const hasErrorBinder = binderList.some((b) =>
-            split.errorSide.has(b),
-        );
+        const hasErrorBinder = binderList.some((b) => split.errorSide.has(b));
         if (
             hasSuccessBinder &&
             hasErrorBinder &&
@@ -898,6 +918,7 @@ function checkScopeClosure(
     errors: ValidationError[],
 ): void {
     const bodyBindings = buildBindingMap(loopNode.body.nodes);
+    const outerBindings = buildBindingMap(outerNodes);
     // Also include names available via $from: "input" and $from: "state"
     // (those are legal cross-scope references). We only check $from: "scope".
 
@@ -911,7 +932,6 @@ function checkScopeClosure(
         for (const ref of refs) {
             if (!bodyBindings.has(ref.name)) {
                 // Check if this name exists in the outer scope
-                const outerBindings = buildBindingMap(outerNodes);
                 if (outerBindings.has(ref.name)) {
                     errors.push({
                         path: ref.templatePath,
@@ -985,6 +1005,7 @@ function checkStateSoundness(
             inputs,
             `${prefix}.body.nodes.${id}.inputs`,
         );
+        const inputsPrefix = `${prefix}.body.nodes.${id}.inputs.`;
         for (const ref of stateRefs) {
             if (!stateNames.has(ref.name)) {
                 errors.push({
@@ -997,18 +1018,12 @@ function checkStateSoundness(
                 // Type-compatibility: check the state variable's schema
                 // type against the consumer's expected type at this position.
                 const stateSchema = loopNode.state[ref.name].schema;
-                const inputKey = ref.templatePath.split(".").pop()!;
-                const consumerPropDef =
-                    inputSchema.properties?.[inputKey];
-                const consumerPropSchema =
-                    consumerPropDef !== undefined &&
-                    typeof consumerPropDef !== "boolean"
-                        ? consumerPropDef
-                        : undefined;
-                if (
-                    stateSchema.type &&
-                    consumerPropSchema?.type
-                ) {
+                const consumerPropSchema = resolveConsumerPropertySchema(
+                    ref.templatePath,
+                    inputsPrefix,
+                    inputSchema,
+                );
+                if (stateSchema.type && consumerPropSchema?.type) {
                     const stateTypes = normalizeTypeSet(stateSchema.type);
                     const consumerTypes = normalizeTypeSet(
                         consumerPropSchema.type,
@@ -1342,6 +1357,54 @@ function isTopSchema(schema: JSONSchema): boolean {
     return Object.keys(schema).length === 0;
 }
 
+/**
+ * Property-order-independent JSON stringification for schema comparison.
+ * Object keys are sorted recursively so structurally identical schemas
+ * produce the same string regardless of key insertion order.
+ */
+function canonicalStringify(value: unknown): string {
+    if (value === null || typeof value !== "object") {
+        return JSON.stringify(value);
+    }
+    if (Array.isArray(value)) {
+        return "[" + value.map(canonicalStringify).join(",") + "]";
+    }
+    const sorted = Object.keys(value as Record<string, unknown>).sort();
+    return (
+        "{" +
+        sorted
+            .map(
+                (k) =>
+                    JSON.stringify(k) +
+                    ":" +
+                    canonicalStringify((value as Record<string, unknown>)[k]),
+            )
+            .join(",") +
+        "}"
+    );
+}
+
+/**
+ * Look up the consumer's expected schema for an input field given a
+ * template path. Returns undefined for nested paths (containing "." or
+ * "[" after the inputs prefix) since those can't be directly mapped to
+ * an inputSchema property.
+ */
+function resolveConsumerPropertySchema(
+    templatePath: string,
+    inputsPrefix: string,
+    inputSchema: JSONSchema,
+): JSONSchema | undefined {
+    if (!templatePath.startsWith(inputsPrefix)) return undefined;
+    const fieldName = templatePath.slice(inputsPrefix.length);
+    if (!fieldName || fieldName.includes(".") || fieldName.includes("[")) {
+        return undefined;
+    }
+    const propDef = inputSchema.properties?.[fieldName];
+    if (!propDef || typeof propDef === "boolean") return undefined;
+    return propDef;
+}
+
 // ---- Pass 7: Type compatibility ----
 
 /** Context for resolving template types within a scope. */
@@ -1365,9 +1428,9 @@ function jsonValueToSchema(value: unknown): JSONSchema {
     if (Array.isArray(value)) {
         if (value.length === 0) return { type: "array" };
         const elemSchemas = value.map(jsonValueToSchema);
-        const firstJson = JSON.stringify(elemSchemas[0]);
+        const firstKey = canonicalStringify(elemSchemas[0]);
         const allSame = elemSchemas.every(
-            (s) => JSON.stringify(s) === firstJson,
+            (s) => canonicalStringify(s) === firstKey,
         );
         return allSame
             ? { type: "array", items: elemSchemas[0] }
@@ -1376,9 +1439,7 @@ function jsonValueToSchema(value: unknown): JSONSchema {
     if (typeof value === "object") {
         const properties: Record<string, JSONSchema> = {};
         const required: string[] = [];
-        for (const [k, v] of Object.entries(
-            value as Record<string, unknown>,
-        )) {
+        for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
             properties[k] = jsonValueToSchema(v);
             required.push(k);
         }
@@ -1412,9 +1473,9 @@ function resolveTemplateType(
             .map((e) => resolveTemplateType(e, ctx))
             .filter((s): s is JSONSchema => s !== undefined);
         if (elemSchemas.length === 0) return { type: "array" };
-        const firstJson = JSON.stringify(elemSchemas[0]);
+        const firstKey = canonicalStringify(elemSchemas[0]);
         const allSame = elemSchemas.every(
-            (s) => JSON.stringify(s) === firstJson,
+            (s) => canonicalStringify(s) === firstKey,
         );
         return allSame
             ? { type: "array", items: elemSchemas[0] }
@@ -1597,16 +1658,10 @@ function validateTypeCompatibility(
             const inputs = node.inputs;
             const inputProps = node.inputSchema.properties ?? {};
             for (const [fieldName, templateValue] of Object.entries(inputs)) {
-                const resolved = resolveTemplateType(
-                    templateValue,
-                    ctx,
-                );
+                const resolved = resolveTemplateType(templateValue, ctx);
                 if (!resolved) continue;
                 const consumerPropDef = inputProps[fieldName];
-                if (
-                    !consumerPropDef ||
-                    typeof consumerPropDef === "boolean"
-                ) {
+                if (!consumerPropDef || typeof consumerPropDef === "boolean") {
                     continue;
                 }
                 if (!isStructuralSubtype(resolved, consumerPropDef)) {
@@ -1640,9 +1695,7 @@ function validateTypeCompatibility(
 
             // Check cases keys against selectorSchema enum
             if (node.selectorSchema.enum) {
-                const validKeys = new Set(
-                    node.selectorSchema.enum.map(String),
-                );
+                const validKeys = new Set(node.selectorSchema.enum.map(String));
                 for (const caseKey of Object.keys(node.cases)) {
                     if (!validKeys.has(caseKey)) {
                         errors.push({
@@ -1685,15 +1738,9 @@ function validateTypeCompatibility(
                     node.output,
                     bodyCtx,
                 );
-                if (
-                    outputResolved &&
-                    !isTopSchema(node.outputSchema)
-                ) {
+                if (outputResolved && !isTopSchema(node.outputSchema)) {
                     if (
-                        !isStructuralSubtype(
-                            outputResolved,
-                            node.outputSchema,
-                        )
+                        !isStructuralSubtype(outputResolved, node.outputSchema)
                     ) {
                         errors.push({
                             path: `${path}.output`,
@@ -1775,9 +1822,7 @@ function checkPhiMergeTypes(
                 if (!binderSchema) continue;
 
                 // Apply path projection if present
-                const refPath = obj["path"] as
-                    | (string | number)[]
-                    | undefined;
+                const refPath = obj["path"] as (string | number)[] | undefined;
                 const projected =
                     refPath && refPath.length > 0
                         ? resolveSchemaPath(binderSchema, refPath)
@@ -2000,6 +2045,7 @@ function validateSchemaCompat(
             inputs = node.inputs;
 
             // Also check iterateState and output templates.
+            const bodyBindings = buildBindingMap(node.body.nodes);
             for (const [stateName, stateTemplate] of Object.entries(
                 node.iterateState,
             )) {
@@ -2009,7 +2055,6 @@ function validateSchemaCompat(
                 );
                 for (const ref of stateRefs) {
                     // iterateState refs resolve in the body scope
-                    const bodyBindings = buildBindingMap(node.body.nodes);
                     const producerSchema = bodyBindings.get(ref.name);
                     if (!producerSchema) continue;
                     const err = checkSchemaCompat(
@@ -2026,7 +2071,6 @@ function validateSchemaCompat(
             const outputRefs = collectScopeRefs(node.output, `${path}.output`);
             for (const ref of outputRefs) {
                 // output refs resolve in the body scope
-                const bodyBindings = buildBindingMap(node.body.nodes);
                 const producerSchema = bodyBindings.get(ref.name);
                 if (!producerSchema) continue;
                 const err = checkSchemaCompat(
@@ -2049,6 +2093,7 @@ function validateSchemaCompat(
                 ? node.inputSchema
                 : undefined;
 
+        const inputsPrefix = `${path}.inputs.`;
         const refs = collectScopeRefs(inputs, `${path}.inputs`);
         for (const ref of refs) {
             const producerSchema = bindings.get(ref.name);
@@ -2063,29 +2108,13 @@ function validateSchemaCompat(
                 }
                 continue;
             }
-            // Extract consumer expected type from inputSchema.
-            // Only for direct (non-nested) input properties where the
-            // entire value is a scope ref (e.g., inputs.a = { $from: ... }).
-            // Nested refs like inputs.vars.diff can't be checked because
-            // the consumer schema is for "vars" (object), not "vars.diff".
-            let consumerType: string | string[] | undefined;
-            const inputsPrefix = `${path}.inputs.`;
-            if (
-                consumerInputSchema &&
-                ref.templatePath.startsWith(inputsPrefix)
-            ) {
-                const remainder = ref.templatePath.slice(inputsPrefix.length);
-                // Only check when remainder is a simple property name (no dots)
-                if (!remainder.includes(".") && !remainder.includes("[")) {
-                    const props = consumerInputSchema.properties;
-                    if (props && remainder in props) {
-                        const sub = props[remainder];
-                        if (typeof sub !== "boolean") {
-                            consumerType = sub.type;
-                        }
-                    }
-                }
-            }
+            const consumerType = consumerInputSchema
+                ? resolveConsumerPropertySchema(
+                      ref.templatePath,
+                      inputsPrefix,
+                      consumerInputSchema,
+                  )?.type
+                : undefined;
             const err = checkSchemaCompat(
                 producerSchema,
                 ref.path,

--- a/ts/examples/workflow/model/src/validate.ts
+++ b/ts/examples/workflow/model/src/validate.ts
@@ -125,6 +125,15 @@ function buildScopeCFG(
     const edges = new Map<string, Set<string>>();
     const sentinelTargets = new Map<string, Set<"@iterate" | "@exit">>();
 
+    function addSentinel(id: string, target: "@iterate" | "@exit"): void {
+        let st = sentinelTargets.get(id);
+        if (!st) {
+            st = new Set();
+            sentinelTargets.set(id, st);
+        }
+        st.add(target);
+    }
+
     for (const [id, node] of Object.entries(nodes)) {
         const succs = new Set<string>();
         edges.set(id, succs);
@@ -132,12 +141,7 @@ function buildScopeCFG(
         if (node.kind === "task") {
             if (node.next) {
                 if (node.next === "@iterate" || node.next === "@exit") {
-                    let st = sentinelTargets.get(id);
-                    if (!st) {
-                        st = new Set();
-                        sentinelTargets.set(id, st);
-                    }
-                    st.add(node.next);
+                    addSentinel(id, node.next);
                 } else {
                     succs.add(node.next);
                 }
@@ -148,23 +152,13 @@ function buildScopeCFG(
         } else if (node.kind === "branch") {
             for (const target of Object.values(node.cases)) {
                 if (target === "@iterate" || target === "@exit") {
-                    let st = sentinelTargets.get(id);
-                    if (!st) {
-                        st = new Set();
-                        sentinelTargets.set(id, st);
-                    }
-                    st.add(target);
+                    addSentinel(id, target);
                 } else {
                     succs.add(target);
                 }
             }
             if (node.default === "@iterate" || node.default === "@exit") {
-                let st = sentinelTargets.get(id);
-                if (!st) {
-                    st = new Set();
-                    sentinelTargets.set(id, st);
-                }
-                st.add(node.default);
+                addSentinel(id, node.default);
             } else {
                 succs.add(node.default);
             }
@@ -750,11 +744,12 @@ function validateScopeCFG(
                 `with @iterate instead.`,
         });
     }
+
+    // Pass 4 (completion): onError structural rules (does not require acyclicity)
+    validateOnErrorRules(nodes, entry, prefix, errors);
+
     // If cycles exist, skip passes that depend on acyclicity
     if (cycles.length > 0) return;
-
-    // Pass 4 (completion): onError structural rules
-    validateOnErrorRules(nodes, entry, prefix, errors);
 
     // Pass 5: Scope closure (loop bodies only)
     // Checked within the loop body recursion below.
@@ -1161,6 +1156,16 @@ function validateScope(
                 });
             }
 
+            if (
+                !Number.isInteger(node.maxIterations) ||
+                node.maxIterations < 1
+            ) {
+                errors.push({
+                    path: `${path}.maxIterations`,
+                    message: `maxIterations must be a positive integer (got ${node.maxIterations}).`,
+                });
+            }
+
             if (node.next && !nodeIds.has(node.next)) {
                 errors.push({
                     path: `${path}.next`,
@@ -1375,7 +1380,7 @@ function jsonValueToSchema(value: unknown): JSONSchema {
         const elemSchemas = value.map(jsonValueToSchema);
         const firstKey = canonicalStringify(elemSchemas[0]);
         const allSame = elemSchemas.every(
-            (s) => canonicalStringify(s) === firstKey,
+            (s) => s === elemSchemas[0] || canonicalStringify(s) === firstKey,
         );
         return allSame
             ? { type: "array", items: elemSchemas[0] }
@@ -1420,7 +1425,7 @@ function resolveTemplateType(
         if (elemSchemas.length === 0) return { type: "array" };
         const firstKey = canonicalStringify(elemSchemas[0]);
         const allSame = elemSchemas.every(
-            (s) => canonicalStringify(s) === firstKey,
+            (s) => s === elemSchemas[0] || canonicalStringify(s) === firstKey,
         );
         return allSame
             ? { type: "array", items: elemSchemas[0] }
@@ -1625,16 +1630,42 @@ function validateTypeCompatibility(
         if (node.kind === "branch") {
             // Check selector template resolved type vs selectorSchema
             const selectorType = resolveTemplateType(node.selector, ctx);
-            if (selectorType && !isTopSchema(node.selectorSchema)) {
-                if (!isStructuralSubtype(selectorType, node.selectorSchema)) {
-                    errors.push({
-                        path: `${path}.selector`,
-                        message:
-                            `Selector resolved type ` +
-                            `${formatSchemaType(selectorType)} is not ` +
-                            `compatible with selectorSchema ` +
-                            `${formatSchemaType(node.selectorSchema)}.`,
-                    });
+            if (selectorType) {
+                // Verify resolved selector is a primitive type
+                if (selectorType.type) {
+                    const resolvedTypes = normalizeTypeSet(selectorType.type);
+                    const nonPrimitive = resolvedTypes.filter(
+                        (t) =>
+                            t !== "string" &&
+                            t !== "number" &&
+                            t !== "integer" &&
+                            t !== "boolean",
+                    );
+                    if (nonPrimitive.length > 0) {
+                        errors.push({
+                            path: `${path}.selector`,
+                            message:
+                                `Selector resolves to ` +
+                                `${formatSchemaType(selectorType)} which ` +
+                                `cannot be meaningfully coerced to a case ` +
+                                `label. Selector must resolve to string, ` +
+                                `number, or boolean.`,
+                        });
+                    }
+                }
+                if (!isTopSchema(node.selectorSchema)) {
+                    if (
+                        !isStructuralSubtype(selectorType, node.selectorSchema)
+                    ) {
+                        errors.push({
+                            path: `${path}.selector`,
+                            message:
+                                `Selector resolved type ` +
+                                `${formatSchemaType(selectorType)} is not ` +
+                                `compatible with selectorSchema ` +
+                                `${formatSchemaType(node.selectorSchema)}.`,
+                        });
+                    }
                 }
             }
 

--- a/ts/examples/workflow/model/src/validate.ts
+++ b/ts/examples/workflow/model/src/validate.ts
@@ -56,7 +56,7 @@ export function validateWorkflowIR(
     // bindings. This catches references to names that no node binds.
     if (ir.output) {
         const bindings = buildBindingMap(ir.nodes);
-        const outputRefs = collectScopeRefs(ir.output, "output");
+        const outputRefs = collectTemplateRefs(ir.output, "output", "scope");
         for (const ref of outputRefs) {
             if (!bindings.has(ref.name)) {
                 if (!ref.optional) {
@@ -634,12 +634,13 @@ function checkDominance(
     // Coverage (6b): for each $from scope ref in node inputs, check that
     // at least one binder dominates the consumer on every path.
     for (const [id, node] of Object.entries(nodes)) {
-        let inputs: Record<string, Template> | undefined;
-        if (node.kind === "task") inputs = node.inputs;
-        else if (node.kind === "loop") inputs = node.inputs;
-        if (!inputs) continue;
+        if (node.kind !== "task" && node.kind !== "loop") continue;
 
-        const refs = collectScopeRefs(inputs, `${prefix}.${id}.inputs`);
+        const refs = collectTemplateRefs(
+            node.inputs,
+            `${prefix}.${id}.inputs`,
+            "scope",
+        );
         for (const ref of refs) {
             const binderList = binders.get(ref.name);
             if (!binderList || binderList.length === 0) continue; // caught by name resolution
@@ -667,7 +668,11 @@ function checkDominance(
     // Output template coverage: check that output refs are covered on
     // all paths to any terminal.
     if (outputTemplate && outputPrefix) {
-        const outputRefs = collectScopeRefs(outputTemplate, outputPrefix);
+        const outputRefs = collectTemplateRefs(
+            outputTemplate,
+            outputPrefix,
+            "scope",
+        );
         for (const ref of outputRefs) {
             const binderList = binders.get(ref.name);
             if (!binderList || binderList.length === 0) continue;
@@ -818,12 +823,11 @@ function validateOnErrorRules(
     normalTargets.add(entry);
 
     for (const [id, node] of Object.entries(nodes)) {
-        if (node.kind === "task") {
+        if (node.kind === "task" || node.kind === "loop") {
             if (node.next) normalTargets.add(node.next);
             if (node.onError) {
                 const existing = onErrorTargetToTrigger.get(node.onError);
                 if (existing) {
-                    // Rule 2: single trigger
                     errors.push({
                         path: `${prefix}.${id}.onError`,
                         message:
@@ -843,22 +847,6 @@ function validateOnErrorRules(
             }
             if (node.default !== "@iterate" && node.default !== "@exit") {
                 normalTargets.add(node.default);
-            }
-        } else if (node.kind === "loop") {
-            if (node.next) normalTargets.add(node.next);
-            if (node.onError) {
-                const existing = onErrorTargetToTrigger.get(node.onError);
-                if (existing) {
-                    errors.push({
-                        path: `${prefix}.${id}.onError`,
-                        message:
-                            `Recovery node "${node.onError}" is targeted by ` +
-                            `both "${existing}" and "${id}". A recovery ` +
-                            `target must have exactly one trigger in v1.`,
-                    });
-                } else {
-                    onErrorTargetToTrigger.set(node.onError, id);
-                }
             }
         }
     }
@@ -923,12 +911,13 @@ function checkScopeClosure(
     // (those are legal cross-scope references). We only check $from: "scope".
 
     for (const [id, node] of Object.entries(loopNode.body.nodes)) {
-        let inputs: Record<string, Template> | undefined;
-        if (node.kind === "task") inputs = node.inputs;
-        else if (node.kind === "loop") inputs = node.inputs;
-        if (!inputs) continue;
+        if (node.kind !== "task" && node.kind !== "loop") continue;
 
-        const refs = collectScopeRefs(inputs, `${bodyPrefix}.${id}.inputs`);
+        const refs = collectTemplateRefs(
+            node.inputs,
+            `${bodyPrefix}.${id}.inputs`,
+            "scope",
+        );
         for (const ref of refs) {
             if (!bodyBindings.has(ref.name)) {
                 // Check if this name exists in the outer scope
@@ -990,20 +979,12 @@ function checkStateSoundness(
     // and that the state variable's schema type is compatible with the
     // consumer's expected type at that input position.
     for (const [id, node] of Object.entries(loopNode.body.nodes)) {
-        let inputs: Record<string, Template> | undefined;
-        let inputSchema: JSONSchema | undefined;
-        if (node.kind === "task") {
-            inputs = node.inputs;
-            inputSchema = node.inputSchema;
-        } else if (node.kind === "loop") {
-            inputs = node.inputs;
-            inputSchema = node.inputSchema;
-        }
-        if (!inputs) continue;
+        if (node.kind !== "task" && node.kind !== "loop") continue;
 
-        const stateRefs = collectStateRefs(
-            inputs,
+        const stateRefs = collectTemplateRefs(
+            node.inputs,
             `${prefix}.body.nodes.${id}.inputs`,
+            "state",
         );
         const inputsPrefix = `${prefix}.body.nodes.${id}.inputs.`;
         for (const ref of stateRefs) {
@@ -1014,14 +995,14 @@ function checkStateSoundness(
                         `$from "state", name "${ref.name}": no state ` +
                         `variable "${ref.name}" is declared on this loop.`,
                 });
-            } else if (inputSchema) {
+            } else {
                 // Type-compatibility: check the state variable's schema
                 // type against the consumer's expected type at this position.
                 const stateSchema = loopNode.state[ref.name].schema;
                 const consumerPropSchema = resolveConsumerPropertySchema(
                     ref.templatePath,
                     inputsPrefix,
-                    inputSchema,
+                    node.inputSchema,
                 );
                 if (stateSchema.type && consumerPropSchema?.type) {
                     const stateTypes = normalizeTypeSet(stateSchema.type);
@@ -1046,40 +1027,6 @@ function checkStateSoundness(
             }
         }
     }
-}
-
-/**
- * Walk a template and collect all $from: "state" references.
- */
-function collectStateRefs(
-    template: Template,
-    templatePath: string,
-): { name: string; templatePath: string }[] {
-    if (template === null || template === undefined) return [];
-    if (typeof template !== "object") return [];
-    if (Array.isArray(template)) {
-        const refs: { name: string; templatePath: string }[] = [];
-        for (let i = 0; i < template.length; i++) {
-            refs.push(
-                ...collectStateRefs(template[i], `${templatePath}[${i}]`),
-            );
-        }
-        return refs;
-    }
-
-    const obj = template as Record<string, unknown>;
-    if (obj["$from"] === "state") {
-        return [{ name: obj["name"] as string, templatePath }];
-    }
-    if ("$literal" in obj) return [];
-
-    const refs: { name: string; templatePath: string }[] = [];
-    for (const [key, value] of Object.entries(obj)) {
-        refs.push(
-            ...collectStateRefs(value as Template, `${templatePath}.${key}`),
-        );
-    }
-    return refs;
 }
 
 function validateScope(
@@ -1261,9 +1208,7 @@ function buildBindingMap(
 ): Map<string, JSONSchema> {
     const map = new Map<string, JSONSchema>();
     for (const node of Object.values(nodes)) {
-        if (node.kind === "task" && node.bind) {
-            map.set(node.bind, node.outputSchema);
-        } else if (node.kind === "loop" && node.bind) {
+        if ((node.kind === "task" || node.kind === "loop") && node.bind) {
             map.set(node.bind, node.outputSchema);
         }
     }
@@ -1976,33 +1921,43 @@ function checkNodeTaskSchemas(
 }
 
 /**
- * Walk a template and collect all $from: "scope" references.
+ * A reference extracted from a template expression (e.g. $from: "scope"
+ * or $from: "state").
  */
-interface ScopeRef {
+interface TemplateRef {
     name: string;
     path: (string | number)[] | undefined;
     optional: boolean;
     templatePath: string;
 }
 
-function collectScopeRefs(
+/**
+ * Walk a template and collect all $from references matching the given
+ * namespace (e.g. "scope", "state", "input", "constant").
+ */
+function collectTemplateRefs(
     template: Template,
     templatePath: string,
-): ScopeRef[] {
+    fromValue: string,
+): TemplateRef[] {
     if (template === null || template === undefined) return [];
     if (typeof template !== "object") return [];
     if (Array.isArray(template)) {
-        const refs: ScopeRef[] = [];
+        const refs: TemplateRef[] = [];
         for (let i = 0; i < template.length; i++) {
             refs.push(
-                ...collectScopeRefs(template[i], `${templatePath}[${i}]`),
+                ...collectTemplateRefs(
+                    template[i],
+                    `${templatePath}[${i}]`,
+                    fromValue,
+                ),
             );
         }
         return refs;
     }
 
     const obj = template as Record<string, unknown>;
-    if (obj["$from"] === "scope") {
+    if (obj["$from"] === fromValue) {
         return [
             {
                 name: obj["name"] as string,
@@ -2014,13 +1969,42 @@ function collectScopeRefs(
     }
     if ("$literal" in obj) return [];
 
-    const refs: ScopeRef[] = [];
+    const refs: TemplateRef[] = [];
     for (const [key, value] of Object.entries(obj)) {
         refs.push(
-            ...collectScopeRefs(value as Template, `${templatePath}.${key}`),
+            ...collectTemplateRefs(
+                value as Template,
+                `${templatePath}.${key}`,
+                fromValue,
+            ),
         );
     }
     return refs;
+}
+
+/**
+ * Check scope refs in a template against a binding map, pushing
+ * schema compatibility errors.
+ */
+function checkScopeRefsAgainstBindings(
+    template: Template,
+    templatePath: string,
+    bindings: Map<string, JSONSchema>,
+    errors: ValidationError[],
+): void {
+    const refs = collectTemplateRefs(template, templatePath, "scope");
+    for (const ref of refs) {
+        const producerSchema = bindings.get(ref.name);
+        if (!producerSchema) continue;
+        const err = checkSchemaCompat(
+            producerSchema,
+            ref.path,
+            `${ref.templatePath} ($from "scope", name "${ref.name}")`,
+        );
+        if (err) {
+            errors.push({ path: ref.templatePath, message: err });
+        }
+    }
 }
 
 /**
@@ -2037,64 +2021,37 @@ function validateSchemaCompat(
 
     for (const [id, node] of Object.entries(nodes)) {
         const path = `${prefix}.${id}`;
-        let inputs: Record<string, Template> | undefined;
 
-        if (node.kind === "task") {
-            inputs = node.inputs;
-        } else if (node.kind === "loop") {
-            inputs = node.inputs;
-
-            // Also check iterateState and output templates.
+        // For loop nodes, check iterateState and output templates
+        // against body-scope bindings.
+        if (node.kind === "loop") {
             const bodyBindings = buildBindingMap(node.body.nodes);
             for (const [stateName, stateTemplate] of Object.entries(
                 node.iterateState,
             )) {
-                const stateRefs = collectScopeRefs(
+                checkScopeRefsAgainstBindings(
                     stateTemplate,
                     `${path}.iterateState.${stateName}`,
+                    bodyBindings,
+                    errors,
                 );
-                for (const ref of stateRefs) {
-                    // iterateState refs resolve in the body scope
-                    const producerSchema = bodyBindings.get(ref.name);
-                    if (!producerSchema) continue;
-                    const err = checkSchemaCompat(
-                        producerSchema,
-                        ref.path,
-                        `${ref.templatePath} ($from "scope", name "${ref.name}")`,
-                    );
-                    if (err) {
-                        errors.push({ path: ref.templatePath, message: err });
-                    }
-                }
             }
-
-            const outputRefs = collectScopeRefs(node.output, `${path}.output`);
-            for (const ref of outputRefs) {
-                // output refs resolve in the body scope
-                const producerSchema = bodyBindings.get(ref.name);
-                if (!producerSchema) continue;
-                const err = checkSchemaCompat(
-                    producerSchema,
-                    ref.path,
-                    `${ref.templatePath} ($from "scope", name "${ref.name}")`,
-                );
-                if (err) {
-                    errors.push({ path: ref.templatePath, message: err });
-                }
-            }
+            checkScopeRefsAgainstBindings(
+                node.output,
+                `${path}.output`,
+                bodyBindings,
+                errors,
+            );
         }
 
-        if (!inputs) continue;
-
-        // Resolve consumer types from the node's inputSchema for
-        // type compatibility checking on direct input properties.
-        const consumerInputSchema =
-            node.kind === "task" || node.kind === "loop"
-                ? node.inputSchema
-                : undefined;
+        if (node.kind !== "task" && node.kind !== "loop") continue;
 
         const inputsPrefix = `${path}.inputs.`;
-        const refs = collectScopeRefs(inputs, `${path}.inputs`);
+        const refs = collectTemplateRefs(
+            node.inputs,
+            `${path}.inputs`,
+            "scope",
+        );
         for (const ref of refs) {
             const producerSchema = bindings.get(ref.name);
             if (!producerSchema) {
@@ -2108,13 +2065,11 @@ function validateSchemaCompat(
                 }
                 continue;
             }
-            const consumerType = consumerInputSchema
-                ? resolveConsumerPropertySchema(
-                      ref.templatePath,
-                      inputsPrefix,
-                      consumerInputSchema,
-                  )?.type
-                : undefined;
+            const consumerType = resolveConsumerPropertySchema(
+                ref.templatePath,
+                inputsPrefix,
+                node.inputSchema,
+            )?.type;
             const err = checkSchemaCompat(
                 producerSchema,
                 ref.path,

--- a/ts/examples/workflow/model/src/validate.ts
+++ b/ts/examples/workflow/model/src/validate.ts
@@ -76,6 +76,11 @@ function validateScope(
                     path: `${path}.task`,
                     message: `Task "${node.task}" is not registered.`,
                 });
+            } else if (tasks) {
+                const taskDef = tasks.get(node.task);
+                if (taskDef) {
+                    checkNodeTaskSchemas(taskDef, node, path, errors);
+                }
             }
             if (node.next && !nodeIds.has(node.next)) {
                 errors.push({
@@ -228,19 +233,26 @@ function resolveSchemaPath(
     for (const segment of path) {
         if (typeof segment === "number") {
             // Array index: look at items schema
-            if (current.type !== "array" || !current.items) {
+            if (
+                current.type !== "array" ||
+                !current.items ||
+                typeof current.items === "boolean" ||
+                Array.isArray(current.items)
+            ) {
                 return undefined;
             }
-            current = current.items as JSONSchema;
+            current = current.items;
         } else {
             // Object property
-            const props = current.properties as
-                | Record<string, JSONSchema>
-                | undefined;
+            const props = current.properties;
             if (!props || !(segment in props)) {
                 return undefined;
             }
-            current = props[segment];
+            const sub = props[segment];
+            if (typeof sub === "boolean") {
+                return undefined;
+            }
+            current = sub;
         }
     }
     return current;
@@ -289,6 +301,135 @@ function normalizeTypeSet(type: unknown): string[] {
     if (Array.isArray(type)) return type as string[];
     if (typeof type === "string") return [type];
     return [];
+}
+
+/** True when a schema is the top type (empty object: no constraints). */
+function isTopSchema(schema: JSONSchema): boolean {
+    return Object.keys(schema).length === 0;
+}
+
+/**
+ * Validate that a workflow node's inputSchema and outputSchema are
+ * compatible with the registered task definition's schemas.
+ *
+ * Rules:
+ * - Input: the node must declare as required every property the task
+ *   requires. Shared property types must be compatible.
+ * - Output: the node can refine (narrow) the task's output. It must
+ *   keep all task-required properties as required. It may only declare
+ *   properties that the task itself declares. Task properties with
+ *   empty schemas ({}, the top type) accept any refinement.
+ */
+function checkNodeTaskSchemas(
+    taskDef: TaskDefinition,
+    node: { inputSchema: JSONSchema; outputSchema: JSONSchema },
+    path: string,
+    errors: ValidationError[],
+): void {
+    // --- Input: node must satisfy task's requirements ---
+    const taskInputReq = taskDef.inputSchema.required ?? [];
+    const nodeInputReq = node.inputSchema.required ?? [];
+    for (const prop of taskInputReq) {
+        if (!nodeInputReq.includes(prop)) {
+            errors.push({
+                path: `${path}.inputSchema`,
+                message:
+                    `Task requires input "${prop}" but node ` +
+                    `does not declare it as required.`,
+            });
+        }
+    }
+
+    const taskInputProps = taskDef.inputSchema.properties ?? {};
+    const nodeInputProps = node.inputSchema.properties ?? {};
+    for (const [propName, taskPropDef] of Object.entries(taskInputProps)) {
+        if (typeof taskPropDef === "boolean" || isTopSchema(taskPropDef)) {
+            continue;
+        }
+        const nodePropDef = nodeInputProps[propName];
+        if (
+            nodePropDef === undefined ||
+            typeof nodePropDef === "boolean" ||
+            !nodePropDef.type ||
+            !taskPropDef.type
+        ) {
+            continue;
+        }
+        const taskTypes = normalizeTypeSet(taskPropDef.type);
+        const nodeTypes = normalizeTypeSet(nodePropDef.type);
+        const overlap = nodeTypes.some((nt) => taskTypes.includes(nt));
+        if (!overlap) {
+            errors.push({
+                path: `${path}.inputSchema`,
+                message:
+                    `Input property "${propName}": node declares type ` +
+                    `${JSON.stringify(nodePropDef.type)} but task expects ` +
+                    `${JSON.stringify(taskPropDef.type)}.`,
+            });
+        }
+    }
+
+    // --- Output: node can only refine what the task produces ---
+    const taskOutputReq = taskDef.outputSchema.required ?? [];
+    const nodeOutputReq = node.outputSchema.required ?? [];
+    for (const prop of taskOutputReq) {
+        if (!nodeOutputReq.includes(prop)) {
+            errors.push({
+                path: `${path}.outputSchema`,
+                message:
+                    `Task requires output "${prop}" but node ` +
+                    `does not declare it as required.`,
+            });
+        }
+    }
+
+    const taskOutputProps = taskDef.outputSchema.properties ?? {};
+    const nodeOutputProps = node.outputSchema.properties ?? {};
+
+    // Node must not claim output properties the task does not produce,
+    // unless the task's entire outputSchema is unconstrained.
+    if (!isTopSchema(taskDef.outputSchema)) {
+        for (const propName of Object.keys(nodeOutputProps)) {
+            if (!(propName in taskOutputProps)) {
+                errors.push({
+                    path: `${path}.outputSchema`,
+                    message:
+                        `Node declares output property "${propName}" ` +
+                        `but task does not produce it.`,
+                });
+            }
+        }
+    }
+
+    // Type compatibility for output properties (skip top-schema properties).
+    for (const [propName, taskPropDef] of Object.entries(taskOutputProps)) {
+        if (typeof taskPropDef === "boolean" || isTopSchema(taskPropDef)) {
+            continue;
+        }
+        const nodePropDef = nodeOutputProps[propName];
+        if (
+            nodePropDef === undefined ||
+            typeof nodePropDef === "boolean" ||
+            !nodePropDef.type ||
+            !taskPropDef.type
+        ) {
+            continue;
+        }
+        const taskTypes = normalizeTypeSet(taskPropDef.type);
+        const nodeTypes = normalizeTypeSet(nodePropDef.type);
+        // Node output types must be a subset of task types (narrowing).
+        for (const nt of nodeTypes) {
+            if (!taskTypes.includes(nt)) {
+                errors.push({
+                    path: `${path}.outputSchema`,
+                    message:
+                        `Output property "${propName}": node declares ` +
+                        `type "${nt}" but task only produces ` +
+                        `${JSON.stringify(taskPropDef.type)}.`,
+                });
+            }
+        }
+    }
 }
 
 /**
@@ -431,14 +572,12 @@ function validateSchemaCompat(
                 const remainder = ref.templatePath.slice(inputsPrefix.length);
                 // Only check when remainder is a simple property name (no dots)
                 if (!remainder.includes(".") && !remainder.includes("[")) {
-                    const props = consumerInputSchema.properties as
-                        | Record<string, JSONSchema>
-                        | undefined;
+                    const props = consumerInputSchema.properties;
                     if (props && remainder in props) {
-                        consumerType = props[remainder].type as
-                            | string
-                            | string[]
-                            | undefined;
+                        const sub = props[remainder];
+                        if (typeof sub !== "boolean") {
+                            consumerType = sub.type;
+                        }
                     }
                 }
             }

--- a/ts/examples/workflow/model/src/validate.ts
+++ b/ts/examples/workflow/model/src/validate.ts
@@ -1,7 +1,14 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { WorkflowIR, WorkflowNode, Template, JSONSchema } from "./ir.js";
+import {
+    WorkflowIR,
+    WorkflowNode,
+    Template,
+    JSONSchema,
+    ConstantDef,
+    LoopStateVar,
+} from "./ir.js";
 import { TaskDefinition } from "./taskDefinition.js";
 
 export interface ValidationError {
@@ -77,6 +84,19 @@ export function validateWorkflowIR(
     // CFG-based passes: acyclicity, onError rules, termination,
     // scope closure, dominator analysis, state soundness, output binding.
     validateCFGPasses(ir, errors);
+
+    // Pass 7: Type compatibility (compositional resolved types).
+    validateTypeCompatibility(
+        ir.nodes,
+        "nodes",
+        errors,
+        ir.inputSchema,
+        undefined,
+        ir.constants,
+        ir.output,
+        "output",
+        ir.outputSchema,
+    );
 
     return { valid: errors.length === 0, errors };
 }
@@ -658,6 +678,11 @@ function checkDominance(
             }
         }
     }
+
+    // Pass 7 (phi-merge): when multiple binders contribute to the same
+    // name, each binder's output type must be compatible with every
+    // consumer's expected type.
+    checkPhiMergeTypes(nodes, binders, prefix, errors);
 }
 
 // ---- Orchestrate CFG-based passes ----
@@ -1315,6 +1340,470 @@ function normalizeTypeSet(type: unknown): string[] {
 /** True when a schema is the top type (empty object: no constraints). */
 function isTopSchema(schema: JSONSchema): boolean {
     return Object.keys(schema).length === 0;
+}
+
+// ---- Pass 7: Type compatibility ----
+
+/** Context for resolving template types within a scope. */
+interface TypeResolutionContext {
+    bindings: Map<string, JSONSchema>;
+    inputSchema: JSONSchema | undefined;
+    stateVars: Record<string, LoopStateVar> | undefined;
+    constants: Record<string, ConstantDef> | undefined;
+}
+
+/** Derive a JSON Schema from a literal JSON value. */
+function jsonValueToSchema(value: unknown): JSONSchema {
+    if (value === null) return { type: "null" };
+    if (typeof value === "string") return { type: "string" };
+    if (typeof value === "number") {
+        return Number.isInteger(value)
+            ? { type: "integer" }
+            : { type: "number" };
+    }
+    if (typeof value === "boolean") return { type: "boolean" };
+    if (Array.isArray(value)) {
+        if (value.length === 0) return { type: "array" };
+        const elemSchemas = value.map(jsonValueToSchema);
+        const firstJson = JSON.stringify(elemSchemas[0]);
+        const allSame = elemSchemas.every(
+            (s) => JSON.stringify(s) === firstJson,
+        );
+        return allSame
+            ? { type: "array", items: elemSchemas[0] }
+            : { type: "array" };
+    }
+    if (typeof value === "object") {
+        const properties: Record<string, JSONSchema> = {};
+        const required: string[] = [];
+        for (const [k, v] of Object.entries(
+            value as Record<string, unknown>,
+        )) {
+            properties[k] = jsonValueToSchema(v);
+            required.push(k);
+        }
+        return {
+            type: "object",
+            properties,
+            ...(required.length > 0 ? { required } : {}),
+        };
+    }
+    return {};
+}
+
+/**
+ * Compute the JSON Schema type that a template expression resolves to.
+ * Returns undefined if the type cannot be determined (e.g. unknown ref).
+ */
+function resolveTemplateType(
+    template: Template,
+    ctx: TypeResolutionContext,
+): JSONSchema | undefined {
+    if (template === null) return { type: "null" };
+    if (typeof template === "string") return { type: "string" };
+    if (typeof template === "number") {
+        return Number.isInteger(template)
+            ? { type: "integer" }
+            : { type: "number" };
+    }
+    if (typeof template === "boolean") return { type: "boolean" };
+    if (Array.isArray(template)) {
+        const elemSchemas = template
+            .map((e) => resolveTemplateType(e, ctx))
+            .filter((s): s is JSONSchema => s !== undefined);
+        if (elemSchemas.length === 0) return { type: "array" };
+        const firstJson = JSON.stringify(elemSchemas[0]);
+        const allSame = elemSchemas.every(
+            (s) => JSON.stringify(s) === firstJson,
+        );
+        return allSame
+            ? { type: "array", items: elemSchemas[0] }
+            : { type: "array" };
+    }
+
+    const obj = template as Record<string, unknown>;
+
+    if ("$from" in obj) {
+        const from = obj["$from"] as string;
+        const name = obj["name"] as string;
+        const path = obj["path"] as (string | number)[] | undefined;
+
+        let baseSchema: JSONSchema | undefined;
+        switch (from) {
+            case "scope":
+                baseSchema = ctx.bindings.get(name);
+                break;
+            case "input":
+                if (ctx.inputSchema?.properties) {
+                    const prop = ctx.inputSchema.properties[name];
+                    if (prop && typeof prop !== "boolean") {
+                        baseSchema = prop;
+                    }
+                }
+                break;
+            case "state":
+                baseSchema = ctx.stateVars?.[name]?.schema;
+                break;
+            case "constant":
+                baseSchema = ctx.constants?.[name]?.schema;
+                break;
+        }
+        if (!baseSchema) return undefined;
+        if (path && path.length > 0) {
+            return resolveSchemaPath(baseSchema, path);
+        }
+        return baseSchema;
+    }
+
+    if ("$literal" in obj) {
+        return jsonValueToSchema(obj["$literal"]);
+    }
+
+    // Plain object: property-wise composition
+    const properties: Record<string, JSONSchema> = {};
+    const required: string[] = [];
+    for (const [key, value] of Object.entries(obj)) {
+        const propType = resolveTemplateType(value as Template, ctx);
+        if (propType) {
+            properties[key] = propType;
+            required.push(key);
+        }
+    }
+    return {
+        type: "object",
+        properties,
+        ...(required.length > 0 ? { required } : {}),
+    };
+}
+
+/**
+ * Structural subtype check per section 4.2.
+ * Returns true if producer P is compatible with consumer C.
+ */
+function isStructuralSubtype(
+    producer: JSONSchema,
+    consumer: JSONSchema,
+): boolean {
+    if (isTopSchema(consumer)) return true;
+    if (isTopSchema(producer) && !isTopSchema(consumer)) {
+        // Producer is unconstrained; can't prove it's a subtype of
+        // a constrained consumer. Be lenient: skip.
+        return true;
+    }
+
+    // Type check
+    if (producer.type && consumer.type) {
+        const pTypes = normalizeTypeSet(producer.type);
+        const cTypes = normalizeTypeSet(consumer.type);
+        for (const pt of pTypes) {
+            // "integer" is a subtype of "number"
+            const ok = cTypes.some(
+                (ct) => ct === pt || (pt === "integer" && ct === "number"),
+            );
+            if (!ok) return false;
+        }
+    } else if (consumer.type && !producer.type) {
+        return true; // producer unconstrained, be lenient
+    }
+
+    // Object: every required property of C must be present in P
+    // with a compatible type
+    const cRequired = consumer.required ?? [];
+    const pProps = producer.properties ?? {};
+    const cProps = consumer.properties ?? {};
+
+    for (const req of cRequired) {
+        if (!(req in pProps)) return false;
+        const pProp = pProps[req];
+        const cProp = cProps[req];
+        if (
+            pProp &&
+            cProp &&
+            typeof pProp !== "boolean" &&
+            typeof cProp !== "boolean"
+        ) {
+            if (!isStructuralSubtype(pProp, cProp)) return false;
+        }
+    }
+
+    // Check optional consumer props present in producer
+    for (const [key, cPropDef] of Object.entries(cProps)) {
+        if (cRequired.includes(key)) continue;
+        const pPropDef = pProps[key];
+        if (
+            pPropDef &&
+            cPropDef &&
+            typeof pPropDef !== "boolean" &&
+            typeof cPropDef !== "boolean"
+        ) {
+            if (!isStructuralSubtype(pPropDef, cPropDef)) return false;
+        }
+    }
+
+    // Array: element type compatibility
+    if (consumer.items && producer.items) {
+        if (
+            typeof consumer.items !== "boolean" &&
+            typeof producer.items !== "boolean" &&
+            !Array.isArray(consumer.items) &&
+            !Array.isArray(producer.items)
+        ) {
+            if (!isStructuralSubtype(producer.items, consumer.items)) {
+                return false;
+            }
+        }
+    }
+
+    return true;
+}
+
+/**
+ * Validate type compatibility (pass 7) within a scope.
+ *
+ * For each node:
+ * - Compute the resolved type of each input template value and check
+ *   it against the corresponding inputSchema property.
+ * - For branch nodes: check selector resolved type vs selectorSchema
+ *   and validate cases keys against selectorSchema enum (if declared).
+ *
+ * Also checks the scope's output template resolved type against
+ * outputSchema.
+ */
+function validateTypeCompatibility(
+    nodes: Record<string, WorkflowNode>,
+    prefix: string,
+    errors: ValidationError[],
+    scopeInputSchema?: JSONSchema,
+    stateVars?: Record<string, LoopStateVar>,
+    constants?: Record<string, ConstantDef>,
+    outputTemplate?: Template,
+    outputPrefix?: string,
+    outputSchema?: JSONSchema,
+): void {
+    const bindings = buildBindingMap(nodes);
+    const ctx: TypeResolutionContext = {
+        bindings,
+        inputSchema: scopeInputSchema,
+        stateVars,
+        constants,
+    };
+
+    for (const [id, node] of Object.entries(nodes)) {
+        const path = `${prefix}.${id}`;
+
+        if (node.kind === "task" || node.kind === "loop") {
+            // Check each input template value against the corresponding
+            // inputSchema property.
+            const inputs = node.inputs;
+            const inputProps = node.inputSchema.properties ?? {};
+            for (const [fieldName, templateValue] of Object.entries(inputs)) {
+                const resolved = resolveTemplateType(
+                    templateValue,
+                    ctx,
+                );
+                if (!resolved) continue;
+                const consumerPropDef = inputProps[fieldName];
+                if (
+                    !consumerPropDef ||
+                    typeof consumerPropDef === "boolean"
+                ) {
+                    continue;
+                }
+                if (!isStructuralSubtype(resolved, consumerPropDef)) {
+                    errors.push({
+                        path: `${path}.inputs.${fieldName}`,
+                        message:
+                            `Type mismatch: resolved input type ` +
+                            `${formatSchemaType(resolved)} is not ` +
+                            `compatible with expected type ` +
+                            `${formatSchemaType(consumerPropDef)}.`,
+                    });
+                }
+            }
+        }
+
+        if (node.kind === "branch") {
+            // Check selector template resolved type vs selectorSchema
+            const selectorType = resolveTemplateType(node.selector, ctx);
+            if (selectorType && !isTopSchema(node.selectorSchema)) {
+                if (!isStructuralSubtype(selectorType, node.selectorSchema)) {
+                    errors.push({
+                        path: `${path}.selector`,
+                        message:
+                            `Selector resolved type ` +
+                            `${formatSchemaType(selectorType)} is not ` +
+                            `compatible with selectorSchema ` +
+                            `${formatSchemaType(node.selectorSchema)}.`,
+                    });
+                }
+            }
+
+            // Check cases keys against selectorSchema enum
+            if (node.selectorSchema.enum) {
+                const validKeys = new Set(
+                    node.selectorSchema.enum.map(String),
+                );
+                for (const caseKey of Object.keys(node.cases)) {
+                    if (!validKeys.has(caseKey)) {
+                        errors.push({
+                            path: `${path}.cases.${caseKey}`,
+                            message:
+                                `Case key "${caseKey}" is not a valid ` +
+                                `value in selectorSchema.enum ` +
+                                `${JSON.stringify(node.selectorSchema.enum)}.`,
+                        });
+                    }
+                }
+            }
+        }
+
+        // Recurse into loop bodies
+        if (node.kind === "loop" && node.body.entry in node.body.nodes) {
+            const bodyBindings = buildBindingMap(node.body.nodes);
+            const bodyCtx: TypeResolutionContext = {
+                bindings: bodyBindings,
+                inputSchema: node.inputSchema,
+                stateVars: node.state,
+                constants,
+            };
+
+            validateTypeCompatibility(
+                node.body.nodes,
+                `${path}.body.nodes`,
+                errors,
+                node.inputSchema,
+                node.state,
+                constants,
+                node.output,
+                `${path}.output`,
+                node.outputSchema,
+            );
+
+            // Check loop output template type vs loop outputSchema
+            if (node.output && node.outputSchema) {
+                const outputResolved = resolveTemplateType(
+                    node.output,
+                    bodyCtx,
+                );
+                if (
+                    outputResolved &&
+                    !isTopSchema(node.outputSchema)
+                ) {
+                    if (
+                        !isStructuralSubtype(
+                            outputResolved,
+                            node.outputSchema,
+                        )
+                    ) {
+                        errors.push({
+                            path: `${path}.output`,
+                            message:
+                                `Loop output resolved type ` +
+                                `${formatSchemaType(outputResolved)} is not ` +
+                                `compatible with loop outputSchema ` +
+                                `${formatSchemaType(node.outputSchema)}.`,
+                        });
+                    }
+                }
+            }
+        }
+    }
+
+    // Check scope output template type vs outputSchema
+    if (outputTemplate && outputSchema && outputPrefix) {
+        const outputResolved = resolveTemplateType(outputTemplate, ctx);
+        if (outputResolved && !isTopSchema(outputSchema)) {
+            if (!isStructuralSubtype(outputResolved, outputSchema)) {
+                errors.push({
+                    path: outputPrefix,
+                    message:
+                        `Output resolved type ` +
+                        `${formatSchemaType(outputResolved)} is not ` +
+                        `compatible with outputSchema ` +
+                        `${formatSchemaType(outputSchema)}.`,
+                });
+            }
+        }
+    }
+}
+
+/**
+ * Check that every binder of a phi-merged name produces a type
+ * compatible with each consumer's expected type (pass 7 phi-merge).
+ */
+function checkPhiMergeTypes(
+    nodes: Record<string, WorkflowNode>,
+    binders: Map<string, string[]>,
+    prefix: string,
+    errors: ValidationError[],
+): void {
+    for (const [id, node] of Object.entries(nodes)) {
+        if (node.kind !== "task" && node.kind !== "loop") continue;
+        const inputs = node.inputs;
+        const inputProps = node.inputSchema.properties ?? {};
+
+        for (const [fieldName, templateValue] of Object.entries(inputs)) {
+            if (
+                typeof templateValue !== "object" ||
+                templateValue === null ||
+                Array.isArray(templateValue)
+            ) {
+                continue;
+            }
+            const obj = templateValue as Record<string, unknown>;
+            if (obj["$from"] !== "scope") continue;
+            const refName = obj["name"] as string;
+            const binderList = binders.get(refName);
+            if (!binderList || binderList.length < 2) continue;
+
+            const consumerPropDef = inputProps[fieldName];
+            if (
+                !consumerPropDef ||
+                typeof consumerPropDef === "boolean" ||
+                isTopSchema(consumerPropDef)
+            ) {
+                continue;
+            }
+
+            for (const binderId of binderList) {
+                const binderNode = nodes[binderId];
+                if (!binderNode) continue;
+                const binderSchema =
+                    binderNode.kind === "task" || binderNode.kind === "loop"
+                        ? binderNode.outputSchema
+                        : undefined;
+                if (!binderSchema) continue;
+
+                // Apply path projection if present
+                const refPath = obj["path"] as
+                    | (string | number)[]
+                    | undefined;
+                const projected =
+                    refPath && refPath.length > 0
+                        ? resolveSchemaPath(binderSchema, refPath)
+                        : binderSchema;
+                if (!projected) continue;
+
+                if (!isStructuralSubtype(projected, consumerPropDef)) {
+                    errors.push({
+                        path: `${prefix}.${id}.inputs.${fieldName}`,
+                        message:
+                            `Phi-merge: binder "${binderId}" produces ` +
+                            `${formatSchemaType(projected)} which is not ` +
+                            `compatible with consumer's expected type ` +
+                            `${formatSchemaType(consumerPropDef)}.`,
+                    });
+                }
+            }
+        }
+    }
+}
+
+/** Format a schema type for error messages. */
+function formatSchemaType(schema: JSONSchema): string {
+    if (schema.type) return JSON.stringify(schema.type);
+    if (schema.enum) return `enum ${JSON.stringify(schema.enum)}`;
+    return JSON.stringify(schema);
 }
 
 /**

--- a/ts/examples/workflow/model/src/validate.ts
+++ b/ts/examples/workflow/model/src/validate.ts
@@ -74,7 +74,929 @@ export function validateWorkflowIR(
         }
     }
 
+    // CFG-based passes: acyclicity, onError rules, termination,
+    // scope closure, dominator analysis, state soundness, output binding.
+    validateCFGPasses(ir, errors);
+
     return { valid: errors.length === 0, errors };
+}
+
+// ---- CFG data structure ----
+
+interface ScopeCFG {
+    /** nodeId -> set of successor nodeIds (excluding sentinels) */
+    edges: Map<string, Set<string>>;
+    entry: string;
+    /** nodes with no successors (task with no next, or all successors are sentinels) */
+    terminals: Set<string>;
+    /** nodes whose next/case target is a sentinel */
+    sentinelTargets: Map<string, Set<"@iterate" | "@exit">>;
+}
+
+/**
+ * Build a CFG for a scope. Control-flow edges include next, onError,
+ * and branch cases/default. Sentinels (@iterate, @exit) are tracked
+ * separately rather than as graph nodes.
+ */
+function buildScopeCFG(
+    nodes: Record<string, WorkflowNode>,
+    entry: string,
+): ScopeCFG {
+    const edges = new Map<string, Set<string>>();
+    const sentinelTargets = new Map<string, Set<"@iterate" | "@exit">>();
+
+    for (const [id, node] of Object.entries(nodes)) {
+        const succs = new Set<string>();
+        edges.set(id, succs);
+
+        if (node.kind === "task") {
+            if (node.next) {
+                if (node.next === "@iterate" || node.next === "@exit") {
+                    let st = sentinelTargets.get(id);
+                    if (!st) {
+                        st = new Set();
+                        sentinelTargets.set(id, st);
+                    }
+                    st.add(node.next);
+                } else {
+                    succs.add(node.next);
+                }
+            }
+            if (node.onError) {
+                succs.add(node.onError);
+            }
+        } else if (node.kind === "branch") {
+            for (const target of Object.values(node.cases)) {
+                if (target === "@iterate" || target === "@exit") {
+                    let st = sentinelTargets.get(id);
+                    if (!st) {
+                        st = new Set();
+                        sentinelTargets.set(id, st);
+                    }
+                    st.add(target);
+                } else {
+                    succs.add(target);
+                }
+            }
+            if (node.default === "@iterate" || node.default === "@exit") {
+                let st = sentinelTargets.get(id);
+                if (!st) {
+                    st = new Set();
+                    sentinelTargets.set(id, st);
+                }
+                st.add(node.default);
+            } else {
+                succs.add(node.default);
+            }
+        } else if (node.kind === "loop") {
+            if (node.next) {
+                succs.add(node.next);
+            }
+            if (node.onError) {
+                succs.add(node.onError);
+            }
+        }
+    }
+
+    // Terminals: nodes with no non-sentinel successors
+    const terminals = new Set<string>();
+    for (const [id, succs] of edges) {
+        if (succs.size === 0) {
+            terminals.add(id);
+        }
+    }
+
+    return { edges, entry, terminals, sentinelTargets };
+}
+
+// ---- Pass 10: Acyclicity ----
+
+/**
+ * Detect cycles in a scope CFG using DFS with three-color marking.
+ * Returns the set of node IDs involved in cycles (empty if acyclic).
+ */
+function detectCycles(cfg: ScopeCFG): string[][] {
+    const WHITE = 0,
+        GRAY = 1,
+        BLACK = 2;
+    const color = new Map<string, number>();
+    for (const id of cfg.edges.keys()) {
+        color.set(id, WHITE);
+    }
+
+    const cycles: string[][] = [];
+    const stack: string[] = [];
+
+    function dfs(u: string): void {
+        color.set(u, GRAY);
+        stack.push(u);
+        const succs = cfg.edges.get(u);
+        if (succs) {
+            for (const v of succs) {
+                const c = color.get(v);
+                if (c === GRAY) {
+                    // Back edge: extract cycle from stack
+                    const idx = stack.indexOf(v);
+                    cycles.push(stack.slice(idx));
+                } else if (c === WHITE) {
+                    dfs(v);
+                }
+            }
+        }
+        stack.pop();
+        color.set(u, BLACK);
+    }
+
+    // Start from entry, then visit any unreached nodes
+    if (color.has(cfg.entry)) {
+        dfs(cfg.entry);
+    }
+    for (const id of cfg.edges.keys()) {
+        if (color.get(id) === WHITE) {
+            dfs(id);
+        }
+    }
+
+    return cycles;
+}
+
+// ---- Pass 9: Termination ----
+
+/**
+ * Check that every node can reach a terminal (top-level) or a sentinel
+ * (loop body). Uses reverse reachability from terminals/sentinel nodes.
+ */
+function checkTermination(cfg: ScopeCFG, insideLoop: boolean): Set<string> {
+    // Collect "exit" nodes: terminals for top-level, sentinel targets for bodies
+    const exitNodes = new Set<string>();
+    if (insideLoop) {
+        for (const id of cfg.sentinelTargets.keys()) {
+            exitNodes.add(id);
+        }
+        // Also include terminals (nodes with no next) as they can still
+        // be valid in a loop body if they're onError recovery nodes
+        // that don't continue.
+        // Actually, in a loop body, every path must reach a sentinel.
+        // Terminals without sentinels are dead ends.
+    } else {
+        for (const id of cfg.terminals) {
+            exitNodes.add(id);
+        }
+    }
+
+    // Build reverse graph
+    const reverseEdges = new Map<string, Set<string>>();
+    for (const id of cfg.edges.keys()) {
+        reverseEdges.set(id, new Set());
+    }
+    for (const [u, succs] of cfg.edges) {
+        for (const v of succs) {
+            reverseEdges.get(v)?.add(u);
+        }
+    }
+
+    // BFS backwards from exit nodes
+    const reached = new Set<string>();
+    const queue = [...exitNodes];
+    for (const id of queue) {
+        if (reached.has(id)) continue;
+        reached.add(id);
+        const preds = reverseEdges.get(id);
+        if (preds) {
+            for (const p of preds) {
+                if (!reached.has(p)) queue.push(p);
+            }
+        }
+    }
+
+    // Unreachable nodes
+    const unreachable = new Set<string>();
+    for (const id of cfg.edges.keys()) {
+        if (!reached.has(id)) {
+            unreachable.add(id);
+        }
+    }
+    return unreachable;
+}
+
+// ---- Pass 6: Dominator analysis ----
+
+/**
+ * Compute immediate dominators for an acyclic CFG using reverse postorder.
+ * Returns a map from nodeId to its immediate dominator nodeId.
+ * The entry node maps to itself.
+ */
+function computeImmediateDominators(cfg: ScopeCFG): Map<string, string> {
+    // Compute reverse postorder via DFS from entry
+    const rpo: string[] = [];
+    const visited = new Set<string>();
+    function dfs(u: string): void {
+        visited.add(u);
+        const succs = cfg.edges.get(u);
+        if (succs) {
+            for (const v of succs) {
+                if (!visited.has(v)) dfs(v);
+            }
+        }
+        rpo.push(u);
+    }
+    dfs(cfg.entry);
+    rpo.reverse();
+
+    // Map node -> rpo index for O(1) lookup
+    const rpoIndex = new Map<string, number>();
+    for (let i = 0; i < rpo.length; i++) {
+        rpoIndex.set(rpo[i], i);
+    }
+
+    // Build predecessor map (only for reachable nodes)
+    const preds = new Map<string, string[]>();
+    for (const id of rpo) {
+        preds.set(id, []);
+    }
+    for (const [u, succs] of cfg.edges) {
+        if (!rpoIndex.has(u)) continue;
+        for (const v of succs) {
+            if (rpoIndex.has(v)) {
+                preds.get(v)!.push(u);
+            }
+        }
+    }
+
+    // Cooper/Harvey/Kennedy iterative dominator algorithm
+    const idom = new Map<string, string>();
+    idom.set(cfg.entry, cfg.entry);
+
+    function intersect(b1: string, b2: string): string {
+        let f1 = rpoIndex.get(b1)!;
+        let f2 = rpoIndex.get(b2)!;
+        while (f1 !== f2) {
+            while (f1 > f2) {
+                b1 = idom.get(b1)!;
+                f1 = rpoIndex.get(b1)!;
+            }
+            while (f2 > f1) {
+                b2 = idom.get(b2)!;
+                f2 = rpoIndex.get(b2)!;
+            }
+        }
+        return b1;
+    }
+
+    let changed = true;
+    while (changed) {
+        changed = false;
+        for (const b of rpo) {
+            if (b === cfg.entry) continue;
+            const bPreds = preds.get(b)!;
+            // Pick first processed predecessor
+            let newIdom: string | undefined;
+            for (const p of bPreds) {
+                if (idom.has(p)) {
+                    newIdom = p;
+                    break;
+                }
+            }
+            if (newIdom === undefined) continue;
+            for (const p of bPreds) {
+                if (p === newIdom) continue;
+                if (idom.has(p)) {
+                    newIdom = intersect(p, newIdom);
+                }
+            }
+            if (idom.get(b) !== newIdom) {
+                idom.set(b, newIdom);
+                changed = true;
+            }
+        }
+    }
+
+    return idom;
+}
+
+/**
+ * Check whether node `a` dominates node `b` (a is on every path from
+ * entry to b). Uses the idom tree.
+ */
+function dominates(
+    a: string,
+    b: string,
+    idom: Map<string, string>,
+    entry: string,
+): boolean {
+    let cur = b;
+    while (cur !== entry) {
+        if (cur === a) return true;
+        const parent = idom.get(cur);
+        if (!parent || parent === cur) break;
+        cur = parent;
+    }
+    return cur === a;
+}
+
+/**
+ * Collect all nodes dominated by `a` (including `a` itself).
+ */
+function dominatedSet(a: string, idom: Map<string, string>): Set<string> {
+    const result = new Set<string>();
+    // Build children map from idom
+    const children = new Map<string, string[]>();
+    for (const [node, parent] of idom) {
+        if (node === parent) continue; // entry
+        let ch = children.get(parent);
+        if (!ch) {
+            ch = [];
+            children.set(parent, ch);
+        }
+        ch.push(node);
+    }
+    const stack = [a];
+    while (stack.length > 0) {
+        const n = stack.pop()!;
+        result.add(n);
+        const ch = children.get(n);
+        if (ch) stack.push(...ch);
+    }
+    return result;
+}
+
+/**
+ * Build the set of nodes on the "success side" vs "error side" of an
+ * onError split. Used for phi soundness: binders on opposite sides are
+ * mutually exclusive.
+ */
+interface OnErrorSplit {
+    trigger: string;
+    successSide: Set<string>; // nodes dominated via next
+    errorSide: Set<string>; // nodes dominated via onError
+}
+
+function buildOnErrorSplits(
+    nodes: Record<string, WorkflowNode>,
+    cfg: ScopeCFG,
+    idom: Map<string, string>,
+): OnErrorSplit[] {
+    const splits: OnErrorSplit[] = [];
+    for (const [id, node] of Object.entries(nodes)) {
+        if ((node.kind === "task" || node.kind === "loop") && node.onError) {
+            const errorTarget = node.onError;
+            const errorSide = dominatedSet(errorTarget, idom);
+            // Success side: nodes dominated by the next target (if any),
+            // excluding nodes on the error side.
+            let successSide = new Set<string>();
+            const nextTarget = node.kind === "task" ? node.next : node.next;
+            if (
+                nextTarget &&
+                nextTarget !== "@iterate" &&
+                nextTarget !== "@exit"
+            ) {
+                successSide = dominatedSet(nextTarget, idom);
+            }
+            // The trigger node itself is on the success side: its binding
+            // is only produced when it completes without error.
+            successSide.add(id);
+            splits.push({ trigger: id, successSide, errorSide });
+        }
+    }
+    return splits;
+}
+
+/**
+ * Check whether two nodes are on mutually exclusive sides of an onError
+ * split (one on success side, one on error side of the same trigger).
+ */
+function areMutuallyExclusive(
+    a: string,
+    b: string,
+    splits: OnErrorSplit[],
+): boolean {
+    for (const split of splits) {
+        if (
+            (split.successSide.has(a) && split.errorSide.has(b)) ||
+            (split.successSide.has(b) && split.errorSide.has(a))
+        ) {
+            return true;
+        }
+    }
+    return false;
+}
+
+/**
+ * Check whether a binding is covered at a given node (consumer or terminal).
+ *
+ * A binding is covered if:
+ * (a) A single binder dominates the target and is not excluded by an onError
+ *     split (binder on success side, target on error side), OR
+ * (b) Binders on BOTH sides of an onError split exist for this name, the
+ *     trigger dominates the target, and the target is not on either side of
+ *     that specific split (meaning it's downstream of the merge point).
+ *     This is "joint coverage" across mutually exclusive paths.
+ */
+function isBindingCoveredAtNode(
+    binderList: string[],
+    targetId: string,
+    idom: Map<string, string>,
+    cfg: ScopeCFG,
+    splits: OnErrorSplit[],
+): boolean {
+    // (a) Direct coverage: a single binder dominates target without
+    // being on the wrong side of an onError split.
+    const directlyCovered = binderList.some((b) => {
+        if (!dominates(b, targetId, idom, cfg.entry)) return false;
+        for (const split of splits) {
+            if (split.successSide.has(b) && split.errorSide.has(targetId)) {
+                return false;
+            }
+        }
+        return true;
+    });
+    if (directlyCovered) return true;
+
+    // (b) Joint coverage: for some onError split, binders exist on both
+    // sides, and the trigger dominates the target. This means every path
+    // from entry through the trigger to the target passes through a binder
+    // on one side or the other.
+    for (const split of splits) {
+        const hasSuccessBinder = binderList.some((b) =>
+            split.successSide.has(b),
+        );
+        const hasErrorBinder = binderList.some((b) =>
+            split.errorSide.has(b),
+        );
+        if (
+            hasSuccessBinder &&
+            hasErrorBinder &&
+            dominates(split.trigger, targetId, idom, cfg.entry)
+        ) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+/**
+ * Run the dominator-based checks for a scope:
+ * - Coverage (6b): every $from scope ref is covered on all paths
+ * - Phi soundness (6a): no two binders of the same name on the same path
+ */
+function checkDominance(
+    nodes: Record<string, WorkflowNode>,
+    cfg: ScopeCFG,
+    idom: Map<string, string>,
+    prefix: string,
+    errors: ValidationError[],
+    outputTemplate?: Template,
+    outputPrefix?: string,
+): void {
+    const splits = buildOnErrorSplits(nodes, cfg, idom);
+
+    // Build binder sets: name -> list of nodeIds that bind that name
+    const binders = new Map<string, string[]>();
+    for (const [id, node] of Object.entries(nodes)) {
+        if ((node.kind === "task" || node.kind === "loop") && node.bind) {
+            let list = binders.get(node.bind);
+            if (!list) {
+                list = [];
+                binders.set(node.bind, list);
+            }
+            list.push(id);
+        }
+    }
+
+    // Phi soundness (6a): for names with multiple binders, verify they
+    // are on mutually exclusive paths (no binder dominates another binder
+    // of the same name, unless they're on opposite sides of an onError split).
+    for (const [name, binderList] of binders) {
+        if (binderList.length < 2) continue;
+        for (let i = 0; i < binderList.length; i++) {
+            for (let j = i + 1; j < binderList.length; j++) {
+                const a = binderList[i];
+                const b = binderList[j];
+                if (areMutuallyExclusive(a, b, splits)) continue;
+                if (
+                    dominates(a, b, idom, cfg.entry) ||
+                    dominates(b, a, idom, cfg.entry)
+                ) {
+                    errors.push({
+                        path: `${prefix}`,
+                        message:
+                            `Bind name "${name}": nodes "${a}" and "${b}" both ` +
+                            `bind this name and one dominates the other. ` +
+                            `Duplicate binders must be on mutually exclusive paths ` +
+                            `(e.g. opposite sides of a branch or onError split).`,
+                    });
+                }
+            }
+        }
+    }
+
+    // Coverage (6b): for each $from scope ref in node inputs, check that
+    // at least one binder dominates the consumer on every path.
+    for (const [id, node] of Object.entries(nodes)) {
+        let inputs: Record<string, Template> | undefined;
+        if (node.kind === "task") inputs = node.inputs;
+        else if (node.kind === "loop") inputs = node.inputs;
+        if (!inputs) continue;
+
+        const refs = collectScopeRefs(inputs, `${prefix}.${id}.inputs`);
+        for (const ref of refs) {
+            const binderList = binders.get(ref.name);
+            if (!binderList || binderList.length === 0) continue; // caught by name resolution
+            const covered = isBindingCoveredAtNode(
+                binderList,
+                id,
+                idom,
+                cfg,
+                splits,
+            );
+            if (!covered && !ref.optional) {
+                errors.push({
+                    path: ref.templatePath,
+                    message:
+                        `$from "scope", name "${ref.name}": no binder of ` +
+                        `"${ref.name}" dominates node "${id}" on every path ` +
+                        `from entry. The binding may not be available when ` +
+                        `this node executes. Mark the reference as optional ` +
+                        `or restructure so a binder always runs first.`,
+                });
+            }
+        }
+    }
+
+    // Output template coverage: check that output refs are covered on
+    // all paths to any terminal.
+    if (outputTemplate && outputPrefix) {
+        const outputRefs = collectScopeRefs(outputTemplate, outputPrefix);
+        for (const ref of outputRefs) {
+            const binderList = binders.get(ref.name);
+            if (!binderList || binderList.length === 0) continue;
+            // The output is evaluated after the scope reaches a terminal.
+            // Every path from entry to a terminal must pass through a binder.
+            // We check: for each terminal, at least one binder dominates it.
+            for (const terminal of cfg.terminals) {
+                // Skip terminals not reachable from entry
+                if (!idom.has(terminal)) continue;
+                const terminalCovered = isBindingCoveredAtNode(
+                    binderList,
+                    terminal,
+                    idom,
+                    cfg,
+                    splits,
+                );
+                if (!terminalCovered && !ref.optional) {
+                    errors.push({
+                        path: ref.templatePath,
+                        message:
+                            `$from "scope", name "${ref.name}": not covered ` +
+                            `on the path through terminal "${terminal}". ` +
+                            `No binder of "${ref.name}" dominates that path. ` +
+                            `The output may reference an unbound name when ` +
+                            `that path executes.`,
+                    });
+                }
+            }
+        }
+    }
+}
+
+// ---- Orchestrate CFG-based passes ----
+
+function validateCFGPasses(ir: WorkflowIR, errors: ValidationError[]): void {
+    validateScopeCFG(
+        ir.nodes,
+        ir.entry,
+        "nodes",
+        errors,
+        false,
+        ir.output,
+        "output",
+    );
+}
+
+function validateScopeCFG(
+    nodes: Record<string, WorkflowNode>,
+    entry: string,
+    prefix: string,
+    errors: ValidationError[],
+    insideLoop: boolean,
+    outputTemplate?: Template,
+    outputPrefix?: string,
+    skipTermination?: boolean,
+): void {
+    // Don't run CFG passes if entry doesn't exist (already caught)
+    if (!(entry in nodes)) return;
+
+    const cfg = buildScopeCFG(nodes, entry);
+
+    // Pass 10: Acyclicity
+    const cycles = detectCycles(cfg);
+    for (const cycle of cycles) {
+        errors.push({
+            path: prefix,
+            message:
+                `Cycle detected: ${cycle.join(" -> ")} -> ${cycle[0]}. ` +
+                `Intra-scope cycles are not allowed; use a loop construct ` +
+                `with @iterate instead.`,
+        });
+    }
+    // If cycles exist, skip passes that depend on acyclicity
+    if (cycles.length > 0) return;
+
+    // Pass 4 (completion): onError structural rules
+    validateOnErrorRules(nodes, entry, prefix, errors);
+
+    // Pass 5: Scope closure (loop bodies only)
+    // Checked within the loop body recursion below.
+
+    // Pass 9: Termination
+    if (!skipTermination) {
+        const unreachable = checkTermination(cfg, insideLoop);
+        for (const id of unreachable) {
+            errors.push({
+                path: `${prefix}.${id}`,
+                message: insideLoop
+                    ? `Node "${id}" cannot reach any sentinel (@iterate or @exit).`
+                    : `Node "${id}" cannot reach a terminal node.`,
+            });
+        }
+    }
+
+    // Pass 6: Dominator analysis
+    const idom = computeImmediateDominators(cfg);
+    checkDominance(
+        nodes,
+        cfg,
+        idom,
+        prefix,
+        errors,
+        outputTemplate,
+        outputPrefix,
+    );
+
+    // Recurse into loop body scopes
+    for (const [id, node] of Object.entries(nodes)) {
+        if (node.kind === "loop" && node.body.entry in node.body.nodes) {
+            const bodyPrefix = `${prefix}.${id}.body.nodes`;
+
+            // Pass 5: Scope closure
+            checkScopeClosure(node, id, bodyPrefix, prefix, nodes, errors);
+
+            // Pass 11: State soundness
+            checkStateSoundness(node, id, `${prefix}.${id}`, errors);
+
+            validateScopeCFG(
+                node.body.nodes,
+                node.body.entry,
+                bodyPrefix,
+                errors,
+                true,
+                node.output,
+                `${prefix}.${id}.output`,
+                !!node.onError, // skip body termination check when loop has onError
+            );
+        }
+    }
+}
+
+// ---- Pass 4 (completion): onError structural rules ----
+
+function validateOnErrorRules(
+    nodes: Record<string, WorkflowNode>,
+    entry: string,
+    prefix: string,
+    errors: ValidationError[],
+): void {
+    // Collect onError targets and normal targets
+    const onErrorTargetToTrigger = new Map<string, string>();
+    const normalTargets = new Set<string>();
+    normalTargets.add(entry);
+
+    for (const [id, node] of Object.entries(nodes)) {
+        if (node.kind === "task") {
+            if (node.next) normalTargets.add(node.next);
+            if (node.onError) {
+                const existing = onErrorTargetToTrigger.get(node.onError);
+                if (existing) {
+                    // Rule 2: single trigger
+                    errors.push({
+                        path: `${prefix}.${id}.onError`,
+                        message:
+                            `Recovery node "${node.onError}" is targeted by ` +
+                            `both "${existing}" and "${id}". A recovery ` +
+                            `target must have exactly one trigger in v1.`,
+                    });
+                } else {
+                    onErrorTargetToTrigger.set(node.onError, id);
+                }
+            }
+        } else if (node.kind === "branch") {
+            for (const target of Object.values(node.cases)) {
+                if (target !== "@iterate" && target !== "@exit") {
+                    normalTargets.add(target);
+                }
+            }
+            if (node.default !== "@iterate" && node.default !== "@exit") {
+                normalTargets.add(node.default);
+            }
+        } else if (node.kind === "loop") {
+            if (node.next) normalTargets.add(node.next);
+            if (node.onError) {
+                const existing = onErrorTargetToTrigger.get(node.onError);
+                if (existing) {
+                    errors.push({
+                        path: `${prefix}.${id}.onError`,
+                        message:
+                            `Recovery node "${node.onError}" is targeted by ` +
+                            `both "${existing}" and "${id}". A recovery ` +
+                            `target must have exactly one trigger in v1.`,
+                    });
+                } else {
+                    onErrorTargetToTrigger.set(node.onError, id);
+                }
+            }
+        }
+    }
+
+    for (const [target, trigger] of onErrorTargetToTrigger) {
+        const targetNode = nodes[target];
+        if (!targetNode) continue; // existence already checked elsewhere
+
+        // Rule 1: exclusive path
+        if (normalTargets.has(target)) {
+            errors.push({
+                path: `${prefix}.${trigger}.onError`,
+                message:
+                    `Recovery node "${target}" is also reachable via ` +
+                    `a normal path (next, branch case/default, or entry). ` +
+                    `Recovery targets must only be reachable via onError.`,
+            });
+        }
+
+        // Rule 3: no recursive recovery
+        if (
+            (targetNode.kind === "task" || targetNode.kind === "loop") &&
+            targetNode.onError
+        ) {
+            errors.push({
+                path: `${prefix}.${target}.onError`,
+                message:
+                    `Recovery node "${target}" must not itself declare ` +
+                    `onError. Recursive recovery chains are not ` +
+                    `allowed in v1.`,
+            });
+        }
+
+        // Rule 4: recovery target must be a task
+        if (targetNode.kind !== "task") {
+            errors.push({
+                path: `${prefix}.${trigger}.onError`,
+                message:
+                    `Recovery target "${target}" must be a task node ` +
+                    `(got "${targetNode.kind}").`,
+            });
+        }
+    }
+}
+
+// ---- Pass 5: Scope closure ----
+
+function checkScopeClosure(
+    loopNode: {
+        body: { nodes: Record<string, WorkflowNode> };
+        inputs: Record<string, Template>;
+    },
+    loopId: string,
+    bodyPrefix: string,
+    outerPrefix: string,
+    outerNodes: Record<string, WorkflowNode>,
+    errors: ValidationError[],
+): void {
+    const bodyBindings = buildBindingMap(loopNode.body.nodes);
+    // Also include names available via $from: "input" and $from: "state"
+    // (those are legal cross-scope references). We only check $from: "scope".
+
+    for (const [id, node] of Object.entries(loopNode.body.nodes)) {
+        let inputs: Record<string, Template> | undefined;
+        if (node.kind === "task") inputs = node.inputs;
+        else if (node.kind === "loop") inputs = node.inputs;
+        if (!inputs) continue;
+
+        const refs = collectScopeRefs(inputs, `${bodyPrefix}.${id}.inputs`);
+        for (const ref of refs) {
+            if (!bodyBindings.has(ref.name)) {
+                // Check if this name exists in the outer scope
+                const outerBindings = buildBindingMap(outerNodes);
+                if (outerBindings.has(ref.name)) {
+                    errors.push({
+                        path: ref.templatePath,
+                        message:
+                            `$from "scope", name "${ref.name}": references ` +
+                            `outer-scope binding. Loop body nodes cannot ` +
+                            `reach outer-scope bindings via $from "scope". ` +
+                            `Pass the value through the loop's inputs instead.`,
+                    });
+                }
+            }
+        }
+    }
+}
+
+// ---- Pass 11: State soundness ----
+
+function checkStateSoundness(
+    loopNode: {
+        state: Record<string, { schema: JSONSchema; initial: Template }>;
+        iterateState: Record<string, Template>;
+        body: { nodes: Record<string, WorkflowNode> };
+    },
+    loopId: string,
+    prefix: string,
+    errors: ValidationError[],
+): void {
+    const stateNames = new Set(Object.keys(loopNode.state));
+    const iterateNames = new Set(Object.keys(loopNode.iterateState));
+
+    // Every state var must have a corresponding iterateState entry
+    for (const name of stateNames) {
+        if (!iterateNames.has(name)) {
+            errors.push({
+                path: `${prefix}.iterateState`,
+                message:
+                    `State variable "${name}" is declared but has no ` +
+                    `corresponding entry in iterateState.`,
+            });
+        }
+    }
+
+    // Every iterateState entry must correspond to a declared state var
+    for (const name of iterateNames) {
+        if (!stateNames.has(name)) {
+            errors.push({
+                path: `${prefix}.iterateState.${name}`,
+                message:
+                    `iterateState entry "${name}" has no corresponding ` +
+                    `state variable declaration.`,
+            });
+        }
+    }
+
+    // Check $from: "state" refs in body nodes reference declared state vars
+    for (const [id, node] of Object.entries(loopNode.body.nodes)) {
+        let inputs: Record<string, Template> | undefined;
+        if (node.kind === "task") inputs = node.inputs;
+        else if (node.kind === "loop") inputs = node.inputs;
+        if (!inputs) continue;
+
+        const stateRefs = collectStateRefs(
+            inputs,
+            `${prefix}.body.nodes.${id}.inputs`,
+        );
+        for (const ref of stateRefs) {
+            if (!stateNames.has(ref.name)) {
+                errors.push({
+                    path: ref.templatePath,
+                    message:
+                        `$from "state", name "${ref.name}": no state ` +
+                        `variable "${ref.name}" is declared on this loop.`,
+                });
+            }
+        }
+    }
+}
+
+/**
+ * Walk a template and collect all $from: "state" references.
+ */
+function collectStateRefs(
+    template: Template,
+    templatePath: string,
+): { name: string; templatePath: string }[] {
+    if (template === null || template === undefined) return [];
+    if (typeof template !== "object") return [];
+    if (Array.isArray(template)) {
+        const refs: { name: string; templatePath: string }[] = [];
+        for (let i = 0; i < template.length; i++) {
+            refs.push(
+                ...collectStateRefs(template[i], `${templatePath}[${i}]`),
+            );
+        }
+        return refs;
+    }
+
+    const obj = template as Record<string, unknown>;
+    if (obj["$from"] === "state") {
+        return [{ name: obj["name"] as string, templatePath }];
+    }
+    if ("$literal" in obj) return [];
+
+    const refs: { name: string; templatePath: string }[] = [];
+    for (const [key, value] of Object.entries(obj)) {
+        refs.push(
+            ...collectStateRefs(value as Template, `${templatePath}.${key}`),
+        );
+    }
+    return refs;
 }
 
 function validateScope(
@@ -111,11 +1033,20 @@ function validateScope(
                     checkNodeTaskSchemas(taskDef, node, path, errors);
                 }
             }
-            if (node.next && !nodeIds.has(node.next)) {
-                errors.push({
-                    path: `${path}.next`,
-                    message: `Target "${node.next}" does not exist.`,
-                });
+            if (node.next) {
+                if (node.next === "@iterate" || node.next === "@exit") {
+                    if (!insideLoop) {
+                        errors.push({
+                            path: `${path}.next`,
+                            message: `Sentinel "${node.next}" is only valid inside a loop body.`,
+                        });
+                    }
+                } else if (!nodeIds.has(node.next)) {
+                    errors.push({
+                        path: `${path}.next`,
+                        message: `Target "${node.next}" does not exist.`,
+                    });
+                }
             }
             if (node.onError && !nodeIds.has(node.onError)) {
                 errors.push({
@@ -204,6 +1135,12 @@ function validateScope(
                 errors.push({
                     path: `${path}.next`,
                     message: `Target "${node.next}" does not exist.`,
+                });
+            }
+            if (node.onError && !nodeIds.has(node.onError)) {
+                errors.push({
+                    path: `${path}.onError`,
+                    message: `Error target "${node.onError}" does not exist.`,
                 });
             }
         }

--- a/ts/examples/workflow/model/src/validate.ts
+++ b/ts/examples/workflow/model/src/validate.ts
@@ -45,6 +45,35 @@ export function validateWorkflowIR(
     // Static schema compatibility for the top-level scope.
     validateSchemaCompat(ir.nodes, "nodes", errors);
 
+    // Validate that the workflow output template only references existing
+    // bindings. This catches references to names that no node binds.
+    if (ir.output) {
+        const bindings = buildBindingMap(ir.nodes);
+        const outputRefs = collectScopeRefs(ir.output, "output");
+        for (const ref of outputRefs) {
+            if (!bindings.has(ref.name)) {
+                if (!ref.optional) {
+                    errors.push({
+                        path: ref.templatePath,
+                        message:
+                            `$from "scope", name "${ref.name}": no node in ` +
+                            `the workflow binds that name.`,
+                    });
+                }
+            } else {
+                const producerSchema = bindings.get(ref.name)!;
+                const err = checkSchemaCompat(
+                    producerSchema,
+                    ref.path,
+                    `${ref.templatePath} ($from "scope", name "${ref.name}")`,
+                );
+                if (err) {
+                    errors.push({ path: ref.templatePath, message: err });
+                }
+            }
+        }
+    }
+
     return { valid: errors.length === 0, errors };
 }
 
@@ -438,6 +467,7 @@ function checkNodeTaskSchemas(
 interface ScopeRef {
     name: string;
     path: (string | number)[] | undefined;
+    optional: boolean;
     templatePath: string;
 }
 
@@ -463,6 +493,7 @@ function collectScopeRefs(
             {
                 name: obj["name"] as string,
                 path: obj["path"] as (string | number)[] | undefined,
+                optional: obj["optional"] === true,
                 templatePath,
             },
         ];
@@ -553,9 +584,14 @@ function validateSchemaCompat(
         for (const ref of refs) {
             const producerSchema = bindings.get(ref.name);
             if (!producerSchema) {
-                // Binding not found in this scope. Could be valid if
-                // produced conditionally (onError path). Don't error here;
-                // runtime will catch unresolved refs.
+                if (!ref.optional) {
+                    errors.push({
+                        path: ref.templatePath,
+                        message:
+                            `$from "scope", name "${ref.name}": no node in ` +
+                            `this scope binds that name.`,
+                    });
+                }
                 continue;
             }
             // Extract consumer expected type from inputSchema.

--- a/ts/examples/workflow/model/src/validate.ts
+++ b/ts/examples/workflow/model/src/validate.ts
@@ -942,10 +942,18 @@ function checkStateSoundness(
     }
 
     // Check $from: "state" refs in body nodes reference declared state vars
+    // and that the state variable's schema type is compatible with the
+    // consumer's expected type at that input position.
     for (const [id, node] of Object.entries(loopNode.body.nodes)) {
         let inputs: Record<string, Template> | undefined;
-        if (node.kind === "task") inputs = node.inputs;
-        else if (node.kind === "loop") inputs = node.inputs;
+        let inputSchema: JSONSchema | undefined;
+        if (node.kind === "task") {
+            inputs = node.inputs;
+            inputSchema = node.inputSchema;
+        } else if (node.kind === "loop") {
+            inputs = node.inputs;
+            inputSchema = node.inputSchema;
+        }
         if (!inputs) continue;
 
         const stateRefs = collectStateRefs(
@@ -960,6 +968,41 @@ function checkStateSoundness(
                         `$from "state", name "${ref.name}": no state ` +
                         `variable "${ref.name}" is declared on this loop.`,
                 });
+            } else if (inputSchema) {
+                // Type-compatibility: check the state variable's schema
+                // type against the consumer's expected type at this position.
+                const stateSchema = loopNode.state[ref.name].schema;
+                const inputKey = ref.templatePath.split(".").pop()!;
+                const consumerPropDef =
+                    inputSchema.properties?.[inputKey];
+                const consumerPropSchema =
+                    consumerPropDef !== undefined &&
+                    typeof consumerPropDef !== "boolean"
+                        ? consumerPropDef
+                        : undefined;
+                if (
+                    stateSchema.type &&
+                    consumerPropSchema?.type
+                ) {
+                    const stateTypes = normalizeTypeSet(stateSchema.type);
+                    const consumerTypes = normalizeTypeSet(
+                        consumerPropSchema.type,
+                    );
+                    const overlap = consumerTypes.some((ct) =>
+                        stateTypes.includes(ct),
+                    );
+                    if (!overlap) {
+                        errors.push({
+                            path: ref.templatePath,
+                            message:
+                                `$from "state", name "${ref.name}": type ` +
+                                `mismatch: state variable declares ` +
+                                `${JSON.stringify(stateSchema.type)} but ` +
+                                `consumer expects ` +
+                                `${JSON.stringify(consumerPropSchema.type)}.`,
+                        });
+                    }
+                }
             }
         }
     }

--- a/ts/examples/workflow/model/test/validate.spec.ts
+++ b/ts/examples/workflow/model/test/validate.spec.ts
@@ -2180,6 +2180,65 @@ describe("validateWorkflowIR", () => {
                 ),
             ).toBe(true);
         });
+
+        it("rejects $from state reference with incompatible type", () => {
+            const ir = makeMinimalIR({
+                nodes: {
+                    start: {
+                        kind: "loop",
+                        inputs: {},
+                        inputSchema: { type: "object" },
+                        state: {
+                            count: {
+                                schema: { type: "integer" },
+                                initial: 0,
+                            },
+                        },
+                        body: {
+                            entry: "step",
+                            nodes: {
+                                step: {
+                                    kind: "task",
+                                    task: "noop",
+                                    inputSchema: {
+                                        type: "object",
+                                        properties: {
+                                            label: { type: "string" },
+                                        },
+                                    },
+                                    outputSchema: { type: "object" },
+                                    inputs: {
+                                        label: {
+                                            $from: "state",
+                                            name: "count",
+                                        },
+                                    },
+                                    next: "@iterate",
+                                },
+                            },
+                        },
+                        iterateState: {
+                            count: { $from: "state", name: "count" },
+                        },
+                        output: null,
+                        outputSchema: { type: "null" },
+                        maxIterations: 10,
+                        bind: "out",
+                    } as any,
+                },
+                output: null,
+                outputSchema: { type: "null" },
+            });
+            const result = validateWorkflowIR(ir, taskMap("noop"));
+            expect(result.valid).toBe(false);
+            expect(
+                result.errors.some((e) =>
+                    e.message.includes("type mismatch") &&
+                    e.message.includes("integer") &&
+                    e.message.includes("string"),
+                ),
+            ).toBe(true);
+        });
     });
 
     // ---- Phase 7: Output binding coverage (pass 12) ----

--- a/ts/examples/workflow/model/test/validate.spec.ts
+++ b/ts/examples/workflow/model/test/validate.spec.ts
@@ -33,8 +33,8 @@ function makeMinimalIR(overrides?: Partial<WorkflowIR>): WorkflowIR {
 function makeTask(name: string): TaskDefinition {
     return {
         name,
-        inputSchema: { type: "object" },
-        outputSchema: { type: "object" },
+        inputSchema: {},
+        outputSchema: {},
         execute: async () => ({ kind: "ok" as const, output: {} }),
     };
 }
@@ -702,6 +702,251 @@ describe("validateWorkflowIR", () => {
         expect(
             result.errors.some((e) =>
                 e.message.includes("cannot be meaningfully coerced"),
+            ),
+        ).toBe(true);
+    });
+
+    // ---- Node-vs-task schema compatibility ----
+
+    function makeTypedTask(
+        name: string,
+        inputSchema: Record<string, unknown>,
+        outputSchema: Record<string, unknown>,
+    ): TaskDefinition {
+        return {
+            name,
+            inputSchema,
+            outputSchema,
+            execute: async () => ({ kind: "ok" as const, output: {} }),
+        };
+    }
+
+    it("accepts node that refines a top-schema output property", () => {
+        // Task produces { value: {} } (top type); node narrows to object
+        const task = makeTypedTask(
+            "gen",
+            {
+                type: "object",
+                required: ["prompt"],
+                properties: { prompt: { type: "string" } },
+            },
+            { type: "object", required: ["value"], properties: { value: {} } },
+        );
+        const ir = makeMinimalIR({
+            nodes: {
+                start: {
+                    kind: "task",
+                    task: "gen",
+                    inputSchema: {
+                        type: "object",
+                        required: ["prompt"],
+                        properties: { prompt: { type: "string" } },
+                    },
+                    outputSchema: {
+                        type: "object",
+                        required: ["value"],
+                        properties: {
+                            value: {
+                                type: "object",
+                                required: ["name"],
+                                properties: { name: { type: "string" } },
+                            },
+                        },
+                    },
+                    inputs: { prompt: "hello" },
+                    bind: "out",
+                },
+            },
+        });
+        const result = validateWorkflowIR(ir, new Map([["gen", task]]));
+        expect(result.valid).toBe(true);
+    });
+
+    it("rejects node that declares output property task does not produce", () => {
+        const task = makeTypedTask(
+            "gen",
+            { type: "object" },
+            {
+                type: "object",
+                required: ["text"],
+                properties: { text: { type: "string" } },
+            },
+        );
+        const ir = makeMinimalIR({
+            nodes: {
+                start: {
+                    kind: "task",
+                    task: "gen",
+                    inputSchema: { type: "object" },
+                    outputSchema: {
+                        type: "object",
+                        required: ["text", "extra"],
+                        properties: {
+                            text: { type: "string" },
+                            extra: { type: "integer" },
+                        },
+                    },
+                    inputs: {},
+                    bind: "out",
+                },
+            },
+        });
+        const result = validateWorkflowIR(ir, new Map([["gen", task]]));
+        expect(result.valid).toBe(false);
+        expect(result.errors.some((e) => e.message.includes('"extra"'))).toBe(
+            true,
+        );
+        expect(
+            result.errors.some((e) => e.message.includes("does not produce")),
+        ).toBe(true);
+    });
+
+    it("rejects node that drops a task-required output property", () => {
+        const task = makeTypedTask(
+            "gen",
+            { type: "object" },
+            {
+                type: "object",
+                required: ["a", "b"],
+                properties: {
+                    a: { type: "string" },
+                    b: { type: "integer" },
+                },
+            },
+        );
+        const ir = makeMinimalIR({
+            nodes: {
+                start: {
+                    kind: "task",
+                    task: "gen",
+                    inputSchema: { type: "object" },
+                    outputSchema: {
+                        type: "object",
+                        required: ["a"],
+                        properties: { a: { type: "string" } },
+                    },
+                    inputs: {},
+                    bind: "out",
+                },
+            },
+        });
+        const result = validateWorkflowIR(ir, new Map([["gen", task]]));
+        expect(result.valid).toBe(false);
+        expect(
+            result.errors.some((e) =>
+                e.message.includes('requires output "b"'),
+            ),
+        ).toBe(true);
+    });
+
+    it("rejects node that narrows output type incompatibly", () => {
+        const task = makeTypedTask(
+            "gen",
+            { type: "object" },
+            {
+                type: "object",
+                required: ["value"],
+                properties: { value: { type: "string" } },
+            },
+        );
+        const ir = makeMinimalIR({
+            nodes: {
+                start: {
+                    kind: "task",
+                    task: "gen",
+                    inputSchema: { type: "object" },
+                    outputSchema: {
+                        type: "object",
+                        required: ["value"],
+                        properties: { value: { type: "integer" } },
+                    },
+                    inputs: {},
+                    bind: "out",
+                },
+            },
+        });
+        const result = validateWorkflowIR(ir, new Map([["gen", task]]));
+        expect(result.valid).toBe(false);
+        expect(
+            result.errors.some(
+                (e) =>
+                    e.message.includes("integer") &&
+                    e.message.includes("string"),
+            ),
+        ).toBe(true);
+    });
+
+    it("rejects node that drops a task-required input property", () => {
+        const task = makeTypedTask(
+            "gen",
+            {
+                type: "object",
+                required: ["prompt", "endpoint"],
+                properties: {
+                    prompt: { type: "string" },
+                    endpoint: { type: "string" },
+                },
+            },
+            { type: "object" },
+        );
+        const ir = makeMinimalIR({
+            nodes: {
+                start: {
+                    kind: "task",
+                    task: "gen",
+                    inputSchema: {
+                        type: "object",
+                        required: ["prompt"],
+                        properties: { prompt: { type: "string" } },
+                    },
+                    outputSchema: { type: "object" },
+                    inputs: { prompt: "hello" },
+                    bind: "out",
+                },
+            },
+        });
+        const result = validateWorkflowIR(ir, new Map([["gen", task]]));
+        expect(result.valid).toBe(false);
+        expect(
+            result.errors.some((e) =>
+                e.message.includes('requires input "endpoint"'),
+            ),
+        ).toBe(true);
+    });
+
+    it("rejects node with incompatible input type", () => {
+        const task = makeTypedTask(
+            "gen",
+            {
+                type: "object",
+                required: ["count"],
+                properties: { count: { type: "integer" } },
+            },
+            { type: "object" },
+        );
+        const ir = makeMinimalIR({
+            nodes: {
+                start: {
+                    kind: "task",
+                    task: "gen",
+                    inputSchema: {
+                        type: "object",
+                        required: ["count"],
+                        properties: { count: { type: "string" } },
+                    },
+                    outputSchema: { type: "object" },
+                    inputs: { count: "five" },
+                    bind: "out",
+                },
+            },
+        });
+        const result = validateWorkflowIR(ir, new Map([["gen", task]]));
+        expect(result.valid).toBe(false);
+        expect(
+            result.errors.some(
+                (e) =>
+                    e.message.includes("string") &&
+                    e.message.includes("integer"),
             ),
         ).toBe(true);
     });

--- a/ts/examples/workflow/model/test/validate.spec.ts
+++ b/ts/examples/workflow/model/test/validate.spec.ts
@@ -3,6 +3,9 @@
 
 import {
     WorkflowIR,
+    TaskNode,
+    LoopNode,
+    BranchNode,
     TaskDefinition,
     validateWorkflowIR,
 } from "../src/index.js";
@@ -26,6 +29,55 @@ function makeMinimalIR(overrides?: Partial<WorkflowIR>): WorkflowIR {
             },
         },
         output: { $from: "scope", name: "out" },
+        ...overrides,
+    };
+}
+
+/** Build a task node with sensible defaults. */
+function makeTaskNode(overrides?: Partial<TaskNode>): TaskNode {
+    return {
+        kind: "task",
+        task: "noop",
+        inputSchema: { type: "object" },
+        outputSchema: { type: "object" },
+        inputs: {},
+        ...overrides,
+    };
+}
+
+/**
+ * Build a loop node with a single-counter state and a branch body that
+ * exits/iterates. Override any field via `overrides`; override the body
+ * entry or nodes via `bodyOverrides`.
+ */
+function makeLoopNode(
+    overrides?: Partial<LoopNode>,
+    bodyOverrides?: Partial<LoopNode["body"]>,
+): LoopNode {
+    return {
+        kind: "loop",
+        inputs: {},
+        inputSchema: { type: "object" },
+        state: {
+            i: { schema: { type: "integer" }, initial: 0 },
+        },
+        body: {
+            entry: "decide",
+            nodes: {
+                decide: {
+                    kind: "branch",
+                    selector: true,
+                    selectorSchema: { type: "boolean" },
+                    cases: { true: "@exit", false: "@iterate" },
+                    default: "@iterate",
+                } as BranchNode,
+            },
+            ...bodyOverrides,
+        },
+        iterateState: { i: { $from: "state", name: "i" } },
+        output: { $from: "state", name: "i" },
+        outputSchema: { type: "integer" },
+        maxIterations: 10,
         ...overrides,
     };
 }
@@ -70,15 +122,10 @@ describe("validateWorkflowIR", () => {
     it("rejects broken next target", () => {
         const ir = makeMinimalIR({
             nodes: {
-                start: {
-                    kind: "task",
-                    task: "noop",
-                    inputSchema: { type: "object" },
-                    outputSchema: { type: "object" },
-                    inputs: {},
+                start: makeTaskNode({
                     next: "nowhere",
                     bind: "out",
-                },
+                }),
             },
         });
         const result = validateWorkflowIR(ir, taskMap("noop"));
@@ -96,15 +143,10 @@ describe("validateWorkflowIR", () => {
     it("rejects broken onError target", () => {
         const ir = makeMinimalIR({
             nodes: {
-                start: {
-                    kind: "task",
-                    task: "noop",
-                    inputSchema: { type: "object" },
-                    outputSchema: { type: "object" },
-                    inputs: {},
+                start: makeTaskNode({
                     onError: "ghost",
                     bind: "out",
-                },
+                }),
             },
         });
         const result = validateWorkflowIR(ir, taskMap("noop"));
@@ -153,34 +195,15 @@ describe("validateWorkflowIR", () => {
     it("rejects loop with missing body entry", () => {
         const ir = makeMinimalIR({
             nodes: {
-                start: {
-                    kind: "loop",
-                    inputs: {},
-                    inputSchema: { type: "object" },
-                    state: {
-                        i: {
-                            schema: { type: "integer" },
-                            initial: 0,
-                        },
-                    },
-                    body: {
+                start: makeLoopNode(
+                    { bind: "out" },
+                    {
                         entry: "missing",
                         nodes: {
-                            step: {
-                                kind: "task",
-                                task: "noop",
-                                inputSchema: { type: "object" },
-                                outputSchema: { type: "object" },
-                                inputs: {},
-                            },
+                            step: makeTaskNode(),
                         },
                     },
-                    iterateState: { i: { $from: "state", name: "i" } },
-                    output: { $from: "state", name: "i" },
-                    outputSchema: { type: "integer" },
-                    maxIterations: 10,
-                    bind: "out",
-                } as any,
+                ),
             },
         });
         const result = validateWorkflowIR(ir, taskMap("noop"));
@@ -193,35 +216,15 @@ describe("validateWorkflowIR", () => {
     it("rejects loop body node with broken next target", () => {
         const ir = makeMinimalIR({
             nodes: {
-                start: {
-                    kind: "loop",
-                    inputs: {},
-                    inputSchema: { type: "object" },
-                    state: {
-                        i: {
-                            schema: { type: "integer" },
-                            initial: 0,
-                        },
-                    },
-                    body: {
+                start: makeLoopNode(
+                    { bind: "out" },
+                    {
                         entry: "step",
                         nodes: {
-                            step: {
-                                kind: "task",
-                                task: "noop",
-                                inputSchema: { type: "object" },
-                                outputSchema: { type: "object" },
-                                inputs: {},
-                                next: "ghost",
-                            },
+                            step: makeTaskNode({ next: "ghost" }),
                         },
                     },
-                    iterateState: { i: { $from: "state", name: "i" } },
-                    output: { $from: "state", name: "i" },
-                    outputSchema: { type: "integer" },
-                    maxIterations: 10,
-                    bind: "out",
-                } as any,
+                ),
             },
         });
         const result = validateWorkflowIR(ir, taskMap("noop"));
@@ -234,37 +237,7 @@ describe("validateWorkflowIR", () => {
     it("allows sentinel @iterate and @exit inside loop body branch", () => {
         const ir = makeMinimalIR({
             nodes: {
-                start: {
-                    kind: "loop",
-                    inputs: {},
-                    inputSchema: { type: "object" },
-                    state: {
-                        i: {
-                            schema: { type: "integer" },
-                            initial: 0,
-                        },
-                    },
-                    body: {
-                        entry: "decide",
-                        nodes: {
-                            decide: {
-                                kind: "branch",
-                                selector: true,
-                                selectorSchema: { type: "boolean" },
-                                cases: {
-                                    true: "@exit",
-                                    false: "@iterate",
-                                },
-                                default: "@iterate",
-                            } as any,
-                        },
-                    },
-                    iterateState: { i: { $from: "state", name: "i" } },
-                    output: { $from: "state", name: "i" },
-                    outputSchema: { type: "integer" },
-                    maxIterations: 10,
-                    bind: "out",
-                } as any,
+                start: makeLoopNode({ bind: "out" }),
             },
             outputSchema: { type: "integer" },
         });
@@ -294,17 +267,9 @@ describe("validateWorkflowIR", () => {
     it("rejects loop next pointing to non-existent node", () => {
         const ir = makeMinimalIR({
             nodes: {
-                start: {
-                    kind: "loop",
-                    inputs: {},
-                    inputSchema: { type: "object" },
-                    state: {
-                        i: {
-                            schema: { type: "integer" },
-                            initial: 0,
-                        },
-                    },
-                    body: {
+                start: makeLoopNode(
+                    { next: "nowhere", bind: "out" },
+                    {
                         entry: "step",
                         nodes: {
                             step: {
@@ -313,16 +278,10 @@ describe("validateWorkflowIR", () => {
                                 selectorSchema: { type: "boolean" },
                                 cases: { true: "@exit" },
                                 default: "@iterate",
-                            } as any,
+                            } as BranchNode,
                         },
                     },
-                    iterateState: { i: { $from: "state", name: "i" } },
-                    output: { $from: "state", name: "i" },
-                    outputSchema: { type: "integer" },
-                    maxIterations: 10,
-                    next: "nowhere",
-                    bind: "out",
-                } as any,
+                ),
             },
         });
         const result = validateWorkflowIR(ir);
@@ -360,15 +319,10 @@ describe("validateWorkflowIR", () => {
     it("includes path in error messages", () => {
         const ir = makeMinimalIR({
             nodes: {
-                start: {
-                    kind: "task",
-                    task: "noop",
-                    inputSchema: { type: "object" },
-                    outputSchema: { type: "object" },
-                    inputs: {},
+                start: makeTaskNode({
                     next: "ghost",
                     bind: "out",
-                },
+                }),
             },
         });
         const result = validateWorkflowIR(ir, taskMap("noop"));
@@ -379,34 +333,15 @@ describe("validateWorkflowIR", () => {
     it("rejects loop body without sentinel when no onError", () => {
         const ir = makeMinimalIR({
             nodes: {
-                start: {
-                    kind: "loop",
-                    inputs: {},
-                    inputSchema: { type: "object" },
-                    state: {
-                        i: {
-                            schema: { type: "integer" },
-                            initial: 0,
-                        },
-                    },
-                    body: {
+                start: makeLoopNode(
+                    { bind: "out" },
+                    {
                         entry: "step",
                         nodes: {
-                            step: {
-                                kind: "task",
-                                task: "noop",
-                                inputSchema: { type: "object" },
-                                outputSchema: { type: "object" },
-                                inputs: {},
-                            },
+                            step: makeTaskNode(),
                         },
                     },
-                    iterateState: { i: { $from: "state", name: "i" } },
-                    output: { $from: "state", name: "i" },
-                    outputSchema: { type: "integer" },
-                    maxIterations: 10,
-                    bind: "out",
-                } as any,
+                ),
             },
         });
         const result = validateWorkflowIR(ir, taskMap("noop"));
@@ -419,43 +354,21 @@ describe("validateWorkflowIR", () => {
     it("allows loop body without sentinel when onError is set", () => {
         const ir = makeMinimalIR({
             nodes: {
-                start: {
-                    kind: "loop",
-                    inputs: {},
-                    inputSchema: { type: "object" },
-                    state: {
-                        i: {
-                            schema: { type: "integer" },
-                            initial: 0,
-                        },
+                start: makeLoopNode(
+                    {
+                        output: null,
+                        outputSchema: { type: "null" },
+                        onError: "recover",
+                        bind: "out",
                     },
-                    body: {
+                    {
                         entry: "step",
                         nodes: {
-                            step: {
-                                kind: "task",
-                                task: "noop",
-                                inputSchema: { type: "object" },
-                                outputSchema: { type: "object" },
-                                inputs: {},
-                            },
+                            step: makeTaskNode(),
                         },
                     },
-                    iterateState: { i: { $from: "state", name: "i" } },
-                    output: null,
-                    outputSchema: { type: "null" },
-                    maxIterations: 10,
-                    onError: "recover",
-                    bind: "out",
-                } as any,
-                recover: {
-                    kind: "task",
-                    task: "noop",
-                    inputSchema: { type: "object" },
-                    outputSchema: { type: "object" },
-                    inputs: {},
-                    bind: "out",
-                },
+                ),
+                recover: makeTaskNode({ bind: "out" }),
             },
         });
         const result = validateWorkflowIR(ir, taskMap("noop"));

--- a/ts/examples/workflow/model/test/validate.spec.ts
+++ b/ts/examples/workflow/model/test/validate.spec.ts
@@ -175,7 +175,7 @@ describe("validateWorkflowIR", () => {
                             },
                         },
                     },
-                    iterateState: {},
+                    iterateState: { i: { $from: "state", name: "i" } },
                     output: { $from: "state", name: "i" },
                     outputSchema: { type: "integer" },
                     maxIterations: 10,
@@ -216,7 +216,7 @@ describe("validateWorkflowIR", () => {
                             },
                         },
                     },
-                    iterateState: {},
+                    iterateState: { i: { $from: "state", name: "i" } },
                     output: { $from: "state", name: "i" },
                     outputSchema: { type: "integer" },
                     maxIterations: 10,
@@ -259,7 +259,7 @@ describe("validateWorkflowIR", () => {
                             } as any,
                         },
                     },
-                    iterateState: {},
+                    iterateState: { i: { $from: "state", name: "i" } },
                     output: { $from: "state", name: "i" },
                     outputSchema: { type: "integer" },
                     maxIterations: 10,
@@ -315,7 +315,7 @@ describe("validateWorkflowIR", () => {
                             } as any,
                         },
                     },
-                    iterateState: {},
+                    iterateState: { i: { $from: "state", name: "i" } },
                     output: { $from: "state", name: "i" },
                     outputSchema: { type: "integer" },
                     maxIterations: 10,
@@ -400,7 +400,7 @@ describe("validateWorkflowIR", () => {
                             },
                         },
                     },
-                    iterateState: {},
+                    iterateState: { i: { $from: "state", name: "i" } },
                     output: { $from: "state", name: "i" },
                     outputSchema: { type: "integer" },
                     maxIterations: 10,
@@ -440,7 +440,7 @@ describe("validateWorkflowIR", () => {
                             },
                         },
                     },
-                    iterateState: {},
+                    iterateState: { i: { $from: "state", name: "i" } },
                     output: null,
                     outputSchema: { type: "null" },
                     maxIterations: 10,
@@ -660,9 +660,16 @@ describe("validateWorkflowIR", () => {
                     kind: "branch",
                     selector: true,
                     selectorSchema: { type: "boolean" },
-                    cases: { true: "start", false: "start" },
-                    default: "start",
+                    cases: { true: "end", false: "end" },
+                    default: "end",
                 } as any,
+                end: {
+                    kind: "task",
+                    task: "noop",
+                    inputSchema: { type: "object" },
+                    outputSchema: { type: "object" },
+                    inputs: {},
+                },
             },
             output: "done",
         });
@@ -677,9 +684,16 @@ describe("validateWorkflowIR", () => {
                     kind: "branch",
                     selector: 1,
                     selectorSchema: { type: "integer" },
-                    cases: { "1": "start", "2": "start" },
-                    default: "start",
+                    cases: { "1": "end", "2": "end" },
+                    default: "end",
                 } as any,
+                end: {
+                    kind: "task",
+                    task: "noop",
+                    inputSchema: { type: "object" },
+                    outputSchema: { type: "object" },
+                    inputs: {},
+                },
             },
             output: "done",
         });
@@ -1078,5 +1092,1197 @@ describe("validateWorkflowIR", () => {
         expect(
             result.errors.some((e) => e.message.includes("noSuchBinding")),
         ).toBe(true);
+    });
+
+    // ---- Phase 1: CFG construction and acyclicity (pass 10) ----
+
+    describe("acyclicity", () => {
+        it("rejects a self-loop (task next points to itself)", () => {
+            const ir = makeMinimalIR({
+                nodes: {
+                    start: {
+                        kind: "task",
+                        task: "noop",
+                        inputSchema: { type: "object" },
+                        outputSchema: { type: "object" },
+                        inputs: {},
+                        next: "start",
+                        bind: "out",
+                    },
+                },
+            });
+            const result = validateWorkflowIR(ir, taskMap("noop"));
+            expect(result.valid).toBe(false);
+            expect(
+                result.errors.some((e) => e.message.includes("Cycle detected")),
+            ).toBe(true);
+        });
+
+        it("rejects a two-node cycle (A -> B -> A)", () => {
+            const ir = makeMinimalIR({
+                nodes: {
+                    start: {
+                        kind: "task",
+                        task: "noop",
+                        inputSchema: { type: "object" },
+                        outputSchema: { type: "object" },
+                        inputs: {},
+                        next: "b",
+                    },
+                    b: {
+                        kind: "task",
+                        task: "noop",
+                        inputSchema: { type: "object" },
+                        outputSchema: { type: "object" },
+                        inputs: {},
+                        next: "start",
+                        bind: "out",
+                    },
+                },
+            });
+            const result = validateWorkflowIR(ir, taskMap("noop"));
+            expect(result.valid).toBe(false);
+            expect(
+                result.errors.some((e) => e.message.includes("Cycle detected")),
+            ).toBe(true);
+        });
+
+        it("rejects a longer cycle (A -> B -> C -> A)", () => {
+            const ir = makeMinimalIR({
+                nodes: {
+                    start: {
+                        kind: "task",
+                        task: "noop",
+                        inputSchema: { type: "object" },
+                        outputSchema: { type: "object" },
+                        inputs: {},
+                        next: "b",
+                    },
+                    b: {
+                        kind: "task",
+                        task: "noop",
+                        inputSchema: { type: "object" },
+                        outputSchema: { type: "object" },
+                        inputs: {},
+                        next: "c",
+                    },
+                    c: {
+                        kind: "task",
+                        task: "noop",
+                        inputSchema: { type: "object" },
+                        outputSchema: { type: "object" },
+                        inputs: {},
+                        next: "start",
+                        bind: "out",
+                    },
+                },
+            });
+            const result = validateWorkflowIR(ir, taskMap("noop"));
+            expect(result.valid).toBe(false);
+            expect(
+                result.errors.some((e) => e.message.includes("Cycle detected")),
+            ).toBe(true);
+        });
+
+        it("accepts a valid acyclic chain", () => {
+            const ir = makeMinimalIR({
+                nodes: {
+                    start: {
+                        kind: "task",
+                        task: "noop",
+                        inputSchema: { type: "object" },
+                        outputSchema: { type: "object" },
+                        inputs: {},
+                        next: "b",
+                    },
+                    b: {
+                        kind: "task",
+                        task: "noop",
+                        inputSchema: { type: "object" },
+                        outputSchema: { type: "object" },
+                        inputs: {},
+                        next: "c",
+                    },
+                    c: {
+                        kind: "task",
+                        task: "noop",
+                        inputSchema: { type: "object" },
+                        outputSchema: { type: "object" },
+                        inputs: {},
+                        bind: "out",
+                    },
+                },
+            });
+            const result = validateWorkflowIR(ir, taskMap("noop"));
+            expect(result.valid).toBe(true);
+        });
+
+        it("rejects a cycle through a branch node", () => {
+            const ir = makeMinimalIR({
+                nodes: {
+                    start: {
+                        kind: "task",
+                        task: "noop",
+                        inputSchema: { type: "object" },
+                        outputSchema: { type: "object" },
+                        inputs: {},
+                        next: "pick",
+                    },
+                    pick: {
+                        kind: "branch",
+                        selectorSchema: { type: "boolean" },
+                        selector: true,
+                        cases: { true: "start" },
+                        default: "end",
+                    },
+                    end: {
+                        kind: "task",
+                        task: "noop",
+                        inputSchema: { type: "object" },
+                        outputSchema: { type: "object" },
+                        inputs: {},
+                        bind: "out",
+                    },
+                },
+            });
+            const result = validateWorkflowIR(ir, taskMap("noop"));
+            expect(result.valid).toBe(false);
+            expect(
+                result.errors.some((e) => e.message.includes("Cycle detected")),
+            ).toBe(true);
+        });
+    });
+
+    // ---- Phase 2: onError structural rules (pass 4) ----
+
+    describe("onError rules", () => {
+        it("rejects recovery target reachable via normal path (exclusive path rule)", () => {
+            const ir = makeMinimalIR({
+                nodes: {
+                    start: {
+                        kind: "task",
+                        task: "noop",
+                        inputSchema: { type: "object" },
+                        outputSchema: { type: "object" },
+                        inputs: {},
+                        next: "handler",
+                        onError: "handler",
+                        bind: "out",
+                    },
+                    handler: {
+                        kind: "task",
+                        task: "noop",
+                        inputSchema: { type: "object" },
+                        outputSchema: { type: "object" },
+                        inputs: {},
+                    },
+                },
+            });
+            const result = validateWorkflowIR(ir, taskMap("noop"));
+            expect(result.valid).toBe(false);
+            expect(
+                result.errors.some((e) =>
+                    e.message.includes("also reachable via a normal path"),
+                ),
+            ).toBe(true);
+        });
+
+        it("rejects recovery target used by multiple triggers (single trigger rule)", () => {
+            const ir = makeMinimalIR({
+                nodes: {
+                    start: {
+                        kind: "task",
+                        task: "noop",
+                        inputSchema: { type: "object" },
+                        outputSchema: { type: "object" },
+                        inputs: {},
+                        next: "second",
+                        onError: "handler",
+                    },
+                    second: {
+                        kind: "task",
+                        task: "noop",
+                        inputSchema: { type: "object" },
+                        outputSchema: { type: "object" },
+                        inputs: {},
+                        onError: "handler",
+                        bind: "out",
+                    },
+                    handler: {
+                        kind: "task",
+                        task: "noop",
+                        inputSchema: { type: "object" },
+                        outputSchema: { type: "object" },
+                        inputs: {},
+                    },
+                },
+            });
+            const result = validateWorkflowIR(ir, taskMap("noop"));
+            expect(result.valid).toBe(false);
+            expect(
+                result.errors.some((e) =>
+                    e.message.includes("exactly one trigger"),
+                ),
+            ).toBe(true);
+        });
+
+        it("rejects recovery target that itself declares onError (no recursive recovery)", () => {
+            const ir = makeMinimalIR({
+                nodes: {
+                    start: {
+                        kind: "task",
+                        task: "noop",
+                        inputSchema: { type: "object" },
+                        outputSchema: { type: "object" },
+                        inputs: {},
+                        onError: "handler",
+                        bind: "out",
+                    },
+                    handler: {
+                        kind: "task",
+                        task: "noop",
+                        inputSchema: { type: "object" },
+                        outputSchema: { type: "object" },
+                        inputs: {},
+                        onError: "handler2",
+                    },
+                    handler2: {
+                        kind: "task",
+                        task: "noop",
+                        inputSchema: { type: "object" },
+                        outputSchema: { type: "object" },
+                        inputs: {},
+                    },
+                },
+            });
+            const result = validateWorkflowIR(ir, taskMap("noop"));
+            expect(result.valid).toBe(false);
+            expect(
+                result.errors.some((e) =>
+                    e.message.includes("Recursive recovery"),
+                ),
+            ).toBe(true);
+        });
+
+        it("rejects recovery target that is not a task node", () => {
+            const ir = makeMinimalIR({
+                nodes: {
+                    start: {
+                        kind: "task",
+                        task: "noop",
+                        inputSchema: { type: "object" },
+                        outputSchema: { type: "object" },
+                        inputs: {},
+                        onError: "handler",
+                        bind: "out",
+                    },
+                    handler: {
+                        kind: "branch",
+                        selectorSchema: { type: "boolean" },
+                        selector: true,
+                        cases: { true: "end" },
+                        default: "end",
+                    } as any,
+                    end: {
+                        kind: "task",
+                        task: "noop",
+                        inputSchema: { type: "object" },
+                        outputSchema: { type: "object" },
+                        inputs: {},
+                    },
+                },
+            });
+            const result = validateWorkflowIR(ir, taskMap("noop"));
+            expect(result.valid).toBe(false);
+            expect(
+                result.errors.some((e) =>
+                    e.message.includes("must be a task node"),
+                ),
+            ).toBe(true);
+        });
+
+        it("accepts valid onError recovery pattern", () => {
+            const ir = makeMinimalIR({
+                nodes: {
+                    start: {
+                        kind: "task",
+                        task: "noop",
+                        inputSchema: { type: "object" },
+                        outputSchema: { type: "object" },
+                        inputs: {},
+                        onError: "recover",
+                        bind: "out",
+                    },
+                    recover: {
+                        kind: "task",
+                        task: "noop",
+                        inputSchema: { type: "object" },
+                        outputSchema: { type: "object" },
+                        inputs: {},
+                        bind: "out",
+                    },
+                },
+            });
+            const result = validateWorkflowIR(ir, taskMap("noop"));
+            expect(result.valid).toBe(true);
+        });
+
+        it("rejects loop node with onError targeting a non-task", () => {
+            const ir = makeMinimalIR({
+                nodes: {
+                    start: {
+                        kind: "loop",
+                        inputs: {},
+                        inputSchema: { type: "object" },
+                        state: {
+                            i: {
+                                schema: { type: "integer" },
+                                initial: 0,
+                            },
+                        },
+                        body: {
+                            entry: "step",
+                            nodes: {
+                                step: {
+                                    kind: "task",
+                                    task: "noop",
+                                    inputSchema: { type: "object" },
+                                    outputSchema: { type: "object" },
+                                    inputs: {},
+                                },
+                            },
+                        },
+                        iterateState: {
+                            i: { $from: "state", name: "i" },
+                        },
+                        output: null,
+                        outputSchema: { type: "null" },
+                        maxIterations: 10,
+                        onError: "handler",
+                    } as any,
+                    handler: {
+                        kind: "branch",
+                        selectorSchema: { type: "boolean" },
+                        selector: true,
+                        cases: { true: "end" },
+                        default: "end",
+                    } as any,
+                    end: {
+                        kind: "task",
+                        task: "noop",
+                        inputSchema: { type: "object" },
+                        outputSchema: { type: "object" },
+                        inputs: {},
+                        bind: "out",
+                    },
+                },
+                output: null,
+                outputSchema: { type: "null" },
+            });
+            const result = validateWorkflowIR(ir, taskMap("noop"));
+            expect(result.valid).toBe(false);
+            expect(
+                result.errors.some((e) =>
+                    e.message.includes("must be a task node"),
+                ),
+            ).toBe(true);
+        });
+    });
+
+    // ---- Phase 3: Termination (pass 9) ----
+
+    describe("termination", () => {
+        it("rejects a node that cannot reach any terminal", () => {
+            // Create a graph where a side branch has no path to a terminal:
+            // start -> end (terminal), but "orphan" is a node with no incoming
+            // or outgoing edges (unreachable). However the termination check
+            // only cares about reachable nodes. Let's create a node that IS
+            // reachable but has no outgoing path to a terminal.
+            // Actually, in a DAG with entry, if a node can't reach a terminal,
+            // it has to be on a dead-end branch. Let's use a branch where one
+            // case leads to a node with no outgoing edges that isn't terminal.
+            // Wait: a node with no `next` IS a terminal. So we need something
+            // more specific. Termination means every node can reach a terminal.
+            // If a node has next pointing to a nonexistent node, that's caught
+            // earlier. Let's test loop body termination instead.
+            const ir = makeMinimalIR({
+                nodes: {
+                    start: {
+                        kind: "loop",
+                        inputs: {},
+                        inputSchema: { type: "object" },
+                        state: {
+                            i: {
+                                schema: { type: "integer" },
+                                initial: 0,
+                            },
+                        },
+                        body: {
+                            entry: "step",
+                            nodes: {
+                                step: {
+                                    kind: "task",
+                                    task: "noop",
+                                    inputSchema: { type: "object" },
+                                    outputSchema: { type: "object" },
+                                    inputs: {},
+                                    next: "dead",
+                                },
+                                dead: {
+                                    kind: "task",
+                                    task: "noop",
+                                    inputSchema: { type: "object" },
+                                    outputSchema: { type: "object" },
+                                    inputs: {},
+                                    // no next, and not pointing to @iterate or @exit
+                                },
+                                sentinel: {
+                                    kind: "task",
+                                    task: "noop",
+                                    inputSchema: { type: "object" },
+                                    outputSchema: { type: "object" },
+                                    inputs: {},
+                                    next: "@iterate",
+                                },
+                            },
+                        },
+                        iterateState: {
+                            i: { $from: "state", name: "i" },
+                        },
+                        output: null,
+                        outputSchema: { type: "null" },
+                        maxIterations: 10,
+                        bind: "out",
+                    } as any,
+                },
+                output: null,
+                outputSchema: { type: "null" },
+            });
+            const result = validateWorkflowIR(ir, taskMap("noop"));
+            expect(result.valid).toBe(false);
+            expect(
+                result.errors.some((e) =>
+                    e.message.includes("cannot reach any sentinel"),
+                ),
+            ).toBe(true);
+        });
+
+        it("accepts loop body where all nodes reach a sentinel", () => {
+            const ir = makeMinimalIR({
+                nodes: {
+                    start: {
+                        kind: "loop",
+                        inputs: {},
+                        inputSchema: { type: "object" },
+                        state: {
+                            i: {
+                                schema: { type: "integer" },
+                                initial: 0,
+                            },
+                        },
+                        body: {
+                            entry: "step",
+                            nodes: {
+                                step: {
+                                    kind: "task",
+                                    task: "noop",
+                                    inputSchema: { type: "object" },
+                                    outputSchema: { type: "object" },
+                                    inputs: {},
+                                    next: "@iterate",
+                                },
+                            },
+                        },
+                        iterateState: {
+                            i: { $from: "state", name: "i" },
+                        },
+                        output: null,
+                        outputSchema: { type: "null" },
+                        maxIterations: 10,
+                        bind: "out",
+                    } as any,
+                },
+                output: null,
+                outputSchema: { type: "null" },
+            });
+            const result = validateWorkflowIR(ir, taskMap("noop"));
+            expect(result.valid).toBe(true);
+        });
+
+        it("rejects top-level node that cannot reach a terminal", () => {
+            // Node "orphan" is reachable from entry via branch but has
+            // next pointing back into the graph forming a dead-end
+            // that was already caught by acyclicity. Instead, test a
+            // node that simply is never reached (unreachable from entry).
+            // Actually, termination checks reachable nodes. Let's use
+            // a valid acyclic graph but inside a loop body where one
+            // branch path leads to a dead-end (no sentinel).
+            // For top-level: a branch where one path ends normally and
+            // the other path is a task with no next (terminal) - that
+            // actually works fine. The termination pass for top-level
+            // just checks that every node can reach SOME terminal.
+            // A disconnected node (not reachable from entry) is not
+            // in the CFG so won't be checked. Let's verify the pass
+            // catches a real case: all nodes reachable, all are
+            // terminals -> passes.
+            const ir = makeMinimalIR({
+                nodes: {
+                    start: {
+                        kind: "task",
+                        task: "noop",
+                        inputSchema: { type: "object" },
+                        outputSchema: { type: "object" },
+                        inputs: {},
+                        bind: "out",
+                    },
+                },
+            });
+            const result = validateWorkflowIR(ir, taskMap("noop"));
+            expect(result.valid).toBe(true);
+            expect(
+                result.errors.some((e) =>
+                    e.message.includes("cannot reach a terminal"),
+                ),
+            ).toBe(false);
+        });
+    });
+
+    // ---- Phase 4: Scope closure (pass 5) ----
+
+    describe("scope closure", () => {
+        it("rejects body node referencing outer-scope binding", () => {
+            const ir = makeMinimalIR({
+                nodes: {
+                    producer: {
+                        kind: "task",
+                        task: "noop",
+                        inputSchema: { type: "object" },
+                        outputSchema: { type: "object" },
+                        inputs: {},
+                        next: "start",
+                        bind: "outerResult",
+                    },
+                    start: {
+                        kind: "loop",
+                        inputs: {},
+                        inputSchema: { type: "object" },
+                        state: {
+                            i: {
+                                schema: { type: "integer" },
+                                initial: 0,
+                            },
+                        },
+                        body: {
+                            entry: "step",
+                            nodes: {
+                                step: {
+                                    kind: "task",
+                                    task: "noop",
+                                    inputSchema: { type: "object" },
+                                    outputSchema: { type: "object" },
+                                    inputs: {
+                                        data: {
+                                            $from: "scope",
+                                            name: "outerResult",
+                                        },
+                                    },
+                                    next: "@iterate",
+                                },
+                            },
+                        },
+                        iterateState: {
+                            i: { $from: "state", name: "i" },
+                        },
+                        output: null,
+                        outputSchema: { type: "null" },
+                        maxIterations: 10,
+                    } as any,
+                },
+                entry: "producer",
+                output: null,
+                outputSchema: { type: "null" },
+            });
+            const result = validateWorkflowIR(ir, taskMap("noop"));
+            expect(result.valid).toBe(false);
+            expect(
+                result.errors.some((e) =>
+                    e.message.includes("outer-scope binding"),
+                ),
+            ).toBe(true);
+        });
+
+        it("accepts body node using $from input and $from state", () => {
+            const ir = makeMinimalIR({
+                nodes: {
+                    start: {
+                        kind: "loop",
+                        inputs: {},
+                        inputSchema: { type: "object" },
+                        state: {
+                            i: {
+                                schema: { type: "integer" },
+                                initial: 0,
+                            },
+                        },
+                        body: {
+                            entry: "step",
+                            nodes: {
+                                step: {
+                                    kind: "task",
+                                    task: "noop",
+                                    inputSchema: { type: "object" },
+                                    outputSchema: { type: "object" },
+                                    inputs: {
+                                        idx: {
+                                            $from: "state",
+                                            name: "i",
+                                        },
+                                    },
+                                    next: "@iterate",
+                                },
+                            },
+                        },
+                        iterateState: {
+                            i: { $from: "state", name: "i" },
+                        },
+                        output: null,
+                        outputSchema: { type: "null" },
+                        maxIterations: 10,
+                        bind: "out",
+                    } as any,
+                },
+                output: null,
+                outputSchema: { type: "null" },
+            });
+            const result = validateWorkflowIR(ir, taskMap("noop"));
+            expect(result.valid).toBe(true);
+        });
+
+        it("rejects nested loop body referencing grandparent scope binding", () => {
+            const ir = makeMinimalIR({
+                nodes: {
+                    producer: {
+                        kind: "task",
+                        task: "noop",
+                        inputSchema: { type: "object" },
+                        outputSchema: { type: "object" },
+                        inputs: {},
+                        next: "outerLoop",
+                        bind: "grandparentData",
+                    },
+                    outerLoop: {
+                        kind: "loop",
+                        inputs: {},
+                        inputSchema: { type: "object" },
+                        state: {
+                            i: {
+                                schema: { type: "integer" },
+                                initial: 0,
+                            },
+                        },
+                        body: {
+                            entry: "innerLoop",
+                            nodes: {
+                                innerLoop: {
+                                    kind: "loop",
+                                    inputs: {},
+                                    inputSchema: { type: "object" },
+                                    state: {
+                                        j: {
+                                            schema: { type: "integer" },
+                                            initial: 0,
+                                        },
+                                    },
+                                    body: {
+                                        entry: "innerStep",
+                                        nodes: {
+                                            innerStep: {
+                                                kind: "task",
+                                                task: "noop",
+                                                inputSchema: {
+                                                    type: "object",
+                                                },
+                                                outputSchema: {
+                                                    type: "object",
+                                                },
+                                                inputs: {
+                                                    val: {
+                                                        $from: "scope",
+                                                        name: "grandparentData",
+                                                    },
+                                                },
+                                                next: "@iterate",
+                                            },
+                                        },
+                                    },
+                                    iterateState: {
+                                        j: {
+                                            $from: "state",
+                                            name: "j",
+                                        },
+                                    },
+                                    output: null,
+                                    outputSchema: { type: "null" },
+                                    maxIterations: 5,
+                                    next: "@iterate",
+                                } as any,
+                            },
+                        },
+                        iterateState: {
+                            i: { $from: "state", name: "i" },
+                        },
+                        output: null,
+                        outputSchema: { type: "null" },
+                        maxIterations: 10,
+                    } as any,
+                },
+                entry: "producer",
+                output: null,
+                outputSchema: { type: "null" },
+            });
+            const result = validateWorkflowIR(ir, taskMap("noop"));
+            expect(result.valid).toBe(false);
+            // The inner body references "grandparentData" which is not
+            // bound in the inner body scope (scope closure violation).
+            expect(
+                result.errors.some((e) =>
+                    e.message.includes("grandparentData"),
+                ),
+            ).toBe(true);
+        });
+    });
+
+    // ---- Phase 5: Dominator analysis (pass 6) ----
+
+    describe("dominator analysis", () => {
+        it("rejects reference to binding behind a branch (not on all paths)", () => {
+            const ir = makeMinimalIR({
+                nodes: {
+                    start: {
+                        kind: "branch",
+                        selectorSchema: { type: "boolean" },
+                        selector: true,
+                        cases: { true: "producer" },
+                        default: "consumer",
+                    },
+                    producer: {
+                        kind: "task",
+                        task: "noop",
+                        inputSchema: { type: "object" },
+                        outputSchema: { type: "object" },
+                        inputs: {},
+                        next: "consumer",
+                        bind: "data",
+                    },
+                    consumer: {
+                        kind: "task",
+                        task: "noop",
+                        inputSchema: { type: "object" },
+                        outputSchema: { type: "object" },
+                        inputs: {
+                            val: { $from: "scope", name: "data" },
+                        },
+                        bind: "out",
+                    },
+                },
+            });
+            const result = validateWorkflowIR(ir, taskMap("noop"));
+            expect(result.valid).toBe(false);
+            expect(
+                result.errors.some((e) =>
+                    e.message.includes("no binder of") &&
+                    e.message.includes("dominates"),
+                ),
+            ).toBe(true);
+        });
+
+        it("accepts reference to binding that dominates the consumer", () => {
+            const ir = makeMinimalIR({
+                nodes: {
+                    start: {
+                        kind: "task",
+                        task: "noop",
+                        inputSchema: { type: "object" },
+                        outputSchema: { type: "object" },
+                        inputs: {},
+                        next: "consumer",
+                        bind: "data",
+                    },
+                    consumer: {
+                        kind: "task",
+                        task: "noop",
+                        inputSchema: { type: "object" },
+                        outputSchema: { type: "object" },
+                        inputs: {
+                            val: { $from: "scope", name: "data" },
+                        },
+                        bind: "out",
+                    },
+                },
+            });
+            const result = validateWorkflowIR(ir, taskMap("noop"));
+            expect(result.valid).toBe(true);
+        });
+
+        it("accepts onError split with shared bind name on both sides", () => {
+            const ir = makeMinimalIR({
+                nodes: {
+                    start: {
+                        kind: "task",
+                        task: "noop",
+                        inputSchema: { type: "object" },
+                        outputSchema: { type: "object" },
+                        inputs: {},
+                        onError: "recover",
+                        bind: "out",
+                    },
+                    recover: {
+                        kind: "task",
+                        task: "noop",
+                        inputSchema: { type: "object" },
+                        outputSchema: { type: "object" },
+                        inputs: {},
+                        bind: "out",
+                    },
+                },
+            });
+            const result = validateWorkflowIR(ir, taskMap("noop"));
+            expect(result.valid).toBe(true);
+        });
+
+        it("rejects duplicate binders on same path (not mutually exclusive)", () => {
+            const ir = makeMinimalIR({
+                nodes: {
+                    start: {
+                        kind: "task",
+                        task: "noop",
+                        inputSchema: { type: "object" },
+                        outputSchema: { type: "object" },
+                        inputs: {},
+                        next: "second",
+                        bind: "data",
+                    },
+                    second: {
+                        kind: "task",
+                        task: "noop",
+                        inputSchema: { type: "object" },
+                        outputSchema: { type: "object" },
+                        inputs: {},
+                        bind: "data",
+                    },
+                },
+                output: { $from: "scope", name: "data" },
+            });
+            const result = validateWorkflowIR(ir, taskMap("noop"));
+            expect(result.valid).toBe(false);
+            expect(
+                result.errors.some((e) =>
+                    e.message.includes("Bind name") &&
+                    e.message.includes("one dominates the other"),
+                ),
+            ).toBe(true);
+        });
+
+        it("allows optional ref to skip coverage check", () => {
+            const ir = makeMinimalIR({
+                nodes: {
+                    start: {
+                        kind: "branch",
+                        selectorSchema: { type: "boolean" },
+                        selector: true,
+                        cases: { true: "producer" },
+                        default: "consumer",
+                    },
+                    producer: {
+                        kind: "task",
+                        task: "noop",
+                        inputSchema: { type: "object" },
+                        outputSchema: { type: "object" },
+                        inputs: {},
+                        next: "consumer",
+                        bind: "data",
+                    },
+                    consumer: {
+                        kind: "task",
+                        task: "noop",
+                        inputSchema: { type: "object" },
+                        outputSchema: { type: "object" },
+                        inputs: {
+                            val: {
+                                $from: "scope",
+                                name: "data",
+                                optional: true,
+                            },
+                        },
+                        bind: "out",
+                    },
+                },
+            });
+            const result = validateWorkflowIR(ir, taskMap("noop"));
+            expect(result.valid).toBe(true);
+        });
+    });
+
+    // ---- Phase 6: State soundness (pass 11) ----
+
+    describe("state soundness", () => {
+        it("rejects missing iterateState entry for declared state var", () => {
+            const ir = makeMinimalIR({
+                nodes: {
+                    start: {
+                        kind: "loop",
+                        inputs: {},
+                        inputSchema: { type: "object" },
+                        state: {
+                            i: {
+                                schema: { type: "integer" },
+                                initial: 0,
+                            },
+                            j: {
+                                schema: { type: "integer" },
+                                initial: 0,
+                            },
+                        },
+                        body: {
+                            entry: "step",
+                            nodes: {
+                                step: {
+                                    kind: "task",
+                                    task: "noop",
+                                    inputSchema: { type: "object" },
+                                    outputSchema: { type: "object" },
+                                    inputs: {},
+                                    next: "@iterate",
+                                },
+                            },
+                        },
+                        iterateState: {
+                            i: { $from: "state", name: "i" },
+                            // missing "j"
+                        },
+                        output: null,
+                        outputSchema: { type: "null" },
+                        maxIterations: 10,
+                        bind: "out",
+                    } as any,
+                },
+                output: null,
+                outputSchema: { type: "null" },
+            });
+            const result = validateWorkflowIR(ir, taskMap("noop"));
+            expect(result.valid).toBe(false);
+            expect(
+                result.errors.some((e) =>
+                    e.message.includes('"j"') &&
+                    e.message.includes("no corresponding entry in iterateState"),
+                ),
+            ).toBe(true);
+        });
+
+        it("rejects $from state reference to unknown state variable", () => {
+            const ir = makeMinimalIR({
+                nodes: {
+                    start: {
+                        kind: "loop",
+                        inputs: {},
+                        inputSchema: { type: "object" },
+                        state: {
+                            i: {
+                                schema: { type: "integer" },
+                                initial: 0,
+                            },
+                        },
+                        body: {
+                            entry: "step",
+                            nodes: {
+                                step: {
+                                    kind: "task",
+                                    task: "noop",
+                                    inputSchema: { type: "object" },
+                                    outputSchema: { type: "object" },
+                                    inputs: {
+                                        idx: {
+                                            $from: "state",
+                                            name: "nonexistent",
+                                        },
+                                    },
+                                    next: "@iterate",
+                                },
+                            },
+                        },
+                        iterateState: {
+                            i: { $from: "state", name: "i" },
+                        },
+                        output: null,
+                        outputSchema: { type: "null" },
+                        maxIterations: 10,
+                        bind: "out",
+                    } as any,
+                },
+                output: null,
+                outputSchema: { type: "null" },
+            });
+            const result = validateWorkflowIR(ir, taskMap("noop"));
+            expect(result.valid).toBe(false);
+            expect(
+                result.errors.some((e) =>
+                    e.message.includes('"nonexistent"') &&
+                    e.message.includes("no state variable"),
+                ),
+            ).toBe(true);
+        });
+
+        it("rejects extra iterateState entry with no state declaration", () => {
+            const ir = makeMinimalIR({
+                nodes: {
+                    start: {
+                        kind: "loop",
+                        inputs: {},
+                        inputSchema: { type: "object" },
+                        state: {
+                            i: {
+                                schema: { type: "integer" },
+                                initial: 0,
+                            },
+                        },
+                        body: {
+                            entry: "step",
+                            nodes: {
+                                step: {
+                                    kind: "task",
+                                    task: "noop",
+                                    inputSchema: { type: "object" },
+                                    outputSchema: { type: "object" },
+                                    inputs: {},
+                                    next: "@iterate",
+                                },
+                            },
+                        },
+                        iterateState: {
+                            i: { $from: "state", name: "i" },
+                            phantom: { $from: "state", name: "phantom" },
+                        },
+                        output: null,
+                        outputSchema: { type: "null" },
+                        maxIterations: 10,
+                        bind: "out",
+                    } as any,
+                },
+                output: null,
+                outputSchema: { type: "null" },
+            });
+            const result = validateWorkflowIR(ir, taskMap("noop"));
+            expect(result.valid).toBe(false);
+            expect(
+                result.errors.some((e) =>
+                    e.message.includes('"phantom"') &&
+                    e.message.includes("no corresponding state variable"),
+                ),
+            ).toBe(true);
+        });
+    });
+
+    // ---- Phase 7: Output binding coverage (pass 12) ----
+
+    describe("output binding coverage", () => {
+        it("rejects output ref not covered on onError path", () => {
+            // start has onError -> recover.
+            // Only start binds "data", recover does not.
+            // Output references "data", so the onError path is uncovered.
+            const ir = makeMinimalIR({
+                nodes: {
+                    start: {
+                        kind: "task",
+                        task: "noop",
+                        inputSchema: { type: "object" },
+                        outputSchema: { type: "object" },
+                        inputs: {},
+                        onError: "recover",
+                        bind: "data",
+                    },
+                    recover: {
+                        kind: "task",
+                        task: "noop",
+                        inputSchema: { type: "object" },
+                        outputSchema: { type: "object" },
+                        inputs: {},
+                        // does NOT bind "data"
+                    },
+                },
+                output: { result: { $from: "scope", name: "data" } },
+            });
+            const result = validateWorkflowIR(ir, taskMap("noop"));
+            expect(result.valid).toBe(false);
+            expect(
+                result.errors.some((e) =>
+                    e.message.includes("not covered on the path through terminal"),
+                ),
+            ).toBe(true);
+        });
+
+        it("accepts output ref covered on all paths (both sides bind)", () => {
+            const ir = makeMinimalIR({
+                nodes: {
+                    start: {
+                        kind: "task",
+                        task: "noop",
+                        inputSchema: { type: "object" },
+                        outputSchema: { type: "object" },
+                        inputs: {},
+                        onError: "recover",
+                        bind: "data",
+                    },
+                    recover: {
+                        kind: "task",
+                        task: "noop",
+                        inputSchema: { type: "object" },
+                        outputSchema: { type: "object" },
+                        inputs: {},
+                        bind: "data",
+                    },
+                },
+                output: { result: { $from: "scope", name: "data" } },
+            });
+            const result = validateWorkflowIR(ir, taskMap("noop"));
+            expect(result.valid).toBe(true);
+        });
+
+        it("rejects output ref not covered on branch path", () => {
+            const ir = makeMinimalIR({
+                nodes: {
+                    start: {
+                        kind: "branch",
+                        selectorSchema: { type: "boolean" },
+                        selector: true,
+                        cases: { true: "producer" },
+                        default: "skipper",
+                    },
+                    producer: {
+                        kind: "task",
+                        task: "noop",
+                        inputSchema: { type: "object" },
+                        outputSchema: { type: "object" },
+                        inputs: {},
+                        bind: "data",
+                    },
+                    skipper: {
+                        kind: "task",
+                        task: "noop",
+                        inputSchema: { type: "object" },
+                        outputSchema: { type: "object" },
+                        inputs: {},
+                        // does NOT bind "data"
+                    },
+                },
+                output: { result: { $from: "scope", name: "data" } },
+            });
+            const result = validateWorkflowIR(ir, taskMap("noop"));
+            expect(result.valid).toBe(false);
+            expect(
+                result.errors.some((e) =>
+                    e.message.includes("not covered on the path through terminal"),
+                ),
+            ).toBe(true);
+        });
     });
 });

--- a/ts/examples/workflow/model/test/validate.spec.ts
+++ b/ts/examples/workflow/model/test/validate.spec.ts
@@ -664,6 +664,7 @@ describe("validateWorkflowIR", () => {
                     default: "start",
                 } as any,
             },
+            output: "done",
         });
         const result = validateWorkflowIR(ir);
         expect(result.valid).toBe(true);
@@ -680,6 +681,7 @@ describe("validateWorkflowIR", () => {
                     default: "start",
                 } as any,
             },
+            output: "done",
         });
         const result = validateWorkflowIR(ir);
         expect(result.valid).toBe(true);
@@ -696,6 +698,7 @@ describe("validateWorkflowIR", () => {
                     default: "start",
                 } as any,
             },
+            output: "done",
         });
         const result = validateWorkflowIR(ir);
         expect(result.valid).toBe(false);
@@ -948,6 +951,132 @@ describe("validateWorkflowIR", () => {
                     e.message.includes("string") &&
                     e.message.includes("integer"),
             ),
+        ).toBe(true);
+    });
+
+    // ---- Unresolved binding detection ----
+
+    it("rejects $from scope reference to non-existent binding", () => {
+        const ir = makeMinimalIR({
+            nodes: {
+                start: {
+                    kind: "task",
+                    task: "noop",
+                    inputSchema: { type: "object" },
+                    outputSchema: { type: "object" },
+                    inputs: {
+                        x: { $from: "scope", name: "ghost" },
+                    },
+                    bind: "out",
+                },
+            },
+        });
+        const result = validateWorkflowIR(ir);
+        expect(result.valid).toBe(false);
+        expect(
+            result.errors.some(
+                (e) =>
+                    e.message.includes("ghost") &&
+                    e.message.includes("no node"),
+            ),
+        ).toBe(true);
+    });
+
+    it("accepts $from scope reference to existing binding", () => {
+        const ir = makeMinimalIR({
+            nodes: {
+                first: {
+                    kind: "task",
+                    task: "noop",
+                    inputSchema: { type: "object" },
+                    outputSchema: { type: "object" },
+                    inputs: {},
+                    next: "second",
+                    bind: "firstOut",
+                },
+                second: {
+                    kind: "task",
+                    task: "noop",
+                    inputSchema: { type: "object" },
+                    outputSchema: { type: "object" },
+                    inputs: {
+                        x: { $from: "scope", name: "firstOut" },
+                    },
+                    bind: "out",
+                },
+            },
+            entry: "first",
+        });
+        const result = validateWorkflowIR(ir);
+        expect(result.valid).toBe(true);
+    });
+
+    it("allows optional $from scope reference to non-existent binding", () => {
+        const ir = makeMinimalIR({
+            nodes: {
+                start: {
+                    kind: "task",
+                    task: "noop",
+                    inputSchema: { type: "object" },
+                    outputSchema: { type: "object" },
+                    inputs: {
+                        x: { $from: "scope", name: "ghost", optional: true },
+                    },
+                    bind: "out",
+                },
+            },
+        });
+        const result = validateWorkflowIR(ir);
+        expect(result.valid).toBe(true);
+    });
+
+    it("rejects workflow output referencing non-existent binding", () => {
+        const ir = makeMinimalIR({
+            output: { $from: "scope", name: "missing" },
+        });
+        const result = validateWorkflowIR(ir);
+        expect(result.valid).toBe(false);
+        expect(
+            result.errors.some(
+                (e) =>
+                    e.message.includes("missing") &&
+                    e.message.includes("no node"),
+            ),
+        ).toBe(true);
+    });
+
+    it("accepts workflow output referencing existing binding", () => {
+        const ir = makeMinimalIR({
+            output: { $from: "scope", name: "out" },
+        });
+        const result = validateWorkflowIR(ir);
+        expect(result.valid).toBe(true);
+    });
+
+    it("rejects nested $from scope reference to non-existent binding", () => {
+        const ir = makeMinimalIR({
+            nodes: {
+                start: {
+                    kind: "task",
+                    task: "noop",
+                    inputSchema: { type: "object" },
+                    outputSchema: { type: "object" },
+                    inputs: {
+                        vars: {
+                            nested: {
+                                $from: "scope",
+                                name: "noSuchBinding",
+                            },
+                        },
+                    },
+                    bind: "out",
+                },
+            },
+        });
+        const result = validateWorkflowIR(ir);
+        expect(result.valid).toBe(false);
+        expect(
+            result.errors.some((e) => e.message.includes("noSuchBinding")),
         ).toBe(true);
     });
 });

--- a/ts/examples/workflow/model/test/validate.spec.ts
+++ b/ts/examples/workflow/model/test/validate.spec.ts
@@ -266,6 +266,7 @@ describe("validateWorkflowIR", () => {
                     bind: "out",
                 } as any,
             },
+            outputSchema: { type: "integer" },
         });
         const result = validateWorkflowIR(ir);
         expect(result.valid).toBe(true);
@@ -552,7 +553,7 @@ describe("validateWorkflowIR", () => {
         expect(result.valid).toBe(true);
     });
 
-    it("allows type union overlap (producer: [string, null], consumer: string)", () => {
+    it("rejects union producer [string, null] against consumer string (null has no match)", () => {
         const ir = makeMinimalIR({
             nodes: {
                 producer: {
@@ -577,6 +578,52 @@ describe("validateWorkflowIR", () => {
                         type: "object",
                         required: ["x"],
                         properties: { x: { type: "string" } },
+                    },
+                    outputSchema: { type: "object" },
+                    inputs: {
+                        x: {
+                            $from: "scope",
+                            name: "data",
+                            path: ["value"],
+                        },
+                    },
+                    bind: "out",
+                },
+            },
+            entry: "producer",
+        });
+        const result = validateWorkflowIR(ir, taskMap("noop"));
+        expect(result.valid).toBe(false);
+        expect(
+            result.errors.some((e) => e.message.includes("not compatible")),
+        ).toBe(true);
+    });
+
+    it("allows union producer [string, null] when consumer also accepts null", () => {
+        const ir = makeMinimalIR({
+            nodes: {
+                producer: {
+                    kind: "task",
+                    task: "noop",
+                    inputSchema: { type: "object" },
+                    outputSchema: {
+                        type: "object",
+                        required: ["value"],
+                        properties: {
+                            value: { type: ["string", "null"] },
+                        },
+                    },
+                    inputs: {},
+                    next: "consumer",
+                    bind: "data",
+                },
+                consumer: {
+                    kind: "task",
+                    task: "noop",
+                    inputSchema: {
+                        type: "object",
+                        required: ["x"],
+                        properties: { x: { type: ["string", "null"] } },
                     },
                     outputSchema: { type: "object" },
                     inputs: {
@@ -672,6 +719,7 @@ describe("validateWorkflowIR", () => {
                 },
             },
             output: "done",
+            outputSchema: { type: "string" },
         });
         const result = validateWorkflowIR(ir);
         expect(result.valid).toBe(true);
@@ -696,6 +744,7 @@ describe("validateWorkflowIR", () => {
                 },
             },
             output: "done",
+            outputSchema: { type: "string" },
         });
         const result = validateWorkflowIR(ir);
         expect(result.valid).toBe(true);
@@ -1889,9 +1938,10 @@ describe("validateWorkflowIR", () => {
             const result = validateWorkflowIR(ir, taskMap("noop"));
             expect(result.valid).toBe(false);
             expect(
-                result.errors.some((e) =>
-                    e.message.includes("no binder of") &&
-                    e.message.includes("dominates"),
+                result.errors.some(
+                    (e) =>
+                        e.message.includes("no binder of") &&
+                        e.message.includes("dominates"),
                 ),
             ).toBe(true);
         });
@@ -1976,9 +2026,10 @@ describe("validateWorkflowIR", () => {
             const result = validateWorkflowIR(ir, taskMap("noop"));
             expect(result.valid).toBe(false);
             expect(
-                result.errors.some((e) =>
-                    e.message.includes("Bind name") &&
-                    e.message.includes("one dominates the other"),
+                result.errors.some(
+                    (e) =>
+                        e.message.includes("Bind name") &&
+                        e.message.includes("one dominates the other"),
                 ),
             ).toBe(true);
         });
@@ -2072,9 +2123,12 @@ describe("validateWorkflowIR", () => {
             const result = validateWorkflowIR(ir, taskMap("noop"));
             expect(result.valid).toBe(false);
             expect(
-                result.errors.some((e) =>
-                    e.message.includes('"j"') &&
-                    e.message.includes("no corresponding entry in iterateState"),
+                result.errors.some(
+                    (e) =>
+                        e.message.includes('"j"') &&
+                        e.message.includes(
+                            "no corresponding entry in iterateState",
+                        ),
                 ),
             ).toBe(true);
         });
@@ -2125,9 +2179,10 @@ describe("validateWorkflowIR", () => {
             const result = validateWorkflowIR(ir, taskMap("noop"));
             expect(result.valid).toBe(false);
             expect(
-                result.errors.some((e) =>
-                    e.message.includes('"nonexistent"') &&
-                    e.message.includes("no state variable"),
+                result.errors.some(
+                    (e) =>
+                        e.message.includes('"nonexistent"') &&
+                        e.message.includes("no state variable"),
                 ),
             ).toBe(true);
         });
@@ -2174,9 +2229,10 @@ describe("validateWorkflowIR", () => {
             const result = validateWorkflowIR(ir, taskMap("noop"));
             expect(result.valid).toBe(false);
             expect(
-                result.errors.some((e) =>
-                    e.message.includes('"phantom"') &&
-                    e.message.includes("no corresponding state variable"),
+                result.errors.some(
+                    (e) =>
+                        e.message.includes('"phantom"') &&
+                        e.message.includes("no corresponding state variable"),
                 ),
             ).toBe(true);
         });
@@ -2232,10 +2288,11 @@ describe("validateWorkflowIR", () => {
             const result = validateWorkflowIR(ir, taskMap("noop"));
             expect(result.valid).toBe(false);
             expect(
-                result.errors.some((e) =>
-                    e.message.includes("type mismatch") &&
-                    e.message.includes("integer") &&
-                    e.message.includes("string"),
+                result.errors.some(
+                    (e) =>
+                        e.message.includes("type mismatch") &&
+                        e.message.includes("integer") &&
+                        e.message.includes("string"),
                 ),
             ).toBe(true);
         });
@@ -2274,7 +2331,9 @@ describe("validateWorkflowIR", () => {
             expect(result.valid).toBe(false);
             expect(
                 result.errors.some((e) =>
-                    e.message.includes("not covered on the path through terminal"),
+                    e.message.includes(
+                        "not covered on the path through terminal",
+                    ),
                 ),
             ).toBe(true);
         });
@@ -2339,7 +2398,586 @@ describe("validateWorkflowIR", () => {
             expect(result.valid).toBe(false);
             expect(
                 result.errors.some((e) =>
-                    e.message.includes("not covered on the path through terminal"),
+                    e.message.includes(
+                        "not covered on the path through terminal",
+                    ),
+                ),
+            ).toBe(true);
+        });
+    });
+
+    describe("type compatibility (pass 7)", () => {
+        it("rejects literal string input where consumer expects integer", () => {
+            const ir = makeMinimalIR({
+                nodes: {
+                    start: {
+                        kind: "task",
+                        task: "noop",
+                        inputSchema: {
+                            type: "object",
+                            required: ["count"],
+                            properties: { count: { type: "integer" } },
+                        },
+                        outputSchema: { type: "object" },
+                        inputs: { count: "not-a-number" },
+                        bind: "out",
+                    },
+                },
+            });
+            const result = validateWorkflowIR(ir);
+            expect(result.valid).toBe(false);
+            expect(
+                result.errors.some(
+                    (e) =>
+                        e.path.includes("inputs.count") &&
+                        e.message.includes("not compatible"),
+                ),
+            ).toBe(true);
+        });
+
+        it("accepts literal string input where consumer expects string", () => {
+            const ir = makeMinimalIR({
+                nodes: {
+                    start: {
+                        kind: "task",
+                        task: "noop",
+                        inputSchema: {
+                            type: "object",
+                            required: ["mode"],
+                            properties: { mode: { type: "string" } },
+                        },
+                        outputSchema: { type: "object" },
+                        inputs: { mode: "fast" },
+                        bind: "out",
+                    },
+                },
+            });
+            const result = validateWorkflowIR(ir);
+            expect(result.valid).toBe(true);
+        });
+
+        it("accepts $literal input with compatible type", () => {
+            const ir = makeMinimalIR({
+                nodes: {
+                    start: {
+                        kind: "task",
+                        task: "noop",
+                        inputSchema: {
+                            type: "object",
+                            required: ["config"],
+                            properties: {
+                                config: {
+                                    type: "object",
+                                    properties: { x: { type: "number" } },
+                                },
+                            },
+                        },
+                        outputSchema: { type: "object" },
+                        inputs: {
+                            config: { $literal: { x: 42 } },
+                        },
+                        bind: "out",
+                    },
+                },
+            });
+            const result = validateWorkflowIR(ir);
+            expect(result.valid).toBe(true);
+        });
+
+        it("rejects $literal input with incompatible type", () => {
+            const ir = makeMinimalIR({
+                nodes: {
+                    start: {
+                        kind: "task",
+                        task: "noop",
+                        inputSchema: {
+                            type: "object",
+                            required: ["count"],
+                            properties: { count: { type: "integer" } },
+                        },
+                        outputSchema: { type: "object" },
+                        inputs: {
+                            count: { $literal: "hello" },
+                        },
+                        bind: "out",
+                    },
+                },
+            });
+            const result = validateWorkflowIR(ir);
+            expect(result.valid).toBe(false);
+            expect(
+                result.errors.some(
+                    (e) =>
+                        e.path.includes("inputs.count") &&
+                        e.message.includes("not compatible"),
+                ),
+            ).toBe(true);
+        });
+
+        it("rejects selector type incompatible with selectorSchema", () => {
+            const ir = makeMinimalIR({
+                nodes: {
+                    start: {
+                        kind: "branch",
+                        selector: 42,
+                        selectorSchema: { type: "string" },
+                        cases: { a: "end" },
+                        default: "end",
+                    } as any,
+                    end: {
+                        kind: "task",
+                        task: "noop",
+                        inputSchema: { type: "object" },
+                        outputSchema: { type: "object" },
+                        inputs: {},
+                        bind: "out",
+                    },
+                },
+            });
+            const result = validateWorkflowIR(ir);
+            expect(result.valid).toBe(false);
+            expect(
+                result.errors.some(
+                    (e) =>
+                        e.path.includes("selector") &&
+                        e.message.includes("Selector resolved type"),
+                ),
+            ).toBe(true);
+        });
+
+        it("accepts selector type compatible with selectorSchema", () => {
+            const ir = makeMinimalIR({
+                nodes: {
+                    start: {
+                        kind: "branch",
+                        selector: "done",
+                        selectorSchema: { type: "string" },
+                        cases: { done: "end" },
+                        default: "end",
+                    } as any,
+                    end: {
+                        kind: "task",
+                        task: "noop",
+                        inputSchema: { type: "object" },
+                        outputSchema: { type: "object" },
+                        inputs: {},
+                        bind: "out",
+                    },
+                },
+            });
+            const result = validateWorkflowIR(ir);
+            expect(result.valid).toBe(true);
+        });
+
+        it("rejects cases key not in selectorSchema enum", () => {
+            const ir = makeMinimalIR({
+                nodes: {
+                    start: {
+                        kind: "branch",
+                        selector: { $from: "input", name: "choice" },
+                        selectorSchema: {
+                            type: "string",
+                            enum: ["yes", "no"],
+                        },
+                        cases: { yes: "end", maybe: "end" },
+                        default: "end",
+                    } as any,
+                    end: {
+                        kind: "task",
+                        task: "noop",
+                        inputSchema: { type: "object" },
+                        outputSchema: { type: "object" },
+                        inputs: {},
+                        bind: "out",
+                    },
+                },
+                inputSchema: {
+                    type: "object",
+                    properties: { choice: { type: "string" } },
+                },
+            });
+            const result = validateWorkflowIR(ir);
+            expect(result.valid).toBe(false);
+            expect(
+                result.errors.some(
+                    (e) =>
+                        e.path.includes("cases.maybe") &&
+                        e.message.includes("not a valid value"),
+                ),
+            ).toBe(true);
+        });
+
+        it("accepts cases keys that are all in selectorSchema enum", () => {
+            const ir = makeMinimalIR({
+                nodes: {
+                    start: {
+                        kind: "branch",
+                        selector: { $from: "input", name: "choice" },
+                        selectorSchema: {
+                            type: "string",
+                            enum: ["yes", "no"],
+                        },
+                        cases: { yes: "end", no: "end" },
+                        default: "end",
+                    } as any,
+                    end: {
+                        kind: "task",
+                        task: "noop",
+                        inputSchema: { type: "object" },
+                        outputSchema: { type: "object" },
+                        inputs: {},
+                        bind: "out",
+                    },
+                },
+                inputSchema: {
+                    type: "object",
+                    properties: { choice: { type: "string" } },
+                },
+            });
+            const result = validateWorkflowIR(ir);
+            expect(result.valid).toBe(true);
+        });
+
+        it("rejects workflow output type incompatible with outputSchema", () => {
+            const ir = makeMinimalIR({
+                nodes: {
+                    start: {
+                        kind: "task",
+                        task: "noop",
+                        inputSchema: { type: "object" },
+                        outputSchema: {
+                            type: "object",
+                            required: ["val"],
+                            properties: { val: { type: "string" } },
+                        },
+                        inputs: {},
+                        bind: "result",
+                    },
+                },
+                output: { $from: "scope", name: "result" },
+                outputSchema: {
+                    type: "object",
+                    required: ["val"],
+                    properties: { val: { type: "integer" } },
+                },
+            });
+            const result = validateWorkflowIR(ir);
+            expect(result.valid).toBe(false);
+            expect(
+                result.errors.some(
+                    (e) =>
+                        e.path === "output" &&
+                        e.message.includes("not compatible"),
+                ),
+            ).toBe(true);
+        });
+
+        it("accepts workflow output type compatible with outputSchema", () => {
+            const ir = makeMinimalIR({
+                nodes: {
+                    start: {
+                        kind: "task",
+                        task: "noop",
+                        inputSchema: { type: "object" },
+                        outputSchema: {
+                            type: "object",
+                            required: ["val"],
+                            properties: { val: { type: "string" } },
+                        },
+                        inputs: {},
+                        bind: "result",
+                    },
+                },
+                output: { $from: "scope", name: "result" },
+                outputSchema: {
+                    type: "object",
+                    required: ["val"],
+                    properties: { val: { type: "string" } },
+                },
+            });
+            const result = validateWorkflowIR(ir);
+            expect(result.valid).toBe(true);
+        });
+
+        it("rejects phi-merge binder with incompatible type", () => {
+            const ir = makeMinimalIR({
+                nodes: {
+                    trigger: {
+                        kind: "task",
+                        task: "noop",
+                        inputSchema: { type: "object" },
+                        outputSchema: { type: "object" },
+                        inputs: {},
+                        next: "success",
+                        onError: "recovery",
+                    },
+                    success: {
+                        kind: "task",
+                        task: "noop",
+                        inputSchema: { type: "object" },
+                        outputSchema: {
+                            type: "object",
+                            required: ["x"],
+                            properties: { x: { type: "string" } },
+                        },
+                        inputs: {},
+                        next: "consumer",
+                        bind: "data",
+                    },
+                    recovery: {
+                        kind: "task",
+                        task: "noop",
+                        inputSchema: { type: "object" },
+                        outputSchema: {
+                            type: "object",
+                            required: ["x"],
+                            properties: { x: { type: "integer" } },
+                        },
+                        inputs: {},
+                        next: "consumer",
+                        bind: "data",
+                    },
+                    consumer: {
+                        kind: "task",
+                        task: "noop",
+                        inputSchema: {
+                            type: "object",
+                            required: ["val"],
+                            properties: { val: { type: "string" } },
+                        },
+                        outputSchema: { type: "object" },
+                        inputs: {
+                            val: {
+                                $from: "scope",
+                                name: "data",
+                                path: ["x"],
+                            },
+                        },
+                        bind: "out",
+                    },
+                },
+                entry: "trigger",
+            });
+            const result = validateWorkflowIR(ir);
+            expect(result.valid).toBe(false);
+            expect(
+                result.errors.some(
+                    (e) =>
+                        e.message.includes("Phi-merge") &&
+                        e.message.includes("recovery"),
+                ),
+            ).toBe(true);
+        });
+
+        it("accepts phi-merge when all binders are compatible", () => {
+            const ir = makeMinimalIR({
+                nodes: {
+                    trigger: {
+                        kind: "task",
+                        task: "noop",
+                        inputSchema: { type: "object" },
+                        outputSchema: { type: "object" },
+                        inputs: {},
+                        next: "success",
+                        onError: "recovery",
+                    },
+                    success: {
+                        kind: "task",
+                        task: "noop",
+                        inputSchema: { type: "object" },
+                        outputSchema: {
+                            type: "object",
+                            required: ["x"],
+                            properties: { x: { type: "string" } },
+                        },
+                        inputs: {},
+                        next: "consumer",
+                        bind: "data",
+                    },
+                    recovery: {
+                        kind: "task",
+                        task: "noop",
+                        inputSchema: { type: "object" },
+                        outputSchema: {
+                            type: "object",
+                            required: ["x"],
+                            properties: { x: { type: "string" } },
+                        },
+                        inputs: {},
+                        next: "consumer",
+                        bind: "data",
+                    },
+                    consumer: {
+                        kind: "task",
+                        task: "noop",
+                        inputSchema: {
+                            type: "object",
+                            required: ["val"],
+                            properties: { val: { type: "string" } },
+                        },
+                        outputSchema: { type: "object" },
+                        inputs: {
+                            val: {
+                                $from: "scope",
+                                name: "data",
+                                path: ["x"],
+                            },
+                        },
+                        bind: "out",
+                    },
+                },
+                entry: "trigger",
+            });
+            const result = validateWorkflowIR(ir);
+            expect(result.valid).toBe(true);
+        });
+
+        it("checks integer is subtype of number", () => {
+            const ir = makeMinimalIR({
+                nodes: {
+                    start: {
+                        kind: "task",
+                        task: "noop",
+                        inputSchema: {
+                            type: "object",
+                            required: ["val"],
+                            properties: { val: { type: "number" } },
+                        },
+                        outputSchema: { type: "object" },
+                        inputs: { val: 42 },
+                        bind: "out",
+                    },
+                },
+            });
+            const result = validateWorkflowIR(ir);
+            expect(result.valid).toBe(true);
+        });
+
+        it("rejects object input missing required consumer property", () => {
+            const ir = makeMinimalIR({
+                nodes: {
+                    start: {
+                        kind: "task",
+                        task: "noop",
+                        inputSchema: {
+                            type: "object",
+                            required: ["cfg"],
+                            properties: {
+                                cfg: {
+                                    type: "object",
+                                    required: ["a", "b"],
+                                    properties: {
+                                        a: { type: "string" },
+                                        b: { type: "string" },
+                                    },
+                                },
+                            },
+                        },
+                        outputSchema: { type: "object" },
+                        inputs: {
+                            cfg: { a: "hello" },
+                        },
+                        bind: "out",
+                    },
+                },
+            });
+            const result = validateWorkflowIR(ir);
+            expect(result.valid).toBe(false);
+            expect(
+                result.errors.some(
+                    (e) =>
+                        e.path.includes("inputs.cfg") &&
+                        e.message.includes("not compatible"),
+                ),
+            ).toBe(true);
+        });
+
+        it("accepts object input with all required consumer properties", () => {
+            const ir = makeMinimalIR({
+                nodes: {
+                    start: {
+                        kind: "task",
+                        task: "noop",
+                        inputSchema: {
+                            type: "object",
+                            required: ["cfg"],
+                            properties: {
+                                cfg: {
+                                    type: "object",
+                                    required: ["a"],
+                                    properties: {
+                                        a: { type: "string" },
+                                    },
+                                },
+                            },
+                        },
+                        outputSchema: { type: "object" },
+                        inputs: {
+                            cfg: { a: "hello", b: "extra" },
+                        },
+                        bind: "out",
+                    },
+                },
+            });
+            const result = validateWorkflowIR(ir);
+            expect(result.valid).toBe(true);
+        });
+
+        it("rejects loop output type incompatible with loop outputSchema", () => {
+            const ir = makeMinimalIR({
+                nodes: {
+                    start: {
+                        kind: "loop",
+                        inputs: {},
+                        inputSchema: { type: "object" },
+                        state: {
+                            i: {
+                                schema: { type: "integer" },
+                                initial: 0,
+                            },
+                        },
+                        body: {
+                            entry: "step",
+                            nodes: {
+                                step: {
+                                    kind: "task",
+                                    task: "noop",
+                                    inputSchema: { type: "object" },
+                                    outputSchema: {
+                                        type: "object",
+                                        required: ["val"],
+                                        properties: {
+                                            val: { type: "string" },
+                                        },
+                                    },
+                                    inputs: {},
+                                    next: "@exit",
+                                    bind: "stepOut",
+                                },
+                            },
+                        },
+                        iterateState: {
+                            i: { $from: "state", name: "i" },
+                        },
+                        output: {
+                            $from: "scope",
+                            name: "stepOut",
+                            path: ["val"],
+                        },
+                        outputSchema: { type: "integer" },
+                        maxIterations: 5,
+                        bind: "out",
+                    } as any,
+                },
+                outputSchema: { type: "integer" },
+            });
+            const result = validateWorkflowIR(ir);
+            expect(result.valid).toBe(false);
+            expect(
+                result.errors.some(
+                    (e) =>
+                        e.path.includes("output") &&
+                        e.message.includes("not compatible"),
                 ),
             ).toBe(true);
         });

--- a/ts/examples/workflow/workflows/branch-reorganize.json
+++ b/ts/examples/workflow/workflows/branch-reorganize.json
@@ -1,0 +1,761 @@
+{
+  "kind": "workflow",
+  "name": "branch-reorganize",
+  "version": "1",
+  "description": "Analyze changes in a feature branch against a base branch, reorganize into separate buildable/testable commits on new branches suitable for independent PRs, then create a validation branch merging all new branches to verify the combined diff matches the original.",
+  "inputSchema": {
+    "type": "object",
+    "required": ["repoPath", "featureBranch"],
+    "properties": {
+      "repoPath": {
+        "type": "string",
+        "description": "Absolute path to the git repo."
+      },
+      "featureBranch": {
+        "type": "string",
+        "description": "The feature branch containing all changes to reorganize."
+      },
+      "baseBranch": {
+        "type": "string",
+        "description": "The base branch to diff against (default: main)."
+      },
+      "branchPrefix": {
+        "type": "string",
+        "description": "Prefix for new branch names (default: reorg/)."
+      },
+      "buildCommand": {
+        "type": "string",
+        "description": "Command to verify each branch builds (default: pnpm run build)."
+      },
+      "testCommand": {
+        "type": "string",
+        "description": "Command to verify each branch passes tests (default: pnpm run test:local)."
+      }
+    }
+  },
+  "outputSchema": {
+    "type": "object",
+    "required": ["plan", "branches", "validationBranch", "validated"],
+    "properties": {
+      "plan": {
+        "type": "object",
+        "description": "The LLM-generated reorganization plan."
+      },
+      "branches": {
+        "type": "array",
+        "items": { "type": "string" },
+        "description": "List of created branch names."
+      },
+      "validationBranch": {
+        "type": "string",
+        "description": "Name of the validation merge branch."
+      },
+      "validated": {
+        "type": "string",
+        "description": "MATCH or MISMATCH indicating whether the validation diff matches the original."
+      }
+    }
+  },
+  "constants": {
+    "analysisPrompt": {
+      "schema": { "type": "string" },
+      "value": "You are an expert software engineer reorganizing a feature branch into clean, independently-reviewable PRs.\n\nGiven the following information about changes in a feature branch:\n- Changed files list\n- Full diff\n\nAnalyze the changes and produce a JSON reorganization plan. Each group becomes a separate branch/PR.\n\nRules:\n1. Each group MUST be independently buildable and pass tests when applied on top of the base branch (plus any dependencies).\n2. Groups should be ordered so later groups may depend on earlier ones (sequential dependency), OR be fully independent.\n3. Every changed file must appear in exactly one group.\n4. Group by logical concern: e.g., refactoring, new feature, bug fix, config changes, test additions.\n5. Prefer smaller, focused groups over large ones.\n6. If a group depends on another, list it in dependsOn. The branch for a dependent group will be based on the merge of its dependencies rather than just the base branch.\n\nRespond with ONLY valid JSON in this exact format (no markdown fencing):\n{\n  \"groups\": [\n    {\n      \"name\": \"short-kebab-case-name\",\n      \"description\": \"What this group does\",\n      \"files\": [\"path/to/file1.ts\", \"path/to/file2.ts\"],\n      \"dependsOn\": [],\n      \"commitMessage\": \"type(scope): description\"\n    }\n  ]\n}\n\nThe dependsOn array lists names of groups that must be merged before this one. Empty means fully independent.\n\nChanged files:\n{{files}}\n\nFull diff:\n{{diff}}"
+    }
+  },
+  "nodes": {
+    "getFullDiff": {
+      "kind": "task",
+      "task": "shell.exec",
+      "inputSchema": {
+        "type": "object",
+        "required": ["command"],
+        "properties": {
+          "command": { "type": "string" },
+          "args": { "type": "array", "items": { "type": "string" } },
+          "cwd": { "type": "string" }
+        }
+      },
+      "outputSchema": {
+        "type": "object",
+        "required": ["stdout", "stderr", "exitCode"],
+        "properties": {
+          "stdout": { "type": "string" },
+          "stderr": { "type": "string" },
+          "exitCode": { "type": "integer" }
+        }
+      },
+      "inputs": {
+        "command": "git",
+        "args": ["diff", "main...HEAD"],
+        "cwd": { "$from": "input", "name": "repoPath" }
+      },
+      "next": "getFileList",
+      "bind": "fullDiff"
+    },
+    "getFileList": {
+      "kind": "task",
+      "task": "shell.exec",
+      "inputSchema": {
+        "type": "object",
+        "required": ["command"],
+        "properties": {
+          "command": { "type": "string" },
+          "args": { "type": "array", "items": { "type": "string" } },
+          "cwd": { "type": "string" }
+        }
+      },
+      "outputSchema": {
+        "type": "object",
+        "required": ["stdout", "stderr", "exitCode"],
+        "properties": {
+          "stdout": { "type": "string" },
+          "stderr": { "type": "string" },
+          "exitCode": { "type": "integer" }
+        }
+      },
+      "inputs": {
+        "command": "git",
+        "args": ["diff", "--name-status", "main...HEAD"],
+        "cwd": { "$from": "input", "name": "repoPath" }
+      },
+      "next": "buildAnalysisPrompt",
+      "bind": "fileList"
+    },
+    "buildAnalysisPrompt": {
+      "kind": "task",
+      "task": "text.template",
+      "inputSchema": {
+        "type": "object",
+        "required": ["template", "vars"],
+        "properties": {
+          "template": { "type": "string" },
+          "vars": { "type": "object" }
+        }
+      },
+      "outputSchema": {
+        "type": "object",
+        "required": ["text"],
+        "properties": { "text": { "type": "string" } }
+      },
+      "inputs": {
+        "template": "{{analysisPrompt}}",
+        "vars": {
+          "analysisPrompt": { "$from": "constant", "name": "analysisPrompt" },
+          "files": { "$from": "scope", "name": "fileList", "path": ["stdout"] },
+          "diff": { "$from": "scope", "name": "fullDiff", "path": ["stdout"] }
+        }
+      },
+      "next": "analyzeDiff",
+      "bind": "analysisInput"
+    },
+    "analyzeDiff": {
+      "kind": "task",
+      "task": "llm.generateJson",
+      "inputSchema": {
+        "type": "object",
+        "required": ["prompt"],
+        "properties": {
+          "prompt": { "type": "string" },
+          "endpoint": { "type": "string" }
+        }
+      },
+      "outputSchema": {
+        "type": "object",
+        "required": ["value"],
+        "properties": {
+          "value": {
+            "type": "object",
+            "required": ["groups"],
+            "properties": {
+              "groups": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "required": ["name", "files", "commitMessage"],
+                  "properties": {
+                    "name": { "type": "string" },
+                    "description": { "type": "string" },
+                    "files": { "type": "array", "items": { "type": "string" } },
+                    "dependsOn": {
+                      "type": "array",
+                      "items": { "type": "string" }
+                    },
+                    "commitMessage": { "type": "string" }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "inputs": {
+        "prompt": {
+          "$from": "scope",
+          "name": "analysisInput",
+          "path": ["text"]
+        },
+        "endpoint": "GPT_4_O_MINI"
+      },
+      "next": "createBranchesLoop",
+      "bind": "analysisResult"
+    },
+    "createBranchesLoop": {
+      "kind": "loop",
+      "inputs": {
+        "groups": {
+          "$from": "scope",
+          "name": "analysisResult",
+          "path": ["value", "groups"]
+        },
+        "repoPath": { "$from": "input", "name": "repoPath" },
+        "featureBranch": { "$from": "input", "name": "featureBranch" }
+      },
+      "inputSchema": {
+        "type": "object",
+        "required": ["groups", "repoPath", "featureBranch"],
+        "properties": {
+          "groups": { "type": "array" },
+          "repoPath": { "type": "string" },
+          "featureBranch": { "type": "string" }
+        }
+      },
+      "state": {
+        "i": { "schema": { "type": "integer" }, "initial": 0 },
+        "branchNames": { "schema": { "type": "array" }, "initial": [] }
+      },
+      "body": {
+        "entry": "pickGroup",
+        "nodes": {
+          "pickGroup": {
+            "kind": "task",
+            "task": "list.elementAt",
+            "inputSchema": {
+              "type": "object",
+              "required": ["list", "index"],
+              "properties": {
+                "list": { "type": "array" },
+                "index": { "type": "integer" }
+              }
+            },
+            "outputSchema": {
+              "type": "object",
+              "required": ["element"],
+              "properties": {
+                "element": {
+                  "type": "object",
+                  "required": ["name", "files", "commitMessage"],
+                  "properties": {
+                    "name": { "type": "string" },
+                    "description": { "type": "string" },
+                    "files": { "type": "array", "items": { "type": "string" } },
+                    "dependsOn": {
+                      "type": "array",
+                      "items": { "type": "string" }
+                    },
+                    "commitMessage": { "type": "string" }
+                  }
+                }
+              }
+            },
+            "inputs": {
+              "list": { "$from": "input", "name": "groups" },
+              "index": { "$from": "state", "name": "i" }
+            },
+            "next": "joinFiles",
+            "bind": "currentGroup"
+          },
+          "joinFiles": {
+            "kind": "task",
+            "task": "string.join",
+            "inputSchema": {
+              "type": "object",
+              "required": ["list", "delimiter"],
+              "properties": {
+                "list": { "type": "array", "items": { "type": "string" } },
+                "delimiter": { "type": "string" }
+              }
+            },
+            "outputSchema": {
+              "type": "object",
+              "required": ["text"],
+              "properties": { "text": { "type": "string" } }
+            },
+            "inputs": {
+              "list": {
+                "$from": "scope",
+                "name": "currentGroup",
+                "path": ["element", "files"]
+              },
+              "delimiter": " "
+            },
+            "next": "buildBranchScript",
+            "bind": "fileListJoined"
+          },
+          "buildBranchScript": {
+            "kind": "task",
+            "task": "text.template",
+            "inputSchema": {
+              "type": "object",
+              "required": ["template", "vars"],
+              "properties": {
+                "template": { "type": "string" },
+                "vars": { "type": "object" }
+              }
+            },
+            "outputSchema": {
+              "type": "object",
+              "required": ["text"],
+              "properties": { "text": { "type": "string" } }
+            },
+            "inputs": {
+              "template": "set -e\ngit checkout -b \"reorg/{{name}}\" main\ngit checkout \"{{featureBranch}}\" -- {{files}}\ngit add .\ngit commit -m \"{{commitMessage}}\"",
+              "vars": {
+                "name": {
+                  "$from": "scope",
+                  "name": "currentGroup",
+                  "path": ["element", "name"]
+                },
+                "featureBranch": { "$from": "input", "name": "featureBranch" },
+                "files": {
+                  "$from": "scope",
+                  "name": "fileListJoined",
+                  "path": ["text"]
+                },
+                "commitMessage": {
+                  "$from": "scope",
+                  "name": "currentGroup",
+                  "path": ["element", "commitMessage"]
+                }
+              }
+            },
+            "next": "execBranchScript",
+            "bind": "branchScript"
+          },
+          "execBranchScript": {
+            "kind": "task",
+            "task": "shell.exec",
+            "inputSchema": {
+              "type": "object",
+              "required": ["command"],
+              "properties": {
+                "command": { "type": "string" },
+                "args": { "type": "array", "items": { "type": "string" } },
+                "cwd": { "type": "string" }
+              }
+            },
+            "outputSchema": {
+              "type": "object",
+              "required": ["stdout", "stderr", "exitCode"],
+              "properties": {
+                "stdout": { "type": "string" },
+                "stderr": { "type": "string" },
+                "exitCode": { "type": "integer" }
+              }
+            },
+            "inputs": {
+              "command": "bash",
+              "args": [
+                "-c",
+                { "$from": "scope", "name": "branchScript", "path": ["text"] }
+              ],
+              "cwd": { "$from": "input", "name": "repoPath" }
+            },
+            "next": "runBuild",
+            "bind": "branchCreated"
+          },
+          "runBuild": {
+            "kind": "task",
+            "task": "shell.exec",
+            "inputSchema": {
+              "type": "object",
+              "required": ["command"],
+              "properties": {
+                "command": { "type": "string" },
+                "args": { "type": "array", "items": { "type": "string" } },
+                "cwd": { "type": "string" }
+              }
+            },
+            "outputSchema": {
+              "type": "object",
+              "required": ["stdout", "stderr", "exitCode"],
+              "properties": {
+                "stdout": { "type": "string" },
+                "stderr": { "type": "string" },
+                "exitCode": { "type": "integer" }
+              }
+            },
+            "inputs": {
+              "command": "bash",
+              "args": ["-c", "pnpm run build"],
+              "cwd": { "$from": "input", "name": "repoPath" }
+            },
+            "next": "runTests",
+            "bind": "buildResult"
+          },
+          "runTests": {
+            "kind": "task",
+            "task": "shell.exec",
+            "inputSchema": {
+              "type": "object",
+              "required": ["command"],
+              "properties": {
+                "command": { "type": "string" },
+                "args": { "type": "array", "items": { "type": "string" } },
+                "cwd": { "type": "string" }
+              }
+            },
+            "outputSchema": {
+              "type": "object",
+              "required": ["stdout", "stderr", "exitCode"],
+              "properties": {
+                "stdout": { "type": "string" },
+                "stderr": { "type": "string" },
+                "exitCode": { "type": "integer" }
+              }
+            },
+            "inputs": {
+              "command": "bash",
+              "args": ["-c", "pnpm run test:local"],
+              "cwd": { "$from": "input", "name": "repoPath" }
+            },
+            "next": "buildBranchNameStr",
+            "bind": "testResult"
+          },
+          "buildBranchNameStr": {
+            "kind": "task",
+            "task": "text.template",
+            "inputSchema": {
+              "type": "object",
+              "required": ["template", "vars"],
+              "properties": {
+                "template": { "type": "string" },
+                "vars": { "type": "object" }
+              }
+            },
+            "outputSchema": {
+              "type": "object",
+              "required": ["text"],
+              "properties": { "text": { "type": "string" } }
+            },
+            "inputs": {
+              "template": "reorg/{{name}}",
+              "vars": {
+                "name": {
+                  "$from": "scope",
+                  "name": "currentGroup",
+                  "path": ["element", "name"]
+                }
+              }
+            },
+            "next": "appendBranchName",
+            "bind": "branchNameStr"
+          },
+          "appendBranchName": {
+            "kind": "task",
+            "task": "list.append",
+            "inputSchema": {
+              "type": "object",
+              "required": ["list", "item"],
+              "properties": {
+                "list": { "type": "array" },
+                "item": {}
+              }
+            },
+            "outputSchema": {
+              "type": "object",
+              "required": ["list"],
+              "properties": { "list": { "type": "array" } }
+            },
+            "inputs": {
+              "list": { "$from": "state", "name": "branchNames" },
+              "item": {
+                "$from": "scope",
+                "name": "branchNameStr",
+                "path": ["text"]
+              }
+            },
+            "next": "returnToBase",
+            "bind": "updatedBranches"
+          },
+          "returnToBase": {
+            "kind": "task",
+            "task": "shell.exec",
+            "inputSchema": {
+              "type": "object",
+              "required": ["command"],
+              "properties": {
+                "command": { "type": "string" },
+                "args": { "type": "array", "items": { "type": "string" } },
+                "cwd": { "type": "string" }
+              }
+            },
+            "outputSchema": {
+              "type": "object",
+              "required": ["stdout", "stderr", "exitCode"],
+              "properties": {
+                "stdout": { "type": "string" },
+                "stderr": { "type": "string" },
+                "exitCode": { "type": "integer" }
+              }
+            },
+            "inputs": {
+              "command": "git",
+              "args": ["checkout", "main"],
+              "cwd": { "$from": "input", "name": "repoPath" }
+            },
+            "next": "stepIdx",
+            "bind": "returnedToBase"
+          },
+          "stepIdx": {
+            "kind": "task",
+            "task": "int.add",
+            "inputSchema": {
+              "type": "object",
+              "required": ["a", "b"],
+              "properties": {
+                "a": { "type": "integer" },
+                "b": { "type": "integer" }
+              }
+            },
+            "outputSchema": {
+              "type": "object",
+              "required": ["result"],
+              "properties": { "result": { "type": "integer" } }
+            },
+            "inputs": {
+              "a": { "$from": "state", "name": "i" },
+              "b": 1
+            },
+            "next": "computeGroupCount",
+            "bind": "nextIdx"
+          },
+          "computeGroupCount": {
+            "kind": "task",
+            "task": "list.length",
+            "inputSchema": {
+              "type": "object",
+              "required": ["list"],
+              "properties": { "list": { "type": "array" } }
+            },
+            "outputSchema": {
+              "type": "object",
+              "required": ["length"],
+              "properties": { "length": { "type": "integer" } }
+            },
+            "inputs": {
+              "list": { "$from": "input", "name": "groups" }
+            },
+            "next": "checkMore",
+            "bind": "groupCount"
+          },
+          "checkMore": {
+            "kind": "task",
+            "task": "int.lessThan",
+            "inputSchema": {
+              "type": "object",
+              "required": ["a", "b"],
+              "properties": {
+                "a": { "type": "integer" },
+                "b": { "type": "integer" }
+              }
+            },
+            "outputSchema": {
+              "type": "object",
+              "required": ["result"],
+              "properties": { "result": { "type": "boolean" } }
+            },
+            "inputs": {
+              "a": { "$from": "scope", "name": "nextIdx", "path": ["result"] },
+              "b": {
+                "$from": "scope",
+                "name": "groupCount",
+                "path": ["length"]
+              }
+            },
+            "next": "loopDecision",
+            "bind": "hasMore"
+          },
+          "loopDecision": {
+            "kind": "branch",
+            "selector": {
+              "$from": "scope",
+              "name": "hasMore",
+              "path": ["result"]
+            },
+            "selectorSchema": { "type": "boolean" },
+            "cases": { "true": "@iterate", "false": "@exit" },
+            "default": "@exit"
+          }
+        }
+      },
+      "iterateState": {
+        "i": { "$from": "scope", "name": "nextIdx", "path": ["result"] },
+        "branchNames": {
+          "$from": "scope",
+          "name": "updatedBranches",
+          "path": ["list"]
+        }
+      },
+      "output": {
+        "$from": "scope",
+        "name": "updatedBranches",
+        "path": ["list"]
+      },
+      "outputSchema": { "type": "array", "items": { "type": "string" } },
+      "maxIterations": 50,
+      "next": "joinBranchNames",
+      "bind": "createdBranches"
+    },
+    "joinBranchNames": {
+      "kind": "task",
+      "task": "string.join",
+      "inputSchema": {
+        "type": "object",
+        "required": ["list", "delimiter"],
+        "properties": {
+          "list": { "type": "array", "items": { "type": "string" } },
+          "delimiter": { "type": "string" }
+        }
+      },
+      "outputSchema": {
+        "type": "object",
+        "required": ["text"],
+        "properties": { "text": { "type": "string" } }
+      },
+      "inputs": {
+        "list": { "$from": "scope", "name": "createdBranches" },
+        "delimiter": " "
+      },
+      "next": "buildMergeScript",
+      "bind": "branchNamesJoined"
+    },
+    "buildMergeScript": {
+      "kind": "task",
+      "task": "text.template",
+      "inputSchema": {
+        "type": "object",
+        "required": ["template", "vars"],
+        "properties": {
+          "template": { "type": "string" },
+          "vars": { "type": "object" }
+        }
+      },
+      "outputSchema": {
+        "type": "object",
+        "required": ["text"],
+        "properties": { "text": { "type": "string" } }
+      },
+      "inputs": {
+        "template": "set -e\ngit checkout -b reorg/validation-merge main\nfor branch in {{branches}}; do\n  git merge --no-edit \"$branch\"\ndone",
+        "vars": {
+          "branches": {
+            "$from": "scope",
+            "name": "branchNamesJoined",
+            "path": ["text"]
+          }
+        }
+      },
+      "next": "execMergeScript",
+      "bind": "mergeScript"
+    },
+    "execMergeScript": {
+      "kind": "task",
+      "task": "shell.exec",
+      "inputSchema": {
+        "type": "object",
+        "required": ["command"],
+        "properties": {
+          "command": { "type": "string" },
+          "args": { "type": "array", "items": { "type": "string" } },
+          "cwd": { "type": "string" }
+        }
+      },
+      "outputSchema": {
+        "type": "object",
+        "required": ["stdout", "stderr", "exitCode"],
+        "properties": {
+          "stdout": { "type": "string" },
+          "stderr": { "type": "string" },
+          "exitCode": { "type": "integer" }
+        }
+      },
+      "inputs": {
+        "command": "bash",
+        "args": [
+          "-c",
+          { "$from": "scope", "name": "mergeScript", "path": ["text"] }
+        ],
+        "cwd": { "$from": "input", "name": "repoPath" }
+      },
+      "next": "buildValidationScript",
+      "bind": "mergeResult"
+    },
+    "buildValidationScript": {
+      "kind": "task",
+      "task": "text.template",
+      "inputSchema": {
+        "type": "object",
+        "required": ["template", "vars"],
+        "properties": {
+          "template": { "type": "string" },
+          "vars": { "type": "object" }
+        }
+      },
+      "outputSchema": {
+        "type": "object",
+        "required": ["text"],
+        "properties": { "text": { "type": "string" } }
+      },
+      "inputs": {
+        "template": "set -e\nORIGINAL=$(git diff main...{{featureBranch}} | sha256sum | cut -d' ' -f1)\nVALIDATION=$(git diff main...reorg/validation-merge | sha256sum | cut -d' ' -f1)\nif [ \"$ORIGINAL\" = \"$VALIDATION\" ]; then\n  echo MATCH\nelse\n  echo MISMATCH\n  echo \"Original SHA: $ORIGINAL\"\n  echo \"Validation SHA: $VALIDATION\"\nfi",
+        "vars": {
+          "featureBranch": { "$from": "input", "name": "featureBranch" }
+        }
+      },
+      "next": "execValidation",
+      "bind": "validationScript"
+    },
+    "execValidation": {
+      "kind": "task",
+      "task": "shell.exec",
+      "inputSchema": {
+        "type": "object",
+        "required": ["command"],
+        "properties": {
+          "command": { "type": "string" },
+          "args": { "type": "array", "items": { "type": "string" } },
+          "cwd": { "type": "string" }
+        }
+      },
+      "outputSchema": {
+        "type": "object",
+        "required": ["stdout", "stderr", "exitCode"],
+        "properties": {
+          "stdout": { "type": "string" },
+          "stderr": { "type": "string" },
+          "exitCode": { "type": "integer" }
+        }
+      },
+      "inputs": {
+        "command": "bash",
+        "args": [
+          "-c",
+          { "$from": "scope", "name": "validationScript", "path": ["text"] }
+        ],
+        "cwd": { "$from": "input", "name": "repoPath" }
+      },
+      "bind": "validationResult"
+    }
+  },
+  "entry": "getFullDiff",
+  "output": {
+    "plan": { "$from": "scope", "name": "analysisResult", "path": ["value"] },
+    "branches": { "$from": "scope", "name": "createdBranches" },
+    "validationBranch": "reorg/validation-merge",
+    "validated": {
+      "$from": "scope",
+      "name": "validationResult",
+      "path": ["stdout"]
+    }
+  }
+}

--- a/ts/examples/workflow/workflows/branch-reorganize.json
+++ b/ts/examples/workflow/workflows/branch-reorganize.json
@@ -2,10 +2,17 @@
   "kind": "workflow",
   "name": "branch-reorganize",
   "version": "1",
-  "description": "Analyze changes in a feature branch against a base branch, reorganize into separate buildable/testable commits on new branches suitable for independent PRs, then create a validation branch merging all new branches to verify the combined diff matches the original.",
+  "description": "Analyze changes in a feature branch against a base branch, reorganize into separate buildable/testable commits on new branches suitable for independent PRs, then create a validation branch merging all new branches to verify the combined diff matches the original. NOTE: The LLM is asked to produce dependsOn arrays for ordering hints, but the workflow currently creates all branches from baseBranch. Dependency-aware branching (topo-sort + merge-based bases) is not yet implemented.",
   "inputSchema": {
     "type": "object",
-    "required": ["repoPath", "featureBranch"],
+    "required": [
+      "repoPath",
+      "featureBranch",
+      "baseBranch",
+      "branchPrefix",
+      "buildCommand",
+      "testCommand"
+    ],
     "properties": {
       "repoPath": {
         "type": "string",
@@ -89,8 +96,33 @@
         "args": ["rev-parse", "--abbrev-ref", "HEAD"],
         "cwd": { "$from": "input", "name": "repoPath" }
       },
-      "next": "getFullDiff",
+      "next": "buildDiffRange",
       "bind": "originalBranch"
+    },
+    "buildDiffRange": {
+      "kind": "task",
+      "task": "text.template",
+      "inputSchema": {
+        "type": "object",
+        "required": ["template", "vars"],
+        "properties": {
+          "template": { "type": "string" },
+          "vars": { "type": "object" }
+        }
+      },
+      "outputSchema": {
+        "type": "object",
+        "required": ["text"],
+        "properties": { "text": { "type": "string" } }
+      },
+      "inputs": {
+        "template": "{{base}}...HEAD",
+        "vars": {
+          "base": { "$from": "input", "name": "baseBranch" }
+        }
+      },
+      "next": "getFullDiff",
+      "bind": "diffRange"
     },
     "getFullDiff": {
       "kind": "task",
@@ -115,7 +147,10 @@
       },
       "inputs": {
         "command": "git",
-        "args": ["diff", "main...HEAD"],
+        "args": [
+          "diff",
+          { "$from": "scope", "name": "diffRange", "path": ["text"] }
+        ],
         "cwd": { "$from": "input", "name": "repoPath" }
       },
       "next": "getFileList",
@@ -144,7 +179,11 @@
       },
       "inputs": {
         "command": "git",
-        "args": ["diff", "--name-status", "main...HEAD"],
+        "args": [
+          "diff",
+          "--name-status",
+          { "$from": "scope", "name": "diffRange", "path": ["text"] }
+        ],
         "cwd": { "$from": "input", "name": "repoPath" }
       },
       "next": "buildAnalysisPrompt",
@@ -239,15 +278,31 @@
           "path": ["value", "groups"]
         },
         "repoPath": { "$from": "input", "name": "repoPath" },
-        "featureBranch": { "$from": "input", "name": "featureBranch" }
+        "featureBranch": { "$from": "input", "name": "featureBranch" },
+        "baseBranch": { "$from": "input", "name": "baseBranch" },
+        "branchPrefix": { "$from": "input", "name": "branchPrefix" },
+        "buildCommand": { "$from": "input", "name": "buildCommand" },
+        "testCommand": { "$from": "input", "name": "testCommand" }
       },
       "inputSchema": {
         "type": "object",
-        "required": ["groups", "repoPath", "featureBranch"],
+        "required": [
+          "groups",
+          "repoPath",
+          "featureBranch",
+          "baseBranch",
+          "branchPrefix",
+          "buildCommand",
+          "testCommand"
+        ],
         "properties": {
           "groups": { "type": "array" },
           "repoPath": { "type": "string" },
-          "featureBranch": { "type": "string" }
+          "featureBranch": { "type": "string" },
+          "baseBranch": { "type": "string" },
+          "branchPrefix": { "type": "string" },
+          "buildCommand": { "type": "string" },
+          "testCommand": { "type": "string" }
         }
       },
       "state": {
@@ -317,7 +372,7 @@
                 "name": "currentGroup",
                 "path": ["element", "files"]
               },
-              "delimiter": " "
+              "delimiter": "\n"
             },
             "next": "buildBranchScript",
             "bind": "fileListJoined"
@@ -339,7 +394,7 @@
               "properties": { "text": { "type": "string" } }
             },
             "inputs": {
-              "template": "set -e\ngit checkout -b \"reorg/{{name}}\" main\ngit checkout \"{{featureBranch}}\" -- {{files}}\ngit add .\ngit commit -m \"{{commitMessage}}\"",
+              "template": "set -e\ngit checkout -b \"{{branchPrefix}}{{name}}\" \"{{baseBranch}}\"\nwhile IFS= read -r f; do\n  [ -n \"$f\" ] && git checkout \"{{featureBranch}}\" -- \"$f\"\ndone <<'FILELIST'\n{{files}}\nFILELIST\ngit add .\ngit commit -m \"{{commitMessage}}\"",
               "vars": {
                 "name": {
                   "$from": "scope",
@@ -347,6 +402,8 @@
                   "path": ["element", "name"]
                 },
                 "featureBranch": { "$from": "input", "name": "featureBranch" },
+                "baseBranch": { "$from": "input", "name": "baseBranch" },
+                "branchPrefix": { "$from": "input", "name": "branchPrefix" },
                 "files": {
                   "$from": "scope",
                   "name": "fileListJoined",
@@ -417,7 +474,7 @@
             },
             "inputs": {
               "command": "bash",
-              "args": ["-c", "pnpm run build"],
+              "args": ["-c", { "$from": "input", "name": "buildCommand" }],
               "cwd": { "$from": "input", "name": "repoPath" }
             },
             "timeoutMs": 600000,
@@ -447,7 +504,7 @@
             },
             "inputs": {
               "command": "bash",
-              "args": ["-c", "pnpm run test:local"],
+              "args": ["-c", { "$from": "input", "name": "testCommand" }],
               "cwd": { "$from": "input", "name": "repoPath" }
             },
             "timeoutMs": 300000,
@@ -471,8 +528,9 @@
               "properties": { "text": { "type": "string" } }
             },
             "inputs": {
-              "template": "reorg/{{name}}",
+              "template": "{{branchPrefix}}{{name}}",
               "vars": {
+                "branchPrefix": { "$from": "input", "name": "branchPrefix" },
                 "name": {
                   "$from": "scope",
                   "name": "currentGroup",
@@ -533,7 +591,7 @@
             },
             "inputs": {
               "command": "git",
-              "args": ["checkout", "main"],
+              "args": ["checkout", { "$from": "input", "name": "baseBranch" }],
               "cwd": { "$from": "input", "name": "repoPath" }
             },
             "next": "stepIdx",
@@ -680,8 +738,10 @@
         "properties": { "text": { "type": "string" } }
       },
       "inputs": {
-        "template": "set -e\ngit checkout -b reorg/validation-merge main\nfor branch in {{branches}}; do\n  git merge --no-edit \"$branch\"\ndone",
+        "template": "set -e\ngit checkout -b {{branchPrefix}}validation-merge \"{{baseBranch}}\"\nfor branch in {{branches}}; do\n  git merge --no-edit \"$branch\"\ndone",
         "vars": {
+          "baseBranch": { "$from": "input", "name": "baseBranch" },
+          "branchPrefix": { "$from": "input", "name": "branchPrefix" },
           "branches": {
             "$from": "scope",
             "name": "branchNamesJoined",
@@ -721,9 +781,34 @@
         ],
         "cwd": { "$from": "input", "name": "repoPath" }
       },
-      "next": "buildValidationScript",
+      "next": "buildValBranchName",
       "onError": "buildCleanupScript",
       "bind": "mergeResult"
+    },
+    "buildValBranchName": {
+      "kind": "task",
+      "task": "text.template",
+      "inputSchema": {
+        "type": "object",
+        "required": ["template", "vars"],
+        "properties": {
+          "template": { "type": "string" },
+          "vars": { "type": "object" }
+        }
+      },
+      "outputSchema": {
+        "type": "object",
+        "required": ["text"],
+        "properties": { "text": { "type": "string" } }
+      },
+      "inputs": {
+        "template": "{{branchPrefix}}validation-merge",
+        "vars": {
+          "branchPrefix": { "$from": "input", "name": "branchPrefix" }
+        }
+      },
+      "next": "buildValidationScript",
+      "bind": "valBranchName"
     },
     "buildValidationScript": {
       "kind": "task",
@@ -742,9 +827,11 @@
         "properties": { "text": { "type": "string" } }
       },
       "inputs": {
-        "template": "set -e\nORIGINAL=$(git diff main...{{featureBranch}} | sha256sum | cut -d' ' -f1)\nVALIDATION=$(git diff main...reorg/validation-merge | sha256sum | cut -d' ' -f1)\nif [ \"$ORIGINAL\" = \"$VALIDATION\" ]; then\n  echo MATCH\nelse\n  echo MISMATCH\n  echo \"Original SHA: $ORIGINAL\"\n  echo \"Validation SHA: $VALIDATION\"\nfi",
+        "template": "set -e\nORIGINAL=$(git diff \"{{baseBranch}}\"...\"{{featureBranch}}\" | sha256sum | cut -d' ' -f1)\nVALIDATION=$(git diff \"{{baseBranch}}\"...\"{{branchPrefix}}validation-merge\" | sha256sum | cut -d' ' -f1)\nif [ \"$ORIGINAL\" = \"$VALIDATION\" ]; then\n  echo MATCH\nelse\n  echo MISMATCH\n  echo \"Original SHA: $ORIGINAL\"\n  echo \"Validation SHA: $VALIDATION\"\nfi",
         "vars": {
-          "featureBranch": { "$from": "input", "name": "featureBranch" }
+          "featureBranch": { "$from": "input", "name": "featureBranch" },
+          "baseBranch": { "$from": "input", "name": "baseBranch" },
+          "branchPrefix": { "$from": "input", "name": "branchPrefix" }
         }
       },
       "next": "execValidation",
@@ -847,7 +934,11 @@
   "output": {
     "plan": { "$from": "scope", "name": "analysisResult", "path": ["value"] },
     "branches": { "$from": "scope", "name": "createdBranches" },
-    "validationBranch": "reorg/validation-merge",
+    "validationBranch": {
+      "$from": "scope",
+      "name": "valBranchName",
+      "path": ["text"]
+    },
     "validated": {
       "$from": "scope",
       "name": "validationResult",

--- a/ts/examples/workflow/workflows/branch-reorganize.json
+++ b/ts/examples/workflow/workflows/branch-reorganize.json
@@ -2,7 +2,7 @@
   "kind": "workflow",
   "name": "branch-reorganize",
   "version": "1",
-  "description": "Analyze changes in a feature branch against a base branch, reorganize into separate buildable/testable commits on new branches suitable for independent PRs, then create a validation branch merging all new branches to verify the combined diff matches the original. NOTE: The LLM is asked to produce dependsOn arrays for ordering hints, but the workflow currently creates all branches from baseBranch. Dependency-aware branching (topo-sort + merge-based bases) is not yet implemented.",
+  "description": "Analyze changes in a feature branch against a base branch, reorganize into separate buildable/testable commits on new branches suitable for independent PRs, then create a validation branch merging all new branches to verify the combined diff matches the original. Groups with dependsOn are created by first merging their dependency branches, so they contain the prerequisite changes.",
   "inputSchema": {
     "type": "object",
     "required": [
@@ -42,7 +42,7 @@
   },
   "outputSchema": {
     "type": "object",
-    "required": ["plan", "branches", "validationBranch", "validated"],
+    "required": [],
     "properties": {
       "plan": {
         "type": "object",
@@ -66,7 +66,7 @@
   "constants": {
     "analysisPrompt": {
       "schema": { "type": "string" },
-      "value": "You are an expert software engineer reorganizing a feature branch into clean, independently-reviewable PRs.\n\nGiven the following information about changes in a feature branch:\n- Changed files list\n- Full diff\n\nAnalyze the changes and produce a JSON reorganization plan. Each group becomes a separate branch/PR.\n\nRules:\n1. Each group MUST be independently buildable and pass tests when applied on top of the base branch (plus any dependencies).\n2. Groups should be ordered so later groups may depend on earlier ones (sequential dependency), OR be fully independent.\n3. Every changed file must appear in exactly one group.\n4. Group by logical concern: e.g., refactoring, new feature, bug fix, config changes, test additions.\n5. Prefer smaller, focused groups over large ones.\n6. If a group depends on another, list it in dependsOn. The branch for a dependent group will be based on the merge of its dependencies rather than just the base branch.\n\nRespond with ONLY valid JSON in this exact format (no markdown fencing):\n{\n  \"groups\": [\n    {\n      \"name\": \"short-kebab-case-name\",\n      \"description\": \"What this group does\",\n      \"files\": [\"path/to/file1.ts\", \"path/to/file2.ts\"],\n      \"dependsOn\": [],\n      \"commitMessage\": \"type(scope): description\"\n    }\n  ]\n}\n\nThe dependsOn array lists names of groups that must be merged before this one. Empty means fully independent.\n\nChanged files:\n{{files}}\n\nFull diff:\n{{diff}}"
+      "value": "You are an expert software engineer reorganizing a feature branch into clean, independently-reviewable PRs.\n\nGiven the following information about changes in a feature branch:\n- Changed files list\n- Full diff\n\nAnalyze the changes and produce a JSON reorganization plan. Each group becomes a separate branch/PR.\n\nRules:\n1. Each group MUST be independently buildable and pass tests when applied on top of the base branch (plus any dependencies).\n2. The groups array MUST be in topological order: if group B depends on group A, A must appear before B in the array.\n3. Every changed file must appear in exactly one group.\n4. Group by logical concern: e.g., refactoring, new feature, bug fix, config changes, test additions.\n5. Prefer smaller, focused groups over large ones.\n6. If a group depends on another, list it in dependsOn. The branch for a dependent group will be created by first merging its dependency branches, so it will contain those changes.\n7. dependsOn references must only refer to groups that appear earlier in the array.\n\nRespond with ONLY valid JSON in this exact format (no markdown fencing):\n{\n  \"groups\": [\n    {\n      \"name\": \"short-kebab-case-name\",\n      \"description\": \"What this group does\",\n      \"files\": [\"path/to/file1.ts\", \"path/to/file2.ts\"],\n      \"dependsOn\": [],\n      \"commitMessage\": \"type(scope): description\"\n    }\n  ]\n}\n\nThe dependsOn array lists names of groups that must be merged before this one. Empty means the branch is created directly from the base branch.\n\nChanged files:\n{{files}}\n\nFull diff:\n{{diff}}"
     }
   },
   "nodes": {
@@ -266,8 +266,27 @@
       },
       "timeoutMs": 120000,
       "next": "createBranchesLoop",
-      "onError": "buildCleanupScript",
+      "onError": "cleanupFromAnalysis",
       "bind": "analysisResult"
+    },
+    "cleanupFromAnalysis": {
+      "kind": "task",
+      "task": "text.template",
+      "inputSchema": {
+        "type": "object",
+        "required": ["template", "vars"],
+        "properties": {
+          "template": { "type": "string" },
+          "vars": { "type": "object" }
+        }
+      },
+      "outputSchema": {
+        "type": "object",
+        "required": ["text"],
+        "properties": { "text": { "type": "string" } }
+      },
+      "inputs": { "template": "", "vars": {} },
+      "next": "buildCleanupScript"
     },
     "createBranchesLoop": {
       "kind": "loop",
@@ -374,8 +393,35 @@
               },
               "delimiter": "\n"
             },
-            "next": "buildBranchScript",
+            "next": "joinDeps",
             "bind": "fileListJoined"
+          },
+          "joinDeps": {
+            "kind": "task",
+            "task": "string.join",
+            "inputSchema": {
+              "type": "object",
+              "required": ["list", "delimiter"],
+              "properties": {
+                "list": { "type": "array", "items": { "type": "string" } },
+                "delimiter": { "type": "string" }
+              }
+            },
+            "outputSchema": {
+              "type": "object",
+              "required": ["text"],
+              "properties": { "text": { "type": "string" } }
+            },
+            "inputs": {
+              "list": {
+                "$from": "scope",
+                "name": "currentGroup",
+                "path": ["element", "dependsOn"]
+              },
+              "delimiter": " "
+            },
+            "next": "buildBranchScript",
+            "bind": "depsJoined"
           },
           "buildBranchScript": {
             "kind": "task",
@@ -394,7 +440,7 @@
               "properties": { "text": { "type": "string" } }
             },
             "inputs": {
-              "template": "set -e\ngit checkout -b \"{{branchPrefix}}{{name}}\" \"{{baseBranch}}\"\nwhile IFS= read -r f; do\n  [ -n \"$f\" ] && git checkout \"{{featureBranch}}\" -- \"$f\"\ndone <<'FILELIST'\n{{files}}\nFILELIST\ngit add .\ngit commit -m \"{{commitMessage}}\"",
+              "template": "set -e\nBRANCH_NAME=\"{{branchPrefix}}{{name}}\"\nDEPS=\"{{deps}}\"\nif [ -n \"$DEPS\" ]; then\n  git checkout -b \"$BRANCH_NAME\" \"{{baseBranch}}\"\n  for dep in $DEPS; do\n    git merge --no-edit \"{{branchPrefix}}$dep\"\n  done\nelse\n  git checkout -b \"$BRANCH_NAME\" \"{{baseBranch}}\"\nfi\nwhile IFS= read -r f; do\n  [ -n \"$f\" ] && git checkout \"{{featureBranch}}\" -- \"$f\"\ndone <<'FILELIST'\n{{files}}\nFILELIST\ngit add .\ngit commit -m \"{{commitMessage}}\"",
               "vars": {
                 "name": {
                   "$from": "scope",
@@ -404,6 +450,11 @@
                 "featureBranch": { "$from": "input", "name": "featureBranch" },
                 "baseBranch": { "$from": "input", "name": "baseBranch" },
                 "branchPrefix": { "$from": "input", "name": "branchPrefix" },
+                "deps": {
+                  "$from": "scope",
+                  "name": "depsJoined",
+                  "path": ["text"]
+                },
                 "files": {
                   "$from": "scope",
                   "name": "fileListJoined",
@@ -695,8 +746,27 @@
       "outputSchema": { "type": "array", "items": { "type": "string" } },
       "maxIterations": 50,
       "next": "joinBranchNames",
-      "onError": "buildCleanupScript",
+      "onError": "cleanupFromLoop",
       "bind": "createdBranches"
+    },
+    "cleanupFromLoop": {
+      "kind": "task",
+      "task": "text.template",
+      "inputSchema": {
+        "type": "object",
+        "required": ["template", "vars"],
+        "properties": {
+          "template": { "type": "string" },
+          "vars": { "type": "object" }
+        }
+      },
+      "outputSchema": {
+        "type": "object",
+        "required": ["text"],
+        "properties": { "text": { "type": "string" } }
+      },
+      "inputs": { "template": "", "vars": {} },
+      "next": "buildCleanupScript"
     },
     "joinBranchNames": {
       "kind": "task",
@@ -782,7 +852,7 @@
         "cwd": { "$from": "input", "name": "repoPath" }
       },
       "next": "buildValBranchName",
-      "onError": "buildCleanupScript",
+      "onError": "cleanupFromMerge",
       "bind": "mergeResult"
     },
     "buildValBranchName": {
@@ -866,8 +936,46 @@
         ],
         "cwd": { "$from": "input", "name": "repoPath" }
       },
-      "onError": "buildCleanupScript",
+      "onError": "cleanupFromValidation",
       "bind": "validationResult"
+    },
+    "cleanupFromMerge": {
+      "kind": "task",
+      "task": "text.template",
+      "inputSchema": {
+        "type": "object",
+        "required": ["template", "vars"],
+        "properties": {
+          "template": { "type": "string" },
+          "vars": { "type": "object" }
+        }
+      },
+      "outputSchema": {
+        "type": "object",
+        "required": ["text"],
+        "properties": { "text": { "type": "string" } }
+      },
+      "inputs": { "template": "", "vars": {} },
+      "next": "buildCleanupScript"
+    },
+    "cleanupFromValidation": {
+      "kind": "task",
+      "task": "text.template",
+      "inputSchema": {
+        "type": "object",
+        "required": ["template", "vars"],
+        "properties": {
+          "template": { "type": "string" },
+          "vars": { "type": "object" }
+        }
+      },
+      "outputSchema": {
+        "type": "object",
+        "required": ["text"],
+        "properties": { "text": { "type": "string" } }
+      },
+      "inputs": { "template": "", "vars": {} },
+      "next": "buildCleanupScript"
     },
     "buildCleanupScript": {
       "kind": "task",
@@ -932,17 +1040,28 @@
   },
   "entry": "recordBranch",
   "output": {
-    "plan": { "$from": "scope", "name": "analysisResult", "path": ["value"] },
-    "branches": { "$from": "scope", "name": "createdBranches" },
+    "plan": {
+      "$from": "scope",
+      "name": "analysisResult",
+      "path": ["value"],
+      "optional": true
+    },
+    "branches": {
+      "$from": "scope",
+      "name": "createdBranches",
+      "optional": true
+    },
     "validationBranch": {
       "$from": "scope",
       "name": "valBranchName",
-      "path": ["text"]
+      "path": ["text"],
+      "optional": true
     },
     "validated": {
       "$from": "scope",
       "name": "validationResult",
-      "path": ["stdout"]
+      "path": ["stdout"],
+      "optional": true
     }
   }
 }

--- a/ts/examples/workflow/workflows/branch-reorganize.json
+++ b/ts/examples/workflow/workflows/branch-reorganize.json
@@ -63,6 +63,35 @@
     }
   },
   "nodes": {
+    "recordBranch": {
+      "kind": "task",
+      "task": "shell.exec",
+      "inputSchema": {
+        "type": "object",
+        "required": ["command"],
+        "properties": {
+          "command": { "type": "string" },
+          "args": { "type": "array", "items": { "type": "string" } },
+          "cwd": { "type": "string" }
+        }
+      },
+      "outputSchema": {
+        "type": "object",
+        "required": ["stdout", "stderr", "exitCode"],
+        "properties": {
+          "stdout": { "type": "string" },
+          "stderr": { "type": "string" },
+          "exitCode": { "type": "integer" }
+        }
+      },
+      "inputs": {
+        "command": "git",
+        "args": ["rev-parse", "--abbrev-ref", "HEAD"],
+        "cwd": { "$from": "input", "name": "repoPath" }
+      },
+      "next": "getFullDiff",
+      "bind": "originalBranch"
+    },
     "getFullDiff": {
       "kind": "task",
       "task": "shell.exec",
@@ -194,9 +223,11 @@
           "name": "analysisInput",
           "path": ["text"]
         },
-        "endpoint": "GPT_4_O_MINI"
+        "endpoint": "GPT_4_1"
       },
+      "timeoutMs": 120000,
       "next": "createBranchesLoop",
+      "onError": "buildCleanupScript",
       "bind": "analysisResult"
     },
     "createBranchesLoop": {
@@ -389,6 +420,7 @@
               "args": ["-c", "pnpm run build"],
               "cwd": { "$from": "input", "name": "repoPath" }
             },
+            "timeoutMs": 600000,
             "next": "runTests",
             "bind": "buildResult"
           },
@@ -418,6 +450,7 @@
               "args": ["-c", "pnpm run test:local"],
               "cwd": { "$from": "input", "name": "repoPath" }
             },
+            "timeoutMs": 300000,
             "next": "buildBranchNameStr",
             "bind": "testResult"
           },
@@ -604,6 +637,7 @@
       "outputSchema": { "type": "array", "items": { "type": "string" } },
       "maxIterations": 50,
       "next": "joinBranchNames",
+      "onError": "buildCleanupScript",
       "bind": "createdBranches"
     },
     "joinBranchNames": {
@@ -688,6 +722,7 @@
         "cwd": { "$from": "input", "name": "repoPath" }
       },
       "next": "buildValidationScript",
+      "onError": "buildCleanupScript",
       "bind": "mergeResult"
     },
     "buildValidationScript": {
@@ -744,10 +779,71 @@
         ],
         "cwd": { "$from": "input", "name": "repoPath" }
       },
+      "onError": "buildCleanupScript",
       "bind": "validationResult"
+    },
+    "buildCleanupScript": {
+      "kind": "task",
+      "task": "text.template",
+      "inputSchema": {
+        "type": "object",
+        "required": ["template", "vars"],
+        "properties": {
+          "template": { "type": "string" },
+          "vars": { "type": "object" }
+        }
+      },
+      "outputSchema": {
+        "type": "object",
+        "required": ["text"],
+        "properties": { "text": { "type": "string" } }
+      },
+      "inputs": {
+        "template": "BRANCH=$(echo '{{branch}}' | tr -d '\\n'); git merge --abort 2>/dev/null; git cherry-pick --abort 2>/dev/null; git checkout \"$BRANCH\" 2>/dev/null; git branch --list 'reorg/*' | xargs -r git branch -D 2>/dev/null; echo \"cleanup done, restored $BRANCH\"",
+        "vars": {
+          "branch": {
+            "$from": "scope",
+            "name": "originalBranch",
+            "path": ["stdout"]
+          }
+        }
+      },
+      "next": "execCleanup",
+      "bind": "cleanupScript"
+    },
+    "execCleanup": {
+      "kind": "task",
+      "task": "shell.exec",
+      "inputSchema": {
+        "type": "object",
+        "required": ["command"],
+        "properties": {
+          "command": { "type": "string" },
+          "args": { "type": "array", "items": { "type": "string" } },
+          "cwd": { "type": "string" }
+        }
+      },
+      "outputSchema": {
+        "type": "object",
+        "required": ["stdout", "stderr", "exitCode"],
+        "properties": {
+          "stdout": { "type": "string" },
+          "stderr": { "type": "string" },
+          "exitCode": { "type": "integer" }
+        }
+      },
+      "inputs": {
+        "command": "bash",
+        "args": [
+          "-c",
+          { "$from": "scope", "name": "cleanupScript", "path": ["text"] }
+        ],
+        "cwd": { "$from": "input", "name": "repoPath" }
+      },
+      "bind": "cleanupResult"
     }
   },
-  "entry": "getFullDiff",
+  "entry": "recordBranch",
   "output": {
     "plan": { "$from": "scope", "name": "analysisResult", "path": ["value"] },
     "branches": { "$from": "scope", "name": "createdBranches" },

--- a/ts/examples/workflow/workflows/d8-summarize-url.json
+++ b/ts/examples/workflow/workflows/d8-summarize-url.json
@@ -158,7 +158,7 @@
           "path": ["result"]
         }
       },
-      "output": { "$from": "scope", "name": "fetchResult", "path": ["body"] },
+      "output": { "$from": "scope", "name": "fetchResult", "path": ["body"], "optional": true },
       "outputSchema": { "type": "string" },
       "maxIterations": 3,
       "next": "buildPrompt",

--- a/ts/examples/workflow/workflows/d8-summarize-url.json
+++ b/ts/examples/workflow/workflows/d8-summarize-url.json
@@ -77,16 +77,9 @@
             "inputs": {
               "url": { "$from": "input", "name": "url" }
             },
-            "next": "fetchSucceeded",
+            "next": "@exit",
             "onError": "incrementAttempt",
             "bind": "fetchResult"
-          },
-          "fetchSucceeded": {
-            "kind": "branch",
-            "selector": "done",
-            "selectorSchema": { "enum": ["done"] },
-            "cases": { "done": "@exit" },
-            "default": "@exit"
           },
           "incrementAttempt": {
             "kind": "task",
@@ -158,7 +151,12 @@
           "path": ["result"]
         }
       },
-      "output": { "$from": "scope", "name": "fetchResult", "path": ["body"], "optional": true },
+      "output": {
+        "$from": "scope",
+        "name": "fetchResult",
+        "path": ["body"],
+        "optional": true
+      },
       "outputSchema": { "type": "string" },
       "maxIterations": 3,
       "next": "buildPrompt",

--- a/ts/pnpm-lock.yaml
+++ b/ts/pnpm-lock.yaml
@@ -152,7 +152,7 @@ importers:
         version: 8.18.1
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@20.19.25)(ts-node@10.9.2(@types/node@20.19.25)(typescript@5.4.5))
+        version: 29.7.0(@types/node@25.5.2)(ts-node@10.9.2(@types/node@25.5.2)(typescript@5.4.5))
       prettier:
         specifier: ^3.5.3
         version: 3.5.3
@@ -932,6 +932,9 @@ importers:
 
   examples/workflow/cli:
     dependencies:
+      dotenv:
+        specifier: ^17.4.2
+        version: 17.4.2
       workflow-engine:
         specifier: workspace:*
         version: link:../engine
@@ -944,7 +947,7 @@ importers:
         version: 29.5.14
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@25.5.2)(ts-node@10.9.2(@types/node@25.5.2)(typescript@5.4.5))
+        version: 29.7.0(@types/node@20.19.25)(ts-node@10.9.2(@types/node@20.19.25)(typescript@5.4.5))
       prettier:
         specifier: ^3.5.3
         version: 3.5.3
@@ -994,6 +997,9 @@ importers:
       '@types/jest':
         specifier: ^29.5.7
         version: 29.5.14
+      '@types/json-schema':
+        specifier: ^7.0.15
+        version: 7.0.15
       jest:
         specifier: ^29.7.0
         version: 29.7.0(@types/node@25.5.2)(ts-node@10.9.2(@types/node@25.5.2)(typescript@5.4.5))
@@ -10810,6 +10816,10 @@ packages:
     resolution: {integrity: sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg==}
     engines: {node: '>=12'}
 
+  dotenv@17.4.2:
+    resolution: {integrity: sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==}
+    engines: {node: '>=12'}
+
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
@@ -16036,7 +16046,7 @@ snapshots:
 
   '@anthropic-ai/claude-agent-sdk@0.2.105':
     dependencies:
-      '@anthropic-ai/sdk': 0.81.0(zod@3.25.76)
+      '@anthropic-ai/sdk': 0.81.0(zod@4.1.13)
       '@modelcontextprotocol/sdk': 1.29.0
     optionalDependencies:
       '@img/sharp-darwin-arm64': 0.34.5
@@ -19327,7 +19337,7 @@ snapshots:
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
       raw-body: 3.0.2
-      zod-to-json-schema: 3.25.1(zod@3.25.76)
+      zod-to-json-schema: 3.25.1(zod@4.1.13)
     transitivePeerDependencies:
       - supports-color
 
@@ -23278,6 +23288,8 @@ snapshots:
       dotenv: 16.5.0
 
   dotenv@16.5.0: {}
+
+  dotenv@17.4.2: {}
 
   dunder-proto@1.0.1:
     dependencies:


### PR DESCRIPTION
# Workflow engine enhancements

## Summary

A series of improvements to the workflow engine, validator, and CLI across `examples/workflow/`.

## Changes

### Structured output and schema validation
- Forward node `outputSchema` to tasks via `TaskContext` so `llm.generateJson` can pass structured output schemas to the LLM API directly
- Adopt `JSONSchema7` from `@types/json-schema` instead of `Record<string, unknown>` for proper typed schema access throughout model, engine, and validator
- Add node-vs-task schema validation (`checkNodeTaskSchemas`) to catch mismatches between node schemas and registered task schemas at load time
- `sealObjects()` for OpenAI structured output compliance (`additionalProperties` + `required`)

### Comprehensive validator passes (section 4.1)
- **Pass 4**: onError structural rules (exclusive path, single trigger, no recursive recovery, task-only target)
- **Pass 5**: Scope closure (body nodes cannot reference outer-scope bindings)
- **Pass 6**: Dominator analysis with joint coverage across onError splits (phi soundness + coverage using Cooper/Harvey/Kennedy idom algorithm)
- **Pass 7**: Type compatibility - compositional type resolution for template expressions with structural subtype checking
- **Pass 9**: Termination (reverse reachability from terminals/sentinels)
- **Pass 10**: CFG construction and acyclicity (three-color DFS cycle detection)
- **Pass 11**: State soundness (state/iterateState correspondence, `$from "state"` name validation)
- **Pass 12**: Output binding coverage (all paths to terminals must be covered)

### Runtime features
- Per-node `timeoutMs` field on `TaskNode` and `LoopNode`, overrides global default
- onError cleanup-then-fail: runner tracks original error through recovery path, reports it when output template is unresolvable after cleanup
- Binding reference validation: validator checks that `$from` scope refs in node inputs and workflow output point to names that some node actually binds
- Replace `Promise.race` timeout with `AbortSignal.timeout`
- `--env <file>` CLI flag to load dotenv files before workflow execution

### Validator quality
- Deduplicate validator: unify template ref collection, simplify node narrowing
- Iterative DFS (explicit stack) to avoid stack overflow on deep graphs
- Canonical JSON stringify for property-order-independent schema equality
- Extract helpers to reduce code duplication across passes

### Dependency-aware branching
- LLM prompt now requires topological ordering and valid `dependsOn` refs
- Added `joinDeps` step to join `dependsOn` array into space-separated string
- Branch script merges dependency branches before cherry-picking files
- `branch-reorganize.json` workflow for analyzing and splitting feature branch changes into separate PR-ready branches

### Bug fixes
- SSRF: cover full 172.16.0.0/12 range in `http.get`
- `list.elementAt`: add bounds check
- `file.read`: eliminate TOCTOU by checking size after read
- `string.split`: add `keepEmpty` option (default false)
- Fix `d8-summarize-url` broken `fetchSucceeded` branch
- Fix `handledError` captures `err.node` (not `err.nodeId`)
- Fix `loadEnvFiles` control flow

## Testing

- 182 model/validator tests (many new), 98+ engine tests - all passing
- Test helpers (`makeTaskNode`/`makeLoopNode`) to reduce fixture boilerplate