### PR TITLE
workflow/dsl: tighten integer/number assignability, enforce unknown semantics, clean up resolved gaps

### DIFF
--- a/ts/docs/design/workflowSystem/dsl/dsl-v0.1-gap.md
+++ b/ts/docs/design/workflowSystem/dsl/dsl-v0.1-gap.md
@@ -19,86 +19,38 @@ new surface area:
    surfaces real structural mismatches, switch error messages from the
    collapsed `'object'` rendering to the existing `formatType` output so
    users can see which fields differ.
-5. ~~**G10: Fix `integer`/`number` assignability.**~~ **DONE.** Assignability
-   is now one-way (`integer` widens to `number`; `number` does not narrow to
-   `integer`). Integer-only arithmetic (`+`, `-`, `*`, `%`) preserves the
-   `integer` type. See §G10 below for details.
-6. **G3: Add TypeScript-style named type aliases.** Once structural
+5. **G3: Add TypeScript-style named type aliases.** Once structural
    assignability is sound, add named type declarations and a type environment.
-7. **G4: Add generics for `llm.generateJson<T>`.** This depends on richer type
+6. **G4: Add generics for `llm.generateJson<T>`.** This depends on richer type
    parsing and checking, and becomes more ergonomic once named aliases exist.
-8. **G18: Add union/literal types.** This is the broadest type-system expansion
+7. **G18: Add union/literal types.** This is the broadest type-system expansion
    and should come after type soundness and named types.
-9. **G11: Decide/document bind stripping for explicit user names.** This is
+8. **G11: Decide/document bind stripping for explicit user names.** This is
    primarily debuggability and spec clarity.
-10. **G9: Decide whether bare task calls need `ExpressionStatement`.** This is
-    AST honesty and visual-editor clarity, but current behavior works.
-11. **G12: Decide `list.append` naming/semantics.** This is naming/API
+9. **G9: Decide whether bare task calls need `ExpressionStatement`.** This is
+   AST honesty and visual-editor clarity, but current behavior works.
+10. **G12: Decide `list.append` naming/semantics.** This is naming/API
     consistency with coordinated emitter, engine, and snapshot churn.
-12. **G20: Audit remaining `identity` / `noop` usage in the emitter.**
+11. **G20: Audit remaining `identity` / `noop` usage in the emitter.**
     Decision 0010 removed `identity` / `noop` as load-bearing at branch
     convergence, but the emitter still synthesizes them in several other
     places. Classify each remaining usage as (a) reducible after 0010,
     (b) forced by an IR shape that could be relaxed additively, or (c)
     inherent to decision 0006 (no expressions). Pure audit; only
     schedules follow-up work.
-13. **G7: Revisit composition patterns only when concrete workflow needs appear.**
+12. **G7: Revisit composition patterns only when concrete workflow needs appear.**
     These patterns push against the visual-node discipline and should stay out
     of scope until justified.
-14. ~~**G29 + G30: `if`/`switch` as value producers.**~~ G30 (mixed-return errors) **DONE**; G29 (deprecate value-producing if/switch?) deferred pending `.wf` survey + G18.
+13. **G29: Revisit value-producing `if`/`switch`.** Deprecation of
+    value-producing `if`/`switch` is deferred pending `.wf` survey + G18.
 
-G1 (sub-workflow calls and cross-file composition) is now resolved; see its
-section below for the landed surface. G24-G28 capture follow-up design
-questions raised during the G1 implementation that have not yet been
-scheduled. G29 and G30 are treated as a unified gap (see §G29+G30 below):
-both arise from the same root cause — `if`/`switch` statements trying to
-act as value-producing expressions in an SSA compiler without a CFG pass.
-G30 (mixed-return errors) is resolved; G29's open question (whether to
-deprecate value-producing `if`/`switch` in favour of ternary) is deferred
-pending a `.wf` survey and G18 (union types).
+G24-G28 capture follow-up design questions raised during the workflow
+composition implementation that have not yet been scheduled.
 
 Dependency spine:
 
 - `G2 -> G17` brings fork/forkMap IR and runtime behavior into spec alignment.
