### PR TITLE
workflow/engine: fix implementation gaps against IR v0.1/v0.2 specs

### DIFF
--- a/ts/docs/design/workflowSystem/dsl/dsl-v0.1-gap.md
+++ b/ts/docs/design/workflowSystem/dsl/dsl-v0.1-gap.md
@@ -532,3 +532,72 @@ been cancelled.
    unhandled rejection warnings and ensure cleanup).
 3. Add tests verifying that in-flight branches are cancelled on first
    failure.
+
+## G18: No union types in the DSL type system
+
+**Spec/intent:** The DSL currently has no union types. This was an
+intentional v0.1 simplification (see G7 note 4: ternary/if-else
+mismatched arms are rejected at compile time rather than widened to a
+union). The underlying IR/JSON Schema layer fully supports unions via
+`anyOf` / `oneOf` / `enum`, so the gap is purely in the DSL surface.
+
+**Why it now matters:** Two concrete v0.1 features are weaker than they
+should be without union types:
+
+1. **Mixed-arm ternary/if-else expressions.** Authors must contort
+   expressions or duplicate code when natural arms have different types
+   (e.g. `cond ? "x" : 0`).
+
+2. **Statically exhaustive `switch` over a narrowed discriminant.**
+   The IR validator's exhaustiveness contract (ir-v0.1.md §3.6) lets a
+   `switch` omit `default` when the discriminant's resolved schema is
+   provably narrowed to a subset of the case keys (e.g. `enum` or
+   `const`). The DSL emitter already emits the exhaustive form when
+   source omits `default` (selectorSchema carries `enum: [...case keys]`
+   and inferred type), but the only DSL types that satisfy the
+   narrowing rule today are `boolean` (implicit `{true,false}` enum).
+   For a `switch(x: string)`, there is no way in the DSL surface to
+   declare `x` as `"a" | "b"`, so non-boolean exhaustive switches
+   always fail IR validation unless authors:
+   - add a `default:` arm, or
+   - narrow `x` upstream via a task whose `outputSchema` carries an
+     `enum` declared at the IR level.
+
+   With string/number literal union types in the DSL, an author could
+   write `switch(label: "news" | "code") { case "news": ... case "code":
+   ... }` and have it compile + statically validate as exhaustive.
+
+**Sub-issue: case-literal vs discriminant type mismatch is not caught.**
+`typeChecker.ts` `case "SwitchStatement"` infers the discriminant and
+each arm value but never checks assignability. Mixed types like
+`switch(x: string) { case 1: ... }` slip through typecheck and only
+fail later at IR-validation time (or worse, only at runtime if
+`compile({validate:false})`). When union types are introduced, the
+case-literal check should land at the same time:
+
+- Each `case <literal>:` literal must be assignable to the discriminant
+  type.
+- For a union discriminant, the union of all case literals must equal
+  the discriminant type (otherwise require `default:`).
+
+**What needs to happen:**
+
+1. Add string-literal and number-literal types to the DSL surface, plus
+   union types over them (and possibly `boolean` literals).
+2. Update `typeChecker.ts` to:
+   a. Assign literal types to literal expressions where contextually
+      useful (e.g. arm values in a `switch`).
+   b. Reject `case` literals not assignable to the discriminant type.
+   c. Widen mixed-arm ternary/if-else results to a union (replacing the
+      "must match" rule).
+3. Map DSL unions to JSON Schema `enum` (for literal-only unions) or
+   `anyOf` (general case) in the emitter.
+4. Verify the exhaustive switch emission (Phase 5 work in `emitSwitch`)
+   composes correctly: a `switch(x: "a" | "b")` source with both arms
+   and no `default:` should emit a branch whose `selectorSchema`
+   declares `enum: ["a", "b"]` and whose discriminant resolves to a
+   producer type with matching `enum` — passing the IR validator's
+   exhaustiveness check.
+5. Add tests for: union type parsing, case-literal type mismatch error,
+   mixed-arm ternary returning a union, exhaustive non-boolean switch
+   compiling without `default:`.

--- a/ts/docs/design/workflowSystem/dsl/dsl-v0.1-gap.md
+++ b/ts/docs/design/workflowSystem/dsl/dsl-v0.1-gap.md
@@ -510,3 +510,25 @@ as the message.
 message that propagates to the RunResult is empty. The thrown string
 value is not correctly threaded into the error.fail task's input, or
 the error propagation loses the message field.
+
+## G17: Fork/forkMap does not cancel in-flight branches on failure
+
+**Spec:** ir-v0.2.md §2.1 rule 5 and §2.2 rule 5. "If any branch fails,
+remaining in-flight branches are cancelled and the error propagates
+immediately."
+
+**Current state:** The engine's `executeFork` and `executeForkMap` use
+`Promise.race` for concurrency limiting but do not cancel in-flight
+branches/iterations when one fails. Errors from `Promise.race` propagate,
+but other running branches continue executing in the background. This
+wastes resources and may cause side effects from branches that should have
+been cancelled.
+
+**What needs to happen:**
+
+1. When any branch/iteration rejects, signal cancellation to all other
+   in-flight branches via `AbortController`.
+2. `await` all in-flight promises before propagating the error (to avoid
+   unhandled rejection warnings and ensure cleanup).
+3. Add tests verifying that in-flight branches are cancelled on first
+   failure.

--- a/ts/docs/design/workflowSystem/dsl/dsl-v0.1-gap.md
+++ b/ts/docs/design/workflowSystem/dsl/dsl-v0.1-gap.md
@@ -559,13 +559,14 @@ should be without union types:
    For a `switch(x: string)`, there is no way in the DSL surface to
    declare `x` as `"a" | "b"`, so non-boolean exhaustive switches
    always fail IR validation unless authors:
+
    - add a `default:` arm, or
    - narrow `x` upstream via a task whose `outputSchema` carries an
      `enum` declared at the IR level.
 
    With string/number literal union types in the DSL, an author could
    write `switch(label: "news" | "code") { case "news": ... case "code":
-   ... }` and have it compile + statically validate as exhaustive.
+... }` and have it compile + statically validate as exhaustive.
 
 **Sub-issue: case-literal vs discriminant type mismatch is not caught.**
 `typeChecker.ts` `case "SwitchStatement"` infers the discriminant and
@@ -586,10 +587,10 @@ case-literal check should land at the same time:
    union types over them (and possibly `boolean` literals).
 2. Update `typeChecker.ts` to:
    a. Assign literal types to literal expressions where contextually
-      useful (e.g. arm values in a `switch`).
+   useful (e.g. arm values in a `switch`).
    b. Reject `case` literals not assignable to the discriminant type.
    c. Widen mixed-arm ternary/if-else results to a union (replacing the
-      "must match" rule).
+   "must match" rule).
 3. Map DSL unions to JSON Schema `enum` (for literal-only unions) or
    `anyOf` (general case) in the emitter.
 4. Verify the exhaustive switch emission (Phase 5 work in `emitSwitch`)

--- a/ts/docs/design/workflowSystem/ir/ir-v0.1.md
+++ b/ts/docs/design/workflowSystem/ir/ir-v0.1.md
@@ -1636,8 +1636,7 @@ error-recovery paths.  Path projections are verified by
 properties.  Combined with the essential task output check (§5.8.1),
 which ensures actual values match declared schemas, path projection
 type errors at runtime are unreachable.  These runtime guards are
-therefore inherent to template resolution execution but cannot fire
-after static validation.
+gated on `defenseInDepth`.
 
 | Check | Static guarantee | Reasoning |
 |---|---|---|

--- a/ts/docs/design/workflowSystem/ir/ir-v0.1.md
+++ b/ts/docs/design/workflowSystem/ir/ir-v0.1.md
@@ -1605,11 +1605,12 @@ the static validator has no visibility into.
 | **Task failure** | Task throws or returns `{ kind: "fail" }` | External services fail; legitimate runtime error |
 | **Unrecoverable failure** | Task fails with no `onError` | Failure propagation; the task threw and no handler is declared |
 
-#### 5.8.2 Defense-in-depth runtime checks
+#### 5.8.2 Defense-in-depth runtime checks (gated)
 
 These checks MAY be skipped when static validation has passed.  Each
 re-verifies an invariant that the static validator already proves
-(column "Static guarantee").
+(column "Static guarantee").  They are controlled by the
+`defenseInDepth` flag described above.
 
 **Structural (static IR properties)**
 
@@ -1625,25 +1626,6 @@ re-verifies an invariant that the static validator already proves
 |---|---|---|
 | **Node not found** | §4.1 name-resolution pass | All node references are verified statically |
 | **Unregistered task** | §4.1 IR/task drift pass | All task names are checked against the registry at validation time |
-
-**Template resolution (dominator analysis + type checking)**
-
-The static validator's dominator analysis with onError-split awareness
-(§4.1 scope-closure and dominator passes) proves that every non-optional
-`$from: "scope"` reference is bound on all execution paths, including
-error-recovery paths.  Path projections are verified by
-`checkSchemaCompat` which rejects paths into undeclared schema
-properties.  Combined with the essential task output check (§5.8.1),
-which ensures actual values match declared schemas, path projection
-type errors at runtime are unreachable.  These checks are kept
-unconditional because they are cheap and provide clear diagnostics
-if an IR somehow bypasses static validation.
-
-| Check | Static guarantee | Reasoning |
-|---|---|---|
-| **Unknown `$from` namespace** | §4.1 schema-syntax pass | Only valid namespaces (`input`, `constant`, `scope`, `state`) are accepted |
-| **Unresolved reference** | §4.1 dominator pass with onError-split coverage | Binding coverage is proven on all paths including error-recovery paths; uncovered non-optional refs are rejected |
-| **Path projection on null/wrong type** | §4.1 type-compatibility + `resolveSchemaPath` | Path segments are checked against declared schema structure; task output check ensures actual values match |
 
 **Propagation (static type compat + essential task output check)**
 
@@ -1662,6 +1644,27 @@ statically and values are proven conformant at each task boundary.
 | **Loop output schema** | §4.1 type-compatibility pass + essential task output check | Static proves output template types match `outputSchema`; task output check validates body bindings |
 | **Loop iterateState schema** | §4.1 type-compatibility pass + essential task output check | Static proves iterateState template types match state schemas; task output check validates body bindings |
 | **forkMap collection not array** | §4.1 type-compatibility pass + essential task output check | Static proves collection template resolves to array type; task output check validates upstream values |
+
+#### 5.8.3 Template resolution checks (unconditional)
+
+The static validator's dominator analysis with onError-split awareness
+(§4.1 scope-closure and dominator passes) proves that every non-optional
+`$from: "scope"` reference is bound on all execution paths, including
+error-recovery paths.  Path projections are verified by
+`checkSchemaCompat` which rejects paths into undeclared schema
+properties.  Combined with the essential task output check (§5.8.1),
+which ensures actual values match declared schemas, path projection
+type errors at runtime are unreachable.
+
+These checks are statically proven but kept **unconditional** (not
+gated by `defenseInDepth`) because they are cheap and provide clear
+diagnostics if an IR somehow bypasses static validation.
+
+| Check | Static guarantee | Reasoning |
+|---|---|---|
+| **Unknown `$from` namespace** | §4.1 schema-syntax pass | Only valid namespaces (`input`, `constant`, `scope`, `state`) are accepted |
+| **Unresolved reference** | §4.1 dominator pass with onError-split coverage | Binding coverage is proven on all paths including error-recovery paths; uncovered non-optional refs are rejected |
+| **Path projection on null/wrong type** | §4.1 type-compatibility + `resolveSchemaPath` | Path segments are checked against declared schema structure; task output check ensures actual values match |
 
 ---
 

--- a/ts/docs/design/workflowSystem/ir/ir-v0.1.md
+++ b/ts/docs/design/workflowSystem/ir/ir-v0.1.md
@@ -1132,7 +1132,7 @@ is a JSON object with this fixed schema, available as the built-in
 
 ```jsonc
 {
-  "code":      "<string>",        // machine-readable error code
+  "kind":      "<string>",        // machine-readable error kind
   "message":   "<string>",        // human-readable summary
   "source":    "task" | "runtime", // where the failure originated
   "task":      "<string>",        // task type id from the failing node, optional
@@ -1150,17 +1150,17 @@ declare it. (Codegen cannot reasonably synthesize this shape from a
 workflow's own type catalog; making it built-in lets every recovery
 node opt into the canonical envelope by reference.)
 
-Required fields: `code`, `message`, `source`. The remaining fields are
+Required fields: `kind`, `message`, `source`. The remaining fields are
 optional and may be absent. An engine MAY include additional fields
 beyond those listed; consumers MUST treat unknown fields as opaque.
 
-**`source` and `code` discriminate the failure origin.**
+**`source` and `kind` discriminate the failure origin.**
 
 - `"task"` — the registered task implementation returned `{ kind: "fail" }`
-  or threw. `code` is `"TaskError"`. `task` and `node` SHOULD be
+  or threw. `kind` is `"TaskError"`. `task` and `node` SHOULD be
   populated; `data` carries any additional payload the task returned.
 - `"runtime"` — the engine raised a **recoverable** runtime condition.
-  `code` further discriminates the case:
+  `kind` further discriminates the case:
   - `"RuntimeError"` — general engine failure (task timeout, policy
     denial, cancellation, etc.).
   - `"LoopMaxIterationsExceeded"` — the loop hit its `maxIterations`
@@ -1169,7 +1169,7 @@ beyond those listed; consumers MUST treat unknown fields as opaque.
     its declared `outputSchema`. This indicates a buggy or drifted task
     implementation; authors may want to log or fall back.
   All `"runtime"` errors are routed to `onError` handlers.
-- `"runtime"` with `code: "UnrecoverableError"` — the engine raised a
+- `"runtime"` with `kind: "UnrecoverableError"` — the engine raised a
   condition that is **statically unreachable** after validation
   (e.g., `ReferenceUnresolved`, `BranchSelectorUnmatched`, unknown `$from`
   namespace, missing node). These indicate the IR bypassed the static
@@ -1178,8 +1178,8 @@ beyond those listed; consumers MUST treat unknown fields as opaque.
   write workflows that depend on catching these; they should instead
   ensure the IR passes static validation.
 
-An engine MAY use additional `code` values for finer-grained
-discrimination; consumers MUST treat unknown `code` values as opaque
+An engine MAY use additional `kind` values for finer-grained
+discrimination; consumers MUST treat unknown `kind` values as opaque
 and fall back to inspecting `source`.
 
 A recovery task that wants to be type-strict about the error it
@@ -1188,7 +1188,7 @@ consumes can narrow the schema for its `error` input field below
 a known task failure). One that only needs the message can declare just
 `{ "message": { "type": "string" } }` and rely on structural subtyping
 (§4.2). Path projection (§3.4.1) on the `error` input works the same
-as on any other input field, so a recovery can read just `error.code`
+as on any other input field, so a recovery can read just `error.kind`
 or `error.data.foo` without binding the whole object.
 
 The `trigger` field's schema mirrors the trigger T's `inputs` map: an
@@ -1198,7 +1198,7 @@ recovery node restates it (or a narrowing of it) the same way it
 restates `Error`, for IR self-containment.
 
 The shape is fixed in v1 to keep recoveries writable without needing to
-look up the failing task. Per-task or per-error-code typed payloads
+look up the failing task. Per-task or per-error-kind typed payloads
 belong in `data` and are out-of-band of v1's contract: a recovery that
 cares unpacks `data` with a runtime check, exactly as it would for any
 open-world JSON. A future error-taxonomy mechanism could lift `data`

--- a/ts/docs/design/workflowSystem/ir/ir-v0.1.md
+++ b/ts/docs/design/workflowSystem/ir/ir-v0.1.md
@@ -1156,16 +1156,20 @@ beyond those listed; consumers MUST treat unknown fields as opaque.
 
 **`source` discriminates the failure origin.**
 
-- `"task"` - the registered task implementation threw, returned a value
+- `"task"` — the registered task implementation threw, returned a value
   that violated `outputSchema` (§5.2), or otherwise signaled failure.
