### PR TITLE
Generate grammar files for coda

### DIFF
--- a/ts/packages/agents/code/package.json
+++ b/ts/packages/agents/code/package.json
@@ -17,6 +17,14 @@
     "./agent/handlers": "./dist/codeActionHandler.js"
   },
   "scripts": {
+    "agc": "agc -i ./src/codeSchema.agr -o ./dist/codeSchema.ag.json",
+    "agc:all": "concurrently npm:agc npm:agc:debug npm:agc:display npm:agc:general npm:agc:workbench npm:agc:extension npm:agc:vscode-shell",
+    "agc:debug": "agc -i ./src/vscode/debugActionsSchema.agr -o ./dist/debugSchema.ag.json",
+    "agc:display": "agc -i ./src/vscode/displayActionsSchema.agr -o ./dist/displaySchema.ag.json",
+    "agc:extension": "agc -i ./src/vscode/extensionsActionsSchema.agr -o ./dist/extensionSchema.ag.json",
+    "agc:general": "agc -i ./src/vscode/generalActionsSchema.agr -o ./dist/generalSchema.ag.json",
+    "agc:vscode-shell": "agc -i ./src/vscode/vscodeConversationActionsSchema.agr -o ./dist/vscodeShellSchema.ag.json",
+    "agc:workbench": "agc -i ./src/vscode/workbenchCommandActionsSchema.agr -o ./dist/workbenchSchema.ag.json",
     "asc": "asc -i ./src/codeActionsSchema.ts -o ./dist/codeSchema.pas.json -t CodeActions -a CodeActivity",
     "asc:all": "concurrently npm:asc npm:asc:debug npm:asc:display npm:asc:general npm:asc:editor npm:asc:workbench npm:asc:extension npm:asc:vscode-shell",
     "asc:debug": "asc -i ./src/vscode/debugActionsSchema.ts -o ./dist/debugSchema.pas.json -t CodeDebugActions",
@@ -26,7 +34,7 @@
     "asc:general": "asc -i ./src/vscode/generalActionsSchema.ts -o ./dist/generalSchema.pas.json -t CodeGeneralActions",
     "asc:vscode-shell": "asc -i ./src/vscode/vscodeConversationActionsSchema.ts -o ./dist/vscodeShellSchema.pas.json -t VSCodeConversationActions",
     "asc:workbench": "asc -i ./src/vscode/workbenchCommandActionsSchema.ts -o ./dist/workbenchSchema.pas.json -t CodeWorkbenchActions",
-    "build": "concurrently npm:tsc npm:asc:all",
+    "build": "concurrently npm:tsc npm:asc:all npm:agc:all",
     "clean": "rimraf --glob dist *.tsbuildinfo *.done.build.log",
     "jest-esm": "node --no-warnings --experimental-vm-modules ./node_modules/jest/bin/jest.js",
     "prettier": "prettier --check . --ignore-path ../../../.prettierignore",
@@ -50,6 +58,7 @@
     "@types/debug": "^4.1.12",
     "@types/jest": "^29.5.7",
     "@types/ws": "^8.5.10",
+    "action-grammar-compiler": "workspace:*",
     "concurrently": "^9.1.2",
     "jest": "^29.7.0",
     "prettier": "^3.5.3",
@@ -58,6 +67,97 @@
   },
   "fluidBuild": {
     "tasks": {
+      "agc": {
+        "dependsOn": [
+          "action-grammar-compiler#tsc"
+        ],
+        "files": {
+          "inputGlobs": [
+            "src/codeSchema.agr"
+          ],
+          "outputGlobs": [
+            "dist/codeSchema.ag.json"
+          ]
+        }
+      },
+      "agc:debug": {
+        "dependsOn": [
+          "action-grammar-compiler#tsc"
+        ],
+        "files": {
+          "inputGlobs": [
+            "src/vscode/debugActionsSchema.agr"
+          ],
+          "outputGlobs": [
+            "dist/debugSchema.ag.json"
+          ]
+        }
+      },
+      "agc:display": {
+        "dependsOn": [
+          "action-grammar-compiler#tsc"
+        ],
+        "files": {
+          "inputGlobs": [
+            "src/vscode/displayActionsSchema.agr"
+          ],
+          "outputGlobs": [
+            "dist/displaySchema.ag.json"
+          ]
+        }
+      },
+      "agc:extension": {
+        "dependsOn": [
+          "action-grammar-compiler#tsc"
+        ],
+        "files": {
+          "inputGlobs": [
+            "src/vscode/extensionsActionsSchema.agr"
+          ],
+          "outputGlobs": [
+            "dist/extensionSchema.ag.json"
+          ]
+        }
+      },
+      "agc:general": {
+        "dependsOn": [
+          "action-grammar-compiler#tsc"
+        ],
+        "files": {
+          "inputGlobs": [
+            "src/vscode/generalActionsSchema.agr"
+          ],
+          "outputGlobs": [
+            "dist/generalSchema.ag.json"
+          ]
+        }
+      },
+      "agc:vscode-shell": {
+        "dependsOn": [
+          "action-grammar-compiler#tsc"
+        ],
+        "files": {
+          "inputGlobs": [
+            "src/vscode/vscodeConversationActionsSchema.agr"
+          ],
+          "outputGlobs": [
+            "dist/vscodeShellSchema.ag.json"
+          ]
+        }
+      },
+      "agc:workbench": {
+        "dependsOn": [
+          "action-grammar-compiler#tsc"
+        ],
+        "files": {
+          "inputGlobs": [
+            "src/vscode/workbenchCommandActionsSchema.agr"
+          ],
+          "outputGlobs": [
+            "dist/workbenchSchema.ag.json"
+          ]
+        }
+      },
       "asc": {
         "dependsOn": [
           "@typeagent/action-schema-compiler#tsc"

--- a/ts/packages/agents/code/src/codeManifest.json
+++ b/ts/packages/agents/code/src/codeManifest.json
@@ -6,6 +6,7 @@
     "description": "Code agent helps you with productivity in using an editor and performing actions like creating files, editor customization, writing code, intelligent code suggestions, real-time error detection, debugging, and source control tasks etc.",
     "originalSchemaFile": "./codeActionsSchema.ts",
     "schemaFile": "../dist/codeSchema.pas.json",
+    "grammarFile": "../dist/codeSchema.ag.json",
     "schemaType": {
       "action": "CodeActions",
       "activity": "CodeActivity"
@@ -17,6 +18,7 @@
         "description": "Code agent that helps you debug code including handling actions like showing the debug panel, adding/toggling breakpoints, stepping in/out of code etc.",
         "originalSchemaFile": "./vscode/debugActionsSchema.ts",
         "schemaFile": "../dist/debugSchema.pas.json",
+        "grammarFile": "../dist/debugSchema.ag.json",
         "schemaType": "CodeDebugActions"
       }
     },
@@ -25,6 +27,7 @@
         "description": "Code agent that helps you work with display keyboard bindings, Zoom in, Zoom out, do text search and replace, show extensions etc.",
         "originalSchemaFile": "./vscode/displayActionsSchema.ts",
         "schemaFile": "../dist/displaySchema.pas.json",
+        "grammarFile": "../dist/displaySchema.ag.json",
         "schemaType": "CodeDisplayActions"
       }
     },
@@ -33,6 +36,7 @@
         "description": "Code agent that helps you navigate within an already-open editor: find a file in the workspace, go to a symbol or line, open a new vscode window, show the command palette, open user settings json, etc.",
         "originalSchemaFile": "./vscode/generalActionsSchema.ts",
         "schemaFile": "../dist/generalSchema.pas.json",
+        "grammarFile": "../dist/generalSchema.ag.json",
         "schemaType": "CodeGeneralActions"
       }
     },
