### PR TITLE
test(actionGrammar): remove duplicate separatorMode tests and fix misnamed hex tests

### DIFF
--- a/ts/packages/actionGrammar/test/grammarCompletionKeywordSpacePunct.spec.ts
+++ b/ts/packages/actionGrammar/test/grammarCompletionKeywordSpacePunct.spec.ts
@@ -95,22 +95,6 @@ describeForEachCompletion(
                 });
             });
 
-            it("separatorMode: comma-ending word before Latin word", () => {
-                // After "hello," the next char is "w" (Latin).
-                // requiresSeparator(",", "w", auto) → false (comma not word-boundary)
-                // → separatorMode should be "optionalSpace"
-                const result = matchGrammarCompletion(grammar, "hello,");
-                expectMetadata(result, {
-                    completions: ["world"],
-                    matchedPrefixLength: 6,
-                    separatorMode: "autoSpacePunctuation",
-                    closedSet: true,
-                    directionSensitive: true,
-                    afterWildcard: "none",
-                    properties: [],
-                });
-            });
-
             it("exact match backs up to last term", () => {
                 const result = matchGrammarCompletion(grammar, "hello, world");
                 // Exact match backs up to the last term.
@@ -167,22 +151,6 @@ describeForEachCompletion(
                 const result = matchGrammarCompletion(grammar, "hello");
                 // "hello" fully matched, no trailing sep → direction-sensitive
                 // requiresSeparator("o", ",", auto) → comma is punct → "optionalSpace"
-                expectMetadata(result, {
-                    completions: [",world"],
-                    matchedPrefixLength: 5,
-                    separatorMode: "autoSpacePunctuation",
-                    closedSet: true,
-                    directionSensitive: true,
-                    afterWildcard: "none",
-                    properties: [],
-                });
-            });
-
-            it("separatorMode: Latin word before comma-starting word", () => {
-                // After "hello" the next char is "," (punctuation).
-                // requiresSeparator("o", ",", auto) → false (comma not word-boundary)
-                // → separatorMode should be "optionalSpace"
-                const result = matchGrammarCompletion(grammar, "hello");
                 expectMetadata(result, {
                     completions: [",world"],
                     matchedPrefixLength: 5,
@@ -517,21 +485,6 @@ describeForEachCompletion(
                     });
                 });
 
-                it("separatorMode after 'hello' before ' world'", () => {
-                    // requiresSeparator("o", " ", auto) → " " not word-boundary → false
-                    // → separatorMode = "optionalSpace"
-                    const result = matchGrammarCompletion(grammar, "hello");
-                    expectMetadata(result, {
-                        completions: [" world"],
-                        matchedPrefixLength: 5,
-                        separatorMode: "autoSpacePunctuation",
-                        closedSet: true,
-                        directionSensitive: true,
-                        afterWildcard: "none",
-                        properties: [],
-                    });
-                });
-
                 it("offers 'next' after 'hello world' (one space)", () => {
                     // One input space: flex-space zero, literal " world" starts at 5
                     const result = matchGrammarCompletion(
@@ -794,22 +747,6 @@ describeForEachCompletion(
                         "hello world",
                     );
                     // None mode → "none"
-                    expectMetadata(result, {
-                        completions: ["next"],
-                        matchedPrefixLength: 11,
-                        separatorMode: "none",
-                        closedSet: true,
-                        directionSensitive: true,
-                        afterWildcard: "none",
-                        properties: [],
-                    });
-                });
-
-                it("separatorMode after ' world' in none mode", () => {
-                    const result = matchGrammarCompletion(
-                        grammar,
-                        "hello world",
-                    );
                     expectMetadata(result, {
                         completions: ["next"],
                         matchedPrefixLength: 11,
@@ -1222,27 +1159,6 @@ describeForEachCompletion(
                 });
             });
 
-            it("separatorMode: comma before entity should be 'optional'", () => {
-                // requiresSeparator(",", "a", auto) → false → optional
-                const result = matchGrammarCompletion(grammar, "hello,");
-                expectMetadata(result, {
-                    completions: [],
-                    matchedPrefixLength: 6,
-                    separatorMode: "autoSpacePunctuation",
-                    closedSet: false,
-                    directionSensitive: true,
-                    afterWildcard: "none",
-                    properties: [
-                        {
-                            match: {
-                                actionName: "test",
-                                parameters: {},
-                            },
-                            propertyNames: ["parameters.x"],
-                        },
-                    ],
-                });
-            });
         });
 
         // ================================================================
@@ -1564,18 +1480,6 @@ describeForEachCompletion(
                 });
             });
 
