### PR TITLE
Improve workflow DSL type diagnostics for structural types

### DIFF
--- a/ts/docs/design/workflowSystem/dsl/dsl-v0.1-gap.md
+++ b/ts/docs/design/workflowSystem/dsl/dsl-v0.1-gap.md
@@ -10,34 +10,30 @@ new surface area:
 
 1. **G17: Cancel in-flight fork/forkMap branches on failure.** Align fork
    execution with the spec's failure and cleanup semantics.
-2. **G22: Improve object/array diagnostics.** Now that G13 (resolved)
-   surfaces real structural mismatches, switch error messages from the
-   collapsed `'object'` rendering to the existing `formatType` output so
-   users can see which fields differ.
-3. **G3: Add TypeScript-style named type aliases.** Once structural
+2. **G3: Add TypeScript-style named type aliases.** Once structural
    assignability is sound, add named type declarations and a type environment.
-4. **G18: Add union/literal types.** This is the broadest type-system expansion
+3. **G18: Add union/literal types.** This is the broadest type-system expansion
    and should come after type soundness and named types.
-5. **G11: Decide/document bind stripping for explicit user names.** This is
+4. **G11: Decide/document bind stripping for explicit user names.** This is
    primarily debuggability and spec clarity.
-6. **G9: Decide whether bare task calls need `ExpressionStatement`.** This is
+5. **G9: Decide whether bare task calls need `ExpressionStatement`.** This is
    AST honesty and visual-editor clarity, but current behavior works.
-7. **G12: Decide `list.append` naming/semantics.** This is naming/API
+6. **G12: Decide `list.append` naming/semantics.** This is naming/API
    consistency with coordinated emitter, engine, and snapshot churn.
-8. **G20: Audit remaining `identity` / `noop` usage in the emitter.**
+7. **G20: Audit remaining `identity` / `noop` usage in the emitter.**
    Decision 0010 removed `identity` / `noop` as load-bearing at branch
    convergence, but the emitter still synthesizes them in several other
    places. Classify each remaining usage as (a) reducible after 0010,
    (b) forced by an IR shape that could be relaxed additively, or (c)
    inherent to decision 0006 (no expressions). Pure audit; only
    schedules follow-up work.
-9. **G7: Revisit composition patterns only when concrete workflow needs appear.**
+8. **G7: Revisit composition patterns only when concrete workflow needs appear.**
    These patterns push against the visual-node discipline and should stay out
    of scope until justified.
-10. **G29 (open part): Decide whether to deprecate value-producing
-    `if`/`switch` in favour of ternary.** The arm-type checking part of
-    G29 (same-type enforcement, `_resolvedSchemas` storage, partial-return
-    as a type error) is resolved; see decision 0011 §6 and the
+9. **G29 (open part): Decide whether to deprecate value-producing
+   `if`/`switch` in favour of ternary.** The arm-type checking part of
+   G29 (same-type enforcement, `_resolvedSchemas` storage, partial-return
+   as a type error) is resolved; see decision 0011 §6 and the
     `G29 + G30` section below. The remaining open question - whether
     value-producing `if`/`switch` should be deprecated entirely - is
     deferred pending a `.wf` survey + G18 (union types).
@@ -471,32 +467,27 @@ name: "_infer" }`) and emit the inferred type in the emitter.
 
 ## G22: Type error messages collapse objects to `'object'`
 
-**Status:** UX gap surfaced by the G13 implementation. Pure diagnostic
-improvement; no semantic change to type checking.
+**Status:** resolved. Assignability and same-type diagnostics now use a shared
+`diagnosticTypeName` wrapper around `formatType`, so object, array, and tuple
+shapes render with their fields. `typeName` remains for short kind-oriented
+messages such as numeric/boolean operand checks.
 
-**Context:** When the type checker reports an assignability error, it
-formats both sides with `typeName(t)`. For object types this function
-returns the literal string `"object"`, discarding all field information.
-This makes object-vs-object mismatches indistinguishable to users.
+**Context:** When the type checker reported assignability and same-type errors,
+it formatted both sides with `typeName(t)`. For object types this function
+returns the literal string `"object"`, discarding all field information. This
+made object-vs-object mismatches indistinguishable to users.
 
 **Current state:**
 
-- `typeName` in `typeChecker.ts` returns `"object"` for any `ObjectTypeInfo`,
-  regardless of fields.
-- Arrays partially benefit from recursion (`string[]`) but their element
-  type collapses to `"object"` when it's an object.
-- Tuples also collapse to `"object"` for each object element.
-- A `formatType` function already exists in `typeChecker.ts` that produces
-  a full TypeScript-style rendering (e.g. `{ name: string, tag?: string }`,
-  `{ x: string }[]`), used today only for LSP hover text.
-- Affected diagnostics include (non-exhaustive):
-  - `Workflow return type 'object' is not assignable to declared type 'object'`
-  - `Type 'object' is not assignable to type 'object'` (const annotations)
-  - `Ternary arms must have the same type: 'object' vs 'object'`
-  - `Operator '===' requires same types on both sides: 'object' vs 'object'`
-- After G13 added structural object/array assignability checks, mismatches
-  between objects are now reported as errors, so the volume of
-  object-vs-object messages users see has grown.
+- Assignability diagnostics for workflow returns, const annotations, default
+  values, and workflow-call arguments use `diagnosticTypeName`.
+- Same-type diagnostics for ternary arms, value-producing `if`/`switch` arms,
+  and `===` / `!==` use `diagnosticTypeName`.
+- `diagnosticTypeName` currently delegates to `formatType`, producing
+  TypeScript-style object, array, and tuple renderings such as
+  `{ name: string; tag?: string }` and `{ x: string }[]`.
+- `typeName` remains available for terse kind-oriented diagnostics, e.g.
+  `Condition must be boolean, got 'string'`.
 
 **Reproduction:**
 
@@ -506,26 +497,8 @@ workflow test(x: { name: string, tag: number }): { name: string, tag?: string } 
 }
 ```
 
