### PR TITLE
Fix intermittent test failure in selectFromPartitions parallel test

### DIFF
--- a/ts/packages/dispatcher/dispatcher/test/unknownSwitcher.spec.ts
+++ b/ts/packages/dispatcher/dispatcher/test/unknownSwitcher.spec.ts
@@ -152,10 +152,10 @@ describe("selectFromPartitions", () => {
         expect(spread).toBeLessThan(10);
 
         // Parallel: total time should be well under sequential (3 × delayMs).
-        // The 2× threshold gives ~100ms of headroom for CI timer jitter while
-        // still catching any accidental sequential execution (which would take
-        // ~300ms and clearly exceed the limit).
-        expect(elapsed).toBeLessThan(delayMs * 2);
+        // The 2.5× threshold gives ~150ms of headroom for CI timer jitter
+        // while still catching any accidental sequential execution (which
+        // would take ~300ms and clearly exceed the limit).
+        expect(elapsed).toBeLessThan(delayMs * 2.5);
     });
 
     test("error from a partition is propagated in order", async () => {


### PR DESCRIPTION
Increase timing threshold from 2x to 2.5x `delayMs` in the "all partitions run in parallel" test to accommodate CI timer jitter while still detecting accidental sequential execution (~300ms).