### PR TITLE
chore(graph-utils): export GraphClient base class

### DIFF
--- a/ts/packages/agents/agentUtils/graphUtils/src/index.ts
+++ b/ts/packages/agents/agentUtils/graphUtils/src/index.ts
@@ -14,7 +14,7 @@ export {
 export { createCalendarGraphClient, CalendarClient } from "./calendarClient.js";
 export { createMailGraphClient, MailClient } from "./mailClient.js";
 export { GraphEntity } from "./graphEntity.js";
-export { ErrorResponse } from "./graphClient.js";
+export { GraphClient, ErrorResponse } from "./graphClient.js";
 
 // Calendar Provider abstraction (multi-provider support)
 export {


### PR DESCRIPTION
Make the `GraphClient` base class available alongside `CalendarClient` / `MailClient` (which already extend it) so downstream agents can build new Microsoft Graph–backed clients without copying the auth/transport plumbing.

### Change
`ts/packages/agents/agentUtils/graphUtils/src/index.ts` — add `GraphClient` to the existing named re-export from `./graphClient.js`.

### Risk
Additive-only. No existing consumer breaks because the export was previously narrower; all current callers use the more specific subclasses or `ErrorResponse`.

### Test
- `pnpm --filter graph-utils build` ✓
- `pnpm --filter graph-utils prettier` ✓
- Verified `GraphClient` shows up in `dist/index.d.ts` after the change.