### PR TITLE
fix(pnpmfile): strip usocket from dbus-next.dependencies too

### DIFF
--- a/ts/.pnpmfile.cjs
+++ b/ts/.pnpmfile.cjs
@@ -2,15 +2,26 @@
 // Licensed under the MIT License.
 
 function readPackage(pkg) {
-    // usocket is a native Unix-domain-socket module pulled in as an optional
-    // dep of dbus-next. It cannot compile on Windows (requires <sys/ioctl.h>),
-    // and electron-builder's install-app-deps tries to rebuild every native
-    // module it finds in node_modules — including optional ones whose own
-    // build scripts pnpm already skipped. Stripping usocket from dbus-next's
-    // optionalDependencies keeps it out of the resolution graph entirely.
-    // dbus-next degrades gracefully to Node's built-in net module without it.
-    if (pkg.name === "dbus-next" && pkg.optionalDependencies?.usocket) {
-        delete pkg.optionalDependencies.usocket;
+    // usocket is a native Unix-domain-socket module pulled in by dbus-next.
+    // It cannot compile on Windows (requires <sys/ioctl.h>), and
+    // electron-builder's install-app-deps tries to rebuild every native module
+    // it finds in node_modules — including optional ones whose own build
+    // scripts pnpm already skipped. Stripping usocket from dbus-next keeps it
+    // out of the resolution graph entirely. dbus-next degrades gracefully to
+    // Node's built-in net module without it.
+    //
+    // dbus-next@0.10.2 lists usocket in BOTH `dependencies` and
+    // `optionalDependencies`; we must strip from both, otherwise a fresh
+    // resolution (e.g. dependabot regenerating pnpm-lock.yaml) picks it up
+    // from `dependencies` and Windows installs fail with
+    //   error C1083: Cannot open include file: 'sys/ioctl.h'
+    if (pkg.name === "dbus-next") {
+        if (pkg.dependencies?.usocket) {
+            delete pkg.dependencies.usocket;
+        }
+        if (pkg.optionalDependencies?.usocket) {
+            delete pkg.optionalDependencies.usocket;
+        }
     }
     return pkg;
 }

--- a/ts/pnpm-lock.yaml
+++ b/ts/pnpm-lock.yaml
@@ -15,7 +15,7 @@ overrides:
   router>path-to-regexp: '>=8.4.0 <9.0.0'
   serialize-javascript: '>=7.0.5 <8.0.0'
 
-pnpmfileChecksum: sha256-HplUxd/UQs83KFaH+N8siaFp49HRIa3jBSEBejhtSo0=
+pnpmfileChecksum: sha256-XN/N69W0uLJqsCRZH1rt+p23fdy7DJIT7V7z9EUTcoM=
 
 importers:
 


### PR DESCRIPTION
## Problem

Recent dependabot PRs (#2360, #2361) and the daily dependabot remediation workflow have been failing the `Install dependencies` step on Windows with:

```
uwrap.cc(2,10): error C1083: Cannot open include file: ''sys/ioctl.h'': No such file or directory
```

This is `usocket@0.3.0` (a native Unix-domain-socket module) trying to compile via `node-gyp`. POSIX-only headers ⇒ Windows build fails.

## Root cause

`dbus-next@0.10.2`''s package.json lists `usocket` in **both**:

```json
"dependencies":         { "usocket": "^0.3.0" },
"optionalDependencies": { "usocket": "^0.3.0" }
```

The existing hook in `ts/.pnpmfile.cjs` only stripped from `optionalDependencies`. `main`''s lockfile happens to be usocket-free, but any fresh resolution (e.g. dependabot regenerating `pnpm-lock.yaml` when bumping an unrelated package) picks usocket back up via the regular `dependencies` entry and Windows installs fail.

## Fix

Strip usocket from both `dependencies` and `optionalDependencies` in the `readPackage` hook. dbus-next degrades gracefully to Node''s built-in `net` module without it (see comment in the hook).

## Verification

- Re-ran `pnpm install --lockfile-only` after the change — lock diff is **only the pnpmfileChecksum**, no actual graph changes (resolution was already usocket-free on main; this change just hardens it against future re-resolutions).
- Expected effect: #2360, #2361, and the daily `fix-dependabot-alerts` workflow should now pass Windows `Install dependencies`.
