### PR TITLE
Add progress reporting and format copilot-plugin files

### DIFF
--- a/ts/packages/copilot-plugin/src/hooks/hook-direct.ts
+++ b/ts/packages/copilot-plugin/src/hooks/hook-direct.ts
@@ -13,25 +13,34 @@ import {
     createClientIO,
     connectToTypeAgent,
 } from "../shared/typeagent-client.js";
+import { emitProgress } from "../shared/hook-progress.js";
 import type { HookInput, HookOutput } from "./types.js";
 
 export async function handleDirect(input: HookInput): Promise<HookOutput> {
-    // In direct mode every user submission goes to TypeAgent first.
-    // If the dispatcher doesn't recognize an action below, we fall through
-    // to the Copilot LLM by returning {}.
+    emitProgress("Routing to TypeAgent...");
+
     const responseCollector = { messages: [] as string[] };
     const clientIO = createClientIO({
         onSetDisplay: (message) => {
             collectMessage(message, undefined, responseCollector);
         },
         onAppendDisplay: (message, mode) => {
+            if (mode === "temporary") {
+                const text = message?.message;
+                if (typeof text === "string" && text.trim()) {
+                    emitProgress(text.trim());
+                }
+                return;
+            }
             collectMessage(message, mode, responseCollector);
         },
     });
 
     let dispatcher: Dispatcher | null = null;
     try {
+        emitProgress("Connecting to TypeAgent...");
         dispatcher = await connectToTypeAgent(clientIO);
+        emitProgress("Processing command...");
         const result = await dispatcher.processCommand(input.prompt);
 
         if (result?.cancelled) {

--- a/ts/packages/copilot-plugin/src/hooks/hook-mcp-redirect.ts
+++ b/ts/packages/copilot-plugin/src/hooks/hook-mcp-redirect.ts
@@ -58,8 +58,6 @@ function getSpecialPrefixGuidance(prompt: string): string | undefined {
 }
 
 export function handleMcpRedirect(input: HookInput): HookOutput {
-   
-
     const psGuidance = getPowerShellSessionGuidance() ?? "";
     const prefixGuidance = getSpecialPrefixGuidance(input.prompt) ?? "";
 

--- a/ts/packages/copilot-plugin/src/hooks/hook-mcp-redirect.ts
+++ b/ts/packages/copilot-plugin/src/hooks/hook-mcp-redirect.ts
@@ -10,7 +10,6 @@
  * to steer the LLM toward TypeAgent's PowerShell agent for system operations.
  */
 
-import { shouldTryTypeAgent } from "../shared/route-detector.js";
 import type { HookInput, HookOutput } from "./types.js";
 
 /**
@@ -59,14 +58,7 @@ function getSpecialPrefixGuidance(prompt: string): string | undefined {
 }
 
 export function handleMcpRedirect(input: HookInput): HookOutput {
-    if (!shouldTryTypeAgent(input.prompt)) {
-        // Even for non-TypeAgent prompts on Windows, inject TypeAgent PowerShell guidance
-        const psGuidance = getPowerShellSessionGuidance();
-        if (psGuidance) {
-            return { additionalContext: psGuidance };
-        }
-        return {};
-    }
+   
 
     const psGuidance = getPowerShellSessionGuidance() ?? "";
     const prefixGuidance = getSpecialPrefixGuidance(input.prompt) ?? "";

--- a/ts/packages/copilot-plugin/src/mcp/server.ts
+++ b/ts/packages/copilot-plugin/src/mcp/server.ts
@@ -40,19 +40,14 @@ function toolResult(text: string): CallToolResult {
 
 /**
  * Format a large result for display. Strips markdown formatting and wraps
- * in a code fence so the LLM preserves newlines and doesn't summarize.
+ * in a code fence so the CLI preserves newlines and structured layout.
  */
 function formatLargeResult(response: string): CallToolResult {
     const lines = response.split("\n").length;
     if (lines > 5) {
         // Strip markdown bold (**text**) — doesn't render inside code fences
         const plain = response.replace(/\*\*([^*]+)\*\*/g, "$1");
-        return toolResult(
-            `[Display the following TypeAgent result verbatim to the user. Do not summarize.]\n\n` +
-                "```\n" +
-                plain +
-                "\n```",
-        );
+        return toolResult("```\n" + plain + "\n```");
     }
     return toolResult(response);
 }
@@ -115,6 +110,7 @@ class TypeAgentMcpServer {
                         "The natural language command to execute, including any special prefixes like 'learn:', 'dev:', 'record:'",
                     ),
             },
+            { displayVerbatim: true } as Record<string, unknown>,
             async (params, extra) =>
                 this.processCommand(params.command, extra as ToolExtra),
         );

--- a/ts/packages/copilot-plugin/src/shared/hook-progress.ts
+++ b/ts/packages/copilot-plugin/src/shared/hook-progress.ts
@@ -19,7 +19,5 @@
  * The message appears as a transient info entry in the CLI timeline.
  */
 export function emitProgress(message: string): void {
-    process.stdout.write(
-        JSON.stringify({ type: "progress", message }) + "\n",
-    );
+    process.stdout.write(JSON.stringify({ type: "progress", message }) + "\n");
 }

--- a/ts/packages/copilot-plugin/src/shared/hook-progress.ts
+++ b/ts/packages/copilot-plugin/src/shared/hook-progress.ts
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+/**
+ * Hook progress protocol helpers.
+ *
+ * Copilot CLI hooks communicate progress to the CLI timeline by writing
+ * NDJSON lines to stdout. Lines matching `{"type":"progress","message":"..."}`
+ * are intercepted by the CLI's hook executor and displayed as ephemeral
+ * info entries; all other stdout content is treated as the hook response.
+ *
+ * IMPORTANT: Progress lines must be complete (terminated by \n) and must
+ * be valid JSON. Partial lines or malformed JSON will be treated as normal
+ * stdout output and corrupt the hook response.
+ */
+
+/**
+ * Write a progress message to stdout using the Copilot CLI hook progress protocol.
+ * The message appears as a transient info entry in the CLI timeline.
+ */
+export function emitProgress(message: string): void {
+    process.stdout.write(
+        JSON.stringify({ type: "progress", message }) + "\n",
+    );
+}


### PR DESCRIPTION
This pull request introduces improvements to the Copilot CLI plugin's progress reporting and output formatting, particularly for interactions with TypeAgent. The main changes include adding a progress message protocol to enhance user feedback during command processing, refining how large results are displayed, and making minor code cleanups.

**Progress reporting enhancements:**

* Added a new `emitProgress` function in `hook-progress.ts` to standardize emitting progress messages from hooks to the CLI, ensuring users receive real-time feedback during long-running operations.
* Integrated `emitProgress` into `handleDirect` in `hook-direct.ts` to provide step-by-step progress updates (e.g., routing, connecting, processing) as commands are handled by TypeAgent.

**Output formatting improvements:**

* Updated `formatLargeResult` in `mcp/server.ts` to simplify the output for large responses by removing summarization instructions and only wrapping the result in a code fence, improving readability in the CLI.

**Minor code and logic changes:**

* Added a `{ displayVerbatim: true }` option to a tool registration in `TypeAgentMcpServer` to indicate that output should be displayed exactly as returned.
* Removed unused import and legacy logic from `hook-mcp-redirect.ts` for cleaner and more maintainable code. [[1]](diffhunk://#diff-3cdebd9eff497c199ab24abbdb5ef9e22eb6f83572ffc40064d6e923e763e1ecL13) [[2]](diffhunk://#diff-3cdebd9eff497c199ab24abbdb5ef9e22eb6f83572ffc40064d6e923e763e1ecL62-L70)