### PR TITLE
Specify JSON output format for Azure CLI invocations

### DIFF
--- a/ts/packages/agents/greeting/src/greetingCommandHandler.ts
+++ b/ts/packages/agents/greeting/src/greetingCommandHandler.ts
@@ -60,7 +60,7 @@ async function initializeGreetingAgentContext(): Promise<GreetingAgentContext> {
 
     // non blocking execution call
     exec(
-        "az ad signed-in-user show",
+        "az ad signed-in-user show -o json",
         { timeout: 15000 },
         (_error, stdout, _stderr) => {
             try {

--- a/ts/tools/scripts/dedupeDeployments.mjs
+++ b/ts/tools/scripts/dedupeDeployments.mjs
@@ -263,6 +263,8 @@ async function listVaultSecretNames(vault) {
                 vault,
                 "--query",
                 "[].name",
+                "-o",
+                "json",
             ],
             { shell: true },
             (e, stdout, stderr) => {

--- a/ts/tools/scripts/inventoryEndpoints.mjs
+++ b/ts/tools/scripts/inventoryEndpoints.mjs
@@ -87,7 +87,7 @@ async function listDeployments(account) {
 async function listKeyVaultSecrets(vaultName) {
     try {
         const raw = await execAsync(
-            `az keyvault secret list --vault-name ${vaultName}`,
+            `az keyvault secret list --vault-name ${vaultName} -o json`,
         );
         return JSON.parse(raw);
     } catch (e) {

--- a/ts/tools/scripts/lib/azureUtils.mjs
+++ b/ts/tools/scripts/lib/azureUtils.mjs
@@ -36,8 +36,16 @@ export async  function getAzCliLoggedInInfo(print = true) {
 }
 
 export async function execAzCliCommand(args) {
+    // Ensure an explicit output format so we don't depend on the user's
+    // configured az CLI default (which can be set to table/tsv/etc. via
+    // `az configure`). Default to JSON unless the caller already specified
+    // an output format.
+    const hasOutputFlag = args.some(
+        (a) => a === "-o" || a === "--output" || a.startsWith("--output="),
+    );
+    const finalArgs = hasOutputFlag ? args : [...args, "-o", "json"];
     return new Promise((res, rej) => {
-        child_process.execFile("az", args, { shell: true }, (err, stdout, stderr) => {
+        child_process.execFile("az", finalArgs, { shell: true }, (err, stdout, stderr) => {
             if (err) {
                 debugError(err.stdout);
                 debugError(err.stderr);

--- a/ts/tools/scripts/lib/pimClient.mjs
+++ b/ts/tools/scripts/lib/pimClient.mjs
@@ -114,7 +114,7 @@ class AzPIMClient {
     async getPrincipalId(continueOnFailure = false) {
         try {
             const accountDetails = JSON.parse(
-                await execAsync("az ad signed-in-user show"),
+                await execAsync("az ad signed-in-user show -o json"),
             );
 
             return accountDetails.id;

--- a/ts/tools/scripts/syncPoolSecrets.mjs
+++ b/ts/tools/scripts/syncPoolSecrets.mjs
@@ -341,6 +341,8 @@ async function vaultListSecretNames(vault) {
                 vault,
                 "--query",
                 "[].name",
+                "-o",
+                "json",
             ],
             { shell: true },
             (e, stdout, stderr) => {


### PR DESCRIPTION
When invoking the Azure CLI to obtain information that we then parse as JSON, explicitly request JSON output instead of relying on the default. The user's `az` CLI default output format may be configured to `table`/`tsv`/etc. via `az configure --defaults output=...`, which would break our `JSON.parse` calls.

### Changes

**Central helper** — `ts/tools/scripts/lib/azureUtils.mjs`:
- `execAzCliCommand` now auto-appends `-o json` unless the caller already specified an output flag (`-o`, `--output`, or `--output=...`). This covers most call sites in `azureDeploy.mjs`, `dedupeDeployments.mjs`, `syncPoolSecrets.mjs`, `provisionGaps.mjs`, `inventoryEndpoints.mjs`, and `azureUtils.mjs` itself.

**Direct `az` invocations bypassing the helper** — added explicit `-o json`:
- `ts/tools/scripts/lib/pimClient.mjs` — `az ad signed-in-user show`
- `ts/tools/scripts/inventoryEndpoints.mjs` — `az keyvault secret list`
- `ts/packages/agents/greeting/src/greetingCommandHandler.ts` — `az ad signed-in-user show`
- `ts/tools/scripts/dedupeDeployments.mjs` — `keyvault secret list` (other calls already specify `-o tsv`/`--output none`)
- `ts/tools/scripts/syncPoolSecrets.mjs` — `keyvault secret list` (same)