### PR TITLE
Add grammar for triggering conversation actions

### DIFF
--- a/ts/packages/dispatcher/dispatcher/src/context/appAgentManager.ts
+++ b/ts/packages/dispatcher/dispatcher/src/context/appAgentManager.ts
@@ -157,10 +157,7 @@ function loadGrammar(actionConfig: ActionConfig): Grammar | undefined {
         return grammarFromJson(JSON.parse(grammarContent.content));
     }
     if (grammarContent.format === "agr") {
-        // Parse raw .agr text into a Grammar at load time. Errors are surfaced
-        // immediately because this path is only used for static (manifest-
-        // declared) grammar files; bad syntax should fail loudly during
-        // development rather than silently disable the rules.
+        // Parse raw .agr at load time; throw on errors so bad syntax fails loudly.
         const errors: string[] = [];
         const grammar = loadGrammarRulesNoThrow(
             `${actionConfig.schemaName}.agr`,

--- a/ts/packages/dispatcher/dispatcher/src/context/appAgentManager.ts
+++ b/ts/packages/dispatcher/dispatcher/src/context/appAgentManager.ts
@@ -153,12 +153,30 @@ function loadGrammar(actionConfig: ActionConfig): Grammar | undefined {
         return undefined;
     }
 
-    if (grammarContent.format !== "ag") {
-        throw new Error(
-            `Unsupported grammar file extension: ${actionConfig.grammarFile}`,
-        );
+    if (grammarContent.format === "ag") {
+        return grammarFromJson(JSON.parse(grammarContent.content));
     }
-    return grammarFromJson(JSON.parse(grammarContent.content));
+    if (grammarContent.format === "agr") {
+        // Parse raw .agr text into a Grammar at load time. Errors are surfaced
+        // immediately because this path is only used for static (manifest-
+        // declared) grammar files; bad syntax should fail loudly during
+        // development rather than silently disable the rules.
+        const errors: string[] = [];
+        const grammar = loadGrammarRulesNoThrow(
+            `${actionConfig.schemaName}.agr`,
+            grammarContent.content,
+            errors,
+        );
+        if (errors.length > 0) {
+            throw new Error(
+                `Failed to parse static grammar for ${actionConfig.schemaName}: ${errors.join(", ")}`,
+            );
+        }
+        return grammar ?? undefined;
+    }
+    throw new Error(
+        `Unsupported grammar format '${(grammarContent as { format: string }).format}' for ${actionConfig.schemaName}`,
+    );
 }
 
 export class AppAgentManager implements ActionConfigProvider {

--- a/ts/packages/dispatcher/dispatcher/src/context/system/action/conversationActionHandler.ts
+++ b/ts/packages/dispatcher/dispatcher/src/context/system/action/conversationActionHandler.ts
@@ -19,7 +19,10 @@ export async function executeConversationAction(
 
     switch (action.actionName) {
         case "newConversation": {
-            const name = action.parameters.name;
+            // Grammar matches that emit `parameters: {}` are normalized away
+            // by the grammar engine, so `action.parameters` may be missing on
+            // grammar-cache hits even though the schema marks it required.
+            const name = action.parameters?.name;
             payload = name
                 ? { subcommand: "new", name }
                 : { subcommand: "new" };

--- a/ts/packages/dispatcher/dispatcher/src/context/system/schema/conversationActionSchema.agr
+++ b/ts/packages/dispatcher/dispatcher/src/context/system/schema/conversationActionSchema.agr
@@ -1,0 +1,144 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+//
+// Natural-language patterns for the built-in system.conversation
+// sub-schema (TypeAgent shell conversation management).
+//
+// These patterns give conversation commands a strong static-grammar
+// match so they resolve from cache instead of requiring an LLM
+// translation, AND so they reliably beat wildcard-heavy patterns from
+// other agents (e.g. browser webflow `setPreferredStore`'s
+// `switch (to)? $(storeName:wildcard) (store)?`) on the cache's match
+// heuristics:
+//   1. Non-wildcard matches win over any wildcard match.
+//   2. Higher nonOptionalCount wins.
+//   3. Higher matchedCount wins.
+//   4. Lower wildcardCharCount wins.
+// Patterns here anchor the literal word "conversation"/"chat"/etc., so
+// they score far higher than open-ended wildcard rules.
+//
+// NOTE: In .agr rule bodies, literal tokens are bare words — single/
+// double quotes around a literal would be matched as literal quote
+// characters in the input. Escapes (`\'`) are used only where a
+// genuine apostrophe must appear in the input (e.g. "let\'s").
+
+<Polite> = (can you | could you | please | would you | i need | let\'s)?;
+
+<ConvNoun> = (conversation | chat | session | tab);
+<ConvNounPlural> = (conversations | chats | sessions | tabs);
+
+// "create/start/make/open/begin a new conversation called/named X"
+<NewConversationNamed> = <Polite> (create | start | make | open | begin) (a | an)? new <ConvNoun> (called | named | titled) $(name:wildcard) -> {
+    actionName: "newConversation",
+    parameters: { name }
+};
+
+// "create/start/make/open/begin a new conversation"  (no name)
+<NewConversation> = <Polite> (create | start | make | open | begin) (a | an)? new <ConvNoun> -> {
+    actionName: "newConversation",
+    parameters: {}
+}
+  | <Polite> new <ConvNoun> -> {
+    actionName: "newConversation",
+    parameters: {}
+};
+
+// "list/show (me) (all/my/our/the) conversations"
+<ListConversation> = <Polite> (list | show | display) (me | us)? (all | my | our | the)? <ConvNounPlural> -> {
+    actionName: "listConversation"
+}
+  | <Polite> (what | which) <ConvNounPlural> (do | are)? (i | we)? have -> {
+    actionName: "listConversation"
+};
+
+// "show (current|this|the) conversation info"
+// "what conversation am i in"
+<ShowConversationInfo> = <Polite> (show | display) (me)? (current | this | the)? <ConvNoun> info -> {
+    actionName: "showConversationInfo"
+}
+  | <Polite> (what | which) <ConvNoun> am i in -> {
+    actionName: "showConversationInfo"
+}
+  | <Polite> current <ConvNoun> info -> {
+    actionName: "showConversationInfo"
+};
+
+// Switch to an existing conversation by name. Multiple phrasings are
+// supported because the user complaint was specifically that
+// "switch conversation to X" was being matched as a browser webflow.
+<SwitchConversationNamed> =
+  // "switch/go/change/open/load/resume to (the) conversation (called|named) X"
+  <Polite> (switch | go | change | open | load | resume) to (the)? <ConvNoun> (called | named)? $(name:wildcard) -> {
+    actionName: "switchConversation",
+    parameters: { name }
+  }
+  // "switch/change (the) conversation to X"
+  | <Polite> (switch | change) (the)? <ConvNoun> to $(name:wildcard) -> {
+    actionName: "switchConversation",
+    parameters: { name }
+  }
+  // "switch/go/change to (the|my) X conversation"
+  | <Polite> (switch | go | change) to (the | my)? $(name:wildcard) <ConvNoun> -> {
+    actionName: "switchConversation",
+    parameters: { name }
+  }
+  // "open/load/resume (the) conversation (called|named) X"
+  | <Polite> (open | load | resume) (the)? <ConvNoun> (called | named)? $(name:wildcard) -> {
+    actionName: "switchConversation",
+    parameters: { name }
+  };
+
+// "(switch to|go to|cycle to)? (the)? next conversation"
+<NextConversation> = <Polite> (switch to | go to | cycle to)? (the)? next <ConvNoun> -> {
+    actionName: "nextConversation"
+}
+  | <Polite> advance to (the)? next <ConvNoun> -> {
+    actionName: "nextConversation"
+};
+
+// "(switch to|go to|cycle to)? (the)? previous/prev conversation"
+<PrevConversation> = <Polite> (switch to | go to | cycle to)? (the)? (previous | prev | last) <ConvNoun> -> {
+    actionName: "prevConversation"
+}
+  | <Polite> back to (the)? (previous | prev) <ConvNoun> -> {
+    actionName: "prevConversation"
+};
+
+// "rename (this|the|current) conversation to X"
+<RenameConversationCurrent> = <Polite> rename (this | the | current) <ConvNoun> to $(newName:wildcard) -> {
+    actionName: "renameConversation",
+    parameters: { newName }
+}
+  | <Polite> call (this | the | current) <ConvNoun> $(newName:wildcard) -> {
+    actionName: "renameConversation",
+    parameters: { newName }
+};
+
+// "rename conversation X to Y"  — the literal noun anchors both wildcards.
+<RenameConversationNamed> = <Polite> rename <ConvNoun> $(name:wildcard) to $(newName:wildcard) -> {
+    actionName: "renameConversation",
+    parameters: { name, newName }
+};
+
+// "delete/remove (the) conversation (called|named) X"
+// "delete/remove (the) X conversation"
+<DeleteConversation> =
+  <Polite> (delete | remove | destroy) (the)? <ConvNoun> (called | named)? $(name:wildcard) -> {
+    actionName: "deleteConversation",
+    parameters: { name }
+  }
+  | <Polite> (delete | remove) (the)? $(name:wildcard) <ConvNoun> -> {
+    actionName: "deleteConversation",
+    parameters: { name }
+  };
+
+<Start> = <NewConversationNamed>
+  | <NewConversation>
+  | <ListConversation>
+  | <ShowConversationInfo>
+  | <SwitchConversationNamed>
+  | <NextConversation>
+  | <PrevConversation>
+  | <RenameConversationCurrent>
+  | <RenameConversationNamed>
+  | <DeleteConversation>;

--- a/ts/packages/dispatcher/dispatcher/src/context/system/systemAgent.ts
+++ b/ts/packages/dispatcher/dispatcher/src/context/system/systemAgent.ts
@@ -175,6 +175,8 @@ export const systemManifest: AppAgentManifest = {
                 schemaFile:
                     "./src/context/system/schema/conversationActionSchema.ts",
                 schemaType: "ConversationAction",
+                grammarFile:
+                    "./src/context/system/schema/conversationActionSchema.agr",
             },
         },
         notify: {

--- a/ts/packages/dispatcher/dispatcher/src/translation/actionConfig.ts
+++ b/ts/packages/dispatcher/dispatcher/src/translation/actionConfig.ts
@@ -55,12 +55,17 @@ function loadSchemaFile(schemaFile: string): SchemaContent {
 
 function loadGrammarFile(grammarFile: string): GrammarContent {
     const fullPath = getPackageFilePath(grammarFile);
-    const isActionGrammar = grammarFile.endsWith(".ag.json");
-    if (!isActionGrammar) {
-        throw new Error(`Unsupported grammar file extension: ${grammarFile}`);
-    }
     const content = fs.readFileSync(fullPath, "utf-8");
-    return { format: "ag", content };
+    if (grammarFile.endsWith(".ag.json")) {
+        return { format: "ag", content };
+    }
+    if (grammarFile.endsWith(".agr")) {
+        // Raw grammar rule source — parsed at load time by the action-grammar
+        // compiler. Lets agents (notably the built-in dispatcher/system agent)
+        // ship a static grammar without an explicit .agr -> .ag.json build step.
+        return { format: "agr", content };
+    }
+    throw new Error(`Unsupported grammar file extension: ${grammarFile}`);
 }
 
 export function getSchemaContent(actionConfig: ActionConfig): SchemaContent {

--- a/ts/packages/dispatcher/dispatcher/src/translation/actionConfig.ts
+++ b/ts/packages/dispatcher/dispatcher/src/translation/actionConfig.ts
@@ -60,9 +60,7 @@ function loadGrammarFile(grammarFile: string): GrammarContent {
         return { format: "ag", content };
     }
     if (grammarFile.endsWith(".agr")) {
-        // Raw grammar rule source — parsed at load time by the action-grammar
-        // compiler. Lets agents (notably the built-in dispatcher/system agent)
-        // ship a static grammar without an explicit .agr -> .ag.json build step.
+        // Raw grammar source; parsed at load time instead of via a build step.
         return { format: "agr", content };
     }
     throw new Error(`Unsupported grammar file extension: ${grammarFile}`);

--- a/ts/packages/dispatcher/dispatcher/test/conversationGrammar.spec.ts
+++ b/ts/packages/dispatcher/dispatcher/test/conversationGrammar.spec.ts
@@ -1,0 +1,197 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+    compileGrammarToNFA,
+    loadGrammarRulesNoThrow,
+    matchNFA,
+} from "action-grammar";
+
+// Resolve the .agr source from the package root regardless of where the
+// compiled spec runs from.  __dirname is dist/test/, so go up two levels
+// to the package root, then into src/.
+const here = path.dirname(fileURLToPath(import.meta.url));
+const grammarPath = path.resolve(
+    here,
+    "..",
+    "..",
+    "src",
+    "context",
+    "system",
+    "schema",
+    "conversationActionSchema.agr",
+);
+
+function makeMatcher() {
+    const content = fs.readFileSync(grammarPath, "utf-8");
+    const errors: string[] = [];
+    const grammar = loadGrammarRulesNoThrow(
+        "conversationActionSchema.agr",
+        content,
+        errors,
+    );
+    if (errors.length > 0 || grammar === undefined) {
+        throw new Error(
+            `Failed to parse conversation grammar: ${errors.join("; ")}`,
+        );
+    }
+    const nfa = compileGrammarToNFA(grammar, "system.conversation");
+    return (input: string) => {
+        const tokens = input.toLowerCase().split(/\s+/);
+        const r = matchNFA(nfa, tokens, false);
+        return r.matched ? (r.actionValue as any) : undefined;
+    };
+}
+
+describe("system.conversation grammar", () => {
+    const match = makeMatcher();
+
+    describe("listConversation", () => {
+        it.each([
+            "list conversations",
+            "list my conversations",
+            "list our conversations",
+            "show conversations",
+            "show all conversations",
+            "show my chats",
+            "display sessions",
+            "what conversations do i have",
+            "which chats do i have",
+            "please list conversations",
+            "can you show my conversations",
+        ])("matches %p", (input) => {
+            const r = match(input);
+            expect(r).toBeDefined();
+            expect(r.actionName).toBe("listConversation");
+        });
+    });
+
+    describe("switchConversation", () => {
+        it("matches 'switch conversation to X'", () => {
+            const r = match("switch conversation to work");
+            expect(r).toBeDefined();
+            expect(r.actionName).toBe("switchConversation");
+            expect(r.parameters.name).toBe("work");
+        });
+
+        it("matches 'switch to conversation X'", () => {
+            const r = match("switch to conversation work");
+            expect(r).toBeDefined();
+            expect(r.actionName).toBe("switchConversation");
+            expect(r.parameters.name).toBe("work");
+        });
+
+        it("matches 'go to the X conversation'", () => {
+            const r = match("go to the work conversation");
+            expect(r).toBeDefined();
+            expect(r.actionName).toBe("switchConversation");
+            expect(r.parameters.name).toBe("work");
+        });
+
+        it("matches 'open conversation named X'", () => {
+            const r = match("open conversation named research");
+            expect(r).toBeDefined();
+            expect(r.actionName).toBe("switchConversation");
+            expect(r.parameters.name).toBe("research");
+        });
+
+        it("does NOT match bare 'switch to X' (no conversation anchor)", () => {
+            // This avoids stealing matches from agents like browser/player that
+            // legitimately use 'switch to X' for their own domain (e.g.
+            // setPreferredStore).  Only anchored phrasings should match.
+            expect(match("switch to test")).toBeUndefined();
+        });
+    });
+
+    describe("nextConversation / prevConversation beat wildcard switchConversation", () => {
+        it("'switch to next conversation' prefers nextConversation", () => {
+            const r = match("switch to next conversation");
+            expect(r).toBeDefined();
+            expect(r.actionName).toBe("nextConversation");
+        });
+
+        it("'go to previous conversation' prefers prevConversation", () => {
+            const r = match("go to previous conversation");
+            expect(r).toBeDefined();
+            expect(r.actionName).toBe("prevConversation");
+        });
+
+        it("'next conversation' matches nextConversation", () => {
+            const r = match("next conversation");
+            expect(r).toBeDefined();
+            expect(r.actionName).toBe("nextConversation");
+        });
+    });
+
+    describe("newConversation", () => {
+        it("matches 'new conversation' (no name)", () => {
+            const r = match("new conversation");
+            expect(r).toBeDefined();
+            expect(r.actionName).toBe("newConversation");
+        });
+
+        it("matches 'create a new conversation called X'", () => {
+            const r = match("create a new conversation called test");
+            expect(r).toBeDefined();
+            expect(r.actionName).toBe("newConversation");
+            expect(r.parameters.name).toBe("test");
+        });
+
+        it("matches 'start a new chat named X'", () => {
+            const r = match("start a new chat named research");
+            expect(r).toBeDefined();
+            expect(r.actionName).toBe("newConversation");
+            expect(r.parameters.name).toBe("research");
+        });
+    });
+
+    describe("renameConversation", () => {
+        it("matches 'rename this conversation to X'", () => {
+            const r = match("rename this conversation to work");
+            expect(r).toBeDefined();
+            expect(r.actionName).toBe("renameConversation");
+            expect(r.parameters.newName).toBe("work");
+        });
+
+        it("matches 'rename conversation X to Y' (both names)", () => {
+            const r = match("rename conversation old to new");
+            expect(r).toBeDefined();
+            expect(r.actionName).toBe("renameConversation");
+            expect(r.parameters.name).toBe("old");
+            expect(r.parameters.newName).toBe("new");
+        });
+    });
+
+    describe("deleteConversation", () => {
+        it("matches 'delete conversation X'", () => {
+            const r = match("delete conversation test");
+            expect(r).toBeDefined();
+            expect(r.actionName).toBe("deleteConversation");
+            expect(r.parameters.name).toBe("test");
+        });
+
+        it("matches 'remove the X conversation'", () => {
+            const r = match("remove the test conversation");
+            expect(r).toBeDefined();
+            expect(r.actionName).toBe("deleteConversation");
+            expect(r.parameters.name).toBe("test");
+        });
+    });
+
+    describe("showConversationInfo", () => {
+        it("matches 'show conversation info'", () => {
+            const r = match("show conversation info");
+            expect(r).toBeDefined();
+            expect(r.actionName).toBe("showConversationInfo");
+        });
+
+        it("matches 'what conversation am i in'", () => {
+            const r = match("what conversation am i in");
+            expect(r).toBeDefined();
+            expect(r.actionName).toBe("showConversationInfo");
+        });
+    });
+});


### PR DESCRIPTION
Allow conversation command to be matched via grammar.

Every agent package normally precompiles its grammar source as part of its build and ships the compiled artifact, but the dispatcher itself isn't a grammar-producing package and has no such build step. Adding one just to ship a single in-tree system grammar would mean new build wiring and a generated artifact for one file. Instead, a small additive change lets the dispatcher load the raw grammar source directly and parse it once at startup. The tradeoff is negligible cost and minimal risk, with no impact on existing agents.