### PR TITLE
devcontainer: fix pnpm install EACCES on first container creation

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -5,15 +5,18 @@ This devcontainer provides a fully configured development environment for TypeAg
 ## Prerequisites
 
 ### Windows
+
 - **Docker Desktop** with WSL 2 backend enabled
 - **VS Code** with the [Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)
 - Recommended: Run `ts/tools/scripts/setup-devcontainer.ps1` to verify prerequisites
 
 ### macOS / Linux
+
 - **Docker Desktop** or Docker Engine
 - **VS Code** with the Dev Containers extension
 
 ### GitHub Codespaces
+
 No local prerequisites - works directly in browser or VS Code.
 
 ## Quick Start
@@ -31,13 +34,16 @@ No local prerequisites - works directly in browser or VS Code.
 ## Container Configurations
 
 ### Standard (`devcontainer.json`)
+
 Default configuration for most development work. Includes:
+
 - Node.js 22, Python 3.12, .NET 8.0
 - pnpm package manager
 - Azure CLI, GitHub CLI
 - Claude Code
 
 **Note:** The Electron shell requires GUI support. To use the shell with devcontainer, you need to start teh agent-server in the container and run the shell on your host machine. The agent server port is forwarded to the host, so the shell will connect correctly:
+
 ```bash
 # In container - start the backend
 pnpm run server
@@ -49,6 +55,7 @@ cd ts && pnpm run shell
 ## Working with the Container
 
 ### Common Commands
+
 ```bash
 cd ts                    # Navigate to TypeScript workspace
 pnpm run build           # Build all packages
@@ -60,13 +67,16 @@ pnpm run start:agent-server          # Start agent server
 ## Using with AI Agents
 
 ### Claude Code
+
 Claude Code is pre-installed in the container:
+
 ```bash
 claude                   # Start interactive session
 claude "your prompt"     # Run with a prompt
 ```
 
 ### Parallel Agent Development with Worktrees
+
 Run multiple AI agents in parallel using git worktrees:
 
 ```bash
@@ -82,43 +92,68 @@ Run multiple AI agents in parallel using git worktrees:
 ```
 
 Each worktree shares the git history but has independent:
