### PR TITLE
Add agent-server publish pipeline  and install script

### DIFF
--- a/pipelines/azure-build-publish-agent-server.yml
+++ b/pipelines/azure-build-publish-agent-server.yml
@@ -1,0 +1,154 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+# Builds the self-contained agent-server artifact per platform (RID) and
+# publishes it (and the optional-agent bundles) as Azure Artifacts Universal
+# packages to the `typeagent` feed, for install on repo-less machines and for
+# `agency artifact` consumption.
+#
+# Manual / scheduled, not per-PR. Models azure-build-ts.yml / -package-shell.yml.
+
+trigger: none
+
+pr:
+  branches:
+    exclude:
+      - "*"
+
+parameters:
+  # "external" = lean artifact that resolves claude/copilot from PATH (Agency
+  # machines / the install-typeagent provisioner). "full" = bundles the CLIs
+  # (works anywhere; larger).
+  - name: variant
+    type: string
+    default: external
+    values:
+      - external
+      - full
+  # Provider profile shipped in the artifact (data/config.<profile>.json).
+  - name: profile
+    type: string
+    default: service
+  - name: publishOptionalAgents
+    type: boolean
+    default: true
+
+variables:
+  - name: buildDirectory
+    value: $(Build.SourcesDirectory)/ts
+  - name: nodeVersion
+    value: 22
+  # Universal-package version (must be valid semver; Build.BuildId is numeric).
+  - name: packageVersion
+    value: 0.0.1-$(Build.BuildId)
+  # Azure Artifacts feed coordinates (dev.azure.com/msctoproj/AI_Systems/_artifacts/feed/typeagent).
+  - name: adoOrgUrl
+    value: https://dev.azure.com/msctoproj
+  - name: adoProject
+    value: AI_Systems
+  - name: adoFeed
+    value: typeagent
+  - name: stagingDir
+    value: $(Build.ArtifactStagingDirectory)
+
+jobs:
+  - job: build_publish_agent_server
+    displayName: Build & publish agent-server artifact
+    strategy:
+      matrix:
+        win32_x64:
+          image: windows-latest
+          platform: win32
+          arch: x64
+        linux_x64:
+          image: ubuntu-latest
+          platform: linux
+          arch: x64
+        osx_x64:
+          image: macos-latest
+          platform: darwin
+          arch: x64
+        # NOTE: arm64 RIDs (win32/linux/darwin-arm64) need self-hosted or
+        # cross-arch agents; hosted images above are x64. Add when available.
+    pool:
+      vmImage: $(image)
+    steps:
+      - template: include-prepare-repo.yml
+        parameters:
+          buildDirectory: $(buildDirectory)
+          nodeVersion: $(nodeVersion)
+          registry: $(REGISTRY)
+
+      - template: include-update-package-version.yml
+        parameters:
+          buildDirectory: $(buildDirectory)
+          prerelease: ci.$(Build.BuildId)
+
+      - script: |
+          npm run build
+        displayName: Build
+        workingDirectory: $(buildDirectory)
+
+      # Produce the self-contained agent-server folder: pnpm deploy + foreign-arch
+      # prune + service profile (drops optional agents) + optional external-cli
+      # prune (drops bundled Claude/Copilot runtimes). Cross-platform via bash.
+      - bash: |
+          set -euo pipefail
+          EXTRA=""
+          if [ "${{ parameters.variant }}" = "external" ]; then EXTRA="--external-cli"; fi
+          node tools/scripts/deployAgentServer.mjs \
+            --out "$(stagingDir)/agent-server" \
+            --platform "$(platform)" --arch "$(arch)" \
+            --profile "${{ parameters.profile }}" $EXTRA
+        displayName: Deploy agent-server ($(platform)-$(arch), ${{ parameters.variant }})
+        workingDirectory: $(buildDirectory)
+
+      # Package the optional (profile-excluded) agents as self-contained bundles.
+      - ${{ if eq(parameters.publishOptionalAgents, true) }}:
+          - bash: |
+              set -euo pipefail
+              node tools/scripts/packageOptionalAgents.mjs \
+                --out "$(stagingDir)/optional-agents" \
+                --profile "${{ parameters.profile }}" \
+                --platform "$(platform)" --arch "$(arch)"
+            displayName: Package optional agents ($(platform)-$(arch))
+            workingDirectory: $(buildDirectory)
+
+      # Publish to the Universal feed. Auth via the build identity's
+      # System.AccessToken (the build service must have feed Publish role).
+      - bash: |
+          set -euo pipefail
+          az extension add --name azure-devops --only-show-errors || true
+          RID="$(platform)-$(arch)"
+          echo "Publishing agent-server.${RID} v$(packageVersion)"
+          az artifacts universal publish \
+            --organization "$(adoOrgUrl)" --project "$(adoProject)" --scope project \
+            --feed "$(adoFeed)" \
+            --name "agent-server.${RID}" --version "$(packageVersion)" \
+            --path "$(stagingDir)/agent-server" \
+            --description "TypeAgent agent-server (${{ parameters.variant }}, profile=${{ parameters.profile }}) for ${RID}"
+        displayName: Publish agent-server.$(platform)-$(arch)
+        workingDirectory: $(buildDirectory)
+        env:
+          AZURE_DEVOPS_EXT_PAT: $(System.AccessToken)
+
+      - ${{ if eq(parameters.publishOptionalAgents, true) }}:
+          - bash: |
+              set -euo pipefail
+              az extension add --name azure-devops --only-show-errors || true
+              RID="$(platform)-$(arch)"
+              for dir in "$(stagingDir)"/optional-agents/*/; do
+                [ -d "$dir" ] || continue
+                name="$(basename "$dir")"
+                echo "Publishing ${name}.${RID} v$(packageVersion)"
+                az artifacts universal publish \
+                  --organization "$(adoOrgUrl)" --project "$(adoProject)" --scope project \
+                  --feed "$(adoFeed)" \
+                  --name "${name}.${RID}" --version "$(packageVersion)" \
+                  --path "$dir" \
+                  --description "TypeAgent optional agent ${name} for ${RID}"
+              done
+            displayName: Publish optional agents ($(platform)-$(arch))
+            workingDirectory: $(buildDirectory)
+            env:
+              AZURE_DEVOPS_EXT_PAT: $(System.AccessToken)

--- a/ts/tools/scripts/install-typeagent.ps1
+++ b/ts/tools/scripts/install-typeagent.ps1
@@ -1,0 +1,138 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+<#
+.SYNOPSIS
+  Install the TypeAgent agent-server (and prerequisites) on a machine WITHOUT
+  the TypeAgent repo or Agency — the non-agency standalone installer.
+
+.DESCRIPTION
+  Complements typeagent-serve.mjs (which assumes the artifact is already present
+  and prerequisites exist). This script provisions what a bare machine lacks:
+
+    1. Verifies Node >= 22.
+    2. For the 'external' artifact variant, provisions the Claude Code + GitHub
+       Copilot CLIs on PATH (the external-cli agent-server resolves them at
+       runtime; see @typeagent/agent-sdk/node claudeExecutableOption). The 'full'
+       variant bundles those runtimes, so this step is skipped.
+    3. Downloads the agent-server Universal package for this RID from the feed.
+    4. (Optional) installs the Copilot CLI plugin from -PluginSource.
+    5. Runs config provisioning (getKeys, browser login) and starts the daemon
+       via the artifact's typeagent-serve.mjs.
+
+  Azure CLI (with az login) is used to download from the feed. This is the
+  install-time exception; runtime config provisioning still uses getKeys'
+  browser credential (no az login needed for that).
+
+.EXAMPLE
+  pwsh ./install-typeagent.ps1
+  pwsh ./install-typeagent.ps1 -Variant full -Version 0.0.1-12345
+#>
+
+[CmdletBinding()]
+param(
+    [ValidateSet("external", "full")]
+    [string]$Variant = "external",
+    [string]$Version = "latest",
+    [string]$InstallDir = "$env:LOCALAPPDATA\TypeAgent\agent-server",
+    [string]$Org = "https://dev.azure.com/msctoproj",
+    [string]$Project = "AI_Systems",
+    [string]$Feed = "typeagent",
+    [string]$PluginSource = "",
+    [switch]$NoStart
+)
+
+$ErrorActionPreference = "Stop"
+
+function Write-Step($msg) { Write-Host "==> $msg" -ForegroundColor Cyan }
+function Fail($msg) { Write-Error $msg; exit 1 }
+
+function Test-Command($name) {
+    return [bool](Get-Command $name -ErrorAction SilentlyContinue)
+}
+
+# --- 1. Node >= 22 -----------------------------------------------------------
+Write-Step "Checking Node.js"
+if (-not (Test-Command node)) {
+    Fail "Node.js >= 22 is required and was not found on PATH. Install it (e.g. 'winget install OpenJS.NodeJS.LTS') and re-run."
+}
+$nodeMajor = (& node -e "process.stdout.write(String(process.versions.node.split('.')[0]))")
+if ([int]$nodeMajor -lt 22) {
+    Fail "Node.js >= 22 required; found v$(& node --version). Upgrade and re-run."
+}
+Write-Host "  Node $(& node --version)"
+
+# --- 2. External-CLI prerequisites (Claude Code + Copilot CLI) ---------------
+if ($Variant -eq "external") {
+    Write-Step "Provisioning external CLIs (claude, copilot)"
+    if (-not (Test-Command npm)) {
+        Fail "npm is required to install the CLIs (ships with Node)."
+    }
+    if (-not (Test-Command claude)) {
+        Write-Host "  Installing Claude Code CLI (npm i -g @anthropic-ai/claude-code)"
+        & npm install -g "@anthropic-ai/claude-code"
+    } else {
+        Write-Host "  claude already on PATH: $((Get-Command claude).Source)"
+    }
+    if (-not (Test-Command copilot)) {
+        Write-Host "  Installing GitHub Copilot CLI (npm i -g @github/copilot)"
+        & npm install -g "@github/copilot"
+    } else {
+        Write-Host "  copilot already on PATH: $((Get-Command copilot).Source)"
+    }
+    Write-Host "  NOTE: both CLIs require a one-time auth (e.g. 'claude' / 'copilot' login) before agent actions work."
+}
+
+# --- 3. Download the agent-server artifact from the feed ---------------------
+Write-Step "Downloading agent-server artifact from feed '$Feed'"
+if (-not (Test-Command az)) {
+    Fail "Azure CLI ('az') is required to download from the feed. Install it and run 'az login'."
+}
+& az extension add --name azure-devops --only-show-errors 2>$null
+try { & az account show --only-show-errors *> $null } catch {
+    Write-Host "  Not logged in — launching 'az login'..."
+    & az login --only-show-errors | Out-Null
+}
+
+$arch = if ($env:PROCESSOR_ARCHITECTURE -match "ARM64") { "arm64" } else { "x64" }
+$rid = "win32-$arch"
+$pkgName = "agent-server.$rid"
+
+if (Test-Path $InstallDir) { Remove-Item -Recurse -Force $InstallDir }
+New-Item -ItemType Directory -Force -Path $InstallDir | Out-Null
+
+Write-Host "  $pkgName ($Version) -> $InstallDir"
+$verArgs = if ($Version -eq "latest") { @("--version", "*") } else { @("--version", $Version) }
+& az artifacts universal download `
+    --organization $Org --project $Project --scope project `
+    --feed $Feed --name $pkgName @verArgs --path $InstallDir --only-show-errors
+if ($LASTEXITCODE -ne 0) { Fail "Artifact download failed for $pkgName." }
+
+$serve = Join-Path $InstallDir "typeagent-serve.mjs"
+if (-not (Test-Path $serve)) { Fail "Downloaded artifact missing typeagent-serve.mjs (unexpected layout)." }
+
+# --- 4. Optional: install the Copilot CLI plugin -----------------------------
+if ($PluginSource -ne "") {
+    Write-Step "Installing Copilot CLI plugin from $PluginSource"
+    $pluginDest = Join-Path $env:USERPROFILE ".copilot\installed-plugins\typeagent"
+    New-Item -ItemType Directory -Force -Path (Split-Path $pluginDest) | Out-Null
+    if (Test-Path $pluginDest) { Remove-Item -Recurse -Force $pluginDest }
+    Copy-Item -Recurse -Force $PluginSource $pluginDest
+    Write-Host "  Plugin copied to $pluginDest"
+}
+
+# --- 5. Provision config + start the daemon ----------------------------------
+Write-Step "Provisioning config (getKeys, browser login)"
+& node $serve provision
+if ($LASTEXITCODE -ne 0) { Fail "Config provisioning failed." }
+
+if (-not $NoStart) {
+    Write-Step "Starting agent-server"
+    & node $serve start
+}
+
+Write-Host ""
+Write-Host "TypeAgent agent-server installed at $InstallDir" -ForegroundColor Green
+Write-Host "  Start:    node `"$serve`" start"
+Write-Host "  Status:   node `"$serve`" status"
+Write-Host "  Stop:     node `"$serve`" stop"


### PR DESCRIPTION

This pull request introduces a new Azure DevOps pipeline for building and publishing the `agent-server` artifact, as well as a standalone PowerShell installer script for deploying the agent-server on Windows machines without the TypeAgent repo or Agency. The changes enable streamlined CI/CD for multi-platform agent-server distribution and provide a robust, user-friendly installation experience on bare Windows environments.

Key changes include:

**CI/CD Pipeline for Agent-Server Distribution:**

* Added `azure-build-publish-agent-server.yml`, a new Azure DevOps pipeline that builds the self-contained `agent-server` artifact for multiple platforms (Windows, Linux, macOS x64), packages optional agents, and publishes them as Universal Packages to the `typeagent` Azure Artifacts feed. The pipeline supports both "external" and "full" artifact variants and is intended for manual or scheduled runs rather than per-PR triggers.

**Standalone Windows Installer Script:**

* Introduced `install-typeagent.ps1`, a comprehensive PowerShell script for installing the `agent-server` on Windows machines without the TypeAgent repository. The script:
  - Verifies Node.js >= 22 is installed.
  - Installs the required external CLIs (`claude`, `copilot`) if the "external" variant is chosen.
  - Downloads the appropriate agent-server artifact from Azure Artifacts using the Azure CLI.
  - Optionally installs the Copilot CLI plugin.
  - Provisions configuration and starts the agent-server daemon.