-            it("separatorMode for required spacing after punctuation word", () => {
-                const result = matchGrammarCompletion(grammar, "hello, ");
-                expectMetadata(result, {
-                    completions: ["world"],
-                    matchedPrefixLength: 6,
-                    separatorMode: "spacePunctuation",
-                    closedSet: true,
-                    directionSensitive: true,
-                    afterWildcard: "none",
-                    properties: [],
-                });
-            });
         });
 
         describe("spacing=optional with punctuation keyword completion", () => {
@@ -1596,18 +1500,6 @@ describeForEachCompletion(
                 });
             });
 
-            it("separatorMode should be 'optionalSpacePunctuation'", () => {
-                const result = matchGrammarCompletion(grammar, "hello,");
-                expectMetadata(result, {
-                    completions: ["world"],
-                    matchedPrefixLength: 6,
-                    separatorMode: "optionalSpacePunctuation",
-                    closedSet: true,
-                    directionSensitive: true,
-                    afterWildcard: "none",
-                    properties: [],
-                });
-            });
         });
 
         describe("spacing=none with punctuation keyword completion", () => {
@@ -1643,18 +1535,6 @@ describeForEachCompletion(
                 });
             });
 
-            it("separatorMode should be 'none'", () => {
-                const result = matchGrammarCompletion(grammar, "hello,");
-                expectMetadata(result, {
-                    completions: ["world"],
-                    matchedPrefixLength: 6,
-                    separatorMode: "none",
-                    closedSet: true,
-                    directionSensitive: true,
-                    afterWildcard: "none",
-                    properties: [],
-                });
-            });
         });
 
         // ================================================================
@@ -1694,18 +1574,6 @@ describeForEachCompletion(
                 });
             });
 
-            it("separatorMode should be 'none' after escaped-space keyword", () => {
-                const result = matchGrammarCompletion(grammar, "hello world");
-                expectMetadata(result, {
-                    completions: ["next"],
-                    matchedPrefixLength: 11,
-                    separatorMode: "none",
-                    closedSet: true,
-                    directionSensitive: true,
-                    afterWildcard: "none",
-                    properties: [],
-                });
-            });
         });
 
         // ================================================================
@@ -2051,23 +1919,6 @@ describeForEachCompletion(
                 });
             });
 
-            it("separatorMode: apostrophe-ending word before Latin word", () => {
-                // The apostrophe is inside the segment "don't" — it is NOT the
-                // boundary character.  matchedPrefixLength = 5, so the char at
-                // prefix[4] is 't' (last char of "don't"), and completionText[0]
-                // is 's' (start of "stop").  requiresSeparator("t", "s", auto)
-                // → both Latin → true → "spacePunctuation".
-                const result = matchGrammarCompletion(grammar, "don't");
-                expectMetadata(result, {
-                    completions: ["stop"],
-                    matchedPrefixLength: 5,
-                    separatorMode: "autoSpacePunctuation",
-                    closedSet: true,
-                    directionSensitive: true,
-                    afterWildcard: "none",
-                    properties: [],
-                });
-            });
         });
 
         // ================================================================
@@ -2524,18 +2375,6 @@ describeForEachCompletion(
                 });
             });
 
-            it("separatorMode should be 'spacePunctuation' for required spacing", () => {
-                const result = matchGrammarCompletion(grammar, "hello world");
-                expectMetadata(result, {
-                    completions: ["next"],
-                    matchedPrefixLength: 11,
-                    separatorMode: "spacePunctuation",
-                    closedSet: true,
-                    directionSensitive: true,
-                    afterWildcard: "none",
-                    properties: [],
-                });
-            });
         });
 
         // ================================================================

--- a/ts/packages/actionGrammar/test/grammarCompletionKeywordSpacePunct.spec.ts
+++ b/ts/packages/actionGrammar/test/grammarCompletionKeywordSpacePunct.spec.ts
@@ -1158,7 +1158,6 @@ describeForEachCompletion(
                     ],
                 });
             });
-
         });
 
         // ================================================================
@@ -1479,7 +1478,6 @@ describeForEachCompletion(
                     properties: [],
                 });
             });