@@ -49,6 +53,7 @@
         "description": "Code agent that helps you perform vscode workbench actions like open a file, close a file etc.",
         "originalSchemaFile": "./vscode/workbenchCommandActionsSchema.ts",
         "schemaFile": "../dist/workbenchSchema.pas.json",
+        "grammarFile": "../dist/workbenchSchema.ag.json",
         "schemaType": "CodeWorkbenchActions"
       }
     },
@@ -57,6 +62,7 @@
         "description": "Code agent that helps you perform vscode extension actions like show, install, update, enable, disable, uninstall extensions etc.",
         "originalSchemaFile": "./vscode/extensionsActionsSchema.ts",
         "schemaFile": "../dist/extensionSchema.pas.json",
+        "grammarFile": "../dist/extensionSchema.ag.json",
         "schemaType": "CodeWorkbenchExtensionActions"
       }
     },
@@ -66,6 +72,7 @@
         "description": "Manage TypeAgent Shell conversations (chat tabs in the TypeAgent VS Code Shell extension): create a new conversation, rename the current conversation, or switch to an existing conversation by name.",
         "originalSchemaFile": "./vscode/vscodeConversationActionsSchema.ts",
         "schemaFile": "../dist/vscodeShellSchema.pas.json",
+        "grammarFile": "../dist/vscodeShellSchema.ag.json",
         "schemaType": "VSCodeConversationActions"
       }
     }

--- a/ts/packages/agents/code/src/codeSchema.agr
+++ b/ts/packages/agents/code/src/codeSchema.agr
@@ -1,33 +1,98 @@
-// Copyright (c) 2024 Code Grammar
-// Natural language interface for code editor actions
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+//
+// Natural language interface for code editor actions.
 
-import { CodeActions } from "./codeActionsSchema.ts";
+import { CodeActions, CodeActivity } from "./codeActionsSchema.ts";
 
-// Start rule - all available actions
-<Start> : CodeActions = <changeColorScheme> | <changeColorSchemeTo> | <splitEditor> | <splitEditorSimple> | <changeEditorLayout> | <newCodeFile> | <newMarkdownFile> | <newTextFile> | <launchVSCode>;
+// <Start> accepts both CodeActions (one-shot) and CodeActivity (long-running).
+// The grammar matcher only recognises a single <Start> entry point; mixing
+// both unions here lets <launchVSCode> (an Activity) coexist with the
+// regular CodeAction rules.
+<Start> : CodeActions | CodeActivity = <changeColorScheme>
+  | <changeColorSchemeTo>
+  | <splitEditor>
+  | <splitEditorSimple>
+  | <changeEditorLayout>
+  | <newCodeFile>
+  | <newMarkdownFile>
+  | <newTextFile>
+  | <launchVSCode>;
 
