### PR TITLE
Remove resolved DSL gap entries

### DIFF
--- a/ts/docs/design/workflowSystem/dsl/dsl-v0.1-gap.md
+++ b/ts/docs/design/workflowSystem/dsl/dsl-v0.1-gap.md
@@ -8,40 +8,33 @@ not yet fully wired end-to-end.
 Address the gaps in dependency order, with correctness and validation before
 new surface area:
 
-1. **G16: Fix `throw` message propagation.** This is a direct user-visible
-   correctness issue in already-supported error semantics.
-2. **G2: Complete fork branch IR schema fields.** Bring emitted fork branch IR
-   into the full sub-scope contract before improving fork runtime behavior.
-3. **G17: Cancel in-flight fork/forkMap branches on failure.** After fork IR is
-   structurally valid, align fork execution with the spec's failure and cleanup
-   semantics.
-4. **G22: Improve object/array diagnostics.** Now that G13 (resolved)
+1. **G17: Cancel in-flight fork/forkMap branches on failure.** Align fork
+   execution with the spec's failure and cleanup semantics.
+2. **G22: Improve object/array diagnostics.** Now that G13 (resolved)
    surfaces real structural mismatches, switch error messages from the
    collapsed `'object'` rendering to the existing `formatType` output so
    users can see which fields differ.
-5. **G3: Add TypeScript-style named type aliases.** Once structural
+3. **G3: Add TypeScript-style named type aliases.** Once structural
    assignability is sound, add named type declarations and a type environment.
-6. **G4: Add generics for `llm.generateJson<T>`.** This depends on richer type
-   parsing and checking, and becomes more ergonomic once named aliases exist.
-7. **G18: Add union/literal types.** This is the broadest type-system expansion
+4. **G18: Add union/literal types.** This is the broadest type-system expansion
    and should come after type soundness and named types.
-8. **G11: Decide/document bind stripping for explicit user names.** This is
+5. **G11: Decide/document bind stripping for explicit user names.** This is
    primarily debuggability and spec clarity.
-9. **G9: Decide whether bare task calls need `ExpressionStatement`.** This is
+6. **G9: Decide whether bare task calls need `ExpressionStatement`.** This is
    AST honesty and visual-editor clarity, but current behavior works.
-10. **G12: Decide `list.append` naming/semantics.** This is naming/API
-    consistency with coordinated emitter, engine, and snapshot churn.
-11. **G20: Audit remaining `identity` / `noop` usage in the emitter.**
-    Decision 0010 removed `identity` / `noop` as load-bearing at branch
-    convergence, but the emitter still synthesizes them in several other
-    places. Classify each remaining usage as (a) reducible after 0010,
-    (b) forced by an IR shape that could be relaxed additively, or (c)
-    inherent to decision 0006 (no expressions). Pure audit; only
-    schedules follow-up work.
-12. **G7: Revisit composition patterns only when concrete workflow needs appear.**
-    These patterns push against the visual-node discipline and should stay out
-    of scope until justified.
-13. **G29 (open part): Decide whether to deprecate value-producing
+7. **G12: Decide `list.append` naming/semantics.** This is naming/API
+   consistency with coordinated emitter, engine, and snapshot churn.
+8. **G20: Audit remaining `identity` / `noop` usage in the emitter.**
+   Decision 0010 removed `identity` / `noop` as load-bearing at branch
+   convergence, but the emitter still synthesizes them in several other
+   places. Classify each remaining usage as (a) reducible after 0010,
+   (b) forced by an IR shape that could be relaxed additively, or (c)
+   inherent to decision 0006 (no expressions). Pure audit; only
+   schedules follow-up work.
+9. **G7: Revisit composition patterns only when concrete workflow needs appear.**
+   These patterns push against the visual-node discipline and should stay out
+   of scope until justified.
+10. **G29 (open part): Decide whether to deprecate value-producing
     `if`/`switch` in favour of ternary.** The arm-type checking part of
     G29 (same-type enforcement, `_resolvedSchemas` storage, partial-return
     as a type error) is resolved; see decision 0011 §6 and the
