### PR TITLE
Discord Agent : Add ability to craft messages based on user goal

### DIFF
--- a/ts/packages/agents/discord/README.md
+++ b/ts/packages/agents/discord/README.md
@@ -51,15 +51,28 @@ The agent will fetch and cache all channels in the server automatically.
 
 ## Implemented Actions
 
-| Action                | Example Phrase                                     | Notes                                                        |
-| --------------------- | -------------------------------------------------- | ------------------------------------------------------------ |
-| `setGuild`            | "set my discord server to 123456789"               | Persists across sessions; triggers channel cache refresh     |
-| `getCurrentUser`      | "who am I on Discord?"                             | Returns bot username, discriminator, and ID                  |
-| `createMessage`       | "send a message to #general saying hello"          | Resolves channel names and `#name` references                |
-| `getChannelMessages`  | "show me the last 5 messages in #general"          | Returns messages with human-readable timestamps and authors  |
-| `listChannels`        | "list discord channels"                            | Shows channels nested under categories; includes type labels |
-| `refreshChannels`     | "refresh discord channels"                         | Force-refreshes the channel name cache from Discord          |
-| `createChannelInvite` | "create an invite for #general that never expires" | Supports `never_expires`, `max_age`, `max_uses`, `temporary` |
+| Action                | Example Phrase                                      | Notes                                                            |
+| --------------------- | --------------------------------------------------- | ---------------------------------------------------------------- |
+| `setGuild`            | "set my discord server to 123456789"                | Persists across sessions; triggers channel cache refresh         |
+| `getCurrentUser`      | "who am I on Discord?"                              | Returns bot username, discriminator, and ID                      |
+| `createMessage`       | "send a message to #general saying hello"           | Resolves channel names and `#name` references                    |
+| `craftMessage`        | "send a message to #general that welcomes everyone" | LLM drafts the message body from a high-level intent (see below) |
+| `getChannelMessages`  | "show me the last 5 messages in #general"           | Returns messages with human-readable timestamps and authors      |
+| `listChannels`        | "list discord channels"                             | Shows channels nested under categories; includes type labels     |
+| `refreshChannels`     | "refresh discord channels"                          | Force-refreshes the channel name cache from Discord              |
+| `createChannelInvite` | "create an invite for #general that never expires"  | Supports `never_expires`, `max_age`, `max_uses`, `temporary`     |
+
+### `createMessage` vs `craftMessage`
+
+The agent picks between two send actions based on phrasing:
+
+- **`createMessage`** — you provide the literal body, typically with _"saying"_, _"with the text"_, or by quoting the content.
+  - "Send `'Hello everyone!'` to #general"
+  - "Post a message in #updates saying the deploy is done"
+- **`craftMessage`** — you describe the intent (using connectors like _"that …"_, _"to …"_, _"about …"_, _"reminding …"_), and an LLM writes the body before posting.
+  - "Send a message to #general that welcomes everyone to the discord"
+  - "Send a message to #events to remind everyone about tonight's plans"
+  - "Post a message in #announcements about the new release"
 
 ## Channel Name Resolution
 

