### PR TITLE
Validate projected phi-merge binder paths

### DIFF
--- a/ts/examples/workflow/model/src/validate.ts
+++ b/ts/examples/workflow/model/src/validate.ts
@@ -3231,7 +3231,16 @@ function checkPhiMergeTypes(
                     refPath && refPath.length > 0
                         ? resolveSchemaPath(binderSchema, refPath)
                         : binderSchema;
-                if (!projected) continue;
+                if (!projected) {
+                    errors.push({
+                        path: `${prefix}.${id}.inputs.${fieldName}`,
+                        message:
+                            `Phi-merge binder "${binderId}" for scope name ` +
+                            `"${refName}" does not declare path ` +
+                            `${JSON.stringify(refPath)} in its outputSchema.`,
+                    });
+                    continue;
+                }
 
                 checkResolvedAssignability(
                     projected,

--- a/ts/examples/workflow/model/test/validate.spec.ts
+++ b/ts/examples/workflow/model/test/validate.spec.ts
@@ -4028,6 +4028,85 @@ describe("validateWorkflowIR", () => {
             ).toBe(true);
         });
 
+        it("rejects phi-merge binder missing projected path", () => {
+            const ir = makeMinimalIR({
+                nodes: {
+                    trigger: {
+                        kind: "task",
+                        task: "noop",
+                        inputSchema: { type: "object" },
+                        outputSchema: { type: "object" },
+                        inputs: {},
+                        next: "success",
+                        onError: "recovery",
+                    },
+                    success: {
+                        kind: "task",
+                        task: "noop",
+                        inputSchema: { type: "object" },
+                        outputSchema: {
+                            type: "object",
+                            required: ["other"],
+                            properties: { other: { type: "string" } },
+                        },
+                        inputs: {},
+                        next: "consumer",
+                        bind: "data",
+                    },
+                    recovery: {
+                        kind: "task",
+                        task: "noop",
+                        inputSchema: {
+                            type: "object",
+                            required: ["error", "trigger"],
+                            properties: {
+                                error: { type: "object" },
+                                trigger: { type: "object" },
+                            },
+                        },
+                        outputSchema: {
+                            type: "object",
+                            required: ["x"],
+                            properties: { x: { type: "string" } },
+                        },
+                        inputs: makeRecoveryInputs(),
+                        next: "consumer",
+                        bind: "data",
+                    },
+                    consumer: {
+                        kind: "task",
+                        task: "noop",
+                        inputSchema: {
+                            type: "object",
+                            required: ["val"],
+                            properties: { val: { type: "string" } },
+                        },
+                        outputSchema: { type: "object" },
+                        inputs: {
+                            val: {
+                                $from: "scope",
+                                name: "data",
+                                path: ["x"],
+                            },
+                        },
+                        bind: "out",
+                    },
+                },
+                entry: "trigger",
+            });
+            const result = validateWorkflowIR(ir);
+            expect(result.valid).toBe(false);
+            expect(
+                result.errors.some(
+                    (e) =>
+                        e.message.includes("Phi-merge binder") &&
+                        e.message.includes("success") &&
+                        e.message.includes('["x"]') &&
+                        e.message.includes("outputSchema"),
+                ),
+            ).toBe(true);
+        });
+
         it("accepts phi-merge when all binders are compatible", () => {
             const ir = makeMinimalIR({
                 nodes: {


### PR DESCRIPTION
## Summary
- report a validation error when a phi-merge binder lacks the projected $from path
- add a regression test for projected paths across multiple binders

## Testing
- pnpm run build
- pnpm run jest-esm --runTestsByPath dist/test/validate.spec.js