-// Main action rules
-<changeColorScheme> = <Polite> ('change' | 'switch' | 'set') ('to' | 'the')? $(theme:string) ('color scheme' | 'theme') -> { actionName: "changeColorScheme", parameters: { theme: theme } };
+// Theme name sub-rule — maps user-friendly tokens to canonical TS ColorTheme
+// literals. ColorTheme members contain '+' which isn't a valid literal token
+// character in the grammar DSL, so the mapping happens here.
+<Theme> = 'monokai dimmed' -> "Monokai Dimmed"
+  | 'monokai' -> "Monokai"
+  | 'solarized dark' -> "Solarized Dark"
+  | 'solarized light' -> "Solarized Light"
+  | 'quiet light' -> "Quiet Light"
+  | 'kimbie dark' -> "Kimbie Dark"
+  | 'abyss' -> "Abyss"
+  | 'red' -> "Red"
+  | ('default high contrast light' | 'high contrast light' | 'high contrast') -> "Default High Contrast Light"
+  | ('default light' | 'light') -> "Default Light+"
+  | ('default dark' | 'dark') -> "Default Dark+";
 
-// Theme name AFTER 'to': "change my [vscode] color theme to Monokai", "set the editor theme to Solarized Dark"
-<changeColorSchemeTo> = <Polite> ('change' | 'switch' | 'set') ('my' | 'the')? ('vscode' | 'code' | 'editor')? ('color scheme' | 'color theme' | 'theme') 'to' $(theme:string) -> { actionName: "changeColorScheme", parameters: { theme: theme } };
+// Code file language sub-rule — maps user-friendly tokens to the canonical
+// TS CodeFileLanguage literals (TS uses camelCase 'javaScript'/'typeScript').
+<CodeLang> = 'html' -> "html"
+  | 'css' -> "css"
+  | 'json' -> "json"
+  | 'python' -> "python"
+  | ('javascript' | 'js') -> "javaScript"
+  | ('typescript' | 'ts') -> "typeScript";
 
-<splitEditor> = <Polite> 'split' ('the'? 'editor')? $(direction:string) ('and'? ('open' | 'put' | 'place'))? $(fileName:string) ('in' | 'on' | 'to') 'the'? $(editorPosition:string) ('side' | 'panel' | 'half')? -> { actionName: "splitEditor", parameters: { direction: direction, editorPosition: editorPosition, fileName: fileName } };
+// String-literal-union sub-rules. The grammar DSL allows $(name:<SubRule>)
+// but not $(name:(a|b|c)), so each union gets a sub-rule that echoes the
+// matched token as its canonical literal.
+<SplitDirection> = 'right' -> "right"
+  | 'left' -> "left"
+  | 'up' -> "up"
+  | 'down' -> "down";
 
-// Direction-only split for the active editor: "split the editor to the right", "split editor right"
-<splitEditorSimple> = <Polite> 'split' ('the')? 'editor' ('to' 'the'?)? $(direction:string) ('side' | 'panel' | 'half')? -> { actionName: "splitEditor", parameters: { direction: direction } };
+<EditorPos> = 'first' -> "first"
+  | 'last' -> "last"
+  | 'active' -> "active";
 
-<changeEditorLayout> = <Polite> ('change' | 'switch' | 'set' | 'go back') ('to' | 'the'? 'editor' 'to')? ('a'? | 'up')? $(columnCount:string) ('column' | 'pane') ('layout' | 'view' | 'mode')? -> { actionName: "changeEditorLayout", parameters: { columnCount: columnCount } };
+<LayoutCols> = 'single' -> "single"
+  | 'double' -> "double"
+  | 'three' -> "three";
 
-<newCodeFile> = <Polite> ('create' | 'make') ('a'? 'new')? $(language:string) 'file' ('called' | 'named')? $(fileName:string) ('with' | 'and' 'add')? $(content:string)? -> { actionName: "newCodeFile", parameters: { fileName: fileName, language: language, content: content } };
+<LaunchMode> = 'last' -> "last"
+  | 'folder' -> "folder"
+  | 'workspace' -> "workspace";
 
-<newMarkdownFile> = <Polite> ('create' | 'make') ('a'? 'new')? ('markdown' | 'md') 'file' ('called' | 'named')? $(fileName:string) ('with' | 'and' 'add')? $(content:string)? -> { actionName: "newMarkdownFile", parameters: { fileName: fileName, content: content } };
+// "change my color theme to Monokai" / "set the editor theme to Solarized Dark"
+<changeColorScheme> = <Polite> ('change' | 'switch' | 'set') ('my' | 'the')? ('vscode' | 'code' | 'editor')? ('color scheme' | 'color theme' | 'theme') 'to' $(theme:<Theme>) -> { actionName: "changeColorScheme", parameters: { theme: theme } };
 
