### PR TITLE
fix(dsl): G13 - structural type comparison for objects/arrays + G22 doc

### DIFF
--- a/ts/docs/design/workflowSystem/dsl/dsl-v0.1-gap.md
+++ b/ts/docs/design/workflowSystem/dsl/dsl-v0.1-gap.md
@@ -15,8 +15,10 @@ new surface area:
 3. **G17: Cancel in-flight fork/forkMap branches on failure.** After fork IR is
    structurally valid, align fork execution with the spec's failure and cleanup
    semantics.
-4. **G13: Fix structural type comparison for objects and arrays.** Type-system
-   expansions should build on sound object and array compatibility checks.
+4. **G22: Improve object/array diagnostics.** Now that G13 (resolved)
+   surfaces real structural mismatches, switch error messages from the
+   collapsed `'object'` rendering to the existing `formatType` output so
+   users can see which fields differ.
 5. **G10: Fix `integer`/`number` assignability.** Make numeric compatibility
    one-way before adding more type-system expressiveness.
 6. **G3: Add TypeScript-style named type aliases.** Once structural
@@ -49,8 +51,8 @@ new surface area:
 Dependency spine:
 
 - `G2 -> G17` brings fork/forkMap IR and runtime behavior into spec alignment.
-- `G13 + G10 -> G3 -> G4 -> G18` builds type-system features on sound
-  assignability.
+- `G10 -> G3 -> G4 -> G18` builds type-system features on sound
+  assignability (G13 resolved the structural-comparison prerequisite).
 
 ## G1: Sub-workflow calls
 
