### PR TITLE
Normalize VS Code extension build and install scripts

### DIFF
--- a/ts/examples/workflow/vscode/package.json
+++ b/ts/examples/workflow/vscode/package.json
@@ -19,8 +19,10 @@
   "main": "./dist/extension.js",
   "scripts": {
     "build": "node esbuild.mjs && node scripts/check-server-bundle.mjs && npm run tsc",
+    "build:ext:vscode": "npm run package",
     "clean": "rimraf --glob dist dist-pub *.vsix *.tsbuildinfo",
     "compile": "node esbuild.mjs",
+    "install:ext:vscode": "code --install-extension dist-pub/workflow-vscode.vsix --force",
     "package": "mkdirp dist-pub && vsce package --allow-star-activation --allow-missing-repository --no-dependencies --allow-package-secrets npm -o dist-pub/workflow-vscode.vsix",
     "prettier": "prettier --check . --ignore-path ../../../.prettierignore",
     "prettier:fix": "prettier --write . --ignore-path ../../../.prettierignore",
@@ -133,6 +135,17 @@
       "build": {
         "dependsOn": [
           "workflow-lsp#build"
+        ]
+      },
+      "build:ext:vscode": {
+        "dependsOn": [
+          "^build",
+          "build"
+        ]
+      },
+      "install:ext:vscode": {
+        "dependsOn": [
+          "build:ext:vscode"
         ]
       }
     }

--- a/ts/package.json
+++ b/ts/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "api": "pnpm -C packages/api exec npm run start",
     "build": "fluid-build . -t build",
-    "build:ext:vscode": "pnpm -C packages/coda run package && pnpm -C packages/vscode-shell run package",
+    "build:ext:vscode": "fluid-build . -t build:ext:vscode",
     "build:shell": "fluid-build agent-shell -t build --dep",
     "check:dep": "node tools/scripts/fix-dependabot-alerts.mjs --dry-run",
     "check:dep:fix": "node tools/scripts/fix-dependabot-alerts.mjs",
@@ -34,7 +34,7 @@
     "getKeys": "node tools/scripts/getKeys.mjs",
     "getKeys:build": "node tools/scripts/getKeys.mjs --vault build-pipeline-kv",
     "postinstall": "pnpm run postinstall:better-sqlite3-node-copy && pnpm run postinstall:better-sqlite3-node-restore",
-    "install:ext:vscode": "pnpm -C packages/coda run deploy:local && pnpm -C packages/vscode-shell run deploy:local",
+    "install:ext:vscode": "fluid-build . -t install:ext:vscode",
     "knowledgeVisualizer": "pnpm -C packages/knowledgeVisualizer exec npm run start",
     "kv": "pnpm -C packages/knowledgeVisualizer exec npm run start",
     "lint": "fluid-build . -t prettier",

--- a/ts/packages/coda/package.json
+++ b/ts/packages/coda/package.json
@@ -19,10 +19,12 @@
   "main": "./out/extension.js",
   "scripts": {
     "build": "pnpm run esbuild-base --sourcemap",
+    "build:ext:vscode": "pnpm run package",
     "clean": "rimraf --glob out dist-pub *.tsbuildinfo *.done.build.log",
     "deploy:local": "pnpm run package && code --install-extension dist-pub/aisystems-coda.vsix --force",
     "esbuild-base": "esbuild ./src/extension.ts --bundle --outfile=out/extension.js --external:vscode --format=cjs --platform=node --log-level=warning",
     "esbuild-watch": "pnpm run esbuild-base --sourcemap --watch",
+    "install:ext:vscode": "code --install-extension dist-pub/aisystems-coda.vsix --force",
     "package": "mkdirp dist-pub && vsce package --allow-star-activation --allow-missing-repository --no-dependencies -o dist-pub/aisystems-coda.vsix",
     "prettier": "prettier --check . --ignore-path ../../.prettierignore",
     "prettier:fix": "prettier --write . --ignore-path ../../.prettierignore",
@@ -77,5 +79,20 @@
   },
   "engines": {
     "vscode": "^1.88.0"
+  },
+  "fluidBuild": {
+    "tasks": {
+      "build:ext:vscode": {
+        "dependsOn": [
+          "^build",
+          "build"
+        ]
+      },
+      "install:ext:vscode": {
+        "dependsOn": [
+          "build:ext:vscode"
+        ]
+      }
+    }
   }
 }

--- a/ts/packages/vscode-shell/package.json
+++ b/ts/packages/vscode-shell/package.json
@@ -18,9 +18,11 @@
   "publisher": "typeagent",
   "main": "./dist/extension.js",
   "scripts": {
+    "build:ext:vscode": "npm run package",
     "clean": "rimraf --glob dist dist-pub *.vsix",
     "compile": "node esbuild.mjs",
     "deploy:local": "npm run package && code --install-extension dist-pub/vscode-shell.vsix --force",
+    "install:ext:vscode": "code --install-extension dist-pub/vscode-shell.vsix --force",
     "package": "mkdirp dist-pub && vsce package --allow-star-activation --allow-missing-repository --no-dependencies --allow-package-secrets npm -o dist-pub/vscode-shell.vsix",
     "vscode:prepublish": "npm run compile",
     "watch": "node esbuild.mjs --watch"
@@ -196,5 +198,20 @@
   "engines": {
     "vscode": "^1.90.0"
   },
-  "icon": "media/icons/icon-80.png"
+  "icon": "media/icons/icon-80.png",
+  "fluidBuild": {
+    "tasks": {
+      "build:ext:vscode": {
+        "dependsOn": [
+          "^build",
+          "compile"
+        ]
+      },
+      "install:ext:vscode": {
+        "dependsOn": [
+          "build:ext:vscode"
+        ]
+      }
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- route root VS Code extension build/install scripts through fluid-build targets
- add package-local build:ext:vscode and install:ext:vscode targets for coda, vscode-shell, and workflow-vscode
- include workflow-vscode in the root extension build/install path so workflow-lsp dependencies are built first

## Verification
- pnpm run build:ext:vscode
- pnpm run install:ext:vscode
- pnpm exec prettier --check package.json packages/coda/package.json packages/vscode-shell/package.json examples/workflow/vscode/package.json