### PR TITLE
fix(shell test): resolve config file dynamically for smoke tests

### DIFF
--- a/ts/packages/shell/test/testHelper.ts
+++ b/ts/packages/shell/test/testHelper.ts
@@ -221,12 +221,7 @@ function resolveTestConfigPath(appPath: string): string {
  */
 export function getLaunchArgs(testGreetings: boolean): string[] {
     const appPath = getAppPath();
-    const args = [
-        appPath,
-        "--test",
-        "--env",
-        resolveTestConfigPath(appPath),
-    ];
+    const args = [appPath, "--test", "--env", resolveTestConfigPath(appPath)];
     if (os.platform() === "linux") {
         // Ubuntu 24.04+ needs --no-sandbox, see https://github.com/electron/electron/issues/18265
         args.push("--no-sandbox");

--- a/ts/packages/shell/test/testHelper.ts
+++ b/ts/packages/shell/test/testHelper.ts
@@ -195,13 +195,10 @@ export function getAppPath(): string {
 }
 
 /**
- * Resolve the config file to pass via --env.
- *
- * After PR #2342 the canonical key-config format is `config.local.yaml`
- * (written by `tools/scripts/getKeys.mjs`), and the legacy `.env` is only
- * produced when `--dotenv` is explicitly passed to getKeys. Prefer the YAML
- * file when present so smoke tests work in both CI (YAML-only) and local
- * developer environments that may still have a `.env`.
+ * Resolve the config file to pass via --env. Prefers `config.local.yaml`
+ * (the canonical key-config format) and falls back to a legacy `.env` so
+ * smoke tests work in both YAML-only and legacy developer environments.
+ * Throws if neither file is present.
  */
 function resolveTestConfigPath(appPath: string): string {
     const yamlPath = path.resolve(appPath, "../../config.local.yaml");

--- a/ts/packages/shell/test/testHelper.ts
+++ b/ts/packages/shell/test/testHelper.ts
@@ -195,6 +195,30 @@ export function getAppPath(): string {
 }
 
 /**
+ * Resolve the config file to pass via --env.
+ *
+ * After PR #2342 the canonical key-config format is `config.local.yaml`
+ * (written by `tools/scripts/getKeys.mjs`), and the legacy `.env` is only
+ * produced when `--dotenv` is explicitly passed to getKeys. Prefer the YAML
+ * file when present so smoke tests work in both CI (YAML-only) and local
+ * developer environments that may still have a `.env`.
+ */
+function resolveTestConfigPath(appPath: string): string {
+    const yamlPath = path.resolve(appPath, "../../config.local.yaml");
+    if (fs.existsSync(yamlPath)) {
+        return yamlPath;
+    }
+    const dotenvPath = path.resolve(appPath, "../../.env");
+    if (fs.existsSync(dotenvPath)) {
+        return dotenvPath;
+    }
+    throw new Error(
+        `No test config file found. Expected either ${yamlPath} or ${dotenvPath}. ` +
+            `Run 'node tools/scripts/getKeys.mjs --vault <name> --commit' to generate one.`,
+    );
+}
+
+/**
  * Get electron launch arguments
  * @returns The arguments to pass to the electron application
  */
@@ -204,7 +228,7 @@ export function getLaunchArgs(testGreetings: boolean): string[] {
         appPath,
         "--test",
         "--env",
-        path.resolve(appPath, "../../.env"),
+        resolveTestConfigPath(appPath),
     ];
     if (os.platform() === "linux") {
         // Ubuntu 24.04+ needs --no-sandbox, see https://github.com/electron/electron/issues/18265


### PR DESCRIPTION
## Problem

The smoke-tests workflow has been failing on every PR (and on `main` itself) since #2342 merged on 2026-05-14. Symptom in CI:

- `Worker teardown timeout of 600000ms exceeded` on `simple.spec.ts:simple`
- `Failed to close instance ... Operation timed out` and `Unable to find chat view...timeout` (10 retry attempts) on the remaining tests

## Root cause

PR #2342 changed `tools/scripts/getKeys.mjs` to default to **YAML** output (`config.local.yaml`); the legacy `.env` is only written when `--dotenv` is explicitly passed. The smoke workflow (`.github/workflows/smoke-tests.yml`) calls:

```
node tools/scripts/getKeys.mjs --vault build-pipeline-kv --commit
```

— no `--dotenv`, so it now writes `ts/config.local.yaml` and **no `.env`** is produced in CI.

But `ts/packages/shell/test/testHelper.ts` hard-coded the env path:

```ts
const args = [appPath, ""--test"", ""--env"", path.resolve(appPath, ""../../.env"")];
```

In `--test` mode, `initializeKeys` calls `loadKeysFromEnvFile(envFile)` which throws `Env file <path> not found`. Shell startup fails before the chat view ever loads → every Playwright test fails the same way.

I confirmed the chain by inspecting #2342's own pre-merge smoke run ([25881071116](https://github.com/microsoft/TypeAgent/actions/runs/25881071116)) — it shows the exact same failure signature and was merged with the failure visible.

## Fix

Make `getLaunchArgs` prefer `config.local.yaml` when present and fall back to `.env` so smoke works in both CI (YAML-only) and local developer environments that still have a `.env`. `shell/keys.ts`'s `parseConfigFileContent` already routes by file extension, so the same code path handles both formats.

## Verification

- `pnpm --filter agent-shell build` ✓
- Local `npx playwright test simple.spec.ts --workers 1`: **5/5 passed** in 3.2m

Awaiting CI confirmation.