-- `G3 -> G4 -> G18` builds type-system features on sound assignability
-  (G10 and G13 are resolved).
-
-## G1: Sub-workflow calls ✅ Resolved
-
-**Status:** Resolved as of the workflow-composition implementation plan
-(Phases 1–7). Multiple workflows in one file _and_ across multiple files
-now compose end-to-end through compiler, engine, and CLI. Cross-workflow
-calls emit `WorkflowCallNode` (not inlined) and the engine resolves the
-target via the IR's `workflows` table.
-
-**What landed:**
-
-- Parser: `export workflow`, `import { … } from "./other.wf"` (with
-  optional aliases), default-expression parameters, named-record args.
-- Type checker: takes the full flat workflow list; resolves single-
-  segment names to either workflow or task (workflow shadows task), and
-  rejects call-graph cycles (across files too).
-- Emitter: emits one `WorkflowBody` per workflow into
-  `WorkflowIR.workflows[name]` and emits `WorkflowCallNode` (kind
-  `"workflowCall"`) at each call site. Default arguments are inlined
-  at the call site per design §4.3.
-- Engine: `WorkflowCallNode` handler creates an isolated child frame,
-  propagates errors out to the caller's `onError`, and honors
-  `timeoutMs`. A concurrent-run guard rejects re-entrancy on the same
-  engine instance.
-- CLI (`wfc`): `--entry <name>` selects the program entry from the
-  entry file's workflows; `--workspace-root <dir>` opts into
-  containment for cross-file imports (otherwise `tsc`-style trust).
-- File loader: BFS-loads `.wf` files, detects duplicate workflow names
-  across files, rejects non-exported / missing imports, rewrites
-  aliased call sites to canonical names before type-check, and uses
-  `realpathSync` for symlink-safe containment.
-
-**References:**
-
-- Design: [`workflow-composition.md`](./workflow-composition.md)
-- IR additions folded into [`../ir/ir-v0.2.md`](../ir/ir-v0.2.md)
-  (no version bump).
+- `G3 -> G4 -> G18` builds type-system features on sound assignability.
 
 ## G2: Parallel branches missing IR schema fields
 
@@ -230,39 +182,6 @@ bindings with synthetic names? The current approach works but:
 2. If keeping current approach: no code change needed, already documented.
 3. If adding `ExpressionStatement`: update parser, ast.ts, emitter, and
    graph extractor.
-
-## G10: integer/number bidirectional compatibility ✅ Resolved
-
-**Context:** JSON Schema defines `integer` as a subtype of `number`
-(one-way: integer values satisfy a number schema, but not vice versa).
-The DSL type checker previously treated them as bidirectionally
-compatible, which let a fractional `number` silently flow into an
-`integer` slot.
-
-**Status:** Resolved. `isAssignableTo` now only widens `integer` to
-`number`; assigning a `number` to an `integer` target is a type error.
-Integer arithmetic (`+`, `-`, `*`, `%`) on two `integer` operands keeps
-the `integer` type via `inferBinaryExpr`; division stays `number`.
-Equality (`===`/`!==`) between `integer` and `number` remains permitted
-in both directions (handled by `isEqualityComparable`), since comparing
-the two is not a precision-loss bug.
-
-**What landed:**
-
-- `typeChecker.ts` `isAssignableTo` primitive case: dropped the
-  `number → integer` direction; only `integer → number` is allowed.
-- `typeChecker.ts` `inferBinaryExpr`: integer-only `+`, `-`, `*`, `%`
-  narrow back to `integer`; `/` stays `number`.
-- Enum-vs-primitive assignability (`primitiveMatchesEnumBase` and
-  the inline enum case) already had the asymmetric rule for the same
-  reason; no change needed there.
-- Tests: replaced `"number is assignable to integer"` with the negative
-  cases `"number is NOT assignable to integer (G10)"`,
-  `"number parameter is NOT assignable to integer return (G10)"`, and
-  `"number value is NOT assignable to integer const annotation (G10)"`.
-- Built-in task audit: `math.floor`, `math.round`, `math.ceil`,
-  `list.length` etc. return `integer`, which still flows into
-  `number`-typed slots — no regressions.
 
 ## G11: Bind stripping removes names from side-effect tasks
 

--- a/ts/docs/design/workflowSystem/dsl/dsl-v0.1-gap.md
+++ b/ts/docs/design/workflowSystem/dsl/dsl-v0.1-gap.md
@@ -19,8 +19,10 @@ new surface area:
    surfaces real structural mismatches, switch error messages from the
    collapsed `'object'` rendering to the existing `formatType` output so
    users can see which fields differ.
-5. **G10: Fix `integer`/`number` assignability.** Make numeric compatibility
-   one-way before adding more type-system expressiveness.
+5. ~~**G10: Fix `integer`/`number` assignability.**~~ **DONE.** Assignability
+   is now one-way (`integer` widens to `number`; `number` does not narrow to
+   `integer`). Integer-only arithmetic (`+`, `-`, `*`, `%`) preserves the
+   `integer` type. See §G10 below for details.
 6. **G3: Add TypeScript-style named type aliases.** Once structural
    assignability is sound, add named type declarations and a type environment.
 7. **G4: Add generics for `llm.generateJson<T>`.** This depends on richer type
@@ -58,8 +60,8 @@ pending a `.wf` survey and G18 (union types).
 Dependency spine:
 
 - `G2 -> G17` brings fork/forkMap IR and runtime behavior into spec alignment.
-- `G10 -> G3 -> G4 -> G18` builds type-system features on sound
-  assignability (G13 resolved the structural-comparison prerequisite).
+- `G3 -> G4 -> G18` builds type-system features on sound assignability
+  (G10 and G13 are resolved).
 
 ## G1: Sub-workflow calls ✅ Resolved
 
@@ -229,36 +231,38 @@ bindings with synthetic names? The current approach works but:
 3. If adding `ExpressionStatement`: update parser, ast.ts, emitter, and
    graph extractor.
 