-<newTextFile> = <Polite> ('create' | 'make') ('a'? 'new')? ('text' | 'txt' | 'plain') 'file' ('called' | 'named')? $(fileName:string) ('with' | 'and' 'add')? $(content:string)? -> { actionName: "newTextFile", parameters: { fileName: fileName, content: content } };
+// "switch to the Monokai color scheme" (theme name before 'color scheme'/'theme')
+<changeColorSchemeTo> = <Polite> ('change' | 'switch' | 'set') ('to' | 'the')? $(theme:<Theme>) ('color scheme' | 'theme') -> { actionName: "changeColorScheme", parameters: { theme: theme } };
 
-<launchVSCode> = <Polite> ('launch' | 'open' | 'start') ('vs code' | 'vscode' | 'code') ('in' $(mode:string) 'mode')? ('at' | 'with' | 'for')? $(path:string)? -> { actionName: "launchVSCode", parameters: { path: path } };
+// Full split: "split the editor right and open utils.ts on the first side"
+<splitEditor> = <Polite> 'split' ('the')? 'editor' $(direction:<SplitDirection>) ('and')? ('open' | 'put' | 'place') $(fileName:string) ('in' | 'on' | 'to') ('the')? $(editorPosition:<EditorPos>) ('side' | 'panel' | 'half')? -> { actionName: "splitEditor", parameters: { direction: direction, editorPosition: editorPosition, fileName: fileName } };
 
-// Shared sub-rules
+// Direction-only split: "split editor right" / "split the editor to the right"
+<splitEditorSimple> = <Polite> 'split' ('the')? 'editor' ('to' ('the')?)? $(direction:<SplitDirection>) ('side' | 'panel' | 'half')? -> { actionName: "splitEditor", parameters: { direction: direction } };
+
+// Editor layout: "change to single column" / "switch to three pane view"
+<changeEditorLayout> = <Polite> ('change' | 'switch' | 'set' | 'go back') ('to')? ('the')? ('editor')? ('to')? ('a')? $(columnCount:<LayoutCols>) ('column' | 'pane') ('layout' | 'view' | 'mode')? -> { actionName: "changeEditorLayout", parameters: { columnCount: columnCount } };
+
+// Two branches so content stays a concrete string (TS NewCodeFileAction.content is required).
+<newCodeFile> = <Polite> ('create' | 'make') ('a')? ('new')? $(language:<CodeLang>) 'file' ('called' | 'named')? $(fileName:string) ('with' | 'and' 'add' | 'containing') $(content:string) -> { actionName: "newCodeFile", parameters: { fileName: fileName, language: language, content: content } }
+  | <Polite> ('create' | 'make') ('a')? ('new')? $(language:<CodeLang>) 'file' ('called' | 'named')? $(fileName:string) -> { actionName: "newCodeFile", parameters: { fileName: fileName, language: language, content: "" } };
+
+// Two branches so content stays a concrete string (TS NewMarkdownFileAction.content is required).
+<newMarkdownFile> = <Polite> ('create' | 'make') ('a')? ('new')? ('markdown' | 'md') 'file' ('called' | 'named')? $(fileName:string) ('with' | 'and' 'add' | 'containing') $(content:string) -> { actionName: "newMarkdownFile", parameters: { fileName: fileName, content: content } }
+  | <Polite> ('create' | 'make') ('a')? ('new')? ('markdown' | 'md') 'file' ('called' | 'named')? $(fileName:string) -> { actionName: "newMarkdownFile", parameters: { fileName: fileName, content: "" } };
+
+// Two branches so content stays a concrete string (TS NewTextFileAction.content is required).
+<newTextFile> = <Polite> ('create' | 'make') ('a')? ('new')? ('text' | 'txt' | 'plain') 'file' ('called' | 'named')? $(fileName:string) ('with' | 'and' 'add' | 'containing') $(content:string) -> { actionName: "newTextFile", parameters: { fileName: fileName, content: content } }
+  | <Polite> ('create' | 'make') ('a')? ('new')? ('text' | 'txt' | 'plain') 'file' ('called' | 'named')? $(fileName:string) -> { actionName: "newTextFile", parameters: { fileName: fileName, content: "" } };
+
+// LaunchVSCodeAction is a CodeActivity. mode is required ("last" | "folder" |
+// "workspace"); path is optional. Two branches give mode-only vs mode+path forms.
+<launchVSCode> = <Polite> ('launch' | 'open' | 'start') ('vs code' | 'vscode' | 'code') ('in')? $(mode:<LaunchMode>) ('mode')? ('at' | 'with' | 'for')? $(path:string) -> { actionName: "launchVSCode", parameters: { mode: mode, path: path } }
+  | <Polite> ('launch' | 'open' | 'start') ('vs code' | 'vscode' | 'code') ('in')? $(mode:<LaunchMode>) ('mode')? -> { actionName: "launchVSCode", parameters: { mode: mode } };
+
 <Polite> = ("can you" | "please" | "would you" | "i need" | "let's")?;
