### PR TITLE
Update progress reporting in plugin and agent

### DIFF
--- a/ts/package.json
+++ b/ts/package.json
@@ -26,6 +26,7 @@
     "cli": "pnpm -C packages/cli run start",
     "cli:dev": "pnpm -C packages/cli run start:dev",
     "copilot": "node packages/copilot-plugin/scripts/launch.mjs",
+    "copilot:dev": "node packages/copilot-plugin/scripts/launch-dev.mjs",
     "docs:generate": "node tools/docsAutogen/bin/docs-autogen.cjs --render --write",
     "docs:generate:dry": "node tools/docsAutogen/bin/docs-autogen.cjs --render --dry-run",
     "docs:generate:llm": "node tools/docsAutogen/bin/docs-autogen.cjs --render --write --llm",

--- a/ts/packages/agents/powershell/src/actionHandler.mts
+++ b/ts/packages/agents/powershell/src/actionHandler.mts
@@ -3,6 +3,7 @@
 
 import {
     type AppAgent,
+    type AppAction,
     type SessionContext,
     type ActionContext,
     type ActionResult,
@@ -298,6 +299,9 @@ async function handlePowerShellFlowAction(
             const scriptParams = (params.scriptParameters as any[]) ?? [];
             const grammarPats = (params.grammarPatterns as any[]) ?? [];
             const allowedCmdlets = (params.allowedCmdlets as string[]) ?? [];
+            const allowedModules = (params.allowedModules as string[]) ?? [
+                "Microsoft.PowerShell.Management",
+            ];
 
             // Validate grammar patterns before saving
             if (
@@ -380,7 +384,7 @@ async function handlePowerShellFlowAction(
                 sandbox: {
                     allowedCmdlets,
                     allowedPaths: ["$env:USERPROFILE", "$PWD", "$env:TEMP"],
-                    allowedModules: ["Microsoft.PowerShell.Management"],
+                    allowedModules,
                     maxExecutionTime: 30,
                     networkAccess: false,
                 },
@@ -426,12 +430,16 @@ async function handlePowerShellFlowAction(
             const newCmdlets =
                 (action.parameters?.allowedCmdlets as string[]) ??
                 existingFlow.sandbox.allowedCmdlets;
+            const newModules =
+                (action.parameters?.allowedModules as string[]) ??
+                existingFlow.sandbox.allowedModules;
 
             // Update the script and sandbox policy while preserving everything else
             await flowStore.updateFlowScript(
                 editFlowName,
                 newScript,
                 newCmdlets,
+                newModules,
             );
             return createActionResultFromTextDisplay(
                 `Updated PowerShell flow '${editFlowName}'`,
@@ -1019,6 +1027,18 @@ const handlers: CommandHandlerTable = {
     },
 };
 
+// Built-in management actions in the root "powershell" schema. Everything else
+// in that schema is a dynamic, user-created flow.
+const POWERSHELL_BUILTIN_ACTIONS = new Set([
+    "listPowerShellFlows",
+    "deletePowerShellFlow",
+    "executePowerShellFlow",
+    "createPowerShellFlow",
+    "editPowerShellFlow",
+    "importPowerShellFlow",
+    "testPowerShellFlow",
+]);
+
 export function instantiate(): AppAgent {
     let agentContext: PowerShellAgentContext = {};
 
@@ -1068,6 +1088,23 @@ export function instantiate(): AppAgent {
                 },
                 context,
             );
+        },
+
+        async validateWildcardMatch(
+            action: AppAction,
+            _context: SessionContext,
+        ): Promise<boolean> {
+            // Only dynamic flow actions live in the root "powershell" schema;
+            // sub-schema (powershell.powershell-*) static actions and built-in
+            // management actions are always valid. A root flow action is valid
+            // only if its flow still exists — this rejects stale cached
+            // constructions that point to a deleted flow instead of letting them
+            // resolve to a now-missing action.
+            if (action.schemaName !== "powershell") return true;
+            if (POWERSHELL_BUILTIN_ACTIONS.has(action.actionName)) return true;
+            const store = agentContext.store;
+            if (!store) return true;
+            return (await store.getFlow(action.actionName)) !== null;
         },
 
         async getDynamicSchema(

--- a/ts/packages/agents/powershell/src/manifest.json
+++ b/ts/packages/agents/powershell/src/manifest.json
@@ -2,6 +2,7 @@
   "emojiChar": "📜",
   "description": "Agent to create and execute PowerShell workflows",
   "defaultEnabled": true,
+  "errorReasoning": true,
   "schema": {
     "description": "Core flow management actions for creating, listing, and executing PowerShell scripts.",
     "originalSchemaFile": "./schema/scriptActions.mts",

--- a/ts/packages/agents/powershell/src/schema/scriptActions.mts
+++ b/ts/packages/agents/powershell/src/schema/scriptActions.mts
@@ -55,6 +55,11 @@ export type CreatePowerShellFlow = {
         }[];
         // PowerShell cmdlets the script uses
         allowedCmdlets: string[];
+        // PowerShell modules to import for the script's cmdlets (e.g.
+        // ["NetTCPIP"] for Get-NetTCPConnection). Include every module required
+        // by allowedCmdlets — use the same list that made testPowerShellFlow
+        // pass, or the flow will fail at invocation with "not recognized".
+        allowedModules?: string[];
     };
 };
 
@@ -68,6 +73,8 @@ export type EditPowerShellFlow = {
         script: string;
         // Updated list of PowerShell cmdlets the script uses
         allowedCmdlets: string[];
+        // Updated list of PowerShell modules to import (optional; preserved if omitted)
+        allowedModules?: string[];
     };
 };
 

--- a/ts/packages/agents/powershell/src/store/powerShellStore.mts
+++ b/ts/packages/agents/powershell/src/store/powerShellStore.mts
@@ -167,6 +167,7 @@ export class PowerShellStore {
         actionName: string,
         newScript: string,
         newCmdlets: string[],
+        newModules?: string[],
     ): Promise<void> {
         this.ensureInitialized();
         const entry = this.index.flows[actionName];
@@ -175,10 +176,13 @@ export class PowerShellStore {
         // Update the script file
         await this.storage.write(entry.scriptPath, newScript);
 
-        // Update the flow definition's sandbox cmdlets
+        // Update the flow definition's sandbox cmdlets (and modules if provided)
         const json = await this.storage.read(entry.flowPath, "utf8");
         const flow = JSON.parse(json) as PowerShellFlowDefinition;
         flow.sandbox.allowedCmdlets = newCmdlets;
+        if (newModules !== undefined) {
+            flow.sandbox.allowedModules = newModules;
+        }
         await this.storage.write(entry.flowPath, JSON.stringify(flow, null, 2));
 
         entry.updated = new Date().toISOString();

--- a/ts/packages/agents/taskflow/src/actionHandler.mts
+++ b/ts/packages/agents/taskflow/src/actionHandler.mts
@@ -3,11 +3,13 @@
 
 import {
     type AppAgent,
+    type AppAction,
     type ActionContext,
     type ActionResult,
     type SessionContext,
     type SchemaContent,
     type GrammarContent,
+    type GrammarValidationResult,
     AppAgentEvent,
 } from "@typeagent/agent-sdk";
 import {
@@ -33,6 +35,41 @@ import registerDebug from "debug";
 const debug = registerDebug("typeagent:taskflow:handler");
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const SAMPLES_DIR = join(__dirname, "..", "samples");
+
+// How long flow authoring will wait for grammar validation before proceeding.
+// Each validation LLM op is itself capped at 30s; this bounds the overall wait
+// so authoring never blocks on a slow/hung validation.
+const GRAMMAR_VALIDATION_WAIT_MS = 15_000;
+
+/**
+ * Await a grammar-validation result, but only up to `budgetMs`. Returns
+ * `undefined` if validation does not finish in time or rejects, so flow
+ * authoring can proceed with the patterns as authored. The underlying
+ * validation keeps running in the background (each LLM op has its own timeout);
+ * any late rejection is swallowed.
+ */
+async function awaitValidationWithinBudget(
+    validation: Promise<GrammarValidationResult>,
+    budgetMs: number,
+): Promise<GrammarValidationResult | undefined> {
+    // Once we stop awaiting, a late rejection must not surface as unhandled.
+    validation.catch(() => {});
+
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const budget = new Promise<undefined>((resolve) => {
+        timer = setTimeout(() => resolve(undefined), budgetMs);
+    });
+
+    try {
+        return await Promise.race([validation, budget]);
+    } catch {
+        return undefined;
+    } finally {
+        if (timer !== undefined) {
+            clearTimeout(timer);
+        }
+    }
+}
 
 // ── Agent context ───────────────────────────────────────────────────────────
 
@@ -212,19 +249,30 @@ async function handleTaskFlowAction(
                 );
             }
 
-            // Validate grammar patterns before saving
+            // Validate grammar patterns before saving. Validation makes LLM
+            // calls, so we wait at most GRAMMAR_VALIDATION_WAIT_MS for it; if it
+            // doesn't finish in time (or errors), we proceed with the patterns
+            // as authored rather than blocking flow creation.
             if (
                 grammarPatterns.length > 0 &&
                 context.sessionContext.validateGrammarPatterns
             ) {
-                const validationResult =
-                    await context.sessionContext.validateGrammarPatterns({
+                const validationResult = await awaitValidationWithinBudget(
+                    context.sessionContext.validateGrammarPatterns({
                         actionName: flowName,
                         description,
                         patterns: grammarPatterns,
-                    });
+                    }),
+                    GRAMMAR_VALIDATION_WAIT_MS,
+                );
 
-                if (!validationResult.approved) {
+                if (validationResult === undefined) {
+                    context.sessionContext.notify(
+                        AppAgentEvent.Warning,
+                        "⚠️ Grammar pattern validation didn't finish within " +
+                            `${GRAMMAR_VALIDATION_WAIT_MS / 1000}s — proceeding with the patterns as authored.`,
+                    );
+                } else if (!validationResult.approved) {
                     const errorMsg = [
                         "❌ Grammar pattern validation failed:",
                         "",
@@ -242,24 +290,24 @@ async function handleTaskFlowAction(
                     return createActionResultFromError(
                         errorMsg + suggestionMsg,
                     );
-                }
+                } else {
+                    if (
+                        validationResult.warnings &&
+                        validationResult.warnings.length > 0
+                    ) {
+                        context.sessionContext.notify(
+                            AppAgentEvent.Warning,
+                            `⚠️ Pattern validation warnings:\n${validationResult.warnings.join("\n")}`,
+                        );
+                    }
 
-                if (
-                    validationResult.warnings &&
-                    validationResult.warnings.length > 0
-                ) {
-                    context.sessionContext.notify(
-                        AppAgentEvent.Warning,
-                        `⚠️ Pattern validation warnings:\n${validationResult.warnings.join("\n")}`,
-                    );
-                }
-
-                // Use refined patterns if provided
-                if (
-                    validationResult.patterns &&
-                    validationResult.patterns.length > 0
-                ) {
-                    grammarPatterns = validationResult.patterns;
+                    // Use refined patterns if provided
+                    if (
+                        validationResult.patterns &&
+                        validationResult.patterns.length > 0
+                    ) {
+                        grammarPatterns = validationResult.patterns;
+                    }
                 }
             }
 
@@ -513,6 +561,15 @@ async function executeFlow(
 
 // ── Instantiate ─────────────────────────────────────────────────────────────
 
+// Built-in management actions in the "taskflow" schema. Everything else is a
+// dynamic, user-created flow.
+const TASKFLOW_BUILTIN_ACTIONS = new Set([
+    "listTaskFlows",
+    "deleteTaskFlow",
+    "createTaskFlow",
+    "editTaskFlow",
+]);
+
 export function instantiate(): AppAgent {
     let agentContext: TaskFlowAgentContext = {};
 
@@ -550,6 +607,19 @@ export function instantiate(): AppAgent {
                 },
                 context,
             );
+        },
+
+        async validateWildcardMatch(
+            action: AppAction,
+            _context: SessionContext,
+        ): Promise<boolean> {
+            // Built-in management actions are always valid; a dynamic flow
+            // action is valid only if its flow still exists, so stale cached
+            // constructions for a deleted flow are rejected rather than
+            // resolving to a now-missing action.
+            if (TASKFLOW_BUILTIN_ACTIONS.has(action.actionName)) return true;
+            if (!_agentStore) return true;
+            return (await _agentStore.getFlow(action.actionName)) !== null;
         },
 
         async getDynamicSchema(

--- a/ts/packages/cli/src/enhancedConsole.ts
+++ b/ts/packages/cli/src/enhancedConsole.ts
@@ -1916,19 +1916,10 @@ async function questionWithCompletion(
                 }
                 return;
             } else if (code === 13) {
-                // Enter - accept completion (if any) AND submit
-                if (
-                    filteredCompletions.length > 0 &&
-                    completionIndex < filteredCompletions.length
-                ) {
-                    const completion = filteredCompletions[completionIndex];
-                    input =
-                        completionPrefix +
-                        (filterStartIndex > completionPrefix.length
-                            ? " "
-                            : "") +
-                        completion;
-                }
+                // Enter - submit the input as typed. The inline completion is
+                // only a suggestion; use Tab to accept it. Enter must never
+                // mutate the input, otherwise typing `@config` and pressing
+                // Enter would submit `@config actions`.
                 if (controller) {
                     controller.accept();
                 }

--- a/ts/packages/commandExecutor/src/commandServer.ts
+++ b/ts/packages/commandExecutor/src/commandServer.ts
@@ -145,7 +145,8 @@ class Logger {
 
     log(message: string): void {
         const s = this.format("INFO", message);
-        console.log(s);
+        // stdout is reserved for the MCP JSON-RPC stream; logs go to stderr.
+        console.error(s);
         this.logStream.write(s + "\n");
     }
 

--- a/ts/packages/commandExecutor/src/server.ts
+++ b/ts/packages/commandExecutor/src/server.ts
@@ -7,9 +7,11 @@ import { loadConfig } from "@typeagent/config";
 // Load config from YAML layers + Key Vault (replacing legacy dotenv).
 await loadConfig({ keyVault: {}, strict: false });
 
-console.log("Starting Command Executor Server");
+// This is a stdio MCP server: stdout is the JSON-RPC channel. All diagnostic
+// output must go to stderr or it corrupts the protocol stream.
+console.error("Starting Command Executor Server");
 
 const commandServer = new CommandServer();
 await commandServer.start();
 
-console.log("Exit Command Executor Server");
+console.error("Exit Command Executor Server");

--- a/ts/packages/copilot-plugin/scripts/launch-dev.mjs
+++ b/ts/packages/copilot-plugin/scripts/launch-dev.mjs
@@ -1,0 +1,92 @@
+#!/usr/bin/env node
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+/**
+ * Launch the *locally-built* GitHub Copilot CLI (copilot-agent-runtime) with
+ * this plugin loaded via --plugin-dir. Mirrors `launch.mjs` but runs the dev
+ * build instead of the copilot binary on PATH.
+ *
+ * Usage (from anywhere in the workspace):
+ *   pnpm copilot:dev                 # interactive session
+ *   pnpm copilot:dev -- -p "prompt"  # non-interactive
+ *
+ * The runtime repo is resolved in this order:
+ *   1. $COPILOT_DEV_DIR if set
+ *   2. ../copilot-agent-runtime relative to the TypeAgent root
+ */
+
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+import { existsSync } from "node:fs";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const pluginRoot = resolve(__dirname, "..");
+const distHook = resolve(pluginRoot, "dist", "hooks", "hook-router.js");
+// TypeAgent root: .../TypeAgent/ts/packages/copilot-plugin/scripts -> up 4
+const typeAgentRoot = resolve(__dirname, "..", "..", "..", "..");
+
+if (!existsSync(distHook)) {
+    process.stderr.write(
+        `[copilot-plugin] Built output not found at ${distHook}.\n` +
+            `Run \`pnpm --filter @typeagent/copilot-plugin build\` first.\n`,
+    );
+    process.exit(1);
+}
+
+function resolveRuntimeDir() {
+    if (process.env.COPILOT_DEV_DIR) {
+        return resolve(process.env.COPILOT_DEV_DIR);
+    }
+    return resolve(typeAgentRoot, "..", "copilot-agent-runtime");
+}
+
+const runtimeDir = resolveRuntimeDir();
+const runtimeEntry = resolve(runtimeDir, "dist-cli", "index.js");
+
+if (!existsSync(runtimeEntry)) {
+    process.stderr.write(
+        `[copilot-plugin] Dev copilot CLI not found at ${runtimeEntry}.\n` +
+            `Set $COPILOT_DEV_DIR to the copilot-agent-runtime checkout, or place it next to TypeAgent.\n` +
+            `Then run \`npm run build\` in that repo.\n`,
+    );
+    process.exit(1);
+}
+
+const userCwd = process.env.INIT_CWD || process.cwd();
+
+const userArgs = process.argv.slice(2);
+if (userArgs[0] === "--") {
+    userArgs.shift();
+}
+
+const args = [
+    "--enable-source-maps",
+    "--report-on-fatalerror",
+    runtimeEntry,
+    "--plugin-dir",
+    pluginRoot,
+    ...userArgs,
+];
+
+const child = spawn(process.execPath, args, {
+    stdio: "inherit",
+    cwd: userCwd,
+});
+
+child.on("exit", (code, signal) => {
+    if (signal) {
+        process.kill(process.pid, signal);
+    } else {
+        process.exit(code ?? 0);
+    }
+});
+
+child.on("error", (err) => {
+    process.stderr.write(
+        `[copilot-plugin] Failed to launch dev copilot: ${err.message}\n`,
+    );
+    process.exit(1);
+});

--- a/ts/packages/copilot-plugin/src/hooks/hook-direct.ts
+++ b/ts/packages/copilot-plugin/src/hooks/hook-direct.ts
@@ -9,7 +9,10 @@
 
 import type { Dispatcher } from "@typeagent/agent-server-client";
 import { awaitCommand } from "@typeagent/dispatcher-types";
-import { collectMessage } from "../shared/message-formatter.js";
+import {
+    collectMessage,
+    extractMessageText,
+} from "../shared/message-formatter.js";
 import {
     createClientIO,
     connectToTypeAgent,
@@ -26,6 +29,7 @@ export async function handleDirect(input: HookInput): Promise<HookOutput> {
             collectMessage(message, undefined, responseCollector);
         },
         onAppendDisplay: (message, mode) => {
+            // Emit progress for temporary messages (status updates)
             if (mode === "temporary") {
                 const text = message?.message;
                 if (typeof text === "string" && text.trim()) {
@@ -33,6 +37,20 @@ export async function handleDirect(input: HookInput): Promise<HookOutput> {
                 }
                 return;
             }
+
+            // Emit progress for info/status messages (tool calls, results during reasoning)
+            // These are skipped by collectMessage but contain useful progress info
+            const msg = message?.message;
+            if (typeof msg === "object" && msg && "kind" in msg) {
+                const kind = (msg as { kind: unknown }).kind;
+                if (kind === "info" || kind === "status") {
+                    const text = extractMessageText(message);
+                    if (text?.trim()) {
+                        emitProgress(text.trim());
+                    }
+                }
+            }
+
             collectMessage(message, mode, responseCollector);
         },
     });

--- a/ts/packages/copilot-plugin/src/hooks/hook-direct.ts
+++ b/ts/packages/copilot-plugin/src/hooks/hook-direct.ts
@@ -21,7 +21,7 @@ import { emitProgress } from "../shared/hook-progress.js";
 import type { HookInput, HookOutput } from "./types.js";
 
 export async function handleDirect(input: HookInput): Promise<HookOutput> {
-    emitProgress("Routing to TypeAgent...");
+    emitProgress("Routing to TypeAgent...", { temporary: true });
 
     const responseCollector = { messages: [] as string[] };
     const clientIO = createClientIO({
@@ -29,25 +29,39 @@ export async function handleDirect(input: HookInput): Promise<HookOutput> {
             collectMessage(message, undefined, responseCollector);
         },
         onAppendDisplay: (message, mode) => {
-            // Emit progress for temporary messages (status updates)
+            // Emit progress for temporary messages (status updates).
+            // Mark them temporary so each replaces the previous status line
+            // instead of accumulating in the timeline.
             if (mode === "temporary") {
                 const text = message?.message;
                 if (typeof text === "string" && text.trim()) {
-                    emitProgress(text.trim());
+                    emitProgress(text.trim(), { temporary: true });
                 }
                 return;
             }
 
-            // Emit progress for info/status messages (tool calls, results during reasoning)
-            // These are skipped by collectMessage but contain useful progress info
+            // Route reasoning display by message kind. These are all progress —
+            // never part of the final response — so we return before collecting.
             const msg = message?.message;
             if (typeof msg === "object" && msg && "kind" in msg) {
                 const kind = (msg as { kind: unknown }).kind;
-                if (kind === "info" || kind === "status") {
-                    const text = extractMessageText(message);
-                    if (text?.trim()) {
-                        emitProgress(text.trim());
+                const text = extractMessageText(message)?.trim();
+                // "status" (e.g. reasoning "thinking") is transient — each
+                // replaces the previous status line.
+                if (kind === "status") {
+                    if (text) {
+                        emitProgress(text, { temporary: true });
                     }
+                    return;
+                }
+                // "info"/"warning"/"error" are persistent: tool calls and their
+                // results (including error results) accumulate, so every call is
+                // shown together with its result rather than an orphaned result.
+                if (kind === "info" || kind === "warning" || kind === "error") {
+                    if (text) {
+                        emitProgress(text);
+                    }
+                    return;
                 }
             }
 
@@ -57,9 +71,9 @@ export async function handleDirect(input: HookInput): Promise<HookOutput> {
 
     let dispatcher: Dispatcher | null = null;
     try {
-        emitProgress("Connecting to TypeAgent...");
+        emitProgress("Connecting to TypeAgent...", { temporary: true });
         dispatcher = await connectToTypeAgent(clientIO);
-        emitProgress("Processing command...");
+        emitProgress("Processing command...", { temporary: true });
         const result = await awaitCommand(dispatcher, input.prompt);
 
         if (result?.cancelled) {

--- a/ts/packages/copilot-plugin/src/mcp/server.ts
+++ b/ts/packages/copilot-plugin/src/mcp/server.ts
@@ -225,11 +225,20 @@ class TypeAgentMcpServer {
                         return;
                     }
 
-                    // Emit progress for info/status messages (tool calls, results during reasoning)
+                    // Emit progress for status/info/warning/error messages
+                    // (reasoning "thinking", tool calls, and their results
+                    // including error results). These are progress, not final
+                    // content, so we stream them and skip responseCollector —
+                    // keeping every tool call paired with its result.
                     const msg = message?.message;
                     if (typeof msg === "object" && msg && "kind" in msg) {
                         const kind = (msg as { kind: unknown }).kind;
-                        if (kind === "info" || kind === "status") {
+                        if (
+                            kind === "info" ||
+                            kind === "status" ||
+                            kind === "warning" ||
+                            kind === "error"
+                        ) {
                             messageCount++;
                             if (extra) {
                                 void this.sendProgress(
@@ -239,7 +248,6 @@ class TypeAgentMcpServer {
                                     0,
                                 );
                             }
-                            // Don't add to responseCollector — these are progress, not final content
                             return;
                         }
                     }

--- a/ts/packages/copilot-plugin/src/mcp/server.ts
+++ b/ts/packages/copilot-plugin/src/mcp/server.ts
@@ -225,6 +225,25 @@ class TypeAgentMcpServer {
                         return;
                     }
 
+                    // Emit progress for info/status messages (tool calls, results during reasoning)
+                    const msg = message?.message;
+                    if (typeof msg === "object" && msg && "kind" in msg) {
+                        const kind = (msg as { kind: unknown }).kind;
+                        if (kind === "info" || kind === "status") {
+                            messageCount++;
+                            if (extra) {
+                                void this.sendProgress(
+                                    extra,
+                                    cleaned,
+                                    messageCount,
+                                    0,
+                                );
+                            }
+                            // Don't add to responseCollector — these are progress, not final content
+                            return;
+                        }
+                    }
+
                     responseCollector.messages.push(cleaned);
                 },
             });

--- a/ts/packages/copilot-plugin/src/shared/hook-progress.ts
+++ b/ts/packages/copilot-plugin/src/shared/hook-progress.ts
@@ -16,8 +16,21 @@
 
 /**
  * Write a progress message to stdout using the Copilot CLI hook progress protocol.
- * The message appears as a transient info entry in the CLI timeline.
+ * The message appears as an info entry in the CLI timeline.
+ *
+ * Pass `{ temporary: true }` for status updates (e.g. "Connecting...") that
+ * should be replaced by the next temporary message rather than accumulate.
+ * Persistent messages (the default) stack up under the current turn.
  */
-export function emitProgress(message: string): void {
-    process.stdout.write(JSON.stringify({ type: "progress", message }) + "\n");
+export function emitProgress(
+    message: string,
+    options?: { temporary?: boolean },
+): void {
+    process.stdout.write(
+        JSON.stringify({
+            type: "progress",
+            message,
+            ...(options?.temporary ? { temporary: true } : {}),
+        }) + "\n",
+    );
 }

--- a/ts/packages/dispatcher/dispatcher/src/context/appAgentManager.ts
+++ b/ts/packages/dispatcher/dispatcher/src/context/appAgentManager.ts
@@ -1421,8 +1421,20 @@ export class AppAgentManager implements ActionConfigProvider {
             }
         }
 
-        // Fallback: read grammar/dynamic.agr from instance storage
-        if (dynamicGrammar === undefined) {
+        // Fallback: read grammar/dynamic.agr from instance storage.
+        //
+        // Only for agents that do NOT implement getDynamicGrammar. An agent that
+        // implements the callback is authoritative about which of its schemas
+        // get dynamic grammar (e.g. PowerShell returns rules for the root
+        // "powershell" schema but undefined for its sub-schemas). Without this
+        // guard, the shared per-agent grammar/dynamic.agr would be loaded into
+        // every sub-schema too, so a flow's grammar would match under a
+        // sub-schema (e.g. powershell.powershell-files) where the flow's action
+        // schema does not exist — producing "Action schema not found".
+        if (
+            dynamicGrammar === undefined &&
+            appAgent.getDynamicGrammar === undefined
+        ) {
             const instanceStorage = sessionContext.instanceStorage;
             if (instanceStorage) {
                 try {
@@ -1831,6 +1843,17 @@ export class AppAgentManager implements ActionConfigProvider {
 
         // Clear translator cache to force re-translation with new schema
         context.translatorCache.clear();
+
+        // Drop construction-cache entries whose schema hash no longer matches
+        // the reloaded schema (e.g. constructions for a deleted or edited flow),
+        // so a stale cached match can't resolve to a now-missing action.
+        try {
+            await context.agentCache.prune();
+        } catch (e) {
+            debugError(
+                `Failed to prune construction cache after reloading ${appAgentName}: ${e}`,
+            );
+        }
     }
 
     public setTraceNamespaces(namespaces: string) {

--- a/ts/packages/dispatcher/dispatcher/src/context/dispatcher/handlers/requestCommandHandler.ts
+++ b/ts/packages/dispatcher/dispatcher/src/context/dispatcher/handlers/requestCommandHandler.ts
@@ -93,7 +93,10 @@ import {
     interpretRequest,
     InterpretResult,
 } from "../../../translation/interpretRequest.js";
-import { displayStatus } from "@typeagent/agent-sdk/helpers/display";
+import {
+    displayStatus,
+    displayError,
+} from "@typeagent/agent-sdk/helpers/display";
 
 const debugExplain = registerDebug("typeagent:explain");
 const debugRequest = registerDebug("typeagent:request");
@@ -527,6 +530,7 @@ export class RequestCommandHandler implements CommandHandler {
                             }
                         },
                     );
+                    let errorReasoningResolved = false;
                     if (needsErrorReasoning) {
                         const { error, failedAction } = execResult;
                         const augmentedRequest =
@@ -553,11 +557,18 @@ export class RequestCommandHandler implements CommandHandler {
                                     },
                                 },
                             );
+                            errorReasoningResolved = true;
                         } catch (e: any) {
                             debugRequest(
                                 `Error-triggered reasoning failed, keeping original error: ${e.message}`,
                             );
                         }
+                    }
+                    // If error-triggered reasoning did not run (schema opted out)
+                    // or failed to resolve the failure, surface the original
+                    // action error instead of silently reporting success.
+                    if (!errorReasoningResolved) {
+                        displayError(execResult.error, context);
                     }
                 }
             }

--- a/ts/packages/dispatcher/dispatcher/src/reasoning/claude.ts
+++ b/ts/packages/dispatcher/dispatcher/src/reasoning/claude.ts
@@ -6,7 +6,10 @@ import {
     AppAction,
     TypeAgentAction,
 } from "@typeagent/agent-sdk";
-import { CommandHandlerContext } from "../context/commandHandlerContext.js";
+import {
+    CommandHandlerContext,
+    getCommandResult,
+} from "../context/commandHandlerContext.js";
 import { ReasoningAction } from "../context/dispatcher/schema/reasoningActionSchema.js";
 import {
     createSdkMcpServer,
@@ -226,6 +229,55 @@ function formatToolCallDisplay(toolName: string, input: any): string {
 
 const formatToolResultDisplay = sharedFormatToolResultDisplay;
 const formatThinkingDisplay = sharedFormatThinkingDisplay;
+
+const mcpExecuteActionTool = `mcp__${mcpServerName}__execute_action`;
+
+/**
+ * Recover the TypeAgent action that an `execute_action` MCP tool call ran.
+ * Returns undefined for any other tool. The reasoning loop invokes TypeAgent
+ * actions exclusively through this tool, so this is how we recover the
+ * structured actions it executed.
+ */
+function extractExecutedAction(
+    toolName: string,
+    input: any,
+): TypeAgentAction | undefined {
+    if (toolName !== mcpExecuteActionTool) {
+        return undefined;
+    }
+    const schemaName = input?.schemaName;
+    const actionName = input?.action?.actionName;
+    if (typeof schemaName !== "string" || typeof actionName !== "string") {
+        return undefined;
+    }
+    return {
+        schemaName,
+        actionName,
+        parameters: input?.action?.parameters,
+    } as TypeAgentAction;
+}
+
+/**
+ * Record actions the reasoning loop successfully executed into the dispatcher's
+ * CommandResult. Reasoning runs actions through the action-executor MCP tools,
+ * bypassing executeActions(), so without this they never appear in
+ * CommandResult.actions. Callers (e.g. the Copilot direct hook) rely on
+ * CommandResult.actions to detect that TypeAgent recognized and handled the
+ * request — a successful `learn:` registers its taskflow action this way.
+ */
+function recordReasoningActions(
+    context: ActionContext<CommandHandlerContext>,
+    actions: TypeAgentAction[],
+): void {
+    if (actions.length === 0) {
+        return;
+    }
+    const commandResult = getCommandResult(context.sessionContext.agentContext);
+    if (commandResult === undefined) {
+        return;
+    }
+    commandResult.actions = [...(commandResult.actions ?? []), ...actions];
+}
 
 function getClaudeOptions(
     context: ActionContext<CommandHandlerContext>,
@@ -530,6 +582,7 @@ function getClaudeOptions(
                 "   - description: updated description (optional)",
                 "   - grammarPatterns: updated patterns as JSON array (optional)",
                 "10. Tell user: 'Task flow registered: ACTION_NAME. It is now available for use.'",
+                "    Any example invocation phrases you show MUST follow '# Showing Invocation Examples'.",
                 "",
                 "DEV MODE RECORDING — interactive improvement loop:",
                 "When triggered with 'dev: learn: [task]':",
@@ -619,6 +672,22 @@ function getClaudeOptions(
                 "- For LLM steps: default 'claude-haiku-4-5-20251001'; 'claude-sonnet-4-6' only for",
                 "  genuinely complex multi-step reasoning",
                 "",
+                "# Showing Invocation Examples",
+                "",
+                "Whenever you tell the user a flow is registered and show example phrases to invoke",
+                "it (for TaskFlow, WebFlow, or PowerShell), derive EVERY example directly from a",
+                "grammar pattern you actually registered for that flow:",
+                "- Keep ALL fixed/literal tokens of the pattern EXACTLY as written — do not drop,",
+                "  add, reorder, or reword any of them (e.g. never shorten 'roots music report' to",
+                "  'roots report', and never append extra words the pattern does not contain).",
+                "- For each $(name:wildcard) capture substitute one concrete, realistic value; for",
+                "  each $(name:number) capture substitute a number.",
+                "- For optional tokens (word)? and alternations (a | b), pick exactly one concrete form.",
+                "- Every example you show MUST be matchable by one of the patterns you registered.",
+                "  Do NOT invent phrasings that no registered pattern covers. If you cannot produce a",
+                "  natural-sounding example from the patterns, fix the patterns (editTaskFlow / the",
+                "  equivalent) rather than showing a phrase that will not match.",
+                "",
                 "# WebFlow Recording",
                 "",
                 "WHEN TO USE WEBFLOW instead of TaskFlow:",
@@ -636,6 +705,7 @@ function getClaudeOptions(
                 "3. The flow is automatically saved to instance storage with grammar patterns and",
                 "   becomes immediately available for grammar matching.",
                 "4. Tell user: 'WebFlow registered: ACTION_NAME. It is now available for use.'",
+                "   Any example invocation phrases you show MUST follow '# Showing Invocation Examples'.",
                 "",
                 ...(process.platform === "win32"
                     ? [
@@ -664,8 +734,15 @@ function getClaudeOptions(
                           "   - scriptParameters: array of { name, type, required, description, default? }",
                           "   - grammarPatterns: array of { pattern, isAlias } with $(param:wildcard) captures",
                           "   - allowedCmdlets: cmdlets the script uses",
+                          "   - allowedModules: modules to load — pass the SAME list you used in",
+                          "     testPowerShellFlow (e.g. ['NetTCPIP'] for Get-NetTCPConnection). The",
+                          "     registered flow runs with EXACTLY the sandbox you supply here, so omitting",
+                          "     allowedModules makes module cmdlets fail at invocation with 'not recognized'",
+                          "     even though the test passed. Always carry over the exact allowedCmdlets",
+                          "     AND allowedModules that made the test succeed.",
                           "6. If testPowerShellFlow FAILS, fix the script and test again before registering",
                           "7. Tell user: 'PowerShell registered: ACTION_NAME. It is now available for use.'",
+                          "   Any example invocation phrases you show MUST follow '# Showing Invocation Examples'.",
                           "",
                           "POWERSHELL SCRIPT RULES:",
                           "- Scripts run in FullLanguage mode with cmdlet whitelisting",
@@ -857,6 +934,8 @@ async function executeReasoningWithoutPlanning(
     let toolUseCount = 0;
     let reasoningStepCount = 0;
     const toolUseIdToName = new Map<string, string>();
+    const pendingExecuteActions = new Map<string, TypeAgentAction>();
+    const executedActions: TypeAgentAction[] = [];
 
     // Process streaming response
     for await (const message of queryInstance) {
@@ -882,6 +961,13 @@ async function executeReasoningWithoutPlanning(
                     toolUseCount++;
                     reasoningStepCount++;
                     toolUseIdToName.set(content.id, content.name);
+                    const executedAction = extractExecutedAction(
+                        content.name,
+                        content.input,
+                    );
+                    if (executedAction) {
+                        pendingExecuteActions.set(content.id, executedAction);
+                    }
                     const actionInfo = extractActionInfo(
                         content.name,
                         content.input,
@@ -914,6 +1000,7 @@ async function executeReasoningWithoutPlanning(
                             {
                                 type: "html",
                                 content: formatThinkingDisplay(thinkingContent),
+                                kind: "status",
                             },
                             "block",
                         );
@@ -934,6 +1021,14 @@ async function executeReasoningWithoutPlanning(
                             }
                         } else if (typeof block.content === "string") {
                             content = block.content;
+                        }
+                        if (!isError) {
+                            const executed = pendingExecuteActions.get(
+                                block.tool_use_id,
+                            );
+                            if (executed) {
+                                executedActions.push(executed);
+                            }
                         }
                         const toolName = toolUseIdToName.get(block.tool_use_id);
                         context.actionIO.appendDiagnosticData({
@@ -982,6 +1077,8 @@ async function executeReasoningWithoutPlanning(
             "Reasoning completed with no tool calls — the model produced a text-only response and did not execute any action. No state was modified.",
         );
     }
+
+    recordReasoningActions(context, executedActions);
 
     return finalResult ? createActionResultNoDisplay(finalResult) : undefined;
 }
@@ -1039,6 +1136,8 @@ async function executeReasoningWithTracing(
         let toolUseCount = 0;
         let reasoningStepCount = 0;
         const toolUseIdToName = new Map<string, string>();
+        const pendingExecuteActions = new Map<string, TypeAgentAction>();
+        const executedActions: TypeAgentAction[] = [];
 
         // Process streaming response with tracing
         for await (const message of queryInstance) {
@@ -1065,6 +1164,16 @@ async function executeReasoningWithTracing(
                         reasoningStepCount++;
                         // Track tool_use_id → name for matching results
                         toolUseIdToName.set(content.id, content.name);
+                        const executedAction = extractExecutedAction(
+                            content.name,
+                            content.input,
+                        );
+                        if (executedAction) {
+                            pendingExecuteActions.set(
+                                content.id,
+                                executedAction,
+                            );
+                        }
                         // Record tool call for tracing
                         tracer.recordToolCall(content.name, content.input);
 
@@ -1102,6 +1211,7 @@ async function executeReasoningWithTracing(
                                     type: "html",
                                     content:
                                         formatThinkingDisplay(thinkingContent),
+                                    kind: "status",
                                 },
                                 "block",
                             );
@@ -1122,6 +1232,15 @@ async function executeReasoningWithTracing(
                                 }
                             } else if (typeof block.content === "string") {
                                 content = block.content;
+                            }
+
+                            if (!isError) {
+                                const executed = pendingExecuteActions.get(
+                                    block.tool_use_id,
+                                );
+                                if (executed) {
+                                    executedActions.push(executed);
+                                }
                             }
 
                             // Record tool result in trace for script extraction
@@ -1267,6 +1386,8 @@ async function executeReasoningWithTracing(
                 }
             }
         }
+
+        recordReasoningActions(context, executedActions);
 
         return finalResult
             ? createActionResultNoDisplay(finalResult)

--- a/ts/packages/dispatcher/dispatcher/src/validation/adversaryScorer.mts
+++ b/ts/packages/dispatcher/dispatcher/src/validation/adversaryScorer.mts
@@ -1,8 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { query } from "@anthropic-ai/claude-agent-sdk";
 import type { PatternValidationResult } from "./types.mjs";
+import {
+    runQueryWithTimeout,
+    DEFAULT_VALIDATION_QUERY_TIMEOUT_MS,
+} from "./queryWithTimeout.mjs";
 import registerDebug from "debug";
 
 const debug = registerDebug("typeagent:validation:adversary");
@@ -47,6 +50,8 @@ export interface AdversaryScorerConfig {
     model?: string;
     concurrency?: number;
     batchSize?: number;
+    /** Hard timeout for each scoring LLM call (ms). */
+    timeoutMs?: number;
 }
 
 export class AdversaryScorer {
@@ -57,6 +62,7 @@ export class AdversaryScorer {
             model: config?.model ?? "claude-sonnet-4-20250514",
             concurrency: config?.concurrency ?? 8,
             batchSize: config?.batchSize ?? 10,
+            timeoutMs: config?.timeoutMs ?? DEFAULT_VALIDATION_QUERY_TIMEOUT_MS,
         };
     }
 
@@ -96,20 +102,11 @@ export class AdversaryScorer {
         );
 
         try {
-            const queryInstance = query({
+            const responseText = await runQueryWithTimeout(
                 prompt,
-                options: { model: this.config.model },
-            });
-
-            let responseText = "";
-            for await (const message of queryInstance) {
-                if (message.type === "result") {
-                    if (message.subtype === "success") {
-                        responseText = message.result || "";
-                        break;
-                    }
-                }
-            }
+                { model: this.config.model },
+                this.config.timeoutMs,
+            );
 
             return this.parseResponse(responseText, patterns);
         } catch (error) {

--- a/ts/packages/dispatcher/dispatcher/src/validation/patternRefiner.mts
+++ b/ts/packages/dispatcher/dispatcher/src/validation/patternRefiner.mts
@@ -1,12 +1,15 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { query } from "@anthropic-ai/claude-agent-sdk";
 import type {
     CollisionDetectionResult,
     PatternValidationResult,
     RefinementResult,
 } from "./types.mjs";
+import {
+    runQueryWithTimeout,
+    DEFAULT_VALIDATION_QUERY_TIMEOUT_MS,
+} from "./queryWithTimeout.mjs";
 import registerDebug from "debug";
 
 const debug = registerDebug("typeagent:validation:refiner");
@@ -41,6 +44,8 @@ Return a JSON array of refined patterns:
 export interface PatternRefinerConfig {
     model?: string;
     maxIterations?: number;
+    /** Hard timeout for each refinement LLM call (ms). */
+    timeoutMs?: number;
 }
 
 export class PatternRefiner {
@@ -50,6 +55,7 @@ export class PatternRefiner {
         this.config = {
             model: config?.model ?? "claude-sonnet-4-20250514",
             maxIterations: config?.maxIterations ?? 2,
+            timeoutMs: config?.timeoutMs ?? DEFAULT_VALIDATION_QUERY_TIMEOUT_MS,
         };
     }
 
@@ -126,20 +132,11 @@ export class PatternRefiner {
                 originalPatterns.map((p, i) => `${i + 1}. "${p}"`).join("\n"),
             );
 
-        const queryInstance = query({
+        const responseText = await runQueryWithTimeout(
             prompt,
-            options: { model: this.config.model },
-        });
-
-        let responseText = "";
-        for await (const message of queryInstance) {
-            if (message.type === "result") {
-                if (message.subtype === "success") {
-                    responseText = message.result || "";
-                    break;
-                }
-            }
-        }
+            { model: this.config.model },
+            this.config.timeoutMs,
+        );
 
         return this.parseRefinements(responseText, originalPatterns);
     }

--- a/ts/packages/dispatcher/dispatcher/src/validation/queryWithTimeout.mts
+++ b/ts/packages/dispatcher/dispatcher/src/validation/queryWithTimeout.mts
@@ -1,0 +1,80 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { query, type Options } from "@anthropic-ai/claude-agent-sdk";
+import registerDebug from "debug";
+
+const debug = registerDebug("typeagent:validation:timeout");
+
+/**
+ * Default upper bound for a single grammar-validation LLM call.
+ *
+ * Grammar validation (adversary scoring, pattern refinement) runs while the
+ * dispatcher command lock is held, so a hung query blocks the entire
+ * dispatcher. This bounds how long any one call can stall.
+ */
+export const DEFAULT_VALIDATION_QUERY_TIMEOUT_MS = 30_000;
+
+/**
+ * Run a single-shot Claude Agent SDK query and return the final success result
+ * text, enforcing a hard timeout.
+ *
+ * On timeout the underlying query is aborted (freeing its subprocess) and this
+ * rejects, so callers fall back to a safe default instead of hanging forever.
+ *
+ * @throws if the query times out or produces no terminal result.
+ */
+export async function runQueryWithTimeout(
+    prompt: string,
+    options: Options,
+    timeoutMs: number = DEFAULT_VALIDATION_QUERY_TIMEOUT_MS,
+): Promise<string> {
+    const abortController = new AbortController();
+    let timer: ReturnType<typeof setTimeout> | undefined;
+
+    const timeoutPromise = new Promise<never>((_, reject) => {
+        timer = setTimeout(() => {
+            abortController.abort();
+            reject(
+                new Error(
+                    `Grammar validation query timed out after ${timeoutMs}ms`,
+                ),
+            );
+        }, timeoutMs);
+    });
+
+    const queryInstance = query({
+        prompt,
+        options: { ...options, abortController },
+    });
+
+    const consume = (async (): Promise<string> => {
+        let responseText = "";
+        for await (const message of queryInstance) {
+            // Break on the first terminal result regardless of subtype so an
+            // error/non-success result can't leave the stream open and hang.
+            if (message.type === "result") {
+                if (message.subtype === "success") {
+                    responseText = message.result ?? "";
+                }
+                break;
+            }
+        }
+        return responseText;
+    })();
+
+    // If the timeout wins the race, the consume promise may reject later when
+    // the abort propagates — swallow it so it doesn't surface as an unhandled
+    // rejection.
+    consume.catch((error) => {
+        debug(`query consumption settled after race: ${error}`);
+    });
+
+    try {
+        return await Promise.race([consume, timeoutPromise]);
+    } finally {
+        if (timer !== undefined) {
+            clearTimeout(timer);
+        }
+    }
+}


### PR DESCRIPTION
This pull request introduces several improvements and fixes across the PowerShell and TaskFlow agents, the Copilot plugin, and the command executor. The main highlights are enhanced flow management (including module support for PowerShell flows), improved grammar validation handling for TaskFlow, better separation of logs and protocol streams for the command executor, and the addition of a developer-friendly Copilot plugin launch script.

**PowerShell Agent Improvements:**

* Added support for specifying `allowedModules` when creating or editing PowerShell flows, enabling scripts to import required PowerShell modules beyond the default. This change propagates through schema definitions, flow handling, and storage logic. [[1]](diffhunk://#diff-507c4463729d0726c89d01529116ed7916b1e7bec38016419f82d2051b18de29R302-R304) [[2]](diffhunk://#diff-f0af3e2b7de54f4941e73ce4b6f506a2ca7cc2c973127ec9fe3543e7c111e051R58-R62) [[3]](diffhunk://#diff-f0af3e2b7de54f4941e73ce4b6f506a2ca7cc2c973127ec9fe3543e7c111e051R76-R77) [[4]](diffhunk://#diff-96fb945b91909dd0416519f3a4ba9c033c1b453c72946d20d9f8fc96eba85c82R170) [[5]](diffhunk://#diff-96fb945b91909dd0416519f3a4ba9c033c1b453c72946d20d9f8fc96eba85c82L178-R185) [[6]](diffhunk://#diff-507c4463729d0726c89d01529116ed7916b1e7bec38016419f82d2051b18de29L383-R387) [[7]](diffhunk://#diff-507c4463729d0726c89d01529116ed7916b1e7bec38016419f82d2051b18de29R433-R442)
* Introduced a `validateWildcardMatch` function to ensure dynamic flow actions are only valid if the corresponding flow exists, preventing stale action references. Built-in management actions are always valid. [[1]](diffhunk://#diff-507c4463729d0726c89d01529116ed7916b1e7bec38016419f82d2051b18de29R1030-R1041) [[2]](diffhunk://#diff-507c4463729d0726c89d01529116ed7916b1e7bec38016419f82d2051b18de29R1093-R1109)

**TaskFlow Agent Enhancements:**

* Grammar pattern validation during flow creation is now bounded by a 15-second timeout, ensuring that flow authoring never blocks indefinitely on slow LLM validation. If validation doesn't finish in time, a warning is issued and authoring proceeds. [[1]](diffhunk://#diff-991b943fecdc0900e5f406f2a3ea687bb0993a280f8116215f69dbdf6d11316bR39-R73) [[2]](diffhunk://#diff-991b943fecdc0900e5f406f2a3ea687bb0993a280f8116215f69dbdf6d11316bL215-R275) [[3]](diffhunk://#diff-991b943fecdc0900e5f406f2a3ea687bb0993a280f8116215f69dbdf6d11316bL245-R293) [[4]](diffhunk://#diff-991b943fecdc0900e5f406f2a3ea687bb0993a280f8116215f69dbdf6d11316bR312)
* Added a `validateWildcardMatch` function for dynamic actions, mirroring the PowerShell agent's logic to reject actions for deleted flows. [[1]](diffhunk://#diff-991b943fecdc0900e5f406f2a3ea687bb0993a280f8116215f69dbdf6d11316bR564-R572) [[2]](diffhunk://#diff-991b943fecdc0900e5f406f2a3ea687bb0993a280f8116215f69dbdf6d11316bR612-R624)

**Developer Experience & Infrastructure:**

* Added a new script, `launch-dev.mjs`, and a corresponding `copilot:dev` npm script for launching the Copilot plugin with a locally-built runtime, streamlining development and testing workflows. [[1]](diffhunk://#diff-3fd4b7991d25f2d5c58511fa1e37a64f5bee7b2cdd85893d8a08229eaf40d6c4R1-R92) [[2]](diffhunk://#diff-89b74a391647a4bcf5a7cabb2e0764b7d650feb2f95d4a5b0c06ff16777a9fe4R29)
* Improved the command executor's logging by redirecting logs to stderr to avoid corrupting the JSON-RPC protocol stream, and updated startup/shutdown messages accordingly. [[1]](diffhunk://#diff-efbcf549451b1d6faa2339bc985fee3f5c11552752905f0051fdbaab76e5fd6dL148-R149) [[2]](diffhunk://#diff-f96a6cbd3bd1984c11d353ebc170063507ed1b8cd0076c8a4bb786af9aaff5c7L10-R17)

**Other Notable Changes:**

* The CLI's enhanced console now ensures that pressing Enter submits the input as typed, never mutating it by accepting an inline completion (which must be explicitly accepted with Tab).
* The PowerShell agent manifest now enables error reasoning by default.
* Minor import improvements to maintain type safety and clarity. [[1]](diffhunk://#diff-507c4463729d0726c89d01529116ed7916b1e7bec38016419f82d2051b18de29R6) [[2]](diffhunk://#diff-991b943fecdc0900e5f406f2a3ea687bb0993a280f8116215f69dbdf6d11316bR6-R12) [[3]](diffhunk://#diff-fb32d22bb37f48acf171b703fb2f110372028bb2193b372877719b8977b54900L12-R15)