-## G10: integer/number bidirectional compatibility
+## G10: integer/number bidirectional compatibility ✅ Resolved
 
 **Context:** JSON Schema defines `integer` as a subtype of `number`
 (one-way: integer values satisfy a number schema, but not vice versa).
-The DSL type checker treats them as bidirectionally compatible.
+The DSL type checker previously treated them as bidirectionally
+compatible, which let a fractional `number` silently flow into an
+`integer` slot.
 
-**Current state:**
+**Status:** Resolved. `isAssignableTo` now only widens `integer` to
+`number`; assigning a `number` to an `integer` target is a type error.
+Integer arithmetic (`+`, `-`, `*`, `%`) on two `integer` operands keeps
+the `integer` type via `inferBinaryExpr`; division stays `number`.
+Equality (`===`/`!==`) between `integer` and `number` remains permitted
+in both directions (handled by `isEqualityComparable`), since comparing
+the two is not a precision-loss bug.
 
-- The type checker's `isAssignable` function treats `integer` and
-  `number` as interchangeable in both directions
-  (typeChecker.ts ~line 99-104).
-- You can pass a `number` value where `integer` is expected without a
-  type error, which is a silent precision-loss bug.
-- Additionally, arithmetic on two `integer` operands always returns
-  `number` (typeChecker.ts ~line 713), even though the result could
-  safely remain `integer` for `+`, `-`, `*`.
+**What landed:**
 
-**What needs to happen:**
-
-1. Make assignability one-way: `integer` assignable to `number`, but
-   `number` NOT assignable to `integer` without an explicit conversion.
-2. Consider returning `integer` from integer-only arithmetic (`+`, `-`,
-   `*`) and `number` only when a `number` operand is involved or for
-   division.
-3. Add type error tests for cases like passing a `number` variable to
-   an input that expects `integer`.
-4. Audit existing task schemas: some tasks (e.g., `math.floor`,
-   `math.round`, `math.ceil`) correctly return `integer`; verify that
-   their results can still flow into `number`-typed inputs after the
-   one-way fix.
+- `typeChecker.ts` `isAssignableTo` primitive case: dropped the
+  `number → integer` direction; only `integer → number` is allowed.
+- `typeChecker.ts` `inferBinaryExpr`: integer-only `+`, `-`, `*`, `%`
+  narrow back to `integer`; `/` stays `number`.
+- Enum-vs-primitive assignability (`primitiveMatchesEnumBase` and
+  the inline enum case) already had the asymmetric rule for the same
+  reason; no change needed there.
+- Tests: replaced `"number is assignable to integer"` with the negative
+  cases `"number is NOT assignable to integer (G10)"`,
+  `"number parameter is NOT assignable to integer return (G10)"`, and
+  `"number value is NOT assignable to integer const annotation (G10)"`.
+- Built-in task audit: `math.floor`, `math.round`, `math.ceil`,
+  `list.length` etc. return `integer`, which still flows into
+  `number`-typed slots — no regressions.
 
 ## G11: Bind stripping removes names from side-effect tasks
 

--- a/ts/docs/design/workflowSystem/dsl/dsl-v0.1-gap.md
+++ b/ts/docs/design/workflowSystem/dsl/dsl-v0.1-gap.md
@@ -41,8 +41,13 @@ new surface area:
 12. **G7: Revisit composition patterns only when concrete workflow needs appear.**
     These patterns push against the visual-node discipline and should stay out
     of scope until justified.
-13. **G29: Revisit value-producing `if`/`switch`.** Deprecation of
-    value-producing `if`/`switch` is deferred pending `.wf` survey + G18.
+13. **G29 (open part): Decide whether to deprecate value-producing
+    `if`/`switch` in favour of ternary.** The arm-type checking part of
+    G29 (same-type enforcement, `_resolvedSchemas` storage, partial-return
+    as a type error) is resolved; see decision 0011 §6 and the
+    `G29 + G30` section below. The remaining open question - whether
+    value-producing `if`/`switch` should be deprecated entirely - is
+    deferred pending a `.wf` survey + G18 (union types).
 
 G24-G28 capture follow-up design questions raised during the workflow
 composition implementation that have not yet been scheduled.
@@ -628,7 +633,7 @@ therefore a non-standard extension with no TypeScript precedent.
 TypeScript (positional only, or explicit destructuring) or keep the
 named-record convenience syntax as a DSL-specific ergonomic feature?
 
-**Raised during:** G1 workflow composition implementation (designing workflow
+**Raised during:** the workflow composition implementation (designing workflow
 call syntax).
 
 ## G25: `export` conflates entry-point selection with cross-file importability; no library compile mode
@@ -672,7 +677,7 @@ concrete problems:
   stem) as the entry when no explicit `--entry` is given, making `export`
   purely a visibility qualifier.
 