-
-<DirectionSpec> = ('vertically' | 'vertical' | 'horizontally' | 'horizontal');

--- a/ts/packages/agents/code/src/vscode/debugActionsSchema.agr
+++ b/ts/packages/agents/code/src/vscode/debugActionsSchema.agr
@@ -1,0 +1,58 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+//
+// Natural language interface for code-debug sub-manifest actions
+// (debug panel, start/continue/stop debugging, step, breakpoints, hover).
+
+import { CodeDebugActions } from "./debugActionsSchema.ts";
+
+<Start> : CodeDebugActions = <showDebugPanel>
+  | <stopDebugging>
+  | <stepInto>
+  | <step>
+  | <startDebugging>
+  | <showHover>
+  | <setBreakpointAtFileLine>
+  | <setBreakpointAtLine>
+  | <removeBreakpointAtFileLine>
+  | <removeBreakpointAtLine>
+  | <toggleBreakpointAtLine>
+  | <removeAllBreakpoints>;
+
+<StepType> = 'into' -> "into"
+  | 'out' -> "out"
+  | 'over' -> "over";
+
+<showDebugPanel> = <Polite> ('show' | 'open') ('the')? 'debug' ('panel' | 'pane' | 'window' | 'view') -> { actionName: "showDebugPanel" };
+
+<startDebugging> = <Polite> ('start' | 'continue' | 'resume' | 'begin') 'debugging' -> { actionName: "startDebugging" }
+  | <Polite> ('debug' | 'continue' | 'resume') ('this' | 'the')? ('program' | 'app')? -> { actionName: "startDebugging" };
+
+<stopDebugging> = <Polite> ('stop' | 'end' | 'terminate' | 'quit') 'debugging' -> { actionName: "stopDebugging" };
+
+// "step into" / "step over" / "step out"
+<step> = <Polite> 'step' $(stepType:<StepType>) -> { actionName: "step", parameters: { stepType: stepType } };
+
+// "step in" alias for "step into"
+<stepInto> = <Polite> 'step in' -> { actionName: "step", parameters: { stepType: "into" } };
+
+<showHover> = <Polite> ('show' | 'display') ('the')? 'hover' -> { actionName: "showHover" };
+
+// "set a breakpoint at line 42 in main.ts"
+<setBreakpointAtFileLine> = <Polite> ('set' | 'add') ('a')? 'breakpoint' ('at' | 'on')? 'line' $(line:number) 'in' $(fileName:wildcard) -> { actionName: "setBreakpoint", parameters: { line: line, fileName: fileName } };
+
+// "set a breakpoint at line 42"
+<setBreakpointAtLine> = <Polite> ('set' | 'add') ('a')? 'breakpoint' ('at' | 'on')? 'line' $(line:number) -> { actionName: "setBreakpoint", parameters: { line: line } };
+
+// "remove the breakpoint at line 42 in main.ts"
+<removeBreakpointAtFileLine> = <Polite> ('remove' | 'delete' | 'clear') ('the')? 'breakpoint' ('at' | 'on')? 'line' $(line:number) 'in' $(fileName:wildcard) -> { actionName: "removeBreakpoint", parameters: { line: line, fileName: fileName } };
+
+// "remove the breakpoint at line 42"
+<removeBreakpointAtLine> = <Polite> ('remove' | 'delete' | 'clear') ('the')? 'breakpoint' ('at' | 'on')? 'line' $(line:number) -> { actionName: "removeBreakpoint", parameters: { line: line } };
+
+// "toggle the breakpoint at line 42"
+<toggleBreakpointAtLine> = <Polite> 'toggle' ('the')? 'breakpoint' ('at' | 'on')? 'line' $(line:number) -> { actionName: "toggleBreakpoint", parameters: { line: line } };
+
+<removeAllBreakpoints> = <Polite> ('remove' | 'delete' | 'clear') 'all' ('the')? 'breakpoints' -> { actionName: "removeAllBreakpoints" };
+
+<Polite> = ("can you" | "please" | "would you" | "i need" | "let's")?;