-Currently reports: `Workflow return type 'object' is not assignable to
-declared type 'object'`. Users cannot tell which field mismatches without
-manually walking both type expressions.
-
-**What needs to happen:**
-
-1. Switch the structural error messages (return-type, const-annotation,
-   ternary-arm, and `===`/`!==`) to use `formatType` instead of
-   `typeName`, or introduce a single shared diagnostic formatter.
-2. Decide whether `typeName` should be removed in favor of `formatType`,
-   or kept for short contexts (e.g. operator operand kind in
-   `must be numeric, got 'string'`). If kept, document the contract.
-3. Consider augmenting object-mismatch messages with the specific
-   offending field path (e.g. `field 'tag' has type 'number' but
-expected 'string'`), reusing the recursion already done inside
-   `isAssignableTo`. This may require threading an error-reason result
-   out of `isAssignableTo` instead of a bare boolean.
-4. Update existing type-checker tests whose substring assertions rely on
-   the collapsed `'object'` rendering, and add tests asserting the
-   richer field-level wording.
+Now reports: `Workflow return type '{ name: string; tag: number }' is not
+assignable to declared type '{ name: string; tag?: string }'`.
 
 ## G24: Named-record call syntax diverges from TypeScript
 

--- a/ts/docs/design/workflowSystem/dsl/dsl-v0.1-gap.md
+++ b/ts/docs/design/workflowSystem/dsl/dsl-v0.1-gap.md
@@ -34,9 +34,9 @@ new surface area:
    `if`/`switch` in favour of ternary.** The arm-type checking part of
    G29 (same-type enforcement, `_resolvedSchemas` storage, partial-return
    as a type error) is resolved; see decision 0011 §6 and the
-    `G29 + G30` section below. The remaining open question - whether
-    value-producing `if`/`switch` should be deprecated entirely - is
-    deferred pending a `.wf` survey + G18 (union types).
+   `G29 + G30` section below. The remaining open question - whether
+   value-producing `if`/`switch` should be deprecated entirely - is
+   deferred pending a `.wf` survey + G18 (union types).
 
 G24-G28 capture follow-up design questions raised during the workflow
 composition implementation that have not yet been scheduled.

--- a/ts/examples/workflow/dsl/src/typeChecker.ts
+++ b/ts/examples/workflow/dsl/src/typeChecker.ts
@@ -452,6 +452,10 @@ export function formatType(t: TypeInfo): string {
     }
 }
 