@@ -54,31 +47,7 @@ composition implementation that have not yet been scheduled.
 
 Dependency spine:
 
-- `G2 -> G17` brings fork/forkMap IR and runtime behavior into spec alignment.
-- `G3 -> G4 -> G18` builds type-system features on sound assignability.
-
-## G2: Parallel branches missing IR schema fields
-
-**Spec:** ir-v0.2.md specifies fork branches have the same sub-scope
-contract as loop bodies: `inputs`, `inputSchema`, `entry`, `nodes`,
-`output`, `outputSchema`.
-
-**Current state:** The emitter only generates `{ entry, nodes }` per
-branch, omitting the schema and I/O fields. The IR validator may reject
-this if it enforces the full branch sub-scope contract.
-
-**What needs to happen:**
-
-1. Emit `inputSchema`, `outputSchema`, `inputs`, and `output` for each
-   fork branch.
-2. Validate that emitted fork IR passes the IR validator.
-
-**Related decision:** The emitter currently generates minimal branch
-scopes (`{ entry, nodes }`) and optionally `{ inputs, scope: { ... } }`
-for branches that need outer references. The full sub-scope contract
-(matching loop bodies) has not been enforced yet. This is a
-spec/implementation mismatch that needs the emitter to populate the
-missing fields.
+- `G3 -> G18` builds type-system features on sound assignability.
 
 ## G3: TypeScript-style type definitions
 
@@ -102,29 +71,6 @@ and inline object literals, but rejects any other identifier as
    name (already works via the "Unknown type" error, but the message
    should distinguish "did you mean to define a type?" from a typo).
 4. Consider whether types should be exportable across workflows.
-
-## G4: `llm.generateJson` needs generics for output typing
-
-**Spec:** `llm.generateJson` produces structured output, but its JSON
-schema is only known at the call site, not from the task's static
-signature.
-
-**Current state:** The builtin's output schema is `{}` (empty object),
-so the type checker infers `unknown` for its return value. Callers
-cannot access fields on the result without a type error ("Cannot access
-property on unknown type"). The only workaround is to assign the result
-to a variable and pass it opaquely to another task.
-
-**What needs to happen:**
-
-1. Add generic type parameter support so callers can write something like
-   `llm.generateJson<{ summary: string }>(prompt)` and the checker
-   infers the return type from the type argument.
-2. The emitter should use the type argument to populate the task node's
-   `outputSchema` in the IR, replacing the `{}` default.
-3. This requires parser support for `<Type>` syntax on call expressions,
-   type checker support for resolving generic instantiations, and emitter
-   support for threading the resolved type into the schema.
 
 ## G7: Composition patterns outside current scope
 
@@ -244,17 +190,6 @@ suggests mutation in many languages (Python `list.append`, JS
 3. Regardless of naming: consider whether the immutable semantics should
    be made explicit in the task name (e.g., `array.appended` or
    `array.concat`) to avoid confusion with mutable append/push.
-
-## G16: `throw` produces empty error message
-
-**Spec:** dsl-v0.1.md section 2.11. `throw "message"` should emit an
-`error.fail` task node that produces a failure with the thrown value
-as the message.
-
-**Current state:** The error.fail task is emitted, but the error
-message that propagates to the RunResult is empty. The thrown string
-value is not correctly threaded into the error.fail task's input, or
-the error propagation loses the message field.
 
 ## G17: Fork/forkMap does not cancel in-flight branches on failure
 


### PR DESCRIPTION
## Summary
- remove resolved G16, G4, and G2 entries from the DSL gap document
- renumber the recommended implementation sequence
- update the dependency spine now that G2 and G4 are resolved

## Verification
- pnpm run jest-esm dist/test/dsl-integration.spec.js -t "throw propagates the message string to RunResult.error"
- pnpm run jest-esm dist/test/compiler.spec.js -t "emits typed outputSchema from type arg|generic result used in downstream expressions"
- pnpm run jest-esm dist/test/typeChecker.spec.js -t "type arg on non-generic task errors|required generic type param errors when omitted|too many type args errors|generic type arg with complex object type"
- pnpm run jest-esm dist/test/compiler.spec.js -t "compiles parallel to a fork node"