--- a/ts/packages/agents/discord/package.json
+++ b/ts/packages/agents/discord/package.json
@@ -24,7 +24,8 @@
     "tsc": "tsc -b"
   },
   "dependencies": {
-    "@typeagent/agent-sdk": "workspace:*"
+    "@typeagent/agent-sdk": "workspace:*",
+    "aiclient": "workspace:*"
   },
   "devDependencies": {
     "@typeagent/action-schema-compiler": "workspace:*",

--- a/ts/packages/agents/discord/src/discordActionHandler.ts
+++ b/ts/packages/agents/discord/src/discordActionHandler.ts
@@ -12,6 +12,7 @@ import {
     createActionResultFromTextDisplay,
     createActionResultFromError,
 } from "@typeagent/agent-sdk/helpers/action";
+import { ChatModel, openai } from "aiclient";
 import { DiscordActions } from "./discordSchema.js";
 
 const DISCORD_API = "https://discord.com/api/v10";
@@ -28,6 +29,7 @@ interface DiscordAgentContext {
     channelList: DiscordChannel[]; // raw channel data for display
     channelsLastFetched: number;
     pollHandle: ReturnType<typeof setInterval> | undefined;
+    craftMessageModel: ChatModel | undefined;
 }
 
 interface DiscordChannel {
@@ -63,6 +65,7 @@ async function initializeAgentContext(): Promise<DiscordAgentContext> {
         channelList: [],
         channelsLastFetched: 0,
         pollHandle: undefined,
+        craftMessageModel: undefined,
     };
 }
 
@@ -267,6 +270,7 @@ async function resolveChannelId(
 
 const GUILD_REQUIRED_ACTIONS = new Set([
     "createMessage",
+    "craftMessage",
     "getChannelMessages",
     "listChannels",
     "refreshChannels",
@@ -275,6 +279,61 @@ const GUILD_REQUIRED_ACTIONS = new Set([
 
 function needsGuild(actionName: string): boolean {
     return GUILD_REQUIRED_ACTIONS.has(actionName);
+}
+
+// LLM occasionally returns extra words after the channel; keep the first
+// token and fold the rest back into the user intent.
+function splitChannelToken(raw: string): { channel: string; rest: string } {
+    const trimmed = raw.trim();
+    const match = trimmed.match(/^(#?\S+)(?:\s+(.*))?$/);
+    if (!match) {
+        return { channel: trimmed, rest: "" };
+    }
+    return { channel: match[1], rest: match[2]?.trim() ?? "" };
+}
+
+async function craftMessageContent(
+    intent: string,
+    channelName: string,
+    agentContext: DiscordAgentContext,
+): Promise<string> {
+    agentContext.craftMessageModel ??= openai.createChatModel(
+        undefined,
+        undefined,
+        undefined,
+        ["discord:craftMessage"],
+    );
+    const chatModel = agentContext.craftMessageModel;
+    const prompt = [
+        "You are drafting a Discord chat message on behalf of a user.",
+        `Target channel: #${channelName}`,
+        `User intent: ${intent}`,
+        "",
+        "Write the message body ONLY — no quotes, no preamble, no explanation,",
+        "no signature. Keep the tone natural and conversational, suitable for",
+        "a Discord channel. Length should fit the intent (usually 1-3 short",
+        "sentences). You may use plain Discord-friendly markdown and emoji",
+        "when it improves the message, but do not overdo it.",
+    ].join("\n");
+
+    const result = await chatModel.complete(prompt);
+    if (!result.success) {
+        throw new Error(`Failed to craft message: ${result.message}`);
+    }
+
+    let content = result.data.trim();
+    // Strip a single layer of wrapping quotes the model sometimes adds.
+    if (
+        (content.startsWith('"') && content.endsWith('"')) ||
+        (content.startsWith("'") && content.endsWith("'")) ||
+        (content.startsWith("“") && content.endsWith("”"))
+    ) {
+        content = content.slice(1, -1).trim();
+    }
+    if (!content) {
+        throw new Error("LLM returned empty content for the message.");
+    }
+    return content;
 }
 
 async function executeAction(
@@ -325,9 +384,12 @@ async function executeAction(
 
         switch (action.actionName) {
             case "createMessage": {
-                const { channel_id, content, tts, nonce } = action.parameters;
+                const { content, tts, nonce } = action.parameters;
+                const { channel } = splitChannelToken(
+                    action.parameters.channel_id,
+                );
                 const resolvedId = await resolveChannelId(
-                    channel_id,
+                    channel,
                     agentContext,
                     sessionContext,
                 );
@@ -340,7 +402,35 @@ async function executeAction(
                 );
                 const msg = (await response.json()) as { id: string };
                 return createActionResultFromTextDisplay(
-                    `Message sent! ID: ${msg.id} in #${channel_id}`,
+                    `Message sent! ID: ${msg.id} in #${channel.replace(/^#/, "")}`,
+                );
+            }
+            case "craftMessage": {
+                const { intent, tts } = action.parameters;
+                const { channel, rest } = splitChannelToken(
+                    action.parameters.channel_id,
+                );
+                const resolvedId = await resolveChannelId(
+                    channel,
+                    agentContext,
+                    sessionContext,
+                );
+                const channelName = channel.replace(/^#/, "");
+                const fullIntent = rest ? `${rest} ${intent}`.trim() : intent;
+                const content = await craftMessageContent(
+                    fullIntent,
+                    channelName,
+                    agentContext,
+                );
+                const body: Record<string, unknown> = { content };
+                if (tts !== undefined) body.tts = tts;
+                const response = await discordFetch(
+                    `/channels/${resolvedId}/messages`,
+                    { method: "POST", body: JSON.stringify(body) },
+                );
+                const msg = (await response.json()) as { id: string };
+                return createActionResultFromTextDisplay(
+                    `Crafted and sent to #${channelName} (ID: ${msg.id}):\n${content}`,
                 );
             }
             case "getChannelMessages": {

--- a/ts/packages/agents/discord/src/discordActionHandler.ts
+++ b/ts/packages/agents/discord/src/discordActionHandler.ts
@@ -285,11 +285,14 @@ function needsGuild(actionName: string): boolean {
 // token and fold the rest back into the user intent.
 function splitChannelToken(raw: string): { channel: string; rest: string } {
     const trimmed = raw.trim();
-    const match = trimmed.match(/^(#?\S+)(?:\s+(.*))?$/);
-    if (!match) {
+    const spaceIdx = trimmed.search(/\s/);
+    if (spaceIdx === -1) {
         return { channel: trimmed, rest: "" };
     }
-    return { channel: match[1], rest: match[2]?.trim() ?? "" };
+    return {
+        channel: trimmed.slice(0, spaceIdx),
+        rest: trimmed.slice(spaceIdx + 1).trim(),
+    };
 }
 
 async function craftMessageContent(

--- a/ts/packages/agents/discord/src/discordManifest.json
+++ b/ts/packages/agents/discord/src/discordManifest.json
@@ -1,9 +1,9 @@
 {
   "emojiChar": "💬",
-  "description": "Discord messaging and server management integration",
+  "description": "Discord chat agent — send messages, draft messages from intent, list channels, browse channel history, manage server/channel invites.",
   "defaultEnabled": true,
   "schema": {
-    "description": "Discord agent actions",
+    "description": "Discord agent. Use for anything involving Discord channels, messages, members, invites, or servers — e.g. sending a chat message to a channel, drafting a message from a high-level intent (\"send a message to #general that welcomes everyone\" or \"...to remind everyone about tonight's plans\"), listing channels, fetching recent messages, or creating channel invites.",
     "originalSchemaFile": "./discordSchema.ts",
     "schemaFile": "../dist/discordSchema.pas.json",
     "grammarFile": "../dist/discordSchema.ag.json",

--- a/ts/packages/agents/discord/src/discordSchema.agr
+++ b/ts/packages/agents/discord/src/discordSchema.agr
@@ -46,6 +46,36 @@
     }
 };
 
+// craftMessage
+<CraftMessage> = send a message (to|in) (the)? (channel)? $(channel_id:word) (that|to|about|asking|reminding|telling|inviting|announcing|welcoming|congratulating|wishing) $(intent:wildcard) -> {
+    actionName: "craftMessage",
+    parameters: {
+        channel_id,
+        intent
+    }
+}
+  | post a message (to|in) (the)? (channel)? $(channel_id:word) (that|to|about|asking|reminding|telling|inviting|announcing|welcoming|congratulating|wishing) $(intent:wildcard) -> {
+    actionName: "craftMessage",
+    parameters: {
+        channel_id,
+        intent
+    }
+}
+  | (please)? write a message (to|in) (the)? (channel)? $(channel_id:word) (that|to|about|asking|reminding|telling|inviting|announcing|welcoming|congratulating|wishing) $(intent:wildcard) -> {
+    actionName: "craftMessage",
+    parameters: {
+        channel_id,
+        intent
+    }
+}
+  | (can you)? create a (new)? message in (the)? (channel)? $(channel_id:word) (that|to|about|asking|reminding|telling|inviting|announcing|welcoming|congratulating|wishing) $(intent:wildcard) -> {
+    actionName: "craftMessage",
+    parameters: {
+        channel_id,
+        intent
+    }
+};
+
 // getChannelMessages
 <GetChannelMessages> = (can you)? show me (the)? (latest|recent)? messages from (the)? channel $(channel_id:wildcard) -> {
     actionName: "getChannelMessages",
@@ -1350,6 +1380,7 @@
 import { DiscordActions } from "./discordSchema.ts";
 
 <Start> : DiscordActions = <CreateMessage>
+  | <CraftMessage>
   | <GetChannelMessages>
   | <CreateGuild>
   | <GetGuild>

--- a/ts/packages/agents/discord/src/discordSchema.ts
+++ b/ts/packages/agents/discord/src/discordSchema.ts
@@ -3,6 +3,7 @@
 
 export type DiscordActions =
     | CreateMessageAction
+    | CraftMessageAction
     | GetChannelMessagesAction
     | CreateGuildAction
     | GetGuildAction
@@ -67,6 +68,30 @@ export type CreateMessageAction = {
         content: string;
         // A unique identifier for the message.
         nonce?: string;
+        // Whether the message should be sent as text-to-speech.
+        tts?: boolean;
+    };
+};
+
+// Drafts a message via LLM from a high-level intent, then posts it.
+// Use when the user describes what the message should convey
+// ("that ...", "to ...", "about ...", "reminding ...", "asking ...")
+// instead of supplying literal content.
+// Sample phrases:
+//   - "Send a message to #general that welcomes everyone to the discord"
+//   - "Send a message to #general to remind everyone about tonight's plans"
+//   - "Post a message in #announcements about the new release"
+//   - "Write a message in #random asking who's free tomorrow"
+//   - "Send a message in #events reminding people to RSVP"
+export type CraftMessageAction = {
+    actionName: "craftMessage";
+    parameters: {
+        // Single channel token (ID, bare name, or "#name"). Must not
+        // contain spaces — anything after the channel belongs in `intent`.
+        channel_id: string;
+        // What the message should convey — everything the user said about
+        // the message after the channel and connector word.
+        intent: string;
         // Whether the message should be sent as text-to-speech.
         tts?: boolean;
     };

--- a/ts/pnpm-lock.yaml
+++ b/ts/pnpm-lock.yaml
@@ -2275,6 +2275,9 @@ importers:
       '@typeagent/agent-sdk':
         specifier: workspace:*
         version: link:../../agentSdk
+      aiclient:
+        specifier: workspace:*
+        version: link:../../aiclient
     devDependencies:
       '@typeagent/action-schema-compiler':
         specifier: workspace:*


### PR DESCRIPTION
## Summary

Adds a new `craftMessage` action to the Discord agent that drafts message bodies from a high-level intent via LLM, while leaving the existing `createMessage` (literal-text) flow untouched.

For example : 
<img width="540" height="227" alt="image" src="https://github.com/user-attachments/assets/cade1ae5-8274-40bc-82ae-fd7533b7d1af" />
<img width="874" height="116" alt="image" src="https://github.com/user-attachments/assets/f80d9775-cf77-43b4-bc41-149a31058f2c" />