--- a/ts/packages/agents/code/src/vscode/displayActionsSchema.agr
+++ b/ts/packages/agents/code/src/vscode/displayActionsSchema.agr
@@ -1,0 +1,53 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+//
+// Natural language interface for code-display sub-manifest actions
+// (zoom, panels, markdown preview, zen mode, settings).
+
+import { CodeDisplayActions } from "./displayActionsSchema.ts";
+
+<Start> : CodeDisplayActions = <zoomIn>
+  | <zoomOut>
+  | <fontZoomReset>
+  | <showExplorer>
+  | <showSearch>
+  | <showSourceControl>
+  | <showOutputPanel>
+  | <toggleSearchDetails>
+  | <replaceInFiles>
+  | <openMarkdownPreviewToSide>
+  | <openMarkdownPreview>
+  | <zenMode>
+  | <closeEditor>
+  | <openSettings>;
+
+<zoomIn> = <Polite> 'zoom in' ('the')? ('editor')? -> { actionName: "zoomIn" };
+
+<zoomOut> = <Polite> 'zoom out' ('the')? ('editor')? -> { actionName: "zoomOut" };
+
+<fontZoomReset> = <Polite> ('reset' | 'restore') ('the')? ('font' | 'editor')? 'zoom' -> { actionName: "fontZoomReset" }
+  | <Polite> 'zoom' ('reset' | 'to default') -> { actionName: "fontZoomReset" };
+
+<showExplorer> = <Polite> ('show' | 'open' | 'reveal') ('the')? ('file')? ('explorer' | 'explorer pane' | 'explorer panel') -> { actionName: "showExplorer" };
+
+<showSearch> = <Polite> ('show' | 'open') ('the')? ('text')? ('search' | 'search and replace' | 'replace') ('pane' | 'panel' | 'window' | 'sidebar')? -> { actionName: "showSearch" };
+
+<showSourceControl> = <Polite> ('show' | 'open') ('the')? ('source control' | 'scm' | 'git' 'panel') -> { actionName: "showSourceControl" };
+
+<showOutputPanel> = <Polite> ('show' | 'open') ('the')? 'output' ('panel' | 'pane' | 'window')? -> { actionName: "showOutputPanel" };
+
+<toggleSearchDetails> = <Polite> 'toggle' ('the')? 'search details' -> { actionName: "toggleSearchDetails" };
+
+<replaceInFiles> = <Polite> 'replace in' ('the')? 'files' -> { actionName: "replaceInFiles" };
+
+<openMarkdownPreviewToSide> = <Polite> ('open' | 'show') ('the')? 'markdown preview' ('to' ('the')? 'side' | 'on' ('the')? 'side') -> { actionName: "openMarkdownPreviewToSide" };
+
+<openMarkdownPreview> = <Polite> ('open' | 'show') ('the')? 'markdown preview' -> { actionName: "openMarkdownPreview" };
+
+<zenMode> = <Polite> ('enter' | 'go' 'into' | 'toggle' | 'turn on')? ('zen mode' | 'distraction free mode') -> { actionName: "zenMode" };
+
+<closeEditor> = <Polite> 'close' ('the')? ('current' | 'active')? ('editor' | 'file' | 'tab') -> { actionName: "closeEditor" };
+
+<openSettings> = <Polite> ('open' | 'show') ('the')? ('vscode' | 'editor')? ('user')? 'settings' -> { actionName: "openSettings" };
+
+<Polite> = ("can you" | "please" | "would you" | "i need" | "let's")?;

--- a/ts/packages/agents/code/src/vscode/extensionsActionsSchema.agr
+++ b/ts/packages/agents/code/src/vscode/extensionsActionsSchema.agr
@@ -1,0 +1,35 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+//
+// Natural language interface for code-extension sub-manifest actions
+// (check, install, enable, disable, show extensions; reload window).
+
+import { CodeWorkbenchExtensionActions } from "./extensionsActionsSchema.ts";
+
+<Start> : CodeWorkbenchExtensionActions = <reloadWindow>
+  | <showExtensions>
+  | <checkExtensionAvailable>
+  | <installExtension>
+  | <enableExtension>
+  | <disableExtension>;
+
+<reloadWindow> = <Polite> 'reload' ('the')? ('vscode')? 'window' -> { actionName: "reloadWindow" };
+
+<showExtensions> = <Polite> ('show' | 'open') ('the')? 'extensions' ('panel' | 'pane' | 'view' | 'sidebar')? -> { actionName: "showExtensions" };
+
+// "is the copilot extension available" / "check if copilot extension is available"
+<checkExtensionAvailable> = <Polite> ('is' | 'check' ('if')?) ('the')? $(filterByUserQuery:wildcard) 'extension' ('available' | 'installed') -> { actionName: "checkExtensionAvailable", parameters: { filterByUserQuery: filterByUserQuery } };
+
+// "install the copilot extension" / "install extension prettier"
+<installExtension> = <Polite> 'install' ('the')? $(extensionQuery:wildcard) 'extension' -> { actionName: "installExtension", parameters: { extensionQuery: extensionQuery } }
+  | <Polite> 'install extension' $(extensionQuery:wildcard) -> { actionName: "installExtension", parameters: { extensionQuery: extensionQuery } };
+
+// "enable the prettier extension" / "enable extension azure functions"
+<enableExtension> = <Polite> ('enable' | 'turn on' | 'activate') ('the')? $(extensionQuery:wildcard) 'extension' -> { actionName: "enableExtension", parameters: { extensionQuery: extensionQuery } }
+  | <Polite> ('enable' | 'turn on' | 'activate') 'extension' $(extensionQuery:wildcard) -> { actionName: "enableExtension", parameters: { extensionQuery: extensionQuery } };
+
+// "disable the prettier extension" / "disable extension azure functions"
+<disableExtension> = <Polite> ('disable' | 'turn off' | 'deactivate') ('the')? $(extensionQuery:wildcard) 'extension' -> { actionName: "disableExtension", parameters: { extensionQuery: extensionQuery } }
+  | <Polite> ('disable' | 'turn off' | 'deactivate') 'extension' $(extensionQuery:wildcard) -> { actionName: "disableExtension", parameters: { extensionQuery: extensionQuery } };
+
+<Polite> = ("can you" | "please" | "would you" | "i need" | "let's")?;

