### PR TITLE
devcontainer: improve CLI flags, pnpm store, and Dockerfile caching

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,8 @@
+FROM mcr.microsoft.com/devcontainers/base:ubuntu-24.04
+
+# Pre-install system libraries so post-create.sh doesn't need to apt-get install
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+    libsecret-1-0 \
+    libsecret-1-dev \
+    && rm -rf /var/lib/apt/lists/*

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -113,8 +113,14 @@ Useful options:
 # Recreate container first
 .devcontainer/scripts/start-devcontainer.sh --recreate --ssh
 
-# Rebuild the devcontainer image
+# Rebuild the devcontainer image (implies --recreate)
 .devcontainer/scripts/start-devcontainer.sh --rebuild
+
+# Remove container and associated Docker volumes
+.devcontainer/scripts/start-devcontainer.sh --clean
+
+# Full reset: rebuild image + clean volumes
+.devcontainer/scripts/start-devcontainer.sh --reset
 
 # Use alternate devcontainer config
 .devcontainer/scripts/start-devcontainer.sh --config .devcontainer/vnc/devcontainer.json
@@ -298,10 +304,19 @@ git reset --hard
 To rebuild with fresh state:
 
 1. Command Palette: `Dev Containers: Rebuild Container`
+2. Or from the CLI: `.devcontainer/scripts/start-devcontainer.sh --rebuild`
 
-To rebuild without cache:
+To rebuild without cache and clean volumes:
 
 1. Command Palette: `Dev Containers: Rebuild Container Without Cache`
+2. Or from the CLI: `.devcontainer/scripts/start-devcontainer.sh --reset`
+
+## Container Image
+
+The devcontainer uses a custom Dockerfile (`.devcontainer/Dockerfile`) that
+extends the base Ubuntu 24.04 image with pre-installed system libraries
+(libsecret). This avoids running `apt-get install` on every container
+creation and leverages Docker's layer cache for fast rebuilds.
 
 ## Resources
 

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -111,7 +111,10 @@ Useful options:
 
 ```bash
 # Recreate container first
-.devcontainer/scripts/start-devcontainer.sh --remove-existing-container --ssh
+.devcontainer/scripts/start-devcontainer.sh --recreate --ssh
+
+# Rebuild the devcontainer image
+.devcontainer/scripts/start-devcontainer.sh --rebuild
 
 # Use alternate devcontainer config
 .devcontainer/scripts/start-devcontainer.sh --config .devcontainer/vnc/devcontainer.json

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -71,7 +71,6 @@
   ],
 
   "containerEnv": {
-    "PNPM_HOME": "/home/codespace/.local/share/pnpm",
     "LOCAL_GIT_USER_NAME": "${localEnv:LOCAL_GIT_USER_NAME}",
     "LOCAL_GIT_USER_EMAIL": "${localEnv:LOCAL_GIT_USER_EMAIL}"
     // For Codespaces, set these as repository secrets:

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "TypeAgent Development",
-  "image": "mcr.microsoft.com/devcontainers/base:ubuntu-24.04",
+  "build": { "dockerfile": "Dockerfile" },
 
   // Multi-arch base image (linux/amd64 and linux/arm64) so this configuration
   // works on Apple Silicon as well as x86_64 hosts.

--- a/.devcontainer/scripts/post-create.sh
+++ b/.devcontainer/scripts/post-create.sh
@@ -119,6 +119,7 @@ echo ""
 echo "Enabling corepack and pnpm..."
 if command -v corepack &> /dev/null; then
     corepack enable || echo "Warning: corepack enable failed"
+    # Use the pnpm version pinned in package.json (packageManager field)
     corepack install || echo "Warning: corepack install failed"
 else
     echo "Warning: corepack not found, checking for pnpm..."

--- a/.devcontainer/scripts/post-create.sh
+++ b/.devcontainer/scripts/post-create.sh
@@ -119,7 +119,7 @@ echo ""
 echo "Enabling corepack and pnpm..."
 if command -v corepack &> /dev/null; then
     corepack enable || echo "Warning: corepack enable failed"
-    corepack prepare pnpm@latest --activate || echo "Warning: corepack prepare failed"
+    corepack install || echo "Warning: corepack install failed"
 else
     echo "Warning: corepack not found, checking for pnpm..."
     if ! command -v pnpm &> /dev/null; then
@@ -135,6 +135,10 @@ if ! command -v pnpm &> /dev/null; then
 fi
 
 echo "pnpm version: $(pnpm --version)"
+
+# Point pnpm store at the Docker named volume so it persists across rebuilds
+pnpm config set store-dir /home/codespace/.local/share/pnpm/store --global
+echo "pnpm store-dir: $(pnpm store path)"
 
 echo ""
 echo "Installing system libraries required by TypeAgent..."

--- a/.devcontainer/scripts/post-create.sh
+++ b/.devcontainer/scripts/post-create.sh
@@ -148,15 +148,26 @@ APT_PACKAGES=(
     libsecret-1-0
     libsecret-1-dev
 )
-if command -v apt-get &> /dev/null; then
-    if ! sudo DEBIAN_FRONTEND=noninteractive apt-get update -y; then
-        echo "  warn: apt-get update failed"
+# Skip if already baked into the image (via .devcontainer/Dockerfile)
+MISSING_PKGS=()
+for pkg in "${APT_PACKAGES[@]}"; do
+    if ! dpkg -s "$pkg" &>/dev/null; then
+        MISSING_PKGS+=("$pkg")
     fi
-    if ! sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends "${APT_PACKAGES[@]}"; then
-        echo "  warn: failed to install: ${APT_PACKAGES[*]}"
+done
+if [[ ${#MISSING_PKGS[@]} -gt 0 ]]; then
+    if command -v apt-get &> /dev/null; then
+        if ! sudo DEBIAN_FRONTEND=noninteractive apt-get update -y; then
+            echo "  warn: apt-get update failed"
+        fi
+        if ! sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends "${MISSING_PKGS[@]}"; then
+            echo "  warn: failed to install: ${MISSING_PKGS[*]}"
+        fi
+    else
+        echo "  warn: apt-get not available, skipping system library install"
     fi
 else
-    echo "  warn: apt-get not available, skipping system library install"
+    echo "  all packages already installed"
 fi
 
 echo ""

--- a/.devcontainer/scripts/start-devcontainer.sh
+++ b/.devcontainer/scripts/start-devcontainer.sh
@@ -17,7 +17,8 @@ Start the TypeAgent devcontainer. Optionally configure host SSH access.
 Options:
   --workspace-folder PATH        Workspace folder to open (default: repo root)
   --config PATH                  Devcontainer config file (optional)
-  --remove-existing-container    Recreate container before startup
+  --recreate                     Recreate container before startup
+  --rebuild                      Rebuild image and recreate container before startup
   --ssh                          After startup, run setup-ssh-access.sh
   --insecure-local               Pass through to setup-ssh-access.sh (implies --ssh)
   -h, --help                     Show this help text
@@ -25,7 +26,8 @@ Options:
 Examples:
   $(basename "$0")
   $(basename "$0") --ssh
-  $(basename "$0") --remove-existing-container --ssh
+  $(basename "$0") --recreate --ssh
+  $(basename "$0") --rebuild
   $(basename "$0") --config .devcontainer/vnc/devcontainer.json
 EOF
 }
@@ -47,6 +49,7 @@ read_git_identity() {
 WORKSPACE_FOLDER="$DEFAULT_WORKSPACE_FOLDER"
 CONFIG_PATH=""
 REMOVE_EXISTING=0
+REBUILD=0
 SETUP_SSH=0
 INSECURE_LOCAL=0
 
@@ -62,8 +65,13 @@ while [[ $# -gt 0 ]]; do
             CONFIG_PATH=$(cd -- "$(dirname -- "$2")" && pwd)/$(basename -- "$2")
             shift 2
             ;;
-        --remove-existing-container)
+        --recreate|--remove-existing-container)
             REMOVE_EXISTING=1
+            shift
+            ;;
+        --rebuild)
+            REMOVE_EXISTING=1
+            REBUILD=1
             shift
             ;;
         --ssh)
@@ -113,6 +121,9 @@ if [[ -n "$CONFIG_PATH" ]]; then
 fi
 if [[ $REMOVE_EXISTING -eq 1 ]]; then
     UP_CMD+=(--remove-existing-container)
+fi
+if [[ $REBUILD -eq 1 ]]; then
+    UP_CMD+=(--build-no-cache)
 fi
 
 log "Starting devcontainer..."

--- a/.devcontainer/scripts/start-devcontainer.sh
+++ b/.devcontainer/scripts/start-devcontainer.sh
@@ -19,6 +19,8 @@ Options:
   --config PATH                  Devcontainer config file (optional)
   --recreate                     Recreate container before startup
   --rebuild                      Rebuild image and recreate container before startup
+  --clean                        Remove container and associated Docker volumes
+  --reset                        Rebuild image and clean volumes (--rebuild + --clean)
   --ssh                          After startup, run setup-ssh-access.sh
   --insecure-local               Pass through to setup-ssh-access.sh (implies --ssh)
   -h, --help                     Show this help text
@@ -50,6 +52,7 @@ WORKSPACE_FOLDER="$DEFAULT_WORKSPACE_FOLDER"
 CONFIG_PATH=""
 REMOVE_EXISTING=0
 REBUILD=0
+CLEAN_VOLUMES=0
 SETUP_SSH=0
 INSECURE_LOCAL=0
 
@@ -72,6 +75,17 @@ while [[ $# -gt 0 ]]; do
         --rebuild)
             REMOVE_EXISTING=1
             REBUILD=1
+            shift
+            ;;
+        --clean)
+            REMOVE_EXISTING=1
+            CLEAN_VOLUMES=1
+            shift
+            ;;
+        --reset)
+            REMOVE_EXISTING=1
+            REBUILD=1
+            CLEAN_VOLUMES=1
             shift
             ;;
         --ssh)
@@ -124,6 +138,32 @@ if [[ $REMOVE_EXISTING -eq 1 ]]; then
 fi
 if [[ $REBUILD -eq 1 ]]; then
     UP_CMD+=(--build-no-cache)
+fi
+
+if [[ $CLEAN_VOLUMES -eq 1 ]]; then
+    # Stop and remove the container first so volumes are no longer in use
+    CONTAINER_ID=$(docker ps -aq --filter "label=devcontainer.local_folder=$WORKSPACE_FOLDER" | head -1)
+    if [[ -n "$CONTAINER_ID" ]]; then
+        log "Stopping container $CONTAINER_ID..."
+        docker rm -f "$CONTAINER_ID" >/dev/null 2>&1 || true
+    fi
+
+    log "Removing Docker volumes..."
+    VOLUME_PREFIXES=(
+        "pnpm-global-store"
+        "typeagent-node_modules-"
+        "typeagent-agent-worktrees-"
+        "claude-code-config-"
+    )
+    for prefix in "${VOLUME_PREFIXES[@]}"; do
+        for vol in $(docker volume ls -q --filter "name=$prefix" 2>/dev/null); do
+            if docker volume rm "$vol" 2>/dev/null; then
+                log "  removed $vol"
+            else
+                log "  warn: could not remove $vol"
+            fi
+        done
+    done
 fi
 
 log "Starting devcontainer..."

--- a/.devcontainer/scripts/start-devcontainer.sh
+++ b/.devcontainer/scripts/start-devcontainer.sh
@@ -156,11 +156,11 @@ if [[ $CLEAN_VOLUMES -eq 1 ]]; then
         "claude-code-config-"
     )
     for prefix in "${VOLUME_PREFIXES[@]}"; do
-        for vol in $(docker volume ls -q --filter "name=$prefix" 2>/dev/null); do
-            if docker volume rm "$vol" 2>/dev/null; then
+        for vol in $(docker volume ls -q --filter "name=^$prefix" 2>/dev/null); do
+            if err=$(docker volume rm "$vol" 2>&1); then
                 log "  removed $vol"
             else
-                log "  warn: could not remove $vol"
+                log "  warn: could not remove $vol: $err"
             fi
         done
     done

--- a/.devcontainer/vnc/devcontainer.json
+++ b/.devcontainer/vnc/devcontainer.json
@@ -70,7 +70,6 @@
   ],
 
   "containerEnv": {
-    "PNPM_HOME": "/home/codespace/.local/share/pnpm",
     "LOCAL_GIT_USER_NAME": "${localEnv:LOCAL_GIT_USER_NAME}",
     "LOCAL_GIT_USER_EMAIL": "${localEnv:LOCAL_GIT_USER_EMAIL}"
   },

--- a/.devcontainer/vnc/devcontainer.json
+++ b/.devcontainer/vnc/devcontainer.json
@@ -8,7 +8,7 @@
   // desktop-lite feature historically supports amd64 only, so on Apple
   // Silicon this config may still require Rosetta/QEMU emulation just for
   // the VNC desktop. The standard (non-VNC) config runs natively on arm64.
-  "image": "mcr.microsoft.com/devcontainers/base:ubuntu-24.04",
+  "build": { "dockerfile": "../Dockerfile" },
 
   "features": {
     // VNC desktop for Electron shell support


### PR DESCRIPTION
## Summary

Improve the devcontainer wrapper script UX, fix the pnpm store path, and add a Dockerfile for layer caching.

## Changes

### start-devcontainer.sh
- Rename `--remove-existing-container` to `--recreate` (old name kept as alias)
- Add `--rebuild` flag (implies `--recreate`, passes `--build-no-cache`)
- Add `--clean` flag (stops container, removes associated Docker volumes)
- Add `--reset` flag (`--rebuild` + `--clean` for a fully fresh slate)
- Volume cleanup stops the container first so volumes are not in use
- Volume name filter uses anchored prefix to avoid matching other projects

### post-create.sh
- Use `corepack install` instead of `corepack prepare pnpm@latest` to use the repo-pinned pnpm version
- Set pnpm `store-dir` via `pnpm config set` so the Docker named volume is actually used
- Skip `apt-get install` when packages are already present (Dockerfile)

### Dockerfile (new)
- Extends base image with pre-installed libsecret
- Avoids apt-get on every container creation; leverages Docker layer cache

### devcontainer.json / vnc/devcontainer.json
- Switch from `image` to `build` using new Dockerfile
- Remove unused `PNPM_HOME` env var

### README
- Document all new flags with examples
- Add Container Image section explaining the Dockerfile