### PR TITLE
Improve VSCode agent Font Color / Input UX

### DIFF
--- a/ts/packages/chat-ui/styles/chat.css
+++ b/ts/packages/chat-ui/styles/chat.css
@@ -40,6 +40,12 @@
   border: solid 1px rgb(224, 224, 224);
   border-radius: 6px;
   position: relative;
+  /* Show the text caret across the whole input surface (container padding,
+     wrapper, ghost text) so the entire box reads as an editable area —
+     not just the contenteditable .user-textarea inside it. Buttons inside
+     the container override this via their own `cursor: pointer` (see
+     .chat-input-button). */
+  cursor: text;
 }
 
 .chat-input.listening {

--- a/ts/packages/dispatcher/dispatcher/src/context/system/handlers/configCommandHandlers.ts
+++ b/ts/packages/dispatcher/dispatcher/src/context/system/handlers/configCommandHandlers.ts
@@ -229,9 +229,23 @@ function buildAgentStatusHtml(
     showAction: boolean,
     showCommand: boolean,
 ): string {
-    const thStyle = `text-align:center;padding:4px 8px;font-weight:600;font-size:13px;color:#64748b;border-bottom:2px solid #e2e8f0`;
+    // Color tokens use `var(--vscode-*, <fallback>)` so the VS Code chat
+    // webview picks up the user's theme (light / dark / high-contrast),
+    // while other clients (Electron shell, browser UI) — where the
+    // --vscode-* CSS variables are undefined — render the original
+    // hardcoded slate palette unchanged via the comma-fallback.
+    const C_HEADER = "var(--vscode-descriptionForeground,#64748b)";
+    const C_HEADER_BORDER = "var(--vscode-panel-border,#e2e8f0)";
+    const C_ROW_BORDER = "var(--vscode-panel-border,#f1f5f9)";
+    const C_AGENT = "var(--vscode-foreground,#1e293b)";
+    const C_SUB = "var(--vscode-descriptionForeground,#475569)";
+    const C_ERR = "var(--vscode-errorForeground,#dc2626)";
+    const C_UNKNOWN = "var(--vscode-descriptionForeground,#64748b)";
+    const C_WARN = "var(--vscode-editorWarning-foreground,#b45309)";
+
+    const thStyle = `text-align:center;padding:4px 8px;font-weight:600;font-size:13px;color:${C_HEADER};border-bottom:2px solid ${C_HEADER_BORDER}`;
     const headerCols = [
-        `<th style="text-align:left;padding:4px 12px 4px 8px;font-weight:600;font-size:13px;color:#64748b;border-bottom:2px solid #e2e8f0">Agent</th>`,
+        `<th style="text-align:left;padding:4px 12px 4px 8px;font-weight:600;font-size:13px;color:${C_HEADER};border-bottom:2px solid ${C_HEADER_BORDER}">Agent</th>`,
     ];
     if (showSchema) headerCols.push(`<th style="${thStyle}">Schemas</th>`);
     if (showAction) headerCols.push(`<th style="${thStyle}">Actions</th>`);
@@ -244,8 +258,8 @@ function buildAgentStatusHtml(
         const displayName = isAppAgent ? name : name.replace(/^[^.]+\./, "");
         const indent = isAppAgent ? "0" : "20px";
         const fontWeight = isAppAgent ? "600" : "400";
-        const color = isAppAgent ? "#1e293b" : "#475569";
-        const bb = isAppAgent ? "1px solid #f1f5f9" : "none";
+        const color = isAppAgent ? C_AGENT : C_SUB;
+        const bb = isAppAgent ? `1px solid ${C_ROW_BORDER}` : "none";
         const tdStyle = `text-align:center;padding:3px 8px;border-bottom:${bb}`;
 
         // Per-agent badges (app-agent rows only): load failure first, then
@@ -257,7 +271,7 @@ function buildAgentStatusHtml(
             const loadError = agents.getLoadError(name);
             if (loadError !== undefined) {
                 const tip = `Failed to load: ${loadError.message ?? String(loadError)}`;
-                warning += ` <span title="${escapeAttr(tip)}" style="color:#dc2626;cursor:help" aria-label="${escapeAttr(tip)}">⛔</span>`;
+                warning += ` <span title="${escapeAttr(tip)}" style="color:${C_ERR};cursor:help" aria-label="${escapeAttr(tip)}">⛔</span>`;
             }
             if (agents.hasUnknownReadiness(name)) {
                 // Agent is known to implement checkReadiness but hasn't
@@ -267,14 +281,14 @@ function buildAgentStatusHtml(
                 // of implicitly claiming it's ready.
                 const tip =
                     "Readiness state unknown — agent is not currently loaded. Enable it (or run `@config agent refresh <name>` after enabling) to re-probe its setup state.";
-                warning += ` <span title="${escapeAttr(tip)}" style="color:#64748b;cursor:help" aria-label="${escapeAttr(tip)}">❓</span>`;
+                warning += ` <span title="${escapeAttr(tip)}" style="color:${C_UNKNOWN};cursor:help" aria-label="${escapeAttr(tip)}">❓</span>`;
             } else {
                 const report = agents.getReadiness(name);
                 if (report.state !== "ready") {
                     const tip = report.message
                         ? `${report.state}: ${report.message}`
                         : report.state;
-                    warning += ` <span title="${escapeAttr(tip)}" style="color:#b45309;cursor:help" aria-label="${escapeAttr(tip)}">⚠</span>`;
+                    warning += ` <span title="${escapeAttr(tip)}" style="color:${C_WARN};cursor:help" aria-label="${escapeAttr(tip)}">⚠</span>`;
                 }
             }
         }

--- a/ts/packages/shell/demo/DEMO_SETUP.md
+++ b/ts/packages/shell/demo/DEMO_SETUP.md
@@ -52,10 +52,10 @@ Run these once in the **Electron shell** before starting Part 1, then save the
 session so the vscode-shell sidebar inherits them:
 
 ```
-@config schema code on             # editor actions (split, theme, new file)
-@config schema desktop on          # for "switch to Code"
-@config schema github-cli on       # all github actions
-@config schema onboarding off      # prevents "Integration not found" on "create scratch.ts"
+@config schema code               # editor actions (split, theme, new file)
+@config schema desktop            # for "switch to Code"
+@config schema github-cli         # all github actions
+@config schema --off onboarding   # prevents "Integration not found" on "create scratch.ts"
 @config request reasoning copilot  # PR/issue memory across turns
 @session save vscode-demo
 ```
@@ -95,8 +95,8 @@ listener installed by the webview.
 | `show check runs for that PR` runs `gh run view <num>` and 404s                    | Reasoning maps "for that PR" to a workflow-run id, and there's no conversation memory of the prior PR       | Use the explicit phrasing `show check runs for PR N [in OWNER/REPO]` (now backed by `gh pr checks`)                                   |
 | `create scratch.ts` returns "Unknown action name: code.code-general"               | Reasoning hallucinates a sub-schema name as an action name                                                  | Rephrase as `create a typescript file scratch.ts with a hello world function` (drop "called" and "new"); long-term tracked in plan.md |
 | `splitEditor` returns "Did not handle the action"                                  | Installed coda is older than `ts/packages/coda` source                                                      | Rebuild & reinstall coda                                                                                                              |
-| `splitEditor` returns "No websocket connection"                                    | Code agent WS server isn't up in this session                                                               | `@config schema code on` (the agent-server's discovery channel will then publish the dynamic port to the coda extension)              |
-| `create scratch.ts` returns "Integration ... not found"                            | Onboarding agent grabbed the request                                                                        | `@config schema onboarding off`                                                                                                       |
+| `splitEditor` returns "No websocket connection"                                    | Code agent WS server isn't up in this session                                                               | `@config schema code` (the agent-server's discovery channel will then publish the dynamic port to the coda extension)                 |
+| `create scratch.ts` returns "Integration ... not found"                            | Onboarding agent grabbed the request                                                                        | `@config schema --off onboarding`                                                                                                     |
 | `change my color theme to ...` toggles the title-bar instead of the theme          | Desktop agent grabbed the request because the prompt didn't say "vscode"                                    | Use the exact wording in the demo file                                                                                                |
 | "remind me which PR we were just looking at" hallucinates PR #123 / `example/repo` | Reasoning has no conversation memory                                                                        | `@config request reasoning copilot`                                                                                                   |
 | `switch to Code` doesn't foreground the IDE                                        | autoShell missing or desktop agent not pointed at it                                                        | Rebuild `dotnet/autoShell` and re-link                                                                                                |

--- a/ts/packages/vscode-shell/README.md
+++ b/ts/packages/vscode-shell/README.md
@@ -85,8 +85,14 @@ Electron shell — don't implement that client action and would otherwise
 silently no-op the request). Enable it once per session in the chat:
 
 ```
-@config schema code-vscode-shell on
+@config schema code.code-vscode-shell
 ```
+
+Note: this is the **full canonical** sub-schema name (`<parent>.<sub-key>`).
+The schema appears as just `code-vscode-shell` in the `@config schema` table —
+the parent prefix is hidden in the display but **required** when toggling.
+
+To later disable it again, use `@config schema --off code.code-vscode-shell`.
 
 The setting is persisted in your TypeAgent user settings, so you only
 need to do this on first use. After it's on, you can drive the


### PR DESCRIPTION
- Improve Documentation
- Use VS Code theme default font colors (with fallback to existing hardcoded colors)
- Make the entire input box show a text cursor as appropriate.

Original Text Color on Dark Theme : 
<img width="828" height="497" alt="original" src="https://github.com/user-attachments/assets/6606d66b-7e48-4a95-a51b-e262d08854b6" />

New Text Color on Dark Theme : 
<img width="816" height="453" alt="VSCode Text" src="https://github.com/user-attachments/assets/7590810e-48d9-4c5b-8f45-937fe4aa34e8" />
