### PR TITLE
diagnose(shell): instrument command back stack for windows-only CI failure

### DIFF
--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -140,6 +140,21 @@ jobs:
           npm run shell:test
         working-directory: ts/packages/shell
 
+      # DIAGNOSTIC: upload Playwright test-results (traces, screenshots, videos)
+      # and the HTML report so we can grab them after a CI failure.
+      # TODO: remove after diagnosing the windows-only `command backstack`
+      # failure.
+      - name: Upload Playwright artifacts on failure (windows)
+        if: ${{ failure() && runner.os == 'windows' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-windows-${{ matrix.version }}
+          path: |
+            ts/packages/shell/test-results/**
+            ts/packages/shell/playwright-report/**
+          if-no-files-found: ignore
+          retention-days: 7
+
       - name: Shell Tests - smoke (linux)
         if: ${{ steps.filter.outputs.ts != 'false' && runner.os == 'Linux' }}
         timeout-minutes: 60

--- a/ts/packages/shell/src/renderer/src/chat/chatView.ts
+++ b/ts/packages/shell/src/renderer/src/chat/chatView.ts
@@ -1616,6 +1616,17 @@ export class ChatView {
                     const currentContent: string =
                         this.chatInput?.textarea.getTextEntry().innerHTML ?? "";
 
+                    // DIAGNOSTIC: log pre-rebuild state for windows command
+                    // backstack investigation. TODO: remove after diagnosing.
+                    const __diagPreLen = this.commandBackStack.length;
+                    const __diagPreIdx = this.commandBackStackIndex;
+                    const __diagPreAtIdx =
+                        this.commandBackStack[this.commandBackStackIndex];
+                    const __diagRebuild =
+                        this.commandBackStack.length === 0 ||
+                        this.commandBackStack[this.commandBackStackIndex] !==
+                            currentContent;
+
                     if (
                         this.commandBackStack.length === 0 ||
                         this.commandBackStack[this.commandBackStackIndex] !==
@@ -1661,6 +1672,16 @@ export class ChatView {
                     }
 
                     this.chatInput?.textarea.moveCursorToEnd();
+
+                    // DIAGNOSTIC: log post-state. TODO: remove after diagnosing.
+                    console.log(
+                        `DIAG[chatView] key=${ev.key} preLen=${__diagPreLen} preIdx=${__diagPreIdx} ` +
+                            `preAtIdx=${JSON.stringify(__diagPreAtIdx)} ` +
+                            `currentContent=${JSON.stringify(currentContent)} ` +
+                            `rebuild=${__diagRebuild} ` +
+                            `postLen=${this.commandBackStack.length} postIdx=${this.commandBackStackIndex} ` +
+                            `stack=${JSON.stringify(this.commandBackStack)}`,
+                    );
 
                     return false;
                 }

--- a/ts/packages/shell/test/hostWindow.spec.ts
+++ b/ts/packages/shell/test/hostWindow.spec.ts
@@ -153,6 +153,17 @@ test.describe("Shell interface tests", () => {
 
         // start the app
         await runTestCallback(async (mainWindow: Page) => {
+            // DIAGNOSTIC: forward renderer console.log to test stdout so the
+            // DIAG[chatView] lines emitted from inside the ChatView keydown
+            // handler appear in the Playwright report.
+            // TODO: remove after diagnosing.
+            mainWindow.on("console", (msg) => {
+                const text = msg.text();
+                if (text.startsWith("DIAG")) {
+                    console.log(`[renderer] ${text}`);
+                }
+            });
+
             // issue some commands
             const commands: string[] = ["@history", "@help", "@config agent"];
             for (let i = 0; i < commands.length; i++) {
@@ -171,6 +182,35 @@ test.describe("Shell interface tests", () => {
             // hit escape to clear out the input box and get us to a known state
             await element.press("Escape");
 
+            // DIAGNOSTIC: dump the relevant DOM state up front so the CI
+            // failure log carries enough evidence to identify whether bubbles
+            // are missing, hidden, mis-classed, or have an innerHTML that
+            // doesn't round-trip through `textarea.innerHTML =`.
+            // TODO: remove after diagnosing the windows-only `command
+            // backstack` failure.
+            const domSnapshot = await mainWindow.evaluate(() => {
+                const nodes = Array.from(
+                    document.querySelectorAll(".chat-message-container-user"),
+                );
+                return nodes.map((n) => {
+                    const content = n.querySelector(".chat-message-content");
+                    const first =
+                        content?.firstElementChild as HTMLElement | null;
+                    return {
+                        classes: (n as HTMLElement).className,
+                        hasContent: !!content,
+                        firstTag: first?.tagName ?? null,
+                        firstClass: first?.className ?? null,
+                        firstInnerHTML: first?.innerHTML ?? null,
+                        firstInnerText: first?.innerText ?? null,
+                    };
+                });
+            });
+            console.log(
+                "DIAG user-bubble DOM snapshot:",
+                JSON.stringify(domSnapshot, null, 2),
+            );
+
             // go through the command back stack to the end and make sure we get the expected
             // results. (command and cursor location)
             for (let i = commands.length - 1; i >= -1; i--) {
@@ -179,6 +219,10 @@ test.describe("Shell interface tests", () => {
 
                 // make sure that the text box now has the proper command
                 const text = await element.innerText();
+                const innerHtml = await element.innerHTML();
+                console.log(
+                    `DIAG ArrowUp i=${i} innerText=${JSON.stringify(text)} innerHTML=${JSON.stringify(innerHtml)}`,
+                );
 
                 // when we get to the end and hit up again it should still have the last command
                 let cmd = commands[i];
@@ -189,6 +233,13 @@ test.describe("Shell interface tests", () => {
                 expect(text, "Wrong back stack command found!").toBe(cmd);
             }
 
+            // DIAGNOSTIC: ChatView is not currently exposed on window, so we
+            // can only observe its effects via the DOM and via what the input
+            // textarea shows after each key. The per-iteration log below is
+            // sufficient: if the rebuild branch fires inside the ArrowDown
+            // handler, the textarea content will not change (or will change in
+            // a way that exposes the innerHTML round-trip mismatch).
+
             // now reverse the process
             for (let i = 1; i <= commands.length; i++) {
                 // press the up arrow
@@ -196,6 +247,10 @@ test.describe("Shell interface tests", () => {
 
                 // make sure that the text box now has the proper command
                 const text = await element.innerText();
+                const innerHtml = await element.innerHTML();
+                console.log(
+                    `DIAG ArrowDown i=${i} innerText=${JSON.stringify(text)} innerHTML=${JSON.stringify(innerHtml)}`,
+                );
 
                 // when we get to the end and hit up again it should still have the last command
                 let cmd = commands[i];


### PR DESCRIPTION
**Pivot: this PR is now diagnostic-only.**

The original key-based fix was force-pushed away because it did not address the CI failure (CI still failed identically on the same test, same line, same values: `ArrowDown #1 expected `@history`, received `@greeting --mock`) even though the same test passes 3/3 locally on Windows.

Rather than ship a speculative fix and conflate two issues, this PR reverts `chatView.ts` to `main` and adds diagnostic instrumentation so the next CI run will capture:

- `DIAG[chatView]` log inside the `ArrowUp`/`ArrowDown` handler: pre-state (`commandBackStack` length, index, content at index), the computed `currentContent`, the rebuild decision, post-state, and the full stack on every key press.
- Forwarding of renderer `DIAG` console messages to Playwright stdout.
- Pre-test DOM snapshot of every `.chat-message-container-user` bubble.
- Playwright artifact upload step on Windows failure (test-results/trace.zip, playwright-report).

Once the next CI run captures the actual state, this commit will be reverted and the real fix will be derived from the evidence.

Supersedes the diagnostics on PR #2367.