### PR TITLE
devcontainer: preserve ~/.vscode-server across container recreate

### DIFF
--- a/.devcontainer/agent/devcontainer.json
+++ b/.devcontainer/agent/devcontainer.json
@@ -135,7 +135,10 @@
     // with anything the host has built.
     "source=typeagent-node_modules-${devcontainerId},target=${containerWorkspaceFolder}/ts/node_modules,type=volume",
     "source=claude-code-config-${devcontainerId},target=/home/codespace/.claude,type=volume",
-    "source=copilot-cli-config-${devcontainerId},target=/home/codespace/.copilot,type=volume"
+    "source=copilot-cli-config-${devcontainerId},target=/home/codespace/.copilot,type=volume",
+    // VS Code server data (extensions, settings cache, workspace storage, history)
+    // so editor state survives container recreate.
+    "source=vscode-server-${devcontainerId},target=/home/codespace/.vscode-server,type=volume"
   ],
 
   "containerEnv": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -67,7 +67,10 @@
     // Claude Code config persistence
     "source=claude-code-config-${devcontainerId},target=/home/codespace/.claude,type=volume",
     // Copilot CLI chat log persistence
-    "source=copilot-cli-config-${devcontainerId},target=/home/codespace/.copilot,type=volume"
+    "source=copilot-cli-config-${devcontainerId},target=/home/codespace/.copilot,type=volume",
+    // VS Code server data (extensions, settings cache, workspace storage, history)
+    // so editor state survives container recreate.
+    "source=vscode-server-${devcontainerId},target=/home/codespace/.vscode-server,type=volume"
   ],
 
   "containerEnv": {

--- a/.devcontainer/scripts/post-create.sh
+++ b/.devcontainer/scripts/post-create.sh
@@ -43,6 +43,7 @@ VOLUME_PATHS=(
     "/home/codespace/.local/share/pnpm/store"
     "/home/codespace/.claude"
     "/home/codespace/.copilot"
+    "/home/codespace/.vscode-server"
 )
 # Discover the workspace ts/node_modules path dynamically (works for worktrees
 # and for variants that mount the workspace outside /workspaces, e.g. the

--- a/.devcontainer/vnc/devcontainer.json
+++ b/.devcontainer/vnc/devcontainer.json
@@ -66,7 +66,10 @@
     "source=pnpm-global-store,target=/home/codespace/.local/share/pnpm/store,type=volume",
     "source=typeagent-node_modules-${devcontainerId},target=${containerWorkspaceFolder}/ts/node_modules,type=volume",
     "source=claude-code-config-${devcontainerId},target=/home/codespace/.claude,type=volume",
-    "source=copilot-cli-config-${devcontainerId},target=/home/codespace/.copilot,type=volume"
+    "source=copilot-cli-config-${devcontainerId},target=/home/codespace/.copilot,type=volume",
+    // VS Code server data (extensions, settings cache, workspace storage, history)
+    // so editor state survives container recreate.
+    "source=vscode-server-${devcontainerId},target=/home/codespace/.vscode-server,type=volume"
   ],
 
   "containerEnv": {


### PR DESCRIPTION
## Summary

Adds a named Docker volume mounted at `/home/codespace/.vscode-server` for all three devcontainer variants (`agent`, default, `vnc`) so that VS Code server data survives container recreate. This includes installed extensions, settings cache, workspace storage, command history, and Copilot agent window session state (chat history, in-progress agent sessions).

## Changes

- `.devcontainer/agent/devcontainer.json`: add `vscode-server-${devcontainerId}` volume mount.
- `.devcontainer/devcontainer.json`: same.
- `.devcontainer/vnc/devcontainer.json`: same.
- `.devcontainer/scripts/post-create.sh`: include `/home/codespace/.vscode-server` in `VOLUME_PATHS` so ownership/permissions are normalized on container start.

## Motivation

Previously, recreating the devcontainer wiped extensions and editor state - including Copilot agent chat sessions stored under `.vscode-server/data/User/workspaceStorage/` - forcing a slow re-install and losing in-progress agent context on every rebuild. With the volume in place, the VS Code server reuses prior state and agent sessions persist across recreates.