-**Raised during:** G1 workflow composition implementation (designing
+**Raised during:** the workflow composition implementation (designing
 export / entry-point semantics).
 
 ## G26: No DSL syntax for `timeoutMs` on workflow calls
@@ -697,7 +702,7 @@ field is only reachable by tools that build IR directly.
   — declares max runtime on the callee declaration rather than each call
   site. Simpler but less flexible (no per-call override).
 
-**Raised during:** G1 workflow composition implementation (designing
+**Raised during:** the workflow composition implementation (designing
 sub-workflow call nodes in the IR).
 
 ## G27: No per-file namespacing for exported workflows in IR
@@ -721,7 +726,7 @@ schema for registry-style resolution) but it is not used by the bundler today.
 - **Accept mangling**: keep `__f{N}_{name}` as the implementation detail and
   expose a `workflowOrigins` side-table mapping mangled name → original path + name.
 
-**Raised during:** G1 workflow composition implementation (building the
+**Raised during:** the workflow composition implementation (building the
 cross-file bundler and name mangling strategy).
 
 ## G28: `maxConcurrency` only accepts literal integers

--- a/ts/docs/design/workflowSystem/dsl/workflow-composition.md
+++ b/ts/docs/design/workflowSystem/dsl/workflow-composition.md
@@ -5,21 +5,21 @@
 ## Context
 
 The DSL spec (`dsl/dsl-v0.1.md` §4) permits multiple workflows per file and
-sub-workflow calls, and the current implementation lowers those calls by
-emitting an unregistered `workflow.<name>` task node (see
-`dsl/dsl-v0.1-gap.md` G1). That lowering is a placeholder: the type
-checker only sees one workflow at a time, the emitter does not inline,
-and the engine has no resolution path for the synthetic task name.
+sub-workflow calls. Earlier the implementation lowered those calls by
+emitting an unregistered `workflow.<name>` task node as a placeholder: the
+type checker only saw one workflow at a time, the emitter did not inline,
+and the engine had no resolution path for the synthetic task name.
 
-The narrow gap (G1) can be closed in several ways, but the question
-underneath it is broader and worth answering on its own terms: **how
-should workflows compose, principally?** This document records that
-answer, ignoring migration and implementation cost. It is not (yet) the
-authoritative spec; it is the target the IR and DSL should evolve
-toward.
+That narrow gap has since been closed end-to-end (parser, type checker,
+emitter, engine, CLI; see commits landing the `WorkflowCallNode` and
+cross-file bundler). The question underneath it remains broader and worth
+answering on its own terms: **how should workflows compose, principally?**
+This document records that answer, ignoring migration and implementation
+cost. It is not (yet) the authoritative spec; it is the target the IR and
+DSL should evolve toward.
 
 This doc is **cross-cutting**: it lives under `dsl/` because the
-gap that motivates it is a DSL gap (G1) and §4 ("DSL ergonomics") is
+originating gap was a DSL gap and §4 ("DSL ergonomics") is
 the bulk of the content, but §2 specifies the supporting IR changes
 (new node kind, workflow table). The two co-evolve and are not split.
 
@@ -528,8 +528,10 @@ helps without changing what the IR (or the source) means.
   forbidding the language construct.
 
 Follow-up edits implied by adoption (not part of this doc's scope):
-the dsl-v0.1 spec §4 wording, the dsl-v0.1-gap G1 entry, and the
-IR spec's node-kind table all need updating when this lands.
+the dsl-v0.1 spec §4 wording and the IR spec's node-kind table need
+updating when this lands. (The original sub-workflow-call gap entry in
+`dsl-v0.1-gap.md` has already been removed now that the narrow fix
+shipped.)
 
 ## 8. Decisions
 
@@ -556,9 +558,9 @@ IR spec's node-kind table all need updating when this lands.
 
 - Replaces, in spirit, the §4 wording of `dsl/dsl-v0.1.md` (inlining as
   semantics).
-- Subsumes the framing question behind `dsl/dsl-v0.1-gap.md` G1; the
-  narrow G1 fix should be chosen with this target in mind even if full
-  adoption is later.
+- Subsumes the framing question behind the (now-resolved) sub-workflow-call
+  gap; that narrow fix was chosen with this target in mind, even though
+  full adoption of the principled position is later work.
 - Touches the same surface as `ir/workflow-scope-proposal.md` (sub-scope
   contracts); a workflow body is structurally another sub-scope.
 - Should be cross-referenced from `principles/principle-gaps.md`.

--- a/ts/docs/design/workflowSystem/ir/decisions/0011-top-schema-unknown-semantics.md
+++ b/ts/docs/design/workflowSystem/ir/decisions/0011-top-schema-unknown-semantics.md
@@ -1,57 +1,48 @@
 # Decision 0011: `{}` = unknown semantics for bound producer schemas
 
-**Status:** Proposed.
-**Supersedes:** The implicit "any" behaviour in the current validator.
-**Related:** ir-v0.1.md §4.1 pass 7; G29 (dsl-v0.1-gap.md); validator-soundness plan.
-
-**End state:** The validator MUST error (not warn) on bound producers with
-`{}` outputSchema. Warnings are an intermediate step while emitter gaps are
-closed. This document records both the principle and the enforcement target.
+**Status:** Accepted (implemented).
+**Supersedes:** The implicit "any" behaviour in the previous validator.
+**Related:** ir-v0.1.md §4.1 pass 7; G29 (dsl-v0.1-gap.md).
 
 ---
 
 ## 1. Problem
 
-`outputSchema: {}` appears in two semantically different roles across the IR
-today, but the validator treats both identically as **"any"** — it skips all
-subtype checks when the producer schema is `{}`. This is unsound for the
-second role.
+`outputSchema: {}` appears in two semantically different roles across the IR,
+but the old validator treated both identically as **"any"** (skipping all
+subtype checks when the producer schema is `{}`). This is unsound when a
+downstream consumer reads from a `{}`-typed reference into a typed slot.
 
-| Role                                  | Example nodes                        | Semantics needed                             |
-| ------------------------------------- | ------------------------------------ | -------------------------------------------- |
-| Pure CFG node, no consumer            | `noop`, `merge` (no `bind`)          | `{}` is irrelevant; skip silently ✓          |
-| Bound producer, type not yet inferred | `BranchNode` with `bind`, arm scopes | `{}` means **unknown** — warn on path access |
-| Bound producer, type IS knowable      | emitter gap (e.g. forkMap body)      | Fix the emitter; emit the real schema        |
-
-The IR specification (§1.1) requires that _"every type check… is determinable
-from the IR alone, cheaply."_ A `{}` on a bound producer makes that impossible:
-the validator cannot verify that downstream consumers use the value correctly.
+| Role                                 | Example nodes                        | Semantics needed                      |
+| ------------------------------------ | ------------------------------------ | ------------------------------------- |
+| Pure CFG node, no consumer           | `noop`, `merge` (no `bind`)          | `{}` is irrelevant; skip silently     |
+| Bound producer, type not fully known | `BranchNode` with `bind`, arm scopes | `{}` means **unknown** (top type)     |
+| Bound producer, type IS knowable     | emitter gap (e.g. destructuring)     | Fix the emitter; emit the real schema |
 
 ---
 
 ## 2. Decision
 
-**`{}` on a bound producer is valid IR but semantically `unknown`, not `any`.**
+**`{}` on a bound producer is valid IR, semantically `unknown` (top type).**
 
-Concretely:
+Enforcement is **consumer-side** via `checkUnknownAssignability`:
 
 1. **Assignability TO `{}`** (consumer is `{}`): anything is assignable to
-   unknown. No change. Continue to skip the check silently.
+   unknown. Skip silently (no error).
 
 2. **Assignability FROM `{}` to a typed consumer** (producer is `{}`):
-   the validator MUST eventually **error**. While emitter gaps remain
-   (i.e. while DSL-compiled IR can still produce `{}` on bound producers due
-   to unresolved G29), the validator emits a **warning** as an intermediate
-   step. Once emitter gaps are closed (Phases 2-4 of the soundness plan), the
-   warning is promoted to an error.
+   the validator **errors**. A consumer that requires a concrete type cannot
+   safely read from an unknown producer without a runtime type guard.
 
-3. **Path access on a `{}` producer** (`resolveSchemaPath({}, ["foo", ...])`):
-   same staged approach — **warning** while emitter gaps exist, **error** once
-   all bound producers carry concrete schemas.
-
-4. **Unbound CFG nodes** (nodes with no `bind`, pure sequencing): their
-   `outputSchema: {}` is correct and irrelevant. No warning is needed because
+3. **Unbound CFG nodes** (nodes with no `bind`, pure sequencing): their
+   `outputSchema: {}` is correct and irrelevant. No error is raised because
    no consumer references them.
+
+4. **Captured references in sub-scopes**: The emitter's `propagateBodySchemas`
+   post-pass resolves captured-ref schemas from the parent scope into each
+   sub-scope's `inputSchema.properties`. This prevents false positives where
+   a capture was conservatively typed as `{}` but the parent has a concrete
+   schema.
 
 ---
 
@@ -81,95 +72,66 @@ Writing _to_ the top type is always safe (anything is a subtype).
 
 This mirrors TypeScript's `unknown`:
 
-- `T → unknown`: always safe ✓
-- `unknown → T`: requires narrowing (here: a concrete schema) — warn if absent
+- `T → unknown`: always safe
+- `unknown → T`: error (requires a concrete schema on the producer)
 
 ---
 
-## 5. Validator changes required
+## 5. Implementation
 
-Add `warnings: ValidationWarning[]` to `ValidationResult` (a new array
-parallel to `errors`, with the same `{ path, message }` shape).
+The validator enforces consumer-side checks via `checkUnknownAssignability()`.
+This function is called at three sites:
 
-Two warning sites in `validate.ts`:
+1. **`node.inputs` fields** - when a resolved template type is `{}` but the
+   consumer property requires a concrete type.
+2. **Branch `selector`** - when the selector resolves to `{}` but
+   `selectorSchema` requires a concrete type.
+3. **`scope.output`** - when the workflow output template resolves to `{}` but
+   the body's `outputSchema` is concrete.
 
-```typescript
-// checkStructuralSubtype (currently line ~2562)
-if (isTopSchema(consumer)) return; // still silent ✓
-if (isTopSchema(producer) && !isTopSchema(consumer)) {
-  // was: silent skip
-  warnings.push({
-    path,
-    message:
-      `Producer schema is unconstrained ({}); cannot verify ` +
-      `assignability to ${formatSchemaType(consumer)}. ` +
-      `Add a concrete outputSchema to enable static checking.`,
-  });
-  return;
-}
+Error message format:
 
-// resolveSchemaPath — when called with a non-empty path on a {} schema
-if (isTopSchema(schema) && path.length > 0) {
-  warnings.push({
-    path: refPath,
-    message:
-      `Path [${path.join(".")}] accessed on unconstrained schema ({}); ` +
-      `cannot verify the field exists at runtime.`,
-  });
-  return {}; // current behaviour preserved; warning added
-}
+```
+{producerLabel} resolves to {} (unknown); not assignable to
+{consumerLabel} {formatSchemaType(consumer)}. Only consumers that
+accept unknown (schema {}) may read from an unknown producer.
 ```
 
+The emitter's `propagateBodySchemas` post-pass resolves captured-reference
+schemas from the parent scope into sub-scope `inputSchema.properties`, so
+sub-scopes that capture typed bindings don't see `{}` at runtime.
+
 ---
 
-## 6. Emitter obligations and G29 resolution
+## 6. Emitter obligations
 
-Before Phase 5b (validator errors) can land, the emitter must produce zero `{}`
-on any bound producer. This requires two tracks:
+The emitter should produce concrete `outputSchema` on all bound producers
+where the type is statically known. Current coverage:
 
-**Track A — immediately fixable (type already known):**
-
-| Site                                               | Fix                                                                |
-| -------------------------------------------------- | ------------------------------------------------------------------ |
-| `forkMap` body `outputSchema` (emitter.ts ~2397)   | Wire the already-computed `elementSchema` into `body.outputSchema` |
-| `fork` parallel branch body `outputSchema` (~2278) | Compute terminal node's outputSchema; same pattern as forkMap      |
-
-**Track B — requires G29 resolution (branch/arm types):**
-
-G29 is resolved prescriptively here:
-
-1. **Same-type enforcement for `if`/`switch` arms.** The type checker must
-   error when value-producing arms return different types (matching ternary).
-2. **Partial return is a type error.** When `resultBind` is set on a branch
-   node, both arms must return a value. `thenOutput ?? null` as a fallback must
-   become unreachable.
-3. **Store result types in `_resolvedSchemas`.** After checking `IfStatement`,
-   `SwitchStatement`, and `TernaryExpr`, store the result type at the node's
-   `loc.offset` — same pattern as `AttemptsNode` (gap 8). The emitter reads it
-   back to set `branch.outputSchema` and `arm.scope.outputSchema`.
-
-Once Track A and B are done:
-
-| Site                                             | Fix                                            |
-| ------------------------------------------------ | ---------------------------------------------- |
-| `if/else` branch `outputSchema` (~603)           | Read from `_resolvedSchemas` at `s.loc.offset` |
-| `switch` branch `outputSchema` (~729)            | Same                                           |
-| Ternary branch `outputSchema` (~1419)            | Read from `_resolvedSchemas` at `e.loc.offset` |
-| Arm `scope.outputSchema` (via `buildArmScope`)   | Pass resolved type instead of `{}`             |
-| Ternary literal identity wrappers (~1366, ~1397) | Infer from literal value's JSON Schema type    |
+| Site                                           | Status                                             |
+| ---------------------------------------------- | -------------------------------------------------- |
+| Generic task calls                             | Done (resolvedSchemas)                             |
+| `forkMap` body outputSchema                    | Done                                               |
+| `fork` parallel branch body outputSchema       | Done                                               |
+| `attempts` loop body output                    | Done                                               |
+| Destructuring pick nodes                       | Done (symbolTypes)                                 |
+| Pure-literal return identity wrapper           | Done                                               |
+| Branch `outputSchema` (if/switch/ternary bind) | Done                                               |
+| Arm `scope.outputSchema`                       | Done                                               |
+| Ternary literal identity wrappers              | Uses `{}` (accepted; consumer-side catches misuse) |
+| Noop merge nodes                               | Uses `{}` (unbound; irrelevant)                    |
 
 ---
 
 ## 7. IR spec impact
 
-§4.1 pass 7 (type compatibility) should add a note:
+§4.1 pass 7 (type compatibility) should state:
 
 > A producer schema of `{}` (the universal top type) is treated as **unknown**
 > for validation purposes. Assignability _to_ `{}` is unconditionally satisfied.
-> Assignability _from_ `{}` to a typed consumer, or path projection on `{}`,
-> is a validation **error**. (During the transition period while emitter gaps
-> are being closed, this is a warning; it becomes an error once the DSL
-> compiler no longer emits `{}` on bound producers.)
+> Assignability _from_ `{}` to a typed consumer is a validation **error**.
+> Unbound nodes (no `bind`) with `outputSchema: {}` are exempt because no
+> consumer can reference them.
 
 ---
 
@@ -178,9 +140,8 @@ Once Track A and B are done:
 - **Decision 0001 (bound outputs):** A node without `bind` has no addressable
   output. Its `outputSchema` is required by the IR grammar but is irrelevant to
   consumers. The unknown semantics decision applies only to _bound_ producers.
-- **G29 (branch arm output types):** Resolved prescriptively in §6 above.
-  Same-type enforcement for if/switch arms, partial-return as type error, and
-  result type storage in `_resolvedSchemas` are the three required type-checker
-  changes. G29 is no longer open once §6 Track B is implemented.
+- **G29 (branch arm output types):** Resolved. The type checker enforces
+  same-type arms, stores result types in `_resolvedSchemas`, and the emitter
+  reads them back to set `branch.outputSchema` and `arm.scope.outputSchema`.
 - **G18 (union types):** When `anyOf` is introduced for heterogeneous arm types,
-  branch `outputSchema` can be a concrete union instead of `{}`.
+  branch `outputSchema` can be a concrete union instead of requiring same-type.

--- a/ts/docs/design/workflowSystem/ir/decisions/0011-top-schema-unknown-semantics.md
+++ b/ts/docs/design/workflowSystem/ir/decisions/0011-top-schema-unknown-semantics.md
@@ -108,18 +108,18 @@ sub-scopes that capture typed bindings don't see `{}` at runtime.
 The emitter should produce concrete `outputSchema` on all bound producers
 where the type is statically known. Current coverage:
 
-| Site                                           | Status                                             |
-| ---------------------------------------------- | -------------------------------------------------- |
-| Generic task calls                             | Done (resolvedSchemas)                             |
-| `forkMap` body outputSchema                    | Done                                               |
-| `fork` parallel branch body outputSchema       | Done                                               |
-| `attempts` loop body output                    | Done                                               |
-| Destructuring pick nodes                       | Done (symbolTypes)                                 |
-| Pure-literal return identity wrapper           | Done                                               |
-| Branch `outputSchema` (if/switch/ternary bind) | Done                                               |
-| Arm `scope.outputSchema`                       | Done                                               |
-| Ternary literal identity wrappers              | Uses `{}` (accepted; consumer-side catches misuse) |
-| Noop merge nodes                               | Uses `{}` (unbound; irrelevant)                    |
+| Site                                           | Status                                                               |
+| ---------------------------------------------- | -------------------------------------------------------------------- |
+| Generic task calls                             | Done (resolvedSchemas)                                               |
+| `forkMap` body outputSchema                    | Done                                                                 |
+| `fork` parallel branch body outputSchema       | Done                                                                 |
+| `attempts` loop body output                    | Done                                                                 |
+| Destructuring pick nodes                       | Done (symbolTypes)                                                   |
+| Pure-literal return identity wrapper           | Done                                                                 |
+| Branch `outputSchema` (if/switch/ternary bind) | Done                                                                 |
+| Arm `scope.outputSchema`                       | Done                                                                 |
+| Ternary literal identity wrappers              | Done (uses `_resolvedSchemas`; `{}` only as error-recovery fallback) |
+| Noop merge nodes                               | Uses `{}` (unbound; irrelevant)                                      |
 
 ---
 

--- a/ts/examples/workflow/dsl/src/typeChecker.ts
+++ b/ts/examples/workflow/dsl/src/typeChecker.ts
@@ -348,12 +348,15 @@ function isAssignableTo(target: TypeInfo, source: TypeInfo): boolean {
     if (target.kind !== source.kind) return false;
     switch (target.kind) {
         case "primitive": {
+            // Safe: the `target.kind !== source.kind` guard above proves
+            // source is also a PrimitiveType. Cast matches the pattern
+            // used by the object/array/tuple cases below.
             const s = source as PrimitiveType;
             // JSON Schema treats `integer` as a subtype of `number`:
             // every integer satisfies a number schema, but a number may
             // be fractional and so does NOT satisfy an integer schema.
-            // Assignability is therefore one-way: integer → number is
-            // allowed; number → integer is rejected (G10).
+            // Assignability is therefore one-way: integer to number is
+            // allowed; number to integer is rejected.
             if (target.name === "number" && s.name === "integer") return true;
             return target.name === s.name;
         }

--- a/ts/examples/workflow/dsl/src/typeChecker.ts
+++ b/ts/examples/workflow/dsl/src/typeChecker.ts
@@ -349,11 +349,12 @@ function isAssignableTo(target: TypeInfo, source: TypeInfo): boolean {
     switch (target.kind) {
         case "primitive": {
             const s = source as PrimitiveType;
-            if (
-                (target.name === "integer" && s.name === "number") ||
-                (target.name === "number" && s.name === "integer")
-            )
-                return true;
+            // JSON Schema treats `integer` as a subtype of `number`:
+            // every integer satisfies a number schema, but a number may
+            // be fractional and so does NOT satisfy an integer schema.
+            // Assignability is therefore one-way: integer → number is
+            // allowed; number → integer is rejected (G10).
+            if (target.name === "number" && s.name === "integer") return true;
             return target.name === s.name;
         }
         case "object": {

--- a/ts/examples/workflow/dsl/test/typeChecker.spec.ts
+++ b/ts/examples/workflow/dsl/test/typeChecker.spec.ts
@@ -1531,7 +1531,7 @@ describe("type checker", () => {
         `);
     });
 
