### PR TITLE
Fix npm prerelease publish and remove deprecated always-auth

### DIFF
--- a/pipelines/azure-build-ts.yml
+++ b/pipelines/azure-build-ts.yml
@@ -91,7 +91,6 @@ jobs:
       - script: |
           echo $(ADO_REGISTRY)
           echo "registry=$(ADO_REGISTRY)" > .npmrc
-          echo "always-auth=true" >> .npmrc
           cat .npmrc
         displayName: "Create .npmrc file."
         workingDirectory: $(NpmRcDirectory)
@@ -104,7 +103,7 @@ jobs:
       - script: |
           for file in $(publishedPackageDirectory)/*.tgz; do
             echo "Publishing file: $file"
-            npm publish --registry=$(ADO_REGISTRY) "$file"
+            npm publish --registry=$(ADO_REGISTRY) --tag=latest "$file"
           done
         displayName: "Publish packages"
         workingDirectory: $(NpmRcDirectory)

--- a/pipelines/include-prepare-repo.yml
+++ b/pipelines/include-prepare-repo.yml
@@ -16,7 +16,6 @@ steps:
 
   - bash: |
       echo "registry=${{ parameters.registry }}" > .npmrc
-      echo "always-auth=true" >> .npmrc
       cat .npmrc
     displayName: Set npm registry
     workingDirectory: ${{ parameters.buildDirectory }}


### PR DESCRIPTION
## Summary
- add --tag=latest to npm publish in the TS pipeline so prerelease versions can be published
- remove deprecated always-auth=true from generated .npmrc in TS pipeline and shared prepare template

## Why
- npm now requires an explicit tag when publishing prerelease versions
- always-auth produces a warning and is no longer needed with npmAuthenticate and registry-scoped auth

## Testing
- validated YAML diagnostics locally in VS Code after edits