### PR TITLE
test(workflow/engine): fix shell.exec tests for Windows cross-platform compatibility

### DIFF
--- a/ts/examples/workflow/engine/test/engine.spec.ts
+++ b/ts/examples/workflow/engine/test/engine.spec.ts
@@ -1288,8 +1288,11 @@ describe("WorkflowEngine (IR v1)", () => {
                             },
                         },
                         inputs: {
-                            command: "echo",
-                            args: ["hello", "world"] as Template,
+                            command: "node",
+                            args: [
+                                "-e",
+                                "process.stdout.write('hello world')",
+                            ] as unknown as Template,
                         },
                         bind: "result",
                     },
@@ -1331,6 +1334,10 @@ describe("WorkflowEngine (IR v1)", () => {
                             required: ["command"],
                             properties: {
                                 command: { type: "string" },
+                                args: {
+                                    type: "array",
+                                    items: { type: "string" },
+                                },
                             },
                         },
                         outputSchema: {
@@ -1343,7 +1350,8 @@ describe("WorkflowEngine (IR v1)", () => {
                             },
                         },
                         inputs: {
-                            command: "false",
+                            command: "node",
+                            args: ["-e", "process.exit(1)"] as unknown as Template,
                         },
                         bind: "result",
                     },

--- a/ts/examples/workflow/engine/test/engine.spec.ts
+++ b/ts/examples/workflow/engine/test/engine.spec.ts
@@ -1351,7 +1351,10 @@ describe("WorkflowEngine (IR v1)", () => {
                         },
                         inputs: {
                             command: "node",
-                            args: ["-e", "process.exit(1)"] as unknown as Template,
+                            args: [
+                                "-e",
+                                "process.exit(1)",
+                            ] as unknown as Template,
                         },
                         bind: "result",
                     },


### PR DESCRIPTION
## Summary

Two `shell.exec` tests in `examples/workflow/engine/test/engine.spec.ts` were failing on Windows because they used Unix-only commands via `execFile()`, which does not invoke a shell and therefore cannot find shell built-ins or Unix utilities that aren't on PATH.

## Root cause

`execFile()` resolves executables by direct PATH lookup — no shell is invoked. On Windows:
- `echo` is a shell built-in (not a standalone `.exe`), so `execFile("echo", ...)` fails with ENOENT
- `false` doesn't exist as a standalone executable unless Git/MSYS tools are on PATH

GitHub's `windows-latest` CI runners have Git tools on PATH (so CI passed), but the tests fail on clean Windows environments.

## Changes

**`examples/workflow/engine/test/engine.spec.ts`**

| Test | Before | After |
|------|--------|-------|
| "runs a command and captures stdout" | `echo hello world` | `node -e "process.stdout.write('hello world')"` |
| "returns non-zero exit code as ok" | `false` | `node -e "process.exit(1)"` |

Both replacements use `node`, which is always on PATH in any Node.js environment, making the tests truly cross-platform.

## Testing

- ✅ All 38 packages pass `test:local` on Windows
- ✅ The 3 `shell.exec task` tests all pass (including the previously passing "fails on command not found")