-    test("number is NOT assignable to integer (G10)", () => {
+    test("number is NOT assignable to integer", () => {
         expectError(
             `workflow test(): integer {
                 const x: number = 5;
@@ -1541,21 +1541,55 @@ describe("type checker", () => {
         );
     });
 
-    test("number parameter is NOT assignable to integer return (G10)", () => {
+    test("number parameter is NOT assignable to integer return", () => {
         expectError(
             `workflow test(x: number): integer { return x; }`,
             "not assignable to declared type",
         );
     });
 
-    test("number value is NOT assignable to integer const annotation (G10)", () => {
+    test("number value is NOT assignable to integer const annotation", () => {
         expectError(
             `workflow test(x: number): number {
                 const y: integer = x;
                 return y;
             }`,
+            "Type 'number' is not assignable to type 'integer'",
+        );
+    });
+
+    test("number field is NOT assignable to integer field (nested)", () => {
+        expectError(
+            `workflow test(x: number): { n: integer } {
+                return { n: x };
+            }`,
             "not assignable",
         );
+    });
+
+    test("number[] is NOT assignable to integer[] (array element)", () => {
+        expectError(
+            `workflow test(xs: number[]): integer[] {
+                return xs;
+            }`,
+            "not assignable",
+        );
+    });
+
+    test("integer field IS assignable to number field (nested widening)", () => {
+        expectNoErrors(`
+            workflow test(x: integer): { n: number } {
+                return { n: x };
+            }
+        `);
+    });
+
+    test("integer[] IS assignable to number[] (array widening)", () => {
+        expectNoErrors(`
+            workflow test(xs: integer[]): number[] {
+                return xs;
+            }
+        `);
     });
 
     test("array literal infers element type from first element", () => {

--- a/ts/examples/workflow/dsl/test/typeChecker.spec.ts
+++ b/ts/examples/workflow/dsl/test/typeChecker.spec.ts
@@ -1531,13 +1531,31 @@ describe("type checker", () => {
         `);
     });
 
-    test("number is assignable to integer", () => {
-        expectNoErrors(`
-            workflow test(): integer {
+    test("number is NOT assignable to integer (G10)", () => {
+        expectError(
+            `workflow test(): integer {
                 const x: number = 5;
                 return x;
-            }
-        `);
+            }`,
+            "not assignable to declared type",
+        );
+    });
+
+    test("number parameter is NOT assignable to integer return (G10)", () => {
+        expectError(
+            `workflow test(x: number): integer { return x; }`,
+            "not assignable to declared type",
+        );
+    });
+
+    test("number value is NOT assignable to integer const annotation (G10)", () => {
+        expectError(
+            `workflow test(x: number): number {
+                const y: integer = x;
+                return y;
+            }`,
+            "not assignable",
+        );
     });
 
     test("array literal infers element type from first element", () => {


### PR DESCRIPTION
## Summary

Four commits cleaning up the workflow DSL type checker and supporting design docs.

### Type checker (`examples/workflow/dsl`)

- **`integer` is now one-way assignable to `number`** in assignment / parameter / return positions, matching JSON Schema semantics where `integer` is a subtype of `number`. `number` is still rejected where `integer` is required.
- **Equality compare (`===`, `!==`) stays bidirectional** between `integer` and `number` - mixed-type equality is well-defined at runtime.
- Added unit tests covering both the primitive case and nested cases (`number[]` vs `integer[]`, object fields, return types, const annotations).
- Tightened the const-annotation test to assert the exact error wording (`Type 'number' is not assignable to type 'integer'`).
- Kept an `as PrimitiveType` cast with a short safety comment (same pattern as the object/array/tuple branches above it).

### Design docs

- `docs/design/workflowSystem/dsl/dsl-v0.1-gap.md`:
  - Removed resolved `G1` (sub-workflow calls) and `G10` (integer/number assignability) entries.
  - Reworded follow-up `G24-G27` "Raised during: G1 ..." notes to drop references to the now-removed entry.
  - Split the `G29` recommended-sequence item into resolved (arm-typing) vs deferred (deprecation) parts.
- `docs/design/workflowSystem/dsl/workflow-composition.md`: noted the narrow sub-workflow-call gap is now resolved end-to-end; removed dangling cross-references to the deleted `G1` entry.
- `docs/design/workflowSystem/ir/decisions/0011-top-schema-unknown-semantics.md`: updated the "ternary literal identity wrappers" row to reflect that the emitter actually consumes `_resolvedSchemas`; the bare `{}` is only an error-recovery fallback.

## Validation

- `pnpm run build` clean.
- `pnpm --filter @typeagent/workflow-dsl test` - 208/208 passing.
