### PR TITLE
Implement fork cancellation semantics

### DIFF
--- a/ts/docs/design/workflowSystem/dsl/dsl-v0.1-gap.md
+++ b/ts/docs/design/workflowSystem/dsl/dsl-v0.1-gap.md
@@ -8,8 +8,10 @@ not yet fully wired end-to-end.
 Address the gaps in dependency order, with correctness and validation before
 new surface area:
 
-1. **G17: Cancel in-flight fork/forkMap branches on failure.** Align fork
-   execution with the spec's failure and cleanup semantics.
+1. **G22: Improve object/array diagnostics.** Now that G13 (resolved)
+   surfaces real structural mismatches, switch error messages from the
+   collapsed `'object'` rendering to the existing `formatType` output so
+   users can see which fields differ.
 2. **G3: Add TypeScript-style named type aliases.** Once structural
    assignability is sound, add named type declarations and a type environment.
 3. **G18: Add union/literal types.** This is the broadest type-system expansion
@@ -186,28 +188,6 @@ suggests mutation in many languages (Python `list.append`, JS
 3. Regardless of naming: consider whether the immutable semantics should
    be made explicit in the task name (e.g., `array.appended` or
    `array.concat`) to avoid confusion with mutable append/push.
-
-## G17: Fork/forkMap does not cancel in-flight branches on failure
-
-**Spec:** ir-v0.2.md §2.1 rule 5 and §2.2 rule 5. "If any branch fails,
-remaining in-flight branches are cancelled and the error propagates
-immediately."
-
-**Current state:** The engine's `executeFork` and `executeForkMap` use
-`Promise.race` for concurrency limiting but do not cancel in-flight
-branches/iterations when one fails. Errors from `Promise.race` propagate,
-but other running branches continue executing in the background. This
-wastes resources and may cause side effects from branches that should have
-been cancelled.
-
-**What needs to happen:**
-
-1. When any branch/iteration rejects, signal cancellation to all other
-   in-flight branches via `AbortController`.
-2. `await` all in-flight promises before propagating the error (to avoid
-   unhandled rejection warnings and ensure cleanup).
-3. Add tests verifying that in-flight branches are cancelled on first
-   failure.
 
 ## G18: No union types in the DSL type system
 

--- a/ts/docs/design/workflowSystem/dsl/dsl-v0.1-gap.md
+++ b/ts/docs/design/workflowSystem/dsl/dsl-v0.1-gap.md
@@ -8,31 +8,27 @@ not yet fully wired end-to-end.
 Address the gaps in dependency order, with correctness and validation before
 new surface area:
 
-1. **G22: Improve object/array diagnostics.** Now that G13 (resolved)
-   surfaces real structural mismatches, switch error messages from the
-   collapsed `'object'` rendering to the existing `formatType` output so
-   users can see which fields differ.
-2. **G3: Add TypeScript-style named type aliases.** Once structural
+1. **G3: Add TypeScript-style named type aliases.** Once structural
    assignability is sound, add named type declarations and a type environment.
-3. **G18: Add union/literal types.** This is the broadest type-system expansion
+2. **G18: Add union/literal types.** This is the broadest type-system expansion
    and should come after type soundness and named types.
-4. **G11: Decide/document bind stripping for explicit user names.** This is
+3. **G11: Decide/document bind stripping for explicit user names.** This is
    primarily debuggability and spec clarity.
-5. **G9: Decide whether bare task calls need `ExpressionStatement`.** This is
+4. **G9: Decide whether bare task calls need `ExpressionStatement`.** This is
    AST honesty and visual-editor clarity, but current behavior works.
-6. **G12: Decide `list.append` naming/semantics.** This is naming/API
+5. **G12: Decide `list.append` naming/semantics.** This is naming/API
    consistency with coordinated emitter, engine, and snapshot churn.
-7. **G20: Audit remaining `identity` / `noop` usage in the emitter.**
+6. **G20: Audit remaining `identity` / `noop` usage in the emitter.**
    Decision 0010 removed `identity` / `noop` as load-bearing at branch
    convergence, but the emitter still synthesizes them in several other
    places. Classify each remaining usage as (a) reducible after 0010,
    (b) forced by an IR shape that could be relaxed additively, or (c)
    inherent to decision 0006 (no expressions). Pure audit; only
    schedules follow-up work.
-8. **G7: Revisit composition patterns only when concrete workflow needs appear.**
+7. **G7: Revisit composition patterns only when concrete workflow needs appear.**
    These patterns push against the visual-node discipline and should stay out
    of scope until justified.
-9. **G29 (open part): Decide whether to deprecate value-producing
+8. **G29 (open part): Decide whether to deprecate value-producing
    `if`/`switch` in favour of ternary.** The arm-type checking part of
    G29 (same-type enforcement, `_resolvedSchemas` storage, partial-return
    as a type error) is resolved; see decision 0011 §6 and the

--- a/ts/examples/workflow/engine/src/runner.ts
+++ b/ts/examples/workflow/engine/src/runner.ts
@@ -64,6 +64,92 @@ interface RunCtx {
     wfCallStack: readonly string[];
 }
 
+async function runCancellableConcurrent<T>(
+    items: T[],
+    concurrency: number,
+    parentSignal: AbortSignal,
+    runItem: (item: T, signal: AbortSignal) => Promise<void>,
+): Promise<void> {
+    type ConcurrentResult = { ok: true } | { ok: false; error: unknown };
+
+    const abortController = new AbortController();
+    const abortSignal = abortController.signal;
+    const propagateParentAbort = () =>
+        abortController.abort(parentSignal.reason);
+
+    if (parentSignal.aborted) {
+        propagateParentAbort();
+    } else {
+        parentSignal.addEventListener("abort", propagateParentAbort, {
+            once: true,
+        });
+    }
+
+    try {
+        const queue = [...items];
+        const executing = new Set<Promise<ConcurrentResult>>();
+        let failed = false;
+        let firstError: unknown;
+
+        const recordFailure = (err: unknown) => {
+            if (!failed) {
+                failed = true;
+                firstError = err;
+                queue.length = 0;
+                if (!abortSignal.aborted) {
+                    abortController.abort(err);
+                }
+            }
+        };
+
+        while (queue.length > 0 || executing.size > 0) {
+            while (
+                !failed &&
+                queue.length > 0 &&
+                executing.size < concurrency
+            ) {
+                const item = queue.shift()!;
+                const promise = runItem(item, abortSignal)
+                    .then(
+                        () => ({ ok: true }) as ConcurrentResult,
+                        (err) => {
+                            recordFailure(err);
+                            return {
+                                ok: false,
+                                error: err,
+                            } as ConcurrentResult;
+                        },
+                    )
+                    .finally(() => {
+                        executing.delete(promise);
+                    });
+                executing.add(promise);
+            }
+
+            if (failed) {
+                await Promise.allSettled(executing);
+                throw firstError;
+            }
+
+            if (executing.size === 0) {
+                break;
+            }
+
+            const result = await Promise.race(executing);
+            if (!result.ok) {
+                await Promise.allSettled(executing);
+                throw result.error;
+            }
+        }
+
+        if (failed) {
+            throw firstError;
+        }
+    } finally {
+        parentSignal.removeEventListener("abort", propagateParentAbort);
+    }
+}
+
 // ---- Template resolution ----
 // Note: the error throws below (unknown namespace, unresolved reference,
 // path projection failures) should never fire when static validation is
@@ -1389,11 +1475,10 @@ export class WorkflowEngine {
             const concurrency = node.maxConcurrency ?? branchNames.length;
             const results: Record<string, unknown> = {};
 
-            // Execute branches with concurrency limiting
-            const executing = new Set<Promise<void>>();
-            const branchQueue = [...branchNames];
-
-            const runBranch = async (bName: string) => {
+            const runBranch = async (
+                bName: string,
+                branchSignal: AbortSignal,
+            ) => {
                 const branch = node.branches[bName];
                 const branchInput = resolveTemplate(
                     branch.inputs,
@@ -1411,7 +1496,7 @@ export class WorkflowEngine {
                     branchScope,
                     branchScopePath,
                     runId,
-                    signal,
+                    branchSignal,
                     ctx,
                     policy,
                     approve,
@@ -1424,18 +1509,12 @@ export class WorkflowEngine {
                 );
             };
 
-            while (branchQueue.length > 0 || executing.size > 0) {
-                while (branchQueue.length > 0 && executing.size < concurrency) {
-                    const bName = branchQueue.shift()!;
-                    const p = runBranch(bName).then(() => {
-                        executing.delete(p);
-                    });
-                    executing.add(p);
-                }
-                if (executing.size > 0) {
-                    await Promise.race(executing);
-                }
-            }
+            await runCancellableConcurrent(
+                branchNames,
+                concurrency,
+                signal,
+                runBranch,
+            );
 
             if (node.bind) {
                 outerScope.bindings.set(node.bind, results);
@@ -1538,10 +1617,7 @@ export class WorkflowEngine {
             const concurrency = node.maxConcurrency ?? items.length;
             const results: unknown[] = new Array(items.length).fill(null);
 
-            const executing = new Set<Promise<void>>();
-            const indexQueue = items.map((_, i) => i);
-
-            const runItem = async (index: number) => {
+            const runItem = async (index: number, itemSignal: AbortSignal) => {
                 this.emit({
                     type: "forkMapIterationStarted",
                     runId,
@@ -1573,7 +1649,7 @@ export class WorkflowEngine {
                     itemScope,
                     itemScopePath,
                     runId,
-                    signal,
+                    itemSignal,
                     ctx,
                     policy,
                     approve,
@@ -1594,18 +1670,12 @@ export class WorkflowEngine {
                 });
             };
 
-            while (indexQueue.length > 0 || executing.size > 0) {
-                while (indexQueue.length > 0 && executing.size < concurrency) {
-                    const idx = indexQueue.shift()!;
-                    const p = runItem(idx).then(() => {
-                        executing.delete(p);
-                    });
-                    executing.add(p);
-                }
-                if (executing.size > 0) {
-                    await Promise.race(executing);
-                }
-            }
+            await runCancellableConcurrent(
+                items.map((_, i) => i),
+                concurrency,
+                signal,
+                runItem,
+            );
 
             if (node.bind) {
                 outerScope.bindings.set(node.bind, results);

--- a/ts/examples/workflow/engine/test/engine.spec.ts
+++ b/ts/examples/workflow/engine/test/engine.spec.ts
@@ -16,6 +16,8 @@ import {
     JSONSchema,
     ConstantDef,
     TaskDefinition,
+    TaskContext,
+    TaskResult,
     TaskPolicy,
     Template,
     validateWorkflowIR,
@@ -7077,6 +7079,131 @@ describe("WorkflowEngine (IR v1)", () => {
             expect(result.success).toBe(false);
             expect(result.error?.message).toContain("branch blew up");
         });
+
+        it("fork cancels in-flight branches when a sibling fails", async () => {
+            const reg = new TaskRegistry();
+            for (const t of allBuiltinTasks) reg.register(t);
+
+            let slowStarted = false;
+            let slowAborted = false;
+
+            reg.register({
+                name: "mock.slowUntilAbort",
+                sideEffects: false,
+                inputSchema: { type: "object" },
+                outputSchema: { type: "object" },
+                async execute(_input: unknown, ctx: TaskContext) {
+                    slowStarted = true;
+                    return new Promise<TaskResult>((resolve, reject) => {
+                        const abort = () => {
+                            slowAborted = true;
+                            clearTimeout(timer);
+                            reject(new Error("slow branch aborted"));
+                        };
+                        const timer = setTimeout(
+                            () =>
+                                resolve({
+                                    kind: "ok",
+                                    output: { late: true },
+                                }),
+                            5000,
+                        );
+                        if (ctx.signal.aborted) {
+                            abort();
+                        } else {
+                            ctx.signal.addEventListener("abort", abort, {
+                                once: true,
+                            });
+                        }
+                    });
+                },
+            });
+            reg.register({
+                name: "mock.failTask",
+                sideEffects: false,
+                inputSchema: { type: "object" },
+                outputSchema: { type: "object" },
+                async execute() {
+                    return {
+                        kind: "fail" as const,
+                        error: { message: "branch blew up" },
+                    };
+                },
+            });
+
+            const eng = new WorkflowEngine(reg);
+            const ir: WorkflowIR = wrapIR({
+                kind: "workflow",
+                name: "fork-cancel",
+                version: "1",
+                inputSchema: { type: "object" },
+                outputSchema: {},
+                entry: "fork_0",
+                nodes: {
+                    fork_0: {
+                        kind: "fork",
+                        maxConcurrency: 2,
+                        branches: {
+                            slow: {
+                                inputs: {},
+                                scope: {
+                                    inputSchema: {},
+                                    entry: "slow",
+                                    nodes: {
+                                        slow: {
+                                            kind: "task",
+                                            task: "mock.slowUntilAbort",
+                                            inputSchema: { type: "object" },
+                                            outputSchema: { type: "object" },
+                                            inputs: {},
+                                            bind: "r",
+                                        },
+                                    },
+                                    output: { $from: "scope", name: "r" },
+                                    outputSchema: { type: "object" },
+                                },
+                            },
+                            bad: {
+                                inputs: {},
+                                scope: {
+                                    inputSchema: {},
+                                    entry: "fail",
+                                    nodes: {
+                                        fail: {
+                                            kind: "task",
+                                            task: "mock.failTask",
+                                            inputSchema: { type: "object" },
+                                            outputSchema: { type: "object" },
+                                            inputs: {},
+                                            bind: "r",
+                                        },
+                                    },
+                                    output: { $from: "scope", name: "r" },
+                                    outputSchema: { type: "object" },
+                                },
+                            },
+                        },
+                        outputSchema: { type: "object" },
+                        bind: "forkOut",
+                    },
+                },
+                output: { $from: "scope", name: "forkOut" },
+            });
+
+            const start = Date.now();
+            const result = await eng.run(ir, {
+                input: {},
+                policy: allowAllPolicy,
+                skipValidation: true,
+            });
+            const elapsed = Date.now() - start;
+
+            expect(result.success).toBe(false);
+            expect(result.error?.message).toContain("branch blew up");
+            expect(slowStarted).toBe(true);
+            expect(slowAborted).toBe(true);
+            expect(elapsed).toBeLessThan(500);
+        });
     });
 
     // ---- ForkMap execution ----
@@ -7492,6 +7619,124 @@ describe("WorkflowEngine (IR v1)", () => {
             });
             expect(result.success).toBe(false);
             expect(result.error?.message).toContain("iteration failed on 3");
+        });
+
+        it("forkMap cancels in-flight iterations and stops queued work on failure", async () => {
+            const reg = new TaskRegistry();
+            for (const t of allBuiltinTasks) reg.register(t);
+
+            const started: number[] = [];
+            let slowAborted = false;
+
+            reg.register({
+                name: "mock.mixedItem",
+                sideEffects: false,
+                inputSchema: {
+                    type: "object",
+                    required: ["n"],
+                    properties: { n: { type: "number" } },
+                },
+                outputSchema: { type: "number" },
+                async execute(input: any, ctx: TaskContext) {
+                    started.push(input.n);
+                    if (input.n === 2) {
+                        return {
+                            kind: "fail" as const,
+                            error: { message: "iteration failed on 2" },
+                        };
+                    }
+                    return new Promise<TaskResult>((resolve, reject) => {
+                        const abort = () => {
+                            slowAborted = true;
+                            clearTimeout(timer);
+                            reject(new Error("slow iteration aborted"));
+                        };
+                        const timer = setTimeout(
+                            () => resolve({ kind: "ok", output: input.n }),
+                            5000,
+                        );
+                        if (ctx.signal.aborted) {
+                            abort();
+                        } else {
+                            ctx.signal.addEventListener("abort", abort, {
+                                once: true,
+                            });
+                        }
+                    });
+                },
+            });
+
+            const eng = new WorkflowEngine(reg);
+            const ir: WorkflowIR = wrapIR({
+                kind: "workflow",
+                name: "forkmap-cancel",
+                version: "1",
+                inputSchema: {
+                    type: "object",
+                    required: ["nums"],
+                    properties: {
+                        nums: { type: "array", items: { type: "number" } },
+                    },
+                },
+                outputSchema: { type: "array" },
+                entry: "fm",
+                nodes: {
+                    fm: {
+                        kind: "forkMap",
+                        collection: { $from: "input", name: "nums" },
+                        collectionSchema: {
+                            type: "array",
+                            items: { type: "number" },
+                        },
+                        elementParam: "n",
+                        body: {
+                            inputSchema: {},
+                            entry: "step",
+                            nodes: {
+                                step: {
+                                    kind: "task",
+                                    task: "mock.mixedItem",
+                                    inputSchema: {
+                                        type: "object",
+                                        required: ["n"],
+                                        properties: {
+                                            n: { type: "number" },
+                                        },
+                                    },
+                                    outputSchema: { type: "number" },
+                                    inputs: {
+                                        n: { $from: "input", name: "n" },
+                                    },
+                                    bind: "r",
+                                },
+                            },
+                            output: { $from: "scope", name: "r" },
+                            outputSchema: { type: "number" },
+                        },
+                        outputSchema: {
+                            type: "array",
+                            items: { type: "number" },
+                        },
+                        maxConcurrency: 2,
+                        bind: "out",
+                    },
+                },
+                output: { $from: "scope", name: "out" },
+            });
+
+            const start = Date.now();
+            const result = await eng.run(ir, {
+                input: { nums: [1, 2, 3] },
+                policy: allowAllPolicy,
+                skipValidation: true,
+            });
+            const elapsed = Date.now() - start;
+
+            expect(result.success).toBe(false);
+            expect(result.error?.message).toContain("iteration failed on 2");
+            expect(slowAborted).toBe(true);
+            expect(started).toEqual([1, 2]);
+            expect(elapsed).toBeLessThan(500);
         });
     });
 

--- a/ts/examples/workflow/engine/test/engine.spec.ts
+++ b/ts/examples/workflow/engine/test/engine.spec.ts
@@ -7204,6 +7204,157 @@ describe("WorkflowEngine (IR v1)", () => {
             expect(slowAborted).toBe(true);
             expect(elapsed).toBeLessThan(500);
         });
+
+        it("fork stops queued branches when a sibling fails", async () => {
+            const reg = new TaskRegistry();
+            for (const t of allBuiltinTasks) reg.register(t);
+
+            const started: string[] = [];
+            let slowAborted = false;
+
+            reg.register({
+                name: "mock.slowBranch",
+                sideEffects: false,
+                inputSchema: { type: "object" },
+                outputSchema: { type: "object" },
+                async execute(_input: unknown, ctx: TaskContext) {
+                    started.push("slow");
+                    return new Promise<TaskResult>((resolve, reject) => {
+                        const abort = () => {
+                            slowAborted = true;
+                            clearTimeout(timer);
+                            reject(new Error("slow branch aborted"));
+                        };
+                        const timer = setTimeout(
+                            () => resolve({ kind: "ok", output: {} }),
+                            5000,
+                        );
+                        if (ctx.signal.aborted) {
+                            abort();
+                        } else {
+                            ctx.signal.addEventListener("abort", abort, {
+                                once: true,
+                            });
+                        }
+                    });
+                },
+            });
+            reg.register({
+                name: "mock.failBranch",
+                sideEffects: false,
+                inputSchema: { type: "object" },
+                outputSchema: { type: "object" },
+                async execute() {
+                    started.push("bad");
+                    return {
+                        kind: "fail" as const,
+                        error: { message: "branch blew up" },
+                    };
+                },
+            });
+            reg.register({
+                name: "mock.queuedBranch",
+                sideEffects: false,
+                inputSchema: { type: "object" },
+                outputSchema: { type: "object" },
+                async execute() {
+                    started.push("queued");
+                    return { kind: "ok" as const, output: {} };
+                },
+            });
+
+            const eng = new WorkflowEngine(reg);
+            const ir: WorkflowIR = wrapIR({
+                kind: "workflow",
+                name: "fork-queued-cancel",
+                version: "1",
+                inputSchema: { type: "object" },
+                outputSchema: {},
+                entry: "fork_0",
+                nodes: {
+                    fork_0: {
+                        kind: "fork",
+                        maxConcurrency: 2,
+                        branches: {
+                            slow: {
+                                inputs: {},
+                                scope: {
+                                    inputSchema: {},
+                                    entry: "slow",
+                                    nodes: {
+                                        slow: {
+                                            kind: "task",
+                                            task: "mock.slowBranch",
+                                            inputSchema: { type: "object" },
+                                            outputSchema: { type: "object" },
+                                            inputs: {},
+                                            bind: "r",
+                                        },
+                                    },
+                                    output: { $from: "scope", name: "r" },
+                                    outputSchema: { type: "object" },
+                                },
+                            },
+                            bad: {
+                                inputs: {},
+                                scope: {
+                                    inputSchema: {},
+                                    entry: "fail",
+                                    nodes: {
+                                        fail: {
+                                            kind: "task",
+                                            task: "mock.failBranch",
+                                            inputSchema: { type: "object" },
+                                            outputSchema: { type: "object" },
+                                            inputs: {},
+                                            bind: "r",
+                                        },
+                                    },
+                                    output: { $from: "scope", name: "r" },
+                                    outputSchema: { type: "object" },
+                                },
+                            },
+                            queued: {
+                                inputs: {},
+                                scope: {
+                                    inputSchema: {},
+                                    entry: "queued",
+                                    nodes: {
+                                        queued: {
+                                            kind: "task",
+                                            task: "mock.queuedBranch",
+                                            inputSchema: { type: "object" },
+                                            outputSchema: { type: "object" },
+                                            inputs: {},
+                                            bind: "r",
+                                        },
+                                    },
+                                    output: { $from: "scope", name: "r" },
+                                    outputSchema: { type: "object" },
+                                },
+                            },
+                        },
+                        outputSchema: { type: "object" },
+                        bind: "forkOut",
+                    },
+                },
+                output: { $from: "scope", name: "forkOut" },
+            });
+
+            const start = Date.now();
+            const result = await eng.run(ir, {
+                input: {},
+                policy: allowAllPolicy,
+                skipValidation: true,
+            });
+            const elapsed = Date.now() - start;
+
+            expect(result.success).toBe(false);
+            expect(result.error?.message).toContain("branch blew up");
+            expect(slowAborted).toBe(true);
+            expect(started).toEqual(["slow", "bad"]);
+            expect(elapsed).toBeLessThan(500);
+        });
     });
 
     // ---- ForkMap execution ----


### PR DESCRIPTION
## Summary
- add shared cancellable concurrency handling for fork and forkMap execution
- abort in-flight sibling branches or iterations on first failure and await cleanup before propagating the original error
- mark G17 as resolved in the workflow DSL gap list

## Testing
- `pnpm -C ts/examples/workflow/engine run tsc`
- `pnpm -C ts/examples/workflow/engine run jest-esm --testPathPattern=".*engine[.]spec[.]js" -t "cancels in-flight"`