### PR TITLE
[CI Diagnostic only - do not merge] shell: diagnostic logging + artifact upload for windows command-backstack failure

### DIFF
--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -140,6 +140,21 @@ jobs:
           npm run shell:test
         working-directory: ts/packages/shell
 
+      # DIAGNOSTIC: upload Playwright test-results (traces, screenshots, videos)
+      # and the HTML report so we can grab them after a CI failure.
+      # TODO: remove after diagnosing the windows-only `command backstack`
+      # failure.
+      - name: Upload Playwright artifacts on failure (windows)
+        if: ${{ failure() && runner.os == 'windows' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-windows-${{ matrix.version }}
+          path: |
+            ts/packages/shell/test-results/**
+            ts/packages/shell/playwright-report/**
+          if-no-files-found: ignore
+          retention-days: 7
+
       - name: Shell Tests - smoke (linux)
         if: ${{ steps.filter.outputs.ts != 'false' && runner.os == 'Linux' }}
         timeout-minutes: 60

--- a/ts/packages/shell/test/hostWindow.spec.ts
+++ b/ts/packages/shell/test/hostWindow.spec.ts
@@ -171,6 +171,35 @@ test.describe("Shell interface tests", () => {
             // hit escape to clear out the input box and get us to a known state
             await element.press("Escape");
 
+            // DIAGNOSTIC: dump the relevant DOM state up front so the CI
+            // failure log carries enough evidence to identify whether bubbles
+            // are missing, hidden, mis-classed, or have an innerHTML that
+            // doesn't round-trip through `textarea.innerHTML =`.
+            // TODO: remove after diagnosing the windows-only `command
+            // backstack` failure.
+            const domSnapshot = await mainWindow.evaluate(() => {
+                const nodes = Array.from(
+                    document.querySelectorAll(".chat-message-container-user"),
+                );
+                return nodes.map((n) => {
+                    const content = n.querySelector(".chat-message-content");
+                    const first =
+                        content?.firstElementChild as HTMLElement | null;
+                    return {
+                        classes: (n as HTMLElement).className,
+                        hasContent: !!content,
+                        firstTag: first?.tagName ?? null,
+                        firstClass: first?.className ?? null,
+                        firstInnerHTML: first?.innerHTML ?? null,
+                        firstInnerText: first?.innerText ?? null,
+                    };
+                });
+            });
+            console.log(
+                "DIAG user-bubble DOM snapshot:",
+                JSON.stringify(domSnapshot, null, 2),
+            );
+
             // go through the command back stack to the end and make sure we get the expected
             // results. (command and cursor location)
             for (let i = commands.length - 1; i >= -1; i--) {
@@ -179,6 +208,10 @@ test.describe("Shell interface tests", () => {
 
                 // make sure that the text box now has the proper command
                 const text = await element.innerText();
+                const innerHtml = await element.innerHTML();
+                console.log(
+                    `DIAG ArrowUp i=${i} innerText=${JSON.stringify(text)} innerHTML=${JSON.stringify(innerHtml)}`,
+                );
 
                 // when we get to the end and hit up again it should still have the last command
                 let cmd = commands[i];
@@ -189,6 +222,13 @@ test.describe("Shell interface tests", () => {
                 expect(text, "Wrong back stack command found!").toBe(cmd);
             }
 
+            // DIAGNOSTIC: ChatView is not currently exposed on window, so we
+            // can only observe its effects via the DOM and via what the input
+            // textarea shows after each key. The per-iteration log below is
+            // sufficient: if the rebuild branch fires inside the ArrowDown
+            // handler, the textarea content will not change (or will change in
+            // a way that exposes the innerHTML round-trip mismatch).
+
             // now reverse the process
             for (let i = 1; i <= commands.length; i++) {
                 // press the up arrow
@@ -196,6 +236,10 @@ test.describe("Shell interface tests", () => {
 
                 // make sure that the text box now has the proper command
                 const text = await element.innerText();
+                const innerHtml = await element.innerHTML();
+                console.log(
+                    `DIAG ArrowDown i=${i} innerText=${JSON.stringify(text)} innerHTML=${JSON.stringify(innerHtml)}`,
+                );
 
                 // when we get to the end and hit up again it should still have the last command
                 let cmd = commands[i];


### PR DESCRIPTION
## Why

The `hostWindow.spec.ts` › `command backstack` Playwright test fails deterministically on the `shell_and_cli (windows-latest, 22)` smoke matrix (3/3 retries, identical signature) but cannot be reproduced locally on Windows. We have no Playwright trace because the workflow doesn't upload `test-results/`. This PR is a **diagnostic-only** change — no production code is modified.

Failure signature (run [26115105842](https://github.com/microsoft/TypeAgent/actions/runs/26115105842)):

```
Error: Wrong back stack command found!
Expected: "@history"
Received: "@greeting --mock"
  at hostWindow.spec.ts:206:65   (first iteration of the ArrowDown loop)
```

The ArrowUp walk passes — text correctly walks `@config agent` → `@help` → `@history` → `@greeting --mock` → clamp. The very first ArrowDown then fails to move off `@greeting --mock`.

## What this PR adds

1. **Per-keypress logging** in the test: `innerText` and `innerHTML` of the input element after each ArrowUp / ArrowDown, prefixed `DIAG`.
2. **A one-shot user-bubble DOM snapshot** before the first ArrowUp: classes, `firstElementChild` tag/class/innerHTML/innerText for every `.chat-message-container-user`.
3. **A Playwright artifact upload** step in `smoke-tests.yml` that fires only on Windows failure, uploading `ts/packages/shell/test-results/` and `ts/packages/shell/playwright-report/` so the trace (`trace.zip`) is downloadable and can be opened with `npx playwright show-trace`.

## Current hypothesis (to be confirmed by the diagnostic)

Local Windows runs already show a structural asymmetry between user bubbles:
- Typed commands (`@history`, `@help`, `@config agent`): `firstElementChild.innerHTML` is **plain text** (`"@history"`).
- Seeded `@greeting --mock`: `firstElementChild.innerHTML` is **span-wrapped** (`<span class="chat-message-user-text">@greeting --mock</span>`).

Pre-#2341, the backstack DOM selector was `:not(.history):not(.chat-message-hidden)`; #2341 simplified it to `:not(.chat-message-hidden)`. If the `@greeting --mock` bubble has `.history` in CI but not locally (e.g. due to saved chat-history reload differences), the simplified selector now pulls it into the stack with a different `innerHTML` shape than the typed-command entries. The rebuild guard in `chatView.ts:1619-1623` (`stack[index] !== currentContent`) would then re-fire on the first ArrowDown because `textarea.innerHTML =` doesn't round-trip the span identically — and the rebuild resets `commandBackStackIndex` to `0`, leaving the textarea stuck on the seeded entry. The diagnostic confirms or rules this out.

## How to revert

Once the failure is understood, drop this commit (or the two hunks marked `DIAGNOSTIC (talzacc/diagnose-windows-backstack)`). No production code paths are touched.