### PR TITLE
fix: increase timing threshold in unknownSwitcher parallel test

### DIFF
--- a/ts/packages/dispatcher/dispatcher/test/unknownSwitcher.spec.ts
+++ b/ts/packages/dispatcher/dispatcher/test/unknownSwitcher.spec.ts
@@ -114,14 +114,15 @@ describe("selectFromPartitions", () => {
 
     test("all partitions run in parallel", async () => {
         const startTimes: number[] = [];
+        const delayMs = 100;
         const makeTimedTranslator = (
             result: Result<AssistantSelection>,
-            delayMs: number,
+            delay: number,
         ) => ({
             translate: (_request: string) => {
                 startTimes.push(Date.now());
                 return new Promise<Result<AssistantSelection>>((resolve) =>
-                    setTimeout(() => resolve(result), delayMs),
+                    setTimeout(() => resolve(result), delay),
                 );
             },
         });
@@ -129,15 +130,15 @@ describe("selectFromPartitions", () => {
         const partitions = [
             {
                 names: ["a"],
-                translator: makeTimedTranslator(unknownResult, 20),
+                translator: makeTimedTranslator(unknownResult, delayMs),
             },
             {
                 names: ["b"],
-                translator: makeTimedTranslator(unknownResult, 20),
+                translator: makeTimedTranslator(unknownResult, delayMs),
             },
             {
                 names: ["c"],
-                translator: makeTimedTranslator(unknownResult, 20),
+                translator: makeTimedTranslator(unknownResult, delayMs),
             },
         ];
 
@@ -150,8 +151,11 @@ describe("selectFromPartitions", () => {
         const spread = Math.max(...startTimes) - Math.min(...startTimes);
         expect(spread).toBeLessThan(10);
 
-        // Parallel: total time should be close to one delay (not 3×)
-        expect(elapsed).toBeLessThan(120);
+        // Parallel: total time should be well under sequential (3 × delayMs).
+        // The 2× threshold gives ~100ms of headroom for CI timer jitter while
+        // still catching any accidental sequential execution (which would take
+        // ~300ms and clearly exceed the limit).
+        expect(elapsed).toBeLessThan(delayMs * 2);
     });
 
     test("error from a partition is propagated in order", async () => {


### PR DESCRIPTION
## Summary

Fixes intermittent CI failures in the `selectFromPartitions` "all partitions run in parallel" test in `ts/packages/dispatcher/dispatcher/test/unknownSwitcher.spec.ts`.

## Changes

- Extracted the per-translator delay into a `delayMs` constant (100ms) shared across all three partitions.
- Renamed the inner parameter to `delay` to avoid shadowing.
- Replaced the hard-coded `expect(elapsed).toBeLessThan(120)` upper bound with `expect(elapsed).toBeLessThan(delayMs * 2)`.

## Why

The previous threshold (120ms over a 20ms delay) left very little headroom for timer jitter on busy CI runners, causing intermittent failures. The new 2× threshold gives ~100ms of slack while still being far below the ~300ms a sequential execution would take, so it continues to catch any regression that accidentally runs partitions serially.