-
         });
 
         describe("spacing=optional with punctuation keyword completion", () => {
@@ -1499,7 +1497,6 @@ describeForEachCompletion(
                     properties: [],
                 });
             });
-
         });
 
         describe("spacing=none with punctuation keyword completion", () => {
@@ -1534,7 +1531,6 @@ describeForEachCompletion(
                     properties: [],
                 });
             });
-
         });
 
         // ================================================================
@@ -1573,7 +1569,6 @@ describeForEachCompletion(
                     properties: [],
                 });
             });
-
         });
 
         // ================================================================
@@ -1918,7 +1913,6 @@ describeForEachCompletion(
                     properties: [],
                 });
             });
-
         });
 
         // ================================================================
@@ -2374,7 +2368,6 @@ describeForEachCompletion(
                     properties: [],
                 });
             });
-
         });
 
         // ================================================================

--- a/ts/packages/actionGrammar/test/grammarMatcherBasic.spec.ts
+++ b/ts/packages/actionGrammar/test/grammarMatcherBasic.spec.ts
@@ -173,12 +173,12 @@ describeForEachMatcher("Grammar Matcher - Basic", (testMatchGrammar) => {
             expect(testMatchGrammar(grammar, "+0b0101")).toStrictEqual([]);
         });
 
-        it("number variable - minus octal", () => {
+        it("number variable - minus hex", () => {
             const g = `<Start> = $(x:number) -> x;`;
             const grammar = loadGrammarRules("test.grammar", g);
             expect(testMatchGrammar(grammar, "-0x123")).toStrictEqual([]);
         });
-        it("number variable - plus octal", () => {
+        it("number variable - plus hex", () => {
             const g = `<Start> = $(x:number) -> x;`;
             const grammar = loadGrammarRules("test.grammar", g);
             expect(testMatchGrammar(grammar, "+0x123")).toStrictEqual([]);


### PR DESCRIPTION
## Summary

After a content-based duplicate analysis of all 80 test spec files in `ts/packages/actionGrammar/test/`, two sets of issues were found and fixed.

### 1. Remove 11 duplicate tests (`grammarCompletionKeywordSpacePunct.spec.ts`)

Each `separatorMode: ...` test was an exact duplicate of an adjacent functional test in the same `describe` block — same grammar, same input, same expected output. The `separatorMode` tests appear to have been added redundantly to document the separator mode value, but that value is already asserted by the existing functional test.

Removed tests and their canonical equivalents:

| Removed (duplicate) | Kept (canonical) |
|---|---|
| `"separatorMode: comma-ending word before Latin word"` | `"offers second segment after first segment typed"` |
| `"separatorMode: Latin word before comma-starting word"` | `"offers second segment after 'hello'"` |
| `"separatorMode after 'hello' before ' world'"` | `"offers second segment ' world' after 'hello'"` |
| `"separatorMode after ' world' in none mode"` | `"offers 'next' after 'hello world' (literal space consumed)"` |
| `"separatorMode: comma before entity should be 'optional'"` | `"offers property completion after 'hello,'"` |
| `"separatorMode for required spacing after punctuation word"` | `"offers second segment after 'hello, '"` |
| `"separatorMode should be 'optionalSpacePunctuation'"` | `"offers second segment after 'hello,'"` (optional mode) |
| `"separatorMode should be 'none'"` | `"offers second segment after 'hello,'"` (none mode) |
| `"separatorMode should be 'none' after escaped-space keyword"` | `"offers 'next' after 'hello world'"` (none mode) |
| `"separatorMode: apostrophe-ending word before Latin word"` | `"offers 'stop' after \"don't\""` |
| `"separatorMode should be 'spacePunctuation' for required spacing"` | `"offers 'next' after 'hello world'"` (required mode) |

> Note: `"separatorMode: colon-ending word before Latin word"` was intentionally kept — it tests a different input (`"set:"`) than its adjacent test (`"set: value"`).

### 2. Fix misnamed hex tests (`grammarMatcherBasic.spec.ts`)

Two tests were copy-pasted with the wrong names — they test hexadecimal inputs (`-0x123`, `+0x123`) but were named "octal":

| Before | After |
|---|---|
| `"number variable - minus octal"` | `"number variable - minus hex"` |
| `"number variable - plus octal"` | `"number variable - plus hex"` |

The true octal tests (lines 154/159, testing `-0o123`/`+0o123`) already have the correct "octal" names.