### PR TITLE
workflow-dsl: preserve blank lines by default in formatter

### DIFF
--- a/ts/examples/workflow/dsl/src/ast.ts
+++ b/ts/examples/workflow/dsl/src/ast.ts
@@ -144,6 +144,11 @@ export interface ConstStatement {
     loc: SourceLocation;
     leadingComments?: Comment[];
     trailingComments?: Comment[];
+    /** True when there was at least one blank line before this statement
+     *  (or its leading comments) in the original source. The formatter
+     *  emits one blank line before the statement when `keepBlankLines`
+     *  is enabled in `FormatOptions`. */
+    blankLineBefore?: boolean;
     /** Line of the last token of this statement (used by the formatter
      * to decide whether a trailing comment is inline or block-style). */
     endLine?: number;
@@ -170,6 +175,7 @@ export interface DestructuringConst {
     leadingComments?: Comment[];
     trailingComments?: Comment[];
     endLine?: number;
+    blankLineBefore?: boolean;
 }
 
 export interface IfStatement {
@@ -181,6 +187,7 @@ export interface IfStatement {
     leadingComments?: Comment[];
     trailingComments?: Comment[];
     endLine?: number;
+    blankLineBefore?: boolean;
     /** Comments inside an empty `then` block. */
     thenInnerComments?: Comment[];
     /** Comments inside an empty `else` block. */
@@ -215,6 +222,7 @@ export interface SwitchStatement {
     leadingComments?: Comment[];
     trailingComments?: Comment[];
     endLine?: number;
+    blankLineBefore?: boolean;
     /** Comments inside an empty `default:` arm body. */
     defaultInnerComments?: Comment[];
     /** Comments that appear inside the switch body before any case/default
@@ -243,6 +251,7 @@ export interface ThrowStatement {
     leadingComments?: Comment[];
     trailingComments?: Comment[];
     endLine?: number;
+    blankLineBefore?: boolean;
 }
 
 export interface ReturnStatement {
@@ -252,6 +261,7 @@ export interface ReturnStatement {
     leadingComments?: Comment[];
     trailingComments?: Comment[];
     endLine?: number;
+    blankLineBefore?: boolean;
 }
 
 export interface BreakStatement {
@@ -260,6 +270,7 @@ export interface BreakStatement {
     leadingComments?: Comment[];
     trailingComments?: Comment[];
     endLine?: number;
+    blankLineBefore?: boolean;
 }
 
 // ---- Expressions ----

--- a/ts/examples/workflow/dsl/src/formatter.ts
+++ b/ts/examples/workflow/dsl/src/formatter.ts
@@ -53,12 +53,18 @@ export interface FormatOptions {
      *  to `Infinity` to never wrap based on width; set to `0` to
      *  always wrap when an alternative multi-line layout exists. */
     printWidth?: number;
+    /** When `true`, a single blank line is emitted before any statement
+     *  that had at least one blank line before it in the original source.
+     *  Multiple consecutive blank lines are collapsed to one. Default `false`
+     *  (blank lines are stripped, producing compact deterministic output). */
+    keepBlankLines?: boolean;
 }
 
 interface ResolvedOptions {
     indent: number;
     eol: string;
     printWidth: number;
+    keepBlankLines: boolean;
 }
 
 /** Format a single workflow declaration as DSL source text. */
@@ -67,6 +73,7 @@ export function format(decl: WorkflowDecl, options?: FormatOptions): string {
         indent: options?.indent ?? 4,
         eol: options?.eol ?? "\n",
         printWidth: options?.printWidth ?? 100,
+        keepBlankLines: options?.keepBlankLines ?? false,
     };
     validateFormatOptions(opts);
     const p = new Printer(opts);
@@ -604,6 +611,7 @@ class Printer {
     // ---- Statements ----
 
     private printStatement(s: Statement): void {
+        if (s.blankLineBefore && this.opts.keepBlankLines) this.newline();
         this.printLeadingComments(s.leadingComments);
         switch (s.kind) {
             case "ConstStatement": {

--- a/ts/examples/workflow/dsl/src/formatter.ts
+++ b/ts/examples/workflow/dsl/src/formatter.ts
@@ -55,8 +55,8 @@ export interface FormatOptions {
     printWidth?: number;
     /** When `true`, a single blank line is emitted before any statement
      *  that had at least one blank line before it in the original source.
-     *  Multiple consecutive blank lines are collapsed to one. Default `false`
-     *  (blank lines are stripped, producing compact deterministic output). */
+     *  Multiple consecutive blank lines are collapsed to one. Default `true`.
+     *  Set to `false` to strip blank lines for compact deterministic output. */
     keepBlankLines?: boolean;
 }
 
@@ -73,7 +73,7 @@ export function format(decl: WorkflowDecl, options?: FormatOptions): string {
         indent: options?.indent ?? 4,
         eol: options?.eol ?? "\n",
         printWidth: options?.printWidth ?? 100,
-        keepBlankLines: options?.keepBlankLines ?? false,
+        keepBlankLines: options?.keepBlankLines ?? true,
     };
     validateFormatOptions(opts);
     const p = new Printer(opts);

--- a/ts/examples/workflow/dsl/src/parser.ts
+++ b/ts/examples/workflow/dsl/src/parser.ts
@@ -585,22 +585,45 @@ export class Parser {
         innerComments: Comment[] | undefined;
     } {
         const stmts: Statement[] = [];
+        let prevEndLine: number | undefined = undefined;
         while (
             this.peek().kind !== TokenKind.RBrace &&
             this.peek().kind !== TokenKind.EOF
         ) {
-            const s = this.parseStatement();
-            if (s) stmts.push(s);
+            const s = this.parseStatement(prevEndLine);
+            if (s) {
+                stmts.push(s);
+                prevEndLine = s.endLine;
+            }
         }
         const innerComments = this.finalizeBlock(stmts);
         return { stmts, innerComments };
     }
 
-    private parseStatement(): Statement | undefined {
+    /**
+     * Parse a single statement, optionally detecting a blank line between
+     * the previous statement (whose last token was on `prevEndLine`) and
+     * this one. When `prevEndLine` is `undefined` (first statement in a
+     * block), blank-line detection is skipped so no blank line is injected
+     * at the top of a block.
+     */
+    private parseStatement(prevEndLine?: number): Statement | undefined {
         const leadingComments = this.takeLeadingComments();
+        // Detect blank line: if the gap between the previous statement's end
+        // line and the first line of this item (leading comment or token) is
+        // >= 2 there is at least one blank line in between.
+        let blankLineBefore = false;
+        if (prevEndLine !== undefined) {
+            const firstLine =
+                leadingComments !== undefined && leadingComments.length > 0
+                    ? leadingComments[0].pos.line
+                    : this.peek().line;
+            blankLineBefore = firstLine - prevEndLine >= 2;
+        }
         const stmt = this.parseStatementInner();
         if (stmt) {
             if (leadingComments) stmt.leadingComments = leadingComments;
+            if (blankLineBefore) stmt.blankLineBefore = true;
             const endLine = this.lastToken?.line;
             if (endLine !== undefined) {
                 stmt.endLine = endLine;
@@ -915,14 +938,18 @@ export class Parser {
     } {
         this.inSwitchDepth++;
         const stmts: Statement[] = [];
+        let prevEndLine: number | undefined = undefined;
         while (
             this.peek().kind !== TokenKind.Case &&
             this.peek().kind !== TokenKind.Default &&
             this.peek().kind !== TokenKind.RBrace &&
             this.peek().kind !== TokenKind.EOF
         ) {
-            const s = this.parseStatement();
-            if (s) stmts.push(s);
+            const s = this.parseStatement(prevEndLine);
+            if (s) {
+                stmts.push(s);
+                prevEndLine = s.endLine;
+            }
         }
         // For switch arms we differ from generic finalizeBlock: only
         // capture inline-trailing comments (same source line as the last

--- a/ts/examples/workflow/dsl/test/commentNeutrality.spec.ts
+++ b/ts/examples/workflow/dsl/test/commentNeutrality.spec.ts
@@ -89,6 +89,7 @@ function stripTrivia(value: unknown): unknown {
             if (k === "elseOnNewLine") continue;
             if (k === "multiLine") continue;
             if (k === "endLine") continue;
+            if (k === "blankLineBefore") continue;
             // Drop every source-position field. These shift when comments
             // appear or when the formatter re-emits the same AST.
             if (

--- a/ts/examples/workflow/dsl/test/formatter.spec.ts
+++ b/ts/examples/workflow/dsl/test/formatter.spec.ts
@@ -283,13 +283,13 @@ describe("formatter: keepBlankLines option", () => {
         expect(out).toMatch(/const x = a;\n\n\s*return x;/);
     });
 
-    test("blank line is stripped by default (keepBlankLines:false)", () => {
+    test("blank line is stripped when keepBlankLines:false", () => {
         const src = `workflow w(a: string): string {
     const x = a;
 
     return x;
 }`;
-        const out = format(parse(src));
+        const out = format(parse(src), { keepBlankLines: false });
         expect(out).not.toMatch(/const x = a;\n\n/);
     });
 

--- a/ts/examples/workflow/dsl/test/formatter.spec.ts
+++ b/ts/examples/workflow/dsl/test/formatter.spec.ts
@@ -271,6 +271,91 @@ describe("formatter: options", () => {
     });
 });
 
+describe("formatter: keepBlankLines option", () => {
+    test("blank line between statements is preserved when keepBlankLines:true", () => {
+        const src = `workflow w(a: string): string {
+    const x = a;
+
+    return x;
+}`;
+        const out = format(parse(src), { keepBlankLines: true });
+        // There should be a blank line between the const and return.
+        expect(out).toMatch(/const x = a;\n\n\s*return x;/);
+    });
+
+    test("blank line is stripped by default (keepBlankLines:false)", () => {
+        const src = `workflow w(a: string): string {
+    const x = a;
+
+    return x;
+}`;
+        const out = format(parse(src));
+        expect(out).not.toMatch(/const x = a;\n\n/);
+    });
+
+    test("multiple blank lines collapse to one", () => {
+        const src = `workflow w(a: string): string {
+    const x = a;
+
+
+
+    return x;
+}`;
+        const out = format(parse(src), { keepBlankLines: true });
+        // Exactly one blank line (not two or three).
+        expect(out).toMatch(/const x = a;\n\n\s*return x;/);
+        expect(out).not.toMatch(/const x = a;\n\n\n/);
+    });
+
+    test("no blank line at start of block even when keepBlankLines:true", () => {
+        const src = `workflow w(a: string): string {
+
+    const x = a;
+    return x;
+}`;
+        const out = format(parse(src), { keepBlankLines: true });
+        // The block should not open with a blank line.
+        expect(out).toMatch(/\{\n\s+const x/);
+    });
+
+    test("blank lines preserved inside nested if block", () => {
+        const src = `workflow w(a: boolean, b: string): string {
+    if (a) {
+        const x = b;
+
+        return x;
+    }
+    return b;
+}`;
+        const out = format(parse(src), { keepBlankLines: true });
+        expect(out).toMatch(/const x = b;\n\n\s*return x;/);
+    });
+
+    test("blank line before statement with leading comment", () => {
+        const src = `workflow w(a: string): string {
+    const x = a;
+
+    // separator
+    return x;
+}`;
+        const out = format(parse(src), { keepBlankLines: true });
+        // Blank line before the comment that leads the return.
+        expect(out).toMatch(/const x = a;\n\n\s*\/\/ separator\n\s*return x;/);
+    });
+
+    test("keepBlankLines round-trips stably", () => {
+        const src = `workflow w(a: string): string {
+    const x = a;
+
+    return x;
+}`;
+        const opts = { keepBlankLines: true };
+        const once = format(parse(src), opts);
+        const twice = format(parse(once), opts);
+        expect(twice).toBe(once);
+    });
+});
+
 describe("formatter: expression edge cases", () => {
     test("nested ternary round-trips and re-parses to same shape", () => {
         const src = `workflow w(a: boolean, b: boolean, c: boolean): string {

--- a/ts/examples/workflow/lsp/test/serverIntegration.spec.ts
+++ b/ts/examples/workflow/lsp/test/serverIntegration.spec.ts
@@ -66,7 +66,11 @@ async function startSession(debounceMs = 5) {
         client,
         server,
         publishes,
-        cleanup: () => {
+        cleanup: async () => {
+            // Add a small delay to let pending operations and error handlers complete
+            // before disposing connections. This prevents "Connection is disposed" errors
+            // when error handlers try to send notifications after test completion.
+            await new Promise((resolve) => setTimeout(resolve, 50));
             client.dispose();
             server.dispose();
             pipes.serverTransport.input.destroy();
@@ -115,7 +119,7 @@ describe("server integration", () => {
             expect(session.publishes[0]!.uri).toBe("file:///t.wf");
             expect(session.publishes[0]!.diagnostics.length).toBeGreaterThan(0);
         } finally {
-            session.cleanup();
+            await session.cleanup();
         }
     });
 
@@ -149,7 +153,7 @@ describe("server integration", () => {
                 ),
             );
         } finally {
-            session.cleanup();
+            await session.cleanup();
         }
     });
 
@@ -175,7 +179,7 @@ describe("server integration", () => {
             // Result may be null if x resolves as const; we just verify no crash.
             expect(result === null || typeof result === "object").toBe(true);
         } finally {
-            session.cleanup();
+            await session.cleanup();
         }
     });
 
@@ -211,7 +215,7 @@ describe("server integration", () => {
             // Should include keywords
             expect(labels).toContain("const");
         } finally {
-            session.cleanup();
+            await session.cleanup();
         }
     });
 
@@ -247,7 +251,7 @@ describe("server integration", () => {
             }
             // null is also acceptable (cursor not quite on the identifier)
         } finally {
-            session.cleanup();
+            await session.cleanup();
         }
     });
 
@@ -282,7 +286,7 @@ describe("server integration", () => {
                 }
             }
         } finally {
-            session.cleanup();
+            await session.cleanup();
         }
     });
 
@@ -313,7 +317,7 @@ describe("server integration", () => {
             );
             expect(Array.isArray(result)).toBe(true);
         } finally {
-            session.cleanup();
+            await session.cleanup();
         }
     });
 
@@ -341,7 +345,7 @@ describe("server integration", () => {
                 expect(result.ir).toBeDefined();
             }
         } finally {
-            session.cleanup();
+            await session.cleanup();
         }
     });
 
@@ -380,7 +384,7 @@ describe("server integration", () => {
             expect(Array.isArray(result.graph!.edges)).toBe(true);
             expect(Array.isArray(result.graph!.params)).toBe(true);
         } finally {
-            session.cleanup();
+            await session.cleanup();
         }
     });
 
@@ -410,7 +414,7 @@ describe("server integration", () => {
             expect(result.errors.length).toBeGreaterThan(0);
             expect(result.errors.every((e) => e.phase === "lex")).toBe(true);
         } finally {
-            session.cleanup();
+            await session.cleanup();
         }
     });
 });


### PR DESCRIPTION
## Summary
This PR includes fixes for:
1. LSP server integration test cleanup - prevents race condition causing "Connection is disposed" errors
2. Workflow DSL formatter enhancements - preserve blank lines by default

## Changes

### LSP Server Integration Tests (examples/workflow/lsp)
- `examples/workflow/lsp/test/serverIntegration.spec.ts`: Make cleanup function async with 50ms delay
  - Allows pending error handlers to complete before disposing connections
  - Fixes CI failure: "definition returns location for a const reference (Phase 2)"
  - Updates all 10 test cases to properly await cleanup

### Workflow DSL Formatter (examples/workflow/dsl)
- `ts/examples/workflow/dsl/src/parser.ts`: records statement-level blank-line intent
- `ts/examples/workflow/dsl/src/ast.ts`: carries blank-line metadata on statements
- `ts/examples/workflow/dsl/src/formatter.ts`: emits blank lines based on metadata and defaults `keepBlankLines` to `true`
- `ts/examples/workflow/dsl/test/formatter.spec.ts`: adds keepBlankLines coverage and updates default/explicit-false expectations
- `ts/examples/workflow/dsl/test/commentNeutrality.spec.ts`: test update for preserved blank lines

## Validation
- LSP integration tests: All 10 serverIntegration tests pass (including previously failing definition test)
- Formatter tests: `pnpm run test -- formatter.spec.ts` in `ts/examples/workflow/dsl` (pass)