--- a/ts/packages/agents/code/src/vscode/generalActionsSchema.agr
+++ b/ts/packages/agents/code/src/vscode/generalActionsSchema.agr
@@ -1,0 +1,31 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+//
+// Natural language interface for code-general sub-manifest actions
+// (command palette, goto file/line/symbol, user settings, keyboard shortcuts).
+
+import { CodeGeneralActions } from "./generalActionsSchema.ts";
+
+<Start> : CodeGeneralActions = <showCommandPalette>
+  | <showUserSettings>
+  | <showKeyboardShortcuts>
+  | <gotoFileOrLineOrSymbol>
+  | <gotoBare>;
+
+<GotoTarget> = 'file' -> "file"
+  | 'line' -> "line"
+  | 'symbol' -> "symbol";
+
+<showCommandPalette> = <Polite> ('show' | 'open') ('the')? 'command palette' -> { actionName: "showCommandPalette" };
+
+<showUserSettings> = <Polite> ('show' | 'open') ('the')? ('user')? 'settings' ('json')? -> { actionName: "showUserSettings" };
+
+<showKeyboardShortcuts> = <Polite> ('show' | 'open') ('the')? ('keyboard shortcuts' | 'keybindings' | 'key bindings') -> { actionName: "showKeyboardShortcuts" };
+
+// "go to file foo.ts" / "go to line 42" / "go to symbol parse"
+<gotoFileOrLineOrSymbol> = <Polite> ('go to' | 'goto' | 'jump to') $(goto:<GotoTarget>) $(ref:wildcard) -> { actionName: "gotoFileOrLineOrSymbol", parameters: { goto: goto, ref: ref } };
+
+// "go to file" with no target name
+<gotoBare> = <Polite> ('go to' | 'goto' | 'jump to') $(goto:<GotoTarget>) -> { actionName: "gotoFileOrLineOrSymbol", parameters: { goto: goto } };
+
+<Polite> = ("can you" | "please" | "would you" | "i need" | "let's")?;

--- a/ts/packages/agents/code/src/vscode/vscodeConversationActionsSchema.agr
+++ b/ts/packages/agents/code/src/vscode/vscodeConversationActionsSchema.agr
@@ -1,0 +1,39 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+//
+// Natural language interface for code-vscode-shell sub-manifest actions
+// (TypeAgent Shell conversation management in VS Code).
+
+import { VSCodeConversationActions } from "./vscodeConversationActionsSchema.ts";
+
+<Start> : VSCodeConversationActions = <newConversationNamed>
+  | <newConversation>
+  | <renameConversation>
+  | <switchConversationNamed>
+  | <switchConversation>
+  | <deleteConversationNamed>
+  | <deleteConversation>;
+
+// "new conversation called X" / "start a new conversation named X"
+<newConversationNamed> = <Polite> ('start' | 'create' | 'open' | 'begin')? ('a')? 'new' ('chat' | 'conversation' | 'tab') ('called' | 'named') $(name:wildcard) -> { actionName: "newConversation", parameters: { name: name } };
+
+// "new conversation" / "start a new chat"
+<newConversation> = <Polite> ('start' | 'create' | 'open' | 'begin')? ('a')? 'new' ('chat' | 'conversation' | 'tab') -> { actionName: "newConversation", parameters: {} };
+
+// "rename this conversation to X" / "rename the conversation to X"
+<renameConversation> = <Polite> 'rename' ('this' | 'the' | 'current') ('chat' | 'conversation' | 'tab') 'to' $(newName:wildcard) -> { actionName: "renameConversation", parameters: { newName: newName } };
+
+// "switch to the X conversation" / "switch conversation to X"
+<switchConversationNamed> = <Polite> ('switch' | 'go') 'to' ('the')? $(name:wildcard) ('chat' | 'conversation') -> { actionName: "switchConversation", parameters: { name: name } }
+  | <Polite> 'switch' ('chat' | 'conversation' | 'tab') 'to' $(name:wildcard) -> { actionName: "switchConversation", parameters: { name: name } };
+
+// "switch conversation" (no name — UI prompts)
+<switchConversation> = <Polite> 'switch' ('chat' | 'conversation' | 'tab') -> { actionName: "switchConversation", parameters: {} };
+
+// "delete the X conversation"
+<deleteConversationNamed> = <Polite> ('delete' | 'remove') ('the')? $(name:wildcard) ('chat' | 'conversation') -> { actionName: "deleteConversation", parameters: { name: name } };
+
+// "delete a conversation" (no name — UI prompts)
+<deleteConversation> = <Polite> ('delete' | 'remove') ('a' | 'the')? ('chat' | 'conversation' | 'tab') -> { actionName: "deleteConversation", parameters: {} };
+
+<Polite> = ("can you" | "please" | "would you" | "i need" | "let's")?;