+
 - Working directory and file changes
 - Node modules (via pnpm's content-addressable store)
 - Branch state
 
 ## Forwarded Ports
 
-| Port | Service |
-|------|---------|
-| 3000 | API Server (HTTP) |
-| 3443 | API Server (HTTPS) |
-| 8999 | Agent Server (WebSocket) |
-| 8081 | Browser Agent (WebSocket) |
-| 8082 | Code Agent (WebSocket) |
+| Port | Service                         |
+| ---- | ------------------------------- |
+| 3000 | API Server (HTTP)               |
+| 3443 | API Server (HTTPS)              |
+| 8999 | Agent Server (WebSocket)        |
+| 8081 | Browser Agent (WebSocket)       |
+| 8082 | Code Agent (WebSocket)          |
 | 6080 | noVNC Desktop (VNC config only) |
 
 ## Troubleshooting
 
 ### Container fails to start
+
 1. Ensure Docker Desktop is running
 2. Try rebuilding: `Dev Containers: Rebuild Container`
 3. Check Docker has sufficient resources (4 CPU, 8GB RAM minimum)
 
 ### pnpm install fails
+
 ```bash
 # Clear pnpm cache and retry
 pnpm store prune
 pnpm install
 ```
 
+### `EACCES` / permission denied on `ts/node_modules` during `pnpm install`
+
+The devcontainer mounts a Docker named volume at `ts/node_modules` (and at the pnpm
+global store). Docker creates these mount points owned by `root:root`, but the
+container runs as the non-root `codespace` user, which causes `pnpm install` to
+fail with permission errors on a fresh container.
+
+The `post-create.sh` script automatically `chown`s these paths to `codespace`
+on first launch. If you hit this manually, run:
+
+```bash
+sudo chown -R codespace:codespace \
+    /workspaces/TypeAgent/ts/node_modules \
+    /home/codespace/.local/share/pnpm \
+    /home/codespace/.claude
+cd /workspaces/TypeAgent/ts && pnpm install
+```
+
 ### Permission errors
+
 The container runs as the `codespace` user. If you encounter permission issues:
+
 ```bash
 sudo chown -R codespace:codespace /workspaces/TypeAgent
 ```
 
 ### Line ending issues (Windows)
+
 If scripts fail with `\r': command not found`, the repository may have CRLF line endings. Fix with:
+
 ```bash
 git config core.autocrlf input
 git rm --cached -r .
@@ -128,9 +163,11 @@ git reset --hard
 ## Rebuilding the Container
 
 To rebuild with fresh state:
+
 1. Command Palette: `Dev Containers: Rebuild Container`
 
 To rebuild without cache:
+
 1. Command Palette: `Dev Containers: Rebuild Container Without Cache`
 
 ## Resources

--- a/.devcontainer/scripts/post-create.sh
+++ b/.devcontainer/scripts/post-create.sh
@@ -31,6 +31,36 @@ ENV=$(detect_env)
 echo "Environment: $ENV"
 echo ""
 
+# Fix ownership of Docker named-volume mount points.
+# Named volumes mounted into the container are owned by root:root by default,
+# which prevents the non-root `codespace` user from writing into them
+# (e.g. `pnpm install` -> EACCES on ts/node_modules).
+echo "Fixing ownership of mounted volume directories..."
+VOLUME_PATHS=(
+    "/home/codespace/.local/share/pnpm"
+    "/home/codespace/.local/share/pnpm/store"
+    "/home/codespace/.claude"
+)
+# Discover the workspace ts/node_modules path dynamically (works for worktrees too)
+WS_TS_DIR=""
+if [[ -d "/workspaces/TypeAgent/ts" ]]; then
+    WS_TS_DIR="/workspaces/TypeAgent/ts"
+else
+    WS_TS_DIR=$(find /workspaces -maxdepth 2 -type d -name "ts" 2>/dev/null | head -1)
+fi
+if [[ -n "$WS_TS_DIR" ]]; then
+    VOLUME_PATHS+=("$WS_TS_DIR/node_modules")
+fi
+
+for p in "${VOLUME_PATHS[@]}"; do
+    if [[ -e "$p" ]]; then
+        sudo chown -R codespace:codespace "$p" 2>/dev/null \
+            && echo "  chowned $p" \
+            || echo "  warn: could not chown $p"
+    fi
+done
+echo ""
+
 # Navigate to TypeScript workspace
 echo "Looking for TypeScript workspace..."
 if [[ -d "/workspaces/TypeAgent/ts" ]]; then


### PR DESCRIPTION
## Problem

On first creation of the devcontainer, `pnpm install` fails with `EACCES: permission denied` writing into `ts/node_modules`.

## Root cause

`.devcontainer/devcontainer.json` mounts three Docker named volumes:

- `${containerWorkspaceFolder}/ts/node_modules`
- `/home/codespace/.local/share/pnpm/store`
- `/home/codespace/.claude`

Docker creates the mount-point directories owned by `root:root`. The container's `remoteUser` is `codespace` (UID 1000), so when `post-create.sh` runs `pnpm install` as `codespace` it can't write into `ts/node_modules` (or populate the global pnpm store).

## Fix

- `.devcontainer/scripts/post-create.sh`: before running `pnpm install`, `sudo chown -R codespace:codespace` the three mounted volume paths. The `ts` workspace path is discovered dynamically so worktrees keep working.
- `.devcontainer/README.md`: document the symptom and a manual recovery command in the Troubleshooting section.

## Reviewer notes

- No code or build changes; only the devcontainer shell script and its README.
- Behaviour is a no-op on subsequent container starts (paths already owned by `codespace`).
- Verified via inspection; full validation requires rebuilding the devcontainer (`Dev Containers: Rebuild Container`).