+function diagnosticTypeName(t: TypeInfo): string {
+    return formatType(t);
+}
+
 // ---- Scope ----
 
 class Scope {
@@ -790,7 +794,7 @@ export class TypeChecker {
                     !isAssignableTo(paramType, defaultType)
                 ) {
                     this.addError(
-                        `Default value of type '${typeName(defaultType)}' is not assignable to parameter '${p.name}' of type '${typeName(paramType)}'`,
+                        `Default value of type '${diagnosticTypeName(defaultType)}' is not assignable to parameter '${p.name}' of type '${diagnosticTypeName(paramType)}'`,
                         p.default.loc.line,
                         p.default.loc.col,
                     );
@@ -806,7 +810,7 @@ export class TypeChecker {
             !isAssignableTo(declared, returnType)
         ) {
             this.addError(
-                `Workflow return type '${typeName(returnType)}' is not assignable to declared type '${typeName(declared)}'`,
+                `Workflow return type '${diagnosticTypeName(returnType)}' is not assignable to declared type '${diagnosticTypeName(declared)}'`,
                 wf.loc.line,
                 wf.loc.col,
             );
@@ -1087,7 +1091,7 @@ export class TypeChecker {
                         !isAssignableTo(declared, valueType)
                     ) {
                         this.addError(
-                            `Type '${typeName(valueType)}' is not assignable to type '${typeName(declared)}'`,
+                            `Type '${diagnosticTypeName(valueType)}' is not assignable to type '${diagnosticTypeName(declared)}'`,
                             s.loc.line,
                             s.loc.col,
                         );
@@ -1202,7 +1206,7 @@ export class TypeChecker {
                         !isAssignableTo(elseType, thenType)
                     ) {
                         this.addError(
-                            `if/else arms must return the same type: '${typeName(thenType)}' vs '${typeName(elseType)}'`,
+                            `if/else arms must return the same type: '${diagnosticTypeName(thenType)}' vs '${diagnosticTypeName(elseType)}'`,
                             s.loc.line,
                             s.loc.col,
                         );
@@ -1311,7 +1315,7 @@ export class TypeChecker {
                                     ? "default arm"
                                     : `arm ${i + 1}`;
                             this.addError(
-                                `switch arms must return the same type: ${otherLabel} returns '${typeName(allTypes[i]!)}' but arm 1 returns '${typeName(resultType)}'`,
+                                `switch arms must return the same type: ${otherLabel} returns '${diagnosticTypeName(allTypes[i]!)}' but arm 1 returns '${diagnosticTypeName(resultType)}'`,
                                 s.loc.line,
                                 s.loc.col,
                             );
@@ -1562,7 +1566,7 @@ export class TypeChecker {
                     !isAssignableTo(altType, consType)
                 ) {
                     this.addError(
-                        `Ternary arms must have the same type: '${typeName(consType)}' vs '${typeName(altType)}'`,
+                        `Ternary arms must have the same type: '${diagnosticTypeName(consType)}' vs '${diagnosticTypeName(altType)}'`,
                         e.loc.line,
                         e.loc.col,
                     );
@@ -1844,7 +1848,7 @@ export class TypeChecker {
                     !isEqualityComparable(left, right)
                 ) {
                     this.addError(
-                        `Operator '${e.op}' requires same types on both sides: '${typeName(left)}' vs '${typeName(right)}'`,
+                        `Operator '${e.op}' requires same types on both sides: '${diagnosticTypeName(left)}' vs '${diagnosticTypeName(right)}'`,
                         e.loc.line,
                         e.loc.col,
                     );
@@ -2075,7 +2079,7 @@ export class TypeChecker {
                 !isAssignableTo(declared, actual)
             ) {
                 this.addError(
-                    `Argument of type '${typeName(actual)}' is not assignable to parameter '${p.name}' of type '${typeName(declared)}'`,
+                    `Argument of type '${diagnosticTypeName(actual)}' is not assignable to parameter '${p.name}' of type '${diagnosticTypeName(declared)}'`,
                     b.value.loc.line,
                     b.value.loc.col,
                 );

--- a/ts/examples/workflow/dsl/test/typeChecker.spec.ts
+++ b/ts/examples/workflow/dsl/test/typeChecker.spec.ts
@@ -1096,7 +1096,7 @@ describe("type checker", () => {
             `workflow test(): { name: string } {
                 return test.exec(command: "ls");
             }`,
-            "not assignable to declared type",
+            "Workflow return type '{ stdout: string; exitCode: integer }' is not assignable to declared type '{ name: string }'",
         );
     });
 
@@ -1106,7 +1106,7 @@ describe("type checker", () => {
                 const r: { a: string, b: number, c: boolean } = x;
                 return r.a;
             }`,
-            "not assignable to type",
+            "Type '{ a: string; b: number }' is not assignable to type '{ a: string; b: number; c: boolean }'",
         );
     });
 
@@ -1115,7 +1115,7 @@ describe("type checker", () => {
             `workflow test(flag: boolean, x: { a: string }): { a: string } {
                 return flag ? x : test.exec(command: "b");
             }`,
-            "same type",
+            "Ternary arms must have the same type: '{ a: string }' vs '{ stdout: string; exitCode: integer }'",
         );
     });
 
@@ -1124,7 +1124,16 @@ describe("type checker", () => {
             `workflow test(items: string[]): number[] {
                 return items;
             }`,
-            "not assignable to declared type",
+            "Workflow return type 'string[]' is not assignable to declared type 'number[]'",
+        );
+    });
+
+    test("object array mismatch in equality shows full object shape", () => {
+        expectError(
+            `workflow test(x: { a: string }, xs: { a: string }[]): boolean {
+                return x === xs;
+            }`,
+            "Operator '===' requires same types on both sides: '{ a: string }' vs '{ a: string }[]'",
         );
     });
 


### PR DESCRIPTION
## Summary
- switch structural assignability/same-type diagnostics in workflow DSL type checker to render full type shapes via `diagnosticTypeName` (using `formatType`)
- keep `typeName` available for concise kind-oriented errors
- update and extend type checker tests to assert explicit structural type text in diagnostics
- update `dsl-v0.1-gap.md` to mark G22 as resolved and describe current behavior

## Validation
- `pnpm -C ts/examples/workflow/dsl run test:local`
  - 17 suites passed, 887 tests passed