--- a/ts/packages/agents/code/src/vscode/workbenchCommandActionsSchema.agr
+++ b/ts/packages/agents/code/src/vscode/workbenchCommandActionsSchema.agr
@@ -1,0 +1,46 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+//
+// Natural language interface for code-workbench sub-manifest actions
+// (open file, open folder, create folder, build tasks, integrated terminal).
+
+import { CodeWorkbenchActions } from "./workbenchCommandActionsSchema.ts";
+
+<Start> : CodeWorkbenchActions = <workbenchOpenFile>
+  | <workbenchOpenFolder>
+  | <workbenchCreateFolderUnder>
+  | <workbenchCreateFolder>
+  | <workbenchBuildRelatedTaskInFolder>
+  | <workbenchBuildRelatedTask>
+  | <openInIntegratedTerminalInFolder>
+  | <openInIntegratedTerminal>;
+
+<BuildTask> = 'build' -> "build"
+  | 'rebuild' -> "rebuild"
+  | 'clean' -> "clean";
+
+// "open file foo.ts" / "open the file main.ts"
+<workbenchOpenFile> = <Polite> 'open' ('the')? 'file' $(fileName:wildcard) -> { actionName: "workbenchOpenFile", parameters: { fileName: fileName } };
+
+// "open folder src" / "open the folder packages"
+<workbenchOpenFolder> = <Polite> ('open' | 'show' | 'reveal') ('the')? 'folder' $(folderName:wildcard) -> { actionName: "workbenchOpenFolder", parameters: { folderName: folderName } };
+
+// "create a folder tests under src/utils"
+<workbenchCreateFolderUnder> = <Polite> ('create' | 'make' | 'add') ('a')? ('new')? 'folder' $(folderName:wildcard) ('under' | 'in') $(relativeTo:wildcard) -> { actionName: "workbenchCreateFolderFromExplorer", parameters: { folderName: folderName, relativeTo: relativeTo } };
+
+// "create a folder tests"
+<workbenchCreateFolder> = <Polite> ('create' | 'make' | 'add') ('a')? ('new')? 'folder' ('called' | 'named')? $(folderName:wildcard) -> { actionName: "workbenchCreateFolderFromExplorer", parameters: { folderName: folderName } };
+
+// "build the dispatcher folder" / "rebuild the cache project"
+<workbenchBuildRelatedTaskInFolder> = <Polite> $(task:<BuildTask>) ('the')? $(folderName:wildcard) ('folder' | 'project' | 'package') -> { actionName: "workbenchBuildRelatedTask", parameters: { task: task, folderName: folderName } };
+
+// "build the workspace" / "rebuild"
+<workbenchBuildRelatedTask> = <Polite> $(task:<BuildTask>) ('the')? ('workspace' | 'root' | 'project')? -> { actionName: "workbenchBuildRelatedTask", parameters: { task: task } };
+
+// "open the integrated terminal in src"
+<openInIntegratedTerminalInFolder> = <Polite> ('open' | 'show') ('the')? ('integrated')? 'terminal' 'in' $(folderName:wildcard) -> { actionName: "openInIntegratedTerminal", parameters: { folderName: folderName } };
+
+// "open the integrated terminal"
+<openInIntegratedTerminal> = <Polite> ('open' | 'show') ('the')? ('integrated')? 'terminal' -> { actionName: "openInIntegratedTerminal", parameters: {} };
+
+<Polite> = ("can you" | "please" | "would you" | "i need" | "let's")?;

--- a/ts/pnpm-lock.yaml
+++ b/ts/pnpm-lock.yaml
@@ -155,7 +155,7 @@ importers:
         version: 8.18.1
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@22.19.19)(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.4.5))
+        version: 29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.4.5))
       prettier:
         specifier: ^3.5.3
         version: 3.5.3
@@ -2160,12 +2160,15 @@ importers:
       '@types/ws':
         specifier: ^8.5.10
         version: 8.18.1
+      action-grammar-compiler:
+        specifier: workspace:*
+        version: link:../../actionGrammarCompiler
       concurrently:
         specifier: ^9.1.2
         version: 9.1.2
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.4.5))
+        version: 29.7.0(@types/node@22.19.19)(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.4.5))
       prettier:
         specifier: ^3.5.3
         version: 3.5.3


### PR DESCRIPTION
## Wire grammar files for the code agent
 
 Enables deterministic, LLM-free routing for common VS Code phrases (e.g. "create a markdown file …") so they consistently dispatch to the `code` agent instead of being misrouted by LLM translation.
 
 ### Changes
 - Added `grammarFile` to the `code` root manifest and to 6 sub-manifests (`debug`, `display`, `general`, `vscode-shell`, `workbench`, `extension`).
 - Authored new `.agr` grammar files for each sub-manifest.
 - Rewrote `codeSchema.agr` to cover the top-level actions plus the `launchVSCode` activity, using a single inline-union `<Start>` rule.
 - Added `agc` / `agc:<sub>` scripts and fluid-build tasks; wired `build` to run `tsc` + `asc:all` + `agc:all`.
 
 ### Notes
 - Editor sub-schema intentionally skipped — schema is too complex for a useful grammar.