@@ -321,35 +323,6 @@ suggests mutation in many languages (Python `list.append`, JS
 3. Regardless of naming: consider whether the immutable semantics should
    be made explicit in the task name (e.g., `array.appended` or
    `array.concat`) to avoid confusion with mutable append/push.
-
-## G13: `typeEq` skips structural comparison for objects and arrays
-
-**Context:** The type checker's `typeEq(target, source)` function is used
-for return type validation, const annotation checking, and ternary arm
-compatibility. It skips structural comparison for object and array kinds.
-
-**Current state:**
-
-- `typeEq` checks primitive kinds by name, handles `unknown`/`never`
-  correctly, and handles `integer`/`number` compatibility.
-- For objects and arrays it falls through to `return true` without
-  comparing fields or element types.
-- This means `{ a: string }` is considered compatible with
-  `{ x: number, y: number }` in all contexts where `typeEq` is called.
-- Affected call sites: return type vs declared type (line ~263), const
-  annotation vs inferred type (line ~308), ternary arm compatibility
-  (line ~549).
-
-**What needs to happen:**
-
-1. Add structural comparison for object types: check that all required
-   fields in the target exist in the source with compatible types.
-2. Add element-type comparison for array types.
-3. Consider splitting into two functions: `typeEq` for operator checks
-   (where the current loose behavior is fine) and `isAssignableTo` for
-   the structural contexts.
-4. Add tests for mismatched object types in return position and ternary
-   arms.
 
 ## G16: `throw` produces empty error message
 
@@ -639,3 +612,61 @@ name: "_infer" }`) and emit the inferred type in the emitter.
    match the inferred element type.
 4. Add LSP hover and inlay-hint support that shows the inferred return
    type next to the workflow name when the annotation is omitted.
+
+## G22: Type error messages collapse objects to `'object'`
+
+**Status:** UX gap surfaced by the G13 implementation. Pure diagnostic
+improvement; no semantic change to type checking.
+
+**Context:** When the type checker reports an assignability error, it
+formats both sides with `typeName(t)`. For object types this function
+returns the literal string `"object"`, discarding all field information.
+This makes object-vs-object mismatches indistinguishable to users.
+
+**Current state:**
+
+- `typeName` in `typeChecker.ts` returns `"object"` for any `ObjectTypeInfo`,
+  regardless of fields.
+- Arrays partially benefit from recursion (`string[]`) but their element
+  type collapses to `"object"` when it's an object.
+- Tuples also collapse to `"object"` for each object element.
+- A `formatType` function already exists in `typeChecker.ts` that produces
+  a full TypeScript-style rendering (e.g. `{ name: string, tag?: string }`,
+  `{ x: string }[]`), used today only for LSP hover text.
+- Affected diagnostics include (non-exhaustive):
+  - `Workflow return type 'object' is not assignable to declared type 'object'`
+  - `Type 'object' is not assignable to type 'object'` (const annotations)
+  - `Ternary arms must have the same type: 'object' vs 'object'`
+  - `Operator '===' requires same types on both sides: 'object' vs 'object'`
+- After G13 added structural object/array assignability checks, mismatches
+  between objects are now reported as errors, so the volume of
+  object-vs-object messages users see has grown.
+
+**Reproduction:**
+
+```
+workflow test(x: { name: string, tag: number }): { name: string, tag?: string } {
+    return x;
+}
+```
+
+Currently reports: `Workflow return type 'object' is not assignable to
+declared type 'object'`. Users cannot tell which field mismatches without
+manually walking both type expressions.
+
+**What needs to happen:**
+
+1. Switch the structural error messages (return-type, const-annotation,
+   ternary-arm, and `===`/`!==`) to use `formatType` instead of
+   `typeName`, or introduce a single shared diagnostic formatter.
+2. Decide whether `typeName` should be removed in favor of `formatType`,
+   or kept for short contexts (e.g. operator operand kind in
+   `must be numeric, got 'string'`). If kept, document the contract.
+3. Consider augmenting object-mismatch messages with the specific
+   offending field path (e.g. `field 'tag' has type 'number' but
+expected 'string'`), reusing the recursion already done inside
+   `isAssignableTo`. This may require threading an error-reason result
+   out of `isAssignableTo` instead of a bare boolean.
+4. Update existing type-checker tests whose substring assertions rely on
+   the collapsed `'object'` rendering, and add tests asserting the
+   richer field-level wording.

--- a/ts/examples/workflow/dsl/src/typeChecker.ts
+++ b/ts/examples/workflow/dsl/src/typeChecker.ts
@@ -104,7 +104,20 @@ function isUnresolved(t: TypeInfo): boolean {
     return t.kind === "unresolved";
 }
 
-function typeEq(a: TypeInfo, b: TypeInfo): boolean {
+/**
+ * Loose kind-level compatibility check used only by the `===`/`!==`
+ * operator. Returns true if comparing `a` and `b` with strict equality is
+ * not obviously a type error.
+ *
+ * This is intentionally permissive for objects, arrays, and tuples (any
+ * two values of the same kind are considered comparable), since without
+ * union types in the DSL a stricter check would reject reasonable
+ * comparisons. See G18 for the eventual tightening.
+ *
+ * For structural assignability (return types, const annotations, ternary
+ * arms), use `isAssignableTo` instead.
+ */
+function isEqualityComparable(a: TypeInfo, b: TypeInfo): boolean {
     // Unresolved (error recovery): compatible with everything.
     if (a.kind === "unresolved" || b.kind === "unresolved") return true;
     // never is the bottom type: source=never assignable to any target,
@@ -126,6 +139,68 @@ function typeEq(a: TypeInfo, b: TypeInfo): boolean {
         return a.name === b.name;
     }
     return true; // structural comparison not needed for operator checks
+}
+
+/**
+ * Returns true if `source` is assignable to `target`.
+ * Performs recursive structural comparison for objects and arrays.
+ */
+function isAssignableTo(target: TypeInfo, source: TypeInfo): boolean {
+    if (target.kind === "unresolved" || source.kind === "unresolved") return true;
+    if (source.kind === "never") return true;
+    if (target.kind === "never") return false;
+    if (target.kind === "unknown") return true;
+    if (source.kind === "unknown") return false;
+    if (target.kind !== source.kind) return false;
+    switch (target.kind) {
+        case "primitive": {
+            const s = source as PrimitiveType;
+            if (
+                (target.name === "integer" && s.name === "number") ||
+                (target.name === "number" && s.name === "integer")
+            )
+                return true;
+            return target.name === s.name;
+        }
+        case "object": {
+            const s = source as ObjectTypeInfo;
+            for (const [fieldName, fieldInfo] of target.fields) {
+                const sourceField = s.fields.get(fieldName);
+                if (fieldInfo.optional) {
+                    // Optional target field: absent in source is fine, but if
+                    // present it must still have a compatible type.
+                    if (!sourceField) continue;
+                    if (!isAssignableTo(fieldInfo.type, sourceField.type))
+                        return false;
+                    continue;
+                }
+                if (!sourceField) return false;
+                // A required target field cannot be satisfied by an optional
+                // source field: the source field might be absent at runtime.
+                if (sourceField.optional) return false;
+                if (!isAssignableTo(fieldInfo.type, sourceField.type))
+                    return false;
+            }
+            return true;
+        }
+        case "array": {
+            const s = source as ArrayTypeInfo;
+            return isAssignableTo(target.element, s.element);
+        }
+        case "tuple": {
+            const s = source as TupleTypeInfo;
+            if (target.elements.length !== s.elements.length) return false;
+            return target.elements.every((t, i) =>
+                isAssignableTo(t, s.elements[i]),
+            );
+        }
+        default: {
+            // Exhaustiveness check: if a new TypeInfo kind is added, this
+            // becomes a compile error rather than silently returning true.
+            const _exhaustive: never = target;
+            return _exhaustive;
+        }
+    }
 }
 
 function typeName(t: TypeInfo): string {
@@ -305,7 +380,7 @@ export class TypeChecker {
         const returnType = this.checkStatements(wf.body, scope);
         // Validate return type matches declaration
         const declared = this.resolveTypeExpr(wf.returnType);
-        if (returnType.kind !== "unresolved" && !typeEq(declared, returnType)) {
+        if (returnType.kind !== "unresolved" && !isAssignableTo(declared, returnType)) {
             this.addError(
                 `Workflow return type '${typeName(returnType)}' is not assignable to declared type '${typeName(declared)}'`,
                 wf.loc.line,
@@ -398,7 +473,7 @@ export class TypeChecker {
                     const declared = this.resolveTypeExpr(s.typeAnnotation);
                     if (
                         !isUnresolved(valueType) &&
-                        !typeEq(declared, valueType)
+                        !isAssignableTo(declared, valueType)
                     ) {
                         this.addError(
                             `Type '${typeName(valueType)}' is not assignable to type '${typeName(declared)}'`,
@@ -675,7 +750,10 @@ export class TypeChecker {
                 // result is the other arm's type (matches TypeScript).
                 if (consType.kind === "never") return altType;
                 if (altType.kind === "never") return consType;
-                if (!typeEq(consType, altType)) {
+                if (
+                    !isAssignableTo(consType, altType) ||
+                    !isAssignableTo(altType, consType)
+                ) {
                     this.addError(
                         `Ternary arms must have the same type: '${typeName(consType)}' vs '${typeName(altType)}'`,
                         e.loc.line,
@@ -892,7 +970,7 @@ export class TypeChecker {
                     right.kind !== "never" &&
                     left.kind !== "unknown" &&
                     right.kind !== "unknown" &&
-                    !typeEq(left, right)
+                    !isEqualityComparable(left, right)
                 ) {
                     this.addError(
                         `Operator '${e.op}' requires same types on both sides: '${typeName(left)}' vs '${typeName(right)}'`,

--- a/ts/examples/workflow/dsl/src/typeChecker.ts
+++ b/ts/examples/workflow/dsl/src/typeChecker.ts
@@ -146,7 +146,8 @@ function isEqualityComparable(a: TypeInfo, b: TypeInfo): boolean {
  * Performs recursive structural comparison for objects and arrays.
  */
 function isAssignableTo(target: TypeInfo, source: TypeInfo): boolean {
-    if (target.kind === "unresolved" || source.kind === "unresolved") return true;
+    if (target.kind === "unresolved" || source.kind === "unresolved")
+        return true;
     if (source.kind === "never") return true;
     if (target.kind === "never") return false;
     if (target.kind === "unknown") return true;
@@ -380,7 +381,10 @@ export class TypeChecker {
         const returnType = this.checkStatements(wf.body, scope);
         // Validate return type matches declaration
         const declared = this.resolveTypeExpr(wf.returnType);
-        if (returnType.kind !== "unresolved" && !isAssignableTo(declared, returnType)) {
+        if (
+            returnType.kind !== "unresolved" &&
+            !isAssignableTo(declared, returnType)
+        ) {
             this.addError(
                 `Workflow return type '${typeName(returnType)}' is not assignable to declared type '${typeName(declared)}'`,
                 wf.loc.line,

--- a/ts/examples/workflow/dsl/test/typeChecker.spec.ts
+++ b/ts/examples/workflow/dsl/test/typeChecker.spec.ts
@@ -606,4 +606,140 @@ describe("type checker", () => {
             workflow test(): unknown { throw "boom"; }
         `);
     });
