### PR TITLE
fix(workflow-lsp): prevent uncaught 'Connection is disposed' during teardown

### DIFF
--- a/ts/examples/workflow/lsp/src/server.ts
+++ b/ts/examples/workflow/lsp/src/server.ts
@@ -283,6 +283,27 @@ export function createServer(
         dispose: () => {
             for (const t of pendingDiagnostics.values()) clearTimeout(t);
             pendingDiagnostics.clear();
+            // Neutralize the connection's logger before disposing. The
+            // jsonrpc layer calls `logger.error(...)` from the `.catch`
+            // of pending `messageWriter.write` promises when the
+            // underlying stream is torn down (common in tests). That
+            // logger is `connection.console`, whose `send()` invokes
+            // `connection.sendNotification`, which throws synchronously
+            // once the connection is disposed. The throw escapes the
+            // internal `.catch` and surfaces as an uncaught exception.
+            // Replacing the log methods with no-ops avoids that race.
+            const noop = () => {};
+            try {
+                Object.assign(connection.console, {
+                    error: noop,
+                    warn: noop,
+                    info: noop,
+                    log: noop,
+                    debug: noop,
+                });
+            } catch {
+                // Ignore: console may already be inaccessible.
+            }
             connection.dispose();
         },
     };


### PR DESCRIPTION
## Problem

Intermittent CI failure in `examples/workflow/lsp` tests:

```
ConnectionError: Connection is disposed.
    at throwIfClosedOrDisposed (vscode-jsonrpc/lib/common/connection.js:832:19)
    at Object.sendNotification (vscode-jsonrpc/lib/common/connection.js:910:13)
    at RemoteConsoleImpl.send (vscode-languageserver/lib/common/server.js:104:33)
    at RemoteConsoleImpl.error (vscode-languageserver/lib/common/server.js:88:14)
    at vscode-jsonrpc/lib/common/connection.js:951:24
```

## Root cause

When the underlying transport is destroyed (common during jest teardown), `vscode-jsonrpc`'s pending `messageWriter.write(...)` promise rejects. Its internal `.catch` calls `logger.error(...)`. That `logger` is the server's `connection.console` (a `RemoteConsoleImpl`), whose `send()` invokes `connection.sendNotification(...)`, which throws **synchronously** via `throwIfClosedOrDisposed()` once the connection is disposed. The synchronous throw escapes the internal `.catch` and surfaces as an uncaught exception that crashes the worker.

## Fix

In `server.dispose()`, replace `connection.console.{error,warn,info,log,debug}` with no-ops before calling `connection.dispose()`. Any post-dispose log attempts from the jsonrpc layer now no-op instead of throwing.

## Validation

Built and ran the LSP test suite 5 times in a row locally; all 121 tests pass on each run with no uncaught exceptions.