### PR TITLE
devcontainer: add agent variant with host-mirrored worktree paths

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -74,6 +74,13 @@ Lifecycle flags:
 | `--clean`    | Recreate the container and remove its Docker volumes   |
 | `--reset`    | `--rebuild` plus `--clean` (full fresh start)          |
 
+For local-only workflows where you want SSH set up with host-key checks
+disabled, pass `--insecure-local` (implies `--ssh`):
+
+```bash
+.devcontainer/scripts/start-devcontainer.sh --insecure-local
+```
+
 ## Variants in detail
 
 ### `standard` - `.devcontainer/devcontainer.json`

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,298 +1,395 @@
 # TypeAgent Development Container
 
-This devcontainer provides a fully configured development environment for TypeAgent with all required tools and dependencies.
+A fully configured Linux development environment for TypeAgent: Node.js 22,
+Python 3.12, .NET 8.0, pnpm, Azure CLI, GitHub CLI, and Claude Code, in a
+container you can run locally or in GitHub Codespaces.
+
+## Pick a variant
+
+| Variant    | Config file                             | Use when                                                |
+| ---------- | --------------------------------------- | ------------------------------------------------------- |
+| `standard` | `.devcontainer/devcontainer.json`       | Codespaces, or local dev without GUI/agent worktrees    |
+| `vnc`      | `.devcontainer/vnc/devcontainer.json`   | You need the Electron shell GUI inside the container    |
+| `agent`    | `.devcontainer/agent/devcontainer.json` | Local only: VS Code agent windows that create worktrees |
+
+Quick decision aid:
+
+- Codespaces or just want to build? → **standard**
+- Need the Electron shell GUI? → **vnc**
+- Running VS Code agent windows that auto-create git worktrees? → **agent**
+
+See [Variants in detail](#variants-in-detail) below for what each one
+changes and why.
 
 ## Prerequisites
 
-### Windows
+### Local (Linux / macOS / Windows)
 
-- **Docker Desktop** with WSL 2 backend enabled
-- **VS Code** with the [Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)
-- Recommended: Run `ts/tools/scripts/setup-devcontainer.ps1` to verify prerequisites
-
-### macOS / Linux
-
-- **Docker Desktop** or Docker Engine
-- **VS Code** with the Dev Containers extension
+- **Docker Desktop** (Windows / macOS) or **Docker Engine** (Linux)
+- **VS Code** with the
+  [Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)
+- Windows only: WSL 2 backend enabled in Docker Desktop. You can run
+  `ts/tools/scripts/setup-devcontainer.ps1` to verify.
 
 ### GitHub Codespaces
 
-No local prerequisites - works directly in browser or VS Code.
+No local prerequisites. Only the `standard` variant works in Codespaces;
+`vnc` and `agent` require host-side resources that Codespaces does not
+provide.
 
-## Quick Start
+## Quick start
 
-1. Open the TypeAgent folder in VS Code
-2. When prompted "Reopen in Container", click **Reopen in Container**
-   - Or use Command Palette: `Dev Containers: Reopen in Container`
-3. Wait for the container to build (first time takes 5-10 minutes)
-4. Once ready, open a terminal and run:
+### From VS Code (Reopen in Container)
+
+1. Open the TypeAgent folder in VS Code.
+2. When prompted "Reopen in Container", click **Reopen in Container**, or use
+   the Command Palette: `Dev Containers: Reopen in Container`.
+3. To pick a non-default variant, use `Dev Containers: Reopen in Container
+Using a Different Configuration File…` and select `vnc/` or `agent/`.
+4. First build takes 5-10 minutes. When it finishes:
    ```bash
    cd ts
    pnpm run build
    ```
 
-## Container Configurations
+### From the CLI (`start-devcontainer.sh`)
 
-### Standard (`devcontainer.json`)
-
-Default configuration for most development work. Includes:
-
-- Node.js 22, Python 3.12, .NET 8.0
-- pnpm package manager
-- Azure CLI, GitHub CLI
-- Claude Code
-
-**Note:** The Electron shell requires GUI support. To use the shell with devcontainer, you need to start the agent-server in the container and run the shell on your host machine. The agent server port is forwarded to the host, so the shell will connect correctly:
+Use this wrapper when you want a single command that also forwards your host
+git identity and (optionally) sets up SSH access. `--config` accepts a short
+name (`vnc`, `agent`) or an explicit path.
 
 ```bash
-# In container - start the backend
+.devcontainer/scripts/start-devcontainer.sh                 # standard
+.devcontainer/scripts/start-devcontainer.sh --config vnc
+.devcontainer/scripts/start-devcontainer.sh --config agent
+.devcontainer/scripts/start-devcontainer.sh --ssh           # also wire host SSH
+```
+
+Lifecycle flags:
+
+| Flag         | Effect                                                 |
+| ------------ | ------------------------------------------------------ |
+| `--recreate` | Recreate the container (keep image, keep volumes)      |
+| `--rebuild`  | Rebuild the image without cache (implies `--recreate`) |
+| `--clean`    | Recreate the container and remove its Docker volumes   |
+| `--reset`    | `--rebuild` plus `--clean` (full fresh start)          |
+
+## Variants in detail
+
+### `standard` - `.devcontainer/devcontainer.json`
+
+The default. Works in Codespaces and locally. Source tree is bind-mounted
+under `/workspaces/<repo>/`, and `ts/node_modules` lives on a Docker named
+volume so native modules stay container-local.
+
+Does not support VS Code agent windows that auto-create git worktrees: a
+separate host VS Code window cannot open a worktree path that exists only
+inside the container. Use the `agent` variant for that workflow. (In
+Codespaces the agent worktree feature does work natively, because every
+attached VS Code window sees the same `/workspaces/...` paths in the same
+Codespace VM.)
+
+### `vnc` - `.devcontainer/vnc/devcontainer.json`
+
+Same as `standard` plus the `desktop-lite` feature for a noVNC web desktop
+on port 6080. Use this when you need to run Electron (the TypeAgent shell)
+inside the container. Heavier resource requirements (4 CPU, 16 GB RAM).
+
+The `desktop-lite` feature is amd64-only, so on Apple Silicon this variant
+may require Rosetta / QEMU emulation.
+
+### `agent` - `.devcontainer/agent/devcontainer.json` (local only)
+
+Variant designed for VS Code agent windows that auto-create git worktrees.
+VS Code's Copilot CLI agent writes worktrees to a hardcoded
+`<dirname(repo)>/<basename(repo)>.worktrees`, which is not configurable. To
+make those worktrees usable from both host and container, this variant:
+
+- Bind-mounts the repo at its **host absolute path** (rather than
+  `/workspaces/<repo>`) so `${localWorkspaceFolder}` resolves the same on
+  both sides.
+- Adds a second bind for `<repo>.worktrees` at the matching host path
+  (created on the host by `initializeCommand` if missing).
+- Sets `updateRemoteUserUID: true` so the in-container `codespace` user is
+  re-chowned to your host UID and can write through the bind mount.
+- Keeps `ts/node_modules` on a named volume - do **not** share native
+  module builds with the host.
+
+Worktrees created by an agent window are visible at the same path on the
+host, so a separate host VS Code window can open them directly. This does
+not work in Codespaces (no host path).
+
+## Working inside the container
+
+### Common commands
+
+```bash
+cd ts
+pnpm run build              # build all packages
+pnpm run cli                # run the CLI
+pnpm run test:local         # run unit tests
+pnpm run start:agent-server # start the agent server
+```
+
+### Electron shell (hybrid)
+
+For variants without the VNC desktop, run the backend in the container and
+the Electron shell on your host - the agent server port is forwarded:
+
+```bash
+# In container
 pnpm run server
 
-# On host machine - run the Electron shell
+# On host
 cd ts && pnpm run shell
 ```
 
-## Working with the Container
+### Git identity
 
-### SSH Access
+How your git identity ends up inside the container depends on how you
+started it:
 
-The universal devcontainer image includes an SSH server. To set up key-based
-access from your host machine, run:
+- **VS Code "Reopen in Container"**: the Dev Containers extension
+  automatically projects your host `~/.gitconfig` into the container
+  (controlled by the `dev.containers.copyGitConfig` user setting, on by
+  default). Your `user.name` / `user.email` are already present.
+- **`start-devcontainer.sh`**: the wrapper does **not** copy
+  `~/.gitconfig`. It only forwards `user.name` and `user.email` via the
+  `LOCAL_GIT_USER_NAME` / `LOCAL_GIT_USER_EMAIL` env vars, which
+  `post-create.sh` writes into the container's global git config if no
+  identity is already set.
+- **Codespaces**: identity is provisioned from your GitHub account.
+
+Verify with:
+
+```bash
+git config --global --list
+```
+
+If you are using the container for untrusted / agent work, you almost
+certainly want to disable the automatic `~/.gitconfig` projection - see
+[Hardening for untrusted / agent use](#hardening-for-untrusted--agent-use).
+
+### Parallel agents via worktrees
+
+```bash
+../scripts/agent-worktree.sh feature-name        # create
+../scripts/agent-worktree.sh --cleanup feature-name
+```
+
+Each worktree shares git history but has independent working tree, branch
+state, and (via pnpm's content-addressable store) effective `node_modules`.
+
+## SSH access
+
+The base image includes an SSH server. To configure key-based access from
+the host:
 
 ```bash
 .devcontainer/scripts/setup-ssh-access.sh
 ```
 
-The script will:
+The script:
 
-- create `~/.ssh/typeagent-devcontainer` if it does not already exist
-- find the running TypeAgent devcontainer from Docker labels
-- add the public key to `~/.ssh/authorized_keys` for the `codespace` user in the container
-- add or update an SSH config entry named `typeagent-devcontainer`
-- enforce key-only SSH auth in both client config and container sshd settings
-- use `StrictHostKeyChecking accept-new` by default
-- when run in WSL, also detect your Windows `%USERPROFILE%/.ssh` directory
-- copy the same keypair into Windows `~/.ssh` so Windows OpenSSH can use it directly
-- add or update the same `typeagent-devcontainer` host entry in Windows SSH config
-- use Windows-native paths for the copied key and `known_hosts` entry in that Windows config
+- generates `~/.ssh/typeagent-devcontainer` if missing,
+- finds the running TypeAgent container via Docker labels,
+- installs the public key in the container's `authorized_keys` for
+  `codespace`,
+- writes an SSH config entry named `typeagent-devcontainer`,
+- enforces key-only auth in both client and container sshd config,
+- defaults to `StrictHostKeyChecking accept-new`,
+- in WSL, also mirrors the keypair and config into Windows
+  `%USERPROFILE%/.ssh`.
 
-By default, generated SSH config uses `StrictHostKeyChecking accept-new`.
-For local-only workflows where you intentionally want host key checks disabled,
-use:
+For local-only workflows where you intentionally want host-key checking
+off:
 
 ```bash
 .devcontainer/scripts/setup-ssh-access.sh --insecure-local
 ```
 
-After it completes, connect with:
+When using a non-default variant, pass it through:
+
+```bash
+.devcontainer/scripts/setup-ssh-access.sh --config vnc
+.devcontainer/scripts/setup-ssh-access.sh --config agent
+```
+
+Connect:
 
 ```bash
 ssh typeagent-devcontainer
 ```
 
-If you use a non-default devcontainer config, pass it explicitly:
-
-```bash
-.devcontainer/scripts/setup-ssh-access.sh --config .devcontainer/vnc/devcontainer.json
-```
-
-### One-Command Start (and Optional SSH Setup)
-
-Use this wrapper to start the devcontainer from the command line. If your
-VS Code agent window only supports tunnel/SSH connections, pass `--ssh` to
-also configure host SSH access in the same step:
-
-```bash
-.devcontainer/scripts/start-devcontainer.sh         # start only
-.devcontainer/scripts/start-devcontainer.sh --ssh   # start + configure SSH
-```
-
-Useful options:
-
-```bash
-# Recreate container first
-.devcontainer/scripts/start-devcontainer.sh --recreate --ssh
-
-# Rebuild the devcontainer image (implies --recreate)
-.devcontainer/scripts/start-devcontainer.sh --rebuild
-
-# Remove container and associated Docker volumes
-.devcontainer/scripts/start-devcontainer.sh --clean
-
-# Full reset: rebuild image + clean volumes
-.devcontainer/scripts/start-devcontainer.sh --reset
-
-# Use alternate devcontainer config
-.devcontainer/scripts/start-devcontainer.sh --config .devcontainer/vnc/devcontainer.json
-
-# Local-only mode with host key checks disabled (implies --ssh)
-.devcontainer/scripts/start-devcontainer.sh --insecure-local
-```
-
-After it completes with `--ssh`:
-
-```bash
-ssh typeagent-devcontainer
-```
-
-### Common Commands
-
-```bash
-cd ts                    # Navigate to TypeScript workspace
-pnpm run build           # Build all packages
-pnpm run cli             # Run the CLI
-pnpm run test:local      # Run unit tests
-pnpm run start:agent-server          # Start agent server
-```
-
-### Git Configuration
-
-During container creation, the post-create script keeps any existing container
-Git identity, or sets `user.name` and `user.email` from the
-`LOCAL_GIT_USER_NAME` and `LOCAL_GIT_USER_EMAIL` environment variables when
-those values are provided. The devcontainer configs pass those host-side
-environment variables through with `${localEnv:...}`, and the
-`start-devcontainer.sh` wrapper fills them from your host `~/.gitconfig`
-using `git config --global` before calling `devcontainer up`.
-
-After rebuilding the container, you can verify with:
-
-```bash
-git config --global --list
-git config user.name
-git config user.email
-```
-
-## Using with AI Agents
+## AI agents
 
 ### Claude Code
 
-Claude Code is pre-installed in the container:
+Pre-installed:
 
 ```bash
-claude                   # Start interactive session
-claude "your prompt"     # Run with a prompt
+claude                   # interactive session
+claude "your prompt"     # one-shot
 ```
 
-### Parallel Agent Development with Worktrees
+### Hardening for untrusted / agent use
 
-Run multiple AI agents in parallel using git worktrees:
+When you plan to give a coding agent broad shell access in the container,
+assume any credential reachable from the container is reachable by the
+agent (and by anything that prompt-injects it). Lock down what the host
+wires in.
+
+**1. Disable VS Code's automatic credential / SSH wiring.**
+
+The Dev Containers extension by default copies your host `~/.gitconfig`,
+installs a git credential helper that proxies back to the host, and
+forwards SSH and GPG agent sockets. Turn those off in your **User**
+`settings.json` (not the repo's devcontainer config):
+
+```jsonc
+{
+  "dev.containers.copyGitConfig": false,
+  "dev.containers.gitCredentialHelperConfigLocation": "none",
+  "dev.containers.forwardSSH": false,
+  "dev.containers.forwardGPG": false,
+}
+```
+
+Older VS Code versions use the `remote.containers.*` prefix.
+
+`start-devcontainer.sh` does not copy `~/.gitconfig`; it only forwards
+`user.name` / `user.email` via `LOCAL_GIT_USER_*` env vars. No host
+credential helpers or SSH agents are wired in by the wrapper.
+
+**2. Verify inside the container.**
 
 ```bash
-# Create a worktree for an agent
-../scripts/agent-worktree.sh feature-name
-
-# This creates:
-#   ../agent-feature-name/     - isolated working directory
-#   ../agent-feature-name/ts/  - TypeScript workspace
-
-# Clean up when done
-../scripts/agent-worktree.sh --cleanup feature-name
+git config --global --get credential.helper   # should be empty
+ls -la ~/.gitconfig                           # only the identity from post-create
+echo "$SSH_AUTH_SOCK"                         # should be empty
 ```
 
-Each worktree shares the git history but has independent:
+**3. If the agent needs to push, use a scoped bot credential.**
 
-- Working directory and file changes
-- Node modules (via pnpm's content-addressable store)
-- Branch state
+Preferred, in order:
 
-## Forwarded Ports
+- **Fine-grained GitHub PAT** scoped to "Only select repositories" with the
+  minimum permissions (typically `Contents: RW`, `Pull requests: RW`,
+  `Metadata: R`) and a short expiration. In the container:
+  ```bash
+  echo "$GH_BOT_TOKEN" | gh auth login --with-token --hostname github.com
+  gh auth setup-git
+  ```
+- **Per-repo SSH deploy key** generated _inside_ the container and added to
+  the target repo's Settings → Deploy keys.
+- **GitHub App installation token** for shared/org bots.
 
-Standard config (`devcontainer.json`):
+Avoid: forwarding your personal SSH agent, bind-mounting
+`~/.git-credentials`, or running `gh auth login` with your personal
+account.
 
-| Port | Service                                         |
-| ---- | ----------------------------------------------- |
-| 2222 | Dev Container SSH (host-published on 127.0.0.1) |
-| 3000 | API Server (HTTP)                               |
-| 3443 | API Server (HTTPS)                              |
-| 8999 | Agent Server (WebSocket)                        |
-| 8081 | Browser Agent (WebSocket)                       |
-| 8082 | Code Agent (WebSocket)                          |
+**4. Extra isolation.**
 
-VNC config (`vnc/devcontainer.json`) adds:
+- Run the agent in a dedicated worktree so it only sees one branch's tree.
+- Restrict the bot identity to an `agent/*` branch namespace and require a
+  PR into `main`.
+- Revoke the bot token / deploy key after the session.
 
-| Port | Service           |
-| ---- | ----------------- |
-| 6080 | noVNC Web Desktop |
-| 5901 | VNC Client        |
+## Reference
 
-## Container User
+### Forwarded ports
 
-The container runs as `codespace` with UID/GID 1001 (matches the Codespaces
-convention and the previous universal base image). All workspace and cache
-paths are accessed via Docker named volumes, not host bind mounts of source
-files, so this UID does not need to match your host user. If you add a host
-bind mount later and your host user shares UID 1001, be aware of the implicit
-file-ownership overlap.
+| Port | Service                                         | Variants |
+| ---- | ----------------------------------------------- | -------- |
+| 2222 | Dev container SSH (host-published on 127.0.0.1) | all      |
+| 3000 | API server (HTTP)                               | all      |
+| 3443 | API server (HTTPS)                              | all      |
+| 8081 | Browser agent (WebSocket)                       | all      |
+| 8082 | Code agent (WebSocket)                          | all      |
+| 8999 | Agent server (WebSocket)                        | all      |
+| 5901 | VNC client                                      | `vnc`    |
+| 6080 | noVNC web desktop                               | `vnc`    |
+
+### Container user
+
+Runs as `codespace`, UID/GID 1001 (matches the Codespaces convention).
+
+- In `standard` and `vnc`, source files live in Docker named volumes or are
+  Codespaces-managed, so UID alignment with the host is not required.
+- In `agent`, the host bind mount needs UID alignment. The variant sets
+  `updateRemoteUserUID: true` to re-chown `codespace` to your host UID on
+  first start.
+
+### Volumes and mounts
+
+| Mount point in container                  | Type   | Purpose                                               |
+| ----------------------------------------- | ------ | ----------------------------------------------------- |
+| workspace folder                          | bind   | Source tree (host or Codespaces filesystem)           |
+| `<workspace>/ts/node_modules`             | volume | Container-local `node_modules` (native build)         |
+| `/home/codespace/.local/share/pnpm/store` | volume | Shared pnpm content-addressable store                 |
+| `/home/codespace/.claude`                 | volume | Claude Code config                                    |
+| `/home/codespace/.copilot`                | volume | Copilot CLI config                                    |
+| `<host repo>.worktrees`                   | bind   | Agent worktrees, same path host & container (`agent`) |
+
+### Container image
+
+`.devcontainer/Dockerfile` extends the Ubuntu 24.04 base with pre-installed
+system libraries (libsecret). This avoids `apt-get install` on every
+container creation and leverages Docker's layer cache for fast rebuilds.
 
 ## Troubleshooting
 
 ### Container fails to start
 
-1. Ensure Docker Desktop is running
-2. Try rebuilding: `Dev Containers: Rebuild Container`
-3. Check Docker has sufficient resources (4 CPU, 8GB RAM minimum)
+1. Ensure Docker Desktop / Engine is running.
+2. Try `Dev Containers: Rebuild Container`, or
+   `.devcontainer/scripts/start-devcontainer.sh --rebuild`.
+3. Confirm Docker has sufficient resources (4 CPU, 8 GB RAM minimum; 16 GB
+   for `vnc`).
 
-### pnpm install fails
+### `pnpm install` fails
 
 ```bash
-# Clear pnpm cache and retry
 pnpm store prune
 pnpm install
 ```
 
-### `EACCES` / permission denied on `ts/node_modules` during `pnpm install`
+### `EACCES` on `ts/node_modules` or pnpm store
 
-The devcontainer mounts a Docker named volume at `ts/node_modules` (and at the pnpm
-global store). Docker creates these mount points owned by `root:root`, but the
-container runs as the non-root `codespace` user, which causes `pnpm install` to
-fail with permission errors on a fresh container.
-
-The `post-create.sh` script automatically `chown`s these paths to `codespace`
-on first launch. If you hit this manually, run:
+The `ts/node_modules` and pnpm store named volumes are created by Docker
+as `root:root` on first mount. `post-create.sh` chowns them to `codespace`
+automatically. If you ever hit this manually after the script has run:
 
 ```bash
 sudo chown -R codespace:codespace \
-    /workspaces/TypeAgent/ts/node_modules \
+    "$(pwd)/ts/node_modules" \
     /home/codespace/.local/share/pnpm \
-   /home/codespace/.claude \
-   /home/codespace/.copilot
-cd /workspaces/TypeAgent/ts && pnpm install
+    /home/codespace/.claude \
+    /home/codespace/.copilot
+cd ts && pnpm install
 ```
 
-### Permission errors
+Do **not** blindly `chown -R` the workspace tree itself in the `agent`
+variant: it is a host bind mount, and the change will be visible on the
+host.
 
-The container runs as the `codespace` user. If you encounter permission issues:
+### Agent window cannot create `<repo>.worktrees` (access denied)
 
-```bash
-sudo chown -R codespace:codespace /workspaces/TypeAgent
-```
-
-### Agent window cannot create `/workspaces/*.worktrees` (access denied)
-
-Agent windows may create sibling worktree folders such as
-`/workspaces/TypeAgent3.worktrees`.
-If this path is root-owned, worktree creation fails with access denied.
-
-Run:
-
-```bash
-sudo mkdir -p /workspaces/TypeAgent3.worktrees
-sudo chown codespace:codespace /workspaces/TypeAgent3.worktrees
-```
-
-Then retry creating the worktree.
-
-This is also handled automatically on fresh container creation by
-`.devcontainer/scripts/post-create.sh`.
-
-The standard and VNC devcontainer configs now mount a dedicated Docker
-named volume at `/workspaces/<repo>.worktrees` so agent-window worktrees
-have a stable writable location across container restarts and rebuilds.
+- `standard` / `vnc` (local Docker): not supported. The worktree path
+  exists only inside the container, so a separate host VS Code window
+  cannot open it. Switch to the `agent` variant.
+- `standard` in Codespaces: should just work; both windows attach to the
+  same Codespace VM. If you hit a permission error, run
+  `sudo mkdir -p /workspaces/<repo>.worktrees && sudo chown
+codespace:codespace /workspaces/<repo>.worktrees`.
+- `agent`: the path is a host bind mount created by `initializeCommand`.
+  If it's missing, create it on the host (`mkdir -p <repo>.worktrees`) and
+  rebuild the container so the bind is re-established.
 
 ### Line ending issues (Windows)
 
-If scripts fail with `\r': command not found`, the repository may have CRLF line endings. Fix with:
+If scripts fail with `\r': command not found`, the repo has CRLF line
+endings. Fix with:
 
 ```bash
 git config core.autocrlf input
@@ -300,24 +397,12 @@ git rm --cached -r .
 git reset --hard
 ```
 
-## Rebuilding the Container
+## Rebuilding
 
-To rebuild with fresh state:
-
-1. Command Palette: `Dev Containers: Rebuild Container`
-2. Or from the CLI: `.devcontainer/scripts/start-devcontainer.sh --rebuild`
-
-To rebuild without cache and clean volumes:
-
-1. Command Palette: `Dev Containers: Rebuild Container Without Cache`
-2. Or from the CLI: `.devcontainer/scripts/start-devcontainer.sh --reset`
-
-## Container Image
-
-The devcontainer uses a custom Dockerfile (`.devcontainer/Dockerfile`) that
-extends the base Ubuntu 24.04 image with pre-installed system libraries
-(libsecret). This avoids running `apt-get install` on every container
-creation and leverages Docker's layer cache for fast rebuilds.
+| Goal                                | Command Palette                                   | CLI                               |
+| ----------------------------------- | ------------------------------------------------- | --------------------------------- |
+| Recreate container                  | `Dev Containers: Rebuild Container`               | `start-devcontainer.sh --rebuild` |
+| Rebuild image, drop volumes (reset) | `Dev Containers: Rebuild Container Without Cache` | `start-devcontainer.sh --reset`   |
 
 ## Resources
 

--- a/.devcontainer/agent/devcontainer-lock.json
+++ b/.devcontainer/agent/devcontainer-lock.json
@@ -1,0 +1,49 @@
+{
+  "features": {
+    "ghcr.io/anthropics/devcontainer-features/claude-code:1.0": {
+      "version": "1.0.5",
+      "resolved": "ghcr.io/anthropics/devcontainer-features/claude-code@sha256:cfc2e7d3e9fd3b9b01f8d5cb158508a884c8c0ede2e23ed10f32dea5d4ffe69a",
+      "integrity": "sha256:cfc2e7d3e9fd3b9b01f8d5cb158508a884c8c0ede2e23ed10f32dea5d4ffe69a"
+    },
+    "ghcr.io/devcontainers/features/azure-cli:1": {
+      "version": "1.2.9",
+      "resolved": "ghcr.io/devcontainers/features/azure-cli@sha256:4549175fbfd3475d1d62e82f6e5425d03954a6ae06027b2515b0ba41a8206417",
+      "integrity": "sha256:4549175fbfd3475d1d62e82f6e5425d03954a6ae06027b2515b0ba41a8206417"
+    },
+    "ghcr.io/devcontainers/features/common-utils:2": {
+      "version": "2.5.8",
+      "resolved": "ghcr.io/devcontainers/features/common-utils@sha256:c42fdefe6d737a3a6f61cc52b23c7c9a565d08cc4d9c303669a7cf2ee5fd81fc",
+      "integrity": "sha256:c42fdefe6d737a3a6f61cc52b23c7c9a565d08cc4d9c303669a7cf2ee5fd81fc"
+    },
+    "ghcr.io/devcontainers/features/dotnet:2": {
+      "version": "2.5.0",
+      "resolved": "ghcr.io/devcontainers/features/dotnet@sha256:0fc16547ed4db6d7ff2a9f5981d2b93eb314e568affb9958029ad794f1f9a093",
+      "integrity": "sha256:0fc16547ed4db6d7ff2a9f5981d2b93eb314e568affb9958029ad794f1f9a093"
+    },
+    "ghcr.io/devcontainers/features/git-lfs:1": {
+      "version": "1.2.5",
+      "resolved": "ghcr.io/devcontainers/features/git-lfs@sha256:71c2b371cf12ab7fcec47cf17369c6f59156100dad9abf9e4c593049d789de72",
+      "integrity": "sha256:71c2b371cf12ab7fcec47cf17369c6f59156100dad9abf9e4c593049d789de72"
+    },
+    "ghcr.io/devcontainers/features/github-cli:1": {
+      "version": "1.1.0",
+      "resolved": "ghcr.io/devcontainers/features/github-cli@sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671",
+      "integrity": "sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671"
+    },
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "1.7.1",
+      "resolved": "ghcr.io/devcontainers/features/node@sha256:8c0de46939b61958041700ee89e3493f3b2e4131a06dc46b4d9423427d06e5f6",
+      "integrity": "sha256:8c0de46939b61958041700ee89e3493f3b2e4131a06dc46b4d9423427d06e5f6"
+    },
+    "ghcr.io/devcontainers/features/python:1": {
+      "version": "1.8.0",
+      "resolved": "ghcr.io/devcontainers/features/python@sha256:fbcad6955caeecc5ad3f7886baf652e25cba5225a6c4c2287c536de2e5607511",
+      "integrity": "sha256:fbcad6955caeecc5ad3f7886baf652e25cba5225a6c4c2287c536de2e5607511"
+    },
+    "ghcr.io/devcontainers/features/sshd:1": {
+      "version": "1.1.0",
+      "resolved": "ghcr.io/devcontainers/features/sshd@sha256:f5251b8e4325f68f7280973c6cd65daff414449c66f240621502d4e8e74eb7ee",
+      "integrity": "sha256:f5251b8e4325f68f7280973c6cd65daff414449c66f240621502d4e8e74eb7ee"
+    }
+  }
+}

--- a/.devcontainer/agent/devcontainer.json
+++ b/.devcontainer/agent/devcontainer.json
@@ -1,0 +1,177 @@
+{
+  "name": "TypeAgent Development (Agent Worktrees)",
+  "build": { "dockerfile": "../Dockerfile" },
+
+  // Variant of the standard devcontainer where the container sees the
+  // workspace at the SAME absolute path as the host. This lets VS Code's
+  // Copilot CLI agent worktree feature work end-to-end:
+  //
+  //   src/vs/platform/agentHost/node/copilot/copilotAgent.ts
+  //   getCopilotWorktreesRoot() -> <parent>/<basename>.worktrees
+  //
+  // is hardcoded, so the only way to have host VS Code open an agent-
+  // created worktree at the same path the container created it is to
+  // make the parent directory a single bind mount with matching paths.
+  //
+  // This config is LOCAL-ONLY (Linux/macOS host with Docker). It will not
+  // work in Codespaces - there is no `localWorkspaceFolder` on the cloud
+  // host. Use ../devcontainer.json (the default config) for Codespaces.
+  //
+  // Prerequisites on the host:
+  //   - Your host user's UID matches the `codespace` user inside the
+  //     container. `updateRemoteUserUID` below handles the common case
+  //     by re-chowning `codespace` to your host UID on first start.
+  //   - The sibling `<repo>.worktrees` directory must exist on the host
+  //     before container start (Docker bind-mount requirement). The
+  //     `initializeCommand` below creates it automatically.
+
+  "features": {
+    "ghcr.io/anthropics/devcontainer-features/claude-code:1.0": {},
+    "ghcr.io/devcontainers/features/sshd:1": {
+      "version": "latest"
+    },
+    "ghcr.io/devcontainers/features/git-lfs:1": {
+      "autoPull": false
+    },
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "22",
+      "nodeGypDependencies": true
+    },
+    "ghcr.io/devcontainers/features/python:1": {
+      "version": "3.12",
+      "installTools": true
+    },
+    "ghcr.io/devcontainers/features/dotnet:2": {
+      "version": "8.0"
+    },
+    "ghcr.io/devcontainers/features/azure-cli:1": {},
+    "ghcr.io/devcontainers/features/github-cli:1": {},
+    "ghcr.io/devcontainers/features/common-utils:2": {
+      "installZsh": true,
+      "configureZshAsDefaultShell": true,
+      "installOhMyZsh": true,
+      "username": "codespace",
+      "userUid": "1001",
+      "userGid": "1001"
+    }
+  },
+
+  // Re-chown the `codespace` user to the host user's UID/GID on container
+  // start so the bind-mounted source tree (owned by the host user) is
+  // writable from inside the container.
+  "updateRemoteUserUID": true,
+
+  // Hardening for agent use:
+  // - userEnvProbe "none" stops the Dev Containers CLI from sourcing your
+  //   host login shell and copying its environment (including any tokens
+  //   or agent-friendly env vars) into the container.
+  // - runArgs apply Docker-level constraints: drop all capabilities then
+  //   add back only those the post-create script needs (chown/dac_override
+  //   /fowner for volume ownership fixes; setuid/setgid because sudo and
+  //   the common-utils feature need them), and cap the process table to
+  //   limit fork-bomb blast radius.
+  //
+  // Note: `--security-opt=no-new-privileges` is intentionally NOT set,
+  // because it blocks setuid binaries (including sudo), which
+  // post-create.sh needs to chown the named-volume mountpoints Docker
+  // creates as root:root on first start.
+  "userEnvProbe": "none",
+  "runArgs": [
+    "--cap-drop=ALL",
+    // Needed by post-create.sh (chown volume mountpoints, sudo, common-utils)
+    "--cap-add=CHOWN",
+    "--cap-add=DAC_OVERRIDE",
+    "--cap-add=FOWNER",
+    "--cap-add=SETUID",
+    "--cap-add=SETGID",
+    // Needed by sudo to manipulate the capability bounding set, and by
+    // sshd's privilege separation (chroot, dropping caps on the child).
+    "--cap-add=SETPCAP",
+    "--cap-add=SYS_CHROOT",
+    "--cap-add=KILL",
+    // Needed if sshd binds a privileged port; harmless if it doesn't.
+    "--cap-add=NET_BIND_SERVICE",
+    // Silences `sudo: unable to send audit message` warnings; also used
+    // by sshd when logging auth events to the kernel audit subsystem.
+    "--cap-add=AUDIT_WRITE",
+    "--pids-limit=4096"
+  ],
+
+  "appPort": ["127.0.0.1:2222:2222"],
+
+  "forwardPorts": [8999, 8081, 8082, 3000, 3443],
+  "portsAttributes": {
+    "8999": { "label": "Agent Server (WebSocket)", "onAutoForward": "notify" },
+    "8081": { "label": "Browser Agent (WebSocket)", "onAutoForward": "notify" },
+    "8082": { "label": "Code Agent (WebSocket)", "onAutoForward": "notify" },
+    "3000": { "label": "API Server (HTTP)", "onAutoForward": "notify" },
+    "3443": { "label": "API Server (HTTPS)", "onAutoForward": "notify" }
+  },
+
+  // Ensure the sibling worktrees directory exists on the host before the
+  // container starts; Docker bind mounts fail if the source path is
+  // missing. Runs on the host, so we can use POSIX `mkdir -p` safely.
+  "initializeCommand": "mkdir -p '${localWorkspaceFolder}.worktrees'",
+
+  // Mirror the host path INSIDE the container by bind-mounting the repo
+  // at its host absolute path. A second bind mount exposes the sibling
+  // `<repo>.worktrees` directory at the matching host path so that
+  // VS Code's Copilot CLI agent (which writes worktrees to a hardcoded
+  // `<dirname(repo)>/<basename(repo)>.worktrees`) resolves to the same
+  // location on host and container.
+  "workspaceMount": "source=${localWorkspaceFolder},target=${localWorkspaceFolder},type=bind,consistency=cached",
+  "workspaceFolder": "${localWorkspaceFolder}",
+
+  "mounts": [
+    // Sibling worktrees directory bound at the same host path so the
+    // Copilot CLI agent worktree feature resolves identically on both
+    // sides.
+    "source=${localWorkspaceFolder}.worktrees,target=${localWorkspaceFolder}.worktrees,type=bind,consistency=cached",
+    // Global pnpm store - shared across containers for fast installs.
+    "source=pnpm-global-store,target=/home/codespace/.local/share/pnpm/store,type=volume",
+    // Per-container node_modules stays on a named volume. We deliberately
+    // do NOT bind-mount this to the host: native modules (better-sqlite3,
+    // etc.) are compiled for the container's libc/arch and would clash
+    // with anything the host has built.
+    "source=typeagent-node_modules-${devcontainerId},target=${containerWorkspaceFolder}/ts/node_modules,type=volume",
+    "source=claude-code-config-${devcontainerId},target=/home/codespace/.claude,type=volume",
+    "source=copilot-cli-config-${devcontainerId},target=/home/codespace/.copilot,type=volume"
+  ],
+
+  "containerEnv": {
+    "LOCAL_GIT_USER_NAME": "${localEnv:LOCAL_GIT_USER_NAME}",
+    "LOCAL_GIT_USER_EMAIL": "${localEnv:LOCAL_GIT_USER_EMAIL}"
+  },
+
+  "postCreateCommand": "bash .devcontainer/scripts/post-create.sh",
+  "postStartCommand": "bash .devcontainer/scripts/post-start.sh",
+
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "dbaeumer.vscode-eslint",
+        "esbenp.prettier-vscode",
+        "ms-python.python",
+        "ms-python.vscode-pylance",
+        "ms-dotnettools.csharp",
+        "ms-azuretools.vscode-azurefunctions",
+        "github.copilot",
+        "humao.rest-client"
+      ],
+      "settings": {
+        "editor.formatOnSave": true,
+        "editor.defaultFormatter": "esbenp.prettier-vscode",
+        "typescript.tsdk": "node_modules/typescript/lib",
+        "terminal.integrated.defaultProfile.linux": "zsh"
+      }
+    }
+  },
+
+  "remoteUser": "codespace",
+
+  "hostRequirements": {
+    "cpus": 4,
+    "memory": "8gb",
+    "storage": "32gb"
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -64,8 +64,6 @@
     "source=pnpm-global-store,target=/home/codespace/.local/share/pnpm/store,type=volume",
     // Per-container node_modules (symlinks to global store)
     "source=typeagent-node_modules-${devcontainerId},target=${containerWorkspaceFolder}/ts/node_modules,type=volume",
-    // Per-container writable sibling worktree root for agent windows
-    "source=typeagent-agent-worktrees-${devcontainerId},target=/workspaces/${localWorkspaceFolderBasename}.worktrees,type=volume",
     // Claude Code config persistence
     "source=claude-code-config-${devcontainerId},target=/home/codespace/.claude,type=volume",
     // Copilot CLI chat log persistence

--- a/.devcontainer/scripts/post-create.sh
+++ b/.devcontainer/scripts/post-create.sh
@@ -33,28 +33,6 @@ ENV=$(detect_env)
 echo "Environment: $ENV"
 echo ""
 
-# Ensure worktree roots are writable for agent windows.
-echo "Preparing worktree roots for agent windows..."
-WORKSPACE_DIR=$(pwd -P)
-WORKTREES_DIR="${WORKSPACE_DIR}.worktrees"
-for dir in "$WORKTREES_DIR"; do
-    if [[ ! -d "$dir" ]]; then
-        if sudo mkdir -p "$dir"; then
-            echo "  created $dir"
-        else
-            echo "  warn: could not create $dir"
-            continue
-        fi
-    fi
-
-    if sudo chown codespace:codespace "$dir"; then
-        echo "  $dir owned by codespace"
-    else
-        echo "  warn: could not set ownership for $dir"
-    fi
-done
-echo ""
-
 # Fix ownership of Docker named-volume mount points.
 # Named volumes mounted into the container are owned by root:root by default,
 # which prevents the non-root `codespace` user from writing into them
@@ -66,9 +44,16 @@ VOLUME_PATHS=(
     "/home/codespace/.claude"
     "/home/codespace/.copilot"
 )
-# Discover the workspace ts/node_modules path dynamically (works for worktrees too)
+# Discover the workspace ts/node_modules path dynamically (works for worktrees
+# and for variants that mount the workspace outside /workspaces, e.g. the
+# `agent` devcontainer that bind-mounts the host path verbatim).
 WS_TS_DIR=""
-if [[ -d "/workspaces/TypeAgent/ts" ]]; then
+_REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || true)
+if [[ -n "$_REPO_ROOT" ]] && [[ -d "$_REPO_ROOT/ts" ]]; then
+    WS_TS_DIR="$_REPO_ROOT/ts"
+elif [[ -d "$(pwd)/ts" ]]; then
+    WS_TS_DIR="$(pwd)/ts"
+elif [[ -d "/workspaces/TypeAgent/ts" ]]; then
     WS_TS_DIR="/workspaces/TypeAgent/ts"
 else
     WS_TS_DIR=$(find /workspaces -maxdepth 2 -type d -name "ts" 2>/dev/null | head -1)

--- a/.devcontainer/scripts/start-devcontainer.sh
+++ b/.devcontainer/scripts/start-devcontainer.sh
@@ -169,6 +169,7 @@ if [[ $CLEAN_VOLUMES -eq 1 ]]; then
         "pnpm-global-store"
         "typeagent-node_modules-"
         "claude-code-config-"
+        "copilot-cli-config-"
     )
     for prefix in "${VOLUME_PREFIXES[@]}"; do
         for vol in $(docker volume ls -q --filter "name=^$prefix" 2>/dev/null); do