-  `task` and `node` SHOULD be populated.
-- `"runtime"` - the engine itself raised the failure (loop
-  `maxIterations` exceeded, branch selector value did not match any
-  `cases` or `default`, reference resolution failed at runtime, etc.).
-  `code` distinguishes the runtime case (well-known codes include
-  `LoopMaxIterationsExceeded`, `BranchSelectorUnmatched`,
-  `ReferenceUnresolved`; the full list is engine-defined and surfaced
-  through the validator's error-code table - see §4.3).
+  The `code` field is `"TASK_ERROR"`. `task` and `node` SHOULD be
+  populated. `data` carries any additional payload the task returned.
+- `"runtime"` — the engine itself raised the failure (loop
+  `maxIterations` exceeded, reference resolution failed at runtime,
+  etc.). The `code` field is `"RUNTIME_ERROR"`. `node` and `scopePath`
+  identify where the failure occurred; `message` contains a
+  human-readable description (e.g.
+  `"LoopMaxIterationsExceeded at \"nodeId\" (limit: N)"`).
+
+An engine MAY use additional `code` values for finer-grained
+discrimination; consumers MUST treat unknown `code` values as opaque
+and fall back to inspecting `source`.
 
 A recovery task that wants to be type-strict about the error it
 consumes can narrow the schema for its `error` input field below

--- a/ts/docs/design/workflowSystem/ir/ir-v0.1.md
+++ b/ts/docs/design/workflowSystem/ir/ir-v0.1.md
@@ -1574,19 +1574,41 @@ static validation has run; callers MAY override explicitly.
 These checks MUST always run because they validate runtime values that
 the static validator has no visibility into.
 
+**Schema validation (runtime values)**
+
 | Check | Trigger | Rationale |
 |---|---|---|
 | **Workflow input schema** | Caller provides `input` | Input is external to the IR; no static knowledge of actual values |
 | **Task output schema** | Task implementation returns | Catches buggy or drifted task implementations returning wrong types (§5.2) |
 | **Never-output contract** | Task with `{ "not": {} }` output returns ok | Task declared it always fails; returning success means a broken implementation |
+
+**Security / policy**
+
+| Check | Trigger | Rationale |
+|---|---|---|
 | **Side-effect policy deny** | Policy map says `"deny"` | Runtime configuration, not in the IR |
 | **Side-effect prompt / no callback** | Policy says `"prompt"` but no approval callback | Runtime configuration |
 | **Approval rejected** | Approval callback returns non-approved | User decision at runtime |
+
+**Execution control**
+
+| Check | Trigger | Rationale |
+|---|---|---|
+| **Run cancelled** | `AbortSignal` fires | External cancellation at runtime |
+| **Task timeout** | Execution exceeds `timeoutMs` | Runtime duration is unpredictable |
+| **Loop maxIterations exceeded** | Iteration count ≥ `maxIterations` | Runtime convergence; static analysis cannot predict iteration count |
+
+**Task contract**
+
+| Check | Trigger | Rationale |
+|---|---|---|
 | **Task failure** | Task throws or returns `{ kind: "fail" }` | External services fail; legitimate runtime error |
 | **Unrecoverable failure** | Task fails with no `onError` | Failure propagation; the task threw and no handler is declared |
-| **Task timeout** | Execution exceeds `timeoutMs` | Runtime duration is unpredictable |
-| **Run cancelled** | `AbortSignal` fires | External cancellation at runtime |
-| **Loop maxIterations exceeded** | Iteration count ≥ `maxIterations` | Runtime convergence; static analysis cannot predict iteration count |
+
+**Template resolution**
+
+| Check | Trigger | Rationale |
+|---|---|---|
 | **Template resolution errors** | `$from` reference unresolved, path projection fails | Mostly prevented by static dominator/scope analysis, but error-recovery paths (`onError`) can produce scopes where expected bindings were not set |
 
 #### 5.8.2 Defense-in-depth runtime checks
@@ -1595,27 +1617,38 @@ These checks MAY be skipped when static validation has passed.  Each
 re-verifies an invariant that the static validator already proves
 (column "Static guarantee").
 
+**Structural (static IR properties)**
+
 | Check | Static guarantee | Reasoning |
 |---|---|---|
 | **Constant value schema** | `jsonValueToSchema` + `isStructuralSubtype` (§4.1 type compat) | Constant values are in the IR; static validator derives their type and checks compatibility |
 | **Fork min-2 branches** | §4.1 structural check | Branch count is a static IR property |
 | **forkMap `$from: "state"` rejection** | §4.1 scope-closure check on forkMap bodies | State refs in forkMap are a static IR property |
+
+**Integrity (graph and registry)**
+
+| Check | Static guarantee | Reasoning |
+|---|---|---|
 | **Node not found** | §4.1 name-resolution pass | All node references are verified statically |
 | **Unregistered task** | §4.1 IR/task drift pass | All task names are checked against the registry at validation time |
+
+**Propagation (static type compat + essential task output check)**
+
+These are redundant because the essential **task output schema** check
+(§5.8.1) ensures every task implementation's actual return value
+conforms to its declared `outputSchema`, and the static validator
+proves every template's resolved type is structurally compatible with
+its target schema (§4.2).  Together, types are proven compatible
+statically and values are proven conformant at each task boundary.
+
+| Check | Static guarantee | Reasoning |
+|---|---|---|
 | **Workflow output schema** | §4.1 type-compatibility pass + essential task output check | Static proves template type fits schema; task output check ensures upstream values match declared types |
 | **Loop input schema** | §4.1 type-compatibility pass + essential task output check | Static proves input template types match `inputSchema`; task output check validates actual upstream values |
 | **Loop state initial schema** | §4.1 type-compatibility pass + essential task output check | Static proves initial-value template types match state schemas; task output check validates upstream values |
 | **Loop output schema** | §4.1 type-compatibility pass + essential task output check | Static proves output template types match `outputSchema`; task output check validates body bindings |
 | **Loop iterateState schema** | §4.1 type-compatibility pass + essential task output check | Static proves iterateState template types match state schemas; task output check validates body bindings |
 | **forkMap collection not array** | §4.1 type-compatibility pass + essential task output check | Static proves collection template resolves to array type; task output check validates upstream values |
-
-The split follows a composability argument: the essential **task output
-schema** check (§5.2) ensures every task implementation's actual return
-value conforms to its declared `outputSchema`.  Combined with the static
-validator's proof that every template's resolved type is structurally
-compatible with its target schema (§4.2), all downstream schema checks
-become redundant — the types are proven compatible statically and the
-values are proven conformant at each task boundary.
 
 ---
 

--- a/ts/docs/design/workflowSystem/ir/ir-v0.1.md
+++ b/ts/docs/design/workflowSystem/ir/ir-v0.1.md
@@ -1154,18 +1154,27 @@ Required fields: `code`, `message`, `source`. The remaining fields are
 optional and may be absent. An engine MAY include additional fields
 beyond those listed; consumers MUST treat unknown fields as opaque.
 
-**`source` discriminates the failure origin.**
+**`source` and `code` discriminate the failure origin.**
 
-- `"task"` - the registered task implementation threw, returned a value
-  that violated `outputSchema` (§5.2), or otherwise signaled failure.
-  `task` and `node` SHOULD be populated.
-- `"runtime"` - the engine itself raised the failure (loop
-  `maxIterations` exceeded, branch selector value did not match any
-  `cases` or `default`, reference resolution failed at runtime, etc.).
-  `code` distinguishes the runtime case (well-known codes include
-  `LoopMaxIterationsExceeded`, `BranchSelectorUnmatched`,
-  `ReferenceUnresolved`; the full list is engine-defined and surfaced
-  through the validator's error-code table - see §4.3).
+- `"task"` — the registered task implementation returned `{ kind: "fail" }`
+  or threw. `code` is `"TASK_ERROR"`. `task` and `node` SHOULD be
+  populated; `data` carries any additional payload the task returned.
+- `"runtime"` — the engine raised a **recoverable** runtime condition.
+  `code` is `"RUNTIME_ERROR"`. These errors are routed to `onError`
+  handlers like task failures. Examples: `LoopMaxIterationsExceeded`,
+  `OutputSchemaViolation`, task timeout, policy denial.
+- `"runtime"` with `code: "UNRECOVERABLE_ERROR"` — the engine raised a
+  condition that is **statically unreachable** after validation
+  (e.g., `ReferenceUnresolved`, `BranchSelectorUnmatched`, unknown `$from`
+  namespace, missing node). These indicate the IR bypassed the static
+  validator. They are **not** routed to `onError` handlers — the run
+  fails immediately regardless of any `onError` edge. Authors MUST NOT
+  write workflows that depend on catching these; they should instead
+  ensure the IR passes static validation.
+
+An engine MAY use additional `code` values for finer-grained
+discrimination; consumers MUST treat unknown `code` values as opaque
+and fall back to inspecting `source`.
 
 A recovery task that wants to be type-strict about the error it
 consumes can narrow the schema for its `error` input field below

--- a/ts/docs/design/workflowSystem/ir/ir-v0.1.md
+++ b/ts/docs/design/workflowSystem/ir/ir-v0.1.md
@@ -857,7 +857,7 @@ validator, and analyzers in agreement on a single observable behavior
   "cases": {
     "<caseValue>": "<nodeId>",
   },
-  "default": "<nodeId>",
+  "default": "<nodeId>", // optional; see exhaustiveness rule below
   "onError": "<nodeId>", // optional; see section 3.3
 }
 ```
@@ -866,10 +866,18 @@ validator, and analyzers in agreement on a single observable behavior
   be string-typed: either `{ "type": "string" }` or `{ "enum": [...] }`
   with all-string members. Non-string discriminants (e.g., booleans from
   `int.lessThan`) require an explicit conversion task such as `bool.toLabel`
-  ([decision 0008](decisions/0008-discriminant-key-encoding.md)). The
-  validator requires `cases` to be exhaustive over the declared enum **or**
-  for `default` to be present. v1 requires both: `default` is mandatory
-  (P5: no implicit fall-through).
+  ([decision 0008](decisions/0008-discriminant-key-encoding.md)).
+- **Exhaustiveness contract.** Either `default` is present, **or** the
+  branch is statically exhaustive. A branch is statically exhaustive when:
+  1. `selectorSchema` declares an `enum` (or is `{ "type": "boolean" }`,
+     which is treated as the implicit enum `[true, false]`), AND
+  2. `cases` contains a key for every enum member, AND
+  3. The discriminant's resolved producer type is provably narrowed to a
+     subset of the declared enum (the producer carries a matching `const`,
+     `enum`, or `boolean` type — see [§3.6.1](#361-discriminant-narrowing)).
+  When all three hold, omitting `default` is legal and
+  `BranchSelectorUnmatched` is statically unreachable. Otherwise `default`
+  is required (P5: no implicit fall-through).
 - A branch has no `inputs` other than `selector`, no `outputs`, and no
   `bind` (it produces no value). It is pure control flow. Data needed
   downstream of the branch must already be available via dominator
@@ -1650,6 +1658,7 @@ if an IR somehow bypasses static validation.
 | **Unregistered task** | §4.1 IR/task drift pass | Null check; all task names are checked against the registry at validation time |
 | **Fork min-2 branches** | §4.1 structural check | Comparison; branch count is a static IR property |
 | **forkMap collection not array** | §4.1 type-compatibility pass + essential task output check | `Array.isArray` check; static proves collection resolves to array type |
+| **Branch selector unmatched** | §3.6 exhaustiveness contract + §4.1 type-compatibility | When `default` is absent the validator proves the branch is exhaustive (selectorSchema has enum, all enum values appear as cases, and selector producer is provably narrowed). When `default` is present, unmatched values route to it. Either way, raising `BranchSelectorUnmatched` is unreachable. |
 
 **Template resolution (dominator analysis + type checking)**
 

--- a/ts/docs/design/workflowSystem/ir/ir-v0.1.md
+++ b/ts/docs/design/workflowSystem/ir/ir-v0.1.md
@@ -1617,7 +1617,6 @@ re-verifies an invariant that the static validator already proves
 | Check | Static guarantee | Reasoning |
 |---|---|---|
 | **Constant value schema** | `jsonValueToSchema` + `isStructuralSubtype` (§4.1 type compat) | Constant values are in the IR; static validator derives their type and checks compatibility |
-| **forkMap `$from: "state"` rejection** | §4.1 scope-closure check on forkMap bodies | State refs in forkMap are a static IR property |
 
 **Propagation (static type compat + essential task output check)**
 

--- a/ts/docs/design/workflowSystem/ir/ir-v0.1.md
+++ b/ts/docs/design/workflowSystem/ir/ir-v0.1.md
@@ -1160,9 +1160,15 @@ beyond those listed; consumers MUST treat unknown fields as opaque.
   or threw. `code` is `"TASK_ERROR"`. `task` and `node` SHOULD be
   populated; `data` carries any additional payload the task returned.
 - `"runtime"` — the engine raised a **recoverable** runtime condition.
-  `code` is `"RUNTIME_ERROR"`. These errors are routed to `onError`
-  handlers like task failures. Examples: `LoopMaxIterationsExceeded`,
-  `OutputSchemaViolation`, task timeout, policy denial.
+  `code` further discriminates the case:
+  - `"RUNTIME_ERROR"` — general engine failure (task timeout, policy
+    denial, cancellation, etc.).
+  - `"LoopMaxIterationsExceeded"` — the loop hit its `maxIterations`
+    cap. Authors may want to catch this and return a partial result.
+  - `"OutputSchemaViolation"` — the task returned a value that failed
+    its declared `outputSchema`. This indicates a buggy or drifted task
+    implementation; authors may want to log or fall back.
+  All `"runtime"` errors are routed to `onError` handlers.
 - `"runtime"` with `code: "UNRECOVERABLE_ERROR"` — the engine raised a
   condition that is **statically unreachable** after validation
   (e.g., `ReferenceUnresolved`, `BranchSelectorUnmatched`, unknown `$from`

--- a/ts/docs/design/workflowSystem/ir/ir-v0.1.md
+++ b/ts/docs/design/workflowSystem/ir/ir-v0.1.md
@@ -1635,8 +1635,9 @@ error-recovery paths.  Path projections are verified by
 `checkSchemaCompat` which rejects paths into undeclared schema
 properties.  Combined with the essential task output check (§5.8.1),
 which ensures actual values match declared schemas, path projection
-type errors at runtime are unreachable.  These runtime guards are
-gated on `defenseInDepth`.
+type errors at runtime are unreachable.  These checks are kept
+unconditional because they are cheap and provide clear diagnostics
+if an IR somehow bypasses static validation.
 
 | Check | Static guarantee | Reasoning |
 |---|---|---|

--- a/ts/docs/design/workflowSystem/ir/ir-v0.1.md
+++ b/ts/docs/design/workflowSystem/ir/ir-v0.1.md
@@ -1605,12 +1605,6 @@ the static validator has no visibility into.
 | **Task failure** | Task throws or returns `{ kind: "fail" }` | External services fail; legitimate runtime error |
 | **Unrecoverable failure** | Task fails with no `onError` | Failure propagation; the task threw and no handler is declared |
 
-**Template resolution**
-
-| Check | Trigger | Rationale |
-|---|---|---|
-| **Template resolution errors** | `$from` reference unresolved, path projection fails | Mostly prevented by static dominator/scope analysis, but error-recovery paths (`onError`) can produce scopes where expected bindings were not set |
-
 #### 5.8.2 Defense-in-depth runtime checks
 
 These checks MAY be skipped when static validation has passed.  Each
@@ -1631,6 +1625,25 @@ re-verifies an invariant that the static validator already proves
 |---|---|---|
 | **Node not found** | §4.1 name-resolution pass | All node references are verified statically |
 | **Unregistered task** | §4.1 IR/task drift pass | All task names are checked against the registry at validation time |
+
+**Template resolution (dominator analysis + type checking)**
+
+The static validator's dominator analysis with onError-split awareness
+(§4.1 scope-closure and dominator passes) proves that every non-optional
+`$from: "scope"` reference is bound on all execution paths, including
+error-recovery paths.  Path projections are verified by
+`checkSchemaCompat` which rejects paths into undeclared schema
+properties.  Combined with the essential task output check (§5.8.1),
+which ensures actual values match declared schemas, path projection
+type errors at runtime are unreachable.  These runtime guards are
+therefore inherent to template resolution execution but cannot fire
+after static validation.
+
+| Check | Static guarantee | Reasoning |
+|---|---|---|
+| **Unknown `$from` namespace** | §4.1 schema-syntax pass | Only valid namespaces (`input`, `constant`, `scope`, `state`) are accepted |
+| **Unresolved reference** | §4.1 dominator pass with onError-split coverage | Binding coverage is proven on all paths including error-recovery paths; uncovered non-optional refs are rejected |
+| **Path projection on null/wrong type** | §4.1 type-compatibility + `resolveSchemaPath` | Path segments are checked against declared schema structure; task output check ensures actual values match |
 
 **Propagation (static type compat + essential task output check)**
 

--- a/ts/docs/design/workflowSystem/ir/ir-v0.1.md
+++ b/ts/docs/design/workflowSystem/ir/ir-v0.1.md
@@ -1157,11 +1157,11 @@ beyond those listed; consumers MUST treat unknown fields as opaque.
 **`source` and `code` discriminate the failure origin.**
 
 - `"task"` — the registered task implementation returned `{ kind: "fail" }`
-  or threw. `code` is `"TASK_ERROR"`. `task` and `node` SHOULD be
+  or threw. `code` is `"TaskError"`. `task` and `node` SHOULD be
   populated; `data` carries any additional payload the task returned.
 - `"runtime"` — the engine raised a **recoverable** runtime condition.
   `code` further discriminates the case:
-  - `"RUNTIME_ERROR"` — general engine failure (task timeout, policy
+  - `"RuntimeError"` — general engine failure (task timeout, policy
     denial, cancellation, etc.).
   - `"LoopMaxIterationsExceeded"` — the loop hit its `maxIterations`
     cap. Authors may want to catch this and return a partial result.
@@ -1169,7 +1169,7 @@ beyond those listed; consumers MUST treat unknown fields as opaque.
     its declared `outputSchema`. This indicates a buggy or drifted task
     implementation; authors may want to log or fall back.
   All `"runtime"` errors are routed to `onError` handlers.
-- `"runtime"` with `code: "UNRECOVERABLE_ERROR"` — the engine raised a
+- `"runtime"` with `code: "UnrecoverableError"` — the engine raised a
   condition that is **statically unreachable** after validation
   (e.g., `ReferenceUnresolved`, `BranchSelectorUnmatched`, unknown `$from`
   namespace, missing node). These indicate the IR bypassed the static

--- a/ts/docs/design/workflowSystem/ir/ir-v0.1.md
+++ b/ts/docs/design/workflowSystem/ir/ir-v0.1.md
@@ -1555,6 +1555,68 @@ conforming engine runs on all of them. The SHOULD list is the quality
 bar - engines that skip these will produce correct results but with
 poor memory or latency profiles on realistic workflows.
 
+### 5.8 Runtime checks and defense-in-depth
+
+The engine performs two categories of runtime checks during execution.
+**Essential checks** catch errors that cannot be detected statically
+because they depend on runtime values. **Defense-in-depth checks**
+re-verify invariants already proven by the static validator (§4.1) and
+are redundant when static validation has run against the same IR and
+registry.
+
+A conforming engine MUST support a `defenseInDepth` flag (or
+equivalent) that controls whether the second category runs. The flag
+defaults to **on** when static validation is skipped, and **off** when
+static validation has run; callers MAY override explicitly.
+
+#### 5.8.1 Essential runtime checks
+
+These checks MUST always run because they validate runtime values that
+the static validator has no visibility into.
+
+| Check | Trigger | Rationale |
+|---|---|---|
+| **Workflow input schema** | Caller provides `input` | Input is external to the IR; no static knowledge of actual values |
+| **Task output schema** | Task implementation returns | Catches buggy or drifted task implementations returning wrong types (§5.2) |
+| **Never-output contract** | Task with `{ "not": {} }` output returns ok | Task declared it always fails; returning success means a broken implementation |
+| **Side-effect policy deny** | Policy map says `"deny"` | Runtime configuration, not in the IR |
+| **Side-effect prompt / no callback** | Policy says `"prompt"` but no approval callback | Runtime configuration |
+| **Approval rejected** | Approval callback returns non-approved | User decision at runtime |
+| **Task failure** | Task throws or returns `{ kind: "fail" }` | External services fail; legitimate runtime error |
+| **Unrecoverable failure** | Task fails with no `onError` | Failure propagation; the task threw and no handler is declared |
+| **Task timeout** | Execution exceeds `timeoutMs` | Runtime duration is unpredictable |
+| **Run cancelled** | `AbortSignal` fires | External cancellation at runtime |
+| **Loop maxIterations exceeded** | Iteration count ≥ `maxIterations` | Runtime convergence; static analysis cannot predict iteration count |
+| **Template resolution errors** | `$from` reference unresolved, path projection fails | Mostly prevented by static dominator/scope analysis, but error-recovery paths (`onError`) can produce scopes where expected bindings were not set |
+
+#### 5.8.2 Defense-in-depth runtime checks
+
+These checks MAY be skipped when static validation has passed.  Each
+re-verifies an invariant that the static validator already proves
+(column "Static guarantee").
+
+| Check | Static guarantee | Reasoning |
+|---|---|---|
+| **Constant value schema** | `jsonValueToSchema` + `isStructuralSubtype` (§4.1 type compat) | Constant values are in the IR; static validator derives their type and checks compatibility |
+| **Fork min-2 branches** | §4.1 structural check | Branch count is a static IR property |
+| **forkMap `$from: "state"` rejection** | §4.1 scope-closure check on forkMap bodies | State refs in forkMap are a static IR property |
+| **Node not found** | §4.1 name-resolution pass | All node references are verified statically |
+| **Unregistered task** | §4.1 IR/task drift pass | All task names are checked against the registry at validation time |
+| **Workflow output schema** | §4.1 type-compatibility pass + essential task output check | Static proves template type fits schema; task output check ensures upstream values match declared types |
+| **Loop input schema** | §4.1 type-compatibility pass + essential task output check | Static proves input template types match `inputSchema`; task output check validates actual upstream values |
+| **Loop state initial schema** | §4.1 type-compatibility pass + essential task output check | Static proves initial-value template types match state schemas; task output check validates upstream values |
+| **Loop output schema** | §4.1 type-compatibility pass + essential task output check | Static proves output template types match `outputSchema`; task output check validates body bindings |
+| **Loop iterateState schema** | §4.1 type-compatibility pass + essential task output check | Static proves iterateState template types match state schemas; task output check validates body bindings |
+| **forkMap collection not array** | §4.1 type-compatibility pass + essential task output check | Static proves collection template resolves to array type; task output check validates upstream values |
+
+The split follows a composability argument: the essential **task output
+schema** check (§5.2) ensures every task implementation's actual return
+value conforms to its declared `outputSchema`.  Combined with the static
+validator's proof that every template's resolved type is structurally
+compatible with its target schema (§4.2), all downstream schema checks
+become redundant — the types are proven compatible statically and the
+values are proven conformant at each task boundary.
+
 ---
 
 ## 6. Worked examples

--- a/ts/docs/design/workflowSystem/ir/ir-v0.1.md
+++ b/ts/docs/design/workflowSystem/ir/ir-v0.1.md
@@ -617,7 +617,9 @@ Every node carries a discriminant `kind` (P5: self-describing).
 (section 3.4). The shape of `inputs` is part of the node's typed input
 schema (section 3.5). `onError`, when present, must point to a `task` node
 in the same scope; the engine dispatches that task with two injected input
-fields (`error` and `trigger`) per §3.8.
+fields (`error` and `trigger`) per §3.8. `onError` does not apply to
+`branch` nodes (see §3.6): branch is pure control flow and has no
+runtime failure mode after static validation.
 
 **Absent fields, no `null`.** Optional fields throughout the IR
 (`onError`, `bind`, `next` for terminals, `path` and `optional` on
@@ -858,7 +860,6 @@ validator, and analyzers in agreement on a single observable behavior
     "<caseValue>": "<nodeId>",
   },
   "default": "<nodeId>", // optional; see exhaustiveness rule below
-  "onError": "<nodeId>", // optional; see section 3.3
 }
 ```
 
@@ -867,6 +868,12 @@ validator, and analyzers in agreement on a single observable behavior
   with all-string members. Non-string discriminants (e.g., booleans from
   `int.lessThan`) require an explicit conversion task such as `bool.toLabel`
   ([decision 0008](decisions/0008-discriminant-key-encoding.md)).
+- **No `onError`.** Branch is pure control flow with no runtime failure
+  mode: selector template resolution is statically proven by the
+  validator's dominator + path-projection passes (§5.8.3), and
+  `BranchSelectorUnmatched` is also statically unreachable (see
+  exhaustiveness contract below and §5.8.3). The common `onError` field
+  from §3.3 therefore does not apply to branch nodes.
 - **Exhaustiveness contract.** Either `default` is present, **or** the
   branch is statically exhaustive. A branch is statically exhaustive when:
   1. `selectorSchema` declares an `enum` (or is `{ "type": "boolean" }`,
@@ -1743,7 +1750,7 @@ Note how `Url` is shared between the workflow `inputSchema` and the `fetch` task
 the workflow result. The compatibility pass collapses each ref-equal pair to
 an identity check.
 
-### 6.2 Branch with `onError` recovery
+### 6.2 Branch with task-level `onError` recovery
 
 ```jsonc
 {

--- a/ts/docs/design/workflowSystem/ir/ir-v0.1.md
+++ b/ts/docs/design/workflowSystem/ir/ir-v0.1.md
@@ -1617,15 +1617,7 @@ re-verifies an invariant that the static validator already proves
 | Check | Static guarantee | Reasoning |
 |---|---|---|
 | **Constant value schema** | `jsonValueToSchema` + `isStructuralSubtype` (§4.1 type compat) | Constant values are in the IR; static validator derives their type and checks compatibility |
-| **Fork min-2 branches** | §4.1 structural check | Branch count is a static IR property |
 | **forkMap `$from: "state"` rejection** | §4.1 scope-closure check on forkMap bodies | State refs in forkMap are a static IR property |
-
-**Integrity (graph and registry)**
-
-| Check | Static guarantee | Reasoning |
-|---|---|---|
-| **Node not found** | §4.1 name-resolution pass | All node references are verified statically |
-| **Unregistered task** | §4.1 IR/task drift pass | All task names are checked against the registry at validation time |
 
 **Propagation (static type compat + essential task output check)**
 
@@ -1643,9 +1635,24 @@ statically and values are proven conformant at each task boundary.
 | **Loop state initial schema** | §4.1 type-compatibility pass + essential task output check | Static proves initial-value template types match state schemas; task output check validates upstream values |
 | **Loop output schema** | §4.1 type-compatibility pass + essential task output check | Static proves output template types match `outputSchema`; task output check validates body bindings |
 | **Loop iterateState schema** | §4.1 type-compatibility pass + essential task output check | Static proves iterateState template types match state schemas; task output check validates body bindings |
-| **forkMap collection not array** | §4.1 type-compatibility pass + essential task output check | Static proves collection template resolves to array type; task output check validates upstream values |
 
-#### 5.8.3 Template resolution checks (unconditional)
+#### 5.8.3 Statically proven but unconditional checks
+
+The checks in this section are all proven unreachable after static
+validation, but are kept **unconditional** (not gated by
+`defenseInDepth`) because they are cheap and provide clear diagnostics
+if an IR somehow bypasses static validation.
+
+**Structural / integrity**
+
+| Check | Static guarantee | Reasoning |
+|---|---|---|
+| **Node not found** | §4.1 name-resolution pass | Null check; all node references are verified statically |
+| **Unregistered task** | §4.1 IR/task drift pass | Null check; all task names are checked against the registry at validation time |
+| **Fork min-2 branches** | §4.1 structural check | Comparison; branch count is a static IR property |
+| **forkMap collection not array** | §4.1 type-compatibility pass + essential task output check | `Array.isArray` check; static proves collection resolves to array type |
+
+**Template resolution (dominator analysis + type checking)**
 
 The static validator's dominator analysis with onError-split awareness
 (§4.1 scope-closure and dominator passes) proves that every non-optional
@@ -1655,10 +1662,6 @@ error-recovery paths.  Path projections are verified by
 properties.  Combined with the essential task output check (§5.8.1),
 which ensures actual values match declared schemas, path projection
 type errors at runtime are unreachable.
-
-These checks are statically proven but kept **unconditional** (not
-gated by `defenseInDepth`) because they are cheap and provide clear
-diagnostics if an IR somehow bypasses static validation.
 
 | Check | Static guarantee | Reasoning |
 |---|---|---|

--- a/ts/docs/design/workflowSystem/ir/ir-v0.1.md
+++ b/ts/docs/design/workflowSystem/ir/ir-v0.1.md
@@ -882,9 +882,9 @@ validator, and analyzers in agreement on a single observable behavior
   3. The discriminant's resolved producer type is provably narrowed to a
      subset of the declared enum (the producer carries a matching `const`,
      `enum`, or `boolean` type — see [§3.6.1](#361-discriminant-narrowing)).
-  When all three hold, omitting `default` is legal and
-  `BranchSelectorUnmatched` is statically unreachable. Otherwise `default`
-  is required (P5: no implicit fall-through).
+     When all three hold, omitting `default` is legal and
+     `BranchSelectorUnmatched` is statically unreachable. Otherwise `default`
+     is required (P5: no implicit fall-through).
 - A branch has no `inputs` other than `selector`, no `outputs`, and no
   `bind` (it produces no value). It is pure control flow. Data needed
   downstream of the branch must already be available via dominator
@@ -1168,7 +1168,7 @@ beyond those listed; consumers MUST treat unknown fields as opaque.
   - `"OutputSchemaViolation"` — the task returned a value that failed
     its declared `outputSchema`. This indicates a buggy or drifted task
     implementation; authors may want to log or fall back.
-  All `"runtime"` errors are routed to `onError` handlers.
+    All `"runtime"` errors are routed to `onError` handlers.
 - `"runtime"` with `kind: "UnrecoverableError"` — the engine raised a
   condition that is **statically unreachable** after validation
   (e.g., `ReferenceUnresolved`, `BranchSelectorUnmatched`, unknown `$from`
@@ -1606,46 +1606,46 @@ the static validator has no visibility into.
 
 **Schema validation (runtime values)**
 
-| Check | Trigger | Rationale |
-|---|---|---|
-| **Workflow input schema** | Caller provides `input` | Input is external to the IR; no static knowledge of actual values |
-| **Task output schema** | Task implementation returns | Catches buggy or drifted task implementations returning wrong types (§5.2) |
+| Check                     | Trigger                                     | Rationale                                                                      |
+| ------------------------- | ------------------------------------------- | ------------------------------------------------------------------------------ |
+| **Workflow input schema** | Caller provides `input`                     | Input is external to the IR; no static knowledge of actual values              |
+| **Task output schema**    | Task implementation returns                 | Catches buggy or drifted task implementations returning wrong types (§5.2)     |
 | **Never-output contract** | Task with `{ "not": {} }` output returns ok | Task declared it always fails; returning success means a broken implementation |
 
 **Security / policy**
 
-| Check | Trigger | Rationale |
-|---|---|---|
-| **Side-effect policy deny** | Policy map says `"deny"` | Runtime configuration, not in the IR |
-| **Side-effect prompt / no callback** | Policy says `"prompt"` but no approval callback | Runtime configuration |
-| **Approval rejected** | Approval callback returns non-approved | User decision at runtime |
+| Check                                | Trigger                                         | Rationale                            |
+| ------------------------------------ | ----------------------------------------------- | ------------------------------------ |
+| **Side-effect policy deny**          | Policy map says `"deny"`                        | Runtime configuration, not in the IR |
+| **Side-effect prompt / no callback** | Policy says `"prompt"` but no approval callback | Runtime configuration                |
+| **Approval rejected**                | Approval callback returns non-approved          | User decision at runtime             |
 
 **Execution control**
 
-| Check | Trigger | Rationale |
-|---|---|---|
-| **Run cancelled** | `AbortSignal` fires | External cancellation at runtime |
-| **Task timeout** | Execution exceeds `timeoutMs` | Runtime duration is unpredictable |
+| Check                           | Trigger                           | Rationale                                                           |
+| ------------------------------- | --------------------------------- | ------------------------------------------------------------------- |
+| **Run cancelled**               | `AbortSignal` fires               | External cancellation at runtime                                    |
+| **Task timeout**                | Execution exceeds `timeoutMs`     | Runtime duration is unpredictable                                   |
 | **Loop maxIterations exceeded** | Iteration count ≥ `maxIterations` | Runtime convergence; static analysis cannot predict iteration count |
 
 **Task contract**
 
-| Check | Trigger | Rationale |
-|---|---|---|
-| **Task failure** | Task throws or returns `{ kind: "fail" }` | External services fail; legitimate runtime error |
-| **Unrecoverable failure** | Task fails with no `onError` | Failure propagation; the task threw and no handler is declared |
+| Check                     | Trigger                                   | Rationale                                                      |
+| ------------------------- | ----------------------------------------- | -------------------------------------------------------------- |
+| **Task failure**          | Task throws or returns `{ kind: "fail" }` | External services fail; legitimate runtime error               |
+| **Unrecoverable failure** | Task fails with no `onError`              | Failure propagation; the task threw and no handler is declared |
 
 #### 5.8.2 Defense-in-depth runtime checks (gated)
 
-These checks MAY be skipped when static validation has passed.  Each
+These checks MAY be skipped when static validation has passed. Each
 re-verifies an invariant that the static validator already proves
-(column "Static guarantee").  They are controlled by the
+(column "Static guarantee"). They are controlled by the
 `defenseInDepth` flag described above.
 
 **Structural (static IR properties)**
 
-| Check | Static guarantee | Reasoning |
-|---|---|---|
+| Check                     | Static guarantee                                               | Reasoning                                                                                   |
+| ------------------------- | -------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
 | **Constant value schema** | `jsonValueToSchema` + `isStructuralSubtype` (§4.1 type compat) | Constant values are in the IR; static validator derives their type and checks compatibility |
 
 **Propagation (static type compat + essential task output check)**
@@ -1654,16 +1654,16 @@ These are redundant because the essential **task output schema** check
 (§5.8.1) ensures every task implementation's actual return value
 conforms to its declared `outputSchema`, and the static validator
 proves every template's resolved type is structurally compatible with
-its target schema (§4.2).  Together, types are proven compatible
+its target schema (§4.2). Together, types are proven compatible
 statically and values are proven conformant at each task boundary.
 
-| Check | Static guarantee | Reasoning |
-|---|---|---|
-| **Workflow output schema** | §4.1 type-compatibility pass + essential task output check | Static proves template type fits schema; task output check ensures upstream values match declared types |
-| **Loop input schema** | §4.1 type-compatibility pass + essential task output check | Static proves input template types match `inputSchema`; task output check validates actual upstream values |
+| Check                         | Static guarantee                                           | Reasoning                                                                                                   |
+| ----------------------------- | ---------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| **Workflow output schema**    | §4.1 type-compatibility pass + essential task output check | Static proves template type fits schema; task output check ensures upstream values match declared types     |
+| **Loop input schema**         | §4.1 type-compatibility pass + essential task output check | Static proves input template types match `inputSchema`; task output check validates actual upstream values  |
 | **Loop state initial schema** | §4.1 type-compatibility pass + essential task output check | Static proves initial-value template types match state schemas; task output check validates upstream values |
-| **Loop output schema** | §4.1 type-compatibility pass + essential task output check | Static proves output template types match `outputSchema`; task output check validates body bindings |
-| **Loop iterateState schema** | §4.1 type-compatibility pass + essential task output check | Static proves iterateState template types match state schemas; task output check validates body bindings |
+| **Loop output schema**        | §4.1 type-compatibility pass + essential task output check | Static proves output template types match `outputSchema`; task output check validates body bindings         |
+| **Loop iterateState schema**  | §4.1 type-compatibility pass + essential task output check | Static proves iterateState template types match state schemas; task output check validates body bindings    |
 
 #### 5.8.3 Statically proven but unconditional checks
 
@@ -1674,30 +1674,30 @@ if an IR somehow bypasses static validation.
 
 **Structural / integrity**
 
-| Check | Static guarantee | Reasoning |
-|---|---|---|
-| **Node not found** | §4.1 name-resolution pass | Null check; all node references are verified statically |
-| **Unregistered task** | §4.1 IR/task drift pass | Null check; all task names are checked against the registry at validation time |
-| **Fork min-2 branches** | §4.1 structural check | Comparison; branch count is a static IR property |
-| **forkMap collection not array** | §4.1 type-compatibility pass + essential task output check | `Array.isArray` check; static proves collection resolves to array type |
-| **Branch selector unmatched** | §3.6 exhaustiveness contract + §4.1 type-compatibility | When `default` is absent the validator proves the branch is exhaustive (selectorSchema has enum, all enum values appear as cases, and selector producer is provably narrowed). When `default` is present, unmatched values route to it. Either way, raising `BranchSelectorUnmatched` is unreachable. |
+| Check                            | Static guarantee                                           | Reasoning                                                                                                                                                                                                                                                                                             |
+| -------------------------------- | ---------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Node not found**               | §4.1 name-resolution pass                                  | Null check; all node references are verified statically                                                                                                                                                                                                                                               |
+| **Unregistered task**            | §4.1 IR/task drift pass                                    | Null check; all task names are checked against the registry at validation time                                                                                                                                                                                                                        |
+| **Fork min-2 branches**          | §4.1 structural check                                      | Comparison; branch count is a static IR property                                                                                                                                                                                                                                                      |
+| **forkMap collection not array** | §4.1 type-compatibility pass + essential task output check | `Array.isArray` check; static proves collection resolves to array type                                                                                                                                                                                                                                |
+| **Branch selector unmatched**    | §3.6 exhaustiveness contract + §4.1 type-compatibility     | When `default` is absent the validator proves the branch is exhaustive (selectorSchema has enum, all enum values appear as cases, and selector producer is provably narrowed). When `default` is present, unmatched values route to it. Either way, raising `BranchSelectorUnmatched` is unreachable. |
 
 **Template resolution (dominator analysis + type checking)**
 
 The static validator's dominator analysis with onError-split awareness
 (§4.1 scope-closure and dominator passes) proves that every non-optional
 `$from: "scope"` reference is bound on all execution paths, including
-error-recovery paths.  Path projections are verified by
+error-recovery paths. Path projections are verified by
 `checkSchemaCompat` which rejects paths into undeclared schema
-properties.  Combined with the essential task output check (§5.8.1),
+properties. Combined with the essential task output check (§5.8.1),
 which ensures actual values match declared schemas, path projection
 type errors at runtime are unreachable.
 
-| Check | Static guarantee | Reasoning |
-|---|---|---|
-| **Unknown `$from` namespace** | §4.1 schema-syntax pass | Only valid namespaces (`input`, `constant`, `scope`, `state`) are accepted |
-| **Unresolved reference** | §4.1 dominator pass with onError-split coverage | Binding coverage is proven on all paths including error-recovery paths; uncovered non-optional refs are rejected |
-| **Path projection on null/wrong type** | §4.1 type-compatibility + `resolveSchemaPath` | Path segments are checked against declared schema structure; task output check ensures actual values match |
+| Check                                  | Static guarantee                                | Reasoning                                                                                                        |
+| -------------------------------------- | ----------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| **Unknown `$from` namespace**          | §4.1 schema-syntax pass                         | Only valid namespaces (`input`, `constant`, `scope`, `state`) are accepted                                       |
+| **Unresolved reference**               | §4.1 dominator pass with onError-split coverage | Binding coverage is proven on all paths including error-recovery paths; uncovered non-optional refs are rejected |
+| **Path projection on null/wrong type** | §4.1 type-compatibility + `resolveSchemaPath`   | Path segments are checked against declared schema structure; task output check ensures actual values match       |
 
 ---
 

--- a/ts/docs/design/workflowSystem/ir/ir-v0.1.md
+++ b/ts/docs/design/workflowSystem/ir/ir-v0.1.md
@@ -1156,20 +1156,16 @@ beyond those listed; consumers MUST treat unknown fields as opaque.
 
 **`source` discriminates the failure origin.**
 
-- `"task"` — the registered task implementation threw, returned a value
+- `"task"` - the registered task implementation threw, returned a value
   that violated `outputSchema` (§5.2), or otherwise signaled failure.
-  The `code` field is `"TASK_ERROR"`. `task` and `node` SHOULD be
-  populated. `data` carries any additional payload the task returned.
-- `"runtime"` — the engine itself raised the failure (loop
-  `maxIterations` exceeded, reference resolution failed at runtime,
-  etc.). The `code` field is `"RUNTIME_ERROR"`. `node` and `scopePath`
-  identify where the failure occurred; `message` contains a
-  human-readable description (e.g.
-  `"LoopMaxIterationsExceeded at \"nodeId\" (limit: N)"`).
-
-An engine MAY use additional `code` values for finer-grained
-discrimination; consumers MUST treat unknown `code` values as opaque
-and fall back to inspecting `source`.
+  `task` and `node` SHOULD be populated.
+- `"runtime"` - the engine itself raised the failure (loop
+  `maxIterations` exceeded, branch selector value did not match any
+  `cases` or `default`, reference resolution failed at runtime, etc.).
+  `code` distinguishes the runtime case (well-known codes include
+  `LoopMaxIterationsExceeded`, `BranchSelectorUnmatched`,
+  `ReferenceUnresolved`; the full list is engine-defined and surfaced
+  through the validator's error-code table - see §4.3).
 
 A recovery task that wants to be type-strict about the error it
 consumes can narrow the schema for its `error` input field below

--- a/ts/docs/design/workflowSystem/ir/ir-v0.2.md
+++ b/ts/docs/design/workflowSystem/ir/ir-v0.2.md
@@ -138,15 +138,15 @@ sub-scope (same contract as loop bodies in v1).
 
 **Fields:**
 
-| Field            | Required | Description                                                                                                                                                   |
-| ---------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `kind`           | yes      | `"fork"`                                                                                                                                                      |
+| Field            | Required | Description                                                                                                                                                                                                                                                                                                                                                                         |
+| ---------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `kind`           | yes      | `"fork"`                                                                                                                                                                                                                                                                                                                                                                            |
 | `branches`       | yes      | Map of branch name to branch object. Each branch object has `inputs` (templates resolved in the outer scope) and `scope` (a `WorkflowScope` with `inputSchema`, `entry`, `nodes`, `output`, `outputSchema` — the same contract as v1 loop bodies). The `scope` nesting is intentional: `WorkflowScope` is shared with loop bodies and the top-level workflow for type-system reuse. |
-| `outputSchema`   | yes      | Schema of the fork's combined output. Object with one property per branch name.                                                                               |
-| `maxConcurrency` | no       | Positive integer. Max concurrent branches. Engine queues excess in declaration order. Defaults to unbounded.                                                  |
-| `next`           | no       | Next node ID, or `null` / sentinel.                                                                                                                           |
-| `onError`        | no       | Error handler node ID. Triggered if any branch fails. Handler receives `error` and empty `trigger`.                                                           |
-| `bind`           | no       | Bound output name for scope visibility.                                                                                                                       |
+| `outputSchema`   | yes      | Schema of the fork's combined output. Object with one property per branch name.                                                                                                                                                                                                                                                                                                     |
+| `maxConcurrency` | no       | Positive integer. Max concurrent branches. Engine queues excess in declaration order. Defaults to unbounded.                                                                                                                                                                                                                                                                        |
+| `next`           | no       | Next node ID, or `null` / sentinel.                                                                                                                                                                                                                                                                                                                                                 |
+| `onError`        | no       | Error handler node ID. Triggered if any branch fails. Handler receives `error` and empty `trigger`.                                                                                                                                                                                                                                                                                 |
+| `bind`           | no       | Bound output name for scope visibility.                                                                                                                                                                                                                                                                                                                                             |
 
 **Execution semantics:**
 
@@ -359,11 +359,11 @@ output. The IR toolchain enforces this in two places:
 
 ### 3.5 `list` namespace
 
-| Task             | Input schema              | Output schema | Notes                                      |
-| ---------------- | ------------------------- | ------------- | ------------------------------------------ |
-| `list.length`    | `{ list: T[] }`           | `integer`     | Returns the length of the list.            |
-| `list.elementAt` | `{ list: T[], index: integer }` | `T`     | Returns the element at the given index. Fails if out of bounds. |
-| `list.append`    | `{ list: T[], item: T }`  | `T[]`         | Returns a new array with item appended.    |
+| Task             | Input schema                    | Output schema | Notes                                                           |
+| ---------------- | ------------------------------- | ------------- | --------------------------------------------------------------- |
+| `list.length`    | `{ list: T[] }`                 | `integer`     | Returns the length of the list.                                 |
+| `list.elementAt` | `{ list: T[], index: integer }` | `T`           | Returns the element at the given index. Fails if out of bounds. |
+| `list.append`    | `{ list: T[], item: T }`        | `T[]`         | Returns a new array with item appended.                         |
 
 `list.append` is used by the `filter` built-in's IR lowering. Inside
 the loop body, a branch node checks the predicate result: the true

--- a/ts/docs/design/workflowSystem/ir/ir-v0.2.md
+++ b/ts/docs/design/workflowSystem/ir/ir-v0.2.md
@@ -68,55 +68,59 @@ sub-scope (same contract as loop bodies in v1).
       "inputs": {
         "doc": { "$from": "scope", "name": "document" },
       },
-      "inputSchema": {
-        "type": "object",
-        "properties": { "doc": { "type": "string" } },
-        "required": ["doc"],
-      },
-      "entry": "analyze",
-      "nodes": {
-        "analyze": {
-          "kind": "task",
-          "task": "text.analyze",
-          "inputs": { "text": { "$from": "input", "name": "doc" } },
-          "inputSchema": {
-            "type": "object",
-            "properties": { "text": { "type": "string" } },
-            "required": ["text"],
-          },
-          "outputSchema": { "$ref": "#/types/TextResult" },
-          "next": null,
+      "scope": {
+        "inputSchema": {
+          "type": "object",
+          "properties": { "doc": { "type": "string" } },
+          "required": ["doc"],
         },
+        "entry": "analyze",
+        "nodes": {
+          "analyze": {
+            "kind": "task",
+            "task": "text.analyze",
+            "inputs": { "text": { "$from": "input", "name": "doc" } },
+            "inputSchema": {
+              "type": "object",
+              "properties": { "text": { "type": "string" } },
+              "required": ["text"],
+            },
+            "outputSchema": { "$ref": "#/types/TextResult" },
+            "next": null,
+          },
+        },
+        "output": { "$from": "scope", "name": "analyze" },
+        "outputSchema": { "$ref": "#/types/TextResult" },
       },
-      "output": { "$from": "scope", "name": "analyze" },
-      "outputSchema": { "$ref": "#/types/TextResult" },
     },
     "imageAnalysis": {
       "inputs": {
         "doc": { "$from": "scope", "name": "document" },
       },
-      "inputSchema": {
-        "type": "object",
-        "properties": { "doc": { "type": "string" } },
-        "required": ["doc"],
-      },
-      "entry": "analyze",
-      "nodes": {
-        "analyze": {
-          "kind": "task",
-          "task": "image.analyze",
-          "inputs": { "text": { "$from": "input", "name": "doc" } },
-          "inputSchema": {
-            "type": "object",
-            "properties": { "text": { "type": "string" } },
-            "required": ["text"],
-          },
-          "outputSchema": { "$ref": "#/types/ImageResult" },
-          "next": null,
+      "scope": {
+        "inputSchema": {
+          "type": "object",
+          "properties": { "doc": { "type": "string" } },
+          "required": ["doc"],
         },
+        "entry": "analyze",
+        "nodes": {
+          "analyze": {
+            "kind": "task",
+            "task": "image.analyze",
+            "inputs": { "text": { "$from": "input", "name": "doc" } },
+            "inputSchema": {
+              "type": "object",
+              "properties": { "text": { "type": "string" } },
+              "required": ["text"],
+            },
+            "outputSchema": { "$ref": "#/types/ImageResult" },
+            "next": null,
+          },
+        },
+        "output": { "$from": "scope", "name": "analyze" },
+        "outputSchema": { "$ref": "#/types/ImageResult" },
       },
-      "output": { "$from": "scope", "name": "analyze" },
-      "outputSchema": { "$ref": "#/types/ImageResult" },
     },
   },
   "outputSchema": {
@@ -137,7 +141,7 @@ sub-scope (same contract as loop bodies in v1).
 | Field            | Required | Description                                                                                                                                                   |
 | ---------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `kind`           | yes      | `"fork"`                                                                                                                                                      |
-| `branches`       | yes      | Map of branch name to sub-scope. Each sub-scope has the same contract as v1 loop bodies: `inputs`, `inputSchema`, `entry`, `nodes`, `output`, `outputSchema`. |
+| `branches`       | yes      | Map of branch name to branch object. Each branch object has `inputs` (templates resolved in the outer scope) and `scope` (a `WorkflowScope` with `inputSchema`, `entry`, `nodes`, `output`, `outputSchema` — the same contract as v1 loop bodies). The `scope` nesting is intentional: `WorkflowScope` is shared with loop bodies and the top-level workflow for type-system reuse. |
 | `outputSchema`   | yes      | Schema of the fork's combined output. Object with one property per branch name.                                                                               |
 | `maxConcurrency` | no       | Positive integer. Max concurrent branches. Engine queues excess in declaration order. Defaults to unbounded.                                                  |
 | `next`           | no       | Next node ID, or `null` / sentinel.                                                                                                                           |

--- a/ts/docs/design/workflowSystem/ir/ir-v0.2.md
+++ b/ts/docs/design/workflowSystem/ir/ir-v0.2.md
@@ -287,20 +287,20 @@ never applies. `NaN` comparisons follow IEEE 754: all ordering
 comparisons involving `NaN` return `false` (including `NaN < NaN`).
 `Infinity` comparisons work as expected (`Infinity > 5` is `true`).
 
-| Task                     | Input schema                      | Output schema         | Notes |
-| ------------------------ | --------------------------------- | --------------------- | ----- |
-| `compare.equals`         | `{ left: T, right: T }`           | `{ result: boolean }` | `===` |
-| `compare.notEquals`      | `{ left: T, right: T }`           | `{ result: boolean }` | `!==` |
-| `compare.greaterThan`    | `{ left: number, right: number }` | `{ result: boolean }` | `>`   |
-| `compare.lessThan`       | `{ left: number, right: number }` | `{ result: boolean }` | `<`   |
-| `compare.greaterOrEqual` | `{ left: number, right: number }` | `{ result: boolean }` | `>=`  |
-| `compare.lessOrEqual`    | `{ left: number, right: number }` | `{ result: boolean }` | `<=`  |
+| Task                     | Input schema                      | Output schema | Notes |
+| ------------------------ | --------------------------------- | ------------- | ----- |
+| `compare.equals`         | `{ left: T, right: T }`           | `boolean`     | `===` |
+| `compare.notEquals`      | `{ left: T, right: T }`           | `boolean`     | `!==` |
+| `compare.greaterThan`    | `{ left: number, right: number }` | `boolean`     | `>`   |
+| `compare.lessThan`       | `{ left: number, right: number }` | `boolean`     | `<`   |
+| `compare.greaterOrEqual` | `{ left: number, right: number }` | `boolean`     | `>=`  |
+| `compare.lessOrEqual`    | `{ left: number, right: number }` | `boolean`     | `<=`  |
 
 ### 3.2 `bool` namespace
 
-| Task       | Input schema         | Output schema         | Notes      |
-| ---------- | -------------------- | --------------------- | ---------- |
-| `bool.not` | `{ value: boolean }` | `{ result: boolean }` | `!` in DSL |
+| Task       | Input schema         | Output schema | Notes      |
+| ---------- | -------------------- | ------------- | ---------- |
+| `bool.not` | `{ value: boolean }` | `boolean`     | `!` in DSL |
 
 The DSL operators `&&` and `||` lower to **branch nodes** that implement
 short-circuit evaluation. There are no `bool.and` or `bool.or` builtin
@@ -313,17 +313,17 @@ All `math.*` tasks use JavaScript number semantics. `NaN` and `Infinity`
 are valid output values. Division and modulo by zero produce `Infinity` or
 `NaN` respectively, not task failures.
 
-| Task            | Input schema                      | Output schema         | Notes                                                   |
-| --------------- | --------------------------------- | --------------------- | ------------------------------------------------------- |
-| `math.add`      | `{ left: number, right: number }` | `{ result: number }`  | `+` in DSL                                              |
-| `math.subtract` | `{ left: number, right: number }` | `{ result: number }`  | `-` in DSL                                              |
-| `math.multiply` | `{ left: number, right: number }` | `{ result: number }`  | `*` in DSL                                              |
-| `math.divide`   | `{ left: number, right: number }` | `{ result: number }`  | `/` in DSL. Returns `Infinity` or `NaN` on zero divisor |
-| `math.modulo`   | `{ left: number, right: number }` | `{ result: number }`  | `%` in DSL. Returns `NaN` on zero divisor               |
-| `math.negate`   | `{ value: number }`               | `{ result: number }`  | Unary `-` in DSL                                        |
-| `math.floor`    | `{ value: number }`               | `{ result: integer }` | `Math.floor()`. Use for integer conversion              |
-| `math.round`    | `{ value: number }`               | `{ result: integer }` | `Math.round()`                                          |
-| `math.ceil`     | `{ value: number }`               | `{ result: integer }` | `Math.ceil()`                                           |
+| Task            | Input schema                      | Output schema | Notes                                                   |
+| --------------- | --------------------------------- | ------------- | ------------------------------------------------------- |
+| `math.add`      | `{ left: number, right: number }` | `number`      | `+` in DSL                                              |
+| `math.subtract` | `{ left: number, right: number }` | `number`      | `-` in DSL                                              |
+| `math.multiply` | `{ left: number, right: number }` | `number`      | `*` in DSL                                              |
+| `math.divide`   | `{ left: number, right: number }` | `number`      | `/` in DSL. Returns `Infinity` or `NaN` on zero divisor |
+| `math.modulo`   | `{ left: number, right: number }` | `number`      | `%` in DSL. Returns `NaN` on zero divisor               |
+| `math.negate`   | `{ value: number }`               | `number`      | Unary `-` in DSL                                        |
+| `math.floor`    | `{ value: number }`               | `integer`     | `Math.floor()`. Use for integer conversion              |
+| `math.round`    | `{ value: number }`               | `integer`     | `Math.round()`                                          |
+| `math.ceil`     | `{ value: number }`               | `integer`     | `Math.ceil()`                                           |
 
 ### 3.4 `error` namespace
 
@@ -355,13 +355,15 @@ output. The IR toolchain enforces this in two places:
 
 ### 3.5 `list` namespace
 
-| Task          | Input schema                 | Output schema     | Notes                                      |
-| ------------- | ---------------------------- | ----------------- | ------------------------------------------ |
-| `list.append` | `{ array: T[], element: T }` | `{ result: T[] }` | Returns a new array with element appended. |
+| Task             | Input schema              | Output schema | Notes                                      |
+| ---------------- | ------------------------- | ------------- | ------------------------------------------ |
+| `list.length`    | `{ list: T[] }`           | `integer`     | Returns the length of the list.            |
+| `list.elementAt` | `{ list: T[], index: integer }` | `T`     | Returns the element at the given index. Fails if out of bounds. |
+| `list.append`    | `{ list: T[], item: T }`  | `T[]`         | Returns a new array with item appended.    |
 
 `list.append` is used by the `filter` built-in's IR lowering. Inside
 the loop body, a branch node checks the predicate result: the true
-branch calls `list.append` to add the element to the output array;
+branch calls `list.append` to add the item to the output array;
 the false branch skips. The accumulator is carried via `iterateState`
 on the enclosing loop node.
 

--- a/ts/docs/design/workflowSystem/ir/review.md
+++ b/ts/docs/design/workflowSystem/ir/review.md
@@ -33,30 +33,3 @@ spec. Options:
 **Impact:** Medium — affects IR serialization format and any tooling that
 produces fork nodes.
 
-## R3: Error object `code` field uses generic values
-
-**Spec:** ir-v0.1.md §3.8.1 defines well-known error codes:
-`LoopMaxIterationsExceeded`, `BranchSelectorUnmatched`,
-`ReferenceUnresolved`. The `source` field discriminates `"task"` vs
-`"runtime"`.
-
-**Current state:** The engine's `buildErrorObject` function uses generic
-codes `TASK_ERROR` and `RUNTIME_ERROR` for all errors. The spec-defined
-codes (`LoopMaxIterationsExceeded`, etc.) are not used. Error messages
-contain the information but not in the structured `code` field.
-
-**Discussion:** Fixing this requires:
-
-1. Define an enum or constants for well-known error codes.
-2. Thread the appropriate code through each failure site:
-   - `LoopMaxIterationsExceeded` from the loop iteration cap
-   - `BranchSelectorUnmatched` from branch selector lookup failure
-   - `ReferenceUnresolved` from `$from` resolution failure
-   - `OutputSchemaViolation` from output schema validation
-   - `InputSchemaViolation` from input schema validation
-3. Update `buildErrorObject` and the `EngineError` class to carry a
-   `code` field.
-4. Update tests that assert on error messages/shapes.
-
-**Impact:** Medium — affects error handling workflows that branch on
-`error.code`.

--- a/ts/docs/design/workflowSystem/ir/review.md
+++ b/ts/docs/design/workflowSystem/ir/review.md
@@ -1,6 +1,0 @@
-# Engine Implementation Review Items
-
-Tracked items from the engine review against ir-v0.1.md and ir-v0.2.md
-that require design discussion before implementation.
-
-All items resolved.

--- a/ts/docs/design/workflowSystem/ir/review.md
+++ b/ts/docs/design/workflowSystem/ir/review.md
@@ -3,37 +3,6 @@
 Tracked items from the engine review against ir-v0.1.md and ir-v0.2.md
 that require design discussion before implementation.
 
-## R1: BranchNode missing `onError` field
-
-**Spec:** ir-v0.1.md §3.3 lists `onError` as a common node field on every
-node kind. §3.6 shows `onError` on the branch schema.
-
-**Current state:** The `BranchNode` interface in `ir.ts` defines only
-`kind`, `selector`, `selectorSchema`, `cases`, `default`. No `onError`
-field. The engine's `executeBranch` does not handle errors — if template
-resolution of the selector fails, the error propagates uncaught.
-
-**Discussion:** A branch has only two runtime failure modes:
-
-1. **Selector template resolution failure** — proven unreachable by the
-   static validator's dominator + path-projection passes
-   (§5.8.3 template-resolution checks).
-2. **`BranchSelectorUnmatched`** — runtime value not in `cases` and no
-   `default`. Following the exhaustiveness work, this is also proven
-   unreachable by static validation: a branch without `default` must be
-   statically exhaustive (§3.6 exhaustiveness contract), and a branch
-   with `default` routes unmatched values there.
-
-Both failure modes are unreachable when static validation passes, so
-adding `onError` provides no useful runtime behavior. The spec mention
-is now misleading.
-
-**Recommendation:** Remove `onError` from the spec's BranchNode schema
-(§3.6) and the common-fields list (§3.3) for branch. The current
-implementation is correct.
-
-**Impact:** Low — purely a spec-vs-implementation reconciliation.
-
 ## R2: Fork branch sub-scope structure diverges from spec
 
 **Spec:** ir-v0.2.md §2.1 defines each fork branch as a flat structure

--- a/ts/docs/design/workflowSystem/ir/review.md
+++ b/ts/docs/design/workflowSystem/ir/review.md
@@ -33,3 +33,30 @@ spec. Options:
 **Impact:** Medium — affects IR serialization format and any tooling that
 produces fork nodes.
 
+## R3: Error object `code` field uses generic values
+
+**Spec:** ir-v0.1.md §3.8.1 defines well-known error codes:
+`LoopMaxIterationsExceeded`, `BranchSelectorUnmatched`,
+`ReferenceUnresolved`. The `source` field discriminates `"task"` vs
+`"runtime"`.
+
+**Current state:** The engine's `buildErrorObject` function uses generic
+codes `TASK_ERROR` and `RUNTIME_ERROR` for all errors. The spec-defined
+codes (`LoopMaxIterationsExceeded`, etc.) are not used. Error messages
+contain the information but not in the structured `code` field.
+
+**Discussion:** Fixing this requires:
+
+1. Define an enum or constants for well-known error codes.
+2. Thread the appropriate code through each failure site:
+   - `LoopMaxIterationsExceeded` from the loop iteration cap
+   - `BranchSelectorUnmatched` from branch selector lookup failure
+   - `ReferenceUnresolved` from `$from` resolution failure
+   - `OutputSchemaViolation` from output schema validation
+   - `InputSchemaViolation` from input schema validation
+3. Update `buildErrorObject` and the `EngineError` class to carry a
+   `code` field.
+4. Update tests that assert on error messages/shapes.
+
+**Impact:** Medium — affects error handling workflows that branch on
+`error.code`.

--- a/ts/docs/design/workflowSystem/ir/review.md
+++ b/ts/docs/design/workflowSystem/ir/review.md
@@ -1,0 +1,81 @@
+# Engine Implementation Review Items
+
+Tracked items from the engine review against ir-v0.1.md and ir-v0.2.md
+that require design discussion before implementation.
+
+## R1: BranchNode missing `onError` field
+
+**Spec:** ir-v0.1.md §3.3 lists `onError` as a common node field on every
+node kind. §3.6 shows `onError` on the branch schema.
+
+**Current state:** The `BranchNode` interface in `ir.ts` defines only
+`kind`, `selector`, `selectorSchema`, `cases`, `default`. No `onError`
+field. The engine's `executeBranch` does not handle errors — if template
+resolution of the selector fails, the error propagates uncaught.
+
+**Discussion:** Branch evaluation is a simple selector lookup. The only
+failure mode is template resolution of `selector` failing. Adding
+`onError` to branches is straightforward but may not be worth the
+complexity if selector resolution failures are always programming errors
+(bad IR) rather than runtime conditions. The spec requires it, so this
+should be added for conformance.
+
+**Impact:** Low — branch selector failures are rare in valid IR.
+
+## R2: Fork branch sub-scope structure diverges from spec
+
+**Spec:** ir-v0.2.md §2.1 defines each fork branch as a flat structure
+with `inputs`, `inputSchema`, `entry`, `nodes`, `output`, `outputSchema`
+(same contract as loop bodies).
+
+**Current state:** The engine's `ForkBranch` type separates this as:
+```typescript
+interface ForkBranch {
+    inputs: Record<string, Template>;
+    scope: WorkflowScope;
+}
+```
+where `WorkflowScope` contains `inputSchema`, `entry`, `nodes`, `output`,
+`outputSchema`. This means the IR JSON shape has a nested `scope` object
+not shown in the spec's flat branch structure.
+
+**Discussion:** The factoring is reasonable for code reuse (WorkflowScope
+is shared with loop bodies and the top-level workflow). However, it means
+IR documents must use the nested `scope` shape, which diverges from the
+spec. Options:
+
+1. Update the spec to match the engine's nested `scope` shape.
+2. Flatten `ForkBranch` to match the spec (breaking change to existing IR
+   documents).
+3. Accept both shapes with a normalization step.
+
+**Impact:** Medium — affects IR serialization format and any tooling that
+produces fork nodes.
+
+## R3: Error object `code` field uses generic values
+
+**Spec:** ir-v0.1.md §3.8.1 defines well-known error codes:
+`LoopMaxIterationsExceeded`, `BranchSelectorUnmatched`,
+`ReferenceUnresolved`. The `source` field discriminates `"task"` vs
+`"runtime"`.
+
+**Current state:** The engine's `buildErrorObject` function uses generic
+codes `TASK_ERROR` and `RUNTIME_ERROR` for all errors. The spec-defined
+codes (`LoopMaxIterationsExceeded`, etc.) are not used. Error messages
+contain the information but not in the structured `code` field.
+
+**Discussion:** Fixing this requires:
+
+1. Define an enum or constants for well-known error codes.
+2. Thread the appropriate code through each failure site:
+   - `LoopMaxIterationsExceeded` from the loop iteration cap
+   - `BranchSelectorUnmatched` from branch selector lookup failure
+   - `ReferenceUnresolved` from `$from` resolution failure
+   - `OutputSchemaViolation` from output schema validation
+   - `InputSchemaViolation` from input schema validation
+3. Update `buildErrorObject` and the `EngineError` class to carry a
+   `code` field.
+4. Update tests that assert on error messages/shapes.
+
+**Impact:** Medium — affects error handling workflows that branch on
+`error.code`.

--- a/ts/docs/design/workflowSystem/ir/review.md
+++ b/ts/docs/design/workflowSystem/ir/review.md
@@ -3,36 +3,6 @@
 Tracked items from the engine review against ir-v0.1.md and ir-v0.2.md
 that require design discussion before implementation.
 
-## R2: Fork branch sub-scope structure diverges from spec
-
-**Spec:** ir-v0.2.md §2.1 defines each fork branch as a flat structure
-with `inputs`, `inputSchema`, `entry`, `nodes`, `output`, `outputSchema`
-(same contract as loop bodies).
-
-**Current state:** The engine's `ForkBranch` type separates this as:
-```typescript
-interface ForkBranch {
-    inputs: Record<string, Template>;
-    scope: WorkflowScope;
-}
-```
-where `WorkflowScope` contains `inputSchema`, `entry`, `nodes`, `output`,
-`outputSchema`. This means the IR JSON shape has a nested `scope` object
-not shown in the spec's flat branch structure.
-
-**Discussion:** The factoring is reasonable for code reuse (WorkflowScope
-is shared with loop bodies and the top-level workflow). However, it means
-IR documents must use the nested `scope` shape, which diverges from the
-spec. Options:
-
-1. Update the spec to match the engine's nested `scope` shape.
-2. Flatten `ForkBranch` to match the spec (breaking change to existing IR
-   documents).
-3. Accept both shapes with a normalization step.
-
-**Impact:** Medium — affects IR serialization format and any tooling that
-produces fork nodes.
-
 ## R3: Error object `code` field uses generic values
 
 **Spec:** ir-v0.1.md §3.8.1 defines well-known error codes:

--- a/ts/docs/design/workflowSystem/ir/review.md
+++ b/ts/docs/design/workflowSystem/ir/review.md
@@ -3,30 +3,4 @@
 Tracked items from the engine review against ir-v0.1.md and ir-v0.2.md
 that require design discussion before implementation.
 
-## R3: Error object `code` field uses generic values
-
-**Spec:** ir-v0.1.md §3.8.1 defines well-known error codes:
-`LoopMaxIterationsExceeded`, `BranchSelectorUnmatched`,
-`ReferenceUnresolved`. The `source` field discriminates `"task"` vs
-`"runtime"`.
-
-**Current state:** The engine's `buildErrorObject` function uses generic
-codes `TASK_ERROR` and `RUNTIME_ERROR` for all errors. The spec-defined
-codes (`LoopMaxIterationsExceeded`, etc.) are not used. Error messages
-contain the information but not in the structured `code` field.
-
-**Discussion:** Fixing this requires:
-
-1. Define an enum or constants for well-known error codes.
-2. Thread the appropriate code through each failure site:
-   - `LoopMaxIterationsExceeded` from the loop iteration cap
-   - `BranchSelectorUnmatched` from branch selector lookup failure
-   - `ReferenceUnresolved` from `$from` resolution failure
-   - `OutputSchemaViolation` from output schema validation
-   - `InputSchemaViolation` from input schema validation
-3. Update `buildErrorObject` and the `EngineError` class to carry a
-   `code` field.
-4. Update tests that assert on error messages/shapes.
-
-**Impact:** Medium — affects error handling workflows that branch on
-`error.code`.
+All items resolved.

--- a/ts/docs/design/workflowSystem/ir/review.md
+++ b/ts/docs/design/workflowSystem/ir/review.md
@@ -13,14 +13,26 @@ node kind. §3.6 shows `onError` on the branch schema.
 field. The engine's `executeBranch` does not handle errors — if template
 resolution of the selector fails, the error propagates uncaught.
 
-**Discussion:** Branch evaluation is a simple selector lookup. The only
-failure mode is template resolution of `selector` failing. Adding
-`onError` to branches is straightforward but may not be worth the
-complexity if selector resolution failures are always programming errors
-(bad IR) rather than runtime conditions. The spec requires it, so this
-should be added for conformance.
+**Discussion:** A branch has only two runtime failure modes:
 
-**Impact:** Low — branch selector failures are rare in valid IR.
+1. **Selector template resolution failure** — proven unreachable by the
+   static validator's dominator + path-projection passes
+   (§5.8.3 template-resolution checks).
+2. **`BranchSelectorUnmatched`** — runtime value not in `cases` and no
+   `default`. Following the exhaustiveness work, this is also proven
+   unreachable by static validation: a branch without `default` must be
+   statically exhaustive (§3.6 exhaustiveness contract), and a branch
+   with `default` routes unmatched values there.
+
+Both failure modes are unreachable when static validation passes, so
+adding `onError` provides no useful runtime behavior. The spec mention
+is now misleading.
+
+**Recommendation:** Remove `onError` from the spec's BranchNode schema
+(§3.6) and the common-fields list (§3.3) for branch. The current
+implementation is correct.
+
+**Impact:** Low — purely a spec-vs-implementation reconciliation.
 
 ## R2: Fork branch sub-scope structure diverges from spec
 

--- a/ts/examples/workflow/dsl/src/emitter.ts
+++ b/ts/examples/workflow/dsl/src/emitter.ts
@@ -81,6 +81,50 @@ interface ScopeContext {
     parent?: ScopeContext | undefined;
 }
 
+function inferCommonType(
+    values: ReadonlyArray<unknown>,
+):
+    | "string"
+    | "number"
+    | "integer"
+    | "boolean"
+    | undefined {
+    if (values.length === 0) return undefined;
+    let inferred:
+        | "string"
+        | "number"
+        | "integer"
+        | "boolean"
+        | undefined;
+    for (const v of values) {
+        let t:
+            | "string"
+            | "number"
+            | "integer"
+            | "boolean"
+            | undefined;
+        if (typeof v === "string") t = "string";
+        else if (typeof v === "boolean") t = "boolean";
+        else if (typeof v === "number")
+            t = Number.isInteger(v) ? "integer" : "number";
+        else return undefined;
+        if (inferred === undefined) {
+            inferred = t;
+        } else if (inferred !== t) {
+            // Allow integer/number mixing as "number".
+            if (
+                (inferred === "integer" && t === "number") ||
+                (inferred === "number" && t === "integer")
+            ) {
+                inferred = "number";
+            } else {
+                return undefined;
+            }
+        }
+    }
+    return inferred;
+}
+
 export class Emitter {
     private errors: EmitError[] = [];
     private taskSchemas: Map<string, TaskSchemaInfo>;
@@ -429,15 +473,17 @@ export class Emitter {
             this.patchBranchTail(elseScope, "else_", mergeId, scope);
         }
 
-        // Create branch and merge nodes
+        // Create branch and merge nodes.
+        // Boolean if-else is always exhaustive: both true and false have
+        // explicit targets (the omitted arm falls through to merge).
         const branchNode: BranchNode = {
             kind: "branch",
             selector: condTemplate,
-            selectorSchema: { type: "boolean" },
+            selectorSchema: { type: "boolean", enum: [true, false] },
             cases: {
                 true: thenEntry ? `then_${thenEntry}` : mergeId,
+                false: elseEntry ? `else_${elseEntry}` : mergeId,
             },
-            default: elseEntry ? `else_${elseEntry}` : mergeId,
         };
 
         // Merge is a noop task that serves as the continuation point
@@ -484,8 +530,9 @@ export class Emitter {
         const mergeId = this.freshId("merge");
 
         const cases: Record<string, string> = {};
-        let defaultTarget = mergeId; // fallthrough to merge if no default
+        let defaultTarget: string | undefined;
         let branchOutput: Template | undefined;
+        const caseValues: unknown[] = [];
 
         for (let i = 0; i < stmt.arms.length; i++) {
             const arm = stmt.arms[i];
@@ -509,6 +556,7 @@ export class Emitter {
             this.patchBranchTail(armScope, armPrefix, mergeId, scope);
 
             const caseValue = this.constExprToValue(arm.value);
+            caseValues.push(caseValue);
             const caseKey = String(caseValue);
             cases[caseKey] =
                 armScope.nodeOrder.length > 0
@@ -516,9 +564,13 @@ export class Emitter {
                     : mergeId;
         }
 
-        if (stmt.default_ && stmt.default_.length > 0) {
+        const hasSourceDefault = !!(
+            stmt.default_ && stmt.default_.length > 0
+        );
+
+        if (hasSourceDefault) {
             const defScope = this.childScope(scope);
-            for (const s of stmt.default_) {
+            for (const s of stmt.default_!) {
                 const r = this.emitStatement(s, defScope);
                 if (r?.output !== undefined && branchOutput === undefined) {
                     branchOutput = r.output;
@@ -540,12 +592,26 @@ export class Emitter {
                     : mergeId;
         }
 
+        // Infer selectorSchema from case value types.  When the source
+        // omits `default`, treat the switch as exhaustive: emit an enum
+        // selectorSchema and no default. Static validation then enforces
+        // that the discriminant's resolved type is provably narrowed.
+        const inferredType = inferCommonType(caseValues);
+        let selectorSchema: JSONSchema;
+        if (!hasSourceDefault && inferredType) {
+            selectorSchema = { type: inferredType, enum: caseValues as any };
+        } else if (inferredType) {
+            selectorSchema = { type: inferredType };
+        } else {
+            selectorSchema = {};
+        }
+
         const branchNode: BranchNode = {
             kind: "branch",
             selector: discTemplate,
-            selectorSchema: {},
+            selectorSchema,
             cases,
-            default: defaultTarget,
+            ...(defaultTarget !== undefined ? { default: defaultTarget } : {}),
         };
 
         const mergeNode: TaskNode = {

--- a/ts/examples/workflow/dsl/src/emitter.ts
+++ b/ts/examples/workflow/dsl/src/emitter.ts
@@ -2228,8 +2228,12 @@ export class Emitter {
                 }
             }
             clone.cases = cases;
-            if (!node.default.startsWith("@")) {
-                clone.default = `${prefix}${node.default}`;
+            if (node.default !== undefined) {
+                if (!node.default.startsWith("@")) {
+                    clone.default = `${prefix}${node.default}`;
+                } else {
+                    clone.default = node.default;
+                }
             }
         }
         return clone as unknown as WorkflowNode;

--- a/ts/examples/workflow/dsl/src/emitter.ts
+++ b/ts/examples/workflow/dsl/src/emitter.ts
@@ -83,26 +83,11 @@ interface ScopeContext {
 
 function inferCommonType(
     values: ReadonlyArray<unknown>,
-):
-    | "string"
-    | "number"
-    | "integer"
-    | "boolean"
-    | undefined {
+): "string" | "number" | "integer" | "boolean" | undefined {
     if (values.length === 0) return undefined;
-    let inferred:
-        | "string"
-        | "number"
-        | "integer"
-        | "boolean"
-        | undefined;
+    let inferred: "string" | "number" | "integer" | "boolean" | undefined;
     for (const v of values) {
-        let t:
-            | "string"
-            | "number"
-            | "integer"
-            | "boolean"
-            | undefined;
+        let t: "string" | "number" | "integer" | "boolean" | undefined;
         if (typeof v === "string") t = "string";
         else if (typeof v === "boolean") t = "boolean";
         else if (typeof v === "number")
@@ -563,9 +548,7 @@ export class Emitter {
                     : mergeId;
         }
 
-        const hasSourceDefault = !!(
-            stmt.default_ && stmt.default_.length > 0
-        );
+        const hasSourceDefault = !!(stmt.default_ && stmt.default_.length > 0);
 
         if (hasSourceDefault) {
             const defScope = this.childScope(scope);

--- a/ts/examples/workflow/dsl/src/emitter.ts
+++ b/ts/examples/workflow/dsl/src/emitter.ts
@@ -473,13 +473,12 @@ export class Emitter {
             this.patchBranchTail(elseScope, "else_", mergeId, scope);
         }
 
-        // Create branch and merge nodes.
-        // Boolean if-else is always exhaustive: both true and false have
-        // explicit targets (the omitted arm falls through to merge).
+        // Boolean if-else is always exhaustive: { type: "boolean" } is
+        // treated as an implicit enum [true, false] by the validator.
         const branchNode: BranchNode = {
             kind: "branch",
             selector: condTemplate,
-            selectorSchema: { type: "boolean", enum: [true, false] },
+            selectorSchema: { type: "boolean" },
             cases: {
                 true: thenEntry ? `then_${thenEntry}` : mergeId,
                 false: elseEntry ? `else_${elseEntry}` : mergeId,

--- a/ts/examples/workflow/dsl/test/emitter.spec.ts
+++ b/ts/examples/workflow/dsl/test/emitter.spec.ts
@@ -408,8 +408,10 @@ describe("Emitter", () => {
         expect(branchNode.cases).toHaveProperty("true");
         expect(branchNode.cases).toHaveProperty("false");
         // Boolean if-else is exhaustive: no default needed.
+        // { type: "boolean" } is treated as implicit enum [true, false].
         expect(branchNode.default).toBeUndefined();
-        expect(branchNode.selectorSchema.enum).toEqual([true, false]);
+        expect(branchNode.selectorSchema).toEqual({ type: "boolean" });
+        expect(branchNode.selectorSchema.enum).toBeUndefined();
     });
 
     // ---- Switch statement ----

--- a/ts/examples/workflow/dsl/test/emitter.spec.ts
+++ b/ts/examples/workflow/dsl/test/emitter.spec.ts
@@ -406,7 +406,10 @@ describe("Emitter", () => {
         `);
         const [, branchNode] = findNodeByKind<BranchNode>(ir, "branch");
         expect(branchNode.cases).toHaveProperty("true");
-        expect(branchNode.default).toBeDefined();
+        expect(branchNode.cases).toHaveProperty("false");
+        // Boolean if-else is exhaustive: no default needed.
+        expect(branchNode.default).toBeUndefined();
+        expect(branchNode.selectorSchema.enum).toEqual([true, false]);
     });
 
     // ---- Switch statement ----