+
+    // ---- G13: Structural type comparison for objects and arrays ----
+
+    test("object type mismatch in return position", () => {
+        expectError(
+            `workflow test(): { name: string } {
+                return test.exec(command: "ls");
+            }`,
+            "not assignable to declared type",
+        );
+    });
+
+    test("object with missing required field in const annotation", () => {
+        expectError(
+            `workflow test(x: { a: string, b: number }): string {
+                const r: { a: string, b: number, c: boolean } = x;
+                return r.a;
+            }`,
+            "not assignable to type",
+        );
+    });
+
+    test("object type mismatch in ternary arms", () => {
+        expectError(
+            `workflow test(flag: boolean, x: { a: string }): { a: string } {
+                return flag ? x : test.exec(command: "b");
+            }`,
+            "same type",
+        );
+    });
+
+    test("array element type mismatch in return position", () => {
+        expectError(
+            `workflow test(items: string[]): number[] {
+                return items;
+            }`,
+            "not assignable to declared type",
+        );
+    });
+
+    test("matching object types pass structural check", () => {
+        expectNoErrors(`
+            workflow test(): { stdout: string, exitCode: integer } {
+                return test.exec(command: "ls");
+            }
+        `);
+    });
+
+    test("structural subtype with extra fields is assignable to narrower type", () => {
+        expectNoErrors(`
+            workflow test(): { stdout: string } {
+                return test.exec(command: "ls");
+            }
+        `);
+    });
+
+    test("array element types match pass", () => {
+        expectNoErrors(`
+            workflow test(items: string[]): string[] {
+                return items;
+            }
+        `);
+    });
+
+    test("optional field absent in source is assignable", () => {
+        expectNoErrors(`
+            workflow test(x: { name: string }): { name: string, tag?: string } {
+                return x;
+            }
+        `);
+    });
+
+    test("optional field present in source with wrong type is not assignable", () => {
+        expectError(
+            `workflow test(x: { name: string, tag: number }): { name: string, tag?: string } {
+                return x;
+            }`,
+            "not assignable to declared type",
+        );
+    });
+
+    test("ternary narrow then wide object arms errors regardless of order (then=narrow)", () => {
+        expectError(
+            `workflow test(flag: boolean, a: { x: string }, b: { x: string, y: number }): { x: string } {
+                return flag ? a : b;
+            }`,
+            "same type",
+        );
+    });
+
+    test("ternary narrow then wide object arms errors regardless of order (then=wide)", () => {
+        expectError(
+            `workflow test(flag: boolean, a: { x: string }, b: { x: string, y: number }): { x: string, y: number } {
+                return flag ? b : a;
+            }`,
+            "same type",
+        );
+    });
+
+    test("ternary with identical object types passes", () => {
+        expectNoErrors(`
+            workflow test(flag: boolean, a: { x: string }, b: { x: string }): { x: string } {
+                return flag ? a : b;
+            }
+        `);
+    });
+
+    test("ternary with parallel arms of different tuple lengths errors", () => {
+        expectError(
+            `workflow test(flag: boolean): string {
+                const r = flag
+                    ? parallel(() => { return "a"; }, () => { return 1; })
+                    : parallel(() => { return "a"; }, () => { return 1; }, () => { return true; });
+                const [a] = r;
+                return a;
+            }`,
+            "same type",
+        );
+    });
+
+    test("optional source field is not assignable to required target field", () => {
+        expectError(
+            `workflow test(x: { name?: string }): { name: string } {
+                return x;
+            }`,
+            "not assignable to declared type",
+        );
+    });
+
+    test("required source field satisfies required target field", () => {
+        expectNoErrors(`
+            workflow test(x: { name: string }): { name: string } {
+                return x;
+            }
+        `);
+    });
 });


