### PR TITLE
Fix build warnings

### DIFF
--- a/ts/packages/textPro/src/html.ts
+++ b/ts/packages/textPro/src/html.ts
@@ -551,7 +551,6 @@ export class HtmlToMdConvertor {
             case "h6":
             case "span":
             case "code":
-            case "code":
             case "blockquote":
                 this.appendInnerText(element);
                 break;

--- a/ts/packages/textPro/src/markdown.ts
+++ b/ts/packages/textPro/src/markdown.ts
@@ -339,9 +339,6 @@ export class MarkdownKnowledgeCollector implements MarkdownBlockHandler {
             case "heading":
                 this.onHeading(token as md.Tokens.Heading);
                 break;
-            case "image":
-                this.onImage(token as md.Tokens.Image);
-                break;
             case "link":
                 this.onLink(token as md.Tokens.Link);
                 break;


### PR DESCRIPTION
This pull request makes minor code cleanups in the HTML and Markdown parsing logic, removing unnecessary or duplicate case handling from the switch statements.

- In `HtmlToMdConvertor` (`html.ts`), a duplicate case for `"code"` was removed from the element processing switch statement.
- In `MarkdownKnowledgeCollector` (`markdown.ts`), the case for `"image"` was removed from the token handling switch statement.