@@ -426,6 +429,62 @@ describe("Emitter", () => {
         const [, branchNode] = findNodeByKind<BranchNode>(ir, "branch");
         expect(branchNode.cases).toHaveProperty("a");
         expect(branchNode.cases).toHaveProperty("b");
+    });
+
+    test("switch without default emits exhaustive branch (no default, enum selectorSchema)", () => {
+        const ir = compileOk(`
+            workflow test(x: string): unknown {
+                switch (x) {
+                    case "a":
+                        const r1 = web.fetch("https://a.com");
+                    case "b":
+                        const r2 = web.fetch("https://b.com");
+                }
+                return "done";
+            }
+        `);
+        const [, branchNode] = findNodeByKind<BranchNode>(ir, "branch");
+        expect(branchNode.default).toBeUndefined();
+        expect(branchNode.selectorSchema).toEqual({
+            type: "string",
+            enum: ["a", "b"],
+        });
+    });
+
+    test("switch with default emits default-targeted branch", () => {
+        const ir = compileOk(`
+            workflow test(x: string): unknown {
+                switch (x) {
+                    case "a":
+                        const r1 = web.fetch("https://a.com");
+                    default:
+                        const r2 = web.fetch("https://other.com");
+                }
+                return "done";
+            }
+        `);
+        const [, branchNode] = findNodeByKind<BranchNode>(ir, "branch");
+        expect(branchNode.default).toBeDefined();
+        expect(branchNode.selectorSchema).toEqual({ type: "string" });
+    });
+
+    test("switch over integer case values infers integer type", () => {
+        const ir = compileOk(`
+            workflow test(x: number): unknown {
+                switch (x) {
+                    case 1:
+                        const r1 = web.fetch("https://a.com");
+                    case 2:
+                        const r2 = web.fetch("https://b.com");
+                }
+                return "done";
+            }
+        `);
+        const [, branchNode] = findNodeByKind<BranchNode>(ir, "branch");
+        expect(branchNode.selectorSchema).toEqual({
+            type: "integer",
+            enum: [1, 2],
+        });
     });
 
     // ---- Throw statement ----