### PR DESCRIPTION
## Summary

Resolves DSL gap **G13** (`typeEq` skipped structural comparison for objects and arrays) and documents the follow-up UX gap **G22** that the fix surfaces.

## Changes

### `ts/examples/workflow/dsl/src/typeChecker.ts`
- Split the old `typeEq` into two functions with distinct contracts:
  - `isEqualityComparable(a, b)`: the previous loose, kind-level check, now used only by `===`/`!==` (intentionally permissive until union types land, tracked as G18).
  - `isAssignableTo(target, source)`: a new recursive structural assignability check covering primitives (including `integer`/`number` interop), objects (required vs optional fields, field-type recursion), arrays (element type), and tuples (length + element types). Includes an exhaustiveness `never` check so new `TypeInfo` kinds will fail to compile rather than silently pass.
- Switched the three structural call sites to `isAssignableTo`:
  - Workflow return type vs declared type.
  - `const` annotation vs inferred value type.
  - Ternary arm compatibility (now requires assignability in both directions).
- `===`/`!==` continues to use `isEqualityComparable` to avoid false positives in the absence of union types.

### `ts/examples/workflow/dsl/test/typeChecker.spec.ts`
Added structural-comparison tests covering:
- Object mismatch in return position, const annotation, and ternary arms.
- Array element-type mismatch.
- Structural width subtyping (extra fields are assignable to a narrower target).
- Optional fields: absent-in-source is OK; present-with-wrong-type is not; required target cannot be satisfied by optional source.
- Ternary narrow-vs-wide errors regardless of arm order, and identical types pass.

### `ts/docs/design/workflowSystem/dsl/dsl-v0.1-gap.md`
- Removed the G13 detail section and replaced its slot in the recommended sequence with **G22**.
- Updated the dependency-spine bullet to note G13 is resolved.
- Added the **G22** detail section: type-error messages currently collapse object/array types to `'object'` via `typeName`, making the now-fired structural mismatches indistinguishable. Outlines switching the diagnostics to the existing `formatType`, optionally surfacing the offending field path, and updating affected tests.

## Notes

- No runtime/IR/emitter changes; this is purely a type-checker correctness fix plus docs.
- New tests pass; existing tests unaffected.
