### PR TITLE
Align Spotify agent with new spotify api updates

### DIFF
--- a/ts/packages/agents/player/README.md
+++ b/ts/packages/agents/player/README.md
@@ -7,15 +7,32 @@ To turn on Spotify integration you will need additional setup with Spotify to us
 1. Go to https://developer.spotify.com/dashboard.
 2. Log into Spotify with your user account if you are not already logged in.
 3. Click the button in the upper right labeled "Create App".
-4. Fill in the form, making sure the Redirect URI is http://127.0.0.1:PORT/callback, where PORT is a **_previously unused_** four-digit port number you choose for the authorization redirect.
+4. Fill in the form, making sure the Redirect URI is `http://127.0.0.1:PORT/callback`, where `PORT` is a **_previously unused_** four-digit port number you choose for the authorization redirect.
 5. Click the settings button and copy down the Client ID and Client Secret (the client secret requires you to click 'View client secret').
-6. In your `config.local.yaml`, set the Spotify credentials under the `spotify` section (see `config.sample.yaml`). Or in the legacy `.env` file, set `SPOTIFY_APP_CLI` to your Client ID and `SPOTIFY_APP_CLISEC` to your Client Secret. Also set `SPOTIFY_APP_PORT` to the PORT on your local machine that you chose in step 4.
+6. In your `config.local.yaml`, set the Spotify credentials under the `spotify` section (see `config.sample.yaml`):
+   ```yaml
+   spotify:
+     clientId: <your-client-id>
+     clientSecret: <your-client-secret>
+     port: <PORT> # must match the redirect URI you registered in step 4
+   ```
+   The legacy `.env` file is also still supported: set `SPOTIFY_APP_CLI` to your Client ID, `SPOTIFY_APP_CLISEC` to your Client Secret, and `SPOTIFY_APP_PORT` to the port from step 4.
+7. While your Spotify app is in [Development Mode](https://developer.spotify.com/documentation/web-api/concepts/quota-modes), open the app's **User Management** page on the dashboard and add the Spotify account(s) that will use the integration. Accounts that are not on this allowlist will get `403 Forbidden` from most Web API endpoints.
+
+> [!NOTE]
+> Several Web API endpoints (playback control, playlist read/write, the Web Playback SDK) require a Spotify **Premium** account. Free accounts can sign in but most actions will fail.
 
 ## Music Player Spotify Integration
 
-To turn on Spotify in the shell or interactive mode, run `@config spotify on`. There will be an one time authorization with the browser for the new app to access your account. Afterward, refresh token will be store in `$(HOME)/.typeagent/profiles/<profile>/player/token.json` to get the access token again without prompting.
+The `player` agent (package name `music`) implements Spotify support. Enable it like any other agent, then do a one-time OAuth login:
 
-You can use `@config spotify off`, to turn off running the action.
+1. Enable the agent: `@config agent player on`
+2. Authenticate: `@player spotify login` — this opens the browser for a one-time authorization. Afterward, the refresh token is stored (DPAPI-encrypted on Windows, Keychain on macOS, libsecret on Linux via `@azure/msal-node-extensions`) at `$(HOME)/.typeagent/profiles/<profile>/player/token`, so subsequent runs mint access tokens without prompting.
+3. (Optional) Load Spotify listening history: `@player spotify load <path-to-history-file>`
+4. To clear the cached token: `@player spotify logout`
+5. To disable the agent entirely: `@config agent player off`
+
+To actually hear audio, an active Spotify client must be running and signed in as the same user (the Spotify desktop app, mobile app, or any browser tab on `open.spotify.com`) — the agent controls playback on whichever device Spotify reports as active.
 
 ## Trademarks
 

--- a/ts/packages/agents/player/src/client.ts
+++ b/ts/packages/agents/player/src/client.ts
@@ -51,7 +51,7 @@ import {
     addTracksToPlaylist,
     getRecommendationsFromTrackCollection,
     getRecentlyPlayed,
-    limitMax,
+    searchLimitMax,
 } from "./endpoints.js";
 import { htmlStatus, printStatus } from "./playback.js";
 import { SpotifyService } from "./service.js";
@@ -449,7 +449,7 @@ export async function searchTracks(
     const query: SpotifyApi.SearchForItemParameterObject = {
         q: queryString,
         type: "track",
-        limit: limitMax,
+        limit: searchLimitMax,
         offset: 0,
     };
     const data = await search(query, context.service);
@@ -465,7 +465,7 @@ export async function searchForPlaylists(
     const query: SpotifyApi.SearchForItemParameterObject = {
         q: queryString,
         type: "playlist",
-        limit: limitMax,
+        limit: searchLimitMax,
         offset: 0,
     };
     const data = await search(query, context.service);

--- a/ts/packages/agents/player/src/client.ts
+++ b/ts/packages/agents/player/src/client.ts
@@ -852,29 +852,21 @@ async function playPlaylistAction(
         }
     }
     if (playlist) {
-        const playlistResponse = await getPlaylistTracks(
+        const tracks = await getPlaylistTracks(
             clientContext.service,
             playlist.id,
         );
-        if (playlistResponse) {
-            const collection = new PlaylistTrackCollection(
-                playlist,
-                playlistResponse.items.map((item) => item.track!),
-            );
-            let actionResult = await playTrackCollection(
-                collection,
-                clientContext,
-            );
+        const collection = new PlaylistTrackCollection(playlist, tracks);
+        let actionResult = await playTrackCollection(collection, clientContext);
 
-            // add the playlist as an entity
-            actionResult.entities.push({
-                name: playlist.name,
-                type: ["playlist"],
-                uniqueId: playlist.id,
-            });
+        // add the playlist as an entity
+        actionResult.entities.push({
+            name: playlist.name,
+            type: ["playlist"],
+            uniqueId: playlist.id,
+        });
 
-            return actionResult;
-        }
+        return actionResult;
     }
     return createNotFoundActionResult(`playlist ${playlistName}`);
 }
@@ -1147,22 +1139,17 @@ export async function handleCall(
                 }
             }
             if (playlist) {
-                const playlistResponse = await getPlaylistTracks(
+                const tracks = await getPlaylistTracks(
                     clientContext.service,
                     playlist.id,
                 );
-                if (playlistResponse) {
-                    const collection = new PlaylistTrackCollection(
-                        playlist,
-                        playlistResponse.items.map((item) => item.track!),
-                    );
-                    console.log(chalk.magentaBright("Playlist:"));
-                    await updateTrackListAndPrint(collection, clientContext);
-                    return htmlTrackNames(
-                        collection,
-                        `Playlist: ${playlist.name}`,
-                    );
-                }
+                const collection = new PlaylistTrackCollection(
+                    playlist,
+                    tracks,
+                );
+                console.log(chalk.magentaBright("Playlist:"));
+                await updateTrackListAndPrint(collection, clientContext);
+                return htmlTrackNames(collection, `Playlist: ${playlist.name}`);
             }
             return createNotFoundActionResult(`Playlist ${playlistName}`);
         }
@@ -1197,26 +1184,21 @@ export async function handleCall(
                         clientContext.userData!.data,
                     );
 
-                    const playlistResponse = await getPlaylistTracks(
+                    const tracks = await getPlaylistTracks(
                         clientContext.service,
                         playlist.id,
                     );
 
-                    if (playlistResponse) {
-                        const collection = new PlaylistTrackCollection(
-                            playlist,
-                            playlistResponse.items.map((item) => item.track!),
-                        );
-                        console.log(chalk.magentaBright("Playlist:"));
-                        await updateTrackListAndPrint(
-                            collection,
-                            clientContext,
-                        );
-                        return htmlTrackNames(
-                            collection,
-                            `Playlist: ${playlist.name}`,
-                        );
-                    }
+                    const collection = new PlaylistTrackCollection(
+                        playlist,
+                        tracks,
+                    );
+                    console.log(chalk.magentaBright("Playlist:"));
+                    await updateTrackListAndPrint(collection, clientContext);
+                    return htmlTrackNames(
+                        collection,
+                        `Playlist: ${playlist.name}`,
+                    );
                 } else {
                     return createErrorActionResult("No playlist found");
                 }

--- a/ts/packages/agents/player/src/endpoints.ts
+++ b/ts/packages/agents/player/src/endpoints.ts
@@ -665,39 +665,28 @@ export async function addTracksToPlaylist(
 export async function getPlaylistTracks(
     service: SpotifyService,
     playlistId: string,
-) {
-    // /tracks was deprecated 2024-11-27 (returns 403); /items is the replacement
-    // but renames `items[].track` to `items[].item` (with an `item.type`
-    // discriminator). Normalize back to the legacy shape and drop non-track
-    // items (e.g. episodes) so callers can keep using PlaylistTrackResponse.
-    const response = await fetchGet<SpotifyApi.PlaylistTrackResponse>(
+): Promise<SpotifyApi.TrackObjectFull[]> {
+    // /tracks was deprecated 2024-11-27 (returns 403); use /items instead. Each
+    // entry's payload lives under `.item` and may be a track or an episode —
+    // keep only tracks so callers get a clean TrackObjectFull[].
+    type PlaylistItem = {
+        item?: SpotifyApi.TrackObjectFull & { type?: string };
+    };
+    const response = await fetchGet<{ items: PlaylistItem[] }>(
         service,
         `https://api.spotify.com/v1/playlists/${encodeURIComponent(playlistId)}/items`,
     );
-    if (response?.items) {
-        const normalized: SpotifyApi.PlaylistTrackObject[] = [];
-        for (const raw of response.items as unknown[]) {
-            const item = raw as Partial<SpotifyApi.PlaylistTrackObject> & {
-                item?: SpotifyApi.TrackObjectFull & { type?: string };
-            };
-            if (item.track) {
-                normalized.push(item as SpotifyApi.PlaylistTrackObject);
-                continue;
-            }
-            const payload = item.item;
-            if (
-                payload &&
-                (payload.type === undefined || payload.type === "track")
-            ) {
-                normalized.push({
-                    ...item,
-                    track: payload,
-                } as SpotifyApi.PlaylistTrackObject);
-            }
+    const tracks: SpotifyApi.TrackObjectFull[] = [];
+    for (const entry of response.items ?? []) {
+        const payload = entry.item;
+        if (
+            payload &&
+            (payload.type === undefined || payload.type === "track")
+        ) {
+            tracks.push(payload);
         }
-        response.items = normalized;
     }
-    return response;
+    return tracks;
 }
 
 export async function deletePlaylist(

--- a/ts/packages/agents/player/src/endpoints.ts
+++ b/ts/packages/agents/player/src/endpoints.ts
@@ -8,8 +8,12 @@ import { createFetchError } from "./utils.js";
 const debugSpotifyRest = registerDebug("typeagent:spotify:rest");
 const debugSpotifyRestVerbose = registerDebug("typeagent:spotify-verbose:rest");
 
-/** Maximum number of items per Spotify API request */
+// Default page size. Most paginated Spotify endpoints accept up to 50.
 export const limitMax = 50;
+
+// /v1/search silently caps `limit` at 10 (undocumented; >10 returns 400
+// "Invalid limit"). Other paginated endpoints still accept limitMax.
+export const searchLimitMax = 10;
 
 export async function search(
     query: SpotifyApi.SearchForItemParameterObject,
@@ -652,7 +656,8 @@ export async function addTracksToPlaylist(
 ) {
     return fetchPost<SpotifyApi.AddTracksToPlaylistResponse>(
         service,
-        `https://api.spotify.com/v1/playlists/${encodeURIComponent(playlistId)}/tracks`,
+        // /tracks was deprecated 2024-11-27 and now 403s; /items is the replacement.
+        `https://api.spotify.com/v1/playlists/${encodeURIComponent(playlistId)}/items`,
         { uris: trackUris },
     );
 }
@@ -661,10 +666,38 @@ export async function getPlaylistTracks(
     service: SpotifyService,
     playlistId: string,
 ) {
-    return fetchGet<SpotifyApi.PlaylistTrackResponse>(
+    // /tracks was deprecated 2024-11-27 (returns 403); /items is the replacement
+    // but renames `items[].track` to `items[].item` (with an `item.type`
+    // discriminator). Normalize back to the legacy shape and drop non-track
+    // items (e.g. episodes) so callers can keep using PlaylistTrackResponse.
+    const response = await fetchGet<SpotifyApi.PlaylistTrackResponse>(
         service,
-        `https://api.spotify.com/v1/playlists/${encodeURIComponent(playlistId)}/tracks`,
+        `https://api.spotify.com/v1/playlists/${encodeURIComponent(playlistId)}/items`,
     );
+    if (response?.items) {
+        const normalized: SpotifyApi.PlaylistTrackObject[] = [];
+        for (const raw of response.items as unknown[]) {
+            const item = raw as Partial<SpotifyApi.PlaylistTrackObject> & {
+                item?: SpotifyApi.TrackObjectFull & { type?: string };
+            };
+            if (item.track) {
+                normalized.push(item as SpotifyApi.PlaylistTrackObject);
+                continue;
+            }
+            const payload = item.item;
+            if (
+                payload &&
+                (payload.type === undefined || payload.type === "track")
+            ) {
+                normalized.push({
+                    ...item,
+                    track: payload,
+                } as SpotifyApi.PlaylistTrackObject);
+            }
+        }
+        response.items = normalized;
+    }
+    return response;
 }
 
 export async function deletePlaylist(
@@ -693,7 +726,7 @@ export async function createPlaylist(
     }
     return fetchPost<SpotifyApi.AddTracksToPlaylistResponse>(
         service,
-        `https://api.spotify.com/v1/playlists/${playlistResponse.id}/tracks`,
+        `https://api.spotify.com/v1/playlists/${playlistResponse.id}/items`,
         { uris },
     );
 }


### PR DESCRIPTION
**Patch the Spotify player agent for three recent Web API breaking changes:** 

1. Switched the deprecated /playlists/{id}/tracks endpoint to /items (with getPlaylistTracks rewritten to return TrackObjectFull[] and read the renamed items[].item payload)
2. Added a separate searchLimitMax = 10 constant for /search (which silently dropped its cap from 50, while other paginated endpoints still accept 50). 
3. Also refreshed the player README with the correct @config agent player on / @player spotify login commands, the current DPAPI-encrypted token cache path, and the Dev Mode user-allowlist plus Premium-account prerequisites.