--- a/.devcontainer/scripts/start-devcontainer.sh
+++ b/.devcontainer/scripts/start-devcontainer.sh
@@ -16,7 +16,10 @@ Start the TypeAgent devcontainer. Optionally configure host SSH access.
 
 Options:
   --workspace-folder PATH        Workspace folder to open (default: repo root)
-  --config PATH                  Devcontainer config file (optional)
+  --config PATH|NAME             Devcontainer config file. Accepts a path or
+                                 a short name resolved against .devcontainer/:
+                                   vnc    -> .devcontainer/vnc/devcontainer.json
+                                   agent  -> .devcontainer/agent/devcontainer.json
   --recreate                     Recreate container before startup
   --rebuild                      Rebuild image and recreate container before startup
   --clean                        Remove container and associated Docker volumes
@@ -30,7 +33,8 @@ Examples:
   $(basename "$0") --ssh
   $(basename "$0") --recreate --ssh
   $(basename "$0") --rebuild
-  $(basename "$0") --config .devcontainer/vnc/devcontainer.json
+  $(basename "$0") --config vnc
+  $(basename "$0") --config agent
 EOF
 }
 
@@ -65,7 +69,19 @@ while [[ $# -gt 0 ]]; do
             ;;
         --config)
             [[ $# -ge 2 ]] || fail "Missing value for $1"
-            CONFIG_PATH=$(cd -- "$(dirname -- "$2")" && pwd)/$(basename -- "$2")
+            # Allow short names (e.g. `vnc`, `agent`) that resolve to
+            # .devcontainer/<name>/devcontainer.json. Anything containing a
+            # slash or ending in .json is treated as a literal path.
+            _cfg_arg=$2
+            if [[ "$_cfg_arg" != */* && "$_cfg_arg" != *.json ]]; then
+                _short="$REPO_ROOT/.devcontainer/$_cfg_arg/devcontainer.json"
+                if [[ -f "$_short" ]]; then
+                    _cfg_arg="$_short"
+                else
+                    fail "Unknown config short name '$_cfg_arg' (expected $_short)"
+                fi
+            fi
+            CONFIG_PATH=$(cd -- "$(dirname -- "$_cfg_arg")" && pwd)/$(basename -- "$_cfg_arg")
             shift 2
             ;;
         --recreate|--remove-existing-container)
@@ -152,7 +168,6 @@ if [[ $CLEAN_VOLUMES -eq 1 ]]; then
     VOLUME_PREFIXES=(
         "pnpm-global-store"
         "typeagent-node_modules-"
-        "typeagent-agent-worktrees-"
         "claude-code-config-"
     )
     for prefix in "${VOLUME_PREFIXES[@]}"; do

--- a/.devcontainer/vnc/devcontainer.json
+++ b/.devcontainer/vnc/devcontainer.json
@@ -65,7 +65,6 @@
   "mounts": [
     "source=pnpm-global-store,target=/home/codespace/.local/share/pnpm/store,type=volume",
     "source=typeagent-node_modules-${devcontainerId},target=${containerWorkspaceFolder}/ts/node_modules,type=volume",
-    "source=typeagent-agent-worktrees-${devcontainerId},target=/workspaces/${localWorkspaceFolderBasename}.worktrees,type=volume",
     "source=claude-code-config-${devcontainerId},target=/home/codespace/.claude,type=volume",
     "source=copilot-cli-config-${devcontainerId},target=/home/codespace/.copilot,type=volume"
   ],


### PR DESCRIPTION
## Summary

Adds a new `.devcontainer/agent/` variant designed for VS Code agent windows that auto-create git worktrees, and cleans up some related dead code in the existing variants.

### Why

VS Code's Copilot agent window creates worktrees at `<dirname(repo)>/<basename(repo)>.worktrees/<branch>`. That base path is computed as a pure function of the repository root, with no setting to override it. In the existing devcontainer setup the worktree therefore lives at `/workspaces/<repo>.worktrees/<branch>` inside the container, which a separate host VS Code window cannot open. The `agent` variant mirrors the host path inside the container so both sides see identical paths.

(Note: this only applies to the agent-host code path. The Git extension's manual `Create Worktree` command is a separate code path that does honor a stored root and prompts for a destination; it is unaffected by this change.)

Tracked upstream as [microsoft/vscode#293884](https://github.com/microsoft/vscode/issues/293884).

### What changed

**New `agent` variant** (`.devcontainer/agent/devcontainer.json`, local-only):
- bind-mounts the repo at its host absolute path (instead of `/workspaces/<repo>`)
- bind-mounts `<repo>.worktrees` at the matching host path
- `initializeCommand` pre-creates the worktrees dir on the host
- `updateRemoteUserUID: true` so `codespace` can write through the bind mount
- keeps `ts/node_modules` on a named volume (native modules stay container-local)
- hardening: `userEnvProbe: none`, `--cap-drop=ALL` with a minimal allowlist for the post-create chown/sudo path and sshd, and `--pids-limit`

**Cleanup in standard / vnc:**
- Removed the unused `typeagent-agent-worktrees-*` named volume. The volume only existed to give agent worktrees a writable spot inside the container, but the worktrees were not visible from the host so the agent flow did not actually work end-to-end. Codespaces handles agent worktrees natively (single VM, shared paths); local Docker uses the agent variant.
- Dropped the matching worktree-prep step from `post-create.sh` and the matching prefix from `start-devcontainer.sh --clean`.
- `post-create.sh` now discovers `ts/node_modules` via `git rev-parse` rather than scanning `/workspaces`, so it works for variants that bind-mount outside `/workspaces`.

**`start-devcontainer.sh`:**
- `--config` accepts short names (`vnc`, `agent`) that resolve to `.devcontainer/<name>/devcontainer.json`. Full paths still work.

**README:** reorganized by reader intent (TL;DR -> variant selection -> quick start -> variants in detail -> working inside -> SSH -> AI agents + hardening -> reference -> troubleshooting). Clarified the three startup paths (VS Code "Reopen in Container", CLI wrapper, Codespaces) and how each handles `~/.gitconfig`. De-duplicated EACCES recipes and removed a stale `chown -R` workspace footgun.

### Validation

- `.devcontainer/scripts/start-devcontainer.sh --config agent --recreate` builds and runs post-create cleanly.
- Standard / vnc continue to build; existing Codespaces flow unaffected.