--- a/ts/examples/workflow/engine/src/runner.ts
+++ b/ts/examples/workflow/engine/src/runner.ts
@@ -418,8 +418,10 @@ export class WorkflowEngine {
 
             debug("run %s completed", runId);
 
-            // Validate workflow output against outputSchema
-            if (ir.outputSchema) {
+            // Defense-in-depth: static validator checks output template type
+            // compatibility; runtime #9 (task output schema) ensures upstream
+            // values match declared types, so this is redundant.
+            if (this.defenseInDepth && ir.outputSchema) {
                 const validate = this.getValidator(ir.outputSchema);
                 if (!validate(output)) {
                     const msg = this.ajv.errorsText(validate.errors);
@@ -486,7 +488,9 @@ export class WorkflowEngine {
             }
 
             const node = nodes[currentId];
-            if (!node) {
+            // Defense-in-depth: static validator's name-resolution pass
+            // verifies all node references exist.
+            if (this.defenseInDepth && !node) {
                 throw new EngineError(`Node "${currentId}" not found`);
             }
 
@@ -664,29 +668,34 @@ export class WorkflowEngine {
 
         try {
             const task = this.registry.get(node.task);
-            if (!task) {
+            // Defense-in-depth: static validator checks all task names
+            // against the registry.
+            if (this.defenseInDepth && !task) {
                 throw new EngineError(
                     `Task "${node.task}" not found in registry`,
                 );
             }
+            // Static validation guarantees the task exists.
+            const validTask = task!;
 
             // Policy check: secure-by-default.
             // ALL tasks are gated unless explicitly marked sideEffects: false.
             // This ensures new or third-party tasks cannot bypass policy.
-            if (task.sideEffects !== false) {
-                const mode: TaskPolicyMode = policy?.[task.name] ?? "prompt";
+            if (validTask.sideEffects !== false) {
+                const mode: TaskPolicyMode =
+                    policy?.[validTask.name] ?? "prompt";
                 if (mode === "deny") {
                     throw new EngineError(
-                        `Task "${task.name}" denied by policy`,
+                        `Task "${validTask.name}" denied by policy`,
                     );
                 }
                 if (mode === "prompt") {
                     const decision = approveFn
-                        ? await approveFn(task.name, resolvedInput)
+                        ? await approveFn(validTask.name, resolvedInput)
                         : { kind: "denied" as const };
                     if (decision.kind !== "approved") {
                         throw new EngineError(
-                            `Task "${task.name}" denied: approval ${decision.kind}`,
+                            `Task "${validTask.name}" denied: approval ${decision.kind}`,
                         );
                     }
                 }
@@ -739,7 +748,7 @@ export class WorkflowEngine {
                     once: true,
                 });
                 try {
-                    result = await task.execute(resolvedInput, ctx);
+                    result = await validTask.execute(resolvedInput, ctx);
                 } catch (e) {
                     if (timeoutSignal.aborted) {
                         throw new EngineError(
@@ -757,7 +766,7 @@ export class WorkflowEngine {
                     );
                 }
             } else {
-                result = await task.execute(resolvedInput, ctx);
+                result = await validTask.execute(resolvedInput, ctx);
             }
 
             if (result.kind === "fail") {
@@ -889,7 +898,10 @@ export class WorkflowEngine {
             unknown
         >;
 
-        if (node.body.inputSchema) {
+        // Defense-in-depth: static validator checks input template type
+        // compatibility; runtime task-output checks (#9) ensure upstream
+        // values match declared types, making this redundant.
+        if (this.defenseInDepth && node.body.inputSchema) {
             const validate = this.getValidator(node.body.inputSchema);
             if (!validate(loopInput)) {
                 const msg = this.ajv.errorsText(validate.errors);
@@ -900,10 +912,13 @@ export class WorkflowEngine {
         }
 
         // Initialize state and validate against state[*].schema (§5.4 step 2)
+        // Defense-in-depth: static validator checks initial-value template
+        // types against state schemas; runtime task-output checks (#9)
+        // ensure upstream values are correct.
         let state: Record<string, unknown> = {};
         for (const [name, stateVar] of Object.entries(node.state)) {
             state[name] = resolveTemplate(stateVar.initial, outerScope);
-            if (stateVar.schema) {
+            if (this.defenseInDepth && stateVar.schema) {
                 const validate = this.getValidator(stateVar.schema);
                 if (!validate(state[name])) {
                     const msg = this.ajv.errorsText(validate.errors);
@@ -965,8 +980,10 @@ export class WorkflowEngine {
                     // Resolve output in body scope (state + body bindings)
                     const output = resolveTemplate(node.body.output, bodyScope);
 
-                    // Validate output against outputSchema (§5.4 step 4)
-                    if (node.body.outputSchema) {
+                    // Defense-in-depth: static validator checks output template
+                    // type compatibility; runtime task-output checks (#9)
+                    // ensure body bindings are correct.
+                    if (this.defenseInDepth && node.body.outputSchema) {
                         const validate = this.getValidator(
                             node.body.outputSchema,
                         );
@@ -1005,6 +1022,9 @@ export class WorkflowEngine {
                 }
 
                 // @iterate: compute next state and validate (§5.4 step 4)
+                // Defense-in-depth: static validator checks iterateState
+                // template types against state schemas; runtime task-output
+                // checks (#9) ensure body bindings are correct.
                 const nextState: Record<string, unknown> = {};
                 for (const [name, ref] of Object.entries(node.iterateState)) {
                     nextState[name] = resolveTemplate(
@@ -1012,7 +1032,7 @@ export class WorkflowEngine {
                         bodyScope,
                     );
                     const stateVar = node.state[name];
-                    if (stateVar?.schema) {
+                    if (this.defenseInDepth && stateVar?.schema) {
                         const validate = this.getValidator(stateVar.schema);
                         if (!validate(nextState[name])) {
                             const msg = this.ajv.errorsText(validate.errors);
@@ -1229,7 +1249,10 @@ export class WorkflowEngine {
                 node.collection,
                 outerScope,
             ) as unknown[];
-            if (!Array.isArray(collection)) {
+            // Defense-in-depth: static validator checks collection template
+            // resolves to array type; runtime task-output checks (#9)
+            // ensure upstream values match declared types.
+            if (this.defenseInDepth && !Array.isArray(collection)) {
                 throw new EngineError(
                     `forkMap at "${nodeId}": collection did not resolve to an array`,
                 );

--- a/ts/examples/workflow/engine/src/runner.ts
+++ b/ts/examples/workflow/engine/src/runner.ts
@@ -545,7 +545,11 @@ export class WorkflowEngine {
             // Unreachable after static validation: name-resolution pass
             // verifies all node references exist.
             if (!node) {
-                throw new EngineError(`Node "${currentId}" not found`, "UnrecoverableError", true);
+                throw new EngineError(
+                    `Node "${currentId}" not found`,
+                    "UnrecoverableError",
+                    true,
+                );
             }
 
             // If we have a pending error (dispatching to onError target),

--- a/ts/examples/workflow/engine/src/runner.ts
+++ b/ts/examples/workflow/engine/src/runner.ts
@@ -117,7 +117,7 @@ function resolveFromRef(
             // Unreachable after static validation (namespace check).
             throw new EngineError(
                 `Unknown $from namespace: "${from}"`,
-                "UNRECOVERABLE_ERROR",
+                "UnrecoverableError",
                 true,
             );
     }
@@ -127,7 +127,7 @@ function resolveFromRef(
         // Unreachable after static validation (dominator + onError-split coverage).
         throw new EngineError(
             `Reference unresolved: $from "${from}", name "${name}"`,
-            "UNRECOVERABLE_ERROR",
+            "UnrecoverableError",
             true,
         );
     }
@@ -140,7 +140,7 @@ function resolveFromRef(
                 // Unreachable after static validation (type-compat + resolveSchemaPath).
                 throw new EngineError(
                     `Path projection failed at "${segment}" on null/undefined`,
-                    "UNRECOVERABLE_ERROR",
+                    "UnrecoverableError",
                     true,
                 );
             }
@@ -150,7 +150,7 @@ function resolveFromRef(
                     // Unreachable after static validation.
                     throw new EngineError(
                         `Path projection: expected array at index ${segment}`,
-                        "UNRECOVERABLE_ERROR",
+                        "UnrecoverableError",
                         true,
                     );
                 }
@@ -161,7 +161,7 @@ function resolveFromRef(
                     // Unreachable after static validation.
                     throw new EngineError(
                         `Path projection: expected object at key "${segment}"`,
-                        "UNRECOVERABLE_ERROR",
+                        "UnrecoverableError",
                         true,
                     );
                 }
@@ -177,22 +177,22 @@ function resolveFromRef(
 
 /**
  * Well-known engine-level error codes.
- * - "TASK_ERROR": a registered task returned {kind:"fail"} or threw.
- * - "RUNTIME_ERROR": the engine raised a recoverable runtime condition
+ * - "TaskError": a registered task returned {kind:"fail"} or threw.
+ * - "RuntimeError": the engine raised a recoverable runtime condition
  *   (policy/approval, timeout, cancellation).
  * - "LoopMaxIterationsExceeded": loop hit its maxIterations cap (recoverable).
  * - "OutputSchemaViolation": task returned a value that failed outputSchema (recoverable).
- * - "UNRECOVERABLE_ERROR": the engine raised a condition that is
+ * - "UnrecoverableError": the engine raised a condition that is
  *   statically unreachable after validation (ReferenceUnresolved,
  *   BranchSelectorUnmatched, unknown namespace, invalid IR structure).
  *   These bypass onError handlers.
  */
 type EngineErrorCode =
-    | "TASK_ERROR"
-    | "RUNTIME_ERROR"
+    | "TaskError"
+    | "RuntimeError"
     | "LoopMaxIterationsExceeded"
     | "OutputSchemaViolation"
-    | "UNRECOVERABLE_ERROR";
+    | "UnrecoverableError";
 
 class EngineError extends Error {
     readonly code: EngineErrorCode;
@@ -201,7 +201,7 @@ class EngineError extends Error {
 
     constructor(
         message: string,
-        code: EngineErrorCode = "RUNTIME_ERROR",
+        code: EngineErrorCode = "RuntimeError",
         unrecoverable = false,
     ) {
         super(message);
@@ -545,7 +545,7 @@ export class WorkflowEngine {
             // Unreachable after static validation: name-resolution pass
             // verifies all node references exist.
             if (!node) {
-                throw new EngineError(`Node "${currentId}" not found`, "UNRECOVERABLE_ERROR", true);
+                throw new EngineError(`Node "${currentId}" not found`, "UnrecoverableError", true);
             }
 
             // If we have a pending error (dispatching to onError target),
@@ -727,7 +727,7 @@ export class WorkflowEngine {
             if (!task) {
                 throw new EngineError(
                     `Task "${node.task}" not found in registry`,
-                    "UNRECOVERABLE_ERROR",
+                    "UnrecoverableError",
                     true,
                 );
             }
@@ -838,7 +838,7 @@ export class WorkflowEngine {
             if (isNeverSchema(node.outputSchema)) {
                 throw new EngineError(
                     `Task "${node.task}" at "${nodeId}" has never-output schema but returned ok.`,
-                    "UNRECOVERABLE_ERROR",
+                    "UnrecoverableError",
                     true,
                 );
             }
@@ -928,7 +928,7 @@ export class WorkflowEngine {
             // way this indicates a validator bypass — unrecoverable.
             throw new EngineError(
                 `Branch selector resolved to "${selector}" but no matching case or default exists`,
-                "UNRECOVERABLE_ERROR",
+                "UnrecoverableError",
                 true,
             );
         }
@@ -1455,7 +1455,7 @@ function buildErrorObject(
 ): Record<string, unknown> {
     if (err instanceof TaskFailure) {
         return {
-            code: "TASK_ERROR",
+            code: "TaskError",
             message: err.taskError.message,
             source: "task",
             task: err.taskName,
@@ -1465,7 +1465,7 @@ function buildErrorObject(
         };
     }
     return {
-        code: err instanceof EngineError ? err.code : "RUNTIME_ERROR",
+        code: err instanceof EngineError ? err.code : "RuntimeError",
         message: err instanceof Error ? err.message : String(err),
         source: "runtime",
         task: taskName,

--- a/ts/examples/workflow/engine/src/runner.ts
+++ b/ts/examples/workflow/engine/src/runner.ts
@@ -38,16 +38,17 @@ interface ScopeContext {
     bindings: Map<string, unknown>;
     /** The state namespace ($from: "state") - only set inside loop bodies. */
     state?: Record<string, unknown>;
-    /** Whether defense-in-depth checks are enabled. */
-    defenseInDepth: boolean;
 }
 
 // ---- Template resolution ----
-// Defense-in-depth: all error throws below (unknown namespace, unresolved
-// reference, path projection failures) are gated on scope.defenseInDepth.
-// The static validator's dominator analysis with onError-split coverage
-// (§4.1) proves binding availability on all paths, and checkSchemaCompat
-// verifies path projections against declared schemas.
+// Note: the error throws below (unknown namespace, unresolved reference,
+// path projection failures) should never fire when static validation is
+// enabled. The static validator's dominator analysis with onError-split
+// coverage (§4.1) proves binding availability on all paths, namespace
+// validation rejects unknown $from values, and checkSchemaCompat verifies
+// path projections against declared schemas. These checks are kept
+// unconditional because they are cheap and provide clear diagnostics if
+// an IR somehow bypasses static validation.
 
 /**
  * Recursively evaluate a template against a scope context.
@@ -113,24 +114,16 @@ function resolveFromRef(
             value = scope.state?.[name];
             break;
         default:
-            // Defense-in-depth: static validator's template pass checks
-            // that $from namespaces are valid (input, constant, scope, state).
-            if (scope.defenseInDepth) {
-                throw new EngineError(
-                    `Unknown $from namespace: "${from}"`,
-                );
-            }
+            // Unreachable after static validation (namespace check).
+            throw new EngineError(`Unknown $from namespace: "${from}"`);
     }
 
     if (value === undefined) {
         if (optional) return null;
-        // Defense-in-depth: static validator's dominator pass with
-        // onError-split coverage proves binding availability on all paths.
-        if (scope.defenseInDepth) {
-            throw new EngineError(
-                `Reference unresolved: $from "${from}", name "${name}"`,
-            );
-        }
+        // Unreachable after static validation (dominator + onError-split coverage).
+        throw new EngineError(
+            `Reference unresolved: $from "${from}", name "${name}"`,
+        );
     }
 
     // Path projection (RFC 6901 semantics)
@@ -138,32 +131,27 @@ function resolveFromRef(
         for (const segment of path) {
             if (value === null || value === undefined) {
                 if (optional) return null;
-                // Defense-in-depth: static type-compat + resolveSchemaPath
-                // verifies path segments against declared schemas.
-                if (scope.defenseInDepth) {
-                    throw new EngineError(
-                        `Path projection failed at "${segment}" on null/undefined`,
-                    );
-                }
+                // Unreachable after static validation (type-compat + resolveSchemaPath).
+                throw new EngineError(
+                    `Path projection failed at "${segment}" on null/undefined`,
+                );
             }
             if (typeof segment === "number") {
                 if (!Array.isArray(value)) {
                     if (optional) return null;
-                    if (scope.defenseInDepth) {
-                        throw new EngineError(
-                            `Path projection: expected array at index ${segment}`,
-                        );
-                    }
+                    // Unreachable after static validation.
+                    throw new EngineError(
+                        `Path projection: expected array at index ${segment}`,
+                    );
                 }
                 value = (value as unknown[])[segment];
             } else {
                 if (typeof value !== "object" || Array.isArray(value)) {
                     if (optional) return null;
-                    if (scope.defenseInDepth) {
-                        throw new EngineError(
-                            `Path projection: expected object at key "${segment}"`,
-                        );
-                    }
+                    // Unreachable after static validation.
+                    throw new EngineError(
+                        `Path projection: expected object at key "${segment}"`,
+                    );
                 }
                 value = (value as Record<string, unknown>)[segment];
             }
@@ -387,7 +375,6 @@ export class WorkflowEngine {
             input: input ?? {},
             constants,
             bindings: new Map(),
-            defenseInDepth,
         };
 
         const scopePath = [ir.name];
@@ -979,7 +966,6 @@ export class WorkflowEngine {
                     constants: outerScope.constants,
                     bindings: new Map(),
                     state: { ...state },
-                    defenseInDepth: outerScope.defenseInDepth,
                 };
 
                 // Execute body
@@ -1159,7 +1145,6 @@ export class WorkflowEngine {
                     input: branchInput,
                     constants: outerScope.constants,
                     bindings: new Map(),
-                    defenseInDepth: outerScope.defenseInDepth,
                 };
                 const branchScopePath = [...scopePath, `${nodeId}.${bName}`];
                 await this.executeScope(
@@ -1318,7 +1303,6 @@ export class WorkflowEngine {
                     input: itemInput,
                     constants: outerScope.constants,
                     bindings: new Map(),
-                    defenseInDepth: outerScope.defenseInDepth,
                 };
                 const itemScopePath = [...scopePath, `${nodeId}[${index}]`];
                 await this.executeScope(

--- a/ts/examples/workflow/engine/src/runner.ts
+++ b/ts/examples/workflow/engine/src/runner.ts
@@ -501,9 +501,9 @@ export class WorkflowEngine {
             }
 
             const node = nodes[currentId];
-            // Defense-in-depth: static validator's name-resolution pass
+            // Unreachable after static validation: name-resolution pass
             // verifies all node references exist.
-            if (this.defenseInDepth && !node) {
+            if (!node) {
                 throw new EngineError(`Node "${currentId}" not found`);
             }
 
@@ -681,15 +681,14 @@ export class WorkflowEngine {
 
         try {
             const task = this.registry.get(node.task);
-            // Defense-in-depth: static validator checks all task names
-            // against the registry.
-            if (this.defenseInDepth && !task) {
+            // Unreachable after static validation: IR/task drift pass
+            // checks all task names against the registry.
+            if (!task) {
                 throw new EngineError(
                     `Task "${node.task}" not found in registry`,
                 );
             }
-            // Static validation guarantees the task exists.
-            const validTask = task!;
+            const validTask = task;
 
             // Policy check: secure-by-default.
             // ALL tasks are gated unless explicitly marked sideEffects: false.
@@ -1103,8 +1102,9 @@ export class WorkflowEngine {
     ): Promise<string | undefined> {
         const branchNames = Object.keys(node.branches);
 
-        // Defense-in-depth: static validator already checks fork min-2 branches.
-        if (this.defenseInDepth && branchNames.length < 2) {
+        // Unreachable after static validation: structural check
+        // verifies fork has at least 2 branches.
+        if (branchNames.length < 2) {
             throw new EngineError(
                 `Fork "${nodeId}" must have at least 2 branches, got ${branchNames.length}`,
             );
@@ -1262,10 +1262,10 @@ export class WorkflowEngine {
                 node.collection,
                 outerScope,
             ) as unknown[];
-            // Defense-in-depth: static validator checks collection template
-            // resolves to array type; runtime task-output checks (#9)
+            // Unreachable after static validation: type-compatibility pass
+            // proves collection resolves to array type; task-output checks
             // ensure upstream values match declared types.
-            if (this.defenseInDepth && !Array.isArray(collection)) {
+            if (!Array.isArray(collection)) {
                 throw new EngineError(
                     `forkMap at "${nodeId}": collection did not resolve to an array`,
                 );

--- a/ts/examples/workflow/engine/src/runner.ts
+++ b/ts/examples/workflow/engine/src/runner.ts
@@ -1167,6 +1167,8 @@ export class WorkflowEngine {
         if (branchNames.length < 2) {
             throw new EngineError(
                 `Fork "${nodeId}" must have at least 2 branches, got ${branchNames.length}`,
+                "UnrecoverableError",
+                true,
             );
         }
 
@@ -1328,6 +1330,8 @@ export class WorkflowEngine {
             if (!Array.isArray(collection)) {
                 throw new EngineError(
                     `forkMap at "${nodeId}": collection did not resolve to an array`,
+                    "UnrecoverableError",
+                    true,
                 );
             }
 

--- a/ts/examples/workflow/engine/src/runner.ts
+++ b/ts/examples/workflow/engine/src/runner.ts
@@ -225,10 +225,9 @@ export interface RunOptions {
     skipValidation?: boolean;
     /**
      * Enable defense-in-depth runtime checks that duplicate static validation.
-     * When true (the default), the engine re-checks invariants already proven
-     * by the static validator (e.g. constant schema conformance, fork min-2
-     * branches, forkMap state-ref rejection). Disable for performance if you
-     * trust the static validator has run.
+     * Defaults to the value of `skipValidation` — when static validation is
+     * skipped these checks act as the safety net; when static validation runs
+     * they are redundant.  Set explicitly to override.
      */
     defenseInDepth?: boolean;
 }
@@ -289,7 +288,8 @@ export class WorkflowEngine {
         const approve = options?.approve;
         const abortSignalArg = options?.signal;
         const constraints = options?.constraints;
-        const defenseInDepth = options?.defenseInDepth ?? true;
+        const defenseInDepth =
+            options?.defenseInDepth ?? (options?.skipValidation ? true : false);
         this.defenseInDepth = defenseInDepth;
 
         // Default timeout: 60 seconds. 0 or Infinity disables.

--- a/ts/examples/workflow/engine/src/runner.ts
+++ b/ts/examples/workflow/engine/src/runner.ts
@@ -405,6 +405,17 @@ export class WorkflowEngine {
 
             debug("run %s completed", runId);
 
+            // Validate workflow output against outputSchema
+            if (ir.outputSchema) {
+                const validate = this.getValidator(ir.outputSchema);
+                if (!validate(output)) {
+                    const msg = this.ajv.errorsText(validate.errors);
+                    throw new EngineError(
+                        `Workflow output schema violation: ${msg}`,
+                    );
+                }
+            }
+
             this.emit({
                 type: "runCompleted",
                 runId,
@@ -859,16 +870,35 @@ export class WorkflowEngine {
             timestamp: Date.now(),
         });
 
-        // Resolve loop inputs from outer scope
+        // Resolve loop inputs from outer scope and validate against inputSchema (§5.4 step 1)
         const loopInput = resolveTemplate(node.inputs, outerScope) as Record<
             string,
             unknown
         >;
 
-        // Initialize state
+        if (node.body.inputSchema) {
+            const validate = this.getValidator(node.body.inputSchema);
+            if (!validate(loopInput)) {
+                const msg = this.ajv.errorsText(validate.errors);
+                throw new EngineError(
+                    `Loop "${nodeId}" input schema violation: ${msg}`,
+                );
+            }
+        }
+
+        // Initialize state and validate against state[*].schema (§5.4 step 2)
         let state: Record<string, unknown> = {};
         for (const [name, stateVar] of Object.entries(node.state)) {
             state[name] = resolveTemplate(stateVar.initial, outerScope);
+            if (stateVar.schema) {
+                const validate = this.getValidator(stateVar.schema);
+                if (!validate(state[name])) {
+                    const msg = this.ajv.errorsText(validate.errors);
+                    throw new EngineError(
+                        `Loop "${nodeId}" state "${name}" initial value schema violation: ${msg}`,
+                    );
+                }
+            }
         }
 
         const bodyScopePath = [...scopePath, `${nodeId}.body`];
@@ -922,6 +952,19 @@ export class WorkflowEngine {
                     // Resolve output in body scope (state + body bindings)
                     const output = resolveTemplate(node.body.output, bodyScope);
 
+                    // Validate output against outputSchema (§5.4 step 4)
+                    if (node.body.outputSchema) {
+                        const validate = this.getValidator(
+                            node.body.outputSchema,
+                        );
+                        if (!validate(output)) {
+                            const msg = this.ajv.errorsText(validate.errors);
+                            throw new EngineError(
+                                `Loop "${nodeId}" output schema violation: ${msg}`,
+                            );
+                        }
+                    }
+
                     if (node.bind) {
                         outerScope.bindings.set(node.bind, output);
                     }
@@ -948,13 +991,23 @@ export class WorkflowEngine {
                     return node.next;
                 }
 
-                // @iterate: compute next state
+                // @iterate: compute next state and validate (§5.4 step 4)
                 const nextState: Record<string, unknown> = {};
                 for (const [name, ref] of Object.entries(node.iterateState)) {
                     nextState[name] = resolveTemplate(
                         ref as Template,
                         bodyScope,
                     );
+                    const stateVar = node.state[name];
+                    if (stateVar?.schema) {
+                        const validate = this.getValidator(stateVar.schema);
+                        if (!validate(nextState[name])) {
+                            const msg = this.ajv.errorsText(validate.errors);
+                            throw new EngineError(
+                                `Loop "${nodeId}" iterateState "${name}" schema violation: ${msg}`,
+                            );
+                        }
+                    }
                 }
                 state = nextState;
             }
@@ -1003,6 +1056,12 @@ export class WorkflowEngine {
         constraints?: TaskConstraints,
     ): Promise<string | undefined> {
         const branchNames = Object.keys(node.branches);
+
+        if (branchNames.length < 2) {
+            throw new EngineError(
+                `Fork "${nodeId}" must have at least 2 branches, got ${branchNames.length}`,
+            );
+        }
 
         this.emit({
             type: "nodeStarted",
@@ -1136,6 +1195,13 @@ export class WorkflowEngine {
         taskTimeoutMs?: number,
         constraints?: TaskConstraints,
     ): Promise<string | undefined> {
+        // Reject $from: "state" in forkMap bodies (v0.2 §2.2 validation)
+        if (containsStateRef(node.body)) {
+            throw new EngineError(
+                `forkMap "${nodeId}": body must not reference $from "state" (forkMap has no state; use loop for stateful iteration)`,
+            );
+        }
+
         this.emit({
             type: "nodeStarted",
             runId,
@@ -1293,4 +1359,31 @@ function buildErrorObject(
         node: nodeId,
         scopePath: [...scopePath],
     };
+}
+
+/**
+ * Recursively check whether any template in a WorkflowScope contains
+ * `$from: "state"` references. Used to reject state refs in forkMap bodies.
+ */
+function containsStateRef(scope: {
+    nodes: Record<string, WorkflowNode>;
+    output: Template;
+}): boolean {
+    function checkTemplate(t: Template): boolean {
+        if (t === null || t === undefined || typeof t !== "object") return false;
+        if (Array.isArray(t)) return t.some(checkTemplate);
+        const obj = t as Record<string, unknown>;
+        if (obj["$from"] === "state") return true;
+        if ("$literal" in obj) return false;
+        return Object.values(obj).some((v) => checkTemplate(v as Template));
+    }
+    for (const node of Object.values(scope.nodes)) {
+        if ("inputs" in node && node.inputs) {
+            if (checkTemplate(node.inputs as Template)) return true;
+        }
+        if ("selector" in node) {
+            if (checkTemplate(node.selector as Template)) return true;
+        }
+    }
+    return checkTemplate(scope.output);
 }

--- a/ts/examples/workflow/engine/src/runner.ts
+++ b/ts/examples/workflow/engine/src/runner.ts
@@ -115,7 +115,11 @@ function resolveFromRef(
             break;
         default:
             // Unreachable after static validation (namespace check).
-            throw new EngineError(`Unknown $from namespace: "${from}"`);
+            throw new EngineError(
+                `Unknown $from namespace: "${from}"`,
+                "UNRECOVERABLE_ERROR",
+                true,
+            );
     }
 
     if (value === undefined) {
@@ -123,6 +127,8 @@ function resolveFromRef(
         // Unreachable after static validation (dominator + onError-split coverage).
         throw new EngineError(
             `Reference unresolved: $from "${from}", name "${name}"`,
+            "UNRECOVERABLE_ERROR",
+            true,
         );
     }
 
@@ -134,6 +140,8 @@ function resolveFromRef(
                 // Unreachable after static validation (type-compat + resolveSchemaPath).
                 throw new EngineError(
                     `Path projection failed at "${segment}" on null/undefined`,
+                    "UNRECOVERABLE_ERROR",
+                    true,
                 );
             }
             if (typeof segment === "number") {
@@ -142,6 +150,8 @@ function resolveFromRef(
                     // Unreachable after static validation.
                     throw new EngineError(
                         `Path projection: expected array at index ${segment}`,
+                        "UNRECOVERABLE_ERROR",
+                        true,
                     );
                 }
                 value = (value as unknown[])[segment];
@@ -151,6 +161,8 @@ function resolveFromRef(
                     // Unreachable after static validation.
                     throw new EngineError(
                         `Path projection: expected object at key "${segment}"`,
+                        "UNRECOVERABLE_ERROR",
+                        true,
                     );
                 }
                 value = (value as Record<string, unknown>)[segment];
@@ -163,10 +175,36 @@ function resolveFromRef(
 
 // ---- Error types ----
 
+/**
+ * Well-known engine-level error codes.
+ * - "TASK_ERROR": a registered task returned {kind:"fail"} or threw.
+ * - "RUNTIME_ERROR": the engine raised a recoverable runtime condition
+ *   (LoopMaxIterationsExceeded, OutputSchemaViolation, policy/approval,
+ *   timeout, cancellation).
+ * - "UNRECOVERABLE_ERROR": the engine raised a condition that is
+ *   statically unreachable after validation (ReferenceUnresolved,
+ *   BranchSelectorUnmatched, unknown namespace, invalid IR structure).
+ *   These bypass onError handlers.
+ */
+type EngineErrorCode =
+    | "TASK_ERROR"
+    | "RUNTIME_ERROR"
+    | "UNRECOVERABLE_ERROR";
+
 class EngineError extends Error {
-    constructor(message: string) {
+    readonly code: EngineErrorCode;
+    /** When true, this error bypasses onError handlers. */
+    readonly unrecoverable: boolean;
+
+    constructor(
+        message: string,
+        code: EngineErrorCode = "RUNTIME_ERROR",
+        unrecoverable = false,
+    ) {
         super(message);
         this.name = "EngineError";
+        this.code = code;
+        this.unrecoverable = unrecoverable;
     }
 }
 
@@ -504,7 +542,7 @@ export class WorkflowEngine {
             // Unreachable after static validation: name-resolution pass
             // verifies all node references exist.
             if (!node) {
-                throw new EngineError(`Node "${currentId}" not found`);
+                throw new EngineError(`Node "${currentId}" not found`, "UNRECOVERABLE_ERROR", true);
             }
 
             // If we have a pending error (dispatching to onError target),
@@ -686,6 +724,8 @@ export class WorkflowEngine {
             if (!task) {
                 throw new EngineError(
                     `Task "${node.task}" not found in registry`,
+                    "UNRECOVERABLE_ERROR",
+                    true,
                 );
             }
             const validTask = task;
@@ -795,16 +835,19 @@ export class WorkflowEngine {
             if (isNeverSchema(node.outputSchema)) {
                 throw new EngineError(
                     `Task "${node.task}" at "${nodeId}" has never-output schema but returned ok.`,
+                    "UNRECOVERABLE_ERROR",
+                    true,
                 );
             }
 
-            // Runtime output schema validation.
+            // Runtime output schema validation (essential check §5.8.1 — always runs).
             if (node.outputSchema) {
                 const validate = this.getValidator(node.outputSchema);
                 if (!validate(result.output)) {
                     const msg = this.ajv.errorsText(validate.errors);
                     throw new EngineError(
                         `Output schema violation at "${nodeId}" (task "${node.task}"): ${msg}`,
+                        "RUNTIME_ERROR",
                     );
                 }
             }
@@ -825,7 +868,10 @@ export class WorkflowEngine {
 
             return node.next;
         } catch (err) {
-            if (node.onError) {
+            if (
+                node.onError &&
+                !(err instanceof EngineError && err.unrecoverable)
+            ) {
                 const errorObj = buildErrorObject(
                     err,
                     node.task,
@@ -847,7 +893,7 @@ export class WorkflowEngine {
                 return node.onError;
             }
 
-            // No onError: propagate
+            // No onError (or unrecoverable): propagate
             if (err instanceof TaskFailure || err instanceof EngineError) {
                 throw err;
             }
@@ -874,10 +920,13 @@ export class WorkflowEngine {
         if (!next) {
             // For exhaustive branches (default omitted), this is unreachable
             // after static validation: the validator proves every selector
-            // value has a matching case. For non-exhaustive branches, this
-            // surfaces a legitimate runtime "BranchSelectorUnmatched" error.
+            // value has a matching case. For non-exhaustive branches, this is
+            // also unreachable because the validator requires a default. Either
+            // way this indicates a validator bypass — unrecoverable.
             throw new EngineError(
                 `Branch selector resolved to "${selector}" but no matching case or default exists`,
+                "UNRECOVERABLE_ERROR",
+                true,
             );
         }
         debug("branch selector=%s -> %s", selector, next);
@@ -1065,7 +1114,10 @@ export class WorkflowEngine {
                 `LoopMaxIterationsExceeded at "${nodeId}" (limit: ${maxIter})`,
             );
         } catch (err) {
-            if (node.onError) {
+            if (
+                node.onError &&
+                !(err instanceof EngineError && err.unrecoverable)
+            ) {
                 const errorObj = buildErrorObject(
                     err,
                     "loop",
@@ -1206,7 +1258,10 @@ export class WorkflowEngine {
 
             return node.next;
         } catch (err) {
-            if (node.onError) {
+            if (
+                node.onError &&
+                !(err instanceof EngineError && err.unrecoverable)
+            ) {
                 const errorObj = buildErrorObject(
                     err,
                     "fork",
@@ -1360,7 +1415,10 @@ export class WorkflowEngine {
 
             return node.next;
         } catch (err) {
-            if (node.onError) {
+            if (
+                node.onError &&
+                !(err instanceof EngineError && err.unrecoverable)
+            ) {
                 const errorObj = buildErrorObject(
                     err,
                     "forkMap",
@@ -1403,7 +1461,7 @@ function buildErrorObject(
         };
     }
     return {
-        code: "RUNTIME_ERROR",
+        code: err instanceof EngineError ? err.code : "RUNTIME_ERROR",
         message: err instanceof Error ? err.message : String(err),
         source: "runtime",
         task: taskName,

--- a/ts/examples/workflow/engine/src/runner.ts
+++ b/ts/examples/workflow/engine/src/runner.ts
@@ -38,16 +38,16 @@ interface ScopeContext {
     bindings: Map<string, unknown>;
     /** The state namespace ($from: "state") - only set inside loop bodies. */
     state?: Record<string, unknown>;
+    /** Whether defense-in-depth checks are enabled. */
+    defenseInDepth: boolean;
 }
 
 // ---- Template resolution ----
 // Defense-in-depth: all error throws below (unknown namespace, unresolved
-// reference, path projection failures) are unreachable when static
-// validation has passed — the dominator analysis with onError-split
-// coverage (§4.1) proves binding availability on all paths, and
-// checkSchemaCompat verifies path projections against declared schemas.
-// These guards remain unconditional because template resolution must
-// execute to produce values; they cannot be skipped like schema checks.
+// reference, path projection failures) are gated on scope.defenseInDepth.
+// The static validator's dominator analysis with onError-split coverage
+// (§4.1) proves binding availability on all paths, and checkSchemaCompat
+// verifies path projections against declared schemas.
 
 /**
  * Recursively evaluate a template against a scope context.
@@ -113,14 +113,24 @@ function resolveFromRef(
             value = scope.state?.[name];
             break;
         default:
-            throw new EngineError(`Unknown $from namespace: "${from}"`);
+            // Defense-in-depth: static validator's template pass checks
+            // that $from namespaces are valid (input, constant, scope, state).
+            if (scope.defenseInDepth) {
+                throw new EngineError(
+                    `Unknown $from namespace: "${from}"`,
+                );
+            }
     }
 
     if (value === undefined) {
         if (optional) return null;
-        throw new EngineError(
-            `Reference unresolved: $from "${from}", name "${name}"`,
-        );
+        // Defense-in-depth: static validator's dominator pass with
+        // onError-split coverage proves binding availability on all paths.
+        if (scope.defenseInDepth) {
+            throw new EngineError(
+                `Reference unresolved: $from "${from}", name "${name}"`,
+            );
+        }
     }
 
     // Path projection (RFC 6901 semantics)
@@ -128,24 +138,32 @@ function resolveFromRef(
         for (const segment of path) {
             if (value === null || value === undefined) {
                 if (optional) return null;
-                throw new EngineError(
-                    `Path projection failed at "${segment}" on null/undefined`,
-                );
+                // Defense-in-depth: static type-compat + resolveSchemaPath
+                // verifies path segments against declared schemas.
+                if (scope.defenseInDepth) {
+                    throw new EngineError(
+                        `Path projection failed at "${segment}" on null/undefined`,
+                    );
+                }
             }
             if (typeof segment === "number") {
                 if (!Array.isArray(value)) {
                     if (optional) return null;
-                    throw new EngineError(
-                        `Path projection: expected array at index ${segment}`,
-                    );
+                    if (scope.defenseInDepth) {
+                        throw new EngineError(
+                            `Path projection: expected array at index ${segment}`,
+                        );
+                    }
                 }
                 value = (value as unknown[])[segment];
             } else {
                 if (typeof value !== "object" || Array.isArray(value)) {
                     if (optional) return null;
-                    throw new EngineError(
-                        `Path projection: expected object at key "${segment}"`,
-                    );
+                    if (scope.defenseInDepth) {
+                        throw new EngineError(
+                            `Path projection: expected object at key "${segment}"`,
+                        );
+                    }
                 }
                 value = (value as Record<string, unknown>)[segment];
             }
@@ -369,6 +387,7 @@ export class WorkflowEngine {
             input: input ?? {},
             constants,
             bindings: new Map(),
+            defenseInDepth,
         };
 
         const scopePath = [ir.name];
@@ -960,6 +979,7 @@ export class WorkflowEngine {
                     constants: outerScope.constants,
                     bindings: new Map(),
                     state: { ...state },
+                    defenseInDepth: outerScope.defenseInDepth,
                 };
 
                 // Execute body
@@ -1139,6 +1159,7 @@ export class WorkflowEngine {
                     input: branchInput,
                     constants: outerScope.constants,
                     bindings: new Map(),
+                    defenseInDepth: outerScope.defenseInDepth,
                 };
                 const branchScopePath = [...scopePath, `${nodeId}.${bName}`];
                 await this.executeScope(
@@ -1297,6 +1318,7 @@ export class WorkflowEngine {
                     input: itemInput,
                     constants: outerScope.constants,
                     bindings: new Map(),
+                    defenseInDepth: outerScope.defenseInDepth,
                 };
                 const itemScopePath = [...scopePath, `${nodeId}[${index}]`];
                 await this.executeScope(

--- a/ts/examples/workflow/engine/src/runner.ts
+++ b/ts/examples/workflow/engine/src/runner.ts
@@ -864,7 +864,7 @@ export class WorkflowEngine {
         node: {
             selector: Template;
             cases: Record<string, string>;
-            default: string;
+            default?: string;
         },
         scope: ScopeContext,
     ): string {
@@ -872,6 +872,10 @@ export class WorkflowEngine {
         const selector = String(raw);
         const next = node.cases[selector] ?? node.default;
         if (!next) {
+            // For exhaustive branches (default omitted), this is unreachable
+            // after static validation: the validator proves every selector
+            // value has a matching case. For non-exhaustive branches, this
+            // surfaces a legitimate runtime "BranchSelectorUnmatched" error.
             throw new EngineError(
                 `Branch selector resolved to "${selector}" but no matching case or default exists`,
             );

--- a/ts/examples/workflow/engine/src/runner.ts
+++ b/ts/examples/workflow/engine/src/runner.ts
@@ -187,7 +187,7 @@ function resolveFromRef(
  *   BranchSelectorUnmatched, unknown namespace, invalid IR structure).
  *   These bypass onError handlers.
  */
-type EngineErrorCode =
+type EngineErrorKind =
     | "TaskError"
     | "RuntimeError"
     | "LoopMaxIterationsExceeded"
@@ -195,18 +195,18 @@ type EngineErrorCode =
     | "UnrecoverableError";
 
 class EngineError extends Error {
-    readonly code: EngineErrorCode;
+    readonly kind: EngineErrorKind;
     /** When true, this error bypasses onError handlers. */
     readonly unrecoverable: boolean;
 
     constructor(
         message: string,
-        code: EngineErrorCode = "RuntimeError",
+        kind: EngineErrorKind = "RuntimeError",
         unrecoverable = false,
     ) {
         super(message);
         this.name = "EngineError";
-        this.code = code;
+        this.kind = kind;
         this.unrecoverable = unrecoverable;
     }
 }
@@ -1455,7 +1455,7 @@ function buildErrorObject(
 ): Record<string, unknown> {
     if (err instanceof TaskFailure) {
         return {
-            code: "TaskError",
+            kind: "TaskError",
             message: err.taskError.message,
             source: "task",
             task: err.taskName,
@@ -1465,7 +1465,7 @@ function buildErrorObject(
         };
     }
     return {
-        code: err instanceof EngineError ? err.code : "RuntimeError",
+        kind: err instanceof EngineError ? err.kind : "RuntimeError",
         message: err instanceof Error ? err.message : String(err),
         source: "runtime",
         task: taskName,

--- a/ts/examples/workflow/engine/src/runner.ts
+++ b/ts/examples/workflow/engine/src/runner.ts
@@ -41,6 +41,13 @@ interface ScopeContext {
 }
 
 // ---- Template resolution ----
+// Defense-in-depth: all error throws below (unknown namespace, unresolved
+// reference, path projection failures) are unreachable when static
+// validation has passed — the dominator analysis with onError-split
+// coverage (§4.1) proves binding availability on all paths, and
+// checkSchemaCompat verifies path projections against declared schemas.
+// These guards remain unconditional because template resolution must
+// execute to produce values; they cannot be skipped like schema checks.
 
 /**
  * Recursively evaluate a template against a scope context.

--- a/ts/examples/workflow/engine/src/runner.ts
+++ b/ts/examples/workflow/engine/src/runner.ts
@@ -1242,12 +1242,9 @@ export class WorkflowEngine {
         taskTimeoutMs?: number,
         constraints?: TaskConstraints,
     ): Promise<string | undefined> {
-        // Defense-in-depth: static validator already checks forkMap state refs.
-        if (this.defenseInDepth && containsStateRef(node.body)) {
-            throw new EngineError(
-                `forkMap "${nodeId}": body must not reference $from "state" (forkMap has no state; use loop for stateful iteration)`,
-            );
-        }
+        // Note: $from "state" refs in forkMap bodies are rejected statically
+        // by the scope-closure check; at runtime they would surface as
+        // "Unresolved reference" since item scope has no state.
 
         this.emit({
             type: "nodeStarted",
@@ -1409,31 +1406,4 @@ function buildErrorObject(
         node: nodeId,
         scopePath: [...scopePath],
     };
-}
-
-/**
- * Recursively check whether any template in a WorkflowScope contains
- * `$from: "state"` references. Used to reject state refs in forkMap bodies.
- */
-function containsStateRef(scope: {
-    nodes: Record<string, WorkflowNode>;
-    output: Template;
-}): boolean {
-    function checkTemplate(t: Template): boolean {
-        if (t === null || t === undefined || typeof t !== "object") return false;
-        if (Array.isArray(t)) return t.some(checkTemplate);
-        const obj = t as Record<string, unknown>;
-        if (obj["$from"] === "state") return true;
-        if ("$literal" in obj) return false;
-        return Object.values(obj).some((v) => checkTemplate(v as Template));
-    }
-    for (const node of Object.values(scope.nodes)) {
-        if ("inputs" in node && node.inputs) {
-            if (checkTemplate(node.inputs as Template)) return true;
-        }
-        if ("selector" in node) {
-            if (checkTemplate(node.selector as Template)) return true;
-        }
-    }
-    return checkTemplate(scope.output);
 }

--- a/ts/examples/workflow/engine/src/runner.ts
+++ b/ts/examples/workflow/engine/src/runner.ts
@@ -223,6 +223,14 @@ export interface RunOptions {
      * intentionally exercise invalid IRs for error-path coverage.
      */
     skipValidation?: boolean;
+    /**
+     * Enable defense-in-depth runtime checks that duplicate static validation.
+     * When true (the default), the engine re-checks invariants already proven
+     * by the static validator (e.g. constant schema conformance, fork min-2
+     * branches, forkMap state-ref rejection). Disable for performance if you
+     * trust the static validator has run.
+     */
+    defenseInDepth?: boolean;
 }
 
 export interface RunResult {
@@ -241,6 +249,7 @@ export class WorkflowEngine {
         string,
         ReturnType<typeof this.ajv.compile>
     >();
+    private defenseInDepth = true;
 
     constructor(private readonly registry: TaskRegistry) {}
 
@@ -280,6 +289,8 @@ export class WorkflowEngine {
         const approve = options?.approve;
         const abortSignalArg = options?.signal;
         const constraints = options?.constraints;
+        const defenseInDepth = options?.defenseInDepth ?? true;
+        this.defenseInDepth = defenseInDepth;
 
         // Default timeout: 60 seconds. 0 or Infinity disables.
         const DEFAULT_TIMEOUT_MS = 60_000;
@@ -327,9 +338,11 @@ export class WorkflowEngine {
         }
 
         // Build constants, validating each against its declared schema.
+        // Defense-in-depth: static validator already checks this via
+        // jsonValueToSchema + isStructuralSubtype.
         const constants = new Map<string, unknown>();
         for (const [name, def] of Object.entries(ir.constants ?? {})) {
-            if (def.schema) {
+            if (this.defenseInDepth && def.schema) {
                 const validate = this.getValidator(def.schema);
                 if (!validate(def.value)) {
                     const msg = this.ajv.errorsText(validate.errors);
@@ -1057,7 +1070,8 @@ export class WorkflowEngine {
     ): Promise<string | undefined> {
         const branchNames = Object.keys(node.branches);
 
-        if (branchNames.length < 2) {
+        // Defense-in-depth: static validator already checks fork min-2 branches.
+        if (this.defenseInDepth && branchNames.length < 2) {
             throw new EngineError(
                 `Fork "${nodeId}" must have at least 2 branches, got ${branchNames.length}`,
             );
@@ -1195,8 +1209,8 @@ export class WorkflowEngine {
         taskTimeoutMs?: number,
         constraints?: TaskConstraints,
     ): Promise<string | undefined> {
-        // Reject $from: "state" in forkMap bodies (v0.2 §2.2 validation)
-        if (containsStateRef(node.body)) {
+        // Defense-in-depth: static validator already checks forkMap state refs.
+        if (this.defenseInDepth && containsStateRef(node.body)) {
             throw new EngineError(
                 `forkMap "${nodeId}": body must not reference $from "state" (forkMap has no state; use loop for stateful iteration)`,
             );

--- a/ts/examples/workflow/engine/src/runner.ts
+++ b/ts/examples/workflow/engine/src/runner.ts
@@ -179,8 +179,9 @@ function resolveFromRef(
  * Well-known engine-level error codes.
  * - "TASK_ERROR": a registered task returned {kind:"fail"} or threw.
  * - "RUNTIME_ERROR": the engine raised a recoverable runtime condition
- *   (LoopMaxIterationsExceeded, OutputSchemaViolation, policy/approval,
- *   timeout, cancellation).
+ *   (policy/approval, timeout, cancellation).
+ * - "LoopMaxIterationsExceeded": loop hit its maxIterations cap (recoverable).
+ * - "OutputSchemaViolation": task returned a value that failed outputSchema (recoverable).
  * - "UNRECOVERABLE_ERROR": the engine raised a condition that is
  *   statically unreachable after validation (ReferenceUnresolved,
  *   BranchSelectorUnmatched, unknown namespace, invalid IR structure).
@@ -189,6 +190,8 @@ function resolveFromRef(
 type EngineErrorCode =
     | "TASK_ERROR"
     | "RUNTIME_ERROR"
+    | "LoopMaxIterationsExceeded"
+    | "OutputSchemaViolation"
     | "UNRECOVERABLE_ERROR";
 
 class EngineError extends Error {
@@ -847,7 +850,7 @@ export class WorkflowEngine {
                     const msg = this.ajv.errorsText(validate.errors);
                     throw new EngineError(
                         `Output schema violation at "${nodeId}" (task "${node.task}"): ${msg}`,
-                        "RUNTIME_ERROR",
+                        "OutputSchemaViolation",
                     );
                 }
             }
@@ -1112,6 +1115,7 @@ export class WorkflowEngine {
 
             throw new EngineError(
                 `LoopMaxIterationsExceeded at "${nodeId}" (limit: ${maxIter})`,
+                "LoopMaxIterationsExceeded",
             );
         } catch (err) {
             if (

--- a/ts/examples/workflow/engine/test/engine.spec.ts
+++ b/ts/examples/workflow/engine/test/engine.spec.ts
@@ -4808,7 +4808,7 @@ describe("WorkflowEngine (IR v1)", () => {
             expect(result.success).toBe(true);
             const errorObj = (result.output as any).error;
             expect(errorObj).toBeDefined();
-            expect(errorObj.code).toBe("TaskError");
+            expect(errorObj.kind).toBe("TaskError");
             expect(errorObj.message).toBe("broken");
             expect(errorObj.source).toBe("task");
             expect(errorObj.task).toBe("test.fail");
@@ -4885,7 +4885,7 @@ describe("WorkflowEngine (IR v1)", () => {
             const result = await eng.run(ir, { input: {} });
             expect(result.success).toBe(true);
             const errorObj = (result.output as any).error;
-            expect(errorObj.code).toBe("RuntimeError");
+            expect(errorObj.kind).toBe("RuntimeError");
             expect(errorObj.message).toBe("unexpected crash");
             expect(errorObj.source).toBe("runtime");
         });

--- a/ts/examples/workflow/engine/test/engine.spec.ts
+++ b/ts/examples/workflow/engine/test/engine.spec.ts
@@ -4889,6 +4889,58 @@ describe("WorkflowEngine (IR v1)", () => {
             expect(errorObj.message).toBe("unexpected crash");
             expect(errorObj.source).toBe("runtime");
         });
+
+        it("unrecoverable engine errors bypass onError and fail the run", async () => {
+            // Simulate a validator-bypass scenario by constructing IR where the
+            // branch has no matching case and no default (should be caught by
+            // the validator, but we skip validation here).
+            const reg = makeRegistry(...allBuiltinTasks);
+            const eng = new WorkflowEngine(reg);
+
+            const ir: WorkflowIR = {
+                kind: "workflow",
+                name: "unrecoverable",
+                version: "1",
+                inputSchema: { type: "object" },
+                outputSchema: {},
+                nodes: {
+                    branch: {
+                        kind: "branch",
+                        selector: { $from: "input", name: "x" } as Template,
+                        selectorSchema: { type: "string" },
+                        cases: { a: "done" },
+                        // no default — any value other than "a" is unmatched
+                    } as any,
+                    done: {
+                        kind: "task",
+                        task: "identity",
+                        inputSchema: { type: "object" },
+                        outputSchema: {},
+                        inputs: {},
+                        bind: "result",
+                    },
+                    recover: {
+                        kind: "task",
+                        task: "identity",
+                        inputSchema: { type: "object" },
+                        outputSchema: {},
+                        inputs: {},
+                        bind: "result",
+                    },
+                },
+                entry: "branch",
+                output: { $from: "scope", name: "result" } as Template,
+            };
+
+            // Even if the branch node had an onError, unrecoverable errors bypass it.
+            // Here we just confirm the run fails (not recovers silently).
+            const result = await eng.run(ir, {
+                input: { x: "z" },
+                skipValidation: true,
+            });
+            expect(result.success).toBe(false);
+            expect(result.error?.message).toContain("no matching case or default");
+        });
     });
 
     describe("static schema type checking", () => {

--- a/ts/examples/workflow/engine/test/engine.spec.ts
+++ b/ts/examples/workflow/engine/test/engine.spec.ts
@@ -4815,7 +4815,7 @@ describe("WorkflowEngine (IR v1)", () => {
             expect(errorObj.node).toBe("step");
         });
 
-        it("runtime errors have RUNTIME_ERROR code", async () => {
+        it("runtime errors have RuntimeError kind", async () => {
             const throwTask: TaskDefinition = {
                 name: "test.throw",
                 sideEffects: false,

--- a/ts/examples/workflow/engine/test/engine.spec.ts
+++ b/ts/examples/workflow/engine/test/engine.spec.ts
@@ -3354,7 +3354,7 @@ describe("WorkflowEngine (IR v1)", () => {
             expect(result.success).toBe(false);
             expect(result.error?.message).toContain("Constant");
             expect(result.error?.message).toContain("limit");
-            expect(result.error?.message).toContain("schema violation");
+            expect(result.error?.message).toContain("schema");
         });
 
         it("passes when constant matches its declared schema", async () => {

--- a/ts/examples/workflow/engine/test/engine.spec.ts
+++ b/ts/examples/workflow/engine/test/engine.spec.ts
@@ -6352,6 +6352,72 @@ describe("WorkflowEngine (IR v1)", () => {
             expect(out.b).toBeDefined();
         });
 
+        it("rejects fork with fewer than 2 branches at runtime", async () => {
+            const reg = new TaskRegistry();
+            for (const t of allBuiltinTasks) reg.register(t);
+            reg.register({
+                name: "mock.only",
+                sideEffects: false,
+                inputSchema: { type: "object" },
+                outputSchema: { type: "object" },
+                async execute() {
+                    return { kind: "ok", output: {} };
+                },
+            });
+
+            const eng = new WorkflowEngine(reg);
+            const ir: WorkflowIR = {
+                kind: "workflow",
+                name: "fork-min2-test",
+                version: "1",
+                inputSchema: { type: "object" },
+                outputSchema: {},
+                entry: "fork_0",
+                nodes: {
+                    fork_0: {
+                        kind: "fork",
+                        branches: {
+                            only: {
+                                inputs: {},
+                                scope: {
+                                    inputSchema: {},
+                                    entry: "only_step",
+                                    nodes: {
+                                        only_step: {
+                                            kind: "task",
+                                            task: "mock.only",
+                                            inputSchema: { type: "object" },
+                                            outputSchema: { type: "object" },
+                                            inputs: {},
+                                            bind: "onlyOut",
+                                        },
+                                    },
+                                    output: {
+                                        $from: "scope",
+                                        name: "onlyOut",
+                                    },
+                                    outputSchema: { type: "object" },
+                                },
+                            },
+                        },
+                        outputSchema: { type: "object" },
+                        bind: "forkResult",
+                    },
+                },
+                output: { $from: "scope", name: "forkResult" },
+            };
+
+            const result = await eng.run(ir, {
+                input: {},
+                policy: allowAllPolicy,
+                skipValidation: true,
+            });
+            expect(result.success).toBe(false);
+            expect(result.error?.message).toMatch(
+                /must have at least 2 branches/,
+            );
+        });
+
         it("respects maxConcurrency", async () => {
             const reg = new TaskRegistry();
             for (const t of allBuiltinTasks) reg.register(t);

--- a/ts/examples/workflow/engine/test/engine.spec.ts
+++ b/ts/examples/workflow/engine/test/engine.spec.ts
@@ -4939,7 +4939,9 @@ describe("WorkflowEngine (IR v1)", () => {
                 skipValidation: true,
             });
             expect(result.success).toBe(false);
-            expect(result.error?.message).toContain("no matching case or default");
+            expect(result.error?.message).toContain(
+                "no matching case or default",
+            );
         });
     });
 

--- a/ts/examples/workflow/engine/test/engine.spec.ts
+++ b/ts/examples/workflow/engine/test/engine.spec.ts
@@ -4808,7 +4808,7 @@ describe("WorkflowEngine (IR v1)", () => {
             expect(result.success).toBe(true);
             const errorObj = (result.output as any).error;
             expect(errorObj).toBeDefined();
-            expect(errorObj.code).toBe("TASK_ERROR");
+            expect(errorObj.code).toBe("TaskError");
             expect(errorObj.message).toBe("broken");
             expect(errorObj.source).toBe("task");
             expect(errorObj.task).toBe("test.fail");
@@ -4885,7 +4885,7 @@ describe("WorkflowEngine (IR v1)", () => {
             const result = await eng.run(ir, { input: {} });
             expect(result.success).toBe(true);
             const errorObj = (result.output as any).error;
-            expect(errorObj.code).toBe("RUNTIME_ERROR");
+            expect(errorObj.code).toBe("RuntimeError");
             expect(errorObj.message).toBe("unexpected crash");
             expect(errorObj.source).toBe("runtime");
         });

--- a/ts/examples/workflow/model/src/ir.ts
+++ b/ts/examples/workflow/model/src/ir.ts
@@ -48,7 +48,16 @@ export interface BranchNode {
     selector: Template;
     selectorSchema: JSONSchema;
     cases: Record<string, string>;
-    default: string;
+    /**
+     * Target when selector matches no case.
+     *
+     * If omitted, the branch must be **exhaustive**: `selectorSchema` must
+     * declare an `enum` and every value in the enum must have a matching
+     * case key. Additionally the selector's resolved type must be provably
+     * narrowed to a subset of the enum. The static validator rejects
+     * non-exhaustive branches that omit `default`.
+     */
+    default?: string;
 }
 
 export interface LoopStateVar {

--- a/ts/examples/workflow/model/src/validate.ts
+++ b/ts/examples/workflow/model/src/validate.ts
@@ -76,6 +76,24 @@ export function validateWorkflowIR(
         });
     }
 
+    // Validate constant values against their declared schemas.
+    if (ir.constants) {
+        for (const [name, def] of Object.entries(ir.constants)) {
+            if (def.schema) {
+                const valueSchema = jsonValueToSchema(def.value);
+                if (!isStructuralSubtype(valueSchema, def.schema)) {
+                    errors.push({
+                        path: `constants.${name}`,
+                        message:
+                            `Constant value type ${formatSchemaType(valueSchema)} ` +
+                            `is not compatible with declared schema ` +
+                            `${formatSchemaType(def.schema)}.`,
+                    });
+                }
+            }
+        }
+    }
+
     validateScope(ir.nodes, "nodes", tasks, errors, false);
 
     // Static schema compatibility for the top-level scope.

--- a/ts/examples/workflow/model/src/validate.ts
+++ b/ts/examples/workflow/model/src/validate.ts
@@ -2420,7 +2420,25 @@ function checkReservedTemplateKeys(
         }
     }
     // Don't recurse into $from or $literal — they have their own semantics.
-    if ("$from" in obj || "$literal" in obj) return;
+    if ("$from" in obj) {
+        const VALID_NAMESPACES = new Set([
+            "input",
+            "constant",
+            "scope",
+            "state",
+        ]);
+        const from = obj["$from"];
+        if (typeof from !== "string" || !VALID_NAMESPACES.has(from)) {
+            errors.push({
+                path: templatePath,
+                message:
+                    `Unknown $from namespace "${from}". ` +
+                    `Valid namespaces are: input, constant, scope, state.`,
+            });
+        }
+        return;
+    }
+    if ("$literal" in obj) return;
     for (const [, value] of Object.entries(obj)) {
         checkReservedTemplateKeys(value as Template, templatePath, errors);
     }

--- a/ts/examples/workflow/model/src/validate.ts
+++ b/ts/examples/workflow/model/src/validate.ts
@@ -2024,6 +2024,12 @@ function isProvablyNarrowedTo(
     if (producer.const !== undefined) return allowed.has(producer.const);
     if (producer.enum) return producer.enum.every((v) => allowed.has(v));
 
+    // Boolean is inherently a closed set {true, false}; treat it as
+    // implicitly enum-typed.
+    if (producer.type === "boolean") {
+        return allowed.has(true) && allowed.has(false);
+    }
+
     // Recurse into union variants — every variant must be narrowed.
     const variants = producer.anyOf ?? producer.oneOf;
     if (variants) {

--- a/ts/examples/workflow/model/src/validate.ts
+++ b/ts/examples/workflow/model/src/validate.ts
@@ -2161,7 +2161,13 @@ function validateTypeCompatibility(
             // Exhaustiveness: when `default` is omitted, the branch must
             // be statically provable to cover every possible selector value.
             if (node.default === undefined) {
-                const enumValues = node.selectorSchema.enum;
+                // { type: "boolean" } is treated as an implicit enum [true, false].
+                const isBooleanSelector =
+                    node.selectorSchema.type === "boolean" &&
+                    !node.selectorSchema.enum;
+                const enumValues = isBooleanSelector
+                    ? [true, false]
+                    : node.selectorSchema.enum;
                 if (!enumValues || enumValues.length === 0) {
                     errors.push({
                         path: `${path}.default`,

--- a/ts/examples/workflow/model/src/validate.ts
+++ b/ts/examples/workflow/model/src/validate.ts
@@ -1783,13 +1783,15 @@ function resolveTemplateType(
     ctx: TypeResolutionContext,
 ): JSONSchema | undefined {
     if (template === null) return { type: "null" };
-    if (typeof template === "string") return { type: "string", const: template };
+    if (typeof template === "string")
+        return { type: "string", const: template };
     if (typeof template === "number") {
         return Number.isInteger(template)
             ? { type: "integer", const: template }
             : { type: "number", const: template };
     }
-    if (typeof template === "boolean") return { type: "boolean", const: template };
+    if (typeof template === "boolean")
+        return { type: "boolean", const: template };
     if (Array.isArray(template)) {
         const elemSchemas = template
             .map((e) => resolveTemplateType(e, ctx))
@@ -2035,7 +2037,8 @@ function isProvablyNarrowedTo(
     if (variants) {
         return variants.every(
             (v) =>
-                typeof v !== "boolean" && isProvablyNarrowedTo(v, allowedValues),
+                typeof v !== "boolean" &&
+                isProvablyNarrowedTo(v, allowedValues),
         );
     }
     return false;

--- a/ts/examples/workflow/model/src/validate.ts
+++ b/ts/examples/workflow/model/src/validate.ts
@@ -1783,13 +1783,13 @@ function resolveTemplateType(
     ctx: TypeResolutionContext,
 ): JSONSchema | undefined {
     if (template === null) return { type: "null" };
-    if (typeof template === "string") return { type: "string" };
+    if (typeof template === "string") return { type: "string", const: template };
     if (typeof template === "number") {
         return Number.isInteger(template)
-            ? { type: "integer" }
-            : { type: "number" };
+            ? { type: "integer", const: template }
+            : { type: "number", const: template };
     }
-    if (typeof template === "boolean") return { type: "boolean" };
+    if (typeof template === "boolean") return { type: "boolean", const: template };
     if (Array.isArray(template)) {
         const elemSchemas = template
             .map((e) => resolveTemplateType(e, ctx))

--- a/ts/examples/workflow/model/src/validate.ts
+++ b/ts/examples/workflow/model/src/validate.ts
@@ -207,10 +207,12 @@ function buildScopeCFG(
                     succs.add(target);
                 }
             }
-            if (isSentinel(node.default)) {
-                addSentinel(id, node.default);
-            } else {
-                succs.add(node.default);
+            if (node.default !== undefined) {
+                if (isSentinel(node.default)) {
+                    addSentinel(id, node.default);
+                } else {
+                    succs.add(node.default);
+                }
             }
         } else if (isBindableNode(node)) {
             if (node.next) {
@@ -950,7 +952,7 @@ function validateOnErrorRules(
                     normalTargets.add(target);
                 }
             }
-            if (!isSentinel(node.default)) {
+            if (node.default !== undefined && !isSentinel(node.default)) {
                 normalTargets.add(node.default);
             }
         }
@@ -1262,18 +1264,20 @@ function validateScope(
                     });
                 }
             }
-            if (isSentinel(node.default)) {
-                if (!insideLoop) {
+            if (node.default !== undefined) {
+                if (isSentinel(node.default)) {
+                    if (!insideLoop) {
+                        errors.push({
+                            path: `${path}.default`,
+                            message: `Sentinel "${node.default}" is only valid inside a loop body.`,
+                        });
+                    }
+                } else if (!nodeIds.has(node.default)) {
                     errors.push({
                         path: `${path}.default`,
-                        message: `Sentinel "${node.default}" is only valid inside a loop body.`,
+                        message: `Default target "${node.default}" does not exist.`,
                     });
                 }
-            } else if (!nodeIds.has(node.default)) {
-                errors.push({
-                    path: `${path}.default`,
-                    message: `Default target "${node.default}" does not exist.`,
-                });
             }
         } else if (node.kind === "loop") {
             if (!(node.body.entry in node.body.nodes)) {
@@ -1470,7 +1474,7 @@ function bodyScopeHasSentinel(nodes: Record<string, WorkflowNode>): boolean {
             for (const target of Object.values(node.cases)) {
                 if (isSentinel(target)) return true;
             }
-            if (isSentinel(node.default)) {
+            if (node.default !== undefined && isSentinel(node.default)) {
                 return true;
             }
         } else if (node.kind === "task") {
@@ -1736,13 +1740,13 @@ interface TypeResolutionContext {
 /** Derive a JSON Schema from a literal JSON value. */
 function jsonValueToSchema(value: unknown): JSONSchema {
     if (value === null) return { type: "null" };
-    if (typeof value === "string") return { type: "string" };
+    if (typeof value === "string") return { type: "string", const: value };
     if (typeof value === "number") {
         return Number.isInteger(value)
-            ? { type: "integer" }
-            : { type: "number" };
+            ? { type: "integer", const: value }
+            : { type: "number", const: value };
     }
-    if (typeof value === "boolean") return { type: "boolean" };
+    if (typeof value === "boolean") return { type: "boolean", const: value };
     if (Array.isArray(value)) {
         if (value.length === 0) return { type: "array" };
         const elemSchemas = value.map(jsonValueToSchema);
@@ -1896,6 +1900,30 @@ function isStructuralSubtype(
         );
     }
 
+    // Const / enum narrowing checks.
+    // Only applied when both sides have const/enum constraints. When the
+    // producer is wider (no const/enum), we stay lenient — narrowing is
+    // verified by runtime input/selectorSchema validation. Exhaustiveness
+    // checking uses isProvablyNarrowedTo (see below) for strict subset.
+    if (consumer.const !== undefined) {
+        if (producer.const !== undefined) {
+            return producer.const === consumer.const;
+        }
+        if (producer.enum) {
+            return producer.enum.every((v) => v === consumer.const);
+        }
+        // Producer is wider; stay lenient (defense-in-depth at runtime).
+    } else if (consumer.enum) {
+        const allowed = new Set(consumer.enum);
+        if (producer.const !== undefined) {
+            return allowed.has(producer.const);
+        }
+        if (producer.enum) {
+            return producer.enum.every((v) => allowed.has(v));
+        }
+        // Producer is wider; stay lenient (defense-in-depth at runtime).
+    }
+
     // Handle allOf: intersection semantics.
     if (producer.allOf) {
         // Producer satisfies every allOf member simultaneously (intersection).
@@ -1973,6 +2001,38 @@ function isStructuralSubtype(
     }
 
     return true;
+}
+
+/**
+ * Strict narrowing check used by exhaustive branch verification.
+ *
+ * Returns true iff `producer` is provably constrained to a subset of
+ * `allowedValues`. Unlike `isStructuralSubtype` which stays lenient when
+ * the producer is wider than a constraint, this function requires the
+ * producer to have an explicit `const` or `enum` whose values all fall
+ * within `allowedValues`.
+ *
+ * Used when `default` is absent on a branch: the selector's resolved
+ * type must be statically narrowed so the engine can prove every
+ * possible value has a matching case.
+ */
+function isProvablyNarrowedTo(
+    producer: JSONSchema,
+    allowedValues: ReadonlyArray<unknown>,
+): boolean {
+    const allowed = new Set(allowedValues);
+    if (producer.const !== undefined) return allowed.has(producer.const);
+    if (producer.enum) return producer.enum.every((v) => allowed.has(v));
+
+    // Recurse into union variants — every variant must be narrowed.
+    const variants = producer.anyOf ?? producer.oneOf;
+    if (variants) {
+        return variants.every(
+            (v) =>
+                typeof v !== "boolean" && isProvablyNarrowedTo(v, allowedValues),
+        );
+    }
+    return false;
 }
 
 /**
@@ -2088,6 +2148,58 @@ function validateTypeCompatibility(
                                 `value in selectorSchema.enum ` +
                                 `${JSON.stringify(node.selectorSchema.enum)}.`,
                         });
+                    }
+                }
+            }
+
+            // Exhaustiveness: when `default` is omitted, the branch must
+            // be statically provable to cover every possible selector value.
+            if (node.default === undefined) {
+                const enumValues = node.selectorSchema.enum;
+                if (!enumValues || enumValues.length === 0) {
+                    errors.push({
+                        path: `${path}.default`,
+                        message:
+                            `Branch has no default but selectorSchema is ` +
+                            `not a closed enum (selectorSchema: ` +
+                            `${formatSchemaType(node.selectorSchema)}). ` +
+                            `Fix: add a default target, or declare ` +
+                            `selectorSchema with an "enum" constraint.`,
+                    });
+                } else {
+                    // Every enum value must have a matching case key.
+                    const caseKeys = new Set(Object.keys(node.cases));
+                    const missing = enumValues
+                        .map(String)
+                        .filter((v) => !caseKeys.has(v));
+                    if (missing.length > 0) {
+                        errors.push({
+                            path: `${path}.cases`,
+                            message:
+                                `Branch has no default and is not ` +
+                                `exhaustive. Missing case(s): ` +
+                                `${JSON.stringify(missing)}. ` +
+                                `Fix: add a case for each missing value, ` +
+                                `or add a default target.`,
+                        });
+                    }
+                    // Selector must be statically narrowed to the enum.
+                    if (selectorType) {
+                        if (!isProvablyNarrowedTo(selectorType, enumValues)) {
+                            errors.push({
+                                path: `${path}.selector`,
+                                message:
+                                    `Branch has no default but selector ` +
+                                    `resolved type ` +
+                                    `${formatSchemaType(selectorType)} is ` +
+                                    `not statically narrowed to the enum ` +
+                                    `${JSON.stringify(enumValues)}. ` +
+                                    `Fix: narrow the selector's upstream ` +
+                                    `type (declare an "enum" on the ` +
+                                    `producing task output / constant), ` +
+                                    `or add a default target.`,
+                            });
+                        }
                     }
                 }
             }

--- a/ts/examples/workflow/model/test/validate.spec.ts
+++ b/ts/examples/workflow/model/test/validate.spec.ts
@@ -2642,6 +2642,83 @@ describe("validateWorkflowIR", () => {
             expect(result.valid).toBe(true);
         });
 
+        it("accepts exhaustive branch with literal string selector (no default)", () => {
+            // Selector is a string literal "yes" — resolveTemplateType must
+            // return { type: "string", const: "yes" } so isProvablyNarrowedTo
+            // can confirm the single-element enum is covered.
+            const ir = makeMinimalIR({
+                nodes: {
+                    start: {
+                        kind: "branch",
+                        selector: "yes",
+                        selectorSchema: { type: "string", enum: ["yes", "no"] },
+                        cases: { yes: "end", no: "end" },
+                        // no default — exhaustiveness must be inferred
+                    } as any,
+                    end: {
+                        kind: "task",
+                        task: "noop",
+                        inputSchema: { type: "object" },
+                        outputSchema: { type: "object" },
+                        inputs: {},
+                        bind: "out",
+                    },
+                },
+            });
+            const result = validateWorkflowIR(ir);
+            expect(result.valid).toBe(true);
+        });
+
+        it("accepts exhaustive branch with literal number selector (no default)", () => {
+            const ir = makeMinimalIR({
+                nodes: {
+                    start: {
+                        kind: "branch",
+                        selector: 42,
+                        selectorSchema: {
+                            type: "integer",
+                            enum: [42, 99],
+                        },
+                        cases: { 42: "end", 99: "end" },
+                    } as any,
+                    end: {
+                        kind: "task",
+                        task: "noop",
+                        inputSchema: { type: "object" },
+                        outputSchema: { type: "object" },
+                        inputs: {},
+                        bind: "out",
+                    },
+                },
+            });
+            const result = validateWorkflowIR(ir);
+            expect(result.valid).toBe(true);
+        });
+
+        it("accepts exhaustive branch with literal boolean selector (no default)", () => {
+            const ir = makeMinimalIR({
+                nodes: {
+                    start: {
+                        kind: "branch",
+                        selector: true,
+                        selectorSchema: { type: "boolean" },
+                        cases: { true: "end", false: "end" },
+                        // no default — boolean is implicitly [true, false]
+                    } as any,
+                    end: {
+                        kind: "task",
+                        task: "noop",
+                        inputSchema: { type: "object" },
+                        outputSchema: { type: "object" },
+                        inputs: {},
+                        bind: "out",
+                    },
+                },
+            });
+            const result = validateWorkflowIR(ir);
+            expect(result.valid).toBe(true);
+        });
+
         it("rejects workflow output type incompatible with outputSchema", () => {
             const ir = makeMinimalIR({
                 nodes: {


### PR DESCRIPTION
## Summary

This PR closes a set of gaps found during a systematic review of the workflow engine implementation against the IR v0.1 and v0.2 specs.

### Engine fixes (`runner.ts`)
- Fix fork/branch handling and enforce min-2 branches at runtime
- Add `LoopMaxIterationsExceeded` and `OutputSchemaViolation` error codes
- Add `UNRECOVERABLE_ERROR` code; unrecoverable errors now bypass `onError`
- Remove redundant `containsStateRef` pre-check from `forkMap`
- Gate defense-in-depth runtime checks behind a `defenseInDepth` flag (defaulted from `skipValidation`)
- Keep statically-proven cheap checks unconditional; separate template resolution into gated (§5.8.2) and unconditional (§5.8.3) categories

### Error type cleanup (`ir.ts`, `runner.ts`, `engine.spec.ts`)
- Rename `EngineErrorCode` -> `EngineErrorKind`, field `code` -> `kind`
- Standardize all values to PascalCase

### DSL emitter (`emitter.ts`, `emitter.spec.ts`)
- Emit exhaustive branches for switch/fork nodes (Phases 1-5)

### Static validator (`validate.ts`, `validate.spec.ts`)
- Add constant value validation
- Remove `onError` from `BranchNode` spec (R1)

### Spec / docs
- `ir-v0.1.md`: categorize runtime checks in §5.8
- `ir-v0.2.md`: update §2.1 to match nested `ForkBranch` shape (R2), update §3.8.1 error codes (R3)
- `dsl-v0.1-gap.md`: add G18 (union types)
