### PR TITLE
Improve webflow recording reliability + tests

### DIFF
--- a/ts/packages/agents/browser/src/agent/discovery/actionHandler.mts
+++ b/ts/packages/agents/browser/src/agent/discovery/actionHandler.mts
@@ -559,12 +559,7 @@ async function handleRegisterSiteSchema(
         ctx.sessionContext.agentContext,
     ).getPageUrl();
 
-    const webFlowStore = ctx.sessionContext.agentContext.webFlowStore;
-    if (!webFlowStore) {
-        throw new Error(
-            "WebFlowStore not available - please ensure TypeAgent server is running",
-        );
-    }
+    const webFlowStore = await getWebFlowStore(ctx.sessionContext);
 
     debug("Building schema from WebFlowStore");
     const domain = new URL(url!).hostname;
@@ -633,10 +628,7 @@ async function handleCreateWebFlowFromRecording(
     action: CreateWebFlowFromRecording,
     ctx: DiscoveryActionHandlerContext,
 ): Promise<DiscoveryActionResult> {
-    const webFlowStore = ctx.sessionContext.agentContext.webFlowStore;
-    if (!webFlowStore) {
-        throw new Error("WebFlowStore not available");
-    }
+    const webFlowStore = await getWebFlowStore(ctx.sessionContext);
 
     const rawSteps = JSON.parse(action.parameters.recordedSteps || "[]");
     const url = action.parameters.startUrl;

--- a/ts/packages/agents/browser/src/extension/contentScript/recording/index.ts
+++ b/ts/packages/agents/browser/src/extension/contentScript/recording/index.ts
@@ -14,6 +14,7 @@ import { getPageHTML, CompressionMode } from "../htmlUtils";
 
 // State variables
 let recording = false;
+let listenersAttached = false;
 let recordedActions: RecordedAction[] = [];
 let actionIndex = 1;
 let recordedHtmlIndex = 0;
@@ -22,6 +23,45 @@ let recordedActionScreenshot: string[] = [];
 let lastUrl = window.location.href;
 let lastScreenshot: string = "";
 let lastPagehtml: string = "";
+
+/**
+ * Attaches the DOM and window event listeners that drive recording.
+ * Safe to call multiple times — guarded by `listenersAttached` so a
+ * restore-after-navigation path does not double-bind on top of an
+ * existing startRecording().
+ */
+function attachRecordingListeners(): void {
+    if (listenersAttached) return;
+    listenersAttached = true;
+
+    document.addEventListener("click", recordClick, true);
+    document.addEventListener("input", recordInput, true);
+    document.addEventListener("keyup", recordTextEntry, true);
+
+    observeDOMChanges();
+
+    window.addEventListener("unload", recordNavigation, true);
+    window.addEventListener("beforeunload", recordNavigation, true);
+    window.addEventListener("popstate", recordNavigation, true);
+    window.addEventListener("hashchange", recordNavigation, true);
+}
+
+/**
+ * Detaches the DOM and window event listeners that drive recording.
+ */
+function detachRecordingListeners(): void {
+    if (!listenersAttached) return;
+    listenersAttached = false;
+
+    document.removeEventListener("click", recordClick, true);
+    document.removeEventListener("input", recordInput, true);
+    document.removeEventListener("keyup", recordTextEntry, true);
+
+    window.removeEventListener("unload", recordNavigation, true);
+    window.removeEventListener("beforeunload", recordNavigation, true);
+    window.removeEventListener("popstate", recordNavigation, true);
+    window.removeEventListener("hashchange", recordNavigation, true);
+}
 
 /**
  * Starts recording user actions
@@ -45,16 +85,7 @@ export async function startRecording(): Promise<void> {
 
     setIdsOnAllElements(0);
 
-    document.addEventListener("click", recordClick, true);
-    document.addEventListener("input", recordInput, true);
-    document.addEventListener("keyup", recordTextEntry, true);
-
-    observeDOMChanges();
-
-    window.addEventListener("unload", recordNavigation);
-    window.addEventListener("beforeunload", recordNavigation);
-    window.addEventListener("popstate", recordNavigation);
-    window.addEventListener("hashchange", recordNavigation);
+    attachRecordingListeners();
 }
 
 /**
@@ -63,14 +94,7 @@ export async function startRecording(): Promise<void> {
  */
 export async function stopRecording(): Promise<any> {
     recording = false;
-    document.removeEventListener("click", recordClick, true);
-    document.removeEventListener("input", recordInput, true);
-    document.removeEventListener("keyup", recordTextEntry, true);
-
-    window.removeEventListener("unload", recordNavigation, true);
-    window.removeEventListener("beforeunload", recordNavigation, true);
-    window.removeEventListener("popstate", recordNavigation, true);
-    window.removeEventListener("hashchange", recordNavigation, true);
+    detachRecordingListeners();
 
     const screenshot = await captureAnnotatedScreenshot();
     recordedActionScreenshot.push(screenshot);
@@ -83,7 +107,11 @@ export async function stopRecording(): Promise<any> {
         type: "recordingStopped",
         recordedActions,
         recordedActionScreenshot,
-        recordedActionHtml,
+        // Service-worker storage and downstream consumers expect the
+        // 'recordedActionPageHTML' key (matches the
+        // chrome.storage.session key and serviceTypes.mts). Rename
+        // on the wire to avoid silently dropping HTML annotations.
+        recordedActionPageHTML: recordedActionHtml,
     });
 
     return {
@@ -103,7 +131,7 @@ export async function saveRecordedActions(): Promise<void> {
         type: "saveRecordedActions",
         recordedActions,
         recordedActionScreenshot,
-        recordedActionHtml,
+        recordedActionPageHTML: recordedActionHtml,
         actionIndex,
         isCurrentlyRecording: recording,
     });
@@ -153,6 +181,31 @@ export function restoreRecordingState(restoredData: any): void {
 
         actionIndex = restoredData.actionIndex ?? 0;
         recording = restoredData.isCurrentlyRecording || false;
+
+        // Listener wiring is limited to the top frame, matching the
+        // start/stop messages from the service worker which are sent
+        // with { frameId: 0 } (see serviceWorker/recording.ts). The
+        // content script runs in every iframe ("all_frames": true) so
+        // without this guard a cross-page restore would attach listeners
+        // and stamp element IDs inside every iframe on the new page.
+        const isTopFrame = window.top === window;
+
+        if (recording) {
+            // If a recording was in progress on the previous page, the
+            // top-frame content script for the new page must reattach the
+            // event listeners — the `recording` flag is restored from
+            // storage but the listeners are not, so without this
+            // clicks/inputs on the destination page are silently dropped.
+            if (isTopFrame) {
+                setIdsOnAllElements(0);
+                attachRecordingListeners();
+            }
+        } else if (isTopFrame) {
+            // Symmetric path: if the restored state says recording has
+            // stopped, make sure no listeners are left attached from an
+            // earlier call in the same content-script lifetime.
+            detachRecordingListeners();
+        }
     }
 }
 
