### PR TITLE
Browser : Enable queued messages

### DIFF
--- a/ts/packages/agents/browser/src/common/serviceTypes.mts
+++ b/ts/packages/agents/browser/src/common/serviceTypes.mts
@@ -439,6 +439,18 @@ export type ChatPanelCallFunctions = {
         data: any;
     }): void;
     dispatcherConnectionStatus(data: { connected: boolean }): void;
+    // ---- Queue lifecycle (opt-in UX; chat panel does not render chips yet) ----
+    // Forwarded from the service worker's ClientIO so the chat panel can opt
+    // into queue chip UX later by implementing these handlers. Current
+    // implementations are no-ops.
+    dispatcherRequestQueued(data: { entry: any; version: number }): void;
+    dispatcherRequestStarted(data: { entry: any; version: number }): void;
+    dispatcherRequestCancelled(data: {
+        requestId: string;
+        reason: any;
+        version: number;
+    }): void;
+    dispatcherQueueStateChanged(data: { snapshot: any }): void;
     /** Inject a command into the chat panel as if the user typed it. */
     injectCommand(data: { command: string }): void;
     /** Start the interactive macro authoring flow. */

--- a/ts/packages/agents/browser/src/extension/serviceWorker/dispatcherConnection.ts
+++ b/ts/packages/agents/browser/src/extension/serviceWorker/dispatcherConnection.ts
@@ -186,6 +186,37 @@ function createChatPanelClientIO(): ClientIO {
         takeAction(requestId, action, data) {
             rpcSend?.("dispatcherTakeAction", { requestId, action, data });
         },
+
+        // ---- Queue lifecycle (opt-in per client) ----
+        //
+        // The browser extension does not yet render queue chips, but we
+        // still implement these handlers so the underlying ClientIO has
+        // them defined. The dispatcher broadcasts queue lifecycle events
+        // to every unfiltered client; clients that omit these methods are
+        // silently skipped via optional chaining
+        // (`cio.requestQueued?.(...)` in sharedDispatcher). When the
+        // browser and another queue-aware client (e.g. the VS Code
+        // extension) are connected to the same conversation, defining
+        // these methods here keeps the wire protocol symmetric and lets
+        // the chat panel side opt into chip UX later by handling these
+        // forwarded messages — without requiring another round-trip
+        // through the service worker.
+        requestQueued(entry, version) {
+            rpcSend?.("dispatcherRequestQueued", { entry, version });
+        },
+        requestStarted(entry, version) {
+            rpcSend?.("dispatcherRequestStarted", { entry, version });
+        },
+        requestCancelled(requestId, reason, version) {
+            rpcSend?.("dispatcherRequestCancelled", {
+                requestId,
+                reason,
+                version,
+            });
+        },
+        queueStateChanged(snapshot) {
+            rpcSend?.("dispatcherQueueStateChanged", { snapshot });
+        },
     };
 }
 

--- a/ts/packages/agents/browser/src/extension/views/chatPanel.ts
+++ b/ts/packages/agents/browser/src/extension/views/chatPanel.ts
@@ -344,6 +344,15 @@ function initialize() {
             dispatcherConnectionStatus(data) {
                 setConnectionStatus(data.connected);
             },
+            // ---- Queue lifecycle (forwarded from the service worker) ----
+            // Chat panel does not render queue chips yet; these handlers
+            // exist so the typed RPC contract is satisfied and so the
+            // panel can opt into chip UX later without touching the
+            // service worker.
+            dispatcherRequestQueued(_data) {},
+            dispatcherRequestStarted(_data) {},
+            dispatcherRequestCancelled(_data) {},
+            dispatcherQueueStateChanged(_data) {},
             injectCommand(data) {
                 chatPanel.injectCommand(data.command);
             },
@@ -607,9 +616,14 @@ function handleUserMessage(
         }
     }
 
-    chatPanel.setEnabled(false);
-    chatPanel.showStatus("Processing...");
-
+    // Don't disable the input here — the chat panel's send() already
+    // swapped the send button for the stop button via setProcessing(),
+    // and we want the user to be able to queue another command while
+    // this one is in flight. The dispatcher will queue concurrent
+    // requests server-side. We just need to be sure that when the
+    // request completes we only flip back to the send button if THIS
+    // request is still the most recent in-flight one (otherwise a
+    // newer submission's stop button would disappear prematurely).
     rpc.invoke("chatPanelProcessCommand", {
         command: text,
         clientRequestId: requestId,
@@ -630,8 +644,9 @@ function handleUserMessage(
             // Add contextual follow-up buttons based on the command
             addContextualFollowUps(text);
 
-            chatPanel.setEnabled(true);
-            chatPanel.focus();
+            if (chatPanel.getActiveRequestId() === requestId) {
+                chatPanel.setIdle();
+            }
         })
         .catch((err: any) => {
             chatPanel.addAgentMessage(
@@ -642,8 +657,9 @@ function handleUserMessage(
                 },
                 "system",
             );
-            chatPanel.setEnabled(true);
-            chatPanel.focus();
+            if (chatPanel.getActiveRequestId() === requestId) {
+                chatPanel.setIdle();
+            }
         });
 }
 


### PR DESCRIPTION
Enable message queueing in the browser extension (without full UX) for a more responsive experience