### PR TITLE
fix(fix-dependabot-alerts): clean-rebuild for final verification

### DIFF
--- a/.github/workflows/fix-dependabot-alerts.yml
+++ b/.github/workflows/fix-dependabot-alerts.yml
@@ -421,10 +421,10 @@ jobs:
           # verification matches the clean-checkout CI build_ts job.
           # fluid-build's incremental cache and tsc's .tsbuildinfo are
           # keyed off the package's own sources + declared dep specs in
-          # package.json; an in-range transitive dep upgrade (e.g.
-          # exifreader 4.30.1 → 4.40.3 under "^4.30.1") doesn't bust the
-          # cache, so a breaking .d.ts change in a dep can pass the
-          # incremental build here while still failing CI's fresh build.
+          # package.json; an in-range transitive dep upgrade doesn't
+          # bust the cache, so a breaking .d.ts change in a dep can
+          # pass the incremental build here while still failing CI's
+          # fresh build.
           pnpm run rebuild
           echo "build_ok=true" >> "$GITHUB_OUTPUT"
         env:

--- a/.github/workflows/fix-dependabot-alerts.yml
+++ b/.github/workflows/fix-dependabot-alerts.yml
@@ -417,7 +417,15 @@ jobs:
         working-directory: ts
         run: |
           node tools/scripts/repo-policy-check.mjs --fix || true
-          pnpm run build
+          # Use `rebuild` (fluid-build --rebuild), not `build`, so the
+          # verification matches the clean-checkout CI build_ts job.
+          # fluid-build's incremental cache and tsc's .tsbuildinfo are
+          # keyed off the package's own sources + declared dep specs in
+          # package.json; an in-range transitive dep upgrade (e.g.
+          # exifreader 4.30.1 → 4.40.3 under "^4.30.1") doesn't bust the
+          # cache, so a breaking .d.ts change in a dep can pass the
+          # incremental build here while still failing CI's fresh build.
+          pnpm run rebuild
           echo "build_ok=true" >> "$GITHUB_OUTPUT"
         env:
           DEBUG_DEMB: true


### PR DESCRIPTION
## Problem

The `Final build verification` step in `.github/workflows/fix-dependabot-alerts.yml` ran `pnpm run build`, which uses **fluid-build** incrementally. fluid-build's per-package fingerprint (and tsc's `.tsbuildinfo`) is keyed off the package's own sources plus the **declared** dep specs in `package.json` — it does **not** invalidate when a transitive dep is bumped within its existing semver range. As a result, a breaking `.d.ts` change in an upgraded dep can pass the script's verification while still failing CI's clean `build_ts` job, producing PRs that break `main` on merge.

### Concrete case: PR #2421

- `exifreader` bumped `4.30.1 → 4.40.3` (in-range under `^4.30.1`)
- The new `exifreader` `TypedTag` generic gained a 2nd nullable-tuple type parameter
- This broke `typechat-utils/src/image.ts:161` — `GPSLatitude`/`GPSLongitude` no longer assignable to the helper that consumes them
- Script's incremental build skipped re-checking `typechat-utils` (no source change, no package.json change) → reported ✅
- CI's fresh checkout did a clean type-check → caught it on all 6 `build_ts` matrix legs

## Fix

Switch the final verification to `pnpm run rebuild` (= `fluid-build . -t build --rebuild`), matching the workload CI's fresh checkout does. The per-package mid-loop incremental build (line 352) is left as-is for speed — the final rebuild is the backstop. Any package that does fail the rebuild gets recorded in the existing rollback-cooldown state so the same broken bump isn't re-proposed for 7 days.

## Follow-up

Next scheduled run should clean-rebuild, fail on the exifreader change, and auto-roll-back, putting `exifreader` on the 7-day cooldown. PR #2421 should be closed.

Repro run: [26750395888](https://github.com/microsoft/TypeAgent/actions/runs/26750395888) (workflow ✅) vs PR #2421's `build_ts` failures (CI ❌).