@@ -179,6 +232,7 @@ export function getRecordingState(): any {
  * @param state The state to set
  */
 export function setRecordingState(state: any): void {
+    const prevRecording = recording;
     if (state.recording !== undefined) recording = state.recording;
     if (state.recordedActions) recordedActions = state.recordedActions;
     if (state.actionIndex !== undefined) actionIndex = state.actionIndex;
@@ -190,6 +244,21 @@ export function setRecordingState(state: any): void {
     if (state.lastUrl) lastUrl = state.lastUrl;
     if (state.lastScreenshot) lastScreenshot = state.lastScreenshot;
     if (state.lastPagehtml) lastPagehtml = state.lastPagehtml;
+
+    // Keep the listener wiring in sync with the recording flag, but only
+    // in the top frame — iframes share the same code path via
+    // "all_frames": true but the service worker scopes start/stop to
+    // { frameId: 0 } and we must not record inside iframes.
+    if (state.recording !== undefined && recording !== prevRecording) {
+        const isTopFrame = window.top === window;
+        if (isTopFrame) {
+            if (recording) {
+                attachRecordingListeners();
+            } else {
+                detachRecordingListeners();
+            }
+        }
+    }
 }
 
 export function setLastScreenshot(value: string) {

--- a/ts/packages/agents/browser/src/extension/serviceWorker/externalBrowserControlServer.ts
+++ b/ts/packages/agents/browser/src/extension/serviceWorker/externalBrowserControlServer.ts
@@ -31,6 +31,40 @@ async function ensureActiveTab() {
     }
     return targetTab;
 }
+
+/**
+ * Resolves once chrome.tabs.onUpdated fires status === "complete" for the
+ * given tabId, or after `timeout` ms. Always register this BEFORE issuing the
+ * navigation (chrome.tabs.update / chrome.tabs.create) so we don't miss the
+ * complete event for the new document. We deliberately don't early-resolve
+ * based on the tab's current status: that would race with chrome.tabs.update
+ * returning a Tab object that still reflects the previous page.
+ */
+function waitForTabComplete(
+    tabId: number,
+    timeout: number = 30000,
+): Promise<void> {
+    return new Promise<void>((resolve) => {
+        let done = false;
+        const finish = () => {
+            if (done) return;
+            done = true;
+            chrome.tabs.onUpdated.removeListener(handler);
+            clearTimeout(timer);
+            resolve();
+        };
+        const handler = (
+            updatedTabId: number,
+            changeInfo: chrome.tabs.TabChangeInfo,
+        ) => {
+            if (updatedTabId === tabId && changeInfo.status === "complete") {
+                finish();
+            }
+        };
+        const timer = setTimeout(finish, timeout);
+        chrome.tabs.onUpdated.addListener(handler);
+    });
+}
 export function createExternalBrowserServer(channel: RpcChannel) {
     const rpcMap = new Map<
         number,
@@ -76,35 +110,59 @@ export function createExternalBrowserServer(channel: RpcChannel) {
                         sendOptions,
                     );
                 } catch (error: any) {
-                    // If the content script isn't loaded, inject it and retry
-                    const errMsg =
-                        typeof error === "string"
-                            ? error
-                            : (error?.message ?? "");
-                    if (
-                        errMsg.includes("Could not establish connection") ||
-                        errMsg.includes("Receiving end does not exist")
-                    ) {
+                    // If the content script isn't loaded, inject it and
+                    // retry with backoff. This still happens for SPA
+                    // navigations or scripted navigations that don't go
+                    // through openWebPage's onUpdated 'complete' gate.
+                    const isNoReceiver = (e: any) => {
+                        const m =
+                            typeof e === "string" ? e : (e?.message ?? "");
+                        return (
+                            m.includes("Could not establish connection") ||
+                            m.includes("Receiving end does not exist")
+                        );
+                    };
+                    if (isNoReceiver(error)) {
+                        let lastError: any = error;
                         try {
                             await injectContentScripts(tabId);
-                            // Small delay to let the content script initialize
-                            await new Promise((r) => setTimeout(r, 100));
-                            await chrome.tabs.sendMessage(
-                                tabId,
-                                { type: "rpc", message },
-                                sendOptions,
-                            );
-                            return;
-                        } catch (retryError) {
-                            console.error(
-                                "Error after injecting content script:",
-                                retryError,
-                            );
-                            if (cb) {
-                                cb(retryError as Error);
+                            // Backoff in multiples of 200 ms (200, 400,
+                            // 600, 800, 1000) to let the freshly-injected
+                            // content script finish initializing. Max
+                            // total wait ~3s before giving up.
+                            for (let attempt = 1; attempt <= 5; attempt++) {
+                                await new Promise((r) =>
+                                    setTimeout(r, 200 * attempt),
+                                );
+                                try {
+                                    await chrome.tabs.sendMessage(
+                                        tabId,
+                                        { type: "rpc", message },
+                                        sendOptions,
+                                    );
+                                    return;
+                                } catch (retryError: any) {
+                                    lastError = retryError;
+                                    // Stop retrying if the error is not
+                                    // a "no receiver" error — different
+                                    // class of failure won't be fixed by
+                                    // waiting longer.
+                                    if (!isNoReceiver(retryError)) {
+                                        break;
+                                    }
+                                }
                             }
-                            return;
+                        } catch (injectError) {
+                            lastError = injectError;
                         }
+                        console.error(
+                            "Error after injecting content script:",
+                            lastError,
+                        );
+                        if (cb) {
+                            cb(lastError as Error);
+                        }
+                        return;
                     }
                     console.error(
                         "Error sending message to content script:",
@@ -177,10 +235,21 @@ export function createExternalBrowserServer(channel: RpcChannel) {
             const resolvedUrl = resolveCustomProtocolUrl(url);
 
             const targetTab = await getActiveTab();
+            // Register the load-complete listener BEFORE issuing the
+            // navigation so we don't miss the event. Awaiting this lets
+            // subsequent RPC calls (awaitPageLoad, extractComponent, ...)
+            // land on the new page's content script instead of racing the
+            // unload of the old one.
             if (targetTab && !options?.newTab) {
-                await chrome.tabs.update(targetTab.id!, { url: resolvedUrl });
+                const tabId = targetTab.id!;
+                const ready = waitForTabComplete(tabId);
+                await chrome.tabs.update(tabId, { url: resolvedUrl });
+                await ready;
             } else {
-                await chrome.tabs.create({ url: resolvedUrl });
+                const created = await chrome.tabs.create({ url: resolvedUrl });
+                if (created.id !== undefined) {
+                    await waitForTabComplete(created.id);
+                }
             }
         },
         closeWebPage: async () => {

--- a/ts/packages/agents/browser/src/extension/serviceWorker/index.ts
+++ b/ts/packages/agents/browser/src/extension/serviceWorker/index.ts
@@ -16,6 +16,7 @@ import { createChromeRpcServer } from "./chromeRpcServer";
 import { createAllHandlers } from "./serviceWorkerRpcHandlers";
 import { setChatPanelRpc } from "./dispatcherConnection";
 import { setContextMenuRpcSend } from "./contextMenu";
+import { clearRecordedActions } from "./storage";
 
 import {
     isWebAgentMessage,
@@ -104,6 +105,57 @@ function setupEventListeners(): void {
                     success: false,
                     error: "Handler not available",
                 });
+                return false;
+            }
+
+            // Recording lifecycle messages sent by the content script
+            // (recording/index.ts and recording/actions.ts) as plain
+            // chrome.runtime.sendMessage calls. These predate the RPC
+            // layer so they need explicit routing here — without it,
+            // every per-action save is silently dropped and recordings
+            // come back empty.
+            if (
+                message.type === "getRecordedActions" ||
+                message.type === "saveRecordedActions" ||
+                message.type === "recordingStopped"
+            ) {
+                if (serviceWorkerHandlers) {
+                    const handlers = serviceWorkerHandlers;
+                    const handler = (handlers as any)[message.type];
+                    if (handler) {
+                        handler(message)
+                            .then((result: any) => sendResponse(result))
+                            .catch((err: any) => {
+                                debugError(
+                                    `Recording handler ${message.type} failed:`,
+                                    err,
+                                );
+                                sendResponse(undefined);
+                            });
+                        return true; // async sendResponse
+                    }
+                }
+                sendResponse(undefined);
+                return false;
+            }
+
+            if (message.type === "clearRecordedActions") {
+                clearRecordedActions()
+                    .then(() => sendResponse({}))
+                    .catch((err: any) => {
+                        debugError("clearRecordedActions failed:", err);
+                        sendResponse({});
+                    });
+                return true; // async sendResponse
+            }
+
+            // SPA URL-change notifications from the recording observer.
+            // Currently informational only — the service worker has no
+            // additional handling beyond storage state already updated by
+            // the subsequent saveRecordedActions call. Ack to avoid the
+            // "message channel closed" warning in chromium.
+            if (message.type === "spaNavigationDetected") {
+                sendResponse({});
                 return false;
             }
         },

--- a/ts/packages/agents/browser/test/contentScript/recording.test.ts
+++ b/ts/packages/agents/browser/test/contentScript/recording.test.ts
@@ -1,0 +1,340 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+/// <reference path="../types/jest-chrome-extensions.d.ts" />
+
+// Mock collaborators so we can observe listener wiring without dragging in
+// the real action handlers (which call chrome.runtime + take screenshots).
+jest.mock("../../src/extension/contentScript/recording/actions", () => ({
+    recordClick: jest.fn(),
+    recordInput: jest.fn(),
+    recordTextEntry: jest.fn(),
+    recordNavigation: jest.fn(),
+}));
+
+jest.mock("../../src/extension/contentScript/recording/capture", () => ({
+    captureUIState: jest.fn().mockResolvedValue(undefined),
+    captureAnnotatedScreenshot: jest.fn().mockResolvedValue(""),
+}));
+
+jest.mock("../../src/extension/contentScript/domUtils", () => ({
+    setIdsOnAllElements: jest.fn(),
+}));
+
+jest.mock("../../src/extension/contentScript/htmlUtils", () => ({
+    getPageHTML: jest.fn().mockReturnValue(""),
+    CompressionMode: { Automation: "automation" },
+}));
+
+let recordingModule: any;
+let actionsMock: {
+    recordClick: jest.Mock;
+    recordInput: jest.Mock;
+    recordTextEntry: jest.Mock;
+    recordNavigation: jest.Mock;
+};
+let domUtilsMock: { setIdsOnAllElements: jest.Mock };
+
+describe("Recording lifecycle — listener attach/detach", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+
+        chrome.runtime.sendMessage.mockImplementation(() => Promise.resolve());
+
+        // Reload module to reset internal state (recording flag, listener
+        // attachment guard) between tests.
+        jest.isolateModules(() => {
+            recordingModule = require("../../src/extension/contentScript/recording");
+            actionsMock = require("../../src/extension/contentScript/recording/actions");
+            domUtilsMock = require("../../src/extension/contentScript/domUtils");
+        });
+    });
+
+    describe("startRecording", () => {
+        it("attaches click/input/keyup listeners on document", async () => {
+            await recordingModule.startRecording();
+
+            document.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+            document.dispatchEvent(new Event("input", { bubbles: true }));
+            document.dispatchEvent(
+                new KeyboardEvent("keyup", { bubbles: true }),
+            );
+
+            expect(actionsMock.recordClick).toHaveBeenCalledTimes(1);
+            expect(actionsMock.recordInput).toHaveBeenCalledTimes(1);
+            expect(actionsMock.recordTextEntry).toHaveBeenCalledTimes(1);
+        });
+
+        it("stamps element IDs when recording starts", async () => {
+            await recordingModule.startRecording();
+            expect(domUtilsMock.setIdsOnAllElements).toHaveBeenCalledWith(0);
+        });
+
+        it("is idempotent — calling twice does not double-bind", async () => {
+            await recordingModule.startRecording();
+            await recordingModule.startRecording();
+
+            document.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+
+            expect(actionsMock.recordClick).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe("stopRecording", () => {
+        it("detaches click/input/keyup listeners", async () => {
+            await recordingModule.startRecording();
+            await recordingModule.stopRecording();
+
+            document.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+            document.dispatchEvent(new Event("input", { bubbles: true }));
+            document.dispatchEvent(
+                new KeyboardEvent("keyup", { bubbles: true }),
+            );
+
+            expect(actionsMock.recordClick).not.toHaveBeenCalled();
+            expect(actionsMock.recordInput).not.toHaveBeenCalled();
+            expect(actionsMock.recordTextEntry).not.toHaveBeenCalled();
+        });
+
+        it("detaches window navigation listeners using capture phase", async () => {
+            // The pre-patch bug: window listeners were attached without a
+            // capture flag (defaulting to bubble) but removed with capture:true,
+            // so removeEventListener was a silent no-op. Verify the round-trip
+            // now actually detaches by checking that hashchange/popstate after
+            // stop do not fire recordNavigation.
+            await recordingModule.startRecording();
+            await recordingModule.stopRecording();
+
+            window.dispatchEvent(new HashChangeEvent("hashchange"));
+            window.dispatchEvent(new PopStateEvent("popstate"));
+
+            expect(actionsMock.recordNavigation).not.toHaveBeenCalled();
+        });
+    });
+
+    describe("restoreRecordingState — cross-page navigation path", () => {
+        it("reattaches listeners when restored state has isCurrentlyRecording=true", () => {
+            // Simulate fresh content script on destination page after a
+            // cross-page navigation: no prior startRecording call, but the
+            // service worker had persisted an active recording.
+            recordingModule.restoreRecordingState({
+                recordedActions: [{ id: 1, type: "click", timestamp: 0 }],
+                actionIndex: 1,
+                isCurrentlyRecording: true,
+            });
+
+            document.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+            document.dispatchEvent(new Event("input", { bubbles: true }));
+
+            expect(actionsMock.recordClick).toHaveBeenCalledTimes(1);
+            expect(actionsMock.recordInput).toHaveBeenCalledTimes(1);
+        });
+
+        it("re-stamps element IDs on the restored page", () => {
+            recordingModule.restoreRecordingState({
+                isCurrentlyRecording: true,
+            });
+            expect(domUtilsMock.setIdsOnAllElements).toHaveBeenCalledWith(0);
+        });
+
+        it("does NOT attach listeners when isCurrentlyRecording=false", () => {
+            recordingModule.restoreRecordingState({
+                recordedActions: [],
+                actionIndex: 0,
+                isCurrentlyRecording: false,
+            });
+
+            document.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+
+            expect(actionsMock.recordClick).not.toHaveBeenCalled();
+            expect(domUtilsMock.setIdsOnAllElements).not.toHaveBeenCalled();
+        });
+
+        it("does NOT double-bind when start was already called in the same context", async () => {
+            // Edge case: same content script lifetime has both startRecording
+            // and a restore call (e.g. SPA route change race). The guard
+            // should keep the listener count at one.
+            await recordingModule.startRecording();
+            recordingModule.restoreRecordingState({
+                isCurrentlyRecording: true,
+            });
+
+            document.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+
+            expect(actionsMock.recordClick).toHaveBeenCalledTimes(1);
+        });
+
+        it("does nothing when restoredData is falsy", () => {
+            expect(() =>
+                recordingModule.restoreRecordingState(undefined),
+            ).not.toThrow();
+            expect(() =>
+                recordingModule.restoreRecordingState(null),
+            ).not.toThrow();
+
+            document.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+
+            expect(actionsMock.recordClick).not.toHaveBeenCalled();
+        });
+    });
+
+    describe("start → stop → restore cycle", () => {
+        it("supports restore after a clean stop without leaking listeners", async () => {
+            await recordingModule.startRecording();
+            await recordingModule.stopRecording();
+
+            recordingModule.restoreRecordingState({
+                isCurrentlyRecording: true,
+            });
+
+            document.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+
+            // Exactly once — listeners from the stop call were detached, and
+            // restore reattached a single set.
+            expect(actionsMock.recordClick).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe("top-frame guard (review fix — iframe leak)", () => {
+        // The content script is registered with "all_frames": true, so it
+        // runs in every iframe. The service worker scopes start/stop to
+        // { frameId: 0 } so listener wiring must also be limited to the
+        // top frame. We simulate an iframe by making window.top !== window.
+        it("does NOT attach listeners in iframes when restoring an active recording", () => {
+            const realTop = window.top;
+            Object.defineProperty(window, "top", {
+                value: {} as Window,
+                configurable: true,
+            });
+            try {
+                recordingModule.restoreRecordingState({
+                    recordedActions: [],
+                    actionIndex: 0,
+                    isCurrentlyRecording: true,
+                });
+
+                document.dispatchEvent(
+                    new MouseEvent("click", { bubbles: true }),
+                );
+                document.dispatchEvent(new Event("input", { bubbles: true }));
+
+                expect(actionsMock.recordClick).not.toHaveBeenCalled();
+                expect(actionsMock.recordInput).not.toHaveBeenCalled();
+                // Element IDs must not be stamped in iframes either —
+                // would cause id collisions across frames at frameId=0.
+                expect(domUtilsMock.setIdsOnAllElements).not.toHaveBeenCalled();
+            } finally {
+                Object.defineProperty(window, "top", {
+                    value: realTop,
+                    configurable: true,
+                });
+            }
+        });
+
+        it("preserves the recording flag in iframes (matches pre-patch behavior)", () => {
+            // Pre-patch, iframes still populated the flag from storage;
+            // they just did not attach listeners. We keep that behavior so
+            // any read of the flag from iframe code paths is unchanged.
+            const realTop = window.top;
+            Object.defineProperty(window, "top", {
+                value: {} as Window,
+                configurable: true,
+            });
+            try {
+                recordingModule.restoreRecordingState({
+                    recordedActions: [],
+                    actionIndex: 0,
+                    isCurrentlyRecording: true,
+                });
+
+                expect(recordingModule.getRecordingState().recording).toBe(
+                    true,
+                );
+            } finally {
+                Object.defineProperty(window, "top", {
+                    value: realTop,
+                    configurable: true,
+                });
+            }
+        });
+    });
+
+    describe("symmetric restore (review fix — Issue 2)", () => {
+        it("detaches listeners when restored state flips recording to false", async () => {
+            // First, get into a state with listeners attached.
+            await recordingModule.startRecording();
+            document.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+            expect(actionsMock.recordClick).toHaveBeenCalledTimes(1);
+
+            // Now restore with isCurrentlyRecording=false. The previous
+            // implementation would leave the listeners attached and the
+            // recording flag false, so subsequent events would still fire
+            // the recorders. The symmetric fix must detach.
+            recordingModule.restoreRecordingState({
+                recordedActions: [],
+                actionIndex: 0,
+                isCurrentlyRecording: false,
+            });
+
+            document.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+
+            // Total recordClick count is still 1 — the post-restore click
+            // must NOT have fired a recorder.
+            expect(actionsMock.recordClick).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe("setRecordingState (review fix — Issue 3)", () => {
+        it("attaches listeners when flipping recording from false to true", () => {
+            recordingModule.setRecordingState({ recording: true });
+
+            document.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+
+            expect(actionsMock.recordClick).toHaveBeenCalledTimes(1);
+        });
+
+        it("detaches listeners when flipping recording from true to false", async () => {
+            await recordingModule.startRecording();
+            recordingModule.setRecordingState({ recording: false });
+
+            document.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+
+            expect(actionsMock.recordClick).not.toHaveBeenCalled();
+        });
+
+        it("does not touch listeners when recording is unchanged", async () => {
+            await recordingModule.startRecording();
+            recordingModule.setRecordingState({ recording: true });
+            recordingModule.setRecordingState({ actionIndex: 5 });
+
+            document.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+
+            // Still exactly one binding — no double-bind from the redundant
+            // setRecordingState(true) call, and no detach from the
+            // unrelated actionIndex update.
+            expect(actionsMock.recordClick).toHaveBeenCalledTimes(1);
+        });
+
+        it("does NOT attach listeners in iframes", () => {
+            const realTop = window.top;
+            Object.defineProperty(window, "top", {
+                value: {} as Window,
+                configurable: true,
+            });
+            try {
+                recordingModule.setRecordingState({ recording: true });
+
+                document.dispatchEvent(
+                    new MouseEvent("click", { bubbles: true }),
+                );
+
+                expect(actionsMock.recordClick).not.toHaveBeenCalled();
+            } finally {
+                Object.defineProperty(window, "top", {
+                    value: realTop,
+                    configurable: true,
+                });
+            }
+        });
+    });
+});


### PR DESCRIPTION
# Fix WebFlow recording end-to-end + post-navigation timing
 
 ## Problem
 
 Recording a WebFlow from the browser extension was broken in three independent ways, and even once a recording was saved, the resulting flow would emit a `Could not establish connection. Receiving end does not exist.` error and feel sluggish after the page rendered.
 
 Root causes, in order along the pipeline:
 
 1. **Recording captured zero steps after the first page** — the content-script's recording module restored its `recording = true` flag from `chrome.storage.session` on each new page, but never reattached the DOM/window listeners, so user clicks fired into the void.
 2. **Save path silently dropped messages** — recent RPC migration moved most messaging behind the RPC envelope, but the content script's `recording/` module still sends `saveRecordedActions`, `recordingStopped`, `getRecordedActions`, `clearRecordedActions`, and `spaNavigationDetected` as plain `chrome.runtime.sendMessage` calls. The SW's plain-message listener only knew about `getTabId`/`getAllWebFlows`/`deleteWebFlow`. A field-name mismatch (`recordedActionHtml` vs `recordedActionPageHTML`) compounded the problem.
 3. **WebFlowStore lazy-init missing in discovery path** — `handleCreateWebFlowFromRecording` and `handleRegisterSiteSchema` read `agentContext.webFlowStore` directly and threw if it wasn't already initialized, while three sibling handlers correctly used the existing `getWebFlowStore()` helper that lazy-initializes on demand.
 4. **Post-navigation race in flow execution** — `openWebPage` returned as soon as `chrome.tabs.update` was queued, so the very next RPC (`awaitPageLoad`, `extractComponent`, …) raced the old document's unload. The existing one-shot 100 ms retry wasn't enough on heavier pages