### PR TITLE
fix(fix-dependabot-alerts): refresh app token before creating PR

### DIFF
--- a/.github/workflows/fix-dependabot-alerts.yml
+++ b/.github/workflows/fix-dependabot-alerts.yml
@@ -431,10 +431,25 @@ jobs:
           echo "shell_ok=true" >> "$GITHUB_OUTPUT"
 
       # ── Create PR ───────────────────────────────────────────────────
+      # GitHub App installation tokens expire after 1 hour. The build/verify
+      # phase routinely runs longer than that, so the original app-token
+      # minted at job start is expired by the time we get here, causing
+      # `gh pr create` to fail with 401 Bad credentials (the `git push`
+      # itself works because actions/checkout uses the workflow's own
+      # GITHUB_TOKEN, which is valid for the full job lifetime). Mint a
+      # fresh app token immediately before any late-running `gh` calls.
+      - name: Refresh GitHub App token
+        id: app-token-pr
+        if: ${{ steps.fix.outputs.changes == 'true' && steps.build.outputs.build_ok == 'true' }}
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.DEPENDABOT_APP_ID }}
+          private-key: ${{ secrets.DEPENDABOT_APP_PRIVATE_KEY }}
+
       - name: Create pull request
         if: ${{ steps.fix.outputs.changes == 'true' && steps.build.outputs.build_ok == 'true' }}
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ steps.app-token-pr.outputs.token }}
         run: |
           BRANCH="automated/fix-dependabot-alerts-$(date +%Y%m%d)-${{ github.run_number }}"
 


### PR DESCRIPTION
GitHub App installation tokens expire after 1 hour, but the `fix-dependabot-alerts` build/verify phase routinely runs longer than that. The original app token minted at job start was expired by the time the `Create pull request` step ran, causing `gh pr list` / `gh pr create` to fail with **401 Bad credentials**. The `git push` itself succeeded because `actions/checkout` uses the workflow's own `GITHUB_TOKEN` (valid for the full job lifetime), so the branch was pushed but no PR was opened.

This change mints a fresh app token immediately before the create-PR step.

**Repro:** workflow_dispatch run [26475336645](https://github.com/microsoft/TypeAgent/actions/runs/26475336645) — job duration 1h 14m; app token minted at 21:10:02, `Create pull request` step ran at 22:24:49 (~14 min past token expiry).

The remediation branch from that run (`automated/fix-dependabot-alerts-20260526-63`) is being opened as a separate PR manually.