### PR TITLE
Add GitHub Copilot as a chat provider and introduce a global provider switch

### DIFF
--- a/ts/packages/agents/markdown/src/agent/translator.ts
+++ b/ts/packages/agents/markdown/src/agent/translator.ts
@@ -52,7 +52,7 @@ export class MarkdownAgent<T extends object> {
 
     constructor(schema: string, schemaName: string, fastModelName: string) {
         this.schema = schema;
-        const apiSettings = ai.azureApiSettingsFromEnv(
+        const apiSettings = ai.apiSettingsFromEnv(
             ai.ModelType.Chat,
             undefined,
             fastModelName,

--- a/ts/packages/aiclient/package.json
+++ b/ts/packages/aiclient/package.json
@@ -35,6 +35,7 @@
   },
   "dependencies": {
     "@azure/identity": "^4.10.0",
+    "@github/copilot-sdk": "0.2.0",
     "@typeagent/config": "workspace:*",
     "async": "^3.2.5",
     "debug": "^4.4.0",

--- a/ts/packages/aiclient/src/copilotModels.ts
+++ b/ts/packages/aiclient/src/copilotModels.ts
@@ -1,0 +1,427 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import {
+    CopilotClient,
+    approveAll,
+    type SessionConfig,
+    type CopilotSession,
+    type AssistantMessageEvent,
+} from "@github/copilot-sdk";
+import {
+    PromptSection,
+    Result,
+    success,
+    error,
+    ImagePromptContent,
+    MultimodalPromptContent,
+} from "typechat";
+import { execSync } from "node:child_process";
+import registerDebug from "debug";
+import {
+    ChatModelWithStreaming,
+    CompletionSettings,
+    CompletionJsonSchema,
+    CompleteUsageStatsCallback,
+} from "./models.js";
+import { CompletionUsageStats } from "./openai.js";
+import { CopilotApiSettings } from "./copilotSettings.js";
+import { TokenCounter } from "./tokenCounter.js";
+
+const debug = registerDebug("typeagent:aiclient:copilot");
+
+let cachedClient: CopilotClient | undefined;
+let startPromise: Promise<CopilotClient> | undefined;
+let cachedCliPath: string | undefined;
+let exitHandlerInstalled = false;
+
+function findCopilotPath(): string {
+    try {
+        const isWindows = process.platform === "win32";
+        const command = isWindows ? "where copilot" : "which copilot";
+        const result = execSync(command, { encoding: "utf8" }).trim();
+        const first = result.split("\n")[0].trim();
+        debug(`Found copilot CLI at: ${first}`);
+        return first;
+    } catch {
+        debug("Could not find copilot CLI in PATH, falling back to 'copilot'");
+        return "copilot";
+    }
+}
+
+async function getClient(cliPathOverride?: string): Promise<CopilotClient> {
+    if (cachedClient) return cachedClient;
+    if (startPromise) return startPromise;
+
+    const cliPath = cliPathOverride ?? cachedCliPath ?? findCopilotPath();
+    cachedCliPath = cliPath;
+
+    startPromise = (async () => {
+        debug(`Starting CopilotClient at ${cliPath}`);
+        const client = new CopilotClient({ cliPath });
+        try {
+            await client.start();
+        } catch (err) {
+            startPromise = undefined;
+            throw new Error(
+                `Failed to start GitHub Copilot CLI client at '${cliPath}'. ` +
+                    `Ensure 'copilot' is installed and authenticated (try 'copilot auth login').\n` +
+                    `Underlying error: ${err instanceof Error ? err.message : String(err)}`,
+            );
+        }
+        cachedClient = client;
+        if (!exitHandlerInstalled) {
+            exitHandlerInstalled = true;
+            process.on("exit", () => {
+                cachedClient?.stop().catch(() => {});
+            });
+        }
+        return client;
+    })();
+    return startPromise;
+}
+
+/**
+ * Public accessor for callers that want to talk to the Copilot CLI
+ * directly (auth status, model listing, reasoning loop). Shares the
+ * same process-wide singleton used by the chat adapter so we don't
+ * spawn two CLI children.
+ */
+export async function getCopilotClient(
+    cliPathOverride?: string,
+): Promise<CopilotClient> {
+    return getClient(cliPathOverride);
+}
+
+function withAbortSignal<T>(
+    promise: Promise<T>,
+    signal: AbortSignal | undefined,
+): Promise<T> {
+    if (!signal) return promise;
+    if (signal.aborted) return Promise.reject(signal.reason);
+    return new Promise<T>((resolve, reject) => {
+        const onAbort = () => reject(signal.reason);
+        signal.addEventListener("abort", onAbort, { once: true });
+        promise.then(
+            (value) => {
+                signal.removeEventListener("abort", onAbort);
+                resolve(value);
+            },
+            (err) => {
+                signal.removeEventListener("abort", onAbort);
+                reject(err);
+            },
+        );
+    });
+}
+
+function rejectImageContent(messages: PromptSection[]): void {
+    const isImage = (c: MultimodalPromptContent) =>
+        (c as ImagePromptContent).type === "image_url";
+    for (const ps of messages) {
+        if (Array.isArray(ps.content) && ps.content.some(isImage)) {
+            throw new Error(
+                "Image content is not supported by the Copilot chat adapter",
+            );
+        }
+    }
+}
+
+function renderPrompt(prompt: string | PromptSection[]): string {
+    if (typeof prompt === "string") return prompt;
+    const sections = prompt;
+    rejectImageContent(sections);
+    const parts: string[] = [];
+    for (const section of sections) {
+        const content =
+            typeof section.content === "string"
+                ? section.content
+                : section.content
+                      .map((c) =>
+                          typeof c === "string"
+                              ? c
+                              : "text" in c && typeof c.text === "string"
+                                ? c.text
+                                : "",
+                      )
+                      .join("");
+        const role = section.role ?? "user";
+        parts.push(`[${role}]\n${content}`);
+    }
+    return parts.join("\n\n");
+}
+
+function buildSessionConfig(
+    settings: CopilotApiSettings,
+    completionSettings: CompletionSettings,
+    streaming: boolean,
+): SessionConfig {
+    const reasoningEffort =
+        (completionSettings.reasoning_effort as
+            | "low"
+            | "medium"
+            | "high"
+            | undefined) ?? settings.reasoningEffort;
+    const config: SessionConfig = {
+        clientName: "TypeAgent",
+        model: settings.modelName,
+        streaming,
+        tools: [],
+        availableTools: [],
+        systemMessage: { mode: "append", content: "" },
+        onPermissionRequest: approveAll,
+        ...(settings.disableInfiniteSessions
+            ? { infiniteSessions: { enabled: false } }
+            : {}),
+        ...(reasoningEffort !== undefined ? { reasoningEffort } : {}),
+    };
+    return config;
+}
+
+function estimateTokens(text: string): number {
+    // Coarse char-based estimate so TokenCounter still has something to
+    // report when the SDK doesn't surface real usage. ~4 chars/token.
+    return Math.max(0, Math.ceil(text.length / 4));
+}
+
+export function createCopilotChatModel(
+    settings: CopilotApiSettings,
+    completionSettings?: CompletionSettings,
+    completionCallback?: (request: any, response: any) => void,
+    tags?: string[],
+): ChatModelWithStreaming {
+    completionSettings ??= {};
+    completionSettings.n ??= 1;
+
+    const model: ChatModelWithStreaming = {
+        completionSettings,
+        completionCallback,
+        complete,
+        completeStream,
+    };
+    return model;
+
+    function reportUsage(
+        promptText: string,
+        responseText: string,
+        usageCallback?: CompleteUsageStatsCallback,
+    ) {
+        const prompt_tokens = estimateTokens(promptText);
+        const completion_tokens = estimateTokens(responseText);
+        const usage: CompletionUsageStats = {
+            prompt_tokens,
+            completion_tokens,
+            total_tokens: prompt_tokens + completion_tokens,
+        };
+        try {
+            TokenCounter.getInstance().add(usage, tags);
+            usageCallback?.(usage);
+        } catch {}
+    }
+
+    async function complete(
+        prompt: string | PromptSection[],
+        usageCallback?: CompleteUsageStatsCallback,
+        _jsonSchema?: CompletionJsonSchema,
+        logFn?: (msg: any) => void,
+        signal?: AbortSignal,
+    ): Promise<Result<string>> {
+        const messages: PromptSection[] =
+            typeof prompt === "string"
+                ? [{ role: "user", content: prompt }]
+                : prompt;
+        const promptText = renderPrompt(messages);
+
+        let client: CopilotClient;
+        try {
+            client = await getClient(settings.cliPath);
+        } catch (err) {
+            return error(err instanceof Error ? err.message : String(err));
+        }
+
+        let session: CopilotSession;
+        try {
+            session = await client.createSession(
+                buildSessionConfig(settings, completionSettings!, false),
+            );
+        } catch (err) {
+            return error(
+                `Failed to create Copilot session: ${err instanceof Error ? err.message : String(err)}`,
+            );
+        }
+
+        try {
+            const response: AssistantMessageEvent | undefined =
+                await withAbortSignal(
+                    session.sendAndWait({ prompt: promptText }),
+                    signal,
+                );
+            const text = response?.data?.content ?? "";
+            if (model.completionCallback) {
+                model.completionCallback(
+                    { prompt: promptText, model: settings.modelName },
+                    response,
+                );
+            }
+            try {
+                if (settings.enableModelRequestLogging && logFn) {
+                    logFn({
+                        prompt: messages,
+                        response: text,
+                        tags,
+                    });
+                }
+            } catch {}
+            reportUsage(promptText, text, usageCallback);
+            return success(text);
+        } catch (err) {
+            return error(err instanceof Error ? err.message : String(err));
+        } finally {
+            session.disconnect().catch(() => {});
+        }
+    }
+
+    async function completeStream(
+        prompt: string | PromptSection[],
+        usageCallback?: CompleteUsageStatsCallback,
+        _jsonSchema?: CompletionJsonSchema,
+        logFn?: (msg: any) => void,
+        signal?: AbortSignal,
+    ): Promise<Result<AsyncIterableIterator<string>>> {
+        const messages: PromptSection[] =
+            typeof prompt === "string"
+                ? [{ role: "user", content: prompt }]
+                : prompt;
+        const promptText = renderPrompt(messages);
+
+        let client: CopilotClient;
+        try {
+            client = await getClient(settings.cliPath);
+        } catch (err) {
+            return error(err instanceof Error ? err.message : String(err));
+        }
+
+        let session: CopilotSession;
+        try {
+            session = await client.createSession(
+                buildSessionConfig(settings, completionSettings!, true),
+            );
+        } catch (err) {
+            return error(
+                `Failed to create Copilot session: ${err instanceof Error ? err.message : String(err)}`,
+            );
+        }
+
+        // Buffer streaming deltas; the consumer pulls from a queue.
+        const queue: Array<{ value?: string; done?: boolean; err?: Error }> =
+            [];
+        let resolveNext: (() => void) | undefined;
+        let collected = "";
+
+        const wake = () => {
+            if (resolveNext) {
+                const r = resolveNext;
+                resolveNext = undefined;
+                r();
+            }
+        };
+
+        const unsubscribeDelta = session.on(
+            "assistant.message_delta",
+            (event: any) => {
+                const delta = event?.data?.deltaContent;
+                if (typeof delta === "string" && delta.length > 0) {
+                    collected += delta;
+                    queue.push({ value: delta });
+                    wake();
+                }
+            },
+        );
+        const unsubscribeMessage = session.on(
+            "assistant.message",
+            (event: any) => {
+                // When the SDK doesn't emit deltas (e.g. streaming
+                // disabled), surface the final content as one chunk.
+                if (collected.length === 0) {
+                    const content = event?.data?.content;
+                    if (typeof content === "string" && content.length > 0) {
+                        collected = content;
+                        queue.push({ value: content });
+                    }
+                }
+            },
+        );
+
+        const completion = withAbortSignal(
+            session.sendAndWait({ prompt: promptText }),
+            signal,
+        )
+            .then((response) => {
+                if (model.completionCallback) {
+                    model.completionCallback(
+                        { prompt: promptText, model: settings.modelName },
+                        response,
+                    );
+                }
+                try {
+                    if (settings.enableModelRequestLogging && logFn) {
+                        logFn({
+                            prompt: messages,
+                            response: collected,
+                            tags,
+                        });
+                    }
+                } catch {}
+                reportUsage(promptText, collected, usageCallback);
+                queue.push({ done: true });
+                wake();
+            })
+            .catch((err: unknown) => {
+                queue.push({
+                    err: err instanceof Error ? err : new Error(String(err)),
+                });
+                wake();
+            });
+
+        const iterator: AsyncIterableIterator<string> = {
+            [Symbol.asyncIterator]() {
+                return this;
+            },
+            async next(): Promise<IteratorResult<string>> {
+                while (true) {
+                    if (queue.length > 0) {
+                        const item = queue.shift()!;
+                        if (item.err) {
+                            await cleanup();
+                            throw item.err;
+                        }
+                        if (item.done) {
+                            await cleanup();
+                            return { value: undefined, done: true };
+                        }
+                        return { value: item.value!, done: false };
+                    }
+                    await new Promise<void>((resolve) => {
+                        resolveNext = resolve;
+                    });
+                }
+            },
+            async return(): Promise<IteratorResult<string>> {
+                await cleanup();
+                return { value: undefined, done: true };
+            },
+        };
+
+        let cleaned = false;
+        async function cleanup() {
+            if (cleaned) return;
+            cleaned = true;
+            unsubscribeDelta();
+            unsubscribeMessage();
+            await completion.catch(() => {});
+            await session.disconnect().catch(() => {});
+        }
+
+        return success(iterator);
+    }
+}

--- a/ts/packages/aiclient/src/copilotSettings.ts
+++ b/ts/packages/aiclient/src/copilotSettings.ts
@@ -1,0 +1,41 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { CommonApiSettings, ModelType } from "./openai.js";
+import { getRuntimeConfig } from "./runtimeConfig.js";
+
+export type CopilotReasoningEffort = "low" | "medium" | "high" | "xhigh";
+
+export type CopilotApiSettings = CommonApiSettings & {
+    provider: "copilot";
+    modelType: ModelType.Chat;
+    modelName: string;
+    cliPath?: string;
+    reasoningEffort?: CopilotReasoningEffort;
+    disableInfiniteSessions: boolean;
+};
+
+const DEFAULT_MODEL = "claude-sonnet-4.5";
+
+export function copilotApiSettingsFromConfig(
+    modelName?: string,
+): CopilotApiSettings {
+    const config = getRuntimeConfig();
+    const copilot = config.copilot;
+    const resolvedModel = modelName ?? copilot?.defaultModel ?? DEFAULT_MODEL;
+    return {
+        provider: "copilot",
+        modelType: ModelType.Chat,
+        endpoint: "copilot-cli",
+        modelName: resolvedModel,
+        ...(copilot?.cliPath !== undefined ? { cliPath: copilot.cliPath } : {}),
+        ...(copilot?.reasoningEffort !== undefined
+            ? { reasoningEffort: copilot.reasoningEffort }
+            : {}),
+        disableInfiniteSessions: copilot?.disableInfiniteSessions ?? true,
+        maxConcurrency: copilot?.maxConcurrency,
+        timeout: copilot?.maxTimeoutMs ?? 120_000,
+        maxRetryAttempts: copilot?.maxRetryAttempts ?? 1,
+        enableModelRequestLogging: copilot?.enableModelRequestLogging,
+    };
+}

--- a/ts/packages/aiclient/src/index.ts
+++ b/ts/packages/aiclient/src/index.ts
@@ -8,6 +8,19 @@ export * as bing from "./bing.js";
 export * from "./restClient.js";
 export * from "./auth.js";
 export * from "./tokenCounter.js";
+export { getCopilotClient } from "./copilotModels.js";
+export {
+    copilotApiSettingsFromConfig,
+    type CopilotApiSettings,
+    type CopilotReasoningEffort,
+} from "./copilotSettings.js";
+export {
+    getActiveModelProvider,
+    setActiveModelProvider,
+    resolveTarget,
+    PROVIDER_MODES,
+    type ProviderMode,
+} from "./providerMode.js";
 export {
     getChatModelNames,
     getChatModelMaxConcurrency,

--- a/ts/packages/aiclient/src/modelResource.ts
+++ b/ts/packages/aiclient/src/modelResource.ts
@@ -4,6 +4,34 @@
 import { openai as ai } from "aiclient";
 import { getOllamaModelNames } from "./ollamaModels.js";
 import { getRuntimeConfig } from "./runtimeConfig.js";
+import { getCopilotClient } from "./copilotModels.js";
+import registerDebug from "debug";
+
+const debugModelResource = registerDebug("typeagent:aiclient:modelresource");
+
+let copilotModelNamesCache: string[] | undefined;
+async function getCopilotModelNames(): Promise<string[]> {
+    if (copilotModelNamesCache !== undefined) return copilotModelNamesCache;
+    const config = getRuntimeConfig();
+    if (config.copilot === undefined) {
+        copilotModelNamesCache = [];
+        return copilotModelNamesCache;
+    }
+    try {
+        const client = await getCopilotClient(config.copilot.cliPath);
+        const models = await client.listModels();
+        copilotModelNamesCache = models
+            .filter((m) => m.policy?.state !== "disabled")
+            .map((m) => `copilot:${m.id}`);
+    } catch (err) {
+        debugModelResource(
+            "Failed to list Copilot models: %s",
+            err instanceof Error ? err.message : String(err),
+        );
+        copilotModelNamesCache = [];
+    }
+    return copilotModelNamesCache;
+}
 
 export function getChatModelMaxConcurrency(
     userMaxConcurrency?: number,
@@ -45,7 +73,12 @@ export async function getChatModelNames() {
         openaiNames.push("openai:LOCAL");
     }
 
-    return [...azureNames, ...openaiNames, ...(await getOllamaModelNames())];
+    return [
+        ...azureNames,
+        ...openaiNames,
+        ...(await getOllamaModelNames()),
+        ...(await getCopilotModelNames()),
+    ];
 }
 
 export function isMultiModalContentSupported(modelName: string | undefined) {

--- a/ts/packages/aiclient/src/openai.ts
+++ b/ts/packages/aiclient/src/openai.ts
@@ -51,6 +51,12 @@ import {
     openAIApiSettingsFromEnv,
 } from "./openaiSettings.js";
 import { AzureApiSettings, azureApiSettingsFromEnv } from "./azureSettings.js";
+import {
+    CopilotApiSettings,
+    copilotApiSettingsFromConfig,
+} from "./copilotSettings.js";
+import { createCopilotChatModel } from "./copilotModels.js";
+import { getActiveModelProvider, resolveTarget } from "./providerMode.js";
 
 export { azureApiSettingsFromEnv, openAIApiSettingsFromEnv };
 
@@ -70,7 +76,7 @@ export type ModelInfo<T> = {
     maxTokens: number;
 };
 
-export type ModelProviders = "openai" | "azure" | "ollama";
+export type ModelProviders = "openai" | "azure" | "ollama" | "copilot";
 
 export type CommonApiSettings = {
     provider: ModelProviders;
@@ -89,7 +95,8 @@ export type CommonApiSettings = {
 export type ApiSettings =
     | OllamaApiSettings
     | AzureApiSettings
-    | OpenAIApiSettings;
+    | OpenAIApiSettings
+    | CopilotApiSettings;
 
 /**
  * Environment variables used to configure OpenAI clients
@@ -161,6 +168,25 @@ export function apiSettingsFromEnv(
     env?: Record<string, string | undefined>,
     endpointName?: string,
 ): ApiSettings {
+    // Provider-mode override applies to chat only. Embeddings, images,
+    // and video stay on whatever the legacy resolver picks (Azure/OpenAI).
+    const mode = getActiveModelProvider();
+    if (mode !== undefined && modelType === ModelType.Chat) {
+        const target = resolveTarget(mode, endpointName ?? "DEFAULT");
+        if (mode === "copilot") {
+            return copilotApiSettingsFromConfig(target);
+        }
+        if (mode === "ollama") {
+            return ollamaApiSettingsFromEnv(modelType, env, target);
+        }
+        if (mode === "openai") {
+            return openAIApiSettingsFromEnv(modelType, env, target);
+        }
+        // mode === "azure" falls through to legacy logic with the (identity-
+        // mapped) target — preserves the historical resolution path.
+        return azureApiSettingsFromEnv(modelType, env, target);
+    }
+
     env ??= process.env;
     if (EnvVars.OPENAI_API_KEY in env) {
         return openAIApiSettingsFromEnv(modelType, env, endpointName);
@@ -239,6 +265,10 @@ function parseEndPointName(endpoint?: string): {
     name?: string;
 } {
     if (endpoint === undefined || endpoint === "") {
+        const mode = getActiveModelProvider();
+        if (mode !== undefined) {
+            return { provider: mode, name: resolveTarget(mode, "DEFAULT") };
+        }
         return {
             provider:
                 EnvVars.OPENAI_ENDPOINT in process.env ? "openai" : "azure",
@@ -247,7 +277,8 @@ function parseEndPointName(endpoint?: string): {
     if (
         endpoint === "openai" ||
         endpoint === "azure" ||
-        endpoint === "ollama"
+        endpoint === "ollama" ||
+        endpoint === "copilot"
     ) {
         return { provider: endpoint };
     }
@@ -259,6 +290,16 @@ function parseEndPointName(endpoint?: string): {
     }
     if (endpoint.startsWith("azure:")) {
         return { provider: "azure", name: endpoint.substring(6) };
+    }
+    if (endpoint.startsWith("copilot:")) {
+        return { provider: "copilot", name: endpoint.substring(8) };
+    }
+    // Provider-mode override: route an unprefixed canonical name through
+    // the active mode's mapping. Explicit prefixes above always win.
+    const mode = getActiveModelProvider();
+    if (mode !== undefined) {
+        const target = resolveTarget(mode, endpoint);
+        return { provider: mode, name: target };
     }
     if (EnvVars.OPENAI_ENDPOINT in process.env) {
         return { provider: "openai", name: endpoint };
@@ -297,7 +338,7 @@ function buildModelPool(
     modelType: ModelType,
     endpointName?: string,
 ): EndpointPool {
-    if (provider !== "ollama") {
+    if (provider !== "ollama" && provider !== "copilot") {
         try {
             const typedName = endpointName?.toLowerCase();
             return discoverEndpointPoolFromConfig(
@@ -329,6 +370,18 @@ export function getChatModelPool(endpoint?: string): EndpointPool {
             undefined,
             endpointName.name,
         );
+        if (settings.maxConcurrency !== undefined) {
+            const q = priorityQueue<() => Promise<any>>(
+                async (task) => task(),
+                settings.maxConcurrency,
+            );
+            settings.throttler = (fn: () => Promise<any>, priority?: number) =>
+                q.push<any>(fn, priority);
+        }
+        pool = makeSingleMemberPool(settings, key);
+    } else if (endpointName.provider === "copilot") {
+        // Copilot is single-endpoint (the spawned CLI); no HTTP pool.
+        const settings = copilotApiSettingsFromConfig(endpointName.name);
         if (settings.maxConcurrency !== undefined) {
             const q = priorityQueue<() => Promise<any>>(
                 async (task) => task(),
@@ -478,6 +531,14 @@ export function createChatModel(
     completionCallback?: (request: any, response: any) => void,
     tags?: string[],
 ): ChatModelWithStreaming {
+    // Tag calls with the active mode so TokenCounter rollups can slice
+    // by provider. Pre-resolved ApiSettings bypass mode override, so
+    // only tag when the override is in effect AND the caller went
+    // through name-based resolution.
+    const activeMode = getActiveModelProvider();
+    if (activeMode !== undefined && typeof endpoint !== "object") {
+        tags = [...(tags ?? []), `mode:${activeMode}`];
+    }
     const pool =
         typeof endpoint === "object"
             ? makeSingleMemberPool(endpoint, `custom:${endpoint.provider}`)
@@ -492,6 +553,14 @@ export function createChatModel(
 
     if (settings.provider === "ollama") {
         return createOllamaChatModel(
+            settings,
+            completionSettings,
+            completionCallback,
+            tags,
+        );
+    }
+    if (settings.provider === "copilot") {
+        return createCopilotChatModel(
             settings,
             completionSettings,
             completionCallback,

--- a/ts/packages/aiclient/src/providerMode.ts
+++ b/ts/packages/aiclient/src/providerMode.ts
@@ -1,0 +1,106 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+/**
+ * Process-wide LLM provider mode override.
+ *
+ * When set, unprefixed `createChatModel` calls (and the settings loaders
+ * they go through) get rewritten to route to the active mode's provider
+ * and target model. Explicit `azure:` / `openai:` / `ollama:` / `copilot:`
+ * prefixes and pre-resolved `ApiSettings` objects bypass the override.
+ *
+ * The built-in canonical name maps live here as module constants. They
+ * are not user-overridable at runtime; users who need different
+ * mappings can either pass an explicit prefix at the call site or
+ * adjust this file. Per-mode default-model selection still flows
+ * through the provider's existing config field (e.g.
+ * `copilot.defaultModel`).
+ */
+
+export type ProviderMode = "azure" | "openai" | "ollama" | "copilot";
+
+export const PROVIDER_MODES: readonly ProviderMode[] = [
+    "azure",
+    "openai",
+    "ollama",
+    "copilot",
+] as const;
+
+let active: ProviderMode | undefined;
+
+export function getActiveModelProvider(): ProviderMode | undefined {
+    return active;
+}
+
+export function setActiveModelProvider(mode: ProviderMode | undefined): void {
+    active = mode;
+}
+
+/**
+ * Canonical TypeAgent identifiers that callers across the codebase
+ * pass to `createChatModel`. `"DEFAULT"` represents the no-name case
+ * (`createChatModel(undefined, ...)`).
+ */
+const CANONICAL_NAMES = [
+    "DEFAULT",
+    "GPT_35_TURBO",
+    "GPT_4_O",
+    "GPT_5",
+    "GPT_5_MINI",
+    "GPT_5_NANO",
+    "GPT_V",
+] as const;
+
+type CanonicalName = (typeof CANONICAL_NAMES)[number];
+
+function isCanonicalName(s: string): s is CanonicalName {
+    return (CANONICAL_NAMES as readonly string[]).includes(s);
+}
+
+/**
+ * Built-in name maps per non-Azure mode. Azure mode is identity — the
+ * canonical names already are Azure deployment names, so no rewriting.
+ * OpenAI mode is identity for now (callers rarely use OpenAI-specific
+ * names; the `openai:LOCAL` form is the explicit escape).
+ */
+const COPILOT_MAP: Record<CanonicalName, string> = {
+    DEFAULT: "claude-sonnet-4.5",
+    GPT_35_TURBO: "claude-haiku-4.5",
+    GPT_4_O: "gpt-4o",
+    GPT_5: "claude-sonnet-4.5",
+    GPT_5_MINI: "gpt-4o-mini",
+    GPT_5_NANO: "gpt-4o-mini",
+    GPT_V: "gpt-4o",
+};
+
+const OLLAMA_MAP: Record<CanonicalName, string> = {
+    DEFAULT: "llama3.2",
+    GPT_35_TURBO: "llama3.2:3b",
+    GPT_4_O: "llama3.1",
+    GPT_5: "llama3.1:70b",
+    GPT_5_MINI: "llama3.2:3b",
+    GPT_5_NANO: "llama3.2:1b",
+    GPT_V: "llava",
+};
+
+/**
+ * Resolve a canonical TypeAgent identifier to a target model id for
+ * the active provider mode. Unknown identifiers fall back to the
+ * mode's `DEFAULT` target.
+ */
+export function resolveTarget(mode: ProviderMode, canonical: string): string {
+    const key = canonical.toUpperCase();
+    switch (mode) {
+        case "copilot":
+            return isCanonicalName(key)
+                ? COPILOT_MAP[key]
+                : COPILOT_MAP.DEFAULT;
+        case "ollama":
+            return isCanonicalName(key) ? OLLAMA_MAP[key] : OLLAMA_MAP.DEFAULT;
+        case "azure":
+        case "openai":
+            // Identity: pass the original name through (callers already
+            // use Azure-deployment-style names).
+            return canonical;
+    }
+}

--- a/ts/packages/aiclient/src/runtimeConfig.ts
+++ b/ts/packages/aiclient/src/runtimeConfig.ts
@@ -18,6 +18,7 @@
  */
 
 import { buildConfig, type Config } from "@typeagent/config";
+import { setActiveModelProvider } from "./providerMode.js";
 
 let cached: Config | undefined;
 
@@ -27,6 +28,9 @@ let cached: Config | undefined;
  */
 export function setRuntimeConfig(config: Config): void {
     cached = config;
+    if (config.modelProvider !== undefined) {
+        setActiveModelProvider(config.modelProvider);
+    }
 }
 
 /**
@@ -39,6 +43,9 @@ export function initRuntimeConfigFromProcessEnv(): Config {
         if (typeof v === "string") flat[k] = v;
     }
     cached = buildConfig(flat);
+    if (cached.modelProvider !== undefined) {
+        setActiveModelProvider(cached.modelProvider);
+    }
     return cached;
 }
 

--- a/ts/packages/config/src/runtime/build.ts
+++ b/ts/packages/config/src/runtime/build.ts
@@ -156,6 +156,8 @@ export function buildConfig(flat: FlatEnv): Config {
     const vault = buildVault(remaining);
     const azureFoundry = buildAzureFoundry(remaining);
     const reasoning = buildReasoning(remaining);
+    const copilot = buildCopilot(remaining);
+    const modelProvider = buildModelProvider(remaining);
 
     return {
         azureOpenAI,
@@ -170,6 +172,8 @@ export function buildConfig(flat: FlatEnv): Config {
         vault,
         ...(azureFoundry ? { azureFoundry } : {}),
         ...(reasoning ? { reasoning } : {}),
+        ...(copilot ? { copilot } : {}),
+        ...(modelProvider !== undefined ? { modelProvider } : {}),
         extra: new Map(remaining),
     };
 }
@@ -780,6 +784,80 @@ function buildAzureFoundry(flat: Map<string, string>) {
             : {}),
         ...(httpEndpointLogicAppConnectionId !== undefined
             ? { httpEndpointLogicAppConnectionId }
+            : {}),
+    };
+}
+
+function buildModelProvider(
+    flat: Map<string, string>,
+): "azure" | "openai" | "ollama" | "copilot" | undefined {
+    const raw = popString(flat, "TYPEAGENT_MODEL_PROVIDER");
+    if (raw === undefined) return undefined;
+    const v = raw.toLowerCase();
+    if (v === "azure" || v === "openai" || v === "ollama" || v === "copilot") {
+        return v;
+    }
+    // Unknown value — leave it in extra rather than emitting a malformed
+    // typed field.
+    flat.set("TYPEAGENT_MODEL_PROVIDER", raw);
+    return undefined;
+}
+
+function buildCopilot(flat: Map<string, string>) {
+    const defaultModel = popString(flat, "COPILOT_DEFAULT_MODEL");
+    const cliPath = popString(flat, "COPILOT_CLI_PATH");
+    const reasoningEffortRaw = popString(flat, "COPILOT_REASONING_EFFORT");
+    const disableInfiniteRaw = popString(
+        flat,
+        "COPILOT_DISABLE_INFINITE_SESSIONS",
+    );
+    const maxConcurrency = popInt(flat, "COPILOT_MAX_CONCURRENCY");
+    const maxTimeoutMs = popInt(flat, "COPILOT_MAX_TIMEOUT");
+    const maxRetryAttempts = popInt(flat, "COPILOT_MAX_RETRYATTEMPTS");
+    const enableLogging = popString(flat, "COPILOT_ENABLE_LOGGING");
+
+    if (
+        defaultModel === undefined &&
+        cliPath === undefined &&
+        reasoningEffortRaw === undefined &&
+        disableInfiniteRaw === undefined &&
+        maxConcurrency === undefined &&
+        maxTimeoutMs === undefined &&
+        maxRetryAttempts === undefined &&
+        enableLogging === undefined
+    ) {
+        return undefined;
+    }
+
+    const reasoningEffort: "low" | "medium" | "high" | "xhigh" | undefined =
+        reasoningEffortRaw === "low" ||
+        reasoningEffortRaw === "medium" ||
+        reasoningEffortRaw === "high" ||
+        reasoningEffortRaw === "xhigh"
+            ? reasoningEffortRaw
+            : undefined;
+    const disableInfiniteSessions =
+        disableInfiniteRaw === undefined
+            ? undefined
+            : disableInfiniteRaw === "1" ||
+              disableInfiniteRaw.toLowerCase() === "true";
+    const enableModelRequestLogging =
+        enableLogging === undefined
+            ? undefined
+            : enableLogging === "1" || enableLogging.toLowerCase() === "true";
+
+    return {
+        ...(defaultModel !== undefined ? { defaultModel } : {}),
+        ...(cliPath !== undefined ? { cliPath } : {}),
+        ...(reasoningEffort !== undefined ? { reasoningEffort } : {}),
+        ...(disableInfiniteSessions !== undefined
+            ? { disableInfiniteSessions }
+            : {}),
+        ...(maxConcurrency !== undefined ? { maxConcurrency } : {}),
+        ...(maxTimeoutMs !== undefined ? { maxTimeoutMs } : {}),
+        ...(maxRetryAttempts !== undefined ? { maxRetryAttempts } : {}),
+        ...(enableModelRequestLogging !== undefined
+            ? { enableModelRequestLogging }
             : {}),
     };
 }

--- a/ts/packages/config/src/runtime/tree.ts
+++ b/ts/packages/config/src/runtime/tree.ts
@@ -437,6 +437,32 @@ export function configToTree(config: Config): ConfigTree {
         if (Object.keys(r).length > 0) tree.reasoning = r;
     }
 
+    if (config.modelProvider !== undefined) {
+        tree.modelProvider = config.modelProvider;
+    }
+
+    if (config.copilot) {
+        const c: ConfigTree = {};
+        if (config.copilot.defaultModel !== undefined)
+            c.defaultModel = config.copilot.defaultModel;
+        if (config.copilot.cliPath !== undefined)
+            c.cliPath = config.copilot.cliPath;
+        if (config.copilot.reasoningEffort !== undefined)
+            c.reasoningEffort = config.copilot.reasoningEffort;
+        if (config.copilot.disableInfiniteSessions !== undefined)
+            c.disableInfiniteSessions = config.copilot.disableInfiniteSessions;
+        if (config.copilot.maxConcurrency !== undefined)
+            c.maxConcurrency = config.copilot.maxConcurrency;
+        if (config.copilot.maxTimeoutMs !== undefined)
+            c.maxTimeoutMs = config.copilot.maxTimeoutMs;
+        if (config.copilot.maxRetryAttempts !== undefined)
+            c.maxRetryAttempts = config.copilot.maxRetryAttempts;
+        if (config.copilot.enableModelRequestLogging !== undefined)
+            c.enableModelRequestLogging =
+                config.copilot.enableModelRequestLogging;
+        if (Object.keys(c).length > 0) tree.copilot = c;
+    }
+
     return tree;
 }
 
@@ -457,6 +483,8 @@ const TYPED_SECTION_KEYS = new Set([
     "vault",
     "azureFoundry",
     "reasoning",
+    "copilot",
+    "modelProvider",
 ]);
 
 export function isTypedSectionKey(key: string): boolean {
@@ -948,6 +976,49 @@ function emitAzureFoundry(node: unknown, out: FlatEnv): void {
     }
 }
 
+function emitModelProvider(node: unknown, out: FlatEnv): void {
+    if (typeof node !== "string") {
+        throw new Error(
+            `Expected a string at 'modelProvider', got ${typeof node}.`,
+        );
+    }
+    out.TYPEAGENT_MODEL_PROVIDER = node;
+}
+
+function emitCopilot(node: unknown, out: FlatEnv): void {
+    const c = asObject(node, "copilot");
+    if (c.defaultModel !== undefined)
+        out.COPILOT_DEFAULT_MODEL = asString(
+            c.defaultModel,
+            "copilot.defaultModel",
+        );
+    if (c.cliPath !== undefined)
+        out.COPILOT_CLI_PATH = asString(c.cliPath, "copilot.cliPath");
+    if (c.reasoningEffort !== undefined)
+        out.COPILOT_REASONING_EFFORT = asString(
+            c.reasoningEffort,
+            "copilot.reasoningEffort",
+        );
+    if (c.disableInfiniteSessions !== undefined)
+        out.COPILOT_DISABLE_INFINITE_SESSIONS = c.disableInfiniteSessions
+            ? "1"
+            : "0";
+    if (c.maxConcurrency !== undefined)
+        out.COPILOT_MAX_CONCURRENCY = String(
+            asNumber(c.maxConcurrency, "copilot.maxConcurrency"),
+        );
+    if (c.maxTimeoutMs !== undefined)
+        out.COPILOT_MAX_TIMEOUT = String(
+            asNumber(c.maxTimeoutMs, "copilot.maxTimeoutMs"),
+        );
+    if (c.maxRetryAttempts !== undefined)
+        out.COPILOT_MAX_RETRYATTEMPTS = String(
+            asNumber(c.maxRetryAttempts, "copilot.maxRetryAttempts"),
+        );
+    if (c.enableModelRequestLogging !== undefined)
+        out.COPILOT_ENABLE_LOGGING = c.enableModelRequestLogging ? "1" : "0";
+}
+
 function emitReasoning(node: unknown, out: FlatEnv): void {
     const r = asObject(node, "reasoning");
     if (r.timeoutMs !== undefined)
@@ -1005,6 +1076,12 @@ export function typedSectionToFlat(key: string, node: unknown): FlatEnv {
             break;
         case "reasoning":
             emitReasoning(node, out);
+            break;
+        case "copilot":
+            emitCopilot(node, out);
+            break;
+        case "modelProvider":
+            emitModelProvider(node, out);
             break;
         default:
             throw new Error(`Not a typed section: '${key}'.`);

--- a/ts/packages/config/src/runtime/types.ts
+++ b/ts/packages/config/src/runtime/types.ts
@@ -208,11 +208,43 @@ export interface AzureFoundryConfig {
     readonly httpEndpointLogicAppConnectionId?: string | undefined;
 }
 
+/**
+ * LLM provider modes for the global override switch. Kept as a string
+ * literal union (not an import from aiclient) to avoid a circular
+ * package dependency — aiclient depends on @typeagent/config, not the
+ * other way around.
+ */
+export type ModelProviderMode = "azure" | "openai" | "ollama" | "copilot";
+
 export interface ReasoningConfig {
     /** Reasoning-loop timeout in milliseconds (0 = disabled). */
     readonly timeoutMs?: number | undefined;
     /** Override the default Copilot reasoning model. */
     readonly copilotModel?: string | undefined;
+}
+
+/**
+ * GitHub Copilot SDK provider configuration. Used by the translation
+ * pipeline when a caller selects `copilot:<model>` (or just `copilot`).
+ * Authentication is handled externally by the `copilot` / `gh` CLI —
+ * there are no credentials here.
+ */
+export interface CopilotConfig {
+    /** Model id used when `copilot:` is selected with no name. */
+    readonly defaultModel?: string | undefined;
+    /** Override the auto-detected `copilot` CLI binary path. */
+    readonly cliPath?: string | undefined;
+    /** Default reasoning effort to forward for capable models. */
+    readonly reasoningEffort?: "low" | "medium" | "high" | "xhigh" | undefined;
+    /**
+     * Disable infinite/persistent sessions so per-call session setup
+     * stays cheap. Defaults to `true` for translation use cases.
+     */
+    readonly disableInfiniteSessions?: boolean | undefined;
+    readonly maxConcurrency?: number | undefined;
+    readonly maxTimeoutMs?: number | undefined;
+    readonly maxRetryAttempts?: number | undefined;
+    readonly enableModelRequestLogging?: boolean | undefined;
 }
 
 /** Root typed configuration. */
@@ -229,6 +261,13 @@ export interface Config {
     readonly vault?: VaultConfig | undefined;
     readonly azureFoundry?: AzureFoundryConfig | undefined;
     readonly reasoning?: ReasoningConfig | undefined;
+    readonly copilot?: CopilotConfig | undefined;
+    /**
+     * Active provider mode for model resolution. When set, unprefixed
+     * `createChatModel` calls route through this provider's mapping.
+     * Bound to `aiclient`'s singleton at startup.
+     */
+    readonly modelProvider?: ModelProviderMode | undefined;
     /**
      * Untyped passthrough: any flat `KEY=value` pair that wasn't
      * recognized by the typed schema lives here. This is what makes

--- a/ts/packages/dispatcher/dispatcher/src/context/system/handlers/configCommandHandlers.ts
+++ b/ts/packages/dispatcher/dispatcher/src/context/system/handlers/configCommandHandlers.ts
@@ -15,7 +15,16 @@ import { getActionContext } from "../../../execute/actionContext.js";
 import { emitActionResult } from "../../../execute/actionHandlers.js";
 
 import { simpleStarRegex } from "@typeagent/common-utils";
-import { openai as ai, getChatModelNames } from "aiclient";
+import {
+    openai as ai,
+    getChatModelNames,
+    getCopilotClient,
+    getActiveModelProvider,
+    setActiveModelProvider,
+    getRuntimeConfig,
+    PROVIDER_MODES,
+    type ProviderMode,
+} from "aiclient";
 import { SessionOptions } from "../../session.js";
 import chalk from "chalk";
 import {
@@ -1847,6 +1856,172 @@ const configExecutionCommandHandlers: CommandHandlerTable = {
     },
 };
 
+function isProviderMode(s: string): s is ProviderMode {
+    return (PROVIDER_MODES as readonly string[]).includes(s);
+}
+
+function effectiveProvider(): ProviderMode {
+    return getActiveModelProvider() ?? "azure";
+}
+
+async function listModelsForProvider(
+    provider: ProviderMode,
+    context: ActionContext<CommandHandlerContext>,
+): Promise<void> {
+    const names = await getChatModelNames();
+    const matched: string[] = [];
+    switch (provider) {
+        case "azure":
+            // Azure entries in getChatModelNames have no prefix.
+            for (const n of names) {
+                if (
+                    !n.startsWith("openai:") &&
+                    !n.startsWith("ollama:") &&
+                    !n.startsWith("copilot:")
+                ) {
+                    matched.push(n);
+                }
+            }
+            break;
+        case "openai":
+            for (const n of names) if (n.startsWith("openai:")) matched.push(n);
+            break;
+        case "ollama":
+            for (const n of names) if (n.startsWith("ollama:")) matched.push(n);
+            break;
+        case "copilot":
+            for (const n of names)
+                if (n.startsWith("copilot:")) matched.push(n);
+            break;
+    }
+
+    const lines = [`Models available under '${provider}':`];
+    if (matched.length === 0) {
+        lines.push("  (none configured)");
+    } else {
+        for (const m of matched) lines.push(`  ${m}`);
+    }
+
+    // For copilot, also surface auth status so users can debug "why
+    // does the list look short?" without a second command.
+    if (provider === "copilot") {
+        try {
+            const client = await getCopilotClient();
+            const status = await client.getAuthStatus();
+            lines.push("");
+            lines.push(
+                `Copilot CLI: ${status.isAuthenticated ? "authenticated" : "NOT authenticated"}` +
+                    (status.login ? ` (${status.login})` : ""),
+            );
+            if (!status.isAuthenticated) {
+                lines.push(
+                    "Run 'copilot auth login' or 'gh auth login --scopes copilot' to sign in.",
+                );
+            }
+        } catch (e) {
+            lines.push("");
+            lines.push(
+                `Copilot CLI unavailable: ${e instanceof Error ? e.message : String(e)}`,
+            );
+        }
+    }
+    displayResult(lines.join("\n"), context);
+}
+
+class ConfigModelProviderCommandHandler implements CommandHandler {
+    public readonly description =
+        "Show or set the active model provider (azure | openai | ollama | copilot)";
+    public readonly parameters = {
+        args: {
+            name: {
+                description:
+                    "Provider to activate (azure | openai | ollama | copilot)",
+                optional: true,
+            },
+            action: {
+                description: "Optional 'list' to list provider's models",
+                optional: true,
+            },
+        },
+    } as const;
+
+    public async run(
+        context: ActionContext<CommandHandlerContext>,
+        params: ParsedCommandParams<typeof this.parameters>,
+    ) {
+        const name = params.args.name;
+        const action = params.args.action;
+
+        // Bare: show available providers, mark current.
+        if (name === undefined) {
+            const current = effectiveProvider();
+            const yamlConfigured = getRuntimeConfig().modelProvider;
+            const lines = ["Available model providers:"];
+            for (const m of PROVIDER_MODES) {
+                const marker = m === current ? " (current)" : "";
+                lines.push(`  ${m}${marker}`);
+            }
+            if (yamlConfigured === undefined) {
+                lines.push("");
+                lines.push(
+                    "No override is active by default — resolution falls back to Azure.",
+                );
+            }
+            displayResult(lines.join("\n"), context);
+            return;
+        }
+
+        if (!isProviderMode(name)) {
+            throw new Error(
+                `Invalid provider '${name}'. Valid providers: ${PROVIDER_MODES.join(", ")}`,
+            );
+        }
+
+        // <name> list: list provider's models.
+        if (action !== undefined) {
+            if (action !== "list") {
+                throw new Error(
+                    `Invalid action '${action}'. Only 'list' is supported.`,
+                );
+            }
+            await listModelsForProvider(name, context);
+            return;
+        }
+
+        // <name>: set active provider.
+        const previous = getActiveModelProvider();
+        setActiveModelProvider(name);
+        // Clear cached translators so the next translation picks up the
+        // new provider mapping.
+        context.sessionContext.agentContext.translatorCache.clear();
+
+        const previousLabel = previous ?? "azure (default)";
+        displayResult(`Model provider: ${previousLabel} → ${name}`, context);
+    }
+
+    public async getCompletion(
+        _context: SessionContext<CommandHandlerContext>,
+        params: PartialParsedCommandParams<ParameterDefinitions>,
+        names: string[],
+    ): Promise<CompletionGroups> {
+        const completions: CompletionGroup[] = [];
+        for (const n of names) {
+            if (n === "name") {
+                completions.push({
+                    name: n,
+                    completions: [...PROVIDER_MODES],
+                });
+            } else if (n === "action") {
+                completions.push({
+                    name: n,
+                    completions: ["list"],
+                });
+            }
+        }
+        return { groups: completions };
+    }
+}
+
 export function getConfigCommandHandlers(): CommandHandlerTable {
     return {
         description: "Configuration commands",
@@ -1889,6 +2064,7 @@ export function getConfigCommandHandlers(): CommandHandlerTable {
             translation: configTranslationCommandHandlers,
             explainer: configExplainerCommandHandlers,
             execution: configExecutionCommandHandlers,
+            modelProvider: new ConfigModelProviderCommandHandler(),
             dev: getToggleHandlerTable(
                 "development mode",
                 async (context, enable) => {

--- a/ts/packages/shell/src/main/speechProcessing.ts
+++ b/ts/packages/shell/src/main/speechProcessing.ts
@@ -30,12 +30,13 @@ Only classify statements as questions or requests if they are complete statement
 `;
 
     constructor() {
+        const apiSettings = openai.apiSettingsFromEnv(
+            openai.ModelType.Chat,
+            undefined,
+            "GPT_5_NANO",
+        );
         this.model = openai.createChatModel(
-            openai.azureApiSettingsFromEnv(
-                openai.ModelType.Chat,
-                undefined,
-                "GPT_5_NANO",
-            ),
+            apiSettings,
             {
                 temperature: 1.0,
                 max_completion_tokens: 8196,

--- a/ts/pnpm-lock.yaml
+++ b/ts/pnpm-lock.yaml
@@ -3197,6 +3197,9 @@ importers:
       '@azure/identity':
         specifier: ^4.10.0
         version: 4.10.0
+      '@github/copilot-sdk':
+        specifier: 0.2.0
+        version: 0.2.0
       '@typeagent/config':
         specifier: workspace:*
         version: link:../config


### PR DESCRIPTION
### Motivation

TypeAgent is wired to Azure OpenAI in dozens of places. `@config translation model X` only redirects the dispatcher's translation pipeline — every other LLM-using site (knowPro indexing, kp answer generation, the cache explainer, email summarization, etc.) hard-codes Azure deployment names like `"GPT_4_O"`. Switching the system to another provider for an evaluation, a demo, or an offline scenario meant editing ~30 call sites by hand.

This PR adds two related capabilities:

  1. **GitHub Copilot as a first-class chat provider.** The Copilot CLI exposes GPT-4o, Claude Sonnet/Haiku, and others through a single authenticated surface. The `@github/copilot-sdk` is already in the repo (used by the agentic reasoning loop); wiring it into `aiclient` lets translation and any chat call route through Copilot with no new keys.

  2. **A single provider-mode switch.** `@config modelProvider <name>` flips the whole process between Azure, OpenAI, Ollama, and Copilot. Unprefixed      `createChatModel("GPT_4_O", …)` calls get rewritten to the active provider's equivalent via a built-in canonical-name map. Explicit provider prefixes and pre-resolved `ApiSettings` still bypass — code that pinned a specific endpoint stays pinned.

### What this enables

  - **Run the whole stack on Copilot or Ollama** with one command — no code changes, the built-in map handles the per-agent calls that hard-code Azure deployment names.
  - **Compare providers side-by-side** during evaluation by toggling at runtime; the translator cache is invalidated on switch so the next request hits the new provider.
  - **Provider-dimensioned telemetry** — overridden calls get a `mode:<name>` tag so `TokenCounter` rollups can slice by backend.

### Scope notes

  - Fully opt-in. With no `modelProvider` set, behavior is unchanged.
  - Override applies to chat only. Embeddings, image, and video stay on Azure (Copilot has no embedding API; Ollama embeddings aren't wired).
  - The reasoning loop is unaffected — it uses the Copilot SDK directly with its own `reasoning.copilotModel` config.
